### PR TITLE
Move Xunlei.Xunleix to Xunlei.Xunlei

### DIFF
--- a/manifests/x/XunLei/xunlei/10.1.34.800/XunLei.xunlei.yaml
+++ b/manifests/x/XunLei/xunlei/10.1.34.800/XunLei.xunlei.yaml
@@ -1,0 +1,22 @@
+PackageIdentifier: XunLei.xunlei
+Publisher: 迅雷网络技术有限公司
+PackageName: 迅雷
+PackageVersion: 10.1.34.800
+License: Copyright (c) Xunlei Inc. All rights reserved.
+InstallerType: exe
+LicenseUrl: http://i.xunlei.com/tos.shtml
+# Moniker:
+Tags:
+- download
+ShortDescription: XunLeiX is a download tool developed by Xunlei.
+PackageUrl: http://x.xunlei.com/
+Installers:
+- Architecture: x64
+  InstallerUrl: https://down.sandai.net/thunderx/XunLeiWebSetup10.1.34.800gw.exe
+  InstallerSha256: 2CF82BD1C7B005ABB191B0A8950123E6EC1243BC004F67611200893284970F50
+  InstallerSwitches:
+    Silent: /S
+    SilentWithProgress: /S
+PackageLocale: en-US
+ManifestType: singleton
+ManifestVersion: 1.0.0


### PR DESCRIPTION
### I have tested to be sure that these packages are the same; Xunlei.Xunlei installs over top of Xunlei.Xunleix which indicates the x may have been a typo or an unnecessary version indicator

- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/denelon/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/30475)