### PR TITLE
update rproject.r's url

### DIFF
--- a/manifests/r/RProject/R/4.1.2/RProject.R.installer.yaml
+++ b/manifests/r/RProject/R/4.1.2/RProject.R.installer.yaml
@@ -15,7 +15,7 @@ FileExtensions:
 - r
 Installers:
 - Architecture: x64
-  InstallerUrl: https://cran.microsoft.com/bin/windows/base/R-4.1.2-win.exe
+  InstallerUrl: https://cloud.r-project.org/bin/windows/base/old/4.1.2/R-4.1.2-win.exe
   InstallerSha256: 6919D3F98E7A83AA1D3A1449B17E52E54ECD267453FFB1033E1D4FED66B088E4
 ManifestType: installer
 ManifestVersion: 1.0.0


### PR DESCRIPTION
Replace the currently used URLs with URLs that can be used permanently since they are only available in the latest version (e.g. #35010).

And, sets up the URL that are automatically forwarded to mirror sites around the world, rather than Microsoft's CRAN mirror in U.S.A. c.f. https://cran.r-project.org/mirrors.html

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/36973)