### PR TITLE
Update Amazon Corretto 8

### DIFF
--- a/manifests/a/Amazon/Corretto/8/8.292.10.1/Amazon.Corretto.8.yaml
+++ b/manifests/a/Amazon/Corretto/8/8.292.10.1/Amazon.Corretto.8.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.singleton.1.0.0.schema.json
+PackageIdentifier: Amazon.Corretto.8
+PackageVersion: 8.292.10.1
+PackageName: Corretto 8.292.10.1 (x64)
+Publisher: Amazon
+PackageUrl: https://docs.aws.amazon.com/corretto/index.html
+License: GPL 2 with Classpath Exception
+LicenseUrl: https://github.com/corretto/corretto-8/blob/develop/LICENSE
+ShortDescription: No-cost, multiplatform, production-ready distribution of the Open Java Development Kit (OpenJDK).
+Installers:
+- Architecture: x64
+  InstallerUrl: https://corretto.aws/downloads/resources/8.292.10.1/amazon-corretto-8.292.10.1-windows-x64.msi
+  InstallerType: msi
+  InstallerSha256: 2da0162344c59856f57f2bdc14e4828fb46a95a6647d126db0b165fcf7472eec
+  InstallerSwitches:
+    Silent: /quiet
+    SilentWithProgress: /passive
+PackageLocale: en-US
+ManifestType: singleton
+ManifestVersion: 1.0.0


### PR DESCRIPTION
Update Amazon Corretto 8 to latest version released on 20 Apr 2021

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/13570)