### PR TITLE
Fix `InstallerUrl` for `Unigine.SuperpositionBenchmark`

### DIFF
--- a/manifests/u/Unigine/SuperpositionBenchmark/1.1/Unigine.SuperpositionBenchmark.installer.yaml
+++ b/manifests/u/Unigine/SuperpositionBenchmark/1.1/Unigine.SuperpositionBenchmark.installer.yaml
@@ -9,7 +9,7 @@ InstallModes:
 Installers:
   - Architecture: x64
     InstallerType: inno
-    InstallerUrl: https://m11-assets.unigine.com/d/Unigine_Superposition-1.1.exe
+    InstallerUrl: https://assets.unigine.com/d/Unigine_Superposition-1.1.exe
     InstallerSha256: de5dbf4f7ad284b709c5db318dbedc1b025a41e50326595a444ee9cbd4a17182
     InstallerSwitches:
       Custom: /NORESTART


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.1 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.1.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----
Fix the `Service unavailable (503)` error when installing Unigine Superposition.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/69619)