### PR TITLE
ojdkbuild 1.8.0_252-2

### DIFF
--- a/manifests/ojdkbuild/ojdkbuild/1.8.0_252-2.yaml
+++ b/manifests/ojdkbuild/ojdkbuild/1.8.0_252-2.yaml
@@ -1,0 +1,16 @@
+Id: ojdkbuild.ojdkbuild
+Version: 1.8.0_252-2
+Name: ojdkbuild 1.8.0_252-2 (x64)
+Publisher: Alex Kashchenko
+Homepage: https://github.com/ojdkbuild/ojdkbuild/wiki/Motivation
+License: GPL 2 with Classpath Exception
+LicenseUrl: https://github.com/ojdkbuild/ojdkbuild/blob/master/LICENSE
+Description: Community builds using source code from OpenJDK project 
+Installers: 
+    - Arch: x64
+      Url: https://github.com/ojdkbuild/ojdkbuild/releases/download/java-1.8.0-openjdk-1.8.0.252-2.b09/java-1.8.0-openjdk-1.8.0.252-2.b09.ojdkbuild.windows.x86_64.msi
+      InstallerType: Msi
+      Sha256: 5dc46c7728830af98e73dd02cc266547c6d4a9f95bd8b8317de7aa774b8c1f28
+      Switches: 
+        Silent: /quiet
+        SilentWithProgress: /passive


### PR DESCRIPTION
[ojdkbuild](https://github.com/ojdkbuild/ojdkbuild) is the upstream JDK used by Red Hat's distribution, this pull request adds the current latest Java 8 JDK.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/810)