### PR TITLE
Add Sublime Merge build 1119

### DIFF
--- a/manifests/SublimeHQ/SublimeMerge/1119.Yaml
+++ b/manifests/SublimeHQ/SublimeMerge/1119.Yaml
@@ -1,0 +1,17 @@
+Id: SublimeHQ.SublimeMerge
+Version: 1119
+Name: Sublime Merge
+Publisher: Sublime HQ
+License: Copyright (c) Sublime HQ Pty Ltd. - Proprietary License
+LicenseUrl: https://www.sublimetext.com/eula
+Tags: git
+Description: Git GUI client from the makers of Sublime Text
+Homepage: https://www.sublimemerge.com/
+InstallerType: exe
+Installers:
+  - Arch: x64
+    Url: https://download.sublimetext.com/sublime_merge_build_1119_x64_setup.exe
+    Sha256: F338C55F522F4DDE05F775A43EABA89BA43300D71798C1ED9017E8B5EF58EFA5
+    Switches:
+      Silent: /VERYSILENT /NORESTART
+      SilentWithProgress: /SILENT /NORESTART


### PR DESCRIPTION
- Sublime Text (by another user Sublime company's manifest) doesn't have any installs witches listed. I can confirm the same switches here are present there as well, didn't want to include them in this PR in case it breaks the bot's CI process.
- Both this and sublime text requires winget to be launched as admin, else the installer fails with an "access denied" dialog

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/361)