### PR TITLE
Update MiniKube v1.15.1 to point to direct link

### DIFF
--- a/manifests/Kubernetes/minikube/1.15.1.yaml
+++ b/manifests/Kubernetes/minikube/1.15.1.yaml
@@ -10,7 +10,7 @@ Description: minikube quickly sets up a local Kubernetes cluster on macOS, Linux
 Homepage: https://minikube.sigs.k8s.io/docs/
 Installers:
   - Arch: x64
-    Url: https://storage.googleapis.com/minikube/releases/latest/minikube-installer.exe
+    Url: https://github.com/kubernetes/minikube/releases/download/v1.15.1/minikube-installer.exe
     Sha256: 88D188440BAB92EFACC47CC1ECF04203F13F068BFC24C9882D5A51D869E94178
     InstallerType: exe
     Switches:


### PR DESCRIPTION
Updates the 1.15.1 package to point to the 1.15.1 version installer rather than "latest"

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate <manifest>`, where `<manifest>` is the name of the manifest you're submitting?
- [x] Have you tested your manifest locally with `winget install -m <manifest>`?

-----


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/5831)