### PR TITLE
Modified: "Preview" packages in `Melvin-Abraham/Google-Assistant`

### DIFF
--- a/manifests/m/Melvin-Abraham/Google-Assistant/1.0.0/Melvin-Abraham.Google-Assistant.locale.en-US.yaml
+++ b/manifests/m/Melvin-Abraham/Google-Assistant/1.0.0/Melvin-Abraham.Google-Assistant.locale.en-US.yaml
@@ -9,6 +9,7 @@ PublisherUrl: https://github.com/Melvin-Abraham
 Author: Melvin L Abraham
 PackageName: Google Assistant
 PackageUrl: https://github.com/Melvin-Abraham/Google-Assistant-Unofficial-Desktop-Client
+Moniker: g-assist
 License: Apache 2.0
 LicenseUrl: https://github.com/Melvin-Abraham/Google-Assistant-Unofficial-Desktop-Client/blob/master/LICENSE
 ShortDescription: A cross-platform unofficial Google Assistant Client for Desktop (powered by Google Assistant SDK)

--- a/manifests/m/Melvin-Abraham/Google-Assistant/Preview/1.0.0-rc.2/Melvin-Abraham.Google-Assistant.yaml
+++ b/manifests/m/Melvin-Abraham/Google-Assistant/Preview/1.0.0-rc.2/Melvin-Abraham.Google-Assistant.yaml
@@ -1,13 +1,14 @@
-PackageIdentifier: Melvin-Abraham.Google-Assistant
+PackageIdentifier: Melvin-Abraham.Google-Assistant.Preview
 Publisher: Melvin Abraham
 PackageName: Google Assistant Unofficial Desktop Client
 Author: Melvin Abraham
 ShortDescription: A cross-platform unofficial Google Assistant Client for Desktop (powered by Google Assistant SDK)
 Tags:
 - google
-- assisstant
+- assistant
 - electron
 PackageUrl: https://github.com/Melvin-Abraham/Google-Assistant-Unofficial-Desktop-Client
+Moniker: g-assist-preview
 License: apache
 LicenseUrl: https://github.com/Melvin-Abraham/Google-Assistant-Unofficial-Desktop-Client/blob/master/LICENSE
 PackageVersion: 1.0.0-rc.2


### PR DESCRIPTION
- Create & move pre-release packages for Google-Assistant in **"Preview"** directory. This will allow users to _download packages from particular channels_ and would prevent _issues with semantic versioning_.
- Add `Moniker` for packages in `Melvin-Abraham.Google-Assistant`
- Fix minor typo in v1.0.0-rc.2 `Tags` stanza

-----

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/denelon/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/30389)