### PR TITLE
Fix Typora-0.9.86.

### DIFF
--- a/manifests/Typora/Typora/0.9.86.yaml
+++ b/manifests/Typora/Typora/0.9.86.yaml
@@ -4,12 +4,11 @@ Name: Typora
 Version: 0.9.86
 License: Typora is developed by @LeeAbner. All rights reserved.
 LicenseUrl: http://support.typora.io/Acknowledgement/
-InstallerType: exe
+InstallerType: inno
 Installers:
-  - Arch: x64 # enumeration of supported architectures
-    Url: https://typora.io/windows/typora-setup-x64.exe
-    Sha256: 4346B67A1409044F39EE50004395A03EEF3443718639E34393AFC25A7162AC3D
+  - Arch: x64
+    Url: https://typora.io/windows/typora-update-x64-0304.exe
+    Sha256: 719DDDC57183CC06C1E9D3B3D743A78AC80BD6A3802D0A9E26D7156FD984EA3A
     Switches:
       Silent: "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART"
       SilentWithProgress: "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART"
-# ManifestVersion: 0.1.0


### PR DESCRIPTION
Old manfiests use same link for every version. When using specific link for
specific release, hash change also.

----

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate <manifest>`, where `<manifest>` is the name of the manifest you're submitting?
- [x] Have you tested your manifest locally with `winget install -m <manifest>`?

-----

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/3561)