### PR TITLE
Update Betterbird to 102.15.1-bb41 and some misc changes

### DIFF
--- a/manifests/b/Betterbird/Betterbird/102.15.1-bb41/Betterbird.Betterbird.installer.yaml
+++ b/manifests/b/Betterbird/Betterbird/102.15.1-bb41/Betterbird.Betterbird.installer.yaml
@@ -6,6 +6,7 @@ PackageVersion: 102.15.1-bb41
 InstallerType: exe
 InstallerSwitches:
   Silent: /S
+  SilentWithProgress: /S
   InstallLocation: /InstallDirectoryPath=<INSTALLPATH>
 UpgradeBehavior: install
 AppsAndFeaturesEntries:

--- a/manifests/b/Betterbird/Betterbird/102.15.1-bb41/Betterbird.Betterbird.installer.yaml
+++ b/manifests/b/Betterbird/Betterbird/102.15.1-bb41/Betterbird.Betterbird.installer.yaml
@@ -1,0 +1,47 @@
+# Created with Komac v1.11.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+
+PackageIdentifier: Betterbird.Betterbird
+PackageVersion: 102.15.1-bb41
+InstallerType: exe
+InstallerSwitches:
+  Silent: /S
+  InstallLocation: /InstallDirectoryPath=<INSTALLPATH>
+UpgradeBehavior: install
+AppsAndFeaturesEntries:
+- DisplayVersion: 102.15.1
+Installers:
+- InstallerLocale: de-DE
+  Architecture: x64
+  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-102.15.1-bb41.de.win64.installer.exe
+  InstallerSha256: A05A475CD64D128AC210EB3C43C66386EB81C6451D94474E12E47E683FF18565
+- InstallerLocale: en-US
+  Architecture: x64
+  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-102.15.1-bb41.en-US.win64.installer.exe
+  InstallerSha256: 2810F9B5DC72DFA2997176BCBF4DD18003916FD8B7AA3DA7491BF95C61EED756
+- InstallerLocale: es-AR
+  Architecture: x64
+  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-102.15.1-bb41.es-AR.win64.installer.exe
+  InstallerSha256: 89BF69664F2C56702BAFE7F57F3EA798469C67D127AE2D8C121F4E9EF92FC948
+- InstallerLocale: fr-FR
+  Architecture: x64
+  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-102.15.1-bb41.fr.win64.installer.exe
+  InstallerSha256: A656D732F531407DA6EFCFD8C0F7BE921AB04CFFEBC12EAF00256ACFABC8761D
+- InstallerLocale: it-IT
+  Architecture: x64
+  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-102.15.1-bb41.it.win64.installer.exe
+  InstallerSha256: 0AC151B8B96D8394C8B9642B740C7A8990831842805F016959885FDA3CD297CE
+- InstallerLocale: ja-JP
+  Architecture: x64
+  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-102.15.1-bb41.ja.win64.installer.exe
+  InstallerSha256: 316A5AE7057E936728CAD7E3A57D2F408719F4891D0817D9883DF8CC17090616
+- InstallerLocale: nl-NL
+  Architecture: x64
+  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-102.15.1-bb41.nl.win64.installer.exe
+  InstallerSha256: FC86F50E20291A2946CE450909AB941F1730223BF6A9EE2B8064B3DBF16D15E7
+- InstallerLocale: pt-BR
+  Architecture: x64
+  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-102.15.1-bb41.pt-BR.win64.installer.exe
+  InstallerSha256: 63E71E14A3977BF08CE29BD382584F96774EC30BFEA8CECA34561EF3DF799F6D
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/b/Betterbird/Betterbird/102.15.1-bb41/Betterbird.Betterbird.locale.de.yaml
+++ b/manifests/b/Betterbird/Betterbird/102.15.1-bb41/Betterbird.Betterbird.locale.de.yaml
@@ -1,0 +1,9 @@
+# Created with Komac v1.11.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.5.0.schema.json
+
+PackageIdentifier: Betterbird.Betterbird
+PackageVersion: 102.15.1-bb41
+PackageLocale: de
+ShortDescription: Betterbird ist eine Variante (Fork) von Mozilla Thunderbird, der zusätzliche Features und Bugfixes enthält.
+ManifestType: locale
+ManifestVersion: 1.5.0

--- a/manifests/b/Betterbird/Betterbird/102.15.1-bb41/Betterbird.Betterbird.locale.en-US.yaml
+++ b/manifests/b/Betterbird/Betterbird/102.15.1-bb41/Betterbird.Betterbird.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# Created with Komac v1.11.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+
+PackageIdentifier: Betterbird.Betterbird
+PackageVersion: 102.15.1-bb41
+PackageLocale: en-US
+Publisher: Betterbird Project
+PublisherUrl: https://www.betterbird.eu
+PublisherSupportUrl: https://www.betterbird.eu/support/index.html
+PrivacyUrl: https://www.betterbird.eu/legal/index.html
+PackageName: Betterbird
+License: Mozilla Public License Version 2.0
+LicenseUrl: https://www.mozilla.org/MPL/2.0
+CopyrightUrl: https://www.betterbird.eu/legal/index.html
+ShortDescription: Betterbird is a fork of Mozilla Thunderbird with additional features and bugfixes.
+Moniker: betterbird
+Tags:
+- e-mail
+- fork
+- mail
+- mozilla
+- thunderbird
+Documentations:
+- DocumentLabel: FAQ
+  DocumentUrl: https://betterbird.eu/faq/index.html
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/b/Betterbird/Betterbird/102.15.1-bb41/Betterbird.Betterbird.locale.es-AR.yaml
+++ b/manifests/b/Betterbird/Betterbird/102.15.1-bb41/Betterbird.Betterbird.locale.es-AR.yaml
@@ -1,0 +1,9 @@
+# Created with Komac v1.11.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.5.0.schema.json
+
+PackageIdentifier: Betterbird.Betterbird
+PackageVersion: 102.15.1-bb41
+PackageLocale: es-AR
+ShortDescription: Betterbird es una bifurcación de Mozilla Thunderbird con funciones y correcciones de errores adicionales.
+ManifestType: locale
+ManifestVersion: 1.5.0

--- a/manifests/b/Betterbird/Betterbird/102.15.1-bb41/Betterbird.Betterbird.locale.fr.yaml
+++ b/manifests/b/Betterbird/Betterbird/102.15.1-bb41/Betterbird.Betterbird.locale.fr.yaml
@@ -1,0 +1,9 @@
+# Created with Komac v1.11.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.5.0.schema.json
+
+PackageIdentifier: Betterbird.Betterbird
+PackageVersion: 102.15.1-bb41
+PackageLocale: fr
+ShortDescription: Betterbird est un fork de Mozilla Thunderbird avec des fonctionnalités et des corrections de bogues supplémentaires.
+ManifestType: locale
+ManifestVersion: 1.5.0

--- a/manifests/b/Betterbird/Betterbird/102.15.1-bb41/Betterbird.Betterbird.locale.it.yaml
+++ b/manifests/b/Betterbird/Betterbird/102.15.1-bb41/Betterbird.Betterbird.locale.it.yaml
@@ -1,0 +1,9 @@
+# Created with Komac v1.11.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.5.0.schema.json
+
+PackageIdentifier: Betterbird.Betterbird
+PackageVersion: 102.15.1-bb41
+PackageLocale: it
+ShortDescription: Betterbird è un fork di Mozilla Thunderbird con funzioni e correzioni di bug aggiuntive.
+ManifestType: locale
+ManifestVersion: 1.5.0

--- a/manifests/b/Betterbird/Betterbird/102.15.1-bb41/Betterbird.Betterbird.locale.nl.yaml
+++ b/manifests/b/Betterbird/Betterbird/102.15.1-bb41/Betterbird.Betterbird.locale.nl.yaml
@@ -1,0 +1,9 @@
+# Created with Komac v1.11.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.5.0.schema.json
+
+PackageIdentifier: Betterbird.Betterbird
+PackageVersion: 102.15.1-bb41
+PackageLocale: nl
+ShortDescription: Betterbird is een afsplitsing van Mozilla Thunderbird met extra functies en bugfixes.
+ManifestType: locale
+ManifestVersion: 1.5.0

--- a/manifests/b/Betterbird/Betterbird/102.15.1-bb41/Betterbird.Betterbird.locale.pt-BR.yaml
+++ b/manifests/b/Betterbird/Betterbird/102.15.1-bb41/Betterbird.Betterbird.locale.pt-BR.yaml
@@ -1,0 +1,9 @@
+# Created with Komac v1.11.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.5.0.schema.json
+
+PackageIdentifier: Betterbird.Betterbird
+PackageVersion: 102.15.1-bb41
+PackageLocale: pt-BR
+ShortDescription: Betterbird é um fork do Mozilla Thunderbird com recursos e correções de bugs adicionais.
+ManifestType: locale
+ManifestVersion: 1.5.0

--- a/manifests/b/Betterbird/Betterbird/102.15.1-bb41/Betterbird.Betterbird.yaml
+++ b/manifests/b/Betterbird/Betterbird/102.15.1-bb41/Betterbird.Betterbird.yaml
@@ -1,0 +1,8 @@
+# Created with Komac v1.11.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+
+PackageIdentifier: Betterbird.Betterbird
+PackageVersion: 102.15.1-bb41
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

I also updated the switches, added the displayversion mapping (it seems that no matter the locale, all apps are installed as "Betterbird (x64 en-US)", corrected the publisher, and removed duplicate fields from the locales.

Also, this installer only supports silent mode and interactive; is putting the silent arguments into silentwithprogress the only solution?

Another also: The app requests elevation; if it is rejected it installs in user mode and vice versa. Are there any custom options needed for this?

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/119776)