### PR TITLE
New version: ChilliBits.Spice version 0.8.3

### DIFF
--- a/manifests/c/ChilliBits/Spice/0.8.3/ChilliBits.Spice.installer.yaml
+++ b/manifests/c/ChilliBits/Spice/0.8.3/ChilliBits.Spice.installer.yaml
@@ -1,0 +1,22 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-4
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+
+PackageIdentifier: ChilliBits.Spice
+PackageVersion: 0.8.3
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: wix
+Scope: machine
+InstallModes:
+- silent
+UpgradeBehavior: install
+ReleaseDate: 2022-06-24
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/spicelang/spice/releases/download/0.8.3/spice_x64_setup.msi
+  InstallerSha256: 12EDE4FF35A0D14D10F88F583ABAABFA9EC99792A6800459F0CBFFB37D357FA3
+  ProductCode: '{8653716E-5CFE-4701-B245-CC458586B74A}'
+ManifestType: installer
+ManifestVersion: 1.1.0

--- a/manifests/c/ChilliBits/Spice/0.8.3/ChilliBits.Spice.locale.de-DE.yaml
+++ b/manifests/c/ChilliBits/Spice/0.8.3/ChilliBits.Spice.locale.de-DE.yaml
@@ -1,0 +1,26 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-4
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.1.0.schema.json
+
+PackageIdentifier: ChilliBits.Spice
+PackageVersion: 0.8.3
+PackageLocale: de-DE
+Publisher: ChilliBits
+PublisherUrl: https://chillibits.com/
+PublisherSupportUrl: https://www.spicelang.com
+PrivacyUrl: https://www.chillibits.com/en/legal-notice/
+Author: Marc Auberer
+PackageName: Spice
+PackageUrl: https://www.spicelang.com/
+# License: 
+# LicenseUrl: 
+# Copyright: 
+# CopyrightUrl: 
+ShortDescription: Spice ist eine statisch typisierte, einfach zu lernende und kompilierte Sprache. Sie bietet Unterstützung für Cross-Compiling und eignet sich besonders für systemnahe Programmierung.
+Description: Die Programmiersprache Spice ist eine kompilierte Sprache, die vor allem mit ihrer Ausführungsgeschwindigkeit und der universelle Einsetzbarkeit punkten kann. Spice orientiert sich teilweise an Golang und C, verbessert allerdings einige Dinge durch Abstraktion die die Produktivität negativ beeinflussen.
+# Moniker: 
+# Tags: 
+# Agreements: 
+# ReleaseNotes: 
+# ReleaseNotesUrl: 
+ManifestType: locale
+ManifestVersion: 1.1.0

--- a/manifests/c/ChilliBits/Spice/0.8.3/ChilliBits.Spice.locale.en-US.yaml
+++ b/manifests/c/ChilliBits/Spice/0.8.3/ChilliBits.Spice.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-4
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+
+PackageIdentifier: ChilliBits.Spice
+PackageVersion: 0.8.3
+PackageLocale: en-US
+Publisher: ChilliBits
+PublisherUrl: https://chillibits.com/
+PublisherSupportUrl: https://www.spicelang.com
+PrivacyUrl: https://www.chillibits.com/en/legal-notice/
+Author: Marc Auberer
+PackageName: Spice
+PackageUrl: https://www.spicelang.com
+License: MIT
+LicenseUrl: https://raw.githubusercontent.com/spicelang/spice/main/LICENSE
+Copyright: (c) Marc Auberer 2021-2022
+# CopyrightUrl: 
+ShortDescription: Spice is a statically-typed, easy to use and compiled programming language. It supports cross-compilation and is especially useful for programming close to the system.
+Description: The Spice Programming Language is a compiled language, which can score with it's blazing fast execution time and the universal applicability. Spice is inspired partially by Golang and C, but improves some things by abstraction which could impact ones productivity in a negative way.
+# Moniker: 
+Tags:
+- antlr
+- chillibits
+- cli
+- compiler
+- docker
+- language
+- llvm
+- programming-language
+- spice
+# Agreements: 
+# ReleaseNotes: 
+ReleaseNotesUrl: https://github.com/spicelang/spice/releases/tag/0.8.3
+ManifestType: defaultLocale
+ManifestVersion: 1.1.0

--- a/manifests/c/ChilliBits/Spice/0.8.3/ChilliBits.Spice.yaml
+++ b/manifests/c/ChilliBits/Spice/0.8.3/ChilliBits.Spice.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-4
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+
+PackageIdentifier: ChilliBits.Spice
+PackageVersion: 0.8.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.1.0


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | Spice | 哔哩哔哩 1.2.2, 哔哩哔哩直播姬    |
| Version     | 0.8.3     | 1.2.2, 4.23.3.3769 |
| Publisher   | ChilliBits   | 哔哩哔哩, 上海幻电信息科技有限公司      |
| ProductCode | {8653716E-5CFE-4701-B245-CC458586B74A}          | BiliBili, {81F6F736-F774-4965-A593-1AFD31ABBB35}_is1    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://github.com/vedantmgoyal2009/vedantmgoyal2009/tree/main/winget-pkgs-automation) in workflow run [2333](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/2555078186>)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/64320)