### PR TITLE
Update Bandizip to 7.08

### DIFF
--- a/manifests/Bandisoft/Bandizip/7.07.yaml
+++ b/manifests/Bandisoft/Bandizip/7.07.yaml
@@ -1,7 +1,7 @@
 Id: Bandisoft.Bandizip
 Publisher: Bandisoft
 Name: Bandizip
-Version: 7.06
+Version: 7.07
 License: Bandizip License Policy
 InstallerType: EXE
 LicenseUrl: https://www.bandisoft.com/bandizip/help/license-policy/
@@ -12,7 +12,7 @@ Homepage: https://www.bandisoft.com/bandizip/
 Installers:
   - Arch: x64
     Url: https://ux-dl.bandisoft.com/bandizip.std/BANDIZIP-SETUP-STD-ALL.EXE
-    Sha256: FAA3F8E15FEF4506D982DCE1DA37D29D9BF2FF33A31237E8D31D2ADABDD4A1FF
+    Sha256: 82977059da927973d21d8a8685a02b165b4140146d4431035e0877a19660104d
     Switches:
         Silent: /S
         SilentWithProgress: /S

--- a/manifests/Bandisoft/Bandizip/7.08.yaml
+++ b/manifests/Bandisoft/Bandizip/7.08.yaml
@@ -12,7 +12,7 @@ Homepage: https://www.bandisoft.com/bandizip/
 Installers:
   - Arch: x64
     Url: https://ux-dl.bandisoft.com/bandizip.std/BANDIZIP-SETUP-STD-ALL.EXE
-    Sha256: 82977059da927973d21d8a8685a02b165b4140146d4431035e0877a19660104d
+    Sha256: f7a6afa38a81b87bcbeacb9f10cec456ad1901a7ef8678cf334ede25349453b4
     Switches:
         Silent: /S
         SilentWithProgress: /S

--- a/manifests/Bandisoft/Bandizip/7.08.yaml
+++ b/manifests/Bandisoft/Bandizip/7.08.yaml
@@ -16,3 +16,4 @@ Installers:
     Switches:
         Silent: /S
         SilentWithProgress: /S
+

--- a/manifests/Bandisoft/Bandizip/7.08.yaml
+++ b/manifests/Bandisoft/Bandizip/7.08.yaml
@@ -1,7 +1,7 @@
 Id: Bandisoft.Bandizip
 Publisher: Bandisoft
 Name: Bandizip
-Version: 7.07
+Version: 7.08
 License: Bandizip License Policy
 InstallerType: EXE
 LicenseUrl: https://www.bandisoft.com/bandizip/help/license-policy/


### PR DESCRIPTION
Since Bandizip does not use seperate download URL for installers of different releases, the previous yaml file is not valid now.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/1640)