### PR TITLE
SumatraPDF has moved binaries to new host

### DIFF
--- a/manifests/s/SumatraPDF/SumatraPDF/3.2/SumatraPDF.SumatraPDF.yaml
+++ b/manifests/s/SumatraPDF/SumatraPDF/3.2/SumatraPDF.SumatraPDF.yaml
@@ -21,7 +21,7 @@ Commands:
 - sumatrapdf
 Installers:
 - Architecture: x64
-  InstallerUrl: https://www.sumatrapdfreader.org/dl2/SumatraPDF-3.2-64-install.exe
+  InstallerUrl: https://kjkpubsf.sfo2.digitaloceanspaces.com/software/sumatrapdf/rel/SumatraPDF-3.2-64-install.exe
   InstallerSha256: 36D95DADF36CEAE35F49BA0DFF47FF628E3433B1150FB5A845F646BE67F90198
   InstallerType: exe
   InstallerSwitches:


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

If you try to `winget install sumatrapdf` right now, you get an error saying the cache doesn't match SHA256 hash.

If you go to the [InstallerUrl](https://github.com/cinderblock/winget-pkgs/blob/master/manifests/s/SumatraPDF/SumatraPDF/3.2/SumatraPDF.SumatraPDF.yaml#L24) in the current manifest, it redirects to `https://www.sumatrapdfreader.org/free-pdf-reader`.

Going to the SumatraPDF download page, there is a new URL to download the binary from. It looks like SumatraPDF has moved their binaries to be distributed from DigitalOcean spaces.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/12525)