### PR TITLE
Update: EclipseAdoptium.Temurin.JDK.11.0.12.7 to support --location flag

### DIFF
--- a/manifests/e/EclipseAdoptium/Temurin/11/JDK/11.0.12.7/EclipseAdoptium.Temurin.11.JDK.installer.yaml
+++ b/manifests/e/EclipseAdoptium/Temurin/11/JDK/11.0.12.7/EclipseAdoptium.Temurin.11.JDK.installer.yaml
@@ -5,6 +5,8 @@ PackageIdentifier: EclipseAdoptium.Temurin.11.JDK
 PackageVersion: 11.0.12.7
 MinimumOSVersion: 10.0.0.0
 InstallerType: wix
+InstallerSwitches:
+  InstallLocation: INSTALLDIR="<INSTALLPATH>"
 Scope: machine
 InstallModes:
 - interactive


### PR DESCRIPTION
The WiX based installer for Eclipse Temurin has a flag that can be used to specify the install location. However, the flag is non-default (`INSTALLDIR`) and has to be manually defined in the manifests for it to be supported by winget via the `--location` parameter.

The flag is specified [here](https://github.com/adoptium/installer/blob/7204362c1f75e145c6716e5b336087f2908a32e3/wix/Main.wxs.template#L17) and has been the same since inception and, accordingly, should work for all existing installers.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.2 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.2.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/93017)