### PR TITLE
More updates to fabricbot

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -3162,24 +3162,117 @@
         "eventNames": [
           "issue_comment"
         ],
-        "taskName": "Helper to add zip-binary to Issue",
+        "taskName": "Helper to add zip-binary to PR",
         "actions": [
           {
             "name": "addLabel",
             "parameters": {
               "label": "zip-binary"
             }
-          },
-          {
-            "name": "removeLabel",
-            "parameters": {
-              "label": "Needs-Attention"
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssueCommentResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "commentContains",
+              "parameters": {
+                "bodyPattern": "/zip",
+                "isRegex": true,
+                "commentPattern": "\\[[Pp]olicy\\]\\s+[zZ]ip[\\s-][bB]inary"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "activitySenderHasPermissions",
+                  "parameters": {
+                    "permissions": "admin"
+                  }
+                },
+                {
+                  "name": "activitySenderHasPermissions",
+                  "parameters": {
+                    "permissions": "write"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "ImJoakim"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "ItzLevvie"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "jedieaston"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "KaranKad"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "OfficialEsco"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "quhxl"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "Trenly"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "mdanish-kh"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "russellbanks"
+                  }
+                }
+              ]
             }
-          },
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issue_comment"
+        ],
+        "taskName": "Helper to add zip-binary to Issue",
+        "actions": [
           {
             "name": "addLabel",
             "parameters": {
-              "label": "Blocking-Issue"
+              "label": "zip-binary"
             }
           }
         ]
@@ -6255,13 +6348,25 @@
           {
             "name": "addReply",
             "parameters": {
-              "comment": "Hello @${issueAuthor},\n\nThis package appears to depend on .dlls that aren't available via symlink.\n\nThis PR is blocked until support for zipped binaries is implemented in:\n* microsoft/winget-cli/issues/2711\n\nTemplate: msftbot/blockingIssue/zipBinary"
+              "comment": "Hello @${issueAuthor},\n\nThis package appears to depend on .dlls that aren't available via symlink.\n\nThis PR is blocked until support for zipped binaries is implemented in:\n* microsoft/winget-cli/issues/2711\nBe sure to add your 👍 to the issue to help raise the priority and avoid posting \"Me too!\" messages to respect those who have subscribed to the issue.\n\nTemplate: msftbot/blockingIssue/zipBinary"
             }
           },
           {
             "name": "addLabel",
             "parameters": {
               "label": "Blocking-Issue"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Needs-Author-Feedback"
+            }
+          },
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "Needs-Attention"
             }
           }
         ]
@@ -6300,7 +6405,7 @@
           {
             "name": "addReply",
             "parameters": {
-              "comment": "Hello @${issueAuthor},\n\nThis package appears to depend on .dlls that aren't available via symlink.\n\nThis package is blocked until support for zipped binaries is implemented in:\n* microsoft/winget-cli/issues/2711\n\nTemplate: msftbot/blockingIssue/zipBinary"
+              "comment": "Hello @${issueAuthor},\n\nThis package appears to depend on .dlls that aren't available via symlink.\n\nThis package is blocked until support for zipped binaries is implemented in:\n* microsoft/winget-cli/issues/2711\nBe sure to add your 👍 to the issue to help raise the priority and avoid posting \"Me too!\" messages to respect those who have subscribed to the issue.\n\nTemplate: msftbot/blockingIssue/zipBinary"
             }
           },
           {

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -2233,6 +2233,12 @@
             "parameters": {
               "label": "Installer-Issue"
             }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Area-External"
+            }
           }
         ]
       }

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -3287,6 +3287,131 @@
     {
       "taskType": "trigger",
       "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestCommentResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "commentContains",
+              "parameters": {
+                "bodyPattern": "/att",
+                "isRegex": true,
+                "commentPattern": "\\[[Pp]olicy\\]\\s+[Nn]eeds[\\s-][Aa]ttention"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "activitySenderHasPermissions",
+                  "parameters": {
+                    "permissions": "admin"
+                  }
+                },
+                {
+                  "name": "activitySenderHasPermissions",
+                  "parameters": {
+                    "permissions": "write"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "ImJoakim"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "ItzLevvie"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "jedieaston"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "KaranKad"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "OfficialEsco"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "quhxl"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "Trenly"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "mdanish-kh"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "russellbanks"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "issue_comment"
+        ],
+        "taskName": "Helper to aassign PR to On-Call",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Needs-Attention"
+            }
+          },
+          {
+            "name": "assignToIcmUserGroup",
+            "parameters": {
+              "groupId": "61b7eb27cfff4b19dc1a8ec7",
+              "assignmentTarget": "Primary"
+            }
+          },
+          {
+            "name": "assignToIcmUserGroup",
+            "parameters": {
+              "groupId": "61b7eb27cfff4b19dc1a8ec7",
+              "assignmentTarget": "FirstBackup"
+            }
+          },
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "Hello ${issueAuthor},\n\nYour pull request requires attention from a repository administrator. It has been assigned to a developer for review.\n\nTemplate: msftbot/manualReview"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
       "subCapability": "IssuesOnlyResponder",
       "version": "1.0",
       "config": {

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -2441,25 +2441,7 @@
           {
             "name": "addLabel",
             "parameters": {
-              "label": "Needs-Author-Feedback"
-            }
-          },
-          {
-            "name": "removeLabel",
-            "parameters": {
-              "label": "Needs-Attention"
-            }
-          },
-          {
-            "name": "addLabel",
-            "parameters": {
               "label": "Interactive-Only-Installer"
-            }
-          },
-          {
-            "name": "addLabel",
-            "parameters": {
-              "label": "Blocking-Issue"
             }
           }
         ]
@@ -2565,12 +2547,6 @@
             "name": "addLabel",
             "parameters": {
               "label": "Interactive-Only-Installer"
-            }
-          },
-          {
-            "name": "addLabel",
-            "parameters": {
-              "label": "Blocking-Issue"
             }
           }
         ]
@@ -6176,9 +6152,21 @@
         },
         "actions": [
           {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Needs-Author-Feedback"
+            }
+          },
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "Needs-Attention"
+            }
+          },
+          {
             "name": "addReply",
             "parameters": {
-              "comment": "Hello @${issueAuthor},\n\nThis package appears to require user interaction to install.\n\nThis PR is blocked until support for interactive installer search filtering is implemented in:\n* microsoft/winget-cli/issues/823\n\nTemplate: msftbot/blockingIssue/interactiveOnlyInstall"
+              "comment": "Hello @${issueAuthor},\n\nThis package appears to require user interaction to install.\n\nThis PR is blocked until support for interactive installer search filtering is implemented in:\n* microsoft/winget-cli/issues/823\nBe sure to add your 👍 to the issue to help raise the priority and avoid posting \"Me too!\" messages to respect those who have subscribed to the issue.\n\nTemplate: msftbot/blockingIssue/interactiveOnlyInstall"
             }
           },
           {
@@ -6223,7 +6211,7 @@
           {
             "name": "addReply",
             "parameters": {
-              "comment": "Hello @${issueAuthor},\n\nThis package appears to require user interaction to install.\n\nThis package is blocked until support for interactive installer search filtering is implemented in:\n* microsoft/winget-cli/issues/823\n\nTemplate: msftbot/blockingIssue/interactiveOnlyInstall"
+              "comment": "Hello @${issueAuthor},\n\nThis package appears to require user interaction to install.\n\nThis package is blocked until support for interactive installer search filtering is implemented in:\n* microsoft/winget-cli/issues/823\nBe sure to add your 👍 to the issue to help raise the priority and avoid posting \"Me too!\" messages to respect those who have subscribed to the issue.\n\nTemplate: msftbot/blockingIssue/interactiveOnlyInstall"
             }
           },
           {

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -6502,7 +6502,7 @@
             "name": "addReply",
             "parameters": {
               "label": "Blocking-Issue",
-              "comment": "Hello @${issueAuthor},\n\nThis package appears to require specific hardware.\n\nThis PR is blocked until support for specific hardware requirements is implemented in:\n* microsoft/winget-cli/issues/1417\n\nTemplate: msftbot/blockingIssue/hardwareDependency"
+              "comment": "Hello @${issueAuthor},\n\nThis package appears to require specific hardware.\n\nThis PR is blocked until support for specific hardware requirements is implemented in:\n* microsoft/winget-cli/issues/1417\nBe sure to add your 👍 to the issue to help raise the priority and avoid posting \"Me too!\" messages to respect those who have subscribed to the issue.\n\nTemplate: msftbot/blockingIssue/hardwareDependency"
             }
           },
           {

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1781,25 +1781,7 @@
           {
             "name": "addLabel",
             "parameters": {
-              "label": "Needs-Author-Feedback"
-            }
-          },
-          {
-            "name": "removeLabel",
-            "parameters": {
-              "label": "Needs-Attention"
-            }
-          },
-          {
-            "name": "addLabel",
-            "parameters": {
               "label": "Dependencies"
-            }
-          },
-          {
-            "name": "addLabel",
-            "parameters": {
-              "label": "Blocking-Issue"
             }
           }
         ]
@@ -1902,21 +1884,9 @@
         "taskName": "Helper to add dependencies to Issue",
         "actions": [
           {
-            "name": "removeLabel",
-            "parameters": {
-              "label": "Needs-Author-Feedback"
-            }
-          },
-          {
             "name": "addLabel",
             "parameters": {
               "label": "Dependencies"
-            }
-          },
-          {
-            "name": "addLabel",
-            "parameters": {
-              "label": "Blocking-Issue"
             }
           }
         ]
@@ -6107,13 +6077,25 @@
           {
             "name": "addReply",
             "parameters": {
-              "comment": "Hello @${issueAuthor},\n\nThis package appears to require dependencies in order to install successfully.\n\nThis PR is blocked until support for dependencies is implemented in:\n* microsoft/winget-cli/issues/163\n\nTemplate: msftbot/blockingIssue/dependencySupport"
+              "comment": "Hello @${issueAuthor},\n\nThis package appears to require dependencies in order to install successfully.\n\nThis PR is blocked until support for dependencies is implemented in:\n* microsoft/winget-cli/issues/163\nBe sure to add your 👍 to the issue to help raise the priority and avoid posting \"Me too!\" messages to respect those who have subscribed to the issue.\n\nTemplate: msftbot/blockingIssue/dependencySupport"
             }
           },
           {
             "name": "addLabel",
             "parameters": {
               "label": "Blocking-Issue"
+            }
+          },
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "Needs-Attention"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Needs-Author-Feedback"
             }
           }
         ]
@@ -6152,7 +6134,7 @@
           {
             "name": "addReply",
             "parameters": {
-              "comment": "Hello @${issueAuthor},\n\nThis package appears to require dependencies in order to install successfully.\n\nThis package is blocked until support for dependencies is implemented in:\n* microsoft/winget-cli/issues/163\n\nTemplate: msftbot/blockingIssue/dependencySupport"
+              "comment": "Hello @${issueAuthor},\n\nThis package appears to require dependencies in order to install successfully.\n\nThis package is blocked until support for dependencies is implemented in:\n* microsoft/winget-cli/issues/163\nBe sure to add your 👍 to the issue to help raise the priority and avoid posting \"Me too!\" messages to respect those who have subscribed to the issue.\n\nTemplate: msftbot/blockingIssue/dependencySupport"
             }
           },
           {


### PR DESCRIPTION
- Updated Messages
  - Dependencies
  - Interactive-Only
  - Zip-Binary
  - Hardware
- Move the `Blocking-Issue` and similar labels to be added by the Label-Added trigger instead of the comment trigger for consistency when labels are added by repository admins
- Allow `Zip-Binary` to be assigned on issues, not just PRs
- Add `Area-External` when `Installer-Issue` is added on PRs
- Allow moderators to add `Needs-Attention` to PRs

cc @denelon
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/106576)