### PR TITLE
Add Miro.Miro 0.7.28 x86

### DIFF
--- a/manifests/m/Miro/Miro/0.7.28/Miro.Miro.installer.yaml
+++ b/manifests/m/Miro/Miro/0.7.28/Miro.Miro.installer.yaml
@@ -18,5 +18,8 @@ Installers:
 - Architecture: x64
   InstallerUrl: https://desktop.miro.com/platforms/win32/Miro.exe
   InstallerSha256: 51A0834F6802CE249FFC1492F99915BAB512A2D1948587754B79BABDA05FEB73
+- Architecture: x86
+  InstallerUrl: https://desktop.miro.com/platforms/win32-x86/Miro.exe
+  InstallerSha256: 47356B6A61254B1B483EC40683DF850D8A3B0193EE8091C321144EBC04A4B57D
 ManifestType: installer
 ManifestVersion: 1.2.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.4 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.4.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

- #98877 updated to 0.7.28, but only the x64 version.
- #98878 is removing the x64 version, but the hash is failing since the x86 version has also changed.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/98967)