### PR TITLE
Fix typo in locale schemas

### DIFF
--- a/doc/manifest/schema/1.0.0/locale.md
+++ b/doc/manifest/schema/1.0.0/locale.md
@@ -19,7 +19,7 @@ PackageVersion:               # The package version
 PackageLocale:                # The package meta-data locale
 Publisher:                    # Optional publisher name
 PublisherURL:                 # Optional publisher home page
-PublisherSupportUrul:         # Optional publisher support page
+PublisherSupportUrl:          # Optional publisher support page
 PrivacyUrl:                   # Optional publisher privacy page
 Author:                       # Optional author
 PackageName:                  # Optional package name

--- a/doc/manifest/schema/1.1.0/defaultLocale.md
+++ b/doc/manifest/schema/1.1.0/defaultLocale.md
@@ -20,7 +20,7 @@ PackageVersion:               # The package version
 PackageLocale:                # The package meta-data locale
 Publisher:                    # The publisher name
 PublisherURL:                 # Optional publisher home page
-PublisherSupportUrul:         # Optional publisher support page
+PublisherSupportUrl:          # Optional publisher support page
 PrivacyUrl:                   # Optional publisher privacy page
 Author:                       # Optional author
 PackageName:                  # The package name

--- a/doc/manifest/schema/1.1.0/locale.md
+++ b/doc/manifest/schema/1.1.0/locale.md
@@ -20,7 +20,7 @@ PackageVersion:               # The package version
 PackageLocale:                # The package meta-data locale
 Publisher:                    # Optional publisher name
 PublisherURL:                 # Optional publisher home page
-PublisherSupportUrul:         # Optional publisher support page
+PublisherSupportUrl:          # Optional publisher support page
 PrivacyUrl:                   # Optional publisher privacy page
 Author:                       # Optional author
 PackageName:                  # Optional package name


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] ~~Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?~~
- [ ] ~~Have you tested your manifest locally with `winget install --manifest <path>`?~~
- [ ] ~~Does your manifest conform to the [1.1 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.1.0)?~~

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

This is a PR to fix a small typo in the locale schemas, where `PublisherSupportUrl` is listed as `PublisherSupportUrul`.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/61770)