### PR TITLE
Update URL for Element.Element version 1.8.5

### DIFF
--- a/manifests/e/Element/Element/1.8.5/Element.Element.installer.yaml
+++ b/manifests/e/Element/Element/1.8.5/Element.Element.installer.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.0.0 using YAML parsing
+﻿# Created with YamlCreate.ps1 v2.0.0 using YAML parsing
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
 
 PackageIdentifier: Element.Element
@@ -13,7 +13,7 @@ Installers:
   Architecture: x64
   InstallerType: nullsoft
   Scope: user
-  InstallerUrl: https://packages.riot.im/desktop/install/win32/x64/Element%20Setup%201.8.5.exe
+  InstallerUrl: https://packages.element.io/desktop/install/win32/x64/Element%20Setup%201.8.5.exe
   InstallerSha256: FD5EC7EC369D4883FE592025EB49AA65BD9E9774AD00C8ABCEBA3E60CA681A8C
   UpgradeBehavior: install
 ManifestType: installer


### PR DESCRIPTION
From latest URL Scan:
> https://packages.riot.im/desktop/install/win32/x64/Element%20Setup%201.8.5.exe for Element.Element version 1.8.5 redirects to https://packages.element.io/desktop/install/win32/x64/Element%20Setup%201.8.5.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105724)