### PR TITLE
New version: wethat.onenotetaggingkit version 5.0.8424

### DIFF
--- a/manifests/w/wethat/onenotetaggingkit/5.0.8424/wethat.onenotetaggingkit.installer.yaml
+++ b/manifests/w/wethat/onenotetaggingkit/5.0.8424/wethat.onenotetaggingkit.installer.yaml
@@ -1,0 +1,15 @@
+# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-8
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+
+PackageIdentifier: wethat.onenotetaggingkit
+PackageVersion: 5.0.8424
+MinimumOSVersion: 10.0.0.0
+InstallerType: wix
+ReleaseDate: 2023-01-24
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/WetHat/OnenoteTaggingKit/releases/download/v5.0.8424/SetupTaggingKitWiX.5.0.8424.msi
+  InstallerSha256: 09257F0190A8634A9B7F3DBE48027B7AE3C83DFD365A1B4640D593E429A52F30
+  ProductCode: '{977B555C-F1BA-4D8C-9A30-D4E611FF7D93}'
+ManifestType: installer
+ManifestVersion: 1.2.0

--- a/manifests/w/wethat/onenotetaggingkit/5.0.8424/wethat.onenotetaggingkit.locale.en-US.yaml
+++ b/manifests/w/wethat/onenotetaggingkit/5.0.8424/wethat.onenotetaggingkit.locale.en-US.yaml
@@ -1,0 +1,37 @@
+# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-8
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+
+PackageIdentifier: wethat.onenotetaggingkit
+PackageVersion: 5.0.8424
+PackageLocale: en-US
+Publisher: WetHat Lab
+PublisherUrl: https://github.com/WetHat/OnenoteTaggingKit
+PublisherSupportUrl: https://github.com/WetHat/OnenoteTaggingKit/issues
+# PrivacyUrl:
+Author: WetHat
+PackageName: OneNote Tagging Kit
+PackageUrl: https://github.com/WetHat/OnenoteTaggingKit
+License: Ms-PL
+LicenseUrl: https://github.com/WetHat/OnenoteTaggingKit/blob/master/license.md
+# Copyright:
+CopyrightUrl: https://github.com/WetHat/OnenoteTaggingKit/blob/master/license.md
+ShortDescription: OneNote (desktop) add-in to manage OneNote pages by page tags
+# Description:
+# Moniker:
+Tags:
+- microsoft-office
+- note
+- office
+- office-extension
+- office-plugin
+- onenote
+- tag
+- tagging
+# Agreements:
+# ReleaseNotes:
+ReleaseNotesUrl: https://github.com/WetHat/OnenoteTaggingKit/releases/tag/v5.0.8424
+# PurchaseUrl:
+# InstallationNotes:
+# Documentations:
+ManifestType: defaultLocale
+ManifestVersion: 1.2.0

--- a/manifests/w/wethat/onenotetaggingkit/5.0.8424/wethat.onenotetaggingkit.yaml
+++ b/manifests/w/wethat/onenotetaggingkit/5.0.8424/wethat.onenotetaggingkit.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-8
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+
+PackageIdentifier: wethat.onenotetaggingkit
+PackageVersion: 5.0.8424
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.2.0


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | OneNote Tagging Kit |     |
| Version     | 5.0.8424     |  |
| Publisher   | WetHat Lab   |       |
| ProductCode |           |     |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://github.com/vedantmgoyal2009/vedantmgoyal2009/tree/main/winget-pkgs-automation) in workflow run [5516](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/3999513395>)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/94550)