### PR TITLE
Update Betterbird to 115

### DIFF
--- a/manifests/b/Betterbird/Betterbird/115.3.1-bb14/Betterbird.Betterbird.installer.yaml
+++ b/manifests/b/Betterbird/Betterbird/115.3.1-bb14/Betterbird.Betterbird.installer.yaml
@@ -1,0 +1,48 @@
+# Created with Komac v1.11.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+
+PackageIdentifier: Betterbird.Betterbird
+PackageVersion: 115.3.1-bb14
+InstallerType: exe
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+  InstallLocation: /InstallDirectoryPath=<INSTALLPATH>
+UpgradeBehavior: install
+AppsAndFeaturesEntries:
+- DisplayVersion: 102.15.1
+Installers:
+- InstallerLocale: de-DE
+  Architecture: x64
+  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.3.1-bb14.de.win64.installer.exe
+  InstallerSha256: D6EB8C528B2D23953EE1039AF5653925950F684B481F75D27A16BFE5B832155D
+- InstallerLocale: en-US
+  Architecture: x64
+  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.3.1-bb14.en-US.win64.installer.exe
+  InstallerSha256: E889E68A22623D7012A4B913B441548205093D74F2E120A42FF7C309DF6CD369
+- InstallerLocale: es-AR
+  Architecture: x64
+  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.3.1-bb14.es-AR.win64.installer.exe
+  InstallerSha256: BAE9D5C72DEBCF4A0F363FA06DA332065497A5710EFDC3A5FEFDC607D63F8853
+- InstallerLocale: fr-FR
+  Architecture: x64
+  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.3.1-bb14.fr.win64.installer.exe
+  InstallerSha256: 6970CBAEF2904FCF88B108618E09580C9E4044A1FA8DCF793E3F878FCFAA7872
+- InstallerLocale: it-IT
+  Architecture: x64
+  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.3.1-bb14.it.win64.installer.exe
+  InstallerSha256: BFCBCBB43646D479043F908086784D03A7E36F1B598260E60D20142125BBC47D
+- InstallerLocale: ja-JP
+  Architecture: x64
+  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.3.1-bb14.ja.win64.installer.exe
+  InstallerSha256: FE7F0F3247E99FF1DE0DD94F9C003EE50C128FAFEF9D6844E1068F8AEC3032BC
+- InstallerLocale: nl-NL
+  Architecture: x64
+  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.3.1-bb14.nl.win64.installer.exe
+  InstallerSha256: 77E5485B93635790FAED2E81047360AA182A778974644E79F0C4F0B3C24B85B9
+- InstallerLocale: pt-BR
+  Architecture: x64
+  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.3.1-bb14.pt-BR.win64.installer.exe
+  InstallerSha256: 35387EEA01B0BCF2DBFC7B9F2D10EFEDEC881F75A03735389E4AAD2B68B272A0
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/b/Betterbird/Betterbird/115.3.1-bb14/Betterbird.Betterbird.installer.yaml
+++ b/manifests/b/Betterbird/Betterbird/115.3.1-bb14/Betterbird.Betterbird.installer.yaml
@@ -10,7 +10,7 @@ InstallerSwitches:
   InstallLocation: /InstallDirectoryPath=<INSTALLPATH>
 UpgradeBehavior: install
 AppsAndFeaturesEntries:
-- DisplayVersion: 102.15.1
+- DisplayVersion: 115.3.1
 Installers:
 - InstallerLocale: de-DE
   Architecture: x64

--- a/manifests/b/Betterbird/Betterbird/115.3.1-bb14/Betterbird.Betterbird.locale.de.yaml
+++ b/manifests/b/Betterbird/Betterbird/115.3.1-bb14/Betterbird.Betterbird.locale.de.yaml
@@ -1,0 +1,9 @@
+# Created with Komac v1.11.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.5.0.schema.json
+
+PackageIdentifier: Betterbird.Betterbird
+PackageVersion: 115.3.1-bb14
+PackageLocale: de
+ShortDescription: Betterbird ist eine Variante (Fork) von Mozilla Thunderbird, der zusätzliche Features und Bugfixes enthält.
+ManifestType: locale
+ManifestVersion: 1.5.0

--- a/manifests/b/Betterbird/Betterbird/115.3.1-bb14/Betterbird.Betterbird.locale.en-US.yaml
+++ b/manifests/b/Betterbird/Betterbird/115.3.1-bb14/Betterbird.Betterbird.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# Created with Komac v1.11.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+
+PackageIdentifier: Betterbird.Betterbird
+PackageVersion: 115.3.1-bb14
+PackageLocale: en-US
+Publisher: Betterbird Project
+PublisherUrl: https://www.betterbird.eu
+PublisherSupportUrl: https://www.betterbird.eu/support/index.html
+PrivacyUrl: https://www.betterbird.eu/legal/index.html
+PackageName: Betterbird
+License: Mozilla Public License Version 2.0
+LicenseUrl: https://www.mozilla.org/MPL/2.0
+CopyrightUrl: https://www.betterbird.eu/legal/index.html
+ShortDescription: Betterbird is a fork of Mozilla Thunderbird with additional features and bugfixes.
+Moniker: betterbird
+Tags:
+- e-mail
+- fork
+- mail
+- mozilla
+- thunderbird
+Documentations:
+- DocumentLabel: FAQ
+  DocumentUrl: https://betterbird.eu/faq/index.html
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/b/Betterbird/Betterbird/115.3.1-bb14/Betterbird.Betterbird.locale.es-AR.yaml
+++ b/manifests/b/Betterbird/Betterbird/115.3.1-bb14/Betterbird.Betterbird.locale.es-AR.yaml
@@ -1,0 +1,9 @@
+# Created with Komac v1.11.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.5.0.schema.json
+
+PackageIdentifier: Betterbird.Betterbird
+PackageVersion: 115.3.1-bb14
+PackageLocale: es-AR
+ShortDescription: Betterbird es una bifurcación de Mozilla Thunderbird con funciones y correcciones de errores adicionales.
+ManifestType: locale
+ManifestVersion: 1.5.0

--- a/manifests/b/Betterbird/Betterbird/115.3.1-bb14/Betterbird.Betterbird.locale.fr.yaml
+++ b/manifests/b/Betterbird/Betterbird/115.3.1-bb14/Betterbird.Betterbird.locale.fr.yaml
@@ -1,0 +1,9 @@
+# Created with Komac v1.11.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.5.0.schema.json
+
+PackageIdentifier: Betterbird.Betterbird
+PackageVersion: 115.3.1-bb14
+PackageLocale: fr
+ShortDescription: Betterbird est un fork de Mozilla Thunderbird avec des fonctionnalités et des corrections de bogues supplémentaires.
+ManifestType: locale
+ManifestVersion: 1.5.0

--- a/manifests/b/Betterbird/Betterbird/115.3.1-bb14/Betterbird.Betterbird.locale.it.yaml
+++ b/manifests/b/Betterbird/Betterbird/115.3.1-bb14/Betterbird.Betterbird.locale.it.yaml
@@ -1,0 +1,9 @@
+# Created with Komac v1.11.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.5.0.schema.json
+
+PackageIdentifier: Betterbird.Betterbird
+PackageVersion: 115.3.1-bb14
+PackageLocale: it
+ShortDescription: Betterbird è un fork di Mozilla Thunderbird con funzioni e correzioni di bug aggiuntive.
+ManifestType: locale
+ManifestVersion: 1.5.0

--- a/manifests/b/Betterbird/Betterbird/115.3.1-bb14/Betterbird.Betterbird.locale.nl.yaml
+++ b/manifests/b/Betterbird/Betterbird/115.3.1-bb14/Betterbird.Betterbird.locale.nl.yaml
@@ -1,0 +1,9 @@
+# Created with Komac v1.11.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.5.0.schema.json
+
+PackageIdentifier: Betterbird.Betterbird
+PackageVersion: 115.3.1-bb14
+PackageLocale: nl
+ShortDescription: Betterbird is een afsplitsing van Mozilla Thunderbird met extra functies en bugfixes.
+ManifestType: locale
+ManifestVersion: 1.5.0

--- a/manifests/b/Betterbird/Betterbird/115.3.1-bb14/Betterbird.Betterbird.locale.pt-BR.yaml
+++ b/manifests/b/Betterbird/Betterbird/115.3.1-bb14/Betterbird.Betterbird.locale.pt-BR.yaml
@@ -1,0 +1,9 @@
+# Created with Komac v1.11.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.5.0.schema.json
+
+PackageIdentifier: Betterbird.Betterbird
+PackageVersion: 115.3.1-bb14
+PackageLocale: pt-BR
+ShortDescription: Betterbird é um fork do Mozilla Thunderbird com recursos e correções de bugs adicionais.
+ManifestType: locale
+ManifestVersion: 1.5.0

--- a/manifests/b/Betterbird/Betterbird/115.3.1-bb14/Betterbird.Betterbird.yaml
+++ b/manifests/b/Betterbird/Betterbird/115.3.1-bb14/Betterbird.Betterbird.yaml
@@ -1,0 +1,8 @@
+# Created with Komac v1.11.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+
+PackageIdentifier: Betterbird.Betterbird
+PackageVersion: 115.3.1-bb14
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---
Betterbird has released a new stable version. Now that all the previous versions are EOL (yes) should they (except the last 102 release) be removed?

Also, smartscreen triggered when installing locally. Is that of concern?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/121243)