### PR TITLE
Quick CHIRP manifest daily-20210706, *no* /LATEST/

### DIFF
--- a/manifests/c/CHIRP/CHIRP/daily-20210706/CHIRP.CHIRP.yaml
+++ b/manifests/c/CHIRP/CHIRP/daily-20210706/CHIRP.CHIRP.yaml
@@ -1,0 +1,15 @@
+PackageIdentifier: CHIRP.CHIRP
+PackageVersion: daily-20210706
+PackageLocale: en-US
+Publisher: CHIRP
+PackageName: CHIRP
+License: GPL-3.0
+ShortDescription: A free, open-source tool for programming your amateur radio / ham radio transceiver.
+Installers: 
+ - Architecture: x86
+   InstallerType: nullsoft
+#   NOTE - when updating this, do NOT use the /LATEST? path; use the specific date subdirectpory
+   InstallerUrl: https://trac.chirp.danplanet.com/chirp_daily/daily-20210706/chirp-daily-20210706-installer.exe
+   InstallerSha256: bf90ddaa3f38d77d1c2c028a6d83cc5046df819fe191d1defaf32069f3a76b1a
+ManifestType: singleton
+ManifestVersion: 1.0.0


### PR DESCRIPTION
Avoids the 404 issue with `/LATEST/` shown in pull #18041 (the previous package, submitted as PR #17607 - used `/LATEST/` in the installer URL path; this PR & manifest replaces `/LATEST/` with `/daily-20210706/`
- Incorrect URL: `https://trac.chirp.danplanet.com/chirp_daily/LATEST/chirp-daily-20210706-installer.exe`
- Correct URL: `https://trac.chirp.danplanet.com/chirp_daily/daily-20210706/chirp-daily-20210706-installer.exe`

Submission guidelines:

- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [X] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----
