### PR TITLE
Add additional filetypes to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,8 @@
+.editorconfig text eol=crlf
+*.json text eol=crlf
+*.md text eol=crlf
+*.ps1 text eol=crlf
+*.txt text eol=crlf
+*.validation text eol=crlf
+*.yml text=auto
 *.yaml text=auto


### PR DESCRIPTION
@denelon @jedieaston @OfficialEsco 

This adds additional file types to the `.gitattributes` file. After testing a `--renormalize`, there are none of the new filetypes which are updated, indicating they all currently have CRLF line endings. This is true because they were all updated as part of #76506. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/77737)