### PR TITLE
VcXsrv uses nullsoft, not a generic exe

### DIFF
--- a/manifests/marha/VcXsrv/1.20.8.1.yaml
+++ b/manifests/marha/VcXsrv/1.20.8.1.yaml
@@ -11,7 +11,4 @@ Installers:
   - Arch: x64
     Url: https://sourceforge.net/projects/vcxsrv/files/latest/download
     Sha256: BA42C20502ACABF6B0626261FAA6E1862DF2F1899B126BA69E72EF9EA90ADDE4
-    InstallerType: exe
-    Switches:
-      Silent: "/S"
-      SilentWithProgress: "/S"
+    InstallerType: nullsoft


### PR DESCRIPTION


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/1086)