### PR TITLE
Move .validation from manifests/m/Microsoft/AccessibilityInsightsAndr…

### DIFF
--- a/manifests/m/Microsoft/AccessibilityInsights/Android/.validation
+++ b/manifests/m/Microsoft/AccessibilityInsights/Android/.validation
@@ -1,0 +1,1 @@
+{"ValidationVersion":"1.0.0","Waivers":[{"WaiverId":"33870126-7f0b-4835-8788-3e1f264979bb","TestPlan":"Validation-Domain","PackagePath":"manifests/m/Microsoft/AccessibilityInsights/Android/2021.924.1"}]}

--- a/manifests/m/Microsoft/AccessibilityInsightsAndroid/.validation
+++ b/manifests/m/Microsoft/AccessibilityInsightsAndroid/.validation
@@ -1,1 +1,0 @@
-{"ValidationVersion":"1.0.0","Waivers":[{"WaiverId":"33870126-7f0b-4835-8788-3e1f264979bb","TestPlan":"Validation-Domain","PackagePath":"manifests/m/Microsoft/AccessibilityInsightsAndroid/2021.714.15"}]}


### PR DESCRIPTION
…oid/2021.714.15 to manifests/m/Microsoft/AccessibilityInsights/Android/2021.924.1

- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/denelon/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/32452)