### PR TITLE
New version: CorporateClashCrew.ToontownCorporateClash version 1.2.4

### DIFF
--- a/manifests/c/CorporateClashCrew/ToontownCorporateClash/1.2.4/CorporateClashCrew.ToontownCorporateClash.installer.yaml
+++ b/manifests/c/CorporateClashCrew/ToontownCorporateClash/1.2.4/CorporateClashCrew.ToontownCorporateClash.installer.yaml
@@ -1,0 +1,14 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+
+PackageIdentifier: CorporateClashCrew.ToontownCorporateClash
+PackageVersion: 1.2.4
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+ReleaseDate: 2022-09-13
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/CorporateClash/pyside2-releases/releases/download/v1.2.4/installer.exe
+  InstallerSha256: 05AFC1EC7035F579EA8351C9E7FA694CA76A76BDA80A9A8CA27AD685DE99A345
+ManifestType: installer
+ManifestVersion: 1.2.0

--- a/manifests/c/CorporateClashCrew/ToontownCorporateClash/1.2.4/CorporateClashCrew.ToontownCorporateClash.locale.en-US.yaml
+++ b/manifests/c/CorporateClashCrew/ToontownCorporateClash/1.2.4/CorporateClashCrew.ToontownCorporateClash.locale.en-US.yaml
@@ -4,14 +4,14 @@
 PackageIdentifier: CorporateClashCrew.ToontownCorporateClash
 PackageVersion: 1.2.4
 PackageLocale: en-US
-Publisher: Corporate Clash Crew
+Publisher: Corporate Clash
 # PublisherUrl: 
 # PublisherSupportUrl: 
 # PrivacyUrl: 
 # Author: 
-PackageName: 'Toontown: Corporate Clash'
+PackageName: 'Corporate Clash Launcher'
 # PackageUrl: 
-License: Closed Source
+License: Proprietary
 # LicenseUrl: 
 # Copyright: 
 # CopyrightUrl: 

--- a/manifests/c/CorporateClashCrew/ToontownCorporateClash/1.2.4/CorporateClashCrew.ToontownCorporateClash.locale.en-US.yaml
+++ b/manifests/c/CorporateClashCrew/ToontownCorporateClash/1.2.4/CorporateClashCrew.ToontownCorporateClash.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+
+PackageIdentifier: CorporateClashCrew.ToontownCorporateClash
+PackageVersion: 1.2.4
+PackageLocale: en-US
+Publisher: Corporate Clash Crew
+# PublisherUrl: 
+# PublisherSupportUrl: 
+# PrivacyUrl: 
+# Author: 
+PackageName: 'Toontown: Corporate Clash'
+# PackageUrl: 
+License: Closed Source
+# LicenseUrl: 
+# Copyright: 
+# CopyrightUrl: 
+ShortDescription: 'Toontown: Corporate Clash is a completely free to play massively multiplayer online game designed to be the new experience of a game many of us loved.'
+# Description: 
+# Moniker: 
+# Tags: 
+# Agreements: 
+# ReleaseNotes: 
+ReleaseNotesUrl: https://github.com/CorporateClash/pyside2-releases/releases/tag/v1.2.4
+# PurchaseUrl: 
+# InstallationNotes: 
+# Documentations: 
+ManifestType: defaultLocale
+ManifestVersion: 1.2.0

--- a/manifests/c/CorporateClashCrew/ToontownCorporateClash/1.2.4/CorporateClashCrew.ToontownCorporateClash.yaml
+++ b/manifests/c/CorporateClashCrew/ToontownCorporateClash/1.2.4/CorporateClashCrew.ToontownCorporateClash.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+
+PackageIdentifier: CorporateClashCrew.ToontownCorporateClash
+PackageVersion: 1.2.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.2.0


### PR DESCRIPTION
### Result: Installation Successful
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | Toontown: Corporate Clash | Corporate Clash Launcher    |
| Version     | 1.2.4     | 1.2.4 |
| Publisher   | Corporate Clash Crew   | Corporate Clash      |
| ProductCode |           | CorporateClashPySide2    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://bittu.eu.org/docs/wpa-intro) in workflow run [3039](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/3065181632>)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/79705)