### PR TITLE
Remove DisplayVersion from Apple.iTunes version 12.12.4.1

### DIFF
--- a/manifests/a/Apple/iTunes/12.12.4.1/Apple.iTunes.installer.yaml
+++ b/manifests/a/Apple/iTunes/12.12.4.1/Apple.iTunes.installer.yaml
@@ -21,7 +21,6 @@ Installers:
   AppsAndFeaturesEntries:
   - Publisher: Apple Inc.
     DisplayName: iTunes
-    DisplayVersion: 12.12.3.5
     InstallerType: msi
     ProductCode: "{781FFA26-A8FF-47B7-9BFB-5F4FB3A72315}"
 - Architecture: x86
@@ -30,7 +29,6 @@ Installers:
   AppsAndFeaturesEntries:
   - Publisher: Apple Inc.
     DisplayName: iTunes
-    DisplayVersion: 12.12.3.5
     InstallerType: msi
 ManifestType: installer
 ManifestVersion: 1.1.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.1 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.1.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

It is not recommended to utilize DisplayVersion field if the DisplayVersion value is same as the PackageVersion value.
This will cause unnecessary version mapping precheck and make automatic updates more error prone.
This one is 1 example of error that is probably caused by auto update.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/65782)