### PR TITLE
Avoid mentioning author on non-actionable PRs

### DIFF
--- a/.github/policies/labelAdded.internalError_Any.yml
+++ b/.github/policies/labelAdded.internalError_Any.yml
@@ -35,7 +35,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 The pull request encountered an internal error and has been assigned to a developer to investigate.

--- a/.github/policies/labelManagement.issueUpdated.yml
+++ b/.github/policies/labelManagement.issueUpdated.yml
@@ -235,7 +235,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 Static analysis has timed out. The PR has been assigned to a developer to investigate.


### PR DESCRIPTION
This change ensures that PR authors are not mentioned in situations where their involvement is not required, such as when a PR encounters an internal error that necessitates the attention of a maintainer. This is done to reduce unnecessary notifications / mention spam to PR authors

cc @stephengillie

-----

 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/winget-pkgs/pull/111513&drop=dogfoodAlpha