### PR TITLE
Add Fortinet.FortiClientVPN

### DIFF
--- a/manifests/f/Fortinet/FortiClientVPN/6.2.0.0780/Fortinet.FortiClientVPN.installer.yaml
+++ b/manifests/f/Fortinet/FortiClientVPN/6.2.0.0780/Fortinet.FortiClientVPN.installer.yaml
@@ -1,0 +1,19 @@
+# Created using wingetcreate 0.3.0.3
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
+
+PackageIdentifier: Fortinet.FortiClientVPN
+PackageVersion: 6.2.0.0780
+InstallerSwitches:
+  Silent: /QUIET /NORESTART
+  SilentWithProgress: /PASSIVE /NORESTART
+Installers:
+- Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://filestore.fortinet.com/forticlient/downloads/FortiClientVPNSetup_6.2.0_x64.exe
+  InstallerSha256: 9202AF4D28A7306645A4B34DEA45EFBCFFE5C94B5DAC8333BC68185B63F88A16
+- Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://filestore.fortinet.com/forticlient/downloads/FortiClientVPNSetup_6.2.0.exe
+  InstallerSha256: 354E93E1B79AFE1F401F6FCDF5F0D84781C24AA30CC5443BC2C1AC87D1BA0188
+ManifestType: installer
+ManifestVersion: 1.0.0

--- a/manifests/f/Fortinet/FortiClientVPN/6.2.0.0780/Fortinet.FortiClientVPN.locale.en-US.yaml
+++ b/manifests/f/Fortinet/FortiClientVPN/6.2.0.0780/Fortinet.FortiClientVPN.locale.en-US.yaml
@@ -1,0 +1,13 @@
+# Created using wingetcreate 0.3.0.3
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.0.0.schema.json
+
+PackageIdentifier: Fortinet.FortiClientVPN
+PackageVersion: 6.2.0.0780
+PackageLocale: en-US
+Publisher: Fortinet Technologies Inc
+PackageName: FortiClient VPN
+Moniker: forticlientvpn
+License: 2019 Fortinet Inc. All rights reserved.
+ShortDescription: FortiClient VPN
+ManifestType: defaultLocale
+ManifestVersion: 1.0.0

--- a/manifests/f/Fortinet/FortiClientVPN/6.2.0.0780/Fortinet.FortiClientVPN.yaml
+++ b/manifests/f/Fortinet/FortiClientVPN/6.2.0.0780/Fortinet.FortiClientVPN.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 0.3.0.3
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.0.0.schema.json
+
+PackageIdentifier: Fortinet.FortiClientVPN
+PackageVersion: 6.2.0.0780
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.0.0


### PR DESCRIPTION
A manifest already exists with this version, however it's misspelled as `Fortinet.FortClientVPN`.
Just for reference the [product page](https://www.fortinet.com/products/endpoint-security/forticlient).

A follow-up PR will remove the misspelled manifest, as suggested [here](https://github.com/microsoft/winget-pkgs/pull/26832#issuecomment-911934347).


- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/26847)