### PR TITLE
Fix: gerardog.gsudo artifacts renamed on v2.0.6, added arm64.

### DIFF
--- a/manifests/g/gerardog/gsudo/2.0.6/gerardog.gsudo.installer.yaml
+++ b/manifests/g/gerardog/gsudo/2.0.6/gerardog.gsudo.installer.yaml
@@ -1,0 +1,31 @@
+# Created with YamlCreate.ps1 v2.2.1 using InputObject 🤖 $debug=QUSU.CRLF.7-2-7
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+
+PackageIdentifier: gerardog.gsudo
+PackageVersion: 2.0.6
+MinimumOSVersion: 10.0.0.0
+InstallerType: wix
+Scope: machine
+InstallerSwitches:
+  Silent: /quiet /norestart
+  SilentWithProgress: /passive /norestart
+UpgradeBehavior: install
+Commands:
+- gsudo
+- sudo
+ReleaseDate: 2023-03-24
+Installers:
+- Architecture: arm64
+  InstallerUrl: https://github.com/gerardog/gsudo/releases/download/v2.0.6/gsudo.setup.arm64.msi
+  InstallerSha256: A9BF868557AC2D7C4FA90302C379C87C78C1A3E014308670C919097A0601854E
+  ProductCode: '{4E66C488-7AF6-446D-A60A-A45085458122}'
+- Architecture: x64
+  InstallerUrl: https://github.com/gerardog/gsudo/releases/download/v2.0.6/gsudo.setup.x64.msi
+  InstallerSha256: 739423CF03B6C2B5F96CA74E82B0286652F72FE95B989F91E1952FB620CF77F6
+  ProductCode: '{E28086AD-3429-4797-828A-E1CE78E05350}'
+- Architecture: x86
+  InstallerUrl: https://github.com/gerardog/gsudo/releases/download/v2.0.6/gsudo.setup.x86.msi
+  InstallerSha256: 8EC7EEF5881E4A1414192B9D40A7572A11898ADDA92B7D95C5ABA5A9628AECB3
+  ProductCode: '{50767380-DC8A-45E5-9063-27FECFEBF959}'
+ManifestType: installer
+ManifestVersion: 1.2.0

--- a/manifests/g/gerardog/gsudo/2.0.6/gerardog.gsudo.locale.en-US.yaml
+++ b/manifests/g/gerardog/gsudo/2.0.6/gerardog.gsudo.locale.en-US.yaml
@@ -1,0 +1,37 @@
+# Created with YamlCreate.ps1 v2.2.1 using InputObject 🤖 $debug=QUSU.CRLF.7-2-7
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+
+PackageIdentifier: gerardog.gsudo
+PackageVersion: 2.0.6
+PackageLocale: en-US
+Publisher: gerardog
+# PublisherUrl:
+PublisherSupportUrl: https://github.com/gerardog/gsudo/issues
+# PrivacyUrl:
+Author: Gerardo Grignoli
+PackageName: gsudo
+PackageUrl: https://github.com/gerardog/gsudo
+License: MIT
+LicenseUrl: https://github.com/gerardog/gsudo/blob/master/LICENSE.txt
+Copyright: Copyright (c) 2021 Gerardo Grignoli and GitHub contributors
+CopyrightUrl: https://github.com/gerardog/gsudo/blob/master/LICENSE.txt
+ShortDescription: A Sudo for Windows - run elevated without spawning a new Console Host Window
+# Description:
+Moniker: gsudo
+Tags:
+- admin
+- command-line
+- elevate
+- priviledge
+- run-as
+- shell
+- sudo
+- terminal
+# Agreements:
+# ReleaseNotes:
+ReleaseNotesUrl: https://github.com/gerardog/gsudo/releases/tag/v2.0.6
+# PurchaseUrl:
+# InstallationNotes:
+# Documentations:
+ManifestType: defaultLocale
+ManifestVersion: 1.2.0

--- a/manifests/g/gerardog/gsudo/2.0.6/gerardog.gsudo.yaml
+++ b/manifests/g/gerardog/gsudo/2.0.6/gerardog.gsudo.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.2.1 using InputObject 🤖 $debug=QUSU.CRLF.7-2-7
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+
+PackageIdentifier: gerardog.gsudo
+PackageVersion: 2.0.6
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.2.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.4 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.4.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/100520)