### PR TITLE
KDE.Dolphin.Release

### DIFF
--- a/manifests/k/KDE/Dolphin/21.04.3/KDE.Dolphin.installer.yaml
+++ b/manifests/k/KDE/Dolphin/21.04.3/KDE.Dolphin.installer.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
 
 PackageIdentifier: KDE.Dolphin
-PackageVersion: 21.04.3
+PackageVersion: master-1255
 Scope: machine
 InstallModes:
 - interactive
@@ -10,7 +10,7 @@ InstallModes:
 Installers:
 - Architecture: x64
   InstallerType: nullsoft
-  InstallerUrl: https://binary-factory.kde.org/job/Dolphin_Release_win64/1255/artifact/dolphin-21.04.3-1255-windows-msvc2019_64-cl.exe
+  InstallerUrl: https://binary-factory.kde.org/view/Windows%2064-bit/job/Dolphin_Release_win64/lastSuccessfulBuild/artifact/dolphin-21.04.3-1255-windows-msvc2019_64-cl.exe
   InstallerSha256: C5FE5779291D5093819AE3153AC0254426F4EFCF188CC8FB32FA73E614F58933
 ManifestType: installer
 ManifestVersion: 1.0.0

--- a/manifests/k/KDE/Dolphin/21.04.3/KDE.Dolphin.installer.yaml
+++ b/manifests/k/KDE/Dolphin/21.04.3/KDE.Dolphin.installer.yaml
@@ -1,7 +1,7 @@
 # Created using wingetcreate 0.4.1.1
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
 
-PackageIdentifier: KDE.Dolphin
+PackageIdentifier: KDE.Dolphin.Release
 PackageVersion: master-1255
 Scope: machine
 InstallModes:


### PR DESCRIPTION
Improvement of the consistency of the version of KDE.Dolphin.Release and all of the other packages that have been created by KDE, and replacement of the URL for the installer with a version that is much more easy to maintain, but shall not cause submission of invalid installers.

This should allow the improvements that have been submitted to http://github.com/microsoft/winget-pkgs/issues/30234 to be merged.

- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/denelon/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/33718)