### PR TITLE
Update URL for BitRecover.WindowsLiveMailConverter version 7.5

### DIFF
--- a/manifests/b/BitRecover/WindowsLiveMailConverter/7.5/BitRecover.WindowsLiveMailConverter.installer.yaml
+++ b/manifests/b/BitRecover/WindowsLiveMailConverter/7.5/BitRecover.WindowsLiveMailConverter.installer.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 1.0.3.0
+﻿# Created using wingetcreate 1.0.3.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
 
 PackageIdentifier: BitRecover.WindowsLiveMailConverter
@@ -6,7 +6,7 @@ PackageVersion: 7.5
 Installers:
 - Architecture: x64
   InstallerType: inno
-  InstallerUrl: https://www.bitrecover.com/dl/bitrecover-windows-live-mail-converter-wizard.exe
+  InstallerUrl: https://dl.bitrecover.com/bitrecover-windows-live-mail-converter-wizard.exe
   InstallerSha256: F081E614F48D50207EE1BC95B9BE04B00193627BC768BAF6961A64254EFD055C
 ManifestType: installer
 ManifestVersion: 1.1.0

--- a/manifests/b/BitRecover/WindowsLiveMailConverter/8.0/BitRecover.WindowsLiveMailConverter.installer.yaml
+++ b/manifests/b/BitRecover/WindowsLiveMailConverter/8.0/BitRecover.WindowsLiveMailConverter.installer.yaml
@@ -2,12 +2,12 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
 
 PackageIdentifier: BitRecover.WindowsLiveMailConverter
-PackageVersion: 7.5
+PackageVersion: 8.0
 Installers:
 - Architecture: x64
   InstallerType: inno
   InstallerUrl: https://dl.bitrecover.com/bitrecover-windows-live-mail-converter-wizard.exe
-  InstallerSha256: F081E614F48D50207EE1BC95B9BE04B00193627BC768BAF6961A64254EFD055C
+  InstallerSha256: 3602A05FACA5226536012F749E0CF15F3B9AC659A86850386615DD2D8775538A
 ManifestType: installer
 ManifestVersion: 1.1.0
 

--- a/manifests/b/BitRecover/WindowsLiveMailConverter/8.0/BitRecover.WindowsLiveMailConverter.locale.en-US.yaml
+++ b/manifests/b/BitRecover/WindowsLiveMailConverter/8.0/BitRecover.WindowsLiveMailConverter.locale.en-US.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
 
 PackageIdentifier: BitRecover.WindowsLiveMailConverter
-PackageVersion: 7.5
+PackageVersion: 8.0
 PackageLocale: en-US
 Publisher: BitRecover
 PublisherUrl: https://www.bitrecover.com/

--- a/manifests/b/BitRecover/WindowsLiveMailConverter/8.0/BitRecover.WindowsLiveMailConverter.yaml
+++ b/manifests/b/BitRecover/WindowsLiveMailConverter/8.0/BitRecover.WindowsLiveMailConverter.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
 
 PackageIdentifier: BitRecover.WindowsLiveMailConverter
-PackageVersion: 7.5
+PackageVersion: 8.0
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.1.0


### PR DESCRIPTION
From latest URL Scan:
> https://www.bitrecover.com/dl/bitrecover-windows-live-mail-converter-wizard.exe for BitRecover.WindowsLiveMailConverter version 7.5 redirects to https://dl.bitrecover.com/bitrecover-windows-live-mail-converter-wizard.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105653)