### PR TITLE
Fix DebaucheeOpenSourceGroup.Barrier version, changed 2.3.3 to 2.3.3-release

### DIFF
--- a/manifests/d/DebaucheeOpenSourceGroup/Barrier/2.3.3-release/DebaucheeOpenSourceGroup.Barrier.yaml
+++ b/manifests/d/DebaucheeOpenSourceGroup/Barrier/2.3.3-release/DebaucheeOpenSourceGroup.Barrier.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: DebaucheeOpenSourceGroup.Barrier
-PackageVersion: 2.3.3
+PackageVersion: 2.3.3-release
 PackageName: Barrier
 Publisher: Debauchee Open Source Group
 PackageUrl: https://github.com/debauchee/barrier/


### PR DESCRIPTION
Corrected version number `2.3.3` to `2.3.3-release`, since the latter is the version that Barrier 2.3.3 reports after installation to both Control Panel and `winget list`.

Currently, version 2.3.3 of Barrier incorrectly shows up as upgradable in `winget upgrade` despite the latest version already being installed. This is caused by a mismatched version number. WinGet thinks the newest version is `2.3.3`. Since the system reports the currently installed version is `2.3.3-release` in both Control Panel and WinGet, `winget upgrade` lists an available update for Barrier even though there isn't.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/17339)