### PR TITLE
New version: Cimbali.pympress version 1.8.0

### DIFF
--- a/manifests/c/Cimbali/pympress/1.7.2/Cimbali.pympress.installer.yaml
+++ b/manifests/c/Cimbali/pympress/1.7.2/Cimbali.pympress.installer.yaml
@@ -3,12 +3,15 @@
 
 PackageIdentifier: Cimbali.pympress
 PackageVersion: 1.7.2
+ProductCode: '{8DBAA4EF-FA88-4C57-88CD-1DAAC4879887}'
 Installers:
 - Architecture: x64
   InstallerType: msi
   InstallerUrl: https://github.com/Cimbali/pympress/releases/download/v1.7.2/pympress-v1.7.2-x86_64.msi
   InstallerSha256: 3044D8DC8A27FDAF31AF7E53CD4F3E0C09CC223A0BDBC1D80AF1679ED0A1A87C
-  ProductCode: '{8DBAA4EF-FA88-4C57-88CD-1DAAC4879887}'
+- Architecture: x86
+  InstallerType: msi
+  InstallerUrl: https://github.com/Cimbali/pympress/releases/download/v1.7.2/pympress-v1.7.2-i686.msi
+  InstallerSha256: B81C273A0D5475BBD2C4707091D3B9D41AD030BBF06BA7AF2B5AE8C26B31E2F4
 ManifestType: installer
 ManifestVersion: 1.2.0
-

--- a/manifests/c/Cimbali/pympress/1.8.0/Cimbali.pympress.installer.yaml
+++ b/manifests/c/Cimbali/pympress/1.8.0/Cimbali.pympress.installer.yaml
@@ -1,0 +1,17 @@
+# Created using wingetcreate 1.2.5.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
+
+PackageIdentifier: Cimbali.pympress
+PackageVersion: 1.8.0
+ProductCode: '{8DBAA4EF-FA88-4C57-88CD-1DAAC4879887}'
+Installers:
+- Architecture: x64
+  InstallerType: msi
+  InstallerUrl: https://github.com/Cimbali/pympress/releases/download/v1.8.0/pympress-v1.8.0-x86_64.msi
+  InstallerSha256: 2610AF28A7A0150D0C41F2F02D29178C55F74C7BFE7AA0F5992FCFCA49FB0522
+- Architecture: x86
+  InstallerType: msi
+  InstallerUrl: https://github.com/Cimbali/pympress/releases/download/v1.8.0/pympress-v1.8.0-i686.msi
+  InstallerSha256: 24cbd4c5fa5dfa1fd58feb93c766b48f220516518982d4927590893b7b52ca1f
+ManifestType: installer
+ManifestVersion: 1.4.0

--- a/manifests/c/Cimbali/pympress/1.8.0/Cimbali.pympress.locale.en-US.yaml
+++ b/manifests/c/Cimbali/pympress/1.8.0/Cimbali.pympress.locale.en-US.yaml
@@ -1,0 +1,16 @@
+# Created using wingetcreate 1.2.5.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.4.0.schema.json
+
+PackageIdentifier: Cimbali.pympress
+PackageVersion: 1.8.0
+PackageLocale: en-US
+Publisher: Cimbali
+PublisherUrl: https://pympress.github.io/
+PublisherSupportUrl: https://github.com/Cimbali/pympress/issues
+PackageName: pympress
+License: GPL2
+LicenseUrl: https://github.com/Cimbali/pympress/blob/master/LICENSE.txt
+CopyrightUrl: https://github.com/Cimbali/pympress/blob/master/LICENSE.txt
+ShortDescription: Pympress is a PDF presentation tool designed for dual-screen setups such as presentations and public talks. Highly configurable, fully-featured, and portable.
+ManifestType: defaultLocale
+ManifestVersion: 1.4.0

--- a/manifests/c/Cimbali/pympress/1.8.0/Cimbali.pympress.yaml
+++ b/manifests/c/Cimbali/pympress/1.8.0/Cimbali.pympress.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.2.5.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.4.0.schema.json
+
+PackageIdentifier: Cimbali.pympress
+PackageVersion: 1.8.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.4.0


### PR DESCRIPTION
I have added the x86 installer to version 1.7.2 and added version 1.8.0.

- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest .\manifests\c\Cimbali\pympress\1.7.2\` and `winget validate --manifest .\manifests\c\Cimbali\pympress\1.8.0\`?
- [X] Have you tested your manifest locally with `winget install --manifest .\manifests\c\Cimbali\pympress\1.7.2\` and `winget install --manifest .\manifests\c\Cimbali\pympress\1.8.0\`?
- [X] Does your manifest conform to the [1.4 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.4.0)? (Version 1.8.0 does, version 1.7.2 does not)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/99524)