### PR TITLE
New version: gerardog.gsudo version 1.5.1

### DIFF
--- a/manifests/g/gerardog/gsudo/1.5.1/gerardog.gsudo.installer.yaml
+++ b/manifests/g/gerardog/gsudo/1.5.1/gerardog.gsudo.installer.yaml
@@ -1,0 +1,23 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+
+PackageIdentifier: gerardog.gsudo
+PackageVersion: 1.5.1
+MinimumOSVersion: 10.0.0.0
+InstallerType: wix
+Scope: machine
+InstallerSwitches:
+  Silent: /quiet /norestart
+  SilentWithProgress: /passive /norestart
+UpgradeBehavior: install
+Commands:
+- gsudo
+- sudo
+ReleaseDate: 2022-09-09
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/gerardog/gsudo/releases/download/v1.5.1/gsudoSetup.msi
+  InstallerSha256: FADE7BAB58CEE651C3B2FF471C75262F5F275F5764FC8102589641B0C6CC2B10
+  ProductCode: '{E6B639F9-B184-4DF2-AC9E-A82174BB9E00}'
+ManifestType: installer
+ManifestVersion: 1.2.0

--- a/manifests/g/gerardog/gsudo/1.5.1/gerardog.gsudo.locale.en-US.yaml
+++ b/manifests/g/gerardog/gsudo/1.5.1/gerardog.gsudo.locale.en-US.yaml
@@ -1,0 +1,37 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+
+PackageIdentifier: gerardog.gsudo
+PackageVersion: 1.5.1
+PackageLocale: en-US
+Publisher: gerardog
+# PublisherUrl: 
+PublisherSupportUrl: https://github.com/gerardog/gsudo/issues
+# PrivacyUrl: 
+Author: Gerardo Grignoli
+PackageName: gsudo
+PackageUrl: https://github.com/gerardog/gsudo
+License: MIT
+LicenseUrl: https://github.com/gerardog/gsudo/blob/master/LICENSE.txt
+Copyright: Copyright (c) 2021 Gerardo Grignoli
+CopyrightUrl: https://github.com/gerardog/gsudo/blob/master/LICENSE.txt
+ShortDescription: A Sudo for Windows - run elevated without spawning a new Console Host Window
+# Description: 
+Moniker: gsudo
+Tags:
+- admin
+- command-line
+- elevate
+- priviledge
+- run-as
+- shell
+- sudo
+- terminal
+# Agreements: 
+# ReleaseNotes: 
+ReleaseNotesUrl: https://github.com/gerardog/gsudo/releases/tag/v1.5.1
+# PurchaseUrl: 
+# InstallationNotes: 
+# Documentations: 
+ManifestType: defaultLocale
+ManifestVersion: 1.2.0

--- a/manifests/g/gerardog/gsudo/1.5.1/gerardog.gsudo.yaml
+++ b/manifests/g/gerardog/gsudo/1.5.1/gerardog.gsudo.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+
+PackageIdentifier: gerardog.gsudo
+PackageVersion: 1.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.2.0


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | gsudo | Certbot    |
| Version     | 1.5.1     | 1.30.0 |
| Publisher   | gerardog   | Electronic Frontier Foundation      |
| ProductCode |           | Certbot    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://bittu.eu.org/docs/wpa-intro) in workflow run [2951](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/3022020830>)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/79173)