### PR TITLE
Update URL for NVAccess.NVDA version 2022.2.4

### DIFF
--- a/manifests/n/NVAccess/NVDA/2022.2.4/NVAccess.NVDA.installer.yaml
+++ b/manifests/n/NVAccess/NVDA/2022.2.4/NVAccess.NVDA.installer.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 1.1.2.0
+﻿# Created using wingetcreate 1.1.2.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
 
 PackageIdentifier: NVAccess.NVDA
@@ -10,7 +10,7 @@ InstallerSwitches:
 Installers:
 - Architecture: x86
   InstallerType: nullsoft
-  InstallerUrl: https://www.nvaccess.org/download/nvda/releases/2022.2.4/nvda_2022.2.4.exe
+  InstallerUrl: https://www.nvaccess.org/files/nvda/releases/2022.2.4/nvda_2022.2.4.exe
   InstallerSha256: C1A2F2CE27731288CAC5C6A72959446DAA1718C1CCD535F8FA7EF6880094E1E6
   ProductCode: NVDA
 ManifestType: installer


### PR DESCRIPTION
From latest URL Scan:
> https://www.nvaccess.org/download/nvda/releases/2022.2.4/nvda_2022.2.4.exe for NVAccess.NVDA version 2022.2.4 redirects to https://www.nvaccess.org/files/nvda/releases/2022.2.4/nvda_2022.2.4.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105771)