### PR TITLE
Swift.Toolchain: Correct dependencies for 5.8.1

### DIFF
--- a/manifests/s/Swift/Toolchain/5.8.1/Swift.Toolchain.installer.yaml
+++ b/manifests/s/Swift/Toolchain/5.8.1/Swift.Toolchain.installer.yaml
@@ -13,12 +13,10 @@ FileExtensions:
 - swift
 Dependencies:
   PackageDependencies:
+  - PackageIdentifier: Git.Git
   - PackageIdentifier: Microsoft.VCRedist.2015+.x64
     MinimumVersion: 14.28.29913.0
-  - PackageIdentifier: Microsoft.WindowsSDK.10.0.22000
-  - PackageIdentifier: Microsoft.VisualStudio.2022.BuildTools
-  - PackageIdentifier: Git.Git
-  - PackageIdentifier: Python.Python.3.10
+  - PackageIdentifier: Python.Python.3.9
 ReleaseDate: 2023-06-01
 AppsAndFeaturesEntries:
 - DisplayName: Swift Developer Package for Windows x86_64


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

Swift has loose dependency on Visual Studio and Windows SDK, which should allow users to use any supported versions as they like. Meanwhile, the Python dependency requires a concrete minor version for each release, as shown in https://github.com/stevapple/swift-windows-toolchain-analysis/blob/main/swift-5.8.1-RELEASE/lldb-dependencies.txt.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/123718)