### PR TITLE
removed incorrect 'v' PackageVersion prefix (partial revert of #16683)

### DIFF
--- a/manifests/a/ActivityWatch/ActivityWatch/0.10.0/ActivityWatch.ActivityWatch.yaml
+++ b/manifests/a/ActivityWatch/ActivityWatch/0.10.0/ActivityWatch.ActivityWatch.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: ActivityWatch.ActivityWatch
-PackageVersion: v0.10.0
+PackageVersion: 0.10.0
 PackageName: ActivityWatch
 Publisher: ActivityWatch Contributors
 License: MPL-2.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

Partially reverted #16683, reason explained therein.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/17564)