### PR TITLE
New version: GyDi.ClashVerge version 1.0.4

### DIFF
--- a/manifests/g/GyDi/ClashVerge/1.0.4/GyDi.ClashVerge.installer.yaml
+++ b/manifests/g/GyDi/ClashVerge/1.0.4/GyDi.ClashVerge.installer.yaml
@@ -1,0 +1,24 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+
+PackageIdentifier: GyDi.ClashVerge
+PackageVersion: 1.0.4
+MinimumOSVersion: 10.0.0.0
+InstallerType: wix
+Scope: machine
+InstallerSwitches:
+  InstallLocation: INSTALLDIR="<INSTALLPATH>"
+UpgradeBehavior: install
+ReleaseDate: 2022-07-17
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/zzzgydi/clash-verge/releases/download/v1.0.4/Clash.Verge_1.0.4_x64_en-US.msi
+  InstallerSha256: 671D9EC14A01B73ACC227ADA7FD7AA78FF598F68763F035CD0086721CCF2A010
+  ProductCode: '{F5AF653F-09D1-46FF-B3BB-A702C030E1E0}'
+- InstallerLocale: zh-CN
+  Architecture: x64
+  InstallerUrl: https://github.com/zzzgydi/clash-verge/releases/download/v1.0.4/Clash.Verge_1.0.4_x64_zh-CN.msi
+  InstallerSha256: AB5C966A46F174C5A746F87F64DD62F31A7C8409D87A7BEF463AD58361FFAB9B
+  ProductCode: '{27588502-D9D1-454D-BC51-2C7C658EEA42}'
+ManifestType: installer
+ManifestVersion: 1.1.0

--- a/manifests/g/GyDi/ClashVerge/1.0.4/GyDi.ClashVerge.locale.en-US.yaml
+++ b/manifests/g/GyDi/ClashVerge/1.0.4/GyDi.ClashVerge.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+
+PackageIdentifier: GyDi.ClashVerge
+PackageVersion: 1.0.4
+PackageLocale: en-US
+Publisher: gydi
+PublisherUrl: https://github.com/zzzgydi
+PublisherSupportUrl: https://github.com/zzzgydi/clash-verge/issues
+# PrivacyUrl: 
+Author: GyDi
+PackageName: Clash Verge
+PackageUrl: https://github.com/zzzgydi/clash-verge
+License: GPL-3.0
+LicenseUrl: https://github.com/zzzgydi/clash-verge/blob/main/LICENSE
+Copyright: © 2022 zzzgydi All Rights Reserved
+# CopyrightUrl: 
+ShortDescription: A Clash GUI based on tauri.
+# Description: 
+# Moniker: 
+Tags:
+- clash
+- network
+- proxy
+- vpn
+# Agreements: 
+# ReleaseNotes: 
+ReleaseNotesUrl: https://github.com/zzzgydi/clash-verge/releases/tag/v1.0.4
+ManifestType: defaultLocale
+ManifestVersion: 1.1.0

--- a/manifests/g/GyDi/ClashVerge/1.0.4/GyDi.ClashVerge.locale.zh-CN.yaml
+++ b/manifests/g/GyDi/ClashVerge/1.0.4/GyDi.ClashVerge.locale.zh-CN.yaml
@@ -1,0 +1,30 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.1.0.schema.json
+
+PackageIdentifier: GyDi.ClashVerge
+PackageVersion: 1.0.4
+PackageLocale: zh-CN
+Publisher: gydi
+PublisherUrl: https://github.com/zzzgydi
+PublisherSupportUrl: https://github.com/zzzgydi/clash-verge/issues
+# PrivacyUrl: 
+Author: GyDi
+PackageName: Clash Verge
+PackageUrl: https://github.com/zzzgydi/clash-verge
+License: GPL-3.0
+LicenseUrl: https://github.com/zzzgydi/clash-verge/blob/main/LICENSE
+Copyright: © 2022 zzzgydi All Rights Reserved
+# CopyrightUrl: 
+ShortDescription: 基于 tauri 的 Clash GUI
+# Description: 
+# Moniker: 
+Tags:
+- clash
+- vpn
+- 代理
+- 网络
+# Agreements: 
+# ReleaseNotes: 
+# ReleaseNotesUrl: 
+ManifestType: locale
+ManifestVersion: 1.1.0

--- a/manifests/g/GyDi/ClashVerge/1.0.4/GyDi.ClashVerge.yaml
+++ b/manifests/g/GyDi/ClashVerge/1.0.4/GyDi.ClashVerge.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+
+PackageIdentifier: GyDi.ClashVerge
+PackageVersion: 1.0.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.1.0


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | Clash Verge | Google Chrome Canary    |
| Version     | 1.0.4     | 105.0.5188.0 |
| Publisher   | gydi   | Google LLC      |
| ProductCode | {F5AF653F-09D1-46FF-B3BB-A702C030E1E0}          | Google Chrome SxS    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://bittu.eu.org/docs/wpa-intro) in workflow run [2770](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/2694181253>)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/66785)