### PR TITLE
Fixed incorrect hash for Docker Desktop version 3.4.0.

### DIFF
--- a/manifests/d/Docker/DockerDesktop/3.4.0/Docker.DockerDesktop.installer.yaml
+++ b/manifests/d/Docker/DockerDesktop/3.4.0/Docker.DockerDesktop.installer.yaml
@@ -1,5 +1,4 @@
-# Created using wingetcreate
-
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
 PackageIdentifier: Docker.DockerDesktop
 PackageVersion: 3.4.0
 MinimumOSVersion: 10.0.0.0
@@ -13,10 +12,11 @@ Installers:
   InstallerType: exe
   Scope: machine
   InstallerUrl: https://desktop.docker.com/win/stable/amd64/65384/Docker%20Desktop%20Installer.exe
-  InstallerSha256: C3B2CEB599288D000E069D509902BC4D542FDF2BD70E0E50A1F8D24AC8E77551
+  InstallerSha256: 6B6FA01EA602DF659D168AE94469EE7D7EDD3A9DDD4FF3722C39C696EEF925B8
   InstallerSwitches:
     Silent: install --quiet
     SilentWithProgress: install --quiet
   UpgradeBehavior: install
 ManifestType: installer
 ManifestVersion: 1.0.0
+

--- a/manifests/d/Docker/DockerDesktop/3.4.0/Docker.DockerDesktop.locale.en-US.yaml
+++ b/manifests/d/Docker/DockerDesktop/3.4.0/Docker.DockerDesktop.locale.en-US.yaml
@@ -1,5 +1,4 @@
-# Created using wingetcreate
-
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultlocale.1.0.0.schema.json
 PackageIdentifier: Docker.DockerDesktop
 PackageVersion: 3.4.0
 PackageLocale: en-US
@@ -20,3 +19,4 @@ Tags:
 - Virtualization
 ManifestType: defaultLocale
 ManifestVersion: 1.0.0
+

--- a/manifests/d/Docker/DockerDesktop/3.4.0/Docker.DockerDesktop.yaml
+++ b/manifests/d/Docker/DockerDesktop/3.4.0/Docker.DockerDesktop.yaml
@@ -1,7 +1,7 @@
-# Created using wingetcreate
-
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.0.0.schema.json
 PackageIdentifier: Docker.DockerDesktop
 PackageVersion: 3.4.0
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.0.0
+


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

------

[With the license changes to Docker Desktop](https://www.docker.com/blog/updating-product-subscriptions/), Docker has updated some of their previous installers to reflect the change.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/26441)