### PR TITLE
Update URL for Element.Element version 1.7.29

### DIFF
--- a/manifests/e/Element/Element/1.7.29/Element.Element.installer.yaml
+++ b/manifests/e/Element/Element/1.7.29/Element.Element.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
 PackageIdentifier: Element.Element
 PackageVersion: 1.7.29
 MinimumOSVersion: 10.0.0.0
@@ -9,7 +9,7 @@ InstallModes:
 Installers:
   - Architecture: x64
     InstallerType: nullsoft
-    InstallerUrl: https://packages.riot.im/desktop/install/win32/x64/Element%20Setup%201.7.29.exe
+    InstallerUrl: https://packages.element.io/desktop/install/win32/x64/Element%20Setup%201.7.29.exe
     InstallerSha256: aaad24e36b352d3aacb87ce2c9b4e18f59745a94eb96e7e9a52a55888390ee46
     Scope: machine
     InstallerLocale: en-US


### PR DESCRIPTION
From latest URL Scan:
> https://packages.riot.im/desktop/install/win32/x64/Element%20Setup%201.7.29.exe for Element.Element version 1.7.29 redirects to https://packages.element.io/desktop/install/win32/x64/Element%20Setup%201.7.29.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105709)