### PR TITLE
New version: Jitsi.Meet version 2022.4.1

### DIFF
--- a/manifests/j/Jitsi/Meet/2022.4.1/Jitsi.Meet.installer.yaml
+++ b/manifests/j/Jitsi/Meet/2022.4.1/Jitsi.Meet.installer.yaml
@@ -1,0 +1,20 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-2
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+
+PackageIdentifier: Jitsi.Meet
+PackageVersion: 2022.4.1
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- silent
+UpgradeBehavior: install
+ReleaseDate: 2022-04-28
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/jitsi/jitsi-meet-electron/releases/download/v2022.4.1/jitsi-meet.exe
+  InstallerSha256: EB2694DF543AD2F50019DB8371F8C6F08DA15BF91812B6D7BABF83CA3EBBE7CA
+ManifestType: installer
+ManifestVersion: 1.1.0

--- a/manifests/j/Jitsi/Meet/2022.4.1/Jitsi.Meet.locale.en-US.yaml
+++ b/manifests/j/Jitsi/Meet/2022.4.1/Jitsi.Meet.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-2
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+
+PackageIdentifier: Jitsi.Meet
+PackageVersion: 2022.4.1
+PackageLocale: en-US
+Publisher: Jitsi Team
+PublisherUrl: https://jitsi.org/
+PublisherSupportUrl: https://github.com/jitsi/jitsi-meet-electron/issues
+PrivacyUrl: https://jitsi.org/security/
+Author: Jitsi Team
+PackageName: Jitsi Meet
+PackageUrl: https://github.com/jitsi/jitsi-meet-electron
+License: Apache License 2.0
+LicenseUrl: https://raw.githubusercontent.com/jitsi/jitsi-meet-electron/master/LICENSE
+# Copyright: 
+CopyrightUrl: https://raw.githubusercontent.com/jitsi/jitsi-meet-electron/master/LICENSE
+ShortDescription: Jitsi Meet is an open-source (Apache) WebRTC JavaScript application that uses Jitsi Videobridge to provide high quality, secure and scalable video conferences.
+# Description: 
+# Moniker: 
+Tags:
+- chat
+- jitsi
+- jitsi-meet
+- meeting
+- video
+# Agreements: 
+# ReleaseNotes: 
+ReleaseNotesUrl: https://github.com/jitsi/jitsi-meet-electron/releases/tag/v2022.4.1
+ManifestType: defaultLocale
+ManifestVersion: 1.1.0

--- a/manifests/j/Jitsi/Meet/2022.4.1/Jitsi.Meet.yaml
+++ b/manifests/j/Jitsi/Meet/2022.4.1/Jitsi.Meet.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-2
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+
+PackageIdentifier: Jitsi.Meet
+PackageVersion: 2022.4.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.1.0


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | Jitsi Meet | RubyMine 2022.1.1, WebStorm 2022.1.1    |
| Version     | 2022.4.1     | 221.5591.3, 221.5591.23 |
| Publisher   | Jitsi Team   | JetBrains s.r.o., JetBrains s.r.o.      |
| ProductCode |           | RubyMine 2022.1.1, WebStorm 2022.1.1    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://github.com/vedantmgoyal2009/vedantmgoyal2009/tree/main/winget-pkgs-automation) in workflow run [1328](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/2246200448>)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/59117)