### PR TITLE
Update SandboxTest.ps1

### DIFF
--- a/Tools/SandboxTest.ps1
+++ b/Tools/SandboxTest.ps1
@@ -71,54 +71,53 @@ $tempFolder = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath $temp
 New-Item $tempFolder -ItemType Directory -ErrorAction SilentlyContinue | Out-Null
 
 # Set dependencies
-
-$apiLatestUrl = if ($Prerelease) { 'https://api.github.com/repos/microsoft/winget-cli/releases?per_page=1' } else { 'https://api.github.com/repos/microsoft/winget-cli/releases/latest' }
-
-
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 $WebClient = New-Object System.Net.WebClient
 
-function Get-LatestUrl {
-  ((Invoke-WebRequest $apiLatestUrl -UseBasicParsing | ConvertFrom-Json).assets | Where-Object { $_.name -match '^Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle$' }).browser_download_url
-}
+function Get-LatestRelease {
+  $apiLatestUrl = if ($Prerelease) { 'https://api.github.com/repos/microsoft/winget-cli/releases?per_page=1' } else { 'https://api.github.com/repos/microsoft/winget-cli/releases/latest' }
+  $releasesAPIResponse = Invoke-RestMethod $apiLatestUrl
+  $assets = $releasesAPIResponse[0].assets
+  $shaFileUrl = $assets.Where({ $_.name -eq 'Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.txt' }).browser_download_url
+  $shaFile = New-TemporaryFile
+  $WebClient.DownloadFile($shaFileUrl, $shaFile.FullName)
 
-function Get-LatestHash {
-  $shaUrl = ((Invoke-WebRequest $apiLatestUrl -UseBasicParsing | ConvertFrom-Json).assets | Where-Object { $_.name -match '^Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.txt$' }).browser_download_url
-
-  $shaFile = Join-Path -Path $tempFolder -ChildPath 'Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.txt'
-  $WebClient.DownloadFile($shaUrl, $shaFile)
-
-  Get-Content $shaFile
+  return @{
+    shaFileUrl     = $assets.Where({ $_.name -eq 'Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.txt' }).browser_download_url
+    msixFileUrl    = $assets.Where({ $_.name -eq 'Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle' }).browser_download_url
+    releaseTag     = $releasesAPIResponse[0].tag_name
+    shaFileContent = $(Get-Content $shaFile.FullName)
+  }
 }
 
 # Hide the progress bar of Invoke-WebRequest
 $oldProgressPreference = $ProgressPreference
 $ProgressPreference = 'SilentlyContinue'
 
+$latestRelease = Get-LatestRelease
 $desktopAppInstaller = @{
-  fileName = 'Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle'
-  url      = $(Get-LatestUrl)
-  hash     = $(Get-LatestHash)
+  url    = $latestRelease.msixFileUrl
+  hash   = $latestRelease.shaFileContent
+  SaveTo = $(Join-Path $env:LOCALAPPDATA -ChildPath "Packages\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe\bin\$($latestRelease.releaseTag)\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle")
 }
 
 $ProgressPreference = $oldProgressPreference
 
 $vcLibsUwp = @{
-  fileName = 'Microsoft.VCLibs.x64.14.00.Desktop.appx'
-  url      = 'https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx'
-  hash     = '9BFDE6CFCC530EF073AB4BC9C4817575F63BE1251DD75AAA58CB89299697A569'
+  url    = 'https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx'
+  hash   = '9BFDE6CFCC530EF073AB4BC9C4817575F63BE1251DD75AAA58CB89299697A569'
+  SaveTo = $(Join-Path $tempFolder -ChildPath 'Microsoft.VCLibs.x64.14.00.Desktop.appx')
 }
 $uiLibsUwp = @{
-  fileName = 'Microsoft.UI.Xaml.2.7.zip'
   url      = 'https://www.nuget.org/api/v2/package/Microsoft.UI.Xaml/2.7.0'
   hash     = '422FD24B231E87A842C4DAEABC6A335112E0D35B86FAC91F5CE7CF327E36A591'
+  SaveTo   = $(Join-Path $tempFolder -ChildPath 'Microsoft.UI.Xaml.2.7.zip')
 }
 
 $dependencies = @($desktopAppInstaller, $vcLibsUwp, $uiLibsUwp)
 
 # Clean temp directory
-
-Get-ChildItem $tempFolder -Recurse -Exclude $dependencies.fileName | Remove-Item -Force -Recurse
+Get-ChildItem $tempFolder -Recurse -Exclude $($(Split-Path $dependencies.SaveTo -Leaf) -replace '\.([^\.]+)$','.*') | Remove-Item -Force -Recurse
 
 if (-Not [String]::IsNullOrWhiteSpace($Manifest)) {
   Copy-Item -Path $Manifest -Recurse -Destination $tempFolder
@@ -131,23 +130,29 @@ Write-Host '--> Checking dependencies'
 $desktopInSandbox = 'C:\Users\WDAGUtilityAccount\Desktop'
 
 foreach ($dependency in $dependencies) {
-  $dependency.file = Join-Path -Path $tempFolder -ChildPath $dependency.fileName
-  $dependency.pathInSandbox = Join-Path -Path $desktopInSandbox -ChildPath (Join-Path -Path $tempFolderName -ChildPath $dependency.fileName)
+  $dependency.pathInSandbox = Join-Path -Path $desktopInSandbox -ChildPath (Join-Path -Path $tempFolderName -ChildPath $(Split-Path $dependency.SaveTo -Leaf))
 
   # Only download if the file does not exist, or its hash does not match.
-  if (-Not ((Test-Path -Path $dependency.file -PathType Leaf) -And $dependency.hash -eq $(Get-FileHash $dependency.file).Hash)) {
+  if (-Not ((Test-Path -Path $dependency.SaveTo) -And $dependency.hash -eq $(Get-FileHash $dependency.SaveTo).Hash)) {
     Write-Host @"
     - Downloading:
       $($dependency.url)
 "@
 
     try {
-      $WebClient.DownloadFile($dependency.url, $dependency.file)
+      # If the directory doesn't already exist, create it
+      $saveDirectory = Split-Path $dependency.SaveTo
+      if (-Not (Test-Path -Path $saveDirectory))
+      {
+        New-Item -ItemType Directory -Path $saveDirectory -Force | Out-Null
+      }
+      $WebClient.DownloadFile($dependency.url, $dependency.SaveTo)
+
     } catch {
       #Pass the exception as an inner exception
       throw [System.Net.WebException]::new("Error downloading $($dependency.url).", $_.Exception)
     }
-    if (-not ($dependency.hash -eq $(Get-FileHash $dependency.file).Hash)) {
+    if (-not ($dependency.hash -eq $(Get-FileHash $dependency.SaveTo).Hash)) {
       throw [System.Activities.VersionMismatchException]::new('Dependency hash does not match the downloaded file')
     }
   }
@@ -157,11 +162,14 @@ foreach ($dependency in $dependencies) {
 # This is a workaround until https://github.com/microsoft/winget-cli/issues/1861 is resolved.
 
 if (-Not (Test-Path (Join-Path -Path $tempFolder -ChildPath \Microsoft.UI.Xaml.2.7\tools\AppX\x64\Release\Microsoft.UI.Xaml.2.7.appx))) {
-  Expand-Archive -Path $uiLibsUwp.file -DestinationPath ($tempFolder + '\Microsoft.UI.Xaml.2.7') -Force
+  Expand-Archive -Path $uiLibsUwp.SaveTo -DestinationPath ($tempFolder + '\Microsoft.UI.Xaml.2.7') -Force
 }
 $uiLibsUwp.file = (Join-Path -Path $tempFolder -ChildPath \Microsoft.UI.Xaml.2.7\tools\AppX\x64\Release\Microsoft.UI.Xaml.2.7.appx)
 $uiLibsUwp.pathInSandbox = Join-Path -Path $desktopInSandbox -ChildPath (Join-Path -Path $tempFolderName -ChildPath \Microsoft.UI.Xaml.2.7\tools\AppX\x64\Release\Microsoft.UI.Xaml.2.7.appx)
 Write-Host
+
+# Copy the version of winget to the sandbox test folder
+Copy-Item -Path $desktopAppInstaller.SaveTo -Destination (Join-Path -Path $tempFolder -ChildPath (Split-Path $desktopAppInstaller.SaveTo -Leaf))
 
 # Create Bootstrap settings
 # Experimental features can be enabled for forward compatibility with PR's
@@ -170,7 +178,7 @@ $bootstrapSettingsContent['$schema'] = 'https://aka.ms/winget-settings.schema.js
 $bootstrapSettingsContent['logging'] = @{level = 'verbose' }
 if ($EnableExperimentalFeatures) {
   $bootstrapSettingsContent['experimentalFeatures'] = @{
-    dependencies    = $true
+    dependencies     = $true
     openLogsArgument = $true
   }
 }


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?

SandboxTest.ps1 currently only has `-PreRelease` to select a version of winget. This is great, but it re-downloads winget every time you switch between using `-PreRelease` and not using it. This PR changes how the script detects winget versions. Instead of checking the `SandboxTest` folder for the winget appx, this change now makes it use the same directory that `WingetVersionManager.ps1` uses. This way, if the user already has the version available in their directory structure, it doesn't need to be downloaded at all. Once the proper appx has been selected, it is then copied to the `SandboxTest` folder. 

This PR also changes how the SHA and download URL for Winget are fetched - meaning that only a single call is made to GitHub API's instead of two calls, so that a new switch for selecting the Winget version can be implemented in a separate PR.


cc @mdanish-kh @SpecterShell @russellbanks @denelon 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/106266)