### PR TITLE
New version: Azul.Zulu.11.JDK version 11.66.15

### DIFF
--- a/manifests/a/Azul/Zulu/11/JDK/11.66.15/Azul.Zulu.11.JDK.installer.yaml
+++ b/manifests/a/Azul/Zulu/11/JDK/11.66.15/Azul.Zulu.11.JDK.installer.yaml
@@ -1,0 +1,38 @@
+# Created with Komac v1.10.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+
+PackageIdentifier: Azul.Zulu.11.JDK
+PackageVersion: 11.66.15
+InstallerLocale: en-US
+InstallerType: wix
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Commands:
+- java
+FileExtensions:
+- class
+- jad
+- jar
+- java
+- jsp
+Installers:
+- Architecture: x86
+  InstallerUrl: https://cdn.azul.com/zulu/bin/zulu11.66.15-ca-jdk11.0.20-win_x64.msi
+  InstallerSha256: 4723A8DFA9F626E250F0C68FF6A6D2AEA7463AABADA77C484519C2B512091F76
+  AppsAndFeaturesEntries:
+  - DisplayName: Azul Zulu JDK 11.66.15 (11.0.20), 64-bit
+    ProductCode: '{FABF5FDB-0580-43D8-B8D4-8B16D0EECAB6}'
+    UpgradeCode: '{14866D8E-52CD-4E5F-BE07-CFE4D198912E}'
+- Architecture: x86
+  InstallerUrl: https://cdn.azul.com/zulu/bin/zulu11.66.15-ca-jdk11.0.20-win_i686.msi
+  InstallerSha256: D95F6F5B46963F270DB6FEDA78B3A975D36DB4968A37AD59D4A98CDF023D779F
+  AppsAndFeaturesEntries:
+  - DisplayName: Azul Zulu JDK 11.66.15 (11.0.20), 32-bit
+    ProductCode: '{A628A8BA-6781-409B-B305-F51AFA97D916}'
+    UpgradeCode: '{2F9117E9-6467-43C9-8BF1-ECDD8C2F3AF4}'
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/a/Azul/Zulu/11/JDK/11.66.15/Azul.Zulu.11.JDK.installer.yaml
+++ b/manifests/a/Azul/Zulu/11/JDK/11.66.15/Azul.Zulu.11.JDK.installer.yaml
@@ -20,7 +20,7 @@ FileExtensions:
 - java
 - jsp
 Installers:
-- Architecture: x86
+- Architecture: x64
   InstallerUrl: https://cdn.azul.com/zulu/bin/zulu11.66.15-ca-jdk11.0.20-win_x64.msi
   InstallerSha256: 4723A8DFA9F626E250F0C68FF6A6D2AEA7463AABADA77C484519C2B512091F76
   AppsAndFeaturesEntries:

--- a/manifests/a/Azul/Zulu/11/JDK/11.66.15/Azul.Zulu.11.JDK.locale.en-US.yaml
+++ b/manifests/a/Azul/Zulu/11/JDK/11.66.15/Azul.Zulu.11.JDK.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# Created with Komac v1.10.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+
+PackageIdentifier: Azul.Zulu.11.JDK
+PackageVersion: 11.66.15
+PackageLocale: en-US
+Publisher: Azul Systems, Inc.
+PublisherUrl: https://www.azul.com
+PublisherSupportUrl: https://www.azul.com/support
+PrivacyUrl: https://www.azul.com/privacy-policy
+Author: Azul Systems, Inc.
+PackageName: Azul Zulu JDK 11
+PackageUrl: https://www.azul.com/downloads/?package=jdk
+License: GPL 2 with Classpath Exception
+LicenseUrl: https://docs.azul.com/core/tpl
+Copyright: Copyright (c) 2013-2022, Azul Systems, Inc.
+ShortDescription: Azul Zulu 11 is a build of OpenJDK 11
+Moniker: zulu-jdk-11
+Tags:
+- java
+- jdk
+- openjdk
+- zulu
+ReleaseNotesUrl: https://docs.azul.com/core/zulu-openjdk/release-notes/july-2023
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/a/Azul/Zulu/11/JDK/11.66.15/Azul.Zulu.11.JDK.yaml
+++ b/manifests/a/Azul/Zulu/11/JDK/11.66.15/Azul.Zulu.11.JDK.yaml
@@ -1,0 +1,8 @@
+# Created with Komac v1.10.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+
+PackageIdentifier: Azul.Zulu.11.JDK
+PackageVersion: 11.66.15
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0


### PR DESCRIPTION
Updates Azul.Zulu.11.JDK to 11.66.15
Adds support for x64 installation.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/118064)