### PR TITLE
Add switch for keeping branch attached

### DIFF
--- a/Tools/PRTest.ps1
+++ b/Tools/PRTest.ps1
@@ -4,7 +4,8 @@ Param(
   [Parameter(Position = 0, HelpMessage = "The Pull Request to checkout.", Mandatory=$true)]
   [String] $PullRequest,
   [Parameter(HelpMessage = "Open the Pull Request's review page in the default browser")]
-  [Switch] $Review = $false
+  [Switch] $Review = $false,
+  [Switch] $KeepBranch = $false
 )
 
 $PullRequest = $PullRequest.TrimStart('#')
@@ -25,7 +26,7 @@ if (-Not (Get-Command "git" -ErrorAction "SilentlyContinue")) {
     return
 }
 
-gh pr checkout $PullRequest --detach -f | Out-Null
+gh pr checkout $PullRequest $(if (!$KeepBranch){'--detach'}) -f | Out-Null
 
 if($LASTEXITCODE -ne 0) {
     Write-Host "There was an error checking out the PR. Make sure you're logged into GitHub via 'gh auth login' and come back here!" -ForegroundColor Red


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?

This PR adds a switch to the PRTest.ps1 script to allow users of the script to open the branch in attached mode rather than detached mode

cc @denelon


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/34310)