### PR TITLE
fix: align Eclipse Temurin definitions with each other

### DIFF
--- a/manifests/e/EclipseAdoptium/Temurin/18/JDK/18.0.2.9/EclipseAdoptium.Temurin.18.JDK.installer.yaml
+++ b/manifests/e/EclipseAdoptium/Temurin/18/JDK/18.0.2.9/EclipseAdoptium.Temurin.18.JDK.installer.yaml
@@ -4,7 +4,6 @@
 PackageIdentifier: EclipseAdoptium.Temurin.18.JDK
 PackageVersion: 18.0.2.9
 InstallerLocale: en-US
-MinimumOSVersion: 10.0.0.0
 InstallerType: wix
 Scope: machine
 InstallModes:

--- a/manifests/e/EclipseAdoptium/Temurin/18/JDK/18.0.2.9/EclipseAdoptium.Temurin.18.JDK.installer.yaml
+++ b/manifests/e/EclipseAdoptium/Temurin/18/JDK/18.0.2.9/EclipseAdoptium.Temurin.18.JDK.installer.yaml
@@ -3,8 +3,10 @@
 
 PackageIdentifier: EclipseAdoptium.Temurin.18.JDK
 PackageVersion: 18.0.2.9
+InstallerLocale: en-US
 MinimumOSVersion: 10.0.0.0
 InstallerType: wix
+Scope: machine
 InstallModes:
 - interactive
 - silent
@@ -16,8 +18,11 @@ UpgradeBehavior: install
 Commands:
 - java
 FileExtensions:
+- class
+- jad
 - jar
 - java
+- jsp
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/adoptium/temurin18-binaries/releases/download/jdk-18.0.2%2B9/OpenJDK18U-jdk_x64_windows_hotspot_18.0.2_9.msi


### PR DESCRIPTION
- use consistent order of keys
- use consistent definition of keys (where applicable)
- use consistent general/generic keys
- add some missing keys (where applicable) such as the install switch to modify the installation location

- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/122796)