### PR TITLE
Use DisplayVersion for OpenRCT2.OpenRCT2 0.3.3

### DIFF
--- a/manifests/o/OpenRCT2/OpenRCT2/0.3.3/OpenRCT2.OpenRCT2.installer.yaml
+++ b/manifests/o/OpenRCT2/OpenRCT2/0.3.3/OpenRCT2.OpenRCT2.installer.yaml
@@ -1,15 +1,24 @@
-# Created with YamlCreate.ps1 v2.1.0 $debug=AUSU.5-1-19041-1320
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+# Created with YamlCreate.ps1 v2.2.1 $debug=QUSU.CRLF.7-3-1.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
 
 PackageIdentifier: OpenRCT2.OpenRCT2
 PackageVersion: 0.3.3
+InstallerLocale: en-US
 MinimumOSVersion: 10.0.0.0
 InstallerType: nullsoft
 InstallerSuccessCodes:
 - 1223
+UpgradeBehavior: install
+Scope: machine
+AppsAndFeaturesEntries:
+  - DisplayVersion: 0.3.3
+    ProductCode: OpenRCT2
 Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.3.3/OpenRCT2-0.3.3-windows-installer-win32.exe
+  InstallerSha256: BDBA1B32B9E107D6A38B25AF29A8842DBAC04573FBE6FAEC54134ED7F169BC8C
 - Architecture: x64
   InstallerUrl: https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.3.3/OpenRCT2-0.3.3-windows-installer-x64.exe
   InstallerSha256: 95AD4481B68E7E5ACB6A59A7C49DF7DC12E9938CBE4A1D8526BCCC8148B6E5E7
 ManifestType: installer
-ManifestVersion: 1.1.0
+ManifestVersion: 1.2.0

--- a/manifests/o/OpenRCT2/OpenRCT2/0.3.3/OpenRCT2.OpenRCT2.locale.en-US.yaml
+++ b/manifests/o/OpenRCT2/OpenRCT2/0.3.3/OpenRCT2.OpenRCT2.locale.en-US.yaml
@@ -1,31 +1,37 @@
-# Created with YamlCreate.ps1 v2.1.0 $debug=AUSU.5-1-19041-1320
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+# Created with YamlCreate.ps1 v2.2.1 $debug=QUSU.CRLF.7-3-1.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
 
 PackageIdentifier: OpenRCT2.OpenRCT2
 PackageVersion: 0.3.3
 PackageLocale: en-US
 Publisher: OpenRCT2
-PublisherUrl: https://openrct2.org/
-# PublisherSupportUrl: 
-# PrivacyUrl: 
-# Author: 
+PublisherUrl: https://openrct2.io/
+# PublisherSupportUrl:
+# PrivacyUrl:
+# Author:
 PackageName: OpenRCT2
-# PackageUrl: 
+PackageUrl: https://openrct2.io/
 License: GPLv3
-# LicenseUrl: 
-# Copyright: 
-# CopyrightUrl: 
-ShortDescription: OpenRCT2 is an open-source re-implementation of RollerCoaster Tycoon 2 (RCT2), expanding the game with new features, fixing bugs and raising game limits.
-# Description: 
-# Moniker: 
+LicenseUrl: https://github.com/OpenRCT2/OpenRCT2/blob/develop/licence.txt
+# Copyright:
+# CopyrightUrl:
+ShortDescription: OpenRCT2 is an open source re-implementation of RollerCoaster Tycoon 2.
+# Description:
+# Moniker:
 Tags:
+- cross-platform
 - game
 - gaming
-- rollercoaster
+- multiplayer
+- open-source
+- roller-coaster
+- roller-coaster-tycoon
 - simulator
-- tycoon
-# Agreements: 
-# ReleaseNotes: 
-# ReleaseNotesUrl: 
+# Agreements:
+# ReleaseNotes:
+# ReleaseNotesUrl:
+# PurchaseUrl:
+# InstallationNotes:
+# Documentations:
 ManifestType: defaultLocale
-ManifestVersion: 1.1.0
+ManifestVersion: 1.2.0

--- a/manifests/o/OpenRCT2/OpenRCT2/0.3.3/OpenRCT2.OpenRCT2.locale.en-US.yaml
+++ b/manifests/o/OpenRCT2/OpenRCT2/0.3.3/OpenRCT2.OpenRCT2.locale.en-US.yaml
@@ -17,7 +17,7 @@ LicenseUrl: https://github.com/OpenRCT2/OpenRCT2/blob/develop/licence.txt
 # CopyrightUrl:
 ShortDescription: OpenRCT2 is an open source re-implementation of RollerCoaster Tycoon 2.
 # Description:
-# Moniker:
+Moniker: openrct2
 Tags:
 - cross-platform
 - game

--- a/manifests/o/OpenRCT2/OpenRCT2/0.3.3/OpenRCT2.OpenRCT2.yaml
+++ b/manifests/o/OpenRCT2/OpenRCT2/0.3.3/OpenRCT2.OpenRCT2.yaml
@@ -1,8 +1,8 @@
-# Created with YamlCreate.ps1 v2.1.0 $debug=AUSU.5-1-19041-1320
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+# Created with YamlCreate.ps1 v2.2.1 $debug=QUSU.CRLF.7-3-1.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
 
 PackageIdentifier: OpenRCT2.OpenRCT2
 PackageVersion: 0.3.3
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.1.0
+ManifestVersion: 1.2.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.4 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.4.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----
- Related to #94743

Note: Intentionally chose DisplayVersion == PackageVersion. See reason here https://github.com/microsoft/winget-pkgs/issues/88726#issuecomment-1398993435


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/94829)