### PR TITLE
New version: Kingston.SSDManager version 1.5.3.2

### DIFF
--- a/manifests/k/Kingston/SSDManager/1.5.3.2/Kingston.SSDManager.installer.yaml
+++ b/manifests/k/Kingston/SSDManager/1.5.3.2/Kingston.SSDManager.installer.yaml
@@ -1,0 +1,20 @@
+# Created using wingetcreate 1.2.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
+
+PackageIdentifier: Kingston.SSDManager
+PackageVersion: 1.5.3.2
+InstallerLocale: en-US
+InstallerSwitches:
+  Silent: /VERYSILENT
+  Custom: /NORESTART
+UpgradeBehavior: install
+Commands:
+- KSM
+Installers:
+- Architecture: x86
+  InstallerType: inno
+  InstallerUrl: https://media.kingston.com/support/downloads/KSM_setup_1.5.3.2.exe
+  InstallerSha256: B3A154A488552C17B22421E9F5B3F9E6210491775276824B717D678F8673A42A
+  ProductCode: '{53F657CD-C4FC-4DCD-826E-6862917532AC}_is1'
+ManifestType: installer
+ManifestVersion: 1.4.0

--- a/manifests/k/Kingston/SSDManager/1.5.3.2/Kingston.SSDManager.locale.en-US.yaml
+++ b/manifests/k/Kingston/SSDManager/1.5.3.2/Kingston.SSDManager.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created using wingetcreate 1.2.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.4.0.schema.json
+
+PackageIdentifier: Kingston.SSDManager
+PackageVersion: 1.5.3.2
+PackageLocale: en-US
+Publisher: Kingston Technology Company, Inc.
+PublisherUrl: https://www.kingston.com/en/support/technical/ssdmanager
+PublisherSupportUrl: https://www.kingston.com/en/support/technical/ssdmanager
+PrivacyUrl: https://www.kingston.com/en/company/privacy
+Author: Kingston Technology Company, Inc
+PackageName: Kingston SSD Manager x64
+PackageUrl: https://www.kingston.com/en/support/technical/ssdmanager
+License: Proprietary
+ShortDescription: Kingston® SSD Manager is an application that provides users with the ability to monitor and manage various aspects of their Kingston® Solid State Drive.
+ManifestType: defaultLocale
+ManifestVersion: 1.4.0

--- a/manifests/k/Kingston/SSDManager/1.5.3.2/Kingston.SSDManager.yaml
+++ b/manifests/k/Kingston/SSDManager/1.5.3.2/Kingston.SSDManager.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.2.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.4.0.schema.json
+
+PackageIdentifier: Kingston.SSDManager
+PackageVersion: 1.5.3.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.4.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] SELF REPORT - Tested manifest locally with `winget install --manifest <path> -h`
- [x] SELF REPORT - Tested manifest locally with `winget uninstall --manifest <path>`
- [x] Does your manifest conform to the [1.4 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.4.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

Author notes:

* Replaced /SILENT with /VERYSILENT for silent install switch.
* Wingetcreate was used to generate the manifest and it auto-swapped the architecture to x86. I suspect while kingston advertises it as a x64 coded application and the application is installed to Program Files (not x86), I think it's purely x86 code.
* To future maintainers: Ensure you update the productcode value with the new GUID (assuming it changes, I don't know). On my machine the powershell `(Get-ChildItem -Path HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall | %{Get-ItemProperty -Path $PSItem.PSPath | Where-Object -Property DisplayName -match "Kingston"}).PSChildName` reveals the GUID.
* Thank you @Trenly for the assist under issue #115324. 