### PR TITLE
Introduce format for .Validation files

### DIFF
--- a/schemas/JSON/validation/ValidationSchema.1.0.0.json
+++ b/schemas/JSON/validation/ValidationSchema.1.0.0.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://aka.ms/winget-validation.schema.json",
+  "$id": "https://aka.ms/winget-validation.1.0.0.schema.json",
   "$schema": "https://json-schema.org/draft/2019-09/schema#",
   "title": "Windows Package Manager Community Repository Manifest Validation Schema",
   "description": "Describes validation file that containers policy waivers that may apply to an application or publisher.",

--- a/schemas/JSON/validation/ValidationSchema.1.0.0.json
+++ b/schemas/JSON/validation/ValidationSchema.1.0.0.json
@@ -5,13 +5,13 @@
   "description": "Describes validation file that containers policy waivers that may apply to an application or publisher.",
   "type": "object",
   "required": [
-    "WaiverVersion",
+    "ValidationVersion",
     "Waivers"
   ],
   "additionalProperties": true,
   "properties": {
-    "WaiverVersion": {
-      "description": "Version of waivers present in this file. Used to handle breaking changes, should the need arise.",
+    "ValidationVersion": {
+      "description": "Version of validation file. Used to handle breaking changes, should the need arise.",
       "type": "string",
       "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
     },

--- a/schemas/JSON/validation/ValidationSchema.json
+++ b/schemas/JSON/validation/ValidationSchema.json
@@ -1,7 +1,7 @@
 {
   "$id": "https://aka.ms/winget-validation.schema.json",
   "$schema": "https://json-schema.org/draft/2019-09/schema#",
-  "title": "winget validation schema",
+  "title": "Windows Package Manager Community Repository Manifest Validation Schema",
   "description": "Describes validation file that containers policy waivers that may apply to an application or publisher.",
   "type": "object",
   "required": [
@@ -22,13 +22,13 @@
         "description": "An id, test plan, and catalog path defining the waiver.",
         "type": "object",
         "required": [
-          "WaiverId",
+          "WaiverIdentifier",
           "TestPlan",
           "PackagePath"
         ],
         "additionalProperties": true,
         "properties": {
-          "WaiverId": {
+          "WaiverIdentifier": {
             "description": "Unique identifier for this waiver.",
             "type": "string"
           },

--- a/schemas/JSON/validation/ValidationSchema.json
+++ b/schemas/JSON/validation/ValidationSchema.json
@@ -1,0 +1,47 @@
+{
+  "$id": "https://aka.ms/winget-validation.schema.json",
+  "$schema": "https://json-schema.org/draft/2019-09/schema#",
+  "title": "winget validation schema",
+  "description": "Describes validation file that containers policy waivers that may apply to an application or publisher.",
+  "type": "object",
+  "required": [
+    "WaiverVersion",
+    "Waivers"
+  ],
+  "additionalProperties": true,
+  "properties": {
+    "WaiverVersion": {
+      "description": "Version of waivers present in this file. Used to handle breaking changes, should the need arise.",
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "Waivers": {
+      "description": "Waivers that apply to this application or publisher",
+      "type": "array",
+      "items": {
+        "description": "An id, test plan, and catalog path defining the waiver.",
+        "type": "object",
+        "required": [
+          "WaiverId",
+          "TestPlan",
+          "PackagePath"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "WaiverId": {
+            "description": "Unique identifier for this waiver.",
+            "type": "string"
+          },
+          "TestPlan": {
+            "description": "Testplan to be waived.",
+            "type": "string"
+          },
+          "PackagePath": {
+            "description": "Path to the metadata being waived.",
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
As part of the validation a pull request, a variety of tests are run to enforce various policy rules for submitting to the winget-pkgs catalog.
.Validation files will provide a mechanism by which waivers to certain policy rules may be persistently granted at either an application or publisher level.

- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/16104)