### PR TITLE
New package: F6CTE.MultiPSK version 4.48.2

### DIFF
--- a/manifests/f/F6CTE/MultiPSK/4.48.2/F6CTE.MultiPSK.installer.yaml
+++ b/manifests/f/F6CTE/MultiPSK/4.48.2/F6CTE.MultiPSK.installer.yaml
@@ -1,0 +1,12 @@
+# Created using wingetcreate 1.5.1.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+
+PackageIdentifier: F6CTE.MultiPSK
+PackageVersion: 4.48.2
+InstallerType: inno
+Installers:
+- Architecture: x86
+  InstallerUrl: http://f6cte.free.fr/MULTIPSK_setup.exe
+  InstallerSha256: C6A336032A10C3F80DE21106911FD29ED90004B3C20B82138F044B5C59673B27
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/f/F6CTE/MultiPSK/4.48.2/F6CTE.MultiPSK.locale.en-US.yaml
+++ b/manifests/f/F6CTE/MultiPSK/4.48.2/F6CTE.MultiPSK.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# Created using wingetcreate 1.5.1.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+
+PackageIdentifier: F6CTE.MultiPSK
+PackageVersion: 4.48.2
+PackageLocale: en-US
+Publisher: F6CTE
+PublisherUrl: http://f6cte.free.fr/index_anglais.htm
+Author: F6CTE
+PackageName: MultiPSK
+PackageUrl: http://f6cte.free.fr/index_anglais.htm
+License: Proprietary
+LicenseUrl: http://f6cte.free.fr/Licence_En.htm
+Copyright: F6CTE
+ShortDescription: Multimode digital transceiver
+Moniker: multipsk
+PurchaseUrl: http://f6cte.free.fr/Licence_En.htm
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/f/F6CTE/MultiPSK/4.48.2/F6CTE.MultiPSK.yaml
+++ b/manifests/f/F6CTE/MultiPSK/4.48.2/F6CTE.MultiPSK.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.5.1.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+
+PackageIdentifier: F6CTE.MultiPSK
+PackageVersion: 4.48.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.4 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.4.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

Closes #113521.

Tested and works fine.

The application gets installed into its default location (`C:\MULTIPSK`). This is intentional - it does not work properly when installed into `C:\Program Files (x86)\MULTIPSK`.
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/winget-pkgs/pull/116640&drop=dogfoodAlpha