### PR TITLE
New version: NhekoReborn.Nheko version 0.10.2

### DIFF
--- a/manifests/n/NhekoReborn/Nheko/0.10.2/NhekoReborn.Nheko.installer.yaml
+++ b/manifests/n/NhekoReborn/Nheko/0.10.2/NhekoReborn.Nheko.installer.yaml
@@ -1,0 +1,17 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+
+PackageIdentifier: NhekoReborn.Nheko
+PackageVersion: 0.10.2
+MinimumOSVersion: 10.0.0.0
+InstallerType: exe
+InstallerSwitches:
+  Silent: --accept-licenses --confirm-command install
+  SilentWithProgress: --accept-licenses --confirm-command install
+ReleaseDate: 2022-09-28
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Nheko-Reborn/nheko/releases/download/v0.10.2/nheko-v0.10.2-installer.exe
+  InstallerSha256: 99E75618695AD83B84ED71604CF9ADB5D434915EF5A4B37A4EB4D8E75126708E
+ManifestType: installer
+ManifestVersion: 1.2.0

--- a/manifests/n/NhekoReborn/Nheko/0.10.2/NhekoReborn.Nheko.locale.en-US.yaml
+++ b/manifests/n/NhekoReborn/Nheko/0.10.2/NhekoReborn.Nheko.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+
+PackageIdentifier: NhekoReborn.Nheko
+PackageVersion: 0.10.2
+PackageLocale: en-US
+Publisher: Mujx
+# PublisherUrl: 
+# PublisherSupportUrl: 
+# PrivacyUrl: 
+# Author: 
+PackageName: Nheko
+PackageUrl: https://nheko-reborn.github.io/
+License: GNU General Public License, Version 3
+LicenseUrl: https://github.com/Nheko-Reborn/nheko/blob/master/COPYING
+# Copyright: 
+# CopyrightUrl: 
+ShortDescription: Desktop client for Matrix using Qt and C++17.
+Description: The motivation behind the project is to provide a native desktop app for Matrix that feels more like a mainstream chat app (Element, Telegram etc) and less like an IRC client.
+# Moniker: 
+Tags:
+- chat
+- matrix
+- messenger
+- voip
+# Agreements: 
+# ReleaseNotes: 
+ReleaseNotesUrl: https://github.com/Nheko-Reborn/nheko/releases/tag/v0.10.2
+# PurchaseUrl: 
+# InstallationNotes: 
+# Documentations: 
+ManifestType: defaultLocale
+ManifestVersion: 1.2.0

--- a/manifests/n/NhekoReborn/Nheko/0.10.2/NhekoReborn.Nheko.yaml
+++ b/manifests/n/NhekoReborn/Nheko/0.10.2/NhekoReborn.Nheko.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+
+PackageIdentifier: NhekoReborn.Nheko
+PackageVersion: 0.10.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.2.0


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | Nheko | JetBrains Hub 2022.2, KDE Connect, KDevelop    |
| Version     | 0.10.2     | 22.2.15088, 22.08.1, 5.6.2 |
| Publisher   | Mujx   | JetBrains, KDE e.V., KDE e.V.      |
| ProductCode |           | {6F9BCA7F-1474-4871-9192-E9A2602888E7}, KDE Connect, KDevelop    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://bittu.eu.org/docs/wpa-intro) in workflow run [3283](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/3146015481>)