### PR TITLE
Remove Validation-Forbidden-URL-Error on pipeline re-run

### DIFF
--- a/.github/policies/labelManagement.issueUpdated.yml
+++ b/.github/policies/labelManagement.issueUpdated.yml
@@ -305,6 +305,8 @@ configuration:
           - removeLabel:
               label: Validation-Unapproved-URL
           - removeLabel:
+              label: Validation-Forbidden-URL-Error
+          - removeLabel:
               label: Validation-Domain
           - removeLabel:
               label: Blocking-Issue


### PR DESCRIPTION
Example case:
- https://github.com/microsoft/winget-pkgs/pull/127883

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/128058)