### PR TITLE
Remove ReleaseNotes due to vanity Url

### DIFF
--- a/manifests/b/BitSum/ProcessLasso/12.1.0.26/BitSum.ProcessLasso.locale.en-US.yaml
+++ b/manifests/b/BitSum/ProcessLasso/12.1.0.26/BitSum.ProcessLasso.locale.en-US.yaml
@@ -24,10 +24,6 @@ Tags:
 - optimizer
 - priority
 - process
-ReleaseNotes: |-
-  - Adjustment to BHP for Alder Lake on Win10 (specifically)
-  - Refinement of memory priority feature
-  - Minor fixes and enhancements
 ReleaseNotesUrl: https://bitsum.com/changes/processlasso/
 ManifestType: defaultLocale
 ManifestVersion: 1.2.0


### PR DESCRIPTION
ReleaseNotes are not removed by wingetbot in its auto-update PRs and should not be used where vanity Urls are used.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/101872)