### PR TITLE
CMake 3.20.0: Add binary directory to PATH on install

### DIFF
--- a/manifests/k/Kitware/CMake/3.20.0/Kitware.CMake.yaml
+++ b/manifests/k/Kitware/CMake/3.20.0/Kitware.CMake.yaml
@@ -13,6 +13,8 @@ Installers:
   InstallerSha256: B9B151DF0BC1C6A3B5B3F77B516C25A9BAEEA0A1DB5DE373AE379195D97017E6
   InstallerType: msi
   ProductCode: "{BE7033C5-8BE9-40D1-8F64-5E2B01708941}"
+  InstallerSwitches:
+    Custom: ADD_CMAKE_TO_PATH=System
 PackageLocale: en-US
 ManifestType: singleton
 ManifestVersion: 1.0.0


### PR DESCRIPTION
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Have you [validated](https://github.com/denelon/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [X] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/33787)