### PR TITLE
Remove DisplayVersion: Google.AndroidStudio.Canary version 2022.1.1.10

### DIFF
--- a/manifests/g/Google/AndroidStudio/Canary/2022.1.1.10/Google.AndroidStudio.Canary.installer.yaml
+++ b/manifests/g/Google/AndroidStudio/Canary/2022.1.1.10/Google.AndroidStudio.Canary.installer.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.1.4 $debug=QUSU.7-2-6
+# Created with YamlCreate.ps1 v2.1.5 $debug=QUSU.CRLF.7-2-6.Win32NT
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
 
 PackageIdentifier: Google.AndroidStudio.Canary
@@ -13,13 +13,12 @@ InstallModes:
 InstallerSuccessCodes:
 - 1223
 UpgradeBehavior: install
+AppsAndFeaturesEntries:
+- DisplayName: Android Studio
+  ProductCode: Android Studio
 Installers:
 - Architecture: x64
   InstallerUrl: https://redirector.gvt1.com/edgedl/android/studio/install/2022.1.1.10/android-studio-2022.1.1.10-windows.exe
   InstallerSha256: 757E805E0D37C80117C9976C59C230E1A9A58F925B9FFA2B05612BD2524E64B3
-  AppsAndFeaturesEntries:
-  - DisplayName: Android Studio
-    DisplayVersion: "2022.1"
-    ProductCode: Android Studio
 ManifestType: installer
 ManifestVersion: 1.2.0

--- a/manifests/g/Google/AndroidStudio/Canary/2022.1.1.10/Google.AndroidStudio.Canary.locale.en-US.yaml
+++ b/manifests/g/Google/AndroidStudio/Canary/2022.1.1.10/Google.AndroidStudio.Canary.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.1.4 $debug=QUSU.7-2-6
+# Created with YamlCreate.ps1 v2.1.5 $debug=QUSU.CRLF.7-2-6.Win32NT
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
 
 PackageIdentifier: Google.AndroidStudio.Canary

--- a/manifests/g/Google/AndroidStudio/Canary/2022.1.1.10/Google.AndroidStudio.Canary.yaml
+++ b/manifests/g/Google/AndroidStudio/Canary/2022.1.1.10/Google.AndroidStudio.Canary.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.1.4 $debug=QUSU.7-2-6
+# Created with YamlCreate.ps1 v2.1.5 $debug=QUSU.CRLF.7-2-6.Win32NT
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
 
 PackageIdentifier: Google.AndroidStudio.Canary


### PR DESCRIPTION
### Reason: I will add all canary versions for 2022.1 but having the same DisplayVersion on multiple versions will break the pipelines. (See #78059)

- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.2 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.2.0)?


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/78060)