### PR TITLE
Prevent auto restart after LibreOffice 7.0 install

### DIFF
--- a/manifests/l/LibreOffice/LibreOffice/7.0.5/LibreOffice.LibreOffice.yaml
+++ b/manifests/l/LibreOffice/LibreOffice/7.0.5/LibreOffice.LibreOffice.yaml
@@ -45,6 +45,9 @@ License: Mozilla Public License Version 2.0
 LicenseUrl: https://www.libreoffice.org/about-us/licenses
 PackageVersion: 7.0.5
 InstallerType: msi
+InstallerSwitches:
+  Silent: /qn /norestart
+  SilentWithProgress: /qn /norestart
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.documentfoundation.org/libreoffice/stable/7.0.5/win/x86_64/LibreOffice_7.0.5_Win_x64.msi


### PR DESCRIPTION
Commit 815c9aa9e4d2fe8e83698cf0df3444f6b44ab2c4 (PR #1210) fixed this for the 6.4 version manifest file.

This change adds the `/qn /norestart` to the 7.0 and 7.1 manifest files where it is missing, resulting in an unprompted PC restart on upgrade.

Fixes #1154

---

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/13680)