### PR TITLE
Add `RequireExplicitUpgrade: true` to Chocolatey 2.0.0.0

### DIFF
--- a/manifests/c/Chocolatey/Chocolatey/2.0.0.0/Chocolatey.Chocolatey.installer.yaml
+++ b/manifests/c/Chocolatey/Chocolatey/2.0.0.0/Chocolatey.Chocolatey.installer.yaml
@@ -6,6 +6,7 @@ PackageVersion: 2.0.0.0
 InstallerLocale: en-US
 InstallerType: wix
 Scope: machine
+RequireExplicitUpgrade: true
 ReleaseDate: 2023-06-06
 AppsAndFeaturesEntries:
 - DisplayName: Chocolatey (Install Only)


### PR DESCRIPTION
Since the package is meant for installation only - 

https://github.com/microsoft/winget-pkgs/blob/825581972c7c8ebd2cea7ea0f490dea6055e65d2/manifests/c/Chocolatey/Chocolatey/2.2.2.0/Chocolatey.Chocolatey.locale.en-US.yaml#L15 

We can remove this package from `winget upgrade --all` flow by adding `RequireExplicitUpgrade: true`



---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/122572)