### PR TITLE
New version: LinuxSuRen.HTTPdownloader version 0.0.67

### DIFF
--- a/manifests/l/LinuxSuRen/HTTPdownloader/0.0.67/LinuxSuRen.HTTPdownloader.installer.yaml
+++ b/manifests/l/LinuxSuRen/HTTPdownloader/0.0.67/LinuxSuRen.HTTPdownloader.installer.yaml
@@ -1,0 +1,15 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-3
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+
+PackageIdentifier: LinuxSuRen.HTTPdownloader
+PackageVersion: 0.0.67
+MinimumOSVersion: 10.0.0.0
+InstallerType: wix
+ReleaseDate: 2022-05-24
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/LinuxSuRen/http-downloader/releases/download/v0.0.67/hd-windows-amd64.msi
+  InstallerSha256: 17AABA3BA6E38B6C78F101D219C97AAC79397A4F9D9F114FF067A8EEE18B94B7
+  ProductCode: '{0B5D88A6-809E-403B-95F4-C8A8793D14FC}'
+ManifestType: installer
+ManifestVersion: 1.1.0

--- a/manifests/l/LinuxSuRen/HTTPdownloader/0.0.67/LinuxSuRen.HTTPdownloader.locale.en-US.yaml
+++ b/manifests/l/LinuxSuRen/HTTPdownloader/0.0.67/LinuxSuRen.HTTPdownloader.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-3
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+
+PackageIdentifier: LinuxSuRen.HTTPdownloader
+PackageVersion: 0.0.67
+PackageLocale: en-US
+Publisher: LinuxSuRen
+PublisherUrl: https://github.com/LinuxSuRen/http-downloader
+PublisherSupportUrl: https://github.com/LinuxSuRen/http-downloader/issues
+# PrivacyUrl: 
+Author: LinuxSuRen
+PackageName: HTTP downloader
+PackageUrl: https://github.com/LinuxSuRen/http-downloader
+License: MIT
+LicenseUrl: https://github.com/LinuxSuRen/http-downloader/blob/master/LICENSE
+Copyright: Copyright (c) 2021 Zhao Xiaojie
+CopyrightUrl: https://github.com/LinuxSuRen/http-downloader/blob/master/LICENSE
+ShortDescription: A download tool that is baked for the GitHub release assets.
+# Description: 
+# Moniker: 
+# Tags: 
+# Agreements: 
+# ReleaseNotes: 
+ReleaseNotesUrl: https://github.com/LinuxSuRen/http-downloader/releases/tag/v0.0.67
+ManifestType: defaultLocale
+ManifestVersion: 1.1.0

--- a/manifests/l/LinuxSuRen/HTTPdownloader/0.0.67/LinuxSuRen.HTTPdownloader.yaml
+++ b/manifests/l/LinuxSuRen/HTTPdownloader/0.0.67/LinuxSuRen.HTTPdownloader.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-3
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+
+PackageIdentifier: LinuxSuRen.HTTPdownloader
+PackageVersion: 0.0.67
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.1.0


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | HTTP downloader | Humble App 1.1.0+321, Google Chrome Canary, KDE Connect, KDevelop, Kile    |
| Version     | 0.0.67     | 1.1.0+321, 104.0.5082.0, 22.04.1, 5.6.2, 2.9.93 |
| Publisher   | LinuxSuRen   | Humble Bundle, Google LLC, KDE e.V., KDE e.V., KDE e.V.      |
| ProductCode | {0B5D88A6-809E-403B-95F4-C8A8793D14FC}          | 2f793df2-2969-529d-b0c0-7960ed40d70e, Google Chrome SxS, KDE Connect, KDevelop, Kile    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://github.com/vedantmgoyal2009/vedantmgoyal2009/tree/main/winget-pkgs-automation) in workflow run [1720](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/2380609964>)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/61900)