### PR TITLE
Update URL for Element.Element version 1.8.0

### DIFF
--- a/manifests/e/Element/Element/1.8.0/Element.Element.installer.yaml
+++ b/manifests/e/Element/Element/1.8.0/Element.Element.installer.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.0.0 using YAML parsing
+﻿# Created with YamlCreate.ps1 v2.0.0 using YAML parsing
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
 
 PackageIdentifier: Element.Element
@@ -13,7 +13,7 @@ Installers:
   Architecture: x64
   InstallerType: nullsoft
   Scope: user
-  InstallerUrl: https://packages.riot.im/desktop/install/win32/x64/Element%20Setup%201.8.0.exe
+  InstallerUrl: https://packages.element.io/desktop/install/win32/x64/Element%20Setup%201.8.0.exe
   InstallerSha256: B85863FF4C29F7B984A1D889DA1EFADCE238AA1531C2EF5DF875F5B34490260E
   UpgradeBehavior: install
 ManifestType: installer


### PR DESCRIPTION
From latest URL Scan:
> https://packages.riot.im/desktop/install/win32/x64/Element%20Setup%201.8.0.exe for Element.Element version 1.8.0 redirects to https://packages.element.io/desktop/install/win32/x64/Element%20Setup%201.8.0.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105718)