### PR TITLE
Update URL for the-sz.Parkdale version 3.06

### DIFF
--- a/manifests/t/the-sz/Parkdale/3.06/the-sz.Parkdale.installer.yaml
+++ b/manifests/t/the-sz/Parkdale/3.06/the-sz.Parkdale.installer.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 1.2.5.0
+﻿# Created using wingetcreate 1.2.5.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
 
 PackageIdentifier: the-sz.Parkdale
@@ -10,7 +10,7 @@ Installers:
   NestedInstallerFiles:
   - RelativeFilePath: ./Parkdale.exe
     PortableCommandAlias: Parkdale.exe
-  InstallerUrl: https://the-sz.com/common/get.php?product=parkdale
+  InstallerUrl: https://the-sz.com/products/parkdale/Parkdale.zip
   InstallerSha256: 3ece85824bd890f40816dfd017ad03b934fcc785ff6ca7895aaae33cd08474de
 ManifestType: installer
 ManifestVersion: 1.4.0


### PR DESCRIPTION
From latest URL Scan:
> https://the-sz.com/common/get.php?product=parkdale for the-sz.Parkdale version 3.06 redirects to https://the-sz.com/products/parkdale/Parkdale.zip

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105806)