### PR TITLE
Update URL for LibreWolf.LibreWolf version 112.0.2-1

### DIFF
--- a/manifests/l/LibreWolf/LibreWolf/112.0.2-1/LibreWolf.LibreWolf.installer.yaml
+++ b/manifests/l/LibreWolf/LibreWolf/112.0.2-1/LibreWolf.LibreWolf.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
 
 PackageIdentifier: LibreWolf.LibreWolf
 PackageVersion: 112.0.2-1
@@ -22,7 +22,7 @@ Installers:
     Architecture: x64
     InstallerType: nullsoft
     Scope: machine
-    InstallerUrl: https://gitlab.com/api/v4/projects/44042130/packages/generic/librewolf/112.0.2-1/./librewolf-112.0.2-1-windows-x86_64-setup.exe
+    InstallerUrl: https://gitlab.com/api/v4/projects/44042130/packages/generic/librewolf/112.0.2-1/librewolf-112.0.2-1-windows-x86_64-setup.exe
     InstallerSha256: 96331ef03f48043a56f038f2a79304e2878fc450fb16c14e30a1465c969b612d
     UpgradeBehavior: install
 ManifestType: installer


### PR DESCRIPTION
From latest URL Scan:
> https://gitlab.com/api/v4/projects/44042130/packages/generic/librewolf/112.0.2-1/./librewolf-112.0.2-1-windows-x86_64-setup.exe for LibreWolf.LibreWolf version 112.0.2-1 redirects to https://gitlab.com/api/v4/projects/44042130/packages/generic/librewolf/112.0.2-1/librewolf-112.0.2-1-windows-x86_64-setup.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105757)