### PR TITLE
New version: Jitsi.Meet version 2023.2.0

### DIFF
--- a/manifests/j/Jitsi/Meet/2023.2.0/Jitsi.Meet.installer.yaml
+++ b/manifests/j/Jitsi/Meet/2023.2.0/Jitsi.Meet.installer.yaml
@@ -1,0 +1,20 @@
+# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-9
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+
+PackageIdentifier: Jitsi.Meet
+PackageVersion: 2023.2.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- silent
+UpgradeBehavior: install
+ReleaseDate: 2023-02-03
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/jitsi/jitsi-meet-electron/releases/download/v2023.2.0/jitsi-meet.exe
+  InstallerSha256: 9B4FF04651C0071C806CCE0F2F9B9E5DF859A1D82FDA5F19300CB3A99F430F13
+ManifestType: installer
+ManifestVersion: 1.2.0

--- a/manifests/j/Jitsi/Meet/2023.2.0/Jitsi.Meet.locale.en-US.yaml
+++ b/manifests/j/Jitsi/Meet/2023.2.0/Jitsi.Meet.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-9
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+
+PackageIdentifier: Jitsi.Meet
+PackageVersion: 2023.2.0
+PackageLocale: en-US
+Publisher: Jitsi Team
+PublisherUrl: https://jitsi.org/
+PublisherSupportUrl: https://github.com/jitsi/jitsi-meet-electron/issues
+PrivacyUrl: https://jitsi.org/security/
+Author: Jitsi Team
+PackageName: Jitsi Meet
+PackageUrl: https://github.com/jitsi/jitsi-meet-electron
+License: Apache License 2.0
+LicenseUrl: https://raw.githubusercontent.com/jitsi/jitsi-meet-electron/master/LICENSE
+# Copyright:
+CopyrightUrl: https://raw.githubusercontent.com/jitsi/jitsi-meet-electron/master/LICENSE
+ShortDescription: Jitsi Meet is an open-source (Apache) WebRTC JavaScript application that uses Jitsi Videobridge to provide high quality, secure and scalable video conferences.
+# Description:
+# Moniker:
+Tags:
+- chat
+- jitsi
+- jitsi-meet
+- meeting
+- video
+# Agreements:
+# ReleaseNotes:
+ReleaseNotesUrl: https://github.com/jitsi/jitsi-meet-electron/releases/tag/v2023.2.0
+# PurchaseUrl:
+# InstallationNotes:
+# Documentations:
+ManifestType: defaultLocale
+ManifestVersion: 1.2.0

--- a/manifests/j/Jitsi/Meet/2023.2.0/Jitsi.Meet.yaml
+++ b/manifests/j/Jitsi/Meet/2023.2.0/Jitsi.Meet.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-9
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+
+PackageIdentifier: Jitsi.Meet
+PackageVersion: 2023.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.2.0


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | Jitsi Meet | JetBrains ETW Host Service (x64), JetBrains Rider 231.6471.8, WebStorm 231.6471.14    |
| Version     | 2023.2.0     | 16.36.0, 231.6471.8, 231.6471.14 |
| Publisher   | Jitsi Team   | JetBrains s.r.o., JetBrains s.r.o., JetBrains s.r.o.      |
| ProductCode |           | {1414134D-F146-42FB-B590-AC7DB059AA97}, JetBrains Rider 231.6471.8, WebStorm 231.6471.14    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://github.com/vedantmgoyal2009/vedantmgoyal2009/tree/main/winget-pkgs-automation) in workflow run [5744](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/4085332954>)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://api.github.com/repos/microsoft/winget-pkgs/pulls/95502)