### PR TITLE
Don't remove Blocking Issue on changes pushed

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -3262,12 +3262,6 @@
           {
             "name": "removeLabel",
             "parameters": {
-              "label": "Blocking-Issue"
-            }
-          },
-          {
-            "name": "removeLabel",
-            "parameters": {
               "label": "Needs-SmartScreen-Investigation"
             }
           },


### PR DESCRIPTION
PRs such as:

* https://github.com/microsoft/winget-pkgs/pull/64058
* https://github.com/microsoft/winget-pkgs/pull/62517

have blocking issues and they're removed on every synchronize event. Its hard to mention @denelon, again and again, to add blocking issues, and sometimes to reopen if they're closed with No-Recent-Activity.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/76500)