### PR TITLE
MFSTBot: Multiple Reviewers

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1207,13 +1207,40 @@
               "parameters": {}
             },
             {
-              "operator": "not",
+              "operator": "and",
               "operands": [
                 {
-                  "name": "hasLabel",
-                  "parameters": {
-                    "label": "Blocking-Issue"
-                  }
+                  "operator": "not",
+                  "operands": [
+                    {
+                      "name": "hasLabel",
+                      "parameters": {
+                        "label": "Blocking-Issue"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "operator": "not",
+                  "operands": [
+                    {
+                      "name": "hasLabel",
+                      "parameters": {
+                        "label": "Needs-Author-Feedback"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "operator": "not",
+                  "operands": [
+                    {
+                      "name": "hasLabel",
+                      "parameters": {
+                        "label": "Needs-Attention"
+                      }
+                    }
+                  ]
                 }
               ]
             }


### PR DESCRIPTION
This PR should make it so MSFTBot won't approve PR's when 1 moderator approves and another requests changes

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/64927)