### PR TITLE
Update URL for NGWIN.PicPick version 5.1.6

### DIFF
--- a/manifests/n/NGWIN/PicPick/5.1.6/NGWIN.PicPick.installer.yaml
+++ b/manifests/n/NGWIN/PicPick/5.1.6/NGWIN.PicPick.installer.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.1.0 $debug=AUSU.5-1-19041-1320
+﻿# Created with YamlCreate.ps1 v2.1.0 $debug=AUSU.5-1-19041-1320
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
 
 PackageIdentifier: NGWIN.PicPick
@@ -28,7 +28,7 @@ FileExtensions:
 - wmf
 Installers:
 - Architecture: x64
-  InstallerUrl: https://www.picpick.org/releases/5.1.6/picpick_inst.exe
+  InstallerUrl: https://download.picpick.app/5.1.6/picpick_inst.exe
   InstallerSha256: D9A85A93390D23654C580A3C06263EC336EB8C7866C6F1FF3CBA44E85DA89BB5
 ManifestType: installer
 ManifestVersion: 1.1.0


### PR DESCRIPTION
From latest URL Scan:
> https://www.picpick.org/releases/5.1.6/picpick_inst.exe for NGWIN.PicPick version 5.1.6 redirects to https://download.picpick.app/5.1.6/picpick_inst.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105758)