### PR TITLE
Changed `PackageName` to make installation easier

### DIFF
--- a/manifests/j/JoeyG/YTDownload/1.2.1/JoeyG.YTDownload.locale.en-US.yaml
+++ b/manifests/j/JoeyG/YTDownload/1.2.1/JoeyG.YTDownload.locale.en-US.yaml
@@ -5,7 +5,8 @@ PackageIdentifier: JoeyG.YTDownload
 PackageVersion: 1.2.1
 PackageLocale: en-US
 Publisher: Joey G
-PackageName: YT-Download
+PackageName: YT Download
+Moniker: yt-download
 License: GPL 3.0
 ShortDescription: A simple GUI based YouTube video and audio downloader
 ManifestType: defaultLocale

--- a/manifests/j/JoeyG/YTDownload/1.2.1/JoeyG.YTDownload.locale.en-US.yaml
+++ b/manifests/j/JoeyG/YTDownload/1.2.1/JoeyG.YTDownload.locale.en-US.yaml
@@ -5,7 +5,7 @@ PackageIdentifier: JoeyG.YTDownload
 PackageVersion: 1.2.1
 PackageLocale: en-US
 Publisher: Joey G
-PackageName: YT Download
+PackageName: YT-Download
 License: GPL 3.0
 ShortDescription: A simple GUI based YouTube video and audio downloader
 ManifestType: defaultLocale


### PR DESCRIPTION
Changed `PackageName` to `YT-Download` instead of `YT Download` in order to make it easier to download the package. Adding the dash allows for the user to *not* have to surround the package name in quotes (e.g., `"YT Download`) in order to download the package.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.4 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.4.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/100141)