### PR TITLE
TravisFallsMSFT/ChangedCustomSwitchesPassedIn

### DIFF
--- a/manifests/Python/Python/3.7.9.yaml
+++ b/manifests/Python/Python/3.7.9.yaml
@@ -15,4 +15,4 @@ Installers:
       Switches:
         Silent: /Quiet
         SilentWithProgress: /Passive
-        Custom: PrependPath=1 TargetDir=C://Python379// InstallAllUsers=1 AssociatedFiles=1 Shortcuts=1 Include_doc=1 Include_exe=1 InstallLauncherAllUsers=1 Include_Lib=1 Include_pip=1 Include_tcltk=1 Include_test=1 Include_tools=1
+        Custom: PrependPath=1 InstallAllUsers=1 AssociatedFiles=1 Shortcuts=1 Include_doc=1 Include_exe=1 InstallLauncherAllUsers=1 Include_Lib=1 Include_pip=1 Include_tcltk=1 Include_test=1 Include_tools=1

--- a/manifests/Python/Python/3.7.9.yaml
+++ b/manifests/Python/Python/3.7.9.yaml
@@ -15,3 +15,4 @@ Installers:
       Switches:
         Silent: /Quiet
         SilentWithProgress: /Passive
+        Custom: PrependPath=1 TargetDir=C://Python379// InstallAllUsers=1 AssociatedFiles=1 Shortcuts=1 Include_doc=1 Include_exe=1 InstallLauncherAllUsers=1 Include_Lib=1 Include_pip=1 Include_tcltk=1 Include_test=1 Include_tools=1


### PR DESCRIPTION
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Have you validated your manifest locally with `winget validate <manifest>`, where `<manifest>` is the name of the manifest you're submitting?
- [X] Have you tested your manifest locally with `winget install -m <manifest>`?

-----
I changed custom switches passed in.  They are now set to:
PrependPath=1, InstallAllUsers=1, AssociatedFiles=1, Shortcuts=1, Include_doc=1, Include_exe=1, InstallLauncherAllUsers=1, Include_Lib=1, Include_pip=1, Include_tcltk=1, Include_test=1, Include_tools=1

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/4720)