### PR TITLE
Update URL for BitRecover.AadhaarCardPasswordRemover version 3

### DIFF
--- a/manifests/b/BitRecover/AadhaarCardPasswordRemover/3.0/BitRecover.AadhaarCardPasswordRemover.installer.yaml
+++ b/manifests/b/BitRecover/AadhaarCardPasswordRemover/3.0/BitRecover.AadhaarCardPasswordRemover.installer.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 1.0.4.0
+﻿# Created using wingetcreate 1.0.4.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
 
 PackageIdentifier: BitRecover.AadhaarCardPasswordRemover
@@ -6,7 +6,7 @@ PackageVersion: 3.0
 Installers:
 - Architecture: x64
   InstallerType: inno
-  InstallerUrl: https://www.bitrecover.com/dl/bitrecover-aadhaar-card-password-remover.exe
+  InstallerUrl: https://dl.bitrecover.com/bitrecover-aadhaar-card-password-remover.exe
   InstallerSha256: C65B94DB009EB0FD00028ADA13C4220E274CF364DCDA616CD1DF6F26BDCC9EF5
 ManifestType: installer
 ManifestVersion: 1.1.0


### PR DESCRIPTION
From latest URL Scan:
> https://www.bitrecover.com/dl/bitrecover-aadhaar-card-password-remover.exe for BitRecover.AadhaarCardPasswordRemover version 3 redirects to https://dl.bitrecover.com/bitrecover-aadhaar-card-password-remover.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105652)