### PR TITLE
Add Red Hat OpenJDK8

### DIFF
--- a/manifests/RedHat/OpenJDK/1.8.0.252-2.b09.yaml
+++ b/manifests/RedHat/OpenJDK/1.8.0.252-2.b09.yaml
@@ -1,0 +1,12 @@
+Id: RedHat.OpenJDK
+Version: 1.8.0.252-2.b09
+Name: Red Hat OpenJDK 8
+Publisher: Red Hat Inc.
+License: GNU General Public License, version 2, with the Classpath Exception
+LicenseUrl: https://openjdk.java.net/legal/gplv2+ce.html
+InstallerType: msi
+Installers:
+  - Arch: x64
+    Url: https://developers.redhat.com/download-manager/file/java-1.8.0-openjdk-1.8.0.252-2.b09.redhat.windows.x86_64.msi
+    Sha256: 5727757aa4ec225f86af2a40d5b0fe98af76f20f32bf6acf888fd5756fa21eb8
+ManifestVersion: 0.1.0


### PR DESCRIPTION
This pull request adds the manifest for [Red Hat OpenJDK](https://developers.redhat.com/products/openjdk/overview) 8.

While the substance of this pull request should be good to merge, I do want to bring up the subject of how Java implementations should be packaged going forward:
- There are multiple versions of Java that are supported (Java 8, Java 11, and Java 14 in the case of Red Hat's builds)
    - Should they be packaged `RedHat.OpenJDK8`, `RedHat.OpenJDK.8`, or all under the `RedHat.OpenJDK` with just their versions differentitating them (please no)
    - Do we just want to distribute the JDK, or should the JRE be packaged too?
- For other implementations there are multiple distributions that may need to be considered (I will bring this up in a future issue though)

edit: I'm a numpty - the URL used here doesn't actually work, jumped the gun on this PR somewhat, forgot that you need to log in first :S Will check whether there are any public downloads, else - apologies for wasting anyone's time.

Either way - the debate about how to package JDK implementations still stands.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/343)