### PR TITLE
New version: Yubico.Authenticator version 6.0.2 

### DIFF
--- a/manifests/y/Yubico/Authenticator/6.0.2/Yubico.Authenticator.installer.yaml
+++ b/manifests/y/Yubico/Authenticator/6.0.2/Yubico.Authenticator.installer.yaml
@@ -1,0 +1,29 @@
+# Created using wingetcreate 1.1.2.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+
+PackageIdentifier: Yubico.Authenticator
+PackageVersion: 6.0.2
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: wix
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: /qn
+  SilentWithProgress: /qb
+  Custom: /norestart
+UpgradeBehavior: install
+Installers:
+- InstallerLocale: en-US
+  Architecture: x64
+  InstallerType: wix
+  InstallerUrl: https://developers.yubico.com/yubioath-flutter/Releases/yubico-authenticator-6.0.2-win64.msi
+  InstallerSha256: 012954E79F091FAF30E26CFAD57BA75ED517AC247D88239A9BEFDBD28AA6A3A7
+  ProductCode: '{306DE726-5F67-4E43-9601-2EA44EE47860}'
+ManifestType: installer
+ManifestVersion: 1.2.0

--- a/manifests/y/Yubico/Authenticator/6.0.2/Yubico.Authenticator.locale.en-US.yaml
+++ b/manifests/y/Yubico/Authenticator/6.0.2/Yubico.Authenticator.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# Created using wingetcreate 1.1.2.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+
+PackageIdentifier: Yubico.Authenticator
+PackageVersion: 6.0.2
+PackageLocale: en-US
+Publisher: Yubico AB
+PublisherUrl: https://www.yubico.com/
+PublisherSupportUrl: https://support.yubico.com
+PrivacyUrl: https://www.yubico.com/support/terms-conditions/privacy-notice/
+Author: Yubico AB
+PackageName: Yubico Authenticator
+PackageUrl: https://www.yubico.com/products/yubico-authenticator/
+License: BSD-2-Clause License
+LicenseUrl: https://raw.githubusercontent.com/Yubico/yubioath-desktop/master/COPYING
+Copyright: Yubico © 2022. All Rights Reserved.
+# CopyrightUrl: 
+ShortDescription: Authenticator to generate 2-step verification codes using your YubiKey
+Description: Authenticator to generate 2-step verification codes using your YubiKey
+Moniker: yubioath
+Tags:
+- 2fa
+- auth
+- security
+- totp
+# Agreements: 
+# ReleaseNotes: 
+# ReleaseNotesUrl: 
+# PurchaseUrl: 
+# InstallationNotes: 
+# Documentations: 
+ManifestType: defaultLocale
+ManifestVersion: 1.2.0

--- a/manifests/y/Yubico/Authenticator/6.0.2/Yubico.Authenticator.locale.en-US.yaml
+++ b/manifests/y/Yubico/Authenticator/6.0.2/Yubico.Authenticator.locale.en-US.yaml
@@ -12,7 +12,7 @@ Author: Yubico AB
 PackageName: Yubico Authenticator
 PackageUrl: https://www.yubico.com/products/yubico-authenticator/
 License: BSD-2-Clause License
-LicenseUrl: https://raw.githubusercontent.com/Yubico/yubioath-desktop/master/COPYING
+LicenseUrl: https://raw.githubusercontent.com/Yubico/yubioath-flutter/main/LICENSE
 Copyright: Yubico © 2022. All Rights Reserved.
 # CopyrightUrl: 
 ShortDescription: Authenticator to generate 2-step verification codes using your YubiKey

--- a/manifests/y/Yubico/Authenticator/6.0.2/Yubico.Authenticator.yaml
+++ b/manifests/y/Yubico/Authenticator/6.0.2/Yubico.Authenticator.yaml
@@ -1,0 +1,9 @@
+# Created using wingetcreate 1.1.2.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+
+PackageIdentifier: Yubico.Authenticator
+PackageVersion: 6.0.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.2.0
+


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.2 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.2.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

Note that Version 6 was a partial rewrite of the application (see https://www.yubico.com/blog/yubico-authenticator-6-is-here/), which is probably why the download url and filename are different now. They also seem to have removed the x86 installer.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/92281)