### PR TITLE
Update for Microsoft build of OpenJDK 11, Oct-PSU release

### DIFF
--- a/manifests/m/Microsoft/OpenJDK/11/11.0.13.8/Microsoft.OpenJDK.11.installer.yaml
+++ b/manifests/m/Microsoft/OpenJDK/11/11.0.13.8/Microsoft.OpenJDK.11.installer.yaml
@@ -1,0 +1,33 @@
+# Created using wingetcreate 0.4.2.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
+
+PackageIdentifier: Microsoft.OpenJDK.11
+PackageVersion: 11.0.13.8
+MinimumOSVersion: 10.0.0.0
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+Installers:
+- Architecture: x64
+  InstallerUrl: https://aka.ms/download-jdk/microsoft-jdk-11.0.13.8.1-windows-x64.msi
+  InstallerSha256: A6651E68C945D880D753C08515BE123DA4BBFEC8FE9A684463D2C336268C7FEE
+  Scope: machine
+  InstallerLocale: en-US
+  ProductCode: '{3CCA84F4-964E-44E4-B8C1-6AF65AAC80CA}'
+  UpgradeBehavior: uninstallPrevious
+  InstallerType: msi
+  InstallerSwitches:
+    Custom: ADDLOCAL=FeatureMain,FeatureEnvironment,FeatureJarFileRunWith,FeatureJavaHome
+- Architecture: arm64
+  InstallerUrl: https://aka.ms/download-jdk/microsoft-jdk-11.0.13.8.1-windows-aarch64.msi
+  InstallerSha256: 67FAECC4AEE9203F767462D1239B1CE2D3E1DCA31ACD0A7A13E9E14E6D7EE62D
+  Scope: machine
+  InstallerLocale: en-US
+  ProductCode: '{02511115-0324-450C-A464-9E2E72A7D1A7}'
+  UpgradeBehavior: uninstallPrevious
+  InstallerType: msi
+  InstallerSwitches:
+    Custom: ADDLOCAL=FeatureMain,FeatureEnvironment,FeatureJarFileRunWith,FeatureJavaHome
+ManifestType: installer
+ManifestVersion: 1.0.0

--- a/manifests/m/Microsoft/OpenJDK/11/11.0.13.8/Microsoft.OpenJDK.11.locale.en-US.yaml
+++ b/manifests/m/Microsoft/OpenJDK/11/11.0.13.8/Microsoft.OpenJDK.11.locale.en-US.yaml
@@ -1,0 +1,21 @@
+# Created using wingetcreate 0.4.2.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.0.0.schema.json
+
+PackageIdentifier: Microsoft.OpenJDK.11
+PackageVersion: 11.0.13.8
+PackageLocale: en-US
+Publisher: Microsoft
+Author: Microsoft
+PackageName: Microsoft Build of OpenJDK with Hotspot 11
+PackageUrl: https://www.microsoft.com/openjdk
+License: GPL2 with Classpath Exception.
+LicenseUrl: https://openjdk.java.net/legal/gplv2+ce.html
+ShortDescription: The Microsoft Build of OpenJDK is a new no-cost long-term supported distribution and Microsoft"s new way to collaborate and contribute to the Java ecosystem.
+Moniker: ms-openjdk-11
+Tags:
+- Java
+- OpenJDK
+- 11
+ManifestType: defaultLocale
+ManifestVersion: 1.0.0
+

--- a/manifests/m/Microsoft/OpenJDK/11/11.0.13.8/Microsoft.OpenJDK.11.yaml
+++ b/manifests/m/Microsoft/OpenJDK/11/11.0.13.8/Microsoft.OpenJDK.11.yaml
@@ -1,0 +1,9 @@
+# Created using wingetcreate 0.4.2.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.0.0.schema.json
+
+PackageIdentifier: Microsoft.OpenJDK.11
+PackageVersion: 11.0.13.8
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.0.0
+


### PR DESCRIPTION
Security fixes from the October PSU for OpenJDK 11. Version `microsoft-jdk-11.0.13.8`.

- improve customer experience, set JDK_HOME on install
- fixes microsoft/openjdk#122
- adds ARM64 architecture support
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/denelon/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/34002)