### PR TITLE
New version: xgi.houdoku version 2.10.1

### DIFF
--- a/manifests/x/xgi/houdoku/2.10.1/xgi.houdoku.installer.yaml
+++ b/manifests/x/xgi/houdoku/2.10.1/xgi.houdoku.installer.yaml
@@ -1,0 +1,28 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+
+PackageIdentifier: xgi.houdoku
+PackageVersion: 2.10.1
+InstallerLocale: en-US
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+ReleaseDate: 2022-09-20
+Installers:
+- Architecture: x64
+  Scope: user
+  InstallerUrl: https://github.com/xgi/houdoku/releases/download/v2.10.1/Houdoku-Setup-2.10.1.exe
+  InstallerSha256: E2D590C537516CB81906B502A71EF88FE54D3CD07E6EBA62464E3FE6232A6892
+  InstallerSwitches:
+    Custom: /CURRENTUSER
+- Architecture: x64
+  Scope: machine
+  InstallerUrl: https://github.com/xgi/houdoku/releases/download/v2.10.1/Houdoku-Setup-2.10.1.exe
+  InstallerSha256: E2D590C537516CB81906B502A71EF88FE54D3CD07E6EBA62464E3FE6232A6892
+  InstallerSwitches:
+    Custom: /ALLUSERS
+ManifestType: installer
+ManifestVersion: 1.2.0

--- a/manifests/x/xgi/houdoku/2.10.1/xgi.houdoku.locale.en-US.yaml
+++ b/manifests/x/xgi/houdoku/2.10.1/xgi.houdoku.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+
+PackageIdentifier: xgi.houdoku
+PackageVersion: 2.10.1
+PackageLocale: en-US
+Publisher: Jake Robertson
+PublisherUrl: https://github.com/xgi/houdoku
+PublisherSupportUrl: https://github.com/xgi/houdoku/issues
+# PrivacyUrl: 
+Author: Jake Robertson
+PackageName: Houdoku
+PackageUrl: https://github.com/xgi/houdoku
+License: MIT
+LicenseUrl: https://raw.githubusercontent.com/xgi/houdoku/master/LICENSE.txt
+Copyright: Copyright (c) 2018 Jake Robertson
+CopyrightUrl: https://raw.githubusercontent.com/xgi/houdoku/master/LICENSE.txt
+ShortDescription: Manga reader and library manager for the desktop
+# Description: 
+Moniker: houdoku
+Tags:
+- comics
+- manga
+- manga-reader
+# Agreements: 
+# ReleaseNotes: 
+ReleaseNotesUrl: https://github.com/xgi/houdoku/releases/tag/v2.10.1
+# PurchaseUrl: 
+# InstallationNotes: 
+# Documentations: 
+ManifestType: defaultLocale
+ManifestVersion: 1.2.0

--- a/manifests/x/xgi/houdoku/2.10.1/xgi.houdoku.yaml
+++ b/manifests/x/xgi/houdoku/2.10.1/xgi.houdoku.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+
+PackageIdentifier: xgi.houdoku
+PackageVersion: 2.10.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.2.0


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | Houdoku | Node.js, Node.js, Octopus Deploy Server, WeMod    |
| Version     | 2.10.1     | 16.17.0, 19.0.0, 2022.3.10530, 8.3.5-beta00 |
| Publisher   | Jake Robertson   | Node.js Foundation, Node.js Foundation, Octopus Deploy Pty. Ltd., WeMod      |
| ProductCode |           | {F55EB18F-3933-4530-90D4-4075D19AF3E7}, {A75E0B91-CB78-458F-BBDC-94A735794416}, {D1CE3E16-3623-462E-8A9C-01DC2EDDE328}, WeMod    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://bittu.eu.org/docs/wpa-intro) in workflow run [3121](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/3088171809>)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/80194)