### PR TITLE
PowerToys 0.59.0 support for ARM64

### DIFF
--- a/manifests/m/Microsoft/PowerToys/0.59.0/Microsoft.PowerToys.installer.yaml
+++ b/manifests/m/Microsoft/PowerToys/0.59.0/Microsoft.PowerToys.installer.yaml
@@ -16,6 +16,9 @@ Installers:
   InstallerType: burn
   InstallerUrl: https://github.com/microsoft/PowerToys/releases/download/v0.59.0/PowerToysSetup-0.59.0-x64.exe
   InstallerSha256: A6742F3C9A477FF50BF3E6F8521FCDC4B7524A81659D0F5C5D850716EFF3D8B8
+- Architecture: arm64
+  InstallerType: burn
+  InstallerUrl: https://github.com/microsoft/PowerToys/releases/download/v0.59.0/PowerToysSetup-0.59.0-arm64.exe
+  InstallerSha256: B7125697BDBF4A6F835757B4CFB9F71A5A5C6E08C073777112A3D212DC04B170
 ManifestType: installer
 ManifestVersion: 1.1.0
-


### PR DESCRIPTION
Add ARM64 installer link for PowerToys (ARM64 builds are available since 0.59.0).

- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [X] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.1 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.1.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/63086)