### PR TITLE
Mention `Documents`/`Agreements` instead of `Document`/`Agreement` field in docs

### DIFF
--- a/doc/manifest/schema/1.1.0/defaultLocale.md
+++ b/doc/manifest/schema/1.1.0/defaultLocale.md
@@ -2,7 +2,7 @@
 [YAML]:                                             https://yaml.org/spec/
 [semantic version]:                                 https://semver.org
 [Available languages for Windows]:                  https://docs.microsoft.com/windows-hardware/manufacture/desktop/available-language-packs-for-windows
-[Default Input Profiles Input Locales in Windows]:  https://docs.microsoft.com/windows-hardware/manufacture/desktop/default-input-locales-for-windows-language-packs
+[locales]:                                          https://docs.microsoft.com/windows-hardware/manufacture/desktop/default-input-locales-for-windows-language-packs
 [install]:                                          https://docs.microsoft.com/windows/package-manager/winget/install
 [list]:                                             https://docs.microsoft.com/windows/package-manager/winget/list
 [upgrade]:                                          https://docs.microsoft.com/windows/package-manager/winget/upgrade
@@ -76,7 +76,7 @@ ManifestVersion: 1.1.0        # The manifest syntax version
   **References:**
 
 * [Available languages for Windows]
-* [Default Input Profiles (Input Locales) in Windows]
+* [Default Input Profiles (Input Locales) in Windows][locales]
 
   >Note: This field is the key to determining which fields are required for the Microsoft community repository. The default locale specified in the version file must match with this value.
  </details>

--- a/doc/manifest/schema/1.1.0/defaultLocale.md
+++ b/doc/manifest/schema/1.1.0/defaultLocale.md
@@ -33,7 +33,7 @@ ShortDescription:             # The short package description
 Description:                  # Optional full package description
 Moniker:                      # Optional most common package term
 Tags:                         # Optional list of package terms
-Agreements:                    # Optional package agreements
+Agreements:                   # Optional package agreements
   - AgreementLabel:           # Optional agreement label
     Agreement:                # Optional agreement text
     AgreementUrl:             # Optional agreement URL

--- a/doc/manifest/schema/1.1.0/defaultLocale.md
+++ b/doc/manifest/schema/1.1.0/defaultLocale.md
@@ -33,7 +33,7 @@ ShortDescription:             # The short package description
 Description:                  # Optional full package description
 Moniker:                      # Optional most common package term
 Tags:                         # Optional list of package terms
-Agreement:                    # Optional package agreements
+Agreements:                    # Optional package agreements
   - AgreementLabel:           # Optional agreement label
     Agreement:                # Optional agreement text
     AgreementUrl:             # Optional agreement URL
@@ -220,7 +220,7 @@ ManifestVersion: 1.1.0        # The manifest syntax version
 
  
 <details>
-  <summary><b>Agreement</b> - List of package agreements</summary>
+  <summary><b>Agreements</b> - List of package agreements</summary>
 
    **Optional Field**
 

--- a/doc/manifest/schema/1.1.0/locale.md
+++ b/doc/manifest/schema/1.1.0/locale.md
@@ -33,7 +33,7 @@ ShortDescription:             # Optional short package description
 Description:                  # Optional full package description
 Moniker:                      # Optional most common package term
 Tags:                         # Optional list of package terms
-Agreement:                    # Optional package agreements
+Agreements:                   # Optional package agreements
   - AgreementLabel:           # Optional agreement label
     Agreement:                # Optional agreement text
     AgreementUrl:             # Optional agreement URL
@@ -218,7 +218,7 @@ ManifestVersion: 1.1.0        # The manifest syntax version
  </details>
  
  <details>
-   <summary><b>Agreement</b> - List of package agreements</summary>
+   <summary><b>Agreements</b> - List of package agreements</summary>
 
    **Optional Field**
 

--- a/doc/manifest/schema/1.1.0/locale.md
+++ b/doc/manifest/schema/1.1.0/locale.md
@@ -2,7 +2,7 @@
 [YAML]:                                             https://yaml.org/spec
 [semantic version]:                                 https://semver.org
 [Available languages for Windows]:                  https://docs.microsoft.com/windows-hardware/manufacture/desktop/available-language-packs-for-windows
-[Default Input Profiles Input Locales in Windows]:  https://docs.microsoft.com/windows-hardware/manufacture/desktop/default-input-locales-for-windows-language-packs
+[locales]:                                          https://docs.microsoft.com/windows-hardware/manufacture/desktop/default-input-locales-for-windows-language-packs
 [install]:                                          https://docs.microsoft.com/windows/package-manager/winget/install
 [list]:                                             https://docs.microsoft.com/windows/package-manager/winget/list
 [upgrade]:                                          https://docs.microsoft.com/windows/package-manager/winget/upgrade
@@ -76,7 +76,7 @@ ManifestVersion: 1.1.0        # The manifest syntax version
   **References**
 
 * [Available languages for Windows]
-* [Default Input Profiles (Input Locales) in Windows]
+* [Default Input Profiles (Input Locales) in Windows][locales]
 
   >Note: This field is the key to determining which fields are required for the Microsoft community repository. The default locale specified in the version file must match with this value.
  </details>

--- a/doc/manifest/schema/1.1.0/singleton.md
+++ b/doc/manifest/schema/1.1.0/singleton.md
@@ -29,16 +29,16 @@ Publisher:                      # The publisher name
 PackageName:                    # The package name
 License:                        # The package license
 ShortDescription:               # The short package description
-Description:                     # Optional full package description
-Moniker:                         # Optional most common package term
-Tags:                            # Optional list of package terms
-Agreements:                      # Optional package agreements
-  - AgreementLabel:              # Optional agreement label
-    Agreement:                   # Optional agreement text
-    AgreementUrl:                # Optional agreement URL
-ReleaseDate:                     # Optional release date
-ReleaseNotes:                    # Optional release notes
-ReleaseNotesUrl:                 # Optional release notes URL
+Description:                    # Optional full package description
+Moniker:                        # Optional most common package term
+Tags:                           # Optional list of package terms
+Agreements:                     # Optional package agreements
+  - AgreementLabel:             # Optional agreement label
+    Agreement:                  # Optional agreement text
+    AgreementUrl:               # Optional agreement URL
+ReleaseDate:                    # Optional release date
+ReleaseNotes:                   # Optional release notes
+ReleaseNotesUrl:                # Optional release notes URL
 Installers:                     # The package installer
   - Architecture:               # The architecture of the installer
     InstallerLocale:            # Optional locale of the installer

--- a/doc/manifest/schema/1.1.0/singleton.md
+++ b/doc/manifest/schema/1.1.0/singleton.md
@@ -32,7 +32,7 @@ ShortDescription:               # The short package description
 Description:                     # Optional full package description
 Moniker:                         # Optional most common package term
 Tags:                            # Optional list of package terms
-Agreement:                       # Optional package agreements
+Agreements:                      # Optional package agreements
   - AgreementLabel:              # Optional agreement label
     Agreement:                   # Optional agreement text
     AgreementUrl:                # Optional agreement URL
@@ -176,7 +176,7 @@ ManifestVersion: 1.1.0
  </details>
  
  <details>
-   <summary><b>Agreement</b> - List of package agreements</summary>
+   <summary><b>Agreements</b> - List of package agreements</summary>
 
    **Optional Field**
 

--- a/doc/manifest/schema/1.1.0/singleton.md
+++ b/doc/manifest/schema/1.1.0/singleton.md
@@ -3,7 +3,6 @@
 [install]:                                  https://docs.microsoft.com/windows/package-manager/winget/install
 [list]:                                     https://docs.microsoft.com/windows/package-manager/winget/list
 [upgrade]:                                  https://docs.microsoft.com/windows/package-manager/winget/upgrade
-[`winget upgrade`]:                         https://docs.microsoft.com/windows/package-manager/winget/upgrade
 [MSIX]:                                     https://docs.microsoft.com/windows/msix/overview
 [MSI]:                                      https://docs.microsoft.com/windows/win32/msi/windows-installer-portal
 [Inno]:                                     https://jrsoftware.org/isinfo.php
@@ -130,7 +129,7 @@ ManifestVersion: 1.1.0
 
  This key represents the version of the package. It is related to the specific release this manifests targets. In some cases you will see a perfectly formed [semantic version] number, and in other cases you might see something different. These may be date driven, or they might have other characters with some package specific meaning for example.
 
- The Windows Package Manager client uses this version to determine if an upgrade for a package is available. In some cases, packages may be released with a marketing driven version, and that causes trouble with the [`winget upgrade`] command. 
+ The Windows Package Manager client uses this version to determine if an upgrade for a package is available. In some cases, packages may be released with a marketing driven version, and that causes trouble with the [`winget upgrade`][upgrade] command.
 
  >Note: The current best practice is to use the value reported in Add / Remove Programs when this version of the package is installed. In some cases, packages do not report a version resulting in an upgrade loop or other unwanted behavior. This practice may seem contrary to using semantic versioning, but it provides the best end to end experience for customers. It will take time for publishers and ISVs to migrate to semantic versioning, and some may intentionally choose to preserve other versioning schemes. In these cases, it is best practice to include the "AppsAndFeaturesEntries" section for each installer.
 </details>

--- a/doc/manifest/schema/1.2.0/defaultLocale.md
+++ b/doc/manifest/schema/1.2.0/defaultLocale.md
@@ -37,7 +37,7 @@ Agreement:                    # Optional package agreements
   - AgreementLabel:           # Optional agreement label
     Agreement:                # Optional agreement text
     AgreementUrl:             # Optional agreement URL
-Documentation:                # Optional documentation
+Documentations:               # Optional documentation
   - DocumentLabel:            # Optional documentation label
     DocumentUrl:              # Optional documentation URL
 ReleaseDate:                  # Optional release date
@@ -261,7 +261,7 @@ ManifestVersion: 1.2.0        # The manifest syntax version
 </details>
 
 <details>
-  <summary><b>Documentation</b> - List of documentation</summary>
+  <summary><b>Documentations</b> - List of documentation</summary>
   
   **Optional Field**
 

--- a/doc/manifest/schema/1.2.0/defaultLocale.md
+++ b/doc/manifest/schema/1.2.0/defaultLocale.md
@@ -2,7 +2,7 @@
 [YAML]:                                             https://yaml.org/spec/
 [semantic version]:                                 https://semver.org
 [Available languages for Windows]:                  https://docs.microsoft.com/windows-hardware/manufacture/desktop/available-language-packs-for-windows
-[Default Input Profiles Input Locales in Windows]:  https://docs.microsoft.com/windows-hardware/manufacture/desktop/default-input-locales-for-windows-language-packs
+[locales]:                                          https://docs.microsoft.com/windows-hardware/manufacture/desktop/default-input-locales-for-windows-language-packs
 [install]:                                          https://docs.microsoft.com/windows/package-manager/winget/install
 [list]:                                             https://docs.microsoft.com/windows/package-manager/winget/list
 [upgrade]:                                          https://docs.microsoft.com/windows/package-manager/winget/upgrade
@@ -81,7 +81,7 @@ ManifestVersion: 1.2.0        # The manifest syntax version
   **References:**
 
 * [Available languages for Windows]
-* [Default Input Profiles (Input Locales) in Windows]
+* [Default Input Profiles (Input Locales) in Windows][locales]
 
   >Note: This field is the key to determining which fields are required for the Microsoft community repository. The default locale specified in the version file must match with this value.
  </details>

--- a/doc/manifest/schema/1.2.0/defaultLocale.md
+++ b/doc/manifest/schema/1.2.0/defaultLocale.md
@@ -33,7 +33,7 @@ ShortDescription:             # The short package description
 Description:                  # Optional full package description
 Moniker:                      # Optional most common package term
 Tags:                         # Optional list of package terms
-Agreement:                    # Optional package agreements
+Agreements:                   # Optional package agreements
   - AgreementLabel:           # Optional agreement label
     Agreement:                # Optional agreement text
     AgreementUrl:             # Optional agreement URL
@@ -225,7 +225,7 @@ ManifestVersion: 1.2.0        # The manifest syntax version
 
  
 <details>
-  <summary><b>Agreement</b> - List of package agreements</summary>
+  <summary><b>Agreements</b> - List of package agreements</summary>
 
    **Optional Field**
 

--- a/doc/manifest/schema/1.2.0/locale.md
+++ b/doc/manifest/schema/1.2.0/locale.md
@@ -33,7 +33,7 @@ ShortDescription:             # Optional short package description
 Description:                  # Optional full package description
 Moniker:                      # Optional most common package term
 Tags:                         # Optional list of package terms
-Agreement:                    # Optional package agreements
+Agreements:                   # Optional package agreements
   - AgreementLabel:           # Optional agreement label
     Agreement:                # Optional agreement text
     AgreementUrl:             # Optional agreement URL
@@ -223,7 +223,7 @@ ManifestVersion: 1.2.0        # The manifest syntax version
  </details>
  
  <details>
-   <summary><b>Agreement</b> - List of package agreements</summary>
+   <summary><b>Agreements/b> - List of package agreements</summary>
 
    **Optional Field**
 

--- a/doc/manifest/schema/1.2.0/locale.md
+++ b/doc/manifest/schema/1.2.0/locale.md
@@ -2,7 +2,7 @@
 [YAML]:                                             https://yaml.org/spec
 [semantic version]:                                 https://semver.org
 [Available languages for Windows]:                  https://docs.microsoft.com/windows-hardware/manufacture/desktop/available-language-packs-for-windows
-[Default Input Profiles Input Locales in Windows]:  https://docs.microsoft.com/windows-hardware/manufacture/desktop/default-input-locales-for-windows-language-packs
+[locales]:                                          https://docs.microsoft.com/windows-hardware/manufacture/desktop/default-input-locales-for-windows-language-packs
 [install]:                                          https://docs.microsoft.com/windows/package-manager/winget/install
 [list]:                                             https://docs.microsoft.com/windows/package-manager/winget/list
 [upgrade]:                                          https://docs.microsoft.com/windows/package-manager/winget/upgrade
@@ -81,7 +81,7 @@ ManifestVersion: 1.2.0        # The manifest syntax version
   **References**
 
 * [Available languages for Windows]
-* [Default Input Profiles (Input Locales) in Windows]
+* [Default Input Profiles (Input Locales) in Windows][locales]
 
   >Note: This field is the key to determining which fields are required for the Microsoft community repository. The default locale specified in the version file must match with this value.
  </details>

--- a/doc/manifest/schema/1.2.0/locale.md
+++ b/doc/manifest/schema/1.2.0/locale.md
@@ -37,7 +37,7 @@ Agreement:                    # Optional package agreements
   - AgreementLabel:           # Optional agreement label
     Agreement:                # Optional agreement text
     AgreementUrl:             # Optional agreement URL
-Documentation:                # Optional documentation
+Documentations:               # Optional documentation
   - DocumentLabel:            # Optional documentation label
     DocumentUrl:              # Optional documentation URL
 ReleaseDate:                  # Optional release date
@@ -257,7 +257,7 @@ ManifestVersion: 1.2.0        # The manifest syntax version
 </details>
 
 <details>
-  <summary><b>Documentation</b> - List of documentation</summary>
+  <summary><b>Documentations</b> - List of documentation</summary>
   
   **Optional Field**
 

--- a/doc/manifest/schema/1.2.0/singleton.md
+++ b/doc/manifest/schema/1.2.0/singleton.md
@@ -32,7 +32,7 @@ ShortDescription:               # The short package description
 Description:                     # Optional full package description
 Moniker:                         # Optional most common package term
 Tags:                            # Optional list of package terms
-Agreement:                       # Optional package agreements
+Agreements:                      # Optional package agreements
   - AgreementLabel:              # Optional agreement label
     Agreement:                   # Optional agreement text
     AgreementUrl:                # Optional agreement URL
@@ -185,7 +185,7 @@ ManifestVersion: 1.2.0
  </details>
  
  <details>
-   <summary><b>Agreement</b> - List of package agreements</summary>
+   <summary><b>Agreements</b> - List of package agreements</summary>
 
    **Optional Field**
 

--- a/doc/manifest/schema/1.2.0/singleton.md
+++ b/doc/manifest/schema/1.2.0/singleton.md
@@ -36,7 +36,7 @@ Agreement:                       # Optional package agreements
   - AgreementLabel:              # Optional agreement label
     Agreement:                   # Optional agreement text
     AgreementUrl:                # Optional agreement URL
-Documentation:                # Optional documentation
+Documentations:               # Optional documentation
   - DocumentLabel:            # Optional documentation label
     DocumentUrl:              # Optional documentation URL
 ReleaseDate:                     # Optional release date
@@ -219,7 +219,7 @@ ManifestVersion: 1.2.0
 </details>
 
 <details>
-  <summary><b>Documentation</b> - List of documentation</summary>
+  <summary><b>Documentations</b> - List of documentation</summary>
   
   **Optional Field**
 

--- a/doc/manifest/schema/1.2.0/singleton.md
+++ b/doc/manifest/schema/1.2.0/singleton.md
@@ -3,7 +3,6 @@
 [install]:                                  https://docs.microsoft.com/windows/package-manager/winget/install
 [list]:                                     https://docs.microsoft.com/windows/package-manager/winget/list
 [upgrade]:                                  https://docs.microsoft.com/windows/package-manager/winget/upgrade
-[`winget upgrade`]:                         https://docs.microsoft.com/windows/package-manager/winget/upgrade
 [MSIX]:                                     https://docs.microsoft.com/windows/msix/overview
 [MSI]:                                      https://docs.microsoft.com/windows/win32/msi/windows-installer-portal
 [Inno]:                                     https://jrsoftware.org/isinfo.php
@@ -139,7 +138,7 @@ ManifestVersion: 1.2.0
 
  This key represents the version of the package. It is related to the specific release this manifests targets. In some cases you will see a perfectly formed [semantic version] number, and in other cases you might see something different. These may be date driven, or they might have other characters with some package specific meaning for example.
 
- The Windows Package Manager client uses this version to determine if an upgrade for a package is available. In some cases, packages may be released with a marketing driven version, and that causes trouble with the [`winget upgrade`] command. 
+ The Windows Package Manager client uses this version to determine if an upgrade for a package is available. In some cases, packages may be released with a marketing driven version, and that causes trouble with the [`winget upgrade`][upgrade] command.
 
  >Note: The current best practice is to use the value reported in Add / Remove Programs when this version of the package is installed. In some cases, packages do not report a version resulting in an upgrade loop or other unwanted behavior. This practice may seem contrary to using semantic versioning, but it provides the best end to end experience for customers. It will take time for publishers and ISVs to migrate to semantic versioning, and some may intentionally choose to preserve other versioning schemes. In these cases, it is best practice to include the "AppsAndFeaturesEntries" section for each installer.
 </details>

--- a/doc/manifest/schema/1.2.0/singleton.md
+++ b/doc/manifest/schema/1.2.0/singleton.md
@@ -29,21 +29,21 @@ Publisher:                      # The publisher name
 PackageName:                    # The package name
 License:                        # The package license
 ShortDescription:               # The short package description
-Description:                     # Optional full package description
-Moniker:                         # Optional most common package term
-Tags:                            # Optional list of package terms
-Agreements:                      # Optional package agreements
-  - AgreementLabel:              # Optional agreement label
-    Agreement:                   # Optional agreement text
-    AgreementUrl:                # Optional agreement URL
-Documentations:               # Optional documentation
-  - DocumentLabel:            # Optional documentation label
-    DocumentUrl:              # Optional documentation URL
-ReleaseDate:                     # Optional release date
-ReleaseNotes:                    # Optional release notes
-ReleaseNotesUrl:                 # Optional release notes URL
-PurchaseUrl:                  # *Not implemented* Optional purchase URL
-InstallationNotes:            # Optional notes displayed upon installation
+Description:                    # Optional full package description
+Moniker:                        # Optional most common package term
+Tags:                           # Optional list of package terms
+Agreements:                     # Optional package agreements
+  - AgreementLabel:             # Optional agreement label
+    Agreement:                  # Optional agreement text
+    AgreementUrl:               # Optional agreement URL
+Documentations:                 # Optional documentation
+  - DocumentLabel:              # Optional documentation label
+    DocumentUrl:                # Optional documentation URL
+ReleaseDate:                    # Optional release date
+ReleaseNotes:                   # Optional release notes
+ReleaseNotesUrl:                # Optional release notes URL
+PurchaseUrl:                    # *Not implemented* Optional purchase URL
+InstallationNotes:              # Optional notes displayed upon installation
 Installers:                     # The package installer
   - Architecture:               # The architecture of the installer
     InstallerLocale:            # Optional locale of the installer


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.2 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.2.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

`winget show` does only shows documentation information when it is provided in the manifest under [`Documentations`](https://github.com/microsoft/winget-cli/blob/1a6ca17040a0577dceb25af3232649e4bd271b81/schemas/JSON/manifests/v1.2.0/manifest.defaultLocale.1.2.0.json#L182-L183) (the array with an `s`), and not when it is under [`Documentation`](https://github.com/microsoft/winget-cli/blob/1a6ca17040a0577dceb25af3232649e4bd271b81/schemas/JSON/manifests/v1.2.0/manifest.defaultLocale.1.2.0.json#L39-L40) (the object).

<details>
<summary>Documentation(s) examples</summary>

Cf RStudio.quarto v1.1.165 manifest [with `Documentation` fields](https://github.com/microsoft/winget-pkgs/blob/master/manifests/r/RStudio/quarto/1.1.165/RStudio.quarto.locale.en-US.yaml#L33-L37)

```yaml
PS C:\> winget show rstudio.quarto --version 1.1.165
Found Quarto [RStudio.quarto]
Version: 1.1.165
Publisher: Rstudio, PBC
Publisher Url: https://www.rstudio.com/
Moniker: quarto
Description:
  Main features of Quarto:
     Create dynamic content with Python, R, Julia, and Observable.
     Author documents as plain text markdown or Jupyter notebooks.
     Publish high-quality articles, reports, presentations, websites, blogs, and books in HTML, PDF, MS Word, ePub, and more.
     Author with scientific markdown, including equations, citations, crossrefs, figure panels, callouts, advanced layout, and more.
Homepage: https://quarto.org/
License: GPL v2
License Url: https://quarto.org/license.html
Copyright: Copyright (C) RStudio, PBC
Copyright Url: https://quarto.org/trademark.html
Tags:
  document
  jupyter
  markdown
  ojs
  pandoc
  publishing
  r
  reproducibility
  rmarkdown
Installer:
  Installer Type: wix
  Installer Locale: en-US
  Installer Url: https://github.com/quarto-dev/quarto-cli/releases/download/v1.1.165/quarto-1.1.165-win.msi
  Installer SHA256: 423d31c68d47388e2a4656bf5b964798e94e743b0fdd2647376eb0d2ec245a72
```

vs. Microsoft.NuGet v6.2.1 [with `Documentations`](https://github.com/microsoft/winget-pkgs/blob/65b35340177b3da09870ee3f000c38e6abd222c9/manifests/m/Microsoft/NuGet/6.2.1/Microsoft.NuGet.locale.en-US.yaml#L27-L33)

```yaml
PS C:\> winget show microsoft.nuget --version 6.2.1
Found NuGet [Microsoft.NuGet]
Version: 6.2.1
Publisher: Microsoft Corporation
Publisher Url: https://microsoft.com
Publisher Support Url: https://support.microsoft.com/en-us
Author: Microsoft Corporation
Moniker: nuget
Description: NuGet is the package manager for .NET. It enables developers to create, share, and consume useful .NET libraries. NuGet client tools provide the ability to produce and consume these libraries as "packages".
Homepage: https://www.nuget.org/
License: Proprietary
License Url: https://www.nuget.org/policies/Terms
Privacy Url: https://go.microsoft.com/fwlink/?LinkID=824704
Copyright: Copyright (c) Microsoft Corporation. All rights reserved.
Release Notes Url: https://docs.microsoft.com/en-us/nuget/release-notes/nuget-6.2
Installation Notes: For more information, visit https://docs.nuget.org/docs/reference/command-line-reference
Documentation:
  NuGet Documentation: https://docs.microsoft.com/en-us/nuget/
  NuGet CLI Reference: https://docs.microsoft.com/en-us/nuget/reference/nuget-exe-cli-reference
  Known Issues: https://docs.microsoft.com/en-us/nuget/release-notes/known-issues
Installer:
  Installer Type: portable
  Installer Url: https://dist.nuget.org/win-x86-commandline/v6.2.1/nuget.exe
  Installer SHA256: a79f342e739fdb3903a92218767e7813e04930dff463621b6d2be2d468b84e05
```

Both manifests use the `defaultLocale.1.2.0.schema`.

```pwsh
PS C:\> winget --info
Windows Package Manager (Preview) v1.4.2161-preview
Copyright (c) Microsoft Corporation. All rights reserved.

Windows: Windows.Desktop v10.0.19041.1889
System Architecture: X64
Package: Microsoft.DesktopAppInstaller v1.19.2161.0
```

</details>

The [docs](https://github.com/microsoft/winget-pkgs/blob/ecb667c743ad1fe52f34718064c0c7b7ae713ff4/doc/manifest/schema/1.2.0/defaultLocale.md?plain=1#L40) reference the `Documentation` (object) field, not the array. This is confusing IMHO. 

Note that the docs reference the array and not the object in other places as well, e.g. `Installers` vs. `Installer`. 

So this changes `Document` to `Documents` and, equivalently, `Agreement` to `Agreements`. 

<details>
<summary>Agreement(s) example</summary>

AIMP seems to be the only manifest to [include `Aggrement`](https://github.com/microsoft/winget-pkgs/blob/ecb667c743ad1fe52f34718064c0c7b7ae713ff4/manifests/a/AIMP/AIMP/5.03.2397/AIMP.AIMP.locale.en-US.yaml#L24), but since it uses the singular tag, `winget show` does not show them. 

```pwsh
PS C:\> winget show AIMP.AIMP --version 5.03.2397
Found AIMP [AIMP.AIMP]
Version: 5.03.2397
Publisher: AIMP DevTeam
Publisher Url: https://www.aimp.ru
Publisher Support Url: https://www.aimp.ru/forum/index.php
Author: Artem Izmaylov
Moniker: aimp
Description: AIMP is a freeware audio player
Homepage: https://www.aimp.ru
License: Proprietary
Copyright: © Artem Izmaylov 2006-2021 | All rights reserved
Tags:
  audio-player
  music-player
Installer:
  Installer Type: exe
  Installer Url: https://aimp.ru/files/windows/builds/aimp_5.03.2397_w64.exe
  Installer SHA256: 99be213b6571b3c3782aa1d466f0d905e2414b6c3c8c209849135f514d1a29de
  Release Date: 2022-08-01
```

It does when changed to `Agreements`. 

PS C:\Users\WDAGUtilityAccount\Desktop\winget-pkgs> winget show -m .\manifests\a\AIMP\AIMP\5.03.2397\
Found AIMP [AIMP.AIMP]
Version: 5.03.2397
Publisher: AIMP DevTeam
Publisher Url: https://www.aimp.ru
Publisher Support Url: https://www.aimp.ru/forum/index.php
Author: Artem Izmaylov
Moniker: aimp
Description: AIMP is a freeware audio player
Homepage: https://www.aimp.ru
License: Proprietary
Copyright: © Artem Izmaylov 2006-2021 | All rights reserved
Tags:
  audio-player
  music-player
Agreements:
EULA: https://www.aimp.ru/?do=eula&os=windows

Installer:
  Installer Type: exe
  Installer Url: https://aimp.ru/files/windows/builds/aimp_5.03.2397_w64.exe
  Installer SHA256: 99be213b6571b3c3782aa1d466f0d905e2414b6c3c8c209849135f514d1a29de
  Release Date: 2022-08-01

</details>

I also made some minor to whitespace and fixed some links along the way (hopefully minor enough to include them in this PR). 


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/76574)