### PR TITLE
New package: ApacheFriends.Xampp.8.1 version 8.1.6-0

### DIFF
--- a/manifests/a/ApacheFriends/Xampp/8/1/8.1.6-0/ApacheFriends.Xampp.8.1.installer.yaml
+++ b/manifests/a/ApacheFriends/Xampp/8/1/8.1.6-0/ApacheFriends.Xampp.8.1.installer.yaml
@@ -1,0 +1,22 @@
+# Created with YamlCreate.ps1 v2.1.2 $debug=NVS1.7-2-5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+
+PackageIdentifier: ApacheFriends.Xampp.8.1
+PackageVersion: 8.1.6-0
+MinimumOSVersion: 10.0.0.0
+InstallerType: exe
+Scope: machine
+InstallModes:
+- interactive
+- silent
+InstallerSwitches:
+  Silent: --mode unattended --launchapps 0
+  SilentWithProgress: --mode unattended --launchapps 0
+UpgradeBehavior: install
+ReleaseDate: 2022-05-16
+Installers:
+- Architecture: x64
+  InstallerUrl: https://downloadsapachefriends.global.ssl.fastly.net/8.1.6/xampp-windows-x64-8.1.6-0-VS16-installer.exe
+  InstallerSha256: EA3BE132739E02A4C5B83014085DAA3E1266CDD3F6BCD8F506AB434F37F0F85D
+ManifestType: installer
+ManifestVersion: 1.1.0

--- a/manifests/a/ApacheFriends/Xampp/8/1/8.1.6-0/ApacheFriends.Xampp.8.1.locale.en-US.yaml
+++ b/manifests/a/ApacheFriends/Xampp/8/1/8.1.6-0/ApacheFriends.Xampp.8.1.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# Created with YamlCreate.ps1 v2.1.2 $debug=NVS1.7-2-5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+
+PackageIdentifier: ApacheFriends.Xampp.8.1
+PackageVersion: 8.1.6-0
+PackageLocale: en-US
+Publisher: Bitnami
+PublisherUrl: https://www.apachefriends.org
+PublisherSupportUrl: https://www.apachefriends.org/community.html
+PrivacyUrl: https://www.apachefriends.org/privacy_policy.html
+Author: Apache Friends
+PackageName: XAMPP 8.1
+# PackageUrl: 
+License: GNU General Public License v2.0
+LicenseUrl: https://www.apachefriends.org/about.html
+Copyright: Copyright (c) 2022, Apache Friends
+# CopyrightUrl: 
+ShortDescription: XAMPP is an easy to install Apache distribution containing MariaDB, PHP and Perl.
+# Description: 
+Moniker: xampp8-1
+Tags:
+- apache
+- mariadb
+- mysql
+- perl
+- php
+# Agreements: 
+# ReleaseNotes: 
+# ReleaseNotesUrl: 
+ManifestType: defaultLocale
+ManifestVersion: 1.1.0

--- a/manifests/a/ApacheFriends/Xampp/8/1/8.1.6-0/ApacheFriends.Xampp.8.1.yaml
+++ b/manifests/a/ApacheFriends/Xampp/8/1/8.1.6-0/ApacheFriends.Xampp.8.1.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.1.2 $debug=NVS1.7-2-5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+
+PackageIdentifier: ApacheFriends.Xampp.8.1
+PackageVersion: 8.1.6-0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.1.0


### PR DESCRIPTION
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.1 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.1.0)?

ApacheFriends provides three channels of XAMPP: `7.4`, `8.0`, and `8.1`. Each channel has updates, so WinGet's packages should be changed accordingly. [Source](https://www.apachefriends.org/download.html)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/67023)