### PR TITLE
Update URL for Element.Element version 1.11.8

### DIFF
--- a/manifests/e/Element/Element/1.11.8/Element.Element.installer.yaml
+++ b/manifests/e/Element/Element/1.11.8/Element.Element.installer.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
+﻿# Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
 
 PackageIdentifier: Element.Element
@@ -13,7 +13,7 @@ InstallModes:
 UpgradeBehavior: install
 Installers:
 - Architecture: x64
-  InstallerUrl: https://packages.riot.im/desktop/install/win32/x64/Element%20Setup%201.11.8.exe
+  InstallerUrl: https://packages.element.io/desktop/install/win32/x64/Element%20Setup%201.11.8.exe
   InstallerSha256: 82A45F976B209EA1CCC53D14902CE9A7F58730B98AB7DD23521F193011A1C1F1
 ManifestType: installer
 ManifestVersion: 1.2.0


### PR DESCRIPTION
From latest URL Scan:
> https://packages.riot.im/desktop/install/win32/x64/Element%20Setup%201.11.8.exe for Element.Element version 1.11.8 redirects to https://packages.element.io/desktop/install/win32/x64/Element%20Setup%201.11.8.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105705)