### PR TITLE
Update URL for GLab.GLab version 1.27.1

### DIFF
--- a/manifests/g/GLab/GLab/1.27.1/GLab.GLab.installer.yaml
+++ b/manifests/g/GLab/GLab/1.27.1/GLab.GLab.installer.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 1.2.5.0
+﻿# Created using wingetcreate 1.2.5.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
 
 PackageIdentifier: GLab.GLab
@@ -13,7 +13,7 @@ InstallModes:
 UpgradeBehavior: install
 Installers:
 - Architecture: x64
-  InstallerUrl: https://gitlab.com/gitlab-org/cli/-/releases/v1.27.1/downloads/glab_1.27.1_Windows_x86_64_installer.exe
+  InstallerUrl: https://gitlab.com/gitlab-org/cli/uploads/0ca1ff595e262159acf84a264622080c/glab_1.27.1_Windows_x86_64_installer.exe
   InstallerSha256: E7A77C8C1376A5E86AA740441C3F85573A159031838DB564E7E08361841B3FD0
 ManifestType: installer
 ManifestVersion: 1.4.0


### PR DESCRIPTION
From latest URL Scan:
> https://gitlab.com/gitlab-org/cli/-/releases/v1.27.1/downloads/glab_1.27.1_Windows_x86_64_installer.exe for GLab.GLab version 1.27.1 redirects to https://gitlab.com/gitlab-org/cli/uploads/0ca1ff595e262159acf84a264622080c/glab_1.27.1_Windows_x86_64_installer.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105754)