### PR TITLE
Prevent auto restart after LibreOffice 7.3.0.3 install

### DIFF
--- a/manifests/t/TheDocumentFoundation/LibreOffice/7.3.0.3/TheDocumentFoundation.LibreOffice.installer.yaml
+++ b/manifests/t/TheDocumentFoundation/LibreOffice/7.3.0.3/TheDocumentFoundation.LibreOffice.installer.yaml
@@ -6,6 +6,9 @@ PackageVersion: 7.3.0.3
 Platform:
 - Windows.Desktop
 MinimumOSVersion: 10.0.0.0
+InstallerSwitches:
+  Silent: /qn /norestart
+  SilentWithProgress: /qb /norestart
 Scope: machine
 UpgradeBehavior: install
 FileExtensions:


### PR DESCRIPTION
Earlier LibreOffice manifests have these flags which prevent automatic system restarts on installation.

See also previous fixups 92ca7106023d0e2b1fa536f6502a0502ab3f06f9 and 1a5c1039ffb73edad007fd9ecaff8b08e335f1b3 
and their related PRs and issue tickets, as well as PR #47070, and #47071.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/47072)