### PR TITLE
Create Nutstore.Nutstore.locale.zh-CN.yaml

### DIFF
--- a/manifests/n/Nutstore/Nutstore/5.2.4/Nutstore.Nutstore.locale.zh-CN.yaml
+++ b/manifests/n/Nutstore/Nutstore/5.2.4/Nutstore.Nutstore.locale.zh-CN.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.0.0.schema.json
+PackageIdentifier: Nutstore.Nutstore
+PackageVersion: 5.2.4
+PackageLocale: zh-CN
+Publisher: 上海亦存网络科技有限公司
+PublisherUrl: https://www.jianguoyun.com
+PublisherSupportUrl: http://help.jianguoyun.com
+PrivacyUrl: http://help.jianguoyun.com/?page_id=3961
+Author: 上海亦存网络科技有限公司
+PackageName: 坚果云
+PackageUrl: https://www.jianguoyun.com
+License: Proprietary
+LicenseUrl: https://help.jianguoyun.com/?page_id=490
+Copyright: © 2020 上海亦存网络科技有限公司
+CopyrightUrl: https://help.jianguoyun.com/?page_id=490
+ShortDescription: Share your files anytime, anywhere, with any device
+#Description: 
+Tags:
+  - 云端
+  - 存储
+  - 云盘
+  - 坚果云
+ManifestType: locale
+ManifestVersion: 1.0.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? 

Help needed: The validation fails with

```
Manifest Error: The multi file manifest is incomplete. A multi file manifest must contain at least version, installer and defaultLocale manifest. File: Nutstore.Nutstore.yaml
```

Please disregard with PR if the above issue does not have a simple fix.

- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Nutstore does not have a locale specific installer and the installer installs English or Chinese depending on system locale. The same is true for its websites.


-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/16489)