### PR TITLE
Added PRTest.ps1.

### DIFF
--- a/Tools/PRTest.ps1
+++ b/Tools/PRTest.ps1
@@ -1,0 +1,41 @@
+# This script does a checkout of a Pull Request using the GitHub CLI, and then runs it using SandboxTest.ps1.
+
+Param(
+  [Parameter(Position = 0, HelpMessage = "The Pull Request to checkout.", Mandatory=$true)]
+  [String] $PullRequest,
+  [Parameter(HelpMessage = "Open the Pull Request's review page in the default browser")]
+  [Switch] $Review = $false
+)
+$ErrorActionPreference = "Stop"
+
+$repositoryRoot = "https://github.com/microsoft/winget-pkgs/"
+
+$rootDirectory = ((Resolve-Path (git rev-parse --show-toplevel)).ToString() + "\")
+
+if (-Not (Get-Command "gh" -ErrorAction "SilentlyContinue")) {
+    Write-Host "The GitHub CLI is not installed. Install it via 'winget install gh' and come back here!" -ForegroundColor Red
+    return
+}
+
+gh pr checkout $PullRequest | Out-Null
+
+if($LASTEXITCODE -ne 0) {
+    Write-Host "There was an error checking out the PR. Make sure you're logged into GitHub via 'gh auth login' and come back here!" -ForegroundColor Red
+    return
+}
+
+$manifest = (git diff --name-only HEAD~1..HEAD)
+if ($manifest.GetType().Name -eq "Object[]") {
+    $path = (Get-Item (Resolve-Path ($rootDirectory + $manifest[0]))).Directory
+}
+else {
+    $path = (Get-Item (Resolve-Path ($rootDirectory + $manifest))).Directory
+}
+
+$sandboxTestPath = (Resolve-Path ($PSScriptRoot.ToString() + "\SandboxTest.ps1")).ToString()
+& $sandboxTestPath $path
+
+if ($Review) {
+    Write-Host "Opening $PullRequest in browser..." -ForegroundColor Green
+    Start-Process ($repositoryRoot + "pull/" + $PullRequest + "/files")
+}


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?

-----

This PR adds a new PowerShell (5.1+) script to the Tools directory, called `PRTest.ps1`. It is designed for use mostly by moderators when doing manual validation of manifests. 

Presuming you have the GitHub CLI installed (and if you don't, it exits), running `.\Tools\PRTest.ps1 <PRNumber>` will checkout the pull request and use the SandboxTest script to launch it inside a Windows Sandbox. Adding the `-Review` flag will open the PR review tab in your default browser, allowing for easy addition of comments.

I apparently don't have enough permissions to add reviewers, so @OfficialEsco @ItzLevvie @palenshus @denelon.
###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/20105)