### PR TITLE
[YamlCreate] Request ARP Values on Quick Update

### DIFF
--- a/Tools/YamlCreate.ps1
+++ b/Tools/YamlCreate.ps1
@@ -948,7 +948,6 @@ Function Read-AppsAndFeaturesEntries {
   )
 
   $_AppsAndFeaturesEntries = @()
-  Write-Host 'Reading ARP Entries'
   # TODO: Support adding AppsAndFeaturesEntries if they don't exist
   if (!$_Installer.AppsAndFeaturesEntries) {
     return

--- a/Tools/YamlCreate.ps1
+++ b/Tools/YamlCreate.ps1
@@ -971,7 +971,7 @@ Function Read-AppsAndFeaturesEntry {
   if ($_AppsAndFeaturesEntry.DisplayName) { $_AppsAndFeaturesEntry['DisplayName'] = Read-ARPDisplayName $_AppsAndFeaturesEntry.DisplayName }
   if ($_AppsAndFeaturesEntry.DisplayVersion) { $_AppsAndFeaturesEntry['DisplayVersion'] = Read-ARPDisplayVersion $_AppsAndFeaturesEntry.DisplayVersion }
   if ($_AppsAndFeaturesEntry.Publisher) { $_AppsAndFeaturesEntry['Publisher'] = Read-ARPPublisher $_AppsAndFeaturesEntry.Publisher }
-  # TODO: Support ProductCode and UpgradeCode
+  # TODO: Support ProductCode, UpgradeCode, and InstallerType
   return Restore-YamlKeyOrder $_AppsAndFeaturesEntry $AppsAndFeaturesEntryProperties -NoComments
 }
 


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?

Currently, YamlCreate ignores AppsAndFeaturesEntries entirely. This PR begins the work of adding support for them.
The support is currently limited to applications with Existing ARP entries and only in the Quick Update flow. 
The support also skips ProductCode and UpgradeCode as there is complexity around those fields related to when they have been fetched automatically from the updated application.

If there are entries that exist, the script will now prompt users to validate that the entry is correct. Providing no response to the prompt will keep the entry as it was.

![image](https://github.com/microsoft/winget-pkgs/assets/12611259/b70a78cd-f93b-44f5-b98d-f80876dc6cfc)


cc @mdanish-kh

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/129471)