### PR TITLE
Update URL for the-sz.CPUGrabEx version 1.15

### DIFF
--- a/manifests/t/the-sz/CPUGrabEx/1.15/the-sz.CPUGrabEx.installer.yaml
+++ b/manifests/t/the-sz/CPUGrabEx/1.15/the-sz.CPUGrabEx.installer.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 1.2.5.0
+﻿# Created using wingetcreate 1.2.5.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
 
 PackageIdentifier: the-sz.CPUGrabEx
@@ -10,7 +10,7 @@ Installers:
   NestedInstallerFiles:
   - RelativeFilePath: ./CPUGrabEx.exe
     PortableCommandAlias: CPUGrabEx.exe
-  InstallerUrl: https://the-sz.com/common/get.php?product=cpugrabex
+  InstallerUrl: https://the-sz.com/products/cpugrabex/CPUGrabEx.zip
   InstallerSha256: 5b94fb530f1c423652a2f850ad0381f5c94d2ef77bb17a31b70092dc0a3bcdc4
 ManifestType: installer
 ManifestVersion: 1.4.0


### PR DESCRIPTION
From latest URL Scan:
> https://the-sz.com/common/get.php?product=cpugrabex for the-sz.CPUGrabEx version 1.15 redirects to https://the-sz.com/products/cpugrabex/CPUGrabEx.zip

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105784)