### PR TITLE
Add Atomic Tanks 6.5

### DIFF
--- a/manifests/Atanks/Atanks/6.5.yaml
+++ b/manifests/Atanks/Atanks/6.5.yaml
@@ -1,0 +1,14 @@
+Id: Atanks.Atanks
+Version: 6.5
+Name: Atomic Tanks
+Publisher: Atanks Team
+License: GPLv2
+AppMoniker: atanks
+Tags: game, tank, atomic, scorched, earth, worms
+Description: Annihilate the other tanks to earn money, then spend it on bigger and better shields and weapons to wipe out the opposition.
+Homepage: https://atanks.sourceforge.io
+Installers:
+  - Arch: x86
+    Url: https://sourceforge.net/projects/atanks/files/atanks/atanks-6.5/atanks-6.5-windows.exe/download
+    Sha256: E9FA1A6C43505237F9AB2751EDAE05B8CB188F12089BD5535E94DD5E9630CCE3
+    InstallerType: nullsoft


### PR DESCRIPTION
Requires Visual C++ 2010 Redist (x86) to run. Keeping as a draft until we can actually define dependencies, unless that's not a problem. Other than that, installs fine and runs in my dev environment.

Part of https://github.com/microsoft/winget-pkgs/issues/897

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/1419)