### PR TITLE
Revert "Change Python3 Moniker for latest version (#85817)"

### DIFF
--- a/manifests/p/Python/Python/3/10/3.10.8/Python.Python.3.10.locale.en-US.yaml
+++ b/manifests/p/Python/Python/3/10/3.10.8/Python.Python.3.10.locale.en-US.yaml
@@ -17,7 +17,7 @@ Copyright: Copyright ©2001-2022. Python Software Foundation.
 CopyrightUrl: https://docs.python.org/3/license.html
 ShortDescription: Python is a programming language that lets you work more quickly and integrate your systems more effectively.
 # Description:
-Moniker: python3
+Moniker: python3.10
 Tags:
 - glue-language
 - programming-language


### PR DESCRIPTION
This reverts commit e5c592982a61be62dfa77f8b4c63539f14e75fcd.

- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [X] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.2 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.2.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

As mentioned in #85817, once a new version of Python is released this needs to be reverted.

PR for Python 3.11.0: #86190

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/86202)