### PR TITLE
Update URL for the-sz.Medford version 1.26

### DIFF
--- a/manifests/t/the-sz/Medford/1.26/the-sz.Medford.installer.yaml
+++ b/manifests/t/the-sz/Medford/1.26/the-sz.Medford.installer.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 1.2.5.0
+﻿# Created using wingetcreate 1.2.5.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
 
 PackageIdentifier: the-sz.Medford
@@ -10,7 +10,7 @@ Installers:
   NestedInstallerFiles:
   - RelativeFilePath: ./Medford.exe
     PortableCommandAlias: Medford.exe
-  InstallerUrl: https://the-sz.com/common/get.php?product=medford
+  InstallerUrl: https://the-sz.com/products/medford/Medford.zip
   InstallerSha256: 16d5665d1cca118c721a5b79427f36e6c9a246ba87e2f8e43011e5ebf1ed8f48
 ManifestType: installer
 ManifestVersion: 1.4.0


### PR DESCRIPTION
From latest URL Scan:
> https://the-sz.com/common/get.php?product=medford for the-sz.Medford version 1.26 redirects to https://the-sz.com/products/medford/Medford.zip

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105801)