### PR TITLE
Atlassian.Sourcetree v3.4.7 user scope installer

### DIFF
--- a/manifests/a/Atlassian/Sourcetree/3.4.7/Atlassian.Sourcetree.installer.yaml
+++ b/manifests/a/Atlassian/Sourcetree/3.4.7/Atlassian.Sourcetree.installer.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 0.4.3.1
+# Created using wingetcreate 0.4.4.1
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
 
 PackageIdentifier: Atlassian.Sourcetree
@@ -17,6 +17,14 @@ Installers:
   InstallerSha256: 10F7A5BE7FB1FF93F49BFE4921635D38555CF45B2DD82600ABA3ECB4A7DBBE60
   InstallerSwitches:
     Custom: ACCEPTEULA=1
+  UpgradeBehavior: install
+  ProductCode: '{C2F82CF6-50FA-41FE-8000-1361A76223FA}'
+- InstallerLocale: en-US
+  Architecture: x64
+  InstallerType: exe
+  Scope: user
+  InstallerUrl: https://product-downloads.atlassian.com/software/sourcetree/windows/ga/SourceTreeSetup-3.4.7.exe
+  InstallerSha256: 115F2EA206CDC1142865BA8FB11D3A8D6D20ACE9B82A5FE5CCCE8806C996B7C5
   UpgradeBehavior: install
   ProductCode: '{C2F82CF6-50FA-41FE-8000-1361A76223FA}'
 ManifestType: installer

--- a/manifests/a/Atlassian/Sourcetree/3.4.7/Atlassian.Sourcetree.installer.yaml
+++ b/manifests/a/Atlassian/Sourcetree/3.4.7/Atlassian.Sourcetree.installer.yaml
@@ -26,7 +26,7 @@ Installers:
   InstallerUrl: https://product-downloads.atlassian.com/software/sourcetree/windows/ga/SourceTreeSetup-3.4.7.exe
   InstallerSha256: 115F2EA206CDC1142865BA8FB11D3A8D6D20ACE9B82A5FE5CCCE8806C996B7C5
   UpgradeBehavior: install
-  ProductCode: '{C2F82CF6-50FA-41FE-8000-1361A76223FA}'
+  ProductCode: 'SourceTree'
 ManifestType: installer
 ManifestVersion: 1.0.0
 


### PR DESCRIPTION
This adds an installer with user scope (in addition to the existing machine scope) to the v3.4.7 manifest of Atlassian.Sourcetree.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/denelon/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/37977)