### PR TITLE
Remove unsupported version of blueedge.win11react.

### DIFF
--- a/manifests/b/blueedge/win11react/0.2.4/blueedge.win11react.installer.yaml
+++ b/manifests/b/blueedge/win11react/0.2.4/blueedge.win11react.installer.yaml
@@ -17,9 +17,5 @@ Installers:
   InstallerUrl: https://github.com/blueedgetechno/win11React/releases/download/0.2.4/Win11React_0.2.4_x64_en-US.msi
   InstallerSha256: AAC9CCB5A311D958884134059500633082ECB979052EC87B8BC7593EE248633B
   ProductCode: '{AC533C66-AB68-4B88-A635-ED4E30E4A9DC}'
-- Architecture: x86
-  InstallerType: inno
-  InstallerUrl: https://github.com/blueedgetechno/win11React/releases/download/0.2.4/Win11React_0.2.4_x86_en-US.exe
-  InstallerSha256: 25928A8BA33E4123C6387668BC9730C839E64D25A0A9ED320EF813607247F5C7
 ManifestType: installer
 ManifestVersion: 1.1.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.1 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.1.0)?

-----


Removed x86 build of blueedge.win11react as we are now only supporting 64bit

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/60984)