### PR TITLE
Update: dorssel.usbipd-win version 2.1.0

### DIFF
--- a/manifests/d/dorssel/usbipd-win/2.1.0/dorssel.usbipd-win.installer.yaml
+++ b/manifests/d/dorssel/usbipd-win/2.1.0/dorssel.usbipd-win.installer.yaml
@@ -6,6 +6,9 @@ PackageVersion: 2.1.0
 MinimumOSVersion: 10.0.0.0
 InstallerType: wix
 Scope: machine
+InstallerSwitches:
+  Silent: /quiet /norestart
+  SilentWithProgress: /passive /norestart
 UpgradeBehavior: install
 ReleaseDate: 2022-01-29
 Installers:

--- a/manifests/d/dorssel/usbipd-win/2.1.0/dorssel.usbipd-win.locale.en-US.yaml
+++ b/manifests/d/dorssel/usbipd-win/2.1.0/dorssel.usbipd-win.locale.en-US.yaml
@@ -12,7 +12,7 @@ PublisherSupportUrl: https://github.com/dorssel/usbipd-win/issues
 PackageName: usbipd-win
 PackageUrl: https://github.com/dorssel/usbipd-win
 License: GNU General Public License, version 2
-LicenseUrl: https://raw.githubusercontent.com/dorssel/usbipd-win/master/COPYING.md
+LicenseUrl: https://raw.githubusercontent.com/dorssel/usbipd-win/v2.1.0/COPYING.md
 Copyright: Copyright (C) 2022 Frans van Dorsselaer
 # CopyrightUrl: 
 ShortDescription: Host locally connected USB devices to other (possibly virtual) machines.


### PR DESCRIPTION
In preparation of switching to a different license in master:
- update LicenseUrl to point to the exact license for this version

Also backport the "no-auto-reboot" switches from version >= 2.3.0.

- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [X] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.2 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.2.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/87653)