### PR TITLE
New version: Datadog.dd-trace-dotnet version 2.18.0

### DIFF
--- a/manifests/d/Datadog/dd-trace-dotnet/2.18.0/Datadog.dd-trace-dotnet.installer.yaml
+++ b/manifests/d/Datadog/dd-trace-dotnet/2.18.0/Datadog.dd-trace-dotnet.installer.yaml
@@ -1,0 +1,32 @@
+# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-7
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+
+PackageIdentifier: Datadog.dd-trace-dotnet
+PackageVersion: 2.18.0
+InstallerLocale: en-US
+MinimumOSVersion: 10.0.0.0
+InstallerType: wix
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2022-10-25
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/DataDog/dd-trace-dotnet/releases/download/v2.18.0/datadog-dotnet-apm-2.18.0-x64.msi
+  InstallerSha256: 73FC51E7F8E366F439EF316153C8D31547BA7AE9A0E05100DCBFE35AA002924B
+  ProductCode: '{BD43E8AE-F430-4081-A743-DF6B17F9A031}'
+  AppsAndFeaturesEntries:
+  - ProductCode: '{E09F647C-C2EF-4D62-9AA8-88282438C925}'
+    DisplayName: Datadog .NET Tracer 64-bit
+- Architecture: x86
+  InstallerUrl: https://github.com/DataDog/dd-trace-dotnet/releases/download/v2.18.0/datadog-dotnet-apm-2.18.0-x86.msi
+  InstallerSha256: 2ED80B328915A6DF0A66D77AAFCD5C29A5097EF4FC6B4EAEE1AA782D3D2283EE
+  ProductCode: '{246F2C97-074B-47F0-80D1-02C71FA60142}'
+  AppsAndFeaturesEntries:
+  - ProductCode: '{DD7B8A76-B304-4230-B27A-9EBA79D011BC}'
+    DisplayName: Datadog .NET Tracer 32-bit
+ManifestType: installer
+ManifestVersion: 1.2.0

--- a/manifests/d/Datadog/dd-trace-dotnet/2.18.0/Datadog.dd-trace-dotnet.installer.yaml
+++ b/manifests/d/Datadog/dd-trace-dotnet/2.18.0/Datadog.dd-trace-dotnet.installer.yaml
@@ -19,14 +19,14 @@ Installers:
   InstallerSha256: 73FC51E7F8E366F439EF316153C8D31547BA7AE9A0E05100DCBFE35AA002924B
   ProductCode: '{BD43E8AE-F430-4081-A743-DF6B17F9A031}'
   AppsAndFeaturesEntries:
-  - ProductCode: '{E09F647C-C2EF-4D62-9AA8-88282438C925}'
+  - ProductCode: '{BD43E8AE-F430-4081-A743-DF6B17F9A031}'
     DisplayName: Datadog .NET Tracer 64-bit
 - Architecture: x86
   InstallerUrl: https://github.com/DataDog/dd-trace-dotnet/releases/download/v2.18.0/datadog-dotnet-apm-2.18.0-x86.msi
   InstallerSha256: 2ED80B328915A6DF0A66D77AAFCD5C29A5097EF4FC6B4EAEE1AA782D3D2283EE
   ProductCode: '{246F2C97-074B-47F0-80D1-02C71FA60142}'
   AppsAndFeaturesEntries:
-  - ProductCode: '{DD7B8A76-B304-4230-B27A-9EBA79D011BC}'
+  - ProductCode: '{246F2C97-074B-47F0-80D1-02C71FA60142}'
     DisplayName: Datadog .NET Tracer 32-bit
 ManifestType: installer
 ManifestVersion: 1.2.0

--- a/manifests/d/Datadog/dd-trace-dotnet/2.18.0/Datadog.dd-trace-dotnet.locale.en-US.yaml
+++ b/manifests/d/Datadog/dd-trace-dotnet/2.18.0/Datadog.dd-trace-dotnet.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-7
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+
+PackageIdentifier: Datadog.dd-trace-dotnet
+PackageVersion: 2.18.0
+PackageLocale: en-US
+Publisher: Datadog, Inc.
+PublisherUrl: https://docs.datadoghq.com/
+PublisherSupportUrl: https://www.datadoghq.com/support/
+PrivacyUrl: https://www.datadoghq.com/legal/privacy/
+Author: Datadog
+PackageName: Datadog .NET Tracer
+PackageUrl: https://docs.datadoghq.com/tracing/
+License: Apache-2.0
+LicenseUrl: https://github.com/DataDog/dd-trace-dotnet/blob/master/LICENSE
+Copyright: Copyright 2017 Datadog, Inc.
+CopyrightUrl: https://github.com/DataDog/dd-trace-dotnet/blob/master/NOTICE
+ShortDescription: Automatic instrumentation for .NET applications
+# Description:
+Moniker: dd-trace-dotnet
+Tags:
+- apm
+- tracing
+# Agreements:
+# ReleaseNotes:
+ReleaseNotesUrl: https://github.com/DataDog/dd-trace-dotnet/releases/tag/v2.18.0
+# PurchaseUrl:
+# InstallationNotes:
+# Documentations:
+ManifestType: defaultLocale
+ManifestVersion: 1.2.0

--- a/manifests/d/Datadog/dd-trace-dotnet/2.18.0/Datadog.dd-trace-dotnet.yaml
+++ b/manifests/d/Datadog/dd-trace-dotnet/2.18.0/Datadog.dd-trace-dotnet.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-7
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+
+PackageIdentifier: Datadog.dd-trace-dotnet
+PackageVersion: 2.18.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.2.0


### PR DESCRIPTION
### Result: Installation Successful
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | Datadog .NET Tracer | Datadog .NET Tracer 64-bit    |
| Version     | 2.18.0     | 2.18.0 |
| Publisher   | Datadog, Inc.   | Datadog, Inc.      |
| ProductCode |           | {BD43E8AE-F430-4081-A743-DF6B17F9A031}    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://github.com/vedantmgoyal2009/vedantmgoyal2009/tree/main/winget-pkgs-automation) in workflow run [3469](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/3336154290>)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/86401)