### PR TITLE
Update URL for NVAccess.NVDA version 2022.3

### DIFF
--- a/manifests/n/NVAccess/NVDA/2022.3/NVAccess.NVDA.installer.yaml
+++ b/manifests/n/NVAccess/NVDA/2022.3/NVAccess.NVDA.installer.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 1.1.2.0
+﻿# Created using wingetcreate 1.1.2.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
 
 PackageIdentifier: NVAccess.NVDA
@@ -10,7 +10,7 @@ InstallerSwitches:
 Installers:
 - Architecture: x86
   InstallerType: nullsoft
-  InstallerUrl: https://www.nvaccess.org/download/nvda/releases/2022.3/nvda_2022.3.exe
+  InstallerUrl: https://www.nvaccess.org/files/nvda/releases/2022.3/nvda_2022.3.exe
   InstallerSha256: 8487F3BDACBD011E1777D1CC165411E41E830F9A9CA75FEA2912CD1C94962620
   ProductCode: NVDA
 ManifestType: installer


### PR DESCRIPTION
From latest URL Scan:
> https://www.nvaccess.org/download/nvda/releases/2022.3/nvda_2022.3.exe for NVAccess.NVDA version 2022.3 redirects to https://www.nvaccess.org/files/nvda/releases/2022.3/nvda_2022.3.exe https://www.nvaccess.org/download/nvda/releases/2022.3.1/nvda_2022.3.1.exe for NVAccess.NVDA version 2022.3.1 redirects to https://www.nvaccess.org/files/nvda/releases/2022.3.1/nvda_2022.3.1.exe https://www.nvaccess.org/download/nvda/releases/2022.3.2/nvda_2022.3.2.exe for NVAccess.NVDA version 2022.3.2 redirects to https://www.nvaccess.org/files/nvda/releases/2022.3.2/nvda_2022.3.2.exe https://www.nvaccess.org/download/nvda/releases/2022.3.3/nvda_2022.3.3.exe for NVAccess.NVDA version 2022.3.3 redirects to https://www.nvaccess.org/files/nvda/releases/2022.3.3/nvda_2022.3.3.exe

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105775)