### PR TITLE
Add '-alpha' to version

### DIFF
--- a/manifests/7Zip/7ZipAlpha/20.0.2-alpha.yaml
+++ b/manifests/7Zip/7ZipAlpha/20.0.2-alpha.yaml
@@ -1,7 +1,7 @@
 Id: 7zip.7zipAlpha
 Name: 7Zip - Alpha
 AppMoniker: 7zip-alpha
-Version: 20.0.2
+Version: 20.0.2-alpha
 Publisher: 7zip
 Author: 7zip
 License: Copyright (C) 1999-2020 Igor Pavlov. - GNU LGPL


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you validated your manifest locally with `winget validate <manifest>`, where `<manifest>` is the name of the manifest you're submitting?
- [ ] Have you tested your manifest locally with `winget install -m <manifest>`?

-----

Have been reflecting on #3756, in particular that the 'alpha' designation was not included in the versioning. Having installed the alpha version just now, I observe that the version within the application also includes the 'alpha' designation (see screenshot, below).

<img width="242" alt="Screenshot 2020-09-30 at 09 57 26" src="https://user-images.githubusercontent.com/820394/94665150-b4522680-0303-11eb-9842-dbd4cbe63a13.png">

For this reason, I'm creating this PR to add '-alpha' to the versioning. Would welcome thoughts on this. @KevinLaMS, you happy with this change?

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/3809)