### PR TITLE
Update URL for Element.Element version 1.9.8

### DIFF
--- a/manifests/e/Element/Element/1.9.8/Element.Element.installer.yaml
+++ b/manifests/e/Element/Element/1.9.8/Element.Element.installer.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.0.4 $debug=QUSU.5-1-19041-1320
+﻿# Created with YamlCreate.ps1 v2.0.4 $debug=QUSU.5-1-19041-1320
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
 
 PackageIdentifier: Element.Element
@@ -13,7 +13,7 @@ InstallModes:
 UpgradeBehavior: install
 Installers:
 - Architecture: x64
-  InstallerUrl: https://packages.riot.im/desktop/install/win32/x64/Element%20Setup%201.9.8.exe
+  InstallerUrl: https://packages.element.io/desktop/install/win32/x64/Element%20Setup%201.9.8.exe
   InstallerSha256: 32939E5ED33E152F81E0B2AE99F408C649DCEC4F484AF9AA384475F45797CD5E
 ManifestType: installer
 ManifestVersion: 1.1.0


### PR DESCRIPTION
From latest URL Scan:
> https://packages.riot.im/desktop/install/win32/x64/Element%20Setup%201.9.8.exe for Element.Element version 1.9.8 redirects to https://packages.element.io/desktop/install/win32/x64/Element%20Setup%201.9.8.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105733)