### PR TITLE
Update URL for NGWIN.PicPick version 6.1.2

### DIFF
--- a/manifests/n/NGWIN/PicPick/6.1.2/NGWIN.PicPick.installer.yaml
+++ b/manifests/n/NGWIN/PicPick/6.1.2/NGWIN.PicPick.installer.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.1.4 $debug=AUSU.7-2-6
+﻿# Created with YamlCreate.ps1 v2.1.4 $debug=AUSU.7-2-6
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
 
 PackageIdentifier: NGWIN.PicPick
@@ -32,7 +32,7 @@ FileExtensions:
 - wmf
 Installers:
 - Architecture: x86
-  InstallerUrl: https://www.picpick.org/releases/6.1.2/picpick_inst.exe
+  InstallerUrl: https://download.picpick.app/6.1.2/picpick_inst.exe
   InstallerSha256: ADE2A287CD6DE5255A6CA5141F389BADC7F071403CFD99E6774CB179F0576DC7
 ManifestType: installer
 ManifestVersion: 1.2.0


### PR DESCRIPTION
From latest URL Scan:
> https://www.picpick.org/releases/6.1.2/picpick_inst.exe for NGWIN.PicPick version 6.1.2 redirects to https://download.picpick.app/6.1.2/picpick_inst.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105765)