### PR TITLE
NDI5Runtime to 5.5.4.0 + Publisher Change

### DIFF
--- a/manifests/n/NDI/NDI5Runtime/5.5.4.0/NDI.NDI5Runtime.installer.yaml
+++ b/manifests/n/NDI/NDI5Runtime/5.5.4.0/NDI.NDI5Runtime.installer.yaml
@@ -1,0 +1,19 @@
+# Created using wingetcreate 1.2.5.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
+
+PackageIdentifier: NDI.NDI5Runtime
+PackageVersion: 5.5.4.0
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: machine
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+Installers:
+- InstallerUrl: http://ndi.link/NDIRedistV5
+  Architecture: x64
+  InstallerType: inno
+  InstallerSha256: 3808572276A708E0617B00979A43D03EC2C5A44ED2B640EFD126500F6CCA8ECF
+ManifestType: installer
+ManifestVersion: 1.4.0

--- a/manifests/n/NDI/NDI5Runtime/5.5.4.0/NDI.NDI5Runtime.locale.en-US.yaml
+++ b/manifests/n/NDI/NDI5Runtime/5.5.4.0/NDI.NDI5Runtime.locale.en-US.yaml
@@ -1,0 +1,16 @@
+# Created using wingetcreate 1.2.5.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.4.0.schema.json
+
+PackageIdentifier: NDI.NDI5Runtime
+PackageVersion: 5.5.4.0
+PackageLocale: en-US
+Publisher: NDI
+PublisherUrl: https://ndi.video/                        
+PackageName: NDI 5 Runtime
+License: Proprietary
+ShortDescription: Bring the NDI support for specific application that requires NDI libraries but do not bundle them with their installer.
+Tags:
+- ndi
+- runtime
+ManifestType: defaultLocale
+ManifestVersion: 1.4.0

--- a/manifests/n/NDI/NDI5Runtime/5.5.4.0/NDI.NDI5Runtime.yaml
+++ b/manifests/n/NDI/NDI5Runtime/5.5.4.0/NDI.NDI5Runtime.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.2.5.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.4.0.schema.json
+
+PackageIdentifier: NDI.NDI5Runtime
+PackageVersion: 5.5.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.4.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.4 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.4.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

This PR will change the Publisher Name (and path) from Newtek to NDI.
I could not find the process in this case > should the old one be removed? or is there an Alias system or a notification?
Thank you

This is (supposedly) the proper one after the failed attempts at #102244 & #102245 

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/102246)