### PR TITLE
Fix url for Docker Desktop version 2.3.0.2

### DIFF
--- a/manifests/Docker/DockerDesktop/2.3.0.2.yaml
+++ b/manifests/Docker/DockerDesktop/2.3.0.2.yaml
@@ -3,10 +3,10 @@ Version: 2.3.0.2
 Name: DockerDesktop
 Publisher: Docker
 Homepage: https://www.docker.com/
-License: Copyright Docker Inc. 2016-2017
+License: Copyright Docker Inc. 2015
 Description: Docker Desktop is an application for MacOS and Windows machines for the building and sharing of containerized applications. Access Docker Desktop and follow the guided onboarding to build your first containerized application in minutes.
 Installers: 
     - Arch: x64
-      Url: https://download.docker.com/win/stable/Docker%20Desktop%20Installer.exe
+      Url: https://download.docker.com/win/stable/45183/Docker%20Desktop%20Installer.exe
       InstallerType: exe
       Sha256: 61B9541FC208336EE35AEEE06F96CD6CD36D7FB44A64DF42BC00A51E3A749841


### PR DESCRIPTION
Fix the download link for Docker Desktop 2.3.0.2, use a static link instead of the floating one that gives you always the latest stable version.

Fixes #1265 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/1271)