### PR TITLE
Fixed InstallerURL for Rufus version 3.21.

### DIFF
--- a/manifests/r/Rufus/Rufus/3.21/Rufus.Rufus.installer.yaml
+++ b/manifests/r/Rufus/Rufus/3.21/Rufus.Rufus.installer.yaml
@@ -12,7 +12,7 @@ AppsAndFeaturesEntries:
 - Publisher: Akeo Consulting
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/pbatard/rufus/releases/download/v3.21/rufus-3.21.exe
+  InstallerUrl: https://github.com/pbatard/rufus/releases/download/v3.21/rufus-3.21p.exe
   InstallerSha256: D0554F1FC47407D678A4D8EACE607272013C475033B636BFB1824ED6B1A22E36
 - Architecture: arm64
   InstallerUrl: https://github.com/pbatard/rufus/releases/download/v3.21/rufus-3.21_arm64.exe


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.2 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.2.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

Resolves #91757. (Although it's worth noting that this won't cause different behavior, it's just going to be consistent with the other URLs which use the p suffixed executable).

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/91998)