### PR TITLE
Remove DisplayVersion from HydrusNetwork.HydrusNetwork version v474

### DIFF
--- a/manifests/h/HydrusNetwork/HydrusNetwork/v474/HydrusNetwork.HydrusNetwork.installer.yaml
+++ b/manifests/h/HydrusNetwork/HydrusNetwork/v474/HydrusNetwork.HydrusNetwork.installer.yaml
@@ -21,7 +21,6 @@ Installers:
   AppsAndFeaturesEntries:
   - DisplayName: Hydrus Network
     Publisher: Hydrus Network
-    DisplayVersion: null
     ProductCode: Hydrus Network_is1
 ManifestType: installer
 ManifestVersion: 1.1.0


### PR DESCRIPTION
It is not recommended to utilize DisplayVersion field if the DisplayVersion value is same as the PackageVersion value.
This will cause unnecessary version mapping precheck and make automatic updates more error prone.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.1 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.1.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

HydrusNetwork is a good example to declare DisplayVersion because one of its version has PackageVersion v479a and DisplayVersion V479. So all versions are recommeneded to declare DisplayVersion.
But for earlier versions of HydrusNetwork installers, version info is not available in ARP entry. So removing the null entries.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/65821)