### PR TITLE
Add Swift 5.4.2 toolchain

### DIFF
--- a/manifests/s/Swift/Toolchain/5.4.2/Swift.Toolchain.yaml
+++ b/manifests/s/Swift/Toolchain/5.4.2/Swift.Toolchain.yaml
@@ -1,0 +1,34 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.0.0.schema.json
+PackageIdentifier: Swift.Toolchain
+PackageVersion: 5.4.2
+PackageName: Swift Toolchain
+PackageLocale: en-US
+Author: Swift Open Source Project
+Publisher: Swift Open Source Project
+ShortDescription: Swift Toolchain for Windows
+PackageUrl: https://www.swift.org/
+License: Copyright (c) Swift Open Source Project
+Moniker: swift
+FileExtensions:
+  - swift
+Tags:
+  - Swift
+Commands:
+  - swift
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Microsoft.VC++2015-2019Redist-x64
+      MinimumVersion: 14.28.29913.0
+    - PackageIdentifier: Microsoft.WindowsSDK
+    - PackageIdentifier: Microsoft.VisualStudio.2019.BuildTools
+    - PackageIdentifier: Git.Git
+Installers:
+  - Architecture: x64
+    InstallerType: burn
+    InstallerUrl: https://swift.org/builds/swift-5.4.2-release/windows10/swift-5.4.2-RELEASE/swift-5.4.2-RELEASE-windows10.exe
+    InstallerSha256: 66b822e9cbfdd1522675f613b4e0b28f38ed40973629028f889a2ff39aa9d182
+    ProductCode: '{74102b32-0048-48eb-b9ed-b477618d923f}'
+    Scope: machine
+    UpgradeBehavior: uninstallPrevious
+ManifestType: singleton
+ManifestVersion: 1.0.0

--- a/manifests/s/Swift/Toolchain/5.4.2/Swift.Toolchain.yaml
+++ b/manifests/s/Swift/Toolchain/5.4.2/Swift.Toolchain.yaml
@@ -4,7 +4,7 @@ PackageVersion: 5.4.2
 PackageName: Swift Toolchain
 PackageLocale: en-US
 Author: Swift Open Source Project
-Publisher: Swift Open Source Project
+Publisher: dt.compnerd.org
 ShortDescription: Swift Toolchain for Windows
 PackageUrl: https://www.swift.org/
 License: Copyright (c) Swift Open Source Project


### PR DESCRIPTION
This introduces a winget package for the Swift toolchain.  The
dependencies are:
- Windows SDK (10.0.17763.0+)
- BuildTools (for VC++ SDK)
- Git
- Python[=3.7.8] (required for the debugger)

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/19313)