### PR TITLE
New package: Microsoft.AppInstaller version 1.21.3133.0

### DIFF
--- a/manifests/m/Microsoft/AppInstaller/1.21.3133.0/Microsoft.AppInstaller.installer.yaml
+++ b/manifests/m/Microsoft/AppInstaller/1.21.3133.0/Microsoft.AppInstaller.installer.yaml
@@ -1,0 +1,29 @@
+# Created using wingetcreate 1.5.7.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+
+PackageIdentifier: Microsoft.AppInstaller
+PackageVersion: 1.21.3133.0
+Platform:
+- Windows.Universal
+MinimumOSVersion: 10.0.17763.0
+InstallerType: msix
+PackageFamilyName: Microsoft.DesktopAppInstaller_8wekyb3d8bbwe
+Installers:
+- InstallerUrl: https://github.com/microsoft/winget-cli/releases/download/v1.6.3133/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle
+  Architecture: x86
+  InstallerSha256: 4886A24EC8A845B3C1BCAFF661CEADE8CCF18C393C3951E78AC60E681201E072
+  SignatureSha256: 90DC8B72B47CD6F04A925542F5A45494A4649DAC4A91A2892994E8E51D7F3927
+- InstallerUrl: https://github.com/microsoft/winget-cli/releases/download/v1.6.3133/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle
+  Architecture: x64
+  InstallerSha256: 4886A24EC8A845B3C1BCAFF661CEADE8CCF18C393C3951E78AC60E681201E072
+  SignatureSha256: 90DC8B72B47CD6F04A925542F5A45494A4649DAC4A91A2892994E8E51D7F3927
+- InstallerUrl: https://github.com/microsoft/winget-cli/releases/download/v1.6.3133/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle
+  Architecture: arm
+  InstallerSha256: 4886A24EC8A845B3C1BCAFF661CEADE8CCF18C393C3951E78AC60E681201E072
+  SignatureSha256: 90DC8B72B47CD6F04A925542F5A45494A4649DAC4A91A2892994E8E51D7F3927
+- InstallerUrl: https://github.com/microsoft/winget-cli/releases/download/v1.6.3133/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle
+  Architecture: arm64
+  InstallerSha256: 4886A24EC8A845B3C1BCAFF661CEADE8CCF18C393C3951E78AC60E681201E072
+  SignatureSha256: 90DC8B72B47CD6F04A925542F5A45494A4649DAC4A91A2892994E8E51D7F3927
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/m/Microsoft/AppInstaller/1.21.3133.0/Microsoft.AppInstaller.locale.en-US.yaml
+++ b/manifests/m/Microsoft/AppInstaller/1.21.3133.0/Microsoft.AppInstaller.locale.en-US.yaml
@@ -1,0 +1,21 @@
+# Created using wingetcreate 1.5.7.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+
+PackageIdentifier: Microsoft.AppInstaller
+PackageVersion: 1.21.3133.0
+PackageLocale: en-US
+Publisher: Microsoft Corporation
+PublisherUrl: https://www.microsoft.com
+PublisherSupportUrl: https://github.com/microsoft/winget-cli/issues
+PrivacyUrl: https://privacy.microsoft.com
+Author: Microsoft
+PackageName: App Installer
+PackageUrl: https://github.com/microsoft/winget-cli
+License: commercial
+Copyright: Copyright (c) Microsoft Corporation. All rights reserved.
+ShortDescription: Microsoft App Installer for Windows 10 makes sideloading Windows 10 apps easy. Windows Package Manager (WinGet) is supported through App Installer starting on Windows 10 1809.
+Description: "Microsoft App Installer for Windows 10 makes sideloading Windows 10 apps easy: Just double-click the app package, and you won't have to run PowerShell to install apps. App Installer presents the package information like app name, publisher, version, display logo, and the capabilities requested by the app. Get right into the app, no hassles--and if installation doesn't work, the error messages were designed to help you fix the problem. Windows Package Manager is supported through App Installer starting on Windows 10 1809. This application is currently only available for desktop PCs."
+Moniker: winget
+ReleaseNotesUrl: https://github.com/microsoft/winget-cli/releases/tag/v1.6.3133
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/m/Microsoft/AppInstaller/1.21.3133.0/Microsoft.AppInstaller.yaml
+++ b/manifests/m/Microsoft/AppInstaller/1.21.3133.0/Microsoft.AppInstaller.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.5.7.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+
+PackageIdentifier: Microsoft.AppInstaller
+PackageVersion: 1.21.3133.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0


### PR DESCRIPTION
Testing adding App Installer to community repository.

This should work for `winget upgrade winget` and `winget upgrade --all`

No dependencies are included since WinGet already has the dependencies if it's installed.

There is **NO** intention to support preview versions of WinGet.

This should work for `winget upgrade winget` and `winget upgrade --all`

---

- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/129354)