### PR TITLE
Add close command to MSFTbot config

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1631,6 +1631,122 @@
     {
       "taskType": "trigger",
       "capabilityId": "IssueResponder",
+      "subCapability": "IssueCommentResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "commentContains",
+              "parameters": {
+                "bodyPattern": "/clo",
+                "isRegex": true,
+                "commentPattern": "Close\\s+with\\s+reason\\s*:[\\w\\s\\-\\(\\)\\[\\]\\{\\}\\\\\\/.+=@#$%&^*`~|'\",<>?]*(?=;)"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "activitySenderHasPermissions",
+                  "parameters": {
+                    "permissions": "admin"
+                  }
+                },
+                {
+                  "name": "activitySenderHasPermissions",
+                  "parameters": {
+                    "permissions": "write"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "ImJoakim"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "ItzLevvie"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "jedieaston"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "KaranKad"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "OfficialEsco"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "quhxl"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "Trenly"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "issue_comment"
+        ],
+        "taskName": "Helper to close",
+        "actions": [
+          {
+            "name": "closeIssue",
+            "parameters": {}
+          },
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "Needs-Triage"
+            }
+          },
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "Needs-Attention"
+            }
+          },
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "Needs-Feedback-Hub"
+            }
+          },
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "Needs-Author-Feedback"
+            }
+          }
+        ]
+      },
+      "disabled": false
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
       "subCapability": "IssuesOnlyResponder",
       "version": "1.0",
       "config": {

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1631,7 +1631,7 @@
     {
       "taskType": "trigger",
       "capabilityId": "IssueResponder",
-      "subCapability": "IssueCommentResponder",
+      "subCapability": "PullRequestCommentResponder",
       "version": "1.0",
       "config": {
         "conditions": {


### PR DESCRIPTION
Allows moderators to close pull requests using `Close with reason <reason>;`

```
PS C:\> $jsonString = '"Close\\s+with\\s+reason\\s*:[\\w\\s\\-\\(\\)\\[\\]\\{\\}\\\\\\/.+=@#$%&^*`~|\",<>?]*(?=;)"'
PS C:\> $regex = $jsonString|ConvertFrom-Json
PS C:\> $regex
Close\s+with\s+reason\s*:[\w\s\-\(\)\[\]\{\}\\\/.+=@#$%&^*`~|",<>?]*(?=;)
PS C:\> 'Close With Reason:  Test' -match $regex
False
PS C:\> 'Close With Reason:  Test;' -match $regex
True
PS C:\> 'Close With Reason:  Test
>>
>> with returns;' -match $regex
True
PS C:\> 'Close With Reason:  Test
>>
>> with returns
>> and special chars
>> %^&*(){}[];' -match $regex
True
PS C:\WINDOWS\>
```

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/66249)