### PR TITLE
Update URL for Feodor2.Mypal version 29.2.0

### DIFF
--- a/manifests/f/Feodor2/Mypal/29.2.0/Feodor2.Mypal.installer.yaml
+++ b/manifests/f/Feodor2/Mypal/29.2.0/Feodor2.Mypal.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
 # Created using wingetcreate
 
 PackageIdentifier: Feodor2.Mypal
@@ -11,7 +11,7 @@ FileExtensions:
 Installers:
 - Architecture: x64
   InstallerType: inno
-  InstallerUrl: https://mypal-browser.org/release/mypal-29.2.0.win64.installer.exe
+  InstallerUrl: https://www.mypal-browser.org/release/mypal-29.2.0.win64.installer.exe
   InstallerSha256: 300971C0473CCE9BD2D79C084CC3C77C857DFA23AE089E3BA484F48A31E69831
 ManifestType: installer
 ManifestVersion: 1.0.0


### PR DESCRIPTION
From latest URL Scan:
> https://mypal-browser.org/release/mypal-29.2.0.win64.installer.exe for Feodor2.Mypal version 29.2.0 redirects to https://www.mypal-browser.org/release/mypal-29.2.0.win64.installer.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105748)