### PR TITLE
Added Visual Studio Build Tools 2019 version 16.10.31515.178.

### DIFF
--- a/manifests/m/Microsoft/VisualStudio/2019/BuildTools/16.10.31515.178/Microsoft.VisualStudio.2019.BuildTools.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/BuildTools/16.10.31515.178/Microsoft.VisualStudio.2019.BuildTools.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.singleton.1.0.0.schema.json
+PackageIdentifier: Microsoft.VisualStudio.2019.BuildTools
+PackageVersion: 16.10.31515.178
+PackageName: Visual Studio Build Tools 2019
+Publisher: Microsoft
+License: Copyright (c) Microsoft Corporation. All rights reserved.
+LicenseUrl: https://visualstudio.microsoft.com/license-terms/
+Tags:
+- C++
+- tools
+- C#
+- build
+- vs
+ShortDescription: Visual Studio Build Tools
+PackageUrl: https://visualstudio.microsoft.com/
+Installers:
+- Architecture: x64
+  InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/acfc792d-506b-4868-9924-aeedc61ae654/1778d923fd40c62c29f85cf4ef63a0c855a61c13b1dd68419bcda2cff38c984f/vs_BuildTools.exe
+  InstallerSha256: 1778D923FD40C62C29F85CF4EF63A0C855A61C13B1DD68419BCDA2CFF38C984F
+  InstallerType: exe
+  InstallerSwitches:
+    Silent: --quiet
+    SilentWithProgress: --passive
+    Custom: --productId Microsoft.VisualStudio.Product.BuildTools --channelId VisualStudio.16.Release --channelUri https://aka.ms/vs/16/release/channel
+PackageLocale: en-US
+ManifestType: singleton
+ManifestVersion: 1.0.0
+Moniker: vs2019-buildtools
+


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

------

Until we get an answer on #19389, I'm going to continue using the build numbers unless someone has a strong opinion otherwise (at least this way coming from _any_ version Visual Studio will upgrade via winget).

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/22025)