### PR TITLE
Fix RetroArch manifests

### DIFF
--- a/manifests/l/Libretro/RetroArch/1.16.0.0/Libretro.RetroArch.installer.yaml
+++ b/manifests/l/Libretro/RetroArch/1.16.0.0/Libretro.RetroArch.installer.yaml
@@ -10,9 +10,9 @@ UpgradeBehavior: install
 Installers:
 - Architecture: x64
   InstallerUrl: https://buildbot.libretro.com/stable/1.16.0/windows/x86_64/RetroArch-Win64-setup.exe
-  InstallerSha256: 2E9A26769F1E7B0E7A6E967EC5B5855F0052096016C938F49F3483569FBF1DB0
+  InstallerSha256: DEB0B6BB73B394A85A939FAD2E8C2BEC164B31FF935B1ED85E6A21B37A7563C1
 - Architecture: x86
   InstallerUrl: https://buildbot.libretro.com/stable/1.16.0/windows/x86/RetroArch-Win32-setup.exe
-  InstallerSha256: A14C792B1A3DC2C218BD2FFD1A7FA9CC63A46FA0BD3FADE3F9354A54DF760998
+  InstallerSha256: D8ED0C5D1312CA9A323A3D90B821CD13F08A5ECA8A27D217BB9F4800EFE20ECE
 ManifestType: installer
 ManifestVersion: 1.5.0


### PR DESCRIPTION
Somehow the manifests have gone out of sync with mainstream.
Downloaded assets for version 1.16.0 02-Nov-2023 and generated the digests right away.
Tested manifest locally and it works as expected.

- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/124539)