### PR TITLE
Update URL for FastCopy.FastCopy version 5.0.0

### DIFF
--- a/manifests/f/FastCopy/FastCopy/5.0.0/FastCopy.FastCopy.installer.yaml
+++ b/manifests/f/FastCopy/FastCopy/5.0.0/FastCopy.FastCopy.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
 
 PackageIdentifier: FastCopy.FastCopy
 PackageVersion: 5.0.0
@@ -14,10 +14,10 @@ UpgradeBehavior: install
 InstallerType: exe
 Installers:
 - Architecture: x64
-  InstallerUrl: https://fastcopy.jp/archive/FastCopy5.0.0_installer.exe
+  InstallerUrl: https://raw.githubusercontent.com/FastCopyLab/FastCopyDist2/main/FastCopy5.0.0_installer.exe
   InstallerSha256: 1057abaf6d3aa736c141787699f92fef68e80621836fcf28cdbc85efd80e7137
 - Architecture: x86
-  InstallerUrl: https://fastcopy.jp/archive/FastCopy5.0.0_installer.exe
+  InstallerUrl: https://raw.githubusercontent.com/FastCopyLab/FastCopyDist2/main/FastCopy5.0.0_installer.exe
   InstallerSha256: 1057abaf6d3aa736c141787699f92fef68e80621836fcf28cdbc85efd80e7137
 ManifestType: installer
 ManifestVersion: 1.2.0


### PR DESCRIPTION
From latest URL Scan:
> https://fastcopy.jp/archive/FastCopy5.0.0_installer.exe for FastCopy.FastCopy version 5.0.0 redirects to https://raw.githubusercontent.com/FastCopyLab/FastCopyDist2/main/FastCopy5.0.0_installer.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105735)