### PR TITLE
Update URL for Element.Element version 1.11.25

### DIFF
--- a/manifests/e/Element/Element/1.11.25/Element.Element.installer.yaml
+++ b/manifests/e/Element/Element/1.11.25/Element.Element.installer.yaml
@@ -1,4 +1,4 @@
-# Automatically updated by the winget bot at 2023/Mar/24
+﻿# Automatically updated by the winget bot at 2023/Mar/24
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
 
 PackageIdentifier: Element.Element
@@ -13,7 +13,7 @@ InstallModes:
 UpgradeBehavior: install
 Installers:
 - Architecture: x64
-  InstallerUrl: https://packages.riot.im/desktop/install/win32/x64/Element%20Setup%201.11.25.exe
+  InstallerUrl: https://packages.element.io/desktop/install/win32/x64/Element%20Setup%201.11.25.exe
   InstallerSha256: F4FC32D0164CB051002439024E8BF55E4D00E3186D843DB0B639B5534E3E1138
 ManifestType: installer
 ManifestVersion: 1.2.0


### PR DESCRIPTION
From latest URL Scan:
> https://packages.riot.im/desktop/install/win32/x64/Element%20Setup%201.11.25.exe for Element.Element version 1.11.25 redirects to https://packages.element.io/desktop/install/win32/x64/Element%20Setup%201.11.25.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105699)