### PR TITLE
KDE.Kate.Release

### DIFF
--- a/manifests/k/KDE/Kate/21.08.2/KDE.Kate.installer.yaml
+++ b/manifests/k/KDE/Kate/21.08.2/KDE.Kate.installer.yaml
@@ -3,7 +3,7 @@ PackageIdentifier: KDE.Kate.Release
 PackageVersion: master-1459
 InstallerType: appx
 UpgradeBehavior: install
-Installers: 
+Installers:
 - Architecture: x64
   InstallerUrl: https://binary-factory.kde.org/view/Windows%2064-bit/job/Kate_Release_win64/lastSuccessfulBuild/artifact/kate-21.08.2-1459-windows-msvc2019_64-cl-sideload.appx
   InstallerSha256: f8692d5dfd0bc6760926579dcab927d545671cc346126f3b71ea6cd598a8e732

--- a/manifests/k/KDE/Kate/21.08.2/KDE.Kate.installer.yaml
+++ b/manifests/k/KDE/Kate/21.08.2/KDE.Kate.installer.yaml
@@ -2,7 +2,7 @@
 PackageIdentifier: KDE.Kate.Release
 PackageVersion: master-1459
 MinimumOSVersion: 
-InstallerType: 
+InstallerType: appx
 Scope: 
 UpgradeBehavior: install
 Installers: 

--- a/manifests/k/KDE/Kate/21.08.2/KDE.Kate.installer.yaml
+++ b/manifests/k/KDE/Kate/21.08.2/KDE.Kate.installer.yaml
@@ -1,7 +1,6 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
 PackageIdentifier: KDE.Kate.Release
 PackageVersion: master-1459
-MinimumOSVersion: 
 InstallerType: appx
 Scope: 
 UpgradeBehavior: install

--- a/manifests/k/KDE/Kate/21.08.2/KDE.Kate.installer.yaml
+++ b/manifests/k/KDE/Kate/21.08.2/KDE.Kate.installer.yaml
@@ -2,7 +2,6 @@
 PackageIdentifier: KDE.Kate.Release
 PackageVersion: master-1459
 InstallerType: appx
-Scope: 
 UpgradeBehavior: install
 Installers: 
 - Architecture: x64

--- a/manifests/k/KDE/Kate/21.08.2/KDE.Kate.installer.yaml
+++ b/manifests/k/KDE/Kate/21.08.2/KDE.Kate.installer.yaml
@@ -1,14 +1,14 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
-PackageIdentifier: KDE.Kate
-PackageVersion: 21.08.2
-MinimumOSVersion: 10.0.0.0
-InstallerType: nullsoft
-Scope: machine
+PackageIdentifier: KDE.Kate.Release
+PackageVersion: master-1459
+MinimumOSVersion: 
+InstallerType: 
+Scope: 
 UpgradeBehavior: install
-Installers:
+Installers: 
 - Architecture: x64
-  InstallerUrl: https://binary-factory.kde.org/view/Windows%2064-bit/job/Kate_Release_win64/1456/artifact/kate-21.08.2-1456-windows-msvc2019_64-cl.exe
-  InstallerSha256: D95F20BE05A06358090201A956D608DD0457CC7916A159403F83E671D7F045A7
+  InstallerUrl: https://binary-factory.kde.org/view/Windows%2064-bit/job/Kate_Release_win64/lastSuccessfulBuild/artifact/kate-21.08.2-1459-windows-msvc2019_64-cl-sideload.appx
+  InstallerSha256: f8692d5dfd0bc6760926579dcab927d545671cc346126f3b71ea6cd598a8e732
 ManifestType: installer
 ManifestVersion: 1.0.0
 


### PR DESCRIPTION
Addition of support for .appx, because .appx is undoubtedly better than mere .exe, and shall cause submission to the "msstore" and "winget" repositories to be more consistent. Also, I did cause the version of KDE.Kate.Release to be more consistent with KDE's other software.

This should allow the improvements that have been submitted to http://github.com/microsoft/winget-pkgs/issues/30234 to be merged.

- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/denelon/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/33718)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/33731)