### PR TITLE
Ignore Malware Scan in Sandbox

### DIFF
--- a/Tools/SandboxTest.ps1
+++ b/Tools/SandboxTest.ps1
@@ -231,6 +231,7 @@ Write-Host @'
 --> Configuring Winget
 '@
 winget settings --Enable LocalManifestFiles
+winget settings --Enable LocalArchiveMalwareScanOverride
 copy -Path $settingsPathInSandbox -Destination C:\Users\WDAGUtilityAccount\AppData\Local\Packages\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe\LocalState\settings.json
 `$originalARP = Get-ARPTable
 Write-Host @'
@@ -239,7 +240,7 @@ Write-Host @'
 --> Installing the Manifest $manifestFileName
 
 '@
-winget install -m '$manifestPathInSandbox' --verbose-logs
+winget install -m '$manifestPathInSandbox' --verbose-logs --ignore-local-archive-malware-scan
 
 Write-Host @'
 


### PR DESCRIPTION
When testing using SandboxTest.ps1 a local manifest file is used. Occasionally, the malware scan will trigger when testing a PR or new manifest in the sandbox. Because these tests are bootstrapped and don't expose the install command, contributors must either go into the winget logs in the sandbox to find the command to attempt a re-install or must know where the local manifest is mapped to.

Because this is contained within the Sandbox, there should be no risk in bypassing the malware scan.

cc @denelon
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/96095)