### PR TITLE
Removed redundant install flags for Wireguard version 0.1.1.

### DIFF
--- a/manifests/Wireguard/Wireguard/0.1.1.yaml
+++ b/manifests/Wireguard/Wireguard/0.1.1.yaml
@@ -12,6 +12,3 @@ Installers:
     Url: https://download.wireguard.com/windows-client/wireguard-amd64-0.1.1.msi
     Sha256: F00DCBE7F1EF225A834AF5E70D90EBE2EF9DA4D016AFC5EDE1B135C708F8134C
     InstallerType: msi
-    Switches:
-      Silent: /quiet
-      SilentWithProgress: /passive


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate <manifest>`, where `<manifest>` is the name of the manifest you're submitting?
- [x] Have you tested your manifest locally with `winget install -m <manifest>`?

-----

It is packaged as an msi, so it doesn't need install flags.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/4526)