### PR TITLE
Wireshark: Switch to x64.

### DIFF
--- a/manifests/WiresharkFoundation/Wireshark/3.2.4.Yaml
+++ b/manifests/WiresharkFoundation/Wireshark/3.2.4.Yaml
@@ -1,15 +1,16 @@
 Id: WiresharkFoundation.Wireshark
+# Packaging guidelines can be found at https://www.wireshark.org/docs/wsdg_html_chunked/ChSrcBinary.html
 Version: 3.2.4
 Name: Wireshark
 Publisher: WiresharkFoundation
 Homepage: https://www.wireshark.org/
-License: The license under which Wireshark is issued is the GNU General Public License version 2. 
-LicenseUrl: hhttps://github.com/wireshark/wireshark/blob/master/COPYING
+License: GPL-2.0-or-later
+LicenseUrl: https://github.com/wireshark/wireshark/blob/master/COPYING
 Description: Wireshark is the world's foremost and widely-used network protocol analyzer. It lets you see what's happening on your network at a microscopic level and is the de facto (and often de jure) standard across many commercial and non-profit enterprises, government agencies, and educational institutions.
 # SystemAppId: Wireshark
 Installers: 
-    - Arch: x86
-      Url: https://1.na.dl.wireshark.org/win32/all-versions/Wireshark-win32-3.2.4.exe
+    - Arch: x64
+      Url: https://1.na.dl.wireshark.org/win64/all-versions/Wireshark-win64-3.2.4.exe
       InstallerType: Nullsoft
-      Sha256: c17e4a812031d5dfd4ef0a4b4dae1b60bb45eb7ce8c9e8b1b5eff4db5bcf4b72
+      Sha256: db2565ee6410b7c57f54aaac86954e4f6a98e2ea31ffbea83e60b981fff57301
 


### PR DESCRIPTION
Switch to the 64-bit installer. Large captures can consume lots of
memory, and we'd prefer that 32-bit installs be the exception rather
than the rule.

Use an SPDX license identifier. Add a comment pointing to the packaging
guidelines.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/1498)