### PR TITLE
chore(kontext): update to 1.6.0

### DIFF
--- a/manifests/o/orbatschow/kontext/1.6.0/orbatschow.kontext.installer.yaml
+++ b/manifests/o/orbatschow/kontext/1.6.0/orbatschow.kontext.installer.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
+PackageIdentifier: orbatschow.kontext
+PackageVersion: 1.6.0
+InstallerLocale: en-US
+InstallerType: zip
+Commands:
+- kontext
+ReleaseDate: 2023-04-23
+Installers:
+- Architecture: x64
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: kontext.exe
+    PortableCommandAlias: kontext
+  InstallerUrl: https://github.com/orbatschow/kontext/releases/download/v1.6.0/kontext_Windows_x86_64.zip
+  InstallerSha256: a3295a531b6cf52bf05989bcd44f96d8e26fbcdd35a6286252a2c55501f3d8ce
+- Architecture: arm
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: kontext.exe
+    PortableCommandAlias: kontext
+  InstallerUrl: https://github.com/orbatschow/kontext/releases/download/v1.6.0/kontext_Windows_arm64.zip
+  InstallerSha256: aceabf4640319b8a6d774c5ffabf09ca4245f8e393936dc962221bc6eaba26f6
+ManifestType: installer
+ManifestVersion: 1.4.0

--- a/manifests/o/orbatschow/kontext/1.6.0/orbatschow.kontext.locale.en-US.yaml
+++ b/manifests/o/orbatschow/kontext/1.6.0/orbatschow.kontext.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.4.0.schema.json
+PackageIdentifier: orbatschow.kontext
+PackageVersion: 1.6.0
+PackageLocale: en-US
+Publisher: Orbatschow
+PublisherUrl: https://orbat.sh
+Author: Orbatschow
+PackageName: kontext
+PackageUrl: https://github.com/orbatschow/kontext/
+License: Apache-2.0
+LicenseUrl: https://github.com/orbatschow/kontext/blob/master/LICENSE
+ShortDescription: Declarative kubeconfig management within a single binary.
+Description: Kontext is a single binary application, that takes yet another approach on kubeconfig management.
+Tags:
+- cli
+- devops-tools
+- golang
+- kubernetes
+- context
+- kubeconfig
+- portable
+- terminal
+ReleaseNotesUrl: https://github.com/orbatschow/kontext/releases/tag/v1.6.0
+ManifestType: defaultLocale
+ManifestVersion: 1.4.0

--- a/manifests/o/orbatschow/kontext/1.6.0/orbatschow.kontext.yaml
+++ b/manifests/o/orbatschow/kontext/1.6.0/orbatschow.kontext.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.4.0.schema.json
+PackageIdentifier: orbatschow.kontext
+PackageVersion: 1.6.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.4.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.4 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.4.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

A new version of `kontext` has been released. This is the new manifest for this version.

Kind Regards
Philip
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/105974)