### PR TITLE
Change Installer Type of VisualStudio.2022.Community

### DIFF
--- a/manifests/m/Microsoft/VisualStudio/2022/Community/17.2.6/Microsoft.VisualStudio.2022.Community.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Community/17.2.6/Microsoft.VisualStudio.2022.Community.installer.yaml
@@ -2,7 +2,7 @@
 PackageIdentifier: Microsoft.VisualStudio.2022.Community
 PackageVersion: 17.2.6
 MinimumOSVersion: 10.0.0.0
-InstallerType: exe
+InstallerType: burn
 InstallerSwitches:
   Silent: --quiet
   SilentWithProgress: --passive


### PR DESCRIPTION
When upgrading Visual Studio Community, it returns code 3010 - reboot required. Changing the installer type to Burn should automatically handle this as a special return code rather than having to add it as an expected return code, and should better represent the actual installer technology

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/68466)