### PR TITLE
Add Google Chrome 83.0.4103.61

### DIFF
--- a/manifests/Google/Chrome/83.0.4103.61.yaml
+++ b/manifests/Google/Chrome/83.0.4103.61.yaml
@@ -1,0 +1,17 @@
+Id: Google.Chrome
+Name: Chrome
+Publisher: Google
+Version: 83.0.4103.61
+Homepage: https://www.google.com/chrome/
+InstallerType: exe
+AppMoniker: chrome
+License: Google Chrome and Chrome OS Additional Terms of Service
+LicenseUrl: https://www.google.com/chrome/terms/
+Installers:
+  - Arch: x64
+    Url: https://dl.google.com/edgedl/chrome/install/ChromeStandaloneSetup64.exe
+    Sha256: 4CA5DF9D36510D35082025FE2AF4F12D0CEBCA4221DE881C8F66530335F97AAD
+    Language: en-US
+    Switches:
+      Silent: "/installsource taggedmi /silent /install \"appguid={8A69D345-D564-463C-AFF1-A69D9E530F96}&iid={7DF7C924-72F2-9B35-53F5-9837D6B76D3F}&lang=en&browser=5&usagestats=0&appname=Google%20Chrome&needsadmin=prefers&ap=x64-stable-statsdef_1&installdataindex=empty\" /installelevated /nomitag"
+      SilentWithProgress: "/installsource taggedmi /silent /install \"appguid={8A69D345-D564-463C-AFF1-A69D9E530F96}&iid={7DF7C924-72F2-9B35-53F5-9837D6B76D3F}&lang=en&browser=5&usagestats=0&appname=Google%20Chrome&needsadmin=prefers&ap=x64-stable-statsdef_1&installdataindex=empty\" /installelevated /nomitag"


### PR DESCRIPTION
This PR updates to the latest version of Google Chrome with the correct link and required arguments for the consumer version.

The previous winget package for Google Chrome downloads the enterprise version which includes a bundle of enterprise management components and deprecated legacy features for interoperability.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/1035)