### PR TITLE
Update: CologneCodeCompany.XYplorer version 25.10.0100

### DIFF
--- a/manifests/c/CologneCodeCompany/XYplorer/25.10.0100/CologneCodeCompany.XYplorer.installer.yaml
+++ b/manifests/c/CologneCodeCompany/XYplorer/25.10.0100/CologneCodeCompany.XYplorer.installer.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.2.10 $debug=NVS0.CRLF.7-3-9.Win32NT
+# Created with YamlCreate.ps1 v2.2.10 $debug=QUSU.CRLF.7-3-9.Win32NT
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
 
 PackageIdentifier: CologneCodeCompany.XYplorer
@@ -14,7 +14,6 @@ InstallerSwitches:
 UpgradeBehavior: install
 Commands:
 - xyplorer
-ReleaseDate: 2023-11-06
 Installers:
 - Architecture: x64
   NestedInstallerType: nullsoft

--- a/manifests/c/CologneCodeCompany/XYplorer/25.10.0100/CologneCodeCompany.XYplorer.locale.en-US.yaml
+++ b/manifests/c/CologneCodeCompany/XYplorer/25.10.0100/CologneCodeCompany.XYplorer.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.2.10 $debug=NVS0.CRLF.7-3-9.Win32NT
+# Created with YamlCreate.ps1 v2.2.10 $debug=QUSU.CRLF.7-3-9.Win32NT
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
 
 PackageIdentifier: CologneCodeCompany.XYplorer
@@ -7,19 +7,24 @@ PackageLocale: en-US
 Publisher: Cologne Code Company
 PublisherUrl: https://www.xyplorer.com
 PublisherSupportUrl: https://www.xyplorer.com/support.php
+# PrivacyUrl:
 Author: Donald Lessau
 PackageName: XYplorer
 PackageUrl: https://www.xyplorer.com
 License: Proprietary
 LicenseUrl: https://www.xyplorer.com/LicenseXY.txt
 Copyright: Copyright © 1997 by Donald Lessau
+# CopyrightUrl:
 ShortDescription: XYplorer is a file manager for Windows
 Description: XYplorer is a file manager for Windows. It features tabbed browsing, a powerful file search, a versatile preview, a highly customizable interface, optional dual pane, and a large array of unique ways to efficiently automate frequently recurring tasks. It's fast and light, it's innovative, and it's portable.
 Moniker: xyplorer
 Tags:
 - file-manager
 - xyplorer
-ReleaseNotesUrl: https://www.xyplorer.com/whatsnew.php#current
+# ReleaseNotes:
+# ReleaseNotesUrl:
 PurchaseUrl: https://www.xyplorer.com/purchase.php
+# InstallationNotes:
+# Documentations:
 ManifestType: defaultLocale
 ManifestVersion: 1.5.0

--- a/manifests/c/CologneCodeCompany/XYplorer/25.10.0100/CologneCodeCompany.XYplorer.yaml
+++ b/manifests/c/CologneCodeCompany/XYplorer/25.10.0100/CologneCodeCompany.XYplorer.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 v2.2.10 $debug=NVS0.CRLF.7-3-9.Win32NT
+# Created with YamlCreate.ps1 v2.2.10 $debug=QUSU.CRLF.7-3-9.Win32NT
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
 
 PackageIdentifier: CologneCodeCompany.XYplorer


### PR DESCRIPTION
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] This PR only modifies one (1) manifest
- [X] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [X] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/126984)

This is not a version update, but an addition to installers. WinGetCreate was failing to update because the x86 installer was missing from the manfiest.