### PR TITLE
Add HybridSaaS moniker for easier installation

### DIFF
--- a/manifests/h/HybridSaaS/HybridSaaS/22.9.23581/HybridSaaS.HybridSaaS.locale.nl-NL.yaml
+++ b/manifests/h/HybridSaaS/HybridSaaS/22.9.23581/HybridSaaS.HybridSaaS.locale.nl-NL.yaml
@@ -9,5 +9,6 @@ PackageName: hybrid-saas
 License: Proprietary
 Copyright: Copyright © 2022 Hybrid SaaS
 ShortDescription: Of u op kantoor of onderweg bent, als u beschikt over een apparaat met een internet verbinding kunt u gebruik maken van Hybrid SaaS, zo beschikken u en uw collega’s real-time de laatste informatie over de projecten van uw bedrijf.
+Moniker: HybridSaaS
 ManifestType: defaultLocale
 ManifestVersion: 1.2.0


### PR DESCRIPTION
Added HybridSaaS moniker to allow for "winget install hybridsaas" to work.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.2 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.2.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/82426)