### PR TITLE
Testing: Added --wait to Visual Studio 2019 Community version 16.11.2.

### DIFF
--- a/manifests/m/Microsoft/VisualStudio/2019/Community/16.11.2/Microsoft.VisualStudio.2019.Community.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Community/16.11.2/Microsoft.VisualStudio.2019.Community.yaml
@@ -23,7 +23,7 @@ Installers:
   InstallerSwitches:
     Silent: --quiet
     SilentWithProgress: --passive
-    Custom: --productId Microsoft.VisualStudio.Product.Community --channelId VisualStudio.16.Release --channelUri https://aka.ms/vs/16/release/channel --add Microsoft.VisualStudio.Workload.Universal
+    Custom: --wait --productId Microsoft.VisualStudio.Product.Community --channelId VisualStudio.16.Release --channelUri https://aka.ms/vs/16/release/channel --add Microsoft.VisualStudio.Workload.Universal
 PackageLocale: en-US
 ManifestType: singleton
 ManifestVersion: 1.0.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

I'm checking something based on https://github.com/microsoft/winget-cli/discussions/1456. I seem to recall that the reason the --wait argument wasn't used with VS was because it would time out during installation validation, but I'm not 100% sure. If it doesn't, then we should probably add the argument so that winget doesn't exit until the installer succeeds or fails.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/27580)