### PR TITLE
New version: Giuspen.Cherrytree version 0.99.55.0

### DIFF
--- a/manifests/g/Giuspen/Cherrytree/0.99.55.0/Giuspen.Cherrytree.installer.yaml
+++ b/manifests/g/Giuspen/Cherrytree/0.99.55.0/Giuspen.Cherrytree.installer.yaml
@@ -2,13 +2,13 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
 
 PackageIdentifier: Giuspen.Cherrytree
-PackageVersion: 0.99.49.0
+PackageVersion: 0.99.55.0
 MinimumOSVersion: 10.0.0.0
 InstallerType: inno
 Scope: machine
 Installers:
 - Architecture: x64
-  InstallerUrl: https://www.giuspen.com/software/cherrytree_0.99.49.0_win64_setup.exe
-  InstallerSha256: 6501F0B44299ABF4FF2C1D4E067C5900ED8056EC1473155965C01BFCEBD6BA0E
+  InstallerUrl: https://www.giuspen.net/software/cherrytree_0.99.55.0_win64_setup.exe
+  InstallerSha256: 22eac4089ce4c5ecd3915ada7bfe0d41b9ded6ec90eb51776f82268dd737d275
 ManifestType: installer
 ManifestVersion: 1.2.0

--- a/manifests/g/Giuspen/Cherrytree/0.99.55.0/Giuspen.Cherrytree.locale.en-US.yaml
+++ b/manifests/g/Giuspen/Cherrytree/0.99.55.0/Giuspen.Cherrytree.locale.en-US.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
 
 PackageIdentifier: Giuspen.Cherrytree
-PackageVersion: 0.99.49.0
+PackageVersion: 0.99.55.0
 PackageLocale: en-US
 Publisher: Giuseppe Penone
 PublisherUrl: https://www.giuspen.com

--- a/manifests/g/Giuspen/Cherrytree/0.99.55.0/Giuspen.Cherrytree.yaml
+++ b/manifests/g/Giuspen/Cherrytree/0.99.55.0/Giuspen.Cherrytree.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
 
 PackageIdentifier: Giuspen.Cherrytree
-PackageVersion: 0.99.49.0
+PackageVersion: 0.99.55.0
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.2.0


### PR DESCRIPTION
version 0.99.49.0 is no longer available; returns 404

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.4 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.4.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/102713)