### PR TITLE
New version: GLab.GLab version 1.23.1

### DIFF
--- a/manifests/g/GLab/GLab/1.23.1/GLab.GLab.installer.yaml
+++ b/manifests/g/GLab/GLab/1.23.1/GLab.GLab.installer.yaml
@@ -1,0 +1,21 @@
+# Created with YamlCreate.ps1 v2.0.4 $debug=QUSU.7-2-1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+
+PackageIdentifier: GLab.GLab
+PackageVersion: 1.23.1
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://gitlab.com/gitlab-org/cli/-/releases/v1.23.1/downloads/glab_1.23.1_Windows_x86_64_installer.exe
+  InstallerSha256: 36f9d45f68ea53cbafdbe96ba4206e4412abb4c2b8f00ba667054523bd7cc89e
+ManifestType: installer
+ManifestVersion: 1.1.0

--- a/manifests/g/GLab/GLab/1.23.1/GLab.GLab.locale.en-US.yaml
+++ b/manifests/g/GLab/GLab/1.23.1/GLab.GLab.locale.en-US.yaml
@@ -1,0 +1,37 @@
+# Created with YamlCreate.ps1 v2.0.4 $debug=QUSU.7-2-1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+
+PackageIdentifier: GLab.GLab
+PackageVersion: 1.23.1
+PackageLocale: en-US
+Publisher: GitLab
+PublisherUrl: https://gitlab.com/gitlab-org/cli
+PublisherSupportUrl: https://gitlab.com/gitlab-org/cli/-/issues
+# PrivacyUrl:
+Author: GitLab
+PackageName: glab
+PackageUrl: https://gitlab.com/gitlab-org/cli
+License: MIT License
+LicenseUrl: https://gitlab.com/gitlab-org/cli/-/raw/main/LICENSE
+Copyright: Copyright (c) 2022-present GitLab B.V.
+CopyrightUrl: https://gitlab.com/gitlab-org/cli/-/raw/main/LICENSE
+ShortDescription: An open-source GitLab command line tool bringing GitLabs cool features to your command line
+Description: GLab is an open source GitLab CLI tool bringing GitLab to your terminal next to where you are already working with git and your code without switching between windows and browser tabs. Work with issues, merge requests, watch running pipelines directly from your CLI among other features. Inspired by gh, the official GitHub CLI tool.
+Moniker: glab
+Tags:
+- cli
+- commandline
+- command-line
+- git
+- gitlab
+- gitlab-ci
+- glab
+- glab-cli
+- golang
+- tool
+- utility
+# Agreements:
+# ReleaseNotes:
+# ReleaseNotesUrl:
+ManifestType: defaultLocale
+ManifestVersion: 1.1.0

--- a/manifests/g/GLab/GLab/1.23.1/GLab.GLab.yaml
+++ b/manifests/g/GLab/GLab/1.23.1/GLab.GLab.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.0.4 $debug=QUSU.7-2-1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+
+PackageIdentifier: GLab.GLab
+PackageVersion: 1.23.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.1.0


### PR DESCRIPTION
- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.2 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.2.0)?

Note: `manifests/g/GLab/GLab/1.23.1` is the name of the directory containing the manifest you're submitting.

-----

Apart from updating the package, this PR also changes the origin (ownership) of the manifest

GitLab is now the official maintainer of the `glab` package.

- Archived original repo: https://github.com/profclems/glab
- Announcement issue: https://github.com/profclems/glab/issues/983
- The new home for the project https://gitlab.com/gitlab-org/cli
- Release mentioned in this PR https://gitlab.com/gitlab-org/cli/-/releases/v1.23.0


I've made a similar PR for

- homebrew: https://github.com/Homebrew/homebrew-core/pull/116608
- scoop: https://github.com/ScoopInstaller/Main/pull/4168



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/90349)