### PR TITLE
New version: webrecorder.replayweb-page version 1.7.2 [FP-D]

### DIFF
--- a/manifests/w/webrecorder/replayweb-page/1.7.2/webrecorder.replayweb-page.installer.yaml
+++ b/manifests/w/webrecorder/replayweb-page/1.7.2/webrecorder.replayweb-page.installer.yaml
@@ -1,0 +1,23 @@
+# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-7
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+
+PackageIdentifier: webrecorder.replayweb-page
+PackageVersion: 1.7.2
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- silent
+UpgradeBehavior: install
+FileExtensions:
+- har
+- wacz
+- warc
+- wbn
+ReleaseDate: 2022-11-05
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/webrecorder/replayweb.page/releases/download/v1.7.2/ReplayWeb.page-1.7.2.exe
+  InstallerSha256: 28F25E667EC79CEC7B759B2DBDCDF9847A6DD43F8CC581AC2A1A3D4316A15E12
+ManifestType: installer
+ManifestVersion: 1.2.0

--- a/manifests/w/webrecorder/replayweb-page/1.7.2/webrecorder.replayweb-page.locale.en-US.yaml
+++ b/manifests/w/webrecorder/replayweb-page/1.7.2/webrecorder.replayweb-page.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-7
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+
+PackageIdentifier: webrecorder.replayweb-page
+PackageVersion: 1.7.2
+PackageLocale: en-US
+Publisher: Webrecorder Software
+PublisherUrl: https://replayweb.page
+PublisherSupportUrl: https://github.com/webrecorder/replayweb.page/issues
+# PrivacyUrl:
+Author: Ilya Kreymer
+PackageName: ReplayWeb.page
+PackageUrl: https://github.com/webrecorder/replayweb.page
+License: AGPL-3.0-only
+LicenseUrl: https://raw.githubusercontent.com/webrecorder/replayweb.page/main/LICENSE
+Copyright: Copyright (c) Ilya Kreymer
+CopyrightUrl: https://raw.githubusercontent.com/webrecorder/replayweb.page/main/LICENSE
+ShortDescription: Serverless Web Archive Replay directly in the browser
+# Description:
+Moniker: replayweb-page
+Tags:
+- archive
+- electron
+- play
+- web
+# Agreements:
+# ReleaseNotes:
+ReleaseNotesUrl: https://github.com/webrecorder/replayweb.page/releases/tag/v1.7.2
+# PurchaseUrl:
+# InstallationNotes:
+# Documentations:
+ManifestType: defaultLocale
+ManifestVersion: 1.2.0

--- a/manifests/w/webrecorder/replayweb-page/1.7.2/webrecorder.replayweb-page.yaml
+++ b/manifests/w/webrecorder/replayweb-page/1.7.2/webrecorder.replayweb-page.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-7
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+
+PackageIdentifier: webrecorder.replayweb-page
+PackageVersion: 1.7.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.2.0


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | ReplayWeb.page |     |
| Version     | 1.7.2     |  |
| Publisher   | Webrecorder Software   |       |
| ProductCode |           |     |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://github.com/vedantmgoyal2009/vedantmgoyal2009/tree/main/winget-pkgs-automation) in workflow run [3681](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/3402780138>)