### PR TITLE
Fix .NET display strings

### DIFF
--- a/manifests/Microsoft/dotnet/3.1.202.yaml
+++ b/manifests/Microsoft/dotnet/3.1.202.yaml
@@ -8,7 +8,7 @@ LicenseUrl: https://github.com/dotnet/core/blob/master/LICENSE.TXT
 MinOSVersion: 6.1.7601
 Description: .NET Core is an open-source, general-purpose development platform. You can create .NET Core apps for Windows, macOS, and Linux for x64, x86, ARM32, and ARM64 processors using multiple programming languages. Frameworks and APIs are provided for cloud, IoT, client UI, and machine learning.
 Homepage: https://docs.microsoft.com/dotnet/core/
-Tags: .NET, .NET Core, dotnet, C#, csharp, F#, fsharp, VB, Visual Basic
+Tags: .NET, .NET Core, dotnet, net, C#, csharp, F#, fsharp, VB, Visual Basic
 Commands: dotnet
 InstallerType: exe
 Installers:


### PR DESCRIPTION
I've changed some of the strings to match the official product names.

@MichaelSimons @richlander:

Do we want to change the package ids? I understand that this is a breaking change but I guess now is the time to do that if we aren't happy with them. These are the current ones:

Id                       | Name
-------------------------|----------------
Microsoft.dotnet         | .NET Core
Microsoft.dotNetFramework| .NET Framework

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/537)