### PR TITLE
Update URL for Feodor2.Mypal version 28.14.2

### DIFF
--- a/manifests/f/Feodor2/Mypal/28.14.2/Feodor2.Mypal.installer.yaml
+++ b/manifests/f/Feodor2/Mypal/28.14.2/Feodor2.Mypal.installer.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.1.0 $debug=AUSU.5-1-19041-1320
+﻿# Created with YamlCreate.ps1 v2.1.0 $debug=AUSU.5-1-19041-1320
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
 
 PackageIdentifier: Feodor2.Mypal
@@ -12,7 +12,7 @@ FileExtensions:
 - url
 Installers:
 - Architecture: x64
-  InstallerUrl: https://mypal-browser.org/release/mypal-28.14.2.win64.installer.exe
+  InstallerUrl: https://www.mypal-browser.org/release/mypal-28.14.2.win64.installer.exe
   InstallerSha256: C177BFB405227F2347DA4E12CCCBB221C2B10EF71305777E4A111F2AA902C38F
 ManifestType: installer
 ManifestVersion: 1.1.0


### PR DESCRIPTION
From latest URL Scan:
> https://mypal-browser.org/release/mypal-28.14.2.win64.installer.exe for Feodor2.Mypal version 28.14.2 redirects to https://www.mypal-browser.org/release/mypal-28.14.2.win64.installer.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105745)