### PR TITLE
Firefox Dev incorrect AppMoinker fix

### DIFF
--- a/manifests/Mozilla/FirefoxDeveloperEdition/77.0b9.yaml
+++ b/manifests/Mozilla/FirefoxDeveloperEdition/77.0b9.yaml
@@ -3,7 +3,7 @@
 Id: Mozilla.FirefoxDeveloperEdition
 Publisher: Mozilla
 Name: Firefox Developer Edition
-AppMoniker: firefox
+AppMoniker: firefox-dev
 Description: Firefox Developer Edition is the blazing fast browser that offers cutting edge developer tools and latest features like CSS Grid support and framework debugging
 Homepage: https://www.mozilla.org/en-US/firefox/developer/
 Tags: Browser, Mozilla, Firefox, Developer


### PR DESCRIPTION
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Have you validated your manifest locally with `winget validate <manifest>`, where `<manifest>` is the name of the manifest you're submitting?
- [X] Have you tested your manifest locally with `winget install -m <manifest>`?

-----

Don't know why it does this, but it tags all the newer manifests as Moniker: firefox
![image](https://user-images.githubusercontent.com/15158490/89691782-1f860a80-d90a-11ea-9171-4415ad376d22.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/2952)