### PR TITLE
Add rustup to manifests

### DIFF
--- a/manifests/Rust/rustup/1.21.1.yaml
+++ b/manifests/Rust/rustup/1.21.1.yaml
@@ -1,5 +1,5 @@
-Id: Rustlang.rustup
-Publisher: Rustlang
+Id: Rust.rustup
+Publisher: Rust
 Name: rustup
 Version: 1.21.1
 AppMoniker: rustup

--- a/manifests/Rustlang/rustup/1.21.1.yaml
+++ b/manifests/Rustlang/rustup/1.21.1.yaml
@@ -17,10 +17,3 @@ Installers:
     Switches:
         Silent: "-y --quiet"
         SilentWithProgress: "-y"
-  - Arch: x86
-    Url: https://static.rust-lang.org/rustup/archive/1.21.1/i686-pc-windows-gnu/rustup-init.exe
-    Sha256: EB4FEF7BA86A5E39F4A9837102AD34F077BE864B80C0B8963CF19FF8897CC66A
-    InstallerType: exe
-    Switches:
-        Silent: "-y --quiet"
-        SilentWithProgress: "-y"

--- a/manifests/Rustlang/rustup/1.21.1.yaml
+++ b/manifests/Rustlang/rustup/1.21.1.yaml
@@ -4,7 +4,7 @@ Name: rustup
 Version: 1.21.1
 AppMoniker: rustup
 Description: Manage multiple rust installations with ease
-Tags: rust, rustlang, rustup, toolchain
+Tags: rust, rustlang, rustup, multirust, install, proxy, toolchain
 Homepage: https://github.com/rust-lang/rustup
 MinOSVersion: 10.0.0.0
 License: MIT or Apache-2.0

--- a/manifests/Rustlang/rustup/1.21.1.yaml
+++ b/manifests/Rustlang/rustup/1.21.1.yaml
@@ -1,4 +1,3 @@
-ManifestVersion: 0.1.0
 Id: Rustlang.rustup
 Publisher: Rustlang
 Name: rustup

--- a/manifests/Rustlang/rustup/1.21.1.yaml
+++ b/manifests/Rustlang/rustup/1.21.1.yaml
@@ -1,0 +1,27 @@
+ManifestVersion: 0.1.0
+Id: Rustlang.rustup
+Publisher: Rustlang
+Name: rustup
+Version: 1.21.1
+AppMoniker: rustup
+Description: Manage multiple rust installations with ease
+Tags: rust, rustlang, rustup, toolchain
+Homepage: https://github.com/rust-lang/rustup
+MinOSVersion: 10.0.0.0
+License: MIT or Apache-2.0
+LicenseUrl: https://opensource.org/licenses/MIT or https://opensource.org/licenses/Apache-2.0
+Installers:
+  - Arch: x64
+    Url: https://static.rust-lang.org/rustup/archive/1.21.1/x86_64-pc-windows-gnu/rustup-init.exe
+    Sha256: D17DF34BA974B9B19CF5C75883A95475AA22DDC364591D75D174090D55711C72
+    InstallerType: exe
+    Switches:
+        Silent: "-y --quiet"
+        SilentWithProgress: "-y"
+  - Arch: x86
+    Url: https://static.rust-lang.org/rustup/archive/1.21.1/i686-pc-windows-gnu/rustup-init.exe
+    Sha256: EB4FEF7BA86A5E39F4A9837102AD34F077BE864B80C0B8963CF19FF8897CC66A
+    InstallerType: exe
+    Switches:
+        Silent: "-y --quiet"
+        SilentWithProgress: "-y"


### PR DESCRIPTION
From the [repository](https://github.com/rust-lang/rustup):

> Rustup installs The Rust Programming Language from the official release channels, enabling you to easily switch between stable, beta, and nightly compilers and keep them updated. It makes cross-compiling simpler with binary builds of the standard library for common platforms. 

Manifest information has been sourced from the repository's respective [`Cargo.toml`](https://github.com/rust-lang/rustup/blob/0602a72e7df9cbbda7b3292cdeccf65af04ed787/Cargo.toml).

As listed in the `README`, I've used the archive to fetch a specific version:

> You can fetch an older version from `https://static.rust-lang.org/rustup/archive/{rustup-version}/{target-triple}/rustup-init[.exe]`

It passed `winget validate` , but I'm not sure if the dual `MIT` and `Apache` license is seen as a valid value for `License` and `LicenseUrl`.



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/1215)