### PR TITLE
Add INSTALLEVEL3 for options important to development to the adoptopenjdk14

### DIFF
--- a/manifests/AdoptOpenJDK/OpenJDK/14.0.1.yaml
+++ b/manifests/AdoptOpenJDK/OpenJDK/14.0.1.yaml
@@ -2,13 +2,16 @@ Id: AdoptOpenJDK.OpenJDK
 Version: 14.0.1
 Name: AdoptOpenJDK 14.0.1+7.1 (x64)
 Publisher: AdoptOpenJDK
-Homepage: https://adoptopenjdk.net
 License: GPL 2 with Classpath Exception
-Tags: Java,JDK,OpenJDK
-LicenseUrl: https://github.com/AdoptOpenJDK/openjdk-jdk/blob/master/LICENSE
-Description: Community-driven, Vendor-neutral build of OpenJDK for Windows x64.
-Installers: 
-    - Arch: x64
-      Url: https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7.1/OpenJDK14U-jdk_x64_windows_hotspot_14.0.1_7.msi
-      InstallerType: Msi
-      Sha256: bd116ad1fb3dbe395df50068761e159348457e79aafb19f6a78d96b258aee2f2
+LicenseUrl: https://adoptopenjdk.net/about.html
+AppMoniker: adoptopenjdk14
+Tags: "openjdk, java, jvm, jdk"
+Description: AdoptOpenJDK with Oracle HotSpot JVM
+Homepage: https://adoptopenjdk.net
+Installers:
+  - Arch: x64
+    Url: https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7.1/OpenJDK14U-jdk_x64_windows_hotspot_14.0.1_7.msi
+    Sha256: BD116AD1FB3DBE395DF50068761E159348457E79AAFB19F6A78D96B258AEE2F2
+    InstallerType: msi
+    Switches: 
+      Custom: INSTALLLEVEL=3


### PR DESCRIPTION
This makes it so that the JAVA_HOME variable is updated and it can be actually utilized by the software that depends on it in order to detect the JDK. Documented on https://adoptopenjdk.net/installation.html?variant=openjdk14&jvmVariant=hotspot#x64_win-jdk

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/930)