### PR TITLE
Update: OpenStreetMap.Josm version 1.5.18543 renumbered to 18543.

### DIFF
--- a/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.installer.yaml
+++ b/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.installer.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
 
 PackageIdentifier: OpenStreetMap.Josm
-PackageVersion: 1.5.18543
+PackageVersion: 18543
 Platform:
 - Windows.Desktop
 FileExtensions:
@@ -19,6 +19,7 @@ Dependencies:
 ReleaseDate: '2022-08-30'
 AppsAndFeaturesEntries:
 - DisplayName: JOSM
+  DisplayVersion: 1.5.18543
   Publisher: JOSM
   ProductCode: '{59540160-84C7-3715-AE89-4B75399AC757}'
 Installers:

--- a/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.locale.bg-BG.yaml
+++ b/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.locale.bg-BG.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.1.0.schema.json
 
 PackageIdentifier: OpenStreetMap.Josm
-PackageVersion: 1.5.18543
+PackageVersion: 18543
 PackageLocale: bg-BG
 Publisher: JOSM
 PackageUrl: https://josm.openstreetmap.de/wiki/Bg:WikiStart

--- a/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.locale.ca-ES.yaml
+++ b/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.locale.ca-ES.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.1.0.schema.json
 
 PackageIdentifier: OpenStreetMap.Josm
-PackageVersion: 1.5.18543
+PackageVersion: 18543
 PackageLocale: ca-ES
 Publisher: JOSM
 PackageUrl: https://josm.openstreetmap.de/wiki/Ca:WikiStart

--- a/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.locale.cs-CZ.yaml
+++ b/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.locale.cs-CZ.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.1.0.schema.json
 
 PackageIdentifier: OpenStreetMap.Josm
-PackageVersion: 1.5.18543
+PackageVersion: 18543
 PackageLocale: cs-CZ
 Publisher: JOSM
 PackageUrl: https://josm.openstreetmap.de/wiki/Cs:WikiStart

--- a/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.locale.da-DK.yaml
+++ b/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.locale.da-DK.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.1.0.schema.json
 
 PackageIdentifier: OpenStreetMap.Josm
-PackageVersion: 1.5.18543
+PackageVersion: 18543
 PackageLocale: da-DK
 Publisher: JOSM
 PackageUrl: https://josm.openstreetmap.de/wiki/Da:WikiStart

--- a/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.locale.de-DE.yaml
+++ b/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.locale.de-DE.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.1.0.schema.json
 
 PackageIdentifier: OpenStreetMap.Josm
-PackageVersion: 1.5.18543
+PackageVersion: 18543
 PackageLocale: de-DE
 Publisher: JOSM
 PackageUrl: https://josm.openstreetmap.de/wiki/De:WikiStart

--- a/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.locale.en-US.yaml
+++ b/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.locale.en-US.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
 
 PackageIdentifier: OpenStreetMap.Josm
-PackageVersion: 1.5.18543
+PackageVersion: 18543
 PackageLocale: en-US
 Publisher: JOSM
 PackageName: JOSM

--- a/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.locale.es-ES.yaml
+++ b/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.locale.es-ES.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.1.0.schema.json
 
 PackageIdentifier: OpenStreetMap.Josm
-PackageVersion: 1.5.18543
+PackageVersion: 18543
 PackageLocale: es-ES
 Publisher: JOSM
 PackageUrl: https://josm.openstreetmap.de/wiki/Es:WikiStart

--- a/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.locale.et-EE.yaml
+++ b/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.locale.et-EE.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.1.0.schema.json
 
 PackageIdentifier: OpenStreetMap.Josm
-PackageVersion: 1.5.18543
+PackageVersion: 18543
 PackageLocale: et-EE
 Publisher: JOSM
 PackageUrl: https://josm.openstreetmap.de/wiki/Et:WikiStart

--- a/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.locale.fi-FI.yaml
+++ b/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.locale.fi-FI.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.1.0.schema.json
 
 PackageIdentifier: OpenStreetMap.Josm
-PackageVersion: 1.5.18543
+PackageVersion: 18543
 PackageLocale: fi-FI
 Publisher: JOSM
 PackageUrl: https://josm.openstreetmap.de/wiki/Fi:WikiStart

--- a/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.locale.fr-FR.yaml
+++ b/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.locale.fr-FR.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.1.0.schema.json
 
 PackageIdentifier: OpenStreetMap.Josm
-PackageVersion: 1.5.18543
+PackageVersion: 18543
 PackageLocale: fr-FR
 Publisher: JOSM
 PackageUrl: https://josm.openstreetmap.de/wiki/Fr:WikiStart

--- a/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.locale.gl-ES.yaml
+++ b/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.locale.gl-ES.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.1.0.schema.json
 
 PackageIdentifier: OpenStreetMap.Josm
-PackageVersion: 1.5.18543
+PackageVersion: 18543
 PackageLocale: gl-ES
 Publisher: JOSM
 PackageUrl: https://josm.openstreetmap.de/wiki/Gl:WikiStart

--- a/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.locale.he-IL.yaml
+++ b/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.locale.he-IL.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.1.0.schema.json
 
 PackageIdentifier: OpenStreetMap.Josm
-PackageVersion: 1.5.18543
+PackageVersion: 18543
 PackageLocale: he-IL
 Publisher: JOSM
 PackageUrl: https://josm.openstreetmap.de/wiki/He:WikiStart

--- a/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.locale.hu-HU.yaml
+++ b/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.locale.hu-HU.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.1.0.schema.json
 
 PackageIdentifier: OpenStreetMap.Josm
-PackageVersion: 1.5.18543
+PackageVersion: 18543
 PackageLocale: hu-HU
 Publisher: JOSM
 PackageUrl: https://josm.openstreetmap.de/wiki/Hu:WikiStart

--- a/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.locale.it-IT.yaml
+++ b/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.locale.it-IT.yaml
@@ -1,10 +1,10 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.1.0.schema.json
 
 PackageIdentifier: OpenStreetMap.Josm
-PackageVersion: 1.5.18543
-PackageLocale: pt-PT
+PackageVersion: 18543
+PackageLocale: it-IT
 Publisher: JOSM
-PackageUrl: https://josm.openstreetmap.de/wiki/Pt:WikiStart
-ShortDescription: JOSM é um editor para OpenStreetMap (OSM) feito em Java 17+
+PackageUrl: https://josm.openstreetmap.de/wiki/It:WikiStart
+ShortDescription: JOSM è un editor per OpenStreetMap (OSM) scritto in Java 17
 ManifestType: locale
 ManifestVersion: 1.2.0

--- a/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.locale.ja-JP.yaml
+++ b/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.locale.ja-JP.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.1.0.schema.json
 
 PackageIdentifier: OpenStreetMap.Josm
-PackageVersion: 1.5.18543
+PackageVersion: 18543
 PackageLocale: ja-JP
 Publisher: JOSM
 PackageUrl: https://josm.openstreetmap.de/wiki/Ja:WikiStart

--- a/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.locale.ko-KR.yaml
+++ b/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.locale.ko-KR.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.1.0.schema.json
 
 PackageIdentifier: OpenStreetMap.Josm
-PackageVersion: 1.5.18543
+PackageVersion: 18543
 PackageLocale: ko-KR
 Publisher: JOSM
 PackageUrl: https://josm.openstreetmap.de/wiki/Ko:WikiStart

--- a/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.locale.nl-NL.yaml
+++ b/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.locale.nl-NL.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.1.0.schema.json
 
 PackageIdentifier: OpenStreetMap.Josm
-PackageVersion: 1.5.18543
+PackageVersion: 18543
 PackageLocale: nl-NL
 Publisher: JOSM
 PackageUrl: https://josm.openstreetmap.de/wiki/Nl:WikiStart

--- a/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.locale.pl-PL.yaml
+++ b/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.locale.pl-PL.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.1.0.schema.json
 
 PackageIdentifier: OpenStreetMap.Josm
-PackageVersion: 1.5.18543
+PackageVersion: 18543
 PackageLocale: pl-PL
 Publisher: JOSM
 PackageUrl: https://josm.openstreetmap.de/wiki/Pl:WikiStart

--- a/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.locale.pt-PT.yaml
+++ b/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.locale.pt-PT.yaml
@@ -1,10 +1,10 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.1.0.schema.json
 
 PackageIdentifier: OpenStreetMap.Josm
-PackageVersion: 1.5.18543
-PackageLocale: it-IT
+PackageVersion: 18543
+PackageLocale: pt-PT
 Publisher: JOSM
-PackageUrl: https://josm.openstreetmap.de/wiki/It:WikiStart
-ShortDescription: JOSM è un editor per OpenStreetMap (OSM) scritto in Java 17
+PackageUrl: https://josm.openstreetmap.de/wiki/Pt:WikiStart
+ShortDescription: JOSM é um editor para OpenStreetMap (OSM) feito em Java 17+
 ManifestType: locale
 ManifestVersion: 1.2.0

--- a/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.locale.ru-RU.yaml
+++ b/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.locale.ru-RU.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.1.0.schema.json
 
 PackageIdentifier: OpenStreetMap.Josm
-PackageVersion: 1.5.18543
+PackageVersion: 18543
 PackageLocale: ru-RU
 Publisher: JOSM
 PackageUrl: https://josm.openstreetmap.de/wiki/Ru:WikiStart

--- a/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.locale.sr-Latn-RS.yaml
+++ b/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.locale.sr-Latn-RS.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.1.0.schema.json
 
 PackageIdentifier: OpenStreetMap.Josm
-PackageVersion: 1.5.18543
+PackageVersion: 18543
 PackageLocale: sr-Latn-RS
 Publisher: JOSM
 PackageUrl: https://josm.openstreetmap.de/wiki/Sr-Latin:WikiStart

--- a/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.locale.uk-UA.yaml
+++ b/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.locale.uk-UA.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.1.0.schema.json
 
 PackageIdentifier: OpenStreetMap.Josm
-PackageVersion: 1.5.18543
+PackageVersion: 18543
 PackageLocale: uk-UA
 Publisher: JOSM
 PackageUrl: https://josm.openstreetmap.de/wiki/Uk:WikiStart

--- a/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.locale.zh-CN.yaml
+++ b/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.locale.zh-CN.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.1.0.schema.json
 
 PackageIdentifier: OpenStreetMap.Josm
-PackageVersion: 1.5.18543
+PackageVersion: 18543
 PackageLocale: zh-CN
 Publisher: JOSM
 PackageUrl: https://josm.openstreetmap.de/wiki/Zh_CN:WikiStart

--- a/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.locale.zh-TW.yaml
+++ b/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.locale.zh-TW.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.1.0.schema.json
 
 PackageIdentifier: OpenStreetMap.Josm
-PackageVersion: 1.5.18543
+PackageVersion: 18543
 PackageLocale: zh-TW
 Publisher: JOSM
 PackageUrl: https://josm.openstreetmap.de/wiki/Zh_TW:WikiStart

--- a/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.yaml
+++ b/manifests/o/OpenStreetMap/Josm/18543/OpenStreetMap.Josm.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
 
 PackageIdentifier: OpenStreetMap.Josm
-PackageVersion: 1.5.18543
+PackageVersion: 18543
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.2.0


### PR DESCRIPTION
OpenStreetMap.Josm version 1.5.18543 renumbered to simply 18543. DisplayVersion added.  
See #51082
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.2 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.2.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/82351)