### PR TITLE
Update Python.Python.3.12 version 3.12.0

### DIFF
--- a/manifests/p/Python/Python/3/12/3.12.0/Python.Python.3.12.installer.yaml
+++ b/manifests/p/Python/Python/3/12/3.12.0/Python.Python.3.12.installer.yaml
@@ -18,7 +18,6 @@ FileExtensions:
 - pyw
 - pyz
 - pyzw
-ElevationRequirement: elevatesSelf
 Installers:
 - Architecture: x86
   Scope: user
@@ -34,6 +33,7 @@ Installers:
     UpgradeCode: '{7D426D03-49F7-5C13-8BB0-53574B728B6E}'
 - Architecture: x86
   Scope: machine
+  ElevationRequirement: elevatesSelf
   InstallerUrl: https://www.python.org/ftp/python/3.12.0/python-3.12.0.exe
   InstallerSha256: 78FE137B4B78274E455CE678BA2E296CA7C3C6A0E53806BF09E4F8986B64C632
   InstallerSwitches:
@@ -52,6 +52,7 @@ Installers:
   InstallerSwitches:
     InstallLocation: DefaultJustForMeTargetDir=<INSTALLPATH>
     Custom: InstallAllUsers=0 PrependPath=1
+  ProductCode: '{cf9c4d97-48a7-4a27-b9fc-91b88a803c40}'
   AppsAndFeaturesEntries:
   - DisplayName: Python 3.12.0 (64-bit)
     DisplayVersion: 3.12.150.0
@@ -59,12 +60,13 @@ Installers:
     UpgradeCode: '{114AEC44-152B-5746-952F-F20CE3CAB54A}'
 - Architecture: x64
   Scope: machine
+  ElevationRequirement: elevatesSelf
   InstallerUrl: https://www.python.org/ftp/python/3.12.0/python-3.12.0-amd64.exe
   InstallerSha256: C6BDF93F4B2DE6DFA1A3A847E7C24AE10EDF7F6318653D452CD4381415700ADA
   InstallerSwitches:
     InstallLocation: DefaultAllUsersTargetDir=<INSTALLPATH>
     Custom: InstallAllUsers=1 PrependPath=1
-  ProductCode: '{2001d062-3b62-4fc6-a275-e9fa5ad9c809}'
+  ProductCode: '{cf9c4d97-48a7-4a27-b9fc-91b88a803c40}'
   AppsAndFeaturesEntries:
   - DisplayName: Python 3.12.0 (64-bit)
     DisplayVersion: 3.12.150.0
@@ -84,6 +86,7 @@ Installers:
     UpgradeCode: '{1C6E0C70-86FC-5723-BB61-9555AC97B97E}'
 - Architecture: arm64
   Scope: machine
+  ElevationRequirement: elevatesSelf
   InstallerUrl: https://www.python.org/ftp/python/3.12.0/python-3.12.0-arm64.exe
   InstallerSha256: 05EB076CE9FE248D4A6295F75BE328808B22877F9538CF9EFFE89938AEBC9532
   InstallerSwitches:


### PR DESCRIPTION
- Fix ProductCode
- Elevation is only required for `Scope: machine` installs

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/121843)