### PR TITLE
Respond with comments when moderators add Dependencies, Interactive, or Hardware Labels

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -5932,6 +5932,10 @@
           "project_card"
         ],
         "taskName": "Respond to PR author regarding the Validation-Domain error",
+        "dangerZone": {
+          "respondToBotActions": true,
+          "acceptRespondToBotActions": true
+        },
         "actions": [
           {
             "name": "addReply",
@@ -5978,6 +5982,10 @@
           "project_card"
         ],
         "taskName": "Blocked by Dependencies",
+        "dangerZone": {
+          "respondToBotActions": true,
+          "acceptRespondToBotActions": true
+        },
         "actions": [
           {
             "name": "addReply",
@@ -6018,6 +6026,10 @@
           "project_card"
         ],
         "taskName": "Blocked by Interactive Only Installer",
+        "dangerZone": {
+          "respondToBotActions": true,
+          "acceptRespondToBotActions": true
+        },
         "actions": [
           {
             "name": "addReply",
@@ -6110,6 +6122,10 @@
           "project_card"
         ],
         "taskName": "Blocked by specific Hardware Requirements",
+        "dangerZone": {
+          "respondToBotActions": true,
+          "acceptRespondToBotActions": true
+        },
         "actions": [
           {
             "name": "addReply",


### PR DESCRIPTION
Currently, when moderators add the dependencies label to a PR, the label doesn't trigger the autoresponder to add the message describing what the dependencies label means. This change should allow fabricbot to process the event label triggers even if they were kicked off by fabricbot

cc @denelon
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/101250)