### PR TITLE
Update: xanderfrangos.twinkletray version 1.14.3

### DIFF
--- a/manifests/x/xanderfrangos/twinkletray/1.14.3/xanderfrangos.twinkletray.installer.yaml
+++ b/manifests/x/xanderfrangos/twinkletray/1.14.3/xanderfrangos.twinkletray.installer.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.1.2 $debug=QUSU.7-2-5
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-5
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
 
 PackageIdentifier: xanderfrangos.twinkletray
@@ -10,6 +10,7 @@ Scope: user
 InstallModes:
 - silent
 UpgradeBehavior: install
+ReleaseDate: 2022-07-15
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/xanderfrangos/twinkle-tray/releases/download/v1.14.3/Twinkle.Tray.v1.14.3.exe

--- a/manifests/x/xanderfrangos/twinkletray/1.14.3/xanderfrangos.twinkletray.locale.en-US.yaml
+++ b/manifests/x/xanderfrangos/twinkletray/1.14.3/xanderfrangos.twinkletray.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.1.2 $debug=QUSU.7-2-5
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-5
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
 
 PackageIdentifier: xanderfrangos.twinkletray
@@ -24,6 +24,6 @@ Tags:
 - tray
 # Agreements: 
 # ReleaseNotes: 
-# ReleaseNotesUrl: 
+ReleaseNotesUrl: https://github.com/xanderfrangos/twinkle-tray/releases/tag/v1.14.3
 ManifestType: defaultLocale
 ManifestVersion: 1.1.0

--- a/manifests/x/xanderfrangos/twinkletray/1.14.3/xanderfrangos.twinkletray.yaml
+++ b/manifests/x/xanderfrangos/twinkletray/1.14.3/xanderfrangos.twinkletray.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.1.2 $debug=QUSU.7-2-5
+# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-5
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
 
 PackageIdentifier: xanderfrangos.twinkletray


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | Twinkle Tray | Crushee 2.4.5, WeMod, Wire    |
| Version     | 1.14.3     | 2.4.5, 8.3.0, 3.28.4253 |
| Publisher   | Xander Frangos   | Xander Frangos, WeMod, Wire      |
| ProductCode |           | a1798972-af44-56bd-8be5-8d28919d65dc, WeMod, wire    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://bittu.eu.org/docs/wpa-intro) in workflow run [2786](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/2770018177>)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/68252)