### PR TITLE
New version: nrittsti.NTag version 1.2.13

### DIFF
--- a/manifests/n/nrittsti/NTag/1.2.13/nrittsti.NTag.installer.yaml
+++ b/manifests/n/nrittsti/NTag/1.2.13/nrittsti.NTag.installer.yaml
@@ -1,0 +1,20 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+
+PackageIdentifier: nrittsti.NTag
+PackageVersion: 1.2.13
+InstallerLocale: en-US
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+Scope: machine
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+ReleaseDate: 2022-10-08
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/nrittsti/ntag/releases/download/v1.2.13/ntag-1.2.13-win-setup.exe
+  InstallerSha256: 87E1BB01B1D38541F9752E81099F0B409E7DE0B3C22969692C347E9C26EFEA7B
+ManifestType: installer
+ManifestVersion: 1.2.0

--- a/manifests/n/nrittsti/NTag/1.2.13/nrittsti.NTag.locale.en-US.yaml
+++ b/manifests/n/nrittsti/NTag/1.2.13/nrittsti.NTag.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+
+PackageIdentifier: nrittsti.NTag
+PackageVersion: 1.2.13
+PackageLocale: en-US
+Publisher: Nico Rittstieg
+PublisherUrl: https://github.com/nrittsti/ntag
+PublisherSupportUrl: https://github.com/nrittsti/ntag/issues
+# PrivacyUrl: 
+Author: Nico Rittstieg
+PackageName: NTag
+PackageUrl: https://github.com/nrittsti/ntag
+License: GNU General Public License v3.0
+LicenseUrl: https://raw.githubusercontent.com/nrittsti/ntag/master/LICENCE
+Copyright: Copyright (C) 2007 Free Software Foundation, Inc.
+CopyrightUrl: https://raw.githubusercontent.com/nrittsti/ntag/master/LICENCE
+ShortDescription: NTag is a cross platform-graphical tag editor focused on everyday life use cases.
+Description: NTag is a cross platform-graphical tag editor focused on everyday life use cases.
+# Moniker: 
+Tags:
+- id3
+- javafx
+- tagging
+# Agreements: 
+# ReleaseNotes: 
+ReleaseNotesUrl: https://github.com/nrittsti/ntag/releases/tag/v1.2.13
+# PurchaseUrl: 
+# InstallationNotes: 
+# Documentations: 
+ManifestType: defaultLocale
+ManifestVersion: 1.2.0

--- a/manifests/n/nrittsti/NTag/1.2.13/nrittsti.NTag.yaml
+++ b/manifests/n/nrittsti/NTag/1.2.13/nrittsti.NTag.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+
+PackageIdentifier: nrittsti.NTag
+PackageVersion: 1.2.13
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.2.0


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | NTag |     |
| Version     | 1.2.13     |  |
| Publisher   | Nico Rittstieg   |       |
| ProductCode |           |     |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://github.com/vedantmgoyal2009/vedantmgoyal2009/tree/main/winget-pkgs-automation) in workflow run [3130](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/3211310220>)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/82850)