### PR TITLE
Add WindowsWDK as a versioned package (22000)

### DIFF
--- a/manifests/m/Microsoft/WindowsWDK/10/0/22000/10.1.22000.1/Microsoft.WindowsWDK.10.0.22000.installer.yaml
+++ b/manifests/m/Microsoft/WindowsWDK/10/0/22000/10.1.22000.1/Microsoft.WindowsWDK.10.0.22000.installer.yaml
@@ -1,0 +1,18 @@
+# Created using wingetcreate 1.5.2.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+
+PackageIdentifier: Microsoft.WindowsWDK.10.0.22000
+PackageVersion: 10.1.22000.1
+MinimumOSVersion: 10.0.0.0
+InstallerType: burn
+InstallerSwitches:
+  Silent: /q
+  SilentWithProgress: /q
+  Log: " "
+UpgradeBehavior: uninstallPrevious
+Installers:
+- Architecture: x86
+  InstallerUrl: https://download.microsoft.com/download/7/d/6/7d602355-8ae9-414c-ae36-109ece2aade6/wdk/wdksetup.exe
+  InstallerSha256: 6538402F1D71836D5B9C2B9A705A2599F2FC2D03A9616B33BCA3D9D9768CA374
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/m/Microsoft/WindowsWDK/10/0/22000/10.1.22000.1/Microsoft.WindowsWDK.10.0.22000.locale.en-US.yaml
+++ b/manifests/m/Microsoft/WindowsWDK/10/0/22000/10.1.22000.1/Microsoft.WindowsWDK.10.0.22000.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created using wingetcreate 1.5.2.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+
+PackageIdentifier: Microsoft.WindowsWDK.10.0.22000
+PackageVersion: 10.1.22000.1
+PackageLocale: en-US
+Publisher: Microsoft Corporation
+PublisherUrl: https://www.microsoft.com/en-us/
+PublisherSupportUrl: https://support.microsoft.com/en-us
+PrivacyUrl: https://privacy.microsoft.com/en-us/privacystatement
+Author: Microsoft Corporation
+PackageName: Windows Driver Kit - Windows 10.1.22000.1
+License: Proprietary
+Copyright: Copyright (c) Microsoft Corporation. All rights reserved.
+ShortDescription: The Windows Driver Kit is used to develop, test, and deploy Windows drivers.
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/m/Microsoft/WindowsWDK/10/0/22000/10.1.22000.1/Microsoft.WindowsWDK.10.0.22000.yaml
+++ b/manifests/m/Microsoft/WindowsWDK/10/0/22000/10.1.22000.1/Microsoft.WindowsWDK.10.0.22000.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.5.2.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+
+PackageIdentifier: Microsoft.WindowsWDK.10.0.22000
+PackageVersion: 10.1.22000.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0


### PR DESCRIPTION
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] This PR only modifies one (1) manifest
- [X] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [X] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

This change adds a new `Microsoft.WindowsWDK.10.0.22000` package intended to replace the non-versioned `Microsoft.WindowsWDK` package.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/118713)