### PR TITLE
Update URL for NGWIN.PicPick version 6.3.2

### DIFF
--- a/manifests/n/NGWIN/PicPick/6.3.2/NGWIN.PicPick.installer.yaml
+++ b/manifests/n/NGWIN/PicPick/6.3.2/NGWIN.PicPick.installer.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 1.1.2.0
+﻿# Created using wingetcreate 1.1.2.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
 
 PackageIdentifier: NGWIN.PicPick
@@ -32,7 +32,7 @@ FileExtensions:
 Installers:
 - Architecture: x86
   InstallerType: nullsoft
-  InstallerUrl: https://www.picpick.org/releases/6.3.2/picpick_inst.exe
+  InstallerUrl: https://download.picpick.app/6.3.2/picpick_inst.exe
   InstallerSha256: EA73B354D3C627D777D95F8CBD75CEC85BA60D6916F05015BC2BB80E76C9D5D4
 ManifestType: installer
 ManifestVersion: 1.2.0


### PR DESCRIPTION
From latest URL Scan:
> https://www.picpick.org/releases/6.3.2/picpick_inst.exe for NGWIN.PicPick version 6.3.2 redirects to https://download.picpick.app/6.3.2/picpick_inst.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105768)