### PR TITLE
Add location support to PuTTY

### DIFF
--- a/manifests/p/PuTTY/PuTTY/0.74.0.0/PuTTY.PuTTY.installer.yaml
+++ b/manifests/p/PuTTY/PuTTY/0.74.0.0/PuTTY.PuTTY.installer.yaml
@@ -6,6 +6,8 @@ PackageVersion: "0.74.0.0"
 MinimumOSVersion: 10.0.0.0
 InstallerType: wix
 Scope: machine
+InstallerSwitches:
+  InstallLocation: INSTALLDIR="<INSTALLPATH>"
 InstallModes:
 - interactive
 - silent

--- a/manifests/p/PuTTY/PuTTY/0.75.0.0/PuTTY.PuTTY.installer.yaml
+++ b/manifests/p/PuTTY/PuTTY/0.75.0.0/PuTTY.PuTTY.installer.yaml
@@ -6,6 +6,8 @@ PackageVersion: 0.75.0.0
 MinimumOSVersion: 10.0.0.0
 InstallerType: wix
 Scope: machine
+InstallerSwitches:
+  InstallLocation: INSTALLDIR="<INSTALLPATH>"
 InstallModes:
 - interactive
 - silent

--- a/manifests/p/PuTTY/PuTTY/0.76.0.0/PuTTY.PuTTY.installer.yaml
+++ b/manifests/p/PuTTY/PuTTY/0.76.0.0/PuTTY.PuTTY.installer.yaml
@@ -8,6 +8,8 @@ Platform:
 MinimumOSVersion: 10.0.0.0
 InstallerType: wix
 Scope: machine
+InstallerSwitches:
+  InstallLocation: INSTALLDIR="<INSTALLPATH>"
 InstallModes:
 - interactive
 - silent


### PR DESCRIPTION
Define the InstallLocation switch in PuTTY manifests.
Allows `winget install PuTTY.PuTTY -l "<INSTALLPATH>"` to work.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/51018)