### PR TITLE
Add version: Tricentis.NeoLoad version 8.1.1

### DIFF
--- a/manifests/t/Tricentis/NeoLoad/8.1.1/Tricentis.NeoLoad.installer.yaml
+++ b/manifests/t/Tricentis/NeoLoad/8.1.1/Tricentis.NeoLoad.installer.yaml
@@ -17,6 +17,8 @@ InstallerSwitches:
 UpgradeBehavior: uninstallPrevious
 FileExtensions:
 - nlp
+AppsAndFeaturesEntries:
+  - DisplayName: NeoLoad 8.1.1
 Installers:
 - Architecture: x64
   InstallerUrl: https://d24mnm5myvorwj.cloudfront.net/documents/download/neoload/v8.1/neoload_8_1_1_windows_x64.exe

--- a/manifests/t/Tricentis/NeoLoad/8.1.1/Tricentis.NeoLoad.installer.yaml
+++ b/manifests/t/Tricentis/NeoLoad/8.1.1/Tricentis.NeoLoad.installer.yaml
@@ -1,0 +1,28 @@
+# Created with YamlCreate.ps1 v2.1.2 $debug=QUSU.7-2-5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+
+PackageIdentifier: Tricentis.NeoLoad
+PackageVersion: 8.1.1
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: exe
+Scope: machine
+InstallModes:
+- interactive
+- silent
+InstallerSwitches:
+  Silent: -q
+  SilentWithProgress: -q
+UpgradeBehavior: uninstallPrevious
+FileExtensions:
+- nlp
+Installers:
+- Architecture: x64
+  InstallerUrl: https://d24mnm5myvorwj.cloudfront.net/documents/download/neoload/v8.1/neoload_8_1_1_windows_x64.exe
+  InstallerSha256: 2BC2B084851A4ECE10CA68AEE39B3F45CBF82157965BD5A25D6EAFDB46C27F1F
+- Architecture: x86
+  InstallerUrl: https://d24mnm5myvorwj.cloudfront.net/documents/download/neoload/v8.1/neoload_8_1_1_windows_x86.exe
+  InstallerSha256: 3205D45D9386FC7C6FD244279D1224DC2AEEFDB37980E115F3D83AA2B850235B
+ManifestType: installer
+ManifestVersion: 1.1.0

--- a/manifests/t/Tricentis/NeoLoad/8.1.1/Tricentis.NeoLoad.locale.en-US.yaml
+++ b/manifests/t/Tricentis/NeoLoad/8.1.1/Tricentis.NeoLoad.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# Created with YamlCreate.ps1 v2.1.2 $debug=QUSU.7-2-5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+
+PackageIdentifier: Tricentis.NeoLoad
+PackageVersion: 8.1.1
+PackageLocale: en-US
+Publisher: Tricentis
+PublisherUrl: https://www.tricentis.com/
+PublisherSupportUrl: https://support-hub.tricentis.com/open
+PrivacyUrl: https://www.tricentis.com/legal-information/privacy-policy/
+# Author: Tricentis
+PackageName: NeoLoad
+PackageUrl: https://www.tricentis.com/products/performance-testing-neoload/
+License: Proprietary
+LicenseUrl: https://www.tricentis.com/legal-information/terms-of-use/
+Copyright: Copyright (c) 2022 Tricentis. All Rights Reserved 
+# CopyrightUrl: 
+ShortDescription: Automate API and Application Performance Testing
+# Description: 
+Moniker: neoload
+Tags:
+- load-testing
+- performance-testing
+# Agreements: 
+# ReleaseNotes: 
+# ReleaseNotesUrl: 
+ManifestType: defaultLocale
+ManifestVersion: 1.1.0

--- a/manifests/t/Tricentis/NeoLoad/8.1.1/Tricentis.NeoLoad.yaml
+++ b/manifests/t/Tricentis/NeoLoad/8.1.1/Tricentis.NeoLoad.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.1.2 $debug=QUSU.7-2-5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+
+PackageIdentifier: Tricentis.NeoLoad
+PackageVersion: 8.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.1.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.1 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.1.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----
@Trenly Sorry for tagging you again, but I just wanted to quickly ask whether AppsAndFeaturesEntries is mandatory for this version? Or is it just a good idea to add AppsAndFeaturesEntries wherever the PackageName does not match DisplayName? (ofcourse we must add it where the version is in between the PackageName)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/66950)