### PR TITLE
Update dependency for Microsoft.WindowsTerminal version 1.18.2681.0

### DIFF
--- a/manifests/m/Microsoft/WindowsTerminal/1.18.2681.0/Microsoft.WindowsTerminal.installer.yaml
+++ b/manifests/m/Microsoft/WindowsTerminal/1.18.2681.0/Microsoft.WindowsTerminal.installer.yaml
@@ -16,7 +16,7 @@ PackageFamilyName: Microsoft.WindowsTerminal_8wekyb3d8bbwe
 Dependencies:
   PackageDependencies:
     - PackageIdentifier: Microsoft.UI.Xaml.2.8
-      MinimumVersion: 2.8.4
+      MinimumVersion: 8.2306.22001.0
 Installers:
 - Architecture: x86
   InstallerUrl: https://github.com/microsoft/terminal/releases/download/v1.18.2681.0/Microsoft.WindowsTerminal_1.18.2681.0_8wekyb3d8bbwe.msixbundle


### PR DESCRIPTION
The previous PR for Windows Terminal referenced UI Xaml 2.8 version 2.8.4

Because WinGet wasn't able to detect that UI Xaml 2.8 was installed, the manifest for Microsoft.UI.Xaml.2.8 was updated to use the full version and not contain AppsAndFeaturesEntries. This did not break anything, since the new version was greater than 2.8.4.

This PR updates the Windows Terminal manifest to reference the full version number just so that everything is consistent.

![image](https://github.com/microsoft/winget-pkgs/assets/12611259/e71cd869-fdab-4653-919c-4b1819b61902)


cc @denelon
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/121107)