### PR TITLE
Fix GnuCash installer URL

### DIFF
--- a/manifests/g/GnuCash/GnuCash/5.4/GnuCash.GnuCash.installer.yaml
+++ b/manifests/g/GnuCash/GnuCash/5.4/GnuCash.GnuCash.installer.yaml
@@ -15,7 +15,7 @@ UpgradeBehavior: install
 ReleaseDate: 2023-09-24
 Installers:
 - Architecture: x86
-  InstallerUrl: https://github.com/Gnucash/gnucash/releases/download/5.4/gnucash-5.4.setup.exe
+  InstallerUrl: https://github.com/Gnucash/gnucash/releases/download/5.4/gnucash-5.4-1.setup.exe
   InstallerSha256: 5BFED628750FC034B56FC6285A1B7B0BF9BC8AA1D831E7A946D523BE27351D48
 ManifestType: installer
 ManifestVersion: 1.5.0

--- a/manifests/g/GnuCash/GnuCash/5.4/GnuCash.GnuCash.installer.yaml
+++ b/manifests/g/GnuCash/GnuCash/5.4/GnuCash.GnuCash.installer.yaml
@@ -16,6 +16,6 @@ ReleaseDate: 2023-09-24
 Installers:
 - Architecture: x86
   InstallerUrl: https://github.com/Gnucash/gnucash/releases/download/5.4/gnucash-5.4-1.setup.exe
-  InstallerSha256: 5BFED628750FC034B56FC6285A1B7B0BF9BC8AA1D831E7A946D523BE27351D48
+  InstallerSha256: E1925591BBDDDD80B1FF8DDF0634652EF098072BD96A5BB98F000CDCC5C841FF
 ManifestType: installer
 ManifestVersion: 1.5.0


### PR DESCRIPTION
The current install URL leads to a 404, preventing an update of GnuCash through winget.  The installer URL for GnuCash seems to have changed after release.

See the [Github Release](https://github.com/Gnucash/gnucash/releases/tag/5.4) to verify the adjusted URL is now the correct one.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/121452)