### PR TITLE
Add UpgradeBehaviour into Current Version Microsoft.ADKPEAddon

### DIFF
--- a/manifests/m/Microsoft/ADKPEAddon/10.1.22621.1/Microsoft.ADKPEAddon.installer.yaml
+++ b/manifests/m/Microsoft/ADKPEAddon/10.1.22621.1/Microsoft.ADKPEAddon.installer.yaml
@@ -6,6 +6,7 @@ InstallerType: burn
 InstallerSwitches:
   Silent: /quiet
   SilentWithProgress: /quiet
+UpgradeBehavior: uninstallPrevious
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.microsoft.com/download/5/2/5/525dcde0-c7b8-487a-894d-0952775a78c7/adkwinpeaddons/adkwinpesetup.exe


### PR DESCRIPTION
During the winget upgrade of Microsoft.ADKPEAddon, it always returns to code 2008 when UpgradeBehaviour was not set.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/101966)