### PR TITLE
New version: Riiid.pollapo version 0.0.50

### DIFF
--- a/manifests/r/Riiid/pollapo/0.0.50/Riiid.pollapo.installer.yaml
+++ b/manifests/r/Riiid/pollapo/0.0.50/Riiid.pollapo.installer.yaml
@@ -1,0 +1,18 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+
+PackageIdentifier: Riiid.pollapo
+PackageVersion: 0.0.50
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: msi
+Scope: machine
+ReleaseDate: 2022-07-05
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/pbkit/pbkit/releases/download/v0.0.50/pollapo-windows-installer.msi
+  InstallerSha256: 974E766E36AD30006A477AA7E3E718EAF0E961FC7040A08E5966364A87C98A5D
+  ProductCode: '{AF81B94A-7880-472B-9931-EA798691811D}'
+ManifestType: installer
+ManifestVersion: 1.1.0

--- a/manifests/r/Riiid/pollapo/0.0.50/Riiid.pollapo.locale.en-US.yaml
+++ b/manifests/r/Riiid/pollapo/0.0.50/Riiid.pollapo.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+
+PackageIdentifier: Riiid.pollapo
+PackageVersion: 0.0.50
+PackageLocale: en-US
+Publisher: Riiid
+PublisherUrl: https://github.com/pbkit
+PublisherSupportUrl: https://github.com/pbkit/pbkit/issues
+# PrivacyUrl: 
+Author: Jongho Jeon
+PackageName: pollapo
+PackageUrl: https://github.com/pbkit/pbkit
+License: MIT/APACHE
+LicenseUrl: https://github.com/pbkit/pbkit#license
+# Copyright: 
+CopyrightUrl: https://github.com/pbkit/pbkit#license
+ShortDescription: Riiid protobuf dependency manager
+# Description: 
+# Moniker: 
+# Tags: 
+# Agreements: 
+# ReleaseNotes: 
+ReleaseNotesUrl: https://github.com/pbkit/pbkit/releases/tag/v0.0.50
+ManifestType: defaultLocale
+ManifestVersion: 1.1.0

--- a/manifests/r/Riiid/pollapo/0.0.50/Riiid.pollapo.yaml
+++ b/manifests/r/Riiid/pollapo/0.0.50/Riiid.pollapo.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+
+PackageIdentifier: Riiid.pollapo
+PackageVersion: 0.0.50
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.1.0


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | pollapo | k6, Dolphin, JetBrains Hub 2022.2, Signal 5.48.0, RunJS 2.5.1, Signal Beta 5.49.0-beta.1, Kate, KDE Connect, Kile, Microsoft OneDrive    |
| Version     | 0.0.50     | 0.39.0, 22.04.2, 22.2.14830, 5.48.0, 2.5.1, 5.49.0-beta.1, 22.04.2, 22.04.2, 2.9.93, 22.136.0626.0001 |
| Publisher   | Riiid   | Raintank Inc. d.b.a. Grafana Labs, KDE e.V., JetBrains, Signal Messenger, LLC, Haas Labs Ltd, Signal Messenger, LLC, KDE e.V., KDE e.V., KDE e.V., Microsoft Corporation      |
| ProductCode | {AF81B94A-7880-472B-9931-EA798691811D}          | {1BF72727-E524-4746-8549-C8F48722188F}, Dolphin, {21C8737D-5536-4A3B-9CBA-2339BE734252}, 7d96caee-06e6-597c-9f2f-c7bb2e0948b4, 9418672c-b8c4-5f58-bbea-3006241fc04b, b39ac3a0-cc73-5ec2-ba18-5ab3c4de1ca1, Kate, KDE Connect, Kile, OneDriveSetup.exe    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://github.com/vedantmgoyal2009/vedantmgoyal2009/tree/main/winget-pkgs-automation) in workflow run [2570](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/2616072111>)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/65152)