### PR TITLE
Fix Version Pycharm Community 2020.3 -> 203.5981.165

### DIFF
--- a/manifests/j/JetBrains/PyCharm/Community/203.5981.165/JetBrains.PyCharm.Community.yaml
+++ b/manifests/j/JetBrains/PyCharm/Community/203.5981.165/JetBrains.PyCharm.Community.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: JetBrains.PyCharm.Community
-PackageVersion: 2020.3
+PackageVersion: 203.5981.165
 PackageName: PyCharm Community Edition
 Publisher: JetBrains
 PackageUrl: https://www.jetbrains.com/pycharm/


### PR DESCRIPTION
Current package lists the version as the "marketing" name ( 2020.3 ), instead of the build version that windows sees ( 203.5981.165 ).

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/14798)