### PR TITLE
Update URL for the-sz.Auburn version 1.26

### DIFF
--- a/manifests/t/the-sz/Auburn/1.26/the-sz.Auburn.installer.yaml
+++ b/manifests/t/the-sz/Auburn/1.26/the-sz.Auburn.installer.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 1.2.5.0
+﻿# Created using wingetcreate 1.2.5.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
 
 PackageIdentifier: the-sz.Auburn
@@ -10,7 +10,7 @@ Installers:
   NestedInstallerFiles:
   - RelativeFilePath: ./AuburnSetup.exe
     PortableCommandAlias: AuburnSetup.exe
-  InstallerUrl: https://the-sz.com/common/get.php?product=auburn
+  InstallerUrl: https://the-sz.com/products/auburn/AuburnSetup.zip
   InstallerSha256: 68ac6bf4756ca7c0f33ba4132243e4c14c99130f9b569297b2509a16471443f4
 ManifestType: installer
 ManifestVersion: 1.4.0


### PR DESCRIPTION
From latest URL Scan:
> https://the-sz.com/common/get.php?product=auburn for the-sz.Auburn version 1.26 redirects to https://the-sz.com/products/auburn/AuburnSetup.zip

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105778)