### PR TITLE
Revert "Update metadata for Microsoft.VisualStudio.2019.Enterprise-Preview"

### DIFF
--- a/manifests/m/Microsoft/VisualStudio/2019/Enterprise-Preview/16.11.31320.298/Microsoft.VisualStudio.2019.Enterprise-Preview.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Enterprise-Preview/16.11.31320.298/Microsoft.VisualStudio.2019.Enterprise-Preview.yaml
@@ -10,16 +10,11 @@ PackageName: "Visual Studio Enterprise 2019 Preview"
 PackageUrl: "https://visualstudio.microsoft.com/vs/preview/"
 License: "Microsoft Pre-Release Software License"
 LicenseUrl: "https://visualstudio.microsoft.com/license-terms/mlt110718/"
-Copyright: "© Microsoft Corporation. All rights reserved."
+Copyright: "© 2021 Microsoft"
 CopyrightUrl: "https://www.microsoft.com/en-us/legal/copyright"
 ShortDescription: "End-to-end solution for teams of any size. Best if you have a Visual Studio Enterprise subscription."
 Description: "An integrated, end-to-end solution for teams of any size with demanding quality and scale needs.\nTake advantage of comprehensive tools and services to design, build, and deploy complex enterprise\napplications."
 Moniker: "vs2019-enterprise-preview"
-Tags:
-  - "c++"
-  - "c#"
-  - "vs"
-  - "ide"
 InstallerLocale: "en-US"
 Platform:
   - "Windows.Desktop"
@@ -38,7 +33,7 @@ InstallerSuccessCodes:
   - 1641
   - 3010
 Commands:
-  - "devenv"
+  - devenv
 Protocols:
   - "git-client"
   - "vsls"


### PR DESCRIPTION
Reverts microsoft/winget-pkgs#14238

This PR should not have been merged. It changed the InstallerSwitches so that it won't have any workloads, and therefore is a bit of a useless install.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/16498)