### PR TITLE
fixing rammichael.7+TaskbarTweaker installer URL has been declared as phishing URL by cloudflare

### DIFF
--- a/manifests/r/rammichael/7+TaskbarTweaker/5.12.3/rammichael.7+TaskbarTweaker.installer.yaml
+++ b/manifests/r/rammichael/7+TaskbarTweaker/5.12.3/rammichael.7+TaskbarTweaker.installer.yaml
@@ -14,7 +14,7 @@ InstallModes:
 UpgradeBehavior: install
 Installers:
 - Architecture: neutral
-  InstallerUrl: https://rammichael.com/downloads/7tt_setup.exe
+  InstallerUrl: https://ramensoftware.com/downloads/7tt_setup.exe
   InstallerSha256: A010F23A4D41E590093A9419C17769680CF302DCABED0237273A97E05B2AB67F
 ManifestType: installer
 ManifestVersion: 1.0.0


### PR DESCRIPTION
Update rammichael.7+TaskbarTweaker.installer.yaml

The previous URL `https://rammichael.com/downloads/7tt_setup.exe` has been declared by cloudflare as phishing URL. It seems that the hostname has been changed to `ramensoftware.com`

- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.1 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.1.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/59477)