### PR TITLE
TheDocumentFoundation.LibreOffice version 7.3.1.3

### DIFF
--- a/manifests/t/TheDocumentFoundation/LibreOffice/7.3.1.3/TheDocumentFoundation.LibreOffice.installer.yaml
+++ b/manifests/t/TheDocumentFoundation/LibreOffice/7.3.1.3/TheDocumentFoundation.LibreOffice.installer.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
 
 PackageIdentifier: TheDocumentFoundation.LibreOffice
-PackageVersion: 7.3.0.3
+PackageVersion: 7.3.1.3
 Platform:
 - Windows.Desktop
 MinimumOSVersion: 10.0.0.0
@@ -42,13 +42,13 @@ FileExtensions:
 Installers:
 - Architecture: x64
   InstallerType: msi
-  InstallerUrl: https://download.documentfoundation.org/libreoffice/stable/7.3.0/win/x86_64/LibreOffice_7.3.0_Win_x64.msi
-  InstallerSha256: 845860AC152EA936734824984C5A60295D1468B5E0E9CB5A5FD88E9C325352B5
+  InstallerUrl: https://download.documentfoundation.org/libreoffice/stable/7.3.1/win/x86_64/LibreOffice_7.3.1_Win_x64.msi
+  InstallerSha256: fac74bbeed343424207dc7877fbc447ac391a0ceb90bdbac1b8fdbfef8d8f589
   ProductCode: '{8113FFA7-4CB7-4855-A319-1DB2A7FB9733}'
 - Architecture: x86
   InstallerType: msi
-  InstallerUrl: https://download.documentfoundation.org/libreoffice/stable/7.3.0/win/x86/LibreOffice_7.3.0_Win_x86.msi
-  InstallerSha256: 5C453D771601CE46286B51CC1571A88FF0C3C517F3F6A45CAAB39447243CB4C4
+  InstallerUrl: https://download.documentfoundation.org/libreoffice/stable/7.3.1/win/x86/LibreOffice_7.3.1_Win_x86.msi
+  InstallerSha256: 9f66b4900167ab3d4ab1b3c802d7666ac985a220bd21f22439da21c120c5a8da
   ProductCode: '{64439621-E949-4084-9AF1-57C34515D808}'
 ManifestType: installer
 ManifestVersion: 1.1.0

--- a/manifests/t/TheDocumentFoundation/LibreOffice/7.3.1.3/TheDocumentFoundation.LibreOffice.locale.en-US.yaml
+++ b/manifests/t/TheDocumentFoundation/LibreOffice/7.3.1.3/TheDocumentFoundation.LibreOffice.locale.en-US.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
 
 PackageIdentifier: TheDocumentFoundation.LibreOffice
-PackageVersion: 7.3.0.3
+PackageVersion: 7.3.1.3
 PackageLocale: en-US
 Publisher: The Document Foundation
 PublisherUrl: https://www.documentfoundation.org/

--- a/manifests/t/TheDocumentFoundation/LibreOffice/7.3.1.3/TheDocumentFoundation.LibreOffice.yaml
+++ b/manifests/t/TheDocumentFoundation/LibreOffice/7.3.1.3/TheDocumentFoundation.LibreOffice.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
 
 PackageIdentifier: TheDocumentFoundation.LibreOffice
-PackageVersion: 7.3.0.3
+PackageVersion: 7.3.1.3
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.1.0


### PR DESCRIPTION
The 7.3.0.3 version no longer exists on the download site.
Renamed the directory to 7.3.1.3.
Updated references to version number in manifests.
Updated hashes for install files.

- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [X] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/51990)