### PR TITLE
Use DisplayVersion for OpenRCT2.OpenRCT2 0.3.4.1

### DIFF
--- a/manifests/o/OpenRCT2/OpenRCT2/0.3.4.1/OpenRCT2.OpenRCT2.installer.yaml
+++ b/manifests/o/OpenRCT2/OpenRCT2/0.3.4.1/OpenRCT2.OpenRCT2.installer.yaml
@@ -1,28 +1,24 @@
-# Created with YamlCreate.ps1 v2.0.0 using YAML parsing
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
+# Created with YamlCreate.ps1 v2.2.1 $debug=QUSU.CRLF.7-3-1.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
 
 PackageIdentifier: OpenRCT2.OpenRCT2
 PackageVersion: 0.3.4.1
+InstallerLocale: en-US
 MinimumOSVersion: 10.0.0.0
-InstallModes:
-- interactive
-- silent
+InstallerType: nullsoft
 InstallerSuccessCodes:
 - 1223
+Scope: machine
+UpgradeBehavior: install
+AppsAndFeaturesEntries:
+  - DisplayVersion: 0.3.4.1
+    ProductCode: OpenRCT2
 Installers:
-- InstallerLocale: en-US
-  Architecture: x64
-  InstallerType: nullsoft
-  Scope: machine
-  InstallerUrl: https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.3.4.1/OpenRCT2-0.3.4.1-windows-installer-x64.exe
-  InstallerSha256: DAC7ADEE170A84529E7366BD407B93CCACF0A6D792A4245F5142B3BB316A9592
-  UpgradeBehavior: install
-- InstallerLocale: en-US
-  Architecture: x86
-  InstallerType: nullsoft
-  Scope: machine
+- Architecture: x86
   InstallerUrl: https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.3.4.1/OpenRCT2-0.3.4.1-windows-installer-win32.exe
   InstallerSha256: D872DEBC2A71C70CCE1B1722E2E609EB1425C5815B7A7AA4699E120BC4FE9F1C
-  UpgradeBehavior: install
+- Architecture: x64
+  InstallerUrl: https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.3.4.1/OpenRCT2-0.3.4.1-windows-installer-x64.exe
+  InstallerSha256: DAC7ADEE170A84529E7366BD407B93CCACF0A6D792A4245F5142B3BB316A9592
 ManifestType: installer
-ManifestVersion: 1.0.0
+ManifestVersion: 1.2.0

--- a/manifests/o/OpenRCT2/OpenRCT2/0.3.4.1/OpenRCT2.OpenRCT2.locale.en-US.yaml
+++ b/manifests/o/OpenRCT2/OpenRCT2/0.3.4.1/OpenRCT2.OpenRCT2.locale.en-US.yaml
@@ -17,7 +17,7 @@ LicenseUrl: https://github.com/OpenRCT2/OpenRCT2/blob/develop/licence.txt
 # CopyrightUrl:
 ShortDescription: OpenRCT2 is an open source re-implementation of RollerCoaster Tycoon 2.
 # Description:
-# Moniker:
+Moniker: openrct2
 Tags:
 - cross-platform
 - game

--- a/manifests/o/OpenRCT2/OpenRCT2/0.3.4.1/OpenRCT2.OpenRCT2.locale.en-US.yaml
+++ b/manifests/o/OpenRCT2/OpenRCT2/0.3.4.1/OpenRCT2.OpenRCT2.locale.en-US.yaml
@@ -1,28 +1,37 @@
-# Created with YamlCreate.ps1 v2.0.0 using YAML parsing
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.0.0.schema.json
+# Created with YamlCreate.ps1 v2.2.1 $debug=QUSU.CRLF.7-3-1.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
 
 PackageIdentifier: OpenRCT2.OpenRCT2
 PackageVersion: 0.3.4.1
 PackageLocale: en-US
 Publisher: OpenRCT2
 PublisherUrl: https://openrct2.io/
-PublisherSupportUrl: https://github.com/OpenRCT2/OpenRCT2/issues
-Author: OpenRCT2
+# PublisherSupportUrl:
+# PrivacyUrl:
+# Author:
 PackageName: OpenRCT2
-PackageUrl: https://openrct2.io
-License: GNU General Public License v3.0
-LicenseUrl: https://raw.githubusercontent.com/OpenRCT2/OpenRCT2/develop/licence.txt
-CopyrightUrl: https://raw.githubusercontent.com/OpenRCT2/OpenRCT2/develop/licence.txt
+PackageUrl: https://openrct2.io/
+License: GPLv3
+LicenseUrl: https://github.com/OpenRCT2/OpenRCT2/blob/develop/licence.txt
+# Copyright:
+# CopyrightUrl:
 ShortDescription: OpenRCT2 is an open source re-implementation of RollerCoaster Tycoon 2.
-Moniker: openrct2
+# Description:
+# Moniker:
 Tags:
+- cross-platform
 - game
 - gaming
-- open-source
-- cross-platform
-- simulator
 - multiplayer
+- open-source
 - roller-coaster
 - roller-coaster-tycoon
+- simulator
+# Agreements:
+# ReleaseNotes:
+# ReleaseNotesUrl:
+# PurchaseUrl:
+# InstallationNotes:
+# Documentations:
 ManifestType: defaultLocale
-ManifestVersion: 1.0.0
+ManifestVersion: 1.2.0

--- a/manifests/o/OpenRCT2/OpenRCT2/0.3.4.1/OpenRCT2.OpenRCT2.yaml
+++ b/manifests/o/OpenRCT2/OpenRCT2/0.3.4.1/OpenRCT2.OpenRCT2.yaml
@@ -1,8 +1,8 @@
-# Created with YamlCreate.ps1 v2.0.0 using YAML parsing
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.0.0.schema.json
+# Created with YamlCreate.ps1 v2.2.1 $debug=QUSU.CRLF.7-3-1.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
 
 PackageIdentifier: OpenRCT2.OpenRCT2
 PackageVersion: 0.3.4.1
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.0.0
+ManifestVersion: 1.2.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.4 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.4.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----
- Related to #94743

Note: Intentionally chose DisplayVersion == PackageVersion. See reason here https://github.com/microsoft/winget-pkgs/issues/88726#issuecomment-1398993435


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/94830)