### PR TITLE
Release aztfexport v0.11.0, which was known as aztfy

### DIFF
--- a/manifests/m/Microsoft/Azure/AztfExport/0.11.0/Microsoft.Azure.AztfExport.installer.yaml
+++ b/manifests/m/Microsoft/Azure/AztfExport/0.11.0/Microsoft.Azure.AztfExport.installer.yaml
@@ -1,0 +1,24 @@
+# Created using wingetcreate 1.2.5.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
+
+PackageIdentifier: Microsoft.Azure.AztfExport
+PackageVersion: 0.11.0
+Scope: machine
+UpgradeBehavior: install
+Commands:
+- aztfy
+AppsAndFeaturesEntries:
+- DisplayName: aztfexport
+Installers:
+- Architecture: x64
+  InstallerType: wix
+  InstallerUrl: https://github.com/Azure/aztfexport/releases/download/v0.11.0/aztfexport_v0.11.0_x64.msi
+  InstallerSha256: bb6cfa517a151258c50abbcbd5df3b21744842453d3d3f384d90785e1ff54956
+  ProductCode: '{882EFDA5-0FE5-4754-A88B-EDB6E48E4860}'
+- Architecture: x86
+  InstallerType: wix
+  InstallerUrl: https://github.com/Azure/aztfexport/releases/download/v0.11.0/aztfexport_v0.11.0_x86.msi
+  InstallerSha256: ebe4ba476c132351415e517d634ea9a6bb6cca2a8f576925534043f987d68a74
+  ProductCode: '{6B205B56-533E-4038-901E-EDE55A2D2DC2}'
+ManifestType: installer
+ManifestVersion: 1.4.0

--- a/manifests/m/Microsoft/Azure/AztfExport/0.11.0/Microsoft.Azure.AztfExport.locale.en-US.yaml
+++ b/manifests/m/Microsoft/Azure/AztfExport/0.11.0/Microsoft.Azure.AztfExport.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# Created using wingetcreate 1.2.5.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.4.0.schema.json
+
+PackageIdentifier: Microsoft.Azure.AztfExport
+PackageVersion: 0.11.0
+PackageLocale: en-US
+Publisher: Microsoft
+PublisherUrl: https://github.com/Azure/aztfexport
+PublisherSupportUrl: https://github.com/Azure/aztfexport/issues
+PackageName: Microsoft Azure Export for Terraform
+PackageUrl: https://github.com/Azure/aztfexport
+License: Mozilla Public License 2.0
+LicenseUrl: https://github.com/Azure/aztfexport/blob/main/LICENSE
+Copyright: Copyright (c) Microsoft Corporation, Copyright (c) HashiCorp
+ShortDescription: A tool to bring your existing Azure resources under the management of Terraform.
+Description: |-
+  Microsoft Azure Export for Terraform imports the resources that are supported by the Terraform AzureRM provider into the Terraform state, and generates the corresponding Terraform configuration.
+  Both the Terraform state and configuration are expected to be consistent with the resources' remote state, i.e., terraform plan shows no diff.
+  The user then is able to use Terraform to manage these resources.
+Moniker: aztfexport
+Tags:
+- aztfexport
+- azure
+- terraform
+ManifestType: defaultLocale
+ManifestVersion: 1.4.0

--- a/manifests/m/Microsoft/Azure/AztfExport/0.11.0/Microsoft.Azure.AztfExport.yaml
+++ b/manifests/m/Microsoft/Azure/AztfExport/0.11.0/Microsoft.Azure.AztfExport.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.2.5.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.4.0.schema.json
+
+PackageIdentifier: Microsoft.Azure.AztfExport
+PackageVersion: 0.11.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.4.0


### PR DESCRIPTION
- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.4 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.4.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----
This PR creates a new package entry called `aztfexport`, which was previously known as `aztfy`. I just copy over the v0.10.0 of `aztfy` and do the corresponding update/rename. I'm not sure whether I need to deprecate `aztfy` in some way (though `aztfy` is still able to be downloaded for its old versions).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/98742)