### PR TITLE
Move Microsoft.VC++2015-2022Redist-x64 14.32.31302.0 to Microsoft.VCR…

### DIFF
--- a/manifests/m/Microsoft/VCRedist/2015+/x64/14.32.31302.0/Microsoft.VCRedist.2015+.x64.installer.yaml
+++ b/manifests/m/Microsoft/VCRedist/2015+/x64/14.32.31302.0/Microsoft.VCRedist.2015+.x64.installer.yaml
@@ -1,0 +1,38 @@
+# Created with YamlCreate.ps1 v2.1.1 $debug=QUSU.7-2-1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+
+PackageIdentifier: Microsoft.VCRedist.2015+.x64
+PackageVersion: 14.32.31302.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: burn
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: /quiet /install
+  SilentWithProgress: /passive /install
+  Custom: /norestart
+  Upgrade: /norestart
+InstallerSuccessCodes:
+- 3010
+UpgradeBehavior: install
+ReleaseDate: 2022-03-17
+Installers:
+- Architecture: x64
+  InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/f359701c-0fda-414e-83c2-31d65ee7f308/4B2947448BF80CC987A440B43A1AA07152B9057915C68930061C74E0B40BA05B/VC_redist.x64.exe
+  InstallerSha256: 4B2947448BF80CC987A440B43A1AA07152B9057915C68930061C74E0B40BA05B
+  ProductCode: '{9f7f52eb-dcd8-47d7-a48e-c1dc5f31fbca}'
+  AppsAndFeaturesEntries:
+  - Publisher: Microsoft Corporation
+    DisplayName: Microsoft Visual C++ 2015-2022 Redistributable (x64) - 14.32.31302
+    DisplayVersion: 14.32.31302.0
+    InstallerType: burn
+    ProductCode: '{9f7f52eb-dcd8-47d7-a48e-c1dc5f31fbca}'
+ManifestType: installer
+ManifestVersion: 1.1.0
+
+

--- a/manifests/m/Microsoft/VCRedist/2015+/x64/14.32.31302.0/Microsoft.VCRedist.2015+.x64.locale.en-US.yaml
+++ b/manifests/m/Microsoft/VCRedist/2015+/x64/14.32.31302.0/Microsoft.VCRedist.2015+.x64.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# Created with YamlCreate.ps1 v2.1.1 $debug=QUSU.7-2-1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+
+PackageIdentifier: Microsoft.VCRedist.2015+.x64
+PackageVersion: 14.32.31302.0
+PackageLocale: en-US
+Publisher: Microsoft Corporation
+PublisherUrl: https://www.microsoft.com/en-us/
+PublisherSupportUrl: https://support.microsoft.com/en-us
+PrivacyUrl: https://privacy.microsoft.com/en-us/privacystatement
+Author: Microsoft Corporation
+PackageName: Microsoft Visual C++ 2015-2022 Redistributable (x64)
+# PackageUrl: 
+License: Proprietary
+# LicenseUrl: 
+Copyright: Copyright (c) Microsoft Corporation
+# CopyrightUrl: 
+ShortDescription: The Microsoft Visual C++ 2015-2022 Redistributable Package (x64)
+Description: |-
+  The Microsoft Visual C++ 2015-2022 Redistributable Package (x64) installs runtime components of Visual C++ Libraries required to run 64-bit applications developed with Visual C++ 2015, 2017, 2019 and 2022 on a computer that does not have Visual C++ 2015, 2017, 2019 and 2022 installed.
+Moniker: vcredistx64
+Tags:
+- c++
+- redist
+- redistributable
+- visual
+- visual-c++
+# Agreements: 
+# ReleaseNotes: 
+# ReleaseNotesUrl: 
+ManifestType: defaultLocale
+ManifestVersion: 1.1.0
+
+

--- a/manifests/m/Microsoft/VCRedist/2015+/x64/14.32.31302.0/Microsoft.VCRedist.2015+.x64.yaml
+++ b/manifests/m/Microsoft/VCRedist/2015+/x64/14.32.31302.0/Microsoft.VCRedist.2015+.x64.yaml
@@ -1,0 +1,10 @@
+# Created with YamlCreate.ps1 v2.1.1 $debug=QUSU.7-2-1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+
+PackageIdentifier: Microsoft.VCRedist.2015+.x64
+PackageVersion: 14.32.31302.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.1.0
+
+


### PR DESCRIPTION
…edist.2015+.x64 14.32.31302.0

- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.2 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.2.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/81327)