### PR TITLE
Add advice in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ I recommend running the script in the location where you want to produce the man
 ### Using Windows Package Manager YAML Generator
 If you prefer to use a GUI to generate YAML files, you can use the **Windows Package Manager YAML Generator**. It is available as an app [in the Microsoft Store](https://www.microsoft.com/en-us/p/windows-package-manager-yaml-generator/9p3n60fs22k5) and the code is also available [on GitHub](https://github.com/ptorr-msft/WinGetYamlGenerator).
 
+Atention that although Windows Package Manager YAML Generator can create YAML files with multiple installers, winget don't support more than one installer for now.
+
 ## Test your manifest
 Now that you have authored your manifest, you should make sure it works as expected.
 1) Verify the syntax.  You can do that by typing the following command: `winget validate <manifest>`

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ I recommend running the script in the location where you want to produce the man
 ### Using Windows Package Manager YAML Generator
 If you prefer to use a GUI to generate YAML files, you can use the **Windows Package Manager YAML Generator**. It is available as an app [in the Microsoft Store](https://www.microsoft.com/en-us/p/windows-package-manager-yaml-generator/9p3n60fs22k5) and the code is also available [on GitHub](https://github.com/ptorr-msft/WinGetYamlGenerator).
 
-Atention that although Windows Package Manager YAML Generator can create YAML files with multiple installers, winget don't support more than one installer for now.
+Although the Windows Package Manager YAML Generator can create YAML files with multiple installers, winget does not support more than one installer for now.
 
 ## Test your manifest
 Now that you have authored your manifest, you should make sure it works as expected.


### PR DESCRIPTION
At this time winget don't support more than one installer, such as giving both installer of x86 and installer of x64. 
For example, [#702](https://github.com/microsoft/winget-pkgs/pull/702)
Contributor are supposed to be told to avoid barren efforts.
![image](https://user-images.githubusercontent.com/40438607/82622126-923af000-9c0f-11ea-898c-48fbba1dc0df.png)



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/706)