### PR TITLE
New package: HottaStudio.TowerofFantasy version 1.0.0

### DIFF
--- a/manifests/h/HottaStudio/TowerofFantasy/1.0.0/HottaStudio.TowerofFantasy.installer.yaml
+++ b/manifests/h/HottaStudio/TowerofFantasy/1.0.0/HottaStudio.TowerofFantasy.installer.yaml
@@ -1,0 +1,15 @@
+# Created with YamlCreate.ps1 v2.1.3 $debug=NVS1.7-2-5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+
+PackageIdentifier: HottaStudio.TowerofFantasy
+PackageVersion: 1.0.0
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+UpgradeBehavior: install
+Installers:
+- Architecture: x86
+  InstallerUrl: https://www.toweroffantasy-global.com/download/TofMiniLoader_official.wg.intl.exe
+  InstallerSha256: EF3DA4B7C93DA3194641787EFE3970AD772AE3AE92E6190812F10625EBCF273C
+  ProductCode: tof_launcher
+ManifestType: installer
+ManifestVersion: 1.1.0

--- a/manifests/h/HottaStudio/TowerofFantasy/1.0.0/HottaStudio.TowerofFantasy.locale.en-US.yaml
+++ b/manifests/h/HottaStudio/TowerofFantasy/1.0.0/HottaStudio.TowerofFantasy.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# Created with YamlCreate.ps1 v2.1.3 $debug=NVS1.7-2-5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+
+PackageIdentifier: HottaStudio.TowerofFantasy
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: Hotta Studio
+PublisherUrl: https://www.toweroffantasy-global.com/
+# PublisherSupportUrl: 
+PrivacyUrl: https://www.toweroffantasy-global.com/PrivacyPolicy.html
+Author: Hotta Studio
+PackageName: Tower of Fantasy
+PackageUrl: https://www.toweroffantasy-global.com/
+License: Proprietary
+# LicenseUrl: 
+Copyright: Copyright (c) Hotta Studio
+# CopyrightUrl: 
+ShortDescription: Tower of Fantasy is a 3D open-world Anime MMORPG.
+# Description: 
+Moniker: toweroffantasy
+Tags:
+- tof
+Agreement: 
+  - AgreementLabel: EULA
+    AgreementUrl: https://www.toweroffantasy-global.com/UserAgreement.html
+# ReleaseNotes: 
+# ReleaseNotesUrl: 
+# PurchaseUrl: 
+# InstallationNotes: 
+# Documentations: 
+ManifestType: defaultLocale
+ManifestVersion: 1.1.0

--- a/manifests/h/HottaStudio/TowerofFantasy/1.0.0/HottaStudio.TowerofFantasy.yaml
+++ b/manifests/h/HottaStudio/TowerofFantasy/1.0.0/HottaStudio.TowerofFantasy.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.1.3 $debug=NVS1.7-2-5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+
+PackageIdentifier: HottaStudio.TowerofFantasy
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.1.0


### PR DESCRIPTION
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [X] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.1 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.1.0)?

Tower of Fantasy doesn't write any `DisplayVersion` value.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/69608)