### PR TITLE
Update: Waterfox.WaterfoxClassic version 56.5

### DIFF
--- a/manifests/w/Waterfox/WaterfoxClassic/56.5/Waterfox.WaterfoxClassic.installer.yaml
+++ b/manifests/w/Waterfox/WaterfoxClassic/56.5/Waterfox.WaterfoxClassic.installer.yaml
@@ -1,29 +1,30 @@
+# Created using YamlCreate.ps1 v1.1.5
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
+
 PackageIdentifier: Waterfox.WaterfoxClassic
 PackageVersion: 56.5
 MinimumOSVersion: 10.0.0.0
 FileExtensions:
-  - html
-  - htm
-  - url
-  - pdf
+- html
+- htm
+- url
+- pdf
 Protocols:
-  - http
-  - https
+- http
+- https
 Commands:
-  - waterfox
+- waterfox
 InstallModes:
-  - interactive
-  - silent
-  - silentWithProgress
+- interactive
+- silent
 Installers:
-  - Architecture: x64
-    InstallerType: nullsoft
-    InstallerUrl: https://cdn.waterfox.net/releases/win64/installer/Waterfox%20Classic%202021.04.1%20Setup.exe
-    InstallerSha256: AC7F34C33C7E6E979EAD28BCAF91FD192644929FB2A781C3669CB4ADDCBAF509
-#    ProductCode: 
-    Scope: machine
-    InstallerLocale: en-US
-    UpgradeBehavior: install
+- InstallerLocale: en-US
+  Architecture: x64
+  InstallerType: nullsoft
+  Scope: machine
+  InstallerUrl: https://cdn.waterfox.net/releases/win64/installer/Waterfox%20Classic%202021.07%20Setup.exe
+  InstallerSha256: 34E41B845E9205645923520AB7B76A04AE914A16BB29DEAAC5EBEB0ED0040C0C
+  UpgradeBehavior: install
 ManifestType: installer
 ManifestVersion: 1.0.0
+

--- a/manifests/w/Waterfox/WaterfoxClassic/56.5/Waterfox.WaterfoxClassic.locale.en-US.yaml
+++ b/manifests/w/Waterfox/WaterfoxClassic/56.5/Waterfox.WaterfoxClassic.locale.en-US.yaml
@@ -1,4 +1,6 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultlocale.1.0.0.schema.json
+# Created using YamlCreate.ps1 v1.1.5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.0.0.schema.json
+
 PackageIdentifier: Waterfox.WaterfoxClassic
 PackageVersion: 56.5
 PackageLocale: en-US
@@ -17,11 +19,12 @@ ShortDescription: For legacy platforms and users.
 #Description: 
 Moniker: waterfox-classic
 Tags:
-  - browser
-  - web browser
-  - foss
-  - open source
-  - cross platform
-  - gecko
+- browser
+- web-browser
+- internet-browser foss
+- open-source
+- cross-platform
+- gecko
 ManifestType: defaultLocale
 ManifestVersion: 1.0.0
+

--- a/manifests/w/Waterfox/WaterfoxClassic/56.5/Waterfox.WaterfoxClassic.locale.en-US.yaml
+++ b/manifests/w/Waterfox/WaterfoxClassic/56.5/Waterfox.WaterfoxClassic.locale.en-US.yaml
@@ -21,7 +21,8 @@ Moniker: waterfox-classic
 Tags:
 - browser
 - web-browser
-- internet-browser foss
+- internet-browser
+- foss
 - open-source
 - cross-platform
 - gecko

--- a/manifests/w/Waterfox/WaterfoxClassic/56.5/Waterfox.WaterfoxClassic.yaml
+++ b/manifests/w/Waterfox/WaterfoxClassic/56.5/Waterfox.WaterfoxClassic.yaml
@@ -1,6 +1,9 @@
+# Created using YamlCreate.ps1 v1.1.5
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.0.0.schema.json
+
 PackageIdentifier: Waterfox.WaterfoxClassic
 PackageVersion: 56.5
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.0.0
+


### PR DESCRIPTION
Version number not getting updated

- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [X] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

```
PS C:\Users\Esco\Downloads> winget install -m M:\w\Waterfox\WaterfoxClassic\56.5\                                       
Found Waterfox Classic [Waterfox.WaterfoxClassic]
This application is licensed to you by its owner.
Microsoft is not responsible for, nor does it grant any licenses to, third-party packages.
Downloading https://cdn.waterfox.net/releases/win64/installer/Waterfox%20Classic%202021.07%20Setup.exe
  ██████████████████████████████  72.3 MB / 72.3 MB
Successfully verified installer hash
Starting package install...
Successfully installed
```

![image](https://user-images.githubusercontent.com/15158490/126043047-46a7753d-eb08-48ac-a9d7-a6004df03882.png)


-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/21581)