### PR TITLE
Update Ghisler.TotalCommander - Correct file HASH

### DIFF
--- a/manifests/g/Ghisler/TotalCommander/11.00/Ghisler.TotalCommander.installer.yaml
+++ b/manifests/g/Ghisler/TotalCommander/11.00/Ghisler.TotalCommander.installer.yaml
@@ -11,7 +11,7 @@ UpgradeBehavior: install
 Installers:
 - Architecture: x64
   InstallerUrl: https://totalcommander.ch/win/tcmd1100x64.exe
-  InstallerSha256: 085D171D8A9AF4B56EBD90CE23E3C5C5B092470E338CC5333B7061B0F20828CD
+  InstallerSha256: 9928f1fc20924d3ab3f9edb958b7205c1982077eeb5b1f10fa7072dad358a104
 - Architecture: x86
   InstallerUrl: https://totalcommander.ch/win/tcmd1100x32.exe
   InstallerSha256: 95A1162B98CEBED60C48FC853A26E7833C91F8805A94FAF6EF5BF588F13E7F1B


### PR DESCRIPTION
Changed the x64 installerSha256 hash to reflect the correct has of the actually downloaded file.
See #115556

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.4 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.4.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/winget-pkgs/pull/115597&drop=dogfoodAlpha