### PR TITLE
New version: Lexikos.AutoHotkey version 1.1.35.00

### DIFF
--- a/manifests/l/Lexikos/AutoHotkey/1.1.35.00/Lexikos.AutoHotkey.installer.yaml
+++ b/manifests/l/Lexikos/AutoHotkey/1.1.35.00/Lexikos.AutoHotkey.installer.yaml
@@ -1,0 +1,27 @@
+# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-7
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+
+PackageIdentifier: Lexikos.AutoHotkey
+PackageVersion: 1.1.35.00
+InstallerLocale: en-US
+MinimumOSVersion: 10.0.0.0
+InstallerType: exe
+Scope: machine
+InstallModes:
+- interactive
+- silent
+InstallerSwitches:
+  Silent: /s
+UpgradeBehavior: uninstallPrevious
+Protocols:
+- http
+- https
+FileExtensions:
+- ahk
+ReleaseDate: 2022-10-30
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/Lexikos/AutoHotkey_L/releases/download/v1.1.35.00/AutoHotkey_1.1.35.00_setup.exe
+  InstallerSha256: 8E61B9221DD7AEAB8C362C7D580EEC35E192317BB8C645909E0CE95B91C1332A
+ManifestType: installer
+ManifestVersion: 1.2.0

--- a/manifests/l/Lexikos/AutoHotkey/1.1.35.00/Lexikos.AutoHotkey.locale.en-US.yaml
+++ b/manifests/l/Lexikos/AutoHotkey/1.1.35.00/Lexikos.AutoHotkey.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-7
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+
+PackageIdentifier: Lexikos.AutoHotkey
+PackageVersion: 1.1.35.00
+PackageLocale: en-US
+Publisher: Lexikos
+PublisherUrl: https://autohotkey.com
+PublisherSupportUrl: https://www.autohotkey.com/boards
+# PrivacyUrl:
+Author: Steve Gray
+PackageName: AutoHotkey
+PackageUrl: https://autohotkey.com
+License: GPL-2.0
+LicenseUrl: https://github.com/Lexikos/AutoHotkey_L/blob/master/license.txt
+# Copyright:
+# CopyrightUrl:
+ShortDescription: a free, open-source scripting language for Windows that allows users to easily create small to complex scripts for all kinds of tasks such as:form fillers, auto-clicking, macros, etc.
+# Description:
+Moniker: ahk
+Tags:
+- ahk
+- autohotkey
+# Agreements:
+# ReleaseNotes:
+ReleaseNotesUrl: https://github.com/Lexikos/AutoHotkey_L/releases/tag/v1.1.35.00
+# PurchaseUrl:
+# InstallationNotes:
+# Documentations:
+ManifestType: defaultLocale
+ManifestVersion: 1.2.0

--- a/manifests/l/Lexikos/AutoHotkey/1.1.35.00/Lexikos.AutoHotkey.yaml
+++ b/manifests/l/Lexikos/AutoHotkey/1.1.35.00/Lexikos.AutoHotkey.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-7
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+
+PackageIdentifier: Lexikos.AutoHotkey
+PackageVersion: 1.1.35.00
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.2.0


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | AutoHotkey | KDevelop    |
| Version     | 1.1.35.00     | 5.6.2 |
| Publisher   | Lexikos   | KDE e.V.      |
| ProductCode |           | KDevelop    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://github.com/vedantmgoyal2009/vedantmgoyal2009/tree/main/winget-pkgs-automation) in workflow run [3543](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/3355667150>)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/86939)