### PR TITLE
Move Microsoft.VC++2015-2019Redist-x64 14.28.29325.2 to Microsoft.VCR…

### DIFF
--- a/manifests/m/Microsoft/VCRedist/2015+/x64/14.28.29325.2/Microsoft.VCRedist.2015+.x64.installer.yaml
+++ b/manifests/m/Microsoft/VCRedist/2015+/x64/14.28.29325.2/Microsoft.VCRedist.2015+.x64.installer.yaml
@@ -1,0 +1,27 @@
+# Created with YamlCreate.ps1 v2.0.0 using YAML parsing
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
+
+PackageIdentifier: Microsoft.VCRedist.2015+.x64
+PackageVersion: 14.28.29325.2
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSuccessCodes:
+- 3010
+Installers:
+- InstallerLocale: en-US
+  Architecture: x64
+  InstallerType: burn
+  Scope: machine
+  InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/89a3b9df-4a09-492e-8474-8f92c115c51d/B1A32C71A6B7D5978904FB223763263EA5A7EB23B2C44A0D60E90D234AD99178/VC_redist.x64.exe
+  InstallerSha256: B1A32C71A6B7D5978904FB223763263EA5A7EB23B2C44A0D60E90D234AD99178
+  UpgradeBehavior: install
+  ProductCode: '{33628a12-6787-4b9f-95a1-92449f69fae0}'
+ManifestType: installer
+ManifestVersion: 1.0.0
+
+

--- a/manifests/m/Microsoft/VCRedist/2015+/x64/14.28.29325.2/Microsoft.VCRedist.2015+.x64.locale.en-US.yaml
+++ b/manifests/m/Microsoft/VCRedist/2015+/x64/14.28.29325.2/Microsoft.VCRedist.2015+.x64.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# Created with YamlCreate.ps1 v2.0.0 using YAML parsing
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.0.0.schema.json
+
+PackageIdentifier: Microsoft.VCRedist.2015+.x64
+PackageVersion: 14.28.29325.2
+PackageLocale: en-US
+Publisher: Microsoft Corporation
+PublisherUrl: https://www.microsoft.com/en-us/
+PublisherSupportUrl: https://support.microsoft.com/en-us
+PrivacyUrl: https://privacy.microsoft.com/en-us/privacystatement
+Author: Microsoft Corporation
+PackageName: Microsoft Visual C++ 2015-2019 Redistributable (x64)
+# PackageUrl: 
+License: Proprietary
+# LicenseUrl: 
+Copyright: Copyright (c) Microsoft Corporation
+# CopyrightUrl: 
+ShortDescription: The Microsoft Visual C++ 2015-2019 Redistributable Package (x64)
+Description: The Microsoft Visual C++ 2015-2019 Redistributable Package (x64) installs runtime components of Visual C++ Libraries required to run 64-bit applications developed with Visual C++ 2015, 2017 and 2019 on a computer that does not have Visual C++ 2015, 2017 and 2019 installed.
+Moniker: vcredistx64
+Tags:
+- visual-c++
+- visual
+- c++
+- redist
+- redistributable
+ManifestType: defaultLocale
+ManifestVersion: 1.0.0
+
+

--- a/manifests/m/Microsoft/VCRedist/2015+/x64/14.28.29325.2/Microsoft.VCRedist.2015+.x64.yaml
+++ b/manifests/m/Microsoft/VCRedist/2015+/x64/14.28.29325.2/Microsoft.VCRedist.2015+.x64.yaml
@@ -1,0 +1,10 @@
+# Created with YamlCreate.ps1 v2.0.0 using YAML parsing
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.0.0.schema.json
+
+PackageIdentifier: Microsoft.VCRedist.2015+.x64
+PackageVersion: 14.28.29325.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.0.0
+
+


### PR DESCRIPTION
…edist.2015+.x64 14.28.29325.2

- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.2 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.2.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/81313)