### PR TITLE
Revert "Update manifest for Microsoft.VisualStudio.2019.BuildTools"

### DIFF
--- a/manifests/m/Microsoft/VisualStudio/2019/BuildTools/16.10.31321.278/Microsoft.VisualStudio.2019.BuildTools.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/BuildTools/16.10.31321.278/Microsoft.VisualStudio.2019.BuildTools.yaml
@@ -1,46 +1,29 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.singleton.1.0.0.schema.json
-PackageIdentifier: "Microsoft.VisualStudio.2019.BuildTools"
-PackageVersion: "16.10.31321.278"
-PackageLocale: "en-US"
-Publisher: "Microsoft Corporation"
-PublisherUrl: "https://www.microsoft.com/"
-PublisherSupportUrl: "https://visualstudio.microsoft.com/vs/support/"
-PrivacyUrl: "https://privacy.microsoft.com/"
-PackageName: "Visual Studio Build Tools 2019"
-PackageUrl: "https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2019"
-License: "Microsoft Software License"
-LicenseUrl: "https://visualstudio.microsoft.com/license-terms/mlt031519/"
-Copyright: "© Microsoft Corporation. All rights reserved."
-CopyrightUrl: "https://www.microsoft.com/en-us/legal/copyright"
-ShortDescription: "These Build Tools allow you to build Visual Studio projects from a command-line interface."
-Description: "These Build Tools allow you to build Visual Studio projects from a command-line interface. Supported\nprojects include: ASP.NET, Azure, C++ desktop, ClickOnce, containers, .NET Core, .NET Desktop,\nNode.js, Office and SharePoint, Python, TypeScript, Unit Tests, UWP, WCF, and Xamarin."
-Moniker: "vs2019-buildtools"
+PackageIdentifier: Microsoft.VisualStudio.2019.BuildTools
+PackageVersion: 16.10.31321.278
+PackageName: Visual Studio Build Tools 2019
+Publisher: Microsoft
+License: Copyright (c) Microsoft Corporation. All rights reserved.
+LicenseUrl: https://visualstudio.microsoft.com/license-terms/
 Tags:
-  - "c++"
-  - "c#"
-  - "vs"
-  - "build"
-  - "tools"
-InstallerLocale: "en-US"
-Platform:
-  - "Windows.Desktop"
-MinimumOSVersion: "6.1.7601.17514"
-InstallerType: "exe"
-Scope: "machine"
-InstallModes:
-  - "interactive"
-  - "silent"
-  - "silentWithProgress"
-InstallerSwitches:
-  Silent: "--quiet"
-  SilentWithProgress: "--passive"
-  InstallLocation: "--installPath <INSTALLPATH>"
-InstallerSuccessCodes:
-  - 1641
-  - 3010
+- C++
+- tools
+- C#
+- build
+- vs
+ShortDescription: Visual Studio Build Tools
+PackageUrl: https://visualstudio.microsoft.com/
 Installers:
-  - Architecture: "x86"
-    InstallerUrl: "https://download.visualstudio.microsoft.com/download/pr/cb1d5164-e767-4886-8955-2df3a7c816a8/ccac76bbd83f9d0e78a32f8bb22be6d2aca3fb5f10bf870504d8d84f36ab3440/vs_BuildTools.exe"
-    InstallerSha256: "ccac76bbd83f9d0e78a32f8bb22be6d2aca3fb5f10bf870504d8d84f36ab3440"
-ManifestType: "singleton"
-ManifestVersion: "1.0.0"
+- Architecture: x64
+  InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/cb1d5164-e767-4886-8955-2df3a7c816a8/ccac76bbd83f9d0e78a32f8bb22be6d2aca3fb5f10bf870504d8d84f36ab3440/vs_BuildTools.exe
+  InstallerSha256: CCAC76BBD83F9D0E78A32F8BB22BE6D2ACA3FB5F10BF870504D8D84F36AB3440
+  InstallerType: exe
+  InstallerSwitches:
+    Silent: --quiet
+    SilentWithProgress: --passive
+    Custom: --productId Microsoft.VisualStudio.Product.BuildTools --channelId VisualStudio.16.Release --channelUri https://aka.ms/vs/16/release/channel
+PackageLocale: en-US
+ManifestType: singleton
+ManifestVersion: 1.0.0
+Moniker: vs2019-buildtools
+


### PR DESCRIPTION
Reverts microsoft/winget-pkgs#14217

This PR should not have been merged. It changed the InstallerSwitches so that it won't have any workloads, and therefore is a bit of a useless install.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/16502)