### PR TITLE
Update URL for the-sz.Richmond version 1.04

### DIFF
--- a/manifests/t/the-sz/Richmond/1.04/the-sz.Richmond.installer.yaml
+++ b/manifests/t/the-sz/Richmond/1.04/the-sz.Richmond.installer.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 1.2.5.0
+﻿# Created using wingetcreate 1.2.5.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
 
 PackageIdentifier: the-sz.Richmond
@@ -10,7 +10,7 @@ Installers:
   NestedInstallerFiles:
   - RelativeFilePath: ./Richmond.exe
     PortableCommandAlias: Richmond.exe
-  InstallerUrl: https://the-sz.com/common/get.php?product=richmond
+  InstallerUrl: https://the-sz.com/products/richmond/Richmond.zip
   InstallerSha256: 30baf7fcf363d6babbd34f4b2140bcfd8013a76c819d2afe4dde4f654a65fa58
 ManifestType: installer
 ManifestVersion: 1.4.0


### PR DESCRIPTION
From latest URL Scan:
> https://the-sz.com/common/get.php?product=richmond for the-sz.Richmond version 1.04 redirects to https://the-sz.com/products/richmond/Richmond.zip

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105810)