### PR TITLE
Update JetBrains.IntelliJIDEA.Community.installer.yaml

### DIFF
--- a/manifests/j/JetBrains/IntelliJIDEA/Community/2023.1/JetBrains.IntelliJIDEA.Community.installer.yaml
+++ b/manifests/j/JetBrains/IntelliJIDEA/Community/2023.1/JetBrains.IntelliJIDEA.Community.installer.yaml
@@ -17,7 +17,6 @@ FileExtensions:
 ReleaseDate: 2023-03-28
 AppsAndFeaturesEntries:
 - DisplayName: IntelliJ IDEA Community Edition 2023.1
-  DisplayVersion: 231.8109.175
   ProductCode: IntelliJ IDEA Community Edition 2023.1
 Installers:
 - Architecture: x64


### PR DESCRIPTION
"DisplayVersion" field with build number interferes with newer manifests, where DisplayVersion from ARP and PackageVersion are identical. The numbering scheme is incompatible and needs to be removed from this old manifest.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/121913)