### PR TITLE
Update URL for Element.Element version 1.7.30

### DIFF
--- a/manifests/e/Element/Element/1.7.30/Element.Element.installer.yaml
+++ b/manifests/e/Element/Element/1.7.30/Element.Element.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
 # Created using wingetcreate
 
 PackageIdentifier: Element.Element
@@ -13,7 +13,7 @@ Installers:
   Architecture: x64
   InstallerType: nullsoft
   Scope: machine
-  InstallerUrl: https://packages.riot.im/desktop/install/win32/x64/Element%20Setup%201.7.30.exe
+  InstallerUrl: https://packages.element.io/desktop/install/win32/x64/Element%20Setup%201.7.30.exe
   InstallerSha256: 915F127861FEBF88CCEBE27971C9D8E5375650BD215960C70141F314B408A126
   UpgradeBehavior: install
 ManifestType: installer


### PR DESCRIPTION
From latest URL Scan:
> https://packages.riot.im/desktop/install/win32/x64/Element%20Setup%201.7.30.exe for Element.Element version 1.7.30 redirects to https://packages.element.io/desktop/install/win32/x64/Element%20Setup%201.7.30.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105710)