### PR TITLE
Move Preview Dapr releases to `Preview` folder

### DIFF
--- a/manifests/d/Dapr/CLI/Preview/1.9.0-rc.1/Dapr.CLI.Preview.installer.yaml
+++ b/manifests/d/Dapr/CLI/Preview/1.9.0-rc.1/Dapr.CLI.Preview.installer.yaml
@@ -1,0 +1,15 @@
+# Created using wingetcreate 1.1.2.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+
+PackageIdentifier: Dapr.CLI.Preview
+PackageVersion: 1.9.0-rc.1
+Installers:
+- InstallerLocale: en-US
+  Architecture: x64
+  InstallerType: wix
+  InstallerUrl: https://github.com/dapr/cli/releases/download/v1.9.0-rc.1/dapr.msi
+  InstallerSha256: 69bc3848c82c0d6b211fefd05b43d875d5fcf3355d3a29d95186e6901ec0a60a
+  ProductCode: '{8F585665-3A4E-4D47-8B2C-E76EC7DD1D4F}'
+ManifestType: installer
+ManifestVersion: 1.2.0
+

--- a/manifests/d/Dapr/CLI/Preview/1.9.0-rc.1/Dapr.CLI.Preview.locale.en-US.yaml
+++ b/manifests/d/Dapr/CLI/Preview/1.9.0-rc.1/Dapr.CLI.Preview.locale.en-US.yaml
@@ -1,0 +1,16 @@
+# Created using wingetcreate 1.1.2.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+
+PackageIdentifier: Dapr.CLI.Preview
+PackageVersion: 1.9.0-rc.1
+PackageLocale: en-US
+Publisher: Dapr
+PublisherUrl: https://dapr.io
+PackageName: CLI
+PackageUrl: https://github.com/dapr/cli
+License: Apache 2.0
+LicenseUrl: https://github.com/dapr/cli/blob/master/LICENSE
+ShortDescription: Dapr's official command-line tool
+ManifestType: defaultLocale
+ManifestVersion: 1.2.0
+

--- a/manifests/d/Dapr/CLI/Preview/1.9.0-rc.1/Dapr.CLI.Preview.yaml
+++ b/manifests/d/Dapr/CLI/Preview/1.9.0-rc.1/Dapr.CLI.Preview.yaml
@@ -1,0 +1,9 @@
+# Created using wingetcreate 1.1.2.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+
+PackageIdentifier: Dapr.CLI.Preview
+PackageVersion: 1.9.0-rc.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.2.0
+


### PR DESCRIPTION
Signed-off-by: shivamkm07 <shivamkm07@gmail.com>

The PR moves Dapr.CLI preview releases to Dapr.CLI.Preview folder to separate stable releases from preview releases.

Stable Release Identifier: Dapr.CLI
Preview Release Identifier: Dapr.CLI.Preview

- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.2 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.2.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/82508)