### PR TITLE
New package: TeraTermProject.teraterm5 version 5.0

### DIFF
--- a/manifests/t/TeraTermProject/teraterm5/5.0/TeraTermProject.teraterm5.installer.yaml
+++ b/manifests/t/TeraTermProject/teraterm5/5.0/TeraTermProject.teraterm5.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+# Created using wingetcreate
+
+PackageIdentifier: TeraTermProject.teraterm5
+PackageVersion: 5.0
+MinimumOSVersion: 10.0.0.0
+Installers:
+- Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://github.com/TeraTermProject/osdn-download/releases/download/teraterm-5.0/teraterm-5.0.exe
+  InstallerSha256: 43a71423b088d3b510a89502a68a733bacd985afb63ddae96af6a689c39f011b
+  InstallerSwitches:
+    Silent: /Silent
+    SilentWithProgress: /Silent
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/t/TeraTermProject/teraterm5/5.0/TeraTermProject.teraterm5.locale.en-US.yaml
+++ b/manifests/t/TeraTermProject/teraterm5/5.0/TeraTermProject.teraterm5.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+# Created using wingetcreate
+
+PackageIdentifier: TeraTermProject.teraterm5
+PackageVersion: 5.0
+PackageLocale: en-US
+Publisher: TeraTerm Project
+PackageName: Tera Term 5
+PackageUrl: https://ttssh2.osdn.jp/index.html.en
+License: 3-clause BSD license
+LicenseUrl: https://ttssh2.osdn.jp/manual/5/en/about/copyright.html
+CopyrightUrl: https://ttssh2.osdn.jp/manual/5/en/about/copyright.html
+ShortDescription: open-source, free, software terminal emulator
+Moniker: teraterm5
+Tags:
+- teraterm
+- teraterm5
+Documentations:
+- DocumentLabel: Tera Term Help
+  DocumentUrl: https://ttssh2.osdn.jp/manual/5/en/
+- DocumentLabel: MACRO Help
+  DocumentUrl: https://ttssh2.osdn.jp/manual/5/en/macro/
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/t/TeraTermProject/teraterm5/5.0/TeraTermProject.teraterm5.locale.ja-JP.yaml
+++ b/manifests/t/TeraTermProject/teraterm5/5.0/TeraTermProject.teraterm5.locale.ja-JP.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+# Created using wingetcreate
+
+PackageIdentifier: TeraTermProject.teraterm5
+PackageVersion: 5.0
+PackageLocale: ja-JP
+Publisher: TeraTerm Project
+PackageName: Tera Term 5
+PackageUrl: https://ttssh2.osdn.jp/index.html.ja
+License: 三条項BSDライセンス
+LicenseUrl: https://ttssh2.osdn.jp/manual/5/ja/about/copyright.html
+CopyrightUrl: https://ttssh2.osdn.jp/manual/5/ja/about/copyright.html
+ShortDescription: オープンソースでフリーソフトウェアのターミナルエミュレーター
+Tags:
+- teraterm
+- teraterm5
+Documentations:
+- DocumentLabel: Tera Term ヘルプ
+  DocumentUrl: https://ttssh2.osdn.jp/manual/5/ja/
+- DocumentLabel: MACRO ヘルプ
+  DocumentUrl: https://ttssh2.osdn.jp/manual/5/ja/macro/
+ManifestType: locale
+ManifestVersion: 1.5.0

--- a/manifests/t/TeraTermProject/teraterm5/5.0/TeraTermProject.teraterm5.yaml
+++ b/manifests/t/TeraTermProject/teraterm5/5.0/TeraTermProject.teraterm5.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+# Created using wingetcreate
+
+PackageIdentifier: TeraTermProject.teraterm5
+PackageVersion: 5.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0


### PR DESCRIPTION
* The contents of the teraterm package were Tera Term 4 (version 4.x), but now Tera Term 5 (version 5.0) has been added.

* Tera Term 5 can install with Tera Term 4. The automatic installation location for the teraterm package is %PROGRAMFILES(X86)%\teraterm, and the teraterm5 package is %PROGRAMFILES(X86)%\teraterm5. (See https://ttssh2.osdn.jp/manual/5/en/usage/migrate_to_5.html )

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/123090)