### PR TITLE
Moved MITMediaLab.Scratch.1 v1.4.0.0

### DIFF
--- a/manifests/m/MITMediaLab/Scratch/1/1.4.0.0/MITMediaLab.Scratch.1.installer.yaml
+++ b/manifests/m/MITMediaLab/Scratch/1/1.4.0.0/MITMediaLab.Scratch.1.installer.yaml
@@ -1,0 +1,24 @@
+﻿# Created using YamlCreate.ps1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
+
+PackageIdentifier: MITMediaLab.Scratch.1
+PackageVersion: 1.4.0.0
+MinimumOSVersion: 10.0.0.0
+Platform:
+- Windows.Desktop
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+Installers:
+- InstallerLocale: en-US
+  Architecture: x86
+  InstallerType: nullsoft
+  Scope: machine
+  InstallerUrl: https://download.scratch.mit.edu/ScratchInstaller1.4.exe
+  InstallerSha256: 158E92BE788EEA3149F808B172D265E08F6C9DA5DA81634915CB09354CD04D08
+  InstallerSwitches:
+    Custom: /NORESTART
+  UpgradeBehavior: install
+ManifestType: installer
+ManifestVersion: 1.0.0

--- a/manifests/m/MITMediaLab/Scratch/1/1.4.0.0/MITMediaLab.Scratch.1.locale.en-US.yaml
+++ b/manifests/m/MITMediaLab/Scratch/1/1.4.0.0/MITMediaLab.Scratch.1.locale.en-US.yaml
@@ -1,0 +1,24 @@
+﻿# Created using YamlCreate.ps1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultlocale.1.0.0.schema.json
+
+PackageIdentifier: MITMediaLab.Scratch.1
+PackageVersion: 1.4.0.0
+PackageLocale: en-US
+Publisher: MIT Media Lab Lifelong Kindergarten Group
+PublisherUrl: https://scratch.mit.edu/
+PublisherSupportUrl: https://scratch.mit.edu/discuss/
+PrivacyUrl: https://scratch.mit.edu/privacy_policy
+Author: MIT Media Lab
+PackageName: Scratch
+PackageUrl: https://scratch.mit.edu/
+License: GPLv2
+LicenseUrl: https://scratch.mit.edu/terms_of_use
+#Copyright: 
+#CopyrightUrl: 
+ShortDescription: With Scratch, you can program your own interactive stories, games, and animations and share your creations with others in the online community.
+Description: With Scratch, you can program your own interactive stories, games, and animations and share your creations with others in the online community.
+Moniker: scratch1
+Tags:
+- scratch
+ManifestType: defaultLocale
+ManifestVersion: 1.0.0

--- a/manifests/m/MITMediaLab/Scratch/1/1.4.0.0/MITMediaLab.Scratch.1.yaml
+++ b/manifests/m/MITMediaLab/Scratch/1/1.4.0.0/MITMediaLab.Scratch.1.yaml
@@ -1,0 +1,8 @@
+﻿# Created using YamlCreate.ps1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.0.0.schema.json
+
+PackageIdentifier: MITMediaLab.Scratch.1
+PackageVersion: 1.4.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.0.0


### PR DESCRIPTION
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [X] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

```
PS C:\Users\Esco\Downloads> winget validate M:\m\MITMediaLab\Scratch\1\1.4.0.0\
Manifest validation succeeded.
PS C:\Users\Esco\Downloads> winget install -m M:\m\MITMediaLab\Scratch\1\1.4.0.0\
Found Scratch [MITMediaLab.Scratch.1]
This application is licensed to you by its owner.
Microsoft is not responsible for, nor does it grant any licenses to, third-party packages.
Downloading https://download.scratch.mit.edu/ScratchInstaller1.4.exe
  ██████████████████████████████  33.0 MB / 33.0 MB
Successfully verified installer hash
Starting package install...
Successfully installed
```

![image](https://user-images.githubusercontent.com/15158490/122474986-45694a80-cfc4-11eb-942a-35e5ed8eda73.png)


-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/17944)