### PR TITLE
Package Fix: PsiphonInc.Psiphon -4 March 2023- hash and arch match

### DIFF
--- a/manifests/p/PsiphonInc/Psiphon/3.0/PsiphonInc.Psiphon.installer.yaml
+++ b/manifests/p/PsiphonInc/Psiphon/3.0/PsiphonInc.Psiphon.installer.yaml
@@ -1,12 +1,13 @@
-# Created with YamlCreate.ps1 v2.2.2 $debug=NVS1.CRLF.7-3-1.Win32NT
+# Created with YamlCreate.ps1 v2.2.3 $debug=NVS0.CRLF.5-1-19041-2364.Win32NT
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
 
 PackageIdentifier: PsiphonInc.Psiphon
 PackageVersion: "3.0"
+InstallerLocale: en-US
 InstallerType: portable
 Installers:
-- Architecture: x64
+- Architecture: x86
   InstallerUrl: https://psiphon.ca/psiphon3.exe
-  InstallerSha256: E98FB973657ED41EA2834B76F07DD6F65F5E1E3D8A444E655C5BDF06531F5C34
+  InstallerSha256: BE3693739A705392D4C28E19FD2F1E1674EC596D0073FFD912B55D3782AF40D7
 ManifestType: installer
 ManifestVersion: 1.4.0

--- a/manifests/p/PsiphonInc/Psiphon/3.0/PsiphonInc.Psiphon.locale.en-US.yaml
+++ b/manifests/p/PsiphonInc/Psiphon/3.0/PsiphonInc.Psiphon.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.2.2 $debug=NVS1.CRLF.7-3-1.Win32NT
+# Created with YamlCreate.ps1 v2.2.3 $debug=NVS0.CRLF.5-1-19041-2364.Win32NT
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.4.0.schema.json
 
 PackageIdentifier: PsiphonInc.Psiphon
@@ -13,7 +13,7 @@ PackageName: Psiphon
 PackageUrl: https://psiphon.ca/
 License: Proprietary
 LicenseUrl: https://psiphon.ca/license.html
-Copyright: Copyright (c) 2022 Psiphon Inc.
+Copyright: Copyright (c) 2023 Psiphon Inc.
 # CopyrightUrl:
 ShortDescription: Psiphon is a relay-based internet restriction circumventor and it consists of a client application and a set of servers.
 # Description:

--- a/manifests/p/PsiphonInc/Psiphon/3.0/PsiphonInc.Psiphon.yaml
+++ b/manifests/p/PsiphonInc/Psiphon/3.0/PsiphonInc.Psiphon.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.2.2 $debug=NVS1.CRLF.7-3-1.Win32NT
+# Created with YamlCreate.ps1 v2.2.3 $debug=NVS0.CRLF.5-1-19041-2364.Win32NT
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.4.0.schema.json
 
 PackageIdentifier: PsiphonInc.Psiphon


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.4 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.4.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/98466)