### PR TITLE
JLis.Jpki.Application version 3.4.0

### DIFF
--- a/manifests/j/JLis/Jpki/Application/3.4.0/JLis.Jpki.Application.installer.yaml
+++ b/manifests/j/JLis/Jpki/Application/3.4.0/JLis.Jpki.Application.installer.yaml
@@ -1,0 +1,17 @@
+# Created using wingetcreate 1.1.2.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+
+PackageIdentifier: JLis.Jpki.Application
+PackageVersion: 3.4.0
+Installers:
+- InstallerLocale: ja-JP
+  MinimumOSVersion: 6.3.9600
+  Architecture: x86
+  InstallerType: exe
+  Scope: machine
+  InstallerUrl: https://www2.jpki.go.jp/client/download/003/JPKIAppli03-04.exe
+  InstallerSha256: 6AF55D356B0BF6F3E954ED311743C39C0C8C2C673BEC88AA5159E9A786596138
+  UpgradeBehavior: install
+ManifestType: installer
+ManifestVersion: 1.2.0
+

--- a/manifests/j/JLis/Jpki/Application/3.4.0/JLis.Jpki.Application.locale.ja-JP.yaml
+++ b/manifests/j/JLis/Jpki/Application/3.4.0/JLis.Jpki.Application.locale.ja-JP.yaml
@@ -1,0 +1,23 @@
+# Created using wingetcreate 1.1.2.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+
+PackageIdentifier: JLis.Jpki.Application
+PackageVersion: 3.4.0
+PackageLocale: ja-JP
+Publisher: J-LIS
+PublisherUrl: https://www.jpki.go.jp/
+PublisherSupportUrl: https://www.jpki.go.jp/contact/index.html
+PrivacyUrl: https://www.jpki.go.jp/jpkiguide/privacy.html
+Author: J-LIS
+PackageName: JPKI Application
+PackageUrl: https://www.jpki.go.jp/download/win.html
+License: Proprietary
+LicenseUrl: https://www.jpki.go.jp/download/win.html
+Copyright: Copyright (C) J-LIS All Rights Reserved.
+CopyrightUrl: https://www.jpki.go.jp/jpkiguide/copyright.html
+ShortDescription: JPKI利用者ソフト（利用者クライアントソフト）
+Description: JPKI利用者ソフト（利用者クライアントソフト）は、公的個人認証サービスを利用した電子申請を行うときに、マイナンバーカードに搭載された電子証明書を使用して署名を付与するための専用ソフトウェアです。
+Moniker: JPKI
+ManifestType: defaultLocale
+ManifestVersion: 1.2.0
+

--- a/manifests/j/JLis/Jpki/Application/3.4.0/JLis.Jpki.Application.yaml
+++ b/manifests/j/JLis/Jpki/Application/3.4.0/JLis.Jpki.Application.yaml
@@ -1,0 +1,9 @@
+# Created using wingetcreate 1.1.2.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+
+PackageIdentifier: JLis.Jpki.Application
+PackageVersion: 3.4.0
+DefaultLocale: ja-JP
+ManifestType: version
+ManifestVersion: 1.2.0
+


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.2 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.2.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

JPKI is a public PKI in Japan.
Japanese citizens can have their individual number card which includes a NFC chip to communicate with PCs or smartphones. This applications is for communicating between Windows PCs and the card.

Since the application and their installer only supports Japanese (ja-JP), this manifest only supports ja-JP locale too.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/91014)