### PR TITLE
New version: webrecorder.replayweb-page version 1.7.1

### DIFF
--- a/manifests/w/webrecorder/replayweb-page/1.7.1/webrecorder.replayweb-page.installer.yaml
+++ b/manifests/w/webrecorder/replayweb-page/1.7.1/webrecorder.replayweb-page.installer.yaml
@@ -1,0 +1,23 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+
+PackageIdentifier: webrecorder.replayweb-page
+PackageVersion: 1.7.1
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- silent
+UpgradeBehavior: install
+FileExtensions:
+- har
+- wacz
+- warc
+- wbn
+ReleaseDate: 2022-10-10
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/webrecorder/replayweb.page/releases/download/v1.7.1/ReplayWeb.page-1.7.1.exe
+  InstallerSha256: D87A3CB630819106745392B53C99C0BF4C6118D0A4A5854AD928974116F9422C
+ManifestType: installer
+ManifestVersion: 1.2.0

--- a/manifests/w/webrecorder/replayweb-page/1.7.1/webrecorder.replayweb-page.locale.en-US.yaml
+++ b/manifests/w/webrecorder/replayweb-page/1.7.1/webrecorder.replayweb-page.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+
+PackageIdentifier: webrecorder.replayweb-page
+PackageVersion: 1.7.1
+PackageLocale: en-US
+Publisher: Webrecorder Software
+PublisherUrl: https://replayweb.page
+PublisherSupportUrl: https://github.com/webrecorder/replayweb.page/issues
+# PrivacyUrl: 
+Author: Ilya Kreymer
+PackageName: ReplayWeb.page
+PackageUrl: https://github.com/webrecorder/replayweb.page
+License: AGPL-3.0-only
+LicenseUrl: https://raw.githubusercontent.com/webrecorder/replayweb.page/main/LICENSE
+Copyright: Copyright (c) Ilya Kreymer
+CopyrightUrl: https://raw.githubusercontent.com/webrecorder/replayweb.page/main/LICENSE
+ShortDescription: Serverless Web Archive Replay directly in the browser
+# Description: 
+Moniker: replayweb-page
+Tags:
+- archive
+- electron
+- play
+- web
+# Agreements: 
+# ReleaseNotes: 
+ReleaseNotesUrl: https://github.com/webrecorder/replayweb.page/releases/tag/v1.7.1
+# PurchaseUrl: 
+# InstallationNotes: 
+# Documentations: 
+ManifestType: defaultLocale
+ManifestVersion: 1.2.0

--- a/manifests/w/webrecorder/replayweb-page/1.7.1/webrecorder.replayweb-page.yaml
+++ b/manifests/w/webrecorder/replayweb-page/1.7.1/webrecorder.replayweb-page.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+
+PackageIdentifier: webrecorder.replayweb-page
+PackageVersion: 1.7.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.2.0


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | ReplayWeb.page | Octopus Deploy Server    |
| Version     | 1.7.1     | 2022.3.10623 |
| Publisher   | Webrecorder Software   | Octopus Deploy Pty. Ltd.      |
| ProductCode |           | {70781655-E44F-4B9C-983C-EF2308C1EF7D}    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://github.com/vedantmgoyal2009/vedantmgoyal2009/tree/main/winget-pkgs-automation) in workflow run [3150](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/3217190420>)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/83027)