### PR TITLE
update osfmount manifest to 3.1.1002.0

### DIFF
--- a/manifests/p/PassmarkSoftware/OSFMount/3.1.1002.0/PassmarkSoftware.OSFMount.installer.yaml
+++ b/manifests/p/PassmarkSoftware/OSFMount/3.1.1002.0/PassmarkSoftware.OSFMount.installer.yaml
@@ -2,11 +2,11 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.0.0.schema.json
 
 PackageIdentifier: PassmarkSoftware.OSFMount
-PackageVersion: 3.1.1001.0
+PackageVersion: 3.1.1002.0
 Installers:
 - Architecture: x64
   InstallerType: inno
   InstallerUrl: https://www.osforensics.com/downloads/osfmount.exe
-  InstallerSha256: FD4012A9DF1E1FCD93E473E4498E51D19A2AFD9379CD657DB1CC023E3C0DC7D6
+  InstallerSha256: A67E2D31CE96488EDE8D9CDD896D368821AAD4CBBD9A78D394ED29AC17A13914
 ManifestType: installer
 ManifestVersion: 1.0.0

--- a/manifests/p/PassmarkSoftware/OSFMount/3.1.1002.0/PassmarkSoftware.OSFMount.locale.en-US.yaml
+++ b/manifests/p/PassmarkSoftware/OSFMount/3.1.1002.0/PassmarkSoftware.OSFMount.locale.en-US.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.0.0.schema.json
 
 PackageIdentifier: PassmarkSoftware.OSFMount
-PackageVersion: 3.1.1001.0
+PackageVersion: 3.1.1002.0
 PackageLocale: en-US
 Publisher: Passmark Software
 PackageName: OSFMount

--- a/manifests/p/PassmarkSoftware/OSFMount/3.1.1002.0/PassmarkSoftware.OSFMount.yaml
+++ b/manifests/p/PassmarkSoftware/OSFMount/3.1.1002.0/PassmarkSoftware.OSFMount.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.0.0.schema.json
 
 PackageIdentifier: PassmarkSoftware.OSFMount
-PackageVersion: 3.1.1001.0
+PackageVersion: 3.1.1002.0
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.0.0


### PR DESCRIPTION
changed 3.1.1001.0 to 3.1.1002.0 and fixed hash, since site does not offer old downloads making old manifests useless

- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/121266)