### PR TITLE
New version: OctopusDeploy.Server version 2022.2.8011

### DIFF
--- a/manifests/o/OctopusDeploy/Server/2022.2.8011/OctopusDeploy.Server.installer.yaml
+++ b/manifests/o/OctopusDeploy/Server/2022.2.8011/OctopusDeploy.Server.installer.yaml
@@ -1,0 +1,22 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+
+PackageIdentifier: OctopusDeploy.Server
+PackageVersion: 2022.2.8011
+InstallerLocale: en-US
+MinimumOSVersion: 10.0.0.0
+InstallerType: wix
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2022-08-29
+Installers:
+- Architecture: x64
+  InstallerUrl: https://download.octopusdeploy.com/octopus/Octopus.2022.2.8011-x64.msi
+  InstallerSha256: 95AE0DA985EC26A90C0CA7266F7023BD75F5C907AC43F0A661A327EE1C35C515
+  ProductCode: '{A3165EDA-3C3A-4CBD-A24B-F75664352417}'
+ManifestType: installer
+ManifestVersion: 1.2.0

--- a/manifests/o/OctopusDeploy/Server/2022.2.8011/OctopusDeploy.Server.locale.en-US.yaml
+++ b/manifests/o/OctopusDeploy/Server/2022.2.8011/OctopusDeploy.Server.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+
+PackageIdentifier: OctopusDeploy.Server
+PackageVersion: 2022.2.8011
+PackageLocale: en-US
+Publisher: Octopus Deploy Pty. Ltd.
+PublisherUrl: https://octopus.com/downloads
+PublisherSupportUrl: https://octopus.com/support
+PrivacyUrl: https://octopus.com/legal/privacy
+# Author: 
+PackageName: Octopus Deploy Server
+PackageUrl: https://octopus.com/
+License: Proprietary
+LicenseUrl: https://octopus.com/legal/customer-agreement
+Copyright: Copyright © 2021 Octopus Deploy
+CopyrightUrl: https://octopus.com/legal/customer-agreement
+ShortDescription: Octopus Deploy makes it easy to automate your deployments and operations runbooks from a single place, helping you ship code faster, improve reliability, and break down dev & ops silos.
+# Description: 
+Moniker: octopus-server
+Tags:
+- build
+- deploy
+- devops
+- dotnet
+- octopus
+# Agreements: 
+# ReleaseNotes: 
+# ReleaseNotesUrl: 
+# PurchaseUrl: 
+# InstallationNotes: 
+# Documentations: 
+ManifestType: defaultLocale
+ManifestVersion: 1.2.0

--- a/manifests/o/OctopusDeploy/Server/2022.2.8011/OctopusDeploy.Server.yaml
+++ b/manifests/o/OctopusDeploy/Server/2022.2.8011/OctopusDeploy.Server.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+
+PackageIdentifier: OctopusDeploy.Server
+PackageVersion: 2022.2.8011
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.2.0


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | Octopus Deploy Server |     |
| Version     | 2022.2.8011     |  |
| Publisher   | Octopus Deploy Pty. Ltd.   |       |
| ProductCode |           |     |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://bittu.eu.org/docs/wpa-intro) in workflow run [2811](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/2966590236>)