### PR TITLE
Update: Beyond Compare 4: 4.4.7.28397

### DIFF
--- a/manifests/s/ScooterSoftware/BeyondCompare4/4.4.7.28397/ScooterSoftware.BeyondCompare4.installer.yaml
+++ b/manifests/s/ScooterSoftware/BeyondCompare4/4.4.7.28397/ScooterSoftware.BeyondCompare4.installer.yaml
@@ -1,0 +1,47 @@
+# Created with YamlCreate.ps1 v2.1.1 $debug=QUSU.5-1-19041-1320
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+
+PackageIdentifier: ScooterSoftware.BeyondCompare4
+PackageVersion: 4.4.7.28397
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: /SP- /SILENT /NORESTART
+  SilentWithProgress: /SP- /VERYSILENT /NORESTART
+  Custom: /NORESTART
+UpgradeBehavior: install
+Commands:
+- bcomp
+Installers:
+- InstallerLocale: en-US
+  Architecture: neutral
+  InstallerUrl: https://www.scootersoftware.com/BCompare-4.4.7.28397.exe
+  InstallerSha256: 5B14F35BF4219FDCC138A4A6ED8F20605D455027A94A50AB37DB64E53153D141
+  ProductCode: BeyondCompare4_is1
+- InstallerLocale: de-DE
+  Architecture: neutral
+  InstallerUrl: https://www.scootersoftware.com/BCompare-de-4.4.7.28397.exe
+  InstallerSha256: E3ABA498539E9872231B3C3960074B9396D48F763104CE2485B40B5C855223A6
+  ProductCode: BeyondCompare4_is1
+- InstallerLocale: fr-FR
+  Architecture: neutral
+  InstallerUrl: https://www.scootersoftware.com/BCompare-fr-4.4.7.28397.exe
+  InstallerSha256: 9E2F5BF0FC85758A75AF18AB5B3D884869E4CF2CBED27770F3ABCE5FC158C6C2
+  ProductCode: BeyondCompare4_is1
+- InstallerLocale: ja-JP
+  Architecture: neutral
+  InstallerUrl: https://www.scootersoftware.com/BCompare-jp-4.4.7.28397.exe
+  InstallerSha256: ECC7A88B4B821DA58CD463E85FDCB2A1C82BFA31B31A1DF9B8B69112503C23DA
+  ProductCode: BeyondCompare4_is1
+- InstallerLocale: zh-CN
+  Architecture: neutral
+  InstallerUrl: https://www.scootersoftware.com/BCompare-zh-4.4.7.28397.exe
+  InstallerSha256: 9DA5BAB97EB3D97EEABB1EED85EC1A03EA5D28021F558D5AAEFC8AE48AA2BF00
+  ProductCode: BeyondCompare4_is1
+ManifestType: installer
+ManifestVersion: 1.1.0

--- a/manifests/s/ScooterSoftware/BeyondCompare4/4.4.7.28397/ScooterSoftware.BeyondCompare4.locale.en-US.yaml
+++ b/manifests/s/ScooterSoftware/BeyondCompare4/4.4.7.28397/ScooterSoftware.BeyondCompare4.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# Created with YamlCreate.ps1 v2.1.1 $debug=QUSU.5-1-19041-1320
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+
+PackageIdentifier: ScooterSoftware.BeyondCompare4
+PackageVersion: 4.4.7.28397
+PackageLocale: en-US
+Publisher: Scooter Software
+PublisherUrl: https://www.scootersoftware.com
+PublisherSupportUrl: https://www.scootersoftware.com/support.php
+PrivacyUrl: https://www.scootersoftware.com/index.php?zz=kb_privacy
+# Author: 
+PackageName: Beyond Compare 4
+PackageUrl: https://www.scootersoftware.com
+License: Proprietary
+LicenseUrl: http://www.scootersoftware.com/index.php?zz=kb_licensev4
+Copyright: Copyright © 2020 Scooter Software, Inc
+CopyrightUrl: https://www.scootersoftware.com/index.php?zz=legal
+ShortDescription: Beyond Compare is a multi-platform utility that combines directory compare and file compare functions in one package.
+Description: Beyond Compare allows you to quickly and easily compare your files and folders. By using simple, powerful commands you can focus on the differences you're interested in and ignore those you're not. You can then merge the changes, synchronize your files, and generate reports for your records.
+# Moniker: 
+Tags:
+- compare
+- diff
+- file-compare
+- folder-compare
+- folder-merge
+- text-compare
+- text-merge
+- utility
+# Agreements: 
+# ReleaseNotes: 
+# ReleaseNotesUrl: 
+ManifestType: defaultLocale
+ManifestVersion: 1.1.0

--- a/manifests/s/ScooterSoftware/BeyondCompare4/4.4.7.28397/ScooterSoftware.BeyondCompare4.locale.zh-CN.yaml
+++ b/manifests/s/ScooterSoftware/BeyondCompare4/4.4.7.28397/ScooterSoftware.BeyondCompare4.locale.zh-CN.yaml
@@ -1,0 +1,32 @@
+# Created with YamlCreate.ps1 v2.1.1 $debug=QUSU.5-1-19041-1320
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.1.0.schema.json
+
+PackageIdentifier: ScooterSoftware.BeyondCompare4
+PackageVersion: 4.4.7.28397
+PackageLocale: zh-CN
+Publisher: Scooter Software
+PublisherUrl: https://www.scootersoftware.com
+PublisherSupportUrl: https://www.scootersoftware.com/support.php
+PrivacyUrl: https://www.scootersoftware.com/index.php?zz=kb_privacy
+# Author: 
+PackageName: Beyond Compare 4
+PackageUrl: https://www.scootersoftware.com
+License: Proprietary
+LicenseUrl: http://www.scootersoftware.com/index.php?zz=kb_licensev4
+Copyright: Copyright © 2020 Scooter Software, Inc
+CopyrightUrl: https://www.scootersoftware.com/index.php?zz=legal
+ShortDescription: 强大专业的文件和文件夹对比工具
+Description: Beyond Compare 是一款强大专业的文件和文件夹对比工具。使用它可以很方便地比较出两个文件或文件夹的差异，相差的每一个字节用颜色加以标识，让您查看方便，支持众多种格式的对比。
+# Moniker: 
+Tags:
+- diff
+- 合并
+- 同步
+- 对比
+- 差异
+- 比较
+# Agreements: 
+# ReleaseNotes: 
+# ReleaseNotesUrl: 
+ManifestType: locale
+ManifestVersion: 1.1.0

--- a/manifests/s/ScooterSoftware/BeyondCompare4/4.4.7.28397/ScooterSoftware.BeyondCompare4.yaml
+++ b/manifests/s/ScooterSoftware/BeyondCompare4/4.4.7.28397/ScooterSoftware.BeyondCompare4.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.1.1 $debug=QUSU.5-1-19041-1320
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+
+PackageIdentifier: ScooterSoftware.BeyondCompare4
+PackageVersion: 4.4.7.28397
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.1.0


### PR DESCRIPTION
Beyond Compare 4 Change Log
4.4.7.28397 - October 19, 2023
Notable Changes

    macOS: Fixed blurry text on Intel CPU systems with retina displays running macOS 14 Sonoma.
    Linux: Fixed typo in RPM uninstall script in 4.4.5 and 4.4.6. To upgrade/uninstall those versions see https://www.scootersoftware.com/kb/linuxpreun
    Fixed hex compare incorrectly marking single matches as different.
    General updates and stability fixes.

File Formats

    Windows: - Updated pdftotext to v4.04.

Folder Compare

    Linux: Updated smb:// support for KDE and DBUS integration.

Hex Compare

    Fixed incorrectly marking single matches as different.

Installer

    Linux: RPM installer no longer tries to import our GPG key automatically.
    Linux: Updated RPM repository GPG key for Fedora 38 compatibility.
    Linux: Fixed typo in rpm pre-uninstall script.

Misc

    macOS: Fixed blurry text on Intel CPU systems with retina displays running macOS 14 Sonoma.
    macOS: Fixed "Beyond Compare" top level menu item not appearing in macOS Sonoma betas.
    Windows: Fixed showing menu items as checked on Windows 11.

Options

    Windows: - Fixed Options dialog "Explorer Integration" saying it's a portable install if BC was installed and registered by an administrator and is run by a limited user.

Crashes

    Linux: Fixed crash when simultaneously running multiple command line quick compares.

---

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/124365)