### PR TITLE
Added MITMediaLab.Scratch.3 v3.23.1

### DIFF
--- a/manifests/m/MITMediaLab/Scratch/3/3.23.1/MITMediaLab.Scratch.3.installer.yaml
+++ b/manifests/m/MITMediaLab/Scratch/3/3.23.1/MITMediaLab.Scratch.3.installer.yaml
@@ -1,0 +1,33 @@
+﻿# Created using YamlCreate.ps1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
+
+PackageIdentifier: MITMediaLab.Scratch.3
+PackageVersion: 3.23.1
+MinimumOSVersion: 10.0.0.0
+Platform:
+- Windows.Desktop
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+Installers:
+- InstallerLocale: en-US
+  Architecture: x64
+  InstallerType: nullsoft
+  Scope: user
+  InstallerUrl: https://downloads.scratch.mit.edu/desktop/Scratch%203.23.1%20Setup.exe
+  InstallerSha256: 646B6D8939808E0080581B28F2680CF50FEC86A3796EE9924A78886169484E4D
+  InstallerSwitches:
+    Custom: /NORESTART /CURRENTUSER
+  UpgradeBehavior: install
+- InstallerLocale: en-US
+  Architecture: x64
+  InstallerType: nullsoft
+  Scope: machine
+  InstallerUrl: https://downloads.scratch.mit.edu/desktop/Scratch%203.23.1%20Setup.exe
+  InstallerSha256: 646B6D8939808E0080581B28F2680CF50FEC86A3796EE9924A78886169484E4D
+  InstallerSwitches:
+    Custom: /NORESTART /ALLUSERS
+  UpgradeBehavior: install
+ManifestType: installer
+ManifestVersion: 1.0.0

--- a/manifests/m/MITMediaLab/Scratch/3/3.23.1/MITMediaLab.Scratch.3.locale.en-US.yaml
+++ b/manifests/m/MITMediaLab/Scratch/3/3.23.1/MITMediaLab.Scratch.3.locale.en-US.yaml
@@ -1,0 +1,24 @@
+﻿# Created using YamlCreate.ps1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultlocale.1.0.0.schema.json
+
+PackageIdentifier: MITMediaLab.Scratch.3
+PackageVersion: 3.23.1
+PackageLocale: en-US
+Publisher: Scratch Foundation
+PublisherUrl: https://scratch.mit.edu/
+PublisherSupportUrl: https://scratch.mit.edu/discuss/
+PrivacyUrl: https://scratch.mit.edu/privacy_policy
+Author: MIT Media Lab
+PackageName: Scratch 3
+PackageUrl: https://scratch.mit.edu/
+License: GPLv2
+LicenseUrl: https://scratch.mit.edu/terms_of_use
+#Copyright: 
+#CopyrightUrl: 
+ShortDescription: With Scratch, you can program your own interactive stories, games, and animations and share your creations with others in the online community.
+Description: With Scratch, you can program your own interactive stories, games, and animations and share your creations with others in the online community.
+Moniker: scratch3
+Tags:
+- scratch
+ManifestType: defaultLocale
+ManifestVersion: 1.0.0

--- a/manifests/m/MITMediaLab/Scratch/3/3.23.1/MITMediaLab.Scratch.3.yaml
+++ b/manifests/m/MITMediaLab/Scratch/3/3.23.1/MITMediaLab.Scratch.3.yaml
@@ -1,0 +1,8 @@
+﻿# Created using YamlCreate.ps1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.0.0.schema.json
+
+PackageIdentifier: MITMediaLab.Scratch.3
+PackageVersion: 3.23.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.0.0


### PR DESCRIPTION
Closes #16177

- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [X] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

```
PS C:\Users\Esco\Downloads> winget install -m M:\m\MITMediaLab\Scratch\3\3.23.1\
Found Scratch 3 [MITMediaLab.Scratch.3]
This application is licensed to you by its owner.
Microsoft is not responsible for, nor does it grant any licenses to, third-party packages.
Downloading https://downloads.scratch.mit.edu/desktop/Scratch%203.23.1%20Setup.exe
  ██████████████████████████████   152 MB /  152 MB
Successfully verified installer hash
Starting package install...
Successfully installed
```

![image](https://user-images.githubusercontent.com/15158490/122473602-6335b000-cfc2-11eb-8645-00bfa1fc087a.png)


-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/17936)