### PR TITLE
Remove DisplayVersion equal to PackageVersion

### DIFF
--- a/manifests/t/Tgstation/Server/5.13.3/Tgstation.Server.installer.yaml
+++ b/manifests/t/Tgstation/Server/5.13.3/Tgstation.Server.installer.yaml
@@ -17,7 +17,7 @@ Installers:
   Dependencies:
     PackageDependencies:
     - PackageIdentifier: Microsoft.DotNet.HostingBundle.6
-  ProductCode: '{D24887FA-3228-4509-B5F3-4E07E349F278}'
+  ProductCode: '{5E37CC87-1B06-432A-BF53-FB7EA95A5DFF}'
   UnsupportedOSArchitectures:
   - arm
   - arm64

--- a/manifests/t/Tgstation/Server/5.13.3/Tgstation.Server.installer.yaml
+++ b/manifests/t/Tgstation/Server/5.13.3/Tgstation.Server.installer.yaml
@@ -24,7 +24,6 @@ Installers:
   AppsAndFeaturesEntries:
   - DisplayName: tgstation-server
     Publisher: /tg/station 13
-    DisplayVersion: 5.13.3
   ElevationRequirement: elevatesSelf
   ReleaseDate: 2023-07-17
 ManifestType: installer


### PR DESCRIPTION
DisplayVersion should not be used when it's equal to PackageVersion. See https://github.com/microsoft/winget-pkgs/pull/65816#issue-1301301147

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/118056)