### PR TITLE
Using reported version 3.2 instead of 3.2.1.0 used only on their website

### DIFF
--- a/manifests/g/gergelycsernak/euroscope/3.2/gergelycsernak.euroscope.yaml
+++ b/manifests/g/gergelycsernak/euroscope/3.2/gergelycsernak.euroscope.yaml
@@ -1,6 +1,6 @@
 PackageIdentifier: gergelycsernak.euroscope
 PackageName: euroscope
-PackageVersion: 3.2.1.0
+PackageVersion: 3.2
 Publisher: Gergely Csernak
 License: copyright (c) Gergely Csernak
 PackageUrl: https://www.euroscope.hu/wp/


### PR DESCRIPTION
Winget reports version 3.2 after installation instead of 3.2.1.0, which causes unwanted behaviour when upgrading.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/15583)