### PR TITLE
Manifest Update for Microsoft.XMLNotepad v2.8.0.34

### DIFF
--- a/manifests/m/Microsoft/XMLNotepad/2.8.0.34/Microsoft.XMLNotepad.installer.yaml
+++ b/manifests/m/Microsoft/XMLNotepad/2.8.0.34/Microsoft.XMLNotepad.installer.yaml
@@ -1,0 +1,26 @@
+# Created using YamlCreate.ps1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
+
+PackageIdentifier: Microsoft.XMLNotepad
+PackageVersion: 2.8.0.34
+FileExtensions:
+- xml
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+Installers:
+- Platform:
+  - Windows.Universal
+  - Windows.Desktop
+  MinimumOSVersion: 10.0.18362.0
+  Architecture: neutral
+  InstallerType: msix
+  Scope: user
+  InstallerUrl: https://lovettsoftwarestorage.blob.core.windows.net/downloads/XmlNotepad.Net/2.8.0.34/XmlNotepadPackage_2.8.0.34_Test/XmlNotepadPackage_2.8.0.34_AnyCPU.msixbundle
+  InstallerSha256: D596FD6238E9BD2E5D92D8DF0108B485582A53B3B3DA48D983085B26AEB281A3
+  SignatureSha256: 4C817482B24E0AB38CEF0A62D66F85432A6CB36DB8CE7D47E07D9204F429ED97
+  PackageFamilyName: 5632ff08-aa93-439a-b09f-677eb3664250_b2j8apzf1bbh6
+  UpgradeBehavior: install
+ManifestType: installer
+ManifestVersion: 1.0.0

--- a/manifests/m/Microsoft/XMLNotepad/2.8.0.34/Microsoft.XMLNotepad.locale.en-US.yaml
+++ b/manifests/m/Microsoft/XMLNotepad/2.8.0.34/Microsoft.XMLNotepad.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# Created using YamlCreate.ps1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultlocale.1.0.0.schema.json
+
+PackageIdentifier: Microsoft.XMLNotepad
+PackageVersion: 2.8.0.34
+PackageLocale: en-US
+Publisher: Microsoft Corporation
+PublisherUrl: https://github.com/microsoft/XmlNotepad
+PublisherSupportUrl: https://github.com/microsoft/XmlNotepad/issues
+#PrivacyUrl: 
+Author: Chris Lovett
+PackageName: XML Notepad
+PackageUrl: https://github.com/microsoft/xmlnotepad
+License: MIT License
+LicenseUrl: https://raw.githubusercontent.com/microsoft/XmlNotepad/master/LICENSE
+Copyright: Copyright (c) 2016 clovett
+CopyrightUrl: https://raw.githubusercontent.com/microsoft/XmlNotepad/master/LICENSE
+ShortDescription: XML Notepad is a lightweight and fast tool for editing XML documents.
+Description: XML Notepad is a lightweight and fast tool for editing XML documents. XML has proliferated across the planet and XML Notepad has been downloaded over 3 million times!
+Moniker: xmlnotepad
+Tags:
+- xml editor
+- xml
+ManifestType: defaultLocale
+ManifestVersion: 1.0.0

--- a/manifests/m/Microsoft/XMLNotepad/2.8.0.34/Microsoft.XMLNotepad.yaml
+++ b/manifests/m/Microsoft/XMLNotepad/2.8.0.34/Microsoft.XMLNotepad.yaml
@@ -1,25 +1,8 @@
+# Created using YamlCreate.ps1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.0.0.schema.json
+
 PackageIdentifier: Microsoft.XMLNotepad
-Author: Chris Lovett
-Publisher: Microsoft Corporation
-PackageName: XML Notepad
 PackageVersion: 2.8.0.34
-License: Copyright (C) Microsoft Corporation
-LicenseUrl: https://github.com/microsoft/XmlNotepad/blob/master/LICENSE
-MinimumOSVersion: 10.0.18362.0
-FileExtensions:
-- xml
-Moniker: xmlnotepad
-Tags:
-- xml editor
-- xml
-ShortDescription: XML Notepad is a lightweight and fast tool for editing XML documents.
-PackageUrl: https://github.com/microsoft/xmlnotepad
-Installers:
-- Architecture: neutral
-  InstallerType: msix
-  InstallerUrl: https://lovettsoftwarestorage.blob.core.windows.net/downloads/XmlNotepad.Net/2.8.0.34/XmlNotepadPackage_2.8.0.34_Test/XmlNotepadPackage_2.8.0.34_AnyCPU.msixbundle
-  InstallerSha256: d596fd6238e9bd2e5d92d8df0108b485582a53b3b3da48d983085b26aeb281a3
-  InstallerLocale: en
-PackageLocale: en-US
-ManifestType: singleton
+DefaultLocale: en-US
+ManifestType: version
 ManifestVersion: 1.0.0


### PR DESCRIPTION
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

@lovettchris i created a proper manifest for it, this information is from your manifest, the Installer and the GitHub page for it.
The `PublisherUrl` can be `https://www.microsoft.com` if you prefer and the `PrivacyUrl` can also be directed to `Microsoft.com` if you'd like.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/17678)