### PR TITLE
New package: Nvidia.GeForceGameReadyDriver

### DIFF
--- a/manifests/n/Nvidia/GeForceGameReadyDriver/536.23/Nvidia.GeForceGameReadyDriver.installer.yaml
+++ b/manifests/n/Nvidia/GeForceGameReadyDriver/536.23/Nvidia.GeForceGameReadyDriver.installer.yaml
@@ -13,6 +13,9 @@ Installers:
     Silent: /s
     SilentWithProgress: /s
     Custom: /gfexperienceinitiated /noreboot # Prevent GeForce Experience installation; no reboot
+  ExpectedReturnCodes:
+    - InstallerReturnCode: 3858759936
+      ReturnResponse: systemNotSupported
   Scope: machine
 ManifestType: installer
 ManifestVersion: 1.4.0

--- a/manifests/n/Nvidia/GeForceGameReadyDriver/536.23/Nvidia.GeForceGameReadyDriver.installer.yaml
+++ b/manifests/n/Nvidia/GeForceGameReadyDriver/536.23/Nvidia.GeForceGameReadyDriver.installer.yaml
@@ -13,6 +13,7 @@ Installers:
     Silent: /s
     SilentWithProgress: /s
     Custom: /gfexperienceinitiated /noreboot # Prevent GeForce Experience installation; no reboot
+  ElevationRequirement: elevatesSelf
   ExpectedReturnCodes:
     - InstallerReturnCode: 3858759936
       ReturnResponse: systemNotSupported

--- a/manifests/n/Nvidia/GeForceGameReadyDriver/536.23/Nvidia.GeForceGameReadyDriver.installer.yaml
+++ b/manifests/n/Nvidia/GeForceGameReadyDriver/536.23/Nvidia.GeForceGameReadyDriver.installer.yaml
@@ -1,0 +1,18 @@
+# Created using wingetcreate 1.2.6.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
+
+PackageIdentifier: Nvidia.GeForceGameReadyDriver
+PackageVersion: "536.23"
+Installers:
+- InstallerUrl: https://us.download.nvidia.com/Windows/536.23/536.23-desktop-win10-win11-64bit-international-dch-whql.exe
+  Architecture: x64
+  MinimumOSVersion: 10.0.0.0
+  InstallerType: exe
+  InstallerSha256: 97F29F85425F5D35C6191573F5EF5AE1E38C7750E0E6CE21D1727CFDA8010CA8
+  InstallerSwitches:
+    Silent: /s
+    SilentWithProgress: /s
+    Custom: /gfexperienceinitiated /noreboot # Prevent GeForce Experience installation; no reboot
+  Scope: machine
+ManifestType: installer
+ManifestVersion: 1.4.0

--- a/manifests/n/Nvidia/GeForceGameReadyDriver/536.23/Nvidia.GeForceGameReadyDriver.locale.en-US.yaml
+++ b/manifests/n/Nvidia/GeForceGameReadyDriver/536.23/Nvidia.GeForceGameReadyDriver.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created using wingetcreate 1.2.6.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.4.0.schema.json
+
+PackageIdentifier: Nvidia.GeForceGameReadyDriver
+PackageVersion: "536.23"
+PackageLocale: en-US
+Publisher: NVIDIA Corporation
+PublisherUrl: https://www.nvidia.com/en-us/
+PublisherSupportUrl: https://www.nvidia.com/en-us/support/
+PrivacyUrl: https://www.nvidia.com/en-us/about-nvidia/privacy-policy/
+PackageName: NVIDIA Graphics Driver
+License: Proprietary
+LicenseUrl: https://www.nvidia.com/en-us/drivers/nvidia-license/
+Copyright: Copyright © 2011-2021 NVIDIA Corporation # From installer metadata
+ShortDescription: NVIDIA Game Ready drivers for GeForce-series cards ('Maxwell' and newer)
+ManifestType: defaultLocale
+ManifestVersion: 1.4.0

--- a/manifests/n/Nvidia/GeForceGameReadyDriver/536.23/Nvidia.GeForceGameReadyDriver.yaml
+++ b/manifests/n/Nvidia/GeForceGameReadyDriver/536.23/Nvidia.GeForceGameReadyDriver.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.2.6.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.4.0.schema.json
+
+PackageIdentifier: Nvidia.GeForceGameReadyDriver
+PackageVersion: "536.23"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.4.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.4 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.4.0)?

-----

Re: [#18879](https://github.com/microsoft/winget-pkgs/issues/18879)

It seems that these days:
A) the /s argument works with the self-extractor and
B) they are passed onto the actual setup executable.

Unfortunately, due to the nature of graphics drivers, testing this package is hard, as such it is marked as a draft until we're able to have multiple people validate its functionality.

I have personally successfully installed it on my system (existing older driver, GPU: 980ti).
**Update:** I just used "Display Driver Uninstaller" to completely wipe the Nvidia driver, let it install the Windows Update driver (replicating a fresh Windows install), then installed using my manifest, it worked as expected: up-to-date Graphics Driver, HD Audio Driver and PhysX System Software were installed.

Things to note/review:

* This is my first package submission, I followed the docs and what other packages do to the best of my abilities.
* I used `wingetcreate` to generate the initial manifests, then modified them.
* The version number isn't fully compatible with the manifest schema: `536.23` (expects two dots). Quoting it as a string seems to work.
* I was not able to get `winget update -m .\536.23` to detect my existing installation, but I am not sure if this even works from a local manifest file? From what I can tell, I am supplying the same relevant information as the `Nvidia.PhysX` package, which detects my existing installation.
* `InstallerSwitches` has both `Silent` and `SilentWithProgress`, which are set to `/s`, this follows what other packages seem to do (populating both even with no progress). Should we remove the `SilentWithProgress` one?
* The copyright information is showing "2011-2021", this is from the metadata of the latest installer, which has been released well into 2023.
* Exit codes aren't specified, but it exited with zero on my real PC and non-zero when installing in Windows Sandbox since the installer expects a compatible GPU (which Windows Sandbox doesn't emulate).
* I am supplying arguments to the installer:
  * `/gfexperienceinitiated`: which appears to successfully suppress installation of GeForce Experience (which is available separately in WinGet, and is not required for full driver functionality). **Edit:** This option does not remove GFE if it is already installed (which is good).
  * `/noreboot`: it's been a a long time since the (interactive) driver installer required a reboot from me, and I don't know how to trick it into asking for one. It should definitely be looked into what the consequences of this option are when it does need a reboot, **is it maybe returning with a special exit code if it wants to restart**?
* On their website, Nvidia provides selections for "Recommended/Certified", "Beta", and "Studio Driver" flavors of the driver: https://www.nvidia.com/Download/Find.aspx?lang=en-us
  * "Beta" seems to be currently unused. "Recommended/Certified" is the GameReady driver.
  * Studio Driver is a specialized version for 3D artists and is released more infrequently than the GameReady driver, I'm guessing it's supposed to be an especially stable version of the driver.
  *  Studio drivers only support >= Pascal GPUs, meanwhile the current GameReady driver supports >= Maxwell. Hence I would be unable to test installation of the Studio Driver (My 980ti is Maxwell).
  * Should we potentially reorganize the package to into a "NVIDIA Graphics Driver" package with provides GameReady and Studio Driver installers? Or should we keep this a GameReady driver package and someone could make a separate Studio Driver package in the future? I am pretty sure the two would be exclusive (not sure what policy is on that).

**Edit: Clarified/reworked parts of my comment here**

For completeness, here are all the options which are presumably accessible as command line arguments (extracted from `setup.cfg`)
```
<options>
  <bool name="enableTelemetry" property="EnableTelemetry"/>
  <bool name="clean" property="CleanInstall"/>
  <bool name="prestage" property="PrestageInstall"/>
  <bool name="validate" property="ValidationInstall"/>
  <string name="validationFile" property="ValidationFile"/>
  <bool name="forcereboot" property="RebootRequired"/>
  <bool name="noreboot" property="IgnoreReboot"/>
  <bool name="k" property="RebootRequired"/>
  <bool name="n" property="IgnoreReboot"/>
  <bool name="passive" property="ProgressOnly"/>
  <bool name="noeula" property="SkipEula"/>
  <bool name="nofinish" property="SkipFinish"/>
  <bool name="ignorepnp" property="IgnorePnpFlag"/>
  <bool name="progresswitheula" property="ProgressWithEula"/>
  <bool name="nosplash" property="NoSplashScreen"/>
  <bool name="gfexperienceinitiated" property="GFExperienceInitiated"/>
  <int name="custominvokerid" property="CustomInvokerId"/>
</options>
```
There are some more options available regarding EULA and splash screens, however, with the aforementioned options, it was fully silent for me. Only exception is that it will pop a UAC prompt if winget wasn't run with elevated permissions.
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/winget-pkgs/pull/110618&drop=dogfoodAlpha