### PR TITLE
Added Elastic.Winlogbeat version 7.13.3

### DIFF
--- a/manifests/e/Elastic/Winlogbeat/7.13.3/Elastic.Winlogbeat.installer.yaml
+++ b/manifests/e/Elastic/Winlogbeat/7.13.3/Elastic.Winlogbeat.installer.yaml
@@ -1,0 +1,25 @@
+# Created using wingetcreate 0.2.0.29
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
+
+PackageIdentifier: Elastic.Winlogbeat
+PackageVersion: 7.13.3
+Installers:
+- Architecture: x64
+  InstallerType: msi
+  Scope: machine
+  InstallerUrl: https://artifacts.elastic.co/downloads/beats/winlogbeat/winlogbeat-7.13.3-windows-x86_64.msi
+  InstallerSha256: 03E65A1B2E4E3AED258D96850C60EC8EC4CF1141B08DBE99868D29D36FF89415
+  ProductCode: '{2DE7C165-4793-5EE1-9DF0-372062056E2B}'
+  InstallerLocale: en-US
+  UpgradeBehavior: install
+- Architecture: x86
+  InstallerType: msi
+  Scope: machine
+  InstallerUrl: https://artifacts.elastic.co/downloads/beats/winlogbeat/winlogbeat-7.13.3-windows-x86.msi
+  InstallerSha256: 5B54B725A7CD18CDD5A8A53D2FEA2C3098F82853D9ACE39EC094970E5AE2E8BB
+  ProductCode: '{2DE7C165-4793-5EE1-9DF0-372062056E2B}'
+  InstallerLocale: en-US
+  UpgradeBehavior: install
+ManifestType: installer
+ManifestVersion: 1.0.0
+

--- a/manifests/e/Elastic/Winlogbeat/7.13.3/Elastic.Winlogbeat.locale.en-US.yaml
+++ b/manifests/e/Elastic/Winlogbeat/7.13.3/Elastic.Winlogbeat.locale.en-US.yaml
@@ -1,0 +1,15 @@
+# Created using wingetcreate 0.2.0.29
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.0.0.schema.json
+
+PackageIdentifier: Elastic.Winlogbeat
+PackageVersion: 7.13.3
+PackageLocale: en-US
+Publisher: Elastic
+PackageName: Beats winlogbeat
+PackageUrl: https://www.elastic.co/downloads/beats/winlogbeat
+License: ELASTIC LICENSE AGREEMENT
+LicenseUrl: https://github.com/elastic/beats/blob/master/LICENSE.txt
+ShortDescription: Winlogbeat, the open source tool for shipping Windows event logs to Elasticsearch to get insight into your system, application, and security information.
+ManifestType: defaultLocale
+ManifestVersion: 1.0.0
+

--- a/manifests/e/Elastic/Winlogbeat/7.13.3/Elastic.Winlogbeat.yaml
+++ b/manifests/e/Elastic/Winlogbeat/7.13.3/Elastic.Winlogbeat.yaml
@@ -1,0 +1,9 @@
+# Created using wingetcreate 0.2.0.29
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.0.0.schema.json
+
+PackageIdentifier: Elastic.Winlogbeat
+PackageVersion: 7.13.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.0.0
+


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/52826317/124946184-1b2d0a80-e00f-11eb-8247-519f0e083b3e.png)

```
PS C:\Users\WDAGUtilityAccount\Desktop\manifests> winget install -m "C:\Users\WDAGUtilityAccount\Desktop\manifests\e\Elastic\Winlogbeat\7.13.3"
Found Beats winlogbeat [Elastic.Winlogbeat]
This application is licensed to you by its owner.
Microsoft is not responsible for, nor does it grant any licenses to, third-party packages.
Downloading https://artifacts.elastic.co/downloads/beats/winlogbeat/winlogbeat-7.13.3-windows-x86_64.msi
  ██████████████████████████████  19.5 MB / 19.5 MB
Successfully verified installer hash
Starting package install...
Successfully installed
```

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/20214)