### PR TITLE
yt-dlp.yt-dlp.nightly: add ffmpeg dependency

### DIFF
--- a/manifests/y/yt-dlp/yt-dlp/nightly/2023.11.07.161837/yt-dlp.yt-dlp.nightly.installer.yaml
+++ b/manifests/y/yt-dlp/yt-dlp/nightly/2023.11.07.161837/yt-dlp.yt-dlp.nightly.installer.yaml
@@ -7,6 +7,9 @@ InstallerLocale: en-US
 InstallerType: portable
 Commands:
 - yt-dlp
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Gyan.FFmpeg
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/yt-dlp/yt-dlp-nightly-builds/releases/download/2023.11.07.161837/yt-dlp.exe


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

ffmpeg is strongly recommended and required to download youtube videos (which this is what most users will use yt-dlp for)
![изображение](https://github.com/microsoft/winget-pkgs/assets/5204968/b0d5b0a6-dbe4-4490-9bdb-0f2f75d7dcec)

