### PR TITLE
New package: stedolan.jq version 1.6

### DIFF
--- a/manifests/s/stedolan/jq/1.6/stedolan.jq.installer.yaml
+++ b/manifests/s/stedolan/jq/1.6/stedolan.jq.installer.yaml
@@ -1,0 +1,14 @@
+# Created using wingetcreate 1.1.2.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+
+PackageIdentifier: stedolan.jq
+PackageVersion: 1.6
+Installers:
+  - Architecture: x64
+    InstallerType: portable
+    InstallerUrl: https://github.com/stedolan/jq/releases/download/jq-1.6/jq-win64.exe
+    InstallerSha256: A51D36968DCBDEABB3142C6F5CF9B401A65DC3A095F3144BD0C118D5BB192753
+    Commands:
+      - jq
+ManifestType: installer
+ManifestVersion: 1.2.0

--- a/manifests/s/stedolan/jq/1.6/stedolan.jq.locale.en-US.yaml
+++ b/manifests/s/stedolan/jq/1.6/stedolan.jq.locale.en-US.yaml
@@ -1,0 +1,12 @@
+# Created using wingetcreate 1.1.2.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+
+PackageIdentifier: stedolan.jq
+PackageVersion: 1.6
+PackageLocale: en-US
+Publisher: stedolan
+PackageName: jq
+License: MIT License
+ShortDescription: jq is a lightweight and flexible command-line JSON processor.
+ManifestType: defaultLocale
+ManifestVersion: 1.2.0

--- a/manifests/s/stedolan/jq/1.6/stedolan.jq.yaml
+++ b/manifests/s/stedolan/jq/1.6/stedolan.jq.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.1.2.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+
+PackageIdentifier: stedolan.jq
+PackageVersion: 1.6
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.2.0


### PR DESCRIPTION
Resubmit portable package previously rejected (#29559, #43960) because portable
packages were not supported.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.2 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.2.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

PRs #29559, #43960 were previously rejected because portable packages were not yet supported.
MIT License was picked for jq based on the license information on the [official website](https://stedolan.github.io/jq/).

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/70767)