### PR TITLE
Fix DeepL Installer Hash

### DIFF
--- a/manifests/d/DeepL/DeepL/4.5.0.8268/DeepL.DeepL.installer.yaml
+++ b/manifests/d/DeepL/DeepL/4.5.0.8268/DeepL.DeepL.installer.yaml
@@ -7,17 +7,17 @@ InstallerLocale: en-US
 MinimumOSVersion: 10.0.0.0
 InstallerType: exe
 InstallModes:
-- interactive
-- silent
+  - interactive
+  - silent
 InstallerSwitches:
   Silent: -verysilent
   SilentWithProgress: -silent
 UpgradeBehavior: install
 ReleaseDate: 2023-03-09
 Installers:
-- Architecture: x64
-  InstallerUrl: https://appdownload.deepl.com/windows/0install/DeepLSetup.exe
-  InstallerSha256: CAC8435C33DFFCD0D198FF1619D3B266070172FA341A7A5A846B3299675A0BBB
-  ProductCode: https%3a##appdownload.deepl.com#windows#0install#deepl.xml
+  - Architecture: x64
+    InstallerUrl: https://appdownload.deepl.com/windows/0install/DeepLSetup.exe
+    InstallerSha256: CCDDE4FDA138A52C9E1E3D9C230ACBE413E4DC121BDBBD1DD43B1EB36B966219
+    ProductCode: https%3a##appdownload.deepl.com#windows#0install#deepl.xml
 ManifestType: installer
 ManifestVersion: 1.4.0


### PR DESCRIPTION
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.4 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.4.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.


Installer Hash from the Web Installer has changed, but the version of DeepL stayed the same. Therefore the DeepL Installation currently does not work from winget. This PR fixes this.
-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/103723)