### PR TITLE
Update URL for Element.Element version 1.8.2

### DIFF
--- a/manifests/e/Element/Element/1.8.2/Element.Element.installer.yaml
+++ b/manifests/e/Element/Element/1.8.2/Element.Element.installer.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.0.0 using YAML parsing
+﻿# Created with YamlCreate.ps1 v2.0.0 using YAML parsing
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
 
 PackageIdentifier: Element.Element
@@ -13,7 +13,7 @@ Installers:
   Architecture: x64
   InstallerType: nullsoft
   Scope: user
-  InstallerUrl: https://packages.riot.im/desktop/install/win32/x64/Element%20Setup%201.8.2.exe
+  InstallerUrl: https://packages.element.io/desktop/install/win32/x64/Element%20Setup%201.8.2.exe
   InstallerSha256: C17689598472F5A13CDBA71BAD14A7D505F9B5273E3E0462542BDCB329B4869E
   UpgradeBehavior: install
 ManifestType: installer


### PR DESCRIPTION
From latest URL Scan:
> https://packages.riot.im/desktop/install/win32/x64/Element%20Setup%201.8.2.exe for Element.Element version 1.8.2 redirects to https://packages.element.io/desktop/install/win32/x64/Element%20Setup%201.8.2.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105721)