### PR TITLE
New version: leezer3.OpenBVE version 1.8.4.2

### DIFF
--- a/manifests/l/leezer3/OpenBVE/1.8.4.2/leezer3.OpenBVE.installer.yaml
+++ b/manifests/l/leezer3/OpenBVE/1.8.4.2/leezer3.OpenBVE.installer.yaml
@@ -1,0 +1,14 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+
+PackageIdentifier: leezer3.OpenBVE
+PackageVersion: 1.8.4.2
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+ReleaseDate: 2022-09-08
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/leezer3/OpenBVE/releases/download/1.8.4.2/openBVE-1.8.4.2-setup.exe
+  InstallerSha256: 8F66A8CCCC5805132105491B4797694E59CB0DE1AB10F980E7943C949E2E8B86
+ManifestType: installer
+ManifestVersion: 1.2.0

--- a/manifests/l/leezer3/OpenBVE/1.8.4.2/leezer3.OpenBVE.locale.en-US.yaml
+++ b/manifests/l/leezer3/OpenBVE/1.8.4.2/leezer3.OpenBVE.locale.en-US.yaml
@@ -1,0 +1,37 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+
+PackageIdentifier: leezer3.OpenBVE
+PackageVersion: 1.8.4.2
+PackageLocale: en-US
+Publisher: The OpenBVE Project
+PublisherUrl: https://github.com/leezer3
+PublisherSupportUrl: https://github.com/leezer3/OpenBVE/issues
+# PrivacyUrl: 
+Author: leezer3
+PackageName: openBVE
+PackageUrl: https://github.com/leezer3/OpenBVE
+License: public domain
+# LicenseUrl: 
+# Copyright: 
+# CopyrightUrl: 
+ShortDescription: free train simulator game
+# Description: 
+# Moniker: 
+Tags:
+- csharp
+- dotnet
+- game
+- metro
+- railway
+- subway
+- train
+- underground
+# Agreements: 
+# ReleaseNotes: 
+ReleaseNotesUrl: https://github.com/leezer3/OpenBVE/releases/tag/1.8.4.2
+# PurchaseUrl: 
+# InstallationNotes: 
+# Documentations: 
+ManifestType: defaultLocale
+ManifestVersion: 1.2.0

--- a/manifests/l/leezer3/OpenBVE/1.8.4.2/leezer3.OpenBVE.yaml
+++ b/manifests/l/leezer3/OpenBVE/1.8.4.2/leezer3.OpenBVE.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+
+PackageIdentifier: leezer3.OpenBVE
+PackageVersion: 1.8.4.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.2.0


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | openBVE | k6, DataGrip 2022.2.3, Dolphin, JetBrains YouTrack 2022.2, Kate, KDE Connect, KDevelop, Kile, JetBrains Toolbox    |
| Version     | 1.8.4.2     | 0.40.0, 222.4167.22, 22.08.1, 22.2.55618, 22.08.1, 22.08.1, 5.6.2, 2.9.93, 1.25.12999 |
| Publisher   | The OpenBVE Project   | Raintank Inc. d.b.a. Grafana Labs, JetBrains s.r.o., KDE e.V., JetBrains, KDE e.V., KDE e.V., KDE e.V., KDE e.V., JetBrains      |
| ProductCode |           | {D350A187-7962-40A4-99C1-F76C3DF3D45C}, DataGrip 2022.2.3, Dolphin, {40BEEFA8-8A39-490B-BEA0-357F66E843C9}, Kate, KDE Connect, KDevelop, Kile, Toolbox    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://bittu.eu.org/docs/wpa-intro) in workflow run [2951](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/3022020830>)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/79186)