### PR TITLE
Update moniker for Python 3.11.2

### DIFF
--- a/manifests/p/Python/Python/3/11/3.11.2/Python.Python.3.11.locale.en-US.yaml
+++ b/manifests/p/Python/Python/3/11/3.11.2/Python.Python.3.11.locale.en-US.yaml
@@ -20,7 +20,7 @@ Copyright: |-
   Copyright (c) 1991-1995 Stichting Mathematisch Centrum, Amsterdam. All Rights Reserved.
 CopyrightUrl: https://www.python.org/about/legal/
 ShortDescription: Python is a programming language that lets you work more quickly and integrate your systems more effectively.
-Moniker: python3
+Moniker: python3.11
 Tags:
 - language
 - programming


### PR DESCRIPTION
3.12.0 is a stable release of python so `python3` moniker should be shifted to Python.Python.3.12 PackageId

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/121837)