### PR TITLE
Force Git version >= 2.35.2

### DIFF
--- a/Tools/YamlCreate.ps1
+++ b/Tools/YamlCreate.ps1
@@ -23,12 +23,101 @@ if ($help) {
     exit
 }
 
-# Check whether the script is present inside a fork/clone of microsoft/winget-pkgs repository
-try {
-    $script:gitTopLevel = (Resolve-Path $(git rev-parse --show-toplevel)).Path
-} catch {
-    # If there was an exception, the user isn't in a git repo. Throw a custom exception and pass the original exception as an InternalException
-    throw [UnmetDependencyException]::new('This script must be run from inside a clone of the winget-pkgs repository', $_.Exception)
+# Custom menu prompt that listens for keypresses. Requires a prompt and array of entries at minimum. Entries preceeded with `*` are shown in green
+# Returns a console key value
+Function Invoke-KeypressMenu {
+    Param
+    (
+        [Parameter(Mandatory = $true, Position = 0)]
+        [string] $Prompt,
+        [Parameter(Mandatory = $true, Position = 1)]
+        [string[]] $Entries,
+        [Parameter(Mandatory = $false)]
+        [string] $HelpText,
+        [Parameter(Mandatory = $false)]
+        [string] $HelpTextColor,
+        [Parameter(Mandatory = $false)]
+        [string] $DefaultString
+    )
+
+    Write-Host "`n"
+    Write-Host -ForegroundColor 'Yellow' "$Prompt"
+    if ($PSBoundParameters.ContainsKey('HelpText') -and (![string]::IsNullOrWhiteSpace($HelpText))) {
+        if ($PSBoundParameters.ContainsKey('HelpTextColor') -and (![string]::IsNullOrWhiteSpace($HelpTextColor))) {
+            Write-Host -ForegroundColor $HelpTextColor $HelpText
+        } else {
+            Write-Host -ForegroundColor 'Blue' $HelpText
+        }
+    }
+    foreach ($entry in $Entries) {
+        $_isDefault = $entry.StartsWith('*')
+        if ($_isDefault) {
+            $_entry = '  ' + $entry.Substring(1)
+            $_color = 'Green'
+        } else {
+            $_entry = '  ' + $entry
+            $_color = 'White'
+        }
+        Write-Host -ForegroundColor $_color $_entry
+    }
+    Write-Host
+    if ($PSBoundParameters.ContainsKey('DefaultString') -and (![string]::IsNullOrWhiteSpace($DefaultString))) {
+        Write-Host -NoNewline "Enter Choice (default is '$DefaultString'): "
+    } else {
+        Write-Host -NoNewline 'Enter Choice ('
+        Write-Host -NoNewline -ForegroundColor 'Green' 'Green'
+        Write-Host -NoNewline ' is default): '
+    }
+
+    do {
+        $keyInfo = [Console]::ReadKey($false)
+    } until ($keyInfo.Key)
+
+    return $keyInfo.Key
+}
+
+#If the user has git installed, make sure it is a patched version
+if (Get-Command 'git.exe' -ErrorAction SilentlyContinue) {
+    $GitMinimumVersion = [System.Version]::Parse('2.35.2')
+    $gitVersionString = ((git version) | Select-String '([0-9]{1,}\.){3,4}').Matches.Value.Trim(' ', '.')
+    $gitVersion = [System.Version]::Parse($gitVersionString)
+    if ($gitVersion -lt $GitMinimumVersion) {
+        # Prompt user to install git
+        if (Get-Command 'winget.exe' -ErrorAction SilentlyContinue) {
+            $_menu = @{
+                entries       = @('[Y] Upgrade Git'; '[N] Do not upgrade')
+                Prompt        = 'The version of git installed on your machine does not satisfy the requirement of version >= 2.35.2; Would you like to upgrade?'
+                HelpText      = "Upgrading will attempt to upgrade git using winget`n"
+                DefaultString = ''
+            }
+            switch (Invoke-KeypressMenu -Prompt $_menu['Prompt'] -Entries $_menu['Entries'] -DefaultString $_menu['DefaultString'] -HelpText $_menu['HelpText']) {
+                'Y' { 
+                    Write-Host
+                    try {
+                        winget upgrade --id Git.Git --exact
+                    } catch {
+                        throw [UnmetDependencyException]::new('Git could not be upgraded sucessfully', $_)
+                    } finally {
+                        $gitVersionString = ((git version) | Select-String '([0-9]{1,}\.){3,4}').Matches.Value.Trim(' ', '.')
+                        $gitVersion = [System.Version]::Parse($gitVersionString)
+                        if ($gitVersion -lt $GitMinimumVersion) {
+                            throw [UnmetDependencyException]::new('Git could not be upgraded sucessfully')
+                        }
+                    }
+                 }
+                default { Write-Host; throw [UnmetDependencyException]::new('The version of git installed on your machine does not satisfy the requirement of version >= 2.35.2') }
+            }
+        } else {
+            throw [UnmetDependencyException]::new('The version of git installed on your machine does not satisfy the requirement of version >= 2.35.2')
+        }
+    }
+    # Check whether the script is present inside a fork/clone of microsoft/winget-pkgs repository
+    try {
+        $script:gitTopLevel = (Resolve-Path $(git rev-parse --show-toplevel)).Path
+    } catch {
+        # If there was an exception, the user isn't in a git repo. Throw a custom exception and pass the original exception as an InternalException
+        throw [UnmetDependencyException]::new('This script must be run from inside a clone of the winget-pkgs repository', $_.Exception)
+    }
 }
 
 # Installs `powershell-yaml` as a dependency for parsing yaml content
@@ -242,59 +331,6 @@ Function Write-MulticolorLine {
         Write-Host -ForegroundColor $Colors[$_index] -NoNewline $String
         $_index++
     }
-}
-
-# Custom menu prompt that listens for keypresses. Requires a prompt and array of entries at minimum. Entries preceeded with `*` are shown in green
-# Returns a console key value
-Function Invoke-KeypressMenu {
-    Param
-    (
-        [Parameter(Mandatory = $true, Position = 0)]
-        [string] $Prompt,
-        [Parameter(Mandatory = $true, Position = 1)]
-        [string[]] $Entries,
-        [Parameter(Mandatory = $false)]
-        [string] $HelpText,
-        [Parameter(Mandatory = $false)]
-        [string] $HelpTextColor,
-        [Parameter(Mandatory = $false)]
-        [string] $DefaultString
-    )
-
-    Write-Host "`n"
-    Write-Host -ForegroundColor 'Yellow' "$Prompt"
-    if ($PSBoundParameters.ContainsKey('HelpText') -and (![string]::IsNullOrWhiteSpace($HelpText))) {
-        if ($PSBoundParameters.ContainsKey('HelpTextColor') -and (![string]::IsNullOrWhiteSpace($HelpTextColor))) {
-            Write-Host -ForegroundColor $HelpTextColor $HelpText
-        } else {
-            Write-Host -ForegroundColor 'Blue' $HelpText
-        }
-    }
-    foreach ($entry in $Entries) {
-        $_isDefault = $entry.StartsWith('*')
-        if ($_isDefault) {
-            $_entry = '  ' + $entry.Substring(1)
-            $_color = 'Green'
-        } else {
-            $_entry = '  ' + $entry
-            $_color = 'White'
-        }
-        Write-Host -ForegroundColor $_color $_entry
-    }
-    Write-Host
-    if ($PSBoundParameters.ContainsKey('DefaultString') -and (![string]::IsNullOrWhiteSpace($DefaultString))) {
-        Write-Host -NoNewline "Enter Choice (default is '$DefaultString'): "
-    } else {
-        Write-Host -NoNewline 'Enter Choice ('
-        Write-Host -NoNewline -ForegroundColor 'Green' 'Green'
-        Write-Host -NoNewline ' is default): '
-    }
-
-    do {
-        $keyInfo = [Console]::ReadKey($false)
-    } until ($keyInfo.Key)
-
-    return $keyInfo.Key
 }
 
 # Checks a URL and returns the status code received from the URL


### PR DESCRIPTION
https://github.blog/2022-04-12-git-security-vulnerability-announced/

Although YamlCreate is not impacted directly (due to the fact that it depends on where the user has cloned the repository), it is good stewardship to ensure users are not unintentionally vulnerable. Therefore, if a user has `Git.Git` installed it should be version >= 2.35.2 in order to run YamlCreate, since the script can run git commands on the users behalf

This change adds the following logic -
* If `Git.Git` is not installed, there is no vulnerability, continue to main portion of the script
* If `Git.Git` is installed, ensure it is greater than v2.35.1
  * If greater than v2.35.1, it is already patched, continue to the main portion of the script
  * Else, check if winget is installed
    * If winget is installed, prompt the user to upgrade `Git.Git`
    * If user elects not to upgrade, throw dependency exception
    * If user upgrades
      * If successful, continue to main portion of the script
      * If unsuccessful, throw dependency exception

cc @jedieaston @OfficialEsco @denelon @SpecterShell 


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/57741)