### PR TITLE
Updated Architecture to neutral for Cinchoo.ChoEazyCopy

### DIFF
--- a/manifests/c/Cinchoo/ChoEazyCopy/1.0.1/Cinchoo.ChoEazyCopy.installer.yaml
+++ b/manifests/c/Cinchoo/ChoEazyCopy/1.0.1/Cinchoo.ChoEazyCopy.installer.yaml
@@ -10,7 +10,7 @@ InstallModes:
 - silentWithProgress
 Installers:
 - InstallerLocale: en-US
-  Architecture: x64
+  Architecture: neutral
   InstallerType: exe
   Scope: machine
   InstallerUrl: https://github.com/Cinchoo/ChoEazyCopy/releases/download/v1.0.0.20/ChoEazyCopySetup.exe


### PR DESCRIPTION
Its neutral according to https://github.com/Cinchoo/ChoEazyCopy/issues/14

- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/denelon/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/30790)