### PR TITLE
NoMachine.NoMachineClient: fix incorrect installed version

### DIFF
--- a/manifests/n/NoMachine/NoMachineClient/7.7.4/NoMachine.NoMachineClient.installer.yaml
+++ b/manifests/n/NoMachine/NoMachineClient/7.7.4/NoMachine.NoMachineClient.installer.yaml
@@ -10,7 +10,7 @@ InstallerType: inno
 Scope: machine
 Installers:
 - Architecture: x64
-  InstallerUrl: https://download.nomachine.com/packages/7.7-PRODUCTION/Windows/nomachine-enterprise-desktop_7.7.4_1.exe
-  InstallerSha256: 3589A8E8EBE37EDF00B08E020BC4C61ED3016AB92D73D6D517615F0547916161
+  InstallerUrl: https://download.nomachine.com/download/7.7/Windows/nomachine-enterprise-client_7.7.4_1.exe
+  InstallerSha256: 9da6f62d3f5926f50d5db5c837bf891a147e22b6cd59dc3c214480ee6560f61e
 ManifestType: installer
 ManifestVersion: 1.1.0

--- a/manifests/n/NoMachine/NoMachineClient/7.7.4/NoMachine.NoMachineClient.locale.en-US.yaml
+++ b/manifests/n/NoMachine/NoMachineClient/7.7.4/NoMachine.NoMachineClient.locale.en-US.yaml
@@ -5,19 +5,19 @@ PackageIdentifier: NoMachine.NoMachineClient
 PackageVersion: 7.7.4
 PackageLocale: en-US
 Publisher: NoMachine S.a.r.l.
-# PublisherUrl: 
-# PublisherSupportUrl: 
-# PrivacyUrl: 
-# Author: 
-PackageName: NoMachine Enterprise
-PackageUrl: https://nomachine.com/
+PublisherUrl: https://www.nomachine.com/
+PublisherSupportUrl: https://www.nomachine.com/support
+PrivacyUrl: https://knowledgebase.nomachine.com/AR05P00977
+Author: NoMachine S.a.r.l.
+PackageName: NoMachine Enterprise Client
+PackageUrl: https://www.nomachine.com/product&p=NoMachine%20Enterprise%20Client
 License: Commercial
 # LicenseUrl: 
-# Copyright: 
+Copyright: Copyright (c) 2002-2021 NoMachine S.à r.l.
 # CopyrightUrl: 
-ShortDescription: Free remote desktop for everybody (Client only)
-# Description: 
-Moniker: nomachine-enterprise
+ShortDescription: Client to connect to remote host where NoMachine server is installed. NoMachine Enterprise Client does not contain the server part.
+# Description:
+Moniker: nomachine-enterprise-client
 Tags:
 - nomachine
 - remote-access


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/denelon/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

Fixed NoMachine.NoMachineClient that installed "NoMachine Desktop" instead of "NoMachine Entreprise Client".

This was the case with the 7.3.2 version that was the initial version on Winget, but "NoMachine Entreprise Client" was changed to "NoMachine Desktop" when updating to 7.4.1. "NoMachine Desktop" contains the server, it does not match with the "client only" description so reverting back to "NoMachine Entreprise Client".

Also updated the manifest to be more clear on what version contains the server or not and added more accurate information.

Note: Have the possibility to install the client only is important to comply some security rules especially in enterprise.



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/41131)