### PR TITLE
AutoHotkey: remove elevation requirement for user-scoped installs

### DIFF
--- a/manifests/a/AutoHotkey/AutoHotkey/2.0.2/AutoHotkey.AutoHotkey.installer.yaml
+++ b/manifests/a/AutoHotkey/AutoHotkey/2.0.2/AutoHotkey.AutoHotkey.installer.yaml
@@ -8,45 +8,33 @@ InstallModes:
 - interactive
 - silent
 InstallerSwitches:
+  Silent: /silent
+  SilentWithProgress: /silent
   InstallLocation: /installto "<INSTALLPATH>" # /to "<INSTALLPATH>"
 InstallLocationRequired: true
+ProductCode: AutoHotkey
 UpgradeBehavior: install
 FileExtensions:
 - ahk
 ReleaseDate: 2023-01-02
-ElevationRequirement: elevationRequired
 Installers:
 - Architecture: x86
   Scope: user
   InstallerUrl: https://github.com/AutoHotkey/AutoHotkey/releases/download/v2.0.2/AutoHotkey_2.0.2_setup.exe
   InstallerSha256: 9C8B1AECAF1BDDED80BEC98EC5AB5B9B9754CBCE9439DD9EACC7D1774D1438F8
-  InstallerSwitches:
-    Silent: /user /silent
-    SilentWithProgress: /user /silent
-  ProductCode: AutoHotkey
 - Architecture: x86
   Scope: machine
   InstallerUrl: https://github.com/AutoHotkey/AutoHotkey/releases/download/v2.0.2/AutoHotkey_2.0.2_setup.exe
   InstallerSha256: 9C8B1AECAF1BDDED80BEC98EC5AB5B9B9754CBCE9439DD9EACC7D1774D1438F8
-  InstallerSwitches:
-    Silent: /elevate /silent
-    SilentWithProgress: /elevate /silent
-  ProductCode: AutoHotkey
+  ElevationRequirement: elevationRequired
 - Architecture: x64
   Scope: user
   InstallerUrl: https://github.com/AutoHotkey/AutoHotkey/releases/download/v2.0.2/AutoHotkey_2.0.2_setup.exe
   InstallerSha256: 9C8B1AECAF1BDDED80BEC98EC5AB5B9B9754CBCE9439DD9EACC7D1774D1438F8
-  InstallerSwitches:
-    Silent: /user /silent
-    SilentWithProgress: /user /silent
-  ProductCode: AutoHotkey
 - Architecture: x64
   Scope: machine
   InstallerUrl: https://github.com/AutoHotkey/AutoHotkey/releases/download/v2.0.2/AutoHotkey_2.0.2_setup.exe
   InstallerSha256: 9C8B1AECAF1BDDED80BEC98EC5AB5B9B9754CBCE9439DD9EACC7D1774D1438F8
-  InstallerSwitches:
-    Silent: /elevate /silent
-    SilentWithProgress: /elevate /silent
-  ProductCode: AutoHotkey
+  ElevationRequirement: elevationRequired
 ManifestType: installer
 ManifestVersion: 1.2.0


### PR DESCRIPTION
Moves the ElevationRequirement key from the manifest root to just the machine installers, since it's not necessary for a user-scoped install.

I also removed /user and /elevate switches from the installer commands. I could be wrong and can't find full documentation on the installer switches; but from testing, they don't appear to make any difference if the /silent switch is present.

Also moved the ProductCode key to the manifest root since it's commmon on all installers.

Two other things I attempted but failed at: removing the installation location requirement and properly supporting interactive installs.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.4 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.4.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/96799)