### PR TITLE
Revert "fix: ensure YAML files have CRLF line endings as specified in editorconfig"

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.yaml text eol=crlf
+*.yaml text=auto


### PR DESCRIPTION
Reverts microsoft/winget-pkgs#71918.

Unfortunately, there are too many files in the repo that don't have consistent line endings. Once we have tooling updated and some warnings/errors in place for validating manifest line endings, then it should be safe to set CRLF everywhere. 

(@Trenly says it a lot more eloquently than I do in #72254)

cc: @denelon

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/72327)