### PR TITLE
Update Anaconda.Anaconda3.installer.yaml to correct version py310_2023.03-0

### DIFF
--- a/manifests/a/Anaconda/Anaconda3/2023.03/Anaconda.Anaconda3.installer.yaml
+++ b/manifests/a/Anaconda/Anaconda3/2023.03/Anaconda.Anaconda3.installer.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
 
 PackageIdentifier: Anaconda.Anaconda3
-PackageVersion: "2023.03"
+PackageVersion: "py310_2023.03-0"
 MinimumOSVersion: 10.0.0.0
 InstallerType: nullsoft
 UpgradeBehavior: uninstallPrevious


### PR DESCRIPTION
After installation winget shows the current version as `py310_2023.03-0`, thus `winget upgrade --all` tries to upgrade to `2023.03`

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.4 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.4.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/103014)