### PR TITLE
Remove DisplayVersion from Microsoft.WindowsSDK version 10.0.19041.685

### DIFF
--- a/manifests/m/Microsoft/WindowsSDK/10.0.19041.685/Microsoft.WindowsSDK.installer.yaml
+++ b/manifests/m/Microsoft/WindowsSDK/10.0.19041.685/Microsoft.WindowsSDK.installer.yaml
@@ -12,279 +12,210 @@ Installers:
     SilentWithProgress: /q
   AppsAndFeaturesEntries:
   - DisplayName: Application Verifier x64 External Package
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft
     ProductCode: '{8A4CD158-E6B3-6D91-D7DE-10098BC980E2}'
   - DisplayName: Universal CRT Tools x64
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{CD06199B-41C1-AE6D-7567-984CC68792C3}'
   - DisplayName: Windows App Certification Kit Native Components
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{D2886D0B-F38D-EB07-2108-B6218761F8F9}'
   - DisplayName: Windows SDK DirectX x64 Remote
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{EBD149F6-9F46-49E4-ED99-25D2A0ECDBBD}'
   - DisplayName: Windows SDK Desktop Tools arm64
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{06E580FA-F3B2-08E9-4DC0-0AB55D985CBB}'
   - DisplayName: Windows IoT Extension SDK
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{084094EF-6AC9-480A-7CC1-04199047BBDD}'
   - DisplayName: WinRT Intellisense UAP - en-us
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{0AF3B821-474B-1885-473A-6E3FB4F1CF71}'
   - DisplayName: Windows SDK for Windows Store Apps DirectX x86 Remote
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{0E2FEA3B-C853-DE2A-8A04-BB7D5BF010E0}'
   - DisplayName: WinRT Intellisense PPI - en-us
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{15E29AFF-CB19-A20B-9A81-B0765A63115F}'
   - DisplayName: Windows SDK Desktop Libs x64
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{170B023D-7C1B-2EF4-D3E9-B974A26752AC}'
   - DisplayName: SDK Debuggers
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{1B2DE43F-91D0-EE1E-7C9C-EF16064EB04C}'
   - DisplayName: Windows SDK Desktop Tools x86
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{1C966E96-8553-EF1E-A06F-A8174B3CAA60}'
   - DisplayName: Windows SDK for Windows Store Apps Libs
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{1FBBD022-F751-FE7B-54DF-9FED23892B2F}'
   - DisplayName: WinRT Intellisense IoT - Other Languages
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{216D5F47-257D-6284-5849-B51037875EFA}'
   - DisplayName: Windows App Certification Kit SupportedApiList x86
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{26D02D07-8007-2FD2-6DFE-14B29D09B5FD}'
   - DisplayName: Windows SDK for Windows Store Apps Contracts
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{2A8533B3-8D16-67E4-E729-5BB04EDD2FE4}'
   - DisplayName: Windows SDK Desktop Libs arm
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{2AC29D7B-F29F-34FA-4434-C5DF1F086264}'
   - DisplayName: WinAppDeploy
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{2ADF1977-BF31-E127-B651-AC28A8658317}'
   - DisplayName: Windows SDK for Windows Store Apps Metadata
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{2CFB2180-7C20-5470-4B8A-747512A6AB70}'
   - DisplayName: Windows SDK Facade Windows WinMD Versioned
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{2D296649-CFBE-CF23-EA8E-E24554187B3F}'
   - DisplayName: Windows SDK DirectX x86 Remote
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{313B416A-97E7-F3EF-EDFC-A903A8CA4BC2}'
   - DisplayName: WinRT Intellisense IoT - en-us
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{3335615C-ABEB-960E-2226-4274CD28E046}'
   - DisplayName: Windows SDK Desktop Headers x86
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{3D5981B5-ABF0-1495-7FC3-102D1C75B9C8}'
   - DisplayName: Windows SDK Modern Non-Versioned Developer Tools
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{43AA42C2-D292-CF91-6264-63B7A99CDE99}'
   - DisplayName: Windows SDK Redistributables
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{43B3CDF5-CD8F-9A5E-4598-765F8CB27170}'
   - DisplayName: WinRT Intellisense Mobile - en-us
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{443FF51E-16C3-F23B-18FC-0D1D66024B0B}'
   - DisplayName: Windows Software Development Kit - Windows 10.0.19041.685
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{4591faf1-a2db-4a3d-bfda-aa5a4ebb1587}'
   - DisplayName: Windows IoT Extension SDK Contracts
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{497B2D49-F5C2-CA3B-05FF-22ABF39F2873}'
   - DisplayName: Windows SDK for Windows Store Apps Tools
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{4AC6C7FB-D848-9D68-DCB0-1376083FEA3A}'
   - DisplayName: Windows SDK Desktop Headers arm
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{4BD2B107-B0D3-850C-7135-ACA153D30C78}'
   - DisplayName: Universal CRT Extension SDK
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{4D69FB64-4443-F2DD-DE1C-F14FD98AAC59}'
   - DisplayName: Windows Team Extension SDK Contracts
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{5F616EBF-DF09-A2DA-AB66-3A5341FA611C}'
   - DisplayName: Windows App Certification Kit x64
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{6487BFDF-6FA4-7CC5-0341-AA5D1AB69856}'
   - DisplayName: Universal CRT Headers Libraries and Sources
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{6B56745A-F6A4-C51C-933A-AD96C00683EA}'
   - DisplayName: Windows Mobile Extension SDK
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{718C25EB-084C-6341-1C3E-589DA641C28F}'
   - DisplayName: SDK ARM Redistributables
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{72DB07D6-E166-5A3F-B6E6-4664383781B8}'
   - DisplayName: Windows Mobile Extension SDK Contracts
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{7A9E937D-9757-80CB-A6E3-F4AB6081AEA6}'
   - DisplayName: MSI Development Tools
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{7AAC93B0-F3D7-6B24-6B37-9E74980C1C81}'
   - DisplayName: Windows SDK
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{7B891B74-6BE8-1581-357C-72DD8A82F0F7}'
   - DisplayName: Microsoft .NET Framework 4.8 Targeting Pack
-    DisplayVersion: 4.8.04084
     Publisher: Microsoft Corporation
     ProductCode: '{7D846F37-3C30-47C5-BCEA-2929EE09BE9A}'
   - DisplayName: Windows SDK Desktop Libs x86
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{7DD1F495-F1BF-6A30-620F-AC064DD302D8}'
   - DisplayName: WinRT Intellisense UAP - Other Languages
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{8832F8ED-1035-9ABE-FD73-4E5ABAA84A5C}'
   - DisplayName: Windows SDK for Windows Store Apps Headers
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{8E9DD3FE-3338-8012-81C5-F3AA9B617BAE}'
   - DisplayName: Windows SDK ARM Desktop Tools
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{940042ED-CB90-8E03-BE68-DF8A76E661FD}'
   - DisplayName: Windows SDK Desktop Libs arm64
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{9555AB64-6A00-776F-CA44-568E0E7B9632}'
   - DisplayName: Windows Desktop Extension SDK Contracts
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{A34A6580-86EF-A26A-33A5-80E1919B7F75}'
   - DisplayName: Windows SDK EULA
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporations
     ProductCode: '{A50A075D-973C-1867-4228-738205D555C8}'
   - DisplayName: Universal CRT Redistributable
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{A57CD0A6-4297-FD30-34A4-34758B6F5F69}'
   - DisplayName: Windows SDK for Windows Store Apps
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{A5E4C2C0-D963-40D6-8E5F-60A4DD995331}'
   - DisplayName: Universal General MIDI DLS Extension SDK
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{A7E95C47-B5F4-110C-D27A-DECB03412B96}'
   - DisplayName: Windows IP Over USB
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{AF49D304-3B8C-CFDC-9C6E-292DA7445D3E}'
   - DisplayName: WinRT Intellisense Desktop - Other Languages
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{B42BF427-AFDB-C00F-DB60-6F51395D74A1}'
   - DisplayName: Windows SDK Signing Tools
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{B62A26BB-90A0-82FB-2DDC-3157ADF07833}'
   - DisplayName: WPTx64
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft
     ProductCode: '{BB70FD41-5199-A5A6-064F-4343723C3048}'
   - DisplayName: WinRT Intellisense Desktop - en-us
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{BCF7CA0F-E53C-2A4F-B128-A751EC9A1016}'
   - DisplayName: Universal CRT Tools x86
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{BD75F257-50A4-E0CD-9942-C3550CA3E66A}'
   - DisplayName: Windows SDK Desktop Headers x64
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{C81D239D-863A-D4B4-3562-BC8D3D7C271E}'
   - DisplayName: Windows SDK Desktop Headers arm64
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{C88797F9-0AD8-E022-5BBB-596BC78D4C76}'
   - DisplayName: Windows Team Extension SDK
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{CE7E4A6A-45A2-2968-4B34-D0D4CFCC0E1D}'
   - DisplayName: Windows Desktop Extension SDK
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{D3B54AAA-2B64-5DE2-EA64-9900152E5282}'
   - DisplayName: Microsoft .NET Framework 4.8 SDK
-    DisplayVersion: 4.8.04084
     Publisher: Microsoft Corporation
     ProductCode: '{DA855582-B360-4532-B8C4-ECD1E5A7095B}'
   - DisplayName: Windows SDK AddOn
-    DisplayVersion: 10.1.0.0
     Publisher: Microsoft Corporation
     ProductCode: '{E18618EC-D9DB-4BCE-B382-85ADA2CBB340}'
   - DisplayName: Kits Configuration Installer
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft
     ProductCode: '{E75A9998-E979-760B-6AEB-49763F279EDD}'
   - DisplayName: Windows SDK Desktop Tools x64
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{F9BDEC71-9E56-CFBF-0AE8-E7AF032D07C7}'
   - DisplayName: Windows SDK Modern Versioned Developer Tools
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{FC5A59F8-6BEE-FBB4-C720-47C565A92798}'
   - DisplayName: SDK ARM Additions
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{FCF9D89E-6F79-64FB-B08D-B0E69FF54DEE}'
   - DisplayName: WPT Redistributables
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft
     ProductCode: '{FDF7ED9F-920C-CC11-0290-8B41498C1927}'
   - DisplayName: WinRT Intellisense PPI - Other Languages
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{FF2B49B7-0254-3D6A-4BE0-EF4C59DBCC2B}'
   - DisplayName: Windows SDK for Windows Store Managed Apps Libs
-    DisplayVersion: 10.1.19041.685
     Publisher: Microsoft Corporation
     ProductCode: '{FF7D4409-CF59-34AE-BDC7-8A6146A9BA36}'
 ManifestType: installer


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.1 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.1.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

DisplayVersion should be declared for main component only for multi-component installers at the moment due to the lack of multi-component concept across winget.
For this package, DisplayVersion has same value as PackageVersion.
It is not recommended to utilize DisplayVersion field if the DisplayVersion value is same as the PackageVersion value.
This will cause unnecessary version mapping precheck and make automatic updates more error prone.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/65833)