### PR TITLE
New version: GyDi.ClashVerge version 1.1.1

### DIFF
--- a/manifests/g/GyDi/ClashVerge/1.1.1/GyDi.ClashVerge.installer.yaml
+++ b/manifests/g/GyDi/ClashVerge/1.1.1/GyDi.ClashVerge.installer.yaml
@@ -1,0 +1,24 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+
+PackageIdentifier: GyDi.ClashVerge
+PackageVersion: 1.1.1
+MinimumOSVersion: 10.0.0.0
+InstallerType: wix
+Scope: machine
+InstallerSwitches:
+  InstallLocation: INSTALLDIR="<INSTALLPATH>"
+UpgradeBehavior: install
+ReleaseDate: 2022-10-11
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/zzzgydi/clash-verge/releases/download/v1.1.1/Clash.Verge_1.1.1_x64_en-US.msi
+  InstallerSha256: 530F1A9401E47054E5A53F5DD236A19EF89B582770BEDECBD6C232144C50357C
+  ProductCode: '{D533F1DC-B68B-420F-A3AD-112A713511A5}'
+- InstallerLocale: zh-CN
+  Architecture: x64
+  InstallerUrl: https://github.com/zzzgydi/clash-verge/releases/download/v1.1.1/Clash.Verge_1.1.1_x64_zh-CN.msi
+  InstallerSha256: 4052DCF4C6410B394FEFF5975142B85C4B7B4D43377E0E6ECBD2F0064E51AF64
+  ProductCode: '{2CD3CACC-DFAA-4489-9F54-6A58AF8D863A}'
+ManifestType: installer
+ManifestVersion: 1.2.0

--- a/manifests/g/GyDi/ClashVerge/1.1.1/GyDi.ClashVerge.locale.en-US.yaml
+++ b/manifests/g/GyDi/ClashVerge/1.1.1/GyDi.ClashVerge.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+
+PackageIdentifier: GyDi.ClashVerge
+PackageVersion: 1.1.1
+PackageLocale: en-US
+Publisher: gydi
+PublisherUrl: https://github.com/zzzgydi
+PublisherSupportUrl: https://github.com/zzzgydi/clash-verge/issues
+# PrivacyUrl: 
+Author: GyDi
+PackageName: Clash Verge
+PackageUrl: https://github.com/zzzgydi/clash-verge
+License: GPL-3.0
+LicenseUrl: https://github.com/zzzgydi/clash-verge/blob/main/LICENSE
+Copyright: © 2022 zzzgydi All Rights Reserved
+# CopyrightUrl: 
+ShortDescription: A Clash GUI based on tauri.
+# Description: 
+# Moniker: 
+Tags:
+- clash
+- network
+- proxy
+- vpn
+# Agreements: 
+# ReleaseNotes: 
+ReleaseNotesUrl: https://github.com/zzzgydi/clash-verge/releases/tag/v1.1.1
+# PurchaseUrl: 
+# InstallationNotes: 
+Documentations:
+- DocumentLabel: Guide
+  DocumentUrl: https://github.com/zzzgydi/clash-verge/wiki/%E4%BD%BF%E7%94%A8%E6%8C%87%E5%8D%97
+ManifestType: defaultLocale
+ManifestVersion: 1.2.0

--- a/manifests/g/GyDi/ClashVerge/1.1.1/GyDi.ClashVerge.locale.zh-CN.yaml
+++ b/manifests/g/GyDi/ClashVerge/1.1.1/GyDi.ClashVerge.locale.zh-CN.yaml
@@ -1,0 +1,35 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.2.0.schema.json
+
+PackageIdentifier: GyDi.ClashVerge
+PackageVersion: 1.1.1
+PackageLocale: zh-CN
+Publisher: gydi
+PublisherUrl: https://github.com/zzzgydi
+PublisherSupportUrl: https://github.com/zzzgydi/clash-verge/issues
+# PrivacyUrl: 
+Author: GyDi
+PackageName: Clash Verge
+PackageUrl: https://github.com/zzzgydi/clash-verge
+License: GPL-3.0
+LicenseUrl: https://github.com/zzzgydi/clash-verge/blob/main/LICENSE
+Copyright: © 2022 zzzgydi All Rights Reserved
+# CopyrightUrl: 
+ShortDescription: 基于 tauri 的 Clash GUI
+# Description: 
+# Moniker: 
+Tags:
+- clash
+- vpn
+- 代理
+- 网络
+# Agreements: 
+# ReleaseNotes: 
+# ReleaseNotesUrl: 
+# PurchaseUrl: 
+# InstallationNotes: 
+Documentations:
+- DocumentLabel: 使用指南
+  DocumentUrl: https://github.com/zzzgydi/clash-verge/wiki/%E4%BD%BF%E7%94%A8%E6%8C%87%E5%8D%97
+ManifestType: locale
+ManifestVersion: 1.2.0

--- a/manifests/g/GyDi/ClashVerge/1.1.1/GyDi.ClashVerge.yaml
+++ b/manifests/g/GyDi/ClashVerge/1.1.1/GyDi.ClashVerge.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+
+PackageIdentifier: GyDi.ClashVerge
+PackageVersion: 1.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.2.0


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | Clash Verge | Google Chrome Beta, Foxglove Studio 1.28.0, Google Chrome Canary    |
| Version     | 1.1.1     | 107.0.5304.36, 1.28.0, 108.0.5357.0 |
| Publisher   | gydi   | Google LLC, Foxglove Technologies, Google LLC      |
| ProductCode |           | {3B50F0A9-E7BC-3512-AB92-3925738F8195}, b1a22fb8-f6f3-5e1f-b388-958085c08782, Google Chrome SxS    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://github.com/vedantmgoyal2009/vedantmgoyal2009/tree/main/winget-pkgs-automation) in workflow run [3190](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/3244700505>)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/83410)