### PR TITLE
Use permalink for Yarn download

### DIFF
--- a/manifests/Yarn/Yarn/1.22.4.yaml
+++ b/manifests/Yarn/Yarn/1.22.4.yaml
@@ -7,6 +7,6 @@ License: Distributed under BSD License · Code of Conduct
 Description: Yarn is a package manager that doubles down as project manager. Whether you work on one-shot projects or large monorepos, as a hobbyist or an enterprise user, we've got you covered.
 Installers: 
     - Arch: x86
-      Url: https://classic.yarnpkg.com/latest.msi
+      Url: https://classic.yarnpkg.com/downloads/1.22.4/yarn-1.22.4.msi
       InstallerType: Msi
       Sha256: 6243F09FEF4AA4E873F74133F94DC7DC715463DC14F9F8FE99E2627D99357BFB


### PR DESCRIPTION
`/latest.msi` redirects to the latest version of Yarn. This means that if a new version is released, it'll start downloading the new version rather than the expected version (1.22.4), and the hash won't match.

This PR updates it to use the permalink to the installer for 1.22.4 specifically.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/342)