### PR TITLE
Fix Version: Yubico.Authenticator - Added scope to installers

### DIFF
--- a/manifests/y/Yubico/Authenticator/5.1.0/Yubico.Authenticator.installer.yaml
+++ b/manifests/y/Yubico/Authenticator/5.1.0/Yubico.Authenticator.installer.yaml
@@ -3,6 +3,8 @@
 
 PackageIdentifier: Yubico.Authenticator
 PackageVersion: 5.1.0
+Platform:
+- Windows.Desktop
 MinimumOSVersion: 10.0.0.0
 InstallModes:
 - interactive
@@ -11,6 +13,7 @@ InstallModes:
 Installers:
 - InstallerLocale: en-US
   Architecture: x64
+  Scope: machine
   InstallerType: msi
   InstallerUrl: https://developers.yubico.com/yubioath-desktop/Releases/yubioath-desktop-5.1.0-win64.msi
   InstallerSha256: 76685C8AE1783135DAA33D808F1B3CE34DD9ADE63013DF0F8FBC5FF3A5882997
@@ -22,6 +25,7 @@ Installers:
   ProductCode: '{E00E28E2-DED4-473D-B02A-4C22AE46902F}'
 - InstallerLocale: en-US
   Architecture: x86
+  Scope: machine
   InstallerType: msi
   InstallerUrl: https://developers.yubico.com/yubioath-desktop/Releases/yubioath-desktop-5.1.0-win32.msi
   InstallerSha256: 1F3E08F201FAB6B3C774EB886410E9F9C6FEB0DEBEEE84411D27194945AC7468
@@ -32,5 +36,4 @@ Installers:
   UpgradeBehavior: install
   ProductCode: '{15AF4599-A0CB-4012-B753-30D0D1355908}'
 ManifestType: installer
-ManifestVersion: 1.0.0
-
+ManifestVersion: 1.1.0

--- a/manifests/y/Yubico/Authenticator/5.1.0/Yubico.Authenticator.locale.en-US.yaml
+++ b/manifests/y/Yubico/Authenticator/5.1.0/Yubico.Authenticator.locale.en-US.yaml
@@ -6,14 +6,17 @@ PackageVersion: 5.1.0
 PackageLocale: en-US
 Publisher: Yubico AB
 PublisherUrl: https://www.yubico.com/
-# PublisherSupportUrl: https://support.yubico.com
-
+PublisherSupportUrl: https://support.yubico.com
 PrivacyUrl: https://www.yubico.com/support/terms-conditions/privacy-notice/
+Author: Yubico AB
 PackageName: Yubico Authenticator
 PackageUrl: https://www.yubico.com/products/yubico-authenticator/
+Copyright: Yubico © 2021. All Rights Reserved.
+#CopyrightUrl: 
 License: BSD-2-Clause License
 LicenseUrl: https://raw.githubusercontent.com/Yubico/yubioath-desktop/master/COPYING
 ShortDescription: Authenticator to generate 2-step verification codes using your YubiKey
+Description: Authenticator to generate 2-step verification codes using your YubiKey
 Moniker: yubioath
 Tags:
 - 2fa
@@ -21,5 +24,4 @@ Tags:
 - auth
 - totp
 ManifestType: defaultLocale
-ManifestVersion: 1.0.0
-
+ManifestVersion: 1.1.0

--- a/manifests/y/Yubico/Authenticator/5.1.0/Yubico.Authenticator.yaml
+++ b/manifests/y/Yubico/Authenticator/5.1.0/Yubico.Authenticator.yaml
@@ -5,5 +5,4 @@ PackageIdentifier: Yubico.Authenticator
 PackageVersion: 5.1.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.0.0
-
+ManifestVersion: 1.1.0

--- a/manifests/y/Yubico/YubikeyManager/1.2.3/Yubico.YubikeyManager.installer.yaml
+++ b/manifests/y/Yubico/YubikeyManager/1.2.3/Yubico.YubikeyManager.installer.yaml
@@ -1,15 +1,21 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+
 PackageIdentifier: Yubico.YubikeyManager
 PackageVersion: 1.2.3
+Platform:
+- Windows.Desktop
 Installers:
 - Architecture: x64
+  Scope: machine
   InstallerUrl: https://developers.yubico.com/yubikey-manager-qt/Releases/yubikey-manager-qt-1.2.3-win64.exe
   InstallerSha256: 3AD403D314292F9C7BBD91E7AFD38D8C2B48A6C11C05321C23D64577E1D34FC4
   InstallerType: nullsoft
+  UpgradeBehavior: install
 - Architecture: x86
+  Scope: machine
   InstallerUrl: https://developers.yubico.com/yubikey-manager-qt/Releases/yubikey-manager-qt-1.2.3-win32.exe
   InstallerSha256: A223C619887A8FE407C4C242CF6C3846B5EF27CAB7EA2819FCDFAB30B78DCD24
   InstallerType: nullsoft
+  UpgradeBehavior: install
 ManifestType: installer
-ManifestVersion: 1.0.0
-
+ManifestVersion: 1.1.0

--- a/manifests/y/Yubico/YubikeyManager/1.2.3/Yubico.YubikeyManager.locale.en-US.yaml
+++ b/manifests/y/Yubico/YubikeyManager/1.2.3/Yubico.YubikeyManager.locale.en-US.yaml
@@ -1,17 +1,25 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultlocale.1.0.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+
 PackageIdentifier: Yubico.YubikeyManager
 PackageVersion: 1.2.3
 PackageLocale: en-US
+Publisher: Yubico AB
+PublisherUrl: https://www.yubico.com/
+PublisherSupportUrl: https://support.yubico.com
+PrivacyUrl: https://www.yubico.com/support/terms-conditions/privacy-notice/
+Author: Yubico AB
+PackageName: YubiKey Manager
+PackageUrl: https://www.yubico.com/products/services-software/download/yubikey-manager/
+Copyright: Copyright (c) Yubico 2020. All Rights Reserved.
+#CopyrightUrl: 
+License: BSD 2-Clause "Simplified" License
+LicenseUrl: https://github.com/Yubico/yubikey-manager/blob/main/COPYING
+ShortDescription: Official tool to configure FIDO2, OTP and PIV functionality on your YubiKey
+Description: Official tool to configure FIDO2, OTP and PIV functionality on your YubiKey
 Moniker: yubimgr
 Tags:
 - 2fa
 - security
 - auth
-PackageUrl: https://www.yubico.com/products/services-software/download/yubikey-manager/
-Publisher: Yubico AB
-PackageName: YubiKey Manager
-License: Copyright (c) Yubico 2020. All Rights Reserved.
-ShortDescription: Official tool to configure FIDO2, OTP and PIV functionality on your YubiKey
 ManifestType: defaultLocale
-ManifestVersion: 1.0.0
-
+ManifestVersion: 1.1.0

--- a/manifests/y/Yubico/YubikeyManager/1.2.3/Yubico.YubikeyManager.yaml
+++ b/manifests/y/Yubico/YubikeyManager/1.2.3/Yubico.YubikeyManager.yaml
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.0.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+
 PackageIdentifier: Yubico.YubikeyManager
 PackageVersion: 1.2.3
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.0.0
-
+ManifestVersion: 1.1.0


### PR DESCRIPTION
Updated manifest
added machine scope to installers

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/denelon/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

Adding machine scope to installer as the installer will only install to program files. There is no user scope. 


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/38052)