### PR TITLE
Moved Citrix.Workspace.LTSR

### DIFF
--- a/manifests/c/Citrix/WorkspaceLTSR/22.03.4000/Citrix.WorkspaceLTSR.installer.yaml
+++ b/manifests/c/Citrix/WorkspaceLTSR/22.03.4000/Citrix.WorkspaceLTSR.installer.yaml
@@ -1,7 +1,7 @@
 # Created using wingetcreate 1.2.8.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
 
-PackageIdentifier: Citrix.Workspace.LTSR
+PackageIdentifier: Citrix.WorkspaceLTSR
 PackageVersion: 22.03.4000
 Platform:
 - Windows.Desktop

--- a/manifests/c/Citrix/WorkspaceLTSR/22.03.4000/Citrix.WorkspaceLTSR.locale.en-US.yaml
+++ b/manifests/c/Citrix/WorkspaceLTSR/22.03.4000/Citrix.WorkspaceLTSR.locale.en-US.yaml
@@ -1,7 +1,7 @@
 # Created using wingetcreate 1.2.8.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.4.0.schema.json
 
-PackageIdentifier: Citrix.Workspace.LTSR
+PackageIdentifier: Citrix.WorkspaceLTSR
 PackageVersion: 22.03.4000
 PackageLocale: en-US
 Publisher: Citrix Systems, Inc.

--- a/manifests/c/Citrix/WorkspaceLTSR/22.03.4000/Citrix.WorkspaceLTSR.yaml
+++ b/manifests/c/Citrix/WorkspaceLTSR/22.03.4000/Citrix.WorkspaceLTSR.yaml
@@ -1,7 +1,7 @@
 # Created using wingetcreate 1.2.8.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.4.0.schema.json
 
-PackageIdentifier: Citrix.Workspace.LTSR
+PackageIdentifier: Citrix.WorkspaceLTSR
 PackageVersion: 22.03.4000
 DefaultLocale: en-US
 ManifestType: version


### PR DESCRIPTION
Moved it to its own folder(C/Citrix/WorkspaceLTSR). This is due to WInget-AutoUpdate ignoring it with its whitelist, most likely due to it being under Citrix.Workspace

- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] This PR only modifies one (1) manifest
- [X] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [X] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/122389)