### PR TITLE
New version: Datadog.dd-trace-dotnet version 2.10.0

### DIFF
--- a/manifests/d/Datadog/dd-trace-dotnet/2.10.0/Datadog.dd-trace-dotnet.installer.yaml
+++ b/manifests/d/Datadog/dd-trace-dotnet/2.10.0/Datadog.dd-trace-dotnet.installer.yaml
@@ -1,0 +1,26 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-4
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+
+PackageIdentifier: Datadog.dd-trace-dotnet
+PackageVersion: 2.10.0
+InstallerLocale: en-US
+MinimumOSVersion: 10.0.0.0
+InstallerType: wix
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2022-06-09
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/DataDog/dd-trace-dotnet/releases/download/v2.10.0/datadog-dotnet-apm-2.10.0-x64.msi
+  InstallerSha256: 7011497094CC698C4E98636DAB0BFA8A4BE543194086D2D093193314B1EC4BDC
+  ProductCode: '{3DF2530B-DECC-498D-A46D-90A0ABE23D74}'
+- Architecture: x86
+  InstallerUrl: https://github.com/DataDog/dd-trace-dotnet/releases/download/v2.10.0/datadog-dotnet-apm-2.10.0-x86.msi
+  InstallerSha256: 7EAEAEBB519018208DB7EF526129C24D1491808057FBB8F17A595E89A45C2AF3
+  ProductCode: '{1D5F6AB9-7405-4641-A53E-87A8720436FB}'
+ManifestType: installer
+ManifestVersion: 1.1.0

--- a/manifests/d/Datadog/dd-trace-dotnet/2.10.0/Datadog.dd-trace-dotnet.locale.en-US.yaml
+++ b/manifests/d/Datadog/dd-trace-dotnet/2.10.0/Datadog.dd-trace-dotnet.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-4
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+
+PackageIdentifier: Datadog.dd-trace-dotnet
+PackageVersion: 2.10.0
+PackageLocale: en-US
+Publisher: Datadog, Inc.
+PublisherUrl: https://docs.datadoghq.com/
+PublisherSupportUrl: https://www.datadoghq.com/support/
+PrivacyUrl: https://www.datadoghq.com/legal/privacy/
+Author: Datadog
+PackageName: Datadog .NET Tracer
+PackageUrl: https://docs.datadoghq.com/tracing/
+License: Apache-2.0
+LicenseUrl: https://github.com/DataDog/dd-trace-dotnet/blob/master/LICENSE
+Copyright: Copyright 2017 Datadog, Inc.
+CopyrightUrl: https://github.com/DataDog/dd-trace-dotnet/blob/master/NOTICE
+ShortDescription: Automatic instrumentation for .NET applications
+# Description: 
+Moniker: dd-trace-dotnet
+Tags:
+- apm
+- tracing
+# Agreements: 
+# ReleaseNotes: 
+ReleaseNotesUrl: https://github.com/DataDog/dd-trace-dotnet/releases/tag/v2.10.0
+ManifestType: defaultLocale
+ManifestVersion: 1.1.0

--- a/manifests/d/Datadog/dd-trace-dotnet/2.10.0/Datadog.dd-trace-dotnet.yaml
+++ b/manifests/d/Datadog/dd-trace-dotnet/2.10.0/Datadog.dd-trace-dotnet.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-4
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+
+PackageIdentifier: Datadog.dd-trace-dotnet
+PackageVersion: 2.10.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.1.0


### PR DESCRIPTION
### Result: Installation Successful
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | Datadog .NET Tracer | Datadog .NET Tracer 64-bit    |
| Version     | 2.10.0     | 2.10.0 |
| Publisher   | Datadog, Inc.   | Datadog, Inc.      |
| ProductCode | {3DF2530B-DECC-498D-A46D-90A0ABE23D74}          | {3DF2530B-DECC-498D-A46D-90A0ABE23D74}    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://github.com/vedantmgoyal2009/vedantmgoyal2009/tree/main/winget-pkgs-automation) in workflow run [2033](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/2467653603>)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/63165)