### PR TITLE
Updated Image-Line FL Studio installer to 20.9.2.2963

### DIFF
--- a/manifests/i/ImageLine/FLStudio/20.9.2.2963/ImageLine.FLStudio.installer.yaml
+++ b/manifests/i/ImageLine/FLStudio/20.9.2.2963/ImageLine.FLStudio.installer.yaml
@@ -1,0 +1,16 @@
+# Created with YamlCreate.ps1 v2.0.4 $debug=QUSU.7-2-1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+
+PackageIdentifier: ImageLine.FLStudio
+PackageVersion: 20.9.2.2963
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+InstallerSuccessCodes:
+- 1223
+Installers:
+- Architecture: x64
+  InstallerUrl: https://demodownload.image-line.com/flstudio/flstudio_win64_20.9.2.2963.exe
+  InstallerSha256: 0af2ebe4f6eff8fb35eba8e3ee23fddd10205f11dd2ce7953503504446fcbe14
+  ProductCode: "FL Studio 20"
+ManifestType: installer
+ManifestVersion: 1.1.0

--- a/manifests/i/ImageLine/FLStudio/20.9.2.2963/ImageLine.FLStudio.locale.en-US.yaml
+++ b/manifests/i/ImageLine/FLStudio/20.9.2.2963/ImageLine.FLStudio.locale.en-US.yaml
@@ -1,0 +1,37 @@
+# Created with YamlCreate.ps1 v2.0.4 $debug=QUSU.7-2-1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+
+PackageIdentifier: ImageLine.FLStudio
+PackageVersion: 20.9.2.2963
+PackageLocale: en-US
+Publisher: Image-Line
+PublisherUrl: https://www.image-line.com/
+PublisherSupportUrl: https://www.image-line.com/fl-studio-support/
+PrivacyUrl: https://www.image-line.com/privacy-policy/
+Author: Image Line Software
+PackageName: FL Studio
+PackageUrl: https://www.image-line.com/fl-studio/
+License: Proprietary
+LicenseUrl: https://www.image-line.com/image-line-software-eula/
+# Copyright: 
+# CopyrightUrl: 
+ShortDescription: |
+  Digital Audio Workstation for composing, recording, editing and producing music using samples,  software synthesizers and external MIDI instruments.
+# Description: 
+# Moniker: 
+Tags:
+- audio
+- compose
+- daw
+- digital-audio-workstation
+- loops
+- midi
+- mixing
+- music
+- production
+- vst
+# Agreements: 
+# ReleaseNotes: 
+# ReleaseNotesUrl: 
+ManifestType: defaultLocale
+ManifestVersion: 1.1.0

--- a/manifests/i/ImageLine/FLStudio/20.9.2.2963/ImageLine.FLStudio.yaml
+++ b/manifests/i/ImageLine/FLStudio/20.9.2.2963/ImageLine.FLStudio.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.0.4 $debug=QUSU.7-2-1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+
+PackageIdentifier: ImageLine.FLStudio
+PackageVersion: 20.9.2.2963
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.1.0


### PR DESCRIPTION
Updated the yaml files to include the latest version of FL Studio, version 20.9.2.2963

- [☑ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [☑ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ☑] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [ ☑] Have you tested your manifest locally with `winget install --manifest <path>`?
- [☑ ] Does your manifest conform to the [1.1 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.1.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/65299)