### PR TITLE
installing/updating sumatrapdf for machine scope requires elevation

### DIFF
--- a/manifests/s/SumatraPDF/SumatraPDF/3.5.2/SumatraPDF.SumatraPDF.installer.yaml
+++ b/manifests/s/SumatraPDF/SumatraPDF/3.5.2/SumatraPDF.SumatraPDF.installer.yaml
@@ -43,6 +43,7 @@ Installers:
   Scope: machine
   InstallerUrl: https://files2.sumatrapdfreader.org/software/sumatrapdf/rel/3.5.2/SumatraPDF-3.5.2-install.exe
   InstallerSha256: 65B514E80E5121D5EC94705B4A94ADF3BF8A6EB6DE58D2707DDD72C3D6D3779D
+  ElevationRequirement: elevationRequired
   InstallerSwitches:
     Custom: -allusers
 - Architecture: x64
@@ -53,12 +54,14 @@ Installers:
   Scope: machine
   InstallerUrl: https://files2.sumatrapdfreader.org/software/sumatrapdf/rel/3.5.2/SumatraPDF-3.5.2-64-install.exe
   InstallerSha256: 2BE4A27B83830EA07C6671C3557673D509544E5F70FC6B2DC8CC4388B302C1F2
+  ElevationRequirement: elevationRequired
   InstallerSwitches:
     Custom: -allusers
 - Architecture: arm64
   Scope: machine
   InstallerUrl: https://files2.sumatrapdfreader.org/software/sumatrapdf/rel/3.5.2/SumatraPDF-3.5.2-arm64-install.exe
   InstallerSha256: 8F600E51AA574A424D0263C6C38AABF3F1E24F59AC8ECC26448DE33D24F8CC53
+  ElevationRequirement: elevationRequired
   InstallerSwitches:
     Custom: -allusers
 - Architecture: arm64


### PR DESCRIPTION
Currently, without this setting, winget doesn't elevate the installer and in a non-administrative shell it just fails with exit code 1

- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] This PR only modifies one (1) manifest
- [X] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [X] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

before:

```
Starting package install...
Installer failed with exit code: 1
```

after:

```
Starting package install...
The installer will request to run as administrator, expect a prompt.
Successfully installed
```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/126387)