### PR TITLE
Update manifests: Amazon.Kindle version 2.0.1.70350

### DIFF
--- a/manifests/a/Amazon/Kindle/2.0.1.70350/Amazon.Kindle.installer.yaml
+++ b/manifests/a/Amazon/Kindle/2.0.1.70350/Amazon.Kindle.installer.yaml
@@ -1,10 +1,10 @@
-# Created with YamlCreate.ps1 v2.2.10 $debug=AUSU.CRLF.5-1-19041-3570.Win32NT
+# Created using wingetcreate 1.5.7.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
 
 PackageIdentifier: Amazon.Kindle
 PackageVersion: 2.0.1.70350
 MinimumOSVersion: 6.2.0.0
-InstallerType: exe
+InstallerType: nullsoft
 Scope: user
 InstallModes:
 - interactive

--- a/manifests/a/Amazon/Kindle/2.0.1.70350/Amazon.Kindle.locale.en-US.yaml
+++ b/manifests/a/Amazon/Kindle/2.0.1.70350/Amazon.Kindle.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.2.10 $debug=AUSU.CRLF.5-1-19041-3570.Win32NT
+# Created using wingetcreate 1.5.7.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
 
 PackageIdentifier: Amazon.Kindle
@@ -6,15 +6,10 @@ PackageVersion: 2.0.1.70350
 PackageLocale: en-US
 Publisher: Amazon
 PublisherUrl: https://www.amazon.com/
-# PublisherSupportUrl: https://www.amazon.com/gp/help/customer/display.html?nodeId=GAJYEL5VJLU5KF6L
-# PrivacyUrl: https://www.amazon.com/gp/help/customer/display.html?nodeId=GX7NJQ4ZB8MHFRNJ
-# Author:
 PackageName: Amazon Kindle
 PackageUrl: https://www.amazon.com/gp/browse.html?node=16571048011
 License: Copyright (c) 1996-2023, Amazon.com, Inc. or its affiliates
-# LicenseUrl:
 Copyright: Copyright (c) 1996-2023, Amazon.com, Inc. or its affiliates
-# CopyrightUrl: https://www.amazon.com/gp/help/customer/display.html?nodeId=200499360
 ShortDescription: Your library on your PC - read your books on your PC with the free Kindle app.
 Description: The Kindle app is available for most major smartphones, tablets and computers. That means with our free Kindle reading apps, you can buy a Kindle book once, and read it on any device with the Kindle app installed*. You can also read that same Kindle book on a Kindle device if you own one.
 Moniker: kindle
@@ -30,10 +25,5 @@ Tags:
 - library
 - reader
 - reading
-# ReleaseNotes:
-# ReleaseNotesUrl:
-# PurchaseUrl:
-# InstallationNotes:
-# Documentations:
 ManifestType: defaultLocale
 ManifestVersion: 1.5.0

--- a/manifests/a/Amazon/Kindle/2.0.1.70350/Amazon.Kindle.yaml
+++ b/manifests/a/Amazon/Kindle/2.0.1.70350/Amazon.Kindle.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.2.10 $debug=AUSU.CRLF.5-1-19041-3570.Win32NT
+# Created using wingetcreate 1.5.7.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
 
 PackageIdentifier: Amazon.Kindle


### PR DESCRIPTION
## Description

According to @DenWin , the package installer is inspected as a NullSoft installer wizard. So it's better change `InstallerType` property from `exe` to `nullsoft`, as `winget.exe` can automatically add necessary switches for improving user experience.

- Resolve https://github.com/microsoft/winget-pkgs/issues/125229

## Checks

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/126200)