### PR TITLE
microsoft-git: update SHA-256 of latest installer

### DIFF
--- a/manifests/m/Microsoft/Git/2.33.0.0.0/Microsoft.Git.yaml
+++ b/manifests/m/Microsoft/Git/2.33.0.0.0/Microsoft.Git.yaml
@@ -15,7 +15,7 @@ Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/microsoft/git/releases/download/v2.33.0.vfs.0.0/Git-2.33.0.vfs.0.0-64-bit.exe
   InstallerType: inno
-  InstallerSha256: fb7d6699e00bcd46894c3d43bcf2df9f8bccb26e734d4e54d8518c2ac1ab4cce
+  InstallerSha256: ce29ee9a793b74eb6971db1506f9191fc310b3076fd3b2e76e89dc732ebe7920
 PackageLocale: en-US
 ManifestType: singleton
 ManifestVersion: 1.0.0


### PR DESCRIPTION
After our automated creation of the manifest for microsoft-git version
2.33.0.vfs.0.0, we realized that the signing of the installer was not
quite correct. It was generated by a new automated process that did not
have all of the details correct. We replaced the installer on the GitHub
releases page with a new version that was generated from the same source
but used our older, manual process.

What we forgot to check was that the winget package stores the SHA-256
hash of the older installer, so "winget install microsoft-git" now fails
with a checksum mismatch.

I initially tried to re-run our process for generating the winget
manifest, but it failed to create the new commit, likely because a
manifest already existed. It did compute the latest SHA-256 for me [1].

[1] https://github.com/microsoft/git/runs/3614127425?check_suite_focus=true#step:2:87

- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

_Note:_ I tested `winget install --manifest <path>` and it passed the installer hash check, but then failed with this prompt:

![image](https://user-images.githubusercontent.com/570044/133501133-e9a02c4e-4777-491f-a545-7d2319d75181.png)

Manually running the installer that existed at that path worked.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/27731)