### PR TITLE
BiglySoftware.BiglyBT: Add version 3.2.0.0

### DIFF
--- a/manifests/b/BiglySoftware/BiglyBT/3.2.0.0/BiglySoftware.BiglyBT.installer.yaml
+++ b/manifests/b/BiglySoftware/BiglyBT/3.2.0.0/BiglySoftware.BiglyBT.installer.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+PackageIdentifier: BiglySoftware.BiglyBT
+PackageVersion: 3.2.0.0
+MinimumOSVersion: 10.0.0.0
+InstallerType: exe
+Scope: machine
+InstallModes:
+- interactive
+- silent
+InstallerSwitches:
+  Silent: -q
+  InstallLocation: -dir "<INSTALLPATH>"
+  Log: -Dinstall4j.log="<LOGPATH>"
+UpgradeBehavior: install
+Protocols:
+- magnet
+FileExtensions:
+- torrent
+ProductCode: 0112-2557-8304-7048
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/BiglySoftware/BiglyBT/releases/download/v3.2.0.0/GitHub_BiglyBT_Installer64_J14.exe
+  InstallerSha256: 9F5522117C27664121BB12299DF05C18F46E15D9E9F9E4CCEBB934F9998FEEEE
+- Architecture: x86
+  InstallerUrl: https://github.com/BiglySoftware/BiglyBT/releases/download/v3.2.0.0/GitHub_BiglyBT_Installer32.exe
+  InstallerSha256: 346B4D50DC8E028E3DBBA510B2F5ED5EB2D455FBAC71C62B42C24CEC31633505
+ManifestType: installer
+ManifestVersion: 1.1.0
+ReleaseDate: 2022-10-13

--- a/manifests/b/BiglySoftware/BiglyBT/3.2.0.0/BiglySoftware.BiglyBT.locale.en-US.yaml
+++ b/manifests/b/BiglySoftware/BiglyBT/3.2.0.0/BiglySoftware.BiglyBT.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+PackageIdentifier: BiglySoftware.BiglyBT
+PackageVersion: 3.2.0.0
+PackageLocale: en-US
+Publisher: Bigly Software
+PublisherUrl: https://github.com/BiglySoftware
+PublisherSupportUrl: https://github.com/BiglySoftware/BiglyBT/issues
+PrivacyUrl: https://www.biglybt.com/privacy.php
+PackageName: BiglyBT
+PackageUrl: https://www.biglybt.com/
+License: GPL-2.0-only
+LicenseUrl: https://github.com/BiglySoftware/BiglyBT/blob/master/LICENSE
+ShortDescription: BiglyBT is a feature filled, open source, ad-free, bittorrent client.
+Moniker: biglybt
+Tags:
+- bittorrent
+- bittorrent-client
+- foss
+- open-source
+- torrent
+- torrent-client
+ReleaseNotesUrl: https://github.com/BiglySoftware/BiglyBT/releases/tag/v3.2.0.0
+ManifestType: defaultLocale
+ManifestVersion: 1.1.0

--- a/manifests/b/BiglySoftware/BiglyBT/3.2.0.0/BiglySoftware.BiglyBT.yaml
+++ b/manifests/b/BiglySoftware/BiglyBT/3.2.0.0/BiglySoftware.BiglyBT.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+PackageIdentifier: BiglySoftware.BiglyBT
+PackageVersion: 3.2.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.1.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.2 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.2.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----
Removed the dependency from Oracle.JavaRuntimeEnvironment from the manifest. If Java Runtime Environment is not installed, BiglyBT Windows installers downloads and installs Oracle JRE on its own, that is part of the installation. But removing the dependency lets user install their own preferred Java distribution of their own discretion instead of being forced to install Oracle.JavaRuntimeEnvironment if they want to use BiglyBT. Some will probably prefer the [portable version of JRE in scoop](https://github.com/ScoopInstaller/Java/blob/master/bucket/oraclejre8.json). The J14 installer for 64-bit should be preferable, since most users won't want to install JRE unless they need it. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/86168)