### PR TITLE
Update ApeCloud.kbcli.locale.en-US.yaml License

### DIFF
--- a/manifests/a/ApeCloud/kbcli/0.5.2/ApeCloud.kbcli.locale.en-US.yaml
+++ b/manifests/a/ApeCloud/kbcli/0.5.2/ApeCloud.kbcli.locale.en-US.yaml
@@ -11,7 +11,7 @@ Author: ApeCloud
 PackageName: kbcli
 PackageUrl: https://github.com/apecloud/kbcli
 License: AGPL-3.0
-LicenseUrl: https://github.com/apecloud/kbcli/blob/main/LICENSE.txt
+LicenseUrl: https://github.com/apecloud/kbcli/blob/main/LICENSE
 Copyright: Copyright (C) 2022-2023 ApeCloud Co., Ltd
 ShortDescription: A command line interface for KubeBlocks
 Moniker: kbcli


### PR DESCRIPTION
fix the LINCENSE.TXT not found

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.4 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.4.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/winget-pkgs/pull/110816&drop=dogfoodAlpha