### PR TITLE
Fix: KDE.Kate 22.08.3 download URL

### DIFF
--- a/manifests/k/KDE/Kate/22.08.3/KDE.Kate.installer.yaml
+++ b/manifests/k/KDE/Kate/22.08.3/KDE.Kate.installer.yaml
@@ -11,14 +11,14 @@ UpgradeBehavior: install
 Installers:
 - Architecture: x64
   Scope: user
-  InstallerUrl: https://binary-factory.kde.org/view/Windows%2064-bit/job/Kate_Release_win64/1871/artifact/kate-22.08.3-1871-windows-cl-msvc2019-x86_64.exe
-  InstallerSha256: F94E1E9C9F0AEFB0829847BD719E5D8402FAF6BAE5390224D1CFEA770062873B
+  InstallerUrl: https://binary-factory.kde.org/view/Windows%2064-bit/job/Kate_Release_win64/1876/artifact/kate-22.08.3-1876-windows-cl-msvc2019-x86_64.exe
+  InstallerSha256: 34F1DED64A77C5F5F739E8731BBA29E55E9EA95B0BE1D234BBDE1807C3CF62C8
   InstallerSwitches:
     Custom: /CURRENTUSER
 - Architecture: x64
   Scope: machine
-  InstallerUrl: https://binary-factory.kde.org/view/Windows%2064-bit/job/Kate_Release_win64/1871/artifact/kate-22.08.3-1871-windows-cl-msvc2019-x86_64.exe
-  InstallerSha256: F94E1E9C9F0AEFB0829847BD719E5D8402FAF6BAE5390224D1CFEA770062873B
+  InstallerUrl: https://binary-factory.kde.org/view/Windows%2064-bit/job/Kate_Release_win64/1876/artifact/kate-22.08.3-1876-windows-cl-msvc2019-x86_64.exe
+  InstallerSha256: 34F1DED64A77C5F5F739E8731BBA29E55E9EA95B0BE1D234BBDE1807C3CF62C8
   InstallerSwitches:
     Custom: /ALLUSERS
 ManifestType: installer


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.2 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.2.0)?

Note: `k/KDE/Kate/22.08.3` is the name of the directory containing the manifest you're submitting.

-----

updated the URL for the installer

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/91040)