### PR TITLE
Poster Font Light version 1.0

### DIFF
--- a/manifests/j/Japplis/PosterFont/Light/1.0/Japplis.PosterFont.Light.installer.yaml
+++ b/manifests/j/Japplis/PosterFont/Light/1.0/Japplis.PosterFont.Light.installer.yaml
@@ -1,0 +1,27 @@
+# Created using Apache Ant script from Japplis
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+
+PackageIdentifier: Japplis.PosterFont.Light
+PackageVersion: 1.0
+Platform:
+- Windows.Desktop
+InstallerType: inno
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+Installers:
+- Architecture: x64
+  Scope: machine
+  InstallerUrl: https://www.japplis.com/poster-font/light/versions/PosterFontLight-1.0.exe
+  InstallerSha256: fb355df35ca1f7a466cc224e6ecc3db08de67048d3e92024fa079b0d5aafd682
+  InstallerSwitches:
+    Custom: /ALLUSERS
+- Architecture: x64
+  Scope: user
+  InstallerUrl: https://www.japplis.com/poster-font/light/versions/PosterFontLight-1.0.exe
+  InstallerSha256: fb355df35ca1f7a466cc224e6ecc3db08de67048d3e92024fa079b0d5aafd682
+  InstallerSwitches:
+    Custom: /CURRENTUSER
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/j/Japplis/PosterFont/Light/1.0/Japplis.PosterFont.Light.locale.en-US.yaml
+++ b/manifests/j/Japplis/PosterFont/Light/1.0/Japplis.PosterFont.Light.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# Created using Apache Ant script from Japplis
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+
+PackageIdentifier: Japplis.PosterFont.Light
+PackageVersion: 1.0
+PackageLocale: en-US
+Publisher: Japplis
+PublisherUrl: https://www.japplis.com
+Author: Anthony Goubard
+PackageName: Poster Font Light
+PackageUrl: https://www.japplis.com/poster-font/light/
+License: Shareware
+LicenseUrl: https://www.japplis.com/poster-font/light/license.txt
+Copyright: Copyright © 2011 - 2023 Japplis. All rights reserved.
+ShortDescription: Create beautiful text for your presentations and thumbnails
+Description: |-
+  Poster Font Light - Easily create beautiful titles
+  Create beautiful text for your professional presentations, your website or your video thumbnails. More than 100 templates to choose the effect from.
+ReleaseNotesUrl: https://www.japplis.com/poster-font/light/changes.txt
+Moniker: poster-font-light
+Tags: 
+- font
+- text
+- title
+- presentation
+- poster
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/j/Japplis/PosterFont/Light/1.0/Japplis.PosterFont.Light.yaml
+++ b/manifests/j/Japplis/PosterFont/Light/1.0/Japplis.PosterFont.Light.yaml
@@ -1,0 +1,8 @@
+# Created using Apache Ant script from Japplis
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+
+PackageIdentifier: Japplis.PosterFont.Light
+PackageVersion: 1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

Note that the package ID is Japplis.PosterFont.Light (and PosterFont/Light/1.0 directory) because there will be soon another application with Japplis.PosterFont package ID (and  PosterFont/1.0 directory).
---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/128053)