### PR TITLE
New version: EFF.Certbot version 1.28.0

### DIFF
--- a/manifests/e/EFF/Certbot/1.28.0/EFF.Certbot.installer.yaml
+++ b/manifests/e/EFF/Certbot/1.28.0/EFF.Certbot.installer.yaml
@@ -1,0 +1,20 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-4
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+
+PackageIdentifier: EFF.Certbot
+PackageVersion: 1.28.0
+InstallerLocale: en-US
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+Scope: machine
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+ReleaseDate: 2022-06-08
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/certbot/certbot/releases/download/v1.28.0/certbot-beta-installer-win_amd64.exe
+  InstallerSha256: 745033ED5F1B467F2A2028D996F4705B6A025F7C2A8FD3159C43CEC5C68BD8F0
+ManifestType: installer
+ManifestVersion: 1.1.0

--- a/manifests/e/EFF/Certbot/1.28.0/EFF.Certbot.locale.en-US.yaml
+++ b/manifests/e/EFF/Certbot/1.28.0/EFF.Certbot.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-4
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+
+PackageIdentifier: EFF.Certbot
+PackageVersion: 1.28.0
+PackageLocale: en-US
+Publisher: Electronic Frontier Foundation
+PublisherUrl: https://www.eff.org/
+PublisherSupportUrl: https://github.com/certbot/certbot/issues
+PrivacyUrl: https://www.eff.org/policy
+Author: Electronic Frontier Foundation
+PackageName: Certbot
+PackageUrl: https://certbot.eff.org
+License: Apache v2.0 Licence
+LicenseUrl: https://raw.githubusercontent.com/certbot/certbot/master/LICENSE.txt
+Copyright: Copyright (c) Electronic Frontier Foundation and others
+CopyrightUrl: https://raw.githubusercontent.com/certbot/certbot/master/LICENSE.txt
+ShortDescription: Certbot is a free, open source software tool for automatically using Let's Encrypt certificates on manually-administrated websites to enable HTTPS.
+# Description: 
+# Moniker: 
+# Tags: 
+# Agreements: 
+# ReleaseNotes: 
+ReleaseNotesUrl: https://github.com/certbot/certbot/releases/tag/v1.28.0
+ManifestType: defaultLocale
+ManifestVersion: 1.1.0

--- a/manifests/e/EFF/Certbot/1.28.0/EFF.Certbot.yaml
+++ b/manifests/e/EFF/Certbot/1.28.0/EFF.Certbot.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-4
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+
+PackageIdentifier: EFF.Certbot
+PackageVersion: 1.28.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.1.0


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | Certbot | Discord    |
| Version     | 1.28.0     | 1.0.9005 |
| Publisher   | Electronic Frontier Foundation   | Discord Inc.      |
| ProductCode |           | Discord    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://github.com/vedantmgoyal2009/vedantmgoyal2009/tree/main/winget-pkgs-automation) in workflow run [2020](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/2463815316>)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/63110)