### PR TITLE
Update URL for Element.Element version 1.9.7

### DIFF
--- a/manifests/e/Element/Element/1.9.7/Element.Element.installer.yaml
+++ b/manifests/e/Element/Element/1.9.7/Element.Element.installer.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.0.4 $debug=QUSU.7-2-0
+﻿# Created with YamlCreate.ps1 v2.0.4 $debug=QUSU.7-2-0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
 
 PackageIdentifier: Element.Element
@@ -13,7 +13,7 @@ InstallModes:
 UpgradeBehavior: install
 Installers:
 - Architecture: x64
-  InstallerUrl: https://packages.riot.im/desktop/install/win32/x64/Element%20Setup%201.9.7.exe
+  InstallerUrl: https://packages.element.io/desktop/install/win32/x64/Element%20Setup%201.9.7.exe
   InstallerSha256: B5FE15477E84ACF2AA1EA9AC2CB95D199CF2338A74C016093F4A7DA2B3C7AE31
 ManifestType: installer
 ManifestVersion: 1.1.0


### PR DESCRIPTION
From latest URL Scan:
> https://packages.riot.im/desktop/install/win32/x64/Element%20Setup%201.9.7.exe for Element.Element version 1.9.7 redirects to https://packages.element.io/desktop/install/win32/x64/Element%20Setup%201.9.7.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105731)