### PR TITLE
Removing automatic update link in Zoom.Zoom 5.15.7.20303

### DIFF
--- a/manifests/z/Zoom/Zoom/5.15.7.20303/Zoom.Zoom.installer.yaml
+++ b/manifests/z/Zoom/Zoom/5.15.7.20303/Zoom.Zoom.installer.yaml
@@ -16,8 +16,7 @@ Installers:
 - Architecture: x86
   InstallerType: exe
   Scope: user
-  InstallerUrl: https://zoom.us/client/latest/ZoomInstallerFull.exe
-  InstallerUrl2: https://cdn.zoom.us/prod/5.15.7.20303/ZoomInstallerFull.exe
+  InstallerUrl: https://cdn.zoom.us/prod/5.15.7.20303/ZoomInstallerFull.exe
   InstallerSha256: 62CCE6B0656E53C8D9FB3579A5649E26DA384096BB3C8C9E35B3931872A0DAAA
   InstallModes:
   - interactive
@@ -33,8 +32,7 @@ Installers:
 - Architecture: x64
   InstallerType: exe
   Scope: user
-  InstallerUrl: https://zoom.us/client/latest/ZoomInstallerFull.exe?archType=x64
-  InstallerUrl2: https://cdn.zoom.us/prod/5.15.7.20303/x64/ZoomInstallerFull.exe
+  InstallerUrl: https://cdn.zoom.us/prod/5.15.7.20303/x64/ZoomInstallerFull.exe
   InstallerSha256: 29700AE271823732DE116D3DAD72E0AF73453881E7013755ACE627C122596FEB
   InstallModes:
   - interactive
@@ -49,8 +47,7 @@ Installers:
 - Architecture: arm64
   InstallerType: exe
   Scope: user
-  InstallerUrl: https://zoom.us/client/latest/ZoomInstallerFull.exe?archType=winarm64
-  InstallerUrl2: https://cdn.zoom.us/prod/5.15.7.20303/arm64/ZoomInstallerFull.exe
+  InstallerUrl: https://cdn.zoom.us/prod/5.15.7.20303/arm64/ZoomInstallerFull.exe
   InstallerSha256: 58DD2BC6659453E5FB4FCB33F0EE29C3C141B3635A6800DA601D198BEDB3E83D
   InstallModes:
   - interactive
@@ -65,8 +62,7 @@ Installers:
 - Architecture: x86
   InstallerType: msi
   Scope: machine
-  InstallerUrl: https://zoom.us/client/latest/ZoomInstallerFull.msi
-  InstallerUrl2: https://cdn.zoom.us/prod/5.15.7.20303/ZoomInstallerFull.msi
+  InstallerUrl: https://cdn.zoom.us/prod/5.15.7.20303/ZoomInstallerFull.msi
   InstallerSha256: D9345F78973A4FD4D33D0ABDD9ACB4601A8E951BF09B2805DF6B2005AEF675E6
   ProductCode: '{5AF9E104-FE31-4C54-B1CF-124E5E49C316}'
   AppsAndFeaturesEntries:
@@ -77,8 +73,7 @@ Installers:
 - Architecture: x64
   InstallerType: msi
   Scope: machine
-  InstallerUrl: https://zoom.us/client/latest/ZoomInstallerFull.msi?archType=x64
-  InstallerUrl2: https://cdn.zoom.us/prod/5.15.7.20303/x64/ZoomInstallerFull.msi
+  InstallerUrl: https://cdn.zoom.us/prod/5.15.7.20303/x64/ZoomInstallerFull.msi
   InstallerSha256: 7F36F496622EE34E57986E664EC0751385EB9A5E486052B5515F81900B975B27
   ProductCode: '{FB1B7479-8D2D-4761-818A-B1762E5287D3}'
   AppsAndFeaturesEntries:
@@ -89,8 +84,7 @@ Installers:
 - Architecture: arm64
   InstallerType: msi
   Scope: machine
-  InstallerUrl: https://zoom.us/client/latest/ZoomInstallerFull.msi?archType=winarm64
-  InstallerUrl2: https://cdn.zoom.us/prod/5.15.7.20303/arm64/ZoomInstallerFull.msi
+  InstallerUrl: https://cdn.zoom.us/prod/5.15.7.20303/arm64/ZoomInstallerFull.msi
   InstallerSha256: 5B1AAAC361524A08EBE5D14DD246A4DC3E30CB9B920932041BB94E1EA862C069
   ProductCode: '{99C5D7D1-71C3-45DE-AB61-89824DEB6E4E}'
   AppsAndFeaturesEntries:

--- a/manifests/z/Zoom/Zoom/5.15.7.20303/Zoom.Zoom.installer.yaml
+++ b/manifests/z/Zoom/Zoom/5.15.7.20303/Zoom.Zoom.installer.yaml
@@ -1,6 +1,5 @@
 # Created using wingetcreate 1.5.1.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
-# InstallerUrl will be used as default all the time. If the InstallerUrl redirect link moved to new version location, InstallerUrl2 will take place InstallerUrl if the PackageVersion of application is present in the manifests.
 
 PackageIdentifier: Zoom.Zoom
 PackageVersion: 5.15.7.20303


### PR DESCRIPTION
It look like Zoom.Zoom 5.15.7.20303 is changing to permanent URL. So, Installing previous version can work

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/117809)