### PR TITLE
Add scope to MSEdgeRedirect installer manifest

### DIFF
--- a/manifests/r/rcmaehl/MSEdgeRedirect/0.7.3.0/rcmaehl.MSEdgeRedirect.installer.yaml
+++ b/manifests/r/rcmaehl/MSEdgeRedirect/0.7.3.0/rcmaehl.MSEdgeRedirect.installer.yaml
@@ -14,6 +14,7 @@ UpgradeBehavior: install
 ReleaseDate: 2023-01-16
 Installers:
 - Architecture: x64
+  Scope: machine
   InstallerUrl: https://github.com/rcmaehl/MSEdgeRedirect/releases/download/0.7.3.0/MSEdgeRedirect.exe
   InstallerSha256: D046C14B06347FD0053C3321828AE145E5A5A7CAECDE7C116D24458A8C4268AE
 ManifestType: installer

--- a/manifests/r/rcmaehl/MSEdgeRedirect/0.7.3.0/rcmaehl.MSEdgeRedirect.installer.yaml
+++ b/manifests/r/rcmaehl/MSEdgeRedirect/0.7.3.0/rcmaehl.MSEdgeRedirect.installer.yaml
@@ -7,6 +7,7 @@ Platform:
 - Windows.Desktop
 MinimumOSVersion: 10.0.0.0
 InstallerType: exe
+Scope: machine
 InstallerSwitches:
   Silent: /wingetinstall
   SilentWithProgress: /wingetinstall
@@ -14,7 +15,6 @@ UpgradeBehavior: install
 ReleaseDate: 2023-01-16
 Installers:
 - Architecture: x64
-  Scope: machine
   InstallerUrl: https://github.com/rcmaehl/MSEdgeRedirect/releases/download/0.7.3.0/MSEdgeRedirect.exe
   InstallerSha256: D046C14B06347FD0053C3321828AE145E5A5A7CAECDE7C116D24458A8C4268AE
 ManifestType: installer


### PR DESCRIPTION
`winget install MSEdgeRedirect --scope machine` currently fails with:

> No applicable installer found; see logs for more details.

However, the MSEdgeRedirect package actually _does_ install machine-wide. But it only works when no `--scope` argument is specified.

This adds `Scope: machine` to the installer manifest to fix that.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://api.github.com/repos/microsoft/winget-pkgs/pulls/95673)