### PR TITLE
Fixed version number for Visual Studio 2019 Test Controller version 16.8.6.

### DIFF
--- a/manifests/m/Microsoft/VisualStudio/2019/TestController/16.8.6/Microsoft.VisualStudio.2019.TestController.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/TestController/16.8.6/Microsoft.VisualStudio.2019.TestController.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.singleton.1.0.0.schema.json
 PackageIdentifier: Microsoft.VisualStudio.2019.TestController
-PackageVersion: 16.8.31019.35
+PackageVersion: 16.8.6
 PackageName: Visual Studio 2019 Test Controller
 Publisher: Microsoft Corporation
 PackageUrl: https://visualstudio.microsoft.com/


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

------

Per https://github.com/microsoft/winget-pkgs/pull/19389#issuecomment-888582095.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/22714)