### PR TITLE
Add DisplayVersion to Microsoft.VisualStudio.2017.BuildTools 15.9.51

### DIFF
--- a/manifests/m/Microsoft/VisualStudio/2017/BuildTools/15.9.51/Microsoft.VisualStudio.2017.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2017/BuildTools/15.9.51/Microsoft.VisualStudio.2017.BuildTools.installer.yaml
@@ -23,6 +23,8 @@ Installers:
   InstallerType: exe
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/473f1a59-e5bc-4332-8f76-5ff45df9cd24/c237d0f541dff305e3cd6d591710bf175a040af24570a6fdefca4a39fa7f0a93/vs_BuildTools.exe
   InstallerSha256: C237D0F541DFF305E3CD6D591710BF175A040AF24570A6FDEFCA4A39FA7F0A93
+  AppsAndFeaturesEntries:
+  - DisplayVersion: 15.9.51
 ManifestType: installer
 ManifestVersion: 1.2.0
 


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.4 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.4.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

Add DisplayVersion to avoid infinite upgrade loop because the previous version (15.8.9) used a DisplayVersion so this key should be used in every new manifest now.

- Resolves #95343
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://api.github.com/repos/microsoft/winget-pkgs/pulls/95423)