### PR TITLE
Use download.pdf24.org to distribute the load to multiple servers

### DIFF
--- a/manifests/g/geeksoftwareGmbH/PDF24Creator/11.12.0/geeksoftwareGmbH.PDF24Creator.installer.yaml
+++ b/manifests/g/geeksoftwareGmbH/PDF24Creator/11.12.0/geeksoftwareGmbH.PDF24Creator.installer.yaml
@@ -9,12 +9,12 @@ UpgradeBehavior: install
 Installers:
 - Architecture: x64
   InstallerType: wix
-  InstallerUrl: https://download4.pdf24.org/pdf24-creator-11.12.0-x64.msi
+  InstallerUrl: https://download.pdf24.org/pdf24-creator-11.12.0-x64.msi
   InstallerSha256: FF2FDCB6BDD02FEF37F33ACADAA935A4A37DF4009F7DB90716A98EC610C844D6
   ProductCode: '{33E33736-C48A-45CF-9B85-7C6400267599}'
 - Architecture: x64
   InstallerType: inno
-  InstallerUrl: https://download1.pdf24.org/pdf24-creator-11.12.0-x64.exe
+  InstallerUrl: https://download.pdf24.org/pdf24-creator-11.12.0-x64.exe
   InstallerSha256: B86AFA38D705DF0D95C2A856B7774BC4299A62168DE58AF8CB494C36EC094F38
   InstallerSwitches:
     Custom: /NOUPDATE /NORESTART
@@ -23,12 +23,12 @@ Installers:
     ProductCode: '{81A6F461-0DBA-4F12-B56F-0E977EC10576}_is1'
 - Architecture: x86
   InstallerType: wix
-  InstallerUrl: https://download0.pdf24.org/pdf24-creator-11.12.0-x86.msi
+  InstallerUrl: https://download.pdf24.org/pdf24-creator-11.12.0-x86.msi
   InstallerSha256: BF370F13F5C02826CCAB1099347106B890523603BB49C7764FDAC804852BC0B1
   ProductCode: '{9880F0A2-240B-4620-AFDB-692D9001E5E3}'
 - Architecture: x86
   InstallerType: inno
-  InstallerUrl: https://download0.pdf24.org/pdf24-creator-11.12.0-x86.exe
+  InstallerUrl: https://download.pdf24.org/pdf24-creator-11.12.0-x86.exe
   InstallerSha256: 9CE95C037C72B673F94314A6B3A75A9366CD6B10E5E397108CA76AEB3860C829
   InstallerSwitches:
     Custom: /NOUPDATE /NORESTART


### PR DESCRIPTION
Simple change, but please always use download.pdf24.org as host for the file downloads, just to distribute the network load to multiple PDF24 download servers. Otherwise downloads can take a long time.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/106527)