### PR TITLE
New package: MullvadVPN.MullvadBrowser version 13.0.7

### DIFF
--- a/manifests/m/MullvadVPN/MullvadBrowser/13.0.7/MullvadVPN.MullvadBrowser.installer.yaml
+++ b/manifests/m/MullvadVPN/MullvadBrowser/13.0.7/MullvadVPN.MullvadBrowser.installer.yaml
@@ -1,0 +1,12 @@
+# Created using wingetcreate 1.5.7.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+
+PackageIdentifier: MullvadVPN.MullvadBrowser
+PackageVersion: 13.0.7
+InstallerType: nullsoft
+Installers:
+- InstallerUrl: https://github.com/mullvad/mullvad-browser/releases/download/13.0.7/mullvad-browser-windows-x86_64-portable-13.0.7.exe
+  Architecture: x64
+  InstallerSha256: 7B2C423876CBD8068E5D47587A3138662F91FE2A4353533B15788584F7733023
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/m/MullvadVPN/MullvadBrowser/13.0.7/MullvadVPN.MullvadBrowser.locale.en-US.yaml
+++ b/manifests/m/MullvadVPN/MullvadBrowser/13.0.7/MullvadVPN.MullvadBrowser.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# Created using wingetcreate 1.5.7.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+
+PackageIdentifier: MullvadVPN.MullvadBrowser
+PackageVersion: 13.0.7
+PackageLocale: en-US
+Publisher: Mullvad VPN
+PublisherUrl: https://github.com/mullvad
+PublisherSupportUrl: https://github.com/mullvad/mullvad-browser/issues
+PrivacyUrl: https://mullvad.net/zh-hans/help/privacy-policy/
+PackageName: Mullvad Browser
+PackageUrl: https://github.com/mullvad/mullvad-browser
+License: MPL-2.0 License
+LicenseUrl: https://www.mozilla.org/en-US/MPL/2.0/
+Copyright: Copyright (c) 2023 Mullvad VPN AB
+ShortDescription: Privacy-focused browser for Linux, macOS and Windows.
+ReleaseNotesUrl: https://github.com/mullvad/mullvad-browser/releases/tag/13.0.7
+InstallationNotes: |-
+  This package is PORTABLE and DOES NOT provide an uninstaller!
+  There's NO ARP entries for this package, so you CANNOT remove it using winget or with Control Panel!
+  Please check https://mullvad.net/en/help/install-mullvad-browser for details.
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/m/MullvadVPN/MullvadBrowser/13.0.7/MullvadVPN.MullvadBrowser.yaml
+++ b/manifests/m/MullvadVPN/MullvadBrowser/13.0.7/MullvadVPN.MullvadBrowser.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.5.7.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+
+PackageIdentifier: MullvadVPN.MullvadBrowser
+PackageVersion: 13.0.7
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0


### PR DESCRIPTION
## Description

- Resolve #103178

> [!IMPORTANT]
>
> This package is a Nullsoft-compressed installer wizard. The package itself is portable so NO ARP entries NOR uninstallers are provided for this package. Users CANNOT uninstall this package with `winget.exe` or in _Control Panel_.
>
> - Related #103866

## Checks

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/131512)