### PR TITLE
Rustlang.Rustup Fix 1.25.1 download url

### DIFF
--- a/manifests/r/Rustlang/Rustup/1.25.1/Rustlang.Rustup.installer.yaml
+++ b/manifests/r/Rustlang/Rustup/1.25.1/Rustlang.Rustup.installer.yaml
@@ -12,9 +12,9 @@ InstallerSwitches:
 UpgradeBehavior: install
 Installers:
 - Architecture: x64
-  InstallerUrl: https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe
+  InstallerUrl: https://static.rust-lang.org/rustup/archive/1.25.1/x86_64-pc-windows-msvc/rustup-init.exe
   InstallerSha256: 2220DDB49FEA0E0945B1B5913E33D66BD223A67F19FD1C116BE0318DE7ED9D9C
   ProductCode: Rustup
 ManifestType: installer
-ManifestVersion: 1.1.0
+ManifestVersion: 1.2.0
 

--- a/manifests/r/Rustlang/Rustup/1.25.1/Rustlang.Rustup.locale.en-US.yaml
+++ b/manifests/r/Rustlang/Rustup/1.25.1/Rustlang.Rustup.locale.en-US.yaml
@@ -13,5 +13,5 @@ ShortDescription: The Rust toolchain installer
 Tags:
 - rust
 ManifestType: defaultLocale
-ManifestVersion: 1.1.0
+ManifestVersion: 1.2.0
 

--- a/manifests/r/Rustlang/Rustup/1.25.1/Rustlang.Rustup.yaml
+++ b/manifests/r/Rustlang/Rustup/1.25.1/Rustlang.Rustup.yaml
@@ -3,5 +3,5 @@ PackageIdentifier: Rustlang.Rustup
 PackageVersion: 1.25.1
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.1.0
+ManifestVersion: 1.2.0
 


### PR DESCRIPTION
Rustlang.Rustup Fix 1.25.1 download url
The old URL points to the last version, this is not sustainable as every time they have a new release, the package breaks.

Please use static URLs that point to specific versions.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/microsoft/winget-pkgs/pull/95599).
* __->__ #95599
