### PR TITLE
Revert "Update version: Google.AndroidStudio version 2022.3.1.20"

### DIFF
--- a/manifests/g/Google/AndroidStudio/2022.3.1.20/Google.AndroidStudio.installer.yaml
+++ b/manifests/g/Google/AndroidStudio/2022.3.1.20/Google.AndroidStudio.installer.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 1.5.7.0
+# Created using wingetcreate 1.5.5.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
 
 PackageIdentifier: Google.AndroidStudio
@@ -11,10 +11,10 @@ InstallModes:
 InstallerSuccessCodes:
 - 1223
 UpgradeBehavior: install
-ProductCode: Android Studio
 Installers:
-- Architecture: x86
-  InstallerUrl: https://redirector.gvt1.com/edgedl/android/studio/install/2022.3.1.22/android-studio-2022.3.1.22-windows.exe
-  InstallerSha256: CFB4CF2485493B7DE74BCDC5D1C0421B70291F3E45257CB0E64DA745C48870BC
+- Architecture: x64
+  InstallerUrl: https://redirector.gvt1.com/edgedl/android/studio/install/2022.3.1.20/android-studio-2022.3.1.20-windows.exe
+  InstallerSha256: 495D55BDD8BC1B8C6A41FCC5A31F8DB0FBCD3199A82FC4B0847D32F99FBE11B6
+  ProductCode: Android Studio
 ManifestType: installer
 ManifestVersion: 1.5.0

--- a/manifests/g/Google/AndroidStudio/2022.3.1.20/Google.AndroidStudio.locale.en-US.yaml
+++ b/manifests/g/Google/AndroidStudio/2022.3.1.20/Google.AndroidStudio.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 1.5.7.0
+# Created using wingetcreate 1.5.5.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
 
 PackageIdentifier: Google.AndroidStudio

--- a/manifests/g/Google/AndroidStudio/2022.3.1.20/Google.AndroidStudio.yaml
+++ b/manifests/g/Google/AndroidStudio/2022.3.1.20/Google.AndroidStudio.yaml
@@ -1,4 +1,4 @@
-# Created using wingetcreate 1.5.7.0
+# Created using wingetcreate 1.5.5.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
 
 PackageIdentifier: Google.AndroidStudio


### PR DESCRIPTION
Reverts microsoft/winget-pkgs#127976

There is 2 issues with #127976
1. It changes installer url in 2022.3.1.20 instead of creating new manifest for version 2022.3.1.22
2. Android Studio doesn't support 32-bit OS, there is installer only for x64 architecture

I'll add version 2022.3.1.22 in another pull request.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/128550)