### PR TITLE
New feature: New option for SandboxTest.ps1

### DIFF
--- a/Tools/SandboxTest.ps1
+++ b/Tools/SandboxTest.ps1
@@ -10,7 +10,9 @@ Param(
   [switch] $SkipManifestValidation,
   [switch] $Prerelease,
   [switch] $EnableExperimentalFeatures,
-  [string] $WinGetVersion
+  [string] $WinGetVersion,
+  [Parameter(HelpMessage = 'Additional options for WinGet')]
+  [string] $WinGetOptions
 )
 
 $ErrorActionPreference = 'Stop'
@@ -256,7 +258,7 @@ Write-Host @'
 --> Installing the Manifest $manifestFileName
 
 '@
-winget install -m '$manifestPathInSandbox' --verbose-logs --ignore-local-archive-malware-scan
+winget install -m '$manifestPathInSandbox' --verbose-logs --ignore-local-archive-malware-scan $WinGetOptions
 
 Write-Host @'
 
@@ -354,4 +356,3 @@ $Script
 Write-Host
 
 WindowsSandbox $SandboxTestWsbFile
-


### PR DESCRIPTION
## What's changed

- Resolve https://github.com/microsoft/winget-pkgs/issues/122102 .

This modify `Tools/SandboxTest.ps1`, it add a new `string` type option `-WinGetOptions` for the Powershell script.

Value of this option will passed to `winget.exe` directly in the local manifest installation section.

## Examples

```powershell
# You can explicitly test a 32-bit installer if you are using 64-bit host device.
PS> .\Tools\SandboxTest.ps1 -Manifests <path> -WinGetOptions "-a x86"

# You can explicitly test if "InstallPath" is valid for the manifest
PS> .\Tools\SandboxTest.ps1 -Manifests <path> -WinGetOptions "--location <target_path>`
```

## Checks

This pull request is NOT for manifest submission!

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/122289)