### PR TITLE
New package: YmSoft.Nalgaeset version 10.40.83

### DIFF
--- a/manifests/y/YmSoft/Nalgaeset/10.40.83/YmSoft.Nalgaeset.installer.yaml
+++ b/manifests/y/YmSoft/Nalgaeset/10.40.83/YmSoft.Nalgaeset.installer.yaml
@@ -1,0 +1,20 @@
+PackageIdentifier: YmSoft.Nalgaeset
+PackageVersion: 10.40.83
+Scope: machine
+Installers:
+- InstallerLocale: ko-KR
+  Architecture: x64
+  InstallerType: msi
+  InstallerUrl: http://moogi.new21.org/bin/Ngs1040Setup_x64.msi
+  InstallerSha256: 74E178047A0BD15F8B5FD5A0030B8833B8D785E9C31E4380B803D4D090F56C21
+  ProductCode: "{791710C5-A6D1-4E3D-A9DC-2C9F1A5AF572}"
+  InstallModes: ["silent", "interactive"]
+- InstallerLocale: ko-KR
+  Architecture: x86
+  InstallerType: msi
+  InstallerUrl: http://moogi.new21.org/bin/Ngs1040Setup_x86.msi
+  InstallerSha256: 5DAF24BB24F4FCB6B82F666BB1242277DEE9F3B6C796CC78D6E1279D4F20C8CE
+  ProductCode: "{7C46914A-3F00-4A28-A42B-384D6123DC55}"
+  InstallModes: ["silent", "interactive"]
+ManifestType: installer
+ManifestVersion: 1.1.0

--- a/manifests/y/YmSoft/Nalgaeset/10.40.83/YmSoft.Nalgaeset.locale.en-US.yaml
+++ b/manifests/y/YmSoft/Nalgaeset/10.40.83/YmSoft.Nalgaeset.locale.en-US.yaml
@@ -1,0 +1,12 @@
+PackageIdentifier: YmSoft.Nalgaeset
+PackageVersion: 10.40.83
+PackageLocale: en-US
+Publisher: YmSoft
+PublisherUrl: http://moogi.new21.org/en/
+Author: Hong Minhee
+PackageName: 날개셋 한글 입력기
+PackageUrl: http://moogi.new21.org/en/ngs/
+License: Copyright (c) 2000-2021 Kim Yongmook. All rights reserved.
+ShortDescription: Nalgaeset is a Korean input method software for Microsoft Windows. It mainly consists of both a self-contained text editor and a universal IME for the operating system.
+ManifestType: locale
+ManifestVersion: 1.1.0

--- a/manifests/y/YmSoft/Nalgaeset/10.40.83/YmSoft.Nalgaeset.locale.ko-KR.yaml
+++ b/manifests/y/YmSoft/Nalgaeset/10.40.83/YmSoft.Nalgaeset.locale.ko-KR.yaml
@@ -1,0 +1,22 @@
+PackageIdentifier: YmSoft.Nalgaeset
+PackageVersion: 10.40.83
+PackageLocale: ko-KR
+Publisher: YmSoft
+PublisherUrl: http://moogi.new21.org/
+Author: 洪 民憙 (Hong Minhee)
+PackageName: 날개셋 한글 입력기
+PackageUrl: http://moogi.new21.org/prg4.html
+License: Copyright (c) 2000-2021 Kim Yongmook. All rights reserved.
+ShortDescription: 날개셋 한글 입력기는 Windows용 다용도 한글 입력 프로그램입니다. 동일한 입력 엔진을 공유하는 (1) 자체 한글 입출력 텍스트 에디터와 (2) 한글 IME(외부 모듈)라는 두 형태로 구현되어 있습니다. 아래의 스크린샷에서 빨간 네모가 모두 날개셋 한글 입력기를 구성하는 프로그램입니다.
+ReleaseNotesUrl: http://moogi.new21.org/ngshistory.htm
+Moniker: nalgaeset
+Tags:
+- 한국어
+- 한글
+- 입력기
+- korean
+- hangul
+- hangeul
+- ime
+ManifestType: defaultLocale
+ManifestVersion: 1.1.0

--- a/manifests/y/YmSoft/Nalgaeset/10.40.83/YmSoft.Nalgaeset.yaml
+++ b/manifests/y/YmSoft/Nalgaeset/10.40.83/YmSoft.Nalgaeset.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: YmSoft.Nalgaeset
+PackageVersion: 10.40.83
+DefaultLocale: ko-KR
+ManifestType: version
+ManifestVersion: 1.1.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

> ### [Nalgaeset Hangul Input System](http://moogi.new21.org/en/ngs/)
>
> _Nalgaeset_ is a Korean input method software for Microsoft Windows. It mainly consists of both a self-contained text editor and a universal IME for the operating system. The two programs share the common library, and support virtually every Windows platform from 95/NT4 to 10 of any languages, both 32- and 64-bit.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/46092)