### PR TITLE
PuTTY.PuTTY 0.78.0.0: set UpgradeBehavior: uninstallPrevious

### DIFF
--- a/manifests/p/PuTTY/PuTTY/0.78.0.0/PuTTY.PuTTY.installer.yaml
+++ b/manifests/p/PuTTY/PuTTY/0.78.0.0/PuTTY.PuTTY.installer.yaml
@@ -13,7 +13,7 @@ InstallModes:
 - silentWithProgress
 InstallerSwitches:
   InstallLocation: INSTALLDIR="<INSTALLPATH>"
-UpgradeBehavior: install
+UpgradeBehavior: uninstallPrevious
 FileExtensions:
 - pkk
 - ppk


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.2 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.2.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

The [PuTTY Change Log] notes that

> installing the 0.78 or later Windows installer will not automatically uninstall 0.77 or earlier, due to a change we've made to work around a bug. We recommend uninstalling the old version first, if possible. If both end up installed, uninstalling both and then re-installing the new version will fix things up.

Therefore, this PR sets `UpgradeBehavior: uninstallPrevious` so that any previous version will be uninstalled before upgrading to 0.78.

Thanks,
Kevin

[PuTTY Change Log]: https://www.chiark.greenend.org.uk/~sgtatham/putty/changes.html

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/87021)