### PR TITLE
Fixed generating of yaml file using YamlCreate.ps1

### DIFF
--- a/Tools/YamlCreate.ps1
+++ b/Tools/YamlCreate.ps1
@@ -5,13 +5,14 @@
 
 # define variables
 $OFS = "`r`n"  #linebreak
-$tempFolder=$env:TEMP; 
+$tempFolder = $env:TEMP; 
 # Create a temporary file to generate a sha256 value.
-$Hashfile=$tempFolder + "\TempfileName.txt"
+$Hashfile = $tempFolder + "\TempfileName.txt"
 
 # Prompt for URL
 While ($url.Length -eq 0) {
-$url = Read-Host -Prompt 'Enter the URL to the installer' }
+    $url = Read-Host -Prompt 'Enter the URL to the installer' 
+}
 $OFS
 
 write-host "Downloading URL.  This will take awhile...  "  -ForeGroundColor Blue 
@@ -20,12 +21,12 @@ $WebClient = New-Object System.Net.WebClient
 $WebClient.DownloadFile($URL, $Hashfile)
 
 # This command will get the sha256 hash
-$Hash=get-filehash $hashfile
+$Hash = get-filehash $hashfile
 
 
 $string = "Url: " + $URL  ;
 Write-Output $string
-$string =  "Sha256: " + $Hash.Hash
+$string = "Sha256: " + $Hash.Hash
 $string
 $OFS
 write-host "File downloaded. Please Fill out required fields. "   
@@ -35,34 +36,34 @@ write-host "File downloaded. Please Fill out required fields. "
 ##########################################
 
 While ($id.Length -eq 0) {
-write-host  'Enter the package Id, in the following format <Publisher.Appname>' 
-$id = Read-Host -Prompt 'For example: Microsoft.Excel'
+    write-host  'Enter the package Id, in the following format <Publisher.Appname>' 
+    $id = Read-Host -Prompt 'For example: Microsoft.Excel'
 }
 
 $host.UI.RawUI.ForegroundColor = "White"
-While ($publisher.Length  -eq 0) {
-$publisher = Read-Host -Prompt 'Enter the publisher'
+While ($publisher.Length -eq 0) {
+    $publisher = Read-Host -Prompt 'Enter the publisher'
 }
 
 While ($AppName.Length -eq 0) {
-$AppName = Read-Host -Prompt 'Enter the application name'
+    $AppName = Read-Host -Prompt 'Enter the application name'
 }
 
-While ($version.Length  -eq 0) {
-$version = Read-Host -Prompt 'Enter the version. For example: 1.0, 1.0.0.0'
-$filename=$version + ".yaml"
+While ($version.Length -eq 0) {
+    $version = Read-Host -Prompt 'Enter the version. For example: 1.0, 1.0.0.0'
+    $filename = $version + ".yaml"
 }
 
-While ($License.Length  -eq 0) {
-$License = Read-Host -Prompt 'Enter the License, For example: MIT, or Copyright (c) Microsoft Corporation'
+While ($License.Length -eq 0) {
+    $License = Read-Host -Prompt 'Enter the License, For example: MIT, or Copyright (c) Microsoft Corporation'
 }
 
-While ($InstallerType.Length  -eq 0) {
-$InstallerType = Read-Host -Prompt   'Enter the InstallerType. For example: exe, msi, msix, inno, nullsoft'
+While ($InstallerType.Length -eq 0) {
+    $InstallerType = Read-Host -Prompt   'Enter the InstallerType. For example: exe, msi, msix, inno, nullsoft'
 }
 
-While ($architecture.Length  -eq 0) {
-$architecture = Read-Host -Prompt 'Enter the architecture (x86, x64, arm, arm64, Neutral)'
+While ($architecture.Length -eq 0) {
+    $architecture = Read-Host -Prompt 'Enter the architecture (x86, x64, arm, arm64, Neutral)'
 } 
 
 $LicenseUrl = Read-Host -Prompt   '[OPTIONAL] Enter the license URL'
@@ -79,106 +80,105 @@ $Description = Read-Host -Prompt '[OPTIONAL] Enter a description of the applicat
 
 $OFS
 $string = "Id: " + $id
-write-output $string | out-file $filename
+write-output $string | out-file $filename -Encoding utf8
 write-host "Id: "  -ForeGroundColor Blue -NoNewLine
 write-host $id  -ForeGroundColor White  
 
 $string = "Version: " + $Version
-write-output $string | out-file $filename -append
+write-output $string | out-file $filename -append -Encoding utf8
 write-host "Version: "  -ForeGroundColor Blue -NoNewLine
 write-host $Version -ForeGroundColor White
 
 
 $string = "Name: " + $AppName
-write-output $string | out-file $filename -append
+write-output $string | out-file $filename -append -Encoding utf8
 write-host "Name: "  -ForeGroundColor Blue -NoNewLine
 write-host $AppName  -ForeGroundColor White
 
 $string = "Publisher: " + $Publisher
-write-output $string | out-file $filename -append
+write-output $string | out-file $filename -append -Encoding utf8
 write-host "Publisher: "  -ForeGroundColor Blue -NoNewLine
 write-host $Publisher -ForeGroundColor White
 
 $string = "License: " + $License
-write-output $string | out-file $filename -append
+write-output $string | out-file $filename -append -Encoding utf8
 write-host "License: "  -ForeGroundColor Blue -NoNewLine
 write-host $License  -ForeGroundColor White
 
 if (!($LicenseUrl.length -eq 0)) {
 
-$string = "LicenseUrl: " + $LicenseUrl
-write-output $string | out-file $filename -append
-write-host "LicenseUrl: "  -ForeGroundColor Blue -NoNewLine
-write-host $LicenseUrl  -ForeGroundColor White
+    $string = "LicenseUrl: " + $LicenseUrl
+    write-output $string | out-file $filename -append -Encoding utf8
+    write-host "LicenseUrl: "  -ForeGroundColor Blue -NoNewLine
+    write-host $LicenseUrl  -ForeGroundColor White
 
 }
+
 if (!($AppMoniker.length -eq 0)) {
 
-$string = "AppMoniker: " + $AppMoniker
-write-output $string | out-file $filename -append
-write-host "AppMoniker: "  -ForeGroundColor Blue -NoNewLine
-write-host $AppMoniker  -ForeGroundColor White
+    $string = "AppMoniker: " + $AppMoniker
+    write-output $string | out-file $filename -append -Encoding utf8
+    write-host "AppMoniker: "  -ForeGroundColor Blue -NoNewLine
+    write-host $AppMoniker  -ForeGroundColor White
 
 }
+
 if (!($Commands.length -eq 0)) {
 
-$string = "Commands: " + $Commands
-write-output $string | out-file $filename -append
-write-host "Commands: "  -ForeGroundColor Blue -NoNewLine
-write-host $Commands  -ForeGroundColor White
+    $string = "Commands: " + $Commands
+    write-output $string | out-file $filename -append -Encoding utf8
+    write-host "Commands: "  -ForeGroundColor Blue -NoNewLine
+    write-host $Commands  -ForeGroundColor White
 
 }
+
 if (!($Tags.length -eq 0)) {
 
-$string = "Tags: " + $Tags
-write-output $string | out-file $filename -append
-write-host "Tags: "  -ForeGroundColor Blue -NoNewLine
-write-host $Tags  -ForeGroundColor White
+    $string = "Tags: " + $Tags
+    write-output $string | out-file $filename -append -Encoding utf8
+    write-host "Tags: "  -ForeGroundColor Blue -NoNewLine
+    write-host $Tags  -ForeGroundColor White
 
 }
-
 
 if (!($Description.length -eq 0)) {
 
-$string = "Description: " + $Description
-write-output $string | out-file $filename -append
-write-host "Description: "  -ForeGroundColor Blue -NoNewLine
-write-host $Description  -ForeGroundColor White
+    $string = "Description: " + $Description
+    write-output $string | out-file $filename -append -Encoding utf8
+    write-host "Description: "  -ForeGroundColor Blue -NoNewLine
+    write-host $Description  -ForeGroundColor White
 
 }
 
+if (!($Homepage.Length -eq 0)) {
 
-
-if (!($Homepage.Length -eq 0))  {
-
-$string = "Homepage: "+ $Homepage
-write-output $string | out-file $filename -append
-write-host "Homepage: "  -ForeGroundColor Blue -NoNewLine
-write-host $Homepage  -ForeGroundColor White
+    $string = "Homepage: " + $Homepage
+    write-output $string | out-file $filename -append -Encoding utf8
+    write-host "Homepage: "  -ForeGroundColor Blue -NoNewLine
+    write-host $Homepage  -ForeGroundColor White
 
 }
 
-write-output "Installers:" | out-file $filename -append 
+write-output "Installers:" | out-file $filename -append -Encoding utf8
 
 
 $string = "  - Arch: " + $architecture
-write-output $string | out-file $filename -append
+write-output $string | out-file $filename -append -Encoding utf8
 write-host "Arch: "  -ForeGroundColor Blue -NoNewLine
 write-host $architecture  -ForeGroundColor White
 
-
 $string = "    Url: " + $Url
-write-output $string | out-file $filename -append
+write-output $string | out-file $filename -append -Encoding utf8
 write-host "Url: "  -ForeGroundColor Blue -NoNewLine
 write-host $Url -ForeGroundColor White
 
 $string = "    Sha256: " + $Hash.Hash
-write-output $string | out-file $filename -append
+write-output $string | out-file $filename -append -Encoding utf8
 write-host "Sha256 "  -ForeGroundColor Blue -NoNewLine
 write-host $Hash.Hash  -ForeGroundColor White
 
 $string = "    InstallerType: " + $InstallerType
-write-output $string | out-file $filename -append
+write-output $string | out-file $filename -append -Encoding utf8
 write-host "InstallerType "  -ForeGroundColor Blue -NoNewLine
 write-host $InstallerType  -ForeGroundColor White
 


### PR DESCRIPTION
Fixed issue with generated yaml file. The file is created using UTF-16 LE encoding which make Azure Pipeline fail during validation.

**Repro steps**
1) Use YamlCreate.ps1
2) Generated yaml file is UTF-16 LE encoded
3) Commit and Push changes to GitHub - yaml file is "broken" and validation fails

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/451)