### PR TITLE
Remove MIT License tag from Banana Cake Pop

### DIFF
--- a/manifests/c/ChilliCream/BananaCakePop/1.0.0-preview.31/ChilliCream.BananaCakePop.locale.en-US.yaml
+++ b/manifests/c/ChilliCream/BananaCakePop/1.0.0-preview.31/ChilliCream.BananaCakePop.locale.en-US.yaml
@@ -9,6 +9,7 @@ PublisherUrl: https://chillicream.com/
 PublisherSupportUrl: https://chillicream.com/support
 PackageName: Banana Cake Pop
 PackageUrl: https://chillicream.com/docs/bananacakepop
+License: Proprietary
 Copyright: Copyright (c) 2022 ChilliCream
 ShortDescription: Banana Cake Pop is a cross-platform GraphQL client.
 Description: Banana Cake Pop is our tool to explore schemas, execute operations and get deep performance insights about any GraphQL server out there.

--- a/manifests/c/ChilliCream/BananaCakePop/1.0.0-preview.31/ChilliCream.BananaCakePop.locale.en-US.yaml
+++ b/manifests/c/ChilliCream/BananaCakePop/1.0.0-preview.31/ChilliCream.BananaCakePop.locale.en-US.yaml
@@ -9,9 +9,7 @@ PublisherUrl: https://chillicream.com/
 PublisherSupportUrl: https://chillicream.com/support
 PackageName: Banana Cake Pop
 PackageUrl: https://chillicream.com/docs/bananacakepop
-License: MIT License
-LicenseUrl: https://github.com/ChilliCream/hotchocolate/blob/main/LICENSE
-Copyright: Copyright (c) 2022 ChiliCream
+Copyright: Copyright (c) 2022 ChilliCream
 ShortDescription: Banana Cake Pop is a cross-platform GraphQL client.
 Description: Banana Cake Pop is our tool to explore schemas, execute operations and get deep performance insights about any GraphQL server out there.
 Moniker: banana-cake-pop


### PR DESCRIPTION
Banana Cake Pop is free to use but not open source and not under the MIT license. 
The license file that was referred to was only covering the Hot Chocolate project. 
Banana Cake Pop is not part of that repository.

I have removed the MIT License tag and the reference to the license file of Hot Chocolate.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.0.md)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

See: https://github.com/microsoft/winget-pkgs/issues/55961 and https://github.com/microsoft/winget-pkgs/pull/55692/files






###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/55962)