### PR TITLE
Ghostscript : Change Installer from nullsoft to exe

### DIFF
--- a/manifests/ArtifexSoftware/GhostScript/9.52.yaml
+++ b/manifests/ArtifexSoftware/GhostScript/9.52.yaml
@@ -11,5 +11,8 @@ Homepage: https://www.ghostscript.com
 Installers:
   - Arch: x64
     Url: https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs952/gs952w64.exe
-    InstallerType: nullsoft
+    InstallerType: exe
     Sha256: 02814c278be321dbd07c4540da138a9b7e58407e72aa046959bad07afbef53c5
+    Switches:
+      Silent: /S
+      SilentWithProgress: /S


### PR DESCRIPTION
https://www.ghostscript.com/doc/current/Install.htm
> The installer is NSIS-based (see also Release.htm) and supports a few standard NSIS options: /NCRC disables the CRC check, /S runs the installer or uninstaller silently, /D sets the default installation directory (It must be the last parameter used in the command line and must not contain any quotes, even if the path contains spaces. Only absolute paths are supported).


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/1771)