### PR TITLE
Fix wrong x64 installer issue #125999 (SweetScape.010Editor)

### DIFF
--- a/manifests/s/SweetScape/010Editor/14.0/SweetScape.010Editor.installer.yaml
+++ b/manifests/s/SweetScape/010Editor/14.0/SweetScape.010Editor.installer.yaml
@@ -24,7 +24,7 @@ Installers:
   InstallerUrl: https://download.sweetscape.com/010EditorWin32Installer14.0.exe
   InstallerSha256: 11D96FA10DF0F8E6ADD3509E03B963C398A190890F0EA45D8E56C4DD77CBEAA9
 - Architecture: x64
-  InstallerUrl: https://download.sweetscape.com/010EditorWin32Installer14.0.exe
-  InstallerSha256: 11D96FA10DF0F8E6ADD3509E03B963C398A190890F0EA45D8E56C4DD77CBEAA9
+  InstallerUrl: https://download.sweetscape.com/010EditorWin64Installer14.0.exe
+  InstallerSha256: 9F926AF3BC49DF3AB3B2FA8E9CF97CAF018081DF277C25EE37FAB8C2FDD974BA
 ManifestType: installer
 ManifestVersion: 1.5.0


### PR DESCRIPTION
### Description
Fixes #125999 
### Checks
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/126032)