### PR TITLE
Update URL for the-sz.Bear version 1.6

### DIFF
--- a/manifests/t/the-sz/Bear/1.60/the-sz.Bear.installer.yaml
+++ b/manifests/t/the-sz/Bear/1.60/the-sz.Bear.installer.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 1.2.5.0
+﻿# Created using wingetcreate 1.2.5.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
 
 PackageIdentifier: the-sz.Bear
@@ -10,7 +10,7 @@ Installers:
   NestedInstallerFiles:
   - RelativeFilePath: ./Bear.exe
     PortableCommandAlias: Bear.exe
-  InstallerUrl: https://the-sz.com/common/get.php?product=bear
+  InstallerUrl: https://the-sz.com/products/bear/Bear.zip
   InstallerSha256: 122d5f10febb2a6c4356fc299f0072c078481289c274af7304de9eac99e90a0d
 ManifestType: installer
 ManifestVersion: 1.4.0


### PR DESCRIPTION
From latest URL Scan:
> https://the-sz.com/common/get.php?product=bear for the-sz.Bear version 1.6 redirects to https://the-sz.com/products/bear/Bear.zip

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105780)