### PR TITLE
PDFsam: Skip opening "Thanks" webpage after silent install

### DIFF
--- a/manifests/p/PDFsam/PDFsam/5.1.3.0/PDFsam.PDFsam.installer.yaml
+++ b/manifests/p/PDFsam/PDFsam/5.1.3.0/PDFsam.PDFsam.installer.yaml
@@ -10,6 +10,9 @@ InstallModes:
 - interactive
 - silent
 - silentWithProgress
+InstallerSwitches:
+  Silent: '/qn SKIPTHANKSPAGE=Yes'
+  SilentWithProgress: '/qb SKIPTHANKSPAGE=Yes'
 UpgradeBehavior: install
 ProductCode: '{6CC93D0A-AE26-4E1C-ABD5-DDC7B8F11B9A}'
 ReleaseDate: 2023-08-03


### PR DESCRIPTION
By default, the PDFsam installer opens https://pdfsam.org/thanks/ in the web browser at the conclusion of the installation process, which is distracting and renders the process not-completely-silent.
So this PR now sets the property `SKIPTHANKSPAGE=Yes` in the MSI installer, via a command-line switch, to remedy the issue.
The property is documented in https://github.com/torakiki/pdfsam/wiki/Properties-and-arguments#msi-properties

By experimentation, I also determined that, since we're now explicitly setting switches, explicitly setting `/qn` seems to be necessary to suppress the installer UI (which was already suppressed prior to this PR...somehow).

I don't know how to invoke winget in silent-with-progress mode to test the `SilentWithProgress` value.

---

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/121073)