### PR TITLE
Update: Microsoft.PowerShell version 7.3.1.0

### DIFF
--- a/manifests/m/Microsoft/PowerShell/7.3.1.0/Microsoft.PowerShell.installer.yaml
+++ b/manifests/m/Microsoft/PowerShell/7.3.1.0/Microsoft.PowerShell.installer.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.2.1 $debug=NVS1.CRLF.7-3-0.Win32NT
+# Created with YamlCreate.ps1 v2.2.1 $debug=NVS1.CRLF.7-3-1.Win32NT
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
 
 PackageIdentifier: Microsoft.PowerShell
@@ -8,10 +8,51 @@ InstallModes:
 - silent
 - silentWithProgress
 UpgradeBehavior: install
+InstallerLocale: en-US
 Commands:
 - pwsh
 ReleaseDate: 2022-12-13
 Installers:
+- Architecture: x86
+  MinimumOSVersion: 10.0.17763.0
+  Platform:
+  - Windows.Universal
+  InstallerType: msix
+  Scope: user
+  InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.3.1/PowerShell-7.3.1-win.msixbundle
+  InstallerSha256: F2C9247D6108B42EBCD489FC2EF52078EB450CF7282E4B91B9525A334F38B233
+  SignatureSha256: 1978C22A4C13D87B7B0B2B31773B45E51ED3B10D3BAF681EB6F521592F854F62
+  PackageFamilyName: Microsoft.PowerShell_8wekyb3d8bbwe
+- Architecture: x64
+  MinimumOSVersion: 10.0.17763.0
+  Platform:
+  - Windows.Universal
+  InstallerType: msix
+  Scope: user
+  InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.3.1/PowerShell-7.3.1-win.msixbundle
+  InstallerSha256: F2C9247D6108B42EBCD489FC2EF52078EB450CF7282E4B91B9525A334F38B233
+  SignatureSha256: 1978C22A4C13D87B7B0B2B31773B45E51ED3B10D3BAF681EB6F521592F854F62
+  PackageFamilyName: Microsoft.PowerShell_8wekyb3d8bbwe
+- Architecture: arm
+  MinimumOSVersion: 10.0.17763.0
+  Platform:
+  - Windows.Universal
+  InstallerType: msix
+  Scope: user
+  InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.3.1/PowerShell-7.3.1-win.msixbundle
+  InstallerSha256: F2C9247D6108B42EBCD489FC2EF52078EB450CF7282E4B91B9525A334F38B233
+  SignatureSha256: 1978C22A4C13D87B7B0B2B31773B45E51ED3B10D3BAF681EB6F521592F854F62
+  PackageFamilyName: Microsoft.PowerShell_8wekyb3d8bbwe
+- Architecture: arm64
+  MinimumOSVersion: 10.0.17763.0
+  Platform:
+  - Windows.Universal
+  InstallerType: msix
+  Scope: user
+  InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.3.1/PowerShell-7.3.1-win.msixbundle
+  InstallerSha256: F2C9247D6108B42EBCD489FC2EF52078EB450CF7282E4B91B9525A334F38B233
+  SignatureSha256: 1978C22A4C13D87B7B0B2B31773B45E51ED3B10D3BAF681EB6F521592F854F62
+  PackageFamilyName: Microsoft.PowerShell_8wekyb3d8bbwe
 - Architecture: x64
   InstallerType: wix
   InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.3.1/PowerShell-7.3.1-win-x64.msi
@@ -22,23 +63,5 @@ Installers:
   InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.3.1/PowerShell-7.3.1-win-x86.msi
   InstallerSha256: 0266C3BCF23A35E5400C8DA28BE951986454D33973E56274D0E6217B0C56829A
   ProductCode: '{B549BBBF-33E3-4B5C-8AC0-77D00CEC26EF}'
-- Architecture: arm
-  MinimumOSVersion: 10.0.17763.0
-  Platform:
-  - Windows.Universal
-  InstallerType: msix
-  InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.3.1/PowerShell-7.3.1-win.msixbundle
-  InstallerSha256: F2C9247D6108B42EBCD489FC2EF52078EB450CF7282E4B91B9525A334F38B233
-  SignatureSha256: 1978C22A4C13D87B7B0B2B31773B45E51ED3B10D3BAF681EB6F521592F854F62
-  PackageFamilyName: Microsoft.PowerShell_8wekyb3d8bbwe
-- Architecture: arm64
-  MinimumOSVersion: 10.0.17763.0
-  Platform:
-  - Windows.Universal
-  InstallerType: msix
-  InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.3.1/PowerShell-7.3.1-win.msixbundle
-  InstallerSha256: F2C9247D6108B42EBCD489FC2EF52078EB450CF7282E4B91B9525A334F38B233
-  SignatureSha256: 1978C22A4C13D87B7B0B2B31773B45E51ED3B10D3BAF681EB6F521592F854F62
-  PackageFamilyName: Microsoft.PowerShell_8wekyb3d8bbwe
 ManifestType: installer
 ManifestVersion: 1.2.0

--- a/manifests/m/Microsoft/PowerShell/7.3.1.0/Microsoft.PowerShell.locale.en-US.yaml
+++ b/manifests/m/Microsoft/PowerShell/7.3.1.0/Microsoft.PowerShell.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.2.1 $debug=NVS1.CRLF.7-3-0.Win32NT
+# Created with YamlCreate.ps1 v2.2.1 $debug=NVS1.CRLF.7-3-1.Win32NT
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
 
 PackageIdentifier: Microsoft.PowerShell

--- a/manifests/m/Microsoft/PowerShell/7.3.1.0/Microsoft.PowerShell.yaml
+++ b/manifests/m/Microsoft/PowerShell/7.3.1.0/Microsoft.PowerShell.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.2.1 $debug=NVS1.CRLF.7-3-0.Win32NT
+# Created with YamlCreate.ps1 v2.2.1 $debug=NVS1.CRLF.7-3-1.Win32NT
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
 
 PackageIdentifier: Microsoft.PowerShell


### PR DESCRIPTION
AppManifest.xml in the PowerShell's msixbundle defines four installers: x64, x86, arm, and arm64. This adds the x64 and x86 msixbundle options. Beforehand, x64 and x86 users would always get the MSI.
```xml
<Packages>
<Package Type="application" Version="7.3.1.0" Architecture="arm" FileName="PowerShell-7.3.1-win-arm32.msix" Offset="61" Size="71706346">
	<Resources>
		<Resource Language="en-us"/>
	</Resources>
	<b4:Dependencies>
		<b4:TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.18362.0"/>
	</b4:Dependencies>
</Package>
<Package Type="application" Version="7.3.1.0" Architecture="arm64" FileName="PowerShell-7.3.1-win-arm64.msix" Offset="71706492" Size="73500890">
	<Resources>
		<Resource Language="en-us"/>
	</Resources>
	<b4:Dependencies>
		<b4:TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.18362.0"/>
	</b4:Dependencies>
</Package>
<Package Type="application" Version="7.3.1.0" Architecture="x86" FileName="PowerShell-7.3.1-win-x86.msix" Offset="254813494" Size="101305522">
	<Resources>
		<Resource Language="en-us"/>
	</Resources>
	<b4:Dependencies>
		<b4:TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.18362.0"/>
	</b4:Dependencies>
</Package>
<Package Type="application" Version="7.3.1.0" Architecture="x64" FileName="PowerShell-7.3.1-win-x64.msix" Offset="145207465" Size="109605946">
	<Resources>
		<Resource Language="en-us"/>
	</Resources>
	<b4:Dependencies>
		<b4:TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.18362.0"/>
	</b4:Dependencies>
</Package>
</Packages>
```

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/93510)