### PR TITLE
Update URL for NGWIN.PicPick version 6.0.0

### DIFF
--- a/manifests/n/NGWIN/PicPick/6.0.0/NGWIN.PicPick.installer.yaml
+++ b/manifests/n/NGWIN/PicPick/6.0.0/NGWIN.PicPick.installer.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 0.5.0.1
+﻿# Created using wingetcreate 0.5.0.1
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
 
 PackageIdentifier: NGWIN.PicPick
@@ -32,7 +32,7 @@ FileExtensions:
 Installers:
 - Architecture: x86
   InstallerType: nullsoft
-  InstallerUrl: https://www.picpick.org/releases/6.0.0/picpick_inst.exe
+  InstallerUrl: https://download.picpick.app/6.0.0/picpick_inst.exe
   InstallerSha256: 258C6884B2F26D34FF38262AD1A134B1C92B33156BBF23FED66C3A56C4A43AFE
 ManifestType: installer
 ManifestVersion: 1.1.0


### PR DESCRIPTION
From latest URL Scan:
> https://www.picpick.org/releases/6.0.0/picpick_inst.exe for NGWIN.PicPick version 6.0.0 redirects to https://download.picpick.app/6.0.0/picpick_inst.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105763)