### PR TITLE
Add Go 1.15.7

### DIFF
--- a/manifests/Golang/Go/1.15.7.yaml
+++ b/manifests/Golang/Go/1.15.7.yaml
@@ -1,0 +1,15 @@
+Id: GoLang.Go
+Version: 1.15.7
+Name: Go
+Publisher: Golang
+License: Copyright (c) 2009 The Go Authors
+LicenseUrl: https://github.com/golang/go/blob/go1.15.7/LICENSE
+AppMoniker: go
+Tags: go, golang, go1.15, golang1.15
+Description: Go is an open source programming language that makes it easy to build simple, reliable, and efficient software.
+Homepage: https://golang.org
+Installers:
+  - Arch: x64
+    Url: https://golang.org/dl/go1.15.7.windows-amd64.msi
+    Sha256: 548e73797f07c8f7dcd4e419f396a41702ab68d1bc82ff637587b94bcdc9a462
+    InstallerType: msi


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate <manifest>`, where `<manifest>` is the name of the manifest you're submitting?
- [x] Have you tested your manifest locally with `winget install -m <manifest>`?

-----
I've switched the download URL to use `golang.org/dl/go{version}` as it now seems like it's the canonical download URL.

> The /dl/{file} URLs have been supported for many years but not well
documented. Start using them on the /dl/ HTML page and document them,
so that it is clear that they can be reliably used in scripts or so.
>
> This causes clients to have to make an extra HTTP request (which gets
redirected to the target location serving the file bytes), but compared
to the total work to download a Go file, this is negligible. Clients
that really want to skip the redirect can do so, but the trade-off is
that they need to update the URL if the CDN used for Go file downloads
happens to change. The /dl/{file} links are not expected to change for
Go 1.

https://go-review.googlesource.com/c/website/+/238517/

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-pkgs/pull/6596)