### PR TITLE
[PRTest.ps1] Detached HEAD

### DIFF
--- a/Tools/PRTest.ps1
+++ b/Tools/PRTest.ps1
@@ -17,7 +17,7 @@ if (-Not (Get-Command "gh" -ErrorAction "SilentlyContinue")) {
     return
 }
 
-gh pr checkout $PullRequest | Out-Null
+gh pr checkout $PullRequest --detach -f | Out-Null
 
 if($LASTEXITCODE -ne 0) {
     Write-Host "There was an error checking out the PR. Make sure you're logged into GitHub via 'gh auth login' and come back here!" -ForegroundColor Red

--- a/Tools/PRTest.ps1
+++ b/Tools/PRTest.ps1
@@ -17,6 +17,11 @@ if (-Not (Get-Command "gh" -ErrorAction "SilentlyContinue")) {
     return
 }
 
+if (-Not (Get-Command "git" -ErrorAction "SilentlyContinue")) {
+    Write-Host "Git is not installed. Install it via 'winget install git' and come back here!" -ForegroundColor Red
+    return
+}
+
 gh pr checkout $PullRequest --detach -f | Out-Null
 
 if($LASTEXITCODE -ne 0) {

--- a/Tools/PRTest.ps1
+++ b/Tools/PRTest.ps1
@@ -38,7 +38,7 @@ else {
 }
 
 $sandboxTestPath = (Resolve-Path ($PSScriptRoot.ToString() + "\SandboxTest.ps1")).ToString()
-& $sandboxTestPath $path
+& $sandboxTestPath -Manifest $path -SkipManifestValidation
 
 if ($Review) {
     Write-Host "Opening $PullRequest in browser..." -ForegroundColor Green


### PR DESCRIPTION
@jedieaston adding this change since you didn't get around to it 🙄
Working with a Deatched HEAD dosn't create a bunch of local branches
```
Flags:
      --detach               Checkout PR with a detached HEAD
  -f, --force                Reset the existing local branch to the latest state of the pull request
      --recurse-submodules   Update all submodules after checkout
```

Not really sure what --force does, but i don't think it causes any issues?
```
PS C:\Users\Esco\Github\winget-pkgs> gh pr checkout 22373 --detach -f
From https://github.com/microsoft/winget-pkgs
 * branch                refs/pull/22373/head -> FETCH_HEAD
Updating files: 100% (1322/1322), done.
HEAD is now at 26bab6452 trazyn.weweChat version 1.1.7
```

When jumping from branch to branch you might see this, but i don't think its a problem since its returning exit code 0
```
PS C:\Users\Esco\Github\winget-pkgs> gh pr checkout 22400 --detach -f
From https://github.com/microsoft/winget-pkgs
 * branch                refs/pull/22400/head -> FETCH_HEAD
Warning: you are leaving 1 commit behind, not connected to
any of your branches:

  26bab6452 trazyn.weweChat version 1.1.7

If you want to keep it by creating a new branch, this may be a good time
to do so with:

 git branch <new-branch-name> 26bab6452

HEAD is now at 0245eee78 Fixed scope for Badlion.BadlionClient version 3.2.0
```

```
PS C:\Users\Esco\Github\winget-pkgs> $LASTEXITCODE
0
```

cc @KevinLaMS @palenshus since our main man is MIA

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/22403)