### PR TITLE
Microsoft.WSLg version 1.0.26

### DIFF
--- a/manifests/m/Microsoft/WSLg/1.0.26/Microsoft.WSLg.installer.yaml
+++ b/manifests/m/Microsoft/WSLg/1.0.26/Microsoft.WSLg.installer.yaml
@@ -1,0 +1,15 @@
+# Created using wingetcreate 1.0.4.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+
+PackageIdentifier: Microsoft.WSLg
+PackageVersion: 1.0.26
+Installers:
+- InstallerLocale: en-US
+  Architecture: x64
+  InstallerType: wix
+  InstallerUrl: https://github.com/microsoft/wslg/releases/download/v1.0.26/wsl_graphics_support_x64.msi
+  InstallerSha256: 16877D0A7560B9A98CBEF2CD29B9853249632F473D3DBC7BE418E28613B9EE2E
+  ProductCode: '{E04B0005-A349-4BCC-9662-CA0132007E14}'
+ManifestType: installer
+ManifestVersion: 1.1.0
+

--- a/manifests/m/Microsoft/WSLg/1.0.26/Microsoft.WSLg.locale.en-US.yaml
+++ b/manifests/m/Microsoft/WSLg/1.0.26/Microsoft.WSLg.locale.en-US.yaml
@@ -1,0 +1,13 @@
+# Created using wingetcreate 1.0.4.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+
+PackageIdentifier: Microsoft.WSLg
+PackageVersion: 1.0.26
+PackageLocale: en-US
+Publisher: Microsoft Corporation
+PackageName: Windows Subsystem for Linux WSLg Preview
+License: MIT License
+ShortDescription: GUI app support for WSL2 on Windows 11
+ManifestType: defaultLocale
+ManifestVersion: 1.1.0
+

--- a/manifests/m/Microsoft/WSLg/1.0.26/Microsoft.WSLg.yaml
+++ b/manifests/m/Microsoft/WSLg/1.0.26/Microsoft.WSLg.yaml
@@ -1,0 +1,9 @@
+# Created using wingetcreate 1.0.4.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+
+PackageIdentifier: Microsoft.WSLg
+PackageVersion: 1.0.26
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.1.0
+


### PR DESCRIPTION
I think no Windows package manager recognises WSLg. Installing WSLg without downloading the MSI file (e.g. `choco install wslg`) returns:
```
wslg not installed. The package was not found with the source(s) listed.
 Source(s): 'https://community.chocolatey.org/api/v2/'
 NOTE: When you specify explicit sources, it overrides default sources.
If the package version is a prerelease and you didn't specify `--pre`,
 the package may not be found.
Please see https://docs.chocolatey.org/en-us/troubleshooting for more
 assistance.

Chocolatey installed 0/1 packages. 1 packages failed.
 See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).
```

Same as in WinGet:
```
No package found matching input criteria.
```

and in [Scoop](https://scoop.sh):
```
WARN  Scoop is out of date.
Couldn't find manifest for 'wslg'.
```

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.1 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.1.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/62098)