### PR TITLE
Trigger label description replies in issues

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -6098,7 +6098,7 @@
           "issues",
           "project_card"
         ],
-        "taskName": "Blocked by Dependencies",
+        "taskName": "PR blocked by Dependencies",
         "dangerZone": {
           "respondToBotActions": true,
           "acceptRespondToBotActions": true
@@ -6108,6 +6108,49 @@
             "name": "addReply",
             "parameters": {
               "comment": "Hello @${issueAuthor},\n\nThis package appears to require dependencies in order to install successfully.\n\nThis PR is blocked until support for dependencies is implemented in:\n* microsoft/winget-cli/issues/163\n\nTemplate: msftbot/blockingIssue/dependencySupport"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Blocking-Issue"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "labelAdded",
+              "parameters": {
+                "label": "Dependencies"
+              }
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "Issue blocked by Dependencies",
+        "dangerZone": {
+          "respondToBotActions": false,
+          "acceptRespondToBotActions": true
+        },
+        "actions": [
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "Hello @${issueAuthor},\n\nThis package appears to require dependencies in order to install successfully.\n\nThis issue is blocked until support for dependencies is implemented in:\n* microsoft/winget-cli/issues/163\n\nTemplate: msftbot/blockingIssue/dependencySupport"
             }
           },
           {
@@ -6142,7 +6185,7 @@
           "issues",
           "project_card"
         ],
-        "taskName": "Blocked by Interactive Only Installer",
+        "taskName": "PR blocked by Interactive Only Installer",
         "dangerZone": {
           "respondToBotActions": true,
           "acceptRespondToBotActions": true
@@ -6152,6 +6195,49 @@
             "name": "addReply",
             "parameters": {
               "comment": "Hello @${issueAuthor},\n\nThis package appears to require user interaction to install.\n\nThis PR is blocked until support for interactive installer search filtering is implemented in:\n* microsoft/winget-cli/issues/823\n\nTemplate: msftbot/blockingIssue/interactiveOnlyInstall"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Blocking-Issue"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "labelAdded",
+              "parameters": {
+                "label": "Interactive-Only-Installer"
+              }
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "Issue blocked by Interactive Only Installer",
+        "dangerZone": {
+          "respondToBotActions": false,
+          "acceptRespondToBotActions": true
+        },
+        "actions": [
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "Hello @${issueAuthor},\n\nThis package appears to require user interaction to install.\n\nThis issue is blocked until support for interactive installer search filtering is implemented in:\n* microsoft/winget-cli/issues/823\n\nTemplate: msftbot/blockingIssue/interactiveOnlyInstall"
             }
           },
           {
@@ -6186,7 +6272,7 @@
           "issues",
           "project_card"
         ],
-        "taskName": "Blocked by Zipped Binaries",
+        "taskName": "PR blocked by Zipped Binaries",
         "dangerZone": {
           "respondToBotActions": true,
           "acceptRespondToBotActions": true
@@ -6196,6 +6282,49 @@
             "name": "addReply",
             "parameters": {
               "comment": "Hello @${issueAuthor},\n\nThis package appears to depend on .dlls that aren't available via symlink.\n\nThis PR is blocked until support for zipped binaries is implemented in:\n* microsoft/winget-cli/issues/2711\n\nTemplate: msftbot/blockingIssue/zipBinary"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Blocking-Issue"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "labelAdded",
+              "parameters": {
+                "label": "zip-binary"
+              }
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "Issue blocked by Zipped Binaries",
+        "dangerZone": {
+          "respondToBotActions": false,
+          "acceptRespondToBotActions": true
+        },
+        "actions": [
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "Hello @${issueAuthor},\n\nThis package appears to depend on .dlls that aren't available via symlink.\n\nThis issue is blocked until support for zipped binaries is implemented in:\n* microsoft/winget-cli/issues/2711\n\nTemplate: msftbot/blockingIssue/zipBinary"
             }
           },
           {
@@ -6282,7 +6411,7 @@
           "issues",
           "project_card"
         ],
-        "taskName": "Blocked by specific Hardware Requirements",
+        "taskName": "PR blocked by specific Hardware Requirements",
         "dangerZone": {
           "respondToBotActions": true,
           "acceptRespondToBotActions": true
@@ -6293,6 +6422,50 @@
             "parameters": {
               "label": "Blocking-Issue",
               "comment": "Hello @${issueAuthor},\n\nThis package appears to require specific hardware.\n\nThis PR is blocked until support for specific hardware requirements is implemented in:\n* microsoft/winget-cli/issues/1417\n\nTemplate: msftbot/blockingIssue/hardwareDependency"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Blocking-Issue"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "labelAdded",
+              "parameters": {
+                "label": "Hardware"
+              }
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "Issue blocked by specific Hardware Requirements",
+        "dangerZone": {
+          "respondToBotActions": false,
+          "acceptRespondToBotActions": true
+        },
+        "actions": [
+          {
+            "name": "addReply",
+            "parameters": {
+              "label": "Blocking-Issue",
+              "comment": "Hello @${issueAuthor},\n\nThis package appears to require specific hardware.\n\nThis issue is blocked until support for specific hardware requirements is implemented in:\n* microsoft/winget-cli/issues/1417\n\nTemplate: msftbot/blockingIssue/hardwareDependency"
             }
           },
           {


### PR DESCRIPTION
The reply triggers added in https://github.com/microsoft/winget-pkgs/pull/101250 and https://github.com/microsoft/winget-pkgs/pull/103105 only work when the label is added in a PR. This PR (hopefully) updates the behavior to reply with label description in issues as well.

cc @Trenly

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/103148)