### PR TITLE
Update URL for Element.Element version 1.7.31

### DIFF
--- a/manifests/e/Element/Element/1.7.31/Element.Element.installer.yaml
+++ b/manifests/e/Element/Element/1.7.31/Element.Element.installer.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 0.2.0.29
+﻿# Created using wingetcreate 0.2.0.29
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
 
 PackageIdentifier: Element.Element
@@ -13,7 +13,7 @@ Installers:
   Architecture: x64
   InstallerType: nullsoft
   Scope: user
-  InstallerUrl: https://packages.riot.im/desktop/install/win32/x64/Element%20Setup%201.7.31.exe
+  InstallerUrl: https://packages.element.io/desktop/install/win32/x64/Element%20Setup%201.7.31.exe
   InstallerSha256: F04A0843FE527FEFBF20EDD0C18BD4D25BBA8088DDA98E7583D1C14E8A1AB9E5
   UpgradeBehavior: install
 ManifestType: installer


### PR DESCRIPTION
From latest URL Scan:
> https://packages.riot.im/desktop/install/win32/x64/Element%20Setup%201.7.31.exe for Element.Element version 1.7.31 redirects to https://packages.element.io/desktop/install/win32/x64/Element%20Setup%201.7.31.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105711)