### PR TITLE
Typo fix in iTop.iTopScreenRecorder.locale.en-US.yaml

### DIFF
--- a/manifests/i/iTop/iTopScreenRecorder/3.2.0.1168/iTop.iTopScreenRecorder.locale.en-US.yaml
+++ b/manifests/i/iTop/iTopScreenRecorder/3.2.0.1168/iTop.iTopScreenRecorder.locale.en-US.yaml
@@ -17,6 +17,6 @@ Copyright: © iTop Inc. All rights reserved.
 CopyrightUrl: https://www.itopvpn.com/eula
 ShortDescription: Your Free Screen Recorder - iTop Screen Recorder
 Tags:
-- screen-recoder
+- screen-recorder
 ManifestType: defaultLocale
 ManifestVersion: 1.1.0


### PR DESCRIPTION
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
    - At least I think so.
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
    - I tried. The search result wasn't reassuring.
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
    - I fixed a typo by adding a single character. If this breaks your repo, the blame is on something else.
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
    - Ditto
- [ ] Does your manifest conform to the [1.2 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.2.0)?
    - Ditto

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/82878)