### PR TITLE
Fix wrong installer type in Mozilla.Firefox 82.0.1

### DIFF
--- a/manifests/m/Mozilla/Firefox/82.0.1/Mozilla.Firefox.installer.yaml
+++ b/manifests/m/Mozilla/Firefox/82.0.1/Mozilla.Firefox.installer.yaml
@@ -47,7 +47,7 @@ Installers:
   Scope: machine
   InstallerLocale: es-MX
 - Architecture: arm64
-  InstallerType: msi
+  InstallerType: exe
   InstallerUrl: https://download-installer.cdn.mozilla.net/pub/firefox/releases/82.0.1/win64-aarch64/es-MX/Firefox%20Setup%2082.0.1.exe
   InstallerSha256: 2BF768B5206F1200533D5D1D6308A365A512150FF0613452BAC7FB21A87188B1
   Scope: machine


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/25997)