### PR TITLE
New package: Digimezzo.Dopamine.2 version 2.0.8.4000

### DIFF
--- a/manifests/d/Digimezzo/Dopamine/2/2.0.8.4000/Digimezzo.Dopamine.2.installer.yaml
+++ b/manifests/d/Digimezzo/Dopamine/2/2.0.8.4000/Digimezzo.Dopamine.2.installer.yaml
@@ -1,0 +1,15 @@
+# Created with YamlCreate.ps1 v2.1.2 $debug=NVS1.7-2-5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+
+PackageIdentifier: Digimezzo.Dopamine.2
+PackageVersion: 2.0.8.4000
+MinimumOSVersion: 10.0.0.0
+InstallerType: wix
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://www.digimezzo.com/content/software/dopamine/Dopamine%202.0.9%20(Release).msi
+  InstallerSha256: 6009410B99CC48B15C62B748C7E61D8586CF3FFBB4D2EA03D442E3557F272FFE
+  ProductCode: '{C87A4336-FA79-4FD1-900E-CB24F9D316CD}'
+ManifestType: installer
+ManifestVersion: 1.1.0

--- a/manifests/d/Digimezzo/Dopamine/2/2.0.8.4000/Digimezzo.Dopamine.2.locale.en-US.yaml
+++ b/manifests/d/Digimezzo/Dopamine/2/2.0.8.4000/Digimezzo.Dopamine.2.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# Created with YamlCreate.ps1 v2.1.2 $debug=NVS1.7-2-5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+
+PackageIdentifier: Digimezzo.Dopamine.2
+PackageVersion: 2.0.8.4000
+PackageLocale: en-US
+Publisher: Digimezzo
+# PublisherUrl: 
+# PublisherSupportUrl: 
+# PrivacyUrl: 
+Author: Digimezzo
+PackageName: Dopamine 2
+PackageUrl: https://github.com/digimezzo/dopamine-windows
+License: GNU General Public License v3.0
+LicenseUrl: https://github.com/digimezzo/dopamine-windows/blob/master/LICENSE
+# Copyright: 
+# CopyrightUrl: 
+ShortDescription: An audio player which tries to make organizing and listening to music as simple and pretty as possible.
+# Description: 
+Moniker: dopamine-2
+Tags:
+- dopamine
+- music
+- player
+# Agreements: 
+ReleaseNotes: |
+  Changes
+  • [Fixed] Progress bar goes to zero when a song is paused
+  • [Changed] Updated the Bulgarian translation
+  • [Changed] Updated the Chinese Traditional translation
+  • [Changed] Updated the Spanish translation
+ReleaseNotesUrl: https://github.com/digimezzo/dopamine-windows/releases/tag/v2.0.8
+ManifestType: defaultLocale
+ManifestVersion: 1.1.0

--- a/manifests/d/Digimezzo/Dopamine/2/2.0.8.4000/Digimezzo.Dopamine.2.yaml
+++ b/manifests/d/Digimezzo/Dopamine/2/2.0.8.4000/Digimezzo.Dopamine.2.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.1.2 $debug=NVS1.7-2-5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+
+PackageIdentifier: Digimezzo.Dopamine.2
+PackageVersion: 2.0.8.4000
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.1.0


### PR DESCRIPTION
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.1 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.1.0)?

Dopamine 2 and Dopamine 3 are split on https://digimezzo.com/software so the packages should reflect this.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/67737)