### PR TITLE
Change upgradeBehavior to uninstallPrevious for Logitech G HUB

### DIFF
--- a/manifests/l/Logitech/GHUB/2022.10.6382/Logitech.GHUB.installer.yaml
+++ b/manifests/l/Logitech/GHUB/2022.10.6382/Logitech.GHUB.installer.yaml
@@ -14,7 +14,7 @@ InstallModes:
 InstallerSwitches:
   Silent: --silent
   SilentWithProgress: --silent
-UpgradeBehavior: install
+UpgradeBehavior: uninstallPrevious
 Installers:
 - Architecture: x64
   InstallerUrl: https://download01.logi.com/web/ftp/pub/techsupport/gaming/lghub_installer.exe


### PR DESCRIPTION
Logitech G HUB doesn't upgrade properly if an existing version is already installed, causing it to always show up in the upgrade list unless the installer is manually run.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.2 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.2.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/86591)