### PR TITLE
Cowabungalite | Remove itunes depedency as it's missing required part

### DIFF
--- a/manifests/a/Avangelista/CowabungaLite/1.0.0/Avangelista.CowabungaLite.installer.yaml
+++ b/manifests/a/Avangelista/CowabungaLite/1.0.0/Avangelista.CowabungaLite.installer.yaml
@@ -14,8 +14,9 @@ Installers:
     PortableCommandAlias: cowabungalite
   InstallerUrl: https://github.com/Avangelista/CowabungaLiteWindows/releases/download/1.0.0/CowabungaLite.zip
   InstallerSha256: 7EB2BAB003604682E9D5A9748A29AEC5FAB138AC4E2267E159C988A34ADE9E24
-  Dependencies:
-    PackageDependencies:
-      - PackageIdentifier: Apple.iTunes
+# This can be uncommented once we can use mixed sources
+#  Dependencies:
+#    PackageDependencies:
+#      - PackageIdentifier: 9PB2MZ1ZMB1S # Apple.iTunes doesn't have the required package installed
 ManifestType: installer
 ManifestVersion: 1.4.0


### PR DESCRIPTION
- [ x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x ] This PR only modifies one (1) manifest
- [x ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x ] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

So i had to comment this part out, b/c some parts that itunes uses to talk to the iPhone aren't installed using winget from the source winget/none-microsoft store.
I left what should be configured as a comment, incase mixed sources are allowed. For now users would only need to install the itunes depency seperatly (which really isn't much of a deal breaker)

Hope this is ok to submit, the app will startup but can't really be used beyond that.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/120958)