### PR TITLE
 Fix VLC metadata

### DIFF
--- a/manifests/VideoLAN/VLC/3.0.10.yaml
+++ b/manifests/VideoLAN/VLC/3.0.10.yaml
@@ -1,13 +1,13 @@
 Id: Videolan.Vlc
-Name: VLC Media Player
+Name: VLC media player
 AppMoniker: VLC
 Version: 3.0.10
 Publisher: VideoLAN
 Author: VideoLAN
 License: GNU General Public License Version 2
-LicenseUrl: https://github.com/videolan/vlc/blob/master/COPYING
-MinOSVersion: 10.0.0.0
-Homepage: https://www.videolan.org/
+LicenseUrl: https://www.videolan.org/developers/vlc/COPYING
+MinOSVersion: 5.1.2600.0
+Homepage: https://www.videolan.org/vlc/
 Tags: "Media, media player, player, video, playback, vlc"
 InstallerType: exe
 

--- a/manifests/VideoLAN/VLC/3.0.10.yaml
+++ b/manifests/VideoLAN/VLC/3.0.10.yaml
@@ -15,8 +15,8 @@ InstallerType: exe
 
 Installers: 
   - Arch: x64
-    Url: https://get.videolan.org/vlc/3.0.10/win32/vlc-3.0.10-win32.exe
-    Sha256: CCFB91146CBA92A3EC5274FEE90D2CEE35CFDA7FD38240B3F65DA26D53D28A0B
+    Url: https://get.videolan.org/vlc/3.0.10/win64/vlc-3.0.10-win64.exe
+    Sha256: E0A0883CD6C29AEE23ECFC63573BC09E09F78DE0DA78A6F55AB13FAB1C65850B
     Language: en-US
     Switches: 
       Silent: "/language=en_US /S"


### PR DESCRIPTION
Those modifications fix the version of VLC (64b vs 32b) and fixes some metadata errors, notably for the URL and MinOSVersions.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/323)