### PR TITLE
Remove DisplayVersion from Microsoft.WindowsSDK version 10.0.22000.194

### DIFF
--- a/manifests/m/Microsoft/WindowsSDK/10.0.22000.194/Microsoft.WindowsSDK.installer.yaml
+++ b/manifests/m/Microsoft/WindowsSDK/10.0.22000.194/Microsoft.WindowsSDK.installer.yaml
@@ -12,285 +12,214 @@ Installers:
     SilentWithProgress: /q
   AppsAndFeaturesEntries:
   - DisplayName: Windows SDK DirectX x64 Remote
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{193BDD23-87A7-389F-0C6A-68782ACB9684}'
   - DisplayName: Windows App Certification Kit Native Components
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{44B36ADE-2488-53DA-7F68-79E7405D6FA4}'
   - DisplayName: Application Verifier x64 External Package
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft
     ProductCode: '{6B1CA233-E631-B665-98E5-0F50F6E5567B}'
   - DisplayName: Universal CRT Tools x64
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{96C1C470-4078-7825-7C00-EA9467ADD303}'
   - DisplayName: Windows Mobile Extension SDK Contracts
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{0F1BAEE0-25AF-B83E-5D48-2FFCC68ECEEA}'
   - DisplayName: Windows SDK for Windows Store Apps Tools
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{1046B6ED-F966-5852-BEAA-C1EFF2720370}'
   - DisplayName: Windows SDK for Windows Store Apps Libs
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{12ED94FA-ADBD-CC88-D3B4-D8226FC25810}'
   - DisplayName: Windows SDK Desktop Tools x64
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{155F6D7E-7739-DA9E-E385-E55E1CAE92EC}'
   - DisplayName: Windows Software Development Kit - Windows 10.0.22000.194
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{1b45a8b2-a411-45ca-b322-d15ee6904559}'
   - DisplayName: Windows SDK Desktop Libs x86
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{224A2C9B-5304-BA73-072A-FED79CD1B7E4}'
   - DisplayName: Windows SDK Modern Versioned Developer Tools
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{28837060-345A-67F9-78B6-BAABD4EA2278}'
   - DisplayName: Universal CRT Headers Libraries and Sources
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{2EBC2F45-171A-8693-8A8D-902698C9309E}'
   - DisplayName: Windows SDK Desktop Headers x64
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{3511AC83-8494-1F8D-EC4C-525E1BF03857}'
   - DisplayName: WinRT Intellisense PPI - en-us
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{37BA566C-6B6C-B959-ADE9-5A56AAACA14C}'
   - DisplayName: Windows SDK ARM Desktop Tools
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{39F1449E-B949-E5FE-CE44-064130C74F02}'
   - DisplayName: WPT Redistributables
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft
     ProductCode: '{40FA9688-629A-0BBA-3366-0A0D256F937C}'
   - DisplayName: Windows SDK Desktop Headers x86
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{43B97408-EC80-6EE0-F6C2-40A444C16A8F}'
   - DisplayName: Windows App Certification Kit x64
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{4E89C5D3-3C9B-8289-3C4B-25463DB3A064}'
   - DisplayName: Windows SDK Signing Tools
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{5248A17E-7E26-E32B-BEE1-D6B5322B658D}'
   - DisplayName: Windows SDK Desktop Libs x64
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{5AAC125C-9E7D-5B5F-7484-3B64585AFE6B}'
   - DisplayName: MSI Development Tools
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{62E2BF70-2E1C-3975-31BA-25CDFFE6C448}'
   - DisplayName: WPTx64 (OnecoreUAP)
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft
     ProductCode: '{67820CB6-57A6-6F04-F64F-D56C383D702B}'
   - DisplayName: Windows Desktop Extension SDK Contracts
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{699180FA-06A2-0B6B-0DBA-EF5D85E720BA}'
   - DisplayName: Windows SDK DirectX x86 Remote
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{6C305B4D-9289-EE9C-68DC-E499CEAB5773}'
   - DisplayName: Windows SDK Desktop Libs arm
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{71B5C92E-6053-EBB4-2568-F678C3552FA7}'
   - DisplayName: Windows SDK Desktop Headers arm
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{78A593A3-BB3C-CCB9-2001-0C1BCFFAA42F}'
   - DisplayName: Windows App Certification Kit SupportedApiList x86
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{7A362C1E-DDAF-072E-A39D-39FF0DA115A1}'
   - DisplayName: WinAppDeploy
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{7A61ADCC-6FEA-3F77-BBA1-40348287BE1A}'
   - DisplayName: Windows Team Extension SDK
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{802E9CE7-413C-61A3-6699-896B587BA172}'
   - DisplayName: Windows IoT Extension SDK Contracts
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{8040F75E-CA6D-64AE-CE5E-A0943545482C}'
   - DisplayName: WinRT Intellisense Desktop - Other Languages
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{81F2558C-62AF-D282-5E2D-23BCD5CAE40D}'
   - DisplayName: Windows IP Over USB
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{8E78B421-D58E-C1E0-37F4-6D012DE26890}'
   - DisplayName: WinRT Intellisense UAP - en-us
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{928D8F53-5675-F04A-5849-B583C7AB2240}'
   - DisplayName: Windows SDK Desktop Tools arm64
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{92BE26E2-3C1C-E7E6-DABB-723167A56336}'
   - DisplayName: Microsoft .NET Framework 4.8 SDK
-    DisplayVersion: 4.8.03928
     Publisher: Microsoft Corporation
     ProductCode: '{949C0535-171C-480F-9CF4-D25C9E60FE88}'
   - DisplayName: WPTx64 (DesktopEditions)
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft
     ProductCode: '{95C34E32-1730-3A74-7A5C-67C969054758}'
   - DisplayName: Universal General MIDI DLS Extension SDK
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{99FAD9E3-4997-95BE-E074-A8C0D16C5C57}'
   - DisplayName: Windows SDK
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{9A378A57-CBEF-50B1-519C-C149B11A7290}'
   - DisplayName: SDK Debuggers
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{9D1A6B62-D3A1-C5C0-19B7-ED6329496784}'
   - DisplayName: Windows IoT Extension SDK
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{9FA6A574-84C6-05AD-FB4D-1B673FDC50D6}'
   - DisplayName: Windows Desktop Extension SDK
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{A5FA04AB-A369-2E08-B5C1-C7BAD82C9B38}'
   - DisplayName: Windows SDK for Windows Store Apps Metadata
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{A7BAA72A-6A71-E0D9-6A24-2D591710959E}'
   - DisplayName: WinRT Intellisense Mobile - en-us
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{AF8C6EE9-0285-D6F1-FCCC-E5F4E6F41F05}'
   - DisplayName: Windows SDK for Windows Store Apps Headers
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{AFE744EA-5F8D-B009-4837-0E8C002F8B1F}'
   - DisplayName: Windows SDK Desktop Libs arm64
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{B01759A2-7C09-6B7E-C38D-6F1105D4C682}'
   - DisplayName: SDK ARM Redistributables
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{B50306AF-46B0-1C20-0DCD-F5630AD9935B}'
   - DisplayName: Windows SDK for Windows Store Apps DirectX x86 Remote
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{B81315F5-A888-8D8A-E3C3-8B619A83D2B0}'
   - DisplayName: Microsoft .NET Framework 4.8 Targeting Pack
-    DisplayVersion: 4.8.03761
     Publisher: Microsoft Corporation
     ProductCode: '{BAAF5851-0759-422D-A1E9-90061B597188}'
   - DisplayName: WinRT Intellisense Desktop - en-us
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{BAC94E25-2596-D023-62C5-3D156740293E}'
   - DisplayName: Universal CRT Tools x86
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{BB834924-45F6-9FBC-B802-05125C45F5ED}'
   - DisplayName: WinRT Intellisense UAP - Other Languages
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{BBA772A8-7490-A5EE-295C-18B3E3185199}'
   - DisplayName: Windows SDK Redistributables
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{BE83BDDF-6F6F-515F-4DF1-28F2352791F1}'
   - DisplayName: Universal CRT Redistributable
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{BF1AD352-AF3B-2F11-583B-5F78359447F3}'
   - DisplayName: WinRT Intellisense IoT - Other Languages
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{C9846E81-92F2-ED84-BE9C-74EC0286C905}'
   - DisplayName: WinRT Intellisense PPI - Other Languages
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{C9FDDDB2-8BBF-84A5-30F4-F78DE34EBB1C}'
   - DisplayName: Windows SDK EULA
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporations
     ProductCode: '{CB77D354-EF20-C5E8-9DC4-8AB9ED0EB990}'
   - DisplayName: Windows Team Extension SDK Contracts
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{CC764523-CB6B-E329-223D-88941C9111EA}'
   - DisplayName: Universal CRT Extension SDK
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{CD47E25E-765D-DA92-EAF2-239DF75A5F0A}'
   - DisplayName: Windows SDK Facade Windows WinMD Versioned
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{D14BCE14-F9BD-52CB-3E02-6BDA6F9D73BB}'
   - DisplayName: Windows SDK for Windows Store Managed Apps Libs
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{D73BC31B-E6F3-BC8C-6F5A-8695A9F6E95F}'
   - DisplayName: Windows SDK Desktop Tools x86
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{D9B8930E-E709-8F45-3A72-A862365AC0BC}'
   - DisplayName: Windows Mobile Extension SDK
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{DE05A4B4-7A6B-2ED1-B95E-6C5145CBD3CA}'
   - DisplayName: Kits Configuration Installer
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft
     ProductCode: '{EB6E7BB8-E3AE-3802-D4AD-BBFE6F4D5C91}'
   - DisplayName: Windows SDK for Windows Store Apps
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{EDB04798-19BE-70E0-87EA-BFEE60BB6A4C}'
   - DisplayName: Windows SDK Modern Non-Versioned Developer Tools
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{EEB786DE-05E3-62A6-44F6-D4692ACFA2D5}'
   - DisplayName: Windows SDK Desktop Headers arm64
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{EEDD4C6A-884C-6E3B-1E1E-47751EDC344C}'
   - DisplayName: WinRT Intellisense IoT - en-us
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{F9B97C20-1142-B9F6-13E6-5942FA6C2513}'
   - DisplayName: SDK ARM Additions
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{FE5E643B-E807-0503-3942-8B39D2ACA459}'
   - DisplayName: Windows SDK AddOn
-    DisplayVersion: 10.1.0.0
     Publisher: Microsoft Corporation
     ProductCode: '{FEA4198C-9496-4E35-B7F9-4730F13CE67C}'
   - DisplayName: Windows SDK for Windows Store Apps Contracts
-    DisplayVersion: 10.1.22000.194
     Publisher: Microsoft Corporation
     ProductCode: '{FF9284BA-F21A-A314-A805-1A8D598D8858}'
 ManifestType: installer
 ManifestVersion: 1.1.0
-


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.1 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.1.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

DisplayVersion should be declared for main component only for multi-component installers at the moment due to the lack of multi-component concept across winget.
For this package, DisplayVersion has same value as PackageVersion.
It is not recommended to utilize DisplayVersion field if the DisplayVersion value is same as the PackageVersion value.
This will cause unnecessary version mapping precheck and make automatic updates more error prone.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/65834)