### PR TITLE
Update URL for Feodor2.Mypal version 29.0.1

### DIFF
--- a/manifests/f/Feodor2/Mypal/29.0.1/Feodor2.Mypal.installer.yaml
+++ b/manifests/f/Feodor2/Mypal/29.0.1/Feodor2.Mypal.installer.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 0.5.0.1
+﻿# Created using wingetcreate 0.5.0.1
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
 
 PackageIdentifier: Feodor2.Mypal
@@ -18,11 +18,11 @@ FileExtensions:
 Installers:
 - Architecture: x64
   InstallerType: inno
-  InstallerUrl: https://mypal-browser.org/release/mypal-29.0.1.win64.installer.exe
+  InstallerUrl: https://www.mypal-browser.org/release/mypal-29.0.1.win64.installer.exe
   InstallerSha256: AAF6A8219B796C1A3333F360FBB5A55E1FDFD9A0A87BDB89827D78D94141A037
 - Architecture: x86
   InstallerType: inno
-  InstallerUrl: https://mypal-browser.org/release/mypal-29.0.1.win32.installer.exe
+  InstallerUrl: https://www.mypal-browser.org/release/mypal-29.0.1.win32.installer.exe
   InstallerSha256: A4AAFD7983ECD3A71B082D5E6469D4FA612717B1BFE30AC460D09E7AEE69BADE
 ManifestType: installer
 ManifestVersion: 1.1.0


### PR DESCRIPTION
From latest URL Scan:
> https://mypal-browser.org/release/mypal-29.0.1.win64.installer.exe for Feodor2.Mypal version 29.0.1 redirects to https://www.mypal-browser.org/release/mypal-29.0.1.win64.installer.exe https://mypal-browser.org/release/mypal-29.0.1.win32.installer.exe for Feodor2.Mypal version 29.0.1 redirects to https://www.mypal-browser.org/release/mypal-29.0.1.win32.installer.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105746)