### PR TITLE
adds missing dotnet desktop dependency to ilspy 8.1

### DIFF
--- a/manifests/i/icsharpcode/ILSpy/8.1.1.7464/icsharpcode.ILSpy.installer.yaml
+++ b/manifests/i/icsharpcode/ILSpy/8.1.1.7464/icsharpcode.ILSpy.installer.yaml
@@ -7,6 +7,9 @@ InstallerLocale: en-US
 MinimumOSVersion: 10.0.0.0
 InstallerType: wix
 UpgradeBehavior: install
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.6
 ProductCode: '{A12FDAB1-731B-4A98-9749-D4814E96AFD4}'
 Installers:
 - Architecture: x64


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---


This adds the missing dotnet desktop runtime 6 dependency for all ilspy 8 versions
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/125446)