### PR TITLE
Update Copyright for HashiCorp.Vagrant

### DIFF
--- a/manifests/h/Hashicorp/Vagrant/2.3.4/Hashicorp.Vagrant.locale.en-US.yaml
+++ b/manifests/h/Hashicorp/Vagrant/2.3.4/Hashicorp.Vagrant.locale.en-US.yaml
@@ -13,8 +13,8 @@ PackageName: Vagrant
 PackageUrl: https://www.vagrantup.com
 License: MIT
 LicenseUrl: https://github.com/hashicorp/vagrant/blob/main/LICENSE
-Copyright: Copyright (c) 2010-2022 Mitchell Hashimoto
-# CopyrightUrl:
+Copyright: Copyright (c) 2010 HashiCorp, Inc.
+CopyrightUrl: https://github.com/hashicorp/vagrant/blob/main/LICENSE
 ShortDescription: Vagrant is a tool for building and distributing development environments.
 # Description:
 # Moniker:


### PR DESCRIPTION
Copyright of the package updated in https://github.com/hashicorp/vagrant/blob/main/LICENSE

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/92912)