### PR TITLE
Added plex.plexmediaserver version 1.23.6.4881

### DIFF
--- a/manifests/p/plex/plexmediaserver/1.23.6.4881/plex.plexmediaserver.installer.yaml
+++ b/manifests/p/plex/plexmediaserver/1.23.6.4881/plex.plexmediaserver.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
+
+PackageIdentifier: plex.plexmediaserver
+PackageVersion: 1.23.6.4881
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallModes:
+- interactive
+- silent
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.VC++2015-2019Redist-x86
+Installers:
+- InstallerLocale: en-US
+  Architecture: x86
+  InstallerType: nullsoft
+  Scope: machine
+  InstallerUrl: https://downloads.plex.tv/plex-media-server-new/1.23.6.4881-e2e58f321/windows/PlexMediaServer-1.23.6.4881-e2e58f321-x86.exe
+  InstallerSha256: 7BDEFB1393FE8B108C619DF056CC84B20BEB4DE43DEBE8C738027BCE8E006FAF
+  UpgradeBehavior: install
+ManifestType: installer
+ManifestVersion: 1.0.0

--- a/manifests/p/plex/plexmediaserver/1.23.6.4881/plex.plexmediaserver.locale.en-US.yaml
+++ b/manifests/p/plex/plexmediaserver/1.23.6.4881/plex.plexmediaserver.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.0.0.schema.json
+
+PackageIdentifier: plex.plexmediaserver
+PackageVersion: 1.23.6.4881
+PackageLocale: en-US
+Publisher: Plex, Inc.
+PublisherUrl: https://www.plex.tv
+PublisherSupportUrl: https://support.plex.tv
+PrivacyUrl: https://www.plex.tv/about/privacy-legal
+Author: Plex, Inc.
+PackageName: Plex Media Server
+PackageUrl: https://www.plex.tv/media-server-downloads/
+License: Freemium
+LicenseUrl: https://www.plex.tv/about/privacy-legal/plex-terms-of-service
+Copyright: Copyright © 2021 Plex
+CopyrightUrl: https://www.plex.tv/about/privacy-legal/plex-terms-of-service
+ShortDescription: Host media content in Plex Media Server.
+Moniker: plexmediaserver
+Tags:
+- plex
+- mediaserver
+- streaming
+- video
+- music
+ManifestType: defaultLocale
+ManifestVersion: 1.0.0

--- a/manifests/p/plex/plexmediaserver/1.23.6.4881/plex.plexmediaserver.yaml
+++ b/manifests/p/plex/plexmediaserver/1.23.6.4881/plex.plexmediaserver.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.0.0.schema.json
+
+PackageIdentifier: plex.plexmediaserver
+PackageVersion: 1.23.6.4881
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.0.0


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/52826317/127741731-f7cb283b-04dc-4ddb-8725-743f30e34751.png)

```
PS C:\Users\Test> winget install -m "M:\Git\winget-pkgs\manifests\p\plex\plexmediaserver\1.23.6.4881"
Found Plex Media Server [plex.plexmediaserver]
This application is licensed to you by its owner.
Microsoft is not responsible for, nor does it grant any licenses to, third-party packages.
Downloading https://downloads.plex.tv/plex-media-server-new/1.23.6.4881-e2e58f321/windows/PlexMediaServer-1.23.6.4881-e2e58f321-x86.exe
  ██████████████████████████████  82.6 MB / 82.6 MB
Successfully verified installer hash
Starting package install...
Successfully installed
```

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/23175)