### PR TITLE
Update MITMediaLab.Scratch.yaml

### DIFF
--- a/manifests/m/MITMediaLab/Scratch/3.22.0/MITMediaLab.Scratch.yaml
+++ b/manifests/m/MITMediaLab/Scratch/3.22.0/MITMediaLab.Scratch.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: MITMediaLab.Scratch
-PackageVersion: 3.22.0
+PackageVersion: 3.22.0.0
 PackageName: Scratch
 Publisher: MITMediaLab
 License: GPLv2


### PR DESCRIPTION
Windows identifies version as 3.22.0.0 not 3.22.0 
(See Windows 10's Settings > Apps > Apps & features > app: Scratch 3)

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/14676)