### PR TITLE
Viminstaller requires elevation

### DIFF
--- a/manifests/v/vim/vim/8.2.5136/vim.vim.installer.yaml
+++ b/manifests/v/vim/vim/8.2.5136/vim.vim.installer.yaml
@@ -22,3 +22,4 @@ Installers:
   InstallerSha256: 027F42AFB3AC13EA27527B541C48BAC634C84CB486591C2ACD9FCB1DAF382840
 ManifestType: installer
 ManifestVersion: 1.1.0
+ElevationRequirement: elevationRequired


### PR DESCRIPTION
The Vim installer wants to write to `C:\Program Files` but doesnt' elevate itself.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.1 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.1.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/64010)