### PR TITLE
Added Google.Drive version 50.0.11.0

### DIFF
--- a/manifests/g/Google/Drive/50.0.11.0/Google.Drive.installer.yaml
+++ b/manifests/g/Google/Drive/50.0.11.0/Google.Drive.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
+
+PackageIdentifier: Google.Drive
+PackageVersion: 50.0.11.0
+MinimumOSVersion: 10.0.0.0
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+Installers:
+- Platform:
+  - Windows.Desktop
+  InstallerLocale: en-US
+  Architecture: x64
+  InstallerType: exe
+  Scope: machine
+  InstallerUrl: https://dl.google.com/drive-file-stream/GoogleDrive.exe
+  InstallerSha256: C659012843421859D869CDEDF658F3176D16BC31AE3442656534F801121466A2
+  InstallerSwitches:
+    Silent: --silent --gsuite_shortcuts=false
+    SilentWithProgress: --silent --gsuite_shortcuts=false
+  UpgradeBehavior: install
+ManifestType: installer
+ManifestVersion: 1.0.0

--- a/manifests/g/Google/Drive/50.0.11.0/Google.Drive.locale.en-US.yaml
+++ b/manifests/g/Google/Drive/50.0.11.0/Google.Drive.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.0.0.schema.json
+
+PackageIdentifier: Google.Drive
+PackageVersion: 50.0.11.0
+PackageLocale: en-US
+Publisher: Google LLC
+PublisherUrl: https://www.google.com
+PublisherSupportUrl: https://support.google.com/?hl=en
+PrivacyUrl: https://policies.google.com/privacy?hl=en
+Author: Google LLC
+PackageName: Google Drive
+PackageUrl: https://www.google.com/drive/download/
+License: Proprietary
+LicenseUrl: https://gsuite.google.com/terms/2013/1/premier_terms.html
+Copyright: Copyright (c) Google, Inc.
+CopyrightUrl: https://gsuite.google.com/terms/2013/1/premier_terms.html
+ShortDescription: Mounts Google Drive(s) as a share drive and streams files as needed from the cloud. Alternative to Google Backup and Sync.
+Description: Mounts Google Drive(s) as a share drive and streams files as needed from the cloud. Alternative to Google Backup and Sync.
+Moniker: google-drive
+Tags:
+- google
+- drive
+- filestream
+- sharedrive
+ManifestType: defaultLocale
+ManifestVersion: 1.0.0

--- a/manifests/g/Google/Drive/50.0.11.0/Google.Drive.yaml
+++ b/manifests/g/Google/Drive/50.0.11.0/Google.Drive.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.0.0.schema.json
+
+PackageIdentifier: Google.Drive
+PackageVersion: 50.0.11.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.0.0


### PR DESCRIPTION
Moved from Google.DriveFileStream (#24469) to Google.Drive (this name was actually changed back in January).

![image](https://user-images.githubusercontent.com/52826317/129080580-4196da88-e193-4b53-8b16-683024dce156.png)

![image](https://user-images.githubusercontent.com/52826317/129080329-1b0772c5-6875-4b25-8294-64fecb413fe5.png)

```
PS C:\Users\Test> winget install -m "M:\Git\winget-pkgs\manifests\g\Google\Drive\50.0.11.0"
Found Google Drive [Google.Drive]
This application is licensed to you by its owner.
Microsoft is not responsible for, nor does it grant any licenses to, third-party packages.
Downloading https://dl.google.com/drive-file-stream/GoogleDrive.exe
  ██████████████████████████████   248 MB /  248 MB
Successfully verified installer hash
Starting package install...
Successfully installed
```

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/24470)