### PR TITLE
QuickPar 0.9.1 --> 0.9  -  Change version to match Windows because abandonware

### DIFF
--- a/manifests/p/PeterBClements/QuickPar/0.9/PeterBClements.QuickPar.yaml
+++ b/manifests/p/PeterBClements/QuickPar/0.9/PeterBClements.QuickPar.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: PeterBClements.QuickPar
-PackageVersion: 0.9.1
+PackageVersion: 0.9
 PackageName: QuickPar
 Publisher: Peter B. Clements
 License: Copyright © 2003 Peter B. Clements.


### PR DESCRIPTION
Because this is abandonware from 2004 and will likely never be updated, I've changed the version from 0.9.1 to just 0.9 to match the version shown in Windows, so it doesn't show up in upgrade list forever.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/16890)