### PR TITLE
Correct Dependency: HandBrake.HandBrake version 1.5.1

### DIFF
--- a/manifests/h/HandBrake/HandBrake/1.5.1/HandBrake.HandBrake.installer.yaml
+++ b/manifests/h/HandBrake/HandBrake/1.5.1/HandBrake.HandBrake.installer.yaml
@@ -13,7 +13,7 @@ InstallModes:
 UpgradeBehavior: install
 Dependencies:
   PackageDependencies:
-  - PackageIdentifier: Microsoft.dotnetRuntime.5-x64
+  - PackageIdentifier: Microsoft.dotnetRuntime.6-x64
 Installers:
 - Architecture: arm64
   InstallerUrl: https://github.com/HandBrake/HandBrake/releases/download/1.5.1/HandBrake-1.5.1-arm64-Win_GUI.exe


### PR DESCRIPTION
From https://github.com/HandBrake/HandBrake/releases/tag/1.5.1

> Windows
> * The Windows UI is now .NET 6.0 only. (.NET 5.0 is no longer additionally required)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/46011)