### PR TITLE
fix: align Eclipse Temurin definitions with each other

### DIFF
--- a/manifests/e/EclipseAdoptium/Temurin/18/JDK/18.0.2.101/EclipseAdoptium.Temurin.18.JDK.installer.yaml
+++ b/manifests/e/EclipseAdoptium/Temurin/18/JDK/18.0.2.101/EclipseAdoptium.Temurin.18.JDK.installer.yaml
@@ -3,7 +3,9 @@
 
 PackageIdentifier: EclipseAdoptium.Temurin.18.JDK
 PackageVersion: 18.0.2.101
-MinimumOSVersion: 10.0.0.0
+InstallerLocale: en-US
+InstallerType: wix
+Scope: machine
 InstallModes:
 - interactive
 - silent
@@ -14,9 +16,13 @@ InstallerSwitches:
 UpgradeBehavior: install
 Commands:
 - java
+- javac
 FileExtensions:
+- class
+- jad
 - jar
 - java
+- jsp
 Installers:
 - Architecture: x64
   InstallerType: wix


### PR DESCRIPTION
- use consistent order of keys
- use consistent definition of keys (where applicable)
- use consistent general/generic keys
- add some missing keys (where applicable) such as the install switch to modify the installation location

- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/122795)