### PR TITLE
git-credential-manager-core: add GCM Core 2.0.252

### DIFF
--- a/manifests/Microsoft/GitCredentialManagerCore/2.0.252.766.yaml
+++ b/manifests/Microsoft/GitCredentialManagerCore/2.0.252.766.yaml
@@ -1,0 +1,14 @@
+Id: Microsoft.GitCredentialManagerCore
+Version: 2.0.252.766
+Name: Git Credential Manager Core
+Publisher: Microsoft Corporation
+AppMoniker: git-credential-manager-core
+Homepage: https://aka.ms/gcmcore
+Tags: "gcm, gcmcore, git, credential"
+License: Copyright (C) Microsoft Corporation
+Description: Secure, cross-platform Git credential storage with authentication to GitHub, Azure Repos, and other popular Git hosting services.
+Installers:
+    - Arch: x86
+      Url: https://github.com/microsoft/Git-Credential-Manager-Core/releases/download/v2.0.252-beta/gcmcore-win-x86-2.0.252.766.exe
+      InstallerType: inno
+      Sha256: 480f971a5dca37118846fd173052f6ab512369bef31bd7cd11127c3c6ea365a5


### PR DESCRIPTION
Add a manifest for Git Credential Manager Core, the replacement for the Git Credential Manager for Windows that is cross-platform.

---

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate <manifest>`, where `<manifest>` is the name of the manifest you're submitting?
- [x] Have you tested your manifest locally with `winget install -m <manifest>`?


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/3965)