### PR TITLE
Fixed InstallLocation argument for Python 3 version 3.11.4.

### DIFF
--- a/manifests/p/Python/Python/3/11/3.11.4/Python.Python.3.11.installer.yaml
+++ b/manifests/p/Python/Python/3/11/3.11.4/Python.Python.3.11.installer.yaml
@@ -27,6 +27,7 @@ Installers:
   InstallerSha256: E2C444CDD41F1F52BACCB2C70348476DB8DB2BFCB9DE2AEC9A1CA12987759EEC
   InstallerSwitches:
     Custom: InstallAllUsers=0 PrependPath=1
+    InstallLocation: DefaultJustForMeTargetDir=<INSTALLPATH>
   AppsAndFeaturesEntries:
   - DisplayName: Python 3.11.4 (32-bit)
     DisplayVersion: 3.11.4150.0
@@ -36,6 +37,7 @@ Installers:
   InstallerSha256: E2C444CDD41F1F52BACCB2C70348476DB8DB2BFCB9DE2AEC9A1CA12987759EEC
   InstallerSwitches:
     Custom: InstallAllUsers=1 PrependPath=1
+    InstallLocation: DefaultAllUsersTargetDir=<INSTALLPATH>
   AppsAndFeaturesEntries:
   - DisplayName: Python 3.11.4 (32-bit)
     DisplayVersion: 3.11.4150.0
@@ -45,6 +47,7 @@ Installers:
   InstallerSha256: 47BE821C0F1825D90FC40F83A3EE3D3A691A3E16C8E21AC0CD56371362AAAD50
   InstallerSwitches:
     Custom: InstallAllUsers=0 PrependPath=1
+    InstallLocation: DefaultJustForMeTargetDir=<INSTALLPATH>
   AppsAndFeaturesEntries:
   - DisplayName: Python 3.11.4 (64-bit)
     DisplayVersion: 3.11.4150.0
@@ -63,6 +66,7 @@ Installers:
   InstallerSha256: 7A030384657F9E3A6EBEDFCCE8EB19499A3C7598B7BB240605380B3F9E314CC8
   InstallerSwitches:
     Custom: InstallAllUsers=0 PrependPath=1
+    InstallLocation: DefaultJustForMeTargetDir=<INSTALLPATH>
   AppsAndFeaturesEntries:
   - DisplayName: Python 3.11.4 (ARM64)
     DisplayVersion: 3.11.4150.0
@@ -72,6 +76,7 @@ Installers:
   InstallerSha256: 7A030384657F9E3A6EBEDFCCE8EB19499A3C7598B7BB240605380B3F9E314CC8
   InstallerSwitches:
     Custom: InstallAllUsers=1 PrependPath=1
+    InstallLocation: DefaultAllUsersTargetDir=<INSTALLPATH>
   AppsAndFeaturesEntries:
   - DisplayName: Python 3.11.4 (ARM64)
     DisplayVersion: 3.11.4150.0

--- a/manifests/p/Python/Python/3/11/3.11.4/Python.Python.3.11.installer.yaml
+++ b/manifests/p/Python/Python/3/11/3.11.4/Python.Python.3.11.installer.yaml
@@ -57,6 +57,7 @@ Installers:
   InstallerSha256: 47BE821C0F1825D90FC40F83A3EE3D3A691A3E16C8E21AC0CD56371362AAAD50
   InstallerSwitches:
     Custom: InstallAllUsers=1 PrependPath=1
+    InstallLocation: DefaultAllUsersTargetDir=<INSTALLPATH>
   AppsAndFeaturesEntries:
   - DisplayName: Python 3.11.4 (64-bit)
     DisplayVersion: 3.11.4150.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.4 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.4.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

This PR fixes https://github.com/microsoft/winget-pkgs/issues/45194 for Python 3.11.4.

 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/winget-pkgs/pull/112391&drop=dogfoodAlpha