### PR TITLE
New version: UniversalMediaServer.UniversalMediaServer version 11.5.0

### DIFF
--- a/manifests/u/UniversalMediaServer/UniversalMediaServer/11.5.0/UniversalMediaServer.UniversalMediaServer.installer.yaml
+++ b/manifests/u/UniversalMediaServer/UniversalMediaServer/11.5.0/UniversalMediaServer.UniversalMediaServer.installer.yaml
@@ -1,0 +1,22 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+
+PackageIdentifier: UniversalMediaServer.UniversalMediaServer
+PackageVersion: 11.5.0
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+Scope: machine
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+ReleaseDate: 2022-10-08
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/UniversalMediaServer/UniversalMediaServer/releases/download/11.5.0/UMS-11.5.0.exe
+  InstallerSha256: 475D2E5368A288F29212065873E99B242D8DAFBD4A4AD56D29ACFF1995E7485A
+ManifestType: installer
+ManifestVersion: 1.2.0

--- a/manifests/u/UniversalMediaServer/UniversalMediaServer/11.5.0/UniversalMediaServer.UniversalMediaServer.locale.en-US.yaml
+++ b/manifests/u/UniversalMediaServer/UniversalMediaServer/11.5.0/UniversalMediaServer.UniversalMediaServer.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+
+PackageIdentifier: UniversalMediaServer.UniversalMediaServer
+PackageVersion: 11.5.0
+PackageLocale: en-US
+Publisher: Universial Media Server
+PublisherUrl: https://www.universalmediaserver.com
+PublisherSupportUrl: https://github.com/UniversalMediaServer/UniversalMediaServer/issues
+# PrivacyUrl: 
+# Author: 
+PackageName: Universal Media Server
+PackageUrl: https://github.com/UniversalMediaServer/UniversalMediaServer
+License: GNU General Public License v2.0 (GPLv2)
+LicenseUrl: https://raw.githubusercontent.com/UniversalMediaServer/UniversalMediaServer/master/LICENSE.txt
+# Copyright: 
+CopyrightUrl: https://raw.githubusercontent.com/UniversalMediaServer/UniversalMediaServer/master/LICENSE.txt
+ShortDescription: Universal Media Server is a DLNA-compliant UPnP Media Server. It is capable of sharing video, audio and images between most modern devices.
+# Description: 
+# Moniker: 
+Tags:
+- dlna
+- media-server
+# Agreements: 
+# ReleaseNotes: 
+ReleaseNotesUrl: https://github.com/UniversalMediaServer/UniversalMediaServer/releases/tag/11.5.0
+# PurchaseUrl: 
+# InstallationNotes: 
+# Documentations: 
+ManifestType: defaultLocale
+ManifestVersion: 1.2.0

--- a/manifests/u/UniversalMediaServer/UniversalMediaServer/11.5.0/UniversalMediaServer.UniversalMediaServer.yaml
+++ b/manifests/u/UniversalMediaServer/UniversalMediaServer/11.5.0/UniversalMediaServer.UniversalMediaServer.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+
+PackageIdentifier: UniversalMediaServer.UniversalMediaServer
+PackageVersion: 11.5.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.2.0


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | Universal Media Server | 全球学术快报 0.2.26    |
| Version     | 11.5.0     | 0.2.26 |
| Publisher   | Universial Media Server   | 同方知网（北京）技术有限公司      |
| ProductCode |           | fdb21ffe-a525-5be7-af3a-a9436d18cc4f    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://github.com/vedantmgoyal2009/vedantmgoyal2009/tree/main/winget-pkgs-automation) in workflow run [3130](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/3211310220>)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/82857)