### PR TITLE
Add vim.vim.nightly

### DIFF
--- a/manifests/v/vim/vim/nightly/9.0.1642/vim.vim.nightly.installer.yaml
+++ b/manifests/v/vim/vim/nightly/9.0.1642/vim.vim.nightly.installer.yaml
@@ -1,0 +1,20 @@
+PackageIdentifier: vim.vim.nightly
+PackageVersion: 9.0.1642
+Platform:
+- Windows.Desktop
+InstallerType: nullsoft
+Scope: machine
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+ElevationRequirement: elevationRequired
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/vim/vim-win32-installer/releases/download/v9.0.1642/gvim_9.0.1642_x86.exe
+  InstallerSha256: 9C7023E27F9395D8469DDA6C08A946DA550C343AC263B175FEDD5B12159DDF99
+- Architecture: x64
+  InstallerUrl: https://github.com/vim/vim-win32-installer/releases/download/v9.0.1642/gvim_9.0.1642_x64.exe
+  InstallerSha256: 51BF9A68C81EB49FE9A124B3EAA393AE0EE43B2C206D03AC4D81E634D289125D
+ManifestType: installer
+ManifestVersion: 1.4.0

--- a/manifests/v/vim/vim/nightly/9.0.1642/vim.vim.nightly.locale.en-US.yaml
+++ b/manifests/v/vim/vim/nightly/9.0.1642/vim.vim.nightly.locale.en-US.yaml
@@ -1,0 +1,38 @@
+# Created with WinGet Releaser v2 using Komac v1.7.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.4.0.schema.json
+
+PackageIdentifier: vim.vim.nightly
+PackageVersion: 9.0.1642
+PackageLocale: en-US
+Publisher: Bram Moolenaar et al.
+PublisherUrl: https://github.com/vim/vim-win32-installer
+PublisherSupportUrl: https://github.com/vim/vim-win32-installer/issues
+Author: Bram Moolenaar et al.
+PackageName: Vim
+PackageUrl: http://www.vim.org
+License: Copyright (C) 1991-2020 Bram Moolenaar [Bram@vim.org] - Charityware / GNU GPL compatible
+LicenseUrl: https://github.com/vim/vim-win32-installer#license--copyright
+Copyright: Copyright (C) 1991-2020 Bram Moolenaar [Bram@vim.org]
+CopyrightUrl: https://github.com/vim/vim-win32-installer#license--copyright
+ShortDescription: Vim is a highly configurable text editor built to make creating and changing any kind of text very efficient
+Moniker: vim
+Tags:
+- code-editor
+- g-vim
+- gvim
+- text-editing
+- text-editor
+- tool
+- utility
+- vi
+ReleaseNotes: |-
+  Changes:
+  - 9.0.1642: build failure with tiny features
+  - 9.0.1641: the log file does not give information about window sizes
+  - 9.0.1640: compiler warning for unused variables without crypt feature
+  - 9.0.1639: build failure without the crypt feature
+  - 9.0.1638: crypt tests hang and cause memory errors
+  - 9.0.1637: compiler warning for uninitialized variable
+ReleaseNotesUrl: https://github.com/vim/vim-win32-installer/releases/tag/v9.0.1642
+ManifestType: defaultLocale
+ManifestVersion: 1.4.0

--- a/manifests/v/vim/vim/nightly/9.0.1642/vim.vim.nightly.yaml
+++ b/manifests/v/vim/vim/nightly/9.0.1642/vim.vim.nightly.yaml
@@ -1,0 +1,8 @@
+# Created with WinGet Releaser v2 using Komac v1.7.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.4.0.schema.json
+
+PackageIdentifier: vim.vim.nightly
+PackageVersion: 9.0.1642
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.4.0


### PR DESCRIPTION
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.4 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.4.0)?


Do to popular demand, I am trying to shift away from vim.vim to vim.vim.nightly, see e.g. here https://github.com/vim/vim-win32-installer/issues/311 so creating a new manifest for nightly builds, that can then be used by the https://github.com/vim/vim-win32-installer project to automatically upload new artifacts once https://github.com/vim/vim-win32-installer/pull/314 is merged (but I need to manually create a new manifest first apparently), which I am doing hereby.

 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/winget-pkgs/pull/110399&drop=dogfoodAlpha