### PR TITLE
Fix: YamlCreate using invalid filename for downloading

### DIFF
--- a/Tools/YamlCreate.ps1
+++ b/Tools/YamlCreate.ps1
@@ -257,7 +257,7 @@ Function Read-WinGet-InstallerValues {
 
         try {
             $ContentDisposition = [System.Net.HttpWebRequest]::Create($InstallerUrl).GetResponse().Headers['Content-Disposition']
-            if ($null -ne $ContentDisposition -and $ContentDisposition -match 'filename="?(.*)"?;?') {
+            if ($null -ne $ContentDisposition -and $ContentDisposition -match 'filename="?([^";]+)') {
                 $FileName = $Matches[1]
                 $dest = "$env:TEMP\$FileName"
             }

--- a/Tools/YamlCreate.ps1
+++ b/Tools/YamlCreate.ps1
@@ -256,6 +256,11 @@ Function Read-WinGet-InstallerValues {
         $dest = "$env:TEMP\$FileName"
 
         try {
+            $ContentDisposition = [System.Net.HttpWebRequest]::Create($InstallerUrl).GetResponse().Headers['Content-Disposition']
+            if ($null -ne $ContentDisposition -and $ContentDisposition -match 'filename="?(.*)"?;?') {
+                $FileName = $Matches[1]
+                $dest = "$env:TEMP\$FileName"
+            }
             $WebClient.DownloadFile($InstallerUrl, $dest)
         }
         catch {

--- a/Tools/YamlCreate.ps1
+++ b/Tools/YamlCreate.ps1
@@ -271,10 +271,10 @@ Function Read-WinGet-InstallerValues {
             } else {
                 $Filename = [System.IO.Path]::GetFileName($InstallerUrl)
                 $ContentDisposition = $WebClient.ResponseHeaders['Content-Disposition']
-                if ($null -ne $ContentDisposition -and $ContentDisposition -match "filename\*?=['`"]?(?:UTF-\d['`"]*)?([^;\r\n`"']*)['`"]?;?") {
+                if (-not [string]::IsNullOrWhiteSpace($ContentDisposition) -and $ContentDisposition -match "filename\*?=['`"]?(?:UTF-\d['`"]*)?([^;\r\n`"']*)['`"]?;?") {
                     $FileName = $Matches[1]
                 }
-                Rename-Item -Path $dest -NewName $FileName
+                Rename-Item -Path $dest -NewName $Filename
             }
         }
     }


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/denelon/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----
The script obtains the file name by slicing InstallerUrl variable and appends it to the destinaiton path, but sometimes the url doesn't contain a valid filename, which may cause errors.
For example, if InstallerUrl is set to "https://pinyin.thunisoft.com/webapi/v1/setup/downloadSetup?setupid=21f0e88683894ebcb440759c5aa25c47&filename=HuayuPY-V7.2.0.213.exe", the script will use "downloadSetup?setupid=21f0e88683894ebcb440759c5aa25c47&filename=HuayuPY-V7.2.0.213.exe" as file name, which contains an invalid file name character "?".
Many servers tell the client the real file name by adding a "ContentDisposition" field to the response header. If existed, the modified code will use it instead.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/29454)