### PR TITLE
Fixed incorrect hash for Docker Desktop version 3.2.2.61853.

### DIFF
--- a/manifests/d/Docker/DockerDesktop/3.2.2.61853/Docker.DockerDesktop.yaml
+++ b/manifests/d/Docker/DockerDesktop/3.2.2.61853/Docker.DockerDesktop.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.singleton.1.0.0.schema.json
 PackageIdentifier: Docker.DockerDesktop
 Publisher: Docker Inc.
 PackageName: Docker Desktop
@@ -15,10 +16,11 @@ InstallerType: exe
 Installers:
 - Architecture: x64
   InstallerUrl: https://desktop.docker.com/win/stable/amd64/61853/Docker%20Desktop%20Installer.exe
-  InstallerSha256: 7545f7fbeb0f14958722e51af7b0af925aa04382c0f8eeb95e8d1a4ca7699aec
+  InstallerSha256: 9F19E11F9FAB9AF701C6241C0F7DF35CE68651481835323D3E7E5631EDC030E0
   InstallerSwitches:
     Silent: install --quiet
     SilentWithProgress: install --quiet
 PackageLocale: en-US
 ManifestType: singleton
 ManifestVersion: 1.0.0
+


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

------

[With the license changes to Docker Desktop](https://www.docker.com/blog/updating-product-subscriptions/), Docker has updated some of their previous installers to reflect the change.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/26436)