### PR TITLE
Make sandbox always log verbose install

### DIFF
--- a/Tools/SandboxTest.ps1
+++ b/Tools/SandboxTest.ps1
@@ -204,7 +204,7 @@ Write-Host @'
 --> Installing the Manifest $manifestFileName
 
 '@
-winget install -m '$manifestPathInSandbox'
+winget install -m '$manifestPathInSandbox' --verbose-logs
 
 Write-Host @'
 


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?

When running a test in sandbox, there is no reason to not log verbosely since the sandbox contents will be discarded on closure anyways. This way, when troubleshooting an issue, sandbox logs will be more likely to be informational

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/49783)