### PR TITLE
New version: QTextPad.QTextPad version 1.9.1

### DIFF
--- a/manifests/q/QTextPad/QTextPad/1.9.1/QTextPad.QTextPad.installer.yaml
+++ b/manifests/q/QTextPad/QTextPad/1.9.1/QTextPad.QTextPad.installer.yaml
@@ -1,0 +1,15 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+
+PackageIdentifier: QTextPad.QTextPad
+PackageVersion: 1.9.1
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: machine
+ReleaseDate: 2022-09-01
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/zrax/qtextpad/releases/download/1.9.1/qtextpad-win64-1.9.1.exe
+  InstallerSha256: FC09B71C3CBAF5ACE4E41D9B7BF4F811E489CC7E6281A37BB7ECE5CE35AA6DF7
+ManifestType: installer
+ManifestVersion: 1.2.0

--- a/manifests/q/QTextPad/QTextPad/1.9.1/QTextPad.QTextPad.locale.en-US.yaml
+++ b/manifests/q/QTextPad/QTextPad/1.9.1/QTextPad.QTextPad.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+
+PackageIdentifier: QTextPad.QTextPad
+PackageVersion: 1.9.1
+PackageLocale: en-US
+Publisher: Michael Hansen
+# PublisherUrl: 
+# PublisherSupportUrl: 
+# PrivacyUrl: 
+# Author: 
+PackageName: QTextPad
+PackageUrl: https://github.com/zrax/qtextpad
+License: Copyright (c) 2019-2020 Michael Hansen - GPLv3
+LicenseUrl: https://github.com/zrax/qtextpad/blob/master/COPYING
+# Copyright: 
+# CopyrightUrl: 
+ShortDescription: Lightweight text and code editor using KF5's syntax highlighting repository
+# Description: 
+Moniker: qtextpad
+Tags:
+- code-editor
+- notepad
+- text-editor
+# Agreements: 
+# ReleaseNotes: 
+ReleaseNotesUrl: https://github.com/zrax/qtextpad/releases/tag/1.9.1
+# PurchaseUrl: 
+# InstallationNotes: 
+# Documentations: 
+ManifestType: defaultLocale
+ManifestVersion: 1.2.0

--- a/manifests/q/QTextPad/QTextPad/1.9.1/QTextPad.QTextPad.yaml
+++ b/manifests/q/QTextPad/QTextPad/1.9.1/QTextPad.QTextPad.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+
+PackageIdentifier: QTextPad.QTextPad
+PackageVersion: 1.9.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.2.0


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | QTextPad | Dolphin, PhpStorm 2022.2.2, Plex, ProtonVPN, RubyMine 2022.2.2, WebStorm 2022.2.2, ProtonVPNTap, ProtonVPNTun, ProtonVPN, Kate, KDE Connect, KDevelop, Kile    |
| Version     | 1.9.1     | 22.08.0, 222.4167.9, 1.53.1, 2.0.6, 222.4167.3, 222.4167.9, 1.1.4, 0.13.1, 2.0.6, 22.08.0, 22.08.0, 5.6.2, 2.9.93 |
| Publisher   | Michael Hansen   | KDE e.V., JetBrains s.r.o., Plex, Inc., Proton Technologies AG, JetBrains s.r.o., JetBrains s.r.o., Proton Technologies AG, Proton Technologies AG, Proton Technologies AG, KDE e.V., KDE e.V., KDE e.V., KDE e.V.      |
| ProductCode |           | Dolphin, PhpStorm 2022.2.2, Plex, ProtonVPN 2.0.6, RubyMine 2022.2.2, WebStorm 2022.2.2, {87BDF456-9882-44E6-8FFC-F73B83E42EAD}, {B1EBF050-CC3E-45B0-9DE5-339C6241F3DA}, {E7AD46A7-6578-45D9-A690-BF58D33BA6B5}, Kate, KDE Connect, KDevelop, Kile    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://bittu.eu.org/docs/wpa-intro) in workflow run [2814](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/2979337268>)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/77822)