### PR TITLE
New version: OliverSchwendener.ueli version 8.22.1 [FP-O]

### DIFF
--- a/manifests/o/OliverSchwendener/ueli/8.22.1/OliverSchwendener.ueli.installer.yaml
+++ b/manifests/o/OliverSchwendener/ueli/8.22.1/OliverSchwendener.ueli.installer.yaml
@@ -1,0 +1,21 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+
+PackageIdentifier: OliverSchwendener.ueli
+PackageVersion: 8.22.1
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+Scope: machine
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+ReleaseDate: 2022-07-12
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/oliverschwendener/ueli/releases/download/v8.22.1/ueli-Setup-8.22.1.exe
+  InstallerSha256: 6A2ED0A394BF8FF2B3D6BBFB0D747181504B1074E69AB65DBFBC93992DDD70C3
+ManifestType: installer
+ManifestVersion: 1.1.0

--- a/manifests/o/OliverSchwendener/ueli/8.22.1/OliverSchwendener.ueli.locale.en-US.yaml
+++ b/manifests/o/OliverSchwendener/ueli/8.22.1/OliverSchwendener.ueli.locale.en-US.yaml
@@ -12,9 +12,9 @@ Author: Oliver Schwendener
 PackageName: ueli
 PackageUrl: https://www.ueli.app
 License: MIT License
-LicenseUrl: https://raw.githubusercontent.com/oliverschwendener/ueli/dev/LICENSE
+LicenseUrl: https://raw.githubusercontent.com/oliverschwendener/ueli/main/LICENSE
 Copyright: Copyright (c) 2022 Oliver Schwendener
-CopyrightUrl: https://raw.githubusercontent.com/oliverschwendener/ueli/dev/LICENSE
+CopyrightUrl: https://raw.githubusercontent.com/oliverschwendener/ueli/main/LICENSE
 ShortDescription: This is a keystroke launcher for Windows and macOS.
 # Description: 
 # Moniker: 

--- a/manifests/o/OliverSchwendener/ueli/8.22.1/OliverSchwendener.ueli.locale.en-US.yaml
+++ b/manifests/o/OliverSchwendener/ueli/8.22.1/OliverSchwendener.ueli.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+
+PackageIdentifier: OliverSchwendener.ueli
+PackageVersion: 8.22.1
+PackageLocale: en-US
+Publisher: Oliver Schwendener
+PublisherUrl: https://github.com/oliverschwendener/ueli
+PublisherSupportUrl: https://github.com/oliverschwendener/ueli/issues
+# PrivacyUrl: 
+Author: Oliver Schwendener
+PackageName: ueli
+PackageUrl: https://www.ueli.app
+License: MIT License
+LicenseUrl: https://raw.githubusercontent.com/oliverschwendener/ueli/dev/LICENSE
+Copyright: Copyright (c) 2022 Oliver Schwendener
+CopyrightUrl: https://raw.githubusercontent.com/oliverschwendener/ueli/dev/LICENSE
+ShortDescription: This is a keystroke launcher for Windows and macOS.
+# Description: 
+# Moniker: 
+Tags:
+- electron
+- keystroke
+- launcher
+- productivity
+- typescript
+# Agreements: 
+# ReleaseNotes: 
+ReleaseNotesUrl: https://github.com/oliverschwendener/ueli/releases/tag/v8.22.1
+ManifestType: defaultLocale
+ManifestVersion: 1.1.0

--- a/manifests/o/OliverSchwendener/ueli/8.22.1/OliverSchwendener.ueli.yaml
+++ b/manifests/o/OliverSchwendener/ueli/8.22.1/OliverSchwendener.ueli.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+
+PackageIdentifier: OliverSchwendener.ueli
+PackageVersion: 8.22.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.1.0


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | ueli | Notepad++ (ARM 64-bit), Octopus Deploy Tentacle, Octopus Deploy Server, Obsidian    |
| Version     | 8.22.1     | 8.4.4, 6.1.1531, 2022.2.7336, 0.15.6 |
| Publisher   | Oliver Schwendener   | Notepad++ Team, Octopus Deploy Pty. Ltd., Octopus Deploy Pty. Ltd., Obsidian      |
| ProductCode |           | Notepad++, {BE53F5AD-2D3F-4C7F-AE73-BE73773E1AF2}, {F527A6D7-A202-4A1F-B024-6C35DC5F3925}, bd400747-f0c1-5638-a859-982036102edf    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://bittu.eu.org/docs/wpa-intro) in workflow run [2770](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/2694181253>)