### PR TITLE
Fix `InstallerUrl` for `Unigine.HeavenBenchmark`

### DIFF
--- a/manifests/u/Unigine/HeavenBenchmark/4.0/Unigine.HeavenBenchmark.installer.yaml
+++ b/manifests/u/Unigine/HeavenBenchmark/4.0/Unigine.HeavenBenchmark.installer.yaml
@@ -9,7 +9,7 @@ InstallModes:
 Installers:
   - Architecture: x86
     InstallerType: inno
-    InstallerUrl: https://m11-assets.unigine.com/d/Unigine_Heaven-4.0.exe
+    InstallerUrl: https://assets.unigine.com/d/Unigine_Heaven-4.0.exe
     InstallerSha256: 497865A09AF205A7D2E8812BFC2DD54870216CC1E95541B63CEF89A4433B0E5F
     InstallerSwitches:
       Custom: /NORESTART


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.1 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.1.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

Fix the `Service unavailable (503)` error when installing Unigine Heaven.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/69616)