### PR TITLE
Remove DisplayVersion equal to PackageVersion

### DIFF
--- a/manifests/t/Tgstation/Server/5.13.5/Tgstation.Server.installer.yaml
+++ b/manifests/t/Tgstation/Server/5.13.5/Tgstation.Server.installer.yaml
@@ -17,14 +17,13 @@ Installers:
   Dependencies:
     PackageDependencies:
     - PackageIdentifier: Microsoft.DotNet.HostingBundle.6
-  ProductCode: '{D24887FA-3228-4509-B5F3-4E07E349F278}'
+  ProductCode: '{9BEE0A18-B585-482A-8365-39527A33DF84}'
   UnsupportedOSArchitectures:
   - arm
   - arm64
   AppsAndFeaturesEntries:
   - DisplayName: tgstation-server
     Publisher: /tg/station 13
-    DisplayVersion: 5.13.5
   ElevationRequirement: elevatesSelf
   ReleaseDate: 2023-08-12
 ManifestType: installer


### PR DESCRIPTION
DisplayVersion should not be used when it's equal to PackageVersion. See https://github.com/microsoft/winget-pkgs/pull/65816#issue-1301301147

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/118058)