### PR TITLE
Fix version of ImageLine.FLStudio (remove build number)

### DIFF
--- a/manifests/i/ImageLine/FLStudio/21.0.3/ImageLine.FLStudio.installer.yaml
+++ b/manifests/i/ImageLine/FLStudio/21.0.3/ImageLine.FLStudio.installer.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
 
 PackageIdentifier: ImageLine.FLStudio
-PackageVersion: 21.0.3.3517
+PackageVersion: 21.0.3
 MinimumOSVersion: 10.0.0.0
 InstallerType: nullsoft
 InstallerSuccessCodes:

--- a/manifests/i/ImageLine/FLStudio/21.0.3/ImageLine.FLStudio.locale.en-US.yaml
+++ b/manifests/i/ImageLine/FLStudio/21.0.3/ImageLine.FLStudio.locale.en-US.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
 
 PackageIdentifier: ImageLine.FLStudio
-PackageVersion: 21.0.3.3517
+PackageVersion: 21.0.3
 PackageLocale: en-US
 Publisher: Image-Line
 PublisherUrl: https://www.image-line.com/

--- a/manifests/i/ImageLine/FLStudio/21.0.3/ImageLine.FLStudio.yaml
+++ b/manifests/i/ImageLine/FLStudio/21.0.3/ImageLine.FLStudio.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
 
 PackageIdentifier: ImageLine.FLStudio
-PackageVersion: 21.0.3.3517
+PackageVersion: 21.0.3
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.1.0


### PR DESCRIPTION
- [ x ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ x ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ x ] This PR only modifies one (1) manifest
- [ x ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ x ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ x ] Does your manifest conform to the [1.4 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.4.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

I've found out Image-Line began to include the version of installed product, but they use only partial 'major.minor.patch' string, excluding build number. I've updated the format here because now FLStudio constantly tries to update itself, and this is no longer hidden under `--include-unknown` flag.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/103019)