### PR TITLE
Fix Pycharms Community 2021.1.1 Version to Build #

### DIFF
--- a/manifests/j/JetBrains/PyCharm/Community/2021.1.1/JetBrains.PyCharm.Community.yaml
+++ b/manifests/j/JetBrains/PyCharm/Community/2021.1.1/JetBrains.PyCharm.Community.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.singleton.1.0.0.schema.json
 PackageIdentifier: JetBrains.PyCharm.Community
-PackageVersion: 2021.1.1
+PackageVersion: 211.7142.13
 PackageName: PyCharm Community Edition
 Publisher: JetBrains
 PackageUrl: https://www.jetbrains.com/pycharm/
@@ -8,7 +8,7 @@ License: Apache License 2.0
 LicenseUrl: https://github.com/JetBrains/intellij-community/blob/master/LICENSE.txt
 ShortDescription: IntelliJ Platform IDE for pure Python development.
 InstallerType: nullsoft
-ProductCode: PyCharm Community Edition 2020.3.3
+ProductCode: PyCharm Community Edition 2021.1.1
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.jetbrains.com/python/pycharm-community-2021.1.1.exe


### PR DESCRIPTION
The current package lists the version as the "marketing" name of 2021.1.1, instead of the build version that windows sees. Therefore WinGet thinks an up to date build is out of date.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/14434)