### PR TITLE
Fix JRE link to the correct one for x64

### DIFF
--- a/manifests/Oracle/JavaRuntimeEnvironment/8.0.251.yaml
+++ b/manifests/Oracle/JavaRuntimeEnvironment/8.0.251.yaml
@@ -10,8 +10,8 @@ Description: Java Runtime Environment
 Homepage: https://www.java.com/
 Installers:
   - Arch: x64
-    Url: https://javadl.oracle.com/webapps/download/AutoDL?BundleId=242058_3d5a2bb8f8d4428bbe94aed7ec7ae784
-    Sha256: E1B646C9483352F5FD74D78579B38D4136ECFCFE3E32B8426C70D84D6647463F
+    Url: https://javadl.oracle.com/webapps/download/AutoDL?BundleId=242060_3d5a2bb8f8d4428bbe94aed7ec7ae784
+    Sha256: 26CB9474A8F8F80398054B29515602E48BD3088D167452F525EBB616882B2DC2
     InstallerType: exe
     Switches:
       Silent: "/s"


### PR DESCRIPTION
The link in the current JRE manifest is for x86 but the manifest states the arch is x64. This changes the link and the SHA256 checksum to the correct values for the x64 version

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/1963)