### PR TITLE
Update URL for NVAccess.NVDA version 2022.3.3

### DIFF
--- a/manifests/n/NVAccess/NVDA/2022.3.3/NVAccess.NVDA.installer.yaml
+++ b/manifests/n/NVAccess/NVDA/2022.3.3/NVAccess.NVDA.installer.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 1.1.2.0
+﻿# Created using wingetcreate 1.1.2.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
 
 PackageIdentifier: NVAccess.NVDA
@@ -10,7 +10,7 @@ InstallerSwitches:
 Installers:
 - Architecture: x86
   InstallerType: nullsoft
-  InstallerUrl: https://www.nvaccess.org/download/nvda/releases/2022.3.3/nvda_2022.3.3.exe
+  InstallerUrl: https://www.nvaccess.org/files/nvda/releases/2022.3.3/nvda_2022.3.3.exe
   InstallerSha256: A4F00C67945E65E25FBF2D62A03036F327FEC8DC3C5AD2A3FCF7322088FC769F
   ProductCode: NVDA
 ManifestType: installer


### PR DESCRIPTION
From latest URL Scan:
> https://www.nvaccess.org/download/nvda/releases/2022.3.3/nvda_2022.3.3.exe for NVAccess.NVDA version 2022.3.3 redirects to https://www.nvaccess.org/files/nvda/releases/2022.3.3/nvda_2022.3.3.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105774)