### PR TITLE
New package: Airspy.AdsbSpy version 2.2-RC26

### DIFF
--- a/manifests/a/Airspy/AdsbSpy/2.2-RC26/Airspy.AdsbSpy.installer.yaml
+++ b/manifests/a/Airspy/AdsbSpy/2.2-RC26/Airspy.AdsbSpy.installer.yaml
@@ -1,0 +1,15 @@
+# Created using wingetcreate 1.5.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+
+PackageIdentifier: Airspy.AdsbSpy
+PackageVersion: 2.2-RC26
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: airspy_adsb.exe
+Installers:
+- Architecture: x86
+  InstallerUrl: https://airspy.com/downloads/airspy_adsb_win32.zip
+  InstallerSha256: AA4994A6A45292ABE6535A1ABEF77F20CE2922E94D9E9C7288712D4FA85C5AFA
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/a/Airspy/AdsbSpy/2.2-RC26/Airspy.AdsbSpy.installer.yaml
+++ b/manifests/a/Airspy/AdsbSpy/2.2-RC26/Airspy.AdsbSpy.installer.yaml
@@ -7,6 +7,9 @@ InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
 - RelativeFilePath: airspy_adsb.exe
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x86
 Installers:
 - Architecture: x86
   InstallerUrl: https://airspy.com/downloads/airspy_adsb_win32.zip

--- a/manifests/a/Airspy/AdsbSpy/2.2-RC26/Airspy.AdsbSpy.locale.en-US.yaml
+++ b/manifests/a/Airspy/AdsbSpy/2.2-RC26/Airspy.AdsbSpy.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# Created using wingetcreate 1.5.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+
+PackageIdentifier: Airspy.AdsbSpy
+PackageVersion: 2.2-RC26
+PackageLocale: en-US
+Publisher: Airspy
+PublisherUrl: https://airspy.com/
+PublisherSupportUrl: https://airspy.com/contact/
+Author: Airspy
+PackageName: ADS-B Spy
+PackageUrl: https://airspy.com/download/
+License: Proprietary
+Copyright: Copyright (c) 2023 airspy.com
+ShortDescription: ADS-B decoder for Windows.
+Description: Airspy R0, R2 and Mini can be used as a high performance ADSB receiver capable of 12MHz, 20MHz and 24MHz MLAT. Our original algorithms compare favorably with the top range ADSB receivers. This executable turns your Airspy into an autonomous ADSB station with low power requirements.
+PurchaseUrl: https://airspy.com/purchase
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/a/Airspy/AdsbSpy/2.2-RC26/Airspy.AdsbSpy.yaml
+++ b/manifests/a/Airspy/AdsbSpy/2.2-RC26/Airspy.AdsbSpy.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.5.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+
+PackageIdentifier: Airspy.AdsbSpy
+PackageVersion: 2.2-RC26
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0


### PR DESCRIPTION
## What's changed

- Resolve https://github.com/microsoft/winget-pkgs/issues/115713

## Additional Informations

This is a portable executable file. After installing the package and automatically creating a symbolic link of the executable, it still can't be launched in terminal.

## Checks

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/122775)