### PR TITLE
Update URL for Element.Element version 1.7.26

### DIFF
--- a/manifests/e/Element/Element/1.7.26/Element.Element.installer.yaml
+++ b/manifests/e/Element/Element/1.7.26/Element.Element.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
 PackageIdentifier: Element.Element
 PackageVersion: 1.7.26
 MinimumOSVersion: 10.0.0.0
@@ -9,7 +9,7 @@ InstallModes:
 Installers:
   - Architecture: x64
     InstallerType: nullsoft
-    InstallerUrl: https://packages.riot.im/desktop/install/win32/x64/Element%20Setup%201.7.26.exe
+    InstallerUrl: https://packages.element.io/desktop/install/win32/x64/Element%20Setup%201.7.26.exe
     InstallerSha256: 611F59529344E4617C75E2320ED5DAC1FEA4552F3A6A1B7679651E0A4FD465B1
     Scope: user
     InstallerLocale: en-US


### PR DESCRIPTION
From latest URL Scan:
> https://packages.riot.im/desktop/install/win32/x64/Element%20Setup%201.7.26.exe for Element.Element version 1.7.26 redirects to https://packages.element.io/desktop/install/win32/x64/Element%20Setup%201.7.26.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105706)