### PR TITLE
Fix NetSurf.NetSurf upgrade loop

### DIFF
--- a/manifests/n/NetSurf/NetSurf/3.10.0/NetSurf.NetSurf.installer.yaml
+++ b/manifests/n/NetSurf/NetSurf/3.10.0/NetSurf.NetSurf.installer.yaml
@@ -1,7 +1,7 @@
 # Created using wingetcreate
 
 PackageIdentifier: NetSurf.NetSurf
-PackageVersion: "3.10.0"
+PackageVersion: "\"3.10.0\""
 Installers:
 - Architecture: x86
   InstallerType: nullsoft

--- a/manifests/n/NetSurf/NetSurf/3.10.0/NetSurf.NetSurf.locale.en-US.yaml
+++ b/manifests/n/NetSurf/NetSurf/3.10.0/NetSurf.NetSurf.locale.en-US.yaml
@@ -1,7 +1,7 @@
 # Created using wingetcreate
 
 PackageIdentifier: NetSurf.NetSurf
-PackageVersion: "3.10.0"
+PackageVersion: "\"3.10.0\""
 PackageLocale: en-US
 Publisher: "NetSurf"
 PackageName: NetSurf - NetSurf - Web Browser

--- a/manifests/n/NetSurf/NetSurf/3.10.0/NetSurf.NetSurf.yaml
+++ b/manifests/n/NetSurf/NetSurf/3.10.0/NetSurf.NetSurf.yaml
@@ -1,7 +1,7 @@
 # Created using wingetcreate
 
 PackageIdentifier: NetSurf.NetSurf
-PackageVersion: "3.10.0"
+PackageVersion: "\"3.10.0\""
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.0.0


### PR DESCRIPTION
Currently NetSurf.NetSurf is constantly requesting for upgrade, since the
version advertised in the yaml doesn't match the version is is being installed.
There are quotes around the installed version as below:

    Name                                       Id                                     Version          Available    Source
    ------------------------------------------------------------------------------------------------------------------------
    NetSurf - NetSurf - Web Browser            NetSurf.NetSurf                        "3.10.0"         3.10.0       winget

This attempts to fix it by making the yaml include the quotes around the
version number to match the installed version string scheme.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/27914)