### PR TITLE
Add Manifest: added missing manifest for th-ch.YouTubeMusic 1.11.0

### DIFF
--- a/manifests/t/th-ch/YouTubeMusic/1.11.0/th-ch.YouTubeMusic.installer.yaml
+++ b/manifests/t/th-ch/YouTubeMusic/1.11.0/th-ch.YouTubeMusic.installer.yaml
@@ -1,0 +1,15 @@
+# Created using wingetcreate 1.5.5.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+
+PackageIdentifier: th-ch.YouTubeMusic
+PackageVersion: 1.11.0
+InstallerType: nullsoft
+Commands:
+- youtube-music
+ReleaseDate: "2021-03-09"
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/th-ch/youtube-music/releases/download/v1.11.0/YouTube-Music-Setup-1.11.0.exe
+  InstallerSha256: 7608e1d98eb19b09cd541b00f839f77e0d31e876c65ec9958b002cc7453f843e
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/t/th-ch/YouTubeMusic/1.11.0/th-ch.YouTubeMusic.locale.en-US.yaml
+++ b/manifests/t/th-ch/YouTubeMusic/1.11.0/th-ch.YouTubeMusic.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created using wingetcreate 1.5.5.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+
+PackageIdentifier: th-ch.YouTubeMusic
+PackageVersion: 1.11.0
+PackageLocale: en-US
+Publisher: th-ch
+PublisherUrl: https://github.com/th-ch
+PublisherSupportUrl: https://github.com/th-ch/youtube-music/issues
+PackageName: YouTube Music
+PackageUrl: https://github.com/th-ch/youtube-music
+License: MIT license
+LicenseUrl: https://github.com/th-ch/youtube-music/blob/master/license
+ShortDescription: YouTube Music Desktop App bundled with custom plugins (and built-in ad blocker / downloader)
+ReleaseNotesUrl: https://github.com/th-ch/youtube-music/releases/tag/v1.11.0
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/t/th-ch/YouTubeMusic/1.11.0/th-ch.YouTubeMusic.yaml
+++ b/manifests/t/th-ch/YouTubeMusic/1.11.0/th-ch.YouTubeMusic.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.5.5.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+
+PackageIdentifier: th-ch.YouTubeMusic
+PackageVersion: 1.11.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with winget validate --manifest <path>?
- [x] Have you tested your manifest locally with winget install --manifest <path>?
- [x] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: <path> is the name of the directory containing the manifest you're submitting.

---

This PR adds missing manifest 1.11.0 for the [th-ch.YouTubeMusic](https://github.com/th-ch/youtube-music) package. Note: currently, versions newer than 1.20.0 are not being recognized as newer by winget, due to these versions being prefixed with 'v'.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/123248)