### PR TITLE
Revert "Improve ISSUE_TEMPLATE"

### DIFF
--- a/.github/ISSUE_TEMPLATE/package_request.yml
+++ b/.github/ISSUE_TEMPLATE/package_request.yml
@@ -33,40 +33,14 @@ body:
       options:
         - label: The installer meets the above requirements
           required: true
-  - type: dropdown
-    id: installertype
-    validations:
-      required: true
-    attributes:
-      label: What's the type of your software?
-      multiple: false
-      options:
-        - msix
-        - msi
-        - appx
-        - exe
-        - zip
-        - inno
-        - nullsoft
-        - wix
-        - pwa
-        - burn
-        - portable
-        - I don't know
   - type: textarea
     attributes:
       label: Please provide the following information
       description: If you can provide the following information, it will be easy for us to add the package to the repository.
       value: |
         Download Page Url:
-        Install Options:
         Publisher:
-        Publisher Page:
-        Package Page:
         Package Name:
         Description:
         Package Version:
         Installer URL:
-        License:
-        License Page:
-        Copyright:


### PR DESCRIPTION
Reverts microsoft/winget-pkgs#113305

Most users who are submitting a package request instead of creating the manifest themselves are not likely to know the installer type or install options. 

I would estimate that 90% of package requests are users of winget who just want the software they use to be available in winget - they don't necessarily care about the install options, they don't necessarily care about the license, they just know where they go to download the software. They usually don't know the difference between burn, inno, and nullsoft.

By asking these additional fields of them, it places a higher burden on the person creating the issue and provides very limited value to anyone who would be creating a manifest from it. Given the package name and download URL, it usually isn't hard for someone creating a manifest to find the publisher page or the package page, while asking it of the person creating the issue creates more friction which ultimately leads to a not-great experience.
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/winget-pkgs/pull/113790&drop=dogfoodAlpha