### PR TITLE
Use Validation-Unattended-Failed label ONLY

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1245,7 +1245,7 @@
             {
               "name": "labelAdded",
               "parameters": {
-                "label": "Validation-Unattend-Failed"
+                "label": "Validation-Unattended-Failed"
               }
             }
           ]
@@ -1256,7 +1256,7 @@
           "issues",
           "project_card"
         ],
-        "taskName": "Manual Review: Unattend Installation.  Setup  is not silent.  Did you miss adding switches?",
+        "taskName": "Manual Review: Unattend Installation. Setup is not silent. Did you miss adding switches?",
         "actions": [
           {
             "name": "assignToUser",
@@ -1269,7 +1269,7 @@
           {
             "name": "addReply",
             "parameters": {
-              "comment": "Hello @${issueAuthor},\nDuring installation testing, this application failed to install without user input.  Did you forget to add  Silent or SilentWithProgress switches?\n\nThis can also happen when a dependency is missing. You can test with https://github.com/microsoft/winget-pkgs#test-your-manifest.\n\nPlease investigate a fix and resubmit the Pull Request.\n\nYou may also try using the [Windows Package Manager Manifest Creator](https://github.com/microsoft/winget-create) to determine the proper installer type. If the installer type is MSIX, MSI or a known installer technology like NullSoft, Inno, etc. the wingetcreate tool can detect then the winget client will know what switches to pass. If it's a .exe installer of an unknown type, you will need to search to determine the proper switches for Silent and SilentWithProgress."
+              "comment": "Hello @${issueAuthor},\nThis package appears to require user interaction to complete. Please check to see if this package can be installed unattended, and modify the manifest.\n\nThis can also happen when a dependency is missing. You can test with https://github.com/microsoft/winget-pkgs#test-your-manifest.\n\nPlease investigate a fix and resubmit the Pull Request.\n\nYou may also try using the [Windows Package Manager Manifest Creator](https://github.com/microsoft/winget-create) to determine the proper installer type. If the installer type is MSIX, MSI or a known installer technology like NullSoft, Inno, etc. the wingetcreate tool can detect then the winget client will know what switches to pass. If it's a .exe installer of an unknown type, you will need to search to determine the proper switches for Silent and SilentWithProgress."
             }
           },
           {
@@ -3224,12 +3224,6 @@
           {
             "name": "removeLabel",
             "parameters": {
-              "label": "Validation-Unattend-Failed"
-            }
-          },
-          {
-            "name": "removeLabel",
-            "parameters": {
               "label": "Validation-Installation-Error"
             }
           },
@@ -3615,12 +3609,6 @@
           {
             "name": "removeLabel",
             "parameters": {
-              "label": "Validation-Unattend-Failed"
-            }
-          },
-          {
-            "name": "removeLabel",
-            "parameters": {
               "label": "Validation-Installation-Error"
             }
           },
@@ -3886,46 +3874,6 @@
         ]
       },
       "disabled": false
-    },
-    {
-      "taskType": "trigger",
-      "capabilityId": "IssueResponder",
-      "subCapability": "PullRequestResponder",
-      "version": "1.0",
-      "config": {
-        "conditions": {
-          "operator": "or",
-          "operands": [
-            {
-              "name": "hasLabel",
-              "parameters": {
-                "label": "Validation-Unattend-Failed"
-              }
-            }
-          ]
-        },
-        "eventType": "pull_request",
-        "eventNames": [
-          "pull_request",
-          "issues",
-          "project_card"
-        ],
-        "taskName": "PR has Validation-Unattended-Failed",
-        "actions": [
-          {
-            "name": "addReply",
-            "parameters": {
-              "comment": "Hello @${issueAuthor},\nThis package appears to require user interaction to complete. Please check to see if this package can be installed unattended, and modify the manifest."
-            }
-          },
-          {
-            "name": "addLabel",
-            "parameters": {
-              "label": "Needs-Author-Feedback"
-            }
-          }
-        ]
-      }
     },
     {
       "taskType": "trigger",
@@ -4494,7 +4442,7 @@
             {
               "name": "labelAdded",
               "parameters": {
-                "label": "Validation-Unattend-Failed"
+                "label": "Validation-Unattended-Failed"
               }
             },
             {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/83997633/179023881-dfdc7507-9b5c-4caa-8f57-dc4ec2a64ffc.png)

Two labels are being used for the same purpose. This PR updates @msftbot configuration to use the `Validation-Unattended-Failed` label since it's currently more frequently used than the other label.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/66348)