### PR TITLE
Update URL for the-sz.CDInfo version 1.13

### DIFF
--- a/manifests/t/the-sz/CDInfo/1.13/the-sz.CDInfo.installer.yaml
+++ b/manifests/t/the-sz/CDInfo/1.13/the-sz.CDInfo.installer.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 1.2.5.0
+﻿# Created using wingetcreate 1.2.5.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
 
 PackageIdentifier: the-sz.CDInfo
@@ -10,7 +10,7 @@ Installers:
   NestedInstallerFiles:
   - RelativeFilePath: ./CDInfo.exe
     PortableCommandAlias: CDInfo.exe
-  InstallerUrl: https://the-sz.com/common/get.php?product=cdinfo
+  InstallerUrl: https://the-sz.com/products/cdinfo/CDInfo.zip
   InstallerSha256: 3aa64698d7a0def07b3c95deb81b8f12190e51267f7b7f51f14355881b6efd6a
 ManifestType: installer
 ManifestVersion: 1.4.0


### PR DESCRIPTION
From latest URL Scan:
> https://the-sz.com/common/get.php?product=cdinfo for the-sz.CDInfo version 1.13 redirects to https://the-sz.com/products/cdinfo/CDInfo.zip

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105783)