### PR TITLE
Fix KDE.Filelight 23.08.3 404 error

### DIFF
--- a/manifests/k/KDE/Filelight/23.08.3/KDE.Filelight.installer.yaml
+++ b/manifests/k/KDE/Filelight/23.08.3/KDE.Filelight.installer.yaml
@@ -5,7 +5,7 @@ PackageIdentifier: KDE.Filelight
 PackageVersion: 23.08.3
 InstallerType: nullsoft
 Installers:
-- InstallerUrl: https://binary-factory.kde.org/job/Filelight_Release_win64/lastSuccessfulBuild/artifact/filelight-23.08.3-1545-windows-cl-msvc2019-x86_64.exe
+- InstallerUrl: https://binary-factory.kde.org/job/Filelight_Release_win64/1545/artifact/filelight-23.08.3-1545-windows-cl-msvc2019-x86_64.exe
   Architecture: x64
   InstallerSha256: 7990212221AFFA5E6628791C8E0AB1949866B80D041209A7089C87B5BBC05C7A
 ManifestType: installer


### PR DESCRIPTION
This PR fixes the KDE.Filelight 23.08.3 URL 404 error as caught by PR #128927
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/128965)