### PR TITLE
Fix hash/version to match VoiceMeeter Banana download URL

### DIFF
--- a/manifests/VB-Audio/VoiceMeeterBanana/2.0.5.4.yaml
+++ b/manifests/VB-Audio/VoiceMeeterBanana/2.0.5.4.yaml
@@ -1,5 +1,5 @@
 Id: VB-Audio.VoiceMeeterBanana
-Version: 2.0.5.3
+Version: 2.0.5.4
 Name: VoiceMeeter Banana
 Publisher: VB-Audio
 License: Donationware
@@ -11,7 +11,7 @@ Homepage: https://www.vb-audio.com/Voicemeeter/banana.htm
 Installers:
   - Arch: x64
     Url: https://download.vb-audio.com/Download_CABLE/VoicemeeterProSetup.exe
-    Sha256: 13205B703F4F95C58FBC4DB957E0F3EE32D1FB637B9C77433C418141D97EB338
+    Sha256: F8C7B4EE1DC8297E85E2B16B420BBA8C8C454F610DC2A89D89512CEC58C744E7
     InstallerType: exe
     Switches:
       Silent: -install


### PR DESCRIPTION
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Have you validated your manifest locally with `winget validate <manifest>`, where `<manifest>` is the name of the manifest you're submitting?
- [X] Have you tested your manifest locally with `winget install -m <manifest>`?

-----

We should probably also notify the owners of the software that its breaking hash validation when they replace a version download URL with a newer version. Should be an easy fix for them to append a version string to the filename.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/5218)