### PR TITLE
Update URL for LibreWolf.LibreWolf version 111.0.1-1

### DIFF
--- a/manifests/l/LibreWolf/LibreWolf/111.0.1-1/LibreWolf.LibreWolf.installer.yaml
+++ b/manifests/l/LibreWolf/LibreWolf/111.0.1-1/LibreWolf.LibreWolf.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
 
 PackageIdentifier: LibreWolf.LibreWolf
 PackageVersion: 111.0.1-1
@@ -22,7 +22,7 @@ Installers:
     Architecture: x64
     InstallerType: nullsoft
     Scope: machine
-    InstallerUrl: https://gitlab.com/api/v4/projects/44042130/packages/generic/librewolf/111.0.1-1/./librewolf-111.0.1-1.en-US.win64-setup.exe
+    InstallerUrl: https://gitlab.com/api/v4/projects/44042130/packages/generic/librewolf/111.0.1-1/librewolf-111.0.1-1.en-US.win64-setup.exe
     InstallerSha256: cdca114b4d4a96efd2aa090b2b94db7bde39b35e53a7b897d6931d78358d3e3a
     UpgradeBehavior: install
 ManifestType: installer


### PR DESCRIPTION
From latest URL Scan:
> https://gitlab.com/api/v4/projects/44042130/packages/generic/librewolf/111.0.1-1/./librewolf-111.0.1-1.en-US.win64-setup.exe for LibreWolf.LibreWolf version 111.0.1-1 redirects to https://gitlab.com/api/v4/projects/44042130/packages/generic/librewolf/111.0.1-1/librewolf-111.0.1-1.en-US.win64-setup.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105755)