### PR TITLE
Update URL for Element.Element version 1.11.28

### DIFF
--- a/manifests/e/Element/Element/1.11.28/Element.Element.installer.yaml
+++ b/manifests/e/Element/Element/1.11.28/Element.Element.installer.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-10
+﻿# Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-10
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
 
 PackageIdentifier: Element.Element
@@ -13,7 +13,7 @@ InstallModes:
 UpgradeBehavior: install
 Installers:
 - Architecture: x64
-  InstallerUrl: https://packages.riot.im/desktop/install/win32/x64/Element%20Setup%201.11.28.exe
+  InstallerUrl: https://packages.element.io/desktop/install/win32/x64/Element%20Setup%201.11.28.exe
   InstallerSha256: 1D8E54C6967D812767EC28C2FCA7D301357FBAC38F44EA76FEA83AD13319D9BB
 ManifestType: installer
 ManifestVersion: 1.2.0


### PR DESCRIPTION
From latest URL Scan:
> https://packages.riot.im/desktop/install/win32/x64/Element%20Setup%201.11.28.exe for Element.Element version 1.11.28 redirects to https://packages.element.io/desktop/install/win32/x64/Element%20Setup%201.11.28.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105701)