### PR TITLE
New version: UniversalMediaServer.UniversalMediaServer version 11.1.1.1

### DIFF
--- a/manifests/u/UniversalMediaServer/UniversalMediaServer/11.1.1.1/UniversalMediaServer.UniversalMediaServer.installer.yaml
+++ b/manifests/u/UniversalMediaServer/UniversalMediaServer/11.1.1.1/UniversalMediaServer.UniversalMediaServer.installer.yaml
@@ -1,0 +1,22 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+
+PackageIdentifier: UniversalMediaServer.UniversalMediaServer
+PackageVersion: 11.1.1.1
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+Scope: machine
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+ReleaseDate: 2022-07-04
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/UniversalMediaServer/UniversalMediaServer/releases/download/11.1.1.1/UMS-11.1.1.1.exe
+  InstallerSha256: A926000133A529FD60170C58FDA5D434E168D00ABCB35ABCA1F973CB595C1DD3
+ManifestType: installer
+ManifestVersion: 1.1.0

--- a/manifests/u/UniversalMediaServer/UniversalMediaServer/11.1.1.1/UniversalMediaServer.UniversalMediaServer.locale.en-US.yaml
+++ b/manifests/u/UniversalMediaServer/UniversalMediaServer/11.1.1.1/UniversalMediaServer.UniversalMediaServer.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+
+PackageIdentifier: UniversalMediaServer.UniversalMediaServer
+PackageVersion: 11.1.1.1
+PackageLocale: en-US
+Publisher: Universial Media Server
+PublisherUrl: https://www.universalmediaserver.com
+PublisherSupportUrl: https://github.com/UniversalMediaServer/UniversalMediaServer/issues
+# PrivacyUrl: 
+# Author: 
+PackageName: Universal Media Server
+PackageUrl: https://github.com/UniversalMediaServer/UniversalMediaServer
+License: GNU General Public License v2.0 (GPLv2)
+LicenseUrl: https://raw.githubusercontent.com/UniversalMediaServer/UniversalMediaServer/master/LICENSE.txt
+# Copyright: 
+CopyrightUrl: https://raw.githubusercontent.com/UniversalMediaServer/UniversalMediaServer/master/LICENSE.txt
+ShortDescription: Universal Media Server is a DLNA-compliant UPnP Media Server. It is capable of sharing video, audio and images between most modern devices.
+# Description: 
+# Moniker: 
+Tags:
+- dlna
+- media-server
+# Agreements: 
+# ReleaseNotes: 
+ReleaseNotesUrl: https://github.com/UniversalMediaServer/UniversalMediaServer/releases/tag/11.1.1.1
+ManifestType: defaultLocale
+ManifestVersion: 1.1.0

--- a/manifests/u/UniversalMediaServer/UniversalMediaServer/11.1.1.1/UniversalMediaServer.UniversalMediaServer.yaml
+++ b/manifests/u/UniversalMediaServer/UniversalMediaServer/11.1.1.1/UniversalMediaServer.UniversalMediaServer.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+
+PackageIdentifier: UniversalMediaServer.UniversalMediaServer
+PackageVersion: 11.1.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.1.0


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | Universal Media Server | ProtonVPN, ProtonVPN, ProtonVPNTap, ProtonVPNTun, Signal 5.48.0, Signal Beta 5.49.0-beta.1    |
| Version     | 11.1.1.1     | 2.0.1, 2.0.1, 1.1.4, 0.13.1, 5.48.0, 5.49.0-beta.1 |
| Publisher   | Universial Media Server   | Proton Technologies AG, Proton Technologies AG, Proton Technologies AG, Proton Technologies AG, Signal Messenger, LLC, Signal Messenger, LLC      |
| ProductCode |           | ProtonVPN 2.0.1, {78E8B570-4551-416B-8F87-6917E1EBBAF9}, {87BDF456-9882-44E6-8FFC-F73B83E42EAD}, {B1EBF050-CC3E-45B0-9DE5-339C6241F3DA}, 7d96caee-06e6-597c-9f2f-c7bb2e0948b4, b39ac3a0-cc73-5ec2-ba18-5ab3c4de1ca1    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://github.com/vedantmgoyal2009/vedantmgoyal2009/tree/main/winget-pkgs-automation) in workflow run [2546](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/2609328441>)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/65082)