### PR TITLE
New version: webrecorder.replayweb-page version 1.7.3

### DIFF
--- a/manifests/w/webrecorder/replayweb-page/1.7.3/webrecorder.replayweb-page.installer.yaml
+++ b/manifests/w/webrecorder/replayweb-page/1.7.3/webrecorder.replayweb-page.installer.yaml
@@ -1,0 +1,23 @@
+# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-7
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+
+PackageIdentifier: webrecorder.replayweb-page
+PackageVersion: 1.7.3
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- silent
+UpgradeBehavior: install
+FileExtensions:
+- har
+- wacz
+- warc
+- wbn
+ReleaseDate: 2022-11-22
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/webrecorder/replayweb.page/releases/download/v1.7.3/ReplayWeb.page-1.7.3.exe
+  InstallerSha256: 30D922A9EBD6B1CE3EA8294AFDC017A39BA787C9200E946EB714856C04134D71
+ManifestType: installer
+ManifestVersion: 1.2.0

--- a/manifests/w/webrecorder/replayweb-page/1.7.3/webrecorder.replayweb-page.locale.en-US.yaml
+++ b/manifests/w/webrecorder/replayweb-page/1.7.3/webrecorder.replayweb-page.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-7
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+
+PackageIdentifier: webrecorder.replayweb-page
+PackageVersion: 1.7.3
+PackageLocale: en-US
+Publisher: Webrecorder Software
+PublisherUrl: https://replayweb.page
+PublisherSupportUrl: https://github.com/webrecorder/replayweb.page/issues
+# PrivacyUrl:
+Author: Ilya Kreymer
+PackageName: ReplayWeb.page
+PackageUrl: https://github.com/webrecorder/replayweb.page
+License: AGPL-3.0-only
+LicenseUrl: https://raw.githubusercontent.com/webrecorder/replayweb.page/main/LICENSE
+Copyright: Copyright (c) Ilya Kreymer
+CopyrightUrl: https://raw.githubusercontent.com/webrecorder/replayweb.page/main/LICENSE
+ShortDescription: Serverless Web Archive Replay directly in the browser
+# Description:
+Moniker: replayweb-page
+Tags:
+- archive
+- electron
+- play
+- web
+# Agreements:
+# ReleaseNotes:
+ReleaseNotesUrl: https://github.com/webrecorder/replayweb.page/releases/tag/v1.7.3
+# PurchaseUrl:
+# InstallationNotes:
+# Documentations:
+ManifestType: defaultLocale
+ManifestVersion: 1.2.0

--- a/manifests/w/webrecorder/replayweb-page/1.7.3/webrecorder.replayweb-page.yaml
+++ b/manifests/w/webrecorder/replayweb-page/1.7.3/webrecorder.replayweb-page.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-7
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+
+PackageIdentifier: webrecorder.replayweb-page
+PackageVersion: 1.7.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.2.0


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | ReplayWeb.page | 网易邮箱大师, 搜狐影音    |
| Version     | 1.7.3     | 4.17.8.1009, 7.0.18.0 |
| Publisher   | Webrecorder Software   | NetEase(Hangzhou) Network Co. Ltd., 搜狐公司      |
| ProductCode |           | MailMaster, 搜狐影音    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://github.com/vedantmgoyal2009/vedantmgoyal2009/tree/main/winget-pkgs-automation) in workflow run [4049](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/3520112060>)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/89395)