### PR TITLE
Update URL for the-sz.Rimhill version 1.12

### DIFF
--- a/manifests/t/the-sz/Rimhill/1.12/the-sz.Rimhill.installer.yaml
+++ b/manifests/t/the-sz/Rimhill/1.12/the-sz.Rimhill.installer.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 1.2.5.0
+﻿# Created using wingetcreate 1.2.5.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
 
 PackageIdentifier: the-sz.Rimhill
@@ -10,7 +10,7 @@ Installers:
   NestedInstallerFiles:
   - RelativeFilePath: ./RimhillExSetup.exe
     PortableCommandAlias: RimhillExSetup.exe
-  InstallerUrl: https://the-sz.com/common/get.php?product=rimhillex
+  InstallerUrl: https://the-sz.com/products/rimhillex/RimhillEx.zip
   InstallerSha256: 852510384ed0e65a01b38c1acc89a1ce89a70ff4d29bfa60c7c963c186084458
 ManifestType: installer
 ManifestVersion: 1.4.0


### PR DESCRIPTION
From latest URL Scan:
> https://the-sz.com/common/get.php?product=rimhillex for the-sz.Rimhill version 1.12 redirects to https://the-sz.com/products/rimhillex/RimhillEx.zip

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105811)