### PR TITLE
Move Microsoft.VC++2015-2019Redist-x64 14.26.28720.3 to Microsoft.VCR…

### DIFF
--- a/manifests/m/Microsoft/VCRedist/2015+/x64/14.26.28720.3/Microsoft.VCRedist.2015+.x64.installer.yaml
+++ b/manifests/m/Microsoft/VCRedist/2015+/x64/14.26.28720.3/Microsoft.VCRedist.2015+.x64.installer.yaml
@@ -1,0 +1,27 @@
+# Created with YamlCreate.ps1 v2.0.0 using YAML parsing
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
+
+PackageIdentifier: Microsoft.VCRedist.2015+.x64
+PackageVersion: 14.26.28720.3
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSuccessCodes:
+- 3010
+Installers:
+- InstallerLocale: en-US
+  Architecture: x64
+  InstallerType: burn
+  Scope: machine
+  InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/d60aa805-26e9-47df-b4e3-cd6fcc392333/7D7105C52FCD6766BEEE1AE162AA81E278686122C1E44890712326634D0B055E/VC_redist.x64.exe
+  InstallerSha256: 7D7105C52FCD6766BEEE1AE162AA81E278686122C1E44890712326634D0B055E
+  UpgradeBehavior: install
+  ProductCode: '{7d607fb4-7e28-4c7a-a92f-3fcdaf555faf}'
+ManifestType: installer
+ManifestVersion: 1.0.0
+
+

--- a/manifests/m/Microsoft/VCRedist/2015+/x64/14.26.28720.3/Microsoft.VCRedist.2015+.x64.locale.en-US.yaml
+++ b/manifests/m/Microsoft/VCRedist/2015+/x64/14.26.28720.3/Microsoft.VCRedist.2015+.x64.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# Created with YamlCreate.ps1 v2.0.0 using YAML parsing
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.0.0.schema.json
+
+PackageIdentifier: Microsoft.VCRedist.2015+.x64
+PackageVersion: 14.26.28720.3
+PackageLocale: en-US
+Publisher: Microsoft Corporation
+PublisherUrl: https://www.microsoft.com/en-us/
+PublisherSupportUrl: https://support.microsoft.com/en-us
+PrivacyUrl: https://privacy.microsoft.com/en-us/privacystatement
+Author: Microsoft Corporation
+PackageName: Microsoft Visual C++ 2015-2019 Redistributable (x64)
+# PackageUrl: 
+License: Proprietary
+# LicenseUrl: 
+Copyright: Copyright (c) Microsoft Corporation
+# CopyrightUrl: 
+ShortDescription: The Microsoft Visual C++ 2015-2019 Redistributable Package (x64)
+Description: The Microsoft Visual C++ 2015-2019 Redistributable Package (x64) installs runtime components of Visual C++ Libraries required to run 64-bit applications developed with Visual C++ 2015, 2017 and 2019 on a computer that does not have Visual C++ 2015, 2017 and 2019 installed.
+Moniker: vcredistx64
+Tags:
+- visual-c++
+- redist
+ManifestType: defaultLocale
+ManifestVersion: 1.0.0
+
+

--- a/manifests/m/Microsoft/VCRedist/2015+/x64/14.26.28720.3/Microsoft.VCRedist.2015+.x64.yaml
+++ b/manifests/m/Microsoft/VCRedist/2015+/x64/14.26.28720.3/Microsoft.VCRedist.2015+.x64.yaml
@@ -1,0 +1,10 @@
+# Created with YamlCreate.ps1 v2.0.0 using YAML parsing
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.0.0.schema.json
+
+PackageIdentifier: Microsoft.VCRedist.2015+.x64
+PackageVersion: 14.26.28720.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.0.0
+
+


### PR DESCRIPTION
…edist.2015+.x64 14.26.28720.3

- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.2 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.2.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/81310)