### PR TITLE
Removed redundant install flags for Transmission version 3.00.

### DIFF
--- a/manifests/Transmission/Transmission/3.00.yaml
+++ b/manifests/Transmission/Transmission/3.00.yaml
@@ -12,6 +12,3 @@ Installers:
     Url: https://github.com/transmission/transmission-releases/raw/master/transmission-3.00-x64.msi
     Sha256: C34828A6D2C50C7C590D05CA50249B511D46E9A2A7223323FB3D1421E3F6B9D1
     InstallerType: msi
-    Switches:
-      Silent: /QUIET /NORESTART
-      SilentWithProgress: /PASSIVE /NORESTART


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate <manifest>`, where `<manifest>` is the name of the manifest you're submitting?
- [x] Have you tested your manifest locally with `winget install -m <manifest>`?

-----
It's an MSI, but it had install flags, so I removed them so it would use winget's built in flags.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/4524)