### PR TITLE
fix: align Eclipse Temurin definitions with each other

### DIFF
--- a/manifests/e/EclipseAdoptium/Temurin/21/JRE/21.0.0.35/EclipseAdoptium.Temurin.21.JRE.installer.yaml
+++ b/manifests/e/EclipseAdoptium/Temurin/21/JRE/21.0.0.35/EclipseAdoptium.Temurin.21.JRE.installer.yaml
@@ -3,11 +3,30 @@
 
 PackageIdentifier: EclipseAdoptium.Temurin.21.JRE
 PackageVersion: 21.0.0.35
-InstallerLocale: en-US
-InstallerType: wix
+ReleaseDate: 2023-10-10
 ProductCode: '{3BC47A3F-7E23-4244-9EA1-8E971749EF92}'
 AppsAndFeaturesEntries:
 - DisplayName: Eclipse Temurin JRE with Hotspot 21+35 (x64)
+InstallerLocale: en-US
+MinimumOSVersion: 10.0.0.0
+InstallerType: wix
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Custom: Installlevel=3
+  InstallLocation: INSTALLDIR="<INSTALLPATH>"
+UpgradeBehavior: install
+Commands:
+- java
+FileExtensions:
+- class
+- jad
+- jar
+- java
+- jsp
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21%2B35/OpenJDK21U-jre_x64_windows_hotspot_21_35.msi

--- a/manifests/e/EclipseAdoptium/Temurin/21/JRE/21.0.0.35/EclipseAdoptium.Temurin.21.JRE.installer.yaml
+++ b/manifests/e/EclipseAdoptium/Temurin/21/JRE/21.0.0.35/EclipseAdoptium.Temurin.21.JRE.installer.yaml
@@ -16,7 +16,7 @@ InstallModes:
 - silent
 - silentWithProgress
 InstallerSwitches:
-  Custom: Installlevel=3
+  Custom: INSTALLLEVEL=3
   InstallLocation: INSTALLDIR="<INSTALLPATH>"
 UpgradeBehavior: install
 Commands:

--- a/manifests/e/EclipseAdoptium/Temurin/21/JRE/21.0.0.35/EclipseAdoptium.Temurin.21.JRE.installer.yaml
+++ b/manifests/e/EclipseAdoptium/Temurin/21/JRE/21.0.0.35/EclipseAdoptium.Temurin.21.JRE.installer.yaml
@@ -8,7 +8,6 @@ ProductCode: '{3BC47A3F-7E23-4244-9EA1-8E971749EF92}'
 AppsAndFeaturesEntries:
 - DisplayName: Eclipse Temurin JRE with Hotspot 21+35 (x64)
 InstallerLocale: en-US
-MinimumOSVersion: 10.0.0.0
 InstallerType: wix
 Scope: machine
 InstallModes:


### PR DESCRIPTION
- use consistent order of keys
- use consistent definition of keys (where applicable)
- use consistent general/generic keys
- add some missing keys (where applicable) such as the install switch to modify the installation location

- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/122685)