### PR TITLE
New version: Insecure.Npcap version 1.77

### DIFF
--- a/manifests/i/Insecure/Npcap/1.77/Insecure.Npcap.installer.yaml
+++ b/manifests/i/Insecure/Npcap/1.77/Insecure.Npcap.installer.yaml
@@ -5,8 +5,8 @@ PackageIdentifier: Insecure.Npcap
 PackageVersion: "1.77"
 InstallerType: nullsoft
 Installers:
-- Architecture: x64
-  InstallerUrl: http://matebook-x-pro/Programs/npcap-1.77.exe
-  InstallerSha256: 4B8896513505DDE38B8250BFBB1C413DEECDE78AABDA11F6A65C2EE250DDD79F
+  - Architecture: x64
+    InstallerUrl: https://npcap.com/dist/npcap-1.77.exe
+    InstallerSha256: 4B8896513505DDE38B8250BFBB1C413DEECDE78AABDA11F6A65C2EE250DDD79F
 ManifestType: installer
 ManifestVersion: 1.5.0

--- a/manifests/i/Insecure/Npcap/1.77/Insecure.Npcap.installer.yaml
+++ b/manifests/i/Insecure/Npcap/1.77/Insecure.Npcap.installer.yaml
@@ -1,0 +1,12 @@
+# Created using wingetcreate 1.5.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+
+PackageIdentifier: Insecure.Npcap
+PackageVersion: "1.77"
+InstallerType: nullsoft
+Installers:
+- Architecture: x64
+  InstallerUrl: http://matebook-x-pro/Programs/npcap-1.77.exe
+  InstallerSha256: 4B8896513505DDE38B8250BFBB1C413DEECDE78AABDA11F6A65C2EE250DDD79F
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/i/Insecure/Npcap/1.77/Insecure.Npcap.locale.en-US.yaml
+++ b/manifests/i/Insecure/Npcap/1.77/Insecure.Npcap.locale.en-US.yaml
@@ -1,0 +1,16 @@
+# Created using wingetcreate 1.5.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+
+PackageIdentifier: Insecure.Npcap
+PackageVersion: "1.77"
+PackageLocale: en-US
+Publisher: Insecure
+PublisherUrl: https://insecure.org/fyodor/
+PrivacyUrl: https://insecure.org/privacy.html
+PackageName: Npcap
+PackageUrl: https://nmap.org/npcap/
+License: Proprietary
+Copyright: Copyright 2016 Insecure.Com LLC ("The Nmap Project")
+ShortDescription: Nmap Project's Windows packet capture and transmission library
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/i/Insecure/Npcap/1.77/Insecure.Npcap.yaml
+++ b/manifests/i/Insecure/Npcap/1.77/Insecure.Npcap.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.5.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+
+PackageIdentifier: Insecure.Npcap
+PackageVersion: "1.77"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0


### PR DESCRIPTION
## What's changed

- Related #120225
- Bandwhich requires this package as a `PackageDepency`
- Previous version `0.86` does not contain `packet.dll`, which is required as a `WindowsLibrary` by Bandwhich
- Bandwhich is unable to launch without the latest Npcap

## Checks

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/122129)