### PR TITLE
Remove DisplayVersion from Microsoft.SQLServerManagementStudio versio…

### DIFF
--- a/manifests/m/Microsoft/SQLServerManagementStudio/15.0.18420.0/Microsoft.SQLServerManagementStudio.installer.yaml
+++ b/manifests/m/Microsoft/SQLServerManagementStudio/15.0.18420.0/Microsoft.SQLServerManagementStudio.installer.yaml
@@ -21,39 +21,30 @@ Installers:
   InstallerSha256: 7A2CF984AB8D6F825DD2116165BB109AE8F6A3D65BCC31EA436602E46046205D
   AppsAndFeaturesEntries:
   - DisplayName: Azure Data Studio
-    DisplayVersion: 1.36.2
     Publisher: Microsoft Corporation
     ProductCode: '{6591F69E-6588-4980-81ED-C8FCBD7EC4B8}_is1'
   - DisplayName: Microsoft ODBC Driver 17 for SQL Server
-    DisplayVersion: 17.7.2.1
     Publisher: Microsoft Corporation
     ProductCode: '{853997DA-6FCB-4FB9-918E-E0FF881FAF65}'
   - DisplayName: Microsoft OLE DB Driver for SQL Server
-    DisplayVersion: 18.5.0.0
     Publisher: Microsoft Corporation
     ProductCode: '{9D6F8754-28E9-4940-B319-3FC8588CF18F}'
   - DisplayName: 'Microsoft SQL Server 2012 Native Client '
-    DisplayVersion: 11.4.7462.6
     Publisher: Microsoft Corporation
     ProductCode: '{9D93D367-A2CC-4378-BD63-79EF3FE76C78}'
   - DisplayName: Microsoft Help Viewer 2.3
-    DisplayVersion: 2.3.28307
     Publisher: Microsoft Corporation
     ProductCode: Microsoft Help Viewer 2.3
   - DisplayName: Microsoft SQL Server Management Studio - 18.12
-    DisplayVersion: 15.0.18420.0
     Publisher: Microsoft Corporation
     ProductCode: '{3a2f0f67-2761-49c7-8eed-06f87895ecb8}'
   - DisplayName: Microsoft Visual C++ 2013 Redistributable (x86) - 12.0.40664
-    DisplayVersion: 12.0.40664.0
     Publisher: Microsoft Corporation
     ProductCode: '{9dff3540-fc85-4ed5-ac84-9e3c7fd8bece}'
   - DisplayName: Microsoft Visual C++ 2015-2019 Redistributable (x86) - 14.29.30135
-    DisplayVersion: 14.29.30135.0
     Publisher: Microsoft Corporation
     ProductCode: '{b7a2b241-3f54-4d7d-94d1-8ce0146e03c7}'
   - DisplayName: Microsoft Visual Studio Tools for Applications 2017
-    DisplayVersion: 15.0.27520
     Publisher: Microsoft Corporation
     ProductCode: '{f895a2f1-ae3f-4212-8af1-7fa1f8c212ea}'
 - InstallerLocale: zh-CN
@@ -64,43 +55,33 @@ Installers:
   InstallerSha256: EEFFF58E327CF6078CE70912A734C6D9EBB7DCD2867A7E4D4C23DF9E1B92F253
   AppsAndFeaturesEntries:
   - DisplayName: Azure Data Studio
-    DisplayVersion: 1.36.2
     Publisher: Microsoft Corporation
     ProductCode: '{6591F69E-6588-4980-81ED-C8FCBD7EC4B8}_is1'
   - DisplayName: Microsoft OLE DB Driver for SQL Server
-    DisplayVersion: 18.5.0.0
     Publisher: Microsoft Corporation
     ProductCode: '{898A728A-CCF2-48F5-96DF-ED18DEBE5A6C}'
   - DisplayName: 'Microsoft SQL Server 2012 Native Client '
-    DisplayVersion: 11.4.7001.0
     Publisher: Microsoft Corporation
     ProductCode: '{926B987C-C8DF-4FC8-85C0-622279D90C45}'
   - DisplayName: Microsoft ODBC Driver 17 for SQL Server
-    DisplayVersion: 17.7.2.1
     Publisher: Microsoft Corporation
     ProductCode: '{BE12E5B1-C477-48F5-981D-5C37B4390E02}'
   - DisplayName: Microsoft Help Viewer 2.3
-    DisplayVersion: 2.3.28307
     Publisher: Microsoft Corporation
     ProductCode: Microsoft Help Viewer 2.3
   - DisplayName: Microsoft Help Viewer 2.3 语言包 - 简体中文
-    DisplayVersion: 2.3.28107
     Publisher: Microsoft Corporation
     ProductCode: Microsoft Help Viewer 2.3 语言包 - 简体中文
   - DisplayName: Microsoft Visual Studio Tools for Applications 2017
-    DisplayVersion: 15.0.27520
     Publisher: Microsoft Corporation
     ProductCode: '{0c55d58e-f393-454d-a676-b23e18f6e5c6}'
   - DisplayName: Microsoft Visual C++ 2013 Redistributable (x86) - 12.0.40664
-    DisplayVersion: 12.0.40664.0
     Publisher: Microsoft Corporation
     ProductCode: '{9dff3540-fc85-4ed5-ac84-9e3c7fd8bece}'
   - DisplayName: Microsoft Visual C++ 2015-2019 Redistributable (x86) - 14.29.30135
-    DisplayVersion: 14.29.30135.0
     Publisher: Microsoft Corporation
     ProductCode: '{b7a2b241-3f54-4d7d-94d1-8ce0146e03c7}'
   - DisplayName: Microsoft SQL Server Management Studio - 18.12
-    DisplayVersion: 15.0.18420.0
     Publisher: Microsoft Corporation
     ProductCode: '{f2ae0b98-b197-4264-80dc-c76f202a0abc}'
 - InstallerLocale: pt-BR
@@ -111,43 +92,33 @@ Installers:
   InstallerSha256: 69CA1833EA3BB8EBEF108F05E8D2838DA3569E203B5F4A7B480758CC1C11B0B8
   AppsAndFeaturesEntries:
   - DisplayName: 'Microsoft SQL Server 2012 Native Client '
-    DisplayVersion: 11.4.7001.0
     Publisher: Microsoft Corporation
     ProductCode: '{028D94E4-71C8-4C5F-A05A-81A51DB424C5}'
   - DisplayName: Microsoft ODBC Driver 17 for SQL Server
-    DisplayVersion: 17.7.2.1
     Publisher: Microsoft Corporation
     ProductCode: '{06153AF7-15CB-43FA-BBB8-FEB88C8A7FBA}'
   - DisplayName: Driver do Microsoft OLE DB para SQL Server
-    DisplayVersion: 18.5.0.0
     Publisher: Microsoft Corporation
     ProductCode: '{3F896CD3-B9DF-4A63-99E3-0689E3B00675}'
   - DisplayName: Azure Data Studio
-    DisplayVersion: 1.36.2
     Publisher: Microsoft Corporation
     ProductCode: '{6591F69E-6588-4980-81ED-C8FCBD7EC4B8}_is1'
   - DisplayName: Microsoft Help Viewer 2.3
-    DisplayVersion: 2.3.28307
     Publisher: Microsoft Corporation
     ProductCode: Microsoft Help Viewer 2.3
   - DisplayName: Pacote de Idiomas do Microsoft Help Viewer 2.3 – PTB
-    DisplayVersion: 2.3.28107
     Publisher: Microsoft Corporation
     ProductCode: Pacote de Idiomas do Microsoft Help Viewer 2.3 – PTB
   - DisplayName: Microsoft SQL Server Management Studio - 18.12
-    DisplayVersion: 15.0.18420.0
     Publisher: Microsoft Corporation
     ProductCode: '{60e1b579-5949-42a6-8444-3cbfbdc4ac07}'
   - DisplayName: Microsoft Visual C++ 2013 Redistributable (x86) - 12.0.40664
-    DisplayVersion: 12.0.40664.0
     Publisher: Microsoft Corporation
     ProductCode: '{9dff3540-fc85-4ed5-ac84-9e3c7fd8bece}'
   - DisplayName: Microsoft Visual C++ 2015-2019 Redistributable (x86) - 14.29.30135
-    DisplayVersion: 14.29.30135.0
     Publisher: Microsoft Corporation
     ProductCode: '{b7a2b241-3f54-4d7d-94d1-8ce0146e03c7}'
   - DisplayName: Microsoft Visual Studio Tools for Applications 2017
-    DisplayVersion: 15.0.27520
     Publisher: Microsoft Corporation
     ProductCode: '{bb83825e-a0ae-4de3-9aa3-3e35e3527050}'
 - InstallerLocale: zh-HK
@@ -158,43 +129,33 @@ Installers:
   InstallerSha256: 9D56075B4A15E1D5C221B4CE21EC6E56104C2D7F4C33DAE6334685F3FD5598CE
   AppsAndFeaturesEntries:
   - DisplayName: Azure Data Studio
-    DisplayVersion: 1.36.2
     Publisher: Microsoft Corporation
     ProductCode: '{6591F69E-6588-4980-81ED-C8FCBD7EC4B8}_is1'
   - DisplayName: Microsoft ODBC Driver 17 for SQL Server
-    DisplayVersion: 17.7.2.1
     Publisher: Microsoft Corporation
     ProductCode: '{6810D011-9A7B-4439-B45B-A5FCC3ECF9F1}'
   - DisplayName: Microsoft OLE DB Driver for SQL Server
-    DisplayVersion: 18.5.0.0
     Publisher: Microsoft Corporation
     ProductCode: '{A0EAE12A-A9B1-4A33-B3D8-9960FFF5B1DE}'
   - DisplayName: 'Microsoft SQL Server 2012 Native Client '
-    DisplayVersion: 11.4.7001.0
     Publisher: Microsoft Corporation
     ProductCode: '{F368D878-6568-4738-982D-F30AFEC42351}'
   - DisplayName: Microsoft Help Viewer 2.3
-    DisplayVersion: 2.3.28307
     Publisher: Microsoft Corporation
     ProductCode: Microsoft Help Viewer 2.3
   - DisplayName: Microsoft Help Viewer 2.3 語言套件 - 繁體中文
-    DisplayVersion: 2.3.28107
     Publisher: Microsoft Corporation
     ProductCode: Microsoft Help Viewer 2.3 語言套件 - 繁體中文
   - DisplayName: Microsoft SQL Server Management Studio - 18.12
-    DisplayVersion: 15.0.18420.0
     Publisher: Microsoft Corporation
     ProductCode: '{13fc542d-3b30-4ffd-b5b2-912163ac0e0a}'
   - DisplayName: Microsoft Visual Studio Tools for Applications 2017
-    DisplayVersion: 15.0.27520
     Publisher: Microsoft Corporation
     ProductCode: '{81be98bb-b243-484d-abe4-273c74132aae}'
   - DisplayName: Microsoft Visual C++ 2013 Redistributable (x86) - 12.0.40664
-    DisplayVersion: 12.0.40664.0
     Publisher: Microsoft Corporation
     ProductCode: '{9dff3540-fc85-4ed5-ac84-9e3c7fd8bece}'
   - DisplayName: Microsoft Visual C++ 2015-2019 Redistributable (x86) - 14.29.30135
-    DisplayVersion: 14.29.30135.0
     Publisher: Microsoft Corporation
     ProductCode: '{b7a2b241-3f54-4d7d-94d1-8ce0146e03c7}'
 - InstallerLocale: zh-TW
@@ -205,43 +166,33 @@ Installers:
   InstallerSha256: 9D56075B4A15E1D5C221B4CE21EC6E56104C2D7F4C33DAE6334685F3FD5598CE
   AppsAndFeaturesEntries:
   - DisplayName: Azure Data Studio
-    DisplayVersion: 1.36.2
     Publisher: Microsoft Corporation
     ProductCode: '{6591F69E-6588-4980-81ED-C8FCBD7EC4B8}_is1'
   - DisplayName: Microsoft ODBC Driver 17 for SQL Server
-    DisplayVersion: 17.7.2.1
     Publisher: Microsoft Corporation
     ProductCode: '{6810D011-9A7B-4439-B45B-A5FCC3ECF9F1}'
   - DisplayName: Microsoft OLE DB Driver for SQL Server
-    DisplayVersion: 18.5.0.0
     Publisher: Microsoft Corporation
     ProductCode: '{A0EAE12A-A9B1-4A33-B3D8-9960FFF5B1DE}'
   - DisplayName: 'Microsoft SQL Server 2012 Native Client '
-    DisplayVersion: 11.4.7001.0
     Publisher: Microsoft Corporation
     ProductCode: '{F368D878-6568-4738-982D-F30AFEC42351}'
   - DisplayName: Microsoft Help Viewer 2.3
-    DisplayVersion: 2.3.28307
     Publisher: Microsoft Corporation
     ProductCode: Microsoft Help Viewer 2.3
   - DisplayName: Microsoft Help Viewer 2.3 語言套件 - 繁體中文
-    DisplayVersion: 2.3.28107
     Publisher: Microsoft Corporation
     ProductCode: Microsoft Help Viewer 2.3 語言套件 - 繁體中文
   - DisplayName: Microsoft SQL Server Management Studio - 18.12
-    DisplayVersion: 15.0.18420.0
     Publisher: Microsoft Corporation
     ProductCode: '{13fc542d-3b30-4ffd-b5b2-912163ac0e0a}'
   - DisplayName: Microsoft Visual Studio Tools for Applications 2017
-    DisplayVersion: 15.0.27520
     Publisher: Microsoft Corporation
     ProductCode: '{81be98bb-b243-484d-abe4-273c74132aae}'
   - DisplayName: Microsoft Visual C++ 2013 Redistributable (x86) - 12.0.40664
-    DisplayVersion: 12.0.40664.0
     Publisher: Microsoft Corporation
     ProductCode: '{9dff3540-fc85-4ed5-ac84-9e3c7fd8bece}'
   - DisplayName: Microsoft Visual C++ 2015-2019 Redistributable (x86) - 14.29.30135
-    DisplayVersion: 14.29.30135.0
     Publisher: Microsoft Corporation
     ProductCode: '{b7a2b241-3f54-4d7d-94d1-8ce0146e03c7}'
 - InstallerLocale: de-DE
@@ -252,43 +203,33 @@ Installers:
   InstallerSha256: 09CCF1603D1787365EC7E04CCA333068D4F2C2DD8AFC4B01BDB5EAE0817B8C0A
   AppsAndFeaturesEntries:
   - DisplayName: Microsoft OLE DB-Treiber für SQL Server
-    DisplayVersion: 18.5.0.0
     Publisher: Microsoft Corporation
     ProductCode: '{574C3699-7886-4E7D-99FF-FB93A2FE7B2E}'
   - DisplayName: Azure Data Studio
-    DisplayVersion: 1.36.2
     Publisher: Microsoft Corporation
     ProductCode: '{6591F69E-6588-4980-81ED-C8FCBD7EC4B8}_is1'
   - DisplayName: Microsoft ODBC Driver 17 for SQL Server
-    DisplayVersion: 17.7.2.1
     Publisher: Microsoft Corporation
     ProductCode: '{97FA5676-7F15-4C39-BFA1-CE67BA1833C2}'
   - DisplayName: 'Microsoft SQL Server 2012 Native Client '
-    DisplayVersion: 11.4.7001.0
     Publisher: Microsoft Corporation
     ProductCode: '{F2A516E0-0769-452C-97F6-D8BFD33681CE}'
   - DisplayName: Microsoft Help Viewer 2.3
-    DisplayVersion: 2.3.28307
     Publisher: Microsoft Corporation
     ProductCode: Microsoft Help Viewer 2.3
   - DisplayName: Microsoft Help Viewer 2.3 Sprachpaket – DEU
-    DisplayVersion: 2.3.28107
     Publisher: Microsoft Corporation
     ProductCode: Microsoft Help Viewer 2.3 Sprachpaket – DEU
   - DisplayName: Microsoft SQL Server Management Studio - 18.12
-    DisplayVersion: 15.0.18420.0
     Publisher: Microsoft Corporation
     ProductCode: '{45a4d505-5b1b-4ba1-bcd7-5f69de9475fd}'
   - DisplayName: Microsoft Visual Studio Tools for Applications 2017
-    DisplayVersion: 15.0.27520
     Publisher: Microsoft Corporation
     ProductCode: '{8157009e-b362-4b95-b907-65abaca13a99}'
   - DisplayName: Microsoft Visual C++ 2013 Redistributable (x86) - 12.0.40664
-    DisplayVersion: 12.0.40664.0
     Publisher: Microsoft Corporation
     ProductCode: '{9dff3540-fc85-4ed5-ac84-9e3c7fd8bece}'
   - DisplayName: Microsoft Visual C++ 2015-2019 Redistributable (x86) - 14.29.30135
-    DisplayVersion: 14.29.30135.0
     Publisher: Microsoft Corporation
     ProductCode: '{b7a2b241-3f54-4d7d-94d1-8ce0146e03c7}'
 - InstallerLocale: fr-FR
@@ -299,43 +240,33 @@ Installers:
   InstallerSha256: 3D7202AAFBC51728DF81E3BDE038FDD42C4AB63002F46D5643EB7603933BBCD8
   AppsAndFeaturesEntries:
   - DisplayName: Microsoft OLE DB Driver pour SQL Server
-    DisplayVersion: 18.5.0.0
     Publisher: Microsoft Corporation
     ProductCode: '{3F4BB75B-C67B-4867-A24B-C4E6F8DB6E04}'
   - DisplayName: Azure Data Studio
-    DisplayVersion: 1.36.2
     Publisher: Microsoft Corporation
     ProductCode: '{6591F69E-6588-4980-81ED-C8FCBD7EC4B8}_is1'
   - DisplayName: 'Microsoft SQL Server 2012 Native Client '
-    DisplayVersion: 11.4.7001.0
     Publisher: Microsoft Corporation
     ProductCode: '{7D31DDA0-0C85-46BC-A1D2-3C763924E831}'
   - DisplayName: Microsoft ODBC Driver 17 for SQL Server
-    DisplayVersion: 17.7.2.1
     Publisher: Microsoft Corporation
     ProductCode: '{D487C5C9-811A-4DFB-8DE5-74F8367894E0}'
   - DisplayName: Microsoft Help Viewer 2.3
-    DisplayVersion: 2.3.28307
     Publisher: Microsoft Corporation
     ProductCode: Microsoft Help Viewer 2.3
   - DisplayName: Module linguistique de Microsoft Help Viewer 2.3 - FRA
-    DisplayVersion: 2.3.28107
     Publisher: Microsoft Corporation
     ProductCode: Module linguistique de Microsoft Help Viewer 2.3 - FRA
   - DisplayName: Microsoft Visual Studio Tools for Applications 2017
-    DisplayVersion: 15.0.27520
     Publisher: Microsoft Corporation
     ProductCode: '{118b2506-76a6-47c2-b050-c01220e7d320}'
   - DisplayName: Microsoft Visual C++ 2013 Redistributable (x86) - 12.0.40664
-    DisplayVersion: 12.0.40664.0
     Publisher: Microsoft Corporation
     ProductCode: '{9dff3540-fc85-4ed5-ac84-9e3c7fd8bece}'
   - DisplayName: Microsoft Visual C++ 2015-2019 Redistributable (x86) - 14.29.30135
-    DisplayVersion: 14.29.30135.0
     Publisher: Microsoft Corporation
     ProductCode: '{b7a2b241-3f54-4d7d-94d1-8ce0146e03c7}'
   - DisplayName: Microsoft SQL Server Management Studio - 18.12
-    DisplayVersion: 15.0.18420.0
     Publisher: Microsoft Corporation
     ProductCode: '{bcf04926-7952-41ad-95e0-97e22075aad2}'
 - InstallerLocale: ja-JP
@@ -346,43 +277,33 @@ Installers:
   InstallerSha256: C44D81E8B246C73FCDF80221C8C5262F5A686EFEB0D8C67E497462FAB0072B40
   AppsAndFeaturesEntries:
   - DisplayName: Azure Data Studio
-    DisplayVersion: 1.36.2
     Publisher: Microsoft Corporation
     ProductCode: '{6591F69E-6588-4980-81ED-C8FCBD7EC4B8}_is1'
   - DisplayName: Microsoft ODBC Driver 17 for SQL Server
-    DisplayVersion: 17.7.2.1
     Publisher: Microsoft Corporation
     ProductCode: '{A0F0B766-E003-4F49-BBEB-B1F3755B15A6}'
   - DisplayName: Microsoft OLE DB Driver for SQL Server
-    DisplayVersion: 18.5.0.0
     Publisher: Microsoft Corporation
     ProductCode: '{E3C2C90A-9F67-42E5-8DEE-02B8BE07E9D3}'
   - DisplayName: 'Microsoft SQL Server 2012 Native Client '
-    DisplayVersion: 11.4.7001.0
     Publisher: Microsoft Corporation
     ProductCode: '{EE258404-BFBA-460F-B256-16CADF407713}'
   - DisplayName: Microsoft Help Viewer 2.3
-    DisplayVersion: 2.3.28307
     Publisher: Microsoft Corporation
     ProductCode: Microsoft Help Viewer 2.3
   - DisplayName: Microsoft ヘルプ ビューアー 2.3 Language Pack - 日本語
-    DisplayVersion: 2.3.28107
     Publisher: Microsoft Corporation
     ProductCode: Microsoft ヘルプ ビューアー 2.3 Language Pack - 日本語
   - DisplayName: Microsoft Visual Studio Tools for Applications 2017
-    DisplayVersion: 15.0.27520
     Publisher: Microsoft Corporation
     ProductCode: '{7286d177-10c0-47da-8f9b-b3d5779061d8}'
   - DisplayName: Microsoft Visual C++ 2013 Redistributable (x86) - 12.0.40664
-    DisplayVersion: 12.0.40664.0
     Publisher: Microsoft Corporation
     ProductCode: '{9dff3540-fc85-4ed5-ac84-9e3c7fd8bece}'
   - DisplayName: Microsoft SQL Server Management Studio - 18.12
-    DisplayVersion: 15.0.18420.0
     Publisher: Microsoft Corporation
     ProductCode: '{b5ab066d-c8bf-46e4-8fe0-2c544f058ffe}'
   - DisplayName: Microsoft Visual C++ 2015-2019 Redistributable (x86) - 14.29.30135
-    DisplayVersion: 14.29.30135.0
     Publisher: Microsoft Corporation
     ProductCode: '{b7a2b241-3f54-4d7d-94d1-8ce0146e03c7}'
 - InstallerLocale: ru-RU
@@ -393,43 +314,33 @@ Installers:
   InstallerSha256: BD1D19F80BBF453371AF1AB7879A68D0B52A7EE344CF21103AC7161846861FD6
   AppsAndFeaturesEntries:
   - DisplayName: Microsoft OLE DB Driver for SQL Server
-    DisplayVersion: 18.5.0.0
     Publisher: Microsoft Corporation
     ProductCode: '{05D10238-AB41-4669-AFD3-78CF3C554E65}'
   - DisplayName: 'Microsoft SQL Server 2012 Native Client '
-    DisplayVersion: 11.4.7001.0
     Publisher: Microsoft Corporation
     ProductCode: '{110D001D-425D-4389-A776-4A5F2A7EA9C3}'
   - DisplayName: Azure Data Studio
-    DisplayVersion: 1.36.2
     Publisher: Microsoft Corporation
     ProductCode: '{6591F69E-6588-4980-81ED-C8FCBD7EC4B8}_is1'
   - DisplayName: Microsoft ODBC Driver 17 for SQL Server
-    DisplayVersion: 17.7.2.1
     Publisher: Microsoft Corporation
     ProductCode: '{87599C69-DA25-443B-B0CA-5D5460879088}'
   - DisplayName: Microsoft Help Viewer 2.3
-    DisplayVersion: 2.3.28307
     Publisher: Microsoft Corporation
     ProductCode: Microsoft Help Viewer 2.3
   - DisplayName: Microsoft SQL Server Management Studio - 18.12
-    DisplayVersion: 15.0.18420.0
     Publisher: Microsoft Corporation
     ProductCode: '{00dba8f3-dc1b-430b-bb23-0db28e02ef33}'
   - DisplayName: Microsoft Visual Studio Tools for Applications 2017
-    DisplayVersion: 15.0.27520
     Publisher: Microsoft Corporation
     ProductCode: '{842d50e0-4d38-4922-adc3-2763d61a0f59}'
   - DisplayName: Microsoft Visual C++ 2013 Redistributable (x86) - 12.0.40664
-    DisplayVersion: 12.0.40664.0
     Publisher: Microsoft Corporation
     ProductCode: '{9dff3540-fc85-4ed5-ac84-9e3c7fd8bece}'
   - DisplayName: Microsoft Visual C++ 2015-2019 Redistributable (x86) - 14.29.30135
-    DisplayVersion: 14.29.30135.0
     Publisher: Microsoft Corporation
     ProductCode: '{b7a2b241-3f54-4d7d-94d1-8ce0146e03c7}'
   - DisplayName: Языковой пакет для окна справки (Майкрософт) 2.3 — RUS
-    DisplayVersion: 2.3.28107
     Publisher: Microsoft Corporation
     ProductCode: Языковой пакет для окна справки (Майкрософт) 2.3 — RUS
 - InstallerLocale: ko-KR
@@ -440,43 +351,33 @@ Installers:
   InstallerSha256: 6543C3807C13166DFE15212BBFA9A1FC519CB9F585E1783329AF9A1CA237BB8F
   AppsAndFeaturesEntries:
   - DisplayName: Microsoft OLE DB Driver for SQL Server
-    DisplayVersion: 18.5.0.0
     Publisher: Microsoft Corporation
     ProductCode: '{357B0902-55EE-40F6-8355-E95A93633BCD}'
   - DisplayName: Azure Data Studio
-    DisplayVersion: 1.36.2
     Publisher: Microsoft Corporation
     ProductCode: '{6591F69E-6588-4980-81ED-C8FCBD7EC4B8}_is1'
   - DisplayName: Microsoft ODBC Driver 17 for SQL Server
-    DisplayVersion: 17.7.2.1
     Publisher: Microsoft Corporation
     ProductCode: '{877E5BB1-DFD1-405A-8173-8A34F8F3E174}'
   - DisplayName: 'Microsoft SQL Server 2012 Native Client '
-    DisplayVersion: 11.4.7001.0
     Publisher: Microsoft Corporation
     ProductCode: '{CDC0B879-389B-4192-A25A-02EFDB672EF1}'
   - DisplayName: Microsoft Help Viewer 2.3
-    DisplayVersion: 2.3.28307
     Publisher: Microsoft Corporation
     ProductCode: Microsoft Help Viewer 2.3
   - DisplayName: Microsoft 도움말 뷰어 2.3 언어 팩 - 한국어
-    DisplayVersion: 2.3.28107
     Publisher: Microsoft Corporation
     ProductCode: Microsoft 도움말 뷰어 2.3 언어 팩 - 한국어
   - DisplayName: Microsoft Visual Studio Tools for Applications 2017
-    DisplayVersion: 15.0.27520
     Publisher: Microsoft Corporation
     ProductCode: '{54a954a6-5135-4734-8e93-9a5d24462a82}'
   - DisplayName: Microsoft SQL Server Management Studio - 18.12
-    DisplayVersion: 15.0.18420.0
     Publisher: Microsoft Corporation
     ProductCode: '{6dc2cf06-a8a4-40d9-9adf-5486330e5905}'
   - DisplayName: Microsoft Visual C++ 2013 Redistributable (x86) - 12.0.40664
-    DisplayVersion: 12.0.40664.0
     Publisher: Microsoft Corporation
     ProductCode: '{9dff3540-fc85-4ed5-ac84-9e3c7fd8bece}'
   - DisplayName: Microsoft Visual C++ 2015-2019 Redistributable (x86) - 14.29.30135
-    DisplayVersion: 14.29.30135.0
     Publisher: Microsoft Corporation
     ProductCode: '{b7a2b241-3f54-4d7d-94d1-8ce0146e03c7}'
 - InstallerLocale: it-IT
@@ -487,43 +388,33 @@ Installers:
   InstallerSha256: 41A5E610264A32CFBF2DBB908BB901DAC9F42BA6B1FC6DFBB3D908736A6E8B2C
   AppsAndFeaturesEntries:
   - DisplayName: Azure Data Studio
-    DisplayVersion: 1.36.2
     Publisher: Microsoft Corporation
     ProductCode: '{6591F69E-6588-4980-81ED-C8FCBD7EC4B8}_is1'
   - DisplayName: Microsoft OLE DB Driver per SQL Server
-    DisplayVersion: 18.5.0.0
     Publisher: Microsoft Corporation
     ProductCode: '{85240195-672B-4FB0-A626-2033D00F34F2}'
   - DisplayName: Microsoft ODBC Driver 17 for SQL Server
-    DisplayVersion: 17.7.2.1
     Publisher: Microsoft Corporation
     ProductCode: '{A0FEFFC3-59BE-44AF-ADB5-0E8DA873CC74}'
   - DisplayName: Microsoft SQL Server 2012 Native Client
-    DisplayVersion: 11.4.7001.0
     Publisher: Microsoft Corporation
     ProductCode: '{BF1A4DAE-5CD6-4830-A850-61F047F7CA51}'
   - DisplayName: Microsoft Help Viewer 2.3
-    DisplayVersion: 2.3.28307
     Publisher: Microsoft Corporation
     ProductCode: Microsoft Help Viewer 2.3
   - DisplayName: Microsoft Help Viewer 2.3 Language Pack - ITA
-    DisplayVersion: 2.3.28107
     Publisher: Microsoft Corporation
     ProductCode: Microsoft Help Viewer 2.3 Language Pack - ITA
   - DisplayName: Microsoft Visual C++ 2013 Redistributable (x86) - 12.0.40664
-    DisplayVersion: 12.0.40664.0
     Publisher: Microsoft Corporation
     ProductCode: '{9dff3540-fc85-4ed5-ac84-9e3c7fd8bece}'
   - DisplayName: Microsoft Visual C++ 2015-2019 Redistributable (x86) - 14.29.30135
-    DisplayVersion: 14.29.30135.0
     Publisher: Microsoft Corporation
     ProductCode: '{b7a2b241-3f54-4d7d-94d1-8ce0146e03c7}'
   - DisplayName: Microsoft SQL Server Management Studio - 18.12
-    DisplayVersion: 15.0.18420.0
     Publisher: Microsoft Corporation
     ProductCode: '{bdde6806-317e-4833-b50d-55bdbb7c687d}'
   - DisplayName: Microsoft Visual Studio Tools for Applications 2017
-    DisplayVersion: 15.0.27520
     Publisher: Microsoft Corporation
     ProductCode: '{c41d26bb-6f64-4711-bae6-e53e04d6d316}'
 - InstallerLocale: es-ES
@@ -534,43 +425,33 @@ Installers:
   InstallerSha256: 866D4C3D90E2133731D33BFB00422426B63F7BFB56997B92F846985011F1E765
   AppsAndFeaturesEntries:
   - DisplayName: Azure Data Studio
-    DisplayVersion: 1.36.2
     Publisher: Microsoft Corporation
     ProductCode: '{6591F69E-6588-4980-81ED-C8FCBD7EC4B8}_is1'
   - DisplayName: Microsoft OLE DB Driver for SQL Server
-    DisplayVersion: 18.5.0.0
     Publisher: Microsoft Corporation
     ProductCode: '{7D510BD2-8D34-452D-B49C-169794B2D7F6}'
   - DisplayName: Microsoft ODBC Driver 17 for SQL Server
-    DisplayVersion: 17.7.2.1
     Publisher: Microsoft Corporation
     ProductCode: '{8E5EDD27-DFE5-4EA4-9FDA-82575CB8246B}'
   - DisplayName: 'Microsoft SQL Server 2012 Native Client '
-    DisplayVersion: 11.4.7001.0
     Publisher: Microsoft Corporation
     ProductCode: '{DE88C943-05AB-4969-BD26-3E92B732389E}'
   - DisplayName: Microsoft Help Viewer 2.3
-    DisplayVersion: 2.3.28307
     Publisher: Microsoft Corporation
     ProductCode: Microsoft Help Viewer 2.3
   - DisplayName: Paquete de idioma de Visor de Ayuda de Microsoft 2.3 - ESN
-    DisplayVersion: 2.3.28107
     Publisher: Microsoft Corporation
     ProductCode: Paquete de idioma de Visor de Ayuda de Microsoft 2.3 - ESN
   - DisplayName: Microsoft SQL Server Management Studio - 18.12
-    DisplayVersion: 15.0.18420.0
     Publisher: Microsoft Corporation
     ProductCode: '{2f64147b-c336-48de-92bd-b9be08e0eca3}'
   - DisplayName: Microsoft Visual C++ 2013 Redistributable (x86) - 12.0.40664
-    DisplayVersion: 12.0.40664.0
     Publisher: Microsoft Corporation
     ProductCode: '{9dff3540-fc85-4ed5-ac84-9e3c7fd8bece}'
   - DisplayName: Microsoft Visual C++ 2015-2019 Redistributable (x86) - 14.29.30135
-    DisplayVersion: 14.29.30135.0
     Publisher: Microsoft Corporation
     ProductCode: '{b7a2b241-3f54-4d7d-94d1-8ce0146e03c7}'
   - DisplayName: Microsoft Visual Studio Tools for Applications 2017
-    DisplayVersion: 15.0.27520
     Publisher: Microsoft Corporation
     ProductCode: '{c0c54024-d566-4b3c-ab26-37e60c334a53}'
 ManifestType: installer


### PR DESCRIPTION
It is not recommended to utilize DisplayVersion field if the DisplayVersion value is same as the PackageVersion value.
This will cause unnecessary version mapping precheck and make automatic updates more error prone.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.1 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.1.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

DisplayVersion should be declared for main component only for multi-component installers at the moment due to the lack of multi-component concept across winget.
For this package, DisplayVersion has same value as PackageVersion.
It is not recommended to utilize DisplayVersion field if the DisplayVersion value is same as the PackageVersion value.
This will cause unnecessary version mapping precheck and make automatic updates more error prone.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/65826)