### PR TITLE
[YamlCreate] Auto-set upstream

### DIFF
--- a/Tools/YamlCreate.ps1
+++ b/Tools/YamlCreate.ps1
@@ -2839,7 +2839,7 @@ if ($PromptSubmit -eq '0') {
   }
 
   # check if upstream exists
-  $remoteUpstreamUrl = $(git remote get-url upstream)
+  ($remoteUpstreamUrl = $(git remote get-url upstream)) *> $null
   if ($remoteUpstreamUrl -and $remoteUpstreamUrl -ne $wingetUpstream) {
     git remote set-url upstream $wingetUpstream
   } elseif (!$remoteUpstreamUrl) {

--- a/Tools/YamlCreate.ps1
+++ b/Tools/YamlCreate.ps1
@@ -2843,6 +2843,7 @@ if ($PromptSubmit -eq '0') {
   if ($remoteUpstreamUrl -and $remoteUpstreamUrl -ne $wingetUpstream) {
     git remote set-url upstream $wingetUpstream
   } elseif (!$remoteUpstreamUrl) {
+    Write-Host  -ForegroundColor 'Yellow' 'Upstream does not exist. Permanently adding https://github.com/microsoft/winget-pkgs as remote upstream'
     git remote add upstream $wingetUpstream
   }
 

--- a/Tools/YamlCreate.ps1
+++ b/Tools/YamlCreate.ps1
@@ -2842,7 +2842,7 @@ if ($PromptSubmit -eq '0') {
   $remoteUpstreamUrl = $(git remote get-url upstream)
   if ($remoteUpstreamUrl -and $remoteUpstreamUrl -ne $wingetUpstream) {
     git remote set-url upstream $wingetUpstream
-  } else {
+  } elseif (!$remoteUpstreamUrl) {
     git remote add upstream $wingetUpstream
   }
 

--- a/Tools/YamlCreate.ps1
+++ b/Tools/YamlCreate.ps1
@@ -2847,7 +2847,6 @@ if ($PromptSubmit -eq '0') {
   }
 
   # Fetch the upstream branch, create a commit onto the detached head, and push it to a new branch
-
   git fetch upstream master --quiet
   git switch -d upstream/master
   if ($LASTEXITCODE -eq '0') {

--- a/Tools/YamlCreate.ps1
+++ b/Tools/YamlCreate.ps1
@@ -163,7 +163,7 @@ if ($Settings) {
   exit
 }
 
-$ScriptHeader = '# Created with YamlCreate.ps1 v2.2.2'
+$ScriptHeader = '# Created with YamlCreate.ps1 v2.2.3'
 $ManifestVersion = '1.4.0'
 $PSDefaultParameterValues = @{ '*:Encoding' = 'UTF8' }
 $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
@@ -173,6 +173,7 @@ $callingCulture = [Threading.Thread]::CurrentThread.CurrentCulture
 [Threading.Thread]::CurrentThread.CurrentUICulture = 'en-US'
 [Threading.Thread]::CurrentThread.CurrentCulture = 'en-US'
 if (-not ([System.Environment]::OSVersion.Platform -match 'Win')) { $env:TEMP = '/tmp/' }
+$wingetUpstream = 'https://github.com/microsoft/winget-pkgs.git'
 
 if ($ScriptSettings.EnableDeveloperOptions -eq $true -and $null -ne $ScriptSettings.OverrideManifestVersion) {
   $script:UsesPrerelease = $ScriptSettings.OverrideManifestVersion -gt $ManifestVersion
@@ -2837,7 +2838,16 @@ if ($PromptSubmit -eq '0') {
     git config --add core.safecrlf false
   }
 
+  # check if upstream exists
+  $remoteUpstreamUrl = $(git remote get-url upstream)
+  if ($remoteUpstreamUrl -and $remoteUpstreamUrl -ne $wingetUpstream) {
+    git remote set-url upstream $wingetUpstream
+  } else {
+    git remote add upstream $wingetUpstream
+  }
+
   # Fetch the upstream branch, create a commit onto the detached head, and push it to a new branch
+
   git fetch upstream master --quiet
   git switch -d upstream/master
   if ($LASTEXITCODE -eq '0') {
@@ -2876,6 +2886,10 @@ if ($PromptSubmit -eq '0') {
   } else {
     git config --unset core.safecrlf
   }
+  if ($remoteUpstreamUrl -and $remoteUpstreamUrl -ne $wingetUpstream) {
+    git remote set-url upstream $remoteUpstreamUrl
+  }
+
 } else {
   Write-Host
   [Threading.Thread]::CurrentThread.CurrentUICulture = $callingUICulture


### PR DESCRIPTION
This change makes it so that if a user of YamlCreate doesn't have a remote named `upstream` configured in their cloned fork, it will automatically add the Microsoft repo as the upstream. If the user does have an upstream configured, it will temporarily override the upstream to the Microsoft repo and then restore the user's settings.

CC @jedieaston @mdanish-kh

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/98317)