### PR TITLE
Show Scope and Exclude Invisible Entries in SandboxTest

### DIFF
--- a/Tools/SandboxTest.ps1
+++ b/Tools/SandboxTest.ps1
@@ -212,8 +212,8 @@ function Update-EnvironmentVariables {
 function Get-ARPTable {
   $registry_paths = @('HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*','HKLM:\Software\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*', 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*', 'HKCU:\Software\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*')
   return Get-ItemProperty $registry_paths -ErrorAction SilentlyContinue |
-       Select-Object DisplayName, DisplayVersion, Publisher, @{N='ProductCode'; E={$_.PSChildName}} |
-       Where-Object {$null -ne $_.DisplayName }
+      Where-Object { $_.DisplayName -and (-not $_.SystemComponent -or $_.SystemComponent -ne 1 ) } |
+      Select-Object DisplayName, DisplayVersion, Publisher, @{N='ProductCode'; E={$_.PSChildName}}, @{N='Scope'; E={if($_.PSDrive.Name -eq 'HKCU') {'User'} else {'Machine'}}}
 }
 '@
 
@@ -268,7 +268,7 @@ Write-Host @'
 
 --> Comparing ARP Entries
 '@
-(Compare-Object (Get-ARPTable) `$originalARP -Property DisplayName,DisplayVersion,Publisher,ProductCode)| Select-Object -Property * -ExcludeProperty SideIndicator | Format-Table
+(Compare-Object (Get-ARPTable) `$originalARP -Property DisplayName,DisplayVersion,Publisher,ProductCode,Scope)| Select-Object -Property * -ExcludeProperty SideIndicator | Format-Table
 
 "@
 }


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?

---

This patch:
- Exclude ARP entries that have `SystemComponent` set to 1 and thus not displayed in "Programs and Features". This is useful for installers that write two entries, especially those built by Advanced Installer.
- Show the scope of the ARP entries for diagnosis purpose.

Before:
![image](https://github.com/microsoft/winget-pkgs/assets/56779163/328673d7-1797-4e28-849a-02182addafa7)

After:
![image](https://github.com/microsoft/winget-pkgs/assets/56779163/d7e999db-b290-4ed9-997a-3eec98f0764a)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/118742)