### PR TITLE
Add `ensure-https` workflow

### DIFF
--- a/.github/EnsureHttps.ps1
+++ b/.github/EnsureHttps.ps1
@@ -1,0 +1,24 @@
+#!/usr/bin/env pwsh
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$changedFiles = git diff --name-only "origin/$env:GITHUB_BASE_REF" HEAD -- manifests
+
+foreach ($changedFile in $changedFiles) {
+  $http = Select-String -Path $changedFile `
+    -Pattern '(http://.*)$' `
+    -AllMatches
+  foreach ($match in $http.Matches) {
+    if ($match.Groups[0].Value) {
+      $https = $match.Groups[0].Value.Replace('http://', 'https://')
+      $res = Invoke-WebRequest -Uri $https `
+        -Method HEAD `
+        -TimeoutSec 10 `
+        -UseBasicParsing
+      if ($res.StatusCode -eq 200) {
+        Write-Output "::error file=$changedFile::Found HTTP link: $($match.Value)"
+      }
+    }
+  }
+}

--- a/.github/workflows/ensure-https.yaml
+++ b/.github/workflows/ensure-https.yaml
@@ -1,0 +1,18 @@
+name: Ensure HTTPS
+
+on:
+  pull_request:
+
+jobs:
+  https:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - run: .github/EnsureHttps.ps1
+        shell: pwsh
+


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.2 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.2.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

This partially addresses #90249.

`EnsureHttps.ps1` will:
1. Get a list of changed `.yaml` files in the `manifests` directory for a PR
2. For each changed file:
	1. Check if it contains an `http://` URL
	2. If yes, for each `http://` URL:
		1. It will see if the `https://` equivalent is valid
		2. If yes, it will write out an [error command][2]

[Check out an example of this workflow in my fork][1]

I think this is a good starting point, that can be improved on with URL exclusions, and eventually be made a required workflow. To start with I'd like to run it as an optional workflow to get some feedback.

[1]: https://github.com/JamieMagee/winget-pkgs/actions/runs/3597956799/jobs/6060255513#step:3:5
[2]: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/90273)