### PR TITLE
New version: wethat.onenotetaggingkit version 5.1.8434

### DIFF
--- a/manifests/w/wethat/onenotetaggingkit/5.1.8434/wethat.onenotetaggingkit.installer.yaml
+++ b/manifests/w/wethat/onenotetaggingkit/5.1.8434/wethat.onenotetaggingkit.installer.yaml
@@ -1,0 +1,15 @@
+# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-9
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+
+PackageIdentifier: wethat.onenotetaggingkit
+PackageVersion: 5.1.8434
+MinimumOSVersion: 10.0.0.0
+InstallerType: wix
+ReleaseDate: 2023-02-03
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/WetHat/OnenoteTaggingKit/releases/download/v5.1.8434/SetupTaggingKitWiX.5.1.8434.msi
+  InstallerSha256: 9B5F9992CAB2C5A4C5F838480332453FEDF4D938CEFC8002EC03178B654E2500
+  ProductCode: '{93351BED-CCEF-4C78-8767-EC7DA921557B}'
+ManifestType: installer
+ManifestVersion: 1.2.0

--- a/manifests/w/wethat/onenotetaggingkit/5.1.8434/wethat.onenotetaggingkit.locale.en-US.yaml
+++ b/manifests/w/wethat/onenotetaggingkit/5.1.8434/wethat.onenotetaggingkit.locale.en-US.yaml
@@ -1,0 +1,37 @@
+# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-9
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+
+PackageIdentifier: wethat.onenotetaggingkit
+PackageVersion: 5.1.8434
+PackageLocale: en-US
+Publisher: WetHat Lab
+PublisherUrl: https://github.com/WetHat/OnenoteTaggingKit
+PublisherSupportUrl: https://github.com/WetHat/OnenoteTaggingKit/issues
+# PrivacyUrl:
+Author: WetHat
+PackageName: OneNote Tagging Kit
+PackageUrl: https://github.com/WetHat/OnenoteTaggingKit
+License: Ms-PL
+LicenseUrl: https://github.com/WetHat/OnenoteTaggingKit/blob/master/license.md
+# Copyright:
+CopyrightUrl: https://github.com/WetHat/OnenoteTaggingKit/blob/master/license.md
+ShortDescription: OneNote (desktop) add-in to manage OneNote pages by page tags
+# Description:
+# Moniker:
+Tags:
+- microsoft-office
+- note
+- office
+- office-extension
+- office-plugin
+- onenote
+- tag
+- tagging
+# Agreements:
+# ReleaseNotes:
+ReleaseNotesUrl: https://github.com/WetHat/OnenoteTaggingKit/releases/tag/v5.1.8434
+# PurchaseUrl:
+# InstallationNotes:
+# Documentations:
+ManifestType: defaultLocale
+ManifestVersion: 1.2.0

--- a/manifests/w/wethat/onenotetaggingkit/5.1.8434/wethat.onenotetaggingkit.yaml
+++ b/manifests/w/wethat/onenotetaggingkit/5.1.8434/wethat.onenotetaggingkit.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-9
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+
+PackageIdentifier: wethat.onenotetaggingkit
+PackageVersion: 5.1.8434
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.2.0


### PR DESCRIPTION
### Result: Installation Failed
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | OneNote Tagging Kit | IntelliJ IDEA 231.6471.13    |
| Version     | 5.1.8434     | 231.6471.13 |
| Publisher   | WetHat Lab   | JetBrains s.r.o.      |
| ProductCode |           | IntelliJ IDEA 231.6471.13    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://github.com/vedantmgoyal2009/vedantmgoyal2009/tree/main/winget-pkgs-automation) in workflow run [5746](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/4086244368>)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://api.github.com/repos/microsoft/winget-pkgs/pulls/95513)