### PR TITLE
Remove DisplayVersion from Bisq.Bisq version 1.9.4

### DIFF
--- a/manifests/b/Bisq/Bisq/1.9.4/Bisq.Bisq.installer.yaml
+++ b/manifests/b/Bisq/Bisq/1.9.4/Bisq.Bisq.installer.yaml
@@ -19,7 +19,6 @@ ReleaseDate: 2022-07-05
 AppsAndFeaturesEntries:
 - Publisher: Bisq
   DisplayName: Bisq
-  DisplayVersion: 1.8.2
   InstallerType: msi
   ProductCode: '{9BC5C883-B039-3702-89EC-10885DC89194}'
 Installers:


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.1 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.1.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

It is not recommended to utilize DisplayVersion field if the DisplayVersion value is same as the PackageVersion value.
This will cause unnecessary version mapping precheck and make automatic updates more error prone.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/65795)