### PR TITLE
Add vswhere portable application

### DIFF
--- a/manifests/m/Microsoft/VisualStudio/Locator/3.0.3.9285/Microsoft.VisualStudio.Locator.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/Locator/3.0.3.9285/Microsoft.VisualStudio.Locator.installer.yaml
@@ -13,4 +13,6 @@ Installers:
     - "silent"
   ReleaseDate: "2022-06-02"
 ManifestType: installer
-ManifestVersion: 1.1.0
+ManifestVersion: 1.2.0
+Commands:
+  - vswhere

--- a/manifests/m/Microsoft/VisualStudio/Locator/3.0.3.9285/Microsoft.VisualStudio.Locator.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/Locator/3.0.3.9285/Microsoft.VisualStudio.Locator.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+
+PackageIdentifier: Microsoft.VisualStudio.Locator
+PackageVersion: 3.0.3.9285
+Installers:
+- Architecture: x86
+  InstallerType: portable
+  InstallerUrl: https://github.com/microsoft/vswhere/releases/download/3.0.3/vswhere.exe
+  InstallerSha256: 261D281CE9C95C3E46900E67ACE8C3518DD7B2596774F63C92E2BB1FBCE71D4C
+  Platform:
+    - "Windows.Desktop"
+  InstallModes:
+    - "silent"
+  ReleaseDate: "2022-06-02"
+ManifestType: installer
+ManifestVersion: 1.1.0

--- a/manifests/m/Microsoft/VisualStudio/Locator/3.0.3.9285/Microsoft.VisualStudio.Locator.locale.en-US.yaml
+++ b/manifests/m/Microsoft/VisualStudio/Locator/3.0.3.9285/Microsoft.VisualStudio.Locator.locale.en-US.yaml
@@ -10,6 +10,6 @@ Copyright: Copyright (C) Microsoft Corporation. All rights reserved.
 Description: Find and get information on Visual Studio versions 2017 and newer with optional additional criteria such as version, channel, or installed workloads.
 ShortDescription: Find Visual Studio installations
 ManifestType: defaultLocale
-ManifestVersion: 1.1.0
+ManifestVersion: 1.2.0
 LicenseUrl: https://github.com/microsoft/vswhere/blob/master/LICENSE.txt
 Moniker: vswhere

--- a/manifests/m/Microsoft/VisualStudio/Locator/3.0.3.9285/Microsoft.VisualStudio.Locator.locale.en-US.yaml
+++ b/manifests/m/Microsoft/VisualStudio/Locator/3.0.3.9285/Microsoft.VisualStudio.Locator.locale.en-US.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+
+PackageIdentifier: Microsoft.VisualStudio.Locator
+PackageVersion: 3.0.3.9285
+PackageLocale: en-US
+Publisher: Microsoft Corporation
+PackageName: Visual Studio Locator
+License: MIT
+Copyright: Copyright (C) Microsoft Corporation. All rights reserved.
+Description: Find and get information on Visual Studio versions 2017 and newer with optional additional criteria such as version, channel, or installed workloads.
+ShortDescription: Find Visual Studio installations
+ManifestType: defaultLocale
+ManifestVersion: 1.1.0
+LicenseUrl: https://github.com/microsoft/vswhere/blob/master/LICENSE.txt
+Moniker: vswhere

--- a/manifests/m/Microsoft/VisualStudio/Locator/3.0.3.9285/Microsoft.VisualStudio.Locator.yaml
+++ b/manifests/m/Microsoft/VisualStudio/Locator/3.0.3.9285/Microsoft.VisualStudio.Locator.yaml
@@ -4,4 +4,4 @@ PackageIdentifier: Microsoft.VisualStudio.Locator
 PackageVersion: 3.0.3.9285
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.1.0
+ManifestVersion: 1.2.0

--- a/manifests/m/Microsoft/VisualStudio/Locator/3.0.3.9285/Microsoft.VisualStudio.Locator.yaml
+++ b/manifests/m/Microsoft/VisualStudio/Locator/3.0.3.9285/Microsoft.VisualStudio.Locator.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+
+PackageIdentifier: Microsoft.VisualStudio.Locator
+PackageVersion: 3.0.3.9285
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.1.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.1 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.1.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

Note that I am the creator and maintainer of microsoft/vswhere. I realize that it may be too early given announcement of the 1.2.0 schema changes but wanted to get this process started. vswhere is already in chocolatey and scoop and want to make sure it's available in numerous channels, especially if/when winget is in-box on Windows.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/68853)