### PR TITLE
Add InstallationNote to Chocolatey CLI manifest version 2.0.0.0

### DIFF
--- a/manifests/c/Chocolatey/Chocolatey/2.0.0.0/Chocolatey.Chocolatey.locale.en-US.yaml
+++ b/manifests/c/Chocolatey/Chocolatey/2.0.0.0/Chocolatey.Chocolatey.locale.en-US.yaml
@@ -12,6 +12,7 @@ PackageUrl: https://github.com/chocolatey/choco
 License: Apache v2
 LicenseUrl: https://github.com/chocolatey/choco/blob/develop/LICENSE
 ShortDescription: Chocolatey is The Package Manager for Windows. It was designed to be a decentralized framework for quickly installing applications and tools that you need. It is built on the NuGet infrastructure and uses PowerShell as its focus for delivering packages.
+InstallationNotes: The Chocolatey CLI MSI is intended for installation only! If upgrading from 5.x of Licensed Extension, or 1.x of other Chocolatey products, see the upgrade guide at https://ch0.co/upv2v6 before continuing. Otherwise, run `choco upgrade chocolatey`.
 ReleaseNotes: |-
   Breaking Changes
   - Change default behavior of choco list to be local only - see #158.


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

This PR updates the Chocolatey CLI manifest version 2.0.0.0 `InstallationNote`. This was added to version 2.2.2.0, and we want to ensure it's applied retrospectively to other versions.

/cc @corbob
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/117323)