### PR TITLE
Latest WinGet 1.6

### DIFF
--- a/manifests/m/Microsoft/AppInstaller/1.21.2721.0/Microsoft.AppInstaller.installer.yaml
+++ b/manifests/m/Microsoft/AppInstaller/1.21.2721.0/Microsoft.AppInstaller.installer.yaml
@@ -1,0 +1,29 @@
+# Created using wingetcreate 1.5.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+
+PackageIdentifier: Microsoft.AppInstaller
+PackageVersion: 1.21.2721.0
+Platform:
+- Windows.Universal
+MinimumOSVersion: 10.0.17763.0
+InstallerType: msix
+PackageFamilyName: Microsoft.DesktopAppInstaller_8wekyb3d8bbwe
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/microsoft/winget-cli/releases/download/v1.6.2721/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle
+  InstallerSha256: 820D6708D4AC09EFF314A989A7BBD6567C2A326316A31718072DBC8CECE8856F
+  SignatureSha256: 4291AAEFD266A306BE854CA1D942841EB6531B15FE2A9ECD9269AB484A018D41
+- Architecture: x64
+  InstallerUrl: https://github.com/microsoft/winget-cli/releases/download/v1.6.2721/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle
+  InstallerSha256: 820D6708D4AC09EFF314A989A7BBD6567C2A326316A31718072DBC8CECE8856F
+  SignatureSha256: 4291AAEFD266A306BE854CA1D942841EB6531B15FE2A9ECD9269AB484A018D41
+- Architecture: arm
+  InstallerUrl: https://github.com/microsoft/winget-cli/releases/download/v1.6.2721/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle
+  InstallerSha256: 820D6708D4AC09EFF314A989A7BBD6567C2A326316A31718072DBC8CECE8856F
+  SignatureSha256: 4291AAEFD266A306BE854CA1D942841EB6531B15FE2A9ECD9269AB484A018D41
+- Architecture: arm64
+  InstallerUrl: https://github.com/microsoft/winget-cli/releases/download/v1.6.2721/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle
+  InstallerSha256: 820D6708D4AC09EFF314A989A7BBD6567C2A326316A31718072DBC8CECE8856F
+  SignatureSha256: 4291AAEFD266A306BE854CA1D942841EB6531B15FE2A9ECD9269AB484A018D41
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/m/Microsoft/AppInstaller/1.21.2721.0/Microsoft.AppInstaller.locale.en-US.yaml
+++ b/manifests/m/Microsoft/AppInstaller/1.21.2721.0/Microsoft.AppInstaller.locale.en-US.yaml
@@ -1,0 +1,13 @@
+# Created using wingetcreate 1.5.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+
+PackageIdentifier: Microsoft.AppInstaller
+PackageVersion: 1.21.2721.0
+PackageLocale: en-US
+Publisher: Microsoft Corporation
+PackageName: App Installer (WinGet)
+License: MIT License
+ShortDescription: Microsoft App Installer for Windows 10 makes sideloading Windows 10 apps easy. Windows Package Manager (WinGet) is supported through App Installer starting on Windows 10 1809.
+Moniker: winget
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/m/Microsoft/AppInstaller/1.21.2721.0/Microsoft.AppInstaller.yaml
+++ b/manifests/m/Microsoft/AppInstaller/1.21.2721.0/Microsoft.AppInstaller.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.5.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+
+PackageIdentifier: Microsoft.AppInstaller
+PackageVersion: 1.21.2721.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0


### PR DESCRIPTION
Testing adding App Installer to community repository.

This should work for `winget upgrade winget` and `winget upgrade --all`

No dependencies are included since WinGet already has the dependencies if it's installed.

There is **NO** intention to support preview versions of WinGet.

This should work for `winget upgrade winget` and `winget upgrade --all`

Downgrading via this manifest is not supported.

- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/122011)