### PR TITLE
git-credential-manager-core: GCM Core 2.0.318

### DIFF
--- a/manifests/Microsoft/GitCredentialManagerCore/2.0.318.44100.yaml
+++ b/manifests/Microsoft/GitCredentialManagerCore/2.0.318.44100.yaml
@@ -1,0 +1,14 @@
+Id: Microsoft.GitCredentialManagerCore
+Version: 2.0.318.44100
+Name: Git Credential Manager Core
+Publisher: Microsoft Corporation
+AppMoniker: git-credential-manager-core
+Homepage: https://aka.ms/gcmcore
+Tags: gcm, gcmcore, git, credential
+License: Copyright (C) Microsoft Corporation
+Description: Secure, cross-platform Git credential storage with authentication to GitHub, Azure Repos, and other popular Git hosting services.
+Installers:
+    - Arch: x86
+      Url: https://github.com/microsoft/Git-Credential-Manager-Core/releases/download/v2.0.318-beta/gcmcoreuser-win-x86-2.0.318.44100.exe
+      InstallerType: inno
+      Sha256: 16A5C46BCE68A7CF48B76ED6657AC70D351EFB3A0B5F2CCF4C2E43BA08B142B2


### PR DESCRIPTION
This change starts using the gcmcoreuser-* installer which is preferred.
See: https://github.com/microsoft/Git-Credential-Manager-Core/blob/c9324de539078bcd3738828ed3407a17ec32eb32/README.md#windows

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate <manifest>`, where `<manifest>` is the name of the manifest you're submitting?
- [x] Have you tested your manifest locally with `winget install -m <manifest>`?

-----


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/6146)