### PR TITLE
Add InstallLocation to VMware.WorkstationPlayer 17.0.1

### DIFF
--- a/manifests/v/VMware/WorkstationPlayer/17.0.1/VMware.WorkstationPlayer.installer.yaml
+++ b/manifests/v/VMware/WorkstationPlayer/17.0.1/VMware.WorkstationPlayer.installer.yaml
@@ -12,10 +12,11 @@ InstallerSwitches:
   Silent: /s /v/qn
   SilentWithProgress: /s /v/qb
   Custom: EULAS_AGREED=1 AUTOSOFTWAREUPDATE=0 DATACOLLECTION=0 ADDLOCAL=ALL REBOOT=ReallySuppress
+  InstallLocation: INSTALLDIR="<INSTALLPATH>"
 InstallerSuccessCodes:
-- "3010"
-- "1614"
-- "1641"
+- 3010
+- 1614
+- 1641
 UpgradeBehavior: install
 Dependencies:
   PackageDependencies:


### PR DESCRIPTION
Verified by `winget install -l "C:\Test" --manifest <path_to_manifest>`

Also replaced InstallerSuccessCodes strings to integers to clear manifest schema warnings

-----

- Resolves #102108
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/102123)