### PR TITLE
Remove DisplayVersion from Mozilla.Firefox.DeveloperEdition version 1…

### DIFF
--- a/manifests/m/Mozilla/Firefox/DeveloperEdition/101.0b5/Mozilla.Firefox.DeveloperEdition.installer.yaml
+++ b/manifests/m/Mozilla/Firefox/DeveloperEdition/101.0b5/Mozilla.Firefox.DeveloperEdition.installer.yaml
@@ -9,11 +9,9 @@ Installers:
   ProductCode: '{1294A4C5-9977-480F-9497-C0EA1E630130}'
   AppsAndFeaturesEntries:
   - DisplayName: Firefox Developer Edition (x64 en-US)
-    DisplayVersion: "101.0"
     Publisher: Mozilla
     ProductCode: Firefox Developer Edition 101.0 (x64 en-US)
   - DisplayName: Mozilla Maintenance Service
-    DisplayVersion: "101.0"
     Publisher: Mozilla
     ProductCode: MozillaMaintenanceService
 - Architecture: x86
@@ -23,11 +21,9 @@ Installers:
   ProductCode: '{1294A4C5-9977-480F-9497-C0EA1E630130}'
   AppsAndFeaturesEntries:
   - DisplayName: Mozilla Maintenance Service
-    DisplayVersion: "101.0"
     Publisher: Mozilla
     ProductCode: MozillaMaintenanceService
   - DisplayName: Firefox Developer Edition (x86 en-US)
-    DisplayVersion: "101.0"
     Publisher: Mozilla
     ProductCode: Firefox Developer Edition 101.0 (x86 en-US)
 - Architecture: arm64


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.1 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.1.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

Though Mozilla.Firefox.DeveloperEdition is a good example for using DisplayVersion, multiple winget versions have the same DisplayVersion value(e.g. there're 3 versions all declare 101.0 as DisplayVersion). This will cause a conflict in winget version mapping, so these DisplayVersion are removed for now.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/65850)