### PR TITLE
Metadata: XMind.XMind2020 version 11.0.1

### DIFF
--- a/manifests/x/XMind/XMind2020/11.0.1/XMind.XMind2020.installer.yaml
+++ b/manifests/x/XMind/XMind2020/11.0.1/XMind.XMind2020.installer.yaml
@@ -1,14 +1,19 @@
-# Created using wingetcreate
+# Created using YamlCreate.ps1 v1.1.5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
 
 PackageIdentifier: XMind.XMind2020
 PackageVersion: 11.0.1
+MinimumOSVersion: 10.0.0.0
+InstallModes:
+- silent
 Installers:
-- Architecture: x64
-  InstallerType: exe
+- InstallerLocale: en-US
+  Architecture: x64
+  InstallerType: nullsoft
+  Scope: user
   InstallerUrl: https://dl3.xmind.net/XMind-for-Windows-64bit-11.0.1-202106020137.exe
   InstallerSha256: 93B58DA27622B01C366492164392EA6B2E8C84F700159547158130C0BB7B1A74
-  InstallerSwitches:
-    Silent: /VERYSILENT /NORESTART
-    SilentWithProgress: /VERYSILENT /NORESTART
+  UpgradeBehavior: install
 ManifestType: installer
 ManifestVersion: 1.0.0
+

--- a/manifests/x/XMind/XMind2020/11.0.1/XMind.XMind2020.locale.en-US.yaml
+++ b/manifests/x/XMind/XMind2020/11.0.1/XMind.XMind2020.locale.en-US.yaml
@@ -1,15 +1,25 @@
-# Created using wingetcreate
+# Created using YamlCreate.ps1 v1.1.5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.0.0.schema.json
 
 PackageIdentifier: XMind.XMind2020
 PackageVersion: 11.0.1
 PackageLocale: en-US
 Publisher: XMind Ltd.
+PublisherUrl: https://www.xmind.net
+PublisherSupportUrl: https://support.xmind.net/hc/en-us
+PrivacyUrl: https://www.xmind.net/privacy/
+Author: XMind Ltd.
 PackageName: XMind
 PackageUrl: https://www.xmind.net/xmind2020/
-License: © 2020 XMind Ltd.
+License: Proprietary
+LicenseUrl: https://www.xmind.net/terms/
+Copyright: © 2021 XMind Ltd.
+CopyrightUrl: https://www.xmind.net/terms/
 ShortDescription: A full-featured Swiss Army Knife for your brain.
+#Description: 
 Moniker: xmind
 Tags:
 - xmind
 ManifestType: defaultLocale
 ManifestVersion: 1.0.0
+

--- a/manifests/x/XMind/XMind2020/11.0.1/XMind.XMind2020.yaml
+++ b/manifests/x/XMind/XMind2020/11.0.1/XMind.XMind2020.yaml
@@ -1,7 +1,9 @@
-# Created using wingetcreate
+# Created using YamlCreate.ps1 v1.1.5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.0.0.schema.json
 
 PackageIdentifier: XMind.XMind2020
 PackageVersion: 11.0.1
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.0.0
+


### PR DESCRIPTION
Submitted with wrong InstallerType 🤦‍♂️

- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [X] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

```
PS C:\Users\Esco> winget install XMind.XMind2020
Found XMind [XMind.XMind2020]
This application is licensed to you by its owner.
Microsoft is not responsible for, nor does it grant any licenses to, third-party packages.
Downloading https://dl3.xmind.net/XMind-for-Windows-64bit-11.0.1-202106020137.exe
  ██████████████████████████████  92.1 MB / 92.1 MB
Successfully verified installer hash
Starting package install...
Successfully installed
```

![image](https://user-images.githubusercontent.com/15158490/126041817-c3554432-95c8-4bb3-93c0-68bc555c1b8c.png)


-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/21576)