### PR TITLE
New version: Tableau.Desktop version 23.3.345

### DIFF
--- a/manifests/t/Tableau/Desktop/23.3.345/Tableau.Desktop.installer.yaml
+++ b/manifests/t/Tableau/Desktop/23.3.345/Tableau.Desktop.installer.yaml
@@ -1,0 +1,29 @@
+# Created using wingetcreate 1.5.7.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+
+PackageIdentifier: Tableau.Desktop
+PackageVersion: 23.3.345
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: burn
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Custom: ACCEPTEULA=1
+UpgradeBehavior: install
+ProductCode: '{f57acab5-0241-4e49-9108-3f47cb72497f}'
+AppsAndFeaturesEntries:
+- DisplayName: Tableau 2022.3 (20223.22.1005.1835)
+  Publisher: Tableau Software, LLC
+  ProductCode: '{f57acab5-0241-4e49-9108-3f47cb72497f}'
+  InstallerType: burn
+Installers:
+- Architecture: x64
+  InstallerUrl: https://downloads.tableau.com/esdalt/2023.3.0/TableauDesktop-64bit-2023-3-0.exe
+  InstallerSha256: B3E56E4657B922CB4F8E885331216B09A68CF26A02D9453582574B91DE0970C2
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/t/Tableau/Desktop/23.3.345/Tableau.Desktop.locale.en-US.yaml
+++ b/manifests/t/Tableau/Desktop/23.3.345/Tableau.Desktop.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# Created using wingetcreate 1.5.7.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+
+PackageIdentifier: Tableau.Desktop
+PackageVersion: 23.3.345
+PackageLocale: en-US
+Publisher: Tableau Software, LLC
+PublisherUrl: http://tableau.com
+PublisherSupportUrl: https://www.tableau.com/support
+PrivacyUrl: https://www.tableau.com/privacy
+Author: Tableau Software
+PackageName: Tableau
+PackageUrl: https://www.tableau.com/products/desktop
+License: Proprietary
+LicenseUrl: https://mkt.tableau.com/legal/tableau_eula.pdf
+Copyright: (c) 2003-2022 Tableau Software, LLC.
+CopyrightUrl: https://mkt.tableau.com/legal/tableau_eula.pdf
+ShortDescription: Tableau Desktop is data visualization software that lets you see and understand data in minutes. With other Tableau products, it comprises a complete business intelligence software solution.
+Moniker: tableau-desktop
+Tags:
+- business
+- charts
+- graphs
+- tableau
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/t/Tableau/Desktop/23.3.345/Tableau.Desktop.yaml
+++ b/manifests/t/Tableau/Desktop/23.3.345/Tableau.Desktop.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.5.7.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+
+PackageIdentifier: Tableau.Desktop
+PackageVersion: 23.3.345
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

This intentionally has the same installer URL as the latest version (2023.3.0) and is just a change to the exact version number (23.3.345) to prevent an endless update available loop caused by v23 being installed and v2023 being available.
