### PR TITLE
Revert "Update metadata for Microsoft.VisualStudio.2019.TestController"

### DIFF
--- a/manifests/m/Microsoft/VisualStudio/2019/TestController/16.10.31321.278/Microsoft.VisualStudio.2019.TestController.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/TestController/16.10.31321.278/Microsoft.VisualStudio.2019.TestController.yaml
@@ -1,46 +1,29 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.singleton.1.0.0.schema.json
-PackageIdentifier: "Microsoft.VisualStudio.2019.TestController"
-PackageVersion: "16.10.31321.278"
-PackageLocale: "en-US"
-Publisher: "Microsoft Corporation"
-PublisherUrl: "https://www.microsoft.com/"
-PublisherSupportUrl: "https://visualstudio.microsoft.com/vs/support/"
-PrivacyUrl: "https://privacy.microsoft.com/"
-PackageName: "Visual Studio Load Test Controller 2019"
-PackageUrl: "https://visualstudio.microsoft.com/downloads/#agents-for-visual-studio-2019"
-License: "Microsoft Software License"
-LicenseUrl: "https://visualstudio.microsoft.com/license-terms/mlt031619/"
-Copyright: "© Microsoft Corporation. All rights reserved."
-CopyrightUrl: "https://www.microsoft.com/en-us/legal/copyright"
-ShortDescription: "Agents for Visual Studio 2019 can be used for load, functional, and automated testing."
-Moniker: "vs2019-testcontroller"
+PackageIdentifier: Microsoft.VisualStudio.2019.TestController
+PackageVersion: 16.10.31321.278
+PackageName: Visual Studio Load Test Controller 2019
+Publisher: Microsoft Corporation
+PackageUrl: https://visualstudio.microsoft.com/
+License: Copyright (c) Microsoft Corporation. All rights reserved.
+LicenseUrl: https://visualstudio.microsoft.com/license-terms/
+Moniker: vs2019-testcontroller
 Tags:
-  - "c++"
-  - "c#"
-  - "vs"
-  - "testcontroller"
-InstallerLocale: "en-US"
-Platform:
-  - "Windows.Desktop"
-MinimumOSVersion: "6.1.7601.17514"
-InstallerType: "exe"
-Scope: "machine"
-InstallModes:
-  - "interactive"
-  - "silent"
-  - "silentWithProgress"
-InstallerSwitches:
-  Silent: "--quiet"
-  SilentWithProgress: "--passive"
-  InstallLocation: "--installPath <INSTALLPATH>"
-InstallerSuccessCodes:
-  - 1641
-  - 3010
+- C++
+- vs
+- C#
 Commands:
-  - "devenv"
+- devenv
 Installers:
-  - Architecture: "x86"
-    InstallerUrl: "https://download.visualstudio.microsoft.com/download/pr/cb1d5164-e767-4886-8955-2df3a7c816a8/ee6aee4e189ad1afb1b709a4bb47f2c1b28fd1bc55b067c5c9b35bbcf1d50b8e/vs_TestController.exe"
-    InstallerSha256: "ee6aee4e189ad1afb1b709a4bb47f2c1b28fd1bc55b067c5c9b35bbcf1d50b8e"
-ManifestType: "singleton"
-ManifestVersion: "1.0.0"
+- Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/cb1d5164-e767-4886-8955-2df3a7c816a8/ee6aee4e189ad1afb1b709a4bb47f2c1b28fd1bc55b067c5c9b35bbcf1d50b8e/vs_TestController.exe
+  InstallerSha256: EE6AEE4E189AD1AFB1B709A4BB47F2C1B28FD1BC55B067C5C9B35BBCF1D50B8E
+  InstallerSwitches:
+    Silent: --quiet
+    SilentWithProgress: --passive
+    Custom: --wait --productId Microsoft.VisualStudio.Product.TestController --channelId VisualStudio.16.Release --channelUri https://aka.ms/vs/16/release/channel --add Microsoft.VisualStudio.Workload.Universal
+ShortDescription: Microsoft.VisualStudio.TestController
+PackageLocale: en-US
+ManifestType: singleton
+ManifestVersion: 1.0.0
+


### PR DESCRIPTION
Reverts microsoft/winget-pkgs#14246.

This PR should not have been merged. It changed the InstallerSwitches so that it won't have any workloads, and therefore is a bit of a useless install.