### PR TITLE
Fix stoplight studio 2.10.0's installer url

### DIFF
--- a/manifests/s/Stoplight/Studio/2.10.0/Stoplight.Studio.installer.yaml
+++ b/manifests/s/Stoplight/Studio/2.10.0/Stoplight.Studio.installer.yaml
@@ -6,12 +6,12 @@ PackageVersion: 2.10.0
 Installers:
 - Architecture: x64
   InstallerType: nullsoft
-  InstallerUrl: https://github.com/stoplightio/studio/releases/download/v2.10.0-stable.8821.git-e47fcf5/stoplight-studio-win.exe
-  InstallerSha256: bf2b14267d97d55a1bef37e08a30671f5cb23985f13a71a7956b1a75ef84e574
+  InstallerUrl: https://github.com/stoplightio/studio/releases/download/v2.10.0-stable.8870.git-32fa2af/stoplight-studio-win.exe
+  InstallerSha256: 16cf84a131c12d8c833ba93cae2a57d91e4f6906a13197f19ac8171ca73db19d
   ProductCode: 279242fd-d458-5566-9571-36711297e305
   AppsAndFeaturesEntries:
-  - DisplayName: Stoplight Studio 2.10.0-stable.8821.git-e47fcf5
-    DisplayVersion: 2.10.0-stable.8821.git-e47fcf5
+  - DisplayName: Stoplight Studio 2.10.0-stable.8870.git-32fa2af
+    DisplayVersion: 2.10.0-stable.8870.git-32fa2af
     ProductCode: 279242fd-d458-5566-9571-36711297e305
 ManifestType: installer
 ManifestVersion: 1.2.0

--- a/manifests/s/Stoplight/Studio/2.10.0/Stoplight.Studio.locale.en-US.yaml
+++ b/manifests/s/Stoplight/Studio/2.10.0/Stoplight.Studio.locale.en-US.yaml
@@ -16,7 +16,7 @@ LicenseUrl: https://github.com/stoplightio/studio#license
 Copyright: Copyright © 2022 Stoplight
 ShortDescription: The modern editor for API Design and Technical Writing.
 Moniker: stoplight-studio
-ReleaseNotesUrl: https://github.com/stoplightio/studio/releases/tag/v2.10.0-stable.8821.git-e47fcf5
+ReleaseNotesUrl: https://github.com/stoplightio/studio/releases/tag/v2.10.0-stable.8870.git-32fa2af
 Documentations:
 - DocumentUrl: https://meta.stoplight.io/docs/platform/9f60f2fd436bd-api-design-overview
   DocumentLabel: API Design Overview


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.2 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.2.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

The Stoplight Studio's team has released an update with the same version number and got rid of the [old installer url](https://github.com/stoplightio/studio/releases/download/v2.10.0-stable.8821.git-e47fcf5/stoplight-studio-win.exe). The new release is located [here](https://github.com/stoplightio/studio/releases/tag/v2.10.0-stable.8870.git-32fa2af).

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/91701)