### PR TITLE
fix: align Eclipse Temurin definitions with each other

### DIFF
--- a/manifests/e/EclipseAdoptium/Temurin/17/JDK/17.0.4.101/EclipseAdoptium.Temurin.17.JDK.installer.yaml
+++ b/manifests/e/EclipseAdoptium/Temurin/17/JDK/17.0.4.101/EclipseAdoptium.Temurin.17.JDK.installer.yaml
@@ -3,11 +3,27 @@
 
 PackageIdentifier: EclipseAdoptium.Temurin.17.JDK
 PackageVersion: 17.0.4.101
+InstallerLocale: en-US
 MinimumOSVersion: 10.0.0.0
 InstallerType: wix
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
 InstallerSwitches:
-  Custom: INSTALLLEVEL=3
+  Custom: Installlevel=3
   InstallLocation: INSTALLDIR="<INSTALLPATH>"
+UpgradeBehavior: install
+Commands:
+- java
+- javac
+FileExtensions:
+- class
+- jad
+- jar
+- java
+- jsp
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.4.1%2B1/OpenJDK17U-jdk_x64_windows_hotspot_17.0.4.1_1.msi

--- a/manifests/e/EclipseAdoptium/Temurin/17/JDK/17.0.4.101/EclipseAdoptium.Temurin.17.JDK.installer.yaml
+++ b/manifests/e/EclipseAdoptium/Temurin/17/JDK/17.0.4.101/EclipseAdoptium.Temurin.17.JDK.installer.yaml
@@ -4,7 +4,6 @@
 PackageIdentifier: EclipseAdoptium.Temurin.17.JDK
 PackageVersion: 17.0.4.101
 InstallerLocale: en-US
-MinimumOSVersion: 10.0.0.0
 InstallerType: wix
 Scope: machine
 InstallModes:

--- a/manifests/e/EclipseAdoptium/Temurin/17/JDK/17.0.4.101/EclipseAdoptium.Temurin.17.JDK.installer.yaml
+++ b/manifests/e/EclipseAdoptium/Temurin/17/JDK/17.0.4.101/EclipseAdoptium.Temurin.17.JDK.installer.yaml
@@ -12,7 +12,7 @@ InstallModes:
 - silent
 - silentWithProgress
 InstallerSwitches:
-  Custom: Installlevel=3
+  Custom: INSTALLLEVEL=3
   InstallLocation: INSTALLDIR="<INSTALLPATH>"
 UpgradeBehavior: install
 Commands:


### PR DESCRIPTION
- use consistent order of keys
- use consistent definition of keys (where applicable)
- use consistent general/generic keys
- add some missing keys (where applicable) such as the install switch to modify the installation location

- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/122717)