### PR TITLE
Adding DYMO Connect

### DIFF
--- a/manifests/SanfordLP/DYMOConnect/1.3.1.yaml
+++ b/manifests/SanfordLP/DYMOConnect/1.3.1.yaml
@@ -1,0 +1,17 @@
+Id: SanfordLP.DYMOConnect
+Version: 1.3.1
+Name: DYMO Connect
+Publisher: Sanford L.P.
+License: Copyright (c) Sanford L.P.
+AppMoniker: dymo
+Tags: labelwriter
+Description: DYMO Connect for Desktop enables the creation and printing of labels for LabelWriter 450 series/4XL and LabelManager printers.
+Homepage: https://www.dymo.com/en-US/online-support/dymo-user-guides
+Installers:
+  - Arch: x86
+    Url: http://download.dymo.com/dymo/Software/Win/DCDSetup1.3.1.exe
+    Sha256: 9E8108001C1C234E664B207D898D41E02CCF42BCE39C10DD2F9DF42D4C81EFF9
+    InstallerType: exe
+    Switches:
+        Silent: "/S /v/qn"
+        SilentWithProgress: "/S /v/qn"


### PR DESCRIPTION
This installer is a little weird in that it unwraps other sub-installers including an embedded MSI. `winget` loses track of this chain and says "installed successfully" while one of the chain installers is still operating in the background unpacking things. But eventually it will shake out and it will be installed.

I couldn't find a manifest directive to give `winget` any additional information on how to track the state.

The silent switch comes directly from running `DCDSetup1.3.1.exe /?` and copying out the silent instructions from the installer's built-in help pop-up.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/1076)