### PR TITLE
Modify: Governikus.AusweisApp2 version 1.22.4

### DIFF
--- a/manifests/g/Governikus/AusweisApp2/1.22.4/Governikus.AusweisApp2.installer.yaml
+++ b/manifests/g/Governikus/AusweisApp2/1.22.4/Governikus.AusweisApp2.installer.yaml
@@ -13,7 +13,7 @@ Installers:
 - InstallerLocale: de-DE
   Architecture: x86
   InstallerType: wix
-  InstallerUrl: https://www.ausweisapp.bund.de/fileadmin/user_upload/Software/1.22.4/AusweisApp2-1.22.4.msi
+  InstallerUrl: https://www.ausweisapp.bund.de/fileadmin/user_upload/Software/AusweisApp2-1.22.4.msi
   InstallerSha256: 157C367F4EFCCE86FA2207A1F6224DBDF49EFEB34FE8F9EFE00320953667798B
   ProductCode: '{CAE6E7AE-F42C-4ED8-BADD-B2193B50D906}'
 ManifestType: installer


### PR DESCRIPTION
Upgrade for this package failed for me. Looking at the current download URL from the provider's website, it seems that it has changed slightly. Checksum of the downloaded file still matches.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/50203)