### PR TITLE
New version: naaive.Orange version 0.6.5 [FP]

### DIFF
--- a/manifests/n/naaive/Orange/0.6.5/naaive.Orange.installer.yaml
+++ b/manifests/n/naaive/Orange/0.6.5/naaive.Orange.installer.yaml
@@ -1,0 +1,19 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-2
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+
+PackageIdentifier: naaive.Orange
+PackageVersion: 0.6.5
+MinimumOSVersion: 10.0.0.0
+InstallerType: wix
+Scope: machine
+InstallerSwitches:
+  InstallLocation: INSTALLDIR="<INSTALLPATH>"
+UpgradeBehavior: install
+ReleaseDate: 2022-05-01
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/naaive/orange/releases/download/orange-v0.6.5/Orange_0.6.5_x64_en-US.msi
+  InstallerSha256: 334BC54A82E36E6BF870E7E798FE741FC558B94D3D88463929E82D0E92A1B77F
+  ProductCode: '{26B0A58D-2C95-4303-A1AF-5802DAC8A87D}'
+ManifestType: installer
+ManifestVersion: 1.1.0

--- a/manifests/n/naaive/Orange/0.6.5/naaive.Orange.locale.en-US.yaml
+++ b/manifests/n/naaive/Orange/0.6.5/naaive.Orange.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-2
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+
+PackageIdentifier: naaive.Orange
+PackageVersion: 0.6.5
+PackageLocale: en-US
+Publisher: tauri
+PublisherUrl: https://github.com/naaive
+PublisherSupportUrl: https://github.com/naaive/orange/issues
+# PrivacyUrl: 
+Author: naaive
+PackageName: Orange
+PackageUrl: https://github.com/naaive/orange
+License: GPL-3.0
+LicenseUrl: https://github.com/naaive/orange/blob/release/LICENSE
+# Copyright: 
+# CopyrightUrl: 
+ShortDescription: A cross-platform desktop application for searching local files.
+# Description: 
+# Moniker: 
+Tags:
+- directory
+- file
+- find
+- folder
+- search
+# Agreements: 
+# ReleaseNotes: 
+ReleaseNotesUrl: https://github.com/naaive/orange/releases/tag/orange-v0.6.5
+ManifestType: defaultLocale
+ManifestVersion: 1.1.0

--- a/manifests/n/naaive/Orange/0.6.5/naaive.Orange.locale.zh-CN.yaml
+++ b/manifests/n/naaive/Orange/0.6.5/naaive.Orange.locale.zh-CN.yaml
@@ -1,0 +1,31 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-2
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.1.0.schema.json
+
+PackageIdentifier: naaive.Orange
+PackageVersion: 0.6.5
+PackageLocale: zh-CN
+Publisher: tauri
+PublisherUrl: https://github.com/naaive
+PublisherSupportUrl: https://github.com/naaive/orange/issues
+# PrivacyUrl: 
+Author: naaive
+PackageName: Orange
+PackageUrl: https://github.com/naaive/orange
+License: GPL-3.0
+LicenseUrl: https://github.com/naaive/orange/blob/release/LICENSE
+# Copyright: 
+# CopyrightUrl: 
+ShortDescription: 跨平台的文件搜索引擎
+# Description: 
+# Moniker: 
+Tags:
+- 搜索
+- 文件
+- 文件夹
+- 查找
+- 目录
+# Agreements: 
+# ReleaseNotes: 
+# ReleaseNotesUrl: 
+ManifestType: locale
+ManifestVersion: 1.1.0

--- a/manifests/n/naaive/Orange/0.6.5/naaive.Orange.yaml
+++ b/manifests/n/naaive/Orange/0.6.5/naaive.Orange.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-2
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+
+PackageIdentifier: naaive.Orange
+PackageVersion: 0.6.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.1.0


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | Orange | Kate    |
| Version     | 0.6.5     | 22.04.0 |
| Publisher   | tauri   | KDE e.V.      |
| ProductCode | {26B0A58D-2C95-4303-A1AF-5802DAC8A87D}          | Kate    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://github.com/vedantmgoyal2009/vedantmgoyal2009/tree/main/winget-pkgs-automation) in workflow run [1360](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/2253282150>)