### PR TITLE
Update Kate-20.04.2-938 -> Kate-20.08.0-981.

### DIFF
--- a/manifests/KDE/Kate/20.08.0-981.yaml
+++ b/manifests/KDE/Kate/20.08.0-981.yaml
@@ -1,5 +1,5 @@
 Id: KDE.Kate
-Version: 20.04.2-938
+Version: 20.08.0-981
 Name: Kate
 Publisher: KDE
 License: LGPL-2.0
@@ -10,6 +10,6 @@ Description: Kate is a multi-document editor part of KDE since release 2.2. Bein
 Homepage: https://kate-editor.org/
 Installers:
   - Arch: x64
-    Url: https://binary-factory.kde.org/view/Windows%2064-bit/job/Kate_Release_win64/938/artifact/kate-20.04.2-938-windows-msvc2019_64-cl-sideload.appx
-    Sha256: e7acc4cd118a6996bc123b8ddbf8d41bfcb01ca707b17e48918e7b6b0472f86e
+    Url: https://binary-factory.kde.org/view/Windows%2064-bit/job/Kate_Release_win64/lastSuccessfulBuild/artifact/kate-20.08.0-981-windows-msvc2019_64-cl-sideload.appx
+    Sha256: 445DF7CC671A701851410DBEC2DCD6606D936F405492599C7183F32BD5F5AAEF
     InstallerType: appx


### PR DESCRIPTION
Kate-20.04.2-938 url is not valid anymore. Update is necessary.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate <manifest>`, where `<manifest>` is the name of the manifest you're submitting?
- [x] Have you tested your manifest locally with `winget install -m <manifest>`?

-----


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/3184)