### PR TITLE
Update URL for the-sz.FlashBuilder version 1.44

### DIFF
--- a/manifests/t/the-sz/FlashBuilder/1.44/the-sz.FlashBuilder.installer.yaml
+++ b/manifests/t/the-sz/FlashBuilder/1.44/the-sz.FlashBuilder.installer.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 1.2.5.0
+﻿# Created using wingetcreate 1.2.5.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
 
 PackageIdentifier: the-sz.FlashBuilder
@@ -10,7 +10,7 @@ Installers:
   NestedInstallerFiles:
   - RelativeFilePath: ./FlashBuilderSetup.exe
     PortableCommandAlias: FlashBuilderSetup.exe
-  InstallerUrl: https://the-sz.com/common/get.php?product=flash
+  InstallerUrl: https://the-sz.com/products/flash/FlashBuilderSetup.zip
   InstallerSha256: d2366a5921890d03e7f99ba12d770923e9f2a0695be042098af81c50b82cadb9
 ManifestType: installer
 ManifestVersion: 1.4.0


### PR DESCRIPTION
From latest URL Scan:
> https://the-sz.com/common/get.php?product=flash for the-sz.FlashBuilder version 1.44 redirects to https://the-sz.com/products/flash/FlashBuilderSetup.zip

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105790)