### PR TITLE
New version: Google.AndroidStudio.Canary version 2022.3.1.1

### DIFF
--- a/manifests/g/Google/AndroidStudio/Canary/2022.3.1.1/Google.AndroidStudio.Canary.installer.yaml
+++ b/manifests/g/Google/AndroidStudio/Canary/2022.3.1.1/Google.AndroidStudio.Canary.installer.yaml
@@ -1,5 +1,5 @@
 # Created with Komac 0.9.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
 
 PackageIdentifier: Google.AndroidStudio.Canary
 PackageVersion: 2022.3.1.1
@@ -21,3 +21,5 @@ Installers:
 - Architecture: x64
   InstallerUrl: https://redirector.gvt1.com/edgedl/android/studio/install/2022.3.1.1/android-studio-2022.3.1.1-windows.exe
   InstallerSha256: 71ECA799995910A9F5876EBA73395432B9289FCB121A1EF18163529EC8959BAC
+ManifestType: installer
+ManifestVersion: 1.2.0

--- a/manifests/g/Google/AndroidStudio/Canary/2022.3.1.1/Google.AndroidStudio.Canary.installer.yaml
+++ b/manifests/g/Google/AndroidStudio/Canary/2022.3.1.1/Google.AndroidStudio.Canary.installer.yaml
@@ -1,0 +1,23 @@
+# Created with Komac 0.9.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
+
+PackageIdentifier: Google.AndroidStudio.Canary
+PackageVersion: 2022.3.1.1
+InstallerLocale: en-US
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+Scope: machine
+InstallModes:
+- interactive
+- silent
+InstallerSuccessCodes:
+- 1223
+UpgradeBehavior: install
+ReleaseDate: 2023-01-17
+AppsAndFeaturesEntries:
+- DisplayName: Android Studio
+  ProductCode: Android Studio
+Installers:
+- Architecture: x64
+  InstallerUrl: https://redirector.gvt1.com/edgedl/android/studio/install/2022.3.1.1/android-studio-2022.3.1.1-windows.exe
+  InstallerSha256: 71ECA799995910A9F5876EBA73395432B9289FCB121A1EF18163529EC8959BAC

--- a/manifests/g/Google/AndroidStudio/Canary/2022.3.1.1/Google.AndroidStudio.Canary.locale.en-US.yaml
+++ b/manifests/g/Google/AndroidStudio/Canary/2022.3.1.1/Google.AndroidStudio.Canary.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# Created with Komac 0.9.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.4.0.schema.json
+
+PackageIdentifier: Google.AndroidStudio.Canary
+PackageVersion: 2022.3.1.1
+PackageLocale: en-US
+Publisher: Google LLC
+PublisherUrl: https://developer.android.com/studio
+PublisherSupportUrl: https://developer.android.com/studio/intro
+PrivacyUrl: https://policies.google.com/privacy
+PackageName: Android Studio Canary
+PackageUrl: https://developer.android.com/studio/preview
+License: Android Software Development Kit License Agreement
+LicenseUrl: https://developer.android.com/studio/terms
+Copyright: Copyright (c) Google LLC.
+CopyrightUrl: https://developer.android.com/studio/terms
+ShortDescription: Android Studio provides the fastest tools for building apps on every
+  type of Android device.
+Description: |-
+  Android Studio is Android's official IDE.
+   It is purpose-built for Android to accelerate your development and help you build the highest-quality apps for every Android device.
+Moniker: android-studio-canary
+Tags:
+- aab
+- adb
+- android-development
+- apk
+- canary
+- fastboot
+- ide
+- intellij
+- studio
+ManifestType: defaultLocale
+ManifestVersion: 1.4.0

--- a/manifests/g/Google/AndroidStudio/Canary/2022.3.1.1/Google.AndroidStudio.Canary.locale.en-US.yaml
+++ b/manifests/g/Google/AndroidStudio/Canary/2022.3.1.1/Google.AndroidStudio.Canary.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with Komac 0.9.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.4.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
 
 PackageIdentifier: Google.AndroidStudio.Canary
 PackageVersion: 2022.3.1.1
@@ -31,4 +31,4 @@ Tags:
 - intellij
 - studio
 ManifestType: defaultLocale
-ManifestVersion: 1.4.0
+ManifestVersion: 1.2.0

--- a/manifests/g/Google/AndroidStudio/Canary/2022.3.1.1/Google.AndroidStudio.Canary.yaml
+++ b/manifests/g/Google/AndroidStudio/Canary/2022.3.1.1/Google.AndroidStudio.Canary.yaml
@@ -1,8 +1,8 @@
 # Created with Komac 0.9.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.4.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
 
 PackageIdentifier: Google.AndroidStudio.Canary
 PackageVersion: 2022.3.1.1
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.4.0
+ManifestVersion: 1.2.0

--- a/manifests/g/Google/AndroidStudio/Canary/2022.3.1.1/Google.AndroidStudio.Canary.yaml
+++ b/manifests/g/Google/AndroidStudio/Canary/2022.3.1.1/Google.AndroidStudio.Canary.yaml
@@ -1,0 +1,8 @@
+# Created with Komac 0.9.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.4.0.schema.json
+
+PackageIdentifier: Google.AndroidStudio.Canary
+PackageVersion: 2022.3.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.4.0


### PR DESCRIPTION
### Google.AndroidStudio.Canary 2022.3.1.1

#### Previous version: 2022.2.1.11


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/94698)