### PR TITLE
New version: RivaFarabi.Deckboard version 2.0.56

### DIFF
--- a/manifests/r/RivaFarabi/Deckboard/2.0.56/RivaFarabi.Deckboard.installer.yaml
+++ b/manifests/r/RivaFarabi/Deckboard/2.0.56/RivaFarabi.Deckboard.installer.yaml
@@ -1,0 +1,29 @@
+# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-7
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+
+PackageIdentifier: RivaFarabi.Deckboard
+PackageVersion: 2.0.56
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+ReleaseDate: 2022-11-12
+Installers:
+- Architecture: neutral
+  Scope: user
+  InstallerUrl: https://github.com/rivafarabi/deckboard/releases/download/v2.0.56/Deckboard-Setup-2.0.56.exe
+  InstallerSha256: 74B00D0A15CEABA3722189FBC036548F5D0684D6D715B2F925994878C81E6C9A
+  InstallerSwitches:
+    Custom: /CURRENTUSER
+- Architecture: neutral
+  Scope: machine
+  InstallerUrl: https://github.com/rivafarabi/deckboard/releases/download/v2.0.56/Deckboard-Setup-2.0.56.exe
+  InstallerSha256: 74B00D0A15CEABA3722189FBC036548F5D0684D6D715B2F925994878C81E6C9A
+  InstallerSwitches:
+    Custom: /ALLUSERS
+ManifestType: installer
+ManifestVersion: 1.2.0

--- a/manifests/r/RivaFarabi/Deckboard/2.0.56/RivaFarabi.Deckboard.locale.en-US.yaml
+++ b/manifests/r/RivaFarabi/Deckboard/2.0.56/RivaFarabi.Deckboard.locale.en-US.yaml
@@ -1,0 +1,36 @@
+# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-7
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+
+PackageIdentifier: RivaFarabi.Deckboard
+PackageVersion: 2.0.56
+PackageLocale: en-US
+Publisher: Riva Farabi
+PublisherUrl: https://github.com/rivafarabi/deckboard
+PublisherSupportUrl: https://github.com/rivafarabi/deckboard/issues
+# PrivacyUrl:
+Author: Riva Farabi
+PackageName: Deckboard
+PackageUrl: https://github.com/rivafarabi/deckboard
+License: Copyright © 2022 Riva Farabi
+# LicenseUrl:
+Copyright: Copyright © 2022 Riva Farabi
+# CopyrightUrl:
+ShortDescription: Phone as macro shortcut for your computer in easy way possible.
+Description: Create custom computer macro shortcuts and launch them through your device. No more windows switching to open the folder or website, get Deckboard to simplify them and maximize your productivity! With OBS Studio and Streamlabs OBS supported, bring Deckboard as your personal streaming companion tool! Connect your computer to your device through local WiFi connection by entering IP address or scanning QR code.
+Moniker: deckboard
+Tags:
+- electron
+- macro-recorder
+- macros
+- obs-remote
+- remote-control
+- shortcuts-on-desktop
+- streamlabs-obs-remote
+# Agreements:
+# ReleaseNotes:
+ReleaseNotesUrl: https://github.com/rivafarabi/deckboard/releases/tag/v2.0.56
+# PurchaseUrl:
+# InstallationNotes:
+# Documentations:
+ManifestType: defaultLocale
+ManifestVersion: 1.2.0

--- a/manifests/r/RivaFarabi/Deckboard/2.0.56/RivaFarabi.Deckboard.yaml
+++ b/manifests/r/RivaFarabi/Deckboard/2.0.56/RivaFarabi.Deckboard.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-7
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+
+PackageIdentifier: RivaFarabi.Deckboard
+PackageVersion: 2.0.56
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.2.0


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | Deckboard | Node.js, Node.js, Kate, VidCoder Beta (Portable)    |
| Version     | 2.0.56     | 16.18.0, 20.0.0, 22.08.3, 8.11 |
| Publisher   | Riva Farabi   | Node.js Foundation, Node.js Foundation, KDE e.V., RandomEngy      |
| ProductCode |           | {4317906F-88C3-4031-924E-8456B4CB385F}, {2C50D05A-CBBB-4033-BC19-68036A8038FA}, Kate, RandomEngy.VidCoder.Beta__DefaultSource    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://github.com/vedantmgoyal2009/vedantmgoyal2009/tree/main/winget-pkgs-automation) in workflow run [3824](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/3450160678>)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/88212)