### PR TITLE
New version: nashaofu.dingtalk version 2.1.22 [FP-D]

### DIFF
--- a/manifests/n/nashaofu/dingtalk/2.1.22/nashaofu.dingtalk.installer.yaml
+++ b/manifests/n/nashaofu/dingtalk/2.1.22/nashaofu.dingtalk.installer.yaml
@@ -1,0 +1,24 @@
+# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-7
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+
+PackageIdentifier: nashaofu.dingtalk
+PackageVersion: 2.1.22
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+Scope: machine
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+ReleaseDate: 2022-10-25
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/nashaofu/dingtalk/releases/download/v2.1.22/dingtalk-2.1.22-latest-ia32.exe
+  InstallerSha256: 0B50C1E1B9BD8308A52DA0E6EC3E99636876CCB499C7AFC302AFD09E3A9E09A6
+- Architecture: x64
+  InstallerUrl: https://github.com/nashaofu/dingtalk/releases/download/v2.1.22/dingtalk-2.1.22-latest-x64.exe
+  InstallerSha256: 33C2D0ABA7EBD8FC4613BC7003D19C75099C25D568C43BB6D9E9599E904E4A52
+ManifestType: installer
+ManifestVersion: 1.2.0

--- a/manifests/n/nashaofu/dingtalk/2.1.22/nashaofu.dingtalk.locale.en-US.yaml
+++ b/manifests/n/nashaofu/dingtalk/2.1.22/nashaofu.dingtalk.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-7
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+
+PackageIdentifier: nashaofu.dingtalk
+PackageVersion: 2.1.22
+PackageLocale: en-US
+Publisher: nashaofu
+PublisherUrl: https://github.com/nashaofu/dingtalk
+PublisherSupportUrl: https://github.com/nashaofu/dingtalk/issues
+# PrivacyUrl:
+Author: nashaofu
+PackageName: 钉钉
+PackageUrl: https://github.com/nashaofu/dingtalk
+License: MIT License
+LicenseUrl: https://raw.githubusercontent.com/nashaofu/dingtalk/master/LICENSE
+Copyright: Copyright (c) 2017 nashaofu
+CopyrightUrl: https://raw.githubusercontent.com/nashaofu/dingtalk/master/LICENSE
+ShortDescription: An electron client of dingtalk
+Description: An electron client of dingtalk
+Moniker: dingtalk
+Tags:
+- dingding
+- dingtalk
+- electron
+- enterprise
+- im
+- work
+# Agreements:
+# ReleaseNotes:
+ReleaseNotesUrl: https://github.com/nashaofu/dingtalk/releases/tag/v2.1.22
+# PurchaseUrl:
+# InstallationNotes:
+# Documentations:
+ManifestType: defaultLocale
+ManifestVersion: 1.2.0

--- a/manifests/n/nashaofu/dingtalk/2.1.22/nashaofu.dingtalk.yaml
+++ b/manifests/n/nashaofu/dingtalk/2.1.22/nashaofu.dingtalk.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-7
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+
+PackageIdentifier: nashaofu.dingtalk
+PackageVersion: 2.1.22
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.2.0


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | 钉钉 | Mozilla Maintenance Service, Mozilla Thunderbird (x64 en-US), Mozilla Maintenance Service, Shotcut, Microsoft OneDrive    |
| Version     | 2.1.22     | 106.0.1, 107.0, 107.0, 22.10.25, 22.217.1016.0002 |
| Publisher   | nashaofu   | Mozilla, Mozilla, Mozilla, Meltytech, LLC, Microsoft Corporation      |
| ProductCode |           | MozillaMaintenanceService, Mozilla Thunderbird 107.0 (x64 en-US), MozillaMaintenanceService, Shotcut, OneDriveSetup.exe    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://github.com/vedantmgoyal2009/vedantmgoyal2009/tree/main/winget-pkgs-automation) in workflow run [3469](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/3336154290>)