### PR TITLE
New version: JetBrains.IntelliJIDEA.Edu version 2022.2.1

### DIFF
--- a/manifests/j/JetBrains/IntelliJIDEA/Edu/2022.2.1/JetBrains.IntelliJIDEA.Edu.installer.yaml
+++ b/manifests/j/JetBrains/IntelliJIDEA/Edu/2022.2.1/JetBrains.IntelliJIDEA.Edu.installer.yaml
@@ -1,0 +1,19 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+
+PackageIdentifier: JetBrains.IntelliJIDEA.Edu
+PackageVersion: 2022.2.1
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+Scope: machine
+ReleaseDate: 2022-09-29
+AppsAndFeaturesEntries:
+- DisplayName: IntelliJ IDEA Educational Edition 2022.2
+  DisplayVersion: 222.4167.41
+  ProductCode: IntelliJ IDEA Educational Edition 2022.2
+Installers:
+- Architecture: x64
+  InstallerUrl: https://download-cdn.jetbrains.com/idea/ideaIE-2022.2.1.exe
+  InstallerSha256: D68F56F194DDFA46BE2A5125B58E1E4B91D7D01454BCCB0D558C233EF7B00B4D
+ManifestType: installer
+ManifestVersion: 1.2.0

--- a/manifests/j/JetBrains/IntelliJIDEA/Edu/2022.2.1/JetBrains.IntelliJIDEA.Edu.installer.yaml
+++ b/manifests/j/JetBrains/IntelliJIDEA/Edu/2022.2.1/JetBrains.IntelliJIDEA.Edu.installer.yaml
@@ -7,6 +7,7 @@ MinimumOSVersion: 10.0.0.0
 InstallerType: nullsoft
 Scope: machine
 ReleaseDate: 2022-09-29
+UpgradeBehavior: uninstallPrevious
 AppsAndFeaturesEntries:
 - DisplayName: IntelliJ IDEA Educational Edition 2022.2
   DisplayVersion: 222.4167.41

--- a/manifests/j/JetBrains/IntelliJIDEA/Edu/2022.2.1/JetBrains.IntelliJIDEA.Edu.installer.yaml
+++ b/manifests/j/JetBrains/IntelliJIDEA/Edu/2022.2.1/JetBrains.IntelliJIDEA.Edu.installer.yaml
@@ -9,9 +9,9 @@ Scope: machine
 ReleaseDate: 2022-09-29
 UpgradeBehavior: uninstallPrevious
 AppsAndFeaturesEntries:
-- DisplayName: IntelliJ IDEA Educational Edition 2022.2
+- DisplayName: IntelliJ IDEA Educational Edition 222.4167.41
   DisplayVersion: 222.4167.41
-  ProductCode: IntelliJ IDEA Educational Edition 2022.2
+  ProductCode: IntelliJ IDEA Educational Edition 222.4167.41
 Installers:
 - Architecture: x64
   InstallerUrl: https://download-cdn.jetbrains.com/idea/ideaIE-2022.2.1.exe

--- a/manifests/j/JetBrains/IntelliJIDEA/Edu/2022.2.1/JetBrains.IntelliJIDEA.Edu.locale.en-US.yaml
+++ b/manifests/j/JetBrains/IntelliJIDEA/Edu/2022.2.1/JetBrains.IntelliJIDEA.Edu.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+
+PackageIdentifier: JetBrains.IntelliJIDEA.Edu
+PackageVersion: 2022.2.1
+PackageLocale: en-US
+Publisher: JetBrains s.r.o.
+# PublisherUrl: 
+# PublisherSupportUrl: 
+# PrivacyUrl: 
+# Author: 
+PackageName: IntelliJ IDEA Educational Edition
+PackageUrl: https://www.jetbrains.com/idea/
+License: Copyright JetBrains s.r.o.
+LicenseUrl: https://www.jetbrains.com/legal/docs/toolbox/license.html
+# Copyright: 
+# CopyrightUrl: 
+ShortDescription: A smart IDE to help you learn and teach programming in Java, Kotlin, and Scala.
+# Description: 
+Moniker: intellij-edu
+# Tags: 
+# Agreements: 
+# ReleaseNotes: 
+ReleaseNotesUrl: https://plugins.jetbrains.com/plugin/10081-edutools/what-s-new/edutools-2022-9
+# PurchaseUrl: 
+# InstallationNotes: 
+# Documentations: 
+ManifestType: defaultLocale
+ManifestVersion: 1.2.0

--- a/manifests/j/JetBrains/IntelliJIDEA/Edu/2022.2.1/JetBrains.IntelliJIDEA.Edu.yaml
+++ b/manifests/j/JetBrains/IntelliJIDEA/Edu/2022.2.1/JetBrains.IntelliJIDEA.Edu.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+
+PackageIdentifier: JetBrains.IntelliJIDEA.Edu
+PackageVersion: 2022.2.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.2.0


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | IntelliJ IDEA Educational Edition | DataGrip 2022.2.5    |
| Version     | 2022.2.1     | 222.4345.5 |
| Publisher   | JetBrains s.r.o.   | JetBrains s.r.o.      |
| ProductCode |           | DataGrip 2022.2.5    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://bittu.eu.org/docs/wpa-intro) in workflow run [3299](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/3152186387>)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/81083)