### PR TITLE
Update URL for Feodor2.Mypal version 29.3.0

### DIFF
--- a/manifests/f/Feodor2/Mypal/29.3.0/Feodor2.Mypal.installer.yaml
+++ b/manifests/f/Feodor2/Mypal/29.3.0/Feodor2.Mypal.installer.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.0.0 using YAML parsing
+﻿# Created with YamlCreate.ps1 v2.0.0 using YAML parsing
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
 
 PackageIdentifier: Feodor2.Mypal
@@ -18,10 +18,10 @@ FileExtensions:
 - pdf
 Installers:
 - Architecture: x64
-  InstallerUrl: https://mypal-browser.org/release/mypal-29.3.0.win64.installer.exe
+  InstallerUrl: https://www.mypal-browser.org/release/mypal-29.3.0.win64.installer.exe
   InstallerSha256: F22BB0E63E2F26492A587F77D98BD5418F2C1193D6A6BBDEA015B01DC38DD2D1
 - Architecture: x86
-  InstallerUrl: https://mypal-browser.org/release/mypal-29.3.0.win32.installer.exe
+  InstallerUrl: https://www.mypal-browser.org/release/mypal-29.3.0.win32.installer.exe
   InstallerSha256: 2E94302F30C59EF486E0E163152F40C75205B1988C217F59617180EF6F21986A
 ManifestType: installer
 ManifestVersion: 1.0.0


### PR DESCRIPTION
From latest URL Scan:
> https://mypal-browser.org/release/mypal-29.3.0.win64.installer.exe for Feodor2.Mypal version 29.3.0 redirects to https://www.mypal-browser.org/release/mypal-29.3.0.win64.installer.exe https://mypal-browser.org/release/mypal-29.3.0.win32.installer.exe for Feodor2.Mypal version 29.3.0 redirects to https://www.mypal-browser.org/release/mypal-29.3.0.win32.installer.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105750)