### PR TITLE
New Version RuneLite.RuneLite 2.6.10

### DIFF
--- a/manifests/r/RuneLite/RuneLite/2.6.10/RuneLite.RuneLite.installer.yaml
+++ b/manifests/r/RuneLite/RuneLite/2.6.10/RuneLite.RuneLite.installer.yaml
@@ -1,0 +1,27 @@
+# Created using wingetcreate 1.5.7.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+
+PackageIdentifier: RuneLite.RuneLite
+PackageVersion: 2.6.10
+Platform:
+- Windows.Desktop
+InstallerType: inno
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/runelite/launcher/releases/download/2.6.10/RuneLiteSetup32.exe
+  InstallerSha256: 4B3293E69C7E82E91BE85C71E0D4EAB072222AA3E46C01D2A52789AAC355C604
+- Architecture: x64
+  InstallerUrl: https://github.com/runelite/launcher/releases/download/2.6.10/RuneLiteSetup.exe
+  InstallerSha256: 837370201E436F04CF94972757E18C294B05C30FD9D39AA0DD50513DF6355AF6
+- Architecture: arm64
+  InstallerUrl: https://github.com/runelite/launcher/releases/download/2.6.10/RuneLiteSetupAArch64.exe
+  InstallerSha256: e2bc488c8faa927e35220d4c38bd87f02c604e7d5d678735e2437132e6918b31
+ManifestType: installer
+ManifestVersion: 1.5.0
+ReleaseDate: 2023-11-19

--- a/manifests/r/RuneLite/RuneLite/2.6.10/RuneLite.RuneLite.locale.en-US.yaml
+++ b/manifests/r/RuneLite/RuneLite/2.6.10/RuneLite.RuneLite.locale.en-US.yaml
@@ -1,0 +1,21 @@
+# Created using wingetcreate 1.5.7.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+
+PackageIdentifier: RuneLite.RuneLite
+PackageVersion: 2.6.10
+PackageLocale: en-US
+Publisher: RuneLite
+PublisherUrl: https://runelite.net
+PublisherSupportUrl: https://github.com/runelite/runelite/wiki
+Author: Adam
+PackageName: RuneLite
+PackageUrl: https://github.com/runelite/launcher
+License: BSD-2-CLAUSE
+LicenseUrl: https://raw.githubusercontent.com/runelite/launcher/master/LICENSE
+Copyright: Copyright (c) 2016, Adam <Adam@sigterm.info>
+CopyrightUrl: https://raw.githubusercontent.com/runelite/launcher/master/LICENSE
+ShortDescription: RuneLite is a free, open source OldSchool RuneScape client.
+Moniker: runelite
+ReleaseNotesUrl: https://github.com/runelite/launcher/releases/tag/2.6.8
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/r/RuneLite/RuneLite/2.6.10/RuneLite.RuneLite.yaml
+++ b/manifests/r/RuneLite/RuneLite/2.6.10/RuneLite.RuneLite.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.5.7.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+
+PackageIdentifier: RuneLite.RuneLite
+PackageVersion: 2.6.10
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] This PR only modifies one (1) manifest
- [X] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [X] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

This PR is the first RuneLite.RuneLite manifest that contains the arm64 installer, and also my first winget-pkgs contribution so I'm not sure if it will pass automatic validation.

There is an automatically generated open PR which also seeks to update the version to 2.6.10, but it contains the wrong URL for the x64 version, does not include the new architecture, has been stale for a while, and I don't have write access to modify the existing PR 😄 

I also noticed at least the most recent existing version manifest incorrectly installs the x32 version on x64 PCs, which is what alerted me that there was an issue in the first place. That and there is a closed PR for the version before this, so I have at least one other PR to submit.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/128761)