### PR TITLE
New package: EclipseAdoptium.Temurin.21.JRE version 21.0.0.35

### DIFF
--- a/manifests/e/EclipseAdoptium/Temurin/21/JRE/21.0.0.35/EclipseAdoptium.Temurin.21.JRE.installer.yaml
+++ b/manifests/e/EclipseAdoptium/Temurin/21/JRE/21.0.0.35/EclipseAdoptium.Temurin.21.JRE.installer.yaml
@@ -1,0 +1,16 @@
+# Created using wingetcreate 1.5.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+
+PackageIdentifier: EclipseAdoptium.Temurin.21.JRE
+PackageVersion: 21.0.0.35
+InstallerLocale: en-US
+InstallerType: wix
+ProductCode: '{3BC47A3F-7E23-4244-9EA1-8E971749EF92}'
+AppsAndFeaturesEntries:
+- DisplayName: Eclipse Temurin JRE with Hotspot 21+35 (x64)
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21%2B35/OpenJDK21U-jre_x64_windows_hotspot_21_35.msi
+  InstallerSha256: 8668C6733296DA59D38C140D692539BE4F2E9B19A2360685EF8612273DE065A0
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/e/EclipseAdoptium/Temurin/21/JRE/21.0.0.35/EclipseAdoptium.Temurin.21.JRE.locale.en-US.yaml
+++ b/manifests/e/EclipseAdoptium/Temurin/21/JRE/21.0.0.35/EclipseAdoptium.Temurin.21.JRE.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# Created using wingetcreate 1.5.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+
+PackageIdentifier: EclipseAdoptium.Temurin.21.JRE
+PackageVersion: 21.0.0.35
+PackageLocale: en-US
+Publisher: Eclipse Adoptium
+PublisherUrl: https://adoptium.net/
+PublisherSupportUrl: https://adoptium.net/docs/
+PrivacyUrl: https://www.eclipse.org/legal/privacy.php
+Author: Eclipse Adoptium
+PackageName: Eclipse Temurin JRE with Hotspot
+PackageUrl: https://adoptium.net/
+License: Eclipse Public License
+LicenseUrl: https://www.eclipse.org/legal/epl-2.0/
+Copyright: Copyright © Eclipse Foundation. All Rights Reserved.
+CopyrightUrl: https://www.eclipse.org/legal/copyright.php
+ShortDescription: Eclipse Temurin JRE is the open source Java SE build based upon OpenJRE.
+Description: Eclipse Temurin JRE is the open source Java SE build based upon OpenJRE.
+Tags:
+- openjdk
+- temurin
+- eclipse
+- jre
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/e/EclipseAdoptium/Temurin/21/JRE/21.0.0.35/EclipseAdoptium.Temurin.21.JRE.yaml
+++ b/manifests/e/EclipseAdoptium/Temurin/21/JRE/21.0.0.35/EclipseAdoptium.Temurin.21.JRE.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.5.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+
+PackageIdentifier: EclipseAdoptium.Temurin.21.JRE
+PackageVersion: 21.0.0.35
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0


### PR DESCRIPTION
## What's changed

This is the JRE part of Eclipse Adoptium Temurin 21.

- Resolve https://github.com/microsoft/winget-pkgs/issues/122564

## Checks

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/122566)