### PR TITLE
Visual Studio: treat codes 1641 & 3010 as success

### DIFF
--- a/manifests/m/Microsoft/VisualStudio/2019/BuildTools/16.11.0/Microsoft.VisualStudio.2019.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/BuildTools/16.11.0/Microsoft.VisualStudio.2019.BuildTools.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/45dfa82b-c1f8-4c27-a5a0-1fa7a864ae21/75e7f5779a42dddabc647af82a7eae4bf1417484f0cd1ac9e8fd87cbe7450c39/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/BuildTools/16.11.1/Microsoft.VisualStudio.2019.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/BuildTools/16.11.1/Microsoft.VisualStudio.2019.BuildTools.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/9efbe138-ff42-4deb-95c9-1d78cdc1f98b/920981c883089c445a6a3a617396d089e7999437c1d70fc4629f557a75ac4fa5/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/BuildTools/16.11.10/Microsoft.VisualStudio.2019.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/BuildTools/16.11.10/Microsoft.VisualStudio.2019.BuildTools.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/791f3d28-7e20-45d9-9373-5dcfbdd1f6db/d5eabc3f4472d5ab18662648c8b6a08ea0553699819b88f89d84ec42d12f6ad7/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/BuildTools/16.11.11/Microsoft.VisualStudio.2019.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/BuildTools/16.11.11/Microsoft.VisualStudio.2019.BuildTools.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/73f91fcb-aa18-4bec-8c2f-8270acb22398/775c32ca5efcdc1e2227e52e943bb05bc8a7a9c1acacebb9d4ccc8496cc9906c/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/BuildTools/16.11.12/Microsoft.VisualStudio.2019.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/BuildTools/16.11.12/Microsoft.VisualStudio.2019.BuildTools.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/890a2f3f-4222-451c-b7ea-035d6c583dd7/11a323cd2efd2fc6ea81332e21904cfc703ca1ab80ff81b758877f99b5d7402d/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/BuildTools/16.11.13/Microsoft.VisualStudio.2019.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/BuildTools/16.11.13/Microsoft.VisualStudio.2019.BuildTools.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/d935ace6-0b55-4ef2-8ef2-7921ad9f3d3a/e2dec25f47d3abe13a0874e91d4eede0bfd67adc07d8bf23761b12e81c89bb81/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/BuildTools/16.11.14/Microsoft.VisualStudio.2019.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/BuildTools/16.11.14/Microsoft.VisualStudio.2019.BuildTools.installer.yaml
@@ -8,6 +8,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/dc2793e9-7b80-4f11-9e33-85833e8921a6/e6b0cd7dd16ce03a0cb49e697ca0a5dd23230711235179eb80f6d5c5785d83e4/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/BuildTools/16.11.15/Microsoft.VisualStudio.2019.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/BuildTools/16.11.15/Microsoft.VisualStudio.2019.BuildTools.installer.yaml
@@ -8,6 +8,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/d6eda263-3327-488b-9ed7-ecf65d1a6ada/8e4ae49512d22fda08c439751da9a7729abab1690065da16dbd9f0b0f17bac61/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/BuildTools/16.11.16/Microsoft.VisualStudio.2019.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/BuildTools/16.11.16/Microsoft.VisualStudio.2019.BuildTools.installer.yaml
@@ -8,6 +8,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/b29e5b57-df7c-4e38-acaf-5f8187a76fd0/1345ca588d22a3a5373e62c7d0ba3458d05422c24136e04846754086e252b431/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/BuildTools/16.11.17/Microsoft.VisualStudio.2019.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/BuildTools/16.11.17/Microsoft.VisualStudio.2019.BuildTools.installer.yaml
@@ -8,6 +8,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/d59287e5-e208-462b-8894-db3142c39eca/d5b3a9695dfd9f13cbf3ffdbbcc66abc5e8cb36f61f1042141f4cd5993aa89a4/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/BuildTools/16.11.18/Microsoft.VisualStudio.2019.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/BuildTools/16.11.18/Microsoft.VisualStudio.2019.BuildTools.installer.yaml
@@ -8,6 +8,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/e33403d5-ac1e-4600-b624-d59ccd7b9a13/1eef902363a18c6b3f6ee7aed27611e0e1671942bb937891c44fbb54fba6b7fb/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/BuildTools/16.11.19/Microsoft.VisualStudio.2019.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/BuildTools/16.11.19/Microsoft.VisualStudio.2019.BuildTools.installer.yaml
@@ -8,6 +8,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/6d7709aa-465b-4604-b797-3f9c1d911e67/bf33ca62eacd6ffb4f9e9f8e9e72294ed2b055c1ccbd7a299f5c5451d16c8447/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/BuildTools/16.11.2/Microsoft.VisualStudio.2019.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/BuildTools/16.11.2/Microsoft.VisualStudio.2019.BuildTools.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/bacf7555-1a20-4bf4-ae4d-1003bbc25da8/e6cfafe7eb84fe7f6cfbb10ff239902951f131363231ba0cfcd1b7f0677e6398/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/BuildTools/16.11.20/Microsoft.VisualStudio.2019.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/BuildTools/16.11.20/Microsoft.VisualStudio.2019.BuildTools.installer.yaml
@@ -8,6 +8,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/e84651e1-d13a-4bd2-a658-f47a1011ffd1/05dbd1f3ab48fb4ec86c1db193f6a96aa9a3e7d94fdc29132f2efe12f329ac58/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/BuildTools/16.11.21/Microsoft.VisualStudio.2019.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/BuildTools/16.11.21/Microsoft.VisualStudio.2019.BuildTools.installer.yaml
@@ -8,6 +8,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/8f1eb024-006a-43f6-a372-0721f71058b3/cc5cc690ac094fbfa78dfb8e40089ba52056026579e8d8dc31e95e8ea5466df5/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/BuildTools/16.11.3/Microsoft.VisualStudio.2019.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/BuildTools/16.11.3/Microsoft.VisualStudio.2019.BuildTools.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/22c17f05-944c-48dc-9f68-b1663f9df4cb/07fb37cabe09c87604aebd60daa829e12aa4e75e4d973f6961bd71f36f0e8b11/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/BuildTools/16.11.4/Microsoft.VisualStudio.2019.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/BuildTools/16.11.4/Microsoft.VisualStudio.2019.BuildTools.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/1051e775-b2c9-4b7a-a227-1e60bffe102a/ea5ad34fa76d6410e8200fce285005dafb683eadb767a927ebba56532fbd720f/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/BuildTools/16.11.5/Microsoft.VisualStudio.2019.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/BuildTools/16.11.5/Microsoft.VisualStudio.2019.BuildTools.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/5a50b8ac-2c22-47f1-ba60-70d4257a78fa/4e0f5197da02b62b9fa48f05b55f2e206265785a6f0bab7235ef88fbdbe49e5e/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/BuildTools/16.11.6/Microsoft.VisualStudio.2019.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/BuildTools/16.11.6/Microsoft.VisualStudio.2019.BuildTools.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/f1e43525-cd53-4012-9644-d7846e2c4963/9eb84f3bf5695fd108713fb15b827fe3755fc7c9ea3fa78eb83ed40015fd866b/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/BuildTools/16.11.7/Microsoft.VisualStudio.2019.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/BuildTools/16.11.7/Microsoft.VisualStudio.2019.BuildTools.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/c91ba3a2-4ed9-4ada-ac4a-01f62c9c86a9/5dc5c6649b2d35ab400df8536e8ee509304e48f560c431a264298feead70733c/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/BuildTools/16.11.8/Microsoft.VisualStudio.2019.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/BuildTools/16.11.8/Microsoft.VisualStudio.2019.BuildTools.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/b763973d-da6e-4025-834d-d8bc48e7d37f/4c9d3173a35956d1cf87e0fa8a9c79a0195e6e2acfe39f1ab92522d54a3bebb9/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/BuildTools/16.11.9/Microsoft.VisualStudio.2019.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/BuildTools/16.11.9/Microsoft.VisualStudio.2019.BuildTools.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/9a26f37e-6001-429b-a5db-c5455b93953c/f1c4f7b32e6da59b0a80c3a800d702211551738bcec68331aee1ab06d859be3d/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/Community-Preview/16.11.0 Preview 3.0/Microsoft.VisualStudio.2019.Community-Preview.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Community-Preview/16.11.0 Preview 3.0/Microsoft.VisualStudio.2019.Community-Preview.installer.yaml
@@ -17,9 +17,6 @@ InstallerSwitches:
   Silent: --quiet
   SilentWithProgress: --passive
   InstallLocation: --installPath <INSTALLPATH>
-InstallerSuccessCodes:
-- 1641
-- 3010
 Commands:
 - devenv
 Protocols:
@@ -47,6 +44,9 @@ FileExtensions:
 - vcproj
 - vcxproj
 - xml
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x86
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/e527d47a-814f-44bf-9cf8-2c0d9ed19e47/6630e33cd8f95ecd95072b278170153362915399344dd8a28f1c04d0fe5aa551/vs_Community.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/Community/16.11.21/Microsoft.VisualStudio.2019.Community.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Community/16.11.21/Microsoft.VisualStudio.2019.Community.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/8f1eb024-006a-43f6-a372-0721f71058b3/a86df3c7dfe6c1ec7f81607d851f7a2a72f32d4f34c3bf80fbd7e73c0099b359/vs_Community.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/Enterprise-Preview/16.11.0 Preview 3.0/Microsoft.VisualStudio.2019.Enterprise-Preview.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Enterprise-Preview/16.11.0 Preview 3.0/Microsoft.VisualStudio.2019.Enterprise-Preview.installer.yaml
@@ -17,9 +17,6 @@ InstallerSwitches:
   Silent: --quiet
   SilentWithProgress: --passive
   InstallLocation: --installPath <INSTALLPATH>
-InstallerSuccessCodes:
-- 1641
-- 3010
 Commands:
 - devenv
 Protocols:
@@ -47,6 +44,9 @@ FileExtensions:
 - vcproj
 - vcxproj
 - xml
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x86
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/e527d47a-814f-44bf-9cf8-2c0d9ed19e47/b1feac119b6d8b1705d64da88cbb072dc5d644b9cfe9af901bc1b897d5cb3c66/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/Enterprise/16.11.0/Microsoft.VisualStudio.2019.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Enterprise/16.11.0/Microsoft.VisualStudio.2019.Enterprise.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/45dfa82b-c1f8-4c27-a5a0-1fa7a864ae21/c4a096fe8acd2ece7b27256c2c509fcb3d6520c16557fa68a854bfa511e1661c/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/Enterprise/16.11.1/Microsoft.VisualStudio.2019.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Enterprise/16.11.1/Microsoft.VisualStudio.2019.Enterprise.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/9efbe138-ff42-4deb-95c9-1d78cdc1f98b/1c16b156e24e918d413664a49955d8f1646ad3ebdd171a58fd6877186f1e5d53/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/Enterprise/16.11.10/Microsoft.VisualStudio.2019.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Enterprise/16.11.10/Microsoft.VisualStudio.2019.Enterprise.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/791f3d28-7e20-45d9-9373-5dcfbdd1f6db/9fc1dce1910a05b3a99eeaeadc6e52d378eed4e8ac40a5fcc1e9b04677541608/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/Enterprise/16.11.11/Microsoft.VisualStudio.2019.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Enterprise/16.11.11/Microsoft.VisualStudio.2019.Enterprise.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/73f91fcb-aa18-4bec-8c2f-8270acb22398/0a59f03648724a986e88434e803fd0af56bf7d94c31579954077051e83f31994/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/Enterprise/16.11.12/Microsoft.VisualStudio.2019.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Enterprise/16.11.12/Microsoft.VisualStudio.2019.Enterprise.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/890a2f3f-4222-451c-b7ea-035d6c583dd7/ae44f1edd6b23b601b8a67257e769719246c1934243564f4adc2bd4a98f5067f/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/Enterprise/16.11.14/Microsoft.VisualStudio.2019.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Enterprise/16.11.14/Microsoft.VisualStudio.2019.Enterprise.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/dc2793e9-7b80-4f11-9e33-85833e8921a6/f409376d1740d7131edf1ee83cc6c3224ca6254ce81153fc9fff79fc2b62c668/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/Enterprise/16.11.15/Microsoft.VisualStudio.2019.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Enterprise/16.11.15/Microsoft.VisualStudio.2019.Enterprise.installer.yaml
@@ -8,6 +8,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/d6eda263-3327-488b-9ed7-ecf65d1a6ada/c4498fc3beef4b1a89f88d5086e7bc0d7966399ffb37094fc3a2643bade41354/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/Enterprise/16.11.16/Microsoft.VisualStudio.2019.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Enterprise/16.11.16/Microsoft.VisualStudio.2019.Enterprise.installer.yaml
@@ -8,6 +8,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/b29e5b57-df7c-4e38-acaf-5f8187a76fd0/12c374aee1f00896267e31ec5059d7c65365aafd23e74983e77a5ce96b3d7578/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/Enterprise/16.11.17/Microsoft.VisualStudio.2019.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Enterprise/16.11.17/Microsoft.VisualStudio.2019.Enterprise.installer.yaml
@@ -8,6 +8,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/d59287e5-e208-462b-8894-db3142c39eca/bc84676e6cb47dd08a6d3e47f5ead77f92e684e1c4d2be890ab2e671e054cb0f/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/Enterprise/16.11.18/Microsoft.VisualStudio.2019.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Enterprise/16.11.18/Microsoft.VisualStudio.2019.Enterprise.installer.yaml
@@ -8,6 +8,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/e33403d5-ac1e-4600-b624-d59ccd7b9a13/1453a172fbbbfd4a72e2241856d24e124268fa75aad9f73948280f302993b41e/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/Enterprise/16.11.19/Microsoft.VisualStudio.2019.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Enterprise/16.11.19/Microsoft.VisualStudio.2019.Enterprise.installer.yaml
@@ -8,6 +8,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/6d7709aa-465b-4604-b797-3f9c1d911e67/2e09e43b07c191d0272d1c9cfe81b3cb9431f6b8e723bc1edb9e1a510205b6c6/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/Enterprise/16.11.2/Microsoft.VisualStudio.2019.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Enterprise/16.11.2/Microsoft.VisualStudio.2019.Enterprise.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/bacf7555-1a20-4bf4-ae4d-1003bbc25da8/77fb864ccfcd2e3bfe445b653cd82e51971f41f6550c3d162af4b7d17666348c/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/Enterprise/16.11.20/Microsoft.VisualStudio.2019.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Enterprise/16.11.20/Microsoft.VisualStudio.2019.Enterprise.installer.yaml
@@ -8,6 +8,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/e84651e1-d13a-4bd2-a658-f47a1011ffd1/c1805c2c8d5bad776ba83f3448b0e5442b9cd7877e754e170e9b30eba2ed079d/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/Enterprise/16.11.21/Microsoft.VisualStudio.2019.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Enterprise/16.11.21/Microsoft.VisualStudio.2019.Enterprise.installer.yaml
@@ -8,6 +8,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/8f1eb024-006a-43f6-a372-0721f71058b3/f32acddfea6aa4e90969db6a6c206d66831fd0302be9af598c2a163ce71a0b6b/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/Enterprise/16.11.3/Microsoft.VisualStudio.2019.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Enterprise/16.11.3/Microsoft.VisualStudio.2019.Enterprise.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/22c17f05-944c-48dc-9f68-b1663f9df4cb/4aeaedf7e4ea9e4977eb864e4239c4e4aee57c8520988cf941fecd4e857290ac/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/Enterprise/16.11.4/Microsoft.VisualStudio.2019.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Enterprise/16.11.4/Microsoft.VisualStudio.2019.Enterprise.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/1051e775-b2c9-4b7a-a227-1e60bffe102a/b7eee4db40ed036f60577546cd1083724807fd609ac7c047c258f2ecd5c75846/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/Enterprise/16.11.5/Microsoft.VisualStudio.2019.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Enterprise/16.11.5/Microsoft.VisualStudio.2019.Enterprise.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/5a50b8ac-2c22-47f1-ba60-70d4257a78fa/c54a52d799f3c94e47620fa91c4b1648159af03e0d6276b0c21f1db97c518d72/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/Enterprise/16.11.6/Microsoft.VisualStudio.2019.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Enterprise/16.11.6/Microsoft.VisualStudio.2019.Enterprise.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/f1e43525-cd53-4012-9644-d7846e2c4963/817923dd6b783588558b75f64b5715b39ee511dc1e8797715a50bda97ca8e5b1/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/Enterprise/16.11.7/Microsoft.VisualStudio.2019.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Enterprise/16.11.7/Microsoft.VisualStudio.2019.Enterprise.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/c91ba3a2-4ed9-4ada-ac4a-01f62c9c86a9/5dd69ce9220bf50c77b33ea0c24b260bebd1d2fab6b9349ee67a4bb80b2696df/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/Enterprise/16.11.8/Microsoft.VisualStudio.2019.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Enterprise/16.11.8/Microsoft.VisualStudio.2019.Enterprise.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/b763973d-da6e-4025-834d-d8bc48e7d37f/8cdfb942fb78c4f43ac8421efde8898620b61a6da3846b7ba40097d27d223a48/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/Enterprise/16.11.9/Microsoft.VisualStudio.2019.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Enterprise/16.11.9/Microsoft.VisualStudio.2019.Enterprise.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/9a26f37e-6001-429b-a5db-c5455b93953c/4f7044818c052a28f0b1cc4ca93ea9c593c7f9cc8c30e81164b4df4123b27d4a/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/Professional-Preview/16.11.0 Preview 3.0/Microsoft.VisualStudio.2019.Professional-Preview.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Professional-Preview/16.11.0 Preview 3.0/Microsoft.VisualStudio.2019.Professional-Preview.installer.yaml
@@ -17,9 +17,6 @@ InstallerSwitches:
   Silent: --quiet
   SilentWithProgress: --passive
   InstallLocation: --installPath <INSTALLPATH>
-InstallerSuccessCodes:
-- 1641
-- 3010
 Commands:
 - devenv
 Protocols:
@@ -47,6 +44,9 @@ FileExtensions:
 - vcproj
 - vcxproj
 - xml
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x86
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/e527d47a-814f-44bf-9cf8-2c0d9ed19e47/eed73fbfebef4671a001e70a993bab24954087408afd298b6e345466f9e03652/vs_Professional.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/Professional/16.11.0/Microsoft.VisualStudio.2019.Professional.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Professional/16.11.0/Microsoft.VisualStudio.2019.Professional.installer.yaml
@@ -12,6 +12,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/45dfa82b-c1f8-4c27-a5a0-1fa7a864ae21/bc49a612e1f7e30037fb3b017bc9cd25cf57d7945d2180edd31f378e7a59f82c/vs_Professional.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/Professional/16.11.1/Microsoft.VisualStudio.2019.Professional.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Professional/16.11.1/Microsoft.VisualStudio.2019.Professional.installer.yaml
@@ -12,6 +12,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/9efbe138-ff42-4deb-95c9-1d78cdc1f98b/8a86c551b125b5d9dbc13a1f7f808963debeeacadbcefe6501f5ab7b05a4941d/vs_Professional.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/Professional/16.11.10/Microsoft.VisualStudio.2019.Professional.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Professional/16.11.10/Microsoft.VisualStudio.2019.Professional.installer.yaml
@@ -12,6 +12,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/791f3d28-7e20-45d9-9373-5dcfbdd1f6db/cd440cf67c0cf1519131d1d51a396e44c5b4f7b68b541c9f35c05a310d692f0a/vs_Professional.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/Professional/16.11.11/Microsoft.VisualStudio.2019.Professional.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Professional/16.11.11/Microsoft.VisualStudio.2019.Professional.installer.yaml
@@ -12,6 +12,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/73f91fcb-aa18-4bec-8c2f-8270acb22398/2c7501a4d4e187ca1b307b704516b4b8ca592dd04de7fa416c807c1da5a15c22/vs_Professional.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/Professional/16.11.12/Microsoft.VisualStudio.2019.Professional.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Professional/16.11.12/Microsoft.VisualStudio.2019.Professional.installer.yaml
@@ -12,6 +12,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/890a2f3f-4222-451c-b7ea-035d6c583dd7/e4a50b3365dcfa8877133a4974e88c356c440d5b0e26672e343faeafdeb302a0/vs_Professional.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/Professional/16.11.14/Microsoft.VisualStudio.2019.Professional.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Professional/16.11.14/Microsoft.VisualStudio.2019.Professional.installer.yaml
@@ -12,6 +12,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/dc2793e9-7b80-4f11-9e33-85833e8921a6/2aedd42317717db30c29bb1717ceb300f557c9c6dda07dcd2837e0c0062b4a1a/vs_Professional.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/Professional/16.11.15/Microsoft.VisualStudio.2019.Professional.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Professional/16.11.15/Microsoft.VisualStudio.2019.Professional.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/d6eda263-3327-488b-9ed7-ecf65d1a6ada/e3c9c3d4645f32641a6e4e05a51673335f04c8d3dedeffb1f51e9d76c8ea407c/vs_Professional.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/Professional/16.11.16/Microsoft.VisualStudio.2019.Professional.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Professional/16.11.16/Microsoft.VisualStudio.2019.Professional.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/b29e5b57-df7c-4e38-acaf-5f8187a76fd0/14626efff582bd77995ac0a60688400f91f2b520a82ae219be9d6ff17ee93019/vs_Professional.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/Professional/16.11.17/Microsoft.VisualStudio.2019.Professional.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Professional/16.11.17/Microsoft.VisualStudio.2019.Professional.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/d59287e5-e208-462b-8894-db3142c39eca/674d78f7527fb2c194e3fdba448fdaabda903dbba093dd0c6e9a143bc8b8c93f/vs_Professional.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/Professional/16.11.18/Microsoft.VisualStudio.2019.Professional.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Professional/16.11.18/Microsoft.VisualStudio.2019.Professional.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/e33403d5-ac1e-4600-b624-d59ccd7b9a13/3efb10be49a8f8d5c7449f94851f73c15822c4bcfa72c87ed793f4dbfc83fda9/vs_Professional.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/Professional/16.11.19/Microsoft.VisualStudio.2019.Professional.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Professional/16.11.19/Microsoft.VisualStudio.2019.Professional.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/6d7709aa-465b-4604-b797-3f9c1d911e67/6655e5ef00f68098401596cf380c110e6bef110e0b681ec7aafaa53a5a892126/vs_Professional.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/Professional/16.11.2/Microsoft.VisualStudio.2019.Professional.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Professional/16.11.2/Microsoft.VisualStudio.2019.Professional.installer.yaml
@@ -12,6 +12,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/bacf7555-1a20-4bf4-ae4d-1003bbc25da8/938488ec671252db4188aac5cf158d0610d7a0b107761863aa6a24f63c339e37/vs_Professional.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/Professional/16.11.20/Microsoft.VisualStudio.2019.Professional.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Professional/16.11.20/Microsoft.VisualStudio.2019.Professional.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/e84651e1-d13a-4bd2-a658-f47a1011ffd1/861e7beda1a53c06a318e91d9cdff2e47b3e407401576dc12911083204a092a6/vs_Professional.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/Professional/16.11.21/Microsoft.VisualStudio.2019.Professional.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Professional/16.11.21/Microsoft.VisualStudio.2019.Professional.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/8f1eb024-006a-43f6-a372-0721f71058b3/b09b18277894111a48441c868cb098a5ca1bec4b04becdd4f5aae7bb87856100/vs_Professional.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/Professional/16.11.3/Microsoft.VisualStudio.2019.Professional.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Professional/16.11.3/Microsoft.VisualStudio.2019.Professional.installer.yaml
@@ -12,6 +12,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/22c17f05-944c-48dc-9f68-b1663f9df4cb/5d4e208a6a04e1bf52852d50a133312e43c08d8b1fe83b06b0ce4e5d716a7fed/vs_Professional.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/Professional/16.11.4/Microsoft.VisualStudio.2019.Professional.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Professional/16.11.4/Microsoft.VisualStudio.2019.Professional.installer.yaml
@@ -12,6 +12,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/1051e775-b2c9-4b7a-a227-1e60bffe102a/ba53931da65a08d1e7a92713b129c9d363a80110e5a742049bc8765acf5a3c4e/vs_Professional.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/Professional/16.11.5/Microsoft.VisualStudio.2019.Professional.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Professional/16.11.5/Microsoft.VisualStudio.2019.Professional.installer.yaml
@@ -12,6 +12,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/5a50b8ac-2c22-47f1-ba60-70d4257a78fa/92256e542b91bf17e35e7bf4d4f73c3998c5c83b4402aab77a2f7a780203f23d/vs_Professional.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/Professional/16.11.7/Microsoft.VisualStudio.2019.Professional.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Professional/16.11.7/Microsoft.VisualStudio.2019.Professional.installer.yaml
@@ -12,6 +12,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/f1e43525-cd53-4012-9644-d7846e2c4963/bd89388039ce4232894883b74af15492d7e8ccce3d7ba4e8da2c0e941f393228/vs_Professional.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/Professional/16.11.8/Microsoft.VisualStudio.2019.Professional.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Professional/16.11.8/Microsoft.VisualStudio.2019.Professional.installer.yaml
@@ -12,6 +12,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/b763973d-da6e-4025-834d-d8bc48e7d37f/e122bff0bac32d630b335db65fb61c7da25fea28b7ae58fd65cb2e170ef94f2c/vs_Professional.exe

--- a/manifests/m/Microsoft/VisualStudio/2019/Professional/16.11.9/Microsoft.VisualStudio.2019.Professional.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2019/Professional/16.11.9/Microsoft.VisualStudio.2019.Professional.installer.yaml
@@ -12,6 +12,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/9a26f37e-6001-429b-a5db-c5455b93953c/a36bb31ed7fcf050a42a6e478994811c968d9e69d1b46e871e7508a93778a92e/vs_Professional.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.0.0/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.0.0/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/7aa16be3-9952-4bd2-8ecf-eae91faa0a06/50fdfb4f652e1d3ab4ec79b65bada583af704480a971e9b05c3a52a60036aa7d/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.0.1/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.0.1/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/8cea3871-c742-43fb-bf8b-8da0699ab4af/25c54d66f5cf07b14cdc0d6dab2e3d5da7ec22dead4757e69011bb2b2946e384/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.0.2/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.0.2/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/a53da67f-8d8a-448c-b211-d234d17e6398/cc9bc0f177c57babd1ae7f7674b7a998bf0fc5df157de4b4d5415b308ddb4040/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.0.3/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.0.3/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/ab119488-4f37-455b-a5de-86064bd15c4e/954edbf302ccf0b1f586a610f8cab1a3e9b555c96bebe8751f5fff37569a6626/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.0.5/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.0.5/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/ce8663b0-08ed-410a-9f5d-4f9469d1b2cb/2de792e781ee52a6ba627587ab6061f8a365ad53dd7795a3b0cec5326b56d896/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.0.6/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.0.6/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/928b2d78-4b74-4601-9c82-334cdbb1b3b4/b7938c769e672a87b42a7650b38129fff7b6a51bf0642a5041e4809130af9ab2/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.1.0/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.1.0/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/c30a4f7e-41da-41a5-afe8-ac56abf2740f/c9c5c694fdfdf0b9295c10416d370e4e9d60f5220c2ab9eee9ee147052294d31/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.1.1/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.1.1/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/99543e14-a692-4a98-9ac0-805b0f05f3b4/ba3498d6ade2671c786b5a761a3ff7eb94a0b0f06542e3aa1e157c4c01ac0192/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.1.2/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.1.2/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/c308d1c8-6b87-4859-9de6-c09a446c10ea/fcf8d50ed0987ab233f76445885710df9bb395a98d2828148e2475b3fddaf1f4/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.1.3/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.1.3/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/3f21c6d5-11da-4876-aa78-a2b2cce30660/e3da6424c439c07176e59927e248f80c60c95795a5fab3726649215f790786c2/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.1.4/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.1.4/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/180ad262-2f90-4974-a63e-3e47a5b2033c/0ca09a396d63f84f0739c89aa2bd6a70b8d448715300eddaac558fd81a5af6f1/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.1.5/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.1.5/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/553d5e50-5346-4e9d-8591-ae2b9a137c9c/6fb2c805655f4efaacf4cd3423cddffdb064acdf1b6752bcfac77afe092b7fde/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.1.6/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.1.6/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/949751db-6687-4a88-a0cf-047f10908a29/3d9b988f8850d1af4fae60807d8695249731fc19488eed013d1dd4a21c7309d5/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.2.0/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.2.0/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/dc2793e9-7b80-4f11-9e33-85833e8921a6/f80fd5547351fde319047725aae6a42d3b9a11276ab638901718a56b2e00a046/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.2.1/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.2.1/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
@@ -8,6 +8,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/05734053-383e-4b1a-9950-c7db8a55750d/8453f22d1923c8965d4dc8c8704d03b859b1bc9b7b5e698bba3e54cd238edcf9/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.2.2/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.2.2/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
@@ -8,6 +8,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/d31b13df-910a-40c8-aca6-778a2a7a56e7/6eda8dfcb55a17ca9aa41279e655079f302cc809433c8e3758e7d53c0969546e/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.2.3/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.2.3/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
@@ -8,6 +8,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/ea24168f-493e-42f7-9d95-83e763d3b0a9/85066a0e9902851383f1481fce028164a750ea4c037277179e89aa28480455e0/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.2.4/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.2.4/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
@@ -8,6 +8,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/2246570b-d03f-487d-8eeb-41e4a9c93199/fdf88c98ff664bd3df693d3611800c8b6feaab55cc1a76b00f9b7a5bcc29e322/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.2.5/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.2.5/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
@@ -8,6 +8,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/32bd2bc7-34ab-4d3d-abbf-526f0be7a954/1b4a8add148482a54a2e605610e31a869918981bdd2e7145765d7c1ad7545561/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.2.6/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.2.6/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
@@ -8,6 +8,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/91cf5cbb-c34a-4766-bff6-aea28265d815/645d56f3dc5b12783a0c9a19dc90a2cfc63191d837e6c988fba91e6db3525bf3/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.3.0/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.3.0/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/9e57b328-71ac-4bdd-bb2b-bdfb71417bbb/c9ab896bd762e917b7625fa5a61af9fa3110fdfd11bc2a4270377f057a6dc10f/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.3.1/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.3.1/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
@@ -8,6 +8,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/af9ede5a-5bbf-435e-9cdc-4017b67d3704/185c6e6558660391aa0013dd71f85a80463be8a7e4c8107fcd0c0395fe9d6802/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.3.2/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.3.2/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
@@ -8,6 +8,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/27a23027-9958-4bba-8bc2-a96997f86ad6/27523057fbfe427147f0a87864a11e2c20e7939edc7fc42aa1e69f1311a57867/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.3.3/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.3.3/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
@@ -8,6 +8,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/5fa6fcf5-8e43-4a4c-9ccc-ed024ab2585a/99a4dc8bc320597f73269a283d2a78fee20c521ad3ce69607c0c998d546cd71c/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.3.4/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.3.4/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
@@ -8,6 +8,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/8106c1cc-df87-4854-8865-3b46bef5867c/771fbda86c3f12a52dc9999e39ad80a7cbbd16b9c0b940671b03d3364fe002d4/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.3.5/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.3.5/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
@@ -8,6 +8,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/21ed51cb-52a5-454f-87b6-75a88ef54361/86a51dab223bb29289298a3a4b72c9900c0de5de260791497edbe12fe88a43a5/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.3.6/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.3.6/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
@@ -8,6 +8,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/5c9aef4f-a79b-4b72-b379-14273860b285/bd2dd3a59d2553382f89712d19e4d5c3d930d9a41c9426cf8194dd5a3a75875f/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.4.0/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.4.0/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
@@ -8,6 +8,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/de71f641-13a1-4991-92dc-ba1d44ac1605/714af6dd559604fd9e35463b18167bab1255ec5f171735cc9b2d7c3a37eee00f/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.4.1/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.4.1/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
@@ -8,6 +8,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/2160190b-bb01-4670-9492-34da461fa0c9/fabda7e422ada90c229262a4447c08933ec5bf66a9f38129cd19490eea2dd180/vs_BuildTools.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Community/17.4.1/Microsoft.VisualStudio.2022.Community.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Community/17.4.1/Microsoft.VisualStudio.2022.Community.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/2160190b-bb01-4670-9492-34da461fa0c9/8328f4d1739bc93c4350991b73bb03802bbb30643170ea15e6776b34cad1f9bf/vs_Community.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.0.0/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.0.0/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/7aa16be3-9952-4bd2-8ecf-eae91faa0a06/02179ee54342d77d9e6252dedc92b5fccee40d16168dc4f6df4387796da9a982/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.0.1/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.0.1/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/8cea3871-c742-43fb-bf8b-8da0699ab4af/d0bd1f0bacc72fb356e5eb7ccce4462f1d07f45695e5694fe6e1ab456dcd02a3/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.0.2/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.0.2/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/a53da67f-8d8a-448c-b211-d234d17e6398/281afe86c140b6f0c6650c9b27e9b2e3e0e87b6b33543b78126d7fb5bd72592f/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.0.3/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.0.3/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/ab119488-4f37-455b-a5de-86064bd15c4e/b96aa215cda6f43617a5df317f6ec0e10d202ea33d3bef32b784763c4984d48b/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.0.5/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.0.5/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/ce8663b0-08ed-410a-9f5d-4f9469d1b2cb/bb17a3e90839669d8fe2cc819e1da382915b3d5020ee7732ed16bd05191ccc50/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.0.6/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.0.6/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/928b2d78-4b74-4601-9c82-334cdbb1b3b4/87ef2cecb73a3728569cffaf13eeba64e6f987a1b416d24dabfe132f14d58ba0/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.1.0/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.1.0/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/c30a4f7e-41da-41a5-afe8-ac56abf2740f/d9a9e4d1984ba1180204d21b3bb2491842e07ba94f150b2093d4e062f5e37a33/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.1.1/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.1.1/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/99543e14-a692-4a98-9ac0-805b0f05f3b4/bfcd88d4d03f1ecde6439fce2db7d55e8c4518b2b5d79c17830b619d1a79333c/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.1.2/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.1.2/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/c308d1c8-6b87-4859-9de6-c09a446c10ea/0901a622420df3fdb0ff853dd5fc33bd119dacdc312ca15b943bc7465840a6da/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.1.3/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.1.3/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/3f21c6d5-11da-4876-aa78-a2b2cce30660/88feffd17ce6230211d2bf4d76392f221b8b9c858dbfba2a9d5c4e82df98e63f/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.1.4/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.1.4/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/180ad262-2f90-4974-a63e-3e47a5b2033c/fb588ce837ae36ab148464958ac012d398f2637623a0ed1dc45988cd6534b3e4/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.1.5/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.1.5/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/553d5e50-5346-4e9d-8591-ae2b9a137c9c/ad9bb76d80b44e7bab464f62153474998bec946b4a16a2e1f49ec3389695f47d/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.2.0/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.2.0/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/dc2793e9-7b80-4f11-9e33-85833e8921a6/f9f9a2fa6a053e28b73fb67925c50ce82de0f20a7dbe24fd14c587ef69b6541f/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.2.1/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.2.1/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
@@ -8,6 +8,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/05734053-383e-4b1a-9950-c7db8a55750d/98dcfd76797e262c8c40b100ce3de93a65c2dd9e0ba6cba2e2a1c928a8658eef/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.2.2/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.2.2/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
@@ -8,6 +8,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/d31b13df-910a-40c8-aca6-778a2a7a56e7/3c875c4ffe614b596ae75f39bee116769c0ca743da07ddf2e59f73c7c309dbda/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.2.3/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.2.3/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
@@ -8,6 +8,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/ea24168f-493e-42f7-9d95-83e763d3b0a9/64777625b8f688c6df1dda3e95e8ec57aa9631cb36ef4417b407b8890b6a7a84/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.2.4/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.2.4/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
@@ -8,6 +8,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/2246570b-d03f-487d-8eeb-41e4a9c93199/12e72f16586e6cc3e6f61f9089dab660f32a2f91175d3e580d4629d7e9c72934/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.2.5/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.2.5/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
@@ -8,6 +8,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/32bd2bc7-34ab-4d3d-abbf-526f0be7a954/fa9bab0fbf63e11d637652154b30f25a44d692e721ed26514ff68e70c248b810/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.2.6/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.2.6/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
@@ -8,6 +8,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/91cf5cbb-c34a-4766-bff6-aea28265d815/0d43606b9ec2c60bde79a6683008bd95201ae758bbc5025aa1c7831f8af6ae6e/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.3.0/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.3.0/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/9e57b328-71ac-4bdd-bb2b-bdfb71417bbb/6582df36e8b1eaff676b4342ecc4e2c6c5ea495a24898f750260186fca8724ed/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.3.1/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.3.1/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
@@ -8,6 +8,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/af9ede5a-5bbf-435e-9cdc-4017b67d3704/f40151eadfd6dcc26f6b0d961099181f047202a2160dcade5a963d45882ee254/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.3.2/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.3.2/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
@@ -8,6 +8,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/27a23027-9958-4bba-8bc2-a96997f86ad6/264de14cc89d7e2bfbdafaf53fd586bc18ef3ef4a29c1c201a028fd0e769321a/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.3.3/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.3.3/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
@@ -8,6 +8,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/5fa6fcf5-8e43-4a4c-9ccc-ed024ab2585a/b16a76a934bf339d6c2b1321e7092a1ebec92b049b1a5bd0b9c95c09b18e2e7d/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.3.4/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.3.4/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
@@ -8,6 +8,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/8106c1cc-df87-4854-8865-3b46bef5867c/59ad14eb280fcdafbdbcf66219ad05ad11d114611526ab8597ef338fadda172e/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.3.5/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.3.5/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
@@ -8,6 +8,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/21ed51cb-52a5-454f-87b6-75a88ef54361/4240cd23dfdeb70c3cc398678d85f9958f3bcb1d040c40ac18db61ad2d2ba3ad/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.3.6/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.3.6/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
@@ -8,6 +8,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/5c9aef4f-a79b-4b72-b379-14273860b285/cd049375d7c872eb38e84b2c52d41eb564c79136cb7fc00c0ce2c311d5bd3f9e/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.4.0/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.4.0/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
@@ -8,6 +8,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/de71f641-13a1-4991-92dc-ba1d44ac1605/d14a8a8e35b390379b0091f9552b45e53cb36c4df3b7dde46305a6bd2e4ee0ad/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.4.1/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Enterprise/17.4.1/Microsoft.VisualStudio.2022.Enterprise.installer.yaml
@@ -8,6 +8,9 @@ InstallerSwitches:
   SilentWithProgress: --passive
   Upgrade: update
   Custom: --wait
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/2160190b-bb01-4670-9492-34da461fa0c9/50b533facefd60616d011d3e5093a5485cd13f80d66a9de538372f523f07992f/vs_Enterprise.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Professional/17.0.0/Microsoft.VisualStudio.2022.Professional.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Professional/17.0.0/Microsoft.VisualStudio.2022.Professional.installer.yaml
@@ -12,6 +12,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/7aa16be3-9952-4bd2-8ecf-eae91faa0a06/fb37ea89e0316f4a2424f8bb3523e40f334240045afd84c91b89c3ef345bc831/vs_Professional.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Professional/17.0.1/Microsoft.VisualStudio.2022.Professional.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Professional/17.0.1/Microsoft.VisualStudio.2022.Professional.installer.yaml
@@ -12,6 +12,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/8cea3871-c742-43fb-bf8b-8da0699ab4af/3a48626e64e013104ef47dd7de6a9bc9e2ed75545933210367f451f32d4dc6ab/vs_Professional.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Professional/17.0.2/Microsoft.VisualStudio.2022.Professional.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Professional/17.0.2/Microsoft.VisualStudio.2022.Professional.installer.yaml
@@ -12,6 +12,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/a53da67f-8d8a-448c-b211-d234d17e6398/81a891c1db0f45bc0334967aeb676ec3cab3958d5f64729fee02395e28e7ca16/vs_Professional.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Professional/17.0.3/Microsoft.VisualStudio.2022.Professional.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Professional/17.0.3/Microsoft.VisualStudio.2022.Professional.installer.yaml
@@ -12,6 +12,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/ab119488-4f37-455b-a5de-86064bd15c4e/5c591521ab63a4c7f2e3e77df048d49986269d25cfe04d1034b1d139d1e94948/vs_Professional.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Professional/17.0.5/Microsoft.VisualStudio.2022.Professional.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Professional/17.0.5/Microsoft.VisualStudio.2022.Professional.installer.yaml
@@ -12,6 +12,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/ce8663b0-08ed-410a-9f5d-4f9469d1b2cb/35c3ed5e57c2310956fc5bc6e9d32d9d8c373a757647b555c43be375f789af16/vs_Professional.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Professional/17.0.6/Microsoft.VisualStudio.2022.Professional.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Professional/17.0.6/Microsoft.VisualStudio.2022.Professional.installer.yaml
@@ -12,6 +12,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/928b2d78-4b74-4601-9c82-334cdbb1b3b4/27ac7fc01e192b575d0eb25d327b605d85ee09485d725c7959c47c085e6057be/vs_Professional.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Professional/17.1.0/Microsoft.VisualStudio.2022.Professional.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Professional/17.1.0/Microsoft.VisualStudio.2022.Professional.installer.yaml
@@ -12,6 +12,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/c30a4f7e-41da-41a5-afe8-ac56abf2740f/fafc63f0295d502526e04402bf804488596e8245474a646cb08ac341493d7960/vs_Professional.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Professional/17.1.1/Microsoft.VisualStudio.2022.Professional.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Professional/17.1.1/Microsoft.VisualStudio.2022.Professional.installer.yaml
@@ -12,6 +12,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/99543e14-a692-4a98-9ac0-805b0f05f3b4/a1fd5623e606c1fd769cd2f42134dda9032a3e5d485d2975faa1ca0d9489c0b2/vs_Professional.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Professional/17.1.2/Microsoft.VisualStudio.2022.Professional.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Professional/17.1.2/Microsoft.VisualStudio.2022.Professional.installer.yaml
@@ -12,6 +12,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/c308d1c8-6b87-4859-9de6-c09a446c10ea/7e1522136fe400316491297b3fd038169600aaaf2479dc7cae7bda4034fe136b/vs_Professional.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Professional/17.1.3/Microsoft.VisualStudio.2022.Professional.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Professional/17.1.3/Microsoft.VisualStudio.2022.Professional.installer.yaml
@@ -12,6 +12,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/3f21c6d5-11da-4876-aa78-a2b2cce30660/2c85440c1d8b8cb97aaf3d92c74d12fa7a9ed8552ef76207a5d970ce63685fbc/vs_Professional.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Professional/17.1.4/Microsoft.VisualStudio.2022.Professional.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Professional/17.1.4/Microsoft.VisualStudio.2022.Professional.installer.yaml
@@ -12,6 +12,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/180ad262-2f90-4974-a63e-3e47a5b2033c/44b8415612f1bcb6a2b46a7ab626dbed415b55856c633ac1897e16215e065f75/vs_Professional.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Professional/17.1.5/Microsoft.VisualStudio.2022.Professional.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Professional/17.1.5/Microsoft.VisualStudio.2022.Professional.installer.yaml
@@ -12,6 +12,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/553d5e50-5346-4e9d-8591-ae2b9a137c9c/e8e6e17d564e1f5300b6a2e4a11eae3c00223e57e4f2997bd7c21fb9bdd28243/vs_Professional.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Professional/17.2.0/Microsoft.VisualStudio.2022.Professional.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Professional/17.2.0/Microsoft.VisualStudio.2022.Professional.installer.yaml
@@ -12,6 +12,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/dc2793e9-7b80-4f11-9e33-85833e8921a6/4257911bb7caa947b1e1fbff0afe850522de4c86b52be095b497e165528e86c5/vs_Professional.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Professional/17.2.1/Microsoft.VisualStudio.2022.Professional.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Professional/17.2.1/Microsoft.VisualStudio.2022.Professional.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/05734053-383e-4b1a-9950-c7db8a55750d/36b3f37691cb9da4440cc75fef6dd048899342c4f460631d75c37dfb348e70f4/vs_Professional.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Professional/17.2.2/Microsoft.VisualStudio.2022.Professional.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Professional/17.2.2/Microsoft.VisualStudio.2022.Professional.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/d31b13df-910a-40c8-aca6-778a2a7a56e7/189e64b566600c98168957f9537971e48943afaa0508bbe9fe12c15108dce78c/vs_Professional.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Professional/17.2.3/Microsoft.VisualStudio.2022.Professional.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Professional/17.2.3/Microsoft.VisualStudio.2022.Professional.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/ea24168f-493e-42f7-9d95-83e763d3b0a9/9ee85fff38425925bd11c1879fb2b753487a79fb3926862a0151344e0aae3fe1/vs_Professional.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Professional/17.2.4/Microsoft.VisualStudio.2022.Professional.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Professional/17.2.4/Microsoft.VisualStudio.2022.Professional.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/2246570b-d03f-487d-8eeb-41e4a9c93199/eb763abda2d2056f9e4a3d6b6e733bd4093513aba45032b0fd9652d11a6681d9/vs_Professional.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Professional/17.2.5/Microsoft.VisualStudio.2022.Professional.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Professional/17.2.5/Microsoft.VisualStudio.2022.Professional.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/32bd2bc7-34ab-4d3d-abbf-526f0be7a954/65d976d5e3c5cc9817ed4860f40eb17aa80f24b6376c9a5485dc8dd2c863aba5/vs_Professional.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Professional/17.2.6/Microsoft.VisualStudio.2022.Professional.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Professional/17.2.6/Microsoft.VisualStudio.2022.Professional.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/91cf5cbb-c34a-4766-bff6-aea28265d815/f56d9e9e0d41a89b6fccc9faf68a25a62d5734ff9d00646de832c7320c5db03c/vs_Professional.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Professional/17.3.0/Microsoft.VisualStudio.2022.Professional.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Professional/17.3.0/Microsoft.VisualStudio.2022.Professional.installer.yaml
@@ -12,6 +12,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/9e57b328-71ac-4bdd-bb2b-bdfb71417bbb/90f0e99418718e21c1eb41266ad86735c0ef857dcf18ff49bc537752cf97a013/vs_Professional.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Professional/17.3.1/Microsoft.VisualStudio.2022.Professional.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Professional/17.3.1/Microsoft.VisualStudio.2022.Professional.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/af9ede5a-5bbf-435e-9cdc-4017b67d3704/1d9cbc710cef89137794a2477b03199e99101b94802a24d0fb4d56ca80a6f05d/vs_Professional.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Professional/17.3.2/Microsoft.VisualStudio.2022.Professional.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Professional/17.3.2/Microsoft.VisualStudio.2022.Professional.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/27a23027-9958-4bba-8bc2-a96997f86ad6/2edba67b35f730a6a2a126d0ae436adf5098eb804366072ac8a7473f80458ae2/vs_Professional.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Professional/17.3.3/Microsoft.VisualStudio.2022.Professional.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Professional/17.3.3/Microsoft.VisualStudio.2022.Professional.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/5fa6fcf5-8e43-4a4c-9ccc-ed024ab2585a/0478e596b2f12a910063d226812b322665118965734b5c2aec9998a13fbbabe1/vs_Professional.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Professional/17.3.4/Microsoft.VisualStudio.2022.Professional.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Professional/17.3.4/Microsoft.VisualStudio.2022.Professional.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/8106c1cc-df87-4854-8865-3b46bef5867c/b9d123336e2a56210a27ed3b8cb033ea82e581331ad5dcb50d45ae1c724cfb68/vs_Professional.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Professional/17.3.5/Microsoft.VisualStudio.2022.Professional.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Professional/17.3.5/Microsoft.VisualStudio.2022.Professional.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/21ed51cb-52a5-454f-87b6-75a88ef54361/8ae2579584a5094bc9fc0e80111db40992a7bee69a1e8a9bee632ab04ab47ca4/vs_Professional.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Professional/17.3.6/Microsoft.VisualStudio.2022.Professional.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Professional/17.3.6/Microsoft.VisualStudio.2022.Professional.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/5c9aef4f-a79b-4b72-b379-14273860b285/e128ab7ec69dc27e9ff81342e97d36e5ba35dfe0d0536ba5ec52086018f8e9b6/vs_Professional.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Professional/17.4.0/Microsoft.VisualStudio.2022.Professional.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Professional/17.4.0/Microsoft.VisualStudio.2022.Professional.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/de71f641-13a1-4991-92dc-ba1d44ac1605/e9eb8f872ca4e3b95db25f877cbe1cab28ae149279673a7dcc9c0511d9d6b966/vs_Professional.exe

--- a/manifests/m/Microsoft/VisualStudio/2022/Professional/17.4.1/Microsoft.VisualStudio.2022.Professional.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Professional/17.4.1/Microsoft.VisualStudio.2022.Professional.installer.yaml
@@ -10,6 +10,9 @@ InstallerSwitches:
   Custom: --wait
 Commands:
 - devenv
+InstallerSuccessCodes:
+  - 1641
+  - 3010
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/2160190b-bb01-4670-9492-34da461fa0c9/64c5647e5a633dd1f14d16223d720b546167e242f54f24a642c00df734483049/vs_Professional.exe


### PR DESCRIPTION
* This unifies the handling of 1641 (ERROR_SUCCESS_REBOOT_INITIATED) and 3010 (ERROR_SUCCESS_REBOOT_REQUIRED) across all four VS2019 and VS2022 editions, i.e. where `InstallerUrl:` ended in `/vs_{BuildTools,Community,Enterprise,Professional}.exe`
* Previously only three manifests out of 156 contained these exit codes as `InstallerSuccessCodes:`
* Replacement was done automatically by searching for:  
    `(?<!InstallerSuccessCodes:.+?)(Installers:)`  
  and replacing that with:  
  ```
  InstallerSuccessCodes:
    - 1641
    - 3010
  \1
  ```

-----

- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [X] Have you tested your manifest locally with `winget install --manifest <path>`?
  * **No I haven't and I won't do that for 153 manifests**
- [X] Does your manifest conform to the [1.2 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.2.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/88859)