### PR TITLE
Update Microsoft.Teams to 23257.2618.2432.4374 (latest 2.1)

### DIFF
--- a/manifests/m/Microsoft/Teams/23257.2618.2432.4374/Microsoft.Teams.installer.yaml
+++ b/manifests/m/Microsoft/Teams/23257.2618.2432.4374/Microsoft.Teams.installer.yaml
@@ -1,0 +1,39 @@
+# Created using wingetcreate 1.5.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+
+PackageIdentifier: Microsoft.Teams
+PackageVersion: 23257.2618.2432.4374
+InstallerLocale: en-US
+UpgradeBehavior: install
+Installers:
+- Architecture: x86
+  InstallerType: msix
+  Scope: user
+  InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+  InstallerUrl: https://statics.teams.cdn.office.net/production-windows-x86/23257.2618.2432.4374/MSTeams-x86.msix
+  InstallerSha256: B234937E33D9F5C0F2E50313DB982B439EF246B68B30D6CB41AC5703FCA5911C
+- Architecture: x64
+  InstallerType: msix
+  Scope: user
+  InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+  InstallerUrl: https://statics.teams.cdn.office.net/production-windows-x64/23257.2618.2432.4374/MSTeams-x64.msix
+  InstallerSha256: 7096D314052F5C051455E2BFE9C50834E54282C4397B9334B9F37E379D57BA57
+- Architecture: arm64
+  InstallerType: msix
+  Scope: user
+  InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+  InstallerUrl: https://statics.teams.cdn.office.net/production-windows-arm64/23257.2618.2432.4374/MSTeams-arm64.msix
+  InstallerSha256: 3F4ADD5F73C04EBFF11971D5A0F221002B74715DB4AA731BE48D08DC1C862713
+ReleaseDate: 2023-10-08
+ReleaseNotesUrl: https://support.microsoft.com/en-US/office/neuerungen-in-microsoft-teams-d7092a6d-c896-424c-b362-a472d5f105de
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/m/Microsoft/Teams/23257.2618.2432.4374/Microsoft.Teams.installer.yaml
+++ b/manifests/m/Microsoft/Teams/23257.2618.2432.4374/Microsoft.Teams.installer.yaml
@@ -4,6 +4,7 @@
 PackageIdentifier: Microsoft.Teams
 PackageVersion: 23257.2618.2432.4374
 InstallerLocale: en-US
+MinimumOSVersion: 10.0.17763.0
 UpgradeBehavior: install
 PackageFamilyName: MSTeams_8wekyb3d8bbwe
 Installers:

--- a/manifests/m/Microsoft/Teams/23257.2618.2432.4374/Microsoft.Teams.installer.yaml
+++ b/manifests/m/Microsoft/Teams/23257.2618.2432.4374/Microsoft.Teams.installer.yaml
@@ -5,6 +5,7 @@ PackageIdentifier: Microsoft.Teams
 PackageVersion: 23257.2618.2432.4374
 InstallerLocale: en-US
 UpgradeBehavior: install
+PackageFamilyName: MSTeams_8wekyb3d8bbwe
 Installers:
 - Architecture: x86
   InstallerType: msix

--- a/manifests/m/Microsoft/Teams/23257.2618.2432.4374/Microsoft.Teams.locale.en-US.yaml
+++ b/manifests/m/Microsoft/Teams/23257.2618.2432.4374/Microsoft.Teams.locale.en-US.yaml
@@ -1,0 +1,38 @@
+# Created using wingetcreate 1.5.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+
+PackageIdentifier: Microsoft.Teams
+PackageVersion: 23257.2618.2432.4374
+PackageLocale: en-US
+Publisher: Microsoft Corporation
+PublisherUrl: https://www.microsoft.com/en-us
+PublisherSupportUrl: https://support.microsoft.com/en-us/teams
+PrivacyUrl: https://privacy.microsoft.com/en-us/privacystatement
+Author: Microsoft Corporation
+PackageName: Microsoft Teams
+PackageUrl: https://www.microsoft.com/en-us/microsoft-teams/group-chat-software
+License: Proprietary
+LicenseUrl: https://www.microsoft.com/en-us/legal/terms-of-use
+Copyright: (c) Microsoft Corporation. All rights reserved.
+CopyrightUrl: https://www.microsoft.com/en-us/legal/terms-of-use
+ShortDescription: Make amazing things happen together at home, work, and school.
+Description: Make amazing things happen together at home, work, and school.
+Moniker: teams
+Tags:
+- call
+- calling
+- chat
+- collaborate
+- collaboration
+- conferencing
+- meet
+- meetings
+- team
+- teams
+- video
+- video-conferencing
+- voice
+- voip
+- webinars
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/m/Microsoft/Teams/23257.2618.2432.4374/Microsoft.Teams.yaml
+++ b/manifests/m/Microsoft/Teams/23257.2618.2432.4374/Microsoft.Teams.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.5.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+
+PackageIdentifier: Microsoft.Teams
+PackageVersion: 23257.2618.2432.4374
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0


### PR DESCRIPTION
This update could be a breaking change for some users, since this is the first Version 2 release of Teams within winget. Here it has been switched to MSIX instead of a MSI machine wide installer. Therefore no machine (system) wide installer exists anymore.

- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/122377)