### PR TITLE
Fix IrfanView 4.57 download URL

### DIFF
--- a/manifests/i/IrfanSkiljan/IrfanView/4.57/IrfanSkiljan.IrfanView.installer.yaml
+++ b/manifests/i/IrfanSkiljan/IrfanView/4.57/IrfanSkiljan.IrfanView.installer.yaml
@@ -15,7 +15,7 @@ InstallModes:
 Installers:
   - Architecture: x64
     InstallerType: exe
-    InstallerUrl: http://www.storage.programosy.pl/iview457_x64_setup.exe
+    InstallerUrl: https://download.betanews.com/download/967963863-1/iview457_x64_setup.exe
     InstallerSha256: 6A67F079F8036A30E9E13FD9BAECF0D37DA18106050880A3F12845E445F8786F
     InstallerSwitches:
       Custom: /desktop=1 /thumbs=0 /group=1 /allusers=1 /assoc=0
@@ -27,7 +27,7 @@ Installers:
     UpgradeBehavior: install
   - Architecture: x86
     InstallerType: exe
-    InstallerUrl: http://www.storage.programosy.pl/iview457_setup.exe
+    InstallerUrl: https://download.betanews.com/download/967963863-1/iview457_x64_setup.exe
     InstallerSha256: B6BE47AE716FF9E69E80F4956D7721A22734054CDBC18704A68F2F88028C2842
     InstallerSwitches:
       Custom: /desktop=1 /thumbs=0 /group=1 /allusers=1 /assoc=0

--- a/manifests/i/IrfanSkiljan/IrfanView/4.57/IrfanSkiljan.IrfanView.installer.yaml
+++ b/manifests/i/IrfanSkiljan/IrfanView/4.57/IrfanSkiljan.IrfanView.installer.yaml
@@ -27,7 +27,7 @@ Installers:
     UpgradeBehavior: install
   - Architecture: x86
     InstallerType: exe
-    InstallerUrl: https://download.betanews.com/download/967963863-1/iview457_x64_setup.exe
+    InstallerUrl: https://download.betanews.com/download/967963863-1/iview457_setup.exe
     InstallerSha256: B6BE47AE716FF9E69E80F4956D7721A22734054CDBC18704A68F2F88028C2842
     InstallerSwitches:
       Custom: /desktop=1 /thumbs=0 /group=1 /allusers=1 /assoc=0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

Seems like the mirror that was used for this version deletes old files once new versions get uploaded. This PR changes the download URL to a different mirror. The file itself stays the same, no change to the hash was needed.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/14009)