### PR TITLE
YamlCreate small tweaks

### DIFF
--- a/Tools/YamlCreate.ps1
+++ b/Tools/YamlCreate.ps1
@@ -200,9 +200,9 @@ Function Read-WinGet-InstallerValues {
         $architecture = Read-Host -Prompt 'Architecture' | TrimString
     }
 
-    while ($InstallerType -notin @('exe', 'msi', 'msix', 'inno', 'nullsoft', 'appx', 'wix', 'zip')) {
+    while ($InstallerType -notin @('exe', 'msi', 'msix', 'inno', 'nullsoft', 'appx', 'wix', 'zip', 'burn', 'pwa')) {
         Write-Host
-        Write-Host -ForegroundColor 'Green' -Object '[Required] Enter the InstallerType. For example: exe, msi, msix, inno, nullsoft'
+        Write-Host -ForegroundColor 'Green' -Object '[Required] Enter the InstallerType. For example: exe, msi, msix, inno, nullsoft, appx, wix, burn, pwa, zip'
         $InstallerType = Read-Host -Prompt 'InstallerType' | TrimString
     }
 

--- a/Tools/YamlCreate.ps1
+++ b/Tools/YamlCreate.ps1
@@ -94,27 +94,32 @@ Function Read-PreviousWinGet-Manifest {
                     $regex = '(?ms)Tags:(.+?):'
                     $FetchTags = [regex]::Matches($OldManifestText,$regex) | foreach {$_.groups[1].value }
                     $Tags = $FetchTags.Substring(0, $FetchTags.LastIndexOf(' '))
-                    New-Variable -Name "Tags" -Value ($Tags.Split("- ").Trim()[1..17] -join ", ") -Scope Script -Force
+                    $Tags = $Tags -Split '- '
+                    New-Variable -Name "Tags" -Value ($Tags.Trim()[1..17] -join ", ") -Scope Script -Force
                 } elseif ($Line -eq "FileExtensions:") {
                     $regex = '(?ms)FileExtensions:(.+?):'
                     $FetchFileExtensions = [regex]::Matches($OldManifestText,$regex) | foreach {$_.groups[1].value }
                     $FileExtensions = $FetchFileExtensions.Substring(0, $FetchFileExtensions.LastIndexOf(' '))
-                    New-Variable -Name "FileExtensions" -Value ($FileExtensions.Split("- ").Trim()[1..257] -join ", ") -Scope Script -Force
+                    $FileExtensions = $FileExtensions -Split '- '
+                    New-Variable -Name "FileExtensions" -Value ($FileExtensions.Trim()[1..257] -join ", ") -Scope Script -Force
                 } elseif ($Line -eq "Protocols:") {
                     $regex = '(?ms)Protocols:(.+?):'
                     $FetchProtocols = [regex]::Matches($OldManifestText,$regex) | foreach {$_.groups[1].value }
                     $Protocols = $FetchProtocols.Substring(0, $FetchProtocols.LastIndexOf(' '))
-                    New-Variable -Name "Protocols" -Value ($Protocols.Split("- ").Trim()[1..17] -join ", ") -Scope Script -Force
+                    $Protocols = $Protocols -Split '- '
+                    New-Variable -Name "Protocols" -Value ($Protocols.Trim()[1..17] -join ", ") -Scope Script -Force
                 } elseif ($Line -eq "Commands:") {
                     $regex = '(?ms)Commands:(.+?):'
                     $FetchCommands = [regex]::Matches($OldManifestText,$regex) | foreach {$_.groups[1].value }
                     $Commands = $FetchCommands.Substring(0, $FetchCommands.LastIndexOf(' '))
-                    New-Variable -Name "Commands" -Value ($Commands.Split("- ").Trim()[1..17] -join ", ") -Scope Script -Force
+                    $Commands = $Commands -Split '- '
+                    New-Variable -Name "Commands" -Value ($Commands.Trim()[1..17] -join ", ") -Scope Script -Force
                 } elseif ($Line -eq "InstallerSuccessCodes:") {
                     $regex = '(?ms)InstallerSuccessCodes:(.+?):'
                     $FetchInstallerSuccessCodes = [regex]::Matches($OldManifestText,$regex) | foreach {$_.groups[1].value }
                     $InstallerSuccessCodes = $FetchInstallerSuccessCodes.Substring(0, $FetchInstallerSuccessCodes.LastIndexOf(' '))
-                    New-Variable -Name "InstallerSuccessCodes" -Value ($InstallerSuccessCodes.Split("- ").Trim()[1..17] -join ", ") -Scope Script -Force
+                    $InstallerSuccessCodes = $InstallerSuccessCodes -Split '- '
+                    New-Variable -Name "InstallerSuccessCodes" -Value ($InstallerSuccessCodes.Trim()[1..17] -join ", ") -Scope Script -Force
                 } elseif ($Line -notlike "PackageVersion*" -and $Line -notlike "PackageIdentifier*") {
                     $Variable = $Line.Replace("#","").Split(":").Trim()
                     New-Variable -Name $Variable[0] -Value ($Variable[1..10] -join ":") -Scope Script -Force

--- a/Tools/YamlCreate.ps1
+++ b/Tools/YamlCreate.ps1
@@ -783,6 +783,7 @@ Switch ($Option) {
         Write-WinGet-InstallerManifest
         Write-WinGet-VersionManifest
         Write-WinGet-LocaleManifest
+        if (Get-Command "winget.exe" -ErrorAction SilentlyContinue) {winget validate $AppFolder}
     }
 
     'Update' {
@@ -795,6 +796,7 @@ Switch ($Option) {
         Write-WinGet-InstallerManifest
         Write-WinGet-VersionManifest
         Write-WinGet-LocaleManifest
+        if (Get-Command "winget.exe" -ErrorAction SilentlyContinue) {winget validate $AppFolder}
     }
 
     'NewLocale' {
@@ -802,5 +804,6 @@ Switch ($Option) {
         Read-PreviousWinGet-Manifest
         Read-WinGet-LocaleManifest
         Write-WinGet-LocaleManifest
+        if (Get-Command "winget.exe" -ErrorAction SilentlyContinue) {winget validate $AppFolder}
     }
 }

--- a/Tools/YamlCreate.ps1
+++ b/Tools/YamlCreate.ps1
@@ -149,7 +149,7 @@ Function Read-PreviousWinGet-Manifest {
                     $FetchTags = [regex]::Matches($OldManifestText,$regex) | foreach {$_.groups[1].value }
                     $Tags = $FetchTags.Substring(0, $FetchTags.LastIndexOf(' '))
                     $Tags = $Tags -Split '- '
-                    New-Variable -Name "Tags" -Value ($Tags.Trim()[1..100] -join ", ") -Scope Script -Force
+                    New-Variable -Name "Tags" -Value ($Tags.Trim()[1..17] -join ", ") -Scope Script -Force
                 } elseif ($Line -notlike "PackageLocale*") {
                     $Variable = $Line.Replace("#","").Split(":").Trim()
                     New-Variable -Name $Variable[0] -Value ($Variable[1..10] -join ":") -Scope Script -Force

--- a/Tools/YamlCreate.ps1
+++ b/Tools/YamlCreate.ps1
@@ -148,7 +148,8 @@ Function Read-PreviousWinGet-Manifest {
                     $regex = '(?ms)Tags:(.+?):'
                     $FetchTags = [regex]::Matches($OldManifestText,$regex) | foreach {$_.groups[1].value }
                     $Tags = $FetchTags.Substring(0, $FetchTags.LastIndexOf(' '))
-                    New-Variable -Name "Tags" -Value ($Tags.Split("- ").Trim()[1..100] -join ", ") -Scope Script -Force
+                    $Tags = $Tags -Split '- '
+                    New-Variable -Name "Tags" -Value ($Tags.Trim()[1..100] -join ", ") -Scope Script -Force
                 } elseif ($Line -notlike "PackageLocale*") {
                     $Variable = $Line.Replace("#","").Split(":").Trim()
                     New-Variable -Name $Variable[0] -Value ($Variable[1..10] -join ":") -Scope Script -Force

--- a/Tools/YamlCreate.ps1
+++ b/Tools/YamlCreate.ps1
@@ -115,7 +115,7 @@ Function Read-PreviousWinGet-Manifest {
                     $FetchInstallerSuccessCodes = [regex]::Matches($OldManifestText,$regex) | foreach {$_.groups[1].value }
                     $InstallerSuccessCodes = $FetchInstallerSuccessCodes.Substring(0, $FetchInstallerSuccessCodes.LastIndexOf(' '))
                     New-Variable -Name "InstallerSuccessCodes" -Value ($InstallerSuccessCodes.Split("- ").Trim()[1..17] -join ", ") -Scope Script -Force
-                } elseif ($Line -notlike "PackageVersion*") {
+                } elseif ($Line -notlike "PackageVersion*" -and $Line -notlike "PackageIdentifier*") {
                     $Variable = $Line.Replace("#","").Split(":").Trim()
                     New-Variable -Name $Variable[0] -Value ($Variable[1..10] -join ":") -Scope Script -Force
                 }

--- a/Tools/YamlCreate.ps1
+++ b/Tools/YamlCreate.ps1
@@ -94,27 +94,27 @@ Function Read-PreviousWinGet-Manifest {
                     $regex = '(?ms)Tags:(.+?):'
                     $FetchTags = [regex]::Matches($OldManifestText,$regex) | foreach {$_.groups[1].value }
                     $Tags = $FetchTags.Substring(0, $FetchTags.LastIndexOf(' '))
-                    New-Variable -Name "Tags" -Value ($Tags.Split("- ").Trim()[1..100] -join ", ") -Scope Script -Force
+                    New-Variable -Name "Tags" -Value ($Tags.Split("- ").Trim()[1..17] -join ", ") -Scope Script -Force
                 } elseif ($Line -eq "FileExtensions:") {
                     $regex = '(?ms)FileExtensions:(.+?):'
                     $FetchFileExtensions = [regex]::Matches($OldManifestText,$regex) | foreach {$_.groups[1].value }
                     $FileExtensions = $FetchFileExtensions.Substring(0, $FetchFileExtensions.LastIndexOf(' '))
-                    New-Variable -Name "FileExtensions" -Value ($FileExtensions.Split("- ").Trim()[1..100] -join ", ") -Scope Script -Force
+                    New-Variable -Name "FileExtensions" -Value ($FileExtensions.Split("- ").Trim()[1..257] -join ", ") -Scope Script -Force
                 } elseif ($Line -eq "Protocols:") {
                     $regex = '(?ms)Protocols:(.+?):'
                     $FetchProtocols = [regex]::Matches($OldManifestText,$regex) | foreach {$_.groups[1].value }
                     $Protocols = $FetchProtocols.Substring(0, $FetchProtocols.LastIndexOf(' '))
-                    New-Variable -Name "Protocols" -Value ($Protocols.Split("- ").Trim()[1..100] -join ", ") -Scope Script -Force
+                    New-Variable -Name "Protocols" -Value ($Protocols.Split("- ").Trim()[1..17] -join ", ") -Scope Script -Force
                 } elseif ($Line -eq "Commands:") {
                     $regex = '(?ms)Commands:(.+?):'
                     $FetchCommands = [regex]::Matches($OldManifestText,$regex) | foreach {$_.groups[1].value }
                     $Commands = $FetchCommands.Substring(0, $FetchCommands.LastIndexOf(' '))
-                    New-Variable -Name "Commands" -Value ($Commands.Split("- ").Trim()[1..100] -join ", ") -Scope Script -Force
+                    New-Variable -Name "Commands" -Value ($Commands.Split("- ").Trim()[1..17] -join ", ") -Scope Script -Force
                 } elseif ($Line -eq "InstallerSuccessCodes:") {
                     $regex = '(?ms)InstallerSuccessCodes:(.+?):'
                     $FetchInstallerSuccessCodes = [regex]::Matches($OldManifestText,$regex) | foreach {$_.groups[1].value }
                     $InstallerSuccessCodes = $FetchInstallerSuccessCodes.Substring(0, $FetchInstallerSuccessCodes.LastIndexOf(' '))
-                    New-Variable -Name "InstallerSuccessCodes" -Value ($InstallerSuccessCodes.Split("- ").Trim()[1..100] -join ", ") -Scope Script -Force
+                    New-Variable -Name "InstallerSuccessCodes" -Value ($InstallerSuccessCodes.Split("- ").Trim()[1..17] -join ", ") -Scope Script -Force
                 } elseif ($Line -notlike "PackageVersion*") {
                     $Variable = $Line.Replace("#","").Split(":").Trim()
                     New-Variable -Name $Variable[0] -Value ($Variable[1..10] -join ":") -Scope Script -Force

--- a/Tools/YamlCreate.ps1
+++ b/Tools/YamlCreate.ps1
@@ -685,7 +685,7 @@ $VersionManifest | ForEach-Object {
     } else {
         $_
     }
-} | Out-File -Path $VersionManifestPath -Encoding 'UTF8'
+} | Out-File $VersionManifestPath -Encoding 'UTF8'
 
 Write-Host 
 Write-Host "Yaml file created: $VersionManifestPath"
@@ -725,7 +725,7 @@ $InstallerManifest | ForEach-Object {
     } else {
         $_
     }
-} | Out-File -Path $InstallerManifestPath -Encoding 'UTF8'
+} | Out-File $InstallerManifestPath -Encoding 'UTF8'
 
 Write-Host 
 Write-Host "Yaml file created: $InstallerManifestPath"
@@ -767,7 +767,7 @@ $LocaleManifest | ForEach-Object {
     } else {
         $_
     }
-} | Out-File -Path $LocaleManifestPath -Encoding 'UTF8'
+} | Out-File $LocaleManifestPath -Encoding 'UTF8'
 
 Write-Host 
 Write-Host "Yaml file created: $LocaleManifestPath"

--- a/Tools/YamlCreate.ps1
+++ b/Tools/YamlCreate.ps1
@@ -94,27 +94,27 @@ Function Read-PreviousWinGet-Manifest {
                     $regex = '(?ms)Tags:(.+?):'
                     $FetchTags = [regex]::Matches($OldManifestText,$regex) | foreach {$_.groups[1].value }
                     $Tags = $FetchTags.Substring(0, $FetchTags.LastIndexOf(' '))
-                    New-Variable -Name "Tags" -Value ($Tags.Split("-").Trim()[1..100] -join ", ") -Scope Script -Force
+                    New-Variable -Name "Tags" -Value ($Tags.Split("- ").Trim()[1..100] -join ", ") -Scope Script -Force
                 } elseif ($Line -eq "FileExtensions:") {
                     $regex = '(?ms)FileExtensions:(.+?):'
                     $FetchFileExtensions = [regex]::Matches($OldManifestText,$regex) | foreach {$_.groups[1].value }
                     $FileExtensions = $FetchFileExtensions.Substring(0, $FetchFileExtensions.LastIndexOf(' '))
-                    New-Variable -Name "FileExtensions" -Value ($FileExtensions.Split("-").Trim()[1..100] -join ", ") -Scope Script -Force
+                    New-Variable -Name "FileExtensions" -Value ($FileExtensions.Split("- ").Trim()[1..100] -join ", ") -Scope Script -Force
                 } elseif ($Line -eq "Protocols:") {
                     $regex = '(?ms)Protocols:(.+?):'
                     $FetchProtocols = [regex]::Matches($OldManifestText,$regex) | foreach {$_.groups[1].value }
                     $Protocols = $FetchProtocols.Substring(0, $FetchProtocols.LastIndexOf(' '))
-                    New-Variable -Name "Protocols" -Value ($Protocols.Split("-").Trim()[1..100] -join ", ") -Scope Script -Force
+                    New-Variable -Name "Protocols" -Value ($Protocols.Split("- ").Trim()[1..100] -join ", ") -Scope Script -Force
                 } elseif ($Line -eq "Commands:") {
                     $regex = '(?ms)Commands:(.+?):'
                     $FetchCommands = [regex]::Matches($OldManifestText,$regex) | foreach {$_.groups[1].value }
                     $Commands = $FetchCommands.Substring(0, $FetchCommands.LastIndexOf(' '))
-                    New-Variable -Name "Commands" -Value ($Commands.Split("-").Trim()[1..100] -join ", ") -Scope Script -Force
+                    New-Variable -Name "Commands" -Value ($Commands.Split("- ").Trim()[1..100] -join ", ") -Scope Script -Force
                 } elseif ($Line -eq "InstallerSuccessCodes:") {
                     $regex = '(?ms)InstallerSuccessCodes:(.+?):'
                     $FetchInstallerSuccessCodes = [regex]::Matches($OldManifestText,$regex) | foreach {$_.groups[1].value }
                     $InstallerSuccessCodes = $FetchInstallerSuccessCodes.Substring(0, $FetchInstallerSuccessCodes.LastIndexOf(' '))
-                    New-Variable -Name "InstallerSuccessCodes" -Value ($InstallerSuccessCodes.Split("-").Trim()[1..100] -join ", ") -Scope Script -Force
+                    New-Variable -Name "InstallerSuccessCodes" -Value ($InstallerSuccessCodes.Split("- ").Trim()[1..100] -join ", ") -Scope Script -Force
                 } elseif ($Line -notlike "PackageVersion*") {
                     $Variable = $Line.Replace("#","").Split(":").Trim()
                     New-Variable -Name $Variable[0] -Value ($Variable[1..10] -join ":") -Scope Script -Force
@@ -143,7 +143,7 @@ Function Read-PreviousWinGet-Manifest {
                     $regex = '(?ms)Tags:(.+?):'
                     $FetchTags = [regex]::Matches($OldManifestText,$regex) | foreach {$_.groups[1].value }
                     $Tags = $FetchTags.Substring(0, $FetchTags.LastIndexOf(' '))
-                    New-Variable -Name "Tags" -Value ($Tags.Split("-").Trim()[1..100] -join ", ") -Scope Script -Force
+                    New-Variable -Name "Tags" -Value ($Tags.Split("- ").Trim()[1..100] -join ", ") -Scope Script -Force
                 } elseif ($Line -notlike "PackageLocale*") {
                     $Variable = $Line.Replace("#","").Split(":").Trim()
                     New-Variable -Name $Variable[0] -Value ($Variable[1..10] -join ":") -Scope Script -Force

--- a/Tools/YamlCreate.ps1
+++ b/Tools/YamlCreate.ps1
@@ -27,6 +27,8 @@ filter TrimString {
     $_.Trim()
 }
 
+$ToNatural = { [regex]::Replace($_, '\d+', { $args[0].Value.PadLeft(20) }) }
+
 Function Show-OptionMenu {
     while ([string]::IsNullOrWhiteSpace($OptionMenu)) {
         Clear-Host
@@ -75,7 +77,7 @@ Function Read-WinGet-MandatoryInfo {
 Function Read-PreviousWinGet-Manifest {
     Switch ($Option) {
         'Update' {
-            $script:LastVersion = Get-ChildItem -Path "$AppFolder\..\" | Sort-Object | Select-Object -Last 1 -ExpandProperty 'Name'
+            $script:LastVersion = Get-ChildItem -Path "$AppFolder\..\" | Sort-Object $ToNatural | Select-Object -Last 1 -ExpandProperty 'Name'
             Write-Host -ForegroundColor 'DarkYellow' -Object "Last Version: $LastVersion"
             $script:OldManifests = Get-ChildItem -Path "$AppFolder\..\$LastVersion"
 


### PR DESCRIPTION
+ WinGet validate will run after the manifest have been created, updated and new locale is created
+ Added Natural sorting so it actually picks the last version
+ Tags can now be Cross-Platform instead of having to be Cross Platform

- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/11753)