### PR TITLE
Add LastPass 4.48.0

### DIFF
--- a/manifests/LogMeIn/LastPass/4.48.0.yaml
+++ b/manifests/LogMeIn/LastPass/4.48.0.yaml
@@ -13,5 +13,5 @@ Installers:
     Url: https://download.cloud.lastpass.com/windows_installer/LastPassInstaller.exe
     Sha256: FE81552E915F03D4580675C606D440C7E9C0F740F00CFA9E7710F33B7BBCA26B
     Switches:
-      Silent: -si
-      SilentWithProgress: -si
+      Silent: /quiet
+      SilentWithProgress: /quiet

--- a/manifests/LogMeIn/LastPass/4.48.0.yaml
+++ b/manifests/LogMeIn/LastPass/4.48.0.yaml
@@ -10,7 +10,7 @@ Description: Password manager web browser extension.
 InstallerType: EXE
 Installers:
   - Arch: x64
-    Url: https://download.cloud.lastpass.com/windows_installer/lastpass_x64.exe
+    Url: https://download.cloud.lastpass.com/windows_installer/LastPassInstaller.exe
     Sha256: FE81552E915F03D4580675C606D440C7E9C0F740F00CFA9E7710F33B7BBCA26B
     Switches:
       Silent: -si

--- a/manifests/LogMeIn/LastPass/4.48.0.yaml
+++ b/manifests/LogMeIn/LastPass/4.48.0.yaml
@@ -13,5 +13,5 @@ Installers:
     Url: https://download.cloud.lastpass.com/windows_installer/LastPassInstaller.exe
     Sha256: FE81552E915F03D4580675C606D440C7E9C0F740F00CFA9E7710F33B7BBCA26B
     Switches:
-      Silent: /quiet
-      SilentWithProgress: /quiet
+      Silent: -si --userinstallie --userinstallff --userinstallchrome
+      SilentWithProgress: -si --userinstallie --userinstallff --userinstallchrome

--- a/manifests/LogMeIn/LastPass/4.48.0.yaml
+++ b/manifests/LogMeIn/LastPass/4.48.0.yaml
@@ -1,17 +1,17 @@
 Id: LogMeIn.LastPass
 Name: LastPass
-Version: 4.43.0.7
+Version: 4.48.0
 Publisher: LogMeIn
 AppMoniker: lastpass
 License: Copyright © 2003-2020 LogMeIn, Inc. All rights reserved. - License Freemium
 LicenseUrl: https://www.logmeininc.com/legal
 Homepage: https://microsoftedge.microsoft.com/addons/detail/bbcinlkgjjkejfdpemiealijmmooekmp
 Description: Password manager web browser extension.
-InstallerType: Exe
+InstallerType: EXE
 Installers:
   - Arch: x64
     Url: https://download.cloud.lastpass.com/windows_installer/lastpass_x64.exe
-    Sha256: B5341D5ABB3176CBFEFF27AAAE6CDD2F48FD12D67CA4FF36FFE2147C41E5F413
+    Sha256: FE81552E915F03D4580675C606D440C7E9C0F740F00CFA9E7710F33B7BBCA26B
     Switches:
       Silent: -si
       SilentWithProgress: -si


### PR DESCRIPTION
The old version (4.43.0.7) is remoted because the download URL doesn't change even if a new version has been released. Thus, the installers of the older versions won't pass the SHA256 checksum verification.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/738)