### PR TITLE
Update: JackDevey.Lux version 1.1.1

### DIFF
--- a/manifests/j/JackDevey/Lux/1.1.1/JackDevey.Lux.installer.yaml
+++ b/manifests/j/JackDevey/Lux/1.1.1/JackDevey.Lux.installer.yaml
@@ -1,5 +1,5 @@
-# Created with YamlCreate.ps1 v2.1.2 $debug=MDSU.7-2-5
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+# Created with YamlCreate.ps1 v2.1.4 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
 
 PackageIdentifier: JackDevey.Lux
 PackageVersion: 1.1.1
@@ -9,9 +9,6 @@ InstallModes:
 - interactive
 - silent
 - silentWithProgress
-InstallerSwitches:
-  Silent: /VERYSILENT
-  SilentWithProgress: /SILENT
 UpgradeBehavior: install
 Commands:
 - lux
@@ -29,4 +26,4 @@ Installers:
   - DisplayName: Lux (x86)
     ProductCode: '{E17378AA-71AA-4EFC-8B09-B9A18F395B2F}_is1'
 ManifestType: installer
-ManifestVersion: 1.1.0
+ManifestVersion: 1.2.0

--- a/manifests/j/JackDevey/Lux/1.1.1/JackDevey.Lux.locale.en-US.yaml
+++ b/manifests/j/JackDevey/Lux/1.1.1/JackDevey.Lux.locale.en-US.yaml
@@ -1,5 +1,5 @@
-# Created with YamlCreate.ps1 v2.1.2 $debug=MDSU.7-2-5
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+# Created with YamlCreate.ps1 v2.1.4 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
 
 PackageIdentifier: JackDevey.Lux
 PackageVersion: 1.1.1
@@ -23,10 +23,12 @@ Tags:
 - govee-api
 - lighting-controller
 - lighting-strips
-- lux
 - smart-home
 # Agreements: 
 # ReleaseNotes: 
 ReleaseNotesUrl: https://github.com/jackdevey/Lux/releases/tag/v1.1.1
+# PurchaseUrl: 
+# InstallationNotes: 
+# Documentations: 
 ManifestType: defaultLocale
-ManifestVersion: 1.1.0
+ManifestVersion: 1.2.0

--- a/manifests/j/JackDevey/Lux/1.1.1/JackDevey.Lux.yaml
+++ b/manifests/j/JackDevey/Lux/1.1.1/JackDevey.Lux.yaml
@@ -1,8 +1,8 @@
-# Created with YamlCreate.ps1 v2.1.2 $debug=MDSU.7-2-5
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+# Created with YamlCreate.ps1 v2.1.4 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
 
 PackageIdentifier: JackDevey.Lux
 PackageVersion: 1.1.1
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.1.0
+ManifestVersion: 1.2.0


### PR DESCRIPTION
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [X] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.2 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.2.0)?

1 Redundant installer switches
2. `lux` tag is redundant because the Moniker is `lux`

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/72109)