### PR TITLE
New version: TomWatson.BreakTimer version 1.2.0

### DIFF
--- a/manifests/t/TomWatson/BreakTimer/1.2.0/TomWatson.BreakTimer.installer.yaml
+++ b/manifests/t/TomWatson/BreakTimer/1.2.0/TomWatson.BreakTimer.installer.yaml
@@ -1,0 +1,19 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-4
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+
+PackageIdentifier: TomWatson.BreakTimer
+PackageVersion: 1.2.0
+InstallerLocale: en-US
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2022-06-16
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/tom-james-watson/breaktimer-app/releases/download/v1.2.0/BreakTimer.exe
+  InstallerSha256: FDADDA85A982743F57F65C8A76A95B067D10C8C85F6FC8AC520CF84D8A86AD8F
+ManifestType: installer
+ManifestVersion: 1.1.0

--- a/manifests/t/TomWatson/BreakTimer/1.2.0/TomWatson.BreakTimer.locale.en-US.yaml
+++ b/manifests/t/TomWatson/BreakTimer/1.2.0/TomWatson.BreakTimer.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-4
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+
+PackageIdentifier: TomWatson.BreakTimer
+PackageVersion: 1.2.0
+PackageLocale: en-US
+Publisher: Tom Watson
+# PublisherUrl: 
+# PublisherSupportUrl: 
+# PrivacyUrl: 
+Author: Tom Watson
+PackageName: BreakTimer
+PackageUrl: https://breaktimer.app/
+License: GPL-3.0
+LicenseUrl: https://github.com/tom-james-watson/breaktimer-app/blob/master/LICENSE.md
+Copyright: Copyright © 2019 Thomas James Watson
+# CopyrightUrl: 
+ShortDescription: BreakTimer is a desktop application for managing and enforcing periodic breaks.
+# Description: 
+# Moniker: 
+Tags:
+- cross-platform
+- open-source
+- timer
+# Agreements: 
+# ReleaseNotes: 
+ReleaseNotesUrl: https://github.com/tom-james-watson/breaktimer-app/releases/tag/v1.2.0
+ManifestType: defaultLocale
+ManifestVersion: 1.1.0

--- a/manifests/t/TomWatson/BreakTimer/1.2.0/TomWatson.BreakTimer.yaml
+++ b/manifests/t/TomWatson/BreakTimer/1.2.0/TomWatson.BreakTimer.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-4
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+
+PackageIdentifier: TomWatson.BreakTimer
+PackageVersion: 1.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.1.0


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | BreakTimer | Signal 5.46.0, Signal Beta 5.47.0-beta.1, Kate    |
| Version     | 1.2.0     | 5.46.0, 5.47.0-beta.1, 22.04.2 |
| Publisher   | Tom Watson   | Signal Messenger, LLC, Signal Messenger, LLC, KDE e.V.      |
| ProductCode |           | 7d96caee-06e6-597c-9f2f-c7bb2e0948b4, b39ac3a0-cc73-5ec2-ba18-5ab3c4de1ca1, Kate    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://github.com/vedantmgoyal2009/vedantmgoyal2009/tree/main/winget-pkgs-automation) in workflow run [2204](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/2513491084>)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/63821)