### PR TITLE
New version: Datadog.dd-trace-dotnet version 2.26.0

### DIFF
--- a/manifests/d/Datadog/dd-trace-dotnet/2.26.0/Datadog.dd-trace-dotnet.installer.yaml
+++ b/manifests/d/Datadog/dd-trace-dotnet/2.26.0/Datadog.dd-trace-dotnet.installer.yaml
@@ -1,0 +1,32 @@
+# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-10
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+
+PackageIdentifier: Datadog.dd-trace-dotnet
+PackageVersion: 2.26.0
+InstallerLocale: en-US
+MinimumOSVersion: 10.0.0.0
+InstallerType: wix
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2023-03-09
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/DataDog/dd-trace-dotnet/releases/download/v2.26.0/datadog-dotnet-apm-2.26.0-x64.msi
+  InstallerSha256: 9FCEBBD944EF058D65F09169704B4A7E05C68514A952E7F4CD55E20CF4D9025A
+  ProductCode: '{9194BB12-19D6-4209-99B9-2C2FC9A181DF}'
+  AppsAndFeaturesEntries:
+  - ProductCode: '{5304506E-A4B8-46B0-95F1-42B9A02F169D}'
+    DisplayName: Datadog .NET Tracer 64-bit
+- Architecture: x86
+  InstallerUrl: https://github.com/DataDog/dd-trace-dotnet/releases/download/v2.26.0/datadog-dotnet-apm-2.26.0-x86.msi
+  InstallerSha256: 023F95F93953557C2A16C47B46EDD2B24A93C6324354A05AB4B83A81D5C73BCE
+  ProductCode: '{3DEA2599-FB7F-4ACB-9D17-E8E659BB30E7}'
+  AppsAndFeaturesEntries:
+  - ProductCode: '{ACECFE87-7D8D-481C-A8D5-E93A34D6B963}'
+    DisplayName: Datadog .NET Tracer 32-bit
+ManifestType: installer
+ManifestVersion: 1.2.0

--- a/manifests/d/Datadog/dd-trace-dotnet/2.26.0/Datadog.dd-trace-dotnet.installer.yaml
+++ b/manifests/d/Datadog/dd-trace-dotnet/2.26.0/Datadog.dd-trace-dotnet.installer.yaml
@@ -19,14 +19,12 @@ Installers:
   InstallerSha256: 9FCEBBD944EF058D65F09169704B4A7E05C68514A952E7F4CD55E20CF4D9025A
   ProductCode: '{9194BB12-19D6-4209-99B9-2C2FC9A181DF}'
   AppsAndFeaturesEntries:
-  - ProductCode: '{5304506E-A4B8-46B0-95F1-42B9A02F169D}'
-    DisplayName: Datadog .NET Tracer 64-bit
+  - DisplayName: Datadog .NET Tracer 64-bit
 - Architecture: x86
   InstallerUrl: https://github.com/DataDog/dd-trace-dotnet/releases/download/v2.26.0/datadog-dotnet-apm-2.26.0-x86.msi
   InstallerSha256: 023F95F93953557C2A16C47B46EDD2B24A93C6324354A05AB4B83A81D5C73BCE
   ProductCode: '{3DEA2599-FB7F-4ACB-9D17-E8E659BB30E7}'
   AppsAndFeaturesEntries:
-  - ProductCode: '{ACECFE87-7D8D-481C-A8D5-E93A34D6B963}'
-    DisplayName: Datadog .NET Tracer 32-bit
+  - DisplayName: Datadog .NET Tracer 32-bit
 ManifestType: installer
 ManifestVersion: 1.2.0

--- a/manifests/d/Datadog/dd-trace-dotnet/2.26.0/Datadog.dd-trace-dotnet.locale.en-US.yaml
+++ b/manifests/d/Datadog/dd-trace-dotnet/2.26.0/Datadog.dd-trace-dotnet.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-10
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+
+PackageIdentifier: Datadog.dd-trace-dotnet
+PackageVersion: 2.26.0
+PackageLocale: en-US
+Publisher: Datadog, Inc.
+PublisherUrl: https://docs.datadoghq.com/
+PublisherSupportUrl: https://www.datadoghq.com/support/
+PrivacyUrl: https://www.datadoghq.com/legal/privacy/
+Author: Datadog
+PackageName: Datadog .NET Tracer
+PackageUrl: https://docs.datadoghq.com/tracing/
+License: Apache-2.0
+LicenseUrl: https://github.com/DataDog/dd-trace-dotnet/blob/master/LICENSE
+Copyright: Copyright 2017 Datadog, Inc.
+CopyrightUrl: https://github.com/DataDog/dd-trace-dotnet/blob/master/NOTICE
+ShortDescription: Automatic instrumentation for .NET applications
+# Description:
+Moniker: dd-trace-dotnet
+Tags:
+- apm
+- tracing
+# Agreements:
+# ReleaseNotes:
+ReleaseNotesUrl: https://github.com/DataDog/dd-trace-dotnet/releases/tag/v2.26.0
+# PurchaseUrl:
+# InstallationNotes:
+# Documentations:
+ManifestType: defaultLocale
+ManifestVersion: 1.2.0

--- a/manifests/d/Datadog/dd-trace-dotnet/2.26.0/Datadog.dd-trace-dotnet.yaml
+++ b/manifests/d/Datadog/dd-trace-dotnet/2.26.0/Datadog.dd-trace-dotnet.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-10
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+
+PackageIdentifier: Datadog.dd-trace-dotnet
+PackageVersion: 2.26.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.2.0


### PR DESCRIPTION
### Result: Installation Successful
|             | Manifest                 | Add/Remove Programs                   |
| ----------- | ------------------------ | ------------------------------------- |
| Name        | Datadog .NET Tracer | Datadog .NET Tracer 64-bit    |
| Version     | 2.26.0     | 2.26.0 |
| Publisher   | Datadog, Inc.   | Datadog, Inc.      |
| ProductCode |           | {9194BB12-19D6-4209-99B9-2C2FC9A181DF}    |
#### Auto-updated by [vedantmgoyal2009/winget-pkgs-automation](https://github.com/vedantmgoyal2009/vedantmgoyal2009/tree/main/winget-pkgs-automation) in workflow run [6517](<https://github.com/vedantmgoyal2009/vedantmgoyal2009/actions/runs/4372327900>)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/99000)