### PR TITLE
Fix Obsidian.Obsidian 1.3.5's hashes

### DIFF
--- a/manifests/o/Obsidian/Obsidian/1.3.5/Obsidian.Obsidian.installer.yaml
+++ b/manifests/o/Obsidian/Obsidian/1.3.5/Obsidian.Obsidian.installer.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.2.7 $debug=QUSU.LF.7-3-4.Unix
+# Created with YamlCreate.ps1 v2.2.8 $debug=NVS1.LF.7-3-4.Unix
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
 
 PackageIdentifier: Obsidian.Obsidian
@@ -13,13 +13,13 @@ FileExtensions:
 Installers:
 - Architecture: x86
   InstallerUrl: https://github.com/obsidianmd/obsidian-releases/releases/download/v1.3.5/Obsidian.1.3.5-32.exe
-  InstallerSha256: E784E584DEFED32202CAE82AAE17E90FAAA945FA87BB46498CEDBEC75AC760D6
+  InstallerSha256: BC1F096CF1EE0B337A109B7A99C127FF47EFB97237AC57327AD82FBD5DDCB025
 - Architecture: x64
   InstallerUrl: https://github.com/obsidianmd/obsidian-releases/releases/download/v1.3.5/Obsidian.1.3.5.exe
-  InstallerSha256: 77A88651DDAFEDFF5CDCBCC98DBBAF6A2E70E8D91FDFFC5ED20DDFB25CEEC656
+  InstallerSha256: EB9F4147B200C1EFA6294C9E47AF578F6115C588C3C82F6EF6F9BA097007D9DB
 - Architecture: arm64
   InstallerUrl: https://github.com/obsidianmd/obsidian-releases/releases/download/v1.3.5/Obsidian.1.3.5-arm64.exe
-  InstallerSha256: D4173068C9E761986C14B52C6379257B2E8C201B634D3B4C25DE931DEF6DB73E
+  InstallerSha256: D070646EF972C69CD91ADE71CF1A15B7B58057412D2D6803C7989AC4A21D2EF1
 ManifestType: installer
 ManifestVersion: 1.4.0
 ReleaseDate: 2023-06-01


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.4 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.4.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

The original hashes for Obsidian.Obsidian 1.3.5 have changed, as reported at
- https://github.com/microsoft/winget-pkgs/pull/108652#issuecomment-1574849761

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-pkgs/pull/108825)