### PR TITLE
New version: Nvidia.GeForceNow version 2.0.49.102

### DIFF
--- a/manifests/n/Nvidia/GeForceNow/2.0.49.102/Nvidia.GeForceNow.installer.yaml
+++ b/manifests/n/Nvidia/GeForceNow/2.0.49.102/Nvidia.GeForceNow.installer.yaml
@@ -1,0 +1,34 @@
+# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-9
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+
+PackageIdentifier: Nvidia.GeForceNow
+PackageVersion: 2.0.49.102
+InstallerType: exe
+Scope: user
+InstallModes:
+- silent
+- silentWithProgress
+- interactive
+InstallerSwitches:
+  Silent: -s -n
+  SilentWithProgress: -passive -n
+  Log: -log:"<LOGPATH>"
+  Upgrade: -upgrade
+  Custom: -skipGFNLaunch
+ExpectedReturnCodes:
+- InstallerReturnCode: -469761024
+  ReturnResponse: downgrade
+- InstallerReturnCode: 46
+  ReturnResponse: installInProgress
+UpgradeBehavior: install
+Protocols:
+- discord-481331590383796224
+- geforcenow
+ReleaseDate: 2023-02-14
+Installers:
+- Architecture: x64
+  InstallerUrl: https://ota-downloads.nvidia.com/ota/GeForceNOW-release_FE6B14.exe
+  InstallerSha256: 45462A86B3C1C797EFBD7B9BD9AC67DFB253C36B591E32320E5A660FD81BC7E8
+  ProductCode: '{B2FE1952-0186-46C3-BAEC-A80AA35AC5B8}_GeforceNOW'
+ManifestType: installer
+ManifestVersion: 1.2.0

--- a/manifests/n/Nvidia/GeForceNow/2.0.49.102/Nvidia.GeForceNow.locale.en-US.yaml
+++ b/manifests/n/Nvidia/GeForceNow/2.0.49.102/Nvidia.GeForceNow.locale.en-US.yaml
@@ -26,18 +26,11 @@ Tags:
 - streaming
 # Agreements:
 ReleaseNotes: |-
-  Ultimate Performance Powered by RTX 4080
-  - Our new GeForce NOW Ultimate membership is here and GeForce RTX 4080-class performance is rolling out to members in the US and Europe through NVIDIA’s service. This membership upgrade brings support for the latest NVIDIA RTX technologies. Full ray tracing and DLSS 3 deliver beautiful, cinematic-quality graphics while using AI to keep frame rates smooth in supported games.
-  - Experience never-before-seen cloud gaming features, including: competitive mode streaming at up to 240 frames per second, powered by NVIDIA Reflex, for the lowest latency ever from the cloud; upgraded streaming resolutions at up to 4K 120 fps on the native PC and Mac apps; and new support for native ultrawide resolutions at up to 3840x1600 120fps resolutions for a truly immersive experience.
-  - Members can sign up today for the GeForce NOW Ultimate membership for $19.99 per month or $99.99 for six months. Existing GeForce RTX 3080 members’ accounts have already been converted to Ultimate memberships at their current pricing, and will provide GeForce RTX 4080 performance as soon as it’s available in their regions.
-  - RTX 4080 servers have begun rolling out in North America and Europe with additional servers coming online regularly. Visit the GeForce NOW status page https://status.geforcenow.com to see if RTX 4080 servers are available in your region or www.geforcenow.com for general information.
-
-  Browser Streaming Improvements
-  - Added the Streaming Statistics Overlay on play.geforcenow.com to access real-time streaming statistics using the hotkey Ctrl+N on PC/Chrome OS or Cmd+N on macOS. The same hotkey will also quickly toggle between Standard and Compact modes.
-  - Added support for streaming from Microsoft Edge browser on macOS.
+  Fit and Finish
+  - Improvements to the GeForce NOW loading screen when launching games to show a game wallpaper.
 
   Bug Fixes
-  - Various fixes related to managing connected accounts including “Account Connection Failed” errors when attempting to sync your Ubisoft or Steam library.
+  - Fixed a performance issue when bringing up or closing the GeForce NOW in-game overlay.
 
   Whatcha Thinking?
   - Tell us about your streaming session, or what games you want to play, or how you won that last match even after your teammates dropped. Use that exclamation icon to send feedback in the app and let us know what you think.

--- a/manifests/n/Nvidia/GeForceNow/2.0.49.102/Nvidia.GeForceNow.locale.en-US.yaml
+++ b/manifests/n/Nvidia/GeForceNow/2.0.49.102/Nvidia.GeForceNow.locale.en-US.yaml
@@ -1,0 +1,53 @@
+# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-9
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+
+PackageIdentifier: Nvidia.GeForceNow
+PackageVersion: 2.0.49.102
+PackageLocale: en-US
+Publisher: NVIDIA Corporation
+PublisherUrl: https://www.nvidia.com/
+PublisherSupportUrl: https://www.nvidia.com/en-us/geforce-now/support/
+PrivacyUrl: https://www.nvidia.com/en-us/about-nvidia/privacy-policy/
+Author: NVIDIA Corporation
+PackageName: NVIDIA GeForce NOW
+PackageUrl: https://www.nvidia.com/en-us/geforce-now/
+License: Proprietary
+LicenseUrl: https://www.nvidia.com/en-us/geforce-now/terms-of-use/
+Copyright: © 2023 NVIDIA Corporation. All rights reserved.
+CopyrightUrl: https://www.nvidia.com/en-us/about-nvidia/legal-info/
+ShortDescription: GeForce NOW connects to digital PC game stores so you can stream the library of games you already own
+Description: GeForce NOW instantly transforms nearly any laptop, desktop, Mac, SHIELD TV, Android device, iPhone, or iPad into the PC gaming rig you’ve always dreamed of. Play the most demanding PC games and seamlessly play across your devices.
+# Moniker:
+Tags:
+- cloud-gaming
+- game
+- game-streaming
+- gaming
+- streaming
+# Agreements:
+ReleaseNotes: |-
+  Ultimate Performance Powered by RTX 4080
+  - Our new GeForce NOW Ultimate membership is here and GeForce RTX 4080-class performance is rolling out to members in the US and Europe through NVIDIA’s service. This membership upgrade brings support for the latest NVIDIA RTX technologies. Full ray tracing and DLSS 3 deliver beautiful, cinematic-quality graphics while using AI to keep frame rates smooth in supported games.
+  - Experience never-before-seen cloud gaming features, including: competitive mode streaming at up to 240 frames per second, powered by NVIDIA Reflex, for the lowest latency ever from the cloud; upgraded streaming resolutions at up to 4K 120 fps on the native PC and Mac apps; and new support for native ultrawide resolutions at up to 3840x1600 120fps resolutions for a truly immersive experience.
+  - Members can sign up today for the GeForce NOW Ultimate membership for $19.99 per month or $99.99 for six months. Existing GeForce RTX 3080 members’ accounts have already been converted to Ultimate memberships at their current pricing, and will provide GeForce RTX 4080 performance as soon as it’s available in their regions.
+  - RTX 4080 servers have begun rolling out in North America and Europe with additional servers coming online regularly. Visit the GeForce NOW status page https://status.geforcenow.com to see if RTX 4080 servers are available in your region or www.geforcenow.com for general information.
+
+  Browser Streaming Improvements
+  - Added the Streaming Statistics Overlay on play.geforcenow.com to access real-time streaming statistics using the hotkey Ctrl+N on PC/Chrome OS or Cmd+N on macOS. The same hotkey will also quickly toggle between Standard and Compact modes.
+  - Added support for streaming from Microsoft Edge browser on macOS.
+
+  Bug Fixes
+  - Various fixes related to managing connected accounts including “Account Connection Failed” errors when attempting to sync your Ubisoft or Steam library.
+
+  Whatcha Thinking?
+  - Tell us about your streaming session, or what games you want to play, or how you won that last match even after your teammates dropped. Use that exclamation icon to send feedback in the app and let us know what you think.
+ReleaseNotesUrl: https://www.nvidia.com/en-us/geforce-now/release-highlights/
+# PurchaseUrl:
+# InstallationNotes:
+Documentations:
+- DocumentLabel: FAQ
+  DocumentUrl: https://www.nvidia.com/en-us/geforce-now/faq/
+- DocumentLabel: Quick Start Guides
+  DocumentUrl: https://www.nvidia.com/content/dam/en-zz/Solutions/gfn/webassets/geforce-now-qsg-pc-mac.pdf
+ManifestType: defaultLocale
+ManifestVersion: 1.2.0

--- a/manifests/n/Nvidia/GeForceNow/2.0.49.102/Nvidia.GeForceNow.locale.zh-CN.yaml
+++ b/manifests/n/Nvidia/GeForceNow/2.0.49.102/Nvidia.GeForceNow.locale.zh-CN.yaml
@@ -1,0 +1,36 @@
+# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-9
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.2.0.schema.json
+
+PackageIdentifier: Nvidia.GeForceNow
+PackageVersion: 2.0.49.102
+PackageLocale: zh-CN
+Publisher: NVIDIA Corporation
+PublisherUrl: https://www.nvidia.cn/
+PublisherSupportUrl: https://www.nvidia.com/en-us/geforce-now/support/
+PrivacyUrl: https://www.nvidia.cn/about-nvidia/privacy-policy/
+Author: NVIDIA Corporation
+PackageName: NVIDIA GeForce NOW
+PackageUrl: https://www.nvidia.com/en-us/geforce-now/
+License: 专有软件
+LicenseUrl: https://www.nvidia.com/en-us/geforce-now/terms-of-use/
+Copyright: ©2023 NVIDIA Corporation 版权所有。保留所有权利。
+CopyrightUrl: https://www.nvidia.cn/about-nvidia/legal-info/
+ShortDescription: GeForce NOW 连接数字 PC 游戏平台让你轻松串联游戏库
+Description: GeForce NOW 将近乎所有设备转变为你梦寐以求的 PC 游戏装备，并无缝播放性能要求最高的 PC 游戏。
+# Moniker:
+Tags:
+- 串流
+- 云游戏
+- 游戏
+# Agreements:
+# ReleaseNotes:
+ReleaseNotesUrl: https://www.nvidia.com/en-us/geforce-now/release-highlights/
+# PurchaseUrl:
+# InstallationNotes:
+Documentations:
+- DocumentLabel: 常见问题
+  DocumentUrl: https://www.nvidia.com/en-us/geforce-now/faq/
+- DocumentLabel: 快速入门指南
+  DocumentUrl: https://www.nvidia.com/content/dam/en-zz/Solutions/gfn/webassets/geforce-now-qsg-pc-mac.pdf
+ManifestType: locale
+ManifestVersion: 1.2.0

--- a/manifests/n/Nvidia/GeForceNow/2.0.49.102/Nvidia.GeForceNow.yaml
+++ b/manifests/n/Nvidia/GeForceNow/2.0.49.102/Nvidia.GeForceNow.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-9
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+
+PackageIdentifier: Nvidia.GeForceNow
+PackageVersion: 2.0.49.102
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.2.0


### PR DESCRIPTION
### Result: Installation Successful
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | NVIDIA GeForce NOW | NVIDIA GeForce NOW 2.0.49.102, NVIDIA Install Application    |
| Version     | 2.0.49.102     | 2.0.49.102, 2.1002.373.0 |
| Publisher   | NVIDIA Corporation   | NVIDIA Corporation, NVIDIA Corporation      |
| ProductCode |           | {B2FE1952-0186-46C3-BAEC-A80AA35AC5B8}_GeForceNOW, {B2FE1952-0186-46C3-BAEC-A80AA35AC5B8}_installer    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://github.com/vedantmgoyal2009/vedantmgoyal2009/tree/main/winget-pkgs-automation) in workflow run [6149](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/4229783362>)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/97358)