### PR TITLE
EdrawSoft.EdrawMax.CN version 11.5.2

### DIFF
--- a/manifests/e/EdrawSoft/EdrawMax/CN/11.5.2/EdrawSoft.EdrawMax.CN.installer.yaml
+++ b/manifests/e/EdrawSoft/EdrawMax/CN/11.5.2/EdrawSoft.EdrawMax.CN.installer.yaml
@@ -11,4 +11,3 @@ Installers:
   UpgradeBehavior: install
 ManifestType: installer
 ManifestVersion: 1.0.0
-

--- a/manifests/e/EdrawSoft/EdrawMax/CN/11.5.2/EdrawSoft.EdrawMax.CN.installer.yaml
+++ b/manifests/e/EdrawSoft/EdrawMax/CN/11.5.2/EdrawSoft.EdrawMax.CN.installer.yaml
@@ -1,0 +1,14 @@
+# Created using wingetcreate 0.4.4.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
+
+PackageIdentifier: EdrawSoft.EdrawMax.CN
+PackageVersion: 11.5.2
+Installers:
+- Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://cc-download.edrawsoft.cn/edraw-max_cn_full5374.exe
+  InstallerSha256: B2DCD722F155674A4A40122CB0F976EA7305B32F15C7B3D057F58634C39ABE08
+  UpgradeBehavior: install
+ManifestType: installer
+ManifestVersion: 1.0.0
+

--- a/manifests/e/EdrawSoft/EdrawMax/CN/11.5.2/EdrawSoft.EdrawMax.CN.locale.zh-CN.yaml
+++ b/manifests/e/EdrawSoft/EdrawMax/CN/11.5.2/EdrawSoft.EdrawMax.CN.locale.zh-CN.yaml
@@ -1,0 +1,23 @@
+# Created using wingetcreate 0.4.4.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.0.0.schema.json
+
+PackageIdentifier: EdrawSoft.EdrawMax.CN
+PackageVersion: 11.5.2
+PackageLocale: zh-CN
+Publisher: 深圳市亿图软件有限公司
+PublisherUrl: https://www.edrawsoft.cn/
+PublisherSupportUrl: https://www.edrawsoft.cn/support/
+PrivacyUrl: https://www.edrawsoft.cn/edrawmax-term-services/
+Author: 深圳市亿图软件有限公司
+PackageName: EdrawMax（简体中文）
+PackageUrl: https://www.edrawsoft.cn/edrawmax/
+License: 亿图软件 版权所有© 2014-2022
+Copyright: 亿图软件 版权所有© 2014-2022
+ShortDescription: 集两百多种绘图于一身的综合图形图表设计软件，Visio 国产替代
+Description: 集两百多种绘图于一身的综合图形图表设计软件，Visio 国产替代
+Tags:
+- edrawmax
+- visio
+ManifestType: defaultLocale
+ManifestVersion: 1.0.0
+

--- a/manifests/e/EdrawSoft/EdrawMax/CN/11.5.2/EdrawSoft.EdrawMax.CN.locale.zh-CN.yaml
+++ b/manifests/e/EdrawSoft/EdrawMax/CN/11.5.2/EdrawSoft.EdrawMax.CN.locale.zh-CN.yaml
@@ -20,4 +20,3 @@ Tags:
 - visio
 ManifestType: defaultLocale
 ManifestVersion: 1.0.0
-

--- a/manifests/e/EdrawSoft/EdrawMax/CN/11.5.2/EdrawSoft.EdrawMax.CN.yaml
+++ b/manifests/e/EdrawSoft/EdrawMax/CN/11.5.2/EdrawSoft.EdrawMax.CN.yaml
@@ -6,4 +6,3 @@ PackageVersion: 11.5.2
 DefaultLocale: zh-CN
 ManifestType: version
 ManifestVersion: 1.0.0
-

--- a/manifests/e/EdrawSoft/EdrawMax/CN/11.5.2/EdrawSoft.EdrawMax.CN.yaml
+++ b/manifests/e/EdrawSoft/EdrawMax/CN/11.5.2/EdrawSoft.EdrawMax.CN.yaml
@@ -1,0 +1,9 @@
+# Created using wingetcreate 0.4.4.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.0.0.schema.json
+
+PackageIdentifier: EdrawSoft.EdrawMax.CN
+PackageVersion: 11.5.2
+DefaultLocale: zh-CN
+ManifestType: version
+ManifestVersion: 1.0.0
+


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/denelon/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/40559)

## Information about the installer

According to responses from online technical support, this **Simplified Chinese** version is different from the **International** version `EdrawSoft.EdrawMax` and does NOT support "silent-installation". Users have to interactively install it.

If there are advanced users can handle that "silent-installation" stuff, could you please do me a favour and improve this manifest?