### PR TITLE
Update URL for the-sz.Homedale version 2.05

### DIFF
--- a/manifests/t/the-sz/Homedale/2.05/the-sz.Homedale.installer.yaml
+++ b/manifests/t/the-sz/Homedale/2.05/the-sz.Homedale.installer.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 1.2.5.0
+﻿# Created using wingetcreate 1.2.5.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
 
 PackageIdentifier: the-sz.Homedale
@@ -10,7 +10,7 @@ Installers:
   NestedInstallerFiles:
   - RelativeFilePath: ./Homedale.exe
     PortableCommandAlias: Homedale.exe
-  InstallerUrl: https://the-sz.com/common/get.php?product=homedale
+  InstallerUrl: https://the-sz.com/products/homedale/Homedale.zip
   InstallerSha256: 53bfe594e4d70c9e76db518de60e20eca113b77772d0e0817995621789d6a6ea
 ManifestType: installer
 ManifestVersion: 1.4.0


### PR DESCRIPTION
From latest URL Scan:
> https://the-sz.com/common/get.php?product=homedale for the-sz.Homedale version 2.05 redirects to https://the-sz.com/products/homedale/Homedale.zip

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105795)