### PR TITLE
NVAccess.NVDA manifest: publisher = NV Access Limited

### DIFF
--- a/manifests/NVAccess/NVDA/2020.1.yaml
+++ b/manifests/NVAccess/NVDA/2020.1.yaml
@@ -1,7 +1,7 @@
 Id: NVAccess.NVDA
 Version: 2020.1
 Name: NVDA
-Publisher: NVDA contributor
+Publisher: NV Access Limited
 License: GPL V2
 LicenseUrl: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 AppMoniker: NonVisual Desktop Access


### PR DESCRIPTION
Corrects NVAccess/NVDA manifest:

* Publisher: NVDA contributor -> NV Access Limited (the actual publisher)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/675)