### PR TITLE
Change Python.Python.3.10.6 to use `UpgradeBehavior: uninstallPrevious`

### DIFF
--- a/manifests/p/Python/Python/3/10/3.10.6/Python.Python.3.10.installer.yaml
+++ b/manifests/p/Python/Python/3/10/3.10.6/Python.Python.3.10.installer.yaml
@@ -24,7 +24,7 @@ Installers:
   InstallerSwitches:
     InstallLocation: DefaultJustForMeTargetDir=<INSTALLPATH>
     Custom: InstallAllUsers=0 PrependPath=1
-  UpgradeBehavior: install
+  UpgradeBehavior: uninstallPrevious
   AppsAndFeaturesEntries:
   - DisplayName: Python 3.10.6 (64-bit)
     Publisher: Python Software Foundation
@@ -39,7 +39,7 @@ Installers:
   InstallerSwitches:
     InstallLocation: DefaultAllUsersTargetDir=<INSTALLPATH>
     Custom: InstallAllUsers=1 PrependPath=1
-  UpgradeBehavior: install
+  UpgradeBehavior: uninstallPrevious
   AppsAndFeaturesEntries:
   - DisplayName: Python 3.10.6 (64-bit)
     Publisher: Python Software Foundation
@@ -54,7 +54,7 @@ Installers:
   InstallerSwitches:
     InstallLocation: DefaultJustForMeTargetDir=<INSTALLPATH>
     Custom: InstallAllUsers=0 PrependPath=1
-  UpgradeBehavior: install
+  UpgradeBehavior: uninstallPrevious
   AppsAndFeaturesEntries:
   - DisplayName: Python 3.10.6 (32-bit)
     Publisher: Python Software Foundation
@@ -69,7 +69,7 @@ Installers:
   InstallerSwitches:
     InstallLocation: DefaultAllUsersTargetDir=<INSTALLPATH>
     Custom: InstallAllUsers=1 PrependPath=1
-  UpgradeBehavior: install
+  UpgradeBehavior: uninstallPrevious
   AppsAndFeaturesEntries:
   - DisplayName: Python 3.10.6 (32-bit)
     Publisher: Python Software Foundation


### PR DESCRIPTION

- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [X] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.2 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.2.0)?

---

See dicussion in https://github.com/microsoft/winget-pkgs/pull/86190#pullrequestreview-1156487438 for the reasoning behind this change.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/86353)