### PR TITLE
New version: Jitsi.Meet version 2022.7.1

### DIFF
--- a/manifests/j/Jitsi/Meet/2022.7.1/Jitsi.Meet.installer.yaml
+++ b/manifests/j/Jitsi/Meet/2022.7.1/Jitsi.Meet.installer.yaml
@@ -1,0 +1,20 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+
+PackageIdentifier: Jitsi.Meet
+PackageVersion: 2022.7.1
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- silent
+UpgradeBehavior: install
+ReleaseDate: 2022-07-21
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/jitsi/jitsi-meet-electron/releases/download/v2022.7.1/jitsi-meet.exe
+  InstallerSha256: 01E9122BCD9780D52B96DB8E0FA620B7FF52FD791F1A38946B4A1F3BB0ADFD68
+ManifestType: installer
+ManifestVersion: 1.1.0

--- a/manifests/j/Jitsi/Meet/2022.7.1/Jitsi.Meet.locale.en-US.yaml
+++ b/manifests/j/Jitsi/Meet/2022.7.1/Jitsi.Meet.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+
+PackageIdentifier: Jitsi.Meet
+PackageVersion: 2022.7.1
+PackageLocale: en-US
+Publisher: Jitsi Team
+PublisherUrl: https://jitsi.org/
+PublisherSupportUrl: https://github.com/jitsi/jitsi-meet-electron/issues
+PrivacyUrl: https://jitsi.org/security/
+Author: Jitsi Team
+PackageName: Jitsi Meet
+PackageUrl: https://github.com/jitsi/jitsi-meet-electron
+License: Apache License 2.0
+LicenseUrl: https://raw.githubusercontent.com/jitsi/jitsi-meet-electron/master/LICENSE
+# Copyright: 
+CopyrightUrl: https://raw.githubusercontent.com/jitsi/jitsi-meet-electron/master/LICENSE
+ShortDescription: Jitsi Meet is an open-source (Apache) WebRTC JavaScript application that uses Jitsi Videobridge to provide high quality, secure and scalable video conferences.
+# Description: 
+# Moniker: 
+Tags:
+- chat
+- jitsi
+- jitsi-meet
+- meeting
+- video
+# Agreements: 
+# ReleaseNotes: 
+ReleaseNotesUrl: https://github.com/jitsi/jitsi-meet-electron/releases/tag/v2022.7.1
+ManifestType: defaultLocale
+ManifestVersion: 1.1.0

--- a/manifests/j/Jitsi/Meet/2022.7.1/Jitsi.Meet.yaml
+++ b/manifests/j/Jitsi/Meet/2022.7.1/Jitsi.Meet.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+
+PackageIdentifier: Jitsi.Meet
+PackageVersion: 2022.7.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.1.0


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | Jitsi Meet | MasterGo 1.1.6    |
| Version     | 2022.7.1     | 1.1.6 |
| Publisher   | Jitsi Team   | 北京尽微致广信息技术有限公司      |
| ProductCode |           | com.master.electron    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://bittu.eu.org/docs/wpa-intro) in workflow run [2786](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/2770018177>)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/68159)