### PR TITLE
Update URL for the-sz.Grand version 1.07

### DIFF
--- a/manifests/t/the-sz/Grand/1.07/the-sz.Grand.installer.yaml
+++ b/manifests/t/the-sz/Grand/1.07/the-sz.Grand.installer.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 1.2.5.0
+﻿# Created using wingetcreate 1.2.5.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
 
 PackageIdentifier: the-sz.Grand
@@ -10,7 +10,7 @@ Installers:
   NestedInstallerFiles:
   - RelativeFilePath: ./Grand.exe
     PortableCommandAlias: Grand.exe
-  InstallerUrl: https://the-sz.com/common/get.php?product=grand
+  InstallerUrl: https://the-sz.com/products/grand/Grand.zip
   InstallerSha256: 0c9c5167c2b120695f361f57f039fa57d604143619be4ad6e00351f3564ab9ec
 ManifestType: installer
 ManifestVersion: 1.4.0


### PR DESCRIPTION
From latest URL Scan:
> https://the-sz.com/common/get.php?product=grand for the-sz.Grand version 1.07 redirects to https://the-sz.com/products/grand/Grand.zip

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105791)