### PR TITLE
RARLab.WinRAR: enable Japanese (ja-JP) for 6.02

### DIFF
--- a/manifests/r/RARLab/WinRAR/6.02.0/RARLab.WinRAR.installer.yaml
+++ b/manifests/r/RARLab/WinRAR/6.02.0/RARLab.WinRAR.installer.yaml
@@ -64,14 +64,14 @@ Installers:
     InstallerUrl: https://www.rarlab.com/rar/wrar602hu.exe
     InstallerSha256: 1F09DA7618C0AE06F2EED94A1AE834AE37214E403B517F2454F9436F8385F2A6
 
-#  - InstallerLocale: ja-JP
-#    Architecture: x64
-#    InstallerUrl: https://www.rarlab.com/rar/winrar-x64-602jp.exe
-#    InstallerSha256:     
-#  - InstallerLocale: ja-JP
-#    Architecture: x86
-#    InstallerUrl: https://www.rarlab.com/rar/wrar602jp.exe
-#    InstallerSha256: 
+  - InstallerLocale: ja-JP
+    Architecture: x64
+    InstallerUrl: https://www.rarlab.com/rar/winrar-x64-602jp.exe
+    InstallerSha256:     
+  - InstallerLocale: ja-JP
+    Architecture: x86
+    InstallerUrl: https://www.rarlab.com/rar/wrar602jp.exe
+    InstallerSha256: 
 
   - InstallerLocale: zh-TW
     Architecture: x64


### PR DESCRIPTION
Un comment out for Japanese installer

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/denelon/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest \winget-pkgs\manifests\r\RARLab\WinRAR\6.02.0`? 
- [x] Have you tested your manifest locally with `winget install --manifest \winget-pkgs\manifests\r\RARLab\WinRAR\6.02.0`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/40639)