### PR TITLE
New version: RivaFarabi.Deckboard version 2.0.2

### DIFF
--- a/manifests/r/RivaFarabi/Deckboard/2.0.2/RivaFarabi.Deckboard.installer.yaml
+++ b/manifests/r/RivaFarabi/Deckboard/2.0.2/RivaFarabi.Deckboard.installer.yaml
@@ -1,0 +1,29 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-4
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+
+PackageIdentifier: RivaFarabi.Deckboard
+PackageVersion: 2.0.2
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+ReleaseDate: 2022-06-03
+Installers:
+- Architecture: neutral
+  Scope: user
+  InstallerUrl: https://github.com/rivafarabi/deckboard/releases/download/v2.0.2/Deckboard-Setup-2.0.2.exe
+  InstallerSha256: E231CEDEFA357DECE49F15A86C6C0AD0CF7B8F60F946017B65A03476E6EAB758
+  InstallerSwitches:
+    Custom: /CURRENTUSER
+- Architecture: neutral
+  Scope: machine
+  InstallerUrl: https://github.com/rivafarabi/deckboard/releases/download/v2.0.2/Deckboard-Setup-2.0.2.exe
+  InstallerSha256: E231CEDEFA357DECE49F15A86C6C0AD0CF7B8F60F946017B65A03476E6EAB758
+  InstallerSwitches:
+    Custom: /ALLUSERS
+ManifestType: installer
+ManifestVersion: 1.1.0

--- a/manifests/r/RivaFarabi/Deckboard/2.0.2/RivaFarabi.Deckboard.locale.en-US.yaml
+++ b/manifests/r/RivaFarabi/Deckboard/2.0.2/RivaFarabi.Deckboard.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-4
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+
+PackageIdentifier: RivaFarabi.Deckboard
+PackageVersion: 2.0.2
+PackageLocale: en-US
+Publisher: Riva Farabi
+PublisherUrl: https://github.com/rivafarabi/deckboard
+PublisherSupportUrl: https://github.com/rivafarabi/deckboard/issues
+# PrivacyUrl: 
+Author: Riva Farabi
+PackageName: Deckboard
+PackageUrl: https://github.com/rivafarabi/deckboard
+License: Copyright © 2021 Riva Farabi
+# LicenseUrl: 
+Copyright: Copyright © 2021 Riva Farabi
+# CopyrightUrl: 
+ShortDescription: Phone as macro shortcut for your computer in easy way possible.
+Description: Create custom computer macro shortcuts and launch them through your device. No more windows switching to open the folder or website, get Deckboard to simplify them and maximize your productivity! With OBS Studio and Streamlabs OBS supported, bring Deckboard as your personal streaming companion tool! Connect your computer to your device through local WiFi connection by entering IP address or scanning QR code.
+Moniker: deckboard
+Tags:
+- electron
+- macro-recorder
+- macros
+- obs-remote
+- remote-control
+- shortcuts-on-desktop
+- streamlabs-obs-remote
+# Agreements: 
+# ReleaseNotes: 
+ReleaseNotesUrl: https://github.com/rivafarabi/deckboard/releases/tag/v2.0.2
+ManifestType: defaultLocale
+ManifestVersion: 1.1.0

--- a/manifests/r/RivaFarabi/Deckboard/2.0.2/RivaFarabi.Deckboard.yaml
+++ b/manifests/r/RivaFarabi/Deckboard/2.0.2/RivaFarabi.Deckboard.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-4
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+
+PackageIdentifier: RivaFarabi.Deckboard
+PackageVersion: 2.0.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.1.0


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | Deckboard | Notepad++ (64-bit x64), Prey Anti-Theft, Signal 5.45.0, Signal Beta 5.46.0-beta.1    |
| Version     | 2.0.2     | 8.4.2, 1.10.2, 5.45.0, 5.46.0-beta.1 |
| Publisher   | Riva Farabi   | Notepad++ Team, Prey, Inc., Signal Messenger, LLC, Signal Messenger, LLC      |
| ProductCode |           | Notepad++, {E9AB9261-2F0C-4FD1-90D1-7AC2B136DC16}, 7d96caee-06e6-597c-9f2f-c7bb2e0948b4, b39ac3a0-cc73-5ec2-ba18-5ab3c4de1ca1    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://github.com/vedantmgoyal2009/vedantmgoyal2009/tree/main/winget-pkgs-automation) in workflow run [1911](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/2436904250>)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/62757)