### PR TITLE
VentisMedia.MediaMonkey version 5.0.2

### DIFF
--- a/manifests/v/VentisMedia/MediaMonkey/5/VentisMedia.MediaMonkey.installer.yaml
+++ b/manifests/v/VentisMedia/MediaMonkey/5/VentisMedia.MediaMonkey.installer.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 0.3.0.3
+# Created using wingetcreate 0.4.4.1
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
 
 PackageIdentifier: VentisMedia.MediaMonkey
@@ -67,8 +67,8 @@ Installers:
   Architecture: x86
   InstallerType: inno
   Scope: machine
-  InstallerUrl: https://www.mediamonkey.com/sw/MediaMonkey_5.0.1.2433.exe
-  InstallerSha256: 1D73DE789243A588A43D97948AB42C396AEADF21965DDF2D488E7DC67C7451CE
+  InstallerUrl: https://www.mediamonkey.com/sw/MediaMonkey_5.0.2.2531.exe
+  InstallerSha256: 6AF7216BFF74F6E7A31E0E79456398ADC407B594FE6CC2BE0A9BF1D296E84FA6
   UpgradeBehavior: install
 ManifestType: installer
 ManifestVersion: 1.0.0

--- a/manifests/v/VentisMedia/MediaMonkey/5/VentisMedia.MediaMonkey.locale.en-US.yaml
+++ b/manifests/v/VentisMedia/MediaMonkey/5/VentisMedia.MediaMonkey.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 0.3.0.3
+# Created using wingetcreate 0.4.4.1
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.0.0.schema.json
 
 PackageIdentifier: VentisMedia.MediaMonkey

--- a/manifests/v/VentisMedia/MediaMonkey/5/VentisMedia.MediaMonkey.yaml
+++ b/manifests/v/VentisMedia/MediaMonkey/5/VentisMedia.MediaMonkey.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 0.3.0.3
+# Created using wingetcreate 0.4.4.1
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.0.0.schema.json
 
 PackageIdentifier: VentisMedia.MediaMonkey


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/denelon/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

Note that only the installerUrl and checksum has changed (for the download). MediaMonkey 5 is always installed with package version 5, regardless of the patch version or revision of the installer.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/38816)