### PR TITLE
Use DisplayVersion for OpenRCT2.OpenRCT2 0.4.1

### DIFF
--- a/manifests/o/OpenRCT2/OpenRCT2/0.4.1/OpenRCT2.OpenRCT2.installer.yaml
+++ b/manifests/o/OpenRCT2/OpenRCT2/0.4.1/OpenRCT2.OpenRCT2.installer.yaml
@@ -1,5 +1,5 @@
-# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-5
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+# Created with YamlCreate.ps1 v2.2.1 $debug=QUSU.CRLF.7-3-1.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
 
 PackageIdentifier: OpenRCT2.OpenRCT2
 PackageVersion: 0.4.1
@@ -8,8 +8,11 @@ MinimumOSVersion: 10.0.0.0
 InstallerType: nullsoft
 InstallerSuccessCodes:
 - 1223
+Scope: machine
 UpgradeBehavior: install
-ReleaseDate: 2022-07-04
+AppsAndFeaturesEntries:
+  - DisplayVersion: 0.4.1
+    ProductCode: OpenRCT2
 Installers:
 - Architecture: x86
   InstallerUrl: https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.4.1/OpenRCT2-0.4.1-windows-installer-win32.exe
@@ -18,4 +21,4 @@ Installers:
   InstallerUrl: https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.4.1/OpenRCT2-0.4.1-windows-installer-x64.exe
   InstallerSha256: 55F5D240EEF149DED7D824D81481408F36C95AC8D49C8E6947F7D23E182BEAA2
 ManifestType: installer
-ManifestVersion: 1.1.0
+ManifestVersion: 1.2.0

--- a/manifests/o/OpenRCT2/OpenRCT2/0.4.1/OpenRCT2.OpenRCT2.locale.en-US.yaml
+++ b/manifests/o/OpenRCT2/OpenRCT2/0.4.1/OpenRCT2.OpenRCT2.locale.en-US.yaml
@@ -17,7 +17,7 @@ LicenseUrl: https://github.com/OpenRCT2/OpenRCT2/blob/develop/licence.txt
 # CopyrightUrl:
 ShortDescription: OpenRCT2 is an open source re-implementation of RollerCoaster Tycoon 2.
 # Description:
-# Moniker:
+Moniker: openrct2
 Tags:
 - cross-platform
 - game

--- a/manifests/o/OpenRCT2/OpenRCT2/0.4.1/OpenRCT2.OpenRCT2.locale.en-US.yaml
+++ b/manifests/o/OpenRCT2/OpenRCT2/0.4.1/OpenRCT2.OpenRCT2.locale.en-US.yaml
@@ -1,23 +1,23 @@
-# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-5
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+# Created with YamlCreate.ps1 v2.2.1 $debug=QUSU.CRLF.7-3-1.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
 
 PackageIdentifier: OpenRCT2.OpenRCT2
 PackageVersion: 0.4.1
 PackageLocale: en-US
 Publisher: OpenRCT2
 PublisherUrl: https://openrct2.io/
-# PublisherSupportUrl: 
-# PrivacyUrl: 
-# Author: 
+# PublisherSupportUrl:
+# PrivacyUrl:
+# Author:
 PackageName: OpenRCT2
 PackageUrl: https://openrct2.io/
 License: GPLv3
 LicenseUrl: https://github.com/OpenRCT2/OpenRCT2/blob/develop/licence.txt
-# Copyright: 
-# CopyrightUrl: 
+# Copyright:
+# CopyrightUrl:
 ShortDescription: OpenRCT2 is an open source re-implementation of RollerCoaster Tycoon 2.
-# Description: 
-# Moniker: 
+# Description:
+# Moniker:
 Tags:
 - cross-platform
 - game
@@ -27,8 +27,11 @@ Tags:
 - roller-coaster
 - roller-coaster-tycoon
 - simulator
-# Agreements: 
-# ReleaseNotes: 
-ReleaseNotesUrl: https://github.com/OpenRCT2/OpenRCT2/releases/tag/v0.4.1
+# Agreements:
+# ReleaseNotes:
+# ReleaseNotesUrl:
+# PurchaseUrl:
+# InstallationNotes:
+# Documentations:
 ManifestType: defaultLocale
-ManifestVersion: 1.1.0
+ManifestVersion: 1.2.0

--- a/manifests/o/OpenRCT2/OpenRCT2/0.4.1/OpenRCT2.OpenRCT2.yaml
+++ b/manifests/o/OpenRCT2/OpenRCT2/0.4.1/OpenRCT2.OpenRCT2.yaml
@@ -1,8 +1,8 @@
-# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-5
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+# Created with YamlCreate.ps1 v2.2.1 $debug=QUSU.CRLF.7-3-1.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
 
 PackageIdentifier: OpenRCT2.OpenRCT2
 PackageVersion: 0.4.1
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.1.0
+ManifestVersion: 1.2.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.4 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.4.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----
- Related to #94743

Note: Intentionally chose DisplayVersion == PackageVersion. See reason here https://github.com/microsoft/winget-pkgs/issues/88726#issuecomment-1398993435

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/94835)