### PR TITLE
Update URL for Element.Element version 1.11.29

### DIFF
--- a/manifests/e/Element/Element/1.11.29/Element.Element.installer.yaml
+++ b/manifests/e/Element/Element/1.11.29/Element.Element.installer.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 1.2.5.0
+﻿# Created using wingetcreate 1.2.5.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
 
 PackageIdentifier: Element.Element
@@ -13,7 +13,7 @@ InstallModes:
 UpgradeBehavior: install
 Installers:
 - Architecture: x64
-  InstallerUrl: https://packages.riot.im/desktop/install/win32/x64/Element%20Setup%201.11.29.exe
+  InstallerUrl: https://packages.element.io/desktop/install/win32/x64/Element%20Setup%201.11.29.exe
   InstallerSha256: 487bc03e2c8cd15188e86b61554a149996733b2a647e17488d1a119c89fc9d5f
 ManifestType: installer
 ManifestVersion: 1.4.0


### PR DESCRIPTION
From latest URL Scan:
> https://packages.riot.im/desktop/install/win32/x64/Element%20Setup%201.11.29.exe for Element.Element version 1.11.29 redirects to https://packages.element.io/desktop/install/win32/x64/Element%20Setup%201.11.29.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105702)