### PR TITLE
Notepad++ uses the nullsoft installer

### DIFF
--- a/manifests/Notepad++/Notepad++/7.8.6.yaml
+++ b/manifests/Notepad++/Notepad++/7.8.6.yaml
@@ -1,23 +1,17 @@
 Id: Notepad++.Notepad++
-Name: Notepad++
-AppMoniker: NPP
 Version: 7.8.6
+Name: Notepad++
 Publisher: Notepad++
 Author: DonHo
-License: Copyright - GPL License
-LicenseUrl: https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/LICENSE
+License: GPL 2.0 only
+LicenseUrl: https://raw.githubusercontent.com/notepad-plus-plus/notepad-plus-plus/master/LICENSE
 MinOSVersion: 10.0.0.0
+AppMoniker: npp
+Description: A free source code editor and Notepad replacement that supports several languages.
 Homepage: https://notepad-plus-plus.org/
 Tags: "notepad,text editor,notepadPP, notepad++, editor"
-InstallerType: exe
-
-# ======================= Installers  ================== 
-
-Installers: 
+Installers:
   - Arch: x64
     Url: https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v7.8.6/npp.7.8.6.Installer.x64.exe
     Sha256: 03B3A8E2D0395B2DCAF7CD30CB47106EBAC678CBCD72E81BB5EE0E618927D3DD
-    Language: en-US
-    Switches: 
-      Silent: "/S"
-      SilentWithProgress: "/S"
+    InstallerType: nullsoft


### PR DESCRIPTION
Per https://wiki.ketarin.org/index.php/Setup_instructions

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/725)