### PR TITLE
New version: qishibo.AnotherRedisDesktopManager version 1.5.6

### DIFF
--- a/manifests/q/qishibo/AnotherRedisDesktopManager/1.5.6/qishibo.AnotherRedisDesktopManager.installer.yaml
+++ b/manifests/q/qishibo/AnotherRedisDesktopManager/1.5.6/qishibo.AnotherRedisDesktopManager.installer.yaml
@@ -1,0 +1,28 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-4
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+
+PackageIdentifier: qishibo.AnotherRedisDesktopManager
+PackageVersion: 1.5.6
+InstallerLocale: en-US
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+ReleaseDate: 2022-06-07
+Installers:
+- Architecture: x64
+  Scope: user
+  InstallerUrl: https://github.com/qishibo/AnotherRedisDesktopManager/releases/download/v1.5.6/Another-Redis-Desktop-Manager.1.5.6.exe
+  InstallerSha256: 46473BE9018335D776A667EF447AD059239EBFD72A098E8CF787CE214323A873
+  InstallerSwitches:
+    Custom: /CURRENTUSER
+- Architecture: x64
+  Scope: machine
+  InstallerUrl: https://github.com/qishibo/AnotherRedisDesktopManager/releases/download/v1.5.6/Another-Redis-Desktop-Manager.1.5.6.exe
+  InstallerSha256: 46473BE9018335D776A667EF447AD059239EBFD72A098E8CF787CE214323A873
+  InstallerSwitches:
+    Custom: /ALLUSERS
+ManifestType: installer
+ManifestVersion: 1.1.0

--- a/manifests/q/qishibo/AnotherRedisDesktopManager/1.5.6/qishibo.AnotherRedisDesktopManager.locale.en-US.yaml
+++ b/manifests/q/qishibo/AnotherRedisDesktopManager/1.5.6/qishibo.AnotherRedisDesktopManager.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-4
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+
+PackageIdentifier: qishibo.AnotherRedisDesktopManager
+PackageVersion: 1.5.6
+PackageLocale: en-US
+Publisher: Another
+PublisherUrl: https://github.com/qishibo/AnotherRedisDesktopManager
+PublisherSupportUrl: https://github.com/qishibo/AnotherRedisDesktopManager/issues
+# PrivacyUrl: 
+Author: qii404.me
+PackageName: Another Redis Desktop Manager
+PackageUrl: https://github.com/qishibo/AnotherRedisDesktopManager
+License: MIT License
+LicenseUrl: https://raw.githubusercontent.com/qishibo/AnotherRedisDesktopManager/master/LICENSE
+Copyright: Copyright (c) qii404.me
+CopyrightUrl: https://raw.githubusercontent.com/qishibo/AnotherRedisDesktopManager/master/LICENSE
+ShortDescription: A faster, better and more stable redis desktop manager.
+Description: A faster, better and more stable redis desktop manager [GUI client], compatible with Linux, Windows, Mac. What's more, it won't crash when loading a large number of keys.
+# Moniker: 
+Tags:
+- redis-cluster
+- redis-desktop-manager
+- redis-gui-client
+- redis-sentinel
+- redis-ssh-ssl
+# Agreements: 
+# ReleaseNotes: 
+ReleaseNotesUrl: https://github.com/qishibo/AnotherRedisDesktopManager/releases/tag/v1.5.6
+ManifestType: defaultLocale
+ManifestVersion: 1.1.0

--- a/manifests/q/qishibo/AnotherRedisDesktopManager/1.5.6/qishibo.AnotherRedisDesktopManager.yaml
+++ b/manifests/q/qishibo/AnotherRedisDesktopManager/1.5.6/qishibo.AnotherRedisDesktopManager.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-4
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+
+PackageIdentifier: qishibo.AnotherRedisDesktopManager
+PackageVersion: 1.5.6
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.1.0


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | Another Redis Desktop Manager |     |
| Version     | 1.5.6     |  |
| Publisher   | Another   |       |
| ProductCode |           |     |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://github.com/vedantmgoyal2009/vedantmgoyal2009/tree/main/winget-pkgs-automation) in workflow run [2069](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/2478375144>)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/63314)