### PR TITLE
Update Rufus.Rufus to 4.1

### DIFF
--- a/manifests/r/Rufus/Rufus/4.1/Rufus.Rufus.installer.yaml
+++ b/manifests/r/Rufus/Rufus/4.1/Rufus.Rufus.installer.yaml
@@ -1,0 +1,26 @@
+# Created with YamlCreate.ps1 v2.2.4 $debug=NVS1.CRLF.5-1-22621-1037.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
+
+PackageIdentifier: Rufus.Rufus
+PackageVersion: "4.1"
+MinimumOSVersion: 10.0.0.0
+InstallerType: portable
+Commands:
+- rufus
+AppsAndFeaturesEntries:
+- Publisher: Akeo Consulting
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/pbatard/rufus/releases/download/v4.1/rufus-4.1.exe
+  InstallerSha256: 8F680FDC6E91AFF40066ECEBDCFBE985A058313E6DDC024A9123FE0985493035
+- Architecture: x86
+  InstallerUrl: https://github.com/pbatard/rufus/releases/download/v4.1/rufus-4.1_x86.exe
+  InstallerSha256: D4395B56ADFBE8E0362DB463534E4B11FE8388297B58D0EC9FD9783A544DED93
+- Architecture: arm
+  InstallerUrl: https://github.com/pbatard/rufus/releases/download/v4.1/rufus-4.1_arm.exe
+  InstallerSha256: 553B7224E672B1F234BF4D73C40FBD13834DA4D2150FA3239E793302C8433BC2
+- Architecture: arm64
+  InstallerUrl: https://github.com/pbatard/rufus/releases/download/v4.1/rufus-4.1_arm64.exe
+  InstallerSha256: 393B677FB2F281514B739E8C05FC326829AF0AFEC5FE5F3B91B55FC3B6237C65
+ManifestType: installer
+ManifestVersion: 1.4.0

--- a/manifests/r/Rufus/Rufus/4.1/Rufus.Rufus.locale.en-US.yaml
+++ b/manifests/r/Rufus/Rufus/4.1/Rufus.Rufus.locale.en-US.yaml
@@ -1,0 +1,42 @@
+# Created with YamlCreate.ps1 v2.2.4 $debug=NVS1.CRLF.5-1-22621-1037.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.4.0.schema.json
+
+PackageIdentifier: Rufus.Rufus
+PackageVersion: "4.1"
+PackageLocale: en-US
+Publisher: pbatard
+PublisherUrl: https://github.com/pbatard
+PublisherSupportUrl: https://github.com/pbatard/rufus/issues
+# PrivacyUrl:
+Author: pbatard
+PackageName: Rufus
+PackageUrl: https://rufus.ie
+License: GNU General Public License v3.0
+LicenseUrl: https://github.com/pbatard/rufus/blob/master/LICENSE.txt
+Copyright: Copyright  © 2011-2023 Pete Batard and Rufus contributors
+# CopyrightUrl:
+ShortDescription: Rufus is a utility that helps format and create bootable USB flash drives.
+# Description:
+Moniker: rufus
+Tags:
+- boot
+- formatting
+- foss
+- uefi
+- unetbootin
+- usb
+- utility
+# Agreements:
+ReleaseNotes: |-
+  What's Changed
+  - Add timeouts on enumeration queries that may stall on some systems.
+  - Restore MS-DOS drive creation through the download of binaries from Microsoft.
+  - Update the log button icon.
+  - Fix UEFI:NTFS incompatibility with Windows Dev Kit 2023 platform (pbatard/uefi-ntfs#37).
+  - Fix more GRUB out of range pointer errors with Ubuntu/Fedora when booting in BIOS mode.
+ReleaseNotesUrl: https://github.com/pbatard/rufus/releases/tag/v4.1
+# PurchaseUrl:
+# InstallationNotes:
+# Documentations:
+ManifestType: defaultLocale
+ManifestVersion: 1.4.0

--- a/manifests/r/Rufus/Rufus/4.1/Rufus.Rufus.yaml
+++ b/manifests/r/Rufus/Rufus/4.1/Rufus.Rufus.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.2.4 $debug=NVS1.CRLF.5-1-22621-1037.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.4.0.schema.json
+
+PackageIdentifier: Rufus.Rufus
+PackageVersion: "4.1"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.4.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.4 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.4.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

Regarding, the command `rufus-4.1` passed in the terminal opened the GUI whereas `rufus` alone didn't in my testing, if it is the same for others I will update the command.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/108598)