### PR TITLE
Update `PortableCommandAlias` to an optional field

### DIFF
--- a/doc/manifest/schema/1.4.0/installer.md
+++ b/doc/manifest/schema/1.4.0/installer.md
@@ -35,7 +35,7 @@ Installers:                     	# The list of package installers
     NestedInstallerType:					# The installer type when InstallerType is an archive type
     NestedInstallerFiles:					# Details about the installers when InstallerType is an archive type
       - RelativeFilePath:					# The relative path to the nested installer file
-        PortableCommandAlias:			# The command alias to be used for calling the package. Only applies when NestedInstallerType is 'portable'
+        PortableCommandAlias:			# Optional command alias to be used for calling the package. Only applies when NestedInstallerType is 'portable'
     Scope:                      	# Optional installer scope
     InstallModes:              		# Optional installer modes
     InstallerSwitches:         	 	# Optional installer switches
@@ -292,7 +292,7 @@ ManifestVersion: 1.4.0
 <details>
  <summary><b>PortableCommandAlias</b> - The command alias to be used for calling the package</summary>
 
- **Required Field**
+ **Optional Field**
 
  The alias which is added to the PATH for calling the package from the command line.
 


### PR DESCRIPTION
`PortableCommandAlias` is actually an optional field, and the manifest successfully validates without it.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/97850)