### PR TITLE
Fixed incorrect hash for Docker Desktop version 3.5.0.

### DIFF
--- a/manifests/d/Docker/DockerDesktop/3.5.0/Docker.DockerDesktop.installer.yaml
+++ b/manifests/d/Docker/DockerDesktop/3.5.0/Docker.DockerDesktop.installer.yaml
@@ -1,6 +1,4 @@
-# Created using wingetcreate 0.2.0.29
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
-
 PackageIdentifier: Docker.DockerDesktop
 PackageVersion: 3.5.0
 MinimumOSVersion: 10.0.0.0
@@ -14,7 +12,7 @@ Installers:
   InstallerType: exe
   Scope: machine
   InstallerUrl: https://desktop.docker.com/win/stable/amd64/66024/Docker%20Desktop%20Installer.exe
-  InstallerSha256: B1CAA979B2D29DDB5D207A09F2E768EACEB95587957C64DD25FD17721DB7A2B3
+  InstallerSha256: 60D420F7E69B92D6FF317BF5BFF6F4270DEDB1CAD3333908A7C64640C8E78418
   InstallerSwitches:
     Silent: install --quiet
     SilentWithProgress: install --quiet

--- a/manifests/d/Docker/DockerDesktop/3.5.0/Docker.DockerDesktop.locale.en-US.yaml
+++ b/manifests/d/Docker/DockerDesktop/3.5.0/Docker.DockerDesktop.locale.en-US.yaml
@@ -1,6 +1,4 @@
-# Created using wingetcreate 0.2.0.29
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.0.0.schema.json
-
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultlocale.1.0.0.schema.json
 PackageIdentifier: Docker.DockerDesktop
 PackageVersion: 3.5.0
 PackageLocale: en-US

--- a/manifests/d/Docker/DockerDesktop/3.5.0/Docker.DockerDesktop.yaml
+++ b/manifests/d/Docker/DockerDesktop/3.5.0/Docker.DockerDesktop.yaml
@@ -1,6 +1,4 @@
-# Created using wingetcreate 0.2.0.29
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.0.0.schema.json
-
 PackageIdentifier: Docker.DockerDesktop
 PackageVersion: 3.5.0
 DefaultLocale: en-US


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

------

[With the license changes to Docker Desktop](https://www.docker.com/blog/updating-product-subscriptions/), Docker has updated some of their previous installers to reflect the change.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/26442)