### PR TITLE
Added EXE IntallerType for Mozilla.Firefox v89.0.2 + ru-RU and nb-NO locale

### DIFF
--- a/manifests/m/Mozilla/Firefox/89.0.2/Mozilla.Firefox.installer.yaml
+++ b/manifests/m/Mozilla/Firefox/89.0.2/Mozilla.Firefox.installer.yaml
@@ -1,10 +1,11 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
+
 PackageIdentifier: Mozilla.Firefox
 PackageVersion: 89.0.2
 MinimumOSVersion: 10.0.0.0
+Platform:
+- Windows.Desktop
 InstallModes:
-- interactive
-- silent
 - silentWithProgress
 Commands:
 - firefox
@@ -24,6 +25,16 @@ Installers:
   InstallerSha256: D7C5E9FEE67C411FB41725721B7633EB5A521BB036B113589980364FD892D3CA
   UpgradeBehavior: install
 - InstallerLocale: en-US
+  Architecture: x64
+  InstallerType: exe
+  Scope: machine
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/firefox/releases/89.0.2/win64/en-US/Firefox%20Setup%2089.0.2.exe
+  InstallerSha256: 26AA9CFA04F8BDCE01130B8FE3BC716E665B4463ED4D845762D99A238FFBCC33
+  UpgradeBehavior: install
+  InstallerSwitches:
+    Silent: /S
+    SilentWithProgress: /S
+- InstallerLocale: en-US
   Architecture: x86
   InstallerType: msi
   Scope: machine
@@ -31,15 +42,26 @@ Installers:
   InstallerSha256: 2ECA679159FCA93ED83D3BD7731C3C65B9B30719832DBE34E2D0C8AFF8A1964F
   UpgradeBehavior: install
 - InstallerLocale: en-US
+  Architecture: x86
+  InstallerType: exe
+  Scope: machine
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/firefox/releases/89.0.2/win32/en-US/Firefox%20Setup%2089.0.2.exe
+  InstallerSha256: 6497C70671D10DE4BE5E41B485B12BC2220E701363A8D5F1F4D9C1B4AB51336F
+  UpgradeBehavior: install
+  InstallerSwitches:
+    Silent: /S
+    SilentWithProgress: /S
+- InstallerLocale: en-US
   Architecture: arm64
   InstallerType: exe
   Scope: machine
   InstallerUrl: https://download-installer.cdn.mozilla.net/pub/firefox/releases/89.0.2/win64-aarch64/en-US/Firefox%20Setup%2089.0.2.exe
   InstallerSha256: 848F9153A79658359E1204573A255F95CD988A980764EF1BE6EB98C3709C11D3
   InstallerSwitches:
-    Silent: /s
-    SilentWithProgress: /s
+    Silent: /S
+    SilentWithProgress: /S
   UpgradeBehavior: install
+
 - InstallerLocale: zh-CN
   Architecture: x64
   InstallerType: msi
@@ -47,11 +69,29 @@ Installers:
   InstallerUrl: https://download-installer.cdn.mozilla.net/pub/firefox/releases/89.0.2/win64/zh-CN/Firefox%20Setup%2089.0.2.msi
   InstallerSha256: C0576480FD08E7956A67122EE8FEBAE24BBA3B3C6C067B412CB2AC34A64F5F6A
 - InstallerLocale: zh-CN
+  Architecture: x64
+  InstallerType: exe
+  Scope: machine
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/firefox/releases/89.0.2/win64/zh-CN/Firefox%20Setup%2089.0.2.exe
+  InstallerSha256: 39314F07F15267A50CC3000E8542BA5944E8D44614F5033D0874976EC4471402
+  InstallerSwitches:
+    Silent: /S
+    SilentWithProgress: /S
+- InstallerLocale: zh-CN
   Architecture: x86
   InstallerType: msi
   Scope: machine
   InstallerUrl: https://download-installer.cdn.mozilla.net/pub/firefox/releases/89.0.2/win32/zh-CN/Firefox%20Setup%2089.0.2.msi
   InstallerSha256: 26C43502C108B890E2D56CFCD25106C0CF62084460F10BB6B7949395E50A3E7C
+- InstallerLocale: zh-CN
+  Architecture: x86
+  InstallerType: exe
+  Scope: machine
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/firefox/releases/89.0.2/win32/zh-CN/Firefox%20Setup%2089.0.2.exe
+  InstallerSha256: A0E0D8A340D50E923F9C88E0A1C0423DA2F4955049C13B03702C2569FFB28F2F
+  InstallerSwitches:
+    Silent: /S
+    SilentWithProgress: /S
 - InstallerLocale: zh-CN
   Architecture: arm64
   InstallerType: exe
@@ -59,7 +99,87 @@ Installers:
   InstallerUrl: https://download-installer.cdn.mozilla.net/pub/firefox/releases/89.0.2/win64-aarch64/zh-CN/Firefox%20Setup%2089.0.2.exe
   InstallerSha256: A38463C90C01A2E8144C4A3F4B2063400940CBC1C8C0FE8C69A1BFD6484603F8
   InstallerSwitches:
-    Silent: /s
-    SilentWithProgress: /s
+    Silent: /S
+    SilentWithProgress: /S
+
+- InstallerLocale: en-GB
+  Architecture: x64
+  InstallerType: msi
+  Scope: machine
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/firefox/releases/89.0.2/win64/en-GB/Firefox%20Setup%2089.0.2.msi
+  InstallerSha256: 30022E1791370C393D1030E91BA82F79BED08EF7100C816A479256E05242004F
+- InstallerLocale: en-GB
+  Architecture: x64
+  InstallerType: exe
+  Scope: machine
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/firefox/releases/89.0.2/win64/en-GB/Firefox%20Setup%2089.0.2.exe
+  InstallerSha256: 76643027F65ED34903A5AFDEF581AB2E520EEF7B2223270A855F2D3AB75B7DD3
+  InstallerSwitches:
+    Silent: /S
+    SilentWithProgress: /S
+- InstallerLocale: en-GB
+  Architecture: x86
+  InstallerType: msi
+  Scope: machine
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/firefox/releases/89.0.2/win32/en-GB/Firefox%20Setup%2089.0.2.msi
+  InstallerSha256: 77DC79B74BB4526E8FA5C847D383DB3729AECC94645F165D8C8AFD587D3456BF
+- InstallerLocale: en-GB
+  Architecture: x86
+  InstallerType: exe
+  Scope: machine
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/firefox/releases/89.0.2/win32/en-GB/Firefox%20Setup%2089.0.2.exe
+  InstallerSha256: 9CFF08F99A6254492C791F8EA390FC5F6537B2A49834AA414E80FBBA30C77EA8
+  InstallerSwitches:
+    Silent: /S
+    SilentWithProgress: /S
+- InstallerLocale: en-GB
+  Architecture: arm64
+  InstallerType: exe
+  Scope: machine
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/firefox/releases/89.0.2/win64-aarch64/en-GB/Firefox%20Setup%2089.0.2.exe
+  InstallerSha256: CF6D980845914F5252A84031EE726A6025AA81D08339D382788AE2F16F43BB44
+  InstallerSwitches:
+    Silent: /S
+    SilentWithProgress: /S
+
+- InstallerLocale: ru-RU
+  Architecture: x64
+  InstallerType: msi
+  Scope: machine
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/firefox/releases/89.0.2/win64/ru/Firefox%20Setup%2089.0.2.msi
+  InstallerSha256: 91C206889A1441DB8EE05E69BD9ABE6460A39A6AE6235B14B1C8EC96E27B4B05
+- InstallerLocale: ru-RU
+  Architecture: x64
+  InstallerType: exe
+  Scope: machine
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/firefox/releases/89.0.2/win64/ru/Firefox%20Setup%2089.0.2.exe
+  InstallerSha256: 91B0E7D9A3FF20F858911DC04A0376FC054560A37C1EB57CE00BB889C8F7F14F
+  InstallerSwitches:
+    Silent: /S
+    SilentWithProgress: /S
+- InstallerLocale: ru-RU
+  Architecture: x86
+  InstallerType: msi
+  Scope: machine
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/firefox/releases/89.0.2/win32/ru/Firefox%20Setup%2089.0.2.msi
+  InstallerSha256: D067479C910C68E460407C469E3D2C18507C9FD118228EA805D3C9CEF8C702C9
+- InstallerLocale: ru-RU
+  Architecture: x86
+  InstallerType: exe
+  Scope: machine
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/firefox/releases/89.0.2/win32/ru/Firefox%20Setup%2089.0.2.exe
+  InstallerSha256: 44DCCC7D7C8A50F6A548D9A2933400A9AED3D712562723918ED1D57449B01E51
+  InstallerSwitches:
+    Silent: /S
+    SilentWithProgress: /S
+- InstallerLocale: ru-RU
+  Architecture: arm64
+  InstallerType: exe
+  Scope: machine
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/firefox/releases/89.0.2/win64-aarch64/ru/Firefox%20Setup%2089.0.2.exe
+  InstallerSha256: 31618694856870E0814DC69CCFA7FE3DFC330638038E6856A32156A383E70557
+  InstallerSwitches:
+    Silent: /S
+    SilentWithProgress: /S
 ManifestType: installer
 ManifestVersion: 1.0.0

--- a/manifests/m/Mozilla/Firefox/89.0.2/Mozilla.Firefox.locale.es-MX.yaml
+++ b/manifests/m/Mozilla/Firefox/89.0.2/Mozilla.Firefox.locale.es-MX.yaml
@@ -1,4 +1,5 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.0.0.schema.json
+
 PackageIdentifier: Mozilla.Firefox
 PackageVersion: 89.0.2
 PackageLocale: es-MX
@@ -17,7 +18,7 @@ Tags:
 - browser
 - web browser
 - foss
-- cross platform
+- cross-platform
 - gecko
 - quantum
 - spidermonkey

--- a/manifests/m/Mozilla/Firefox/89.0.2/Mozilla.Firefox.locale.nb-NO.yaml
+++ b/manifests/m/Mozilla/Firefox/89.0.2/Mozilla.Firefox.locale.nb-NO.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.0.0.schema.json
+
+PackageIdentifier: Mozilla.Firefox
+PackageVersion: 89.0.2
+PackageLocale: nb-NO
+Publisher: Mozilla
+PublisherUrl: https://www.mozilla.org/nb-NO/
+PublisherSupportUrl: https://support.mozilla.org/nb-NO/
+PrivacyUrl: https://www.mozilla.org/nb-NO/privacy/websites
+Author: Mozilla Foundation
+PackageName: Mozilla Firefox
+PackageUrl: https://www.mozilla.org/nb-NO/firefox/
+License: Mozilla Public License Version 2.0
+LicenseUrl: https://www.mozilla.org/en-US/MPL/2.0
+CopyrightUrl: https://www.mozilla.org/en-US/foundation/trademarks/policy
+ShortDescription: Mozilla Firefox er gratis programvare med åpen kildekode, bygget av et samfunn på tusenvis fra hele verden. 
+Description: Firefox Browser, også kjent som Mozilla Firefox eller bare Firefox, er en gratis nettleser med åpen kildekode utviklet av Mozilla Foundation og dets datterselskap, Mozilla Corporation. Firefox bruker Gecko-layoutmotoren til å gjengi nettsider, som implementerer gjeldende og forventede webstandarder. I 2017 begynte Firefox å innlemme ny teknologi under kodenavnet Quantum for å fremme parallellitet og et mer intuitivt brukergrensesnitt. Firefox er offisielt tilgjengelig for Windows 7 eller nyere, macOS og Linux. Dens uoffisielle porter er tilgjengelige for forskjellige Unix og Unix-lignende operativsystemer, inkludert FreeBSD, OpenBSD, NetBSD, illumos og Solaris Unix. 
+Tags:
+- nettleser
+- foss
+- cross-platform
+- gecko
+- quantum
+- spidermonkey
+ManifestType: locale
+ManifestVersion: 1.0.0

--- a/manifests/m/Mozilla/Firefox/89.0.2/Mozilla.Firefox.locale.ru-RU.yaml
+++ b/manifests/m/Mozilla/Firefox/89.0.2/Mozilla.Firefox.locale.ru-RU.yaml
@@ -13,7 +13,7 @@ PackageUrl: https://www.mozilla.org/ru/firefox/
 License: Mozilla Public License Version 2.0
 LicenseUrl: https://www.mozilla.org/en-US/MPL/2.0
 CopyrightUrl: https://www.mozilla.org/en-US/foundation/trademarks/policy
-ShortDescription: Mozilla Firefox - это бесплатное программное обеспечение с открытым исходным кодом, созданное сообществом тысяч людей со всего мира.
+ShortDescription: Mozilla Firefox это бесплатное программное обеспечение с открытым исходным кодом, созданное сообществом тысяч людей со всего мира.
 Description: Браузер Firefox, также известный как Mozilla Firefox или просто Firefox, - это бесплатный веб-браузер с открытым исходным кодом, разработанный Mozilla Foundation и его дочерней компанией Mozilla Corporation. Firefox использует механизм компоновки Gecko для отображения веб-страниц, который реализует текущие и ожидаемые веб-стандарты. В 2017 году Firefox начал включать новую технологию под кодовым названием Quantum, чтобы способствовать параллелизму и более интуитивному пользовательскому интерфейсу. Firefox официально доступен для Windows 7 или новее, macOS и Linux. Его неофициальные порты доступны для различных Unix и Unix-подобных операционных систем, включая FreeBSD, OpenBSD, NetBSD, illumos и Solaris Unix. 
 Tags:
 - браузер

--- a/manifests/m/Mozilla/Firefox/89.0.2/Mozilla.Firefox.locale.ru-RU.yaml
+++ b/manifests/m/Mozilla/Firefox/89.0.2/Mozilla.Firefox.locale.ru-RU.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.0.0.schema.json
+
+PackageIdentifier: Mozilla.Firefox
+PackageVersion: 89.0.2
+PackageLocale: ru-RU
+Publisher: Mozilla
+PublisherUrl: https://www.mozilla.org/ru/
+PublisherSupportUrl: https://support.mozilla.org/ru/
+PrivacyUrl: https://www.mozilla.org/ru/privacy/websites
+Author: Mozilla Foundation
+PackageName: Mozilla Firefox
+PackageUrl: https://www.mozilla.org/ru/firefox/
+License: Mozilla Public License Version 2.0
+LicenseUrl: https://www.mozilla.org/en-US/MPL/2.0
+CopyrightUrl: https://www.mozilla.org/en-US/foundation/trademarks/policy
+ShortDescription: Mozilla Firefox - это бесплатное программное обеспечение с открытым исходным кодом, созданное сообществом тысяч людей со всего мира.
+Description: Браузер Firefox, также известный как Mozilla Firefox или просто Firefox, - это бесплатный веб-браузер с открытым исходным кодом, разработанный Mozilla Foundation и его дочерней компанией Mozilla Corporation. Firefox использует механизм компоновки Gecko для отображения веб-страниц, который реализует текущие и ожидаемые веб-стандарты. В 2017 году Firefox начал включать новую технологию под кодовым названием Quantum, чтобы способствовать параллелизму и более интуитивному пользовательскому интерфейсу. Firefox официально доступен для Windows 7 или новее, macOS и Linux. Его неофициальные порты доступны для различных Unix и Unix-подобных операционных систем, включая FreeBSD, OpenBSD, NetBSD, illumos и Solaris Unix. 
+Tags:
+- браузер
+- веб-браузер
+- foss
+- cross-platform
+- gecko
+- quantum
+- spidermonkey
+ManifestType: locale
+ManifestVersion: 1.0.0

--- a/manifests/m/Mozilla/Firefox/89.0.2/Mozilla.Firefox.locale.zh-CN.yaml
+++ b/manifests/m/Mozilla/Firefox/89.0.2/Mozilla.Firefox.locale.zh-CN.yaml
@@ -4,19 +4,20 @@ PackageIdentifier: Mozilla.Firefox
 PackageVersion: 89.0.2
 PackageLocale: zh-CN
 Publisher: Mozilla
-PublisherUrl: https://www.mozilla.org/zh-CN/
-PublisherSupportUrl: https://support.mozilla.org/es/
+PublisherUrl: https://www.firefox.com.cn
+PublisherSupportUrl: https://support.mozilla.org/zh-CN/
 PrivacyUrl: https://www.mozilla.org/zh-CN/privacy/websites/
 Author: Mozilla Foundation
 PackageName: Mozilla Firefox
-PackageUrl: https://www.mozilla.org/zh-CN/firefox/
+PackageUrl: https://www.firefox.com.cn/download/
 License: Mozilla Public License Version 2.0
-LicenseUrl: https://www.mozilla.org/zh-CN/MPL/2.0/
+LicenseUrl: https://www.mozilla.org/en-US/MPL/2.0/
 CopyrightUrl: https://www.mozilla.org/en-US/foundation/trademarks/policy
-ShortDescription: Mozilla Firefox Chinese Simplify
+ShortDescription: Mozilla Firefox 简体中文
+Description: Mozilla Firefox 简体中文
 Tags:
-- browser
-- web browser
+- 浏览器
+- 网页浏览器
 - foss
 - cross-platform
 - gecko

--- a/manifests/m/Mozilla/Firefox/89.0.2/Mozilla.Firefox.locale.zh-CN.yaml
+++ b/manifests/m/Mozilla/Firefox/89.0.2/Mozilla.Firefox.locale.zh-CN.yaml
@@ -1,4 +1,5 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.0.0.schema.json
+
 PackageIdentifier: Mozilla.Firefox
 PackageVersion: 89.0.2
 PackageLocale: zh-CN
@@ -17,7 +18,7 @@ Tags:
 - browser
 - web browser
 - foss
-- cross platform
+- cross-platform
 - gecko
 - quantum
 - spidermonkey

--- a/manifests/m/Mozilla/Firefox/89.0.2/Mozilla.Firefox.yaml
+++ b/manifests/m/Mozilla/Firefox/89.0.2/Mozilla.Firefox.yaml
@@ -1,4 +1,5 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.0.0.schema.json
+
 PackageIdentifier: Mozilla.Firefox
 PackageVersion: 89.0.2
 DefaultLocale: en-US


### PR DESCRIPTION
https://github.com/microsoft/winget-cli/issues/1191

- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/18751)