### PR TITLE
Removed silent flags to show the elevation prompt for non-admin insta…

### DIFF
--- a/manifests/n/Novicon/Munixo/Client/5.0.75.16416/Novicon.Munixo.Client.installer.yaml
+++ b/manifests/n/Novicon/Munixo/Client/5.0.75.16416/Novicon.Munixo.Client.installer.yaml
@@ -12,8 +12,6 @@ InstallModes:
 - silent
 - silentWithProgress
 InstallerSwitches:
-  Silent: /qn
-  SilentWithProgress: /q
   InstallLocation: APPDIR=<INSTALLPATH>
   Log: /lv <LOGPATH>
 Installers:


### PR DESCRIPTION
…llations

With the msi silent flags, the elevation prompt doesn't appear and the installation fails with an error message for non-admin users. The flags need to be removed so the elevation prompty will be shown to the user.

- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.2 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.2.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/77871)