### PR TITLE
Update URL for Element.Element version 1.9.5

### DIFF
--- a/manifests/e/Element/Element/1.9.5/Element.Element.installer.yaml
+++ b/manifests/e/Element/Element/1.9.5/Element.Element.installer.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.0.2 $debug=QUSU.7-2-0
+﻿# Created with YamlCreate.ps1 v2.0.2 $debug=QUSU.7-2-0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
 
 PackageIdentifier: Element.Element
@@ -13,7 +13,7 @@ InstallModes:
 UpgradeBehavior: install
 Installers:
 - Architecture: x64
-  InstallerUrl: https://packages.riot.im/desktop/install/win32/x64/Element%20Setup%201.9.5.exe
+  InstallerUrl: https://packages.element.io/desktop/install/win32/x64/Element%20Setup%201.9.5.exe
   InstallerSha256: FE919F51CCA570905A42BB719AA685D9BE148A6B09AC6C2537FE7A7F1E2E9A0B
 ManifestType: installer
 ManifestVersion: 1.1.0


### PR DESCRIPTION
From latest URL Scan:
> https://packages.riot.im/desktop/install/win32/x64/Element%20Setup%201.9.5.exe for Element.Element version 1.9.5 redirects to https://packages.element.io/desktop/install/win32/x64/Element%20Setup%201.9.5.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105728)