### PR TITLE
Manifest Update for Toinane.Colorpicker v2.0.3

### DIFF
--- a/manifests/t/Toinane/Colorpicker/2.0.3/Toinane.Colorpicker.installer.yaml
+++ b/manifests/t/Toinane/Colorpicker/2.0.3/Toinane.Colorpicker.installer.yaml
@@ -1,0 +1,33 @@
+﻿# Created using YamlCreate.ps1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
+
+PackageIdentifier: Toinane.Colorpicker
+PackageVersion: 2.0.3
+MinimumOSVersion: 10.0.0.0
+Platform:
+- Windows.Desktop
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+Installers:
+- InstallerLocale: en-US
+  Architecture: neutral
+  InstallerType: nullsoft
+  Scope: user
+  InstallerUrl: https://github.com/Toinane/colorpicker/releases/download/2.0.3/colorpicker_setup_2.0.3.exe
+  InstallerSha256: EA138D1B98B6237CCE27E20FFD9DBC82FC52A15FF519C0FF5F9ADDF1888EBF99
+  InstallerSwitches:
+    Custom: /NORESTART /CURRENTUSER
+  UpgradeBehavior: install
+- InstallerLocale: en-US
+  Architecture: neutral
+  InstallerType: nullsoft
+  Scope: machine
+  InstallerUrl: https://github.com/Toinane/colorpicker/releases/download/2.0.3/colorpicker_setup_2.0.3.exe
+  InstallerSha256: EA138D1B98B6237CCE27E20FFD9DBC82FC52A15FF519C0FF5F9ADDF1888EBF99
+  InstallerSwitches:
+    Custom: /NORESTART /ALLUSERS
+  UpgradeBehavior: install
+ManifestType: installer
+ManifestVersion: 1.0.0

--- a/manifests/t/Toinane/Colorpicker/2.0.3/Toinane.Colorpicker.locale.en-US.yaml
+++ b/manifests/t/Toinane/Colorpicker/2.0.3/Toinane.Colorpicker.locale.en-US.yaml
@@ -1,0 +1,27 @@
+﻿# Created using YamlCreate.ps1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultlocale.1.0.0.schema.json
+
+PackageIdentifier: Toinane.Colorpicker
+PackageVersion: 2.0.3
+PackageLocale: en-US
+Publisher: Toinane
+PublisherUrl: https://github.com/Toinane/colorpicker
+PublisherSupportUrl: https://github.com/Toinane/colorpicker/issues
+#PrivacyUrl: 
+Author: Toinane
+PackageName: Colorpicker
+PackageUrl: https://colorpicker.fr/
+License: GNU General Public License v3.0
+LicenseUrl: https://github.com/Toinane/colorpicker/blob/master/LICENSE
+Copyright: Copyright (C) 2007 Free Software Foundation, Inc.
+CopyrightUrl: https://github.com/Toinane/colorpicker/blob/master/LICENSE
+ShortDescription: A mininal but complete colorpicker desktop app.
+Description: A mininal but complete colorpicker desktop app.
+Moniker: colorpicker
+Tags:
+- color
+- design
+- tool
+- picker
+ManifestType: defaultLocale
+ManifestVersion: 1.0.0

--- a/manifests/t/Toinane/Colorpicker/2.0.3/Toinane.Colorpicker.yaml
+++ b/manifests/t/Toinane/Colorpicker/2.0.3/Toinane.Colorpicker.yaml
@@ -1,22 +1,8 @@
+﻿# Created using YamlCreate.ps1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.0.0.schema.json
+
 PackageIdentifier: Toinane.Colorpicker
 PackageVersion: 2.0.3
-PackageName: Colorpicker
-Publisher: Toinane
-License: GPLv3
-LicenseUrl: https://github.com/Toinane/colorpicker/blob/master/LICENSE
-Moniker: colorpicker
-Tags:
-- color
-- design
-- tool
-- picker
-ShortDescription: A mininal but complete colorpicker desktop app.
-PackageUrl: https://colorpicker.fr/
-Installers:
-- Architecture: x86
-  InstallerUrl: https://github.com/Toinane/colorpicker/releases/download/2.0.3/colorpicker_setup_2.0.3.exe
-  InstallerSha256: EA138D1B98B6237CCE27E20FFD9DBC82FC52A15FF519C0FF5F9ADDF1888EBF99
-  InstallerType: nullsoft
-PackageLocale: en-US
-ManifestType: singleton
+DefaultLocale: en-US
+ManifestType: version
 ManifestVersion: 1.0.0


### PR DESCRIPTION
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [X] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

```
PS C:\Users\Esco> winget install -m M:\t\Toinane\Colorpicker\2.0.3\
Found Colorpicker [Toinane.Colorpicker]
This application is licensed to you by its owner.
Microsoft is not responsible for, nor does it grant any licenses to, third-party packages.
Downloading https://github.com/Toinane/colorpicker/releases/download/2.0.3/colorpicker_setup_2.0.3.exe
  ██████████████████████████████  41.2 MB / 41.2 MB
Successfully verified installer hash
Starting package install...
Successfully installed
```

![image](https://user-images.githubusercontent.com/15158490/122622043-b463a380-d097-11eb-9798-fa3edb721baa.png)


-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/18060)