### PR TITLE
Update Piriform Defraggler 2.22.995 SHA256

### DIFF
--- a/manifests/Piriform/Defraggler/2.22.995.yaml
+++ b/manifests/Piriform/Defraggler/2.22.995.yaml
@@ -10,7 +10,7 @@ InstallerType: exe
 Installers:
   - Arch: x64
     Url: https://download.ccleaner.com/dfsetup222.exe
-    Sha256: b53eb82d6a46c812171ca878b7342e1939a0afecc277b0b57c708eef8fc700de
+    Sha256: 167b7192937b39e657def16ffb0fdbbab326f007747505d5c8785811d6b03ab8
     Switches:
           Silent: /S
           SilentWithProgress: /S


### PR DESCRIPTION
Internal installer version 2.22.33.995, which appears to have changed since previous update.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate <manifest>`, where `<manifest>` is the name of the manifest you're submitting?
- [x] Have you tested your manifest locally with `winget install -m <manifest>`?

-----

Install output:

```
winget.exe install -m 2.22.995.yaml
Found Defraggler [Piriform.Defraggler]
This application is licensed to you by its owner.
Microsoft is not responsible for, nor does it grant any licenses to, third-party packages.
Downloading https://download.ccleaner.com/dfsetup222.exe
  ██████████████████████████████  7.12 MB / 7.12 MB
Successfully verified installer hash
Starting package install...
Successfully installed
```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/3471)