### PR TITLE
Update: stevencohn.OneMore version 4.12

### DIFF
--- a/manifests/s/stevencohn/OneMore/4.12/stevencohn.OneMore.installer.yaml
+++ b/manifests/s/stevencohn/OneMore/4.12/stevencohn.OneMore.installer.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.0.4 $debug=QUSU.7-2-0
+# Created with YamlCreate.ps1 v2.0.4 $debug=QUSU.7-2-1
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
 
 PackageIdentifier: stevencohn.OneMore
@@ -17,8 +17,5 @@ Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/stevencohn/OneMore/releases/download/4.12/OneMore_4.12_Setupx64.msi
   InstallerSha256: B0C4F677B1EB935127060517D43516095CFCB2870BBC514D56DB8CC99B2A7DF8
-- Architecture: x86
-  InstallerUrl: https://github.com/stevencohn/OneMore/releases/download/4.12/OneMore_4.12_Setupx86.msi
-  InstallerSha256: 9FD3D32278AA104DEF9DFF60C9D3A2A8361E63733DAEB9475E122E238B81A451
 ManifestType: installer
 ManifestVersion: 1.1.0

--- a/manifests/s/stevencohn/OneMore/4.12/stevencohn.OneMore.locale.en-US.yaml
+++ b/manifests/s/stevencohn/OneMore/4.12/stevencohn.OneMore.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.0.4 $debug=QUSU.7-2-0
+# Created with YamlCreate.ps1 v2.0.4 $debug=QUSU.7-2-1
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
 
 PackageIdentifier: stevencohn.OneMore

--- a/manifests/s/stevencohn/OneMore/4.12/stevencohn.OneMore.yaml
+++ b/manifests/s/stevencohn/OneMore/4.12/stevencohn.OneMore.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.0.4 $debug=QUSU.7-2-0
+# Created with YamlCreate.ps1 v2.0.4 $debug=QUSU.7-2-1
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
 
 PackageIdentifier: stevencohn.OneMore


### PR DESCRIPTION
Dropped x32 support

- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Have you [validated](https://github.com/denelon/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

* Resolves #38911


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/39051)