### PR TITLE
Update moniker for Python 3.11.4

### DIFF
--- a/manifests/p/Python/Python/3/11/3.11.4/Python.Python.3.11.locale.en-US.yaml
+++ b/manifests/p/Python/Python/3/11/3.11.4/Python.Python.3.11.locale.en-US.yaml
@@ -21,7 +21,7 @@ Copyright: |-
 CopyrightUrl: https://www.python.org/about/legal/
 ShortDescription: Python is a programming language that lets you work more quickly and integrate your systems more effectively.
 # Description:
-Moniker: python3
+Moniker: python3.11
 Tags:
 - language
 - programming


### PR DESCRIPTION
3.12.0 is a stable release of python so `python3` moniker should be shifted to Python.Python.3.12 PackageId

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/121839)