### PR TITLE
Fix Typora-0.9.92.

### DIFF
--- a/manifests/Typora/Typora/0.9.92.yaml
+++ b/manifests/Typora/Typora/0.9.92.yaml
@@ -10,7 +10,9 @@ Homepage: https://typora.io/
 Description: Typora gives you a seamless experience as both a reader and a writer. It removes the preview window, mode switcher, syntax symbols of markdown source code, and all other unnecessary distractions. Instead, it provides a real live preview feature to help you concentrate on the content itself.
 InstallerType: inno
 Installers:
-  - Arch: x64 # enumeration of supported architectures
-    Url: https://typora.io/windows/typora-setup-x64.exe
-    Sha256: 478aecce43bd3a300e62c80a0ecb55750ce20cf426f0d27a6f38dd7355982f96
-# ManifestVersion: 0.1.0
+  - Arch: x64
+    Url: https://typora.io/windows/typora-update-x64-0713.exe
+    Sha256: 5630C208537745804476998BE2344D8AB62F6AEBB9B2F1E4371F61D616B2E935
+    Switches:
+      Silent: /VERYSILENT /NORESTART
+      SilentWithProgress: /SILENT /NORESTART


### PR DESCRIPTION
Old manfiests use same link for every version. When using specific link for
specific release, hash change also.


----

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate <manifest>`, where `<manifest>` is the name of the manifest you're submitting?
- [x] Have you tested your manifest locally with `winget install -m <manifest>`?

-----

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/3563)