### PR TITLE
Configure manifest-installer-validation-error label

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -141,7 +141,7 @@
           {
             "name": "addReply",
             "parameters": {
-              "comment": "Hello @${issueAuthor},\nDuring validation, the MSIX package was evaluated. There were either inconsistencies or values not present in the manifest.\nPlease adjust the manifest accordingly."
+              "comment": "Hello @${issueAuthor},\nDuring validation, the MSIX package was evaluated. There were either inconsistencies or values not present in the manifest.\nPlease adjust the manifest accordingly.\n\nTemplate: msftbot/validationError/manifest/installerValidation"
             }
           },
           {

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -125,6 +125,52 @@
             {
               "name": "labelAdded",
               "parameters": {
+                "label": "Manifest-Installer-Validation-Error"
+              }
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "Pipeline: Manifest installer validation error",
+        "actions": [
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "Hello @${issueAuthor},\nDuring validation, the MSIX package was evaluated. There were either inconsistencies or values not present in the manifest.\nPlease adjust the manifest accordingly."
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "PR Author"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Needs-Author-Feedback"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "or",
+          "operands": [
+            {
+              "name": "labelAdded",
+              "parameters": {
                 "label": "URL-Validation-Error"
               }
             }
@@ -2953,6 +2999,12 @@
           {
             "name": "removeLabel",
             "parameters": {
+              "label": "Manifest-Installer-Validation-Error"
+            }
+          },
+          {
+            "name": "removeLabel",
+            "parameters": {
               "label": "URL-Validation-Error"
             }
           },
@@ -3333,6 +3385,12 @@
             "name": "removeLabel",
             "parameters": {
               "label": "Manifest-Validation-Error"
+            }
+          },
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "Manifest-Installer-Validation-Error"
             }
           },
           {


### PR DESCRIPTION
- Adding configuration for `Manifest-Installer-Validation-Error` label.
- This label is added when there are either inconsistencies or values not present in the manifest during the evaluation of an MSIX package. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/67175)