### PR TITLE
Change Unity Hub installer to x64

### DIFF
--- a/manifests/u/UnityTechnologies/UnityHub/2.4.3/UnityTechnologies.UnityHub.yaml
+++ b/manifests/u/UnityTechnologies/UnityHub/2.4.3/UnityTechnologies.UnityHub.yaml
@@ -26,7 +26,7 @@ ShortDescription: UnityTechnologies.UnityHub
 Description: The Unity Hub is a management tool that you can use to manage all of your Unity Projects and installations. Use the Hub to manage multiple installations of the Unity Editor along with their associated components, create new Projects, and open existing Projects.
 PackageUrl: https://unity.com/
 Installers:
-- Architecture: x86
+- Architecture: x64
   InstallerType: exe
   InstallerUrl: https://public-cdn.cloud.unity3d.com/hub/prod/UnityHubSetup.exe
   InstallerSha256: 3CB22764AE2C467486448088D3C045E7D5D209B4ADFECCC3E7DE84BEADB2EF36


### PR DESCRIPTION
Unity Hub is and can only be installed on x64

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/15098)