### PR TITLE
Fix IcecreamEbookReader Package Name

### DIFF
--- a/manifests/i/IcecreamApps/IcecreamEbookReader/6.37/IcecreamApps.IcecreamEbookReader.locale.en-US.yaml
+++ b/manifests/i/IcecreamApps/IcecreamEbookReader/6.37/IcecreamApps.IcecreamEbookReader.locale.en-US.yaml
@@ -9,7 +9,7 @@ Publisher: Icecream Apps
 # PublisherSupportUrl:
 # PrivacyUrl:
 # Author:
-PackageName: Icecream Ebook Reader
+PackageName: Icecream Ebook Reader 6 Version 6.37
 # PackageUrl:
 License: Proprietary
 # LicenseUrl:


### PR DESCRIPTION
Yup, that is the real DisplayName of the package, I don't make the rules

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/122438)