### PR TITLE
[WinGet-Pkgs] WinGet-Pkgs cg-pipeline.yaml migration to 1ESPipeline

### DIFF
--- a/DevOpsPipelineDefinitions/cg-pipeline.yaml
+++ b/DevOpsPipelineDefinitions/cg-pipeline.yaml
@@ -5,16 +5,35 @@
 trigger: none
 pr: none
 
-pool:
-  vmImage: windows-latest
-
 variables:
   runCodesignValidationInjection: ${{ false }}
 
-steps:
-  - task: ComponentGovernanceComponentDetection@0
-    displayName: Component Governance
-    inputs:
-      scanType: 'Register'
-      verbosity: 'Verbose'
-      alertWarningLevel: 'High'
+resources:
+  repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    pool:
+      name: Azure-Pipelines-1ESPT-ExDShared
+      image: windows-2022
+      os: windows
+    customBuildTags:
+    # This is added by 1ES migration tool and it is okay to remove in the future.
+    - ES365AIMigrationTooling
+
+    stages:
+    - stage: Component_Governance
+      jobs:
+      - job: Job
+        steps:
+        - task: ComponentGovernanceComponentDetection@0
+          displayName: Component Governance
+          inputs:
+            scanType: 'Register'
+            verbosity: 'Verbose'
+            alertWarningLevel: 'High'


### PR DESCRIPTION
This PR migrates the following  WinGet-Pkgs cg-pipeline pipelines to 1ESPipeline
- cg-pipeline.yaml

[How Validated:]
The pipeline was triggered from the current topic branch and all passed:
- [cg-pipeline.yaml](https://dev.azure.com/ms/winget-pkgs/_build/results?buildId=507992&view=logs&j=bc38e8b8-e027-53cb-48e7-2adbd1070eca)

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/123664)