### PR TITLE
LibRetro.RetroArch.Nightly.64-bit

### DIFF
--- a/manifests/l/Libretro/RetroArch/Nightly/64-bit/1.10.3.0/Libretro.RetroArch.Nightly.64-bit.installer.yaml
+++ b/manifests/l/Libretro/RetroArch/Nightly/64-bit/1.10.3.0/Libretro.RetroArch.Nightly.64-bit.installer.yaml
@@ -1,0 +1,16 @@
+# Created using wingetcreate 1.0.4.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+
+PackageIdentifier: Libretro.RetroArch.Nightly.64-bit
+PackageVersion: 1.10.3.0
+Installers:
+- Architecture: x64
+  InstallerType: nullsoft
+  InstallerUrl: https://buildbot.libretro.com/nightly/windows/x86_64/RetroArch-Win64-setup.exe
+  InstallerSha256: AAB8A8BD4A382011C9417DBC363DB98CF2BE49AB8D0EFF103B93978FE805C64A
+  InstallerSwitches:
+    Silent: /S
+    SilentWithProgress: /S
+ManifestType: installer
+ManifestVersion: 1.1.0
+

--- a/manifests/l/Libretro/RetroArch/Nightly/64-bit/1.10.3.0/Libretro.RetroArch.Nightly.64-bit.locale.en-US.yaml
+++ b/manifests/l/Libretro/RetroArch/Nightly/64-bit/1.10.3.0/Libretro.RetroArch.Nightly.64-bit.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# Created using wingetcreate 1.0.4.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+
+PackageIdentifier: Libretro.RetroArch.Nightly.64-bit
+PackageVersion: 1.10.3.0
+PackageLocale: en-US
+Publisher: Libretro
+PublisherUrl: https://www.retroarch.com/
+PublisherSupportUrl: https://docs.libretro.com/
+PackageName: RetroArch Nightly
+PackageUrl: https://github.com/libretro/RetroArch/releases/tag/v1.10.3
+License: GPL-3.0
+LicenseUrl: https://github.com/libretro/RetroArch/blob/master/COPYING
+Copyright: The Libretro Team, 2010-2021
+ShortDescription: RetroArch is a frontend for emulators, game engines and media players.
+Description: RetroArch is a frontend for emulators, game engines and media players. It enables you to run classic games on a wide range of computers and consoles through its slick graphical interface. Settings are also unified so configuration is done once and for all. In addition to this, you are able to run original game discs (CDs) from RetroArch. RetroArch has advanced features like shaders, netplay, rewinding, next-frame response times, runahead, machine translation, blind accessibility features, and more!
+Moniker: rarch
+Tags:
+- retro
+- retroarch
+- libretro
+- emu
+ReleaseNotesUrl: https://github.com/libretro/RetroArch/blob/master/CHANGES.md
+ManifestType: defaultLocale
+ManifestVersion: 1.1.0
+

--- a/manifests/l/Libretro/RetroArch/Nightly/64-bit/1.10.3.0/Libretro.RetroArch.Nightly.64-bit.yaml
+++ b/manifests/l/Libretro/RetroArch/Nightly/64-bit/1.10.3.0/Libretro.RetroArch.Nightly.64-bit.yaml
@@ -1,0 +1,9 @@
+# Created using wingetcreate 1.0.4.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+
+PackageIdentifier: Libretro.RetroArch.Nightly.64-bit
+PackageVersion: 1.10.3.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.1.0
+


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.1 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.1.0)?


Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----
![image](https://user-images.githubusercontent.com/4651944/166138163-87089060-1d49-4f56-8254-6b25c0d37117.png)

I have this [PR](https://github.com/microsoft/winget-pkgs/pull/59175) open but I decided to go with separate architecture PR for future proof. While that PR open but fails installer HASH validation, this PR uses same links and everything but doesn't fail installer hash on my local environment. So I'm fine with either one of these PR get merged so I can ninja release on our Stable so I can make PR for stable version.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/59312)