### PR TITLE
Remove bogus special character

### DIFF
--- a/manifests/GitExtensionsTeam/GitExtensions/3.3.1.yaml
+++ b/manifests/GitExtensionsTeam/GitExtensions/3.3.1.yaml
@@ -4,7 +4,7 @@ Name: Git Extensions
 Publisher: Git Extensions Team
 Homepage: https://gitextensions.github.io/
 License: gitextensions/gitextensions is licensed under the  GNU General Public License v3.0
-Description: Git Extensions is a graphical user interface for Git that allows you to control Git without using the commandline
+Description: Git Extensions is a graphical user interface for Git that allows you to control Git without using the commandline
 Installers: 
     - Arch: x64
       Url: https://github.com/gitextensions/gitextensions/releases/download/v3.3.1/GitExtensions-3.3.1.7897.msi


### PR DESCRIPTION
There's bogus special character in GitExtensions package which breaks yaml parsing:
`yaml.reader.ReaderError: unacceptable character #x0008: special characters are not allowed`

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/485)