### PR TITLE
CMake 3.18.3: Add binary directory to PATH on install

### DIFF
--- a/manifests/k/Kitware/CMake/3.18.3/Kitware.CMake.yaml
+++ b/manifests/k/Kitware/CMake/3.18.3/Kitware.CMake.yaml
@@ -13,6 +13,8 @@ Installers:
   InstallerType: msi
   ProductCode: '{238C2206-DBE9-4D81-B7F7-101F3557FF28}'
   InstallerSha256: B0C0B297E6BE934B2B0D6C6B55B47B6FDA52A51F4931F4F7708C3F9B036AB80A
+  InstallerSwitches:
+    Custom: ADD_CMAKE_TO_PATH=System
 PackageLocale: en-US
 ManifestType: singleton
 ManifestVersion: 1.0.0


### PR DESCRIPTION
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Have you [validated](https://github.com/denelon/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [X] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/33806)