### PR TITLE
KDE.Dolphin.Nightly

### DIFF
--- a/manifests/k/KDE/Dolphin/Nightly/master-b6ec4b1c9/KDE.Dolphin.Nightly.installer.yaml
+++ b/manifests/k/KDE/Dolphin/Nightly/master-b6ec4b1c9/KDE.Dolphin.Nightly.installer.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
 
 PackageIdentifier: KDE.Dolphin.Nightly
-PackageVersion: master-b6ec4b1c9
+PackageVersion: master-271
 Scope: machine
 InstallModes:
 - interactive
@@ -10,7 +10,7 @@ InstallModes:
 Installers:
 - Architecture: x64
   InstallerType: nullsoft
-  InstallerUrl: https://binary-factory.kde.org/job/Dolphin_Nightly_win64/271/artifact/dolphin-master-271-windows-msvc2019_64-cl.exe
+  InstallerUrl: https://binary-factory.kde.org/view/Windows%2064-bit/job/Dolphin_Nightly_win64/lastSuccessfulBuild/artifact/dolphin-master-271-windows-msvc2019_64-cl.exe
   InstallerSha256: 486CB47FD3171870A2AAF2A18702645BF780605AF2432FD6013A825EB488D18F
 ManifestType: installer
 ManifestVersion: 1.0.0

--- a/manifests/k/KDE/Dolphin/Nightly/master-b6ec4b1c9/KDE.Dolphin.Nightly.installer.yaml
+++ b/manifests/k/KDE/Dolphin/Nightly/master-b6ec4b1c9/KDE.Dolphin.Nightly.installer.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
 
 PackageIdentifier: KDE.Dolphin.Nightly
-PackageVersion: master-271
+PackageVersion: master-b6ec4b1c9
 Scope: machine
 InstallModes:
 - interactive


### PR DESCRIPTION
Rectification of the version of KDE.Dolphin.Nightly, and replacement of the URL for the installer with a version that is much more easy to maintain, but shall not cause submission of invalid installers.

This should allow the improvements that have been submitted to http://github.com/microsoft/winget-pkgs/issues/30233 to be merged.

- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/denelon/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/33717)