### PR TITLE
Fixed Installer: NathanBeals.WinSSH-Pageant scope type change

### DIFF
--- a/manifests/n/NathanBeals/WinSSH-Pageant/2.3.0/NathanBeals.WinSSH-Pageant.installer.yaml
+++ b/manifests/n/NathanBeals/WinSSH-Pageant/2.3.0/NathanBeals.WinSSH-Pageant.installer.yaml
@@ -8,7 +8,7 @@ Platform:
 - Windows.Desktop
 MinimumOSVersion: 10.0.0.0
 InstallerType: wix
-Scope: user
+Scope: machine
 InstallModes:
 - silent
 - interactive


### PR DESCRIPTION
The installer scope was set to "user" and the Wix installer is using "ALLUSERS"=2 which lets windows determine the install scope, upon first install it was using the "user" scope but when trying to upgrade, it was using the "machine" scope and the upgrade was failing because of a mismatched installerscope.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.2 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.2.0)?

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/91811)