### PR TITLE
Add [Policy] comment triggers for moderator reviews

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1934,6 +1934,236 @@
             {
               "name": "commentContains",
               "parameters": {
+                "bodyPattern": "/appr",
+                "isRegex": true,
+                "commentPattern": "\\[[Pp]olicy\\]\\s+\\s+[aA]pprove"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "activitySenderHasPermissions",
+                  "parameters": {
+                    "permissions": "admin"
+                  }
+                },
+                {
+                  "name": "activitySenderHasPermissions",
+                  "parameters": {
+                    "permissions": "write"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "ImJoakim"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "ItzLevvie"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "jedieaston"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "KaranKad"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "OfficialEsco"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "quhxl"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "Trenly"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "mdanish-kh"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "russellbanks"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "issue_comment"
+        ],
+        "taskName": "Helper to add Moderator-Approved to PR",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Moderator-Approved"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestCommentResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "commentContains",
+              "parameters": {
+                "bodyPattern": "/rej",
+                "isRegex": true,
+                "commentPattern": "\\[[Pp]olicy\\]\\s+\\s+[rR]eject"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "activitySenderHasPermissions",
+                  "parameters": {
+                    "permissions": "admin"
+                  }
+                },
+                {
+                  "name": "activitySenderHasPermissions",
+                  "parameters": {
+                    "permissions": "write"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "ImJoakim"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "ItzLevvie"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "jedieaston"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "KaranKad"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "OfficialEsco"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "quhxl"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "Trenly"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "mdanish-kh"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "russellbanks"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "issue_comment"
+        ],
+        "taskName": "Helper to add Needs-Author-Feedback to PR",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Needs-Author-Feedback"
+            }
+          },
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "Needs-Attention"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": {
+                "type": "prAuthor"
+              }
+            }
+          },
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "Hello @${issueAuthor},\n\nThe package manager bot determined changes have been requested to your PR.\n\nTemplate: msftbot/changesRequested"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestCommentResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "commentContains",
+              "parameters": {
                 "bodyPattern": "/ext",
                 "isRegex": true,
                 "commentPattern": "\\[[Pp]olicy\\]\\s+[aA]rea[\\s-][eE]xternal"

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -2039,9 +2039,9 @@
             {
               "name": "commentContains",
               "parameters": {
-                "bodyPattern": "/rej",
+                "bodyPattern": "/eed",
                 "isRegex": true,
-                "commentPattern": "\\[[Pp]olicy\\]\\s+\\s+[rR]eject"
+                "commentPattern": "\\[[Pp]olicy\\]\\s+\\s+[fF]eedback"
               }
             },
             {


### PR DESCRIPTION
This is a temporary workaround for the pull request review triggers not working. It adds two new comment triggers - `[Policy] Approve` and `[Policy] Reject` which have the same functionality as a `PR Review - Approval` or a `PR Review - Changes Requested` respectively.

cc @denelon

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://api.github.com/repos/microsoft/winget-pkgs/pulls/95721)