### PR TITLE
Update URL for NGWIN.PicPick version 7.0.1

### DIFF
--- a/manifests/n/NGWIN/PicPick/7.0.1/NGWIN.PicPick.installer.yaml
+++ b/manifests/n/NGWIN/PicPick/7.0.1/NGWIN.PicPick.installer.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 1.1.2.0
+﻿# Created using wingetcreate 1.1.2.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
 
 PackageIdentifier: NGWIN.PicPick
@@ -32,7 +32,7 @@ FileExtensions:
 Installers:
 - Architecture: x86
   InstallerType: nullsoft
-  InstallerUrl: https://www.picpick.org/releases/7.0.1/picpick_inst.exe
+  InstallerUrl: https://download.picpick.app/7.0.1/picpick_inst.exe
   InstallerSha256: 0ABBF4359EF59E9C07617CB507BD0F833B07662B0A34456209307EB7159ACBC2
 ManifestType: installer
 ManifestVersion: 1.2.0


### PR DESCRIPTION
From latest URL Scan:
> https://www.picpick.org/releases/7.0.1/picpick_inst.exe for NGWIN.PicPick version 7.0.1 redirects to https://download.picpick.app/7.0.1/picpick_inst.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105769)