### PR TITLE
NDI5Tools change publisher to NDI

### DIFF
--- a/manifests/n/NDI/NDI5Tools/5.5.4.0/NDI.NDI5Tools.installer.yaml
+++ b/manifests/n/NDI/NDI5Tools/5.5.4.0/NDI.NDI5Tools.installer.yaml
@@ -1,0 +1,14 @@
+# Manually Modified by @trouffman to propagte NDI Branding name changes
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+
+PackageIdentifier: NDI.NDI5Tools
+PackageVersion: 5.5.4.0
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: machine
+Installers:
+- Architecture: x64
+  InstallerUrl: https://downloads.ndi.tv/Tools/NDI%205%20Tools.exe
+  InstallerSha256: 1D639C751572CD38D2A8011759BC33D481FC128A119631A0616B8A6217B62AF7
+ManifestType: installer
+ManifestVersion: 1.2.0

--- a/manifests/n/NDI/NDI5Tools/5.5.4.0/NDI.NDI5Tools.locale.en-US.yaml
+++ b/manifests/n/NDI/NDI5Tools/5.5.4.0/NDI.NDI5Tools.locale.en-US.yaml
@@ -1,0 +1,15 @@
+# Manually Modified by @trouffman to propagte NDI Branding name changes
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+
+PackageIdentifier: NDI.NDI5Tools
+PackageVersion: 5.5.4.0
+PackageLocale: en-US
+Publisher: NDI
+PackageName: NDI 5 Tools
+License: Proprietary
+ShortDescription: Set of officials tools to recive and transmit live video and audio with NDI.
+Tags:
+- ndi
+- tools
+ManifestType: defaultLocale
+ManifestVersion: 1.2.0

--- a/manifests/n/NDI/NDI5Tools/5.5.4.0/NDI.NDI5Tools.yaml
+++ b/manifests/n/NDI/NDI5Tools/5.5.4.0/NDI.NDI5Tools.yaml
@@ -1,0 +1,8 @@
+# Manually Modified by @trouffman to propagte NDI Branding name changes
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+
+PackageIdentifier: NDI.NDI5Tools
+PackageVersion: 5.5.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.2.0


### PR DESCRIPTION
This is now officially published by "NDI" and no longer Newtek. This commit change the Publisher / path & add tag for search help.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.4 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.4.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----
