### PR TITLE
Update URL for LibreWolf.LibreWolf version 112.0.1-2

### DIFF
--- a/manifests/l/LibreWolf/LibreWolf/112.0.1-2/LibreWolf.LibreWolf.installer.yaml
+++ b/manifests/l/LibreWolf/LibreWolf/112.0.1-2/LibreWolf.LibreWolf.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
 
 PackageIdentifier: LibreWolf.LibreWolf
 PackageVersion: 112.0.1-2
@@ -22,7 +22,7 @@ Installers:
     Architecture: x64
     InstallerType: nullsoft
     Scope: machine
-    InstallerUrl: https://gitlab.com/api/v4/projects/44042130/packages/generic/librewolf/112.0.1-2/./librewolf-112.0.1-2-windows-x86_64-setup.exe
+    InstallerUrl: https://gitlab.com/api/v4/projects/44042130/packages/generic/librewolf/112.0.1-2/librewolf-112.0.1-2-windows-x86_64-setup.exe
     InstallerSha256: 95273757876d8476a0484452acddecff342a2c64d4eea0ee77e1388b66bdaba4
     UpgradeBehavior: install
 ManifestType: installer


### PR DESCRIPTION
From latest URL Scan:
> https://gitlab.com/api/v4/projects/44042130/packages/generic/librewolf/112.0.1-2/./librewolf-112.0.1-2-windows-x86_64-setup.exe for LibreWolf.LibreWolf version 112.0.1-2 redirects to https://gitlab.com/api/v4/projects/44042130/packages/generic/librewolf/112.0.1-2/librewolf-112.0.1-2-windows-x86_64-setup.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105756)