### PR TITLE
Remove Project-File and Author-Not-Authorized on pipeline re-run

### DIFF
--- a/.github/policies/labelManagement.issueOpened.yml
+++ b/.github/policies/labelManagement.issueOpened.yml
@@ -112,12 +112,11 @@ configuration:
           - removeLabel:
               label: Issue-Bug
       - description: >-
-          When an PR is opened, if the content is in a project folder and user is not repo admin
+          When a PR is opened/updated, if the content is in a project folder and user is not repo admin
           * Add Project-File label
         if:
           - payloadType: Pull_Request
-          - isAction:
-              action: Opened
+          - isOpen
           - or:
             - filesMatchPattern:
                 pattern: ^.github\\.*
@@ -136,12 +135,11 @@ configuration:
           - addLabel:
               label: Project-File
       - description: >-
-          When an PR is opened, if the content contains .validation and user is not repo admin
+          When a PR is opened/updated, if the content contains .validation and user is not repo admin
           * Add Author-Not-Authorized label
         if:
           - payloadType: Pull_Request
-          - isAction:
-              action: Opened
+          - isOpen
           - filesMatchPattern:
                 pattern: ^.*\.validation
           - not:

--- a/.github/policies/labelManagement.issueUpdated.yml
+++ b/.github/policies/labelManagement.issueUpdated.yml
@@ -500,5 +500,9 @@ configuration:
               label: Validation-Open-Url-Failed
           - removeLabel:
               label: Possible-Duplicate
+          - removeLabel:
+              label: Project-File
+          - removeLabel:
+              label: Author-Not-Authorized
 onFailure:
 onSuccess:


### PR DESCRIPTION
- Example case: #124602

These *should* be re-applied if the PR still contains changes to project/validation files

cc @Trenly

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/124634)