### PR TITLE
Update Bandisoft\Honeyview 5.35.yaml

### DIFF
--- a/manifests/Bandisoft/Honeyview/5.35.yaml
+++ b/manifests/Bandisoft/Honeyview/5.35.yaml
@@ -13,7 +13,7 @@ Homepage: https://www.bandisoft.com/honeyview/
 Installers:
   - Arch: x64
     Url: https://dl.bandisoft.com/honeyview/HONEYVIEW-SETUP.EXE
-    Sha256: 40A98E793D7D24DAAB38A4252CB0F639D77210A791A6F01E93673C49BA4829D8
+    Sha256: C782E99E753D18B9917B556E10991AA237BE08EC7447E3619C56C01487BBB22D
     InstallerType: EXE
     Switches:
       Silent: /S

--- a/manifests/Bandisoft/Honeyview/5.35.yaml
+++ b/manifests/Bandisoft/Honeyview/5.35.yaml
@@ -8,7 +8,7 @@ License: Freeware(No Adware/Spyware/Virus), EULA
 LicenseUrl: https://www.bandisoft.com/honeyview/eula/
 AppMoniker: honeyview
 Tags: honeyview, image, viewer, jpeg, jpg, png, exif
-Description: Yet another typical ZIP archiver
+Description: A fast, powerful, and free image viewer.
 Homepage: https://www.bandisoft.com/honeyview/
 Installers:
   - Arch: x64


### PR DESCRIPTION
Correcting Honeyview description - Honeyview is an image viewer not a zip archiver. Also updated SHA256 hash as that wasn't bumped with the latest update.

Submission containing materials of a third party:
 - description taken from official webpage, is Bandisoft's own description of their product.

- [y] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [y] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [y] Have you validated your manifest locally with `winget validate <manifest>`, where `<manifest>` is the name of the manifest you're submitting?
- [y] Have you tested your manifest locally with `winget install -m <manifest>`?

-----


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/5828)