### PR TITLE
Update Licence on NewTek.NDI5Tools

### DIFF
--- a/manifests/n/NewTek/NDI5Tools/5.5.2.0/NewTek.NDI5Tools.locale.en-US.yaml
+++ b/manifests/n/NewTek/NDI5Tools/5.5.2.0/NewTek.NDI5Tools.locale.en-US.yaml
@@ -6,7 +6,7 @@ PackageVersion: 5.5.2.0
 PackageLocale: en-US
 Publisher: NewTek, inc.
 PackageName: NDI 5 Tools
-License: MIT
+License: Proprietary
 ShortDescription: Transmit live video and audio with NDI.
 ManifestType: defaultLocale
 ManifestVersion: 1.2.0


### PR DESCRIPTION
Licence is set to MIT, but this should be set to Proprietary as the "License Agreement.pdf" claim the following once installed. 

Software and Content Data 
License and Limited Warranty
This Software and Content Data License and Limited Warranty applies to NDI® Tools, VMC1™ Software, Virtual Set  Editor™, Animation Store Creator™, NewTek Connect™, NewTek Connect PRO™, NewTek IsoCorder™, NewTek  IsoCorder PRO™, LiveText™, LiveGraphics Creator™, and content data packs including those for VMC1™,  TriCaster®, 3Play™ 3PXD4800™, Virtual Set Editor™, LiveText™, Animation Store Creator™, audio sound tracks and  other software and/or content data products provided by NewTek, Inc. (“NewTek”). 

This is also following the discussion when adding support for another toolset by NewTek at #94292 : https://github.com/microsoft/winget-pkgs/pull/94292

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.2 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.2.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/94442)