### PR TITLE
aws-cli 2.0.16

### DIFF
--- a/manifests/Amazon/AWSCLI/2.0.16.yaml
+++ b/manifests/Amazon/AWSCLI/2.0.16.yaml
@@ -1,0 +1,16 @@
+Id: Amazon.AWSCLI
+Publisher: AWS
+Name: aws-cli
+Version: 2.0.16
+License: Copyright 2012-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved. Licensed under the Apache License, Version 2.0
+LicenseUrl: https://github.com/aws/aws-cli/blob/2.0.16/LICENSE.txt
+Author: Amazon Web Services
+AppMoniker: aws
+Tags: "AWS,aws-cli,cloud"
+Description: Universal Command Line Interface for Amazon Web Services
+Homepage: https://aws.amazon.com/cli/
+InstallerType: msi
+Installers:
+  - Arch: x64
+    Url: https://awscli.amazonaws.com/AWSCLIV2-2.0.16.msi
+    Sha256: bec9e4a1e9fb87246efb878d2168e2b59766c3970c6fb20e335c11d4e5cab77a


### PR DESCRIPTION
This is the equivalent of GH-754 for aws-cli V2.

aws-cli V2 was previously added, however it used a latest download
link and was removed (see GH-659 and GH-682).

This uses the direct download link, kindly pointed out by
@superusercode in GH-659.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/820)