### PR TITLE
DuongDieuPhap.ImageGlass: fix sha256 sum for newer ImageGlass_Kobe_8.6.7.13_x64.msi

### DIFF
--- a/manifests/d/DuongDieuPhap/ImageGlass/8.6.7.13/DuongDieuPhap.ImageGlass.installer.yaml
+++ b/manifests/d/DuongDieuPhap/ImageGlass/8.6.7.13/DuongDieuPhap.ImageGlass.installer.yaml
@@ -61,7 +61,7 @@ ReleaseDate: 2022-06-13
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/d2phap/ImageGlass/releases/download/8.6.7.13/ImageGlass_Kobe_8.6.7.13_x64.msi
-  InstallerSha256: E0F65A63EB3AEE292C0D7C36D3B5E33CEC37BF374658CBE2292E5E56010308DD
+  InstallerSha256: FB6E2A1181EC620B93A75B585236AB13175C607C95D48F72CBFEB40CDA966119
   ProductCode: '{15872342-C9E9-4C65-9586-35B4EFDB806B}'
 - Architecture: x86
   InstallerUrl: https://github.com/d2phap/ImageGlass/releases/download/8.6.7.13/ImageGlass_Kobe_8.6.7.13_x86.msi


### PR DESCRIPTION
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.1 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.1.0)?

-----

The latest 64bit msi got re-released due to an install location bug, and the same version number was reused:
https://github.com/d2phap/ImageGlass/issues/1365

This fixes the checksum so winget is happy.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/63751)