### PR TITLE
Use DisplayVersion for OpenRCT2.OpenRCT2 0.4.2

### DIFF
--- a/manifests/o/OpenRCT2/OpenRCT2/0.4.2/OpenRCT2.OpenRCT2.installer.yaml
+++ b/manifests/o/OpenRCT2/OpenRCT2/0.4.2/OpenRCT2.OpenRCT2.installer.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# Created with YamlCreate.ps1 v2.2.1 $debug=QUSU.CRLF.7-3-1.Win32NT
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
 
 PackageIdentifier: OpenRCT2.OpenRCT2
@@ -6,10 +6,13 @@ PackageVersion: 0.4.2
 InstallerLocale: en-US
 MinimumOSVersion: 10.0.0.0
 InstallerType: nullsoft
+Scope: machine
 InstallerSuccessCodes:
 - 1223
 UpgradeBehavior: install
-ReleaseDate: 2022-10-05
+AppsAndFeaturesEntries:
+  - DisplayVersion: 0.4.2
+    ProductCode: OpenRCT2
 Installers:
 - Architecture: x86
   InstallerUrl: https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.4.2/OpenRCT2-0.4.2-windows-installer-win32.exe

--- a/manifests/o/OpenRCT2/OpenRCT2/0.4.2/OpenRCT2.OpenRCT2.locale.en-US.yaml
+++ b/manifests/o/OpenRCT2/OpenRCT2/0.4.2/OpenRCT2.OpenRCT2.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# Created with YamlCreate.ps1 v2.2.1 $debug=QUSU.CRLF.7-3-1.Win32NT
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
 
 PackageIdentifier: OpenRCT2.OpenRCT2
@@ -6,18 +6,18 @@ PackageVersion: 0.4.2
 PackageLocale: en-US
 Publisher: OpenRCT2
 PublisherUrl: https://openrct2.io/
-# PublisherSupportUrl: 
-# PrivacyUrl: 
-# Author: 
+# PublisherSupportUrl:
+# PrivacyUrl:
+# Author:
 PackageName: OpenRCT2
 PackageUrl: https://openrct2.io/
 License: GPLv3
 LicenseUrl: https://github.com/OpenRCT2/OpenRCT2/blob/develop/licence.txt
-# Copyright: 
-# CopyrightUrl: 
+# Copyright:
+# CopyrightUrl:
 ShortDescription: OpenRCT2 is an open source re-implementation of RollerCoaster Tycoon 2.
-# Description: 
-# Moniker: 
+# Description:
+# Moniker:
 Tags:
 - cross-platform
 - game
@@ -27,11 +27,11 @@ Tags:
 - roller-coaster
 - roller-coaster-tycoon
 - simulator
-# Agreements: 
-# ReleaseNotes: 
-ReleaseNotesUrl: https://github.com/OpenRCT2/OpenRCT2/releases/tag/v0.4.2
-# PurchaseUrl: 
-# InstallationNotes: 
-# Documentations: 
+# Agreements:
+# ReleaseNotes:
+# ReleaseNotesUrl:
+# PurchaseUrl:
+# InstallationNotes:
+# Documentations:
 ManifestType: defaultLocale
 ManifestVersion: 1.2.0

--- a/manifests/o/OpenRCT2/OpenRCT2/0.4.2/OpenRCT2.OpenRCT2.locale.en-US.yaml
+++ b/manifests/o/OpenRCT2/OpenRCT2/0.4.2/OpenRCT2.OpenRCT2.locale.en-US.yaml
@@ -17,7 +17,7 @@ LicenseUrl: https://github.com/OpenRCT2/OpenRCT2/blob/develop/licence.txt
 # CopyrightUrl:
 ShortDescription: OpenRCT2 is an open source re-implementation of RollerCoaster Tycoon 2.
 # Description:
-# Moniker:
+Moniker: openrct2
 Tags:
 - cross-platform
 - game

--- a/manifests/o/OpenRCT2/OpenRCT2/0.4.2/OpenRCT2.OpenRCT2.yaml
+++ b/manifests/o/OpenRCT2/OpenRCT2/0.4.2/OpenRCT2.OpenRCT2.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+# Created with YamlCreate.ps1 v2.2.1 $debug=QUSU.CRLF.7-3-1.Win32NT
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
 
 PackageIdentifier: OpenRCT2.OpenRCT2


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.4 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.4.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----
- Related to #94743

Note: Intentionally chose DisplayVersion == PackageVersion. See reason here https://github.com/microsoft/winget-pkgs/issues/88726#issuecomment-1398993435

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/94836)