### PR TITLE
Update URL for the-sz.Carroll version 1.3

### DIFF
--- a/manifests/t/the-sz/Carroll/1.30/the-sz.Carroll.installer.yaml
+++ b/manifests/t/the-sz/Carroll/1.30/the-sz.Carroll.installer.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 1.2.5.0
+﻿# Created using wingetcreate 1.2.5.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
 
 PackageIdentifier: the-sz.Carroll
@@ -10,7 +10,7 @@ Installers:
   NestedInstallerFiles:
   - RelativeFilePath: ./Setup.exe
     PortableCommandAlias: Setup.exe
-  InstallerUrl: https://the-sz.com/common/get.php?product=carroll
+  InstallerUrl: https://the-sz.com/products/carroll/Carroll.zip
   InstallerSha256: 2af82308dba670210430819c7f44f99cc4153937cb0efc9017ae36b6ce2a7991
 ManifestType: installer
 ManifestVersion: 1.4.0


### PR DESCRIPTION
From latest URL Scan:
> https://the-sz.com/common/get.php?product=carroll for the-sz.Carroll version 1.3 redirects to https://the-sz.com/products/carroll/Carroll.zip

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105785)