### PR TITLE
New version: RivaFarabi.Deckboard version 2.1.1 [FP-D]

### DIFF
--- a/manifests/r/RivaFarabi/Deckboard/2.1.1/RivaFarabi.Deckboard.installer.yaml
+++ b/manifests/r/RivaFarabi/Deckboard/2.1.1/RivaFarabi.Deckboard.installer.yaml
@@ -1,0 +1,29 @@
+# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-9
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+
+PackageIdentifier: RivaFarabi.Deckboard
+PackageVersion: 2.1.1
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+ReleaseDate: 2023-02-05
+Installers:
+- Architecture: neutral
+  Scope: user
+  InstallerUrl: https://github.com/rivafarabi/deckboard/releases/download/v2.1.1/Deckboard-Setup-2.1.1.exe
+  InstallerSha256: 1DA396073362F414DE7FAFD7AFE559FB9FA1196613B41FE9080E90BB58CAB5D1
+  InstallerSwitches:
+    Custom: /CURRENTUSER
+- Architecture: neutral
+  Scope: machine
+  InstallerUrl: https://github.com/rivafarabi/deckboard/releases/download/v2.1.1/Deckboard-Setup-2.1.1.exe
+  InstallerSha256: 1DA396073362F414DE7FAFD7AFE559FB9FA1196613B41FE9080E90BB58CAB5D1
+  InstallerSwitches:
+    Custom: /ALLUSERS
+ManifestType: installer
+ManifestVersion: 1.2.0

--- a/manifests/r/RivaFarabi/Deckboard/2.1.1/RivaFarabi.Deckboard.locale.en-US.yaml
+++ b/manifests/r/RivaFarabi/Deckboard/2.1.1/RivaFarabi.Deckboard.locale.en-US.yaml
@@ -1,0 +1,36 @@
+# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-9
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+
+PackageIdentifier: RivaFarabi.Deckboard
+PackageVersion: 2.1.1
+PackageLocale: en-US
+Publisher: Riva Farabi
+PublisherUrl: https://github.com/rivafarabi/deckboard
+PublisherSupportUrl: https://github.com/rivafarabi/deckboard/issues
+# PrivacyUrl:
+Author: Riva Farabi
+PackageName: Deckboard
+PackageUrl: https://github.com/rivafarabi/deckboard
+License: Copyright © 2022 Riva Farabi
+# LicenseUrl:
+Copyright: Copyright © 2022 Riva Farabi
+# CopyrightUrl:
+ShortDescription: Phone as macro shortcut for your computer in easy way possible.
+Description: Create custom computer macro shortcuts and launch them through your device. No more windows switching to open the folder or website, get Deckboard to simplify them and maximize your productivity! With OBS Studio and Streamlabs OBS supported, bring Deckboard as your personal streaming companion tool! Connect your computer to your device through local WiFi connection by entering IP address or scanning QR code.
+Moniker: deckboard
+Tags:
+- electron
+- macro-recorder
+- macros
+- obs-remote
+- remote-control
+- shortcuts-on-desktop
+- streamlabs-obs-remote
+# Agreements:
+# ReleaseNotes:
+ReleaseNotesUrl: https://github.com/rivafarabi/deckboard/releases/tag/v2.1.1
+# PurchaseUrl:
+# InstallationNotes:
+# Documentations:
+ManifestType: defaultLocale
+ManifestVersion: 1.2.0

--- a/manifests/r/RivaFarabi/Deckboard/2.1.1/RivaFarabi.Deckboard.yaml
+++ b/manifests/r/RivaFarabi/Deckboard/2.1.1/RivaFarabi.Deckboard.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-9
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+
+PackageIdentifier: RivaFarabi.Deckboard
+PackageVersion: 2.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.2.0


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | Deckboard |     |
| Version     | 2.1.1     |  |
| Publisher   | Riva Farabi   |       |
| ProductCode |           |     |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://github.com/vedantmgoyal2009/vedantmgoyal2009/tree/main/winget-pkgs-automation) in workflow run [5788](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/4096742440>)