### PR TITLE
Added WestWind.MarkdownMonster version 1.28.4.0

### DIFF
--- a/manifests/w/WestWind/MarkdownMonster/1.28.4.0/WestWind.MarkdownMonster.installer.yaml
+++ b/manifests/w/WestWind/MarkdownMonster/1.28.4.0/WestWind.MarkdownMonster.installer.yaml
@@ -1,0 +1,16 @@
+# Created using wingetcreate 0.2.0.29
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
+
+PackageIdentifier: WestWind.MarkdownMonster
+PackageVersion: 1.28.4.0
+Installers:
+- Architecture: x86
+  InstallerType: inno
+  Scope: user
+  InstallerUrl: https://github.com/RickStrahl/MarkdownMonsterReleases/raw/master/v1.28/MarkdownMonsterSetup-1.28.4.exe
+  InstallerSha256: FD148656F65F9A36065AC81DB827B72D36D778FD05B37BD00936892D110A47A1
+  InstallerLocale: en-US
+  UpgradeBehavior: install
+ManifestType: installer
+ManifestVersion: 1.0.0
+

--- a/manifests/w/WestWind/MarkdownMonster/1.28.4.0/WestWind.MarkdownMonster.locale.en-US.yaml
+++ b/manifests/w/WestWind/MarkdownMonster/1.28.4.0/WestWind.MarkdownMonster.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# Created using wingetcreate 0.2.0.29
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.0.0.schema.json
+
+PackageIdentifier: WestWind.MarkdownMonster
+PackageVersion: 1.28.4.0
+PackageLocale: en-US
+Publisher: West Wind Technologies
+Author: Rick Strahl, West Wind Technologies
+PackageName: Markdown Monster
+PackageUrl: https://markdownmonster.west-wind.com/
+License: © Rick Strahl, West Wind Technologies, 2015-2021
+LicenseUrl: https://markdownmonster.west-wind.com/license.txt
+ShortDescription: MarkdownMonster - A powerful, yet easy to use Markdown Editor for Windows
+Moniker: markdown-monster
+Tags:
+- markdown
+- editor
+- documentation
+- weblog
+ManifestType: defaultLocale
+ManifestVersion: 1.0.0
+

--- a/manifests/w/WestWind/MarkdownMonster/1.28.4.0/WestWind.MarkdownMonster.yaml
+++ b/manifests/w/WestWind/MarkdownMonster/1.28.4.0/WestWind.MarkdownMonster.yaml
@@ -1,0 +1,9 @@
+# Created using wingetcreate 0.2.0.29
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.0.0.schema.json
+
+PackageIdentifier: WestWind.MarkdownMonster
+PackageVersion: 1.28.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.0.0
+


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/52826317/124764586-68d54480-df35-11eb-8c0d-77cb6d93678f.png)

```
PS C:\Users\WDAGUtilityAccount\Desktop\manifests> winget install -m "C:\Users\WDAGUtilityAccount\Desktop\manifests\w\WestWind\MarkdownMonster\1.28.4.0"
Found Markdown Monster [WestWind.MarkdownMonster]
This application is licensed to you by its owner.
Microsoft is not responsible for, nor does it grant any licenses to, third-party packages.
Downloading https://github.com/RickStrahl/MarkdownMonsterReleases/raw/master/v1.28/MarkdownMonsterSetup-1.28.4.exe
  ██████████████████████████████  18.5 MB / 18.5 MB
Successfully verified installer hash
Starting package install...
Successfully installed
```

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/20097)