### PR TITLE
Update URL for Element.Element version 1.7.33

### DIFF
--- a/manifests/e/Element/Element/1.7.33/Element.Element.installer.yaml
+++ b/manifests/e/Element/Element/1.7.33/Element.Element.installer.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 0.2.0.29
+﻿# Created using wingetcreate 0.2.0.29
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
 
 PackageIdentifier: Element.Element
@@ -13,7 +13,7 @@ Installers:
   Architecture: x64
   InstallerType: nullsoft
   Scope: user
-  InstallerUrl: https://packages.riot.im/desktop/install/win32/x64/Element%20Setup%201.7.33.exe
+  InstallerUrl: https://packages.element.io/desktop/install/win32/x64/Element%20Setup%201.7.33.exe
   InstallerSha256: D3367F7AADE44D236034DCFCED9775700CF49620C5138EE976D59F90D0C411E7
   UpgradeBehavior: install
 ManifestType: installer


### PR DESCRIPTION
From latest URL Scan:
> https://packages.riot.im/desktop/install/win32/x64/Element%20Setup%201.7.33.exe for Element.Element version 1.7.33 redirects to https://packages.element.io/desktop/install/win32/x64/Element%20Setup%201.7.33.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105714)