### PR TITLE
Revert "Update metadata for Microsoft.VisualStudio.2019.Enterprise"

### DIFF
--- a/manifests/m/Microsoft/VisualStudio/2019/Enterprise/16.10.31321.278/Microsoft.VisualStudio.2019.Enterprise.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Enterprise/16.10.31321.278/Microsoft.VisualStudio.2019.Enterprise.yaml
@@ -1,72 +1,27 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.singleton.1.0.0.schema.json
-PackageIdentifier: "Microsoft.VisualStudio.2019.Enterprise"
-PackageVersion: "16.10.31321.278"
-PackageLocale: "en-US"
-Publisher: "Microsoft Corporation"
-PublisherUrl: "https://www.microsoft.com/"
-PublisherSupportUrl: "https://visualstudio.microsoft.com/vs/support/"
-PrivacyUrl: "https://privacy.microsoft.com/"
-PackageName: "Visual Studio Enterprise 2019"
-PackageUrl: "https://visualstudio.microsoft.com/vs/enterprise/"
-License: "Microsoft Software License"
-LicenseUrl: "https://visualstudio.microsoft.com/license-terms/mlt031619/"
-Copyright: "© Microsoft Corporation. All rights reserved."
-CopyrightUrl: "https://www.microsoft.com/en-us/legal/copyright"
-ShortDescription: "Scalable, end-to-end solution for teams of any size."
-Description: "An integrated, end-to-end solution for teams of any size with demanding quality and scale needs.\nTake advantage of comprehensive tools and services to design, build, and deploy complex enterprise\napplications."
-Moniker: "vs2019-enterprise"
+PackageIdentifier: Microsoft.VisualStudio.2019.Enterprise
+PackageVersion: 16.10.31321.278
+PackageName: Visual Studio Enterprise 2019
+Publisher: Microsoft
+License: Copyright (c) Microsoft Corporation
+LicenseUrl: https://visualstudio.microsoft.com/license-terms/
+Moniker: vs2019-enterprise
 Tags:
-  - "c++"
-  - "c#"
-  - "vs"
-  - "ide"
-InstallerLocale: "en-US"
-Platform:
-  - "Windows.Desktop"
-MinimumOSVersion: "6.1.7601.17514"
-InstallerType: "exe"
-Scope: "machine"
-InstallModes:
-  - "interactive"
-  - "silent"
-  - "silentWithProgress"
-InstallerSwitches:
-  Silent: "--quiet"
-  SilentWithProgress: "--passive"
-  InstallLocation: "--installPath <INSTALLPATH>"
-InstallerSuccessCodes:
-  - 1641
-  - 3010
-Commands:
-  - "devenv"
-Protocols:
-  - "git-client"
-  - "vsls"
-  - "vssd"
-  - "vstfs"
-  - "vsweb"
-FileExtensions:
-  - "asm"
-  - "asmx"
-  - "asp"
-  - "aspx"
-  - "c"
-  - "config"
-  - "cpp"
-  - "cppm"
-  - "cs"
-  - "csproj"
-  - "cxx"
-  - "h"
-  - "hpp"
-  - "hxx"
-  - "ts"
-  - "vcproj"
-  - "vcxproj"
-  - "xml"
+- C++
+- vs
+- C#
+ShortDescription: Visual Studio Enterprise
+PackageUrl: https://visualstudio.microsoft.com/
 Installers:
-  - Architecture: "x86"
-    InstallerUrl: "https://download.visualstudio.microsoft.com/download/pr/cb1d5164-e767-4886-8955-2df3a7c816a8/45b8989fc5efacb07008bc1de55ac25d08f5394e41154556d3f72958b995d4a7/vs_Enterprise.exe"
-    InstallerSha256: "45b8989fc5efacb07008bc1de55ac25d08f5394e41154556d3f72958b995d4a7"
-ManifestType: "singleton"
-ManifestVersion: "1.0.0"
+- Architecture: x64
+  InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/cb1d5164-e767-4886-8955-2df3a7c816a8/45b8989fc5efacb07008bc1de55ac25d08f5394e41154556d3f72958b995d4a7/vs_Enterprise.exe
+  InstallerSha256: 45B8989FC5EFACB07008BC1DE55AC25D08F5394E41154556D3F72958B995D4A7
+  InstallerType: exe
+  InstallerSwitches:
+    Silent: --quiet
+    SilentWithProgress: --passive
+    Custom: --productId Microsoft.VisualStudio.Product.Enterprise --channelId VisualStudio.16.Release --channelUri https://aka.ms/vs/16/release/channel --add Microsoft.VisualStudio.Workload.Universal
+PackageLocale: en-US
+ManifestType: singleton
+ManifestVersion: 1.0.0
+


### PR DESCRIPTION
Reverts microsoft/winget-pkgs#14239

This PR should not have been merged. It changed the InstallerSwitches so that it won't have any workloads, and therefore is a bit of a useless install.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/16497)