### PR TITLE
Fixed switches for Visual Studio Build Tools.

### DIFF
--- a/manifests/Microsoft/VisualStudio/BuildTools/16.6.30128.74.yaml
+++ b/manifests/Microsoft/VisualStudio/BuildTools/16.6.30128.74.yaml
@@ -15,4 +15,4 @@ Installers:
     Switches:
         Silent: --quiet
         SilentWithProgress: --passive
-        Custom: --wait --allWorkloads --includeRecommended
+        Custom: --productId Microsoft.VisualStudio.Product.BuildTools --channelId VisualStudio.16.Release --channelUri https://aka.ms/vs/16/release/channel


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate <manifest>`, where `<manifest>` is the name of the manifest you're submitting?
- [x] Have you tested your manifest locally with `winget install -m <manifest>`?

-----

Per #5181, the current version of this manifest installs every single feature of Visual Studio without asking and can cause an automatic reboot. I've aligned it with the other Visual Studio manifests in that it only installs the Build Tools by default, and gives the user the option to add more workloads when the installer appears.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/5216)