### PR TITLE
New version: BornToBeRoot.NETworkManager version 2022.10.31.0

### DIFF
--- a/manifests/b/BornToBeRoot/NETworkManager/2022.10.31.0/BornToBeRoot.NETworkManager.installer.yaml
+++ b/manifests/b/BornToBeRoot/NETworkManager/2022.10.31.0/BornToBeRoot.NETworkManager.installer.yaml
@@ -1,0 +1,23 @@
+# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-7
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+
+PackageIdentifier: BornToBeRoot.NETworkManager
+PackageVersion: 2022.10.31.0
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2022-10-31
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/BornToBeRoot/NETworkManager/releases/download/2022.10.31.0/NETworkManager_2022.10.31.0_Setup.exe
+  InstallerSha256: 18A9528247BFA1880AF61CEAA1401FCA7C8271BC6635B40BA72D77AB065867A0
+ManifestType: installer
+ManifestVersion: 1.2.0

--- a/manifests/b/BornToBeRoot/NETworkManager/2022.10.31.0/BornToBeRoot.NETworkManager.locale.en-US.yaml
+++ b/manifests/b/BornToBeRoot/NETworkManager/2022.10.31.0/BornToBeRoot.NETworkManager.locale.en-US.yaml
@@ -1,0 +1,38 @@
+# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-7
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+
+PackageIdentifier: BornToBeRoot.NETworkManager
+PackageVersion: 2022.10.31.0
+PackageLocale: en-US
+Publisher: BornToBeRoot
+PublisherUrl: https://github.com/BornToBeRoot/NETworkManager
+PublisherSupportUrl: https://github.com/BornToBeRoot/NETworkManager/issues
+# PrivacyUrl:
+Author: BornToBeRoot
+PackageName: NETworkManager
+PackageUrl: https://borntoberoot.net/NETworkManager
+License: GNU General Public License v3.0
+LicenseUrl: https://raw.githubusercontent.com/BornToBeRoot/NETworkManager/master/LICENSE
+# Copyright:
+CopyrightUrl: https://raw.githubusercontent.com/BornToBeRoot/NETworkManager/master/LICENSE
+ShortDescription: A powerful tool for managing networks and troubleshoot network problems!
+# Description:
+Moniker: networkmanager
+Tags:
+- dns
+- ipscanner
+- lldp
+- pingmonitor
+- portscanner
+- putty
+- remotedesktop
+- traceroute
+- wifi
+# Agreements:
+# ReleaseNotes:
+ReleaseNotesUrl: https://github.com/BornToBeRoot/NETworkManager/releases/tag/2022.10.31.0
+# PurchaseUrl:
+# InstallationNotes:
+# Documentations:
+ManifestType: defaultLocale
+ManifestVersion: 1.2.0

--- a/manifests/b/BornToBeRoot/NETworkManager/2022.10.31.0/BornToBeRoot.NETworkManager.yaml
+++ b/manifests/b/BornToBeRoot/NETworkManager/2022.10.31.0/BornToBeRoot.NETworkManager.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-7
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+
+PackageIdentifier: BornToBeRoot.NETworkManager
+PackageVersion: 2022.10.31.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.2.0


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | NETworkManager |     |
| Version     | 2022.10.31.0     |  |
| Publisher   | BornToBeRoot   |       |
| ProductCode |           |     |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://github.com/vedantmgoyal2009/vedantmgoyal2009/tree/main/winget-pkgs-automation) in workflow run [3573](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/3365195230>)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/87020)