### PR TITLE
Fix `InstallerSha256` for `Amazon.Games`

### DIFF
--- a/manifests/a/Amazon/Games/2.1.6485.3/Amazon.Games.installer.yaml
+++ b/manifests/a/Amazon/Games/2.1.6485.3/Amazon.Games.installer.yaml
@@ -1,5 +1,5 @@
-# Created using wingetcreate 0.5.0.1
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+# Created using wingetcreate 1.1.2.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
 
 PackageIdentifier: Amazon.Games
 PackageVersion: 2.1.6485.3
@@ -11,8 +11,8 @@ Installers:
 - Architecture: x86
   InstallerType: exe
   InstallerUrl: https://download.amazongames.com/AmazonGamesSetup.exe
-  InstallerSha256: 49DD00B312A87B9E40695D68D0680360C97189251EE2EF91C8BDABEC40FFFDD7
+  InstallerSha256: 9DBB71CB9C4BCAD710768DB6493317CCF31702A6023AED8700209667F0FAE547
   ProductCode: '{4DD10B06-78A4-4E6F-AA39-25E9C38FA568}'
 ManifestType: installer
-ManifestVersion: 1.1.0
+ManifestVersion: 1.2.0
 

--- a/manifests/a/Amazon/Games/2.1.6485.3/Amazon.Games.installer.yaml
+++ b/manifests/a/Amazon/Games/2.1.6485.3/Amazon.Games.installer.yaml
@@ -14,5 +14,5 @@ Installers:
   InstallerSha256: 9DBB71CB9C4BCAD710768DB6493317CCF31702A6023AED8700209667F0FAE547
   ProductCode: '{4DD10B06-78A4-4E6F-AA39-25E9C38FA568}'
 ManifestType: installer
-ManifestVersion: 1.2.0
+ManifestVersion: 1.1.0
 

--- a/manifests/a/Amazon/Games/2.1.6485.3/Amazon.Games.locale.en-US.yaml
+++ b/manifests/a/Amazon/Games/2.1.6485.3/Amazon.Games.locale.en-US.yaml
@@ -21,5 +21,5 @@ Tags:
 - prime
 - twitch
 ManifestType: defaultLocale
-ManifestVersion: 1.2.0
+ManifestVersion: 1.1.0
 

--- a/manifests/a/Amazon/Games/2.1.6485.3/Amazon.Games.locale.en-US.yaml
+++ b/manifests/a/Amazon/Games/2.1.6485.3/Amazon.Games.locale.en-US.yaml
@@ -1,5 +1,5 @@
-# Created using wingetcreate 0.5.0.1
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+# Created using wingetcreate 1.1.2.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
 
 PackageIdentifier: Amazon.Games
 PackageVersion: 2.1.6485.3
@@ -21,5 +21,5 @@ Tags:
 - prime
 - twitch
 ManifestType: defaultLocale
-ManifestVersion: 1.1.0
+ManifestVersion: 1.2.0
 

--- a/manifests/a/Amazon/Games/2.1.6485.3/Amazon.Games.yaml
+++ b/manifests/a/Amazon/Games/2.1.6485.3/Amazon.Games.yaml
@@ -1,9 +1,9 @@
-# Created using wingetcreate 0.5.0.1
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+# Created using wingetcreate 1.1.2.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
 
 PackageIdentifier: Amazon.Games
 PackageVersion: 2.1.6485.3
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.1.0
+ManifestVersion: 1.2.0
 

--- a/manifests/a/Amazon/Games/2.1.6485.3/Amazon.Games.yaml
+++ b/manifests/a/Amazon/Games/2.1.6485.3/Amazon.Games.yaml
@@ -5,5 +5,5 @@ PackageIdentifier: Amazon.Games
 PackageVersion: 2.1.6485.3
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.2.0
+ManifestVersion: 1.1.0
 


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.1 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.1.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

The param `--force` is suggested when installing this package due to the wrong hash. This fixes it.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/69620)