### PR TITLE
Suppress Microsoft.DotNet.SDK.7 automatic reboot

### DIFF
--- a/manifests/m/Microsoft/DotNet/SDK/7/7.0.100/Microsoft.DotNet.SDK.7.installer.yaml
+++ b/manifests/m/Microsoft/DotNet/SDK/7/7.0.100/Microsoft.DotNet.SDK.7.installer.yaml
@@ -7,6 +7,7 @@ MinimumOSVersion: 6.1.7601
 InstallerSwitches:
   Silent: /quiet
   SilentWithProgress: /passive
+  Custom: /norestart
 Installers:
 - Architecture: arm64
   InstallerType: burn


### PR DESCRIPTION
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [X] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.2 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.2.0)?

Note: `<path>` is `manifests/m/Microsoft/DotNet/SDK/7/7.0.100`

-----

This pull request adds the /norestart command-line argument to the .NET SDK 7 installer to avoid the painful automatic reboot that follows. I installed Microsoft.DotNet.SDK.7 with winget today and I was surprised to see attempt an automatic reboot without a warning, closing most of my programs before I could abort the shutdown. This is definitely not the default behavior most people would want, and it can ruin someone's day if done at the wrong time.

https://twitter.com/awakecoding/status/1597992997043720193

![image](https://user-images.githubusercontent.com/295841/204881537-913e83c9-13bf-4cb4-bd1d-2cf8ab846b41.png)
![image](https://user-images.githubusercontent.com/295841/204881575-f3f04bcc-b8b4-414e-8a44-c7e9b1211a9d.png)

I tested my modification locally and it didn't trigger the automatic reboot. Once this PR gets merged, I'll open another one with a similar change for the other versions of the .NET SDK