### PR TITLE
ElevationRequirement: IDRIX.VeraCrypt version 1.25.9

### DIFF
--- a/manifests/i/IDRIX/VeraCrypt/1.25.9/IDRIX.VeraCrypt.installer.yaml
+++ b/manifests/i/IDRIX/VeraCrypt/1.25.9/IDRIX.VeraCrypt.installer.yaml
@@ -1,15 +1,15 @@
-# Created with YamlCreate.ps1 v2.0.7 $debug=QUSU.7-2-1
+# Created with YamlCreate.ps1 v2.1.0 $debug=AUSU.7-2-1
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
 
 PackageIdentifier: IDRIX.VeraCrypt
 PackageVersion: 1.25.9
-InstallerLocale: en-US
 MinimumOSVersion: 10.0.0.0
 InstallerType: wix
 InstallerSwitches:
   Silent: /qn ACCEPTLICENSE=YES
-  SilentWithProgress: /qn ACCEPTLICENSE=YES
+  SilentWithProgress: /qb ACCEPTLICENSE=YES
   Custom: /norestart
+ElevationRequirement: elevationRequired
 Installers:
 - Architecture: x64
   InstallerUrl: https://launchpad.net/veracrypt/trunk/1.25.9/+download/VeraCrypt_Setup_x64_1.25.9.msi


### PR DESCRIPTION
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [X] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

* Adds ElevationRequirement as its required for Silent Installation
  * https://github.com/microsoft/winget-cli/issues/752#issuecomment-1044387977
However i'm getting exit code 1603 on upgrade (Still successful)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/47663)