### PR TITLE
Fix Typora-0.9.93.

### DIFF
--- a/manifests/Typora/Typora/0.9.93.yaml
+++ b/manifests/Typora/Typora/0.9.93.yaml
@@ -10,7 +10,9 @@ Homepage: https://typora.io/
 Description: Typora gives you a seamless experience as both a reader and a writer. It removes the preview window, mode switcher, syntax symbols of markdown source code, and all other unnecessary distractions. Instead, it provides a real live preview feature to help you concentrate on the content itself.
 InstallerType: inno
 Installers:
-  - Arch: x64 # enumeration of supported architectures
-    Url: https://typora.io/windows/typora-setup-x64.exe
-    Sha256: 128b261ec728156c05a259c4474b008e775fe9ada820b2e53fdacec413b3c749
-# ManifestVersion: 0.1.0
+  - Arch: x64
+    Url: https://typora.io/windows/typora-update-x64-0724.exe
+    Sha256: EB74FFF1EBE166338F95C4FC61FF567A7ECC0AB9DF57B6DBE07CCF57D7094BF3
+    Switches:
+      Silent: /VERYSILENT /NORESTART
+      SilentWithProgress: /SILENT /NORESTART


### PR DESCRIPTION
Old manfiests use same link for every version. When using specific link for
specific release, hash change also.


----

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate <manifest>`, where `<manifest>` is the name of the manifest you're submitting?
- [x] Have you tested your manifest locally with `winget install -m <manifest>`?

-----

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/3564)