### PR TITLE
Update manifest: Neovim.Neovim.Nightly version 0.10.0

### DIFF
--- a/manifests/n/Neovim/Neovim/Nightly/0.10.0/Neovim.Neovim.Nightly.installer.yaml
+++ b/manifests/n/Neovim/Neovim/Nightly/0.10.0/Neovim.Neovim.Nightly.installer.yaml
@@ -7,7 +7,6 @@ InstallerLocale: en-US
 InstallerType: wix
 Scope: machine
 ProductCode: '{0053591A-DB09-4AB9-A3DD-84A7FD9781DF}'
-ReleaseDate: 2023-12-13
 AppsAndFeaturesEntries:
 - DisplayName: Neovim
   UpgradeCode: '{207A1A70-7B0C-418A-A153-CA6883E38F4D}'

--- a/manifests/n/Neovim/Neovim/Nightly/0.10.0/Neovim.Neovim.Nightly.installer.yaml
+++ b/manifests/n/Neovim/Neovim/Nightly/0.10.0/Neovim.Neovim.Nightly.installer.yaml
@@ -14,6 +14,6 @@ AppsAndFeaturesEntries:
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/neovim/neovim/releases/download/nightly/nvim-win64.msi
-  InstallerSha256: AD9C38581ABFBABB9E8164462B4A868A36CE8B2B1EAC039BA40235ED1B786FE3
+  InstallerSha256: 70A6C2A2E7684F305F5823B8AE25E2610A637B4C1C9772EFBF343E02CA448E64
 ManifestType: installer
 ManifestVersion: 1.5.0

--- a/manifests/n/Neovim/Neovim/Nightly/0.10.0/Neovim.Neovim.Nightly.installer.yaml
+++ b/manifests/n/Neovim/Neovim/Nightly/0.10.0/Neovim.Neovim.Nightly.installer.yaml
@@ -6,7 +6,7 @@ PackageVersion: 0.10.0
 InstallerLocale: en-US
 InstallerType: wix
 Scope: machine
-ProductCode: '{0053591A-DB09-4AB9-A3DD-84A7FD9781DF}'
+ProductCode: '{E639C8A1-C0C7-45EB-9E48-4B3FD0DEAD36}'
 AppsAndFeaturesEntries:
 - DisplayName: Neovim
   UpgradeCode: '{207A1A70-7B0C-418A-A153-CA6883E38F4D}'


### PR DESCRIPTION
## Description

The new `InstallerSha256` is copied from [releases page](https://github.com/neovim/neovim/releases/tag/nightly), which tagged on commit neovim/neovim@8f08b1e.

- A previous PR created by @wingetbot didn't modify any property
- Related #130625
- Resolve #130788

> [!IMPORTANT]
>
> As this package is a **nightly** build version of Neovim, updates of this package may perform rapidly. It seems the [neovim/neovim](https://github.com/neovim/neovim) repository only keep a single `nightly` tag, move `nightly` tag everyday to ensure that it always point to the latest "nightly" commit.
>
> Because of #15674, we might not able to catch up with the latest valid nightly version of Neovim. All pull requests of renewal will immeiately being outdated before successfully merged to `master` branch.
>
> We may need some walkaround to solve this problem.

## Checks

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/130797)