### PR TITLE
Move Microsoft.dotNetFramework 4.7.1 to Microsoft.DotNet.Framework.De…

### DIFF
--- a/manifests/m/Microsoft/DotNet/Framework/DeveloperPack_4/4.7.1/Microsoft.DotNet.Framework.DeveloperPack_4.installer.yaml
+++ b/manifests/m/Microsoft/DotNet/Framework/DeveloperPack_4/4.7.1/Microsoft.DotNet.Framework.DeveloperPack_4.installer.yaml
@@ -1,0 +1,18 @@
+# Created with YamlCreate.ps1 v2.1.0 $debug=AUSU.5-1-22572-1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+
+PackageIdentifier: Microsoft.DotNet.Framework.DeveloperPack_4
+PackageVersion: 4.7.1
+InstallerLocale: en-US
+MinimumOSVersion: 10.0.0.0
+InstallerType: exe
+InstallerSwitches:
+  Silent: /install /quiet /norestart
+  SilentWithProgress: /install /passive /norestart
+Installers:
+- Architecture: x64
+  InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/4312fa21-59b0-4451-9482-a1376f7f3ba4/9947fce13c11105b48cba170494e787f/ndp471-kb4033342-x86-x64-allos-enu.exe
+  InstallerSha256: DF6E700D37FF416E2E1D8463DEDEDDF76522CEAF5BB4CC3F197A7F2B9ECCC4AD
+ManifestType: installer
+ManifestVersion: 1.1.0
+

--- a/manifests/m/Microsoft/DotNet/Framework/DeveloperPack_4/4.7.1/Microsoft.DotNet.Framework.DeveloperPack_4.locale.en-US.yaml
+++ b/manifests/m/Microsoft/DotNet/Framework/DeveloperPack_4/4.7.1/Microsoft.DotNet.Framework.DeveloperPack_4.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# Created with YamlCreate.ps1 v2.1.0 $debug=AUSU.5-1-22572-1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+
+PackageIdentifier: Microsoft.DotNet.Framework.DeveloperPack_4
+PackageVersion: 4.7.1
+PackageLocale: en-US
+Publisher: Microsoft
+# PublisherUrl: 
+# PublisherSupportUrl: 
+# PrivacyUrl: 
+# Author: 
+PackageName: .NET Framework
+# PackageUrl: 
+License: Copyright (c) Microsoft Corporation
+# LicenseUrl: 
+# Copyright: 
+# CopyrightUrl: 
+ShortDescription: Microsoft.DotNet.Framework.DeveloperPack_4
+Description: This is an offline installer. There are separate installers for web and offline installation. If you intend to redistribute either of these installers in the setup for your own product or application, we recommend that you choose the web installer because it is smaller and typically downloads faster. You can download the web installer here. Wherever possible, Microsoft recommends you use the Web Installer in lieu of the Offline Package for optimal efficiency and bandwidth requirements. The offline package can be used in situations where the web installer cannot be used due to lack of internet connectivity. This package is larger than the web installer and does not include the language packs. You can download and install the language packs from here.
+Moniker: .netfw
+Tags:
+- .net
+- dotnet
+- net
+- netfx
+# Agreements: 
+# ReleaseNotes: 
+# ReleaseNotesUrl: 
+ManifestType: defaultLocale
+ManifestVersion: 1.1.0
+

--- a/manifests/m/Microsoft/DotNet/Framework/DeveloperPack_4/4.7.1/Microsoft.DotNet.Framework.DeveloperPack_4.yaml
+++ b/manifests/m/Microsoft/DotNet/Framework/DeveloperPack_4/4.7.1/Microsoft.DotNet.Framework.DeveloperPack_4.yaml
@@ -1,0 +1,9 @@
+# Created with YamlCreate.ps1 v2.1.0 $debug=AUSU.5-1-22572-1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+
+PackageIdentifier: Microsoft.DotNet.Framework.DeveloperPack_4
+PackageVersion: 4.7.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.1.0
+


### PR DESCRIPTION
DotNet frameworks are "Out of support" and are not maintained by the DotNet team. These PR's are to move them into the DotNet folder to be more standard. Separate PR's will be opened to fix the metadata.

Recommend moving into Microsoft.DotNet.Framework.DeveloperPack.4 once Schema 1.4 is released

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/90616)