### PR TITLE
New version: CodeSector.TeraCopy version 3.10.0

### DIFF
--- a/manifests/c/CodeSector/TeraCopy/3.10.0/CodeSector.TeraCopy.installer.yaml
+++ b/manifests/c/CodeSector/TeraCopy/3.10.0/CodeSector.TeraCopy.installer.yaml
@@ -1,0 +1,24 @@
+# Created using wingetcreate 1.2.7.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
+
+PackageIdentifier: CodeSector.TeraCopy
+PackageVersion: 3.10.0
+MinimumOSVersion: 10.0.0.0
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+Installers:
+- InstallerLocale: en-US
+  Architecture: neutral
+  InstallerType: exe
+  Scope: machine
+  InstallerUrl: https://codesector.com/files/teracopy3.10.exe
+  InstallerSha256: EEF51827A158C2770FEBB0FF189965F2F170AC9EE0A36CEBCFE3CD3C7713EAFC
+  InstallerSwitches:
+    Silent: /exenoupdates /q
+    SilentWithProgress: /exenoupdates /qb
+  UpgradeBehavior: install
+  ProductCode: '{3B52584E-B01A-456B-A6D9-A2135F8B1E98}'
+ManifestType: installer
+ManifestVersion: 1.4.0

--- a/manifests/c/CodeSector/TeraCopy/3.10.0/CodeSector.TeraCopy.locale.en-US.yaml
+++ b/manifests/c/CodeSector/TeraCopy/3.10.0/CodeSector.TeraCopy.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# Created using wingetcreate 1.2.7.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.4.0.schema.json
+
+PackageIdentifier: CodeSector.TeraCopy
+PackageVersion: 3.10.0
+PackageLocale: en-US
+Publisher: Code Sector
+PublisherUrl: https://codesector.com
+PublisherSupportUrl: https://help.codesector.com
+PrivacyUrl: https://codesector.com/privacy
+Author: Code Sector
+PackageName: TeraCopy
+PackageUrl: https://www.codesector.com/teracopy
+License: Freeware
+LicenseUrl: https://help.codesector.com/knowledge-bases/2/articles/412-end-user-license-agreement
+Copyright: © 2007-2022 Code Sector
+CopyrightUrl: https://help.codesector.com/knowledge-bases/2/articles/412-end-user-license-agreement
+ShortDescription: A popular utility designed to copy files faster and more reliably, providing the user with many features. TeraCopy uses dynamically adjusted buffers to reduce seek time. It can resume broken file transfers and skup bad files during the copying process.
+Moniker: teracopy
+Tags:
+- TeraCopy
+- Copy
+- Files
+- File
+ManifestType: defaultLocale
+ManifestVersion: 1.4.0

--- a/manifests/c/CodeSector/TeraCopy/3.10.0/CodeSector.TeraCopy.yaml
+++ b/manifests/c/CodeSector/TeraCopy/3.10.0/CodeSector.TeraCopy.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.2.7.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.4.0.schema.json
+
+PackageIdentifier: CodeSector.TeraCopy
+PackageVersion: 3.10.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.4.0


### PR DESCRIPTION
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] This PR only modifies one (1) manifest
- [X] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [X] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] SELF REPORT - Tested manifest locally with `winget install --manifest <path> -h`
- [X] SELF REPORT - Tested manifest locally with `winget uninstall --manifest <path>`
- [X] Does your manifest conform to the [1.4 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.4.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/winget-pkgs/pull/111709&drop=dogfoodAlpha

-----

Author notes:
* Replaced installer URL (previously teracopy.exe) with a new version-atomic URL. Hopefully this will serve more static in case the manifest doesn't get updated in future. Currently the URL/hash mismatches because the teracopy.exe URL will always be the latest version.
* Updated silent and silentwithprogress switches to include the /exenoupdates switch so that the installer doesn't auto-attempt to fetch and install the latest version.
* To future maintainers: Ensure you update the productcode value with the new GUID. On my machine the powershell `(Get-ChildItem -Path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall | %{Get-ItemProperty -Path $PSItem.PSPath | Where-Object -Property DisplayName -eq "TeraCopy"}).UninstallString` reveals the GUID.