### PR TITLE
PowerShell 7.2.7 -> Fix

### DIFF
--- a/manifests/m/Microsoft/PowerShell/7.2.7.0/Microsoft.PowerShell.installer.yaml
+++ b/manifests/m/Microsoft/PowerShell/7.2.7.0/Microsoft.PowerShell.installer.yaml
@@ -42,23 +42,5 @@ Installers:
   InstallerSha256: C8ACFDFD23B3612A28FD92F2CC2887E622D040E492BB0FD54612981C996D2137
   SignatureSha256: D1F0A10D7DAA9A2277D408A057E2F52ECC0EDFDEACBFA5FAD0CF4A6F609EC71C
   PackageFamilyName: Microsoft.PowerShell_8wekyb3d8bbwe
-- Architecture: x86
-  MinimumOSVersion: 10.0.17763.0
-  Platform:
-  - Windows.Universal
-  InstallerType: msix
-  InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.2.7/PowerShell-7.2.7-win.msixbundle
-  InstallerSha256: C8ACFDFD23B3612A28FD92F2CC2887E622D040E492BB0FD54612981C996D2137
-  SignatureSha256: D1F0A10D7DAA9A2277D408A057E2F52ECC0EDFDEACBFA5FAD0CF4A6F609EC71C
-  PackageFamilyName: Microsoft.PowerShell_8wekyb3d8bbwe
-- Architecture: x64
-  MinimumOSVersion: 10.0.17763.0
-  Platform:
-  - Windows.Universal
-  InstallerType: msix
-  InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.2.7/PowerShell-7.2.7-win.msixbundle
-  InstallerSha256: C8ACFDFD23B3612A28FD92F2CC2887E622D040E492BB0FD54612981C996D2137
-  SignatureSha256: D1F0A10D7DAA9A2277D408A057E2F52ECC0EDFDEACBFA5FAD0CF4A6F609EC71C
-  PackageFamilyName: Microsoft.PowerShell_8wekyb3d8bbwe
 ManifestType: installer
 ManifestVersion: 1.2.0

--- a/manifests/m/Microsoft/PowerShell/7.2.7.0/Microsoft.PowerShell.locale.en-US.yaml
+++ b/manifests/m/Microsoft/PowerShell/7.2.7.0/Microsoft.PowerShell.locale.en-US.yaml
@@ -29,7 +29,7 @@ Tags:
 - shell
 # Agreements:
 # ReleaseNotes:
-ReleaseNotesUrl: https://github.com/PowerShell/PowerShell/releases/tag/v7.2.6
+ReleaseNotesUrl: https://github.com/PowerShell/PowerShell/releases/tag/v7.2.7
 # PurchaseUrl:
 # InstallationNotes:
 # Documentations:


### PR DESCRIPTION
In the manifest file, remove unneccessary installers for msix package for x64 an x86 (it should only be arm and arm64 architecture that have those). This is causing x64 and x86 users to have to manually uninstall and get msix.

Also fix typo in ReleaseNotesUrl

will fix: https://github.com/PowerShell/PowerShell/issues/18426

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.2 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.2.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----
