### PR TITLE
New version: Jitsi.Meet version 2022.9.1

### DIFF
--- a/manifests/j/Jitsi/Meet/2022.9.1/Jitsi.Meet.installer.yaml
+++ b/manifests/j/Jitsi/Meet/2022.9.1/Jitsi.Meet.installer.yaml
@@ -1,0 +1,20 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+
+PackageIdentifier: Jitsi.Meet
+PackageVersion: 2022.9.1
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- silent
+UpgradeBehavior: install
+ReleaseDate: 2022-09-24
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/jitsi/jitsi-meet-electron/releases/download/v2022.9.1/jitsi-meet.exe
+  InstallerSha256: 09AEB89C393E12D40627ABB2FD9A78BA9C23C0B690EA26AFD9C9B424D520096C
+ManifestType: installer
+ManifestVersion: 1.2.0

--- a/manifests/j/Jitsi/Meet/2022.9.1/Jitsi.Meet.locale.en-US.yaml
+++ b/manifests/j/Jitsi/Meet/2022.9.1/Jitsi.Meet.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+
+PackageIdentifier: Jitsi.Meet
+PackageVersion: 2022.9.1
+PackageLocale: en-US
+Publisher: Jitsi Team
+PublisherUrl: https://jitsi.org/
+PublisherSupportUrl: https://github.com/jitsi/jitsi-meet-electron/issues
+PrivacyUrl: https://jitsi.org/security/
+Author: Jitsi Team
+PackageName: Jitsi Meet
+PackageUrl: https://github.com/jitsi/jitsi-meet-electron
+License: Apache License 2.0
+LicenseUrl: https://raw.githubusercontent.com/jitsi/jitsi-meet-electron/master/LICENSE
+# Copyright: 
+CopyrightUrl: https://raw.githubusercontent.com/jitsi/jitsi-meet-electron/master/LICENSE
+ShortDescription: Jitsi Meet is an open-source (Apache) WebRTC JavaScript application that uses Jitsi Videobridge to provide high quality, secure and scalable video conferences.
+# Description: 
+# Moniker: 
+Tags:
+- chat
+- jitsi
+- jitsi-meet
+- meeting
+- video
+# Agreements: 
+# ReleaseNotes: 
+ReleaseNotesUrl: https://github.com/jitsi/jitsi-meet-electron/releases/tag/v2022.9.1
+# PurchaseUrl: 
+# InstallationNotes: 
+# Documentations: 
+ManifestType: defaultLocale
+ManifestVersion: 1.2.0

--- a/manifests/j/Jitsi/Meet/2022.9.1/Jitsi.Meet.yaml
+++ b/manifests/j/Jitsi/Meet/2022.9.1/Jitsi.Meet.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+
+PackageIdentifier: Jitsi.Meet
+PackageVersion: 2022.9.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.2.0


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | Jitsi Meet |     |
| Version     | 2022.9.1     |  |
| Publisher   | Jitsi Team   |       |
| ProductCode |           |     |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://bittu.eu.org/docs/wpa-intro) in workflow run [3206](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/3119823347>)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/80712)