### PR TITLE
Update: Microsoft.WingetCreate version 1.1.2.0

### DIFF
--- a/manifests/m/Microsoft/WingetCreate/1.1.2.0/Microsoft.WingetCreate.installer.yaml
+++ b/manifests/m/Microsoft/WingetCreate/1.1.2.0/Microsoft.WingetCreate.installer.yaml
@@ -13,6 +13,8 @@ Commands:
 ReleaseDate: 2022-08-05
 Installers:
 - Architecture: x64
+  Platform:
+    - "Windows.Universal"
   InstallerType: msix
   Scope: user
   InstallerUrl: https://github.com/microsoft/winget-create/releases/download/v1.1.2.0/Microsoft.WindowsPackageManagerManifestCreator_1.1.2.0_8wekyb3d8bbwe.msixbundle
@@ -21,6 +23,8 @@ Installers:
   UpgradeBehavior: install
   PackageFamilyName: Microsoft.WindowsPackageManagerManifestCreator_8wekyb3d8bbwe
 - Architecture: x86
+  Platform:
+    - "Windows.Universal"
   InstallerType: msix
   Scope: user
   InstallerUrl: https://github.com/microsoft/winget-create/releases/download/v1.1.2.0/Microsoft.WindowsPackageManagerManifestCreator_1.1.2.0_8wekyb3d8bbwe.msixbundle

--- a/manifests/m/Microsoft/WingetCreate/1.1.2.0/Microsoft.WingetCreate.installer.yaml
+++ b/manifests/m/Microsoft/WingetCreate/1.1.2.0/Microsoft.WingetCreate.installer.yaml
@@ -1,8 +1,9 @@
-# Created with YamlCreate.ps1 v2.1.4 $debug=AUSU.7-2-6
+# Created with YamlCreate.ps1 v2.2.1 $debug=NVS1.CRLF.7-3-1.Win32NT
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
 
 PackageIdentifier: Microsoft.WingetCreate
 PackageVersion: 1.1.2.0
+InstallerLocale: en-US
 MinimumOSVersion: 10.0.17763.0
 InstallModes:
 - interactive
@@ -11,15 +12,27 @@ Commands:
 - wingetcreate
 ReleaseDate: 2022-08-05
 Installers:
-- Architecture: neutral
+- Architecture: x64
   InstallerType: msix
   Scope: user
   InstallerUrl: https://github.com/microsoft/winget-create/releases/download/v1.1.2.0/Microsoft.WindowsPackageManagerManifestCreator_1.1.2.0_8wekyb3d8bbwe.msixbundle
   InstallerSha256: D2BD469FEAAF13B3FE753558AAE31920D8BA2653A763C4702C574B99875B2BA9
   SignatureSha256: 80C0C5698617EC1508427F7D17A1077D83ADA987E1724F866BFA223DBF757E59
-  PackageFamilyName: Microsoft.WindowsPackageManagerManifestCreator_8wekyb3d8bbwe
   UpgradeBehavior: install
-- Architecture: neutral
+  PackageFamilyName: Microsoft.WindowsPackageManagerManifestCreator_8wekyb3d8bbwe
+- Architecture: x86
+  InstallerType: msix
+  Scope: user
+  InstallerUrl: https://github.com/microsoft/winget-create/releases/download/v1.1.2.0/Microsoft.WindowsPackageManagerManifestCreator_1.1.2.0_8wekyb3d8bbwe.msixbundle
+  InstallerSha256: D2BD469FEAAF13B3FE753558AAE31920D8BA2653A763C4702C574B99875B2BA9
+  SignatureSha256: 80C0C5698617EC1508427F7D17A1077D83ADA987E1724F866BFA223DBF757E59
+  UpgradeBehavior: install
+  PackageFamilyName: Microsoft.WindowsPackageManagerManifestCreator_8wekyb3d8bbwe
+- Architecture: x64
+  InstallerType: portable
+  InstallerUrl: https://github.com/microsoft/winget-create/releases/download/v1.1.2.0/wingetcreate.exe
+  InstallerSha256: 66975CCC272DD7F0C86EF888C9DD3A1B63C6B7B4E2827A7EB49F8263C0789B83
+- Architecture: x86
   InstallerType: portable
   InstallerUrl: https://github.com/microsoft/winget-create/releases/download/v1.1.2.0/wingetcreate.exe
   InstallerSha256: 66975CCC272DD7F0C86EF888C9DD3A1B63C6B7B4E2827A7EB49F8263C0789B83

--- a/manifests/m/Microsoft/WingetCreate/1.1.2.0/Microsoft.WingetCreate.installer.yaml
+++ b/manifests/m/Microsoft/WingetCreate/1.1.2.0/Microsoft.WingetCreate.installer.yaml
@@ -14,7 +14,7 @@ ReleaseDate: 2022-08-05
 Installers:
 - Architecture: x64
   Platform:
-    - "Windows.Universal"
+    - Windows.Universal
   InstallerType: msix
   Scope: user
   InstallerUrl: https://github.com/microsoft/winget-create/releases/download/v1.1.2.0/Microsoft.WindowsPackageManagerManifestCreator_1.1.2.0_8wekyb3d8bbwe.msixbundle
@@ -24,7 +24,7 @@ Installers:
   PackageFamilyName: Microsoft.WindowsPackageManagerManifestCreator_8wekyb3d8bbwe
 - Architecture: x86
   Platform:
-    - "Windows.Universal"
+    - Windows.Universal
   InstallerType: msix
   Scope: user
   InstallerUrl: https://github.com/microsoft/winget-create/releases/download/v1.1.2.0/Microsoft.WindowsPackageManagerManifestCreator_1.1.2.0_8wekyb3d8bbwe.msixbundle

--- a/manifests/m/Microsoft/WingetCreate/1.1.2.0/Microsoft.WingetCreate.locale.en-US.yaml
+++ b/manifests/m/Microsoft/WingetCreate/1.1.2.0/Microsoft.WingetCreate.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.1.4 $debug=AUSU.7-2-6
+# Created with YamlCreate.ps1 v2.2.1 $debug=NVS1.CRLF.7-3-1.Win32NT
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
 
 PackageIdentifier: Microsoft.WingetCreate
@@ -11,7 +11,7 @@ PrivacyUrl: https://privacy.microsoft.com/privacystatement
 Author: https://github.com/microsoft/winget-create/graphs/contributors
 PackageName: Windows Package Manager Manifest Creator
 PackageUrl: https://github.com/microsoft/winget-create
-License: MIT License
+License: MIT
 LicenseUrl: https://github.com/microsoft/winget-create/blob/main/LICENSE
 Copyright: Copyright (c) Microsoft Corporation. All rights reserved.
 CopyrightUrl: https://github.com/microsoft/winget-create/blob/main/LICENSE
@@ -23,10 +23,11 @@ Tags:
 - manifests-generator
 - package-manager
 - package-manifests
+- windows
 - winget
 - winget-pkgs
 - yaml
-# Agreements: 
+# Agreements:
 ReleaseNotes: |-
   This release includes v1.2 Schema support as well as logic to help generate and update manifests for portable packages.
   We have also made improvements to address issues when submitting manifests to forked repos that are out of sync with the upstream repository.
@@ -38,8 +39,8 @@ ReleaseNotes: |-
     • Add custom YamlDotNet emitter that makes all fields with newlines use literal style. (#281)
     • Add support for 1.2 Schema (#270)
 ReleaseNotesUrl: https://github.com/microsoft/winget-create/releases/tag/v1.1.2.0
-# PurchaseUrl: 
-# InstallationNotes: 
-# Documentations: 
+# PurchaseUrl:
+# InstallationNotes:
+# Documentations:
 ManifestType: defaultLocale
 ManifestVersion: 1.2.0

--- a/manifests/m/Microsoft/WingetCreate/1.1.2.0/Microsoft.WingetCreate.yaml
+++ b/manifests/m/Microsoft/WingetCreate/1.1.2.0/Microsoft.WingetCreate.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.1.4 $debug=AUSU.7-2-6
+# Created with YamlCreate.ps1 v2.2.1 $debug=NVS1.CRLF.7-3-1.Win32NT
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
 
 PackageIdentifier: Microsoft.WingetCreate


### PR DESCRIPTION
AppxManifest.xml in wingetcreate's msixbundle describes two installers of x64 and x86, not neutral.
```xml
<Package Type="application" Version="1.1.2.0" Architecture="x64"/>
<Package Type="application" Version="1.1.2.0" Architecture="x86"/>
```
```xml
<Dependencies>
   <TargetDeviceFamily Name="Windows.Universal"/>
<Dependencies>
```
```xml
<Resource Language="EN-US"/>
```