### PR TITLE
Fix homepage URL for Bot Framework Composer 1.1.1

### DIFF
--- a/manifests/Microsoft/BotFrameworkComposer/1.1.1.yaml
+++ b/manifests/Microsoft/BotFrameworkComposer/1.1.1.yaml
@@ -6,7 +6,7 @@ License: Copyright (c) Microsoft Corporation
 LicenseUrl: https://github.com/microsoft/BotFramework-Composer/blob/master/LICENSE.md
 Tags: bot, framework, composer
 Description: Bot Framework Composer is an integrated development tool for developers and multi-disciplinary teams to build bots and conversational experiences with the Microsoft Bot Framework. Within this tool, you'll find everything you need to build a sophisticated conversational experience.
-Homepage: https://dev.botframework.com/
+Homepage: https://github.com/microsoft/BotFramework-Composer
 Installers:
   - Arch: x64
     Url: https://github.com/microsoft/BotFramework-Composer/releases/download/v1.1.1/BotFramework-Composer-1.1.1-windows-setup.exe


### PR DESCRIPTION
A previous commit by a contributor changed the homepage URL to Microsoft Bot Framework's homepage instead of Bot Framework Composer's.
This commit is to fix that error.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate <manifest>`, where `<manifest>` is the name of the manifest you're submitting?
- [x] Have you tested your manifest locally with `winget install -m <manifest>`?

-----


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/4992)