### PR TITLE
New version: Riiid.pollapo version 0.0.49

### DIFF
--- a/manifests/r/Riiid/pollapo/0.0.49/Riiid.pollapo.installer.yaml
+++ b/manifests/r/Riiid/pollapo/0.0.49/Riiid.pollapo.installer.yaml
@@ -1,0 +1,18 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+
+PackageIdentifier: Riiid.pollapo
+PackageVersion: 0.0.49
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: msi
+Scope: machine
+ReleaseDate: 2022-06-30
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/pbkit/pbkit/releases/download/v0.0.49/pollapo-windows-installer.msi
+  InstallerSha256: 21F1F927D6D3C365685431AA5C25FF3895FD51B37EEE0487C99A900232964DCA
+  ProductCode: '{98E0DCD5-F0A6-4700-9BDB-F2292407661F}'
+ManifestType: installer
+ManifestVersion: 1.1.0

--- a/manifests/r/Riiid/pollapo/0.0.49/Riiid.pollapo.locale.en-US.yaml
+++ b/manifests/r/Riiid/pollapo/0.0.49/Riiid.pollapo.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+
+PackageIdentifier: Riiid.pollapo
+PackageVersion: 0.0.49
+PackageLocale: en-US
+Publisher: Riiid
+PublisherUrl: https://github.com/pbkit
+PublisherSupportUrl: https://github.com/pbkit/pbkit/issues
+# PrivacyUrl: 
+Author: Jongho Jeon
+PackageName: pollapo
+PackageUrl: https://github.com/pbkit/pbkit
+License: MIT/APACHE
+LicenseUrl: https://github.com/pbkit/pbkit#license
+# Copyright: 
+CopyrightUrl: https://github.com/pbkit/pbkit#license
+ShortDescription: Riiid protobuf dependency manager
+# Description: 
+# Moniker: 
+# Tags: 
+# Agreements: 
+# ReleaseNotes: 
+ReleaseNotesUrl: https://github.com/pbkit/pbkit/releases/tag/v0.0.49
+ManifestType: defaultLocale
+ManifestVersion: 1.1.0

--- a/manifests/r/Riiid/pollapo/0.0.49/Riiid.pollapo.yaml
+++ b/manifests/r/Riiid/pollapo/0.0.49/Riiid.pollapo.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+
+PackageIdentifier: Riiid.pollapo
+PackageVersion: 0.0.49
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.1.0


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | pollapo | MysteriumVPN 10.11.2, OpenRPA, DataGrip 222.3244.4, PyCharm 222.3244.2, PyCharm Community Edition 222.3244.2, Signal 5.47.0, RunJS 2.5.0, Signal Beta 5.48.0-beta.1    |
| Version     | 0.0.49     | 10.11.2, 1.4.33.0, 222.3244.4, 222.3244.2, 222.3244.2, 5.47.0, 2.5.0, 5.48.0-beta.1 |
| Publisher   | Riiid   | Mysterium Network, OpenRPA ApS, JetBrains s.r.o., JetBrains s.r.o., JetBrains s.r.o., Signal Messenger, LLC, Haas Labs Ltd, Signal Messenger, LLC      |
| ProductCode | {98E0DCD5-F0A6-4700-9BDB-F2292407661F}          | 61bc0e33-8fdb-5d71-92e1-b8e7f5047812, {9489615F-DD60-43E2-8105-DC1253AF6134}, DataGrip 222.3244.4, PyCharm 222.3244.2, PyCharm Community Edition 222.3244.2, 7d96caee-06e6-597c-9f2f-c7bb2e0948b4, 9418672c-b8c4-5f58-bbea-3006241fc04b, b39ac3a0-cc73-5ec2-ba18-5ab3c4de1ca1    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://github.com/vedantmgoyal2009/vedantmgoyal2009/tree/main/winget-pkgs-automation) in workflow run [2467](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/2589958620>)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/64807)