### PR TITLE
Fixed typo for Octopus Deploy Server version 2020.6.4809.

### DIFF
--- a/manifests/o/OctopusDeploy/Server/2020.6.4809/OctopusDeploy.Server.yaml
+++ b/manifests/o/OctopusDeploy/Server/2020.6.4809/OctopusDeploy.Server.yaml
@@ -3,7 +3,7 @@ PackageIdentifier: OctopusDeploy.Server
 PackageVersion: 2020.6.4809
 PackageName: Octopus Deploy Server
 Publisher: Octopus Deploy
-License: Copyright Â© 2021 Octopus Deploy
+License: Copyright © 2021 Octopus Deploy
 LicenseUrl: https://octopus.com/legal/customer-agreement
 Moniker: octopus-server
 Tags:


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

------


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/13339)