### PR TITLE
Update URL for NGWIN.PicPick version 5.1.7

### DIFF
--- a/manifests/n/NGWIN/PicPick/5.1.7/NGWIN.PicPick.installer.yaml
+++ b/manifests/n/NGWIN/PicPick/5.1.7/NGWIN.PicPick.installer.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 0.3.0.3
+﻿# Created using wingetcreate 0.3.0.3
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
 
 PackageIdentifier: NGWIN.PicPick
@@ -30,7 +30,7 @@ Installers:
   Architecture: x64
   InstallerType: nullsoft
   Scope: machine
-  InstallerUrl: https://www.picpick.org/releases/5.1.7/picpick_inst.exe
+  InstallerUrl: https://download.picpick.app/5.1.7/picpick_inst.exe
   InstallerSha256: 0455FB16B5BE79B3912E2C5E49D9B803114822D59EABBA202EE6D4D9920E4707
   UpgradeBehavior: install
 ManifestType: installer


### PR DESCRIPTION
From latest URL Scan:
> https://www.picpick.org/releases/5.1.7/picpick_inst.exe for NGWIN.PicPick version 5.1.7 redirects to https://download.picpick.app/5.1.7/picpick_inst.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105760)