### PR TITLE
Update URL for GLab.GLab version 1.27.0

### DIFF
--- a/manifests/g/GLab/GLab/1.27.0/GLab.GLab.installer.yaml
+++ b/manifests/g/GLab/GLab/1.27.0/GLab.GLab.installer.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 1.2.5.0
+﻿# Created using wingetcreate 1.2.5.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
 
 PackageIdentifier: GLab.GLab
@@ -13,7 +13,7 @@ InstallModes:
 UpgradeBehavior: install
 Installers:
 - Architecture: x64
-  InstallerUrl: https://gitlab.com/gitlab-org/cli/-/releases/v1.27.0/downloads/glab_1.27.0_Windows_x86_64_installer.exe
+  InstallerUrl: https://gitlab.com/gitlab-org/cli/uploads/fdb0074b5a9fcbd39b389c27d2aaca9d/glab_1.27.0_Windows_x86_64_installer.exe
   InstallerSha256: BBEA37991D9B8313D978D1ED98EDC47C327714FA5750A1CB2341AB7609B31C21
 ManifestType: installer
 ManifestVersion: 1.4.0


### PR DESCRIPTION
From latest URL Scan:
> https://gitlab.com/gitlab-org/cli/-/releases/v1.27.0/downloads/glab_1.27.0_Windows_x86_64_installer.exe for GLab.GLab version 1.27.0 redirects to https://gitlab.com/gitlab-org/cli/uploads/fdb0074b5a9fcbd39b389c27d2aaca9d/glab_1.27.0_Windows_x86_64_installer.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105753)