### PR TITLE
Add Android Studio

### DIFF
--- a/manifests/Google/AndroidStudio/3.6.3.yaml
+++ b/manifests/Google/AndroidStudio/3.6.3.yaml
@@ -1,0 +1,14 @@
+Id: Google.AndroidStudio
+Version: 3.6.3
+Name: Android Studio
+Publisher: Google
+License: See in https://developer.android.com/studio/terms.
+LicenseUrl: https://developer.android.com/studio/terms
+Tags: android, ide, emulator, kotlin
+Description: Android Studio provides the fastest tools for building apps on every type of Android device.
+Homepage: https://developer.android.com/studio/
+Installers:
+  - Arch: x64
+    Url: https://redirector.gvt1.com/edgedl/android/studio/install/3.6.3.0/android-studio-ide-192.6392135-windows.exe
+    Sha256: 07B6DF807FDA59E69F05B85FF6F6BD0C70D09E57FB151197155EF5F115F96E59
+    InstallerType: nullsoft


### PR DESCRIPTION
Android Studio installer is Nullsoft. 

It exits with status code 1223, and this is a known issue of many Nullsoft based installers when using the `/S` switch. However, the installation goes fine.

Either the `winget` should consider 1223 as a success code in case of Nullsoft, or the Android Studio team has to fix it.

I submitted an issue in Android Studio's issue tracker for that. See https://issuetracker.google.com/issues/157286802.

This pull request duplicates https://github.com/microsoft/winget-pkgs/pull/132.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/843)