### PR TITLE
Change Discord license

### DIFF
--- a/manifests/Discord/Discord/0.0.306.yaml
+++ b/manifests/Discord/Discord/0.0.306.yaml
@@ -4,7 +4,7 @@ AppMoniker: Discord
 Version: 0.0.306
 Publisher: Discord Inc.
 Author: Discord
-License: Copyright (c) 2014-2018 Sebastian McKenzie
+License: Copyright (c) 2015-2020 Discord Inc.
 LicenseUrl: https://discord.com/licenses
 MinOSVersion: 10.0.0.0
 Homepage: https://discord.com/


### PR DESCRIPTION
PR changes Discord's license property to something more appropriate.

Was about to say that Sebastian McKenzie had no involvement in Discord, but it seems that he had just joined Discord [recently](https://twitter.com/sebmck/status/1262794170940284928).


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/444)