### PR TITLE
Updated JAMSoftware.TreeSizeFree to version 4.5.2

### DIFF
--- a/manifests/j/JAMSoftware/TreeSizeFree/4.5.2/JAMSoftware.TreeSizeFree.installer.yaml
+++ b/manifests/j/JAMSoftware/TreeSizeFree/4.5.2/JAMSoftware.TreeSizeFree.installer.yaml
@@ -1,8 +1,7 @@
-# Created using wingetcreate 0.3.0.3
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
 
 PackageIdentifier: JAMSoftware.TreeSizeFree
-PackageVersion: 4.5.1
+PackageVersion: 4.5.2
 Platform:
 - Windows.Desktop
 MinimumOSVersion: 10.0.0.0
@@ -16,7 +15,7 @@ Installers:
   InstallerType: inno
   Scope: machine
   InstallerUrl: https://downloads.jam-software.de/treesize_free/TreeSizeFreeSetup.exe
-  InstallerSha256: 4A161D65627E2E8C2AD60AECA81B33FE15DA5EB5FF98723EF6CE5304185393A3
+  InstallerSha256: 119B33D6074BAF5EF866E7D382F8E009E57CC7F13A0BAB044A39F2F43AEE8EDE
   UpgradeBehavior: install
 ManifestType: installer
 ManifestVersion: 1.0.0

--- a/manifests/j/JAMSoftware/TreeSizeFree/4.5.2/JAMSoftware.TreeSizeFree.locale.en-US.yaml
+++ b/manifests/j/JAMSoftware/TreeSizeFree/4.5.2/JAMSoftware.TreeSizeFree.locale.en-US.yaml
@@ -1,8 +1,7 @@
-# Created using wingetcreate 0.3.0.3
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.0.0.schema.json
 
 PackageIdentifier: JAMSoftware.TreeSizeFree
-PackageVersion: 4.5.1
+PackageVersion: 4.5.2
 PackageLocale: en-US
 Publisher: JAM Software
 PublisherUrl: https://www.jam-software.com

--- a/manifests/j/JAMSoftware/TreeSizeFree/4.5.2/JAMSoftware.TreeSizeFree.yaml
+++ b/manifests/j/JAMSoftware/TreeSizeFree/4.5.2/JAMSoftware.TreeSizeFree.yaml
@@ -1,8 +1,7 @@
-# Created using wingetcreate 0.3.0.3
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.0.0.schema.json
 
 PackageIdentifier: JAMSoftware.TreeSizeFree
-PackageVersion: 4.5.1
+PackageVersion: 4.5.2
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.0.0


### PR DESCRIPTION
Resolves #25827

![image](https://user-images.githubusercontent.com/52826317/130702325-e1714a11-778b-460b-95d0-550e55492080.png)

```
PS C:\Users\Test> winget install -m "M:\Git\winget-pkgs\manifests\j\JAMSoftware\TreeSizeFree\4.5.2"
Found TreeSize Free [JAMSoftware.TreeSizeFree]
This application is licensed to you by its owner.
Microsoft is not responsible for, nor does it grant any licenses to, third-party packages.
Downloading https://downloads.jam-software.de/treesize_free/TreeSizeFreeSetup.exe
  ██████████████████████████████  8.96 MB / 8.96 MB
Successfully verified installer hash
Starting package install...
Successfully installed
```

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

Close #25829

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/25828)