### PR TITLE
Moved and Manifest Update for TUG.TeXworks v0.6.6

### DIFF
--- a/manifests/t/TUG/TeXworks/0.6.6/TUG.TeXworks.installer.yaml
+++ b/manifests/t/TUG/TeXworks/0.6.6/TUG.TeXworks.installer.yaml
@@ -1,0 +1,31 @@
+﻿# Created using YamlCreate.ps1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
+
+PackageIdentifier: TUG.TeXworks
+PackageVersion: 0.6.6
+MinimumOSVersion: 10.0.0.0
+Platform:
+- Windows.Desktop
+FileExtensions:
+- tex
+- ltx
+- sty
+- cls
+- dtx
+- pdf
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+Installers:
+- InstallerLocale: en-US
+  Architecture: x86
+  InstallerType: inno
+  Scope: machine
+  InstallerUrl: https://github.com/TeXworks/texworks/releases/download/release-0.6.6/TeXworks-win-setup-0.6.6-202103111145-git_24442ac.exe
+  InstallerSha256: FB626CF0945B649D5BDD8C812513A758115231D7B715C740F3CE3701B42BD73A
+  InstallerSwitches:
+    Custom: /NORESTART
+  UpgradeBehavior: install
+ManifestType: installer
+ManifestVersion: 1.0.0

--- a/manifests/t/TUG/TeXworks/0.6.6/TUG.TeXworks.locale.en-US.yaml
+++ b/manifests/t/TUG/TeXworks/0.6.6/TUG.TeXworks.locale.en-US.yaml
@@ -4,7 +4,7 @@
 PackageIdentifier: TUG.TeXworks
 PackageVersion: 0.6.6
 PackageLocale: en-US
-Publisher: TeX User Group
+Publisher: TeX Users Group
 PublisherUrl: https://www.tug.org
 PublisherSupportUrl: https://www.tug.org/contact.html
 #PrivacyUrl: 

--- a/manifests/t/TUG/TeXworks/0.6.6/TUG.TeXworks.locale.en-US.yaml
+++ b/manifests/t/TUG/TeXworks/0.6.6/TUG.TeXworks.locale.en-US.yaml
@@ -1,0 +1,25 @@
+﻿# Created using YamlCreate.ps1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultlocale.1.0.0.schema.json
+
+PackageIdentifier: TUG.TeXworks
+PackageVersion: 0.6.6
+PackageLocale: en-US
+Publisher: TeX User Group
+PublisherUrl: https://www.tug.org
+PublisherSupportUrl: https://www.tug.org/contact.html
+#PrivacyUrl: 
+Author: TeX User Group
+PackageName: TeXworks
+PackageUrl: http://www.tug.org/texworks/
+License: GNU GPL v2
+LicenseUrl: https://raw.githubusercontent.com/TeXworks/texworks/release-0.6.6/COPYING
+Copyright: Copyright (C) 1989, 1991 Free Software Foundation, Inc.
+CopyrightUrl: https://raw.githubusercontent.com/TeXworks/texworks/release-0.6.6/COPYING
+ShortDescription: TeXworks is an environment for authoring TeX (LaTeX, ConTeXt, etc) documents, with a Unicode-based, TeX-aware editor, integrated PDF viewer, and a clean, simple interface accessible to casual and non-technical users.
+Description: TeXworks is an environment for authoring TeX (LaTeX, ConTeXt, etc) documents, with a Unicode-based, TeX-aware editor, integrated PDF viewer, and a clean, simple interface accessible to casual and non-technical users.
+Moniker: texworks
+Tags:
+- texworks
+- tex
+ManifestType: defaultLocale
+ManifestVersion: 1.0.0

--- a/manifests/t/TUG/TeXworks/0.6.6/TUG.TeXworks.locale.en-US.yaml
+++ b/manifests/t/TUG/TeXworks/0.6.6/TUG.TeXworks.locale.en-US.yaml
@@ -8,7 +8,7 @@ Publisher: TeX Users Group
 PublisherUrl: https://www.tug.org
 PublisherSupportUrl: https://www.tug.org/contact.html
 #PrivacyUrl: 
-Author: TeX User Group
+Author: TeX Users Group
 PackageName: TeXworks
 PackageUrl: http://www.tug.org/texworks/
 License: GNU GPL v2

--- a/manifests/t/TUG/TeXworks/0.6.6/TUG.TeXworks.yaml
+++ b/manifests/t/TUG/TeXworks/0.6.6/TUG.TeXworks.yaml
@@ -1,0 +1,8 @@
+﻿# Created using YamlCreate.ps1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.0.0.schema.json
+
+PackageIdentifier: TUG.TeXworks
+PackageVersion: 0.6.6
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.0.0


### PR DESCRIPTION
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [X] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

```
PS C:\Users\Esco> winget install -m M:\t\TUG\TeXworks\0.6.6\
Found TeXworks [TUG.TeXworks]
This application is licensed to you by its owner.
Microsoft is not responsible for, nor does it grant any licenses to, third-party packages.
Downloading https://github.com/TeXworks/texworks/releases/download/release-0.6.6/TeXworks-win-setup-0.6.6-202103111145-git_24442ac.exe
  ██████████████████████████████  23.0 MB / 23.0 MB
Successfully verified installer hash
Starting package install...
Successfully installed
```

![image](https://user-images.githubusercontent.com/15158490/122620751-073b5c00-d094-11eb-8e5e-afa7e992cdd3.png)


-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/18045)