### PR TITLE
Correct Git 2.26.2 license

### DIFF
--- a/manifests/Git/Git/2.26.2.yaml
+++ b/manifests/Git/Git/2.26.2.yaml
@@ -3,8 +3,8 @@ Name: Git
 Version: 2.26.2
 Publisher: Git
 Homepage: https://git-scm.com/
-License:  Copyright (C) 1991, 1999 Free Software Foundation, Inc. - GNU General Public License version 2.1
-LicenseUrl: https://github.com/git/git/blob/master/LGPL-2.1
+License: GNU General Public License, version 2
+LicenseUrl: https://github.com/git-for-windows/git/blob/master/COPYING
 Description: Git version control system.
 InstallerType: Inno
 Installers:


### PR DESCRIPTION
* The copyright is incorrect: Free Software Foundation owns the copy right on the license text, not the Git software.
* The version is GPL 2, not LGPL 2.1.
* Updated the URL to point to the correct license file.
* Changed URL to point to the Git For Windows repo, since that is where the software is installed from.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/315)