### PR TITLE
Update URL for Element.Element version 1.11.12

### DIFF
--- a/manifests/e/Element/Element/1.11.12/Element.Element.installer.yaml
+++ b/manifests/e/Element/Element/1.11.12/Element.Element.installer.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-7
+﻿# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-7
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
 
 PackageIdentifier: Element.Element
@@ -13,7 +13,7 @@ InstallModes:
 UpgradeBehavior: install
 Installers:
 - Architecture: x64
-  InstallerUrl: https://packages.riot.im/desktop/install/win32/x64/Element%20Setup%201.11.12.exe
+  InstallerUrl: https://packages.element.io/desktop/install/win32/x64/Element%20Setup%201.11.12.exe
   InstallerSha256: D4DD5D809EB8C7C677A58F9EEAA34EA8F9E0A24F6325FEF5DCCBFE677DA29EBB
 ManifestType: installer
 ManifestVersion: 1.2.0


### PR DESCRIPTION
From latest URL Scan:
> https://packages.riot.im/desktop/install/win32/x64/Element%20Setup%201.11.12.exe for Element.Element version 1.11.12 redirects to https://packages.element.io/desktop/install/win32/x64/Element%20Setup%201.11.12.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105679)