### PR TITLE
New package: pnpm.pnpm version 7.13.5

### DIFF
--- a/manifests/p/pnpm/pnpm/7.13.5/pnpm.pnpm.installer.yaml
+++ b/manifests/p/pnpm/pnpm/7.13.5/pnpm.pnpm.installer.yaml
@@ -1,0 +1,15 @@
+# Created with YamlCreate.ps1 v2.2.0 $debug=NVS1.CRLF.7-2-6.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+
+PackageIdentifier: pnpm.pnpm
+PackageVersion: 7.13.5
+InstallerType: portable
+Commands:
+- pnpm
+ReleaseDate: 2022-10-16
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/pnpm/pnpm/releases/download/v7.13.5/pnpm-win-x64.exe
+  InstallerSha256: 8B20BA5796768E4F2A03F194AAF71A3C3750884CCB5B64B4D3D0C7146E49BEA2
+ManifestType: installer
+ManifestVersion: 1.2.0

--- a/manifests/p/pnpm/pnpm/7.13.5/pnpm.pnpm.locale.en-US.yaml
+++ b/manifests/p/pnpm/pnpm/7.13.5/pnpm.pnpm.locale.en-US.yaml
@@ -1,0 +1,41 @@
+# Created with YamlCreate.ps1 v2.2.0 $debug=NVS1.CRLF.7-2-6.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+
+PackageIdentifier: pnpm.pnpm
+PackageVersion: 7.13.5
+PackageLocale: en-US
+Publisher: pnpm
+PublisherUrl: https://github.com/pnpm/pnpm
+PublisherSupportUrl: https://github.com/pnpm/pnpm/issues
+# PrivacyUrl:
+Author: pnpm contributors
+PackageName: pnpm
+PackageUrl: https://pnpm.io/
+License: MIT
+LicenseUrl: https://github.com/pnpm/pnpm/blob/main/LICENSE
+Copyright: Copyright (c) Zoltan Kochan and other contributors
+CopyrightUrl: https://github.com/pnpm/pnpm/blob/main/LICENSE
+ShortDescription: Fast, disk space efficient package manager.
+# Description:
+Moniker: pnpm
+Tags:
+- dependency-manager
+- install
+- javascript
+- modules
+- node
+- nodejs
+- npm
+- package-manager
+# Agreements:
+# ReleaseNotes:
+ReleaseNotesUrl: https://github.com/pnpm/pnpm/releases/tag/v7.13.5
+# PurchaseUrl:
+# InstallationNotes:
+Documentations:
+- DocumentLabel: Docs
+  DocumentUrl: https://pnpm.io/motivation
+- DocumentLabel: FAQ
+  DocumentUrl: https://pnpm.io/faq
+ManifestType: defaultLocale
+ManifestVersion: 1.2.0

--- a/manifests/p/pnpm/pnpm/7.13.5/pnpm.pnpm.yaml
+++ b/manifests/p/pnpm/pnpm/7.13.5/pnpm.pnpm.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.2.0 $debug=NVS1.CRLF.7-2-6.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+
+PackageIdentifier: pnpm.pnpm
+PackageVersion: 7.13.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.2.0


### PR DESCRIPTION
## Will replace `pnpm.pnpm.6` and `pnpm.pnpm.7`

- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.2 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.2.0)?

### `pnpm.pnpm.6` and `pnpm.pnpm.7` cannot be installed side-by-side and the intended effect of splitting them would be solved with package pinning in Winget 1.4.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/85283)