### PR TITLE
New package: madshi.eac3to version 3.36

### DIFF
--- a/manifests/m/madshi/eac3to/3.36/madshi.eac3to.installer.yaml
+++ b/manifests/m/madshi/eac3to/3.36/madshi.eac3to.installer.yaml
@@ -1,0 +1,18 @@
+# Created using wingetcreate 1.5.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+
+PackageIdentifier: madshi.eac3to
+PackageVersion: "3.36"
+InstallerLocale: en-US
+InstallerType: zip
+Installers:
+- Architecture: x86
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: eac3to/eac3to.exe
+    PortableCommandAlias: eac3to
+  InstallerUrl: http://madshi.net/eac3to.zip
+  InstallerSha256: E7977CF3E87310619986B3D1D30385F66B297B189594EAD3D6518B0673C05905
+ManifestType: installer
+ManifestVersion: 1.5.0
+ReleaseDate: 2007-05-18

--- a/manifests/m/madshi/eac3to/3.36/madshi.eac3to.locale.en-US.yaml
+++ b/manifests/m/madshi/eac3to/3.36/madshi.eac3to.locale.en-US.yaml
@@ -1,0 +1,18 @@
+# Created using wingetcreate 1.5.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+
+PackageIdentifier: madshi.eac3to
+PackageVersion: "3.36"
+PackageLocale: en-US
+Publisher: madshi.net
+PublisherUrl: http://madshi.net/
+Author: madshi.net
+PackageName: eac3to
+PackageUrl: https://forum.doom9.org/showthread.php?t=125966
+License: Proprietary
+ShortDescription: An audio conversion tool.
+InstallationNotes: |
+  This is a commandline "loose executable" file, but currently can't be launched via terminal.
+  Please navigate to folder "%LOCALAPPDATA%/Microsoft/WinGet/Links" and launch manually.
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/m/madshi/eac3to/3.36/madshi.eac3to.yaml
+++ b/manifests/m/madshi/eac3to/3.36/madshi.eac3to.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.5.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+
+PackageIdentifier: madshi.eac3to
+PackageVersion: "3.36"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0


### PR DESCRIPTION
## What's changed

- Resolve https://github.com/microsoft/winget-pkgs/issues/119634

## Notes

It seems a "loose executable" zip compressed file. Succcessfully installed but the main executable `eac3to.exe` cannot launch in terminal (it's a CLI application).

## Checks

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/122569)