### PR TITLE
Rest rebuild pipeline migration to 1 es pipeline.

### DIFF
--- a/DevOpsPipelineDefinitions/rebuild-rest-pipeline.yaml
+++ b/DevOpsPipelineDefinitions/rebuild-rest-pipeline.yaml
@@ -6,72 +6,89 @@ name: '$(Build.DefinitionName)-$(Build.DefinitionVersion)-$(Date:yyyyMMdd)-$(Rev
 trigger: none
 pr: none
 
-jobs:
+resources:
+  repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    pool:
+      name: Azure-Pipelines-1ESPT-ExDShared
+      image: windows-2022
+      os: windows
+    customBuildTags:
+    - ES365AIMigrationTooling
 
-# Agent phase.
-- job: 'Rebuild'
-  displayName: 'Start Rebuild'
-  pool:
-    vmImage: 'windows-latest'
-  variables:
-    skipComponentGovernanceDetection: ${{ true }}
-    runCodesignValidationInjection: ${{ false }}
-  timeoutInMinutes: 0
-  steps:
+    stages:
+    - stage: Rebuild_Publish
+      jobs:
+      # Agent phase.
+      - job: 'Rebuild'
+        displayName: 'Start Rebuild'
+        variables:
+          skipComponentGovernanceDetection: ${{ true }}
+          runCodesignValidationInjection: ${{ false }}
+        timeoutInMinutes: 0
+        steps:
 
-  # Allow scripts to access the system token.
-  - checkout: none
-    persistCredentials: true
+        # Allow scripts to access the system token.
+        - checkout: none
+          persistCredentials: true
 
-  # Downloads all the setup files and its dependencies.
-  - task: AzureCLI@1
-    displayName: 'Azure Setup'
-    inputs:
-      azureSubscription: '$(WinGet.Subscription)'
-      scriptLocation: inlineScript
-      inlineScript: 'az storage blob download-batch -d . --pattern * -s servicewrapper --output none'
-    env:
-      AZURE_STORAGE_CONNECTION_STRING: $(ValidationStorageAccountConnectionString)
+        # Downloads all the setup files and its dependencies.
+        - task: AzureCLI@1
+          displayName: 'Azure Setup'
+          inputs:
+            azureSubscription: '$(WinGet.Subscription)'
+            scriptLocation: inlineScript
+            inlineScript: 'az storage blob download-batch -d . --pattern * -s servicewrapper --output none'
+          env:
+            AZURE_STORAGE_CONNECTION_STRING: $(ValidationStorageAccountConnectionString)
 
-  # WinGet setup
-  - script: 'winget_rebuild_setup.cmd'
-    name: 'wingetsetup'
-    displayName: 'WinGet Setup'
-    workingDirectory: scripts
-    env:
-      HOST_KEY: $(AzureFunctionHostKey)
-      RESTSOURCE_REBUILD_ENDPOINT: $(AzFuncRestSourceRebuildEndpoint)
+        # WinGet setup
+        - task: CmdLine@2
+          name: 'wingetsetup'
+          displayName: 'WinGet Setup'
+          env:
+            HOST_KEY: $(AzureFunctionHostKey)
+            RESTSOURCE_REBUILD_ENDPOINT: $(AzFuncRestSourceRebuildEndpoint)
+          inputs:
+            script: 'winget_rebuild_setup.cmd'
+            workingDirectory: scripts
 
-# Agentless phase. Depends on previous job.
-- job: 'PublishToRestSource'
-  pool: server
-  timeoutInMinutes: 1500
-  displayName: 'Publish to rest source'
-  dependsOn:
-    - 'Rebuild'
-  variables:
-    HostKeySecret: $[ dependencies.Rebuild.outputs['wingetsetup.hostkey']]
-    RestSourceRebuildEndpointSecret: $[ dependencies.Rebuild.outputs['wingetsetup.restsourceRebuildEndpoint']]
-  steps:
+      # Agentless phase. Depends on previous job.
+      - job: 'PublishToRestSource'
+        pool: server
+        timeoutInMinutes: 1500
+        displayName: 'Publish to rest source'
+        dependsOn:
+          - 'Rebuild'
+        variables:
+          HostKeySecret: $[ dependencies.Rebuild.outputs['wingetsetup.hostkey']]
+          RestSourceRebuildEndpointSecret: $[ dependencies.Rebuild.outputs['wingetsetup.restsourceRebuildEndpoint']]
+        steps:
 
-  # Rebuild Rest source.
-  - task: AzureFunction@1
-    displayName: 'Publish to rest source'
-    inputs:
-      function: '$(RestSourceRebuildEndpointSecret)'
-      key: '$(HostKeySecret)'
-      body: |
-        {
-        "operationId": "$(Build.BuildNumber)",
-        "BuildId": "$(Build.BuildId)",
-        "PlanUrl": "$(system.CollectionUri)",
-        "HubName": "$(system.HostType)",
-        "pipelineType": "RebuildPipeline",
-        "ProjectId": "$(system.TeamProjectId)",
-        "PlanId": "$(system.PlanId)", 
-        "JobId": "$(system.JobId)", 
-        "TimelineId": "$(system.TimelineId)", 
-        "TaskInstanceId": "$(system.TaskInstanceId)",
-        "AuthToken": "$(system.AccessToken)"
-        }
-      waitForCompletion: "true"
+        # Rebuild Rest source.
+        - task: AzureFunction@1
+          displayName: 'Publish to rest source'
+          inputs:
+            function: '$(RestSourceRebuildEndpointSecret)'
+            key: '$(HostKeySecret)'
+            body: |
+              {
+              "operationId": "$(Build.BuildNumber)",
+              "BuildId": "$(Build.BuildId)",
+              "PlanUrl": "$(system.CollectionUri)",
+              "HubName": "$(system.HostType)",
+              "pipelineType": "RebuildPipeline",
+              "ProjectId": "$(system.TeamProjectId)",
+              "PlanId": "$(system.PlanId)", 
+              "JobId": "$(system.JobId)", 
+              "TimelineId": "$(system.TimelineId)", 
+              "TaskInstanceId": "$(system.TaskInstanceId)",
+              "AuthToken": "$(system.AccessToken)"
+              }
+            waitForCompletion: "true"

--- a/DevOpsPipelineDefinitions/rebuild-rest-pipeline.yaml
+++ b/DevOpsPipelineDefinitions/rebuild-rest-pipeline.yaml
@@ -23,7 +23,7 @@ extends:
     - ES365AIMigrationTooling
 
     stages:
-    - stage: Rebuild_Publish
+    - stage: WinGetSvc_Rest_Rebuild
       jobs:
       # Agent phase.
       - job: 'Rebuild'


### PR DESCRIPTION
This PR migrates the WinGetSVC Rebuild Rest pipeline to 1ES, including changes to the following files:

- rebuild-rest-pipeline.yaml

The winget-pkgs repo was updated with the changes from the winget-pkgs-preprod repo, which had been merged from the pipeline staging process through [PR](https://github.com/microsoft/winget-pkgs-preprod/pull/13662). This manual copying was necessary because the automatic deployment failed for the production pipeline.

**[How Validated:]**
1. The changes have been validated against the preprod environment by manually triggering the pipeline and ensuring successful runs.
   - [WinGetSvc-Rebuild-Rest-ppe](https://dev.azure.com/ms/winget-pkgs-preprod/_build/results?buildId=518860&view=results)

WinGetSvc-Publish-ppe

- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/129182)