### PR TITLE
Added back x64 installer to Microsoft.PowerBI

### DIFF
--- a/manifests/m/Microsoft/PowerBI/2.96.1061.0/Microsoft.PowerBI.installer.yaml
+++ b/manifests/m/Microsoft/PowerBI/2.96.1061.0/Microsoft.PowerBI.installer.yaml
@@ -8,6 +8,15 @@ Dependencies:
   - PackageIdentifier: Microsoft.EdgeWebView2Runtime
     MinimumVersion: 92.0.902.84
 Installers:
+- Architecture: x64
+  InstallerUrl: https://download.microsoft.com/download/8/8/0/880BCA75-79DD-466A-927D-1ABF1F5454B0/PBIDesktopSetup_x64.exe
+  InstallerType: exe
+  InstallerSha256: 14F081547BC90DB390FB4CF8FE31DBE2C06AB03666D5B7FEE6B7F736380468E3
+  Scope: machine
+  InstallerSwitches:
+    Custom: -norestart ACCEPT_EULA=1
+    Silent: -quiet
+    SilentWithProgress: -passive
 - Architecture: x86
   InstallerUrl: https://download.microsoft.com/download/8/8/0/880BCA75-79DD-466A-927D-1ABF1F5454B0/PBIDesktopSetup.exe
   InstallerType: exe


### PR DESCRIPTION
The bot doesn't add the x64 installer when automatically updating Power BI #26513 

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/26688)