### PR TITLE
Manifest Update for touchbyte.PhotoSync v4.0.4

### DIFF
--- a/manifests/t/touchbyte/PhotoSync/4.0.4/touchbyte.PhotoSync.installer.yaml
+++ b/manifests/t/touchbyte/PhotoSync/4.0.4/touchbyte.PhotoSync.installer.yaml
@@ -1,0 +1,33 @@
+﻿# Created using YamlCreate.ps1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
+
+PackageIdentifier: touchbyte.PhotoSync
+PackageVersion: 4.0.4
+MinimumOSVersion: 10.0.0.0
+Platform:
+- Windows.Desktop
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+Installers:
+- InstallerLocale: en-US
+  Architecture: x64
+  InstallerType: nullsoft
+  Scope: machine
+  InstallerUrl: https://www.photosync-app.com/tl_files/photosync/publish/win/photosync_setup.404/photosync_setup.exe
+  InstallerSha256: 87765769CCC5376CFF424D51017BC115EB1910791D5000112E2697AFFEAD2674
+  InstallerSwitches:
+    Custom: /NORESTART /ALLUSERS
+  UpgradeBehavior: install
+- InstallerLocale: en-US
+  Architecture: x64
+  InstallerType: nullsoft
+  Scope: user
+  InstallerUrl: https://www.photosync-app.com/tl_files/photosync/publish/win/photosync_setup.404/photosync_setup.exe
+  InstallerSha256: 87765769CCC5376CFF424D51017BC115EB1910791D5000112E2697AFFEAD2674
+  InstallerSwitches:
+    Custom: /NORESTART /CURRENTUSER
+  UpgradeBehavior: install
+ManifestType: installer
+ManifestVersion: 1.0.0

--- a/manifests/t/touchbyte/PhotoSync/4.0.4/touchbyte.PhotoSync.locale.en-US.yaml
+++ b/manifests/t/touchbyte/PhotoSync/4.0.4/touchbyte.PhotoSync.locale.en-US.yaml
@@ -1,0 +1,29 @@
+﻿# Created using YamlCreate.ps1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultlocale.1.0.0.schema.json
+
+PackageIdentifier: touchbyte.PhotoSync
+PackageVersion: 4.0.4
+PackageLocale: en-US
+Publisher: touchbyte GmbH
+PublisherUrl: https://www.photosync-app.com
+PublisherSupportUrl: https://www.photosync-app.com/support.html
+PrivacyUrl: https://www.photosync-app.com/legal-notice.html
+Author: touchbyte
+PackageName: PhotoSync
+PackageUrl: https://www.photosync-app.com
+License: Proprietary
+LicenseUrl: https://www.photosync-app.com/legal-notice.html
+Copyright: Copyright (c) touchbyte GmbH
+CopyrightUrl: https://www.photosync-app.com/legal-notice.html
+ShortDescription: Wirelessly transfer & backup your photos & videos.
+Description: Wirelessly transfer & backup your photos & videos.
+Moniker: photosync
+Tags:
+- transfer
+- backup
+- photos
+- videos
+- android
+- ios
+ManifestType: defaultLocale
+ManifestVersion: 1.0.0

--- a/manifests/t/touchbyte/PhotoSync/4.0.4/touchbyte.PhotoSync.yaml
+++ b/manifests/t/touchbyte/PhotoSync/4.0.4/touchbyte.PhotoSync.yaml
@@ -1,25 +1,8 @@
+﻿# Created using YamlCreate.ps1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.0.0.schema.json
+
 PackageIdentifier: touchbyte.PhotoSync
 PackageVersion: 4.0.4
-PackageName: PhotoSync
-Publisher: touchbyte
-License: Copyright (c) touchbyte GmbH
-Tags:
-- transfer
-- backup
-- photos
-- videos
-- android
-- ios
-ShortDescription: Wirelessly transfer & backup your photos & videos.
-PackageUrl: https://www.photosync-app.com/
-Installers:
-- Architecture: x64
-  InstallerUrl: https://www.photosync-app.com/tl_files/photosync/publish/win/photosync_setup.404/photosync_setup.exe
-  InstallerSha256: 87765769CCC5376CFF424D51017BC115EB1910791D5000112E2697AFFEAD2674
-  InstallerType: nullsoft
-  InstallerSwitches:
-    Silent: /S /ALLUSERS
-    SilentWithProgress: /S /ALLUSERS
-PackageLocale: en-US
-ManifestType: singleton
+DefaultLocale: en-US
+ManifestType: version
 ManifestVersion: 1.0.0


### PR DESCRIPTION
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [X] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

```
PS C:\Users\Esco> winget install -m M:\t\touchbyte\PhotoSync\4.0.4\
Found PhotoSync [touchbyte.PhotoSync]
This application is licensed to you by its owner.
Microsoft is not responsible for, nor does it grant any licenses to, third-party packages.
Downloading https://www.photosync-app.com/tl_files/photosync/publish/win/photosync_setup.404/photosync_setup.exe
  ██████████████████████████████  4.93 MB / 4.93 MB
Successfully verified installer hash
Starting package install...
Successfully installed
```

![image](https://user-images.githubusercontent.com/15158490/122623465-6f8e3b80-d09c-11eb-9aa3-9b5e9506ae5b.png)


-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/18078)