### PR TITLE
Update URL for the-sz.Spencer version 1.28

### DIFF
--- a/manifests/t/the-sz/Spencer/1.28/the-sz.Spencer.installer.yaml
+++ b/manifests/t/the-sz/Spencer/1.28/the-sz.Spencer.installer.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 1.2.5.0
+﻿# Created using wingetcreate 1.2.5.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
 
 PackageIdentifier: the-sz.Spencer
@@ -10,7 +10,7 @@ Installers:
   NestedInstallerFiles:
   - RelativeFilePath: ./Spencer.exe
     PortableCommandAlias: Spencer.exe
-  InstallerUrl: https://the-sz.com/common/get.php?product=spencer
+  InstallerUrl: https://the-sz.com/products/spencer/Spencer.zip
   InstallerSha256: 284d6c7932ecb31742477826ff678f6e2743ccbf81d6c60d664d97c4740ef4ce
 ManifestType: installer
 ManifestVersion: 1.4.0


### PR DESCRIPTION
From latest URL Scan:
> https://the-sz.com/common/get.php?product=spencer for the-sz.Spencer version 1.28 redirects to https://the-sz.com/products/spencer/Spencer.zip

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105817)