### PR TITLE
Spotify v1.1.36.734.g8731c306 + Manifest fix

### DIFF
--- a/manifests/Spotify/Spotify/1.1.36.734.g8731c306.yaml
+++ b/manifests/Spotify/Spotify/1.1.36.734.g8731c306.yaml
@@ -15,20 +15,20 @@ LicenseUrl: https://www.spotify.com/us/legal/end-user-agreement
 # ================= Installer =================
 MinOSVersion: 10.0.0.0
 #Channel: stable                # Channel is not supported in this preview (5/24/2020) 
-Version: 1.1.35.458
+Version: 1.1.36.734.g8731c306
 
 Switches:
       Custom: 
       Silent: /Silent
       SilentWithProgress: /Silent
       #Interactive:             # Interactive is not supported in this preview (5/24/2020)
-      #Language: en-US          # Language is not supported in this preview (5/24/2020)
+      Language: en-US
 
 InstallerType: exe
 Installers:
   - Arch: neutral
-    Url: https://download.spotify.com/SpotifyFullSetup.exe
-    Sha256: 35ce7176234b5a050472f00e102fc50ab64ad8e96d53eff66f30f2217938723d
-    #Scope: machine             # Scope is not supported in this preview (5/24/2020)
+    Url: https://download.scdn.co/SpotifySetup.exe
+    Sha256: 2433603a22c01b288aa8647223092de58c5a7f2dbf3cb8bbbb80e78744764343
+    Scope: machine
     
 # ManifestVersion: 0.1.0

--- a/manifests/Spotify/Spotify/1.1.36.734.g8731c306.yaml
+++ b/manifests/Spotify/Spotify/1.1.36.734.g8731c306.yaml
@@ -14,7 +14,7 @@ LicenseUrl: https://www.spotify.com/us/legal/end-user-agreement
 
 # ================= Installer =================
 MinOSVersion: 10.0.0.0
-#Channel: stable                # Channel is not supported in this preview (5/24/2020) 
+#Channel: stable                # Channel is not supported in this preview (5/24/2020)
 Version: 1.1.36.734.g8731c306
 
 Switches:

--- a/manifests/Spotify/Spotify/1.1.37.690.g8f3b16fc.yaml
+++ b/manifests/Spotify/Spotify/1.1.37.690.g8f3b16fc.yaml
@@ -15,20 +15,20 @@ LicenseUrl: https://www.spotify.com/us/legal/end-user-agreement
 # ================= Installer =================
 MinOSVersion: 10.0.0.0
 #Channel: stable                # Channel is not supported in this preview (5/24/2020)
-Version: 1.1.36.734.g8731c306
+Version: 1.1.37.690.g8f3b16fc
 
 Switches:
       Custom: 
       Silent: /Silent
       SilentWithProgress: /Silent
-      #Interactive:             # Interactive is not supported in this preview (5/24/2020)
+      #Interactive:
       Language: en-US
 
 InstallerType: exe
 Installers:
   - Arch: neutral
     Url: https://download.scdn.co/SpotifySetup.exe
-    Sha256: 2433603a22c01b288aa8647223092de58c5a7f2dbf3cb8bbbb80e78744764343
+    Sha256: 04e5dc21f7673656e4b37973064f71683e73b6bd601dfec1a97ecd0e234502db
     Scope: machine
     
 # ManifestVersion: 0.1.0


### PR DESCRIPTION
Apparently SpotifyFullSetup.exe is way behind SpotifySetup.exe

- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Have you validated your manifest locally with `winget validate <manifest>`, where `<manifest>` is the name of the manifest you're submitting?
- [ ] Have you tested your manifest locally with `winget install -m <manifest>`?

-----

I don't have a real vm so i can't test if the install works locally since i the Microsoft Store version


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/2284)