### PR TITLE
Update BiglyBT : Download default 64-bit version instead of the package bundled with Java

### DIFF
--- a/manifests/b/BiglySoftware/BiglyBT/3.5.0.0/BiglySoftware.BiglyBT.installer.yaml
+++ b/manifests/b/BiglySoftware/BiglyBT/3.5.0.0/BiglySoftware.BiglyBT.installer.yaml
@@ -26,7 +26,7 @@ Installers:
   InstallerUrl: https://github.com/BiglySoftware/BiglyBT/releases/download/v3.5.0.0/GitHub_BiglyBT_Installer32.exe
   InstallerSha256: D91EF5D2A1A8AFC3968700B186F4D853B937828180B0DFAD92D64DFD87438161
 - Architecture: x64
-  InstallerUrl: https://github.com/BiglySoftware/BiglyBT/releases/download/v3.5.0.0/GitHub_BiglyBT_Installer64_WithJava.exe
-  InstallerSha256: C942EA92AC147BBC1CC3DF54ECAAF5FA894299E2D214F5AFC67092A0F36D0281
+  InstallerUrl: https://github.com/BiglySoftware/BiglyBT/releases/download/v3.5.0.0/GitHub_BiglyBT_Installer64.exe
+  InstallerSha256: F43C6795BC7CDB4CD70DB264425E9BE6899D794E517EA44639C00BDBC7EA682B
 ManifestType: installer
 ManifestVersion: 1.5.0


### PR DESCRIPTION


- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

Version 3.5.0.0 manifest of BiglyBT downloads the "With Java" edition. The default 64-bit version (which is same as J14 edition in previous versions of this package) also does not need JRE.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/126619)