### PR TITLE
Move .validation for Teams Exploration to the new path

### DIFF
--- a/manifests/m/Microsoft/Teams/Exploration/.validation
+++ b/manifests/m/Microsoft/Teams/Exploration/.validation
@@ -1,0 +1,1 @@
+{"ValidationVersion":"1.0.0","Waivers":[{"WaiverId":"E4CA77AC-03FA-431b-ADF1-A44A15EE0526","TestPlan":"Policy-Test-2.7","PackagePath":"manifests/m/Microsoft/Teams/Exploration/1.4.00.20801"}]}

--- a/manifests/m/Microsoft/TeamsExploration/.validation
+++ b/manifests/m/Microsoft/TeamsExploration/.validation
@@ -1,1 +1,0 @@
-{"ValidationVersion":"1.0.0","Waivers":[{"WaiverId":"E4CA77AC-03FA-431b-ADF1-A44A15EE0526","TestPlan":"Policy-Test-2.7","PackagePath":"manifests/m/Microsoft/TeamsExploration/1.4.00.20801"}]}


### PR DESCRIPTION
`Microsoft.TeamsExploration` has been moved to `Microsoft.Teams.Exploration`

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/35764)