### PR TITLE
Update URL for the-sz.Seaside version 1.38

### DIFF
--- a/manifests/t/the-sz/Seaside/1.38/the-sz.Seaside.installer.yaml
+++ b/manifests/t/the-sz/Seaside/1.38/the-sz.Seaside.installer.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 1.2.5.0
+﻿# Created using wingetcreate 1.2.5.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
 
 PackageIdentifier: the-sz.Seaside
@@ -10,7 +10,7 @@ Installers:
   NestedInstallerFiles:
   - RelativeFilePath: ./SeasideSetup.exe
     PortableCommandAlias: SeasideSetup.exe
-  InstallerUrl: https://the-sz.com/common/get.php?product=seaside
+  InstallerUrl: https://the-sz.com/products/seaside/SeasideSetup.zip
   InstallerSha256: 43f82de323db57583c13738782b8a63c58321cfd0fb600d1b3ab89a6ceeb58c1
 ManifestType: installer
 ManifestVersion: 1.4.0


### PR DESCRIPTION
From latest URL Scan:
> https://the-sz.com/common/get.php?product=seaside for the-sz.Seaside version 1.38 redirects to https://the-sz.com/products/seaside/SeasideSetup.zip

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105814)