### PR TITLE
Update URL for the-sz.Sherwood version 1.09

### DIFF
--- a/manifests/t/the-sz/Sherwood/1.09/the-sz.Sherwood.installer.yaml
+++ b/manifests/t/the-sz/Sherwood/1.09/the-sz.Sherwood.installer.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 1.2.5.0
+﻿# Created using wingetcreate 1.2.5.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
 
 PackageIdentifier: the-sz.Sherwood
@@ -10,7 +10,7 @@ Installers:
   NestedInstallerFiles:
   - RelativeFilePath: ./Sherwood.exe
     PortableCommandAlias: Sherwood.exe
-  InstallerUrl: https://the-sz.com/common/get.php?product=sherwood
+  InstallerUrl: https://the-sz.com/products/sherwood/Sherwood.zip
   InstallerSha256: bc8541a1ca8f86ee790e88ab7bd3c973cc61d8ed608a5d9f4e75048f7b77d2e6
 ManifestType: installer
 ManifestVersion: 1.4.0


### PR DESCRIPTION
From latest URL Scan:
> https://the-sz.com/common/get.php?product=sherwood for the-sz.Sherwood version 1.09 redirects to https://the-sz.com/products/sherwood/Sherwood.zip

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105815)