### PR TITLE
Update Abdelrhman-AK.WinPaletter.installer.yaml – Fix critical typo

### DIFF
--- a/manifests/a/Abdelrhman-AK/WinPaletter/1.0.8.2/Abdelrhman-AK.WinPaletter.installer.yaml
+++ b/manifests/a/Abdelrhman-AK/WinPaletter/1.0.8.2/Abdelrhman-AK.WinPaletter.installer.yaml
@@ -7,7 +7,6 @@ InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
 - RelativeFilePath: WinPaletter.exe
-  PortableCommandAlias: zip
 Installers:
 - Architecture: x86
   InstallerUrl: https://github.com/Abdelrhman-AK/WinPaletter/releases/download/v1.0.8.2/WinPaletter.zip


### PR DESCRIPTION
Same problem as #128150: This package (Abdelrhman-AK.WinPaletter) incorrectly registers "zip" as its portable command alias. Given the nature of the package, this egregious registration could only be a typo.

- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/128306)