### PR TITLE
Fixing URL for the previous version Microsoft.RemoteDesktopClient

### DIFF
--- a/manifests/m/Microsoft/RemoteDesktopClient/1.2.4066.0/Microsoft.RemoteDesktopClient.installer.yaml
+++ b/manifests/m/Microsoft/RemoteDesktopClient/1.2.4066.0/Microsoft.RemoteDesktopClient.installer.yaml
@@ -17,42 +17,42 @@ ReleaseDate: 2023-01-31
 Installers:
 - Architecture: x86
   Scope: user
-  InstallerUrl: https://go.microsoft.com/fwlink/?linkid=2098960
+  InstallerUrl: https://query.prod.cms.rt.microsoft.com/cms/api/am/binary/RW10GYu
   InstallerSha256: 957F4983AA4F54A789FA77B0CD3201910D686A85721BBE9FC52F0EBA6CCB0220
   InstallerSwitches:
     Custom: ALLUSERS=2 MSIINSTALLPERUSER=1
   ProductCode: '{ADD47F6A-1FF0-4F27-B620-C60C89CFF501}'
 - Architecture: x86
   Scope: machine
-  InstallerUrl: https://go.microsoft.com/fwlink/?linkid=2098960
+  InstallerUrl: https://query.prod.cms.rt.microsoft.com/cms/api/am/binary/RW10GYu
   InstallerSha256: 957F4983AA4F54A789FA77B0CD3201910D686A85721BBE9FC52F0EBA6CCB0220
   InstallerSwitches:
     Custom: ALLUSERS=2
   ProductCode: '{ADD47F6A-1FF0-4F27-B620-C60C89CFF501}'
 - Architecture: x64
   Scope: user
-  InstallerUrl: https://go.microsoft.com/fwlink/?linkid=2068602
+  InstallerUrl: https://query.prod.cms.rt.microsoft.com/cms/api/am/binary/RW10DEa
   InstallerSha256: E5673A3319F1C7025E7FBA30435A6BF1DC7E056370231631926A4DD538846DAF
   InstallerSwitches:
     Custom: ALLUSERS=2 MSIINSTALLPERUSER=1
   ProductCode: '{ED244C83-07CB-4E9E-B4F9-FA650B874C37}'
 - Architecture: x64
   Scope: machine
-  InstallerUrl: https://go.microsoft.com/fwlink/?linkid=2068602
+  InstallerUrl: https://query.prod.cms.rt.microsoft.com/cms/api/am/binary/RW10DEa
   InstallerSha256: E5673A3319F1C7025E7FBA30435A6BF1DC7E056370231631926A4DD538846DAF
   InstallerSwitches:
     Custom: ALLUSERS=1
   ProductCode: '{ED244C83-07CB-4E9E-B4F9-FA650B874C37}'
 - Architecture: arm64
   Scope: user
-  InstallerUrl: https://go.microsoft.com/fwlink/?linkid=2098961
+  InstallerUrl: https://query.prod.cms.rt.microsoft.com/cms/api/am/binary/RW10GYw
   InstallerSha256: 1CD4D77BEE82CE8F1C3D07405D930E6E526DABB9B26FDFCA88E1F23D9BB5BD29
   InstallerSwitches:
     Custom: ALLUSERS=2 MSIINSTALLPERUSER=1
   ProductCode: '{232E3416-E053-4F8E-B6C8-D438E6D57DE7}'
 - Architecture: arm64
   Scope: machine
-  InstallerUrl: https://go.microsoft.com/fwlink/?linkid=2098961
+  InstallerUrl: https://query.prod.cms.rt.microsoft.com/cms/api/am/binary/RW10GYw
   InstallerSha256: 1CD4D77BEE82CE8F1C3D07405D930E6E526DABB9B26FDFCA88E1F23D9BB5BD29
   InstallerSwitches:
     Custom: ALLUSERS=1


### PR DESCRIPTION
go.microsoft.com can't be used in here because it always point to the latest version of Microsoft.RemoteDesktopClient. 
Applying URL to the correct sever address that correct URL
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/102416)