### PR TITLE
PowerShell 7.4.0.1 fix: specify display version for 7.4.1.0 to be 7.4.0.1

### DIFF
--- a/manifests/m/Microsoft/PowerShell/Preview/7.4.1.0/Microsoft.PowerShell.Preview.installer.yaml
+++ b/manifests/m/Microsoft/PowerShell/Preview/7.4.1.0/Microsoft.PowerShell.Preview.installer.yaml
@@ -29,7 +29,7 @@ Installers:
   ProductCode: '{B41EB2F8-A40F-420D-98E7-1D6290F6F289}'
   AppsAndFeaturesEntries:
   - Publisher: Microsoft Corporation
-    DisplayName: PowerShell 7-preview-x64
+    DisplayName: PowerShell 7-preview-x86
     DisplayVersion: 7.4.0.1
 - Architecture: arm
   InstallerType: msix

--- a/manifests/m/Microsoft/PowerShell/Preview/7.4.1.0/Microsoft.PowerShell.Preview.installer.yaml
+++ b/manifests/m/Microsoft/PowerShell/Preview/7.4.1.0/Microsoft.PowerShell.Preview.installer.yaml
@@ -18,11 +18,19 @@ Installers:
   InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.4.0-preview.1/PowerShell-7.4.0-preview.1-win-x64.msi
   InstallerSha256: C525E9D5804489183BAFCC90FC195949727593FAA780CC30D1BC01CFEFE09D0D
   ProductCode: '{3AC4078C-B562-4575-B4C9-ABDAD8F6A760}'
+  AppsAndFeaturesEntries:
+  - Publisher: Microsoft Corporation
+    DisplayName: PowerShell 7-preview-x64
+    DisplayVersion: 7.4.0.1
 - Architecture: x86
   InstallerType: wix
   InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.4.0-preview.1/PowerShell-7.4.0-preview.1-win-x86.msi
   InstallerSha256: 51EFBD58C6D7142A38D49D319EFA504DACE48B5681E98067CAFFBBF4151B84EE
   ProductCode: '{B41EB2F8-A40F-420D-98E7-1D6290F6F289}'
+  AppsAndFeaturesEntries:
+  - Publisher: Microsoft Corporation
+    DisplayName: PowerShell 7-preview-x64
+    DisplayVersion: 7.4.0.1
 - Architecture: arm
   InstallerType: msix
   InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.4.0-preview.1/PowerShell-7.4.0-preview.1-win.msixbundle


### PR DESCRIPTION
Add AppsAndFeaturesEntries property in installer to display version for preview version correctly.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.2 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.2.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/92021)