### PR TITLE
Fix AzureCLI 2.6.0

### DIFF
--- a/manifests/Microsoft/AzureCLI/2.6.0.yaml
+++ b/manifests/Microsoft/AzureCLI/2.6.0.yaml
@@ -7,6 +7,6 @@ License: Copyright (C) Microsoft Corporation
 Description: The Azure command-line interface (Azure CLI) is a set of commands used to create and manage Azure resources. The Azure CLI is available across Azure services and is designed to get you working quickly with Azure, with an emphasis on automation.
 Installers:
   - Arch: x64
-    Url: https://aka.ms/installazurecliwindows
+    Url: https://azurecliprod.blob.core.windows.net/msi/azure-cli-2.6.0.msi
     InstallerType: MSI
     Sha256: b7fb439ab63dbea939d8f1d4ba2530dbb5939673e9450ce8ef5b55a71c22d68b


### PR DESCRIPTION
The aks.ms link always navigates to the latest version and the hash will not match when there's a new release. This PR changes the link to the one of 2.6.0 msi.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/1520)