### PR TITLE
New version: FastCopy.IPMsg version 5.6.2

### DIFF
--- a/manifests/f/FastCopy/IPMsg/5.6.2/FastCopy.IPMsg.installer.yaml
+++ b/manifests/f/FastCopy/IPMsg/5.6.2/FastCopy.IPMsg.installer.yaml
@@ -1,0 +1,17 @@
+# Created using wingetcreate 1.5.2.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+
+PackageIdentifier: FastCopy.IPMsg
+PackageVersion: 5.6.2
+MinimumOSVersion: 10.0.0.0
+InstallerType: exe
+Scope: user
+InstallerSwitches:
+  Silent: /SILENT
+  SilentWithProgress: /SILENT
+Installers:
+- Architecture: x86
+  InstallerUrl: https://raw.githubusercontent.com/FastCopyLab/IPMsgDist/main/ipmsg5.6.2_installer.exe
+  InstallerSha256: 2242A3D5ABFBC22B10CC5FDE385D41C0735A333B443B9889E16BD4318EB68E79
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/f/FastCopy/IPMsg/5.6.2/FastCopy.IPMsg.locale.ja-JP.yaml
+++ b/manifests/f/FastCopy/IPMsg/5.6.2/FastCopy.IPMsg.locale.ja-JP.yaml
@@ -1,0 +1,14 @@
+# Created using wingetcreate 1.5.2.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+
+PackageIdentifier: FastCopy.IPMsg
+PackageVersion: 5.6.2
+PackageLocale: ja-JP
+Publisher: H.Shirouzu & FastCopy Lab, LLC.
+PackageName: IP Messenger for Win
+PackageUrl: https://github.com/FastCopyLab/IPMsgDist
+License: Freeware
+ShortDescription: Serverless lightweight Messenger for LAN.
+Moniker: ipmsg
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/f/FastCopy/IPMsg/5.6.2/FastCopy.IPMsg.yaml
+++ b/manifests/f/FastCopy/IPMsg/5.6.2/FastCopy.IPMsg.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.5.2.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+
+PackageIdentifier: FastCopy.IPMsg
+PackageVersion: 5.6.2
+DefaultLocale: ja-JP
+ManifestType: version
+ManifestVersion: 1.5.0


### PR DESCRIPTION
Most of the publisher build website on Github. Windows can install .exe, .msi, .appx, .msix, .appxbundle, .msixbundle, .zip. Sometimes, the app can be found github.com/%Author%/%AppName%/raw/%First_Branch%/%AppName%%Version%
or
github.com/%Author%/%AppName%/releases
So, In this case of the repo the application in the main branch if FastCopyLab/IPMsgDist
When you are in the branch, you might saw tree/master or blob/main
So, the download URL is github.com/FastCopyLab/IPMsgDist/raw/main/IPMsg5.6.2_installer.exe
If any repo same inside the main branch, github.com/FastCopyLab/FastCopyDist2/raw/main/FastCopy5.3.0_installer.exe
If all of them above is no, the application will be in releases directory on github.
Some example of  github.com/FastCopyLab/IPMsgDist/releases 
will go to app release directory. Normally, some of author put .exe, appx, .msix, .msixbundle, .deb, .tar, .appxbundle, .ps1. Less of the author will put hashes in release directory like .txt, .sha256, .sha1, .md5, .txt. A few of author will put .xml, .docx, .msu in the file . Most of author did not put release file there. 81.5% in githjub

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/117881)