### PR TITLE
Upgrades Tarma.PublishOrPerish to version 8.6.4214.8378

### DIFF
--- a/manifests/t/Tarma/PublishOrPerish/8.6.4214.8378/Tarma.PublishOrPerish.installer.yaml
+++ b/manifests/t/Tarma/PublishOrPerish/8.6.4214.8378/Tarma.PublishOrPerish.installer.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
 
 PackageIdentifier: Tarma.PublishOrPerish
-PackageVersion: 8.6.4198.8332
+PackageVersion: 8.6.4214.8378
 InstallerType: exe # InstallMate
 Scope: machine
 InstallModes:
@@ -34,15 +34,11 @@ ExpectedReturnCodes:
 UpgradeBehavior: install
 FileExtensions:
 - pxa
-ReleaseDate: 2022-10-23
+ReleaseDate: 2022-12-08
 Installers:
 - Architecture: x86
   InstallerUrl: https://harzing.com/download/PoP8Setup.exe
-  InstallerSha256: EA177ED4EBFB8DABBAD9DC137AD3DC2C456807C1E61FE9B9FFDE2885338AFE05
-  ProductCode: '{D7808C1C-93A9-4369-8385-A789888ED9D7}'
-- Architecture: x64
-  InstallerUrl: https://harzing.com/download/PoP8Setup.exe
-  InstallerSha256: EA177ED4EBFB8DABBAD9DC137AD3DC2C456807C1E61FE9B9FFDE2885338AFE05
+  InstallerSha256: 3776147f8caa921dbebc486a5eef51a03ae809aa1ef27304a992cbef8a3f8fe9
   ProductCode: '{D7808C1C-93A9-4369-8385-A789888ED9D7}'
 ManifestType: installer
 ManifestVersion: 1.2.0

--- a/manifests/t/Tarma/PublishOrPerish/8.6.4214.8378/Tarma.PublishOrPerish.locale.en-US.yaml
+++ b/manifests/t/Tarma/PublishOrPerish/8.6.4214.8378/Tarma.PublishOrPerish.locale.en-US.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
 
 PackageIdentifier: Tarma.PublishOrPerish
-PackageVersion: 8.6.4198.8332
+PackageVersion: 8.6.4214.8378
 PackageLocale: en-US
 Publisher: Tarma Software Research Ltd
 PublisherUrl: https://harzing.com/

--- a/manifests/t/Tarma/PublishOrPerish/8.6.4214.8378/Tarma.PublishOrPerish.locale.zh-CN.yaml
+++ b/manifests/t/Tarma/PublishOrPerish/8.6.4214.8378/Tarma.PublishOrPerish.locale.zh-CN.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.2.0.schema.json
 
 PackageIdentifier: Tarma.PublishOrPerish
-PackageVersion: 8.6.4198.8332
+PackageVersion: 8.6.4214.8378
 PackageLocale: zh-CN
 Publisher: Tarma Software Research Ltd
 PublisherUrl: https://harzing.com/

--- a/manifests/t/Tarma/PublishOrPerish/8.6.4214.8378/Tarma.PublishOrPerish.yaml
+++ b/manifests/t/Tarma/PublishOrPerish/8.6.4214.8378/Tarma.PublishOrPerish.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
 
 PackageIdentifier: Tarma.PublishOrPerish
-PackageVersion: 8.6.4198.8332
+PackageVersion: 8.6.4214.8378
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.2.0


### PR DESCRIPTION
The previous version is not available anymore, therefore I deleted it.

There is only one installer for the x86 platform.
The installers in the previous version were identical. Therefore I removed the x64 installer.
As a result, future upgrades should work with wingetcreate.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.2 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.2.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/92158)