### PR TITLE
Fix yaml syntax

### DIFF
--- a/manifests/SuperCollider/SuperCollider/3.11.0.yaml
+++ b/manifests/SuperCollider/SuperCollider/3.11.0.yaml
@@ -9,7 +9,7 @@ Tags: supercollider, sc, audio, synthesis, composition, sound
 
 # ================== License ==================
 Homepage: https://supercollider.github.io/
-License: 	GPLv3
+License: GPLv3
 LicenseUrl: https://github.com/supercollider/supercollider/blob/develop/COPYING
 
 # ================= Installer =================


### PR DESCRIPTION
Fixes "found character '\t' that cannot start any token" in pyyaml

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you validated your manifest locally with `winget validate <manifest>`, where `<manifest>` is the name of the manifest you're submitting?
- [ ] Have you tested your manifest locally with `winget install -m <manifest>`?

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/2636)