### PR TITLE
Add Google Chrome 83.0.4103.106

### DIFF
--- a/manifests/Google/Chrome/83.0.4103.106.yaml
+++ b/manifests/Google/Chrome/83.0.4103.106.yaml
@@ -1,0 +1,18 @@
+Id: Google.Chrome
+Publisher: Google
+Name: Chrome
+Description: A fast, secure, and free web browser built for the modern web. Chrome syncs bookmarks across all your devices, fills out forms automatically, and so much more.
+Homepage: https://www.google.com/chrome/
+Tags: Browser, Google, Chromium
+License: Proprietary freeware, based on open source components
+LicenseUrl: https://www.google.com/chrome/terms/
+Version: 83.0.4103.106
+InstallerType: exe
+Installers:
+  - Arch: x64
+    Url: https://dl.google.com/edgedl/chrome/install/ChromeStandaloneSetup64.exe
+    Sha256: 44991EDACB8424698436C45895270E4FC2E9DD22B6C3DEB773F5CA566AB16184
+    Language: en-US
+    Switches:
+      Silent: "/installsource taggedmi /silent /install \"appguid={8A69D345-D564-463C-AFF1-A69D9E530F96}&iid={7DF7C924-72F2-9B35-53F5-9837D6B76D3F}&lang=en&browser=5&usagestats=0&appname=Google%20Chrome&needsadmin=false&ap=x64-stable-statsdef_1&installdataindex=empty\" /installelevated /nomitag"
+      SilentWithProgress: "/installsource taggedmi /silent /install \"appguid={8A69D345-D564-463C-AFF1-A69D9E530F96}&iid={7DF7C924-72F2-9B35-53F5-9837D6B76D3F}&lang=en&browser=5&usagestats=0&appname=Google%20Chrome&needsadmin=false&ap=x64-stable-statsdef_1&installdataindex=empty\" /installelevated /nomitag"


### PR DESCRIPTION
This PR updates to the latest version of Google Chrome.

Note: The previous winget packages for Google Chrome downloads the enterprise version which includes a bundle of enterprise management components and deprecated legacy features for interoperability.

This winget package downloads the consumer version. It currently uses arguments to install per-user instead of per-machine because the previous submissions using per-machine were ignored/rejected: #1035 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/1924)