### PR TITLE
Fixed Join-Path in YamlCreate.ps1.

### DIFF
--- a/Tools/YamlCreate.ps1
+++ b/Tools/YamlCreate.ps1
@@ -80,7 +80,8 @@ if (Test-Path -Path "$PSScriptRoot\..\manifests") {
     $ManifestsFolder = (Resolve-Path ".\").Path
 }
 
-$AppFolder = Join-Path $ManifestsFolder $PackageIdentifier.ToLower().Chars(0) $PackageIdentifierFolder $PackageVersion
+# Rewritten to ensure compatibility with Windows PowerShell 5.0: https://stackoverflow.com/a/28421970
+$AppFolder = Join-Path $ManifestsFolder -ChildPath $PackageIdentifier.ToLower().Chars(0) | Join-Path -ChildPath $PackageIdentifierFolder | Join-Path -ChildPath $PackageVersion
 
 $VersionManifest = $AppFolder + "\$PackageIdentifier" + '.yaml'
 $InstallerManifest = $AppFolder + "\$PackageIdentifier" + '.installer' + '.yaml'


### PR DESCRIPTION
The Join-Path command used to create the full path to the manifest folder in YamlCreate.ps1 was not compatible with versions of PowerShell below 6.0. Since Windows (at least for now, hopefully not forever) only ships with PowerShell 5.0, I fixed it so it will be compatible with both versions. 

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/10291)