### PR TITLE
Added Notepads.Notepads v1.4.5.0

### DIFF
--- a/manifests/n/Notepads/Notepads/1.4.5.0/Notepads.Notepads.installer.yaml
+++ b/manifests/n/Notepads/Notepads/1.4.5.0/Notepads.Notepads.installer.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
+PackageIdentifier: Notepads.Notepads
+PackageVersion: 1.4.5.0
+MinimumOSVersion: 10.0.0.0
+FileExtensions:
+  - txt
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Microsoft.dotNetFramework
+      MinimumVersion: 2.2.29512.0
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+Installers:
+  - Architecture: neutral
+    InstallerType: msix
+    InstallerUrl: https://github.com/JasonStein/Notepads/releases/download/v1.4.5.0/Notepads_1.4.5.0_x86_x64_arm64.msixbundle
+    InstallerSha256: 047E9D12167E2EEA7E899416661914252785BEFD75D7F2CCDDCAEACFBD148ED3
+#    ProductCode: 
+    Scope: user
+    InstallerLocale: en-US
+    UpgradeBehavior: install
+ManifestType: installer
+ManifestVersion: 1.0.0

--- a/manifests/n/Notepads/Notepads/1.4.5.0/Notepads.Notepads.locale.en-US.yaml
+++ b/manifests/n/Notepads/Notepads/1.4.5.0/Notepads.Notepads.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultlocale.1.0.0.schema.json
+PackageIdentifier: Notepads.Notepads
+PackageVersion: 1.4.5.0
+PackageLocale: en-US
+Publisher: Notepads
+PublisherUrl: https://github.com/JasonStein/Notepads/
+PublisherSupportUrl: https://github.com/JasonStein/Notepads/issues
+#PrivacyUrl: 
+Author: Jason Stein
+PackageName: Notepads
+PackageUrl: https://www.notepadsapp.com
+License: MIT License
+LicenseUrl: https://github.com/JasonStein/Notepads/blob/master/LICENSE.md
+#Copyright: 
+#CopyrightUrl: 
+ShortDescription: A modern, lightweight text editor with a minimalist design.
+#Description: 
+Moniker: notepads
+Tags:
+  - notepad
+  - texteditor
+  - fluent design
+  - text editor
+  - foss
+  - open source
+  - uwp
+  - markdown
+ManifestType: defaultLocale
+ManifestVersion: 1.0.0

--- a/manifests/n/Notepads/Notepads/1.4.5.0/Notepads.Notepads.yaml
+++ b/manifests/n/Notepads/Notepads/1.4.5.0/Notepads.Notepads.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.0.0.schema.json
+PackageIdentifier: Notepads.Notepads
+PackageVersion: 1.4.5.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.0.0


### PR DESCRIPTION
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [X] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Hmm i'm not sure if this is a Windows Sandbox issue or i don't understand the dependency
```
Found Notepads [Notepads.Notepads]
This application is licensed to you by its owner.
Microsoft is not responsible for, nor does it grant any licenses to, third-party packages.
Downloading https://github.com/JasonStein/Notepads/releases/download/v1.4.5.0/Notepads_1.4.5.0_x86_x64_arm64.msixbundle
  ██████████████████████████████  30.8 MB / 30.8 MB
Successfully verified installer hash
Starting package install...
  ██████████████████████████████  0%
Install failed: Windows cannot install package 19282JackieLiu.Notepads-Beta_1.4.5.0_x64__echhpq9pdbte8 because this package depends on a framework that could not be found. Provide the framework "Microsoft.NET.Native.Framework.2.2" published by "CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US", with neutral or x64 processor architecture and minimum version 2.2.29512.0, along with this package to install. The frameworks with name "Microsoft.NET.Native.Framework.2.2" currently installed are: {Microsoft.NET.Native.Framework.2.2_2.2.27405.0_x64__8wekyb3d8bbwe}
0x80073cf3 : Package failed updates, dependency or conflict validation.
```

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/12156)