### PR TITLE
Proposal - Split 7-Zip Alpha from 'stable' releases

### DIFF
--- a/manifests/7Zip/7ZipAlpha/20.0.0-alpha-2.yaml
+++ b/manifests/7Zip/7ZipAlpha/20.0.0-alpha-2.yaml
@@ -1,6 +1,6 @@
-Id: 7zip.7zip
-Name: 7Zip
-AppMoniker: 7zip
+Id: 7zip.7zipAlpha
+Name: 7Zip - Alpha
+AppMoniker: 7zip-alpha
 Version: 20.0.0-alpha-2
 Publisher: 7zip
 Author: 7zip

--- a/manifests/7Zip/7ZipAlpha/20.0.0-alpha.yaml
+++ b/manifests/7Zip/7ZipAlpha/20.0.0-alpha.yaml
@@ -1,6 +1,6 @@
-Id: 7zip.7zip
-Name: 7Zip
-AppMoniker: 7zip
+Id: 7zip.7zipApha
+Name: 7Zip - Alpha
+AppMoniker: 7zip-alpha
 Version: 20.0.0-alpha
 Publisher: 7zip
 Author: 7zip


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you validated your manifest locally with `winget validate <manifest>`, where `<manifest>` is the name of the manifest you're submitting?
- [ ] Have you tested your manifest locally with `winget install -m <manifest>`?

-----

Can I suggest that the maintainers consider whether splitting 7-Zip alpha releases from the 'stable' non-alpha releases, might be a good idea? I certainly prefer to install a stable, non-alpha release, wherever possible and I imagine there are others who might be keen on the idea, also...

Would welcome thoughts on this!

Thanks,

Peter

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/3746)