### PR TITLE
New arch: Git.Git version 2.43.0

### DIFF
--- a/manifests/g/Git/Git/2.43.0/Git.Git.installer.yaml
+++ b/manifests/g/Git/Git/2.43.0/Git.Git.installer.yaml
@@ -26,5 +26,13 @@ Installers:
   InstallerUrl: https://github.com/git-for-windows/git/releases/download/v2.43.0.windows.1/Git-2.43.0-64-bit.exe
   Scope: machine
   InstallerSha256: A6058D7C4C16BFA5BCD6FDE051A92DE8C68535FD7EBADE55FC0AB1C41BE3C8D5
+- Architecture: x86
+  InstallerUrl: https://github.com/git-for-windows/git/releases/download/v2.43.0.windows.1/Git-2.43.0-32-bit.exe
+  Scope: user
+  InstallerSha256: AEE1587A4004C6A57B614C81FDC2AE1FA33DE0DAAF6B650CF6467E4253E024A9
+- Architecture: x86
+  InstallerUrl: https://github.com/git-for-windows/git/releases/download/v2.43.0.windows.1/Git-2.43.0-32-bit.exe
+  Scope: machine
+  InstallerSha256: AEE1587A4004C6A57B614C81FDC2AE1FA33DE0DAAF6B650CF6467E4253E024A9
 ManifestType: installer
 ManifestVersion: 1.5.0


### PR DESCRIPTION
Missing x86 (32-bit) architecture of Git.Git package

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/128149)