### PR TITLE
Change x64 to x86 of Code:Block to improve compatibility

### DIFF
--- a/manifests/Codeblocks/Codeblocks/20.03.yaml
+++ b/manifests/Codeblocks/Codeblocks/20.03.yaml
@@ -1,10 +1,10 @@
 Id: CodeBlocks.CodeBlocks
 Version: 20.03
 Name: Code::Blocks
-AppMoniker: codeblocks
 Publisher: The Code::Blocks team
 License: GNU GPLv3
 LicenseUrl: http://www.codeblocks.org/license
+AppMoniker: codeblocks
 Tags: "codeblocks, C++, IDE, admin, foss, cross-platform"
 Description: Free open-source C/C++/Fortran IDE (includes additional GCC/G++ compiler and GDB debugger)
 Homepage: http://www.codeblocks.org/

--- a/manifests/Codeblocks/Codeblocks/20.03.yaml
+++ b/manifests/Codeblocks/Codeblocks/20.03.yaml
@@ -14,6 +14,6 @@ Installers:
 #    Sha256: 862479A6D45B8A36FFC09FC4C63CD0850155088E33BD8CAD9075FB6FCB1F43C2
 #    InstallerType: nullsoft
   - Arch: x86
-    Url: https://nchc.dl.sourceforge.net/project/codeblocks/Binaries/20.03/Windows/32bit/codeblocks-20.03mingw-32bit-setup.exe
+    Url:  http://sourceforge.net//project/codeblocks/Binaries/20.03/Windows/32bit/codeblocks-20.03mingw-32bit-setup.exe
     Sha256: 2FD1983032DE7525CAE7FCC42AE986585CCAF87BFA3DBA71508D6C431CC5A218
     InstallerType: nullsoft

--- a/manifests/Codeblocks/Codeblocks/20.03.yaml
+++ b/manifests/Codeblocks/Codeblocks/20.03.yaml
@@ -1,15 +1,19 @@
-Id: Codeblocks.Codeblocks
+Id: CodeBlocks.CodeBlocks
 Version: 20.03
 Name: Code::Blocks
+AppMoniker: codeblocks
 Publisher: The Code::Blocks team
 License: GNU GPLv3
 LicenseUrl: http://www.codeblocks.org/license
-AppMoniker: codeblocks
 Tags: "codeblocks, C++, IDE, admin, foss, cross-platform"
 Description: Free open-source C/C++/Fortran IDE (includes additional GCC/G++ compiler and GDB debugger)
 Homepage: http://www.codeblocks.org/
 Installers:
-  - Arch: x64
-    Url: http://sourceforge.net/projects/codeblocks/files/Binaries/20.03/Windows/codeblocks-20.03mingw-setup.exe
-    Sha256: 862479A6D45B8A36FFC09FC4C63CD0850155088E33BD8CAD9075FB6FCB1F43C2
+#  - Arch: x64
+#    Url: https://nchc.dl.sourceforge.net/projects/codeblocks/files/Binaries/20.03/Windows/codeblocks-20.03mingw-setup.exe
+#    Sha256: 862479A6D45B8A36FFC09FC4C63CD0850155088E33BD8CAD9075FB6FCB1F43C2
+#    InstallerType: nullsoft
+  - Arch: x86
+    Url: https://nchc.dl.sourceforge.net/project/codeblocks/Binaries/20.03/Windows/32bit/codeblocks-20.03mingw-32bit-setup.exe
+    Sha256: 2FD1983032DE7525CAE7FCC42AE986585CCAF87BFA3DBA71508D6C431CC5A218
     InstallerType: nullsoft

--- a/manifests/Codeblocks/Codeblocks/20.03.yaml
+++ b/manifests/Codeblocks/Codeblocks/20.03.yaml
@@ -1,10 +1,10 @@
 Id: CodeBlocks.CodeBlocks
 Version: 20.03
 Name: Code::Blocks
+AppMoniker: codeblocks
 Publisher: The Code::Blocks team
 License: GNU GPLv3
 LicenseUrl: http://www.codeblocks.org/license
-AppMoniker: codeblocks
 Tags: "codeblocks, C++, IDE, admin, foss, cross-platform"
 Description: Free open-source C/C++/Fortran IDE (includes additional GCC/G++ compiler and GDB debugger)
 Homepage: http://www.codeblocks.org/


### PR DESCRIPTION
many Code:Block users still use x86 windows, like the computer of my school.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/1218)