### PR TITLE
New version: stacks.stacks version 1.9.7

### DIFF
--- a/manifests/s/stacks/stacks/1.9.7/stacks.stacks.installer.yaml
+++ b/manifests/s/stacks/stacks/1.9.7/stacks.stacks.installer.yaml
@@ -1,0 +1,18 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+
+PackageIdentifier: stacks.stacks
+PackageVersion: 1.9.7
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- silent
+UpgradeBehavior: install
+ReleaseDate: 2022-07-05
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/stacks-task-manager/stacks/releases/download/v1.9.7/Stacks-Setup-1.9.7.exe
+  InstallerSha256: 5C5E4D781B3CE051B2A40219A0565A573978EFD42696B129279A347F02A49AAA
+ManifestType: installer
+ManifestVersion: 1.1.0

--- a/manifests/s/stacks/stacks/1.9.7/stacks.stacks.locale.en-US.yaml
+++ b/manifests/s/stacks/stacks/1.9.7/stacks.stacks.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+
+PackageIdentifier: stacks.stacks
+PackageVersion: 1.9.7
+PackageLocale: en-US
+Publisher: Cristian Barlutiu
+PublisherUrl: https://stacks.rocks
+PublisherSupportUrl: https://github.com/stacks-task-manager/stacks/issues
+# PrivacyUrl: 
+Author: Cristian Barlutiu
+PackageName: Stacks
+PackageUrl: https://stacks.rocks
+License: Proprietary
+LicenseUrl: https://stacks.rocks/terms-of-service
+Copyright: © 2021 Stacks. Design with ❤ by Cristian Barlutiu.
+CopyrightUrl: https://stacks.rocks/terms-of-service
+ShortDescription: Stacks is a cross-platform all-in-one project management tool that works on top of a local folder.
+# Description: 
+# Moniker: 
+Tags:
+- cross-platform
+# Agreements: 
+# ReleaseNotes: 
+ReleaseNotesUrl: https://github.com/stacks-task-manager/stacks/releases/tag/v1.9.7
+ManifestType: defaultLocale
+ManifestVersion: 1.1.0

--- a/manifests/s/stacks/stacks/1.9.7/stacks.stacks.yaml
+++ b/manifests/s/stacks/stacks/1.9.7/stacks.stacks.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+
+PackageIdentifier: stacks.stacks
+PackageVersion: 1.9.7
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.1.0


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | Stacks | Dolphin, Plex Media Server, Stopping Plex, Plex Media Server, JetBrains YouTrack 2022.2, JetBrains Hub 2022.2, Signal 5.48.0, Signal Beta 5.49.0-beta.1, KDE Connect, Kile    |
| Version     | 1.9.7     | 22.04.2, 1.27.2.5929, 1.27.2929, 1.27.2929, 22.2.51283, 22.2.14835, 5.48.0, 5.49.0-beta.1, 22.04.2, 2.9.93 |
| Publisher   | Cristian Barlutiu   | KDE e.V., Plex, Inc., Plex, Inc., Plex, Inc., JetBrains, JetBrains, Signal Messenger, LLC, Signal Messenger, LLC, KDE e.V., KDE e.V.      |
| ProductCode |           | Dolphin, {25d7c7bc-288b-4d8a-81bc-4baac9712931}, {6F6FA125-A737-436B-AB8C-AD668E2D25D1}, {C37711DC-ABFD-4374-88A8-A1858EC25B61}, {D39F925B-3C20-409E-9966-743ED04011C7}, {F63E0900-9D14-4C0B-87CF-1423331903C4}, 7d96caee-06e6-597c-9f2f-c7bb2e0948b4, b39ac3a0-cc73-5ec2-ba18-5ab3c4de1ca1, KDE Connect, Kile    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://github.com/vedantmgoyal2009/vedantmgoyal2009/tree/main/winget-pkgs-automation) in workflow run [2581](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/2619382350>)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/65209)