### PR TITLE
Removed installer locale for Microsoft.OpenJDK.11 version 11.0.13.8.

### DIFF
--- a/manifests/m/Microsoft/OpenJDK/11/11.0.13.8/Microsoft.OpenJDK.11.installer.yaml
+++ b/manifests/m/Microsoft/OpenJDK/11/11.0.13.8/Microsoft.OpenJDK.11.installer.yaml
@@ -13,7 +13,6 @@ Installers:
   InstallerUrl: https://aka.ms/download-jdk/microsoft-jdk-11.0.13.8.1-windows-x64.msi
   InstallerSha256: A6651E68C945D880D753C08515BE123DA4BBFEC8FE9A684463D2C336268C7FEE
   Scope: machine
-  InstallerLocale: en-US
   ProductCode: '{3CCA84F4-964E-44E4-B8C1-6AF65AAC80CA}'
   UpgradeBehavior: uninstallPrevious
   InstallerType: msi
@@ -23,7 +22,6 @@ Installers:
   InstallerUrl: https://aka.ms/download-jdk/microsoft-jdk-11.0.13.8.1-windows-aarch64.msi
   InstallerSha256: 67FAECC4AEE9203F767462D1239B1CE2D3E1DCA31ACD0A7A13E9E14E6D7EE62D
   Scope: machine
-  InstallerLocale: en-US
   ProductCode: '{02511115-0324-450C-A464-9E2E72A7D1A7}'
   UpgradeBehavior: uninstallPrevious
   InstallerType: msi


### PR DESCRIPTION
This was causing issues for upgrades if the user isn't using a en-US locale. Since there's only one OpenJDK installer for all languages, this should be a good solution.

Resolves #37076

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/denelon/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/37163)