### PR TITLE
New version: jaegertracing.jaeger 1.47

### DIFF
--- a/manifests/j/jaegertracing/jaeger/1.47/jaegertracing.jaeger.installer.yaml
+++ b/manifests/j/jaegertracing/jaeger/1.47/jaegertracing.jaeger.installer.yaml
@@ -1,0 +1,16 @@
+# Created using wingetcreate 1.2.6.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
+
+PackageIdentifier: jaegertracing.jaeger
+PackageVersion: 1.47
+Installers:
+- Architecture: x64
+  InstallerType: zip
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: jaeger-1.47.0-windows-amd64\jaeger-all-in-one.exe
+    PortableCommandAlias: jaeger-all-in-one
+  InstallerUrl: https://github.com/jaegertracing/jaeger/releases/download/v1.47.0/jaeger-1.47.0-windows-amd64.zip
+  InstallerSha256: FC6C0FD67814B38E743CC677189C02561AE7857BC10730B461AE16F32E72DDA6
+ManifestType: installer
+ManifestVersion: 1.4.0

--- a/manifests/j/jaegertracing/jaeger/1.47/jaegertracing.jaeger.locale.en-US.yaml
+++ b/manifests/j/jaegertracing/jaeger/1.47/jaegertracing.jaeger.locale.en-US.yaml
@@ -1,0 +1,12 @@
+# Created using wingetcreate 1.2.6.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.4.0.schema.json
+
+PackageIdentifier: jaegertracing.jaeger
+PackageVersion: 1.47
+PackageLocale: en-US
+Publisher: jaegertracing
+PackageName: jaeger
+License: Apache License 2.0
+ShortDescription: Open source, end-to-end distributed tracing
+ManifestType: defaultLocale
+ManifestVersion: 1.4.0

--- a/manifests/j/jaegertracing/jaeger/1.47/jaegertracing.jaeger.yaml
+++ b/manifests/j/jaegertracing/jaeger/1.47/jaegertracing.jaeger.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.2.6.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.4.0.schema.json
+
+PackageIdentifier: jaegertracing.jaeger
+PackageVersion: 1.47
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.4.0


### PR DESCRIPTION
New version: [jaegertracing.jaeger 1.47](https://github.com/jaegertracing/jaeger/releases/tag/v1.47.0)
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/winget-pkgs/pull/111545&drop=dogfoodAlpha