### PR TITLE
New package: RubyInstallerTeam.Ruby.3.1 version 3.1.2-1

### DIFF
--- a/manifests/r/RubyInstallerTeam/Ruby/3/1/3.1.2-1/RubyInstallerTeam.Ruby.3.1.installer.yaml
+++ b/manifests/r/RubyInstallerTeam/Ruby/3/1/3.1.2-1/RubyInstallerTeam.Ruby.3.1.installer.yaml
@@ -1,0 +1,25 @@
+# Created with YamlCreate.ps1 v2.1.2 $debug=NVS1.7-2-5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+
+PackageIdentifier: RubyInstallerTeam.Ruby.3.1
+PackageVersion: 3.1.2-1
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+FileExtensions:
+- rb
+- rbw
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-3.1.2-1/rubyinstaller-3.1.2-1-x64.exe
+  InstallerSha256: FC96DFA66C1C09B0F28A6156754DA5A4A63EDD77F4EE15B27BFAB67F9871BB3F
+- Architecture: x86
+  InstallerUrl: https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-3.1.2-1/rubyinstaller-3.1.2-1-x86.exe
+  InstallerSha256: A1550790DDC4B4155D028AE721A2B309A59314860EFDDA02F321548B267A6AAF
+ManifestType: installer
+ManifestVersion: 1.1.0

--- a/manifests/r/RubyInstallerTeam/Ruby/3/1/3.1.2-1/RubyInstallerTeam.Ruby.3.1.locale.en-US.yaml
+++ b/manifests/r/RubyInstallerTeam/Ruby/3/1/3.1.2-1/RubyInstallerTeam.Ruby.3.1.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# Created with YamlCreate.ps1 v2.1.2 $debug=NVS1.7-2-5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+
+PackageIdentifier: RubyInstallerTeam.Ruby.3.1
+PackageVersion: 3.1.2-1
+PackageLocale: en-US
+Publisher: RubyInstaller Team
+PublisherUrl: https://rubyinstaller.org/
+PublisherSupportUrl: https://github.com/oneclick/rubyinstaller2/issues
+# PrivacyUrl: 
+# Author: 
+PackageName: Ruby 3.1
+# PackageUrl: 
+License: BSD-3-Clause License
+LicenseUrl: https://github.com/oneclick/rubyinstaller2/blob/master/LICENSE.txt
+Copyright: Copyright (c) 2007-2022 RubyInstaller Team
+CopyrightUrl: https://github.com/oneclick/rubyinstaller2/blob/master/LICENSE.txt
+ShortDescription: Ruby Programming Language for Windows
+# Description: 
+Moniker: ruby3-1
+Tags:
+- programming
+- ruby
+# Agreements: 
+# ReleaseNotes: 
+# ReleaseNotesUrl: 
+ManifestType: defaultLocale
+ManifestVersion: 1.1.0

--- a/manifests/r/RubyInstallerTeam/Ruby/3/1/3.1.2-1/RubyInstallerTeam.Ruby.3.1.yaml
+++ b/manifests/r/RubyInstallerTeam/Ruby/3/1/3.1.2-1/RubyInstallerTeam.Ruby.3.1.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.1.2 $debug=NVS1.7-2-5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+
+PackageIdentifier: RubyInstallerTeam.Ruby.3.1
+PackageVersion: 3.1.2-1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.1.0


### PR DESCRIPTION
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.1 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.1.0)?

This is a partial address of #47664 in which winget would be able to manage several Ruby versions alongside each other. If this PR is okay, more PRs can be created for each major Ruby version (3.0, 2.7, etc) and then old versions that don't follow this naming schema can be deleted.
