### PR TITLE
Added KDE.KDEConnect version 21.04.3.672

### DIFF
--- a/manifests/k/KDE/KDEConnect/21.04.3.672/KDE.KDEConnect.installer.yaml
+++ b/manifests/k/KDE/KDEConnect/21.04.3.672/KDE.KDEConnect.installer.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
+
+PackageIdentifier: KDE.KDEConnect
+PackageVersion: 21.04.3.672
+Installers:
+- Architecture: x64
+  InstallerType: nullsoft
+  Scope: machine
+  InstallerUrl: https://binary-factory.kde.org/job/kdeconnect-kde_Release_win64/672/artifact/kdeconnect-kde-21.04.3-672-windows-msvc2019_64-cl.exe
+  InstallerSha256: E73E1EDC45BFC6AD290CB93CB293B2F68473411B1A5D4B1F3ED71C77994675D7
+  InstallerSwitches:
+    Custom: /ALLUSERS
+  InstallerLocale: en-US
+  UpgradeBehavior: install
+- Architecture: x64
+  InstallerType: nullsoft
+  Scope: user
+  InstallerUrl: https://binary-factory.kde.org/job/kdeconnect-kde_Release_win64/672/artifact/kdeconnect-kde-21.04.3-672-windows-msvc2019_64-cl.exe
+  InstallerSha256: E73E1EDC45BFC6AD290CB93CB293B2F68473411B1A5D4B1F3ED71C77994675D7
+  InstallerSwitches:
+    Custom: /CURRENTUSER
+  InstallerLocale: en-US
+  UpgradeBehavior: install
+ManifestType: installer
+ManifestVersion: 1.0.0
+

--- a/manifests/k/KDE/KDEConnect/21.04.3.672/KDE.KDEConnect.locale.en-US.yaml
+++ b/manifests/k/KDE/KDEConnect/21.04.3.672/KDE.KDEConnect.locale.en-US.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultlocale.1.0.0.schema.json
+
+PackageIdentifier: KDE.KDEConnect
+PackageVersion: 21.04.3.672
+PackageLocale: en-US
+Publisher: KDE e.V.
+PackageName: KDE Connect
+PackageUrl: https://kdeconnect.kde.org/
+License: GNU GPLv2/GNU GPLv3
+LicenseUrl: https://www.gnu.org/licenses/gpl-2.0.html
+ShortDescription: Enabling communication between all your devices. Made for people like you.
+Moniker: kdeconnect
+Tags:
+- android
+- phone
+- connect
+- kde
+- k
+ManifestType: defaultLocale
+ManifestVersion: 1.0.0
+

--- a/manifests/k/KDE/KDEConnect/21.04.3.672/KDE.KDEConnect.yaml
+++ b/manifests/k/KDE/KDEConnect/21.04.3.672/KDE.KDEConnect.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.0.0.schema.json
+
+PackageIdentifier: KDE.KDEConnect
+PackageVersion: 21.04.3.672
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.0.0
+


### PR DESCRIPTION
```
PS C:\Users\Test> winget install -m "M:\Git\winget-pkgs\manifests\k\KDE\KDEConnect\21.04.3.672" --scope machine
Found KDE Connect [KDE.KDEConnect]
This application is licensed to you by its owner.
Microsoft is not responsible for, nor does it grant any licenses to, third-party packages.
Downloading https://binary-factory.kde.org/job/kdeconnect-kde_Release_win64/672/artifact/kdeconnect-kde-21.04.3-672-windows-msvc2019_64-cl.exe
  ██████████████████████████████  58.5 MB / 58.5 MB
Successfully verified installer hash
Starting package install...
Successfully installed

PS C:\Users\Test> winget install -m "M:\Git\winget-pkgs\manifests\k\KDE\KDEConnect\21.04.3.672" --scope user
Found KDE Connect [KDE.KDEConnect]
This application is licensed to you by its owner.
Microsoft is not responsible for, nor does it grant any licenses to, third-party packages.
Downloading https://binary-factory.kde.org/job/kdeconnect-kde_Release_win64/672/artifact/kdeconnect-kde-21.04.3-672-windows-msvc2019_64-cl.exe
  ██████████████████████████████  58.5 MB / 58.5 MB
Successfully verified installer hash
Starting package install...
Successfully installed
```

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/23815)