### PR TITLE
Fixed incorrect version number for SQL Server Management Studio version 14.0.17289.0.

### DIFF
--- a/manifests/Microsoft/SQLServerManagementStudio/14.0.17289.0.yaml
+++ b/manifests/Microsoft/SQLServerManagementStudio/14.0.17289.0.yaml
@@ -1,5 +1,5 @@
 Id: Microsoft.SQLServerManagementStudio
-Version: 17.9.1
+Version: 14.0.17289.0
 Name: SQL Server Management Studio
 Publisher: Microsoft
 License: Copyright (c) Microsoft Corporation


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with winget validate <manifest>, where <manifest> is the name of the manifest you're submitting?
- [x] Have you tested your manifest locally with winget install -m <manifest>?

----

Per microsoft/winget-cli#828, not using the build number for the version number causes winget to believe there's an update when there isn't one.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/9364)