### PR TITLE
New version: Jackett.Jackett version 0.20.1001.0 [FP]

### DIFF
--- a/manifests/j/Jackett/Jackett/0.20.1001.0/Jackett.Jackett.installer.yaml
+++ b/manifests/j/Jackett/Jackett/0.20.1001.0/Jackett.Jackett.installer.yaml
@@ -1,0 +1,21 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-2
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+
+PackageIdentifier: Jackett.Jackett
+PackageVersion: 0.20.1001.0
+InstallerLocale: en-US
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2022-05-02
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/Jackett/Jackett/releases/download/v0.20.1001/Jackett.Installer.Windows.exe
+  InstallerSha256: F49B2172633962DF109A24A8E377CAF2444DB00BD980224D86DB058B33E5A54B
+ManifestType: installer
+ManifestVersion: 1.1.0

--- a/manifests/j/Jackett/Jackett/0.20.1001.0/Jackett.Jackett.locale.en-US.yaml
+++ b/manifests/j/Jackett/Jackett/0.20.1001.0/Jackett.Jackett.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-2
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+
+PackageIdentifier: Jackett.Jackett
+PackageVersion: 0.20.1001.0
+PackageLocale: en-US
+Publisher: Jackett
+PublisherUrl: https://github.com/Jackett/Jackett
+PublisherSupportUrl: https://github.com/Jackett/Jackett/issues
+# PrivacyUrl: 
+Author: Jackett Contributors
+PackageName: Jackett
+PackageUrl: https://github.com/Jackett/Jackett
+License: GNU General Public License v2.0
+LicenseUrl: https://github.com/Jackett/Jackett/blob/master/LICENSE
+Copyright: Copyright (C) 1989, 1991 Free Software Foundation, Inc.
+CopyrightUrl: https://github.com/Jackett/Jackett/blob/master/LICENSE
+ShortDescription: API Support for your favorite torrent trackers.
+Description: Jackett works as a proxy server, it translates queries from apps (Sonarr, Radarr, SickRage, CouchPotato, Mylar, etc) into tracker-site-specific http queries, parses the html response, then sends results back to the requesting software. This allows for getting recent uploads (like RSS) and performing searches. Jackett is a single repository of maintained indexer scraping and translation logic - removing the burden from other apps.
+Moniker: jackett
+Tags:
+- indexer
+- p2p
+- proxy
+- rss
+- sonarr
+- torent-management
+- torrent
+- torrent-search-engine
+- trackers
+# Agreements: 
+# ReleaseNotes: 
+ReleaseNotesUrl: https://github.com/Jackett/Jackett/releases/tag/v0.20.1001
+ManifestType: defaultLocale
+ManifestVersion: 1.1.0

--- a/manifests/j/Jackett/Jackett/0.20.1001.0/Jackett.Jackett.yaml
+++ b/manifests/j/Jackett/Jackett/0.20.1001.0/Jackett.Jackett.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-2
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+
+PackageIdentifier: Jackett.Jackett
+PackageVersion: 0.20.1001.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.1.0


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | Jackett | ImageMagick 7.1.0-32 Q16-HDRI (64-bit) (2022-04-30), DBeaver 22.0.4 (current user), Google Chrome Canary    |
| Version     | 0.20.1001.0     | 7.1.0.32, 22.0.4, 103.0.5038.0 |
| Publisher   | Jackett   | ImageMagick Studio LLC, DBeaver Corp, Google LLC      |
| ProductCode |           | ImageMagick 7.1.0 Q16-HDRI (64-bit)_is1, DBeaver (current user), Google Chrome SxS    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://github.com/vedantmgoyal2009/vedantmgoyal2009/tree/main/winget-pkgs-automation) in workflow run [1363](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/2258154525>)