### PR TITLE
New version: Jitsi.Meet version 2023.1.2

### DIFF
--- a/manifests/j/Jitsi/Meet/2023.1.2/Jitsi.Meet.installer.yaml
+++ b/manifests/j/Jitsi/Meet/2023.1.2/Jitsi.Meet.installer.yaml
@@ -1,0 +1,20 @@
+# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-8
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+
+PackageIdentifier: Jitsi.Meet
+PackageVersion: 2023.1.2
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- silent
+UpgradeBehavior: install
+ReleaseDate: 2023-01-24
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/jitsi/jitsi-meet-electron/releases/download/v2023.1.2/jitsi-meet.exe
+  InstallerSha256: 81B64140B0918E7078B7A41D0673976D5319AE2DC49497EFBD720F391EFAA10D
+ManifestType: installer
+ManifestVersion: 1.2.0

--- a/manifests/j/Jitsi/Meet/2023.1.2/Jitsi.Meet.locale.en-US.yaml
+++ b/manifests/j/Jitsi/Meet/2023.1.2/Jitsi.Meet.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-8
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+
+PackageIdentifier: Jitsi.Meet
+PackageVersion: 2023.1.2
+PackageLocale: en-US
+Publisher: Jitsi Team
+PublisherUrl: https://jitsi.org/
+PublisherSupportUrl: https://github.com/jitsi/jitsi-meet-electron/issues
+PrivacyUrl: https://jitsi.org/security/
+Author: Jitsi Team
+PackageName: Jitsi Meet
+PackageUrl: https://github.com/jitsi/jitsi-meet-electron
+License: Apache License 2.0
+LicenseUrl: https://raw.githubusercontent.com/jitsi/jitsi-meet-electron/master/LICENSE
+# Copyright:
+CopyrightUrl: https://raw.githubusercontent.com/jitsi/jitsi-meet-electron/master/LICENSE
+ShortDescription: Jitsi Meet is an open-source (Apache) WebRTC JavaScript application that uses Jitsi Videobridge to provide high quality, secure and scalable video conferences.
+# Description:
+# Moniker:
+Tags:
+- chat
+- jitsi
+- jitsi-meet
+- meeting
+- video
+# Agreements:
+# ReleaseNotes:
+ReleaseNotesUrl: https://github.com/jitsi/jitsi-meet-electron/releases/tag/v2023.1.2
+# PurchaseUrl:
+# InstallationNotes:
+# Documentations:
+ManifestType: defaultLocale
+ManifestVersion: 1.2.0

--- a/manifests/j/Jitsi/Meet/2023.1.2/Jitsi.Meet.yaml
+++ b/manifests/j/Jitsi/Meet/2023.1.2/Jitsi.Meet.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-8
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+
+PackageIdentifier: Jitsi.Meet
+PackageVersion: 2023.1.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.2.0


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | Jitsi Meet | RubyMine 231.4840.392    |
| Version     | 2023.1.2     | 231.4840.392 |
| Publisher   | Jitsi Team   | JetBrains s.r.o.      |
| ProductCode |           | RubyMine 231.4840.392    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://github.com/vedantmgoyal2009/vedantmgoyal2009/tree/main/winget-pkgs-automation) in workflow run [5512](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/3997483633>)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/94531)