### PR TITLE
Add Katawa shoujo 1.3.1

### DIFF
--- a/manifests/FourLeafStudios/KatawaShoujo/1.3.1.yaml
+++ b/manifests/FourLeafStudios/KatawaShoujo/1.3.1.yaml
@@ -3,7 +3,7 @@ Version: 1.3.1
 Name: Katawa Shoujo
 Publisher: Four Leaf Studios
 License: CC-BY-NC-ND
-Tags: 4chan, game, videogame, gaming, visual novel, vn, anime, manga, bishojo, renpy, doujinshi, nsfw
+Tags: 4chan, game, videogame, gaming, visual novel, vn, anime, manga, bishojo, renpy, doujinshi, nsfw, r18, 18+, erotic
 Description: Katawa Shoujo is a bishoujo-style visual novel set in the fictional Yamaku High School for disabled children, located somewhere in modern Japan. Hisao Nakai, a normal boy living a normal life, has his life turned upside down when a congenital heart defect forces him to move to a new school after a long hospitalization. Despite his difficulties, Hisao is able to find friends—and perhaps love, if he plays his cards right. There are five main paths corresponding to the 5 main female characters, each path following the storyline pertaining to that character.
 Homepage: https://www.katawa-shoujo.com
 Installers:

--- a/manifests/FourLeafStudios/KatawaShoujo/1.3.1.yaml
+++ b/manifests/FourLeafStudios/KatawaShoujo/1.3.1.yaml
@@ -3,8 +3,8 @@ Version: 1.3.1
 Name: Katawa Shoujo
 Publisher: Four Leaf Studios
 License: CC-BY-NC-ND
-Tags: 4chan, game, videogame, gaming, visual novel, vn, anime, manga, bishojo, renpy, doujinshi, nsfw, r18, 18+, erotic
-Description: Katawa Shoujo is a bishoujo-style visual novel set in the fictional Yamaku High School for disabled children, located somewhere in modern Japan. Hisao Nakai, a normal boy living a normal life, has his life turned upside down when a congenital heart defect forces him to move to a new school after a long hospitalization. Despite his difficulties, Hisao is able to find friends—and perhaps love, if he plays his cards right. There are five main paths corresponding to the 5 main female characters, each path following the storyline pertaining to that character.
+Tags: 4chan, game, videogame, gaming, visual novel, vn, anime, manga, bishojo, renpy, doujinshi, nsfw, r18, 18+, erotic, adult
+Description: Katawa Shoujo is an adult bishoujo-style visual novel set in the fictional Yamaku High School for disabled children, located somewhere in modern Japan. Hisao Nakai, a normal boy living a normal life, has his life turned upside down when a congenital heart defect forces him to move to a new school after a long hospitalization. Despite his difficulties, Hisao is able to find friends—and perhaps love, if he plays his cards right. There are five main paths corresponding to the 5 main female characters, each path following the storyline pertaining to that character.
 Homepage: https://www.katawa-shoujo.com
 Installers:
   - Arch: x86

--- a/manifests/FourLeafStudios/KatawaShoujo/1.3.1.yaml
+++ b/manifests/FourLeafStudios/KatawaShoujo/1.3.1.yaml
@@ -1,0 +1,13 @@
+Id: FourLeafStudios.KatawaShoujo
+Version: 1.3.1
+Name: Katawa Shoujo
+Publisher: Four Leaf Studios
+License: CC-BY-NC-ND
+Tags: 4chan, game, videogame, gaming, visual novel, vn, anime, manga, bishojo, renpy, doujinshi, nsfw
+Description: Katawa Shoujo is a bishoujo-style visual novel set in the fictional Yamaku High School for disabled children, located somewhere in modern Japan. Hisao Nakai, a normal boy living a normal life, has his life turned upside down when a congenital heart defect forces him to move to a new school after a long hospitalization. Despite his difficulties, Hisao is able to find friends—and perhaps love, if he plays his cards right. There are five main paths corresponding to the 5 main female characters, each path following the storyline pertaining to that character.
+Homepage: https://www.katawa-shoujo.com
+Installers:
+  - Arch: x86
+    Url: http://dl.katawa-shoujo.com/gold_1.3.1/[4ls]_katawa_shoujo_1.3.1-[windows][A6A47E20].exe
+    Sha256: F0278D0F955425C60C06C97565ED2151678BFF63C1F2774E5F8670FAF7A21EF8
+    InstallerType: nullsoft


### PR DESCRIPTION
> **Katawa Shoujo** is a bishoujo-style visual novel set in the fictional Yamaku High School for disabled children, located somewhere in modern Japan. Hisao Nakai, a normal boy living a normal life, has his life turned upside down when a congenital heart defect forces him to move to a new school after a long hospitalization. Despite his difficulties, Hisao is able to find friends—and perhaps love, if he plays his cards right. There are five main paths corresponding to the 5 main female characters, each path following the storyline pertaining to that character.


**Please note that this visual novel contains (tasteful) adult content.**

I could not find any rules that are against listing adult-themed games in the repo, nor could I find a mention of this in the CLA. If the repo does not want packages linking to this kind of content, please tell me so. I've attempted to make this as clear as possible in the tags and description.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/715)