### PR TITLE
New version: KiCad.KiCad version 7.0.9

### DIFF
--- a/manifests/k/KiCad/KiCad/7.0.9/KiCad.KiCad.installer.yaml
+++ b/manifests/k/KiCad/KiCad/7.0.9/KiCad.KiCad.installer.yaml
@@ -7,6 +7,8 @@ InstallerType: nullsoft
 InstallModes:
 - interactive
 - silent
+InstallerSwitches:
+  Silent: /S
 UpgradeBehavior: install
 FileExtensions:
 - dcm
@@ -24,10 +26,14 @@ Installers:
 - Architecture: x64
   Scope: machine
   ElevationRequirement: elevatesSelf
+  InstallerSwitches: 
+    Custom: /allusers
   InstallerUrl: https://github.com/KiCad/kicad-source-mirror/releases/download/7.0.9/kicad-7.0.9-x86_64.exe
   InstallerSha256: 4A1A29863B2624FD80FEA200C76E67636F6E9843035FA391D1802BDAE2ECD029
 - Architecture: x64
   Scope: user
+  InstallerSwitches: 
+    Custom: /currentuser
   InstallerUrl: https://github.com/KiCad/kicad-source-mirror/releases/download/7.0.9/kicad-7.0.9-x86_64.exe
   InstallerSha256: 4A1A29863B2624FD80FEA200C76E67636F6E9843035FA391D1802BDAE2ECD029
 ManifestType: installer

--- a/manifests/k/KiCad/KiCad/7.0.9/KiCad.KiCad.installer.yaml
+++ b/manifests/k/KiCad/KiCad/7.0.9/KiCad.KiCad.installer.yaml
@@ -23,6 +23,7 @@ ReleaseDate: 2023-11-08
 Installers:
 - Architecture: x64
   Scope: machine
+  ElevationRequirement: elevatesSelf
   InstallerUrl: https://github.com/KiCad/kicad-source-mirror/releases/download/7.0.9/kicad-7.0.9-x86_64.exe
   InstallerSha256: 4A1A29863B2624FD80FEA200C76E67636F6E9843035FA391D1802BDAE2ECD029
 - Architecture: x64

--- a/manifests/k/KiCad/KiCad/7.0.9/KiCad.KiCad.installer.yaml
+++ b/manifests/k/KiCad/KiCad/7.0.9/KiCad.KiCad.installer.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+
+PackageIdentifier: KiCad.KiCad
+PackageVersion: 7.0.9
+InstallerLocale: en-US
+InstallerType: nullsoft
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+FileExtensions:
+- dcm
+- drl
+- kicad_lib
+- kicad_mod
+- kicad_pcb
+- kicad_wks
+- net
+- pro
+- sch
+ProductCode: '{CF8E6E00-9C03-4440-81C0-21FACB921A6B}'
+ReleaseDate: 2023-11-08
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/KiCad/kicad-source-mirror/releases/download/7.0.9/kicad-7.0.9-x86_64.exe
+  InstallerSha256: 4A1A29863B2624FD80FEA200C76E67636F6E9843035FA391D1802BDAE2ECD029
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/k/KiCad/KiCad/7.0.9/KiCad.KiCad.installer.yaml
+++ b/manifests/k/KiCad/KiCad/7.0.9/KiCad.KiCad.installer.yaml
@@ -22,6 +22,11 @@ ProductCode: '{CF8E6E00-9C03-4440-81C0-21FACB921A6B}'
 ReleaseDate: 2023-11-08
 Installers:
 - Architecture: x64
+  Scope: machine
+  InstallerUrl: https://github.com/KiCad/kicad-source-mirror/releases/download/7.0.9/kicad-7.0.9-x86_64.exe
+  InstallerSha256: 4A1A29863B2624FD80FEA200C76E67636F6E9843035FA391D1802BDAE2ECD029
+- Architecture: x64
+  Scope: user
   InstallerUrl: https://github.com/KiCad/kicad-source-mirror/releases/download/7.0.9/kicad-7.0.9-x86_64.exe
   InstallerSha256: 4A1A29863B2624FD80FEA200C76E67636F6E9843035FA391D1802BDAE2ECD029
 ManifestType: installer

--- a/manifests/k/KiCad/KiCad/7.0.9/KiCad.KiCad.locale.en-US.yaml
+++ b/manifests/k/KiCad/KiCad/7.0.9/KiCad.KiCad.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+
+PackageIdentifier: KiCad.KiCad
+PackageVersion: 7.0.9
+PackageLocale: en-US
+Publisher: KiCad
+PublisherUrl: https://www.kicad.org
+PublisherSupportUrl: https://www.kicad.org/help
+Author: KiCad
+PackageName: KiCad
+PackageUrl: https://www.kicad.org
+License: GPL-3.0
+LicenseUrl: https://gitlab.com/kicad/code/kicad/-/blob/master/LICENSE
+Copyright: Copyright (c) 2014-2023 KiCad Developers
+ShortDescription: KiCad is a free software suite for electronic design automation. It facilitates the design of schematics for electronic circuits and their conversion to PCB designs.
+Moniker: kicad
+Tags:
+- cad
+- eda
+- pcb
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/k/KiCad/KiCad/7.0.9/KiCad.KiCad.yaml
+++ b/manifests/k/KiCad/KiCad/7.0.9/KiCad.KiCad.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+
+PackageIdentifier: KiCad.KiCad
+PackageVersion: 7.0.9
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0


### PR DESCRIPTION
Changed the download link from `https://downloads.kicad.org/` (in the previous versions) to github releases [mirror](https://github.com/KiCad/kicad-source-mirror/releases/)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/126054)