### PR TITLE
Update URL for the-sz.Doro version 2.2

### DIFF
--- a/manifests/t/the-sz/Doro/2.20/the-sz.Doro.installer.yaml
+++ b/manifests/t/the-sz/Doro/2.20/the-sz.Doro.installer.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 1.2.5.0
+﻿# Created using wingetcreate 1.2.5.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
 
 PackageIdentifier: the-sz.Doro
@@ -10,7 +10,7 @@ Installers:
   NestedInstallerFiles:
   - RelativeFilePath: ./DoroSetup.exe
     PortableCommandAlias: DoroSetup.exe
-  InstallerUrl: https://the-sz.com/common/get.php?product=doro
+  InstallerUrl: https://the-sz.com/products/doro/DoroSetup.zip
   InstallerSha256: 1391612fcb8e1c0bcb7048cc603ccb3f2dea9b677aafc78af0c7b8f1b09a1707
 ManifestType: installer
 ManifestVersion: 1.4.0


### PR DESCRIPTION
From latest URL Scan:
> https://the-sz.com/common/get.php?product=doro for the-sz.Doro version 2.2 redirects to https://the-sz.com/products/doro/DoroSetup.zip

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105789)