### PR TITLE
Add location support to PuTTY 0.74.0.0

### DIFF
--- a/manifests/p/PuTTY/PuTTY/0.74.0.0/PuTTY.PuTTY.installer.yaml
+++ b/manifests/p/PuTTY/PuTTY/0.74.0.0/PuTTY.PuTTY.installer.yaml
@@ -6,6 +6,8 @@ PackageVersion: "0.74.0.0"
 MinimumOSVersion: 10.0.0.0
 InstallerType: wix
 Scope: machine
+InstallerSwitches:
+  InstallLocation: INSTALLDIR="<INSTALLPATH>"
 InstallModes:
 - interactive
 - silent


### PR DESCRIPTION
Define the InstallLocation switch in the manifest of PuTTY 0.74.0.0.
Allows `winget install PuTTY.PuTTY -l "<INSTALLPATH>"` to work.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/51022)