### PR TITLE
Move Microsoft.dotNetFramework 4.8 to Microsoft.DotNet.Framework.Deve…

### DIFF
--- a/manifests/m/Microsoft/DotNet/Framework/DeveloperPack_4/4.8/Microsoft.DotNet.Framework.DeveloperPack_4.installer.yaml
+++ b/manifests/m/Microsoft/DotNet/Framework/DeveloperPack_4/4.8/Microsoft.DotNet.Framework.DeveloperPack_4.installer.yaml
@@ -1,0 +1,18 @@
+# Created with YamlCreate.ps1 v2.1.0 $debug=AUSU.5-1-22572-1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+
+PackageIdentifier: Microsoft.DotNet.Framework.DeveloperPack_4
+PackageVersion: "4.8"
+InstallerLocale: en-US
+MinimumOSVersion: 10.0.0.0
+InstallerType: exe
+InstallerSwitches:
+  Silent: /install /quiet /norestart
+  SilentWithProgress: /install /passive /norestart
+Installers:
+- Architecture: x86
+  InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/014120d7-d689-4305-befd-3cb711108212/1f81f3962f75eff5d83a60abd3a3ec7b/ndp48-web.exe
+  InstallerSha256: B9821F28FACFD6B11FFBF3703FF3F218CC3C31B85D6503D5C20570751FF08876
+ManifestType: installer
+ManifestVersion: 1.1.0
+

--- a/manifests/m/Microsoft/DotNet/Framework/DeveloperPack_4/4.8/Microsoft.DotNet.Framework.DeveloperPack_4.locale.en-US.yaml
+++ b/manifests/m/Microsoft/DotNet/Framework/DeveloperPack_4/4.8/Microsoft.DotNet.Framework.DeveloperPack_4.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# Created with YamlCreate.ps1 v2.1.0 $debug=AUSU.5-1-22572-1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+
+PackageIdentifier: Microsoft.DotNet.Framework.DeveloperPack_4
+PackageVersion: "4.8"
+PackageLocale: en-US
+Publisher: Microsoft Corporation
+# PublisherUrl: 
+# PublisherSupportUrl: 
+# PrivacyUrl: 
+# Author: 
+PackageName: .NET Framework
+PackageUrl: https://dotnet.microsoft.com/download/dotnet-framework
+License: Copyright (c) Microsoft Corporation
+# LicenseUrl: 
+# Copyright: 
+# CopyrightUrl: 
+ShortDescription: .NET Framework is a technology that supports building and running Windows apps and web services. .NET Framework is designed to fulfill the following objectives.
+# Description: 
+Moniker: .netfw
+Tags:
+- .net
+- .netframework
+- .netfw
+- dotnet
+- dot-net
+- framework
+# Agreements: 
+# ReleaseNotes: 
+# ReleaseNotesUrl: 
+ManifestType: defaultLocale
+ManifestVersion: 1.1.0
+

--- a/manifests/m/Microsoft/DotNet/Framework/DeveloperPack_4/4.8/Microsoft.DotNet.Framework.DeveloperPack_4.yaml
+++ b/manifests/m/Microsoft/DotNet/Framework/DeveloperPack_4/4.8/Microsoft.DotNet.Framework.DeveloperPack_4.yaml
@@ -1,0 +1,9 @@
+# Created with YamlCreate.ps1 v2.1.0 $debug=AUSU.5-1-22572-1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+
+PackageIdentifier: Microsoft.DotNet.Framework.DeveloperPack_4
+PackageVersion: "4.8"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.1.0
+


### PR DESCRIPTION
DotNet frameworks are "Out of support" and are not maintained by the DotNet team. These PR's are to move them into the DotNet folder to be more standard. Separate PR's will be opened to fix the metadata.

Recommend moving into Microsoft.DotNet.Framework.DeveloperPack.4 once Schema 1.4 is released

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/90615)