### PR TITLE
Add Docker Desktop Edge 2.3.2.0 (46268)

### DIFF
--- a/manifests/Docker/DockerDesktopEdge/2.3.2.0.46268.yaml
+++ b/manifests/Docker/DockerDesktopEdge/2.3.2.0.46268.yaml
@@ -1,0 +1,25 @@
+# ================== General ==================
+
+Id: Docker.DockerDesktopEdge
+Publisher: Docker Inc.
+Name: Docker Desktop Edge
+AppMoniker: docker-edge
+Description: Docker Desktop is an application for MacOS and Windows machines for the building and sharing of containerized applications. Access Docker Desktop and follow the guided onboarding to build your first containerized application in minutes.
+Homepage: https://www.docker.com
+Tags: Container, Containerization, Virtualization
+
+Version: 2.3.2.0.46268
+
+License: Copyright © 2017 Docker Inc. All rights reserved.
+LicenseUrl: https://www.docker.com/legal/docker-software-end-user-license-agreement
+
+# ================= Installer =================
+
+InstallerType: exe
+Installers:
+  - Arch: x64
+    Url: https://desktop.docker.com/win/edge/46268/Docker%20Desktop%20Installer.exe
+    Sha256: 3CC350C3581CED6BD8240AC26AD210C0ED2BB2F396B39839E3F5EC593D24F783
+    Switches:
+      Silent: install --quiet
+      SilentWithProgress: install --quiet


### PR DESCRIPTION
We've released a new version of Docker Desktop Edge 2.3.2.0 (46268).

Signed-off-by: Stefan Scherer <stefan.scherer@docker.com>

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/2121)