### PR TITLE
Update geeksoftwareGmbH.PDF24Creator.installer.yaml

### DIFF
--- a/manifests/g/geeksoftwareGmbH/PDF24Creator/11.11.1/geeksoftwareGmbH.PDF24Creator.installer.yaml
+++ b/manifests/g/geeksoftwareGmbH/PDF24Creator/11.11.1/geeksoftwareGmbH.PDF24Creator.installer.yaml
@@ -9,12 +9,12 @@ UpgradeBehavior: install
 Installers:
 - Architecture: x64
   InstallerType: wix
-  InstallerUrl: https://download1.pdf24.org/pdf24-creator-11.11.1.msi
+  InstallerUrl: https://download.pdf24.org/pdf24-creator-11.11.1-x64.msi
   InstallerSha256: 832CBDF6678D89BC151676417E318F1BD5852563FB9CFF995881C92785AE9CA8
   ProductCode: '{23405AFC-64C1-40C4-ABD7-64809DCF286A}'
 - Architecture: x64
   InstallerType: inno
-  InstallerUrl: https://download1.pdf24.org/pdf24-creator-11.11.1.exe
+  InstallerUrl: https://download.pdf24.org/pdf24-creator-11.11.1-x64.exe
   InstallerSha256: 08AF740A9C8C6734E668A74C4081E0DB866EE046CB7C472A01CDB6EC96766403
   InstallerSwitches:
     Custom: /NOUPDATE /NORESTART


### PR DESCRIPTION
This change adds the -x64 to the path because this refers to the x64 version. Now there is also an x86 build available, which can be downloaded via pdf24-creator-11.11.1-x86.msi and pdf24-creator-11.11.1-x86.exe.

It is also better to use download.pdf24.org as host in the URL because this host distributes the network load between multiple download servers. Last days we have seen that the load on specific PDF24 download servers is relatively high. To get the file faster, it's better to use download.pdf24.org.

- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.4 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.4.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/102813)