### PR TITLE
Configure Sandbox and PRTest for experimental features

### DIFF
--- a/Tools/PRTest.ps1
+++ b/Tools/PRTest.ps1
@@ -5,7 +5,9 @@ Param(
   [String] $PullRequest,
   [Parameter(HelpMessage = "Open the Pull Request's review page in the default browser")]
   [Switch] $Review = $false,
-  [Switch] $KeepBranch = $false
+  [Switch] $KeepBranch = $false,
+  [Switch] $Prerelease = $false,
+  [Switch] $EnableExperimentalFeatures = $false
 )
 
 $PullRequest = $PullRequest.TrimStart('#')
@@ -42,7 +44,7 @@ else {
 }
 
 $sandboxTestPath = (Resolve-Path ($PSScriptRoot.ToString() + "\SandboxTest.ps1")).ToString()
-& $sandboxTestPath -Manifest $path -SkipManifestValidation
+& $sandboxTestPath -Manifest $path -SkipManifestValidation -Prerelease $Prerelease -EnableExperimentalFeatures $EnableExperimentalFeatures
 
 if ($Review) {
     Write-Host "Opening $PullRequest in browser..." -ForegroundColor Green

--- a/Tools/PRTest.ps1
+++ b/Tools/PRTest.ps1
@@ -44,7 +44,13 @@ else {
 }
 
 $sandboxTestPath = (Resolve-Path ($PSScriptRoot.ToString() + "\SandboxTest.ps1")).ToString()
-& $sandboxTestPath -Manifest $path -SkipManifestValidation -Prerelease $Prerelease -EnableExperimentalFeatures $EnableExperimentalFeatures
+$params = @{
+    Manifest = $path
+    SkipManifestValidation = $true
+    Prerelease = $Prerelease
+    EnableExperimentalFeatures = $EnableExperimentalFeatures
+}
+& $sandboxTestPath @params
 
 if ($Review) {
     Write-Host "Opening $PullRequest in browser..." -ForegroundColor Green

--- a/Tools/SandboxTest.ps1
+++ b/Tools/SandboxTest.ps1
@@ -7,7 +7,8 @@ Param(
   [ScriptBlock] $Script,
   [Parameter(HelpMessage = "The folder to map in the Sandbox.")]
   [String] $MapFolder = $pwd,
-  [switch] $SkipManifestValidation
+  [switch] $SkipManifestValidation,
+  [switch] $Prerelease
 )
 
 $ErrorActionPreference = "Stop"
@@ -71,7 +72,8 @@ New-Item $tempFolder -ItemType Directory -ErrorAction SilentlyContinue | Out-Nul
 
 # Set dependencies
 
-$apiLatestUrl = 'https://api.github.com/repos/microsoft/winget-cli/releases/latest'
+$apiLatestUrl = if ($Prerelease) {'https://api.github.com/repos/microsoft/winget-cli/releases?per_page=1'} else  {'https://api.github.com/repos/microsoft/winget-cli/releases/latest'}
+
 
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 $WebClient = New-Object System.Net.WebClient

--- a/Tools/SandboxTest.ps1
+++ b/Tools/SandboxTest.ps1
@@ -1,17 +1,18 @@
 # Parse arguments
 
 Param(
-  [Parameter(Position = 0, HelpMessage = "The Manifest to install in the Sandbox.")]
+  [Parameter(Position = 0, HelpMessage = 'The Manifest to install in the Sandbox.')]
   [String] $Manifest,
-  [Parameter(Position = 1, HelpMessage = "The script to run in the Sandbox.")]
+  [Parameter(Position = 1, HelpMessage = 'The script to run in the Sandbox.')]
   [ScriptBlock] $Script,
-  [Parameter(HelpMessage = "The folder to map in the Sandbox.")]
+  [Parameter(HelpMessage = 'The folder to map in the Sandbox.')]
   [String] $MapFolder = $pwd,
   [switch] $SkipManifestValidation,
-  [switch] $Prerelease
+  [switch] $Prerelease,
+  [switch] $EnableExperimentalFeatures
 )
 
-$ErrorActionPreference = "Stop"
+$ErrorActionPreference = 'Stop'
 
 $mapFolder = (Resolve-Path -Path $MapFolder).Path
 
@@ -30,7 +31,7 @@ if (-Not $SkipManifestValidation -And -Not [String]::IsNullOrWhiteSpace($Manifes
 
   winget.exe validate $Manifest
   switch ($LASTEXITCODE) {
-    '-1978335191' { throw [System.Activities.ValidationException]::new('Manifest validation failed.')}
+    '-1978335191' { throw [System.Activities.ValidationException]::new('Manifest validation failed.') }
     '-1978335192' { Start-Sleep -Seconds 5 }
     Default { continue }
   }
@@ -67,12 +68,11 @@ Remove-Variable sandbox
 
 $tempFolderName = 'SandboxTest'
 $tempFolder = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath $tempFolderName
-
 New-Item $tempFolder -ItemType Directory -ErrorAction SilentlyContinue | Out-Null
 
 # Set dependencies
 
-$apiLatestUrl = if ($Prerelease) {'https://api.github.com/repos/microsoft/winget-cli/releases?per_page=1'} else  {'https://api.github.com/repos/microsoft/winget-cli/releases/latest'}
+$apiLatestUrl = if ($Prerelease) { 'https://api.github.com/repos/microsoft/winget-cli/releases?per_page=1' } else { 'https://api.github.com/repos/microsoft/winget-cli/releases/latest' }
 
 
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
@@ -109,9 +109,9 @@ $vcLibsUwp = @{
   hash     = 'A39CEC0E70BE9E3E48801B871C034872F1D7E5E8EEBE986198C019CF2C271040'
 }
 $uiLibsUwp = @{
-    fileName = 'Microsoft.UI.Xaml.2.7.zip'
-    url = 'https://www.nuget.org/api/v2/package/Microsoft.UI.Xaml/2.7.0'
-    hash = "422FD24B231E87A842C4DAEABC6A335112E0D35B86FAC91F5CE7CF327E36A591"
+  fileName = 'Microsoft.UI.Xaml.2.7.zip'
+  url      = 'https://www.nuget.org/api/v2/package/Microsoft.UI.Xaml/2.7.0'
+  hash     = '422FD24B231E87A842C4DAEABC6A335112E0D35B86FAC91F5CE7CF327E36A591'
 }
 
 $dependencies = @($desktopAppInstaller, $vcLibsUwp, $uiLibsUwp)
@@ -143,10 +143,9 @@ foreach ($dependency in $dependencies) {
 
     try {
       $WebClient.DownloadFile($dependency.url, $dependency.file)
-    }
-    catch {
+    } catch {
       #Pass the exception as an inner exception
-      throw [System.Net.WebException]::new("Error downloading $($dependency.url).",$_.Exception)
+      throw [System.Net.WebException]::new("Error downloading $($dependency.url).", $_.Exception)
     }
     if (-not ($dependency.hash -eq $(Get-FileHash $dependency.file).Hash)) {
       throw [System.Activities.VersionMismatchException]::new('Dependency hash does not match the downloaded file')
@@ -157,12 +156,32 @@ foreach ($dependency in $dependencies) {
 # Extract Microsoft.UI.Xaml from zip (if freshly downloaded).
 # This is a workaround until https://github.com/microsoft/winget-cli/issues/1861 is resolved.
 
-if (-Not (Test-Path (Join-Path -Path $tempFolder -ChildPath \Microsoft.UI.Xaml.2.7\tools\AppX\x64\Release\Microsoft.UI.Xaml.2.7.appx))){
-  Expand-Archive -Path $uiLibsUwp.file -DestinationPath ($tempFolder + "\Microsoft.UI.Xaml.2.7") -Force
+if (-Not (Test-Path (Join-Path -Path $tempFolder -ChildPath \Microsoft.UI.Xaml.2.7\tools\AppX\x64\Release\Microsoft.UI.Xaml.2.7.appx))) {
+  Expand-Archive -Path $uiLibsUwp.file -DestinationPath ($tempFolder + '\Microsoft.UI.Xaml.2.7') -Force
 }  
 $uiLibsUwp.file = (Join-Path -Path $tempFolder -ChildPath \Microsoft.UI.Xaml.2.7\tools\AppX\x64\Release\Microsoft.UI.Xaml.2.7.appx)
 $uiLibsUwp.pathInSandbox = Join-Path -Path $desktopInSandbox -ChildPath (Join-Path -Path $tempFolderName -ChildPath \Microsoft.UI.Xaml.2.7\tools\AppX\x64\Release\Microsoft.UI.Xaml.2.7.appx)
 Write-Host
+
+# Create Bootstrap settings
+# dependencies and portableInstall are enabled for forward compatibility with PR's
+$bootstrapSettingsContent = @{}
+$bootstrapSettingsContent['$schema'] = 'https://aka.ms/winget-settings.schema.json'
+$bootstrapSettingsContent['logging'] = @{level = 'verbose' }
+if ($EnableExperimentalFeatures) {
+  $bootstrapSettingsContent['experimentalFeatures'] = @{
+    dependencies    = $true
+    portableInstall = $true
+  }
+}
+
+$settingsFolderName = 'WingetSettings'
+$settingsFolder = Join-Path -Path $tempFolder -ChildPath $settingsFolderName
+
+New-Item $settingsFolder -ItemType Directory -ErrorAction SilentlyContinue | Out-Null
+$bootstrapSettingsFileName = 'settings.json'
+$bootstrapSettingsContent | ConvertTo-Json | Out-File (Join-Path -Path $settingsFolder -ChildPath $bootstrapSettingsFileName) -Encoding ascii
+$settingsPathInSandbox = Join-Path -Path $desktopInSandbox -ChildPath (Join-Path -Path $tempFolderName -ChildPath "$settingsFolderName\settings.json")
 
 # Create Bootstrap script
 
@@ -212,6 +231,7 @@ Write-Host @'
 --> Configuring Winget
 '@
 winget settings --Enable LocalManifestFiles
+copy -Path $settingsPathInSandbox -Destination C:\Users\WDAGUtilityAccount\AppData\Local\Packages\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe\LocalState\settings.json
 `$originalARP = Get-ARPTable
 Write-Host @'
 
@@ -254,9 +274,9 @@ $Script
 "@
 }
 
-$bootstrapPs1Content += @"
+$bootstrapPs1Content += @'
 Write-Host
-"@
+'@
 
 $bootstrapPs1FileName = 'Bootstrap.ps1'
 $bootstrapPs1Content | Out-File (Join-Path -Path $tempFolder -ChildPath $bootstrapPs1FileName)


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?

This PR makes it so that the SandboxTest script can use the most recent release, even if it is a prerelease, by specifying the `-Prerelease` switch. It also allows for enabling of experimental features in SandboxTest using the `-EnableExperimentalFeatures` switch.  These two switches will help validation when portable apps make it into the prerelease client.

These two switches were also extended to the PRTest script, so that if draft PR's are submitted for portable apps or apps which require dependencies, the PR's can still be tested and queued appropriately for the release of the features into stable.

**cc:** @denelon @jedieaston @OfficialEsco 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/57405)