### PR TITLE
Update URL for Element.Element version 1.7.32

### DIFF
--- a/manifests/e/Element/Element/1.7.32/Element.Element.installer.yaml
+++ b/manifests/e/Element/Element/1.7.32/Element.Element.installer.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 0.2.0.29
+﻿# Created using wingetcreate 0.2.0.29
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
 
 PackageIdentifier: Element.Element
@@ -13,7 +13,7 @@ Installers:
   Architecture: x64
   InstallerType: nullsoft
   Scope: user
-  InstallerUrl: https://packages.riot.im/desktop/install/win32/x64/Element%20Setup%201.7.32.exe
+  InstallerUrl: https://packages.element.io/desktop/install/win32/x64/Element%20Setup%201.7.32.exe
   InstallerSha256: 41B5DFD1028FCC7F285B7A5F808DF8E964D7E3C3B0388C4B62ACF5C4EC4A15EE
   UpgradeBehavior: install
 ManifestType: installer


### PR DESCRIPTION
From latest URL Scan:
> https://packages.riot.im/desktop/install/win32/x64/Element%20Setup%201.7.32.exe for Element.Element version 1.7.32 redirects to https://packages.element.io/desktop/install/win32/x64/Element%20Setup%201.7.32.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105713)