### PR TITLE
Update: EclipseAdoptium.Temurin.JRE.18.0.2.101 to support --location …

### DIFF
--- a/manifests/e/EclipseAdoptium/Temurin/18/JRE/18.0.2.101/EclipseAdoptium.Temurin.18.JRE.installer.yaml
+++ b/manifests/e/EclipseAdoptium/Temurin/18/JRE/18.0.2.101/EclipseAdoptium.Temurin.18.JRE.installer.yaml
@@ -5,14 +5,15 @@ PackageIdentifier: EclipseAdoptium.Temurin.18.JRE
 PackageVersion: 18.0.2.101
 InstallerLocale: en-US
 MinimumOSVersion: 10.0.0.0
+InstallerType: wix
+InstallerSwitches:
+  InstallLocation: INSTALLDIR="<INSTALLPATH>"
 Installers:
 - Architecture: x64
-  InstallerType: wix
   InstallerUrl: https://github.com/adoptium/temurin18-binaries/releases/download/jdk-18.0.2.1%2B1/OpenJDK18U-jre_x64_windows_hotspot_18.0.2.1_1.msi
   InstallerSha256: 1E726C0EA2A8B25C2C75A8174DF173DD54C98CAA0235EF49D84A03292F152BFC
   ProductCode: '{A3D29894-21D5-4D89-9BDE-ABBE6A72D0C1}'
 - Architecture: x86
-  InstallerType: wix
   InstallerUrl: https://github.com/adoptium/temurin18-binaries/releases/download/jdk-18.0.2.1%2B1/OpenJDK18U-jre_x86-32_windows_hotspot_18.0.2.1_1.msi
   InstallerSha256: DFDD3B64D2D5EA56A9BA93C044B84E11E8A4A6D4B42F5DCEB6AC904557E9DF0E
   ProductCode: '{396CD475-AD86-4167-AB9A-6FE749A2C379}'


### PR DESCRIPTION
…flag

The WiX based installer for Eclipse Temurin has a flag that can be used to specify the install location. However, the flag is non-default (`INSTALLDIR`) and has to be manually defined in the manifests for it to be supported by winget via the `--location` parameter.

The flag is specified [here](https://github.com/adoptium/installer/blob/7204362c1f75e145c6716e5b336087f2908a32e3/wix/Main.wxs.template#L17) and has been the same since inception and, accordingly, should work for all existing installers.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.2 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.2.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/93001)