### PR TITLE
Update URL for Element.Element version 1.9.4

### DIFF
--- a/manifests/e/Element/Element/1.9.4/Element.Element.installer.yaml
+++ b/manifests/e/Element/Element/1.9.4/Element.Element.installer.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.0.0 $debug=QUSU.7-1-5
+﻿# Created with YamlCreate.ps1 v2.0.0 $debug=QUSU.7-1-5
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
 
 PackageIdentifier: Element.Element
@@ -13,7 +13,7 @@ InstallModes:
 UpgradeBehavior: install
 Installers:
 - Architecture: x64
-  InstallerUrl: https://packages.riot.im/desktop/install/win32/x64/Element%20Setup%201.9.4.exe
+  InstallerUrl: https://packages.element.io/desktop/install/win32/x64/Element%20Setup%201.9.4.exe
   InstallerSha256: 9B922C8F7DB2587203DC5D54946B1753C574A93357785638CFEE00FD36442E8F
 ManifestType: installer
 ManifestVersion: 1.0.0


### PR DESCRIPTION
From latest URL Scan:
> https://packages.riot.im/desktop/install/win32/x64/Element%20Setup%201.9.4.exe for Element.Element version 1.9.4 redirects to https://packages.element.io/desktop/install/win32/x64/Element%20Setup%201.9.4.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105727)