### PR TITLE
Add log and location Support to Power BI Manifest

### DIFF
--- a/manifests/m/Microsoft/PowerBI/2.102.845.0/Microsoft.PowerBI.installer.yaml
+++ b/manifests/m/Microsoft/PowerBI/2.102.845.0/Microsoft.PowerBI.installer.yaml
@@ -16,6 +16,8 @@ InstallerSwitches:
   Silent: -quiet -norestart
   SilentWithProgress: -passive -norestart
   Custom: ACCEPT_EULA=1
+  InstallLocation: INSTALLLOCATION="<INSTALLPATH>"
+  Log: -log "<LOGPATH>"
 UpgradeBehavior: install
 Dependencies:
   PackageDependencies:


### PR DESCRIPTION
Add support for the Log InstallerSwitch
Add support for the InstallLocation InstallerSwitch
Permits `winget install --id Microsoft.PowerBI --log "$env:USERPROFILE\MyLogFile.log" --location "C:\PowerBI"` to work.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/51025)