### PR TITLE
New version: JetBrains.RubyMine.EarlyAccess version 223.7571.47

### DIFF
--- a/manifests/j/JetBrains/RubyMine/EarlyAccess/223.7571.47/JetBrains.RubyMine.EarlyAccess.installer.yaml
+++ b/manifests/j/JetBrains/RubyMine/EarlyAccess/223.7571.47/JetBrains.RubyMine.EarlyAccess.installer.yaml
@@ -1,0 +1,20 @@
+# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-7
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+
+PackageIdentifier: JetBrains.RubyMine.EarlyAccess
+PackageVersion: 223.7571.47
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+Scope: machine
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: uninstallPrevious
+ReleaseDate: 2022-11-18
+Installers:
+- Architecture: x64
+  InstallerUrl: https://download-cdn.jetbrains.com/ruby/RubyMine-223.7571.47.exe
+  InstallerSha256: 0A550717560E3570FDDFB143C5E621D0E6CFB8A934FBE54CFC97FFF70CEFBBE7
+  ProductCode: RubyMine 223.7571.1
+ManifestType: installer
+ManifestVersion: 1.2.0

--- a/manifests/j/JetBrains/RubyMine/EarlyAccess/223.7571.47/JetBrains.RubyMine.EarlyAccess.locale.en-US.yaml
+++ b/manifests/j/JetBrains/RubyMine/EarlyAccess/223.7571.47/JetBrains.RubyMine.EarlyAccess.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-7
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+
+PackageIdentifier: JetBrains.RubyMine.EarlyAccess
+PackageVersion: 223.7571.47
+PackageLocale: en-US
+Publisher: JetBrains s.r.o.
+PublisherUrl: https://www.jetbrains.com
+PublisherSupportUrl: https://www.jetbrains.com/help
+PrivacyUrl: https://www.jetbrains.com/privacy-security
+Author: JetBrains s.r.o.
+PackageName: RubyMine (EAP)
+PackageUrl: https://www.jetbrains.com/ruby/nextversion
+License: Proprietary
+LicenseUrl: https://www.jetbrains.com/legal/#licensing
+Copyright: Copyright © JetBrains s.r.o.
+CopyrightUrl: https://www.jetbrains.com/legal/#licensing
+ShortDescription: The Ruby and Rails IDE with first-class support for Ruby and Rails, JavaScript and CoffeeScript, ERB and HAML, CSS, Sass and Less, and more.
+Description: The Ruby and Rails IDE with first-class support for Ruby and Rails, JavaScript and CoffeeScript, ERB and HAML, CSS, Sass and Less, and more. Note, however, that because EAPs are always works in progress, some of their features might not always work as expected.
+# Moniker:
+Tags:
+- ide
+- intellij
+- jetbrains
+- ruby
+# Agreements:
+# ReleaseNotes:
+ReleaseNotesUrl: https://youtrack.jetbrains.com/articles/RUBY-A-220365014
+# PurchaseUrl:
+# InstallationNotes:
+# Documentations:
+ManifestType: defaultLocale
+ManifestVersion: 1.2.0

--- a/manifests/j/JetBrains/RubyMine/EarlyAccess/223.7571.47/JetBrains.RubyMine.EarlyAccess.yaml
+++ b/manifests/j/JetBrains/RubyMine/EarlyAccess/223.7571.47/JetBrains.RubyMine.EarlyAccess.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-7
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+
+PackageIdentifier: JetBrains.RubyMine.EarlyAccess
+PackageVersion: 223.7571.47
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.2.0


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | RubyMine (EAP) | PyCharm 2022.2.4    |
| Version     | 223.7571.47     | 222.4459.20 |
| Publisher   | JetBrains s.r.o.   | JetBrains s.r.o.      |
| ProductCode |           | PyCharm 2022.2.4    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://github.com/vedantmgoyal2009/vedantmgoyal2009/tree/main/winget-pkgs-automation) in workflow run [3971](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/3498808870>)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/89171)