### PR TITLE
Update: Azul.Zulu.17.JDK version 17.36.15

### DIFF
--- a/manifests/a/Azul/Zulu/17/JDK/17.36.15/Azul.Zulu.17.JDK.installer.yaml
+++ b/manifests/a/Azul/Zulu/17/JDK/17.36.15/Azul.Zulu.17.JDK.installer.yaml
@@ -20,10 +20,6 @@ FileExtensions:
 - java
 - jsp
 Installers:
-- Architecture: x64
-  InstallerUrl: https://cdn.azul.com/zulu/bin/zulu17.36.13-ca-jdk17.0.4-win_x64.msi
-  InstallerSha256: A1B003A7E1D79952D3C628FD26F5B63F99CC07A3816CF02D1C501ED7CAFE1268
-  ProductCode: '{12332786-EBBC-4226-90F2-CA1A5F508FE7}'
 - Architecture: x86
   InstallerUrl: https://cdn.azul.com/zulu/bin/zulu17.36.15-ca-jdk17.0.4-win_i686.msi
   InstallerSha256: 976002BE947CECA3A94399A1D2C263DC832CE4C5A3B3EF21A1F19714AE5B3C8D


### PR DESCRIPTION
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.1 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.1.0)?

The x64 variation actually has a different version number for this version, `17.36.13`. I've checked in Windows Sandbox and the two variations are writing different version numbers here, so the `17.36.13` should be put in its own version.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/68041)