### PR TITLE
emacs-27.0.91.yaml: arch should be x64

### DIFF
--- a/manifests/GNU/Emacs/27.0.91.yaml
+++ b/manifests/GNU/Emacs/27.0.91.yaml
@@ -8,7 +8,7 @@ Tags: gnu, emacs, text editor, utility, tool
 Description: An extensible, customizable, free/libre text editor - and more.
 Homepage: https://www.gnu.org/software/emacs/
 Installers:
-  - Arch: x86
+  - Arch: x64
     Url: https://alpha.gnu.org/gnu/emacs/pretest/windows/emacs-27/emacs-27.0.91-x86_64-installer.exe
     Sha256: D11A4C7588116102DDC0480A1467D6F13A5DC7C77BCB0715B3FAD3F5DC4D9F5D
     InstallerType: nullsoft


### PR DESCRIPTION
The architecture for Emacs installer should be `x64`, the installer for `x86` one should be `emacs-27.0.91-i686-installer.exe`

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/1281)