### PR TITLE
Fix Python.Python.3.12 3.12.0a5 ReleaseDate

### DIFF
--- a/manifests/p/Python/Python/3/12/3.12.0a5/Python.Python.3.12.installer.yaml
+++ b/manifests/p/Python/Python/3/12/3.12.0a5/Python.Python.3.12.installer.yaml
@@ -99,4 +99,4 @@ Installers:
     ProductCode: '{067921ac-0d21-49d7-80c4-faaafbdb8994}'
 ManifestType: installer
 ManifestVersion: 1.4.0
-ReleaseDate: 2023-2-7
+ReleaseDate: 2023-02-07


### PR DESCRIPTION
The ReleaseDate isn't conforming to the right standard - https://github.com/russellbanks/Komac/issues/225#issuecomment-1623033556

-----

 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/winget-pkgs/pull/111462&drop=dogfoodAlpha