### PR TITLE
Remove redundant .validation at baidu/baidunetdisk

### DIFF
--- a/manifests/b/baidu/baidunetdisk/.validation
+++ b/manifests/b/baidu/baidunetdisk/.validation
@@ -1,1 +1,0 @@
-{"ValidationVersion":"1.0.0","Waivers":[{"WaiverId":"308a8abd-dadb-482e-9f6e-c0a2a347e54f","TestPlan":"Validation-Domain","PackagePath":"manifests/b/baidu/baidunetdisk/7.4.3"}]}


### PR DESCRIPTION
This .validation file is causing issue on the github client.

Issue: https://github.com/microsoft/winget-pkgs/issues/27329

Duplicate of https://github.com/microsoft/winget-pkgs/pull/26535

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/27499)