### PR TITLE
Update URL for the-sz.Royal version 1.68

### DIFF
--- a/manifests/t/the-sz/Royal/1.68/the-sz.Royal.installer.yaml
+++ b/manifests/t/the-sz/Royal/1.68/the-sz.Royal.installer.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 1.2.5.0
+﻿# Created using wingetcreate 1.2.5.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
 
 PackageIdentifier: the-sz.Royal
@@ -10,7 +10,7 @@ Installers:
   NestedInstallerFiles:
   - RelativeFilePath: ./Royal.exe
     PortableCommandAlias: Royal.exe
-  InstallerUrl: https://the-sz.com/common/get.php?product=royal
+  InstallerUrl: https://the-sz.com/products/royal/Royal.zip
   InstallerSha256: a87fe49e0214a59a6a161ec6eee5c142e9d1bbd7febdb2fb1cf3024e7c014153
 ManifestType: installer
 ManifestVersion: 1.4.0


### PR DESCRIPTION
From latest URL Scan:
> https://the-sz.com/common/get.php?product=royal for the-sz.Royal version 1.68 redirects to https://the-sz.com/products/royal/Royal.zip

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105812)