### PR TITLE
Use DisplayVersion for OpenRCT2.OpenRCT2 0.3.5

### DIFF
--- a/manifests/o/OpenRCT2/OpenRCT2/0.3.5/OpenRCT2.OpenRCT2.installer.yaml
+++ b/manifests/o/OpenRCT2/OpenRCT2/0.3.5/OpenRCT2.OpenRCT2.installer.yaml
@@ -1,14 +1,18 @@
-# Created with YamlCreate.ps1 v2.0.0 $debug=QUSU.7-1-5
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
+# Created with YamlCreate.ps1 v2.2.1 $debug=QUSU.CRLF.7-3-1.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
 
 PackageIdentifier: OpenRCT2.OpenRCT2
 PackageVersion: 0.3.5
 InstallerLocale: en-US
 MinimumOSVersion: 10.0.0.0
 InstallerType: nullsoft
+Scope: machine
 InstallerSuccessCodes:
 - 1223
 UpgradeBehavior: install
+AppsAndFeaturesEntries:
+  - DisplayVersion: 0.3.5
+    ProductCode: OpenRCT2
 Installers:
 - Architecture: x86
   InstallerUrl: https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.3.5/OpenRCT2-0.3.5-windows-installer-win32.exe
@@ -17,4 +21,4 @@ Installers:
   InstallerUrl: https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.3.5/OpenRCT2-0.3.5-windows-installer-x64.exe
   InstallerSha256: 5A5F3ED7D5BEC35F63C141640C3D51D652EC91E7E39A2E390306789C7C660D42
 ManifestType: installer
-ManifestVersion: 1.0.0
+ManifestVersion: 1.2.0

--- a/manifests/o/OpenRCT2/OpenRCT2/0.3.5/OpenRCT2.OpenRCT2.locale.en-US.yaml
+++ b/manifests/o/OpenRCT2/OpenRCT2/0.3.5/OpenRCT2.OpenRCT2.locale.en-US.yaml
@@ -17,7 +17,7 @@ LicenseUrl: https://github.com/OpenRCT2/OpenRCT2/blob/develop/licence.txt
 # CopyrightUrl:
 ShortDescription: OpenRCT2 is an open source re-implementation of RollerCoaster Tycoon 2.
 # Description:
-# Moniker:
+Moniker: openrct2
 Tags:
 - cross-platform
 - game

--- a/manifests/o/OpenRCT2/OpenRCT2/0.3.5/OpenRCT2.OpenRCT2.locale.en-US.yaml
+++ b/manifests/o/OpenRCT2/OpenRCT2/0.3.5/OpenRCT2.OpenRCT2.locale.en-US.yaml
@@ -1,30 +1,37 @@
-# Created with YamlCreate.ps1 v2.0.0 $debug=QUSU.7-1-5
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.0.0.schema.json
+# Created with YamlCreate.ps1 v2.2.1 $debug=QUSU.CRLF.7-3-1.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
 
 PackageIdentifier: OpenRCT2.OpenRCT2
 PackageVersion: 0.3.5
 PackageLocale: en-US
 Publisher: OpenRCT2
 PublisherUrl: https://openrct2.io/
-# PublisherSupportUrl: 
-# PrivacyUrl: 
-# Author: 
+# PublisherSupportUrl:
+# PrivacyUrl:
+# Author:
 PackageName: OpenRCT2
 PackageUrl: https://openrct2.io/
 License: GPLv3
 LicenseUrl: https://github.com/OpenRCT2/OpenRCT2/blob/develop/licence.txt
-# Copyright: 
-# CopyrightUrl: 
+# Copyright:
+# CopyrightUrl:
 ShortDescription: OpenRCT2 is an open source re-implementation of RollerCoaster Tycoon 2.
-# Description: 
+# Description:
+# Moniker:
 Tags:
+- cross-platform
 - game
 - gaming
-- open-source
-- cross-platform
-- simulator
 - multiplayer
+- open-source
 - roller-coaster
 - roller-coaster-tycoon
+- simulator
+# Agreements:
+# ReleaseNotes:
+# ReleaseNotesUrl:
+# PurchaseUrl:
+# InstallationNotes:
+# Documentations:
 ManifestType: defaultLocale
-ManifestVersion: 1.0.0
+ManifestVersion: 1.2.0

--- a/manifests/o/OpenRCT2/OpenRCT2/0.3.5/OpenRCT2.OpenRCT2.yaml
+++ b/manifests/o/OpenRCT2/OpenRCT2/0.3.5/OpenRCT2.OpenRCT2.yaml
@@ -1,8 +1,8 @@
-# Created with YamlCreate.ps1 v2.0.0 $debug=QUSU.7-1-5
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.0.0.schema.json
+# Created with YamlCreate.ps1 v2.2.1 $debug=QUSU.CRLF.7-3-1.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
 
 PackageIdentifier: OpenRCT2.OpenRCT2
 PackageVersion: 0.3.5
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.0.0
+ManifestVersion: 1.2.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.4 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.4.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----
- Related to #94743

Note: Intentionally chose DisplayVersion == PackageVersion. See reason here https://github.com/microsoft/winget-pkgs/issues/88726#issuecomment-1398993435

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/94832)