### PR TITLE
Update installer hash of muCommander 0.9.7

### DIFF
--- a/manifests/m/muCommander/muCommander/0.9.7/muCommander.muCommander.installer.yaml
+++ b/manifests/m/muCommander/muCommander/0.9.7/muCommander.muCommander.installer.yaml
@@ -7,7 +7,7 @@ Installers:
 - Architecture: x86
   InstallerType: nullsoft
   InstallerUrl: https://github.com/mucommander/mucommander/releases/download/0.9.7-1/mucommander-0.9.7-1-bundled.exe
-  InstallerSha256: DEC3929AA377122B08AE6205970A36F63CB24C065E4616901FC5A55056AE1E2C
+  InstallerSha256: 05a6e6368c15894e91d879de575eca8de968c3b44391b4cf70b8c56e18b23d05
   ProductCode: 'muCommander'
 ManifestType: installer
 ManifestVersion: 1.0.0


### PR DESCRIPTION
The installer was updated to include Publisher and DisplayVersion, and a different DisplayName (`muCommander` instead of `muCommander (remove only)`)

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/denelon/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/38103)