### PR TITLE
Allow Blank Issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: Review open issues
     url: https://github.com/microsoft/winget-pkgs/issues


### PR DESCRIPTION
There may be times when users have an issue which is not a feature, not a bug report, and not a package request. Users should be able to open issues directly without having to use the forms. This only enables the link circled here -

![image](https://user-images.githubusercontent.com/12611259/137768760-6631ebdb-8a20-4dc9-93ad-6699cfbf162f.png)


cc @denelon 