### PR TITLE
Update URL for Element.Element version 1.10.10

### DIFF
--- a/manifests/e/Element/Element/1.10.10/Element.Element.installer.yaml
+++ b/manifests/e/Element/Element/1.10.10/Element.Element.installer.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-2
+﻿# Created with YamlCreate.ps1 v2.0.7 using InputObject 🤖 $debug=QUSU-7-2-2
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
 
 PackageIdentifier: Element.Element
@@ -13,7 +13,7 @@ InstallModes:
 UpgradeBehavior: install
 Installers:
 - Architecture: x64
-  InstallerUrl: https://packages.riot.im/desktop/install/win32/x64/Element%20Setup%201.10.10.exe
+  InstallerUrl: https://packages.element.io/desktop/install/win32/x64/Element%20Setup%201.10.10.exe
   InstallerSha256: 1376455C95CC01C3928C122ABD9ED915DCC79702229C85734D2744EBDC8EB005
 ManifestType: installer
 ManifestVersion: 1.1.0


### PR DESCRIPTION
From latest URL Scan:
> https://packages.riot.im/desktop/install/win32/x64/Element%20Setup%201.10.10.exe for Element.Element version 1.10.10 redirects to https://packages.element.io/desktop/install/win32/x64/Element%20Setup%201.10.10.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105657)