### PR TITLE
Revert "Update metadata for Microsoft.VisualStudio.2019.TeamExplorer"

### DIFF
--- a/manifests/m/Microsoft/VisualStudio/2019/TeamExplorer/16.10.31321.278/Microsoft.VisualStudio.2019.TeamExplorer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/TeamExplorer/16.10.31321.278/Microsoft.VisualStudio.2019.TeamExplorer.yaml
@@ -1,52 +1,29 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.singleton.1.0.0.schema.json
-PackageIdentifier: "Microsoft.VisualStudio.2019.TeamExplorer"
-PackageVersion: "16.10.31321.278"
-PackageLocale: "en-US"
-Publisher: "Microsoft Corporation"
-PublisherUrl: "https://www.microsoft.com/"
-PublisherSupportUrl: "https://visualstudio.microsoft.com/vs/support/"
-PrivacyUrl: "https://privacy.microsoft.com/"
-PackageName: "Visual Studio Community 2019 Preview"
-PackageUrl: "https://visualstudio.microsoft.com/downloads/#visual-studio-team-explorer-2019"
-License: "Microsoft Software License"
-LicenseUrl: "https://visualstudio.microsoft.com/license-terms/mlt031619/"
-Copyright: "© Microsoft Corporation. All rights reserved."
-CopyrightUrl: "https://www.microsoft.com/en-us/legal/copyright"
-ShortDescription: "A free solution for non-developers to interact with Azure DevOps Server and Azure DevOps."
-Moniker: "vs2019-teamexplorer"
+PackageIdentifier: Microsoft.VisualStudio.2019.TeamExplorer
+PackageVersion: 16.10.31321.278
+PackageName: Visual Studio Team Explorer 2019
+Publisher: Microsoft Corporation
+PackageUrl: https://visualstudio.microsoft.com/
+License: Copyright (c) Microsoft Corporation. All rights reserved.
+ShortDescription: A free solution for non-developers to interact with Team Foundation Server and Visual Studio Team Services.
+LicenseUrl: https://visualstudio.microsoft.com/license-terms/
+Moniker: vs2019-teamexplorer
 Tags:
-  - "c++"
-  - "c#"
-  - "vs"
-  - "ide"
-InstallerLocale: "en-US"
-Platform:
-  - "Windows.Desktop"
-MinimumOSVersion: "6.1.7601.17514"
-InstallerType: "exe"
-Scope: "machine"
-InstallModes:
-  - "interactive"
-  - "silent"
-  - "silentWithProgress"
-InstallerSwitches:
-  Silent: "--quiet"
-  SilentWithProgress: "--passive"
-  InstallLocation: "--installPath <INSTALLPATH>"
-InstallerSuccessCodes:
-  - 1641
-  - 3010
+- C++
+- vs
+- C#
 Commands:
-  - "devenv"
-Protocols:
-  - "git-client"
-  - "vsls"
-  - "vssd"
-  - "vstfs"
-  - "vsweb"
+- devenv
 Installers:
-  - Architecture: "x86"
-    InstallerUrl: "https://download.visualstudio.microsoft.com/download/pr/cb1d5164-e767-4886-8955-2df3a7c816a8/bfc4a204e3be00110c13a32fae0d23ab96e2d0b40c8c193cad058677f68db069/vs_TeamExplorer.exe"
-    InstallerSha256: "bfc4a204e3be00110c13a32fae0d23ab96e2d0b40c8c193cad058677f68db069"
-ManifestType: "singleton"
-ManifestVersion: "1.0.0"
+- Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/cb1d5164-e767-4886-8955-2df3a7c816a8/bfc4a204e3be00110c13a32fae0d23ab96e2d0b40c8c193cad058677f68db069/vs_TeamExplorer.exe
+  InstallerSha256: BFC4A204E3BE00110C13A32FAE0D23AB96E2D0B40C8C193CAD058677F68DB069
+  InstallerSwitches:
+    Silent: --quiet
+    SilentWithProgress: --passive
+    Custom: --wait --productId Microsoft.VisualStudio.Product.TeamExplorer --channelId VisualStudio.16.Release --channelUri https://aka.ms/vs/16/release/channel --add Microsoft.VisualStudio.Workload.Universal
+PackageLocale: en-US
+ManifestType: singleton
+ManifestVersion: 1.0.0
+


### PR DESCRIPTION
Reverts microsoft/winget-pkgs#14242

This PR should not have been merged. It changed the InstallerSwitches so that it won't have any workloads, and therefore is a bit of a useless install.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/16496)