### PR TITLE
Update Google.PlatformTools to 34.0.3

### DIFF
--- a/manifests/g/Google/PlatformTools/34.0.3/Google.PlatformTools.installer.yaml
+++ b/manifests/g/Google/PlatformTools/34.0.3/Google.PlatformTools.installer.yaml
@@ -2,10 +2,10 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
 
 PackageIdentifier: Google.PlatformTools
-PackageVersion: 34.0.1
+PackageVersion: 34.0.3
 UpgradeBehavior: install
 Installers:
-  - InstallerUrl: https://dl.google.com/android/repository/platform-tools_r34.0.1-windows.zip
+  - InstallerUrl: https://dl.google.com/android/repository/platform-tools_r34.0.3-windows.zip
     Architecture: x64
     InstallerType: zip
     NestedInstallerType: portable
@@ -14,7 +14,7 @@ Installers:
         PortableCommandAlias: adb
       - RelativeFilePath: platform-tools/fastboot.exe
         PortableCommandAlias: fastboot
-    InstallerSha256: 5DD9C2BE744C224FA3A7CBE30BA02D2CB378C763BD0F797A7E47E9F3156A5DAA
+    InstallerSha256: FCE992E93EB786FC9F47DF93D83A7B912C46742D45C39D712C02E06D05B72E2B
 ReleaseNotesUrl: https://developer.android.com/studio/releases/platform-tools#3401_march_2023
 ManifestType: installer
 ManifestVersion: 1.4.0

--- a/manifests/g/Google/PlatformTools/34.0.3/Google.PlatformTools.locale.en-US.yaml
+++ b/manifests/g/Google/PlatformTools/34.0.3/Google.PlatformTools.locale.en-US.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.4.0.schema.json
 
 PackageIdentifier: Google.PlatformTools
-PackageVersion: 34.0.1
+PackageVersion: 34.0.3
 PackageLocale: en-US
 Publisher: Google LLC
 PublisherUrl: https://developer.android.com/studio
@@ -17,8 +17,8 @@ CopyrightUrl: https://developer.android.com/studio#downloads
 ShortDescription: Android SDK Platform-Tools is a component for the Android SDK. It includes tools that interface with the Android platform, primarily adb and fastboot.
 Description: Although adb is required for Android app development, app developers will normally just use the copy Studio installs. This download is useful if you want to use adb directly from the command-line and don't have Studio installed. (If you do have Studio installed, you might want to just use the copy it installed because Studio will automatically update it.) fastboot is needed if you want to unlock your device bootloader and flash it with a new system image. This package used to contain systrace, but that has been obsoleted in favor of Studio Profiler, gpuinspector.dev, or Perfetto. Although some new features in adb and fastboot are available only for recent versions of Android, they're backward compatible, so you should only need the latest version of the SDK Platform-Tools and should file bugs if you find exceptions.
 Tags:
-- adb
-- fastboot
-ReleaseDate: 2023-03-01
+  - adb
+  - fastboot
+ReleaseDate: 2023-05-01
 ManifestType: defaultLocale
 ManifestVersion: 1.4.0

--- a/manifests/g/Google/PlatformTools/34.0.3/Google.PlatformTools.yaml
+++ b/manifests/g/Google/PlatformTools/34.0.3/Google.PlatformTools.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.4.0.schema.json
 
 PackageIdentifier: Google.PlatformTools
-PackageVersion: 34.0.1
+PackageVersion: 34.0.3
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.4.0


### PR DESCRIPTION
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.4 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.4.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

This PR fixes the installer Hash issue from V 34.0.1 where Google has changed the zip file but let the version stay the same
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/108182)