### PR TITLE
Package change for Eclipse Adoptium Temurin 16 binaries 🧪

### DIFF
--- a/manifests/e/EclipseAdoptium/Temurin/16/16.0.2.7/EclipseAdoptium.Temurin.16.installer.yaml
+++ b/manifests/e/EclipseAdoptium/Temurin/16/16.0.2.7/EclipseAdoptium.Temurin.16.installer.yaml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
-PackageIdentifier: EclipseFoundation.AdoptiumOpenJDK.16
+PackageIdentifier: EclipseAdoptium.Temurin.16
 PackageVersion: 16.0.2.7
 Installers:
 - Architecture: x64

--- a/manifests/e/EclipseAdoptium/Temurin/16/16.0.2.7/EclipseAdoptium.Temurin.16.locale.en-US.yaml
+++ b/manifests/e/EclipseAdoptium/Temurin/16/16.0.2.7/EclipseAdoptium.Temurin.16.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultlocale.1.0.0.schema.json
-PackageIdentifier: EclipseFoundation.AdoptiumOpenJDK.16
+PackageIdentifier: EclipseAdoptium.Temurin.16
 PackageVersion: 16.0.2.7
 PackageLocale: en-US
 LicenseUrl: https://adoptium.net/about.html
@@ -9,11 +9,12 @@ Tags:
 - java
 - jvm
 - jdk
+- temurin
 PackageUrl: https://adoptium.net
-Publisher: Eclipse Foundation
-PackageName: Eclipse Adoptium Open JDK 16
+Publisher: Eclipse Adoptium
+PackageName: Adoptium Temurin JDK with Hotspot 16
 License: GPL 2 with Classpath Exception
-ShortDescription: Eclipse Adoptium JDK
+ShortDescription: Temurin JDK
 ManifestType: defaultLocale
 ManifestVersion: 1.0.0
 

--- a/manifests/e/EclipseAdoptium/Temurin/16/16.0.2.7/EclipseAdoptium.Temurin.16.yaml
+++ b/manifests/e/EclipseAdoptium/Temurin/16/16.0.2.7/EclipseAdoptium.Temurin.16.yaml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.0.0.schema.json
-PackageIdentifier: EclipseFoundation.AdoptiumOpenJDK.16
+PackageIdentifier: EclipseAdoptium.Temurin.16
 PackageVersion: 16.0.2.7
 DefaultLocale: en-US
 ManifestType: version


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/denelon/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----
Suggested package changes for:
Vendor name change from `Eclipse Foundation` to `Eclipse Adoptium`
Product name change from `AdoptiumOpenJDK` to `Temurin`

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/28540)