### PR TITLE
Fixed installer for vim.vim version 8.2.3114

### DIFF
--- a/manifests/v/vim/vim/8.2.3114/vim.vim.installer.yaml
+++ b/manifests/v/vim/vim/8.2.3114/vim.vim.installer.yaml
@@ -4,12 +4,18 @@ PackageVersion: 8.2.3114
 Installers:
 - Architecture: x64
   InstallerType: nullsoft
-  InstallerUrl: https://github.com/vim/vim-win32-installer/releases/download/v8.2.3113/gvim_8.2.3113_x64.exe
-  InstallerSha256: E269CFC9AFD48BA4EFEC2FF15B0387B0CA761259278B98A28242F459F049E838
+  Scope: machine
+  InstallerUrl: https://github.com/vim/vim-win32-installer/releases/download/v8.2.3114/gvim_8.2.3114_x64_signed.exe
+  InstallerSha256: 3F63359363E6A8765077E23C66DFBD9EFAE28D12F1E37AFB1417B5550638F733
+  InstallerLocale: en-US
+  UpgradeBehavior: install
 - Architecture: x86
   InstallerType: nullsoft
-  InstallerUrl: https://github.com/vim/vim-win32-installer/releases/download/v8.2.3113/gvim_8.2.3113_x86.exe
-  InstallerSha256: A0CF462F8E28DA1FE4E1854F9EF3D174915171499ACA01B839239985827D00C5
+  Scope: machine
+  InstallerUrl: https://github.com/vim/vim-win32-installer/releases/download/v8.2.3114/gvim_8.2.3114_x86_signed.exe
+  InstallerSha256: B33084881E168DA61B1F9DC9225EC3B6031809604AB715AB6FC84B452E22F3F5
+  InstallerLocale: en-US
+  UpgradeBehavior: install
 ManifestType: installer
 ManifestVersion: 1.0.0
 


### PR DESCRIPTION
Installer was for version `8.2.3113` and not version `8.2.3114`

```
PS C:\Users\WDAGUtilityAccount\Desktop\manifests> winget install -m "C:\Users\WDAGUtilityAccount\Desktop\manifests\v\vim\vim\8.2.3114"
Found Vim [vim.vim]
This application is licensed to you by its owner.
Microsoft is not responsible for, nor does it grant any licenses to, third-party packages.
Downloading https://github.com/vim/vim-win32-installer/releases/download/v8.2.3114/gvim_8.2.3114_x64_signed.exe
  ██████████████████████████████  9.22 MB / 9.22 MB
Successfully verified installer hash
Starting package install...
Successfully installed
```

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/20185)