### PR TITLE
fix: align Eclipse Temurin definitions with each other

### DIFF
--- a/manifests/e/EclipseAdoptium/Temurin/11/JRE/11.0.20.101/EclipseAdoptium.Temurin.11.JRE.installer.yaml
+++ b/manifests/e/EclipseAdoptium/Temurin/11/JRE/11.0.20.101/EclipseAdoptium.Temurin.11.JRE.installer.yaml
@@ -3,7 +3,9 @@
 
 PackageIdentifier: EclipseAdoptium.Temurin.11.JRE
 PackageVersion: 11.0.20.101
+ReleaseDate: 2023-08-29
 InstallerLocale: en-US
+MinimumOSVersion: 10.0.0.0
 InstallerType: wix
 Scope: machine
 InstallModes:
@@ -11,6 +13,7 @@ InstallModes:
 - silent
 - silentWithProgress
 InstallerSwitches:
+  Custom: Installlevel=3
   InstallLocation: INSTALLDIR="<INSTALLPATH>"
 UpgradeBehavior: install
 Commands:
@@ -21,7 +24,6 @@ FileExtensions:
 - jar
 - java
 - jsp
-ReleaseDate: 2023-08-29
 Installers:
 - Architecture: x86
   InstallerUrl: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20.1+1/OpenJDK11U-jre_x86-32_windows_hotspot_11.0.20.1_1.msi

--- a/manifests/e/EclipseAdoptium/Temurin/11/JRE/11.0.20.101/EclipseAdoptium.Temurin.11.JRE.installer.yaml
+++ b/manifests/e/EclipseAdoptium/Temurin/11/JRE/11.0.20.101/EclipseAdoptium.Temurin.11.JRE.installer.yaml
@@ -13,7 +13,7 @@ InstallModes:
 - silent
 - silentWithProgress
 InstallerSwitches:
-  Custom: Installlevel=3
+  Custom: INSTALLLEVEL=3
   InstallLocation: INSTALLDIR="<INSTALLPATH>"
 UpgradeBehavior: install
 Commands:

--- a/manifests/e/EclipseAdoptium/Temurin/11/JRE/11.0.20.101/EclipseAdoptium.Temurin.11.JRE.installer.yaml
+++ b/manifests/e/EclipseAdoptium/Temurin/11/JRE/11.0.20.101/EclipseAdoptium.Temurin.11.JRE.installer.yaml
@@ -5,7 +5,6 @@ PackageIdentifier: EclipseAdoptium.Temurin.11.JRE
 PackageVersion: 11.0.20.101
 ReleaseDate: 2023-08-29
 InstallerLocale: en-US
-MinimumOSVersion: 10.0.0.0
 InstallerType: wix
 Scope: machine
 InstallModes:


### PR DESCRIPTION
- use consistent order of keys
- use consistent definition of keys (where applicable)
- use consistent general/generic keys
- add some missing keys (where applicable) such as the install switch to modify the installation location

- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/122674)