### PR TITLE
YamlCreate v2.0.5

### DIFF
--- a/Tools/YamlCreate.ps1
+++ b/Tools/YamlCreate.ps1
@@ -1673,9 +1673,6 @@ Function Write-LocaleManifest {
     }
     if (!$LocaleManifest) { [PSCustomObject]$LocaleManifest = [ordered]@{} }
 
-    # Set the appropriate langage server depending on if it is a default locale file or generic locale file
-    if ($LocaleManifest.ManifestType -eq 'defaultLocale') { $yamlServer = "# yaml-language-server: `$schema=https://aka.ms/winget-manifest.defaultLocale.$ManifestVersion.schema.json" } else { $yamlServer = "# yaml-language-server: `$schema=https://aka.ms/winget-manifest.locale.$ManifestVersion.schema.json" }
-
     # Add the properties to the manifest
     $_Singletons = [ordered]@{
         'PackageIdentifier'   = $PackageIdentifier
@@ -1709,6 +1706,9 @@ Function Write-LocaleManifest {
     if ($LocaleManifest['Moniker']) { $LocaleManifest['Moniker'] = $LocaleManifest['Moniker'] | ToLower | NoWhitespace }
 
     $LocaleManifest = Restore-YamlKeyOrder $LocaleManifest $LocaleProperties
+
+    # Set the appropriate langage server depending on if it is a default locale file or generic locale file
+    if ($LocaleManifest.ManifestType -eq 'defaultLocale') { $yamlServer = "# yaml-language-server: `$schema=https://aka.ms/winget-manifest.defaultLocale.$ManifestVersion.schema.json" } else { $yamlServer = "# yaml-language-server: `$schema=https://aka.ms/winget-manifest.locale.$ManifestVersion.schema.json" }
 
     # Create the folder for the file if it doesn't exist
     New-Item -ItemType 'Directory' -Force -Path $AppFolder | Out-Null

--- a/Tools/YamlCreate.ps1
+++ b/Tools/YamlCreate.ps1
@@ -1655,7 +1655,7 @@ Function Write-InstallerManifest {
 
     # Create the folder for the file if it doesn't exist
     New-Item -ItemType 'Directory' -Force -Path $AppFolder | Out-Null
-    $InstallerManifestPath = $AppFolder + "\$PackageIdentifier" + '.installer' + '.yaml'
+    $script:InstallerManifestPath = $AppFolder + "\$PackageIdentifier" + '.installer' + '.yaml'
 
     # Write the manifest to the file
     $ScriptHeader + "$(Get-DebugString)`n# yaml-language-server: `$schema=https://aka.ms/winget-manifest.installer.$ManifestVersion.schema.json`n" > $InstallerManifestPath
@@ -2303,8 +2303,10 @@ if ($PromptSubmit -eq '0') {
     git switch -d upstream/master
     if ($LASTEXITCODE -eq '0') {
         # Make sure path exists and is valid before hashing
-        if ($script:LocaleManifestPath -and (Test-Path -Path $script:LocaleManifestPath)) { $UniqueBranchID = $(Get-FileHash $script:LocaleManifestPath).Hash[0..6] -Join '' }
-        else { $UniqueBranchID = 'DEL' }
+        $UniqueBranchID = ''
+        if ($script:LocaleManifestPath -and (Test-Path -Path $script:LocaleManifestPath)) { $UniqueBranchID = $UniqueBranchID + $($(Get-FileHash $script:LocaleManifestPath).Hash[0..6] -Join '') }
+        if ($script:InstallerManifestPath -and (Test-Path -Path $script:InstallerManifestPath)) { $UniqueBranchID = $UniqueBranchID + $($(Get-FileHash $script:InstallerManifestPath).Hash[0..6] -Join '') }
+        if (Test-String -IsNull $UniqueBranchID) { $UniqueBranchID = 'DEL' }
         $BranchName = "$PackageIdentifier-$PackageVersion-$UniqueBranchID"
         # Git branch names cannot start with `.` cannot contain any of {`..`, `\`, `~`, `^`, `:`, ` `, `?`, `@{`, `[`}, and cannot end with {`/`, `.lock`, `.`}
         $BranchName = $BranchName -replace '[\~,\^,\:,\\,\?,\@\{,\*,\[,\s]{1,}|[.lock|/|\.]*$|^\.{1,}|\.\.', ''

--- a/Tools/YamlCreate.ps1
+++ b/Tools/YamlCreate.ps1
@@ -67,6 +67,24 @@ $ofs = ', '
     https://github.com/microsoft/winget-pkgs/blob/master/Tools/YamlCreate.ps1
 #>
 
+<# 
+----- TO DO  -----
+# Installer Properties -
+    # Dependencies
+        # - Windows Libraries
+        # - Winget Package Dependencies
+    # Release Date
+    # ARP Data
+        # - Display Name
+        # - Publisher
+        # - Display Version
+# Locale Properties -
+    # Release Notes
+    # Release Notes URL
+# Misc changes -
+    # Sort file extensions
+#>
+
 # Installs `powershell-yaml` as a dependency for parsing yaml content
 if (-not(Get-Module -ListAvailable -Name powershell-yaml)) {
     try {

--- a/Tools/YamlCreate.ps1
+++ b/Tools/YamlCreate.ps1
@@ -54,7 +54,7 @@ if ($Settings) {
     exit
 }
 
-$ScriptHeader = '# Created with YamlCreate.ps1 v2.0.4'
+$ScriptHeader = '# Created with YamlCreate.ps1 v2.0.5'
 $ManifestVersion = '1.1.0'
 $PSDefaultParameterValues = @{ '*:Encoding' = 'UTF8' }
 $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
@@ -81,24 +81,6 @@ $ofs = ', '
     https://github.com/microsoft/winget-pkgs/issues/
 .LINK
     https://github.com/microsoft/winget-pkgs/blob/master/Tools/YamlCreate.ps1
-#>
-
-<# 
------ TO DO  -----
-# Installer Properties -
-    # Dependencies
-        # - Windows Libraries
-        # - Winget Package Dependencies
-    # Release Date
-    # ARP Data
-        # - Display Name
-        # - Publisher
-        # - Display Version
-# Locale Properties -
-    # Release Notes
-    # Release Notes URL
-# Misc changes -
-    # Sort file extensions
 #>
 
 # Fetch Schema data from github for entry validation, key ordering, and automatic commenting


### PR DESCRIPTION
Features
* Prompts for ReleaseDate
* Prompts for ReleaseNotes
* Prompts for ReleaseNotesUrl
* Clears above three fields as volatile when not provided

Bug Fixes
* Resolves issue checking settings before powershell-yaml is installed
* Skips AppLocker checks on non-windows platforms
* Use combined data of installer and locale hashes when creating branch names
* Fixes issue with schema header for defaultLocale being filled as locale instead

cc @denelon @jedieaston 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/41445)