### PR TITLE
New version: UniversalMediaServer.UniversalMediaServer version 11.1.0

### DIFF
--- a/manifests/u/UniversalMediaServer/UniversalMediaServer/11.1.0/UniversalMediaServer.UniversalMediaServer.installer.yaml
+++ b/manifests/u/UniversalMediaServer/UniversalMediaServer/11.1.0/UniversalMediaServer.UniversalMediaServer.installer.yaml
@@ -1,0 +1,22 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-4
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+
+PackageIdentifier: UniversalMediaServer.UniversalMediaServer
+PackageVersion: 11.1.0
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+Scope: machine
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+ReleaseDate: 2022-06-15
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/UniversalMediaServer/UniversalMediaServer/releases/download/11.1.0/UMS-11.1.0.exe
+  InstallerSha256: A63E258FD7769A74C1C559E0F80B8AB11687B202880393007CCE225DAD2F00BD
+ManifestType: installer
+ManifestVersion: 1.1.0

--- a/manifests/u/UniversalMediaServer/UniversalMediaServer/11.1.0/UniversalMediaServer.UniversalMediaServer.locale.en-US.yaml
+++ b/manifests/u/UniversalMediaServer/UniversalMediaServer/11.1.0/UniversalMediaServer.UniversalMediaServer.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-4
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+
+PackageIdentifier: UniversalMediaServer.UniversalMediaServer
+PackageVersion: 11.1.0
+PackageLocale: en-US
+Publisher: Universial Media Server
+PublisherUrl: https://www.universalmediaserver.com
+PublisherSupportUrl: https://github.com/UniversalMediaServer/UniversalMediaServer/issues
+# PrivacyUrl: 
+# Author: 
+PackageName: Universal Media Server
+PackageUrl: https://github.com/UniversalMediaServer/UniversalMediaServer
+License: GNU General Public License v2.0 (GPLv2)
+LicenseUrl: https://raw.githubusercontent.com/UniversalMediaServer/UniversalMediaServer/master/LICENSE.txt
+# Copyright: 
+CopyrightUrl: https://raw.githubusercontent.com/UniversalMediaServer/UniversalMediaServer/master/LICENSE.txt
+ShortDescription: Universal Media Server is a DLNA-compliant UPnP Media Server. It is capable of sharing video, audio and images between most modern devices.
+# Description: 
+# Moniker: 
+Tags:
+- dlna
+- media-server
+# Agreements: 
+# ReleaseNotes: 
+ReleaseNotesUrl: https://github.com/UniversalMediaServer/UniversalMediaServer/releases/tag/11.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.1.0

--- a/manifests/u/UniversalMediaServer/UniversalMediaServer/11.1.0/UniversalMediaServer.UniversalMediaServer.yaml
+++ b/manifests/u/UniversalMediaServer/UniversalMediaServer/11.1.0/UniversalMediaServer.UniversalMediaServer.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-4
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+
+PackageIdentifier: UniversalMediaServer.UniversalMediaServer
+PackageVersion: 11.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.1.0


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | Universal Media Server | Octopus Deploy Server, Signal 5.45.1, Signal Beta 5.46.0-beta.2    |
| Version     | 11.1.0     | 2022.2.6729, 5.45.1, 5.46.0-beta.2 |
| Publisher   | Universial Media Server   | Octopus Deploy Pty. Ltd., Signal Messenger, LLC, Signal Messenger, LLC      |
| ProductCode |           | {50267D5C-33B3-49A8-B750-E870AD9600D1}, 7d96caee-06e6-597c-9f2f-c7bb2e0948b4, b39ac3a0-cc73-5ec2-ba18-5ab3c4de1ca1    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://github.com/vedantmgoyal2009/vedantmgoyal2009/tree/main/winget-pkgs-automation) in workflow run [2163](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/2500837041>)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/63644)