### PR TITLE
Fixed incorrect hash for Docker Desktop version 3.2.3.62196.

### DIFF
--- a/manifests/d/Docker/DockerDesktop/3.2.3.62196/Docker.DockerDesktop.yaml
+++ b/manifests/d/Docker/DockerDesktop/3.2.3.62196/Docker.DockerDesktop.yaml
@@ -16,7 +16,7 @@ InstallerType: exe
 Installers:
 - Architecture: x64
   InstallerUrl: https://desktop.docker.com/win/stable/amd64/62916/Docker%20Desktop%20Installer.exe
-  InstallerSha256: 1484DC06F33EA9B9180969CD8C96E3CE877E4A8CF15D1D22C628156FB754D228
+  InstallerSha256: 2EC4A8140ED61951BF62338A68492567A2029C30C5924B6AE62E7A6D280DAE5C
   InstallerSwitches:
     Silent: install --quiet
     SilentWithProgress: install --quiet


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

------

[With the license changes to Docker Desktop](https://www.docker.com/blog/updating-product-subscriptions/), Docker has updated some of their previous installers to reflect the change.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/26437)