### PR TITLE
Add WireGuard 0.3.14

### DIFF
--- a/manifests/w/WireGuard/WireGuard/0.3.14/WireGuard.WireGuard.installer.yaml
+++ b/manifests/w/WireGuard/WireGuard/0.3.14/WireGuard.WireGuard.installer.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
+PackageIdentifier: WireGuard.WireGuard
+PackageVersion: 0.3.14
+MinimumOSVersion: 10.0.0.0
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+Installers:
+  - Architecture: x64
+    InstallerType: msi
+    InstallerUrl: https://download.wireguard.com/windows-client/wireguard-amd64-0.3.14.msi
+    InstallerSha256: 07473b4a6c62c1a661e85eae221d3b9de36df829645a210998216ca2c467c2fa
+    Scope: machine
+    InstallerLocale: en-US
+    UpgradeBehavior: install
+  - Architecture: arm64
+    InstallerType: msi
+    InstallerUrl: https://download.wireguard.com/windows-client/wireguard-arm64-0.3.14.msi
+    InstallerSha256: 5ba0ce5530bea43a450883c931fe4e4f46ff791d9e9ad76d73ee49ab192b99dd
+    Scope: machine
+    InstallerLocale: en-US
+    UpgradeBehavior: install
+  - Architecture: x86
+    InstallerType: msi
+    InstallerUrl: https://download.wireguard.com/windows-client/wireguard-x86-0.3.14.msi
+    InstallerSha256: 82981689570b14e605af91f45c6c3b613db59b40cfc355d5d1fc01688c4e3f4c
+    Scope: machine
+    InstallerLocale: en-US
+    UpgradeBehavior: install
+ManifestType: installer
+ManifestVersion: 1.0.0

--- a/manifests/w/WireGuard/WireGuard/0.3.14/WireGuard.WireGuard.locale.en-US.yaml
+++ b/manifests/w/WireGuard/WireGuard/0.3.14/WireGuard.WireGuard.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultlocale.1.0.0.schema.json
+PackageIdentifier: WireGuard.WireGuard
+PackageVersion: 0.3.14
+PackageLocale: en-US
+Publisher: WireGuard LLC
+PublisherUrl: https://www.wireguard.com
+#PublisherSupportUrl: 
+#PrivacyUrl: 
+Author: WireGuard LLC
+PackageName: WireGuard
+PackageUrl: https://www.wireguard.com
+License: GPLv2
+LicenseUrl: 'https://www.wireguard.com/#license'
+Copyright: Copyright © 2015-2021 Jason A. Donenfeld. All Rights Reserved.
+#CopyrightUrl: 
+ShortDescription: WireGuard® is an extremely simple yet fast and modern VPN that utilizes state-of-the-art cryptography.
+Description: WireGuard® is an extremely simple yet fast and modern VPN that utilizes state-of-the-art cryptography. It aims to be faster, simpler, leaner, and more useful than IPsec, while avoiding the massive headache. It intends to be considerably more performant than OpenVPN. WireGuard is designed as a general purpose VPN for running on embedded interfaces and super computers alike, fit for many different circumstances. Initially released for the Linux kernel, it is now cross-platform (Windows, macOS, BSD, iOS, Android) and widely deployable. It is currently under heavy development, but already it might be regarded as the most secure, easiest to use, and simplest VPN solution in the industry.
+Moniker: wireguard
+Tags:
+  - vpn
+  - secure
+  - tunnel
+ManifestType: defaultLocale
+ManifestVersion: 1.0.0

--- a/manifests/w/WireGuard/WireGuard/0.3.14/WireGuard.WireGuard.yaml
+++ b/manifests/w/WireGuard/WireGuard/0.3.14/WireGuard.WireGuard.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.0.0.schema.json
+PackageIdentifier: WireGuard.WireGuard
+PackageVersion: 0.3.14
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.0.0


### PR DESCRIPTION
Remove `ProductCode` fields from this version since I was unable to
retrieve those from the MSI packages.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

I've removed `ProductCode` usage on this manifest since was unable to use [previous shared instructions](https://github.com/microsoft/winget-pkgs/pull/10719#issuecomment-830849484) to retrieve the correct values 😞 

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/12457)