### PR TITLE
Update: AdoptOpenJDK.OpenJDK.17 version 17.0.0.18

### DIFF
--- a/manifests/a/AdoptOpenJDK/OpenJDK/17/17.0.0.18/AdoptOpenJDK.OpenJDK.17.installer.yaml
+++ b/manifests/a/AdoptOpenJDK/OpenJDK/17/17.0.0.18/AdoptOpenJDK.OpenJDK.17.installer.yaml
@@ -1,15 +1,15 @@
-# Created using wingetcreate 1.0.4.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+# Created with YamlCreate.ps1 v2.1.3 $debug=QUSU.7-2-5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
 
 PackageIdentifier: AdoptOpenJDK.OpenJDK.17
 PackageVersion: 17.0.0.18
+InstallerLocale: en-US
+MinimumOSVersion: 10.0.0.0
+InstallerType: wix
 Installers:
-- InstallerLocale: en-US
-  Architecture: x64
-  InstallerType: wix
+- Architecture: x64
   InstallerUrl: https://github.com/AdoptOpenJDK/openjdk17-binaries/releases/download/jdk-2021-05-07-13-31/OpenJDK-jdk_x64_windows_openj9_2021-05-06-23-30.msi
   InstallerSha256: 5D50F769B5969D629E95D1CD91A09114DB28A56F0487B94F81BF1D87A678E3BC
   ProductCode: '{45E7C464-0A84-40F3-BDFB-425E1484B9B3}'
 ManifestType: installer
-ManifestVersion: 1.1.0
-
+ManifestVersion: 1.2.0

--- a/manifests/a/AdoptOpenJDK/OpenJDK/17/17.0.0.18/AdoptOpenJDK.OpenJDK.17.locale.en-US.yaml
+++ b/manifests/a/AdoptOpenJDK/OpenJDK/17/17.0.0.18/AdoptOpenJDK.OpenJDK.17.locale.en-US.yaml
@@ -1,20 +1,29 @@
-# Created using wingetcreate 1.0.4.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+# Created with YamlCreate.ps1 v2.1.3 $debug=QUSU.7-2-5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
 
 PackageIdentifier: AdoptOpenJDK.OpenJDK.17
 PackageVersion: 17.0.0.18
 PackageLocale: en-US
 Publisher: AdoptOpenJDK
 PublisherUrl: https://github.com/AdoptOpenJDK/openjdk17-binaries
-PublisherSupportUrl: https://github.com/AdoptOpenJDK/openjdk17-binaries/issues
+# PublisherSupportUrl: 
+# PrivacyUrl: 
 Author: AdoptOpenJDK
 PackageName: AdoptOpenJDK JDK with Eclipse OpenJ9 17
 PackageUrl: https://adoptopenjdk.net
 License: GPL 2 with Classpath Exception
 LicenseUrl: https://adoptopenjdk.net/about.html
+# Copyright: 
+# CopyrightUrl: 
 ShortDescription: AdoptOpenJDK with Eclipse OpenJ9 JVM
+# Description: 
 Moniker: adoptopenjdk17
+# Tags: 
+# Agreements: 
+# ReleaseNotes: 
 ReleaseNotesUrl: https://github.com/AdoptOpenJDK/openjdk17-binaries/releases/tag/jdk-2021-05-07-13-31
+# PurchaseUrl: 
+InstallationNotes: AdoptOpenJDK has been replaced by Eclipse Temurin.
+# Documentations: 
 ManifestType: defaultLocale
-ManifestVersion: 1.1.0
-
+ManifestVersion: 1.2.0

--- a/manifests/a/AdoptOpenJDK/OpenJDK/17/17.0.0.18/AdoptOpenJDK.OpenJDK.17.locale.en-US.yaml
+++ b/manifests/a/AdoptOpenJDK/OpenJDK/17/17.0.0.18/AdoptOpenJDK.OpenJDK.17.locale.en-US.yaml
@@ -23,7 +23,7 @@ Moniker: adoptopenjdk17
 # ReleaseNotes: 
 ReleaseNotesUrl: https://github.com/AdoptOpenJDK/openjdk17-binaries/releases/tag/jdk-2021-05-07-13-31
 # PurchaseUrl: 
-InstallationNotes: AdoptOpenJDK has been replaced by Eclipse Temurin.
+InstallationNotes: AdoptOpenJDK has been replaced by Eclipse Temurin (EclipseAdoptium.Temurin.17.JDK).
 # Documentations: 
 ManifestType: defaultLocale
 ManifestVersion: 1.2.0

--- a/manifests/a/AdoptOpenJDK/OpenJDK/17/17.0.0.18/AdoptOpenJDK.OpenJDK.17.yaml
+++ b/manifests/a/AdoptOpenJDK/OpenJDK/17/17.0.0.18/AdoptOpenJDK.OpenJDK.17.yaml
@@ -1,9 +1,8 @@
-# Created using wingetcreate 1.0.4.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+# Created with YamlCreate.ps1 v2.1.3 $debug=QUSU.7-2-5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
 
 PackageIdentifier: AdoptOpenJDK.OpenJDK.17
 PackageVersion: 17.0.0.18
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.1.0
-
+ManifestVersion: 1.2.0


### PR DESCRIPTION
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [X] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.1 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.1.0)?

Adds installation notes that say that AdoptOpenJDK has been replaced by Eclipse Temurin.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/68961)