### PR TITLE
Update URL for Bitnami.WAMP version 8.1.11-0

### DIFF
--- a/manifests/b/Bitnami/WAMP/8.1.11-0/Bitnami.WAMP.installer.yaml
+++ b/manifests/b/Bitnami/WAMP/8.1.11-0/Bitnami.WAMP.installer.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 1.1.2.0
+﻿# Created using wingetcreate 1.1.2.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
 
 PackageIdentifier: Bitnami.WAMP
@@ -16,7 +16,7 @@ AppsAndFeaturesEntries:
 Installers:
 - Architecture: x64
   InstallerType: exe
-  InstallerUrl: https://bitnami.com/redirect/to/2208347/bitnami-wampstack-8.1.11-0-windows-x64-installer.exe
+  InstallerUrl: https://downloads.bitnami.com/files/stacks/wampstack/8.1.11-0/bitnami-wampstack-8.1.11-0-windows-x64-installer.exe
   InstallerSha256: F26663A30DEE1B78BFCAAEF139D82213CA9076E03D5CBC0C5CFF3858680FC59C
 ManifestType: installer
 ManifestVersion: 1.2.0


### PR DESCRIPTION
From latest URL Scan:
> https://bitnami.com/redirect/to/2208347/bitnami-wampstack-8.1.11-0-windows-x64-installer.exe for Bitnami.WAMP version 8.1.11-0 redirects to https://downloads.bitnami.com/files/stacks/wampstack/8.1.11-0/bitnami-wampstack-8.1.11-0-windows-x64-installer.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105654)