### PR TITLE
Move Microsoft.VC++2015-2022Redist-x64 14.30.30704.0 to Microsoft.VCR…

### DIFF
--- a/manifests/m/Microsoft/VCRedist/2015+/x64/14.30.30704.0/Microsoft.VCRedist.2015+.x64.installer.yaml
+++ b/manifests/m/Microsoft/VCRedist/2015+/x64/14.30.30704.0/Microsoft.VCRedist.2015+.x64.installer.yaml
@@ -1,0 +1,30 @@
+# Created with YamlCreate.ps1 v2.0.0 using YAML parsing
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
+
+PackageIdentifier: Microsoft.VCRedist.2015+.x64
+PackageVersion: 14.30.30704.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSuccessCodes:
+- 3010
+Installers:
+- InstallerLocale: en-US
+  Architecture: x64
+  InstallerType: burn
+  Scope: machine
+  InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/c627417f-7c6d-44a6-86c3-95c1acbbd5f5/A9F5D2EAF67BF0DB0178B6552A71C523C707DF0E2CC66C06BFBC08BDC53387E7/VC_redist.x64.exe
+  InstallerSha256: a9f5d2eaf67bf0db0178b6552a71c523c707df0e2cc66c06bfbc08bdc53387e7
+  InstallerSwitches:
+    Silent: /quiet /install /norestart
+    SilentWithProgress: /passive /install /norestart
+  UpgradeBehavior: install
+  ProductCode: '{57a73df6-4ba9-4c1d-bbbb-517289ff6c13}'
+ManifestType: installer
+ManifestVersion: 1.0.0
+
+

--- a/manifests/m/Microsoft/VCRedist/2015+/x64/14.30.30704.0/Microsoft.VCRedist.2015+.x64.locale.en-US.yaml
+++ b/manifests/m/Microsoft/VCRedist/2015+/x64/14.30.30704.0/Microsoft.VCRedist.2015+.x64.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# Created with YamlCreate.ps1 v2.0.0 using YAML parsing
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.0.0.schema.json
+
+PackageIdentifier: Microsoft.VCRedist.2015+.x64
+PackageVersion: 14.30.30704.0
+PackageLocale: en-US
+Publisher: Microsoft Corporation
+PublisherUrl: https://www.microsoft.com/en-us/
+PublisherSupportUrl: https://support.microsoft.com/en-us
+PrivacyUrl: https://privacy.microsoft.com/en-us/privacystatement
+Author: Microsoft Corporation
+PackageName: Microsoft Visual C++ 2015-2022 Redistributable (x64)
+# PackageUrl: 
+License: Proprietary
+# LicenseUrl: 
+Copyright: Copyright (c) Microsoft Corporation
+# CopyrightUrl: 
+ShortDescription: The Microsoft Visual C++ 2015-2022 Redistributable Package (x64)
+Description: The Microsoft Visual C++ 2015-2022 Redistributable Package (x64) installs runtime components of Visual C++ Libraries required to run 64-bit applications developed with Visual C++ 2015, 2017, 2019 and 2022 on a computer that does not have Visual C++ 2015, 2017, 2019 and 2022 installed.
+Moniker: vcredistx64
+Tags:
+- visual-c++
+- visual
+- c++
+- redist
+- redistributable
+ManifestType: defaultLocale
+ManifestVersion: 1.0.0
+
+

--- a/manifests/m/Microsoft/VCRedist/2015+/x64/14.30.30704.0/Microsoft.VCRedist.2015+.x64.yaml
+++ b/manifests/m/Microsoft/VCRedist/2015+/x64/14.30.30704.0/Microsoft.VCRedist.2015+.x64.yaml
@@ -1,0 +1,10 @@
+# Created with YamlCreate.ps1 v2.0.0 using YAML parsing
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.0.0.schema.json
+
+PackageIdentifier: Microsoft.VCRedist.2015+.x64
+PackageVersion: 14.30.30704.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.0.0
+
+


### PR DESCRIPTION
…edist.2015+.x64 14.30.30704.0

- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.2 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.2.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/81322)