### PR TITLE
Fix Hash for Bot Framework Emulator 4.9.0

### DIFF
--- a/manifests/Microsoft/BotFrameworkEmulator/4.9.0.yaml
+++ b/manifests/Microsoft/BotFrameworkEmulator/4.9.0.yaml
@@ -12,7 +12,7 @@ Installers:
   - Arch: x64
     InstallerType: EXE
     Url: https://github.com/microsoft/BotFramework-Emulator/releases/download/v4.9.0/BotFramework-Emulator-4.9.0-windows-setup.exe
-    Sha256: EDE23BCAD7200D83EFFE6621534D654CBB986ECCADB4E1E35B9EA50C7EF220B8
+    Sha256: 5FF9A31ED28737B4E689BA5A325F88343707E1CF5CCB2014C587E38314A010EE
     Switches:
       Silent: /S
       SilentWithProgress: /S


### PR DESCRIPTION
There was a change to 4.9.0 release, thus, the downloadable doesn't have the same hash anymore and prompts hash error during install using winget.
This PR is to fix it accordingly.

Link to release 4.9.0: https://github.com/microsoft/BotFramework-Emulator/releases/tag/v4.9.0

Previous related PR: #1239

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate <manifest>`, where `<manifest>` is the name of the manifest you're submitting?
- [x] Have you tested your manifest locally with `winget install -m <manifest>`?

-----


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/3268)