### PR TITLE
Add Adobe.Acrobat.Reader.64-Bit v21.007.20099

### DIFF
--- a/manifests/a/Adobe/Acrobat/Reader/64-bit/21.007.20099/Adobe.Acrobat.Reader.64-bit.installer.yaml
+++ b/manifests/a/Adobe/Acrobat/Reader/64-bit/21.007.20099/Adobe.Acrobat.Reader.64-bit.installer.yaml
@@ -1,7 +1,10 @@
+# Created with YamlCreate.ps1 v2.0.0 $debug=AUSU.5-1-19041-1237
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
+
 PackageIdentifier: Adobe.Acrobat.Reader.64-bit
 PackageVersion: 21.007.20099
 MinimumOSVersion: 10.0.0.0
+InstallerType: exe
 Scope: machine
 InstallModes:
 - interactive
@@ -19,28 +22,23 @@ FileExtensions:
 Installers:
 - InstallerLocale: en-US
   Architecture: x64
-  InstallerType: exe
   InstallerUrl: https://ardownload2.adobe.com/pub/adobe/acrobat/win/AcrobatDC/2100720099/AcroRdrDCx642100720099_en_US.exe
-  InstallerSha256: 89B9112CDBB9713F3E08A35F6BB4F6C8BDB658A985AFC9CBBC83A8363F1C8517
+  InstallerSha256: 5C96988674B82E22DEC0F2C7DDED08D2E299328BD26F55B241529B879FA819E4
 - InstallerLocale: de-DE
   Architecture: x64
-  InstallerType: exe
   InstallerUrl: https://ardownload2.adobe.com/pub/adobe/acrobat/win/AcrobatDC/2100720099/AcroRdrDCx642100720099_de_DE.exe
-  InstallerSha256: 89B9112CDBB9713F3E08A35F6BB4F6C8BDB658A985AFC9CBBC83A8363F1C8517
+  InstallerSha256: AF765763EB4DE3019B62C11F6E2C740C6BF404F4CA70B566FB1079B2BF943FCC
 - InstallerLocale: es-ES
   Architecture: x64
-  InstallerType: exe
   InstallerUrl: https://ardownload2.adobe.com/pub/adobe/acrobat/win/AcrobatDC/2100720099/AcroRdrDCx642100720099_es_ES.exe
-  InstallerSha256: 89B9112CDBB9713F3E08A35F6BB4F6C8BDB658A985AFC9CBBC83A8363F1C8517
+  InstallerSha256: 37D25655E7F481E6A38AE93FCC74C24AEDE48A2EAD93CFE9DBD3AA70F972F58A
 - InstallerLocale: fr-FR
   Architecture: x64
-  InstallerType: exe
   InstallerUrl: https://ardownload2.adobe.com/pub/adobe/acrobat/win/AcrobatDC/2100720099/AcroRdrDCx642100720099_fr_FR.exe
-  InstallerSha256: 89B9112CDBB9713F3E08A35F6BB4F6C8BDB658A985AFC9CBBC83A8363F1C8517
+  InstallerSha256: 287A1CD200225D8B9718EA2B2DCB10ADE859832C2BA90BB00800FF4A0ACEE5FC
 - InstallerLocale: ja-JP
   Architecture: x64
-  InstallerType: exe
   InstallerUrl: https://ardownload2.adobe.com/pub/adobe/acrobat/win/AcrobatDC/2100720099/AcroRdrDCx642100720099_ja_JP.exe
-  InstallerSha256: 89B9112CDBB9713F3E08A35F6BB4F6C8BDB658A985AFC9CBBC83A8363F1C8517
+  InstallerSha256: A123BD43AAF3FCF6FAE34C5D1CE77E01DC40EC621C82D9E63BCF9625A639812C
 ManifestType: installer
 ManifestVersion: 1.0.0

--- a/manifests/a/Adobe/Acrobat/Reader/64-bit/21.007.20099/Adobe.Acrobat.Reader.64-bit.installer.yaml
+++ b/manifests/a/Adobe/Acrobat/Reader/64-bit/21.007.20099/Adobe.Acrobat.Reader.64-bit.installer.yaml
@@ -1,0 +1,46 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
+PackageIdentifier: Adobe.Acrobat.Reader.64-bit
+PackageVersion: 21.007.20099
+MinimumOSVersion: 10.0.0.0
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: /sAll /rs /rps /l /re
+  SilentWithProgress: /sAll /rs /rps /l /re
+UpgradeBehavior: install
+FileExtensions:
+- pdf
+- pdfa
+- pdfx
+- xfx
+Installers:
+- InstallerLocale: en-US
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://ardownload2.adobe.com/pub/adobe/acrobat/win/AcrobatDC/2100720099/AcroRdrDCx642100720099_en_US.exe
+  InstallerSha256: 89B9112CDBB9713F3E08A35F6BB4F6C8BDB658A985AFC9CBBC83A8363F1C8517
+- InstallerLocale: de-DE
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://ardownload2.adobe.com/pub/adobe/acrobat/win/AcrobatDC/2100720099/AcroRdrDCx642100720099_de_DE.exe
+  InstallerSha256: 89B9112CDBB9713F3E08A35F6BB4F6C8BDB658A985AFC9CBBC83A8363F1C8517
+- InstallerLocale: es-ES
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://ardownload2.adobe.com/pub/adobe/acrobat/win/AcrobatDC/2100720099/AcroRdrDCx642100720099_es_ES.exe
+  InstallerSha256: 89B9112CDBB9713F3E08A35F6BB4F6C8BDB658A985AFC9CBBC83A8363F1C8517
+- InstallerLocale: fr-FR
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://ardownload2.adobe.com/pub/adobe/acrobat/win/AcrobatDC/2100720099/AcroRdrDCx642100720099_fr_FR.exe
+  InstallerSha256: 89B9112CDBB9713F3E08A35F6BB4F6C8BDB658A985AFC9CBBC83A8363F1C8517
+- InstallerLocale: ja-JP
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://ardownload2.adobe.com/pub/adobe/acrobat/win/AcrobatDC/2100720099/AcroRdrDCx642100720099_ja_JP.exe
+  InstallerSha256: 89B9112CDBB9713F3E08A35F6BB4F6C8BDB658A985AFC9CBBC83A8363F1C8517
+ManifestType: installer
+ManifestVersion: 1.0.0

--- a/manifests/a/Adobe/Acrobat/Reader/64-bit/21.007.20099/Adobe.Acrobat.Reader.64-bit.locale.en-US.yaml
+++ b/manifests/a/Adobe/Acrobat/Reader/64-bit/21.007.20099/Adobe.Acrobat.Reader.64-bit.locale.en-US.yaml
@@ -4,7 +4,7 @@
 PackageIdentifier: Adobe.Acrobat.Reader.64-bit
 PackageVersion: 21.007.20099
 PackageLocale: en-US
-Publisher: Adobe Systems Incorporated
+Publisher: Adobe
 PublisherUrl: https://www.adobe.com
 PublisherSupportUrl: https://helpx.adobe.com/support.html
 PrivacyUrl: https://www.adobe.com/privacy.html

--- a/manifests/a/Adobe/Acrobat/Reader/64-bit/21.007.20099/Adobe.Acrobat.Reader.64-bit.locale.en-US.yaml
+++ b/manifests/a/Adobe/Acrobat/Reader/64-bit/21.007.20099/Adobe.Acrobat.Reader.64-bit.locale.en-US.yaml
@@ -1,4 +1,6 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultlocale.1.0.0.schema.json
+# Created with YamlCreate.ps1 v2.0.0 $debug=AUSU.5-1-19041-1237
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.0.0.schema.json
+
 PackageIdentifier: Adobe.Acrobat.Reader.64-bit
 PackageVersion: 21.007.20099
 PackageLocale: en-US
@@ -23,4 +25,3 @@ Tags:
 - dc
 ManifestType: defaultLocale
 ManifestVersion: 1.0.0
-

--- a/manifests/a/Adobe/Acrobat/Reader/64-bit/21.007.20099/Adobe.Acrobat.Reader.64-bit.locale.en-US.yaml
+++ b/manifests/a/Adobe/Acrobat/Reader/64-bit/21.007.20099/Adobe.Acrobat.Reader.64-bit.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultlocale.1.0.0.schema.json
+PackageIdentifier: Adobe.Acrobat.Reader.64-bit
+PackageVersion: 21.007.20099
+PackageLocale: en-US
+Publisher: Adobe Systems Incorporated
+PublisherUrl: https://www.adobe.com
+PublisherSupportUrl: https://helpx.adobe.com/support.html
+PrivacyUrl: https://www.adobe.com/privacy.html
+Author: Adobe Systems Incorporated
+PackageName: Adobe Acrobat DC (64-bit)
+PackageUrl: https://acrobat.adobe.com/us/en/acrobat/pdf-reader.html
+License: Proprietary, Freeware
+LicenseUrl: https://www.adobe.com/content/dam/cc/en/legal/licenses-terms/pdf/Reader-EULA-en_US-20181207.pdf
+Copyright: Copyright (c) Adobe
+CopyrightUrl: https://www.adobe.com/content/dam/cc/en/legal/licenses-terms/pdf/Reader-EULA-en_US-20181207.pdf
+ShortDescription: The free global standard for reliably viewing, printing, signing, and commenting on PDF documents.
+Description: Adobe Acrobat Reader DC software is the free, trusted global standard for viewing, printing, signing, sharing, and annotating PDFs. It's the only PDF viewer that can open and interact with all types of PDF content – including forms and multimedia.
+Moniker: acrobatreader
+Tags:
+- adobe
+- reader
+- acrobat
+- dc
+ManifestType: defaultLocale
+ManifestVersion: 1.0.0
+

--- a/manifests/a/Adobe/Acrobat/Reader/64-bit/21.007.20099/Adobe.Acrobat.Reader.64-bit.yaml
+++ b/manifests/a/Adobe/Acrobat/Reader/64-bit/21.007.20099/Adobe.Acrobat.Reader.64-bit.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.0.0.schema.json
+PackageIdentifier: Adobe.Acrobat.Reader.64-bit
+PackageVersion: 21.007.20099
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.0.0
+

--- a/manifests/a/Adobe/Acrobat/Reader/64-bit/21.007.20099/Adobe.Acrobat.Reader.64-bit.yaml
+++ b/manifests/a/Adobe/Acrobat/Reader/64-bit/21.007.20099/Adobe.Acrobat.Reader.64-bit.yaml
@@ -1,7 +1,8 @@
+# Created with YamlCreate.ps1 v2.0.0 $debug=AUSU.5-1-19041-1237
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.0.0.schema.json
+
 PackageIdentifier: Adobe.Acrobat.Reader.64-bit
 PackageVersion: 21.007.20099
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.0.0
-


### PR DESCRIPTION
I specifically chose the package identifier to allow for Adobe.Acrobat.Pro to be added later.
This is required to be separate from the 32-bit version until the 1.1 schema which will allow for ARP entry matching, as the 32 bit version of Acrobat Reader and the 64 bit version of Acrobat Reader have different ARP data.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/denelon/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.
 
-----
Closes #32785 


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/33539)