### PR TITLE
New version: Sass.DartSass version 1.64.2

### DIFF
--- a/manifests/s/Sass/DartSass/1.64.2/Sass.DartSass.installer.yaml
+++ b/manifests/s/Sass/DartSass/1.64.2/Sass.DartSass.installer.yaml
@@ -1,0 +1,26 @@
+# Created using wingetcreate 1.2.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
+
+PackageIdentifier: Sass.DartSass
+PackageVersion: 1.64.2
+Installers:
+- InstallerUrl: https://github.com/sass/dart-sass/releases/download/1.64.2/dart-sass-1.64.2-windows-x64.zip
+  Architecture: x64
+  InstallerType: zip
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: dart-sass\sass.bat
+    PortableCommandAlias: sass
+  InstallerSha256: 97b5f8ccd25a9e589f324266e25ff4a3263696dbe20090d32e7d23bbf51e3b08
+  ReleaseDate: 2023-07-31
+- InstallerUrl: https://github.com/sass/dart-sass/releases/download/1.64.2/dart-sass-1.64.2-windows-ia32.zip
+  Architecture: x86
+  InstallerType: zip
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: dart-sass\sass.bat
+    PortableCommandAlias: sass
+  InstallerSha256: abc87d1676a0a5b37ae6e8dc768d390b58c133a08862db4bbcb8985188e2a1cd
+  ReleaseDate: 2023-07-31
+ManifestType: installer
+ManifestVersion: 1.4.0

--- a/manifests/s/Sass/DartSass/1.64.2/Sass.DartSass.locale.en-US.yaml
+++ b/manifests/s/Sass/DartSass/1.64.2/Sass.DartSass.locale.en-US.yaml
@@ -1,0 +1,41 @@
+# Created using wingetcreate 1.2.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.4.0.schema.json
+
+PackageIdentifier: Sass.DartSass
+PackageVersion: 1.64.2
+PackageLocale: en-US
+Publisher: The Sass Team
+PublisherUrl: https://sass-lang.com/
+Author: https://github.com/sass/dart-sass/graphs/contributors
+PackageName: Dart Sass
+PackageUrl: https://github.com/sass/dart-sass
+License: MIT
+LicenseUrl: https://github.com/sass/dart-sass/blob/1.64.2/LICENSE
+Copyright: © 2016–2023 Google, the Sass team, and numerous contributors.
+ShortDescription: The reference compiler for the Sass style sheet language. Sass makes CSS fun.
+Description: |
+  Sass is a style sheet language that is transpiled to CSS. It allows you to use variables, nested rules, mixins, functions, and more, all with a fully CSS-compatible syntax. Sass helps keep large style sheets well-organized and makes it easy to share design within and across projects.
+  This package is Dart Sass, the new Dart implementation of Sass.
+Moniker: sass
+Tags:
+- dart-sass
+- css
+- scss
+- css-preprocessor
+- stylesheet
+- style-sheet
+- stylesheet-preprocessor
+- style-sheet-preprocessor
+ReleaseNotes: |
+  Dart API
+  - Include protocol buffer definitions when uploading the sass package to pub.
+ReleaseNotesUrl: https://github.com/sass/dart-sass/releases/tag/1.64.2
+Documentations:
+- DocumentLabel: Command Line Documentation
+  DocumentUrl: https://sass-lang.com/documentation/cli/dart-sass/
+- DocumentLabel: Language Documentation
+  DocumentUrl: https://sass-lang.com/documentation/
+- DocumentLabel: Learn Sass
+  DocumentUrl: https://sass-lang.com/guide/
+ManifestType: defaultLocale
+ManifestVersion: 1.4.0

--- a/manifests/s/Sass/DartSass/1.64.2/Sass.DartSass.yaml
+++ b/manifests/s/Sass/DartSass/1.64.2/Sass.DartSass.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.2.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.4.0.schema.json
+
+PackageIdentifier: Sass.DartSass
+PackageVersion: 1.64.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.4.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.4 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.4.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

This package uses a batch file as its entry point, calling the Dart executable in a subfolder with a pregenerated snapshot. This setup doesn't work when `sass` is called through a symlink (and in any case the created symlink has the wrong extension, `sass.exe` rather than `sass.bat`), but I didn't think to test that before first submitting the package (I only run winget *without* admin privileges, and I don't have Developer Mode enabled on my machine). The use of a batch file is unlikely to change any time soon, especially on x86 systems. If this is a setup you don't want to support, you may need to remove this package from winget.

 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/winget-pkgs/pull/115382&drop=dogfoodAlpha