### PR TITLE
New application: JernejSimoncic.Wget version 1.21.3

### DIFF
--- a/manifests/j/JernejSimoncic/Wget/1.21.3/JernejSimoncic.Wget.installer.yaml
+++ b/manifests/j/JernejSimoncic/Wget/1.21.3/JernejSimoncic.Wget.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+
+PackageIdentifier: JernejSimoncic.Wget
+PackageVersion: 1.21.3
+InstallerLocale: en-US
+InstallerType: portable
+Commands:
+- wget
+Protocols:
+- http
+- https
+- ftp
+- ftps
+Installers:
+- Architecture: x64
+  InstallerUrl: https://eternallybored.org/misc/wget/1.21.3/64/wget.exe
+  InstallerSha256: F595E2E53680BA2937AC48708BC24E6FB5FF6B6FB97D60EB5040BF073AD933BF
+- Architecture: x86
+  InstallerUrl: https://eternallybored.org/misc/wget/1.21.3/32/wget.exe
+  InstallerSha256: 1E17A4EE77A3A18B4BBC2407AD4582155B266B4A71D684C2BAF0F1AA8E52FD14
+ManifestType: installer
+ManifestVersion: 1.2.0

--- a/manifests/j/JernejSimoncic/Wget/1.21.3/JernejSimoncic.Wget.locale.en-US.yaml
+++ b/manifests/j/JernejSimoncic/Wget/1.21.3/JernejSimoncic.Wget.locale.en-US.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultlocale.1.2.0.schema.json
+
+PackageIdentifier: JernejSimoncic.Wget
+PackageVersion: 1.21.3
+PackageLocale: en-US
+Publisher: Jernej Simoncic
+PublisherUrl: https://eternallybored.org/
+Author: Jernej Simoncic
+PackageName: Wget
+PackageUrl: https://eternallybored.org/misc/wget/
+License: GPL-3.0-or-later
+LicenseUrl: https://git.savannah.gnu.org/cgit/wget.git/plain/COPYING
+ShortDescription: Wget is a command line utility for retrieving files using HTTP, HTTPS, FTP and FTPS.
+Moniker: wget
+Tags:
+- cross-platform
+- downloader
+- open-source
+ManifestType: defaultLocale
+ManifestVersion: 1.2.0

--- a/manifests/j/JernejSimoncic/Wget/1.21.3/JernejSimoncic.Wget.yaml
+++ b/manifests/j/JernejSimoncic/Wget/1.21.3/JernejSimoncic.Wget.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+
+PackageIdentifier: JernejSimoncic.Wget
+PackageVersion: 1.21.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.2.0


### PR DESCRIPTION
Once portable apps support for winget is out, we should remove `GnuWin32.Wget` because it is outdated and replace it with this. There seems no point to keep outdated version from different publisher.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.1 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.1.0)?

Related https://github.com/microsoft/winget-pkgs/issues/12123

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/61438)