### PR TITLE
Update: HottaStudio.TowerofFantasy version 0.0.5.335

### DIFF
--- a/manifests/h/HottaStudio/TowerofFantasy/0.0.5.335/HottaStudio.TowerofFantasy.installer.yaml
+++ b/manifests/h/HottaStudio/TowerofFantasy/0.0.5.335/HottaStudio.TowerofFantasy.installer.yaml
@@ -1,8 +1,8 @@
-# Created with YamlCreate.ps1 v2.1.3 $debug=NVS1.7-2-5
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+# Created with YamlCreate.ps1 v2.1.3 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
 
 PackageIdentifier: HottaStudio.TowerofFantasy
-PackageVersion: 1.0.0
+PackageVersion: 0.0.5.335
 MinimumOSVersion: 10.0.0.0
 InstallerType: nullsoft
 UpgradeBehavior: install
@@ -12,4 +12,4 @@ Installers:
   InstallerSha256: EF3DA4B7C93DA3194641787EFE3970AD772AE3AE92E6190812F10625EBCF273C
   ProductCode: tof_launcher
 ManifestType: installer
-ManifestVersion: 1.1.0
+ManifestVersion: 1.2.0

--- a/manifests/h/HottaStudio/TowerofFantasy/0.0.5.335/HottaStudio.TowerofFantasy.locale.en-US.yaml
+++ b/manifests/h/HottaStudio/TowerofFantasy/0.0.5.335/HottaStudio.TowerofFantasy.locale.en-US.yaml
@@ -1,8 +1,8 @@
-# Created with YamlCreate.ps1 v2.1.3 $debug=NVS1.7-2-5
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+# Created with YamlCreate.ps1 v2.1.3 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
 
 PackageIdentifier: HottaStudio.TowerofFantasy
-PackageVersion: 1.0.0
+PackageVersion: 0.0.5.335
 PackageLocale: en-US
 Publisher: Hotta Studio
 PublisherUrl: https://www.toweroffantasy-global.com/
@@ -29,4 +29,4 @@ Agreement:
 # InstallationNotes: 
 # Documentations: 
 ManifestType: defaultLocale
-ManifestVersion: 1.1.0
+ManifestVersion: 1.2.0

--- a/manifests/h/HottaStudio/TowerofFantasy/0.0.5.335/HottaStudio.TowerofFantasy.yaml
+++ b/manifests/h/HottaStudio/TowerofFantasy/0.0.5.335/HottaStudio.TowerofFantasy.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.1.3 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+
+PackageIdentifier: HottaStudio.TowerofFantasy
+PackageVersion: 0.0.5.335
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.2.0

--- a/manifests/h/HottaStudio/TowerofFantasy/1.0.0/HottaStudio.TowerofFantasy.yaml
+++ b/manifests/h/HottaStudio/TowerofFantasy/1.0.0/HottaStudio.TowerofFantasy.yaml
@@ -1,8 +1,0 @@
-# Created with YamlCreate.ps1 v2.1.3 $debug=NVS1.7-2-5
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
-
-PackageIdentifier: HottaStudio.TowerofFantasy
-PackageVersion: 1.0.0
-DefaultLocale: en-US
-ManifestType: version
-ManifestVersion: 1.1.0


### PR DESCRIPTION
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [X] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.1 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.1.0)?

Tower of Fantasy doesn't write a DisplayVersion, but this is the version that is shown in the launcher:

![tof_launcher_YuqJdwRs66](https://user-images.githubusercontent.com/74878137/185098664-0f304229-c36a-4fea-b5c7-8295f316f9e5.png)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/70343)