### PR TITLE
add ja-JP locale for Mozilla.Firefox version 98.0

### DIFF
--- a/manifests/m/Mozilla/Firefox/98.0/Mozilla.Firefox.locale.ja-JP.yaml
+++ b/manifests/m/Mozilla/Firefox/98.0/Mozilla.Firefox.locale.ja-JP.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.1.0.schema.json
+PackageIdentifier: Mozilla.Firefox
+PackageVersion: "98.0"
+PackageLocale: ja-JP
+Publisher: Mozilla
+PublisherUrl: https://www.mozilla.org/ja/
+PublisherSupportUrl: https://support.mozilla.org/ja/
+PrivacyUrl: https://www.mozilla.org/ja/privacy/websites/
+Author: Mozilla Foundation
+PackageName: Mozilla Firefox
+PackageUrl: https://www.mozilla.org/ja/firefox/
+License: Mozilla Public License Version 2.0
+LicenseUrl: https://www.mozilla.org/en-US/MPL/2.0/
+CopyrightUrl: https://www.mozilla.org/en-US/foundation/trademarks/policy/
+ShortDescription: 高速で軽量、プライバシー重視のブラウザー
+Description: Mozilla Firefox は無料のオープンソースソフトウェアであり、世界中の多数のコミュニティによって開発されています。
+Tags:
+- browser
+- cross-platform
+- foss
+- gecko
+- quantum
+- spidermonkey
+- web
+- web-browser
+ReleaseNotesUrl: https://www.mozilla.org/en-US/firefox/98.0/releasenotes/
+ManifestType: locale
+ManifestVersion: 1.1.0


### PR DESCRIPTION
- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/51030)