### PR TITLE
GH-795 Use direct download for Postman 7.24.0

### DIFF
--- a/manifests/Postman/Postman/7.24.0.yaml
+++ b/manifests/Postman/Postman/7.24.0.yaml
@@ -9,7 +9,7 @@ Description: The Collaboration Platform for API Development
 Homepage: https://www.postman.com/
 Installers:
   - Arch: x64
-    Url: https://dl.pstmn.io/download/latest/win64?filename=Postman-win64-7.24.0-Setup.exe
+    Url: https://dl.pstmn.io/download/version/7.24.0/win64
     Sha256: 0B9791F637DCBBC2069DA97EEA4ABFB0946E6BFF5766533A0C0C56E401E067B0
     InstallerType: exe
     Switches: 


### PR DESCRIPTION
Postman 7.24.0 was using a latest download option, as pointed out
by GH-795. This commit uses the direct download URL.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/819)