### PR TITLE
New package: Apache NetBeans 17

### DIFF
--- a/manifests/a/Apache/NetBeans/17/Apache.NetBeans.installer.yaml
+++ b/manifests/a/Apache/NetBeans/17/Apache.NetBeans.installer.yaml
@@ -1,0 +1,19 @@
+# Created with YamlCreate.ps1 v2.2.4 $debug=NVS0.CRLF.5-1-22621-963.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
+
+PackageIdentifier: Apache.NetBeans
+PackageVersion: "17"
+ReleaseDate: 2023-02-21
+InstallModes:
+- interactive
+- silent
+Installers:
+- Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://dlcdn.apache.org/netbeans/netbeans-installers/17/Apache-NetBeans-17-bin-windows-x64.exe
+  InstallerSha256: 8AC991404FAA60990F44AEA58F48F84FF888A3796DA85B689C3CA50EF4F0E0B3
+  InstallerSwitches:
+    Silent: --silent
+    SilentWithProgress: --silent
+ManifestType: installer
+ManifestVersion: 1.4.0

--- a/manifests/a/Apache/NetBeans/17/Apache.NetBeans.installer.yaml
+++ b/manifests/a/Apache/NetBeans/17/Apache.NetBeans.installer.yaml
@@ -10,7 +10,7 @@ InstallModes:
 Installers:
 - Architecture: x64
   InstallerType: exe
-  InstallerUrl: https://dlcdn.apache.org/netbeans/netbeans-installers/17/Apache-NetBeans-17-bin-windows-x64.exe
+  InstallerUrl: https://archive.apache.org/dist/netbeans/netbeans-installers/17/Apache-NetBeans-17-bin-windows-x64.exe
   InstallerSha256: 8AC991404FAA60990F44AEA58F48F84FF888A3796DA85B689C3CA50EF4F0E0B3
   InstallerSwitches:
     Silent: --silent

--- a/manifests/a/Apache/NetBeans/17/Apache.NetBeans.locale.en-US.yaml
+++ b/manifests/a/Apache/NetBeans/17/Apache.NetBeans.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# Created with YamlCreate.ps1 v2.2.4 $debug=NVS0.CRLF.5-1-22621-963.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.4.0.schema.json
+
+PackageIdentifier: Apache.NetBeans
+PackageVersion: "17"
+PackageLocale: en-US
+Publisher: Apache Software Foundation
+# PublisherUrl:
+# PublisherSupportUrl:
+# PrivacyUrl:
+# Author:
+PackageName: Apache NetBeans
+# PackageUrl:
+License: Apache-2.0
+LicenseUrl: https://github.com/apache/netbeans/blob/master/LICENSE
+# Copyright:
+# CopyrightUrl:
+ShortDescription: Apache NetBeans is an open source development environment, tooling platform, and application framework.
+# Description:
+# Moniker:
+# Tags:
+# Agreements:
+# ReleaseNotes:
+# ReleaseNotesUrl:
+# PurchaseUrl:
+# InstallationNotes:
+# Documentations:
+ManifestType: defaultLocale
+ManifestVersion: 1.4.0

--- a/manifests/a/Apache/NetBeans/17/Apache.NetBeans.yaml
+++ b/manifests/a/Apache/NetBeans/17/Apache.NetBeans.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.2.4 $debug=NVS0.CRLF.5-1-22621-963.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.4.0.schema.json
+
+PackageIdentifier: Apache.NetBeans
+PackageVersion: "17"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.4.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.4 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.4.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

This requires JDK 8+.
![image](https://user-images.githubusercontent.com/95566897/233247665-fac2ca8f-5ef6-4847-82d0-8f2bbb1c2253.png)

Since there's no way to specify JDK in dependency field, I won't added it for now. 

Note: https://github.com/microsoft/winget-cli/blob/master/doc/specs/%23163%20-%20Dependencies.md#external-dependencies
> These include dependencies from outside of the source the original package is distributed. In some cases suitable items may exist in the same source, but for licensing or personal preference, no explicit package should be required. One example is Java. Many vendors offer JREs and JDKs so it may be more reasonable to have a user informed, and allow the user to confirm the presence of a dependency.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/102998)