### PR TITLE
New version: OrangeDrangon.AndroidMessages.Desktop version 5.4.0

### DIFF
--- a/manifests/o/OrangeDrangon/AndroidMessages/Desktop/5.4.0/OrangeDrangon.AndroidMessages.Desktop.installer.yaml
+++ b/manifests/o/OrangeDrangon/AndroidMessages/Desktop/5.4.0/OrangeDrangon.AndroidMessages.Desktop.installer.yaml
@@ -1,0 +1,16 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+
+PackageIdentifier: OrangeDrangon.AndroidMessages.Desktop
+PackageVersion: 5.4.0
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+UpgradeBehavior: install
+ReleaseDate: 2022-09-14
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/OrangeDrangon/android-messages-desktop/releases/download/v5.4.0/Android-Messages-v5.4.0-win-x64.exe
+  InstallerSha256: 88A74EFC816F22BA41CC8E0048CE3AA28A90D784C1328798E2E54D719E79AA16
+  ProductCode: 3ae5efac-9497-59f4-9377-1bd5c9afacf5
+ManifestType: installer
+ManifestVersion: 1.2.0

--- a/manifests/o/OrangeDrangon/AndroidMessages/Desktop/5.4.0/OrangeDrangon.AndroidMessages.Desktop.locale.en-US.yaml
+++ b/manifests/o/OrangeDrangon/AndroidMessages/Desktop/5.4.0/OrangeDrangon.AndroidMessages.Desktop.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+
+PackageIdentifier: OrangeDrangon.AndroidMessages.Desktop
+PackageVersion: 5.4.0
+PackageLocale: en-US
+Publisher: Kyle Rosenberg
+PublisherUrl: https://github.com/OrangeDrangon
+PublisherSupportUrl: https://github.com/OrangeDrangon/android-messages-desktop/issues
+# PrivacyUrl: 
+Author: Kyle Rosenberg
+PackageName: AndroidMessages
+PackageUrl: https://github.com/OrangeDrangon/android-messages-desktop
+License: MIT
+LicenseUrl: https://github.com/OrangeDrangon/android-messages-desktop/blob/master/LICENSE
+# Copyright: 
+CopyrightUrl: https://github.com/OrangeDrangon/android-messages-desktop/blob/master/LICENSE
+ShortDescription: Run Android Messages as a desktop app, a la iMessage
+# Description: 
+# Moniker: 
+Tags:
+- android
+- messages
+# Agreements: 
+# ReleaseNotes: 
+ReleaseNotesUrl: https://github.com/OrangeDrangon/android-messages-desktop/releases/tag/v5.4.0
+# PurchaseUrl: 
+# InstallationNotes: 
+# Documentations: 
+ManifestType: defaultLocale
+ManifestVersion: 1.2.0

--- a/manifests/o/OrangeDrangon/AndroidMessages/Desktop/5.4.0/OrangeDrangon.AndroidMessages.Desktop.yaml
+++ b/manifests/o/OrangeDrangon/AndroidMessages/Desktop/5.4.0/OrangeDrangon.AndroidMessages.Desktop.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+
+PackageIdentifier: OrangeDrangon.AndroidMessages.Desktop
+PackageVersion: 5.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.2.0


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | AndroidMessages | Vortex, Octopus Deploy Server, Signal Beta 5.60.0-beta.1, Logseq, NVIDIA GeForce NOW 2.0.44.105, NVIDIA Install Application    |
| Version     | 5.4.0     | 1.6.10, 2022.3.10483, 5.60.0-beta.1, 0.8.7, 2.0.44.105, 2.1002.373.0 |
| Publisher   | Kyle Rosenberg   | Black Tree Gaming Ltd., Octopus Deploy Pty. Ltd., Signal Messenger, LLC, Logseq, NVIDIA Corporation, NVIDIA Corporation      |
| ProductCode |           | 57979c68-f490-55b8-8fed-8b017a5af2fe, {892B98DF-CD50-40BB-AED4-430A8A2B201F}, b39ac3a0-cc73-5ec2-ba18-5ab3c4de1ca1, Logseq, {B2FE1952-0186-46C3-BAEC-A80AA35AC5B8}_GeForceNOW, {B2FE1952-0186-46C3-BAEC-A80AA35AC5B8}_installer    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://bittu.eu.org/docs/wpa-intro) in workflow run [3039](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/3065181632>)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/79734)