### PR TITLE
New version: VideoLAN.VLC version 3.0.18

### DIFF
--- a/manifests/v/VideoLAN/VLC/3.0.18/VideoLAN.VLC.installer.yaml
+++ b/manifests/v/VideoLAN/VLC/3.0.18/VideoLAN.VLC.installer.yaml
@@ -53,21 +53,21 @@ ReleaseDate: 2022-11-08
 Installers:
 - Architecture: x64
   InstallerType: wix
-  InstallerUrl: https://download.videolan.org/vlc/3.0.18/win64/vlc-3.0.18-win64.msi
+  InstallerUrl: https://download.videolan.org/pub/videolan/vlc/3.0.18/win64/vlc-3.0.18-win64.msi
   InstallerSha256: A618D66B2F753343402200AD17D92EB6D4AB10DB0DD1A098402E2968AA3114C4
   ProductCode: '{B022B1C5-D067-42CB-98E2-D965E4D74CFE}'
 - Architecture: x86
   InstallerType: wix
-  InstallerUrl: https://download.videolan.org/vlc/3.0.18/win32/vlc-3.0.18-win32.msi
+  InstallerUrl: https://download.videolan.org/pub/videolan/vlc/3.0.18/win32/vlc-3.0.18-win32.msi
   InstallerSha256: 72EB05D21A4159450DBB39F2A09C5ED7C8370C9B4CAD75CE36A1A71B9F8A7D11
   ProductCode: '{6799A970-32B3-47B4-89AA-2DF0806FB862}'
 - Architecture: x64
   InstallerType: nullsoft
-  InstallerUrl: https://download.videolan.org/vlc/3.0.18/win64/vlc-3.0.18-win64.exe
+  InstallerUrl: https://download.videolan.org/pub/videolan/vlc/3.0.18/win64/vlc-3.0.18-win64.exe
   InstallerSha256: BA575F153D357EAF3FDBF446B9B93A12CED87C35887CDD83AD4281733EB86602
 - Architecture: x86
   InstallerType: nullsoft
-  InstallerUrl: https://download.videolan.org/vlc/3.0.18/win32/vlc-3.0.18-win32.exe
+  InstallerUrl: https://download.videolan.org/pub/videolan/vlc/3.0.18/win32/vlc-3.0.18-win32.exe
   InstallerSha256: E66F7AC440FF62D90307D2D4ECFB248F1798D2337732EB9ADE93991D45D8A386
 ManifestType: installer
 ManifestVersion: 1.4.0

--- a/manifests/v/VideoLAN/VLC/3.0.18/VideoLAN.VLC.installer.yaml
+++ b/manifests/v/VideoLAN/VLC/3.0.18/VideoLAN.VLC.installer.yaml
@@ -68,6 +68,6 @@ Installers:
 - Architecture: x86
   InstallerType: nullsoft
   InstallerUrl: https://download.videolan.org/pub/videolan/vlc/3.0.18/win32/vlc-3.0.18-win32.exe
-  InstallerSha256: E66F7AC440FF62D90307D2D4ECFB248F1798D2337732EB9ADE93991D45D8A386
+  InstallerSha256: F4BAAA8135E0F9A993F0258A4D095DB475096896BD3ADB48369F1F70C1F0D9D4
 ManifestType: installer
 ManifestVersion: 1.4.0

--- a/manifests/v/VideoLAN/VLC/3.0.18/VideoLAN.VLC.installer.yaml
+++ b/manifests/v/VideoLAN/VLC/3.0.18/VideoLAN.VLC.installer.yaml
@@ -1,0 +1,73 @@
+# Created with Komac v1.6.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
+
+PackageIdentifier: VideoLAN.VLC
+PackageVersion: 3.0.18
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Commands:
+- vlc
+FileExtensions:
+- "264"
+- 3ga
+- 3gp
+- aac
+- avi
+- cda
+- dash
+- dvr
+- flac
+- ifo
+- m2t
+- m2ts
+- m3u8
+- m4v
+- mkv
+- mov
+- mp3
+- mp4
+- mpg
+- mts
+- ogg
+- ogv
+- opus
+- pls
+- rec
+- rmvb
+- snd
+- sub
+- ts
+- vob
+- webm
+- wma
+- wmv
+- zab
+ReleaseDate: 2022-11-08
+Installers:
+- Architecture: x64
+  InstallerType: wix
+  InstallerUrl: https://download.videolan.org/vlc/3.0.18/win64/vlc-3.0.18-win64.msi
+  InstallerSha256: A618D66B2F753343402200AD17D92EB6D4AB10DB0DD1A098402E2968AA3114C4
+  ProductCode: '{B022B1C5-D067-42CB-98E2-D965E4D74CFE}'
+- Architecture: x86
+  InstallerType: wix
+  InstallerUrl: https://download.videolan.org/vlc/3.0.18/win32/vlc-3.0.18-win32.msi
+  InstallerSha256: 72EB05D21A4159450DBB39F2A09C5ED7C8370C9B4CAD75CE36A1A71B9F8A7D11
+  ProductCode: '{6799A970-32B3-47B4-89AA-2DF0806FB862}'
+- Architecture: x64
+  InstallerType: nullsoft
+  InstallerUrl: https://download.videolan.org/vlc/3.0.18/win64/vlc-3.0.18-win64.exe
+  InstallerSha256: BA575F153D357EAF3FDBF446B9B93A12CED87C35887CDD83AD4281733EB86602
+- Architecture: x86
+  InstallerType: nullsoft
+  InstallerUrl: https://download.videolan.org/vlc/3.0.18/win32/vlc-3.0.18-win32.exe
+  InstallerSha256: E66F7AC440FF62D90307D2D4ECFB248F1798D2337732EB9ADE93991D45D8A386
+ManifestType: installer
+ManifestVersion: 1.4.0

--- a/manifests/v/VideoLAN/VLC/3.0.18/VideoLAN.VLC.locale.en-US.yaml
+++ b/manifests/v/VideoLAN/VLC/3.0.18/VideoLAN.VLC.locale.en-US.yaml
@@ -1,0 +1,52 @@
+# Created with Komac v1.6.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.4.0.schema.json
+
+PackageIdentifier: VideoLAN.VLC
+PackageVersion: 3.0.18
+PackageLocale: en-US
+Publisher: VideoLAN
+PublisherUrl: https://www.videolan.org/
+PublisherSupportUrl: https://www.videolan.org/support/
+Author: VideoLAN
+PackageName: VLC media player
+PackageUrl: https://www.videolan.org/vlc/
+License: GNU General Public License Version 2
+LicenseUrl: https://github.com/videolan/vlc/blob/master/COPYING
+Copyright: Copyright (C) 1989, 1991 Free Software Foundation, Inc.
+CopyrightUrl: https://github.com/videolan/vlc/blob/master/COPYING
+ShortDescription: VLC is a free and open source cross-platform multimedia player and framework that plays most multimedia files, and various streaming protocols.
+Description: |-
+  VLC is a free and open source cross-platform multimedia player and framework that plays most multimedia files as well as DVDs, Audio CDs, VCDs, and various streaming protocols.
+
+  Simple, fast and powerful
+  ✓ Plays everything - Files, Discs, Webcams, Devices and Streams.
+  ✓ Pays most codecs with no codec packs needed - MPEG-2, MPEG-4, H.264, MKV, WebM, WMV, MP3...
+  ✓ Runs on all platforms - Windows, Linux, Mac OS X, Unix, iOS, Android ...
+  ✓ Completely Free - no spyware, no ads and no user tracking.
+Moniker: vlc
+Tags:
+- audio
+- cross-platform
+- dvd
+- foss
+- media-player
+- multimedia
+- open-source
+- video
+- video-player
+# Agreements: 
+ReleaseNotes: |-
+  This is the nineteenth release of VLC 3.0 branch, named "Vetinari", in reference to the Lord Patrician from Discworld.
+  
+  This updates contains various fixes and improvements:
+  
+  - Major adaptive streaming update
+  - Codec updates
+  - Fix seeking for some formats
+  - Many updates of third party libraries
+  - Numerous crash fixes
+
+  And many more! Check our news file for more details!
+ReleaseNotesUrl: https://github.com/videolan/vlc/releases/tag/3.0.18
+ManifestType: defaultLocale
+ManifestVersion: 1.4.0

--- a/manifests/v/VideoLAN/VLC/3.0.18/VideoLAN.VLC.yaml
+++ b/manifests/v/VideoLAN/VLC/3.0.18/VideoLAN.VLC.yaml
@@ -1,0 +1,8 @@
+# Created with Komac v1.6.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.4.0.schema.json
+
+PackageIdentifier: VideoLAN.VLC
+PackageVersion: 3.0.18
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.4.0


### PR DESCRIPTION
This version had previously been added, then removed due to a broken URL. All four URLs in this manifest are updated/adjusted to use the preferred path from the vendor, so I think all is well now. Tested thoroughly locally.
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/winget-pkgs/pull/109546&drop=dogfoodAlpha