### PR TITLE
Fix (Docker.DockerDesktop v4.25.0): Installer URL

### DIFF
--- a/manifests/d/Docker/DockerDesktop/4.25.0/Docker.DockerDesktop.installer.yaml
+++ b/manifests/d/Docker/DockerDesktop/4.25.0/Docker.DockerDesktop.installer.yaml
@@ -21,7 +21,7 @@ UpgradeBehavior: install
 ElevationRequirement: elevatesSelf
 Installers:
 - Architecture: x64
-  InstallerUrl: https://desktop.docker.com/win/main/amd64/Docker%20Desktop%20Installer.exe
+  InstallerUrl: https://desktop.docker.com/win/main/amd64/126437/Docker%20Desktop%20Installer.exe
   InstallerSha256: 4C11952FBE7915908A2B0925C46B4E19F0826F75BB0B2F4A83D24CBBE40C53CE
 ManifestType: installer
 ManifestVersion: 1.5.0


### PR DESCRIPTION
## Description

Currently, the latest manifest version of `Docker.DockerDesktop` is using a static URL which always point to the latest installation wizard. This will leed to a hash mismatch error when a newer version is released.

Convert all these URL to a version related one will solve the problem.

- Resolve https://github.com/microsoft/winget-pkgs/issues/123846

## Checks

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/123920)