### PR TITLE
New version: Google.Chrome.Canary version 108.0.5309.0

### DIFF
--- a/manifests/g/Google/Chrome/Canary/108.0.5309.0/Google.Chrome.Canary.installer.yaml
+++ b/manifests/g/Google/Chrome/Canary/108.0.5309.0/Google.Chrome.Canary.installer.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
 
 PackageIdentifier: Google.Chrome.Canary
-PackageVersion: 108.0.5308.0
+PackageVersion: 108.0.5309.0
 Platform:
 - Windows.Desktop
 MinimumOSVersion: 10.0.0.0
@@ -21,7 +21,7 @@ FileExtensions:
 - htm
 - html
 - url
-ReleaseDate: 2022-09-18
+ReleaseDate: 2022-09-19
 Installers:
 - Architecture: x64
   InstallerUrl: https://dl.google.com/tag/s/appguid%3D%7B4EA16AC7-FD5A-47C3-875B-DBF4A2008C20%7D%26usagestats%3D1%26ap%3Dx64-canary-statsdef_1/update2/installers/ChromeSetup.exe

--- a/manifests/g/Google/Chrome/Canary/108.0.5309.0/Google.Chrome.Canary.locale.en-US.yaml
+++ b/manifests/g/Google/Chrome/Canary/108.0.5309.0/Google.Chrome.Canary.locale.en-US.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
 
 PackageIdentifier: Google.Chrome.Canary
-PackageVersion: 108.0.5308.0
+PackageVersion: 108.0.5309.0
 PackageLocale: en-US
 Publisher: Google LLC
 PublisherUrl: https://www.google.com

--- a/manifests/g/Google/Chrome/Canary/108.0.5309.0/Google.Chrome.Canary.locale.nb-NO.yaml
+++ b/manifests/g/Google/Chrome/Canary/108.0.5309.0/Google.Chrome.Canary.locale.nb-NO.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.2.0.schema.json
 
 PackageIdentifier: Google.Chrome.Canary
-PackageVersion: 108.0.5308.0
+PackageVersion: 108.0.5309.0
 PackageLocale: nb-NO
 Publisher: Google LLC
 PublisherUrl: https://www.google.com

--- a/manifests/g/Google/Chrome/Canary/108.0.5309.0/Google.Chrome.Canary.yaml
+++ b/manifests/g/Google/Chrome/Canary/108.0.5309.0/Google.Chrome.Canary.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
 
 PackageIdentifier: Google.Chrome.Canary
-PackageVersion: 108.0.5308.0
+PackageVersion: 108.0.5309.0
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.2.0


### PR DESCRIPTION
### Result: Installation Successful
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | Google Chrome Canary | 百度网盘, Google Chrome Canary    |
| Version     | 108.0.5309.0     | 7.20.2, 108.0.5309.0 |
| Publisher   | Google LLC   | 北京度友科技有限公司, Google LLC      |
| ProductCode |           | 百度云管家, Google Chrome SxS    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://bittu.eu.org/docs/wpa-intro) in workflow run [3102](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/3080911919>)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/80076)