### PR TITLE
Update URL for NGWIN.PicPick version 5.2.1

### DIFF
--- a/manifests/n/NGWIN/PicPick/5.2.1/NGWIN.PicPick.installer.yaml
+++ b/manifests/n/NGWIN/PicPick/5.2.1/NGWIN.PicPick.installer.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.0.4 $debug=QUSU.7-2-1
+﻿# Created with YamlCreate.ps1 v2.0.4 $debug=QUSU.7-2-1
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
 
 PackageIdentifier: NGWIN.PicPick
@@ -32,7 +32,7 @@ FileExtensions:
 - wmf
 Installers:
 - Architecture: x64
-  InstallerUrl: https://www.picpick.org/releases/5.2.1/picpick_inst.exe
+  InstallerUrl: https://download.picpick.app/5.2.1/picpick_inst.exe
   InstallerSha256: 9507F316C8F2DB2ADF7BBA718CE3AD14ADCC3AC22FA7BF359D936411DA979134
 ManifestType: installer
 ManifestVersion: 1.1.0


### PR DESCRIPTION
From latest URL Scan:
> https://www.picpick.org/releases/5.2.1/picpick_inst.exe for NGWIN.PicPick version 5.2.1 redirects to https://download.picpick.app/5.2.1/picpick_inst.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105762)