### PR TITLE
Update: OpenWhisperSystems.Signal version 5.11.0

### DIFF
--- a/manifests/o/OpenWhisperSystems/Signal/5.11.0/OpenWhisperSystems.Signal.installer.yaml
+++ b/manifests/o/OpenWhisperSystems/Signal/5.11.0/OpenWhisperSystems.Signal.installer.yaml
@@ -1,0 +1,20 @@
+# Created with YamlCreate.ps1 v2.0.0 using YAML parsing
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
+
+PackageIdentifier: OpenWhisperSystems.Signal
+PackageVersion: 5.11.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 7.0.0.0
+InstallModes:
+- silent
+Installers:
+- InstallerLocale: en-US
+  Architecture: neutral
+  InstallerType: nullsoft
+  Scope: user
+  InstallerUrl: https://updates.signal.org/desktop/signal-desktop-win-5.11.0.exe
+  InstallerSha256: AB1E3D7D4EEA3C22480213FA878AF761E9166326780574273A7630624551AB51
+  UpgradeBehavior: install
+ManifestType: installer
+ManifestVersion: 1.0.0

--- a/manifests/o/OpenWhisperSystems/Signal/5.11.0/OpenWhisperSystems.Signal.locale.en-US.yaml
+++ b/manifests/o/OpenWhisperSystems/Signal/5.11.0/OpenWhisperSystems.Signal.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# Created with YamlCreate.ps1 v2.0.0 using YAML parsing
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.0.0.schema.json
+
+PackageIdentifier: OpenWhisperSystems.Signal
+PackageVersion: 5.11.0
+PackageLocale: en-US
+Publisher: Open Whisper Systems
+PublisherUrl: https://www.signal.org
+PublisherSupportUrl: https://support.signal.org/hc/en-us
+PrivacyUrl: https://www.signal.org/legal/#privacy-policy
+Author: Open Whisper Systems
+PackageName: Signal
+PackageUrl: https://www.signal.org
+License: GPLv3
+LicenseUrl: https://www.gnu.org/licenses/gpl-3.0.en.html
+Copyright: Copyright 2014-2021 Open Whisper Systems
+CopyrightUrl: https://www.signal.org/legal/#terms-of-service
+ShortDescription: Signal is an encrypted communications application.
+Description: Signal is an encrypted communications application. It uses the Internet to send one-to-one and group messages, which can include files, voice notes, images and videos, and make one-to-one voice and video calls.
+Moniker: signal
+Tags:
+- messaging
+- texting
+- encryption
+- security
+- foss
+- open-source
+- privacy
+- chat
+- cross-platform
+ManifestType: defaultLocale
+ManifestVersion: 1.0.0

--- a/manifests/o/OpenWhisperSystems/Signal/5.11.0/OpenWhisperSystems.Signal.yaml
+++ b/manifests/o/OpenWhisperSystems/Signal/5.11.0/OpenWhisperSystems.Signal.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.0.0 using YAML parsing
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.0.0.schema.json
+
+PackageIdentifier: OpenWhisperSystems.Signal
+PackageVersion: 5.11.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.0.0


### PR DESCRIPTION
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

![image](https://user-images.githubusercontent.com/15158490/127399898-8e51ccc7-c32d-43f9-98b1-53675558536d.png)

Testing Neutral architecture
```
wingetcreate update OpenWhisperSystems.Signal -v 5.11.0 -u https://updates.signal.org/desktop/signal-desktop-win-5.11.0.exe -s
Retrieving latest manifest for OpenWhisperSystems.Signal
Downloading and parsing: https://updates.signal.org/desktop/signal-desktop-win-5.11.0.exe...

Each new installer URL must have a match to an existing installer node based on installer type and architecture.
The following installers failed to match an existing installer node:

X86 Nullsoft installer detected from the url: https://updates.signal.org/desktop/signal-desktop-win-5.11.0.exe
```

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/22606)