### PR TITLE
Update 4.16.0.yaml

### DIFF
--- a/manifests/calibre/calibre/4.16.0.yaml
+++ b/manifests/calibre/calibre/4.16.0.yaml
@@ -9,6 +9,6 @@ Description: Powerful and easy to use e-book manager.
 Homepage: https://calibre-ebook.com/
 Installers:
   - Arch: x64
-    Url: https://github.com/kovidgoyal/calibre/releases/download/v4.16.0/calibre-64bit-4.16.0.msi
+    Url: https://download.calibre-ebook.com/4.16.0/calibre-64bit-4.16.0.msi
     Sha256: 9B8B6AC01FC83A385931AB19455812AB6581CAEA1CE8C732EB163EBAB2164240
     InstallerType: msi


### PR DESCRIPTION
The github urls for old versions of calibre break with every new release because they get deleted from the releases page, this change grabs the installer from the website old releases page instead so it keeps working.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/880)