### PR TITLE
EclipseAdoptium.Temurin.11: Fix x64 installer locale

### DIFF
--- a/manifests/e/EclipseAdoptium/Temurin/11/11.0.12.7/EclipseAdoptium.Temurin.11.installer.yaml
+++ b/manifests/e/EclipseAdoptium/Temurin/11/11.0.12.7/EclipseAdoptium.Temurin.11.installer.yaml
@@ -3,17 +3,18 @@ PackageIdentifier: EclipseAdoptium.Temurin.11
 PackageVersion: 11.0.12.7
 Installers:
 - InstallerLocale: en-US
-  Architecture: x86
-  InstallerType: msi
-  InstallerUrl: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.12%2B7/OpenJDK11U-jdk_x86-32_windows_hotspot_11.0.12_7.msi
-  InstallerSha256: 98A151504D3A2219FC18E33876F83D907AEE84DE90292968EAA0CDB449232F15
-  ProductCode: '{2CAC12C0-6EBB-4C9A-9D83-2499C44F9549}'
-- Architecture: x64
+  Architecture: x64
   InstallerUrl: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.12%2B7/OpenJDK11U-jdk_x64_windows_hotspot_11.0.12_7.msi
   InstallerSha256: 80546D8A36AD0CDF69305F72F42465093B9D0388F45819B05CC640ECD1310B32
   ProductCode: "{ECB70B02-AFF1-4F37-B2DD-F22C3EF186ED}"
   InstallerType: msi
   InstallerSwitches:
     Custom: INSTALLLEVEL=3
+- InstallerLocale: en-US
+  Architecture: x86
+  InstallerType: msi
+  InstallerUrl: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.12%2B7/OpenJDK11U-jdk_x86-32_windows_hotspot_11.0.12_7.msi
+  InstallerSha256: 98A151504D3A2219FC18E33876F83D907AEE84DE90292968EAA0CDB449232F15
+  ProductCode: '{2CAC12C0-6EBB-4C9A-9D83-2499C44F9549}'
 ManifestType: installer
 ManifestVersion: 1.0.0


### PR DESCRIPTION
The locale was missing for the x64 version, which resulted in the x86 version being installed on my x64 en-US Windows.

This change sets the locale and reorders the x64 version at the top for consistency with the other installers.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/denelon/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/29492)