### PR TITLE
Update URL for the-sz.Compton version 1.51

### DIFF
--- a/manifests/t/the-sz/Compton/1.51/the-sz.Compton.installer.yaml
+++ b/manifests/t/the-sz/Compton/1.51/the-sz.Compton.installer.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 1.2.5.0
+﻿# Created using wingetcreate 1.2.5.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
 
 PackageIdentifier: the-sz.Compton
@@ -10,7 +10,7 @@ Installers:
   NestedInstallerFiles:
   - RelativeFilePath: ./Compton.exe
     PortableCommandAlias: Compton.exe
-  InstallerUrl: https://the-sz.com/common/get.php?product=compton
+  InstallerUrl: https://the-sz.com/products/compton/Compton.zip
   InstallerSha256: 84d7f58bd43d9cd5cfc65f077a12e3763f3cae42a932cdff45878570d9fb0d1f
 ManifestType: installer
 ManifestVersion: 1.4.0


### PR DESCRIPTION
From latest URL Scan:
> https://the-sz.com/common/get.php?product=compton for the-sz.Compton version 1.51 redirects to https://the-sz.com/products/compton/Compton.zip

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105787)