### PR TITLE
Tgstation.Server version 0.22.475

### DIFF
--- a/manifests/t/Tgstation/Server/0.22.475/Tgstation.Server.installer.yaml
+++ b/manifests/t/Tgstation/Server/0.22.475/Tgstation.Server.installer.yaml
@@ -1,0 +1,29 @@
+# Created using wingetcreate 1.2.6.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
+
+PackageIdentifier: Tgstation.Server
+PackageVersion: 0.22.475
+Installers:
+- InstallerLocale: en-US
+  Architecture: x86
+  InstallerType: exe
+  Scope: machine
+  InstallerUrl: https://github.com/tgstation/tgstation-server/releases/download/tgstation-server-v0.22.475/tgstation-server-installer.exe
+  InstallerSha256: DDAE2A2226C913C6B047A1BD827FDA9BDBBA11D32AC4585D33CD0D031934C7B2
+  InstallModes:
+  - interactive
+  - silent
+  InstallerSwitches:
+    Silent: /silent
+    SilentWithProgress: /passive
+    Log: /log <LOGPATH>
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.DotNet.AspNetCore.6
+  ProductCode: '{D24887FA-3228-4509-B5F3-4E07E349F278}'
+  UnsupportedOSArchitectures:
+  - arm
+  - arm64
+  ReleaseDate: 2023-06-24
+ManifestType: installer
+ManifestVersion: 1.4.0

--- a/manifests/t/Tgstation/Server/0.22.475/Tgstation.Server.locale.en-US.yaml
+++ b/manifests/t/Tgstation/Server/0.22.475/Tgstation.Server.locale.en-US.yaml
@@ -1,0 +1,21 @@
+# Created using wingetcreate 1.2.6.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.4.0.schema.json
+
+PackageIdentifier: Tgstation.Server
+PackageVersion: 0.22.475
+PackageLocale: en-US
+Publisher: /tg/station 13
+PublisherUrl: https://github.com/tgstation/tgstation-server
+PublisherSupportUrl: https://github.com/tgstation/tgstation-server/discussions/categories/q-a
+Author: Dominion/Cyberboss
+PackageName: tgstation-server
+License: AGPL-3.0
+ShortDescription: A production scale tool for BYOND server management
+Moniker: tgstation-server
+ReleaseNotesUrl: https://github.com/tgstation/tgstation-server/releases/tag/tgstation-server-v0.22.475
+PurchaseUrl: https://github.com/sponsors/Cyberboss
+Documentations:
+- DocumentLabel: README.md
+  DocumentUrl: https://github.com/tgstation/tgstation-server/blob/tgstation-server-v0.22.475/README.md
+ManifestType: defaultLocale
+ManifestVersion: 1.4.0

--- a/manifests/t/Tgstation/Server/0.22.475/Tgstation.Server.yaml
+++ b/manifests/t/Tgstation/Server/0.22.475/Tgstation.Server.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.2.6.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.4.0.schema.json
+
+PackageIdentifier: Tgstation.Server
+PackageVersion: 0.22.475
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.4.0


### PR DESCRIPTION
**_This PR is another [automated pipeline test](https://github.com/tgstation/tgstation-server/pull/1572) (see original at #110814). We were unsatified with the previous .vdproj implementation so we've ported the technology to use Wix Toolset v4. This requires another test manifest validation and thus, this PR. Please do not merge it as this version is not an official release._**

# Automated Pull Request

This pull request was generated by our [deployment pipeline](https://github.com/tgstation/tgstation-server/actions/runs/5436986160/jobs/9887288798) as a result of the release of [tgstation-server-v5.12.7](https://github.com/tgstation/tgstation-server/releases/tag/tgstation-server-v5.12.7). Validation was performed as part of the process.

The user account that created this pull request is available to correct any issues.

**_We would like to be verified as the publisher of this software but we cannot find documentation on how to do so._**

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
  - This PR is generated as a direct result of a new release of `tgstation-server` this should be impossible
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
  - Validation is performed as a prerequisite to deployment.
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
  - Manifest installation and uninstallation is performed as a prerequisite to deployment.
- [x] Does your manifest conform to the [1.4 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.4.0)?