### PR TITLE
Add `UpgradeBehavior: uninstallPrevious` to JupyterLab 3.5.0-1

### DIFF
--- a/manifests/p/ProjectJupyter/JupyterLab/3.5.0-1/ProjectJupyter.JupyterLab.installer.yaml
+++ b/manifests/p/ProjectJupyter/JupyterLab/3.5.0-1/ProjectJupyter.JupyterLab.installer.yaml
@@ -8,7 +8,7 @@ InstallModes:
   - interactive
   - silent
   - silentWithProgress
-UpgradeBehavior: install
+UpgradeBehavior: uninstallPrevious
 Installers:
 - Architecture: x64
   InstallerType: nullsoft


### PR DESCRIPTION

I missed this in my previous PR; The publisher recommends to uninstall the previous version before upgrading. 

Reference: https://github.com/jupyterlab/jupyterlab-desktop/releases/tag/v3.5.0-1
-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/90961)