### PR TITLE
NordVPN.NordVPN - Changed VC++ dependency to 2015-2022 package

### DIFF
--- a/manifests/n/NordVPN/NordVPN/6.41.11.0/NordVPN.NordVPN.installer.yaml
+++ b/manifests/n/NordVPN/NordVPN/6.41.11.0/NordVPN.NordVPN.installer.yaml
@@ -14,7 +14,7 @@ InstallModes:
 UpgradeBehavior: install
 Dependencies:
   PackageDependencies:
-  - PackageIdentifier: Microsoft.VC++2015-2019Redist-x64
+  - PackageIdentifier: Microsoft.VC++2015-2022Redist-x64
 Installers:
 - Architecture: x86
   InstallerUrl: https://downloads.nordcdn.com/apps/windows/NordVPN/6.41.11/NordVPNSetup_x86.exe


### PR DESCRIPTION
Changed VC++ from 2015-2019 package to 2015-2022 package

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/denelon/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/38358)