### PR TITLE
Fixed incorrect hash for Docker Desktop version 3.6.0.

### DIFF
--- a/manifests/d/Docker/DockerDesktop/3.6.0/Docker.DockerDesktop.installer.yaml
+++ b/manifests/d/Docker/DockerDesktop/3.6.0/Docker.DockerDesktop.installer.yaml
@@ -14,7 +14,7 @@ Installers:
   InstallerType: exe
   Scope: machine
   InstallerUrl: https://desktop.docker.com/win/stable/amd64/67351/Docker%20Desktop%20Installer.exe
-  InstallerSha256: 0C9F8AF8C11DC6D2B6112CF3A8DEF1A0EA377B54FF0950A7131F185B12313B82
+  InstallerSha256: 8F36A5B306442D03A87BB80A492558C81902FDABE497AF44A39CA07C161C60A5
   InstallerSwitches:
     Silent: install --quiet
     SilentWithProgress: install --quiet


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

------

[With the license changes to Docker Desktop](https://www.docker.com/blog/updating-product-subscriptions/), Docker has updated some of their previous installers to reflect the change.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/26449)