### PR TITLE
Update: Nvidia.GeForceNow v2.0.31.112

### DIFF
--- a/manifests/n/Nvidia/GeForceNow/2.0.31.112/Nvidia.GeForceNow.installer.yaml
+++ b/manifests/n/Nvidia/GeForceNow/2.0.31.112/Nvidia.GeForceNow.installer.yaml
@@ -1,18 +1,20 @@
+# Created using YamlCreate.ps1 v1.1.5
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
+
 PackageIdentifier: Nvidia.GeForceNow
-PackageVersion: 2.0.30.99
+PackageVersion: 2.0.31.112
 MinimumOSVersion: 10.0.0.0
 InstallModes:
-- interactive
 - silent
-- silentWithProgress
 Installers:
-- Architecture: neutral
-  InstallerType: exe
-  InstallerUrl: https://download.nvidia.com/gfnpc/GeForceNOW-release.exe
-  InstallerSha256: 2C3F88DE4F77F5197A48A877BF85C68A391E97F2AB83A326BB4DF9003B6F2936
-  Scope: user
+- Platform:
+  - Windows.Desktop
   InstallerLocale: en-US
+  Architecture: x64
+  InstallerType: exe
+  Scope: user
+  InstallerUrl: https://download.nvidia.com/gfnpc/GeForceNOW-release.exe
+  InstallerSha256: 49CDACC6650E80AACA97E44F8F0113A2A0C90486A368CFACAEA8DC5AC85101C7
   InstallerSwitches:
     Silent: -s
     SilentWithProgress: -s

--- a/manifests/n/Nvidia/GeForceNow/2.0.31.112/Nvidia.GeForceNow.locale.en-US.yaml
+++ b/manifests/n/Nvidia/GeForceNow/2.0.31.112/Nvidia.GeForceNow.locale.en-US.yaml
@@ -1,6 +1,8 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultlocale.1.0.0.schema.json
+# Created using YamlCreate.ps1 v1.1.5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.0.0.schema.json
+
 PackageIdentifier: Nvidia.GeForceNow
-PackageVersion: 2.0.30.99
+PackageVersion: 2.0.31.112
 PackageLocale: en-US
 Publisher: NVIDIA Corporation
 PublisherUrl: https://www.nvidia.com
@@ -9,7 +11,7 @@ PrivacyUrl: https://www.nvidia.com/en-us/about-nvidia/privacy-policy
 Author: NVIDIA Corporation
 PackageName: NVIDIA GeForce NOW
 PackageUrl: https://www.nvidia.com/en-us/geforce-now
-License: Copyright © 2021 NVIDIA Corporation
+License: Proprietary
 LicenseUrl: https://www.nvidia.com/en-us/drivers/nvidia-license
 Copyright: Copyright © 2021 NVIDIA Corporation
 CopyrightUrl: https://www.nvidia.com/en-us/drivers/nvidia-license

--- a/manifests/n/Nvidia/GeForceNow/2.0.31.112/Nvidia.GeForceNow.yaml
+++ b/manifests/n/Nvidia/GeForceNow/2.0.31.112/Nvidia.GeForceNow.yaml
@@ -1,6 +1,8 @@
+# Created using YamlCreate.ps1 v1.1.5
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.0.0.schema.json
+
 PackageIdentifier: Nvidia.GeForceNow
-PackageVersion: 2.0.30.99
+PackageVersion: 2.0.31.112
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.0.0


### PR DESCRIPTION
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [X] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

```
PS C:\Users\Esco> winget install -m M:\n\Nvidia\GeForceNow\2.0.31.112\
Found NVIDIA GeForce NOW [Nvidia.GeForceNow]
This application is licensed to you by its owner.
Microsoft is not responsible for, nor does it grant any licenses to, third-party packages.
Downloading https://download.nvidia.com/gfnpc/GeForceNOW-release.exe
  ██████████████████████████████   134 MB /  134 MB
Successfully verified installer hash
Starting package install...
Successfully installed
```

![image](https://user-images.githubusercontent.com/15158490/125179736-57b85c00-e1f1-11eb-934c-2705865a7010.png)


-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/20420)