### PR TITLE
Revert "Update manifest for Microsoft.VisualStudio.2019.Community"

### DIFF
--- a/manifests/m/Microsoft/VisualStudio/2019/Community/16.10.31321.278/Microsoft.VisualStudio.2019.Community.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Community/16.10.31321.278/Microsoft.VisualStudio.2019.Community.yaml
@@ -1,72 +1,30 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.singleton.1.0.0.schema.json
-PackageIdentifier: "Microsoft.VisualStudio.2019.Community"
-PackageVersion: "16.10.31321.278"
-PackageLocale: "en-US"
-Publisher: "Microsoft Corporation"
-PublisherUrl: "https://www.microsoft.com/"
-PublisherSupportUrl: "https://visualstudio.microsoft.com/vs/support/"
-PrivacyUrl: "https://privacy.microsoft.com/"
-PackageName: "Visual Studio Community 2019"
-PackageUrl: "https://visualstudio.microsoft.com/vs/community/"
-License: "Microsoft Software License"
-LicenseUrl: "https://visualstudio.microsoft.com/license-terms/mlt031819/"
-Copyright: "© Microsoft Corporation. All rights reserved."
-CopyrightUrl: "https://www.microsoft.com/en-us/legal/copyright"
-ShortDescription: "Powerful IDE, free for students, open-source contributors, and individuals."
-Description: "A fully-featured, extensible, free IDE for creating modern applications for Android, iOS, Windows,\nas well as web applications and cloud services."
-Moniker: "vs2019-community"
+PackageIdentifier: Microsoft.VisualStudio.2019.Community
+PackageVersion: 16.10.31321.278
+PackageName: Visual Studio Community 2019
+Author: Microsoft
+Publisher: Microsoft Corporation
+ShortDescription: The Community edition of Visual Studio, an integrated development environment (IDE) from Microsoft.  Individual developers have no restrictions on their use of the Community edition.
+PackageUrl: https://visualstudio.microsoft.com/
+License: Copyright (c) Microsoft Corporation. All rights reserved.
+LicenseUrl: https://visualstudio.microsoft.com/license-terms/
+Moniker: vs2019-community
 Tags:
-  - "c++"
-  - "c#"
-  - "vs"
-  - "ide"
-InstallerLocale: "en-US"
-Platform:
-  - "Windows.Desktop"
-MinimumOSVersion: "6.1.7601.17514"
-InstallerType: "exe"
-Scope: "machine"
-InstallModes:
-  - "interactive"
-  - "silent"
-  - "silentWithProgress"
-InstallerSwitches:
-  Silent: "--quiet"
-  SilentWithProgress: "--passive"
-  InstallLocation: "--installPath <INSTALLPATH>"
-InstallerSuccessCodes:
-  - 1641
-  - 3010
+- C++
+- vs
+- C#
 Commands:
-  - "devenv"
-Protocols:
-  - "git-client"
-  - "vsls"
-  - "vssd"
-  - "vstfs"
-  - "vsweb"
-FileExtensions:
-  - "asm"
-  - "asmx"
-  - "asp"
-  - "aspx"
-  - "c"
-  - "config"
-  - "cpp"
-  - "cppm"
-  - "cs"
-  - "csproj"
-  - "cxx"
-  - "h"
-  - "hpp"
-  - "hxx"
-  - "ts"
-  - "vcproj"
-  - "vcxproj"
-  - "xml"
+- devenv
 Installers:
-  - Architecture: "x86"
-    InstallerUrl: "https://download.visualstudio.microsoft.com/download/pr/cb1d5164-e767-4886-8955-2df3a7c816a8/cdb3c7017c698d10ffa978951a88a82fbbc5b0b847ca1361b2f90ff648cf7937/vs_Community.exe"
-    InstallerSha256: "cdb3c7017c698d10ffa978951a88a82fbbc5b0b847ca1361b2f90ff648cf7937"
-ManifestType: "singleton"
-ManifestVersion: "1.0.0"
+- Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/cb1d5164-e767-4886-8955-2df3a7c816a8/cdb3c7017c698d10ffa978951a88a82fbbc5b0b847ca1361b2f90ff648cf7937/vs_Community.exe
+  InstallerSha256: CDB3C7017C698D10FFA978951A88A82FBBC5B0B847CA1361B2F90FF648CF7937
+  InstallerSwitches:
+    Silent: --quiet
+    SilentWithProgress: --passive
+    Custom: --productId Microsoft.VisualStudio.Product.Community --channelId VisualStudio.16.Release --channelUri https://aka.ms/vs/16/release/channel --add Microsoft.VisualStudio.Workload.Universal
+PackageLocale: en-US
+ManifestType: singleton
+ManifestVersion: 1.0.0
+


### PR DESCRIPTION
Reverts microsoft/winget-pkgs#14221

This PR should not have been merged. It changed the InstallerSwitches so that it won't have any workloads, and therefore is a bit of a useless install.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/16501)