### PR TITLE
New version: GyDi.ClashVerge version 1.0.0

### DIFF
--- a/manifests/g/GyDi/ClashVerge/1.0.0/GyDi.ClashVerge.installer.yaml
+++ b/manifests/g/GyDi/ClashVerge/1.0.0/GyDi.ClashVerge.installer.yaml
@@ -1,0 +1,19 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-2
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+
+PackageIdentifier: GyDi.ClashVerge
+PackageVersion: 1.0.0
+MinimumOSVersion: 10.0.0.0
+InstallerType: wix
+Scope: machine
+InstallerSwitches:
+  InstallLocation: INSTALLDIR="<INSTALLPATH>"
+UpgradeBehavior: install
+ReleaseDate: 2022-04-25
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/zzzgydi/clash-verge/releases/download/v1.0.0/Clash.Verge_1.0.0_x64_en-US.msi
+  InstallerSha256: CF477B0E5FD5FECF4AB4C9CF7227D31EC7F43B3CAD40DE436E277E0575499FF7
+  ProductCode: '{6DC22DC3-026D-4C3C-861F-DFB35C4670E4}'
+ManifestType: installer
+ManifestVersion: 1.1.0

--- a/manifests/g/GyDi/ClashVerge/1.0.0/GyDi.ClashVerge.locale.en-US.yaml
+++ b/manifests/g/GyDi/ClashVerge/1.0.0/GyDi.ClashVerge.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-2
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+
+PackageIdentifier: GyDi.ClashVerge
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: gydi
+PublisherUrl: https://github.com/zzzgydi
+PublisherSupportUrl: https://github.com/zzzgydi/clash-verge/issues
+# PrivacyUrl: 
+Author: GyDi
+PackageName: Clash Verge
+PackageUrl: https://github.com/zzzgydi/clash-verge
+License: GPL-3.0
+LicenseUrl: https://github.com/zzzgydi/clash-verge/blob/main/LICENSE
+Copyright: © 2022 zzzgydi All Rights Reserved
+# CopyrightUrl: 
+ShortDescription: A Clash GUI based on tauri.
+# Description: 
+# Moniker: 
+Tags:
+- clash
+- network
+- proxy
+- vpn
+# Agreements: 
+# ReleaseNotes: 
+ReleaseNotesUrl: https://github.com/zzzgydi/clash-verge/releases/tag/v1.0.0
+ManifestType: defaultLocale
+ManifestVersion: 1.1.0

--- a/manifests/g/GyDi/ClashVerge/1.0.0/GyDi.ClashVerge.locale.zh-CN.yaml
+++ b/manifests/g/GyDi/ClashVerge/1.0.0/GyDi.ClashVerge.locale.zh-CN.yaml
@@ -1,0 +1,30 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-2
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.1.0.schema.json
+
+PackageIdentifier: GyDi.ClashVerge
+PackageVersion: 1.0.0
+PackageLocale: zh-CN
+Publisher: gydi
+PublisherUrl: https://github.com/zzzgydi
+PublisherSupportUrl: https://github.com/zzzgydi/clash-verge/issues
+# PrivacyUrl: 
+Author: GyDi
+PackageName: Clash Verge
+PackageUrl: https://github.com/zzzgydi/clash-verge
+License: GPL-3.0
+LicenseUrl: https://github.com/zzzgydi/clash-verge/blob/main/LICENSE
+Copyright: © 2022 zzzgydi All Rights Reserved
+# CopyrightUrl: 
+ShortDescription: 基于 tauri 的 Clash GUI
+# Description: 
+# Moniker: 
+Tags:
+- clash
+- vpn
+- 代理
+- 网络
+# Agreements: 
+# ReleaseNotes: 
+# ReleaseNotesUrl: 
+ManifestType: locale
+ManifestVersion: 1.1.0

--- a/manifests/g/GyDi/ClashVerge/1.0.0/GyDi.ClashVerge.yaml
+++ b/manifests/g/GyDi/ClashVerge/1.0.0/GyDi.ClashVerge.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-2
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+
+PackageIdentifier: GyDi.ClashVerge
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.1.0


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | Clash Verge | IAP Desktop, Foxglove Studio 1.9.0, GDevelop 5 5.0.132, Google Chrome Canary    |
| Version     | 1.0.0     | 2.27.810, 1.9.0, 5.0.132, 103.0.5032.0 |
| Publisher   | gydi   | Google Inc, Foxglove Technologies, GDevelop Team, Google LLC      |
| ProductCode |           | {7ECC5E75-9055-4299-8D8F-4C7FFC42490F}, b1a22fb8-f6f3-5e1f-b388-958085c08782, c2a9b91e-8206-5b4e-b81d-9aa27463c28e, Google Chrome SxS    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://github.com/vedantmgoyal2009/vedantmgoyal2009/tree/main/winget-pkgs-automation) in workflow run [1326](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/2245446732>)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/59076)