### PR TITLE
Update: EclipseAdoptium.Temurin.JDK.17.0.4.101 to support --location …

### DIFF
--- a/manifests/e/EclipseAdoptium/Temurin/17/JDK/17.0.4.101/EclipseAdoptium.Temurin.17.JDK.installer.yaml
+++ b/manifests/e/EclipseAdoptium/Temurin/17/JDK/17.0.4.101/EclipseAdoptium.Temurin.17.JDK.installer.yaml
@@ -4,18 +4,18 @@
 PackageIdentifier: EclipseAdoptium.Temurin.17.JDK
 PackageVersion: 17.0.4.101
 MinimumOSVersion: 10.0.0.0
+InstallerType: wix
 InstallerSwitches:
   Custom: INSTALLLEVEL=3
+  InstallLocation: INSTALLDIR="<INSTALLPATH>"
 Installers:
 - Architecture: x64
-  InstallerType: wix
   InstallerUrl: https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.4.1%2B1/OpenJDK17U-jdk_x64_windows_hotspot_17.0.4.1_1.msi
   InstallerSha256: CB0A70D663FA48729F9CFA80D655214E728406A1460F2FA744B614B98972A964
   ProductCode: '{38B5ECF2-F859-46E3-9BA3-15C6E3C07942}'
   AppsAndFeaturesEntries:
   - DisplayName: Eclipse Temurin JDK with Hotspot 17.0.4.1+1 (x64)
 - Architecture: x86
-  InstallerType: wix
   InstallerUrl: https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.4.1%2B1/OpenJDK17U-jdk_x86-32_windows_hotspot_17.0.4.1_1.msi
   InstallerSha256: B104AD00DB3D83FFFBA8F8582E5A96614917449057E04D0A2B44C1515443F2CB
   ProductCode: '{671AE74D-BCF3-4D25-A35B-F5625864947D}'


### PR DESCRIPTION
…flag

The WiX based installer for Eclipse Temurin has a flag that can be used to specify the install location. However, the flag is non-default (`INSTALLDIR`) and has to be manually defined in the manifests for it to be supported by winget via the `--location` parameter.

The flag is specified [here](https://github.com/adoptium/installer/blob/7204362c1f75e145c6716e5b336087f2908a32e3/wix/Main.wxs.template#L17) and has been the same since inception and, accordingly, should work for all existing installers.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.2 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.2.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/93037)