### PR TITLE
Update URL for the-sz.RoyalPro version 1.01

### DIFF
--- a/manifests/t/the-sz/RoyalPro/1.01/the-sz.RoyalPro.installer.yaml
+++ b/manifests/t/the-sz/RoyalPro/1.01/the-sz.RoyalPro.installer.yaml
@@ -10,7 +10,7 @@ Installers:
   NestedInstallerFiles:
   - RelativeFilePath: ./RoyalPro.exe
     PortableCommandAlias: RoyalPro.exe
-  InstallerUrl: https://the-sz.com/products/royal/Royal.zip_pro
+  InstallerUrl: https://the-sz.com/products/royal_pro/RoyalPro.zip
   InstallerSha256: 9786340b0796e60a7441d61b37885039d7d4f48a1a5833e61b7b60f37e3381b5
 ManifestType: installer
 ManifestVersion: 1.4.0

--- a/manifests/t/the-sz/RoyalPro/1.01/the-sz.RoyalPro.installer.yaml
+++ b/manifests/t/the-sz/RoyalPro/1.01/the-sz.RoyalPro.installer.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 1.2.5.0
+﻿# Created using wingetcreate 1.2.5.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
 
 PackageIdentifier: the-sz.RoyalPro
@@ -10,7 +10,7 @@ Installers:
   NestedInstallerFiles:
   - RelativeFilePath: ./RoyalPro.exe
     PortableCommandAlias: RoyalPro.exe
-  InstallerUrl: https://the-sz.com/common/get.php?product=royal_pro
+  InstallerUrl: https://the-sz.com/products/royal/Royal.zip_pro
   InstallerSha256: 9786340b0796e60a7441d61b37885039d7d4f48a1a5833e61b7b60f37e3381b5
 ManifestType: installer
 ManifestVersion: 1.4.0


### PR DESCRIPTION
From latest URL Scan:
> https://the-sz.com/common/get.php?product=royal_pro for the-sz.RoyalPro version 1.01 redirects to https://the-sz.com/products/royal_pro/RoyalPro.zip

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105813)