### PR TITLE
Fixed incorrect hash for Docker Desktop version 3.5.2.

### DIFF
--- a/manifests/d/Docker/DockerDesktop/3.5.2/Docker.DockerDesktop.installer.yaml
+++ b/manifests/d/Docker/DockerDesktop/3.5.2/Docker.DockerDesktop.installer.yaml
@@ -1,6 +1,4 @@
-# Created using wingetcreate 0.2.0.29
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
-
 PackageIdentifier: Docker.DockerDesktop
 PackageVersion: 3.5.2
 Platform:
@@ -16,7 +14,7 @@ Installers:
   InstallerType: exe
   Scope: machine
   InstallerUrl: https://desktop.docker.com/win/stable/amd64/66501/Docker%20Desktop%20Installer.exe
-  InstallerSha256: D6E3ECAF222E1AB595902D28792CCA5151F88C09F009E6AEBDD429F2277383DB
+  InstallerSha256: E39EA7C594892144AFA20A610A539FD0D76008DA9FF2281FF34BAFD0ED58EDD1
   InstallerSwitches:
     Silent: install --quiet
     SilentWithProgress: install --quiet

--- a/manifests/d/Docker/DockerDesktop/3.5.2/Docker.DockerDesktop.locale.en-US.yaml
+++ b/manifests/d/Docker/DockerDesktop/3.5.2/Docker.DockerDesktop.locale.en-US.yaml
@@ -1,6 +1,4 @@
-# Created using wingetcreate 0.2.0.29
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.0.0.schema.json
-
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultlocale.1.0.0.schema.json
 PackageIdentifier: Docker.DockerDesktop
 PackageVersion: 3.5.2
 PackageLocale: en-US

--- a/manifests/d/Docker/DockerDesktop/3.5.2/Docker.DockerDesktop.yaml
+++ b/manifests/d/Docker/DockerDesktop/3.5.2/Docker.DockerDesktop.yaml
@@ -1,6 +1,4 @@
-# Created using wingetcreate 0.2.0.29
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.0.0.schema.json
-
 PackageIdentifier: Docker.DockerDesktop
 PackageVersion: 3.5.2
 DefaultLocale: en-US


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

------

[With the license changes to Docker Desktop](https://www.docker.com/blog/updating-product-subscriptions/), Docker has updated some of their previous installers to reflect the change.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/26444)