### PR TITLE
Vysor.Vysor v4.1.27

### DIFF
--- a/manifests/v/Vysor/Vysor/4.1.27/Vysor.Vysor.installer.yaml
+++ b/manifests/v/Vysor/Vysor/4.1.27/Vysor.Vysor.installer.yaml
@@ -1,0 +1,17 @@
+# Created using wingetcreate 0.2.0.29
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
+
+PackageIdentifier: Vysor.Vysor
+PackageVersion: 4.1.27
+Installers:
+- Architecture: x64
+  InstallerType: exe
+  Scope: user
+  InstallerUrl: https://github.com/koush/vysor.io/releases/download/v4.1.27/Vysor-win-4.1.27.exe
+  InstallerSha256: A4D7363EC7D09366A3898CDADBD93EA8B3D0D3EFE909AEE1A53307A3D84D6203
+  InstallerSwitches:
+    Silent: --silent
+    SilentWithProgress: --silent
+ManifestType: installer
+ManifestVersion: 1.0.0
+

--- a/manifests/v/Vysor/Vysor/4.1.27/Vysor.Vysor.locale.en-US.yaml
+++ b/manifests/v/Vysor/Vysor/4.1.27/Vysor.Vysor.locale.en-US.yaml
@@ -1,0 +1,13 @@
+# Created using wingetcreate 0.2.0.29
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.0.0.schema.json
+
+PackageIdentifier: Vysor.Vysor
+PackageVersion: 4.1.27
+PackageLocale: en-US
+Publisher: Vysor Inc.
+PackageName: Vysor
+License: Copyright © 2021 Vysor Inc.
+ShortDescription: Phone Mirroring Application
+ManifestType: defaultLocale
+ManifestVersion: 1.0.0
+

--- a/manifests/v/Vysor/Vysor/4.1.27/Vysor.Vysor.yaml
+++ b/manifests/v/Vysor/Vysor/4.1.27/Vysor.Vysor.yaml
@@ -1,0 +1,9 @@
+# Created using wingetcreate 0.2.0.29
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.0.0.schema.json
+
+PackageIdentifier: Vysor.Vysor
+PackageVersion: 4.1.27
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.0.0
+


### PR DESCRIPTION
Closes #19779
Installer appears to be InstallShield https://github.com/microsoft/winget-cli/issues/1247

- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [X] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

```
PS C:\Users\Esco\Downloads> winget install -m M:\v\Vysor\Vysor\4.1.27\
Found Vysor [Vysor.Vysor]
This application is licensed to you by its owner.
Microsoft is not responsible for, nor does it grant any licenses to, third-party packages.
Downloading https://github.com/koush/vysor.io/releases/download/v4.1.27/Vysor-win-4.1.27.exe
  ██████████████████████████████   109 MB /  109 MB
Successfully verified installer hash
Starting package install...
Successfully installed
```

![image](https://user-images.githubusercontent.com/15158490/124391788-7fd82480-dcf2-11eb-8a54-02a6d92996cd.png)


-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/19789)