### PR TITLE
Fix Feedback Hub Trigger

### DIFF
--- a/.github/policies/labelManagement.needsFeedbackHub.yml
+++ b/.github/policies/labelManagement.needsFeedbackHub.yml
@@ -25,7 +25,7 @@ configuration:
               - and:
                   - payloadType: Issue_Comment
                   - commentContains:
-                      pattern: '\/feedback'
+                      pattern: '\/feedback(?!\.)'
                       isRegex: True
                   - or:
                       - activitySenderHasPermission:


### PR DESCRIPTION
This PR fixes an issue where the URL in a wingetbot trigger caused the feedback hub to be requested. (See https://github.com/microsoft/winget-pkgs/pull/111530)
This is done by adding `(?!\.)` to the Regex which will cause it to match only if there is not a `.` immediately after the `/feedback`, preventing the URL match.

cc @denelon / @stephengillie
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/winget-pkgs/pull/111679&drop=dogfoodAlpha