### PR TITLE
Manifest update for henry++.simplewall v3.2.4

### DIFF
--- a/manifests/h/Henry++/simplewall/3.2.4/Henry++.simplewall.installer.yaml
+++ b/manifests/h/Henry++/simplewall/3.2.4/Henry++.simplewall.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
+PackageIdentifier: Henry++.simplewall
+PackageVersion: 3.2.4
+MinimumOSVersion: 10.0.0.0
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+Installers:
+  - Architecture: x64
+    InstallerType: exe
+    InstallerUrl: https://github.com/henrypp/simplewall/releases/download/v.3.2.4/simplewall-3.2.4-setup.exe
+    InstallerSha256: 801382078E6F6309335335B875A6B476AD9A30AA29B937FD78C2047406B390AD
+    InstallerSwitches:
+      Silent: /S
+      SilentWithProgress: /S
+#    ProductCode: 
+    Scope: machine
+    InstallerLocale: en-US
+    UpgradeBehavior: install
+ManifestType: installer
+ManifestVersion: 1.0.0

--- a/manifests/h/Henry++/simplewall/3.2.4/Henry++.simplewall.installer.yaml
+++ b/manifests/h/Henry++/simplewall/3.2.4/Henry++.simplewall.installer.yaml
@@ -8,12 +8,9 @@ InstallModes:
   - silentWithProgress
 Installers:
   - Architecture: x64
-    InstallerType: exe
+    InstallerType: nullsoft
     InstallerUrl: https://github.com/henrypp/simplewall/releases/download/v.3.2.4/simplewall-3.2.4-setup.exe
     InstallerSha256: 801382078E6F6309335335B875A6B476AD9A30AA29B937FD78C2047406B390AD
-    InstallerSwitches:
-      Silent: /S
-      SilentWithProgress: /S
 #    ProductCode: 
     Scope: machine
     InstallerLocale: en-US

--- a/manifests/h/Henry++/simplewall/3.2.4/Henry++.simplewall.locale.en-US.yaml
+++ b/manifests/h/Henry++/simplewall/3.2.4/Henry++.simplewall.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultlocale.1.0.0.schema.json
+PackageIdentifier: Henry++.simplewall
+PackageVersion: 3.2.4
+PackageLocale: en-US
+Publisher: Henry++
+PublisherUrl: https://www.henrypp.org
+PublisherSupportUrl: https://github.com/henrypp/simplewall/issues
+#PrivacyUrl: 
+Author: Henry++
+PackageName: simplewall
+PackageUrl: https://www.henrypp.org/product/simplewall
+License: GNU General Public License v3.0
+LicenseUrl: https://github.com/henrypp/simplewall/blob/master/LICENSE
+#Copyright: 
+#CopyrightUrl: 
+ShortDescription: Simple tool to configure Windows Filtering Platform (WFP) which can configure network activity on your computer.
+Description: Simple tool to configure Windows Filtering Platform (WFP) which can configure network activity on your computer. The lightweight application is less than a megabyte, and it is compatible with Windows Vista and higher operating systems. You can download either the installer or portable version. For correct working, need administrator rights.
+Moniker: simplewall
+Tags:
+  - firewall
+  - foss
+  - open source
+  - administration
+  - network
+  - internet
+  - network monitor
+ManifestType: defaultLocale
+ManifestVersion: 1.0.0

--- a/manifests/h/Henry++/simplewall/3.2.4/Henry++.simplewall.locale.en-US.yaml
+++ b/manifests/h/Henry++/simplewall/3.2.4/Henry++.simplewall.locale.en-US.yaml
@@ -14,7 +14,7 @@ LicenseUrl: https://github.com/henrypp/simplewall/blob/master/LICENSE
 #Copyright: 
 #CopyrightUrl: 
 ShortDescription: Simple tool to configure Windows Filtering Platform (WFP) which can configure network activity on your computer.
-Description: Simple tool to configure Windows Filtering Platform (WFP) which can configure network activity on your computer. The lightweight application is less than a megabyte, and it is compatible with Windows Vista and higher operating systems. You can download either the installer or portable version. For correct working, need administrator rights.
+#Description: 
 Moniker: simplewall
 Tags:
   - firewall

--- a/manifests/h/Henry++/simplewall/3.2.4/Henry++.simplewall.yaml
+++ b/manifests/h/Henry++/simplewall/3.2.4/Henry++.simplewall.yaml
@@ -1,25 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.0.0.schema.json
 PackageIdentifier: Henry++.simplewall
-Publisher: Henry++
-PackageName: simplewall
 PackageVersion: 3.2.4
-Moniker: simplewall
-ShortDescription: Simple tool to configure Windows Filtering Platform (WFP) which can configure network activity on your computer.
-PackageUrl: https://www.henrypp.org/product/simplewall
-Tags:
-- administration
-- firewall
-- network
-- internet
-License: GNU General Public License v3.0
-LicenseUrl: https://github.com/henrypp/simplewall/blob/master/LICENSE
-InstallerSwitches:
-  Silent: /S
-  SilentWithProgress: /S
-InstallerType: exe
-Installers:
-- Architecture: x64
-  InstallerUrl: https://github.com/henrypp/simplewall/releases/download/v.3.2.4/simplewall-3.2.4-setup.exe
-  InstallerSha256: 801382078e6f6309335335b875a6b476ad9a30aa29b937fd78c2047406b390ad
-PackageLocale: en-US
-ManifestType: singleton
+DefaultLocale: en-US
+ManifestType: version
 ManifestVersion: 1.0.0


### PR DESCRIPTION
There is some kind of blocking issue with this manifest, if you run the exe it installs as normal into Windows, if you install it via WinGet its not getting registered in Programs and Features but the files are put into C:\Program Files\simplewall like normal...

- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [X] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/11654)