### PR TITLE
Eugeny.Tabby version 1.0.144

### DIFF
--- a/manifests/e/Eugeny/Tabby/1.0.144/Eugeny.Tabby.installer.yaml
+++ b/manifests/e/Eugeny/Tabby/1.0.144/Eugeny.Tabby.installer.yaml
@@ -1,0 +1,34 @@
+# Created using wingetcreate 0.2.0.29
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
+
+PackageIdentifier: Eugeny.Tabby
+PackageVersion: 1.0.144
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+Installers:
+- InstallerLocale: en-US
+  Architecture: x64
+  InstallerType: nullsoft
+  Scope: user
+  InstallerUrl: https://github.com/Eugeny/tabby/releases/download/v1.0.144/tabby-1.0.144-setup.exe
+  InstallerSha256: BBC7B5224703631F896E3859B4EC407D9709642177E4A8D7454AA8D4D325CB38
+  InstallerSwitches:
+    Custom: /CURRENTUSER
+  UpgradeBehavior: install
+- InstallerLocale: en-US
+  Architecture: x64
+  InstallerType: nullsoft
+  Scope: machine
+  InstallerUrl: https://github.com/Eugeny/tabby/releases/download/v1.0.144/tabby-1.0.144-setup.exe
+  InstallerSha256: BBC7B5224703631F896E3859B4EC407D9709642177E4A8D7454AA8D4D325CB38
+  InstallerSwitches:
+    Custom: /ALLUSERS
+  UpgradeBehavior: install
+ManifestType: installer
+ManifestVersion: 1.0.0
+

--- a/manifests/e/Eugeny/Tabby/1.0.144/Eugeny.Tabby.locale.en-US.yaml
+++ b/manifests/e/Eugeny/Tabby/1.0.144/Eugeny.Tabby.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# Created using wingetcreate 0.2.0.29
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.0.0.schema.json
+
+PackageIdentifier: Eugeny.Tabby
+PackageVersion: 1.0.144
+PackageLocale: en-US
+Publisher: Eugene Pankov
+PublisherUrl: https://github.com/Eugeny/
+PublisherSupportUrl: https://github.com/Eugeny/tabby/issues
+Author: Eugene Pankov
+PackageName: Terminus
+PackageUrl: https://github.com/Eugeny/tabby
+License: MIT License
+LicenseUrl: https://raw.githubusercontent.com/Eugeny/tabby/master/LICENSE
+Copyright: Copyright (c) 2017 Eugene Pankov
+CopyrightUrl: https://raw.githubusercontent.com/Eugeny/tabby/master/LICENSE
+ShortDescription: A terminal for a more modern age.
+Description: Tabby is a highly configurable terminal emulator, SSH and serial client for Windows, macOS and Linux
+Moniker: terminus
+Tags:
+- terminal
+- console
+- command-line
+- cli
+- cross-platform
+- electron
+ManifestType: defaultLocale
+ManifestVersion: 1.0.0
+

--- a/manifests/e/Eugeny/Tabby/1.0.144/Eugeny.Tabby.yaml
+++ b/manifests/e/Eugeny/Tabby/1.0.144/Eugeny.Tabby.yaml
@@ -1,0 +1,9 @@
+# Created using wingetcreate 0.2.0.29
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.0.0.schema.json
+
+PackageIdentifier: Eugeny.Tabby
+PackageVersion: 1.0.144
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.0.0
+


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

`Terminus` was renamed to `Tabby`, might need to delete the older versions. https://github.com/microsoft/winget-pkgs/tree/master/manifests/e/Eugeny/Terminus

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/19536)