### PR TITLE
VentisMedia.MediaMonkey5 version 5.0.1.2431

### DIFF
--- a/manifests/v/VentisMedia/MediaMonkey/5/VentisMedia.MediaMonkey.installer.yaml
+++ b/manifests/v/VentisMedia/MediaMonkey/5/VentisMedia.MediaMonkey.installer.yaml
@@ -66,7 +66,7 @@ Installers:
 - InstallerLocale: en-us
   Architecture: x86
   InstallerType: inno
-  Scope: user
+  Scope: machine
   InstallerUrl: https://www.mediamonkey.com/sw/MediaMonkey_5.0.1.2431.exe
   InstallerSha256: 3580C5BEE97860FABD5CCDCBDB532DE2C2AB31689D5643291D46B1ADC3F1A26C
   InstallerSwitches:

--- a/manifests/v/VentisMedia/MediaMonkey/5/VentisMedia.MediaMonkey.installer.yaml
+++ b/manifests/v/VentisMedia/MediaMonkey/5/VentisMedia.MediaMonkey.installer.yaml
@@ -1,20 +1,77 @@
+# Created using YamlCreate.ps1
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
+
 PackageIdentifier: VentisMedia.MediaMonkey
 PackageVersion: 5
 MinimumOSVersion: 10.0.0.0
 FileExtensions:
+- 3gp
+- 3gpp
+- aac
+- adts
+- aif
+- aifc
+- aiff
+- alac
+- ape
+- apl
+- asf
+- asx
+- avi
+- cda
+- cue
+- divx
+- f4v
+- fla
+- flac
+- flv
+- ifo
+- isma
+- m1v
+- m2v
+- m3u
+- m3u8
+- m4a
+- m4b
+- m4p
+- m4v
+- mac
+- mkv
+- mmip
+- mov
 - mp3
+- mp4
+- mpc
+- mpe
+- mpeg
+- mpg
+- mpp
+- mpv
+- ogg
+- ogm
+- ogv
+- pla
+- pls
+- wav
+- webm
+- wm
+- wma
+- wmv
+- xvid
 InstallModes:
-  - interactive
-  - silent
-  - silentWithProgress
+- interactive
+- silent
+- silentWithProgress
 Installers:
-  - Architecture: x86
-    InstallerType: inno
-    InstallerUrl: https://www.mediamonkey.com/sw/MediaMonkey_5.0.0.2338.exe
-    InstallerSha256: 30545D90F20E5F6F402025798171D3F1D8025910F81F9B456E8EA94E9D4264EA
-    Scope: machine
-    InstallerLocale: en-US
-    UpgradeBehavior: install
+- InstallerLocale: en-us
+  Architecture: x86
+  InstallerType: inno
+  Scope: user
+  InstallerUrl: https://www.mediamonkey.com/sw/MediaMonkey_5.0.1.2431.exe
+  InstallerSha256: 3580C5BEE97860FABD5CCDCBDB532DE2C2AB31689D5643291D46B1ADC3F1A26C
+  InstallerSwitches:
+    Silent: /verysilent
+    SilentWithProgress: /silent
+  UpgradeBehavior: install
 ManifestType: installer
 ManifestVersion: 1.0.0

--- a/manifests/v/VentisMedia/MediaMonkey/5/VentisMedia.MediaMonkey.installer.yaml
+++ b/manifests/v/VentisMedia/MediaMonkey/5/VentisMedia.MediaMonkey.installer.yaml
@@ -69,9 +69,6 @@ Installers:
   Scope: machine
   InstallerUrl: https://www.mediamonkey.com/sw/MediaMonkey_5.0.1.2431.exe
   InstallerSha256: 3580C5BEE97860FABD5CCDCBDB532DE2C2AB31689D5643291D46B1ADC3F1A26C
-  InstallerSwitches:
-    Silent: /verysilent
-    SilentWithProgress: /silent
   UpgradeBehavior: install
 ManifestType: installer
 ManifestVersion: 1.0.0

--- a/manifests/v/VentisMedia/MediaMonkey/5/VentisMedia.MediaMonkey.locale.en-US.yaml
+++ b/manifests/v/VentisMedia/MediaMonkey/5/VentisMedia.MediaMonkey.locale.en-US.yaml
@@ -12,7 +12,7 @@ Author: Ventis Media Inc.
 PackageName: MediaMonkey 5
 PackageUrl: https://www.mediamonkey.com/windows
 License: Proprietary
-LicenseUrl: https://www.mediamonkey.com/sw/license.tx
+LicenseUrl: https://www.mediamonkey.com/sw/license.txt
 Copyright: Copyright © 2000-2021 Ventis Media Inc.
 CopyrightUrl: https://www.mediamonkey.com/sw/license.txt
 ShortDescription: MediaMonkey The Media Organizer for Serious Collectors

--- a/manifests/v/VentisMedia/MediaMonkey/5/VentisMedia.MediaMonkey.locale.en-US.yaml
+++ b/manifests/v/VentisMedia/MediaMonkey/5/VentisMedia.MediaMonkey.locale.en-US.yaml
@@ -1,4 +1,6 @@
+# Created using YamlCreate.ps1
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultlocale.1.0.0.schema.json
+
 PackageIdentifier: VentisMedia.MediaMonkey
 PackageVersion: 5
 PackageLocale: en-US
@@ -10,26 +12,27 @@ Author: Ventis Media Inc.
 PackageName: MediaMonkey 5
 PackageUrl: https://www.mediamonkey.com/windows
 License: Proprietary
-LicenseUrl: https://www.mediamonkey.com/sw/license.txt
+LicenseUrl: https://www.mediamonkey.com/sw/license.tx
 Copyright: Copyright © 2000-2021 Ventis Media Inc.
 CopyrightUrl: https://www.mediamonkey.com/sw/license.txt
 ShortDescription: MediaMonkey The Media Organizer for Serious Collectors
 Description: Manage small to large collections of audio files, videos and playlists (100,000+), whether on a hard drive, network, or CDs. Rip CDs, download podcasts, lookup artwork and other missing information online, tag almost any audio or video format, and automatically rename/re-organize files on your hard drive.
 Moniker: mediamonkey
 Tags:
-  - media
-  - audio
-  - video
-  - grabber
-  - library
-  - burn
-  - podcast
-  - convert
-  - party
-  - visualize
-  - organize
-  - rename
-  - tag
-  - manage
+- media
+- audio
+- musicW
+- video
+- grabber
+- library
+- burn
+- podcast
+- convert
+- party
+- visualize
+- organize
+- rename
+- tag
+- manage
 ManifestType: defaultLocale
 ManifestVersion: 1.0.0

--- a/manifests/v/VentisMedia/MediaMonkey/5/VentisMedia.MediaMonkey.locale.en-US.yaml
+++ b/manifests/v/VentisMedia/MediaMonkey/5/VentisMedia.MediaMonkey.locale.en-US.yaml
@@ -9,7 +9,7 @@ PublisherUrl: https://www.mediamonkey.com
 PublisherSupportUrl: https://www.mediamonkey.com/support/knowledge-base/
 PrivacyUrl: https://www.mediamonkey.com/privacy
 Author: Ventis Media Inc.
-PackageName: MediaMonkey 5
+PackageName: MediaMonkey
 PackageUrl: https://www.mediamonkey.com/windows
 License: Proprietary
 LicenseUrl: https://www.mediamonkey.com/sw/license.txt

--- a/manifests/v/VentisMedia/MediaMonkey/5/VentisMedia.MediaMonkey.yaml
+++ b/manifests/v/VentisMedia/MediaMonkey/5/VentisMedia.MediaMonkey.yaml
@@ -1,4 +1,6 @@
+# Created using YamlCreate.ps1
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.0.0.schema.json
+
 PackageIdentifier: VentisMedia.MediaMonkey
 PackageVersion: 5
 DefaultLocale: en-US


### PR DESCRIPTION
Note that only the installerUrl and checksum has changed (for the download). MediaMonkey 5 is always installed with package version 5, regardless of the patch version or revision of the installer. Existing installations cannot be upgraded using winget, but it wouldn't have been possible anyway and at least new installations get the latest possible version.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/23265)