### PR TITLE
Added voidtools.EverythingLite v1.4.1.1009

### DIFF
--- a/manifests/v/voidtools/EverythingLite/1.4.1.1009/voidtools.EverythingLite.installer.yaml
+++ b/manifests/v/voidtools/EverythingLite/1.4.1.1009/voidtools.EverythingLite.installer.yaml
@@ -1,0 +1,53 @@
+﻿# Created using YamlCreate.ps1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
+
+PackageIdentifier: voidtools.EverythingLite
+PackageVersion: 1.4.1.1009
+MinimumOSVersion: 10.0.0.0
+Platform:
+- Windows.Desktop
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+Installers:
+- InstallerLocale: en-US
+  Architecture: x64
+  InstallerType: msi
+  Scope: machine
+  InstallerUrl: https://www.voidtools.com/Everything-1.4.1.1009.x64.Lite.msi
+  InstallerSha256: C4BCC081E817753B0C17BCA969D0D903ED5CDCBB1F3F6A9C7D517B108445127A
+  InstallerSwitches:
+    Custom: /NORESTART
+  ProductCode: '{6902AEA9-F43C-4BF5-8C52-5C58A3317B2D}'
+  UpgradeBehavior: install
+- InstallerLocale: en-US
+  Architecture: x86
+  InstallerType: msi
+  Scope: machine
+  InstallerUrl: https://www.voidtools.com/Everything-1.4.1.1009.x86.Lite.msi
+  InstallerSha256: 69CB58333E6E0331C61834E14F40F5E5B2B338A17F2864BC12EE17BCA1FFF218
+  InstallerSwitches:
+    Custom: /NORESTART
+  ProductCode: '{2F08F515-E9B9-4028-AA4B-A5B4C0E4BC94}'
+  UpgradeBehavior: install
+- InstallerLocale: en-US
+  Architecture: x64
+  InstallerType: nullsoft
+  Scope: machine
+  InstallerUrl: https://www.voidtools.com/Everything-1.4.1.1009.x64.Lite-Setup.exe
+  InstallerSha256: B0CF6864FBC7EF7FFF7F9A3AE3077D2AE917D6D11765101B977304F45E126028
+  InstallerSwitches:
+    Custom: /NORESTART
+  UpgradeBehavior: install
+- InstallerLocale: en-US
+  Architecture: x86
+  InstallerType: nullsoft
+  Scope: machine
+  InstallerUrl: https://www.voidtools.com/Everything-1.4.1.1009.x86.Lite-Setup.exe
+  InstallerSha256: 9A74959D9FD70F46D0CEE61EFB3AFC99D99462353E597217C0EEC47B5F0CD6E8
+  InstallerSwitches:
+    Custom: /NORESTART
+  UpgradeBehavior: install
+ManifestType: installer
+ManifestVersion: 1.0.0

--- a/manifests/v/voidtools/EverythingLite/1.4.1.1009/voidtools.EverythingLite.locale.en-US.yaml
+++ b/manifests/v/voidtools/EverythingLite/1.4.1.1009/voidtools.EverythingLite.locale.en-US.yaml
@@ -1,0 +1,27 @@
+﻿# Created using YamlCreate.ps1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultlocale.1.0.0.schema.json
+
+PackageIdentifier: voidtools.EverythingLite
+PackageVersion: 1.4.1.1009
+PackageLocale: en-US
+Publisher: voidtools
+PublisherUrl: https://www.voidtools.com
+PublisherSupportUrl: https://www.voidtools.com/support/everything
+PrivacyUrl: https://www.voidtools.com/privacy
+Author: David Carpenter
+PackageName: Everything Lite
+PackageUrl: https://www.voidtools.com
+License: MIT
+LicenseUrl: https://www.voidtools.com/License.txt
+Copyright: Copyright (C) 2018 David Carpenter
+CopyrightUrl: https://www.voidtools.com/License.txt
+ShortDescription: Locate files and folders by name instantly.
+Description: Everything is search engine that locates files and folders by filename instantly for Windows. Unlike Windows search Everything initially displays every file and folder on your computer (hence the name Everything). You type in a search filter to limit what files and folders are displayed.
+Moniker: everything-lite
+Tags:
+- file-system
+- indexing
+- search
+- file search
+ManifestType: defaultLocale
+ManifestVersion: 1.0.0

--- a/manifests/v/voidtools/EverythingLite/1.4.1.1009/voidtools.EverythingLite.yaml
+++ b/manifests/v/voidtools/EverythingLite/1.4.1.1009/voidtools.EverythingLite.yaml
@@ -1,0 +1,8 @@
+﻿# Created using YamlCreate.ps1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.0.0.schema.json
+
+PackageIdentifier: voidtools.EverythingLite
+PackageVersion: 1.4.1.1009
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.0.0


### PR DESCRIPTION
ARP Matching is going to be a issue

- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [X] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

```
PS C:\Users\Esco> winget install -m M:\v\voidtools\EverythingLite\1.4.1.1009\
Found Everything Lite [voidtools.EverythingLite]
This application is licensed to you by its owner.
Microsoft is not responsible for, nor does it grant any licenses to, third-party packages.
Downloading https://www.voidtools.com/Everything-1.4.1.1009.x64.Lite.msi
  ██████████████████████████████  1.67 MB / 1.67 MB
Successfully verified installer hash
Starting package install...
Successfully installed
```

MSI
![image](https://user-images.githubusercontent.com/15158490/123524373-104aaf80-d6ca-11eb-98ed-6d369b78b85f.png)
EXE
![image](https://user-images.githubusercontent.com/15158490/123524392-3cfec700-d6ca-11eb-869c-e8eb95516726.png)


-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/18970)