### PR TITLE
Add Version Manager to easily switch between winget versions

### DIFF
--- a/Tools/WingetVersionManager.ps1
+++ b/Tools/WingetVersionManager.ps1
@@ -1,0 +1,75 @@
+#Requires -Version 5
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'This script is not intended to have any outputs piped')]
+
+Param
+(
+    [switch] $Clean,
+    [switch] $Prerelease,
+    [switch] $Latest,
+    [Parameter(Mandatory = $false)]
+    [string] $Version
+)
+
+$releasesAPIResponse = Invoke-RestMethod 'https://api.github.com/repos/microsoft/winget-cli/releases?per_page=100'
+
+if (!$Prerelease) {
+    $releasesAPIResponse = $releasesAPIResponse.Where({ !$_.prerelease })
+}
+
+if ($PSBoundParameters.Keys -contains 'Version') {
+    $releasesAPIResponse = @($releasesAPIResponse.Where({ $_.tag_name -match $('^v?'+[regex]::escape($Version))}))
+}
+
+if ($Latest) {
+    $releasesAPIResponse = @($releasesAPIResponse | Select-Object -First 1)
+}
+
+if ($releasesAPIResponse.Length -lt 1) {
+    Write-Output 'No releases found matching criteria'
+    exit 1
+}
+
+$releasesAPIResponse = $releasesAPIResponse | Sort-Object -Property published_at -Descending
+$assets = $releasesAPIResponse[0].assets
+$shaFileUrl = $assets.Where({ $_.name -eq 'Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.txt' }).browser_download_url
+$msixFileUrl = $assets.Where({ $_.name -eq 'Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle' }).browser_download_url
+$releaseTag = $releasesAPIResponse[0].tag_name
+Write-Host "Found $releaseTag"
+
+if ($Clean){
+    Get-AppxPackage 'Microsoft.DesktopAppInstaller' | Remove-AppxPackage
+}
+
+$shaFile = New-TemporaryFile
+Invoke-WebRequest -Uri $shaFileUrl -OutFile $shaFile
+$sha256 = Get-Content $shaFile -Tail 1
+Remove-Item $shaFile -Force
+
+$versionFolder = Join-Path $env:LOCALAPPDATA -ChildPath "Packages\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe\bin\$releaseTag"
+if (!(Test-Path $versionFolder)) {
+    New-Item -ItemType Directory -Path $versionFolder -Force | Out-Null
+}
+$existingFiles = Get-ChildItem $versionFolder -File
+$msixFile = $null
+foreach ($file in $existingFiles) {
+    if ((Get-FileHash $file.FullName).Hash.ToLower() -eq $sha256) {
+        $msixFile = $file
+        Write-Output 'Found file in local store. Skipping download'
+    }
+}
+if (!$msixFile){
+    $outputPath = Join-Path $versionFolder -ChildPath "winget_$releaseTag.msix"
+    Write-Output "Downloading version $releaseTag to $outputPath"
+    Invoke-WebRequest -Uri $msixFileUrl -OutFile $outputPath
+    $file = Get-Item $outputPath
+    if ((Get-FileHash $file).Hash.ToLower() -ne $sha256) {
+        Write-Output 'Download failed. Installer hashes do not match.'
+        exit 1
+    }
+    else {
+        $msixFile = $file
+    }
+}
+Add-AppxPackage $msixFile.FullName -ForceUpdateFromAnyVersion
+Write-Output 'Checking winget version . . .'
+& winget -v


### PR DESCRIPTION
This allows switching between versions of Winget easily.
```powershell
.\Tools\WingetVersionManager.ps1 1.2  # installs latest version of v1.2*
.\Tools\WingetVersionManager.ps1 -Latest # installs latest release which isn't a pre-release
.\Tools\WingetVersionManager.ps1 -Latest -Prerelease # installs latest prerelease (1.3.2091 currently)
.\Tools\WingetVersionManager.ps1 1.4 # no versions found, as latest version is a prerelease
.\Tools\WingetVersionManager.ps1 1.4 -Prerelase # installs latest version of v1.4*
```

`-Clean` can be specified for a clean install of winget, which removes the package first and then installs the desired version

Binaries are validated with their hash from the GitHub release, and if the file exists on disk, it is not re-downloaded.
Files are stored in the directory winget makes when it is installed so that uninstalling winget also removes downloaded binaries to avoid making a mess on user's machines.

cc @jedieaston @OfficialEsco @denelon 


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/67987)