### PR TITLE
Visual Studio 2019 uses the actual version for the ARP table now instead of the build version

### DIFF
--- a/manifests/m/Microsoft/VisualStudio/2019/Community/16.10.3/Microsoft.VisualStudio.2019.Community.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Community/16.10.3/Microsoft.VisualStudio.2019.Community.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.singleton.1.0.0.schema.json
 PackageIdentifier: Microsoft.VisualStudio.2019.Community
-PackageVersion: 16.10.31424.327
+PackageVersion: 16.10.3
 PackageName: Visual Studio Community 2019
 Author: Microsoft
 Publisher: Microsoft Corporation


### PR DESCRIPTION
Since the version number in the ARP table used the actual version instead of the build version winget might think that this is for an older version of Visual Studio 2019 since the build version for the previous release was 16.10.31410.357 and the actual version for the current version of Visual Studio 2019 is 16.10.3

Same thing also happened with build tools (And most likely other versions that the Visual Studio Installer has)

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/19389)