### PR TITLE
Fixed incorrect hash for Docker Desktop version 3.0.4.51218.

### DIFF
--- a/manifests/d/Docker/DockerDesktop/3.0.4.51218/Docker.DockerDesktop.yaml
+++ b/manifests/d/Docker/DockerDesktop/3.0.4.51218/Docker.DockerDesktop.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.singleton.1.0.0.schema.json
 PackageIdentifier: Docker.DockerDesktop
 Publisher: Docker Inc.
 PackageName: Docker Desktop
@@ -15,10 +16,11 @@ InstallerType: exe
 Installers:
 - Architecture: x64
   InstallerUrl: https://desktop.docker.com/win/stable/51218/Docker%20Desktop%20Installer.exe
-  InstallerSha256: e9fc338e4eeea4290f2cbac5f4575c04844a3a71b22b1336b5e3500cdca778dc
+  InstallerSha256: 5BDE124EE10C9AB195B70662DC05C9377DF625472E15E1D128B715DEFA304069
   InstallerSwitches:
     Silent: install --quiet
     SilentWithProgress: install --quiet
 PackageLocale: en-US
 ManifestType: singleton
 ManifestVersion: 1.0.0
+


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

------

[With the license changes to Docker Desktop](https://www.docker.com/blog/updating-product-subscriptions/), Docker has updated some of their previous installers to reflect the change.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/26432)