### PR TITLE
Update URL for the-sz.Bennett version 1.26

### DIFF
--- a/manifests/t/the-sz/Bennett/1.26/the-sz.Bennett.installer.yaml
+++ b/manifests/t/the-sz/Bennett/1.26/the-sz.Bennett.installer.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 1.2.5.0
+﻿# Created using wingetcreate 1.2.5.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
 
 PackageIdentifier: the-sz.Bennett
@@ -10,7 +10,7 @@ Installers:
   NestedInstallerFiles:
   - RelativeFilePath: ./Bennett.exe
     PortableCommandAlias: Bennett.exe
-  InstallerUrl: https://the-sz.com/common/get.php?product=bennett
+  InstallerUrl: https://the-sz.com/products/bennett/Bennett.zip
   InstallerSha256: 836908a269ed9219b0a0228a23fba9af495a3700f292f15be0cc9d9c0e40ff9e
 ManifestType: installer
 ManifestVersion: 1.4.0


### PR DESCRIPTION
From latest URL Scan:
> https://the-sz.com/common/get.php?product=bennett for the-sz.Bennett version 1.26 redirects to https://the-sz.com/products/bennett/Bennett.zip

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105782)