### PR TITLE
Update URL for NGWIN.PicPick version 6.1.1

### DIFF
--- a/manifests/n/NGWIN/PicPick/6.1.1/NGWIN.PicPick.installer.yaml
+++ b/manifests/n/NGWIN/PicPick/6.1.1/NGWIN.PicPick.installer.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.1.4 $debug=AUSU.7-2-6
+﻿# Created with YamlCreate.ps1 v2.1.4 $debug=AUSU.7-2-6
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
 
 PackageIdentifier: NGWIN.PicPick
@@ -32,7 +32,7 @@ FileExtensions:
 - wmf
 Installers:
 - Architecture: x86
-  InstallerUrl: https://www.picpick.org/releases/6.1.1/picpick_inst.exe
+  InstallerUrl: https://download.picpick.app/6.1.1/picpick_inst.exe
   InstallerSha256: 8A0DC641ED4FE8678AE1EFEE3BD376E9356BE0AA36FF6141AFE49356F0761780
 ManifestType: installer
 ManifestVersion: 1.2.0


### PR DESCRIPTION
From latest URL Scan:
> https://www.picpick.org/releases/6.1.1/picpick_inst.exe for NGWIN.PicPick version 6.1.1 redirects to https://download.picpick.app/6.1.1/picpick_inst.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105764)