### PR TITLE
Fix: Allow packages with 'Backup' in the name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -236,7 +236,7 @@ Generated_Code/
 # to a newer Visual Studio version. Backup files are not needed,
 # because we have git ;-)
 _UpgradeReport_Files/
-Backup*/
+# Backup*/
 UpgradeLog*.XML
 UpgradeLog*.htm
 ServiceFabricBackup/

--- a/.gitignore
+++ b/.gitignore
@@ -236,7 +236,7 @@ Generated_Code/
 # to a newer Visual Studio version. Backup files are not needed,
 # because we have git ;-)
 _UpgradeReport_Files/
-# Backup*/
+Backup*/
 UpgradeLog*.XML
 UpgradeLog*.htm
 ServiceFabricBackup/
@@ -328,3 +328,6 @@ ASALocalRun/
 
 # MFractors (Xamarin productivity tool) working folder 
 .mfractor/
+
+# Anything under the manifests folder should be included
+!manifests/**


### PR DESCRIPTION
@denelon  This line in the gitignore file is causing issues when trying to update packages that have 'Backup' as part of their package id such as `AOMEI.Backupper` or `Google.BackupAndSync`

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/38084)