### PR TITLE
Changed VC++ dependency

### DIFF
--- a/manifests/p/PlayStation/PSRemotePlay/5.0.0.02220/PlayStation.PSRemotePlay.installer.yaml
+++ b/manifests/p/PlayStation/PSRemotePlay/5.0.0.02220/PlayStation.PSRemotePlay.installer.yaml
@@ -8,7 +8,7 @@ Platform:
 MinimumOSVersion: 10.0.0.0
 Dependencies:
   PackageDependencies:
-  - PackageIdentifier: Microsoft.VC++2015-2019Redist-x86
+  - PackageIdentifier: Microsoft.VC++2015-2022Redist-x86
   - PackageIdentifier: Microsoft.VC++2013Redist-x86
   - PackageIdentifier: Microsoft.EdgeWebView2Runtime
 InstallModes:


### PR DESCRIPTION
Changed VC++ dependency because of conflict with newer version of dependency in winget preview client with enabled dependency support.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/55616)