### PR TITLE
Move .validation `LibreOffice.LibreOffice` to `TheDocumentFoundation.LibreOffice`

### DIFF
--- a/manifests/l/LibreOffice/LibreOffice/PreRelease/.validation
+++ b/manifests/l/LibreOffice/LibreOffice/PreRelease/.validation
@@ -1,1 +1,0 @@
-{"ValidationVersion":"1.0.0","Waivers":[{"WaiverId":"1849d2c1-4d97-4d1a-8a0d-7993d88136b8","TestPlan":"Validation-Domain","PackagePath":"manifests/l/LibreOffice/LibreOffice/PreRelease/7.0.0.2"}]}

--- a/manifests/t/TheDocumentFoundation/LibreOffice/PreRelease/.validation
+++ b/manifests/t/TheDocumentFoundation/LibreOffice/PreRelease/.validation
@@ -1,0 +1,1 @@
+{"ValidationVersion":"1.0.0","Waivers":[{"WaiverId":"1849d2c1-4d97-4d1a-8a0d-7993d88136b8","TestPlan":"Validation-Domain","PackagePath":"manifests/t/TheDocumentFoundation/LibreOffice/PreRelease/7.0.0.2"}]}


### PR DESCRIPTION
- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/denelon/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/36204)