### PR TITLE
Revert "Update manifest for Microsoft.VisualStudio.2019.Professional"

### DIFF
--- a/manifests/m/Microsoft/VisualStudio/2019/Professional/16.10.31321.278/Microsoft.VisualStudio.2019.Professional.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Professional/16.10.31321.278/Microsoft.VisualStudio.2019.Professional.yaml
@@ -1,72 +1,29 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.singleton.1.0.0.schema.json
-PackageIdentifier: "Microsoft.VisualStudio.2019.Professional"
-PackageVersion: "16.10.31321.278"
-PackageLocale: "en-US"
-Publisher: "Microsoft Corporation"
-PublisherUrl: "https://www.microsoft.com/"
-PublisherSupportUrl: "https://visualstudio.microsoft.com/vs/support/"
-PrivacyUrl: "https://privacy.microsoft.com/"
-PackageName: "Visual Studio Professional 2019"
-PackageUrl: "https://visualstudio.microsoft.com/vs/professional/"
-License: "Microsoft Software License"
-LicenseUrl: "https://visualstudio.microsoft.com/license-terms/mlt031619/"
-Copyright: "© Microsoft Corporation. All rights reserved."
-CopyrightUrl: "https://www.microsoft.com/en-us/legal/copyright"
-ShortDescription: "Professional IDE best suited to small teams."
-Description: "Professional developer tools and services for individual developers or small teams."
-Moniker: "vs2019-professional"
+PackageIdentifier: Microsoft.VisualStudio.2019.Professional
+PackageVersion: 16.10.31321.278
+PackageName: Visual Studio Professional 2019
+Publisher: Microsoft Corporation
+PackageUrl: https://visualstudio.microsoft.com/
+License: Copyright (c) Microsoft Corporation. All rights reserved.
+LicenseUrl: https://visualstudio.microsoft.com/license-terms/
+Moniker: vs2019-professional
 Tags:
-  - "c++"
-  - "c#"
-  - "vs"
-  - "ide"
-InstallerLocale: "en-US"
-Platform:
-  - "Windows.Desktop"
-MinimumOSVersion: "6.1.7601.17514"
-InstallerType: "exe"
-Scope: "machine"
-InstallModes:
-  - "interactive"
-  - "silent"
-  - "silentWithProgress"
-InstallerSwitches:
-  Silent: "--quiet"
-  SilentWithProgress: "--passive"
-  InstallLocation: "--installPath <INSTALLPATH>"
-InstallerSuccessCodes:
-  - 1641
-  - 3010
+- C++
+- vs
+- C#
 Commands:
-  - "devenv"
-Protocols:
-  - "git-client"
-  - "vsls"
-  - "vssd"
-  - "vstfs"
-  - "vsweb"
-FileExtensions:
-  - "asm"
-  - "asmx"
-  - "asp"
-  - "aspx"
-  - "c"
-  - "config"
-  - "cpp"
-  - "cppm"
-  - "cs"
-  - "csproj"
-  - "cxx"
-  - "h"
-  - "hpp"
-  - "hxx"
-  - "ts"
-  - "vcproj"
-  - "vcxproj"
-  - "xml"
+- devenv
 Installers:
-  - Architecture: "x86"
-    InstallerUrl: "https://download.visualstudio.microsoft.com/download/pr/cb1d5164-e767-4886-8955-2df3a7c816a8/4cf672d18e9ef58b37d608b0be4b4a3aa1a8cfdebb99457a9a1fa14ff27706d2/vs_Professional.exe"
-    InstallerSha256: "4cf672d18e9ef58b37d608b0be4b4a3aa1a8cfdebb99457a9a1fa14ff27706d2"
-ManifestType: "singleton"
-ManifestVersion: "1.0.0"
+- Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/cb1d5164-e767-4886-8955-2df3a7c816a8/4cf672d18e9ef58b37d608b0be4b4a3aa1a8cfdebb99457a9a1fa14ff27706d2/vs_Professional.exe
+  InstallerSha256: 4CF672D18E9EF58B37D608B0BE4B4A3AA1A8CFDEBB99457A9A1FA14FF27706D2
+  InstallerSwitches:
+    Silent: --quiet
+    SilentWithProgress: --passive
+    Custom: --productId Microsoft.VisualStudio.Product.Professional --channelId VisualStudio.16.Release --channelUri https://aka.ms/vs/16/release/channel --add Microsoft.VisualStudio.Workload.Universal
+ShortDescription: Microsoft.VisualStudio.Professional
+PackageLocale: en-US
+ManifestType: singleton
+ManifestVersion: 1.0.0
+


### PR DESCRIPTION
Reverts microsoft/winget-pkgs#14237

This PR should not have been merged. It changed the InstallerSwitches so that it won't have any workloads, and therefore is a bit of a useless install.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/16499)