### PR TITLE
Suppress Safety Warning in SandboxTest.ps1

### DIFF
--- a/Tools/SandboxTest.ps1
+++ b/Tools/SandboxTest.ps1
@@ -235,6 +235,12 @@ Write-Host @'
 Add-AppxPackage -Path '$($desktopAppInstaller.pathInSandbox)' -DependencyPath '$($vcLibsUwp.pathInSandbox)','$($uiLibsUwp.pathInSandbox)'
 
 Write-Host @'
+--> Disabling safety warning when running installer
+'@
+New-Item -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Policies\Associations' | Out-Null
+New-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Policies\Associations' -Name 'ModRiskFileTypes' -Type 'String' -Value '.bat;.exe;.reg;.vbs;.chm;.msi;.js;.cmd' | Out-Null
+
+Write-Host @'
 Tip: you can type 'Update-EnvironmentVariables' to update your environment variables, such as after installing a new software.
 '@
 


### PR DESCRIPTION
...as well as this one, which usually pops up when executing installers that are not signed in Windows Sandbox.
![image](https://github.com/microsoft/winget-pkgs/assets/56779163/af883791-3780-47ec-becf-7ea3ed891b84)

- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/108489)