### PR TITLE
Allow Moderators to remove labels blocking merge without re-run

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1593,6 +1593,117 @@
             {
               "name": "commentContains",
               "parameters": {
+                "bodyPattern": "/feedback",
+                "isRegex": true,
+                "commentPattern": "@[mM][sS][fF][tT][bB][oO][tT]\\s+reset\\s+feedback"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "activitySenderHasPermissions",
+                  "parameters": {
+                    "permissions": "admin"
+                  }
+                },
+                {
+                  "name": "activitySenderHasPermissions",
+                  "parameters": {
+                    "permissions": "write"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "ImJoakim"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "ItzLevvie"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "jedieaston"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "KaranKad"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "OfficialEsco"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "quhxl"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "Trenly"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "issue_comment"
+        ],
+        "taskName": "Helper to reset labels",
+        "actions": [
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "Needs-Author-Feedback"
+            }
+          },
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "Needs-Attention"
+            }
+          },
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "Moderator-Approved"
+            }
+          },
+          {
+            "name": "dismissApprovalPullRequest",
+            "parameters": {
+              "dismissAction": "dismissAll"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestCommentResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "commentContains",
+              "parameters": {
                 "bodyPattern": "/clo",
                 "isRegex": true,
                 "commentPattern": "Close\\s+with\\s+reason\\s*:[\\w\\s\\-\\(\\)\\[\\]\\{\\}\\\\\\/.+=@#$%&^*`~|'\",<>?]*(?=;)"


### PR DESCRIPTION
cc @denelon

This allows for correction of issues like [this](https://github.com/microsoft/winget-pkgs/pull/84591#issuecomment-1281324208) where changes are pushed or pipelines are re-run and the `Needs-Attention` label is added incorrectly

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/85073)