### PR TITLE
Add moniker and command to PowerShell Core

### DIFF
--- a/manifests/Microsoft/Powershell/7.0.0.yaml
+++ b/manifests/Microsoft/Powershell/7.0.0.yaml
@@ -5,6 +5,8 @@ Publisher: Microsoft
 Homepage: https://microsoft.com/PowerShell
 License:  MIT
 Description: PowerShell Core is a cross-platform (Windows, Linux, and macOS) automation and configuration tool/framework that works well with your existing tools and is optimized for dealing with structured data (e.g. JSON, CSV, XML, etc.), REST APIs, and object models. It includes a command-line shell, an associated scripting language and a framework for processing cmdlets.
+AppMoniker: pwsh
+Commands: pwsh
 Installers: 
     - Arch: x64
       Url: https://github.com/PowerShell/PowerShell/releases/download/v7.0.0/PowerShell-7.0.0-win-x64.msi


### PR DESCRIPTION
This updates the PowerShell Core manifest to include `pwsh` as a moniker and command.
Both Scoop and Chocolatey list PowerShell Core as `pwsh`, so this will improve discoverability and consistency for anyone switching over from one of those package managers.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/59)