### PR TITLE
Microsoft.OpenJDK.17 version 17.0.8.7

### DIFF
--- a/manifests/m/Microsoft/OpenJDK/17/17.0.8.7/Microsoft.OpenJDK.17.installer.yaml
+++ b/manifests/m/Microsoft/OpenJDK/17/17.0.8.7/Microsoft.OpenJDK.17.installer.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 1.2.7.0
+# Created using wingetcreate 1.2.8.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
 
 PackageIdentifier: Microsoft.OpenJDK.17
@@ -14,14 +14,12 @@ InstallerSwitches:
 UpgradeBehavior: uninstallPrevious
 ElevationRequirement: elevatesSelf
 Installers:
-- InstallerLocale: en-US
-  Architecture: x64
+- Architecture: x64
   InstallerType: wix
   InstallerUrl: https://aka.ms/download-jdk/microsoft-jdk-17.0.8-windows-x64.msi#winget
   InstallerSha256: F029E88CDADCE4E32BF8E45C2AE31D6015996F10BD836EB255BAE86D8246D332
   ProductCode: '{F0EDFBE3-9512-4E75-8521-1C6DFAFC49A3}'
-- InstallerLocale: en-US
-  Architecture: arm64
+- Architecture: arm64
   InstallerType: wix
   InstallerUrl: https://aka.ms/download-jdk/microsoft-jdk-17.0.8-windows-aarch64.msi#winget
   InstallerSha256: F232EAF819F1BCAABC7E3303F435460839A710C76156900D5DB09B1CA35B12CD

--- a/manifests/m/Microsoft/OpenJDK/17/17.0.8.7/Microsoft.OpenJDK.17.locale.en-US.yaml
+++ b/manifests/m/Microsoft/OpenJDK/17/17.0.8.7/Microsoft.OpenJDK.17.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 1.2.7.0
+# Created using wingetcreate 1.2.8.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.4.0.schema.json
 
 PackageIdentifier: Microsoft.OpenJDK.17
@@ -16,7 +16,7 @@ LicenseUrl: https://openjdk.java.net/legal/gplv2+ce.html
 ShortDescription: The Microsoft Build of OpenJDK is a new no-cost long-term supported distribution and Microsoft's new way to collaborate and contribute to the Java ecosystem.
 Moniker: ms-openjdk-17
 Tags:
-- "17"
+- 17
 - java
 - microsoft-openjdk
 - openjdk

--- a/manifests/m/Microsoft/OpenJDK/17/17.0.8.7/Microsoft.OpenJDK.17.yaml
+++ b/manifests/m/Microsoft/OpenJDK/17/17.0.8.7/Microsoft.OpenJDK.17.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 1.2.7.0
+# Created using wingetcreate 1.2.8.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.4.0.schema.json
 
 PackageIdentifier: Microsoft.OpenJDK.17


### PR DESCRIPTION
I cannot `winget upgrade Microsoft.OpenJDK.17` from version 17.0.7.7 to 17.0.8.7 with the current manifest.

The winget log shows

```
2023-07-21 13:13:03.026 [CLI ] Starting installer selection.
2023-07-21 13:13:03.026 [CLI ] Installer [X64,wix,Machine,en-US] not applicable: Installer locale does not match required locale: en-USRequired locales: [] Or does not satisfy compatible match for Preferred Locales: [de-DE]
```

I therefore deleted the `InstallerLocale: en-US` keys from the Microsoft.OpenJDK.17.installer.yaml. 

The OpenJDK installer is apparently multi-lingual anyway

![grafik](https://github.com/microsoft/winget-pkgs/assets/1423562/8540a366-d44f-4ef6-aabb-87ba6d1453fd)

cc @joe-braley (who submitted the v17.0.8.7 manifest)

-----
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.4 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.4.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/winget-pkgs/pull/112765&drop=dogfoodAlpha