### PR TITLE
Update: GorillaDevs.GDLauncher version 1.1.27

### DIFF
--- a/manifests/g/GorillaDevs/GDLauncher/1.1.27/GorillaDevs.GDLauncher.installer.yaml
+++ b/manifests/g/GorillaDevs/GDLauncher/1.1.27/GorillaDevs.GDLauncher.installer.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.1.2 $debug=QUSU.7-2-5
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-5
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
 
 PackageIdentifier: GorillaDevs.GDLauncher
@@ -13,12 +13,13 @@ InstallModes:
 InstallerSwitches:
   Custom: /NORESTART
 UpgradeBehavior: install
+ReleaseDate: 2022-07-24
+AppsAndFeaturesEntries:
+- DisplayName: GDLauncher 1.1.27
+  ProductCode: 916a734d-6952-56dd-9bc1-8fe0631126cf
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/gorilla-devs/GDLauncher/releases/download/v1.1.27/GDLauncher-win-setup.exe
   InstallerSha256: F671175B96F82B4C9D1C28CDCFFF972F6F17BF65FDB40A3AF2ECAE5217405C8A
-  AppsAndFeaturesEntries:
-  - DisplayName: GDLauncher 1.1.27
-    ProductCode: 916a734d-6952-56dd-9bc1-8fe0631126cf
 ManifestType: installer
 ManifestVersion: 1.1.0

--- a/manifests/g/GorillaDevs/GDLauncher/1.1.27/GorillaDevs.GDLauncher.locale.en-US.yaml
+++ b/manifests/g/GorillaDevs/GDLauncher/1.1.27/GorillaDevs.GDLauncher.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.1.2 $debug=QUSU.7-2-5
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-5
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
 
 PackageIdentifier: GorillaDevs.GDLauncher

--- a/manifests/g/GorillaDevs/GDLauncher/1.1.27/GorillaDevs.GDLauncher.yaml
+++ b/manifests/g/GorillaDevs/GDLauncher/1.1.27/GorillaDevs.GDLauncher.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.1.2 $debug=QUSU.7-2-5
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-5
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
 
 PackageIdentifier: GorillaDevs.GDLauncher


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | GDLauncher | GitHub CLI, GitHub CLI, CAD快速看图v5.17.1.86, GDevelop 5 5.0.139, Google Chrome Canary    |
| Version     | 1.1.27     | 2.14.2, 2.14.3, , 5.0.139, 106.0.5210.0 |
| Publisher   | GorillaDevs   | GitHub, Inc., GitHub, Inc., 广联达科技股份有限公司, GDevelop Team, Google LLC      |
| ProductCode |           | {FD839A1A-FEFD-4436-825F-FC3EDB09ECC0}, {5787E29A-8403-4428-8333-D5BD2B155C20}, {DDD659B5-6B07-4F5A-A0D3-9E8D3147E165}_is1, c2a9b91e-8206-5b4e-b81d-9aa27463c28e, Google Chrome SxS    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://bittu.eu.org/docs/wpa-intro) in workflow run [2786](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/2770018177>)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/68128)