### PR TITLE
Put UpgradeBehavior back for Edge WebView2 Runtime version 97.0.1072.76.

### DIFF
--- a/manifests/m/Microsoft/EdgeWebView2Runtime/97.0.1072.76/Microsoft.EdgeWebView2Runtime.installer.yaml
+++ b/manifests/m/Microsoft/EdgeWebView2Runtime/97.0.1072.76/Microsoft.EdgeWebView2Runtime.installer.yaml
@@ -12,6 +12,8 @@ InstallModes:
 InstallerSwitches:
   Silent: /silent /install
   SilentWithProgress: /silent /install
+# This seems to be the only way to get upgrades to go through winget, see microsoft/winget-cli#1824
+UpgradeBehavior: uninstallPrevious
 ElevationRequirement: elevationRequired
 Installers:
 - Architecture: x64


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

------

I thought the installer issue from https://github.com/microsoft/winget-cli/issues/1824 had been resolved so I removed the key, but it hadn't. The issue reappeared for some people after I removed the UpgradeBehavior. This puts it back.

Sorry for the trouble.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/43955)