### PR TITLE
Change publisher of Lens package from LakendLabs to Mirantis

### DIFF
--- a/manifests/Mirantis/Lens/3.5.1.yaml
+++ b/manifests/Mirantis/Lens/3.5.1.yaml
@@ -1,4 +1,4 @@
-Id: LakendLabs.Lens
+Id: Mirantis.Lens
 Version: 3.5.1
 Name: Lens
 Publisher: Mirantis

--- a/manifests/Mirantis/Lens/3.5.1.yaml
+++ b/manifests/Mirantis/Lens/3.5.1.yaml
@@ -1,7 +1,7 @@
 Id: LakendLabs.Lens
 Version: 3.5.1
 Name: Lens
-Publisher: LakendLabs
+Publisher: Mirantis
 License: MIT
 LicenseUrl: https://github.com/lensapp/lens/blob/master/LICENSE
 AppMoniker: lens


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate <manifest>`, where `<manifest>` is the name of the manifest you're submitting?
- [x] Have you tested your manifest locally with `winget install -m <manifest>`?

-----
Due to Mirantis being the publisher of the Lens IDE we need to change the publisher (https://www.mirantis.com/software/lens/).

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/3649)