### PR TITLE
Fix incorrect version number of MyHeritage.FamilyTreeBuilder

### DIFF
--- a/manifests/m/MyHeritage/FamilyTreeBuilder/8.0.0.8636/MyHeritage.FamilyTreeBuilder.installer.yaml
+++ b/manifests/m/MyHeritage/FamilyTreeBuilder/8.0.0.8636/MyHeritage.FamilyTreeBuilder.installer.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
 
 PackageIdentifier: MyHeritage.FamilyTreeBuilder
-PackageVersion: 8.0.0.8638
+PackageVersion: 8.0.0.8636
 Installers:
 - Architecture: x86
   InstallerType: nullsoft

--- a/manifests/m/MyHeritage/FamilyTreeBuilder/8.0.0.8636/MyHeritage.FamilyTreeBuilder.locale.en-US.yaml
+++ b/manifests/m/MyHeritage/FamilyTreeBuilder/8.0.0.8636/MyHeritage.FamilyTreeBuilder.locale.en-US.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.4.0.schema.json
 
 PackageIdentifier: MyHeritage.FamilyTreeBuilder
-PackageVersion: 8.0.0.8638
+PackageVersion: 8.0.0.8636
 PackageLocale: en-US
 Publisher: MyHeritage
 PublisherUrl: https://www.myheritage.com/

--- a/manifests/m/MyHeritage/FamilyTreeBuilder/8.0.0.8636/MyHeritage.FamilyTreeBuilder.yaml
+++ b/manifests/m/MyHeritage/FamilyTreeBuilder/8.0.0.8636/MyHeritage.FamilyTreeBuilder.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.4.0.schema.json
 
 PackageIdentifier: MyHeritage.FamilyTreeBuilder
-PackageVersion: 8.0.0.8638
+PackageVersion: 8.0.0.8636
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.4.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.4 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.4.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/100843)