### PR TITLE
Fix Microsoft.AzureCLI 2.53.1 x64/x86 InstallerUrls

### DIFF
--- a/manifests/m/Microsoft/AzureCLI/2.53.1/Microsoft.AzureCLI.installer.yaml
+++ b/manifests/m/Microsoft/AzureCLI/2.53.1/Microsoft.AzureCLI.installer.yaml
@@ -4,9 +4,13 @@
 PackageIdentifier: Microsoft.AzureCLI
 PackageVersion: 2.53.1
 Installers:
-- Architecture: x64
+- Architecture: x86
   InstallerType: msi
   InstallerUrl: https://azcliprod.azureedge.net/msi/azure-cli-2.53.1.msi
   InstallerSha256: 57b8e2e4bf02059865eab97ba717ae576d9c45621be85b85045e4b1ed51c6efc
+- Architecture: x64
+  InstallerType: msi
+  InstallerUrl: https://azcliprod.azureedge.net/msi/azure-cli-2.53.1-x64.msi
+  InstallerSha256: 50996b7b802e88fa6f5f7eb31b7713b275d4bcbc9676b83c04800ff5e308f4a6
 ManifestType: installer
 ManifestVersion: 1.2.0

--- a/manifests/m/Microsoft/AzureCLI/2.53.1/Microsoft.AzureCLI.installer.yaml
+++ b/manifests/m/Microsoft/AzureCLI/2.53.1/Microsoft.AzureCLI.installer.yaml
@@ -8,9 +8,11 @@ Installers:
   InstallerType: msi
   InstallerUrl: https://azcliprod.azureedge.net/msi/azure-cli-2.53.1.msi
   InstallerSha256: 57b8e2e4bf02059865eab97ba717ae576d9c45621be85b85045e4b1ed51c6efc
+  ProductCode: '{8912DDBF-70DA-42F0-939A-278E4B42577D}'
 - Architecture: x64
   InstallerType: msi
   InstallerUrl: https://azcliprod.azureedge.net/msi/azure-cli-2.53.1-x64.msi
   InstallerSha256: 50996b7b802e88fa6f5f7eb31b7713b275d4bcbc9676b83c04800ff5e308f4a6
+  ProductCode: '{0A56C26A-2E46-4B19-94EB-8482AD658D53}'
 ManifestType: installer
 ManifestVersion: 1.2.0


### PR DESCRIPTION
This now matches what we did for [2.53.0](https://github.com/microsoft/winget-pkgs/blob/5389630e67e59dedf3162be815c18d61b9976586/manifests/m/Microsoft/AzureCLI/2.53.0/Microsoft.AzureCLI.installer.yaml).

I noticed this when I tried to `winget upgrade --all` and afterwards running `winget upgrade` still showed Microsoft.AzureCLI as out of date at 2.53.0. In turned out I had the 2.53.0 x64 and 2.53.1 x86 installed side by side.

This exact PR has been opened by community members for at least the last three versions: 

- 2.51.0: #116957 @fsdrw08 @BrandonWanHuanSheng
- 2.52.0: #119228 @kkamegawa
- 2.53.0: #121214 @aavdberg @Seros 

@stephengillie @johnstep You probably want to look into fixing the @azclibot. Is that open source?

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/123641)