### PR TITLE
Remove DisplayVersion: Google.AndroidStudio.Beta version 2021.3.1.15

### DIFF
--- a/manifests/g/Google/AndroidStudio/Beta/2021.3.1.15/Google.AndroidStudio.Beta.installer.yaml
+++ b/manifests/g/Google/AndroidStudio/Beta/2021.3.1.15/Google.AndroidStudio.Beta.installer.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.1.4 $debug=QUSU.7-2-6
+# Created with YamlCreate.ps1 v2.1.5 $debug=QUSU.CRLF.7-2-6.Win32NT
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
 
 PackageIdentifier: Google.AndroidStudio.Beta
@@ -15,7 +15,6 @@ InstallerSuccessCodes:
 UpgradeBehavior: install
 AppsAndFeaturesEntries:
 - DisplayName: Android Studio
-  DisplayVersion: "2021.3"
   ProductCode: Android Studio
 Installers:
 - Architecture: x64

--- a/manifests/g/Google/AndroidStudio/Beta/2021.3.1.15/Google.AndroidStudio.Beta.locale.en-US.yaml
+++ b/manifests/g/Google/AndroidStudio/Beta/2021.3.1.15/Google.AndroidStudio.Beta.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.1.4 $debug=QUSU.7-2-6
+# Created with YamlCreate.ps1 v2.1.5 $debug=QUSU.CRLF.7-2-6.Win32NT
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
 
 PackageIdentifier: Google.AndroidStudio.Beta

--- a/manifests/g/Google/AndroidStudio/Beta/2021.3.1.15/Google.AndroidStudio.Beta.yaml
+++ b/manifests/g/Google/AndroidStudio/Beta/2021.3.1.15/Google.AndroidStudio.Beta.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.1.4 $debug=QUSU.7-2-6
+# Created with YamlCreate.ps1 v2.1.5 $debug=QUSU.CRLF.7-2-6.Win32NT
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
 
 PackageIdentifier: Google.AndroidStudio.Beta


### PR DESCRIPTION
### To add previous versions, the DisplayVersion for the latest version needs to be removed, as to not break the pipelines.

- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.2 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.2.0)?


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/78736)