### PR TITLE
OpenJS.NodeJS: Fixed all license urls down to v16.6.1

### DIFF
--- a/manifests/o/OpenJS/NodeJS/16.10.0/OpenJS.NodeJS.locale.en-US.yaml
+++ b/manifests/o/OpenJS/NodeJS/16.10.0/OpenJS.NodeJS.locale.en-US.yaml
@@ -12,9 +12,9 @@ Author: OpenJS Foundation
 PackageName: Node.js
 PackageUrl: https://nodejs.org/en/
 License: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v16.10.0/LICENSE
 Copyright: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v16.10.0/LICENSE
 ShortDescription: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine.
 Description: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine. Node.js uses an event-driven, non-blocking I/O model that makes it lightweight and efficient. Node.js" package ecosystem, npm, is the largest ecosystem of open source libraries in the world.
 Moniker: nodejs
@@ -27,6 +27,6 @@ Tags:
 - npm
 # Agreements: 
 # ReleaseNotes: 
-# ReleaseNotesUrl: 
+ReleaseNotesUrl: https://github.com/nodejs/node/releases/tag/v16.10.0
 ManifestType: defaultLocale
 ManifestVersion: 1.1.0

--- a/manifests/o/OpenJS/NodeJS/16.11.0/OpenJS.NodeJS.locale.en-US.yaml
+++ b/manifests/o/OpenJS/NodeJS/16.11.0/OpenJS.NodeJS.locale.en-US.yaml
@@ -12,9 +12,9 @@ Author: OpenJS Foundation
 PackageName: Node.js
 PackageUrl: https://nodejs.org/en/
 License: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v16.11.0/LICENSE
 Copyright: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v16.11.0/LICENSE
 ShortDescription: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine.
 Description: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine. Node.js uses an event-driven, non-blocking I/O model that makes it lightweight and efficient. Node.js" package ecosystem, npm, is the largest ecosystem of open source libraries in the world.
 Moniker: nodejs
@@ -27,6 +27,6 @@ Tags:
 - npm
 # Agreements: 
 # ReleaseNotes: 
-# ReleaseNotesUrl: 
+ReleaseNotesUrl: https://github.com/nodejs/node/releases/tag/v16.11.0
 ManifestType: defaultLocale
 ManifestVersion: 1.1.0

--- a/manifests/o/OpenJS/NodeJS/16.11.1/OpenJS.NodeJS.locale.en-US.yaml
+++ b/manifests/o/OpenJS/NodeJS/16.11.1/OpenJS.NodeJS.locale.en-US.yaml
@@ -12,9 +12,9 @@ Author: OpenJS Foundation
 PackageName: Node.js
 PackageUrl: https://nodejs.org/en/
 License: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v16.11.1/LICENSE
 Copyright: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v16.11.1/LICENSE
 ShortDescription: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine.
 Description: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine. Node.js uses an event-driven, non-blocking I/O model that makes it lightweight and efficient. Node.js" package ecosystem, npm, is the largest ecosystem of open source libraries in the world.
 Moniker: nodejs
@@ -27,6 +27,6 @@ Tags:
 - npm
 # Agreements: 
 # ReleaseNotes: 
-# ReleaseNotesUrl: 
+ReleaseNotesUrl: https://github.com/nodejs/node/releases/tag/v16.11.1
 ManifestType: defaultLocale
 ManifestVersion: 1.1.0

--- a/manifests/o/OpenJS/NodeJS/16.12.0/OpenJS.NodeJS.locale.en-US.yaml
+++ b/manifests/o/OpenJS/NodeJS/16.12.0/OpenJS.NodeJS.locale.en-US.yaml
@@ -12,9 +12,9 @@ Author: OpenJS Foundation
 PackageName: Node.js
 PackageUrl: https://nodejs.org/en/
 License: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v16.12.0/LICENSE
 Copyright: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v16.12.0/LICENSE
 ShortDescription: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine.
 Description: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine. Node.js uses an event-driven, non-blocking I/O model that makes it lightweight and efficient. Node.js" package ecosystem, npm, is the largest ecosystem of open source libraries in the world.
 Moniker: nodejs
@@ -27,6 +27,6 @@ Tags:
 - npm
 # Agreements: 
 # ReleaseNotes: 
-# ReleaseNotesUrl: 
+ReleaseNotesUrl: https://github.com/nodejs/node/releases/tag/v16.12.0
 ManifestType: defaultLocale
 ManifestVersion: 1.1.0

--- a/manifests/o/OpenJS/NodeJS/16.6.0/OpenJS.NodeJS.locale.en-US.yaml
+++ b/manifests/o/OpenJS/NodeJS/16.6.0/OpenJS.NodeJS.locale.en-US.yaml
@@ -27,6 +27,6 @@ Tags:
 - npm
 # Agreements: 
 # ReleaseNotes: 
-# ReleaseNotesUrl: 
+ReleaseNotesUrl: https://github.com/nodejs/node/releases/tag/v16.6.0
 ManifestType: defaultLocale
 ManifestVersion: 1.1.0

--- a/manifests/o/OpenJS/NodeJS/16.6.1/OpenJS.NodeJS.locale.en-US.yaml
+++ b/manifests/o/OpenJS/NodeJS/16.6.1/OpenJS.NodeJS.locale.en-US.yaml
@@ -12,9 +12,9 @@ Author: OpenJS Foundation
 PackageName: Node.js
 PackageUrl: https://nodejs.org/en/
 License: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.1/LICENSE
 Copyright: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.1/LICENSE
 ShortDescription: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine.
 Description: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine. Node.js uses an event-driven, non-blocking I/O model that makes it lightweight and efficient. Node.js" package ecosystem, npm, is the largest ecosystem of open source libraries in the world.
 Moniker: nodejs
@@ -27,6 +27,6 @@ Tags:
 - npm
 # Agreements: 
 # ReleaseNotes: 
-# ReleaseNotesUrl: 
+ReleaseNotesUrl: https://github.com/nodejs/node/releases/tag/v16.6.1
 ManifestType: defaultLocale
 ManifestVersion: 1.1.0

--- a/manifests/o/OpenJS/NodeJS/16.6.2/OpenJS.NodeJS.locale.en-US.yaml
+++ b/manifests/o/OpenJS/NodeJS/16.6.2/OpenJS.NodeJS.locale.en-US.yaml
@@ -12,9 +12,9 @@ Author: OpenJS Foundation
 PackageName: Node.js
 PackageUrl: https://nodejs.org/en/
 License: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.2/LICENSE
 Copyright: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.2/LICENSE
 ShortDescription: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine.
 Description: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine. Node.js uses an event-driven, non-blocking I/O model that makes it lightweight and efficient. Node.js" package ecosystem, npm, is the largest ecosystem of open source libraries in the world.
 Moniker: nodejs
@@ -27,6 +27,6 @@ Tags:
 - npm
 # Agreements: 
 # ReleaseNotes: 
-# ReleaseNotesUrl: 
+ReleaseNotesUrl: https://github.com/nodejs/node/releases/tag/v16.6.2
 ManifestType: defaultLocale
 ManifestVersion: 1.1.0

--- a/manifests/o/OpenJS/NodeJS/16.7.0/OpenJS.NodeJS.locale.en-US.yaml
+++ b/manifests/o/OpenJS/NodeJS/16.7.0/OpenJS.NodeJS.locale.en-US.yaml
@@ -12,9 +12,9 @@ Author: OpenJS Foundation
 PackageName: Node.js
 PackageUrl: https://nodejs.org/en/
 License: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v16.7.0/LICENSE
 Copyright: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v16.7.0/LICENSE
 ShortDescription: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine.
 Description: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine. Node.js uses an event-driven, non-blocking I/O model that makes it lightweight and efficient. Node.js" package ecosystem, npm, is the largest ecosystem of open source libraries in the world.
 Moniker: nodejs
@@ -27,6 +27,6 @@ Tags:
 - npm
 # Agreements: 
 # ReleaseNotes: 
-# ReleaseNotesUrl: 
+ReleaseNotesUrl: https://github.com/nodejs/node/releases/tag/v16.7.0
 ManifestType: defaultLocale
 ManifestVersion: 1.1.0

--- a/manifests/o/OpenJS/NodeJS/16.8.0/OpenJS.NodeJS.locale.en-US.yaml
+++ b/manifests/o/OpenJS/NodeJS/16.8.0/OpenJS.NodeJS.locale.en-US.yaml
@@ -12,9 +12,9 @@ Author: OpenJS Foundation
 PackageName: Node.js
 PackageUrl: https://nodejs.org/en/
 License: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v16.8.0/LICENSE
 Copyright: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v16.8.0/LICENSE
 ShortDescription: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine.
 Description: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine. Node.js uses an event-driven, non-blocking I/O model that makes it lightweight and efficient. Node.js" package ecosystem, npm, is the largest ecosystem of open source libraries in the world.
 Moniker: nodejs
@@ -27,6 +27,6 @@ Tags:
 - npm
 # Agreements: 
 # ReleaseNotes: 
-# ReleaseNotesUrl: 
+ReleaseNotesUrl: https://github.com/nodejs/node/releases/tag/v16.8.0
 ManifestType: defaultLocale
 ManifestVersion: 1.1.0

--- a/manifests/o/OpenJS/NodeJS/16.9.0/OpenJS.NodeJS.locale.en-US.yaml
+++ b/manifests/o/OpenJS/NodeJS/16.9.0/OpenJS.NodeJS.locale.en-US.yaml
@@ -12,9 +12,9 @@ Author: OpenJS Foundation
 PackageName: Node.js
 PackageUrl: https://nodejs.org/en/
 License: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v16.9.0/LICENSE
 Copyright: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v16.9.0/LICENSE
 ShortDescription: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine.
 Description: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine. Node.js uses an event-driven, non-blocking I/O model that makes it lightweight and efficient. Node.js" package ecosystem, npm, is the largest ecosystem of open source libraries in the world.
 Moniker: nodejs
@@ -27,6 +27,6 @@ Tags:
 - npm
 # Agreements: 
 # ReleaseNotes: 
-# ReleaseNotesUrl: 
+ReleaseNotesUrl: https://github.com/nodejs/node/releases/tag/v16.9.0
 ManifestType: defaultLocale
 ManifestVersion: 1.1.0

--- a/manifests/o/OpenJS/NodeJS/16.9.1/OpenJS.NodeJS.locale.en-US.yaml
+++ b/manifests/o/OpenJS/NodeJS/16.9.1/OpenJS.NodeJS.locale.en-US.yaml
@@ -12,9 +12,9 @@ Author: OpenJS Foundation
 PackageName: Node.js
 PackageUrl: https://nodejs.org/en/
 License: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v16.9.1/LICENSE
 Copyright: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v16.9.1/LICENSE
 ShortDescription: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine.
 Description: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine. Node.js uses an event-driven, non-blocking I/O model that makes it lightweight and efficient. Node.js" package ecosystem, npm, is the largest ecosystem of open source libraries in the world.
 Moniker: nodejs
@@ -27,6 +27,6 @@ Tags:
 - npm
 # Agreements: 
 # ReleaseNotes: 
-# ReleaseNotesUrl: 
+ReleaseNotesUrl: https://github.com/nodejs/node/releases/tag/v16.9.1
 ManifestType: defaultLocale
 ManifestVersion: 1.1.0

--- a/manifests/o/OpenJS/NodeJS/17.0.0/OpenJS.NodeJS.locale.en-US.yaml
+++ b/manifests/o/OpenJS/NodeJS/17.0.0/OpenJS.NodeJS.locale.en-US.yaml
@@ -12,9 +12,9 @@ Author: OpenJS Foundation
 PackageName: Node.js
 PackageUrl: https://nodejs.org/en/
 License: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v17.0.0/LICENSE
 Copyright: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v17.0.0/LICENSE
 ShortDescription: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine.
 Description: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine. Node.js uses an event-driven, non-blocking I/O model that makes it lightweight and efficient. Node.js" package ecosystem, npm, is the largest ecosystem of open source libraries in the world.
 Moniker: nodejs
@@ -27,6 +27,6 @@ Tags:
 - npm
 # Agreements: 
 # ReleaseNotes: 
-# ReleaseNotesUrl: 
+ReleaseNotesUrl: https://github.com/nodejs/node/releases/tag/v17.0.0
 ManifestType: defaultLocale
 ManifestVersion: 1.1.0

--- a/manifests/o/OpenJS/NodeJS/17.0.1/OpenJS.NodeJS.locale.en-US.yaml
+++ b/manifests/o/OpenJS/NodeJS/17.0.1/OpenJS.NodeJS.locale.en-US.yaml
@@ -12,9 +12,9 @@ Author: OpenJS Foundation
 PackageName: Node.js
 PackageUrl: https://nodejs.org/en/
 License: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v17.0.1/LICENSE
 Copyright: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v17.0.1/LICENSE
 ShortDescription: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine.
 Description: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine. Node.js uses an event-driven, non-blocking I/O model that makes it lightweight and efficient. Node.js" package ecosystem, npm, is the largest ecosystem of open source libraries in the world.
 Moniker: nodejs
@@ -27,6 +27,6 @@ Tags:
 - npm
 # Agreements: 
 # ReleaseNotes: 
-# ReleaseNotesUrl: 
+ReleaseNotesUrl: https://github.com/nodejs/node/releases/tag/v17.0.1
 ManifestType: defaultLocale
 ManifestVersion: 1.1.0

--- a/manifests/o/OpenJS/NodeJS/17.1.0/OpenJS.NodeJS.locale.en-US.yaml
+++ b/manifests/o/OpenJS/NodeJS/17.1.0/OpenJS.NodeJS.locale.en-US.yaml
@@ -12,9 +12,9 @@ Author: OpenJS Foundation
 PackageName: Node.js
 PackageUrl: https://nodejs.org/en/
 License: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v17.1.0/LICENSE
 Copyright: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v17.1.0/LICENSE
 ShortDescription: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine.
 Description: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine. Node.js uses an event-driven, non-blocking I/O model that makes it lightweight and efficient. Node.js" package ecosystem, npm, is the largest ecosystem of open source libraries in the world.
 # Moniker: 
@@ -27,6 +27,6 @@ Tags:
 - npm
 # Agreements: 
 # ReleaseNotes: 
-# ReleaseNotesUrl: 
+ReleaseNotesUrl: https://github.com/nodejs/node/releases/tag/v17.1.0 
 ManifestType: defaultLocale
 ManifestVersion: 1.1.0

--- a/manifests/o/OpenJS/NodeJS/17.2.0/OpenJS.NodeJS.locale.en-US.yaml
+++ b/manifests/o/OpenJS/NodeJS/17.2.0/OpenJS.NodeJS.locale.en-US.yaml
@@ -12,9 +12,9 @@ Author: OpenJS Foundation
 PackageName: Node.js
 PackageUrl: https://nodejs.org/en/
 License: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v17.2.0/LICENSE
 Copyright: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v17.2.0/LICENSE
 ShortDescription: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine.
 Description: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine. Node.js uses an event-driven, non-blocking I/O model that makes it lightweight and efficient. Node.js" package ecosystem, npm, is the largest ecosystem of open source libraries in the world.
 # Moniker: 
@@ -27,6 +27,6 @@ Tags:
 - npm
 # Agreements: 
 # ReleaseNotes: 
-# ReleaseNotesUrl: 
+ReleaseNotesUrl: https://github.com/nodejs/node/releases/tag/v17.2.0
 ManifestType: defaultLocale
 ManifestVersion: 1.1.0

--- a/manifests/o/OpenJS/NodeJS/17.3.0/OpenJS.NodeJS.locale.en-US.yaml
+++ b/manifests/o/OpenJS/NodeJS/17.3.0/OpenJS.NodeJS.locale.en-US.yaml
@@ -12,9 +12,9 @@ Author: OpenJS Foundation
 PackageName: Node.js
 PackageUrl: https://nodejs.org/en/
 License: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v17.3.0/LICENSE
 Copyright: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v17.3.0/LICENSE
 ShortDescription: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine.
 Description: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine. Node.js uses an event-driven, non-blocking I/O model that makes it lightweight and efficient. Node.js" package ecosystem, npm, is the largest ecosystem of open source libraries in the world.
 # Moniker: 
@@ -27,6 +27,6 @@ Tags:
 - npm
 # Agreements: 
 # ReleaseNotes: 
-# ReleaseNotesUrl: 
+ReleaseNotesUrl: https://github.com/nodejs/node/releases/tag/v17.3.0
 ManifestType: defaultLocale
 ManifestVersion: 1.1.0

--- a/manifests/o/OpenJS/NodeJS/17.3.1/OpenJS.NodeJS.locale.en-US.yaml
+++ b/manifests/o/OpenJS/NodeJS/17.3.1/OpenJS.NodeJS.locale.en-US.yaml
@@ -12,9 +12,9 @@ Author: OpenJS Foundation
 PackageName: Node.js
 PackageUrl: https://nodejs.org/en/
 License: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v16.3.1/LICENSE
 Copyright: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v16.3.1/LICENSE
 ShortDescription: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine.
 Description: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine. Node.js uses an event-driven, non-blocking I/O model that makes it lightweight and efficient. Node.js" package ecosystem, npm, is the largest ecosystem of open source libraries in the world.
 # Moniker: 
@@ -27,6 +27,6 @@ Tags:
 - npm
 # Agreements: 
 # ReleaseNotes: 
-# ReleaseNotesUrl: 
+ReleaseNotesUrl: https://github.com/nodejs/node/releases/tag/v17.3.1
 ManifestType: defaultLocale
 ManifestVersion: 1.1.0

--- a/manifests/o/OpenJS/NodeJS/17.4.0/OpenJS.NodeJS.locale.en-US.yaml
+++ b/manifests/o/OpenJS/NodeJS/17.4.0/OpenJS.NodeJS.locale.en-US.yaml
@@ -12,9 +12,9 @@ Author: OpenJS Foundation
 PackageName: Node.js
 PackageUrl: https://nodejs.org/en/
 License: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v17.4.0/LICENSE
 Copyright: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v17.4.0/LICENSE
 ShortDescription: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine.
 Description: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine. Node.js uses an event-driven, non-blocking I/O model that makes it lightweight and efficient. Node.js" package ecosystem, npm, is the largest ecosystem of open source libraries in the world.
 # Moniker: 
@@ -27,6 +27,6 @@ Tags:
 - npm
 # Agreements: 
 # ReleaseNotes: 
-# ReleaseNotesUrl: 
+ReleaseNotesUrl: https://github.com/nodejs/node/releases/tag/v17.4.0
 ManifestType: defaultLocale
 ManifestVersion: 1.1.0

--- a/manifests/o/OpenJS/NodeJS/17.5.0/OpenJS.NodeJS.locale.en-US.yaml
+++ b/manifests/o/OpenJS/NodeJS/17.5.0/OpenJS.NodeJS.locale.en-US.yaml
@@ -12,9 +12,9 @@ Author: OpenJS Foundation
 PackageName: Node.js
 PackageUrl: https://nodejs.org/en/
 License: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v17.5.0/LICENSE
 Copyright: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v17.5.0/LICENSE
 ShortDescription: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine.
 Description: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine. Node.js uses an event-driven, non-blocking I/O model that makes it lightweight and efficient. Node.js" package ecosystem, npm, is the largest ecosystem of open source libraries in the world.
 # Moniker: 

--- a/manifests/o/OpenJS/NodeJS/17.6.0/OpenJS.NodeJS.locale.en-US.yaml
+++ b/manifests/o/OpenJS/NodeJS/17.6.0/OpenJS.NodeJS.locale.en-US.yaml
@@ -12,9 +12,9 @@ Author: OpenJS Foundation
 PackageName: Node.js
 PackageUrl: https://nodejs.org/en/
 License: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v17.6.0/LICENSE
 Copyright: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v17.6.0/LICENSE
 ShortDescription: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine.
 Description: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine. Node.js uses an event-driven, non-blocking I/O model that makes it lightweight and efficient. Node.js" package ecosystem, npm, is the largest ecosystem of open source libraries in the world.
 # Moniker: 

--- a/manifests/o/OpenJS/NodeJS/17.7.0/OpenJS.NodeJS.locale.en-US.yaml
+++ b/manifests/o/OpenJS/NodeJS/17.7.0/OpenJS.NodeJS.locale.en-US.yaml
@@ -12,9 +12,9 @@ Author: OpenJS Foundation
 PackageName: Node.js
 PackageUrl: https://nodejs.org/en/
 License: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v17.7.0/LICENSE
 Copyright: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v17.7.0/LICENSE
 ShortDescription: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine.
 Description: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine. Node.js uses an event-driven, non-blocking I/O model that makes it lightweight and efficient. Node.js" package ecosystem, npm, is the largest ecosystem of open source libraries in the world.
 # Moniker: 

--- a/manifests/o/OpenJS/NodeJS/17.7.1/OpenJS.NodeJS.locale.en-US.yaml
+++ b/manifests/o/OpenJS/NodeJS/17.7.1/OpenJS.NodeJS.locale.en-US.yaml
@@ -12,9 +12,9 @@ Author: OpenJS Foundation
 PackageName: Node.js
 PackageUrl: https://nodejs.org/en/
 License: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v17.7.1/LICENSE
 Copyright: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v17.7.1/LICENSE
 ShortDescription: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine.
 Description: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine. Node.js uses an event-driven, non-blocking I/O model that makes it lightweight and efficient. Node.js" package ecosystem, npm, is the largest ecosystem of open source libraries in the world.
 # Moniker: 

--- a/manifests/o/OpenJS/NodeJS/17.7.2/OpenJS.NodeJS.locale.en-US.yaml
+++ b/manifests/o/OpenJS/NodeJS/17.7.2/OpenJS.NodeJS.locale.en-US.yaml
@@ -12,9 +12,9 @@ Author: OpenJS Foundation
 PackageName: Node.js
 PackageUrl: https://nodejs.org/en/
 License: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v17.7.2/LICENSE
 Copyright: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v17.7.2/LICENSE
 ShortDescription: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine.
 Description: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine. Node.js uses an event-driven, non-blocking I/O model that makes it lightweight and efficient. Node.js" package ecosystem, npm, is the largest ecosystem of open source libraries in the world.
 # Moniker: 

--- a/manifests/o/OpenJS/NodeJS/17.8.0/OpenJS.NodeJS.locale.en-US.yaml
+++ b/manifests/o/OpenJS/NodeJS/17.8.0/OpenJS.NodeJS.locale.en-US.yaml
@@ -12,9 +12,9 @@ Author: OpenJS Foundation
 PackageName: Node.js
 PackageUrl: https://nodejs.org/en/
 License: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v17.8.0/LICENSE
 Copyright: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v17.8.0/LICENSE
 ShortDescription: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine.
 Description: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine. Node.js uses an event-driven, non-blocking I/O model that makes it lightweight and efficient. Node.js" package ecosystem, npm, is the largest ecosystem of open source libraries in the world.
 # Moniker: 

--- a/manifests/o/OpenJS/NodeJS/17.9.0/OpenJS.NodeJS.locale.en-US.yaml
+++ b/manifests/o/OpenJS/NodeJS/17.9.0/OpenJS.NodeJS.locale.en-US.yaml
@@ -12,9 +12,9 @@ Author: OpenJS Foundation
 PackageName: Node.js
 PackageUrl: https://nodejs.org/en/
 License: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v17.9.0/LICENSE
 Copyright: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v17.9.0/LICENSE
 ShortDescription: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine.
 Description: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine. Node.js uses an event-driven, non-blocking I/O model that makes it lightweight and efficient. Node.js" package ecosystem, npm, is the largest ecosystem of open source libraries in the world.
 # Moniker: 

--- a/manifests/o/OpenJS/NodeJS/18.0.0/OpenJS.NodeJS.locale.en-US.yaml
+++ b/manifests/o/OpenJS/NodeJS/18.0.0/OpenJS.NodeJS.locale.en-US.yaml
@@ -12,9 +12,9 @@ Author: OpenJS Foundation
 PackageName: Node.js
 PackageUrl: https://nodejs.org/en/
 License: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+LicenseUrl: https://raw.githubusercontent.com/nodejs/node/v18.0.0/LICENSE
 Copyright: Copyright (c) Joyent, Inc. and other Node contributors. All rights reserved.
-CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v16.6.0/LICENSE
+CopyrightUrl: https://raw.githubusercontent.com/nodejs/node/v18.0.0/LICENSE
 ShortDescription: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine.
 Description: Node.js is a JavaScript runtime built on Chrome"s V8 JavaScript engine. Node.js uses an event-driven, non-blocking I/O model that makes it lightweight and efficient. Node.js" package ecosystem, npm, is the largest ecosystem of open source libraries in the world.
 # Moniker: 


### PR DESCRIPTION
& added release notes urls down to v16.6.0

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.1 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.1.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/61334)