### PR TITLE
Update URL for Feodor2.Mypal version 29.2.1

### DIFF
--- a/manifests/f/Feodor2/Mypal/29.2.1/Feodor2.Mypal.installer.yaml
+++ b/manifests/f/Feodor2/Mypal/29.2.1/Feodor2.Mypal.installer.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 0.5.0.1
+﻿# Created using wingetcreate 0.5.0.1
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
 
 PackageIdentifier: Feodor2.Mypal
@@ -18,11 +18,11 @@ FileExtensions:
 Installers:
 - Architecture: x64
   InstallerType: inno
-  InstallerUrl: https://mypal-browser.org/release/mypal-29.2.1.win64.installer.exe
+  InstallerUrl: https://www.mypal-browser.org/release/mypal-29.2.1.win64.installer.exe
   InstallerSha256: 182660A480B0A544E57F7F46276B858D3EB15ECF5306D8FE05C0B88B41EDCA27
 - Architecture: x86
   InstallerType: inno
-  InstallerUrl: https://mypal-browser.org/release/mypal-29.2.1.win32.installer.exe
+  InstallerUrl: https://www.mypal-browser.org/release/mypal-29.2.1.win32.installer.exe
   InstallerSha256: 33E29E922BB1043B198A85616A3DEDC971206AC5B26D734E6E12720CFA3572B5
 ManifestType: installer
 ManifestVersion: 1.1.0


### PR DESCRIPTION
From latest URL Scan:
> https://mypal-browser.org/release/mypal-29.2.1.win64.installer.exe for Feodor2.Mypal version 29.2.1 redirects to https://www.mypal-browser.org/release/mypal-29.2.1.win64.installer.exe https://mypal-browser.org/release/mypal-29.2.1.win32.installer.exe for Feodor2.Mypal version 29.2.1 redirects to https://www.mypal-browser.org/release/mypal-29.2.1.win32.installer.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105749)