### PR TITLE
New version: Jackett.Jackett version 0.20.986.0

### DIFF
--- a/manifests/j/Jackett/Jackett/0.20.986.0/Jackett.Jackett.installer.yaml
+++ b/manifests/j/Jackett/Jackett/0.20.986.0/Jackett.Jackett.installer.yaml
@@ -1,0 +1,21 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-2
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+
+PackageIdentifier: Jackett.Jackett
+PackageVersion: 0.20.986.0
+InstallerLocale: en-US
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2022-04-29
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/Jackett/Jackett/releases/download/v0.20.986/Jackett.Installer.Windows.exe
+  InstallerSha256: CF72487ADA2E1E05F392913283420AA03A637AC80AE27155C97A541B28E9ED5D
+ManifestType: installer
+ManifestVersion: 1.1.0

--- a/manifests/j/Jackett/Jackett/0.20.986.0/Jackett.Jackett.locale.en-US.yaml
+++ b/manifests/j/Jackett/Jackett/0.20.986.0/Jackett.Jackett.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-2
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+
+PackageIdentifier: Jackett.Jackett
+PackageVersion: 0.20.986.0
+PackageLocale: en-US
+Publisher: Jackett
+PublisherUrl: https://github.com/Jackett/Jackett
+PublisherSupportUrl: https://github.com/Jackett/Jackett/issues
+# PrivacyUrl: 
+Author: Jackett Contributors
+PackageName: Jackett
+PackageUrl: https://github.com/Jackett/Jackett
+License: GNU General Public License v2.0
+LicenseUrl: https://github.com/Jackett/Jackett/blob/master/LICENSE
+Copyright: Copyright (C) 1989, 1991 Free Software Foundation, Inc.
+CopyrightUrl: https://github.com/Jackett/Jackett/blob/master/LICENSE
+ShortDescription: API Support for your favorite torrent trackers.
+Description: Jackett works as a proxy server, it translates queries from apps (Sonarr, Radarr, SickRage, CouchPotato, Mylar, etc) into tracker-site-specific http queries, parses the html response, then sends results back to the requesting software. This allows for getting recent uploads (like RSS) and performing searches. Jackett is a single repository of maintained indexer scraping and translation logic - removing the burden from other apps.
+Moniker: jackett
+Tags:
+- indexer
+- p2p
+- proxy
+- rss
+- sonarr
+- torent-management
+- torrent
+- torrent-search-engine
+- trackers
+# Agreements: 
+# ReleaseNotes: 
+ReleaseNotesUrl: https://github.com/Jackett/Jackett/releases/tag/v0.20.986
+ManifestType: defaultLocale
+ManifestVersion: 1.1.0

--- a/manifests/j/Jackett/Jackett/0.20.986.0/Jackett.Jackett.yaml
+++ b/manifests/j/Jackett/Jackett/0.20.986.0/Jackett.Jackett.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-2
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+
+PackageIdentifier: Jackett.Jackett
+PackageVersion: 0.20.986.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.1.0


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | Jackett | JabRef, Mountain Duck, Mountain Duck, Mountain Duck, Mountain Duck, Harmonoid version 0.2.2.0, Hearthstone Deck Tracker    |
| Version     | 0.20.986.0     | 5.6.60000, 1.0.31, 4.11.3.19561, 4.11.3.19561, 1.0.31, 0.2.2.0, 1.17.13 |
| Publisher   | Jackett   | JabRef, iterate GmbH, iterate GmbH, iterate GmbH, iterate GmbH, Hitesh Kumar Saini, HearthSim      |
| ProductCode |           | {1C4583B7-20D6-3EB5-8DA0-DA068C309F6B}, {6B614678-4B2B-49C4-8B2E-250D1C649AB4}, {8132943D-74BE-46B5-9B89-851EDCC9963B}, {2bb3ab62-a303-4e00-9e11-4fef6be0a6e0}, {77CCC0C6-4664-4C8F-9C07-42BE12B8F721}, {C2D0837C-0DBE-432B-865E-53C092A56DFB}_is1, HearthstoneDeckTracker    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://github.com/vedantmgoyal2009/vedantmgoyal2009/tree/main/winget-pkgs-automation) in workflow run [1326](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/2245446732>)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/59083)