### PR TITLE
Disable Duplicate(?) Task

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -364,7 +364,8 @@
           "project_card"
         ]
       },
-      "id": "xn8_sQh_33"
+      "id": "xn8_sQh_33",
+      "disabled": true
     },
     {
       "taskType": "trigger",


### PR DESCRIPTION
* Resolves #34408

I believe the task on L315-368 has incorrect triggers and is causing the Needs-Author-Feedback label to be removed as it is detecting @wingetbot adding the labels as an event, and thus triggering the action.

I also believe this is duplicate, as the task on L369-415 removes the Needs-Author-Feedback label and replaces it with Needs-Attention when the PR Author comments and the one on L416-462 does the same when responding to Review feedback.

@denelon - I'm not sure if this is the right way of disabling tasks, I just went based on what was in the config for other tasks; I'm  also not sure if it would be better to remove this task entirely; Obviously I can't test this myself, but I don't know if you do either?

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/65410)