### PR TITLE
Update emacs-27.0.91 -> emacs-27.1

### DIFF
--- a/manifests/GNU/Emacs/27.1.yaml
+++ b/manifests/GNU/Emacs/27.1.yaml
@@ -1,5 +1,5 @@
 Id: GNU.Emacs
-Version: 27.0.91
+Version: 27.1
 Name: GNU Emacs
 Publisher: GNU Project
 License: GPL
@@ -9,6 +9,6 @@ Description: An extensible, customizable, free/libre text editor - and more.
 Homepage: https://www.gnu.org/software/emacs/
 Installers:
   - Arch: x64
-    Url: https://alpha.gnu.org/gnu/emacs/pretest/windows/emacs-27/emacs-27.0.91-x86_64-installer.exe
-    Sha256: D11A4C7588116102DDC0480A1467D6F13A5DC7C77BCB0715B3FAD3F5DC4D9F5D
+    Url: https://alpha.gnu.org/gnu/emacs/pretest/windows/emacs-27/emacs-27.1-x86_64-installer.exe
+    Sha256: AE5712CEA4C8454F93B9D7E244B76D805F9BF3B2B891D03DFBB418BA98397A4D
     InstallerType: nullsoft


### PR DESCRIPTION
Emacs 27.0.91 url is not valid anymore because of the update. Update is necessary.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate <manifest>`, where `<manifest>` is the name of the manifest you're submitting?
- [x] Have you tested your manifest locally with `winget install -m <manifest>`?

-----


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/3067)