### PR TITLE
New version: Datadog.dd-trace-dotnet version 2.8.0

### DIFF
--- a/manifests/d/Datadog/dd-trace-dotnet/2.8.0/Datadog.dd-trace-dotnet.installer.yaml
+++ b/manifests/d/Datadog/dd-trace-dotnet/2.8.0/Datadog.dd-trace-dotnet.installer.yaml
@@ -1,0 +1,26 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-3
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+
+PackageIdentifier: Datadog.dd-trace-dotnet
+PackageVersion: 2.8.0
+InstallerLocale: en-US
+MinimumOSVersion: 10.0.0.0
+InstallerType: wix
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2022-05-05
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/DataDog/dd-trace-dotnet/releases/download/v2.8.0/datadog-dotnet-apm-2.8.0-x64.msi
+  InstallerSha256: 22A6036AA57F98C1EF1EC483B8CE798C1E502220EE48EF588AA81E6D73DB98CE
+  ProductCode: '{43354AE2-CC9F-4D7F-8CF5-F394C23F0D7E}'
+- Architecture: x86
+  InstallerUrl: https://github.com/DataDog/dd-trace-dotnet/releases/download/v2.8.0/datadog-dotnet-apm-2.8.0-x86.msi
+  InstallerSha256: 833B0FEA6C8ABC83BD6F213B8C0774D7A07DA486463730E5C30B034FE3DC7BCD
+  ProductCode: '{7931227B-69B5-4E05-B468-2380FD8A536D}'
+ManifestType: installer
+ManifestVersion: 1.1.0

--- a/manifests/d/Datadog/dd-trace-dotnet/2.8.0/Datadog.dd-trace-dotnet.locale.en-US.yaml
+++ b/manifests/d/Datadog/dd-trace-dotnet/2.8.0/Datadog.dd-trace-dotnet.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-3
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+
+PackageIdentifier: Datadog.dd-trace-dotnet
+PackageVersion: 2.8.0
+PackageLocale: en-US
+Publisher: Datadog, Inc.
+PublisherUrl: https://docs.datadoghq.com/
+PublisherSupportUrl: https://www.datadoghq.com/support/
+PrivacyUrl: https://www.datadoghq.com/legal/privacy/
+Author: Datadog
+PackageName: Datadog .NET Tracer
+PackageUrl: https://docs.datadoghq.com/tracing/
+License: Apache-2.0
+LicenseUrl: https://github.com/DataDog/dd-trace-dotnet/blob/master/LICENSE
+Copyright: Copyright 2017 Datadog, Inc.
+CopyrightUrl: https://github.com/DataDog/dd-trace-dotnet/blob/master/NOTICE
+ShortDescription: Automatic instrumentation for .NET applications
+# Description: 
+Moniker: dd-trace-dotnet
+Tags:
+- apm
+- tracing
+# Agreements: 
+# ReleaseNotes: 
+ReleaseNotesUrl: https://github.com/DataDog/dd-trace-dotnet/releases/tag/v2.8.0
+ManifestType: defaultLocale
+ManifestVersion: 1.1.0

--- a/manifests/d/Datadog/dd-trace-dotnet/2.8.0/Datadog.dd-trace-dotnet.yaml
+++ b/manifests/d/Datadog/dd-trace-dotnet/2.8.0/Datadog.dd-trace-dotnet.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-3
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+
+PackageIdentifier: Datadog.dd-trace-dotnet
+PackageVersion: 2.8.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.1.0


### PR DESCRIPTION
### Result: Installation Successful
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | Datadog .NET Tracer | Datadog .NET Tracer 64-bit    |
| Version     | 2.8.0     | 2.8.0 |
| Publisher   | Datadog, Inc.   | Datadog, Inc.      |
| ProductCode | {43354AE2-CC9F-4D7F-8CF5-F394C23F0D7E}          | {43354AE2-CC9F-4D7F-8CF5-F394C23F0D7E}    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://github.com/vedantmgoyal2009/vedantmgoyal2009/tree/main/winget-pkgs-automation) in workflow run [1408](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/2276079784>)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/59602)