### PR TITLE
Update the Geany 1.36 manifest

### DIFF
--- a/manifests/Geany/Geany/1.36.yaml
+++ b/manifests/Geany/Geany/1.36.yaml
@@ -1,20 +1,15 @@
 Id: Geany.Geany
-Name: Geany
-AppMoniker: geany
 Version: 1.36
+Name: Geany
 Publisher: Geany
-Author: Geany
-License: Copyright (C) 1989, 1991 Free Software Foundation, Inc. - GNU General Public License
-LicenseUrl: https://github.com/geany/geany/blob/master/COPYING
-MinOSVersion: 10.0.0.0
+License: GPL 2.0 or later
+LicenseUrl: https://raw.githubusercontent.com/geany/geany/master/COPYING
+AppMoniker: geany
+Tags: "text, editor, ide, scintilla"
+Description: A powerful, stable and lightweight programmer's text editor that provides tons of useful features without bogging down your workflow.
 Homepage: https://www.geany.org
-Description: Geany is a powerful, stable and lightweight programmer's text editor that provides tons of useful features without bogging down your workflow. It runs on Linux, Windows and MacOS is translated into over 40 languages, and has built-in support for more than 50 programming languages.
-Tags: "editor,Geany,texteditor"
-InstallerType: Inno
-Installers: 
-  - Arch: x64 
+Installers:
+  - Arch: x86
     Url: https://download.geany.org/geany-1.36_setup.exe
     Sha256: 1549B62F9E9FDDE825AE45245BAFC3A47CE85F4555F28B06E3A9C600340751DF
-    Switches: 
-      Silent: /S
-      SilentWithProgress: /S
+    InstallerType: nullsoft

--- a/manifests/Geany/Geany/1.36.yaml
+++ b/manifests/Geany/Geany/1.36.yaml
@@ -5,7 +5,7 @@ Publisher: Geany
 License: GPL 2.0 or later
 LicenseUrl: https://raw.githubusercontent.com/geany/geany/master/COPYING
 AppMoniker: geany
-Tags: "text, editor, ide, scintilla"
+Tags: "text, editor, ide, scintilla, Geany, texteditor"
 Description: A powerful, stable and lightweight programmer's text editor that provides tons of useful features without bogging down your workflow.
 Homepage: https://www.geany.org
 Installers:


### PR DESCRIPTION
This updates the manifest to recognize that the installer is nullsoft, is actually for 32bit machines and up, adds a moniker, removes in the min OS version since it supports earlier than 10, and adjusts how the licensing info is included.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/904)