### PR TITLE
Update URL for Element.Element version 1.9.9

### DIFF
--- a/manifests/e/Element/Element/1.9.9/Element.Element.installer.yaml
+++ b/manifests/e/Element/Element/1.9.9/Element.Element.installer.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.0.4 $debug=QUSU.7-2-1
+﻿# Created with YamlCreate.ps1 v2.0.4 $debug=QUSU.7-2-1
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
 
 PackageIdentifier: Element.Element
@@ -13,7 +13,7 @@ InstallModes:
 UpgradeBehavior: install
 Installers:
 - Architecture: x64
-  InstallerUrl: https://packages.riot.im/desktop/install/win32/x64/Element%20Setup%201.9.9.exe
+  InstallerUrl: https://packages.element.io/desktop/install/win32/x64/Element%20Setup%201.9.9.exe
   InstallerSha256: 8D80E8AD091BC830035D794C89915335AEDEC690DB33450E5A3E34ABFBDD0110
 ManifestType: installer
 ManifestVersion: 1.1.0


### PR DESCRIPTION
From latest URL Scan:
> https://packages.riot.im/desktop/install/win32/x64/Element%20Setup%201.9.9.exe for Element.Element version 1.9.9 redirects to https://packages.element.io/desktop/install/win32/x64/Element%20Setup%201.9.9.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105734)