### PR TITLE
Ignore usernames when checking spelling

### DIFF
--- a/.github/actions/spelling/patterns.txt
+++ b/.github/actions/spelling/patterns.txt
@@ -20,6 +20,8 @@
 [Uu][Rr][Ll]
 # Ignore groupID's
 "(_id|groupId)": "[a-zA-Z0-9]{24}"
+# Ignore usernames, preceeded by an @
+(\[|\b)@[A-Za-z0-9-]+(\]|\b)
 
 # FAQ items
 \`[A-Z]\`[a-z]{2,}\b


### PR DESCRIPTION
Moderators.md lists a number of usernames that are being caught by the spell checker, but clearly are meant to be there.  Don't fail the spellcheck because of them.

This doesn't seem to affect the builds in microsoft/winget-pkgs, but I'm definitely getting failures reported for the builds in my fork, which I need to push to in order to be able to submit PRs here.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.2 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.2.0)?

Obviously a bunch of the above checks aren't relevant for this PR!

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/89510)