### PR TITLE
Add Epic Games Launcher 10.15.2

### DIFF
--- a/manifests/EpicGames/EpicGamesLauncher/10.15.2.Yaml
+++ b/manifests/EpicGames/EpicGamesLauncher/10.15.2.Yaml
@@ -1,0 +1,15 @@
+Id: EpicGames.EpicGamesLauncher
+Version: 10.15.2
+Name: Epic Games Launcher
+Publisher: Epic Games Inc.
+License: Epic Games Store End User License
+LicenseUrl: https://www.epicgames.com/store/en-US/eula
+AppMoniker: egs
+Tags: store
+Description: Epic Games Launcher for the Epic Games Store and Unreal Engine
+Homepage: https://www.epicgames.com/store
+InstallerType: msi
+Installers:
+  - Arch: x64
+    Url: https://launcher-public-service-prod06.ol.epicgames.com/launcher/api/installer/download/EpicGamesLauncherInstaller.msi
+    Sha256: 8FE278AB292644E97CF4CFC81BF91C413E8129E4628BFE4FC2901C3F0958E3DE


### PR DESCRIPTION
For the Epic Games Store as well as Unreal Engine dev (its a dual purpose launcher).

I will note that URL's sub-domain doesn't look stable "https://launcher-public-service-prod06.ol.epicgames.com".

I checked under VPN from other regions and other settings and it seemed stable (same subdomain). It might not be the case over time, therefore this is something that might need addressing (from Epic's side or by updating manifest here as changes occur).

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/337)