### PR TITLE
Update URL for the-sz.PortScan version 1.91

### DIFF
--- a/manifests/t/the-sz/PortScan/1.91/the-sz.PortScan.installer.yaml
+++ b/manifests/t/the-sz/PortScan/1.91/the-sz.PortScan.installer.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 1.2.5.0
+﻿# Created using wingetcreate 1.2.5.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
 
 PackageIdentifier: the-sz.PortScan
@@ -10,7 +10,7 @@ Installers:
   NestedInstallerFiles:
   - RelativeFilePath: ./PortScan.exe
     PortableCommandAlias: PortScan.exe
-  InstallerUrl: https://the-sz.com/common/get.php?product=portscan
+  InstallerUrl: https://the-sz.com/products/portscan/PortScan.zip
   InstallerSha256: 8e48a8f6bb6743ed2458d144ecc7b668d6afefd3cb5ab825e09203c8da961070
 ManifestType: installer
 ManifestVersion: 1.4.0


### PR DESCRIPTION
From latest URL Scan:
> https://the-sz.com/common/get.php?product=portscan for the-sz.PortScan version 1.91 redirects to https://the-sz.com/products/portscan/PortScan.zip

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105807)