### PR TITLE
Update URL for FastCopy.IPMsg version 5.1.1

### DIFF
--- a/manifests/f/FastCopy/IPMsg/5.1.1/FastCopy.IPMsg.installer.yaml
+++ b/manifests/f/FastCopy/IPMsg/5.1.1/FastCopy.IPMsg.installer.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.1.0 $debug=AUSU.5-1-19041-1320
+﻿# Created with YamlCreate.ps1 v2.1.0 $debug=AUSU.5-1-19041-1320
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
 
 PackageIdentifier: FastCopy.IPMsg
@@ -11,7 +11,7 @@ InstallerSwitches:
   SilentWithProgress: /SILENT
 Installers:
 - Architecture: x86
-  InstallerUrl: https://ipmsg.org/archive/ipmsg5.1.1_installer.exe
+  InstallerUrl: https://raw.githubusercontent.com/FastCopyLab/IPMsgDist/main/ipmsg5.1.1_installer.exe
   InstallerSha256: 187C3AD830AF628434204BD14AAC38D77ACB5FD83AA23A97A84F0D49FC71D15D
 ManifestType: installer
 ManifestVersion: 1.1.0


### PR DESCRIPTION
From latest URL Scan:
> https://ipmsg.org/archive/ipmsg5.1.1_installer.exe for FastCopy.IPMsg version 5.1.1 redirects to https://raw.githubusercontent.com/FastCopyLab/IPMsgDist/main/ipmsg5.1.1_installer.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105739)