### PR TITLE
New version: Datadog.dd-trace-dotnet version 2.12.0 [FP-O]

### DIFF
--- a/manifests/d/Datadog/dd-trace-dotnet/2.12.0/Datadog.dd-trace-dotnet.installer.yaml
+++ b/manifests/d/Datadog/dd-trace-dotnet/2.12.0/Datadog.dd-trace-dotnet.installer.yaml
@@ -17,10 +17,14 @@ Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/DataDog/dd-trace-dotnet/releases/download/v2.12.0/datadog-dotnet-apm-2.12.0-x64.msi
   InstallerSha256: 0C72273FFAF44391C3BE0AF0E0C2EF23FB26B87B6052BD5A05DD29395FAE760C
-  ProductCode: '{0B1B9893-7610-4F33-96E8-AAD653F4ECDA}'
+  AppsAndFeaturesEntries: 
+  - ProductCode: '{0B1B9893-7610-4F33-96E8-AAD653F4ECDA}'
+    DisplayName: Datadog .NET Tracer 64-bit
 - Architecture: x86
   InstallerUrl: https://github.com/DataDog/dd-trace-dotnet/releases/download/v2.12.0/datadog-dotnet-apm-2.12.0-x86.msi
   InstallerSha256: 1793BFA122F664937C85EFD970DAB6C1681450A61B91205AB742B390DA2E222B
-  ProductCode: '{D518BD35-B9B6-4E2A-81AD-82D0333C6F99}'
+  AppsAndFeaturesEntries: 
+  - ProductCode: '{D518BD35-B9B6-4E2A-81AD-82D0333C6F99}'
+    DisplayName: Datadog .NET Tracer 32-bit
 ManifestType: installer
 ManifestVersion: 1.1.0

--- a/manifests/d/Datadog/dd-trace-dotnet/2.12.0/Datadog.dd-trace-dotnet.installer.yaml
+++ b/manifests/d/Datadog/dd-trace-dotnet/2.12.0/Datadog.dd-trace-dotnet.installer.yaml
@@ -1,0 +1,26 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+
+PackageIdentifier: Datadog.dd-trace-dotnet
+PackageVersion: 2.12.0
+InstallerLocale: en-US
+MinimumOSVersion: 10.0.0.0
+InstallerType: wix
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2022-07-13
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/DataDog/dd-trace-dotnet/releases/download/v2.12.0/datadog-dotnet-apm-2.12.0-x64.msi
+  InstallerSha256: 0C72273FFAF44391C3BE0AF0E0C2EF23FB26B87B6052BD5A05DD29395FAE760C
+  ProductCode: '{0B1B9893-7610-4F33-96E8-AAD653F4ECDA}'
+- Architecture: x86
+  InstallerUrl: https://github.com/DataDog/dd-trace-dotnet/releases/download/v2.12.0/datadog-dotnet-apm-2.12.0-x86.msi
+  InstallerSha256: 1793BFA122F664937C85EFD970DAB6C1681450A61B91205AB742B390DA2E222B
+  ProductCode: '{D518BD35-B9B6-4E2A-81AD-82D0333C6F99}'
+ManifestType: installer
+ManifestVersion: 1.1.0

--- a/manifests/d/Datadog/dd-trace-dotnet/2.12.0/Datadog.dd-trace-dotnet.locale.en-US.yaml
+++ b/manifests/d/Datadog/dd-trace-dotnet/2.12.0/Datadog.dd-trace-dotnet.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+
+PackageIdentifier: Datadog.dd-trace-dotnet
+PackageVersion: 2.12.0
+PackageLocale: en-US
+Publisher: Datadog, Inc.
+PublisherUrl: https://docs.datadoghq.com/
+PublisherSupportUrl: https://www.datadoghq.com/support/
+PrivacyUrl: https://www.datadoghq.com/legal/privacy/
+Author: Datadog
+PackageName: Datadog .NET Tracer
+PackageUrl: https://docs.datadoghq.com/tracing/
+License: Apache-2.0
+LicenseUrl: https://github.com/DataDog/dd-trace-dotnet/blob/master/LICENSE
+Copyright: Copyright 2017 Datadog, Inc.
+CopyrightUrl: https://github.com/DataDog/dd-trace-dotnet/blob/master/NOTICE
+ShortDescription: Automatic instrumentation for .NET applications
+# Description: 
+Moniker: dd-trace-dotnet
+Tags:
+- apm
+- tracing
+# Agreements: 
+# ReleaseNotes: 
+ReleaseNotesUrl: https://github.com/DataDog/dd-trace-dotnet/releases/tag/v2.12.0
+ManifestType: defaultLocale
+ManifestVersion: 1.1.0

--- a/manifests/d/Datadog/dd-trace-dotnet/2.12.0/Datadog.dd-trace-dotnet.yaml
+++ b/manifests/d/Datadog/dd-trace-dotnet/2.12.0/Datadog.dd-trace-dotnet.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+
+PackageIdentifier: Datadog.dd-trace-dotnet
+PackageVersion: 2.12.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.1.0


### PR DESCRIPTION
### Result: Installation Successful
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | Datadog .NET Tracer | Datadog .NET Tracer 64-bit    |
| Version     | 2.12.0     | 2.12.0 |
| Publisher   | Datadog, Inc.   | Datadog, Inc.      |
| ProductCode | {0B1B9893-7610-4F33-96E8-AAD653F4ECDA}          | {0B1B9893-7610-4F33-96E8-AAD653F4ECDA}    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://bittu.eu.org/docs/wpa-intro) in workflow run [2740](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/2665481050>)