### PR TITLE
Added KDE.KDEConnect v21.04.1.610 build 610

### DIFF
--- a/manifests/k/KDE/KDEConnect/21.04.1.610/KDE.KDEConnect.installer.yaml
+++ b/manifests/k/KDE/KDEConnect/21.04.1.610/KDE.KDEConnect.installer.yaml
@@ -1,0 +1,14 @@
+# Created using wingetcreate
+
+PackageIdentifier: KDE.KDEConnect
+PackageVersion: 21.04.1.610
+Installers:
+- Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://binary-factory.kde.org/job/kdeconnect-kde_Release_win64/610/artifact/kdeconnect-kde-21.04.1-610-windows-msvc2019_64-cl.exe
+  InstallerSha256: 474A4FB9D4BE54E70347AD5256A771EF8EAAF582B9271D33CF5F1AA2E3881CBB
+  InstallerSwitches:
+    Silent: /S
+    SilentWithProgress: /S
+ManifestType: installer
+ManifestVersion: 1.0.0

--- a/manifests/k/KDE/KDEConnect/21.04.1.610/KDE.KDEConnect.locale.en-US.yaml
+++ b/manifests/k/KDE/KDEConnect/21.04.1.610/KDE.KDEConnect.locale.en-US.yaml
@@ -3,7 +3,7 @@
 PackageIdentifier: KDE.KDEConnect
 PackageVersion: 21.04.1.610
 PackageLocale: en-US
-Publisher: KDE e.V
+Publisher: KDE e.V.
 PackageName: KDE Connect
 PackageUrl: https://kdeconnect.kde.org/
 License: GNU GPLv2/GNU GPLv3

--- a/manifests/k/KDE/KDEConnect/21.04.1.610/KDE.KDEConnect.locale.en-US.yaml
+++ b/manifests/k/KDE/KDEConnect/21.04.1.610/KDE.KDEConnect.locale.en-US.yaml
@@ -1,0 +1,20 @@
+# Created using wingetcreate
+
+PackageIdentifier: KDE.KDEConnect
+PackageVersion: 21.04.1.610
+PackageLocale: en-US
+Publisher: KDE e.V
+PackageName: KDE Connect
+PackageUrl: https://kdeconnect.kde.org/
+License: GNU GPLv2/GNU GPLv3
+LicenseUrl: https://www.gnu.org/licenses/gpl-2.0.html
+ShortDescription: Enabling communication between all your devices. Made for people like you.
+Moniker: kdeconnect
+Tags:
+- android
+- phone
+- connect
+- kde
+- k
+ManifestType: defaultLocale
+ManifestVersion: 1.0.0

--- a/manifests/k/KDE/KDEConnect/21.04.1.610/KDE.KDEConnect.yaml
+++ b/manifests/k/KDE/KDEConnect/21.04.1.610/KDE.KDEConnect.yaml
@@ -1,0 +1,7 @@
+# Created using wingetcreate
+
+PackageIdentifier: KDE.KDEConnect
+PackageVersion: 21.04.1.610
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.0.0


### PR DESCRIPTION
Tiny issue where PackageVersion is actually 21.04.1, think we need a folder cleanup @jedieaston

- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [X] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/16320)