### PR TITLE
Include additional installer types from the v0.1 spec in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Publisher: string # the name of the publisher
 Name: string # the name of the application
 Version: string # version numbering format
 License: string # the open source license or copyright
-InstallerType: string # enumeration of supported installer types (exe, msi, msix)
+InstallerType: string # enumeration of supported installer types (exe, msi, msix, inno, wix, nullsoft, appx)
 Installers:
   - Arch: string # enumeration of supported architectures
     URL: string # path to download installation file


### PR DESCRIPTION
Many users are using this page to write manifests manually and are unaware of the additional types established in the v0.1 spec that are available. This pull request mentions them. I will submit an additional pull request that mentions the generator located in the winget-pkgs Tools folder. Based on https://github.com/MicrosoftDocs/windows-uwp/pull/2468 .
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/695)