### PR TITLE
Republish Microsoft.Azd 1.4.400 (package 1.4.3)

### DIFF
--- a/manifests/m/Microsoft/Azd/1.4.400/Microsoft.Azd.installer.yaml
+++ b/manifests/m/Microsoft/Azd/1.4.400/Microsoft.Azd.installer.yaml
@@ -1,0 +1,16 @@
+# Created using wingetcreate 1.5.5.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+
+PackageIdentifier: Microsoft.Azd
+PackageVersion: 1.4.400
+InstallerLocale: en-US
+InstallerType: wix
+InstallerSwitches:
+  Custom: INSTALLEDBY="winget"
+ProductCode: '{487AFABD-E830-460B-944A-5B3470AEA2AA}'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Azure/azure-dev/releases/download/azure-dev-cli_1.4.3/azd-windows-amd64.msi
+  InstallerSha256: 84484B3F394BA7DAAA2D51CFAA92F314376237878958C4ADA198A1C9C26A3DF9
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/m/Microsoft/Azd/1.4.400/Microsoft.Azd.locale.en-US.yaml
+++ b/manifests/m/Microsoft/Azd/1.4.400/Microsoft.Azd.locale.en-US.yaml
@@ -1,0 +1,20 @@
+# Created using wingetcreate 1.5.5.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+
+PackageIdentifier: Microsoft.Azd
+PackageVersion: 1.4.400
+PackageLocale: en-US
+Publisher: Microsoft Corporation
+PublisherUrl: https://github.com/Azure/azure-dev/
+PublisherSupportUrl: https://github.com/Azure/azure-dev/issues
+PrivacyUrl: https://go.microsoft.com/fwlink/?LinkId=521839
+PackageName: Azure Developer CLI
+PackageUrl: https://github.com/Azure/azure-dev/releases/tag/azure-dev-cli_0.6.0-beta.2
+License: MIT License
+LicenseUrl: https://github.com/Azure/azure-dev/blob/main/LICENSE
+Copyright: Copyright 2022 (c) Microsoft Corporation.
+ShortDescription: A developer CLI that accelerates the time it takes for you to get started on Azure.
+Description: A developer CLI that accelerates the time it takes for you to get started on Azure. The Azure Developer CLI (azd) provides a set of developer-friendly commands that map to key stages in your workflow - code, build, deploy, monitor, repeat.
+Moniker: azd
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/m/Microsoft/Azd/1.4.400/Microsoft.Azd.yaml
+++ b/manifests/m/Microsoft/Azd/1.4.400/Microsoft.Azd.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.5.5.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+
+PackageIdentifier: Microsoft.Azd
+PackageVersion: 1.4.400
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0


### PR DESCRIPTION
Reverts #123987, resolves #124600

Because Windows Installer `ProductVersion` only [supports 3 fields that affect upgrade behavior](https://learn.microsoft.com/windows/win32/msi/productversion), we - like many other products - pack a semver with optional prerelease metadata into a dotted triple using the algorithm: `major.minor.(patch * 100 + preview version)`.

So the manifest version 1.4.400 is `azd` version 1.4.3 which was published by our pipeline prior to this manifest being inserted.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/124602)