### PR TITLE
Update ApacheFriends.Xampp.8.2.installer.yaml to reflect the correct …

### DIFF
--- a/manifests/a/ApacheFriends/Xampp/8/2/8.2.4/ApacheFriends.Xampp.8.2.installer.yaml
+++ b/manifests/a/ApacheFriends/Xampp/8/2/8.2.4/ApacheFriends.Xampp.8.2.installer.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
 
 PackageIdentifier: ApacheFriends.Xampp.8.2
-PackageVersion: 8.2.4
+PackageVersion: 8.2.4-0
 InstallerLocale: en-US
 Scope: machine
 InstallModes:


### PR DESCRIPTION
After installation Winget shows the installer as 8.4.2-0 instead of 8.4.2 so updated the version number so that `winget upgrade --all` does not try to unnecessarily upgrade the package from 8.4.2-0 to 8.4.2-0

…version

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.4 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.4.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/103013)