### PR TITLE
fix: align Eclipse Temurin definitions with each other

### DIFF
--- a/manifests/e/EclipseAdoptium/Temurin/20/JDK/20.0.1.9/EclipseAdoptium.Temurin.20.JDK.installer.yaml
+++ b/manifests/e/EclipseAdoptium/Temurin/20/JDK/20.0.1.9/EclipseAdoptium.Temurin.20.JDK.installer.yaml
@@ -3,7 +3,12 @@
 
 PackageIdentifier: EclipseAdoptium.Temurin.20.JDK
 PackageVersion: 20.0.1.9
+ReleaseDate: 2023-04-21
+AppsAndFeaturesEntries:
+- DisplayName: Eclipse Temurin JDK with Hotspot 20.0.1+9 (x64)
+  UpgradeCode: '{2E56835F-A75B-A45C-9FBD-FDE06C741239}'
 InstallerLocale: en-US
+MinimumOSVersion: 10.0.0.0
 InstallerType: wix
 Scope: machine
 InstallModes:
@@ -11,20 +16,18 @@ InstallModes:
 - silent
 - silentWithProgress
 InstallerSwitches:
+  Custom: Installlevel=3
   InstallLocation: INSTALLDIR="<INSTALLPATH>"
 UpgradeBehavior: install
 Commands:
 - java
+- javac
 FileExtensions:
 - class
 - jad
 - jar
 - java
 - jsp
-ReleaseDate: 2023-04-21
-AppsAndFeaturesEntries:
-- DisplayName: Eclipse Temurin JDK with Hotspot 20.0.1+9 (x64)
-  UpgradeCode: '{2E56835F-A75B-A45C-9FBD-FDE06C741239}'
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/adoptium/temurin20-binaries/releases/download/jdk-20.0.1+9/OpenJDK20U-jdk_x64_windows_hotspot_20.0.1_9.msi

--- a/manifests/e/EclipseAdoptium/Temurin/20/JDK/20.0.1.9/EclipseAdoptium.Temurin.20.JDK.installer.yaml
+++ b/manifests/e/EclipseAdoptium/Temurin/20/JDK/20.0.1.9/EclipseAdoptium.Temurin.20.JDK.installer.yaml
@@ -16,7 +16,7 @@ InstallModes:
 - silent
 - silentWithProgress
 InstallerSwitches:
-  Custom: Installlevel=3
+  Custom: INSTALLLEVEL=3
   InstallLocation: INSTALLDIR="<INSTALLPATH>"
 UpgradeBehavior: install
 Commands:

--- a/manifests/e/EclipseAdoptium/Temurin/20/JDK/20.0.1.9/EclipseAdoptium.Temurin.20.JDK.installer.yaml
+++ b/manifests/e/EclipseAdoptium/Temurin/20/JDK/20.0.1.9/EclipseAdoptium.Temurin.20.JDK.installer.yaml
@@ -8,7 +8,6 @@ AppsAndFeaturesEntries:
 - DisplayName: Eclipse Temurin JDK with Hotspot 20.0.1+9 (x64)
   UpgradeCode: '{2E56835F-A75B-A45C-9FBD-FDE06C741239}'
 InstallerLocale: en-US
-MinimumOSVersion: 10.0.0.0
 InstallerType: wix
 Scope: machine
 InstallModes:


### PR DESCRIPTION
- use consistent order of keys
- use consistent definition of keys (where applicable)
- use consistent general/generic keys
- add some missing keys (where applicable) such as the install switch to modify the installation location

- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/122690)