### PR TITLE
Removed moniker for Python 3.12.0a1.

### DIFF
--- a/manifests/p/Python/Python/3/12/3.12.0a1/Python.Python.3.12.locale.en-US.yaml
+++ b/manifests/p/Python/Python/3/12/3.12.0a1/Python.Python.3.12.locale.en-US.yaml
@@ -16,7 +16,6 @@ LicenseUrl: https://docs.python.org/3/license.html
 Copyright: Copyright ©2001-2022. Python Software Foundation.
 CopyrightUrl: https://docs.python.org/3/license.html
 ShortDescription: Python is a programming language that lets you work more quickly and integrate your systems more effectively.
-Moniker: python3
 Tags:
 - glue-language
 - programming-language


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.2 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.2.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

The moniker `python3` should be pointing towards the latest *stable* release.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/89869)