### PR TITLE
Uninstall before VC++2015-2022 before upgrading

### DIFF
--- a/manifests/m/Microsoft/VC++2015-2022Redist-x64/14.30.30704.0/Microsoft.VC++2015-2022Redist-x64.installer.yaml
+++ b/manifests/m/Microsoft/VC++2015-2022Redist-x64/14.30.30704.0/Microsoft.VC++2015-2022Redist-x64.installer.yaml
@@ -22,7 +22,7 @@ Installers:
   InstallerSwitches:
     Silent: /quiet /install /norestart
     SilentWithProgress: /passive /install /norestart
-  UpgradeBehavior: install
+  UpgradeBehavior: uninstallPrevious
   ProductCode: '{57a73df6-4ba9-4c1d-bbbb-517289ff6c13}'
 ManifestType: installer
 ManifestVersion: 1.0.0

--- a/manifests/m/Microsoft/VC++2015-2022Redist-x64/14.31.30818.0/Microsoft.VC++2015-2022Redist-x64.installer.yaml
+++ b/manifests/m/Microsoft/VC++2015-2022Redist-x64/14.31.30818.0/Microsoft.VC++2015-2022Redist-x64.installer.yaml
@@ -22,7 +22,7 @@ Installers:
   InstallerSwitches:
     Silent: /quiet /install /norestart
     SilentWithProgress: /passive /install /norestart
-  UpgradeBehavior: install
+  UpgradeBehavior: uninstallPrevious
   ProductCode: '{69becc62-c3d6-4307-9fc5-738d92cdf886}'
 ManifestType: installer
 ManifestVersion: 1.0.0

--- a/manifests/m/Microsoft/VC++2015-2022Redist-x64/14.31.30919.0/Microsoft.VC++2015-2022Redist-x64.installer.yaml
+++ b/manifests/m/Microsoft/VC++2015-2022Redist-x64/14.31.30919.0/Microsoft.VC++2015-2022Redist-x64.installer.yaml
@@ -22,7 +22,7 @@ Installers:
   InstallerSwitches:
     Silent: /quiet /install /norestart
     SilentWithProgress: /passive /install /norestart
-  UpgradeBehavior: install
+  UpgradeBehavior: uninstallPrevious
   ProductCode: '{7c829c52-b42c-4e7d-8078-6d2bf6235dab}'
 ManifestType: installer
 ManifestVersion: 1.0.0

--- a/manifests/m/Microsoft/VC++2015-2022Redist-x64/14.31.31005.0/Microsoft.VC++2015-2022Redist-x64.installer.yaml
+++ b/manifests/m/Microsoft/VC++2015-2022Redist-x64/14.31.31005.0/Microsoft.VC++2015-2022Redist-x64.installer.yaml
@@ -18,7 +18,7 @@ InstallerSwitches:
   SilentWithProgress: /passive /install /norestart
 InstallerSuccessCodes:
 - 3010
-UpgradeBehavior: install
+UpgradeBehavior: uninstallPrevious
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/36270b27-6b33-460f-b309-72fe8ad2e9c1/C3261464D8EA58988BCD946AFD4C82DC64405335C4E9BA75402837AED32F3EFC/VC_redist.x64.exe

--- a/manifests/m/Microsoft/VC++2015-2022Redist-x64/14.31.31103.0/Microsoft.VC++2015-2022Redist-x64.installer.yaml
+++ b/manifests/m/Microsoft/VC++2015-2022Redist-x64/14.31.31103.0/Microsoft.VC++2015-2022Redist-x64.installer.yaml
@@ -18,7 +18,7 @@ InstallerSwitches:
   SilentWithProgress: /passive /install /norestart
 InstallerSuccessCodes:
 - 3010
-UpgradeBehavior: install
+UpgradeBehavior: uninstallPrevious
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/d22ecb93-6eab-4ce1-89f3-97a816c55f04/37ED59A66699C0E5A7EBEEF7352D7C1C2ED5EDE7212950A1B0A8EE289AF4A95B/VC_redist.x64.exe

--- a/manifests/m/Microsoft/VC++2015-2022Redist-x64/14.32.31302.0/Microsoft.VC++2015-2022Redist-x64.installer.yaml
+++ b/manifests/m/Microsoft/VC++2015-2022Redist-x64/14.32.31302.0/Microsoft.VC++2015-2022Redist-x64.installer.yaml
@@ -19,7 +19,7 @@ InstallerSwitches:
   Upgrade: /norestart
 InstallerSuccessCodes:
 - 3010
-UpgradeBehavior: install
+UpgradeBehavior: uninstallPrevious
 ReleaseDate: 2022-03-17
 Installers:
 - Architecture: x64

--- a/manifests/m/Microsoft/VC++2015-2022Redist-x64/14.32.31326.0/Microsoft.VC++2015-2022Redist-x64.installer.yaml
+++ b/manifests/m/Microsoft/VC++2015-2022Redist-x64/14.32.31326.0/Microsoft.VC++2015-2022Redist-x64.installer.yaml
@@ -19,7 +19,7 @@ InstallerSwitches:
   Custom: /norestart
 InstallerSuccessCodes:
 - 3010
-UpgradeBehavior: install
+UpgradeBehavior: uninstallPrevious
 ReleaseDate: 2022-04-08
 AppsAndFeaturesEntries:
 - Publisher: Microsoft Corporation

--- a/manifests/m/Microsoft/VC++2015-2022Redist-x86/14.30.30704.0/Microsoft.VC++2015-2022Redist-x86.installer.yaml
+++ b/manifests/m/Microsoft/VC++2015-2022Redist-x86/14.30.30704.0/Microsoft.VC++2015-2022Redist-x86.installer.yaml
@@ -22,7 +22,7 @@ Installers:
   InstallerSwitches:
     Silent: /quiet /install /norestart
     SilentWithProgress: /passive /install /norestart
-  UpgradeBehavior: install
+  UpgradeBehavior: uninstallPrevious
   ProductCode: '{4d8dcf8c-a72a-43e1-9833-c12724db736e}'
 ManifestType: installer
 ManifestVersion: 1.0.0

--- a/manifests/m/Microsoft/VC++2015-2022Redist-x86/14.31.30818.0/Microsoft.VC++2015-2022Redist-x86.installer.yaml
+++ b/manifests/m/Microsoft/VC++2015-2022Redist-x86/14.31.30818.0/Microsoft.VC++2015-2022Redist-x86.installer.yaml
@@ -22,7 +22,7 @@ Installers:
   InstallerSwitches:
     Silent: /quiet /install /norestart
     SilentWithProgress: /passive /install /norestart
-  UpgradeBehavior: install
+  UpgradeBehavior: uninstallPrevious
   ProductCode: '{d1bbd622-8c01-4a94-af2c-e3b60fc6f5b5}'
 ManifestType: installer
 ManifestVersion: 1.0.0

--- a/manifests/m/Microsoft/VC++2015-2022Redist-x86/14.31.30919.0/Microsoft.VC++2015-2022Redist-x86.installer.yaml
+++ b/manifests/m/Microsoft/VC++2015-2022Redist-x86/14.31.30919.0/Microsoft.VC++2015-2022Redist-x86.installer.yaml
@@ -22,7 +22,7 @@ Installers:
   InstallerSwitches:
     Silent: /quiet /install /norestart
     SilentWithProgress: /passive /install /norestart
-  UpgradeBehavior: install
+  UpgradeBehavior: uninstallPrevious
   ProductCode: '{29c95400-65a1-41f3-9615-5049fa9cbd5b}'
 ManifestType: installer
 ManifestVersion: 1.0.0

--- a/manifests/m/Microsoft/VC++2015-2022Redist-x86/14.31.31005.0/Microsoft.VC++2015-2022Redist-x86.installer.yaml
+++ b/manifests/m/Microsoft/VC++2015-2022Redist-x86/14.31.31005.0/Microsoft.VC++2015-2022Redist-x86.installer.yaml
@@ -18,7 +18,7 @@ InstallerSwitches:
   SilentWithProgress: /passive /install /norestart
 InstallerSuccessCodes:
 - 3010
-UpgradeBehavior: install
+UpgradeBehavior: uninstallPrevious
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/36270b27-6b33-460f-b309-72fe8ad2e9c1/C160CF4F7405B3AE263A46EC87445F3E851CD64389AEF4A2C2D9029127DF40D5/VC_redist.x86.exe

--- a/manifests/m/Microsoft/VC++2015-2022Redist-x86/14.31.31103.0/Microsoft.VC++2015-2022Redist-x86.installer.yaml
+++ b/manifests/m/Microsoft/VC++2015-2022Redist-x86/14.31.31103.0/Microsoft.VC++2015-2022Redist-x86.installer.yaml
@@ -18,7 +18,7 @@ InstallerSwitches:
   SilentWithProgress: /passive /install /norestart
 InstallerSuccessCodes:
 - 3010
-UpgradeBehavior: install
+UpgradeBehavior: uninstallPrevious
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/8e32d7eb-5130-4dc8-9c3e-5891f375e112/B7AE307237F869E09F7413691A2CD1944357B5CEE28049C0A0D3430B47BB3EDC/VC_redist.x86.exe

--- a/manifests/m/Microsoft/VC++2015-2022Redist-x86/14.32.31302.0/Microsoft.VC++2015-2022Redist-x86.installer.yaml
+++ b/manifests/m/Microsoft/VC++2015-2022Redist-x86/14.32.31302.0/Microsoft.VC++2015-2022Redist-x86.installer.yaml
@@ -19,7 +19,7 @@ InstallerSwitches:
   Upgrade: /norestart
 InstallerSuccessCodes:
 - 3010
-UpgradeBehavior: install
+UpgradeBehavior: uninstallPrevious
 ReleaseDate: 2022-03-17
 Installers:
 - Architecture: x64

--- a/manifests/m/Microsoft/VC++2015-2022Redist-x86/14.32.31326.0/Microsoft.VC++2015-2022Redist-x86.installer.yaml
+++ b/manifests/m/Microsoft/VC++2015-2022Redist-x86/14.32.31326.0/Microsoft.VC++2015-2022Redist-x86.installer.yaml
@@ -19,7 +19,7 @@ InstallerSwitches:
   Custom: /norestart
 InstallerSuccessCodes:
 - 3010
-UpgradeBehavior: install
+UpgradeBehavior: uninstallPrevious
 ReleaseDate: 2022-04-08
 AppsAndFeaturesEntries:
 - Publisher: Microsoft Corporation


### PR DESCRIPTION
Otherwise winget upgrade will always flag as outdated, because the older package will be still there.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.1 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.1.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

Otherwise, the old version is kept installed (since multiple versions of it can be installed at the same time), and therefore, `winget upgrade` always flags the package as outdated unless the user manually uninstalls it.

I can confirm and reproduce this behavior for the VC++2015-2022 packages, and although I believe this can also be the case for other variants of it, I didn't try to reproduce it.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/58746)