### PR TITLE
Delete manifests/n/NextDNS/NextDNS/Prerelease directory

### DIFF
--- a/manifests/n/NextDNS/NextDNS/Prerelease/.validation
+++ b/manifests/n/NextDNS/NextDNS/Prerelease/.validation
@@ -1,1 +1,0 @@
-{"ValidationVersion":"1.0.0","Waivers":[{"WaiverId":"8a621053-b047-4ccb-8f41-223900c739a7","TestPlan":"Policy-Test-2.8","PackagePath":"manifests/n/NextDNS/NextDNS/Prerelease/3.0.4","CommitId":"d6aa7d238ae0280c30fce100047a560fbedb4b47"}]}


### PR DESCRIPTION
Reason: Corresponding manifests removed due to 404 Url

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/98121)