### PR TITLE
Rename Version: SergeySerkov.TagScanner 6.1.11 to 6.1.12

### DIFF
--- a/manifests/s/SergeySerkov/TagScanner/6.1.12/SergeySerkov.TagScanner.installer.yaml
+++ b/manifests/s/SergeySerkov/TagScanner/6.1.12/SergeySerkov.TagScanner.installer.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
 
 PackageIdentifier: SergeySerkov.TagScanner
-PackageVersion: 6.1.11
+PackageVersion: 6.1.12
 Platform:
 - Windows.Desktop
 MinimumOSVersion: 10.0.0.0

--- a/manifests/s/SergeySerkov/TagScanner/6.1.12/SergeySerkov.TagScanner.locale.en-US.yaml
+++ b/manifests/s/SergeySerkov/TagScanner/6.1.12/SergeySerkov.TagScanner.locale.en-US.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
 
 PackageIdentifier: SergeySerkov.TagScanner
-PackageVersion: 6.1.11
+PackageVersion: 6.1.12
 PackageLocale: en-US
 Publisher: Sergey Serkov
 PublisherUrl: https://www.xdlab.ru/en/

--- a/manifests/s/SergeySerkov/TagScanner/6.1.12/SergeySerkov.TagScanner.yaml
+++ b/manifests/s/SergeySerkov/TagScanner/6.1.12/SergeySerkov.TagScanner.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
 
 PackageIdentifier: SergeySerkov.TagScanner
-PackageVersion: 6.1.11
+PackageVersion: 6.1.12
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.1.0


### PR DESCRIPTION
Software and installer clearly say 6.1.12 yet the version in this repo is called 6.1.11

- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Have you [validated](https://github.com/denelon/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [X] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/40014)