### PR TITLE
Add `RequireExplicitUpgrade: true` to Chocolatey MSI 2.1.0

### DIFF
--- a/manifests/c/Chocolatey/Chocolatey/2.1.0/Chocolatey.Chocolatey.installer.yaml
+++ b/manifests/c/Chocolatey/Chocolatey/2.1.0/Chocolatey.Chocolatey.installer.yaml
@@ -5,6 +5,7 @@ PackageIdentifier: Chocolatey.Chocolatey
 PackageVersion: 2.1.0
 InstallerLocale: en-US
 Scope: machine
+RequireExplicitUpgrade: true
 AppsAndFeaturesEntries:
 - DisplayName: Chocolatey (Install Only)
   UpgradeCode: '{62FC4E65-47F0-488A-B841-ECA07E98A58B}'


### PR DESCRIPTION
Since the package is meant for installation only - 

https://github.com/microsoft/winget-pkgs/blob/825581972c7c8ebd2cea7ea0f490dea6055e65d2/manifests/c/Chocolatey/Chocolatey/2.2.2.0/Chocolatey.Chocolatey.locale.en-US.yaml#L15 

We can remove this package from `winget upgrade --all` flow by adding `RequireExplicitUpgrade: true`

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/122573)