### PR TITLE
Improve how YamlCreate writes to files

### DIFF
--- a/Tools/YamlCreate.ps1
+++ b/Tools/YamlCreate.ps1
@@ -2084,7 +2084,7 @@ Function Write-ManifestContent {
     [string] $FilePath,
     [Parameter(Mandatory = $true, Position = 1)]
     [PSCustomObject] $YamlContent,
-    [Parameter(Mandatory = $true, Position = 1)]
+    [Parameter(Mandatory = $true, Position = 2)]
     [string] $Schema
   )
   [System.IO.File]::WriteAllLines($FilePath, @(


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?

Previously, YamlCreate would write the header to a file, then append the manifest content, read the content back in, perform some transforms on the raw content, re-write it all back out to file, read the content back in, and re-write it all back out *again* with the proper encoding. This is highly inefficient due to the extra time spent writing to file and reading from file and only gets worse the larger manifest files get.

This PR changes the flow to write all the content in one shot by performing the final content transformations in memory. Since the conversion to raw content would be happening anyways, there is no increased resource utilization of the script. It also abstracts the common code to a function and makes it a little bit easier to follow exactly what the code is doing.

cc @mdanish-kh @denelon @stephengillie
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/129167)