### PR TITLE
7zip.7zip: Added `/S` silent mode switch only for exe installers (#108155)

### DIFF
--- a/manifests/7/7zip/7zip/22.01/7zip.7zip.installer.yaml
+++ b/manifests/7/7zip/7zip/22.01/7zip.7zip.installer.yaml
@@ -60,6 +60,9 @@ Installers:
   AppsAndFeaturesEntries:
   - DisplayName: 7-Zip 22.01 (x64)
   ElevationRequirement: elevatesSelf
+  InstallerSwitches:
+    Silent: /S
+    SilentWithProgress: /S
 - Architecture: x86
   InstallerType: exe
   InstallerUrl: https://7-zip.org/a/7z2201.exe
@@ -67,10 +70,16 @@ Installers:
   AppsAndFeaturesEntries:
   - DisplayName: 7-Zip 22.01
   ElevationRequirement: elevatesSelf
+  InstallerSwitches:
+    Silent: /S
+    SilentWithProgress: /S
 - Architecture: arm64
   InstallerType: exe
   InstallerUrl: https://7-zip.org/a/7z2201-arm64.exe
   InstallerSha256: 700DEA3E4012319A09CCADFCE91CF090334CFE658D0BDC42204E77ACBEA1EF99
+  InstallerSwitches:
+    Silent: /S
+    SilentWithProgress: /S
 - InstallerLocale: en-US
   Architecture: x86
   InstallerType: wix


### PR DESCRIPTION
After #108170 removed `/S` silent mode switch, exe installers showed the interactive UI. Added `/S` silent mode switch only for exe installers

- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] This PR only modifies one (1) manifest
- [X] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [X] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.4 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.4.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/108737)