### PR TITLE
Fix Bandisoft.Honeyview InstallerSha256 doesn't match error

### DIFF
--- a/manifests/b/Bandisoft/Honeyview/5.38/Bandisoft.Honeyview.installer.yaml
+++ b/manifests/b/Bandisoft/Honeyview/5.38/Bandisoft.Honeyview.installer.yaml
@@ -41,7 +41,7 @@ Installers:
   InstallerType: exe
   Scope: machine
   InstallerUrl: https://dl.bandisoft.com/honeyview/HONEYVIEW-SETUP.EXE
-  InstallerSha256: D664D1DABBC2137D44C2631B89D483D9CB5B34C6D3CF01A3E18978BF1B5820FC
+  InstallerSha256: be25f887ab07f2a98a77977eb75d51a322add39dfca845b08431b75039d9e95e
   InstallerSwitches:
     Silent: /S
     SilentWithProgress: /S


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

I installed the Honeyview and got an error about the hash match. So I check it and calc correct hash value.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/16330)