### PR TITLE
vim.nightly: fix url and hash for x86 Arch

### DIFF
--- a/manifests/v/vim/vim/nightly/9.0.1677/vim.vim.nightly.installer.yaml
+++ b/manifests/v/vim/vim/nightly/9.0.1677/vim.vim.nightly.installer.yaml
@@ -15,8 +15,8 @@ ReleaseDate: 2023-07-09
 ElevationRequirement: elevationRequired
 Installers:
 - Architecture: x86
-  InstallerUrl: https://github.com/vim/vim-win32-installer/releases/download/v9.0.1677/gvim_9.0.1677_x64.exe
-  InstallerSha256: 417420C6D65AB9C552437F1BD2E61F32C37EF4854847945156202FF50D5F5DD0
+  InstallerUrl: https://github.com/vim/vim-win32-installer/releases/download/v9.0.1677/gvim_9.0.1677_x86.exe
+  InstallerSha256: 517349B73BB91CF97A340DE9886987BDC318A99F2107E744818CE7D4956099E2
 - Architecture: x64
   InstallerUrl: https://github.com/vim/vim-win32-installer/releases/download/v9.0.1677/gvim_9.0.1677_x64.exe
   InstallerSha256: 417420C6D65AB9C552437F1BD2E61F32C37EF4854847945156202FF50D5F5DD0


### PR DESCRIPTION
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] This PR only modifies one (1) manifest
- [X] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? manually verified
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? (no, not installed)
- [X] Does your manifest conform to the [1.4 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.4.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----


So #111716 again created PR with wrong x86 link and shasum (https://github.com/vedantmgoyal2009/winget-releaser/issues/173). 

Fix this for the latest upload for vim.vim.nightly.


 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/winget-pkgs/pull/111904&drop=dogfoodAlpha