### PR TITLE
Testing: Added ARP entries for user scoped Teams installers

### DIFF
--- a/manifests/m/Microsoft/Teams/1.5.00.21668/Microsoft.Teams.installer.yaml
+++ b/manifests/m/Microsoft/Teams/1.5.00.21668/Microsoft.Teams.installer.yaml
@@ -1,6 +1,4 @@
-# Created with YamlCreate.ps1 v2.2.0 $debug=AUSU.CRLF.5-1-19041-1682.Win32NT
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
-
 PackageIdentifier: Microsoft.Teams
 PackageVersion: 1.5.00.21668
 MinimumOSVersion: 10.0.0.0
@@ -15,6 +13,8 @@ Installers:
   InstallerSwitches:
     Silent: /s
     SilentWithProgress: /s
+  AppsAndFeaturesEntries:
+  - ProductCode: Teams
 - Architecture: x64
   InstallerType: wix
   Scope: machine
@@ -29,6 +29,8 @@ Installers:
   InstallerSwitches:
     Silent: /s
     SilentWithProgress: /s
+  AppsAndFeaturesEntries:
+  - ProductCode: Teams
 - Architecture: x86
   InstallerType: wix
   Scope: machine
@@ -51,3 +53,4 @@ Installers:
   ProductCode: '{C082BDFE-B874-4543-B507-CDFD6F23EFF0}'
 ManifestType: installer
 ManifestVersion: 1.2.0
+


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.2 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.2.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

Trying to see if ARP entries can help the Teams update disaster...

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/81977)