### PR TITLE
New version: qishibo.AnotherRedisDesktopManager version 1.5.8 [FP-D]

### DIFF
--- a/manifests/q/qishibo/AnotherRedisDesktopManager/1.5.8/qishibo.AnotherRedisDesktopManager.installer.yaml
+++ b/manifests/q/qishibo/AnotherRedisDesktopManager/1.5.8/qishibo.AnotherRedisDesktopManager.installer.yaml
@@ -1,0 +1,28 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+
+PackageIdentifier: qishibo.AnotherRedisDesktopManager
+PackageVersion: 1.5.8
+InstallerLocale: en-US
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+ReleaseDate: 2022-08-21
+Installers:
+- Architecture: x64
+  Scope: user
+  InstallerUrl: https://github.com/qishibo/AnotherRedisDesktopManager/releases/download/v1.5.8/Another-Redis-Desktop-Manager.1.5.8.exe
+  InstallerSha256: B9EF94E6C29399DB5924F8F8E53757A7CFFAB8ED1A7207E97F4BEE1AA02076B6
+  InstallerSwitches:
+    Custom: /CURRENTUSER
+- Architecture: x64
+  Scope: machine
+  InstallerUrl: https://github.com/qishibo/AnotherRedisDesktopManager/releases/download/v1.5.8/Another-Redis-Desktop-Manager.1.5.8.exe
+  InstallerSha256: B9EF94E6C29399DB5924F8F8E53757A7CFFAB8ED1A7207E97F4BEE1AA02076B6
+  InstallerSwitches:
+    Custom: /ALLUSERS
+ManifestType: installer
+ManifestVersion: 1.2.0

--- a/manifests/q/qishibo/AnotherRedisDesktopManager/1.5.8/qishibo.AnotherRedisDesktopManager.locale.en-US.yaml
+++ b/manifests/q/qishibo/AnotherRedisDesktopManager/1.5.8/qishibo.AnotherRedisDesktopManager.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+
+PackageIdentifier: qishibo.AnotherRedisDesktopManager
+PackageVersion: 1.5.8
+PackageLocale: en-US
+Publisher: Another
+PublisherUrl: https://github.com/qishibo/AnotherRedisDesktopManager
+PublisherSupportUrl: https://github.com/qishibo/AnotherRedisDesktopManager/issues
+# PrivacyUrl: 
+Author: qii404.me
+PackageName: Another Redis Desktop Manager
+PackageUrl: https://github.com/qishibo/AnotherRedisDesktopManager
+License: MIT License
+LicenseUrl: https://raw.githubusercontent.com/qishibo/AnotherRedisDesktopManager/master/LICENSE
+Copyright: Copyright (c) qii404.me
+CopyrightUrl: https://raw.githubusercontent.com/qishibo/AnotherRedisDesktopManager/master/LICENSE
+ShortDescription: A faster, better and more stable redis desktop manager.
+Description: A faster, better and more stable redis desktop manager [GUI client], compatible with Linux, Windows, Mac. What's more, it won't crash when loading a large number of keys.
+# Moniker: 
+Tags:
+- redis-cluster
+- redis-desktop-manager
+- redis-gui-client
+- redis-sentinel
+- redis-ssh-ssl
+# Agreements: 
+# ReleaseNotes: 
+ReleaseNotesUrl: https://github.com/qishibo/AnotherRedisDesktopManager/releases/tag/v1.5.8
+# PurchaseUrl: 
+# InstallationNotes: 
+# Documentations: 
+ManifestType: defaultLocale
+ManifestVersion: 1.2.0

--- a/manifests/q/qishibo/AnotherRedisDesktopManager/1.5.8/qishibo.AnotherRedisDesktopManager.yaml
+++ b/manifests/q/qishibo/AnotherRedisDesktopManager/1.5.8/qishibo.AnotherRedisDesktopManager.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+
+PackageIdentifier: qishibo.AnotherRedisDesktopManager
+PackageVersion: 1.5.8
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.2.0


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | Another Redis Desktop Manager |     |
| Version     | 1.5.8     |  |
| Publisher   | Another   |       |
| ProductCode |           |     |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://bittu.eu.org/docs/wpa-intro) in workflow run [2811](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/2966590236>)