### PR TITLE
Move Microsoft.VC++2015-2022Redist-x64 14.32.31332.0 to Microsoft.VCR…

### DIFF
--- a/manifests/m/Microsoft/VCRedist/2015+/x64/14.32.31332.0/Microsoft.VCRedist.2015+.x64.installer.yaml
+++ b/manifests/m/Microsoft/VCRedist/2015+/x64/14.32.31332.0/Microsoft.VCRedist.2015+.x64.installer.yaml
@@ -1,0 +1,35 @@
+# Created with YamlCreate.ps1 v2.1.4 $debug=AUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+
+PackageIdentifier: Microsoft.VCRedist.2015+.x64
+PackageVersion: 14.32.31332.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: burn
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: /quiet /install
+  SilentWithProgress: /passive /install
+  Upgrade: /norestart
+  Custom: /norestart
+InstallerSuccessCodes:
+- 3010
+UpgradeBehavior: install
+AppsAndFeaturesEntries:
+- DisplayName: Microsoft Visual C++ 2015-2022 Redistributable (x64) - 14.32.31332
+  Publisher: Microsoft Corporation
+  ProductCode: '{3746f21b-c990-4045-bb33-1cf98cff7a68}'
+  InstallerType: burn
+Installers:
+- Architecture: x64
+  InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/ed95ef9e-da02-4735-9064-bd1f7f69b6ed/CE6593A1520591E7DEA2B93FD03116E3FC3B3821A0525322B0A430FAA6B3C0B4/VC_redist.x64.exe
+  InstallerSha256: CE6593A1520591E7DEA2B93FD03116E3FC3B3821A0525322B0A430FAA6B3C0B4
+ManifestType: installer
+ManifestVersion: 1.2.0
+
+

--- a/manifests/m/Microsoft/VCRedist/2015+/x64/14.32.31332.0/Microsoft.VCRedist.2015+.x64.locale.en-US.yaml
+++ b/manifests/m/Microsoft/VCRedist/2015+/x64/14.32.31332.0/Microsoft.VCRedist.2015+.x64.locale.en-US.yaml
@@ -1,0 +1,36 @@
+# Created with YamlCreate.ps1 v2.1.4 $debug=AUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+
+PackageIdentifier: Microsoft.VCRedist.2015+.x64
+PackageVersion: 14.32.31332.0
+PackageLocale: en-US
+Publisher: Microsoft Corporation
+PublisherUrl: https://www.microsoft.com/en-us/
+PublisherSupportUrl: https://support.microsoft.com/en-us
+PrivacyUrl: https://privacy.microsoft.com/en-us/privacystatement
+Author: Microsoft Corporation
+PackageName: Microsoft Visual C++ 2015-2022 Redistributable (x64)
+# PackageUrl: 
+License: Proprietary
+# LicenseUrl: 
+Copyright: Copyright (c) Microsoft Corporation
+# CopyrightUrl: 
+ShortDescription: The Microsoft Visual C++ 2015-2022 Redistributable Package (x64)
+Description: The Microsoft Visual C++ 2015-2022 Redistributable Package (x64) installs runtime components of Visual C++ Libraries required to run 64-bit applications developed with Visual C++ 2015, 2017, 2019 and 2022 on a computer that does not have Visual C++ 2015, 2017, 2019 and 2022 installed.
+Moniker: vcredistx64
+Tags:
+- c++
+- redist
+- redistributable
+- visual
+- visual-c++
+# Agreements: 
+# ReleaseNotes: 
+# ReleaseNotesUrl: 
+# PurchaseUrl: 
+# InstallationNotes: 
+# Documentations: 
+ManifestType: defaultLocale
+ManifestVersion: 1.2.0
+
+

--- a/manifests/m/Microsoft/VCRedist/2015+/x64/14.32.31332.0/Microsoft.VCRedist.2015+.x64.yaml
+++ b/manifests/m/Microsoft/VCRedist/2015+/x64/14.32.31332.0/Microsoft.VCRedist.2015+.x64.yaml
@@ -1,0 +1,10 @@
+# Created with YamlCreate.ps1 v2.1.4 $debug=AUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+
+PackageIdentifier: Microsoft.VCRedist.2015+.x64
+PackageVersion: 14.32.31332.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.2.0
+
+


### PR DESCRIPTION
…edist.2015+.x64 14.32.31332.0

- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.2 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.2.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/81329)