### PR TITLE
Correct casing in Id and Name

### DIFF
--- a/manifests/Microsoft/Powershell/7.0.1.yaml
+++ b/manifests/Microsoft/Powershell/7.0.1.yaml
@@ -1,6 +1,6 @@
-Id: Microsoft.Powershell
+Id: Microsoft.PowerShell
 Version: 7.0.1
-Name: Powershell
+Name: PowerShell
 Publisher: Microsoft
 Homepage: https://microsoft.com/PowerShell
 License:  MIT


### PR DESCRIPTION
Manifests contain `Powershell` rather than PowerShell. This caught me out when running `winget install -e Microsoft.PowerShell`.

This PR corrects the casing.

Ref https://github.com/microsoft/winget-cli/issues/282

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/884)