### PR TITLE
Remove user scope from filips.FirefoxPWA 2.5.0

### DIFF
--- a/manifests/f/filips/FirefoxPWA/2.5.0/filips.FirefoxPWA.installer.yaml
+++ b/manifests/f/filips/FirefoxPWA/2.5.0/filips.FirefoxPWA.installer.yaml
@@ -5,49 +5,25 @@ PackageIdentifier: filips.FirefoxPWA
 PackageVersion: 2.5.0
 InstallerLocale: en-US
 MinimumOSVersion: 10.0.0.0
+ElevationRequirement: elevatesSelf
+Scope: machine
 UpgradeBehavior: uninstallPrevious
 Installers:
 - Architecture: x86
   InstallerType: wix
-  Scope: user
   InstallerUrl: https://github.com/filips123/PWAsForFirefox/releases/download/v2.5.0/firefoxpwa-2.5.0-x86.msi
   InstallerSha256: 41A33DB0C2744EE1A00AFF1E8313C5C0836EC7F69C257D45EADB4E97C6F96E44
   Dependencies:
     PackageDependencies:
     - PackageIdentifier: Microsoft.VCRedist.2015+.x86
-  InstallerSwitches:
-    Custom: MSIINSTALLPERUSER=1 
   ProductCode: '{26B06047-B49A-4896-8A1D-34B442C5BD7C}'
 - Architecture: x64
   InstallerType: wix
-  Scope: user
   InstallerUrl: https://github.com/filips123/PWAsForFirefox/releases/download/v2.5.0/firefoxpwa-2.5.0-x86_64.msi
   InstallerSha256: 70663D8A5512F9F3D1EFA969621F5356E3A0487357843507273F6C2BA12E197D
   Dependencies:
     PackageDependencies:
     - PackageIdentifier: Microsoft.VCRedist.2015+.x64
-  InstallerSwitches:
-    Custom: MSIINSTALLPERUSER=1
-  ProductCode: '{8E3B86C6-C901-4FC2-844D-EBA318766026}'
-- Architecture: x86
-  InstallerType: wix
-  Scope: machine
-  InstallerUrl: https://github.com/filips123/PWAsForFirefox/releases/download/v2.5.0/firefoxpwa-2.5.0-x86.msi
-  InstallerSha256: 41A33DB0C2744EE1A00AFF1E8313C5C0836EC7F69C257D45EADB4E97C6F96E44
-  Dependencies:
-    PackageDependencies:
-    - PackageIdentifier: Microsoft.VCRedist.2015+.x86
-  ElevationRequirement: elevatesSelf
-  ProductCode: '{26B06047-B49A-4896-8A1D-34B442C5BD7C}'
-- Architecture: x64
-  InstallerType: wix
-  Scope: machine
-  InstallerUrl: https://github.com/filips123/PWAsForFirefox/releases/download/v2.5.0/firefoxpwa-2.5.0-x86_64.msi
-  InstallerSha256: 70663D8A5512F9F3D1EFA969621F5356E3A0487357843507273F6C2BA12E197D
-  Dependencies:
-    PackageDependencies:
-    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
-  ElevationRequirement: elevatesSelf
   ProductCode: '{8E3B86C6-C901-4FC2-844D-EBA318766026}'
 ManifestType: installer
 ManifestVersion: 1.4.0

--- a/manifests/f/filips/FirefoxPWA/2.5.0/filips.FirefoxPWA.installer.yaml
+++ b/manifests/f/filips/FirefoxPWA/2.5.0/filips.FirefoxPWA.installer.yaml
@@ -7,7 +7,6 @@ InstallerLocale: en-US
 MinimumOSVersion: 10.0.0.0
 ElevationRequirement: elevatesSelf
 Scope: machine
-UpgradeBehavior: uninstallPrevious
 Installers:
 - Architecture: x86
   InstallerType: wix


### PR DESCRIPTION
`user` scope for WiX installers generally does not work well because of a bug/design issue with WiX installers in that the installer installs per-user but incorrectly writes the uninstall entries to HKEY_LOCAL_MACHINE that makes WinGet think it's a per-machine install. This causes users not being able to upgrade the package after installation through WinGet. For best UX, it's best to remove the user scope from the manifest

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/107661)