### PR TITLE
Make Chrome's moniker more ubiquitous

### DIFF
--- a/manifests/g/Google/Chrome/91.0.4472.124/Google.Chrome.locale.en-US.yaml
+++ b/manifests/g/Google/Chrome/91.0.4472.124/Google.Chrome.locale.en-US.yaml
@@ -14,7 +14,7 @@ LicenseUrl: https://www.google.com/chrome/terms/
 Copyright: © 2021 Google, Inc.
 CopyrightUrl: https://www.google.com/chrome/terms/
 ShortDescription: A fast, secure, and free web browser built for the modern web. Chrome syncs bookmarks across all your devices, fills out forms automatically, and so much more.
-Moniker: googlechrome
+Moniker: chrome
 Tags:
 - google
 - chromium


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.
-----
I feel that "Chrome" is used as the moniker more often than "googlechrome" is. When asked what browser they use, most would likely say "I use Chrome" 
