### PR TITLE
Added darktable.darktable version 3.6.0

### DIFF
--- a/manifests/d/darktable/darktable/3.6.0/darktable.darktable.installer.yaml
+++ b/manifests/d/darktable/darktable/3.6.0/darktable.darktable.installer.yaml
@@ -1,0 +1,31 @@
+# Created using wingetcreate 0.2.0.29
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
+
+PackageIdentifier: darktable.darktable
+PackageVersion: 3.6.0
+MinimumOSVersion: 10.0.0.0
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+FileExtensions:
+- jpeg
+- cr2
+- nef
+- hdr
+- pfm
+- raf
+- exr
+- tiff
+- ppm
+Installers:
+- Architecture: x64
+  InstallerType: nullsoft
+  InstallerUrl: https://github.com/darktable-org/darktable/releases/download/release-3.6.0/darktable-3.6.0.1-win64.exe
+  InstallerSha256: 986B7BD1BEA817013F8B7AB6E93907AC3B8B93F66671612E3F36A5C40D321EEA
+  Scope: machine
+  InstallerLocale: en-US
+  UpgradeBehavior: install
+ManifestType: installer
+ManifestVersion: 1.0.0
+

--- a/manifests/d/darktable/darktable/3.6.0/darktable.darktable.locale.en-US.yaml
+++ b/manifests/d/darktable/darktable/3.6.0/darktable.darktable.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# Created using wingetcreate 0.2.0.29
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.0.0.schema.json
+
+PackageIdentifier: darktable.darktable
+PackageVersion: 3.6.0
+PackageLocale: en-US
+Publisher: the darktable project
+PackageName: darktable
+PackageUrl: https://www.darktable.org/
+License: GPL-3.0
+LicenseUrl: https://github.com/darktable-org/darktable/blob/master/LICENSE
+ShortDescription: Free and open-source photography application software and raw developer.
+Moniker: darktable
+Tags:
+- photography
+- editor
+- raw
+- photo
+- lighttable
+- darkroom
+- images
+- negatives
+ManifestType: defaultLocale
+ManifestVersion: 1.0.0
+

--- a/manifests/d/darktable/darktable/3.6.0/darktable.darktable.yaml
+++ b/manifests/d/darktable/darktable/3.6.0/darktable.darktable.yaml
@@ -1,0 +1,9 @@
+# Created using wingetcreate 0.2.0.29
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.0.0.schema.json
+
+PackageIdentifier: darktable.darktable
+PackageVersion: 3.6.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.0.0
+


### PR DESCRIPTION
Closes #20033

![image](https://user-images.githubusercontent.com/52826317/124703024-ccd61980-def1-11eb-9132-32e9d5a0a7b1.png)

```
PS C:\Users\WDAGUtilityAccount\Desktop\manifests> winget install -m "C:\Users\WDAGUtilityAccount\Desktop\manifests\d\darktable\darktable\3.6.0"
Found darktable [darktable.darktable]
This application is licensed to you by its owner.
Microsoft is not responsible for, nor does it grant any licenses to, third-party packages.
Downloading https://github.com/darktable-org/darktable/releases/download/release-3.6.0/darktable-3.6.0.1-win64.exe
  ██████████████████████████████  86.1 MB / 86.1 MB
Successfully verified installer hash
Starting package install...
Successfully installed
```

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/20049)