### PR TITLE
Fix checksum for XnViewMP 1.4.3

### DIFF
--- a/manifests/x/XnSoft/XnViewMP/1.4.3/XnSoft.XnViewMP.installer.yaml
+++ b/manifests/x/XnSoft/XnViewMP/1.4.3/XnSoft.XnViewMP.installer.yaml
@@ -23,6 +23,6 @@ FileExtensions:
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.xnview.com/XnViewMP-win-x64.exe
-  InstallerSha256: BFA54A5C8C05528C4D3015C51AE3376071E311D37F90CDE4843AA444CFDACBE5
+  InstallerSha256: 195FC268AFB86DE303EB5E24C168129A6FB59DEB5DD0C0DC4207641E96970CC9
 ManifestType: installer
 ManifestVersion: 1.2.0


### PR DESCRIPTION
Some change happened upstream. The version of installer didn't change (at least based on metadata), but the checksum did change. It causes problems while attempting to install currently. This PR fixes it.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.4 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.4.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/98061)