### PR TITLE
Add Merge-Ready Label when Approving PRs

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1153,6 +1153,12 @@
             }
           },
           {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Merge-Ready"
+            }
+          },
+          {
             "name": "addReply",
             "parameters": {
               "comment": "Hello ${issueAuthor},\nValidation has completed.\n\nTemplate: msftbot/validationCompleted"

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -4441,6 +4441,12 @@
           {
             "name": "removeLabel",
             "parameters": {
+              "label": "Merge-Ready"
+            }
+          },
+          {
+            "name": "removeLabel",
+            "parameters": {
               "label": "Validation-Hash-Verification-Failed"
             }
           },
@@ -4847,6 +4853,12 @@
         ],
         "taskName": "Remove all Event Labels on rerun (not moderator approved)",
         "actions": [
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "Merge-Ready"
+            }
+          },
           {
             "name": "removeLabel",
             "parameters": {
@@ -6238,6 +6250,67 @@
             }
           }
         ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "labelAdded",
+                  "parameters": {
+                    "label": "Needs-Attention"
+                  }
+                },
+                {
+                  "name": "labelAdded",
+                  "parameters": {
+                    "label": "Needs-Author-Feedback"
+                  }
+                },
+                {
+                  "name": "labelAdded",
+                  "parameters": {
+                    "label": "Blocking-Issue"
+                  }
+                },
+                {
+                  "name": "labelRemoved",
+                  "parameters": {
+                    "label": "Moderator-Approved"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "actions": [
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "Merge-Ready"
+            }
+          }
+        ],
+        "taskName": "Remove Merge-Ready when Feedback Needed",
+        "dangerZone": {
+          "respondToBotActions": true,
+          "acceptRespondToBotActions": true
+        }
       }
     },
     {


### PR DESCRIPTION
As seen in #101001, there is a set of conditions that can allow PR's to be merged without going through the validation process fully. This appears to be due to the change in fabricbot to use the GitHub native auto-merge instead of fabricbot performing the merge. 

Fabricbot can enable auto-merge only based on one label at a time. This PR is to add a separate label that can give better control of when auto-merge is enabled

Expected behavior - 
* `Merge-Ready` label only added at the same time fabricbot approves a PR
* `Merge-Ready` label removed when changes are pushed to a PR
* `Merge-Ready` label removed when changes are requested on a PR or feedback is needed
* `Merge-Ready` label removed when pipeline is re-run

There will need to be a follow-up PR to this one to change the auto-merge to be based on this new label.

cc @denelon
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/101251)