### PR TITLE
Fix PowerShell 7.1.1 manifest

### DIFF
--- a/manifests/Microsoft/Powershell/7.1.1.yaml
+++ b/manifests/Microsoft/Powershell/7.1.1.yaml
@@ -1,8 +1,7 @@
 Id: Microsoft.PowerShell
 Version: 7.1.1
 Name: PowerShell
-Publisher: Microsoft Corporation
-Author: Microsoft
+Publisher: Microsoft
 Homepage: https://microsoft.com/PowerShell
 License:  MIT
 Description: PowerShell is a cross-platform (Windows, Linux, and macOS) automation and configuration tool/framework that works well with your existing tools and is optimized for dealing with structured data (e.g. JSON, CSV, XML, etc.), REST APIs, and object models. It includes a command-line shell, an associated scripting language and a framework for processing cmdlets.


### PR DESCRIPTION
I noticed the PS 7.1.1 manifest from https://github.com/microsoft/winget-pkgs/pull/6223 isn't quite consistent with the others. I don't know what the policy is on changing existing manifests, but here's a PR to make the corrections for consistency in case it's allowed.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate <manifest>`, where `<manifest>` is the name of the manifest you're submitting?
- [x] Have you tested your manifest locally with `winget install -m <manifest>`?

-----


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/6414)