### PR TITLE
Update URL for GLab.GLab version 1.23.1

### DIFF
--- a/manifests/g/GLab/GLab/1.23.1/GLab.GLab.installer.yaml
+++ b/manifests/g/GLab/GLab/1.23.1/GLab.GLab.installer.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.0.4 $debug=QUSU.7-2-1
+﻿# Created with YamlCreate.ps1 v2.0.4 $debug=QUSU.7-2-1
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
 
 PackageIdentifier: GLab.GLab
@@ -15,7 +15,7 @@ InstallModes:
 UpgradeBehavior: install
 Installers:
 - Architecture: x64
-  InstallerUrl: https://gitlab.com/gitlab-org/cli/-/releases/v1.23.1/downloads/glab_1.23.1_Windows_x86_64_installer.exe
+  InstallerUrl: https://gitlab.com/gitlab-org/cli/uploads/75a7bacb8cbc212933741000a17c8be1/glab_1.23.1_Windows_x86_64_installer.exe
   InstallerSha256: 36f9d45f68ea53cbafdbe96ba4206e4412abb4c2b8f00ba667054523bd7cc89e
 ManifestType: installer
 ManifestVersion: 1.1.0


### PR DESCRIPTION
From latest URL Scan:
> https://gitlab.com/gitlab-org/cli/-/releases/v1.23.1/downloads/glab_1.23.1_Windows_x86_64_installer.exe for GLab.GLab version 1.23.1 redirects to https://gitlab.com/gitlab-org/cli/uploads/75a7bacb8cbc212933741000a17c8be1/glab_1.23.1_Windows_x86_64_installer.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105751)