### PR TITLE
Bluefish: change to https:// schema 

### DIFF
--- a/manifests/b/Bluefish/Bluefish/2.2.12rc2/Bluefish.Bluefish.locale.en-US.yaml
+++ b/manifests/b/Bluefish/Bluefish/2.2.12rc2/Bluefish.Bluefish.locale.en-US.yaml
@@ -5,12 +5,12 @@ PackageIdentifier: Bluefish.Bluefish
 PackageVersion: 2.2.12rc2
 PackageLocale: en-US
 Publisher: The Bluefish Developers
-PublisherUrl: http://bluefish.openoffice.nl/index.html
+PublisherUrl: https://bluefish.openoffice.nl/index.html
 PublisherSupportUrl: https://bfwiki.tellefsen.net/index.php/Manual_2_ToC
 #PrivacyUrl: 
 #Author: 
 PackageName: Bluefish
-PackageUrl: http://bluefish.openoffice.nl/features.html
+PackageUrl: https://bluefish.openoffice.nl/features.html
 License: GNU GPL
 LicenseUrl: https://sourceforge.net/p/bluefish/code/HEAD/tree/trunk/bluefish/COPYING
 #Copyright: 

--- a/manifests/b/Bluefish/Bluefish/2.2.13/Bluefish.Bluefish.locale.en-US.yaml
+++ b/manifests/b/Bluefish/Bluefish/2.2.13/Bluefish.Bluefish.locale.en-US.yaml
@@ -5,10 +5,10 @@ PackageIdentifier: Bluefish.Bluefish
 PackageVersion: 2.2.13
 PackageLocale: en-US
 Publisher: The Bluefish Developers
-PublisherUrl: http://bluefish.openoffice.nl/index.html
+PublisherUrl: https://bluefish.openoffice.nl/index.html
 PublisherSupportUrl: https://bfwiki.tellefsen.net/index.php/Manual_2_ToC
 PackageName: Bluefish
-PackageUrl: http://bluefish.openoffice.nl/features.html
+PackageUrl: https://bluefish.openoffice.nl/features.html
 License: GNU GPL
 LicenseUrl: https://sourceforge.net/p/bluefish/code/HEAD/tree/trunk/bluefish/COPYING
 ShortDescription: Bluefish is a powerful editor targeted towards programmers and webdevelopers, with many options to write websites, scripts and programming code.


### PR DESCRIPTION
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.4 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.4.0)?

-----

Per repology https://repology.org/repository/winget/problems

> Homepage link http://bluefish.openoffice.nl/features.html is a permanent redirect to its HTTPS counterpart https://bluefish.openoffice.nl/features.html and should be updated.

Please squash commits (having issues on my side)
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/winget-pkgs/pull/113711&drop=dogfoodAlpha