### PR TITLE
Fix #411 // YAML-Create Encoding UTF8

### DIFF
--- a/Tools/YamlCreate.ps1
+++ b/Tools/YamlCreate.ps1
@@ -182,6 +182,10 @@ write-output $string | out-file $filename -append
 write-host "InstallerType "  -ForeGroundColor Blue -NoNewLine
 write-host $InstallerType  -ForeGroundColor White
 
+$FileOldEnconding = Get-Content -Raw $filename
+Remove-Item -Path $filename
+$Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+[System.IO.File]::WriteAllLines($filename, $FileOldEnconding, $Utf8NoBomEncoding)
 
 $string = "Yaml file created:  " + $filename
 write-output $string


### PR DESCRIPTION
When creating the Manifest with YAMLCreate.ps1 you generate UTF-16 LE. I inserted code to recreate the file with forced UTF8-encondign without BOM to fix #411 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/462)