### PR TITLE
Added MariaDB 10.6.9.0

### DIFF
--- a/manifests/m/MariaDB/Server/10.6.9.0/MariaDB.Server.installer.yaml
+++ b/manifests/m/MariaDB/Server/10.6.9.0/MariaDB.Server.installer.yaml
@@ -1,0 +1,25 @@
+# Created using wingetcreate 1.1.2.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+
+PackageIdentifier: MariaDB.Server
+PackageVersion: 10.6.9.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+AppsAndFeaturesEntries:
+- DisplayName: MariaDB 10.6 (x64)
+Installers:
+- Architecture: x64
+  InstallerType: wix
+  InstallerUrl: https://archive.mariadb.org/mariadb-10.6.9/winx64-packages/mariadb-10.6.9-winx64.msi
+  InstallerSha256: 803EBFC01E6B83CFFF2EBCB3E94A49687C2F22E1328BBAB833D08EDA8DBC9072
+  ProductCode: '{AC545F8B-0E3B-47E7-A61A-8246BD36747A}'
+ManifestType: installer
+ManifestVersion: 1.2.0
+

--- a/manifests/m/MariaDB/Server/10.6.9.0/MariaDB.Server.locale.en-US.yaml
+++ b/manifests/m/MariaDB/Server/10.6.9.0/MariaDB.Server.locale.en-US.yaml
@@ -8,7 +8,7 @@ Publisher: MariaDB Corporation Ab
 PublisherUrl: https://mariadb.org
 PrivacyUrl: https://mariadb.org/privacy-policy/
 Author: MariaDB Corporation Ab
-PackageName: MariaDB 10.6
+PackageName: MariaDB
 PackageUrl: https://mariadb.org
 License: GPL 2.0 only
 LicenseUrl: https://mariadb.com/kb/en/mariadb-license/

--- a/manifests/m/MariaDB/Server/10.6.9.0/MariaDB.Server.locale.en-US.yaml
+++ b/manifests/m/MariaDB/Server/10.6.9.0/MariaDB.Server.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# Created using wingetcreate 1.1.2.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+
+PackageIdentifier: MariaDB.Server
+PackageVersion: 10.6.9.0
+PackageLocale: en-US
+Publisher: MariaDB Corporation Ab
+PublisherUrl: https://mariadb.org
+PrivacyUrl: https://mariadb.org/privacy-policy/
+Author: MariaDB Corporation Ab
+PackageName: MariaDB 10.6
+PackageUrl: https://mariadb.org
+License: GPL 2.0 only
+LicenseUrl: https://mariadb.com/kb/en/mariadb-license/
+Copyright: Copyright @ 2009 - 2022 MariaDB Foundation.
+ShortDescription: Community developed fork of MySQL server.
+Moniker: mariadb
+Tags:
+- database
+- mysql
+- rdbms
+- sql
+ManifestType: defaultLocale
+ManifestVersion: 1.2.0
+

--- a/manifests/m/MariaDB/Server/10.6.9.0/MariaDB.Server.yaml
+++ b/manifests/m/MariaDB/Server/10.6.9.0/MariaDB.Server.yaml
@@ -1,0 +1,9 @@
+# Created using wingetcreate 1.1.2.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+
+PackageIdentifier: MariaDB.Server
+PackageVersion: 10.6.9.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.2.0
+


### PR DESCRIPTION
Signed-off-by: Daniel Sutton <daniel@sootysec.uk>

Adding new version of MariaDB 10.6 as 10.6 is a LTS release which 6th July 2026 whist the other branch releases are only supported for 1 year.

- [x ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x ] Does your manifest conform to the [1.2 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.2.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/79529)