### PR TITLE
ALVR.ALVR version 18.2.3 `Documentations` field

### DIFF
--- a/manifests/a/ALVR/ALVR/18.2.3/ALVR.ALVR.locale.en-US.yaml
+++ b/manifests/a/ALVR/ALVR/18.2.3/ALVR.ALVR.locale.en-US.yaml
@@ -29,7 +29,7 @@ ReleaseNotes: Fix missing x264/5 shared libraries for xtask --bundle-ffmpeg/port
 ReleaseNotesUrl: https://github.com/alvr-org/ALVR/releases/tag/v18.2.3
 # PurchaseUrl: 
 # InstallationNotes: 
-Documentation:
+Documentations:
   - DocumentLabel: Wiki
     DocumentUrl: https://github.com/alvr-org/ALVR/wiki
 ManifestType: defaultLocale


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.2 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.2.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

rename `Documentation` -> `Documentations` field cf. https://github.com/microsoft/winget-pkgs/pull/76574


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/76583)