### PR TITLE
Revert "Update metadata for Microsoft.VisualStudio.2019.TestAgent"

### DIFF
--- a/manifests/m/Microsoft/VisualStudio/2019/TestAgent/16.10.31321.278/Microsoft.VisualStudio.2019.TestAgent.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/TestAgent/16.10.31321.278/Microsoft.VisualStudio.2019.TestAgent.yaml
@@ -1,44 +1,28 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.singleton.1.0.0.schema.json
-PackageIdentifier: "Microsoft.VisualStudio.2019.TestAgent"
-PackageVersion: "16.10.31321.278"
-PackageLocale: "en-US"
-Publisher: "Microsoft Corporation"
-PublisherUrl: "https://www.microsoft.com/"
-PublisherSupportUrl: "https://visualstudio.microsoft.com/vs/support/"
-PrivacyUrl: "https://privacy.microsoft.com/"
-PackageName: "Visual Studio Test Agent 2019"
-PackageUrl: "https://visualstudio.microsoft.com/downloads/#agents-for-visual-studio-2019"
-License: "Microsoft Software License"
-LicenseUrl: "https://visualstudio.microsoft.com/license-terms/mlt031619/"
-Copyright: "© Microsoft Corporation. All rights reserved."
-CopyrightUrl: "https://www.microsoft.com/en-us/legal/copyright"
-ShortDescription: "Agents for Visual Studio 2019 can be used for load, functional, and automated testing."
-Moniker: "vs2019-testagent"
+PackageIdentifier: Microsoft.VisualStudio.2019.TestAgent
+PackageVersion: 16.10.31321.278
+PackageName: Visual Studio Test Agent 2019
+Publisher: Microsoft Corporation
+PackageUrl: https://visualstudio.microsoft.com/
+License: Copyright (c) Microsoft Corporation. All rights reserved.
+LicenseUrl: https://visualstudio.microsoft.com/license-terms/
+Moniker: vs2019-testagent
 Tags:
-  - "c++"
-  - "c#"
-  - "vs"
-  - "testagent"
-InstallerLocale: "en-US"
-Platform:
-  - "Windows.Desktop"
-MinimumOSVersion: "6.1.7601.17514"
-InstallerType: "exe"
-Scope: "machine"
-InstallModes:
-  - "interactive"
-  - "silent"
-  - "silentWithProgress"
-InstallerSwitches:
-  Silent: "--quiet"
-  SilentWithProgress: "--passive"
-  InstallLocation: "--installPath <INSTALLPATH>"
-InstallerSuccessCodes:
-  - 1641
-  - 3010
+- C++
+- vs
+- C#
+- testagent
 Installers:
-  - Architecture: "x86"
-    InstallerUrl: "https://download.visualstudio.microsoft.com/download/pr/cb1d5164-e767-4886-8955-2df3a7c816a8/bbc9acadb3defd264840100d8021272da8ca578f0f42f9ff5e6afb873a769f6e/vs_TestAgent.exe"
-    InstallerSha256: "bbc9acadb3defd264840100d8021272da8ca578f0f42f9ff5e6afb873a769f6e"
-ManifestType: "singleton"
-ManifestVersion: "1.0.0"
+- Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/cb1d5164-e767-4886-8955-2df3a7c816a8/bbc9acadb3defd264840100d8021272da8ca578f0f42f9ff5e6afb873a769f6e/vs_TestAgent.exe
+  InstallerSha256: BBC9ACADB3DEFD264840100D8021272DA8CA578F0F42F9FF5E6AFB873A769F6E
+  InstallerSwitches:
+    Silent: --quiet
+    SilentWithProgress: --passive
+    Custom: --wait --productId Microsoft.VisualStudio.Product.TestAgent --channelId VisualStudio.16.Release --channelUri https://aka.ms/vs/16/release/channel --add Microsoft.VisualStudio.Workload.Universal
+ShortDescription: Microsoft.VisualStudio.TestAgent
+PackageLocale: en-US
+ManifestType: singleton
+ManifestVersion: 1.0.0
+


### PR DESCRIPTION
Reverts microsoft/winget-pkgs#14245

This PR should not have been merged. It changed the InstallerSwitches so that it won't have any workloads, and therefore is a bit of a useless install.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/16495)