### PR TITLE
Visual Studio 2022 17.5.0 Professional Preview.

### DIFF
--- a/manifests/m/Microsoft/VisualStudio/2022/Professional/Preview/17.5.0/Microsoft.VisualStudio.2022.Professional.Preview.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Professional/Preview/17.5.0/Microsoft.VisualStudio.2022.Professional.Preview.installer.yaml
@@ -1,0 +1,55 @@
+# Created using wingetcreate 1.2.2.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
+
+PackageIdentifier: Microsoft.VisualStudio.2022.Professional.Preview
+PackageVersion: 17.5.0
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSuccessCodes:
+- 1641
+- 3010
+Commands:
+- devenv
+Protocols:
+- git-client
+- vsls
+- vssd
+- vstfs
+- vsweb
+FileExtensions:
+- asm
+- asmx
+- asp
+- aspx
+- c
+- config
+- cpp
+- cppm
+- cs
+- csproj
+- cxx
+- h
+- hpp
+- hxx
+- sln
+- ts
+- vcproj
+- vcxproj
+- xml
+Installers:
+- InstallerLocale: en-US
+  Architecture: x64
+  InstallerType: exe
+  Scope: machine
+  InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/a71c8249-7971-4584-abc1-25a334bb8231/a969b2a9f95638abe93644ee9eb9432198d1d4d1c8822b0c2bbea4e98d76b829/vs_Professional.exe
+  InstallerSha256: A969B2A9F95638ABE93644EE9EB9432198D1D4D1C8822B0C2BBEA4E98D76B829
+  InstallerSwitches:
+    Silent: --add Microsoft.VisualStudio.Component.CoreEditor --quiet --norestart --wait
+    SilentWithProgress: --add Microsoft.VisualStudio.Component.CoreEditor --passive --norestart --wait
+    Interactive: --add Microsoft.VisualStudio.Workload.Universal --includeRecommended --wait
+    InstallLocation: --installPath <INSTALLPATH>
+  UpgradeBehavior: install
+ManifestType: installer
+ManifestVersion: 1.4.0

--- a/manifests/m/Microsoft/VisualStudio/2022/Professional/Preview/17.5.0/Microsoft.VisualStudio.2022.Professional.Preview.locale.en-US.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Professional/Preview/17.5.0/Microsoft.VisualStudio.2022.Professional.Preview.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# Created using wingetcreate 1.2.2.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.4.0.schema.json
+
+PackageIdentifier: Microsoft.VisualStudio.2022.Professional.Preview
+PackageVersion: 17.5.0
+PackageLocale: en-US
+Publisher: Microsoft Corporation
+PublisherUrl: https://www.microsoft.com/
+PublisherSupportUrl: https://visualstudio.microsoft.com/vs/support/
+PrivacyUrl: https://privacy.microsoft.com/
+PackageName: Visual Studio Professional 2022 Preview
+PackageUrl: https://visualstudio.microsoft.com/vs/preview/vs2022/
+License: Microsoft Pre-Release Software License
+LicenseUrl: https://visualstudio.microsoft.com/license-terms/vs2022-prerelease/
+Copyright: © 2021 Microsoft
+CopyrightUrl: https://www.microsoft.com/en-us/legal/copyright
+ShortDescription: Visual Studio 2022 Professional Preview
+Description: Visual Studio Professional is a powerful, fully-featured IDE for developers designing, building, and deploying innovative applications for any platform.
+Moniker: vs2022-Professional-preview
+Tags:
+- c#
+- c++
+- ide
+- visualstudio
+- vs
+ManifestType: defaultLocale
+ManifestVersion: 1.4.0

--- a/manifests/m/Microsoft/VisualStudio/2022/Professional/Preview/17.5.0/Microsoft.VisualStudio.2022.Professional.Preview.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/Professional/Preview/17.5.0/Microsoft.VisualStudio.2022.Professional.Preview.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.2.2.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.4.0.schema.json
+
+PackageIdentifier: Microsoft.VisualStudio.2022.Professional.Preview
+PackageVersion: 17.5.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.4.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.4 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.4.0)?
----

## What
- Add the latest 17.5.0 Preview to the 2022\Professional\Preview folder.

## Why
As part of Microsoft's work to take ownership of the Visual Studio WinGet repo, we are deleting, moving, and adding manifests in support of various Channel/SKU combinations.

Rather than have it's own top level folder under '2022', we would like to maintain one set of 'Preview' manifests under the 'Professional' sku folder.  This will provide support for the latest 2022 Professional Preview VS.

Furthermore, we are renaming the Preview PackageIdentifier to remove the '-', in keeping with current naming conventions.

Related to https://github.com/microsoft/winget-pkgs/issues/94161
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/95837)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/95838)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/95839)