### PR TITLE
fix some spelling found by Check Spelling workflow

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -19,6 +19,7 @@ ISVs
 Komac
 LOGPATH
 malware
+Mariocube
 microsoft
 MSFT
 msftbot
@@ -30,6 +31,7 @@ opensource
 PEET
 PWAs
 ranhpa
+ranpha
 Redistributables
 Runtimes
 screenshots

--- a/.github/actions/spelling/excludes.txt
+++ b/.github/actions/spelling/excludes.txt
@@ -61,6 +61,7 @@ ignore$
 \.zip$
 ^\.(?!github/)
 ^\.github/actions/spelling/
+^\.github/policies/moderatorTriggers\.yml$
 ^\.github/workflows/spellCheck\.yml$
 (?:^|/)Tools/
 (?:^|/)manifests/

--- a/.github/policies/flaggedPackages.yml
+++ b/.github/policies/flaggedPackages.yml
@@ -91,7 +91,7 @@ configuration:
 
                 | Git GitCredentialManager | Publisher has requested removal | #100542 |
 
-                | Ranpha LavFiltersMegamix | Package is known to be an unofficial redistritbution which hijacks the official package | #95155 |
+                | Ranpha LavFiltersMegamix | Package is known to be an unofficial redistribution which hijacks the official package | #95155 |
 
                 | Mariocube - Any | Publisher is known to distribute packages unofficially with misrepresentation of origin | #109796 / #103191 (comment) |
 


### PR DESCRIPTION
This fixes some errors thrown by the Check Spelling workflow, see https://github.com/dpprdan/winget-pkgs/actions/runs/5452378176/jobs/9919806090#step:2:659

Please modify directly, if you don't agree with my fixes. 

Relates to #100816

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.4 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.4.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/winget-pkgs/pull/111249&drop=dogfoodAlpha