### PR TITLE
New version: xgi.houdoku version 2.9.4 [FP-D]

### DIFF
--- a/manifests/x/xgi/houdoku/2.9.4/xgi.houdoku.installer.yaml
+++ b/manifests/x/xgi/houdoku/2.9.4/xgi.houdoku.installer.yaml
@@ -1,0 +1,28 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+
+PackageIdentifier: xgi.houdoku
+PackageVersion: 2.9.4
+InstallerLocale: en-US
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+ReleaseDate: 2022-09-02
+Installers:
+- Architecture: x64
+  Scope: user
+  InstallerUrl: https://github.com/xgi/houdoku/releases/download/v2.9.4/Houdoku-Setup-2.9.4.exe
+  InstallerSha256: 78EFF5E6662F17F9B76DFC55D83918C3C359FAEC9C82B7893ABE1A28B43ED6DE
+  InstallerSwitches:
+    Custom: /CURRENTUSER
+- Architecture: x64
+  Scope: machine
+  InstallerUrl: https://github.com/xgi/houdoku/releases/download/v2.9.4/Houdoku-Setup-2.9.4.exe
+  InstallerSha256: 78EFF5E6662F17F9B76DFC55D83918C3C359FAEC9C82B7893ABE1A28B43ED6DE
+  InstallerSwitches:
+    Custom: /ALLUSERS
+ManifestType: installer
+ManifestVersion: 1.2.0

--- a/manifests/x/xgi/houdoku/2.9.4/xgi.houdoku.locale.en-US.yaml
+++ b/manifests/x/xgi/houdoku/2.9.4/xgi.houdoku.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+
+PackageIdentifier: xgi.houdoku
+PackageVersion: 2.9.4
+PackageLocale: en-US
+Publisher: Jake Robertson
+PublisherUrl: https://github.com/xgi/houdoku
+PublisherSupportUrl: https://github.com/xgi/houdoku/issues
+# PrivacyUrl: 
+Author: Jake Robertson
+PackageName: Houdoku
+PackageUrl: https://github.com/xgi/houdoku
+License: MIT
+LicenseUrl: https://raw.githubusercontent.com/xgi/houdoku/master/LICENSE.txt
+Copyright: Copyright (c) 2018 Jake Robertson
+CopyrightUrl: https://raw.githubusercontent.com/xgi/houdoku/master/LICENSE.txt
+ShortDescription: Manga reader and library manager for the desktop
+# Description: 
+Moniker: houdoku
+Tags:
+- comics
+- manga
+- manga-reader
+# Agreements: 
+# ReleaseNotes: 
+ReleaseNotesUrl: https://github.com/xgi/houdoku/releases/tag/v2.9.4
+# PurchaseUrl: 
+# InstallationNotes: 
+# Documentations: 
+ManifestType: defaultLocale
+ManifestVersion: 1.2.0

--- a/manifests/x/xgi/houdoku/2.9.4/xgi.houdoku.yaml
+++ b/manifests/x/xgi/houdoku/2.9.4/xgi.houdoku.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+
+PackageIdentifier: xgi.houdoku
+PackageVersion: 2.9.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.2.0


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | Houdoku | KDE Connect, Kile    |
| Version     | 2.9.4     | 22.08.0, 2.9.93 |
| Publisher   | Jake Robertson   | KDE e.V., KDE e.V.      |
| ProductCode |           | KDE Connect, Kile    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://bittu.eu.org/docs/wpa-intro) in workflow run [2819](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/2981830069>)