### PR TITLE
Update URL for the-sz.Lacey version 2.84

### DIFF
--- a/manifests/t/the-sz/Lacey/2.84/the-sz.Lacey.installer.yaml
+++ b/manifests/t/the-sz/Lacey/2.84/the-sz.Lacey.installer.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 1.2.5.0
+﻿# Created using wingetcreate 1.2.5.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
 
 PackageIdentifier: the-sz.Lacey
@@ -10,7 +10,7 @@ Installers:
   NestedInstallerFiles:
   - RelativeFilePath: ./Lacey.exe
     PortableCommandAlias: Lacey.exe
-  InstallerUrl: https://the-sz.com/common/get.php?product=lacey
+  InstallerUrl: https://the-sz.com/products/lacey/Lacey.zip
   InstallerSha256: 881580a18cd41c36b8d747e137503417ba43b57713efa9f0537ec7ab0a993864
 ManifestType: installer
 ManifestVersion: 1.4.0


### PR DESCRIPTION
From latest URL Scan:
> https://the-sz.com/common/get.php?product=lacey for the-sz.Lacey version 2.84 redirects to https://the-sz.com/products/lacey/Lacey.zip

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105799)