### PR TITLE
Update manifest: Fork.Fork version 1.90.1

### DIFF
--- a/manifests/f/Fork/Fork/1.90.1/Fork.Fork.installer.yaml
+++ b/manifests/f/Fork/Fork/1.90.1/Fork.Fork.installer.yaml
@@ -1,5 +1,5 @@
-# Automatically updated by the winget bot at 2023/Nov/10
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+# Created using wingetcreate 1.5.7.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
 
 PackageIdentifier: Fork.Fork
 PackageVersion: 1.90.1
@@ -17,10 +17,10 @@ InstallerSwitches:
   Silent: /s
   SilentWithProgress: /s
 UpgradeBehavior: install
+RequireExplicitUpgrade: true
 Installers:
 - Architecture: x86
-  InstallerUrl: https://git-fork.com/update/win/ForkInstaller.exe
+  InstallerUrl: https://cdn.fork.dev/win/Fork-1.90.1.exe
   InstallerSha256: 7E40B318F3589C4C99FDD216478887F13EFE1C7E2B95641D0914F03308329237
 ManifestType: installer
-ManifestVersion: 1.2.0
-RequireExplicitUpgrade: true
+ManifestVersion: 1.5.0

--- a/manifests/f/Fork/Fork/1.90.1/Fork.Fork.locale.en-US.yaml
+++ b/manifests/f/Fork/Fork/1.90.1/Fork.Fork.locale.en-US.yaml
@@ -1,22 +1,31 @@
-# Automatically updated by the winget bot at 2023/Nov/10
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+# Created using wingetcreate 1.5.7.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
 
 PackageIdentifier: Fork.Fork
 PackageVersion: 1.90.1
 PackageLocale: en-US
 Publisher: Fork
-PublisherUrl: https://git-fork.com
+PublisherUrl: https://fork.dev/about
 Author: Fork
 PackageName: Fork - a fast and friendly git client
-PackageUrl: https://git-fork.com
+PackageUrl: https://fork.dev/
 License: Proprietary
-LicenseUrl: https://git-fork.com/license
+LicenseUrl: https://fork.dev/license
 Copyright: Copyright © 2021 Danil Pristupov
-CopyrightUrl: https://git-fork.com/license
+CopyrightUrl: https://fork.dev/license
 ShortDescription: A fast and friendly git client for Mac and Windows.
-Description: A fast and friendly git client for Mac and Windows.
 Moniker: git-fork
 Tags:
 - git
+ReleaseNotes: |-
+  New: Rework LFS Locks dialog. Add filter and ability to unlock multiple files
+  Improved: Add Webstorm to Open In dropdown
+  Improved: Show warning in Push window when branch has unpushed submodules
+  Improved: Show LFS progress on Pull
+  Improved: Add external diff to context menu in History dialog
+  Fixed: Gitea integration doesn't show all repos in Accounts
+  Fixed: File history for submodule doesn't work
+  Fixed: Incorrect LFS progress value when pushing more than 2Gb
+ReleaseNotesUrl: https://fork.dev/releasenoteswin
 ManifestType: defaultLocale
-ManifestVersion: 1.2.0
+ManifestVersion: 1.5.0

--- a/manifests/f/Fork/Fork/1.90.1/Fork.Fork.yaml
+++ b/manifests/f/Fork/Fork/1.90.1/Fork.Fork.yaml
@@ -1,8 +1,8 @@
-# Automatically updated by the winget bot at 2023/Nov/10
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+# Created using wingetcreate 1.5.7.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
 
 PackageIdentifier: Fork.Fork
 PackageVersion: 1.90.1
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.2.0
+ManifestVersion: 1.5.0


### PR DESCRIPTION
## Description

Old version of the manifest is outdated and the vanity-like `InstallerUrl` response HTTP 404.

Renew the manifest on `InstallerUrl` property. The official team of this package has changed their download server to a CDN-like, version related URL. 

- Resolve #130752

## Checks

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/130779)