### PR TITLE
Chore: Add 1.1.0 Schema to PR Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 - [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
 - [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
 - [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
-- [ ] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?
+- [ ] Does your manifest conform to the [1.0 schema](/microsoft/winget-cli/tree/master/schemas/JSON/manifests/v1.0.0) or the [1.1 schema](/microsoft/winget-cli/tree/master/schemas/JSON/manifests/v1.1.0)?
 
 Note: `<path>` is the name of the directory containing the manifest you're submitting.
 


### PR DESCRIPTION
With the pipelines now (mostly) allowing for 1.1.0 schemas, the PR Template should be updated to reflect this

@denelon

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/44282)