### PR TITLE
Update: bdash-app.bdash version 1.15.2

### DIFF
--- a/manifests/b/bdash-app/bdash/1.15.2/bdash-app.bdash.installer.yaml
+++ b/manifests/b/bdash-app/bdash/1.15.2/bdash-app.bdash.installer.yaml
@@ -1,5 +1,5 @@
-# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-5
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 =QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
 
 PackageIdentifier: bdash-app.bdash
 PackageVersion: 1.15.2
@@ -12,4 +12,4 @@ Installers:
   InstallerUrl: https://github.com/bdash-app/bdash/releases/download/v1.15.2/Bdash-Setup-1.15.2.exe
   InstallerSha256: 3749DB7D64E78A3CB579B844794FF2909E9F8B4C85B42EBEAADA0E85AD1DD8B8
 ManifestType: installer
-ManifestVersion: 1.1.0
+ManifestVersion: 1.2.0

--- a/manifests/b/bdash-app/bdash/1.15.2/bdash-app.bdash.locale.en-US.yaml
+++ b/manifests/b/bdash-app/bdash/1.15.2/bdash-app.bdash.locale.en-US.yaml
@@ -1,5 +1,5 @@
-# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-5
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 =QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
 
 PackageIdentifier: bdash-app.bdash
 PackageVersion: 1.15.2
@@ -26,5 +26,8 @@ Tags:
 # Agreements: 
 # ReleaseNotes: 
 ReleaseNotesUrl: https://github.com/bdash-app/bdash/releases/tag/v1.15.2
+# PurchaseUrl: 
+# InstallationNotes: 
+# Documentations: 
 ManifestType: defaultLocale
-ManifestVersion: 1.1.0
+ManifestVersion: 1.2.0

--- a/manifests/b/bdash-app/bdash/1.15.2/bdash-app.bdash.yaml
+++ b/manifests/b/bdash-app/bdash/1.15.2/bdash-app.bdash.yaml
@@ -1,8 +1,8 @@
-# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-5
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 =QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
 
 PackageIdentifier: bdash-app.bdash
 PackageVersion: 1.15.2
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.1.0
+ManifestVersion: 1.2.0


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | Bdash | balena-cli, TickTick version 4.2.7.0, BBCiPlayerDownloads    |
| Version     | 1.15.2     | 14.3.0, 4.2.7.0, 2.13.9 |
| Publisher   | Kazuhito Hokamura   | Balena Inc. (https://balena.io/), Appest.com, British Broadcasting Corporation      |
| ProductCode |           | balena-cli, {1A434D02-8C9A-41A2-9BBE-C97A1E31ABC1}_is1, bbciplayerdownloads    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://bittu.eu.org/docs/wpa-intro) in workflow run [2794](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/2890440258>)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/71025)