### PR TITLE
Update URL for NGWIN.PicPick version 5.2.0

### DIFF
--- a/manifests/n/NGWIN/PicPick/5.2.0/NGWIN.PicPick.installer.yaml
+++ b/manifests/n/NGWIN/PicPick/5.2.0/NGWIN.PicPick.installer.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.0.2 $debug=QUSU.7-2-0
+﻿# Created with YamlCreate.ps1 v2.0.2 $debug=QUSU.7-2-0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
 
 PackageIdentifier: NGWIN.PicPick
@@ -31,7 +31,7 @@ FileExtensions:
 - j2c
 Installers:
 - Architecture: x64
-  InstallerUrl: https://www.picpick.org/releases/5.2.0/picpick_inst.exe
+  InstallerUrl: https://download.picpick.app/5.2.0/picpick_inst.exe
   InstallerSha256: 4D9ED6B2FE7681743CEE5E06B27E66BDA0EA6E41D5EE6FFFB65F6ED9E0344A4D
 ManifestType: installer
 ManifestVersion: 1.1.0


### PR DESCRIPTION
From latest URL Scan:
> https://www.picpick.org/releases/5.2.0/picpick_inst.exe for NGWIN.PicPick version 5.2.0 redirects to https://download.picpick.app/5.2.0/picpick_inst.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105761)