### PR TITLE
New version: EclipseAdoptium.Temurin.18 version 18.0.2.9

### DIFF
--- a/manifests/e/EclipseAdoptium/Temurin/18/18.0.2.9/EclipseAdoptium.Temurin.18.installer.yaml
+++ b/manifests/e/EclipseAdoptium/Temurin/18/18.0.2.9/EclipseAdoptium.Temurin.18.installer.yaml
@@ -1,0 +1,27 @@
+# Created with YamlCreate.ps1 v2.1.2 $debug=NVS1.7-2-5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+
+PackageIdentifier: EclipseAdoptium.Temurin.18
+PackageVersion: 18.0.2.9
+MinimumOSVersion: 10.0.0.0
+InstallerType: wix
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Custom: INSTALLLEVEL=3
+UpgradeBehavior: install
+Commands:
+- java
+FileExtensions:
+- jar
+- java
+ReleaseDate: 2022-07-22
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/adoptium/temurin18-binaries/releases/download/jdk-18.0.2%2B9/OpenJDK18U-jdk_x64_windows_hotspot_18.0.2_9.msi
+  InstallerSha256: B3F9FD4F94E9F117387DE4ECBFAF0903A93E64C39683236ACBA583E75D41BA07
+  ProductCode: '{22D0B199-5AB8-406F-BCE4-E76156A023BB}'
+ManifestType: installer
+ManifestVersion: 1.1.0

--- a/manifests/e/EclipseAdoptium/Temurin/18/18.0.2.9/EclipseAdoptium.Temurin.18.locale.en-US.yaml
+++ b/manifests/e/EclipseAdoptium/Temurin/18/18.0.2.9/EclipseAdoptium.Temurin.18.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# Created with YamlCreate.ps1 v2.1.2 $debug=NVS1.7-2-5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+
+PackageIdentifier: EclipseAdoptium.Temurin.18
+PackageVersion: 18.0.2.9
+PackageLocale: en-US
+Publisher: Eclipse Adoptium
+PublisherUrl: https://www.eclipse.org/
+PublisherSupportUrl: https://adoptium.net/support/
+PrivacyUrl: https://www.eclipse.org/legal/privacy.php
+# Author: 
+PackageName: Eclipse Temurin JDK with Hotspot 18
+PackageUrl: https://adoptium.net
+License: GPL 2 with Classpath Exception
+LicenseUrl: https://adoptium.net/about.html
+# Copyright: 
+# CopyrightUrl: 
+ShortDescription: Temurin JDK
+Description: Java™ is the world's leading programming language and platform. The Adoptium Working Group promotes and supports high-quality, TCK certified runtimes and associated technology for use across the Java™ ecosystem. Eclipse Temurin is the name of the OpenJDK distribution from Adoptium.
+Moniker: temurin18
+Tags:
+- adoptopenjdk
+- java
+- jdk
+- jvm
+- openjdk
+- temurin
+# Agreements: 
+# ReleaseNotes: 
+# ReleaseNotesUrl: 
+ManifestType: defaultLocale
+ManifestVersion: 1.1.0

--- a/manifests/e/EclipseAdoptium/Temurin/18/18.0.2.9/EclipseAdoptium.Temurin.18.yaml
+++ b/manifests/e/EclipseAdoptium/Temurin/18/18.0.2.9/EclipseAdoptium.Temurin.18.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.1.2 $debug=NVS1.7-2-5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+
+PackageIdentifier: EclipseAdoptium.Temurin.18
+PackageVersion: 18.0.2.9
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.1.0


### PR DESCRIPTION
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.1 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.1.0)?

The x86 installer has not been released as of yet. [Source](https://github.com/adoptium/temurin18-binaries/releases/tag/jdk-18.0.2%2B9)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/67632)