### PR TITLE
Move Microsoft.VC++2015-2019Redist-x64 14.29.30040.0 to Microsoft.VCR…

### DIFF
--- a/manifests/m/Microsoft/VCRedist/2015+/x64/14.29.30040.0/Microsoft.VCRedist.2015+.x64.installer.yaml
+++ b/manifests/m/Microsoft/VCRedist/2015+/x64/14.29.30040.0/Microsoft.VCRedist.2015+.x64.installer.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
+PackageIdentifier: Microsoft.VCRedist.2015+.x64
+PackageVersion: 14.29.30040.0
+MinimumOSVersion: 10.0.0.0
+InstallerSuccessCodes:
+  - 3010
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+Installers:
+  - Architecture: x64
+    InstallerType: exe
+    InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/36e45907-8554-4390-ba70-9f6306924167/97CC5066EB3C7246CF89B735AE0F5A5304A7EE33DC087D65D9DFF3A1A73FE803/VC_redist.x64.exe
+    InstallerSha256: 97CC5066EB3C7246CF89B735AE0F5A5304A7EE33DC087D65D9DFF3A1A73FE803
+    ProductCode: "{5c6cccca-61ec-4667-a8d9-e133a59a5a73}"
+    InstallerSwitches:
+      Silent: /quiet /install /norestart
+      SilentWithProgress: /passive /install /norestart
+#    ProductCode: " "
+    Scope: machine
+    InstallerLocale: en-US
+    UpgradeBehavior: install
+ManifestType: installer
+ManifestVersion: 1.0.0
+
+

--- a/manifests/m/Microsoft/VCRedist/2015+/x64/14.29.30040.0/Microsoft.VCRedist.2015+.x64.locale.en-US.yaml
+++ b/manifests/m/Microsoft/VCRedist/2015+/x64/14.29.30040.0/Microsoft.VCRedist.2015+.x64.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultlocale.1.0.0.schema.json
+PackageIdentifier: Microsoft.VCRedist.2015+.x64
+PackageVersion: 14.29.30040.0
+PackageLocale: en-US
+Publisher: Microsoft Corporation
+#PublisherUrl: 
+#PublisherSupportUrl: 
+#PrivacyUrl: 
+Author: Microsoft
+PackageName: Microsoft Visual C++ 2015-2019 Redistributable (x64)
+#PackageUrl: 
+License: Copyright (c) Microsoft Corporation
+#LicenseUrl: 
+Copyright: Copyright (c) Microsoft Corporation
+#CopyrightUrl: 
+ShortDescription: Microsoft.VCRedist.2015+.x64
+Description: The Microsoft Visual C++ 2015-2019 Redistributable Package (x64) installs runtime components of Visual C++ Libraries required to run 64-bit applications developed with Visual C++ 2015, 2017 and 2019 on a computer that does not have Visual C++ 2015, 2017 and 2019 installed.
+Tags:
+  - visual c++
+  - redist
+ManifestType: defaultLocale
+ManifestVersion: 1.0.0
+
+

--- a/manifests/m/Microsoft/VCRedist/2015+/x64/14.29.30040.0/Microsoft.VCRedist.2015+.x64.yaml
+++ b/manifests/m/Microsoft/VCRedist/2015+/x64/14.29.30040.0/Microsoft.VCRedist.2015+.x64.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.0.0.schema.json
+PackageIdentifier: Microsoft.VCRedist.2015+.x64
+PackageVersion: 14.29.30040.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.0.0
+
+


### PR DESCRIPTION
…edist.2015+.x64 14.29.30040.0

- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.2 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.2.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/81318)