### PR TITLE
Fix Spellcheck

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,3 +17,6 @@ indent_size = 2
 # Overrides for Markdown Files - Use tab for indents (accessibility)
 [*.md]
 indent_style = tab
+
+[{allow.txt,excludes.txt,patterns.txt}]
+end_of_line = lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,4 @@
 *.validation text eol=crlf
 *.yml text=auto
 *.yaml text=auto
+.github/actions/spelling/** text eol=lf


### PR DESCRIPTION
@denelon @jedieaston 

Because the spell check action runs on ubuntu-latest it must explicitly have LF line endings and not CRLF endings. This PR makes sure of that

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/78782)