### PR TITLE
Update URL for Feodor2.Mypal version 29.1.0

### DIFF
--- a/manifests/f/Feodor2/Mypal/29.1.0/Feodor2.Mypal.installer.yaml
+++ b/manifests/f/Feodor2/Mypal/29.1.0/Feodor2.Mypal.installer.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 0.5.0.1
+﻿# Created using wingetcreate 0.5.0.1
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
 
 PackageIdentifier: Feodor2.Mypal
@@ -18,11 +18,11 @@ FileExtensions:
 Installers:
 - Architecture: x64
   InstallerType: inno
-  InstallerUrl: https://mypal-browser.org/release/mypal-29.1.0.win64.installer.exe
+  InstallerUrl: https://www.mypal-browser.org/release/mypal-29.1.0.win64.installer.exe
   InstallerSha256: E5BC6FFD32CD6BF1E800EB77B1868167AD7817527F859DD005A5C5C08BF2B252
 - Architecture: x86
   InstallerType: inno
-  InstallerUrl: https://mypal-browser.org/release/mypal-29.1.0.win32.installer.exe
+  InstallerUrl: https://www.mypal-browser.org/release/mypal-29.1.0.win32.installer.exe
   InstallerSha256: 8B7D18E1D11571A41E51D5DED16777767260762307ED0B4B4A61B14100F873F8
 ManifestType: installer
 ManifestVersion: 1.1.0


### PR DESCRIPTION
From latest URL Scan:
> https://mypal-browser.org/release/mypal-29.1.0.win64.installer.exe for Feodor2.Mypal version 29.1.0 redirects to https://www.mypal-browser.org/release/mypal-29.1.0.win64.installer.exe https://mypal-browser.org/release/mypal-29.1.0.win32.installer.exe for Feodor2.Mypal version 29.1.0 redirects to https://www.mypal-browser.org/release/mypal-29.1.0.win32.installer.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105747)