### PR TITLE
Copied Puppet Agent version 3.8.7 to correct publisher.

### DIFF
--- a/manifests/Puppet/puppet-agent/3.8.7.0.yaml
+++ b/manifests/Puppet/puppet-agent/3.8.7.0.yaml
@@ -1,13 +1,13 @@
-Id: PuppetLabs.puppet
+Id: Puppet.puppet-agent
 Publisher: PupppetLabs
-Name: puppet
+Name: Puppet Agent
 Version: 3.8.7.0
-License: Apache License 2.0
+License: Apache 2.0
 InstallerType: msi
 LicenseUrl: https://github.com/puppetlabs/puppet/blob/master/LICENSE
 AppMoniker: puppet
-Tags: puppet, scm
-Description: Puppet is an open-core software configuration management tool
+Tags:  puppet, pe, puppetlabs
+Description: Puppet is a tool that helps you manage and automate the configuration of servers.
 Homepage: https://puppet.com/
 Installers:
   - Arch: x64

--- a/manifests/PuppetLabs/puppet/3.8.7.0.yaml
+++ b/manifests/PuppetLabs/puppet/3.8.7.0.yaml
@@ -1,0 +1,17 @@
+Id: PuppetLabs.puppet
+Publisher: PupppetLabs
+Name: puppet
+Version: 3.8.7.0
+License: Apache License 2.0
+InstallerType: msi
+LicenseUrl: https://github.com/puppetlabs/puppet/blob/master/LICENSE
+AppMoniker: puppet
+Tags: puppet, scm
+Description: Puppet is an open-core software configuration management tool
+Homepage: https://puppet.com/
+Installers:
+  - Arch: x64
+    InstallerType: msi
+    Url: https://downloads.puppetlabs.com/windows/puppet-3.8.7.msi
+    Sha256: 6CDDBC4341D285766D4B2AB9C1D5008036C5EA702146BC94423CA945160BC9CE
+


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate <manifest>`, where `<manifest>` is the name of the manifest you're submitting?
- [x] Have you tested your manifest locally with `winget install -m <manifest>`?

-----

This manifest was under a different publisher and name, which caused AppMoniker conflicts. This should resolve it unless the bot throws a fit :)

Edit: The bot threw a fit. Now this PR only adds version 3.8.7 to the correct place, and PR #7076 deletes the old one. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/7075)