### PR TITLE
Eugeny.Tabby 1.0.197 - Fixed Installer hash mismatch

### DIFF
--- a/manifests/e/Eugeny/Tabby/1.0.197/Eugeny.Tabby.installer.yaml
+++ b/manifests/e/Eugeny/Tabby/1.0.197/Eugeny.Tabby.installer.yaml
@@ -1,4 +1,4 @@
-# Created with [WinGet Automation](https://github.com/vedantmgoyal2009/winget-manifests-manager) using Komac v1.7.0
+# Created with Komac v1.6.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
 
 PackageIdentifier: Eugeny.Tabby
@@ -9,33 +9,28 @@ InstallerType: nullsoft
 InstallModes:
 - interactive
 - silent
+InstallerSwitches:
+  Custom: /CURRENTUSER
 UpgradeBehavior: install
 FileExtensions:
 - yaml
+ReleaseDate: 2023-04-27
 Installers:
 - Architecture: x64
   Scope: user
-  InstallerUrl: https://github.com/Eugeny/tabby/releases/download/v1.0.197/tabby-1.0.197-setup-arm64.exe
-  InstallerSha256: D0238A9969D8981D39CB0AA6458F231F171B4E54607FC26A4B247B5355ACCB5A
-  InstallerSwitches:
-    Custom: /CURRENTUSER
+  InstallerUrl: https://github.com/Eugeny/tabby/releases/download/v1.0.197/tabby-1.0.197-setup-x64.exe
+  InstallerSha256: 7112B623A885DE4C669846469C75A4AF1F0562941201DDF0EDA1E87ADA2FAC4D
 - Architecture: x64
   Scope: machine
-  InstallerUrl: https://github.com/Eugeny/tabby/releases/download/v1.0.197/tabby-1.0.197-setup-arm64.exe
-  InstallerSha256: D0238A9969D8981D39CB0AA6458F231F171B4E54607FC26A4B247B5355ACCB5A
-  InstallerSwitches:
-    Custom: /ALLUSERS
+  InstallerUrl: https://github.com/Eugeny/tabby/releases/download/v1.0.197/tabby-1.0.197-setup-x64.exe
+  InstallerSha256: 7112B623A885DE4C669846469C75A4AF1F0562941201DDF0EDA1E87ADA2FAC4D
 - Architecture: arm64
   Scope: user
-  InstallerUrl: https://github.com/Eugeny/tabby/releases/download/v1.0.197/tabby-1.0.197-setup-x64.exe
-  InstallerSha256: 55FB4F3AA2F7E45D1A9ED112E4B7D20BE25B8BABBC24A0A8CE46A157097FA002
-  InstallerSwitches:
-    Custom: /CURRENTUSER
+  InstallerUrl: https://github.com/Eugeny/tabby/releases/download/v1.0.197/tabby-1.0.197-setup-arm64.exe
+  InstallerSha256: 220777C18D964CB16F7DAE60423CAC9FD5CB10C97465DD0A3F05DA314BBE1AB5
 - Architecture: arm64
   Scope: machine
-  InstallerUrl: https://github.com/Eugeny/tabby/releases/download/v1.0.197/tabby-1.0.197-setup-x64.exe
-  InstallerSha256: 55FB4F3AA2F7E45D1A9ED112E4B7D20BE25B8BABBC24A0A8CE46A157097FA002
-  InstallerSwitches:
-    Custom: /ALLUSERS
+  InstallerUrl: https://github.com/Eugeny/tabby/releases/download/v1.0.197/tabby-1.0.197-setup-arm64.exe
+  InstallerSha256: 220777C18D964CB16F7DAE60423CAC9FD5CB10C97465DD0A3F05DA314BBE1AB5
 ManifestType: installer
 ManifestVersion: 1.4.0

--- a/manifests/e/Eugeny/Tabby/1.0.197/Eugeny.Tabby.locale.en-US.yaml
+++ b/manifests/e/Eugeny/Tabby/1.0.197/Eugeny.Tabby.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# Created with [WinGet Automation](https://github.com/vedantmgoyal2009/winget-manifests-manager) using Komac v1.7.0
+# Created with Komac v1.6.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.4.0.schema.json
 
 PackageIdentifier: Eugeny.Tabby

--- a/manifests/e/Eugeny/Tabby/1.0.197/Eugeny.Tabby.yaml
+++ b/manifests/e/Eugeny/Tabby/1.0.197/Eugeny.Tabby.yaml
@@ -1,4 +1,4 @@
-# Created with [WinGet Automation](https://github.com/vedantmgoyal2009/winget-manifests-manager) using Komac v1.7.0
+# Created with Komac v1.6.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.4.0.schema.json
 
 PackageIdentifier: Eugeny.Tabby


### PR DESCRIPTION
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] This PR only modifies one (1) manifest
- [X] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [X] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.4 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.4.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/winget-pkgs/pull/109082&drop=dogfoodAlpha