### PR TITLE
Delete .validation file for Microsoft.DotNetWorkload.Android

### DIFF
--- a/manifests/m/Microsoft/DotNetWorkload/Android/.validation
+++ b/manifests/m/Microsoft/DotNetWorkload/Android/.validation
@@ -1,1 +1,0 @@
-{"ValidationVersion":"1.0.0","Waivers":[{"WaiverId":"3ea256f5-4b23-4070-a95a-55f83993c226","TestPlan":"Validation-Domain","PackagePath":"manifests/m/Microsoft/DotNetWorkload/Android/11.0.200.196"}]}


### PR DESCRIPTION
- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.1 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.1.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----
This deletes a deprecated .NET manifest as described in https://github.com/dotnet/core/issues/7428.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/61219)