### PR TITLE
KDE.Dolphin.Nightly version master-b6ec4b1c9

### DIFF
--- a/manifests/k/KDE/Dolphin/Nightly/master-b6ec4b1c9/KDE.Dolphin.Nightly.installer.yaml
+++ b/manifests/k/KDE/Dolphin/Nightly/master-b6ec4b1c9/KDE.Dolphin.Nightly.installer.yaml
@@ -1,0 +1,17 @@
+# Created using wingetcreate 0.4.1.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
+
+PackageIdentifier: KDE.Dolphin.Nightly
+PackageVersion: master-b6ec4b1c9
+Scope: machine
+InstallModes:
+- interactive
+- silent
+Installers:
+- Architecture: x64
+  InstallerType: nullsoft
+  InstallerUrl: https://binary-factory.kde.org/job/Dolphin_Nightly_win64/271/artifact/dolphin-master-271-windows-msvc2019_64-cl.exe
+  InstallerSha256: 486CB47FD3171870A2AAF2A18702645BF780605AF2432FD6013A825EB488D18F
+ManifestType: installer
+ManifestVersion: 1.0.0
+

--- a/manifests/k/KDE/Dolphin/Nightly/master-b6ec4b1c9/KDE.Dolphin.Nightly.locale.en-US.yaml
+++ b/manifests/k/KDE/Dolphin/Nightly/master-b6ec4b1c9/KDE.Dolphin.Nightly.locale.en-US.yaml
@@ -1,0 +1,18 @@
+# Created using wingetcreate 0.4.1.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.0.0.schema.json
+
+PackageIdentifier: KDE.Dolphin.Nightly
+PackageVersion: master-b6ec4b1c9
+PackageLocale: en-US
+Publisher: KDE e.V.
+PackageName: Dolphin Nightly
+License: GPL-2.0
+ShortDescription: Dolphin is KDE's file manager that lets you navigate and browse the contents of your hard drives, USB sticks, SD cards, and more.
+Moniker: dolphin-nightly
+Tags:
+- file-manager
+- nightly
+- open-source
+ManifestType: defaultLocale
+ManifestVersion: 1.0.0
+

--- a/manifests/k/KDE/Dolphin/Nightly/master-b6ec4b1c9/KDE.Dolphin.Nightly.yaml
+++ b/manifests/k/KDE/Dolphin/Nightly/master-b6ec4b1c9/KDE.Dolphin.Nightly.yaml
@@ -1,0 +1,9 @@
+# Created using wingetcreate 0.4.1.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.0.0.schema.json
+
+PackageIdentifier: KDE.Dolphin.Nightly
+PackageVersion: master-b6ec4b1c9
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.0.0
+


### PR DESCRIPTION
Resolves https://github.com/microsoft/winget-pkgs/issues/30233
Added `PackageName` as `Dolphin Nightly` even though ARP has `Dolphin`
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/denelon/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/30564)