### PR TITLE
Fix: Update version and filename to reflect .NET SDK version

### DIFF
--- a/manifests/Microsoft/dotnet/5.0.102.yaml
+++ b/manifests/Microsoft/dotnet/5.0.102.yaml
@@ -1,5 +1,5 @@
 Id: Microsoft.dotnet
-Version: 5.1.220.61417
+Version: 5.0.102
 Name: .NET SDK
 Publisher: Microsoft
 License: MIT


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate <manifest>`, where `<manifest>` is the name of the manifest you're submitting?
- [x] Have you tested your manifest locally with `winget install -m <manifest>`?

-----

This PR aims to align the manifest for .NET SDK 5.0.102.
As of now, the order of SDK versions is incorrect, as can be seen on the below image.

![image](https://user-images.githubusercontent.com/36488481/107887143-3da97480-6f04-11eb-940a-5b94e1a67850.png)

When running `winget install Microsoft.dotnet`  winget will install .NET SDK 5.0.102 instead of 5.0.103 due to the sort order.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/7456)