### PR TITLE
Rebuild pipeline migration to 1 es pipeline

### DIFF
--- a/DevOpsPipelineDefinitions/rebuild-pipeline.yaml
+++ b/DevOpsPipelineDefinitions/rebuild-pipeline.yaml
@@ -29,7 +29,7 @@ extends:
     - ES365AIMigrationTooling
 
     stages:
-    - stage: Rebuild_SignPackage_Publish_Cleanup
+    - stage: WinGetSvc_Rebuild
       jobs:
       # Agent phase.
       - job: 'Rebuild'

--- a/DevOpsPipelineDefinitions/rebuild-pipeline.yaml
+++ b/DevOpsPipelineDefinitions/rebuild-pipeline.yaml
@@ -12,173 +12,190 @@ variables:
   Rebuild.EnableContainerBackup: $[coalesce(variables.EnableContainerBackup, 'False')]
   Rebuild.ClearContainer: $[coalesce(variables.ClearContainer, 'False')]
 
-jobs:
+resources:
+  repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    pool:
+      name: Azure-Pipelines-1ESPT-ExDShared
+      image: windows-2022
+      os: windows
+    customBuildTags:
+    - ES365AIMigrationTooling
 
-# Agent phase.
-- job: 'Rebuild'
-  displayName: 'Start Rebuild'
-  pool:
-    vmImage: 'windows-latest'
-  variables:
-    skipComponentGovernanceDetection: ${{ true }}
-    runCodesignValidationInjection: ${{ false }}
-  timeoutInMinutes: 0
-  
-  steps:
+    stages:
+    - stage: Rebuild_SignPackage_Publish_Cleanup
+      jobs:
+      # Agent phase.
+      - job: 'Rebuild'
+        displayName: 'Start Rebuild'
+        variables:
+          skipComponentGovernanceDetection: ${{ true }}
+          runCodesignValidationInjection: ${{ false }}
+        timeoutInMinutes: 0
+        
+        steps:
 
-  # Allow scripts to access the system token.
-  - checkout: self
-    persistCredentials: true
-    clean: true
+        # Allow scripts to access the system token.
+        - checkout: self
+          persistCredentials: true
+          clean: true
 
-  # Downloads all the setup files and its dependencies.
-  - task: AzureCLI@1
-    displayName: 'Azure Setup'
-    inputs:
-      azureSubscription: '$(WinGet.Subscription)'
-      scriptLocation: inlineScript
-      inlineScript: 'az storage blob download-batch -d . --pattern * -s servicewrapper --output none'
-    env:
-      AZURE_STORAGE_CONNECTION_STRING: $(ValidationStorageAccountConnectionString)
+        # Downloads all the setup files and its dependencies.
+        - task: AzureCLI@1
+          displayName: 'Azure Setup'
+          inputs:
+            azureSubscription: '$(WinGet.Subscription)'
+            scriptLocation: inlineScript
+            inlineScript: 'az storage blob download-batch -d . --pattern * -s servicewrapper --output none'
+          env:
+            AZURE_STORAGE_CONNECTION_STRING: $(ValidationStorageAccountConnectionString)
 
-  # WinGet setup
-  - script: 'winget_rebuild_setup.cmd'
-    name: 'wingetsetup'
-    displayName: 'WinGet Setup'
-    workingDirectory: scripts
-    env:
-      HOST_KEY: $(AzureFunctionHostKey)
-      SIGN_ENDPOINT: $(AzFuncSignEndpoint)
-      PUBLISH_ENDPOINT: $(AzFuncRebuildPublishEndpoint)
-      CLEANUP_ENDPOINT: $(AzFuncRebuildCleanupEndpoint)
-      RESTSOURCE_REBUILD_ENDPOINT: $(AzFuncRestSourceRebuildEndpoint)
+        # WinGet setup
+        - task: CmdLine@2
+          name: 'wingetsetup'
+          displayName: 'WinGet Setup'
+          env:
+            HOST_KEY: $(AzureFunctionHostKey)
+            SIGN_ENDPOINT: $(AzFuncSignEndpoint)
+            PUBLISH_ENDPOINT: $(AzFuncRebuildPublishEndpoint)
+            CLEANUP_ENDPOINT: $(AzFuncRebuildCleanupEndpoint)
+            RESTSOURCE_REBUILD_ENDPOINT: $(AzFuncRestSourceRebuildEndpoint)
+          inputs:
+            script: 'winget_rebuild_setup.cmd'
+            workingDirectory: scripts
 
-  - task: CmdLine@2
-    displayName: 'Validate Manifests'
-    inputs:
-      script: 'WinGetSvcWrapper.exe rebuild --operationId %BUILD_BUILDNUMBER%'
-      failOnStderr: true
-    condition: succeeded()
-    env:
-      ValidationConnectionString: $(ValidationStorageAccountConnectionString)
-      ExecutionEnvironment: $(ExecutionEnvironment)
-      PackagePublisher: $(PackagePublisher)
-      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-      DIApplicationInsightKey: $(DIApplicationInsightKey)
-      WinGet:AppConfig:Primary: $(AppConfigPrimary)
-      WinGet:AppConfig:Secondary: $(AppConfigSecondary)
-      DevOpsOrganization: $(DevOpsOrganization)
-      DevOpsProjectName: $(DevOpsProjectName)
-      DevOpsPublishPipelineDefinitionId: $(DevOpsPublishPipelineDefinitionId)
+        - task: CmdLine@2
+          displayName: 'Validate Manifests'
+          inputs:
+            script: 'WinGetSvcWrapper.exe rebuild --operationId %BUILD_BUILDNUMBER%'
+            failOnStderr: true
+          condition: succeeded()
+          env:
+            ValidationConnectionString: $(ValidationStorageAccountConnectionString)
+            ExecutionEnvironment: $(ExecutionEnvironment)
+            PackagePublisher: $(PackagePublisher)
+            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+            DIApplicationInsightKey: $(DIApplicationInsightKey)
+            WinGet:AppConfig:Primary: $(AppConfigPrimary)
+            WinGet:AppConfig:Secondary: $(AppConfigSecondary)
+            DevOpsOrganization: $(DevOpsOrganization)
+            DevOpsProjectName: $(DevOpsProjectName)
+            DevOpsPublishPipelineDefinitionId: $(DevOpsPublishPipelineDefinitionId)
 
-# Agentless phase. Depends on previous job. 
-- job: 'SignPackage'
-  pool: server
-  timeoutInMinutes: 1500
-  displayName: 'Sign package'
-  dependsOn:
-    - 'Rebuild'
-  variables:
-    HostKeySecret: $[ dependencies.Rebuild.outputs['wingetsetup.hostkey']]
-    SignEndpointSecret: $[ dependencies.Rebuild.outputs['wingetsetup.signEndpoint']]
-  steps:
+      # Agentless phase. Depends on previous job. 
+      - job: 'SignPackage'
+        pool: server
+        timeoutInMinutes: 1500
+        displayName: 'Sign package'
+        dependsOn:
+          - 'Rebuild'
+        variables:
+          HostKeySecret: $[ dependencies.Rebuild.outputs['wingetsetup.hostkey']]
+          SignEndpointSecret: $[ dependencies.Rebuild.outputs['wingetsetup.signEndpoint']]
+        steps:
 
-  # Sign package.
-  - task: AzureFunction@1
-    displayName: 'Signing package'
-    inputs:
-      function: '$(SignEndpointSecret)'
-      key: '$(HostKeySecret)'
-      body: |
-        {
-        "operationId": "$(Build.BuildNumber)",
-        "BuildId": "$(Build.BuildId)",
-        "PlanUrl": "$(system.CollectionUri)",
-        "HubName": "$(system.HostType)",
-        "pipelineType": "RebuildPipeline",
-        "ProjectId": "$(system.TeamProjectId)",
-        "PlanId": "$(system.PlanId)", 
-        "JobId": "$(system.JobId)", 
-        "TimelineId": "$(system.TimelineId)", 
-        "TaskInstanceId": "$(system.TaskInstanceId)",
-        "AuthToken": "$(system.AccessToken)"
-        }
-      waitForCompletion: "true"
+        # Sign package.
+        - task: AzureFunction@1
+          displayName: 'Signing package'
+          inputs:
+            function: '$(SignEndpointSecret)'
+            key: '$(HostKeySecret)'
+            body: |
+              {
+              "operationId": "$(Build.BuildNumber)",
+              "BuildId": "$(Build.BuildId)",
+              "PlanUrl": "$(system.CollectionUri)",
+              "HubName": "$(system.HostType)",
+              "pipelineType": "RebuildPipeline",
+              "ProjectId": "$(system.TeamProjectId)",
+              "PlanId": "$(system.PlanId)", 
+              "JobId": "$(system.JobId)", 
+              "TimelineId": "$(system.TimelineId)", 
+              "TaskInstanceId": "$(system.TaskInstanceId)",
+              "AuthToken": "$(system.AccessToken)"
+              }
+            waitForCompletion: "true"
 
-# Agentless phase. Depends on previous job.
-- job: 'Publish'
-  pool: server
-  timeoutInMinutes: 1500
-  displayName: 'Publish'
-  dependsOn:
-    - 'Rebuild'
-    - 'SignPackage'
-  variables:
-    HostKeySecret: $[ dependencies.Rebuild.outputs['wingetsetup.hostkey']]
-    PublishEndpointSecret: $[ dependencies.Rebuild.outputs['wingetsetup.publishEndpoint']]
-  steps:
+      # Agentless phase. Depends on previous job.
+      - job: 'Publish'
+        pool: server
+        timeoutInMinutes: 1500
+        displayName: 'Publish'
+        dependsOn:
+          - 'Rebuild'
+          - 'SignPackage'
+        variables:
+          HostKeySecret: $[ dependencies.Rebuild.outputs['wingetsetup.hostkey']]
+          PublishEndpointSecret: $[ dependencies.Rebuild.outputs['wingetsetup.publishEndpoint']]
+        steps:
 
-  # Rebuild Publish.
-  - task: AzureFunction@1
-    displayName: 'Publish'
-    inputs:
-      function: '$(PublishEndpointSecret)'
-      key: '$(HostKeySecret)'
-      body: |
-        {
-        "operationId": "$(Build.BuildNumber)",
-        "BuildId": "$(Build.BuildId)",
-        "PlanUrl": "$(system.CollectionUri)",
-        "HubName": "$(system.HostType)",
-        "pipelineType": "RebuildPipeline",
-        "ProjectId": "$(system.TeamProjectId)",
-        "PlanId": "$(system.PlanId)", 
-        "JobId": "$(system.JobId)", 
-        "TimelineId": "$(system.TimelineId)", 
-        "TaskInstanceId": "$(system.TaskInstanceId)",
-        "AuthToken": "$(system.AccessToken)",
-        "ContainerName": "$(CacheContainerName)",
-        "CommitTablePartitionKey": "$(CommitTablePartitionKey)",
-        "CommitTableRowKey": "$(CommitTableRowKey)",
-        "EnableContainerBackup": "$(Rebuild.EnableContainerBackup)",
-        "SkipManifestIndexUpdate": "$(Rebuild.SkipManifestIndexUpdate)",
-        "ClearContainer": "$(Rebuild.ClearContainer)",
-        }
-      waitForCompletion: "true"
+        # Rebuild Publish.
+        - task: AzureFunction@1
+          displayName: 'Publish'
+          inputs:
+            function: '$(PublishEndpointSecret)'
+            key: '$(HostKeySecret)'
+            body: |
+              {
+              "operationId": "$(Build.BuildNumber)",
+              "BuildId": "$(Build.BuildId)",
+              "PlanUrl": "$(system.CollectionUri)",
+              "HubName": "$(system.HostType)",
+              "pipelineType": "RebuildPipeline",
+              "ProjectId": "$(system.TeamProjectId)",
+              "PlanId": "$(system.PlanId)", 
+              "JobId": "$(system.JobId)", 
+              "TimelineId": "$(system.TimelineId)", 
+              "TaskInstanceId": "$(system.TaskInstanceId)",
+              "AuthToken": "$(system.AccessToken)",
+              "ContainerName": "$(CacheContainerName)",
+              "CommitTablePartitionKey": "$(CommitTablePartitionKey)",
+              "CommitTableRowKey": "$(CommitTableRowKey)",
+              "EnableContainerBackup": "$(Rebuild.EnableContainerBackup)",
+              "SkipManifestIndexUpdate": "$(Rebuild.SkipManifestIndexUpdate)",
+              "ClearContainer": "$(Rebuild.ClearContainer)",
+              }
+            waitForCompletion: "true"
 
-# Agentless phase. Depends on previous job.
-- job: 'Cleanup'
-  pool: server
-  timeoutInMinutes: 1500
-  displayName: 'Cleanup'
-  dependsOn:
-    - 'Rebuild'
-    - 'SignPackage'
-    - 'Publish'
-  condition: and(succeededOrFailed(), ne(variables['Rebuild.SkipPausePublishPipeline'], 'True'))
-  variables:
-    HostKeySecret: $[ dependencies.Rebuild.outputs['wingetsetup.hostkey']]
-    CleanupEndpointSecret: $[ dependencies.Rebuild.outputs['wingetsetup.cleanupEndpoint']]
-  steps:
+      # Agentless phase. Depends on previous job.
+      - job: 'Cleanup'
+        pool: server
+        timeoutInMinutes: 1500
+        displayName: 'Cleanup'
+        dependsOn:
+          - 'Rebuild'
+          - 'SignPackage'
+          - 'Publish'
+        condition: and(succeededOrFailed(), ne(variables['Rebuild.SkipPausePublishPipeline'], 'True'))
+        variables:
+          HostKeySecret: $[ dependencies.Rebuild.outputs['wingetsetup.hostkey']]
+          CleanupEndpointSecret: $[ dependencies.Rebuild.outputs['wingetsetup.cleanupEndpoint']]
+        steps:
 
-  # Rebuild cleanup.
-  - task: AzureFunction@1
-    displayName: 'Cleanup'
-    inputs:
-      function: '$(CleanupEndpointSecret)'
-      key: '$(HostKeySecret)'
-      body: |
-        {
-        "operationId": "$(Build.BuildNumber)",
-        "BuildId": "$(Build.BuildId)",
-        "PlanUrl": "$(system.CollectionUri)",
-        "HubName": "$(system.HostType)",
-        "pipelineType": "RebuildPipeline",
-        "ProjectId": "$(system.TeamProjectId)",
-        "PlanId": "$(system.PlanId)", 
-        "JobId": "$(system.JobId)", 
-        "TimelineId": "$(system.TimelineId)", 
-        "TaskInstanceId": "$(system.TaskInstanceId)",
-        "AuthToken": "$(system.AccessToken)",
-        }
-      waitForCompletion: "true"
+        # Rebuild cleanup.
+        - task: AzureFunction@1
+          displayName: 'Cleanup'
+          inputs:
+            function: '$(CleanupEndpointSecret)'
+            key: '$(HostKeySecret)'
+            body: |
+              {
+              "operationId": "$(Build.BuildNumber)",
+              "BuildId": "$(Build.BuildId)",
+              "PlanUrl": "$(system.CollectionUri)",
+              "HubName": "$(system.HostType)",
+              "pipelineType": "RebuildPipeline",
+              "ProjectId": "$(system.TeamProjectId)",
+              "PlanId": "$(system.PlanId)", 
+              "JobId": "$(system.JobId)", 
+              "TimelineId": "$(system.TimelineId)", 
+              "TaskInstanceId": "$(system.TaskInstanceId)",
+              "AuthToken": "$(system.AccessToken)",
+              }
+            waitForCompletion: "true"


### PR DESCRIPTION
This PR migrates the WinGetSVC rebuild pipeline to 1ES, including changes to the following files:

- rebuild-pipeline.yaml

The winget-pkgs repo was updated with the changes from the winget-pkgs-preprod repo, which had been merged from the pipeline staging process through [PR](https://github.com/microsoft/winget-pkgs-preprod/pull/13662). This manual copying was necessary because the automatic deployment failed for the production pipeline.

**[How Validated:]**

The changes have been validated against the preprod environment by manually triggering the pipeline and ensuring successful runs.
- [WinGetSvc-Rebuild-ppe](https://dev.azure.com/ms/winget-pkgs-preprod/_build/results?buildId=518864&view=results)

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/129089)