### PR TITLE
New version: xgi.houdoku version 2.10.0

### DIFF
--- a/manifests/x/xgi/houdoku/2.10.0/xgi.houdoku.installer.yaml
+++ b/manifests/x/xgi/houdoku/2.10.0/xgi.houdoku.installer.yaml
@@ -1,0 +1,28 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+
+PackageIdentifier: xgi.houdoku
+PackageVersion: 2.10.0
+InstallerLocale: en-US
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+ReleaseDate: 2022-09-16
+Installers:
+- Architecture: x64
+  Scope: user
+  InstallerUrl: https://github.com/xgi/houdoku/releases/download/v2.10.0/Houdoku-Setup-2.10.0.exe
+  InstallerSha256: C5154057A8FA6726985DC31DB2E103A03FAD6C1E2F2D16C84A540861030DA37C
+  InstallerSwitches:
+    Custom: /CURRENTUSER
+- Architecture: x64
+  Scope: machine
+  InstallerUrl: https://github.com/xgi/houdoku/releases/download/v2.10.0/Houdoku-Setup-2.10.0.exe
+  InstallerSha256: C5154057A8FA6726985DC31DB2E103A03FAD6C1E2F2D16C84A540861030DA37C
+  InstallerSwitches:
+    Custom: /ALLUSERS
+ManifestType: installer
+ManifestVersion: 1.2.0

--- a/manifests/x/xgi/houdoku/2.10.0/xgi.houdoku.locale.en-US.yaml
+++ b/manifests/x/xgi/houdoku/2.10.0/xgi.houdoku.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+
+PackageIdentifier: xgi.houdoku
+PackageVersion: 2.10.0
+PackageLocale: en-US
+Publisher: Jake Robertson
+PublisherUrl: https://github.com/xgi/houdoku
+PublisherSupportUrl: https://github.com/xgi/houdoku/issues
+# PrivacyUrl: 
+Author: Jake Robertson
+PackageName: Houdoku
+PackageUrl: https://github.com/xgi/houdoku
+License: MIT
+LicenseUrl: https://raw.githubusercontent.com/xgi/houdoku/master/LICENSE.txt
+Copyright: Copyright (c) 2018 Jake Robertson
+CopyrightUrl: https://raw.githubusercontent.com/xgi/houdoku/master/LICENSE.txt
+ShortDescription: Manga reader and library manager for the desktop
+# Description: 
+Moniker: houdoku
+Tags:
+- comics
+- manga
+- manga-reader
+# Agreements: 
+# ReleaseNotes: 
+ReleaseNotesUrl: https://github.com/xgi/houdoku/releases/tag/v2.10.0
+# PurchaseUrl: 
+# InstallationNotes: 
+# Documentations: 
+ManifestType: defaultLocale
+ManifestVersion: 1.2.0

--- a/manifests/x/xgi/houdoku/2.10.0/xgi.houdoku.yaml
+++ b/manifests/x/xgi/houdoku/2.10.0/xgi.houdoku.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+
+PackageIdentifier: xgi.houdoku
+PackageVersion: 2.10.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.2.0


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | Houdoku | GoLand 2022.2.3, MasterGo 1.3.0, KDevelop    |
| Version     | 2.10.0     | 222.4167.25, 1.3.0, 5.6.2 |
| Publisher   | Jake Robertson   | JetBrains s.r.o., 北京尽微致广信息技术有限公司, KDE e.V.      |
| ProductCode |           | GoLand 2022.2.3, com.master.electron, KDevelop    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://bittu.eu.org/docs/wpa-intro) in workflow run [3045](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/3068529224>)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/79836)