### PR TITLE
Fix `InstallerUrl` for `Unigine.ValleyBenchmark`

### DIFF
--- a/manifests/u/Unigine/ValleyBenchmark/1.0/Unigine.ValleyBenchmark.installer.yaml
+++ b/manifests/u/Unigine/ValleyBenchmark/1.0/Unigine.ValleyBenchmark.installer.yaml
@@ -11,7 +11,7 @@ InstallModes:
 Installers:
 - Architecture: x86
   InstallerType: inno
-  InstallerUrl: https://m11-assets.unigine.com/d/Unigine_Valley-1.0.exe
+  InstallerUrl: https://assets.unigine.com/d/Unigine_Valley-1.0.exe
   InstallerSha256: 312B2A4363DA3E7E4401AB97A3329D656CB0C00A9AE4E84B189653676C5EED75
   InstallerSwitches:
     Custom: /NORESTART


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.1 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.1.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----
Fix the `Service unavailable (503)` error when installing Unigine Valley.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/69618)