### PR TITLE
New package: Python.Python.3.13 version 3.13.0a2

### DIFF
--- a/manifests/p/Python/Python/3/13/3.13.0a2/Python.Python.3.13.installer.yaml
+++ b/manifests/p/Python/Python/3/13/3.13.0a2/Python.Python.3.13.installer.yaml
@@ -1,0 +1,98 @@
+# Created using wingetcreate 1.5.7.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+
+PackageIdentifier: Python.Python.3.13
+PackageVersion: 3.13.0a2
+InstallerType: burn
+UpgradeBehavior: install
+Commands:
+- py
+- python
+- pythonw
+- pyw
+FileExtensions:
+- py
+- pyc
+- pyd
+- pyo
+- pyw
+- pyz
+- pyzw
+Installers:
+- InstallerUrl: https://www.python.org/ftp/python/3.13.0/python-3.13.0a2.exe
+  Architecture: x86
+  Scope: user
+  InstallerSha256: D01811AAA1D02207A62B3AC293286A5EF92B287ECE1399FDD5D07650DF558863
+  InstallerSwitches:
+    InstallLocation: DefaultJustForMeTargetDir=<INSTALLPATH>
+    Custom: InstallAllUsers=0 PrependPath=1
+  AppsAndFeaturesEntries:
+  - DisplayName: Python 3.13.0a2 (32-bit)
+    DisplayVersion: 3.13.102.0
+    ProductCode: "{680818b4-824d-47b0-acf6-6cbcff4de84c}"
+    # UpgradeCode:
+- InstallerUrl: https://www.python.org/ftp/python/3.13.0/python-3.13.0a2.exe
+  Architecture: x86
+  Scope: machine
+  ElevationRequirement: elevatesSelf
+  InstallerSha256: D01811AAA1D02207A62B3AC293286A5EF92B287ECE1399FDD5D07650DF558863
+  InstallerSwitches:
+    InstallLocation: DefaultAllUsersTargetDir=<INSTALLPATH>
+    Custom: InstallAllUsers=1 PrependPath=1
+  AppsAndFeaturesEntries:
+  - DisplayName: Python 3.13.0a2 (32-bit)
+    DisplayVersion: 3.13.102.0
+    ProductCode: "{680818b4-824d-47b0-acf6-6cbcff4de84c}"
+    # UpgradeCode:
+- InstallerUrl: https://www.python.org/ftp/python/3.13.0/python-3.13.0a2-amd64.exe
+  Architecture: x64
+  Scope: user
+  InstallerSha256: 51BF70F0DA3DE1C27C5788389A4F080A8A88B7DF9F04F0A40ADCA6087FF21757
+  InstallerSwitches:
+    InstallLocation: DefaultJustForMeTargetDir=<INSTALLPATH>
+    Custom: InstallAllUsers=0 PrependPath=1
+  AppsAndFeaturesEntries:
+  - DisplayName: Python 3.13.0a2 (64-bit)
+    DisplayVersion: 3.13.102.0
+    ProductCode: "{8f79d820-99a6-441a-88c7-e6ece52c92a8}"
+    # UpgradeCode:
+- InstallerUrl: https://www.python.org/ftp/python/3.13.0/python-3.13.0a2-amd64.exe
+  Architecture: x64
+  Scope: machine
+  ElevationRequirement: elevatesSelf
+  InstallerSha256: 51BF70F0DA3DE1C27C5788389A4F080A8A88B7DF9F04F0A40ADCA6087FF21757
+  InstallerSwitches:
+    InstallLocation: DefaultAllUsersTargetDir=<INSTALLPATH>
+    Custom: InstallAllUsers=1 PrependPath=1
+  AppsAndFeaturesEntries:
+  - DisplayName: Python 3.13.0a2 (64-bit)
+    DisplayVersion: 3.13.102.0
+    ProductCode: "{8f79d820-99a6-441a-88c7-e6ece52c92a8}"
+    # UpgradeCode:
+- InstallerUrl: https://www.python.org/ftp/python/3.13.0/python-3.13.0a2-arm64.exe
+  Architecture: arm64
+  Scope: user
+  InstallerSha256: 486D30F79F4B563247A811741990EDD66F40D9DF3F803312BD4A83B5D66B3906
+  InstallerSwitches:
+    InstallLocation: DefaultJustForMeTargetDir=<INSTALLPATH>
+    Custom: InstallAllUsers=0 PrependPath=1
+  AppsAndFeaturesEntries:
+  - DisplayName: Python 3.13.0a2 (ARM64)
+    DisplayVersion: 3.13.102.0
+    # ProductCode:
+    # UpgradeCode:
+- InstallerUrl: https://www.python.org/ftp/python/3.13.0/python-3.13.0a2-arm64.exe
+  Architecture: arm64
+  Scope: machine
+  ElevationRequirement: elevatesSelf
+  InstallerSha256: 486D30F79F4B563247A811741990EDD66F40D9DF3F803312BD4A83B5D66B3906
+  InstallerSwitches:
+    InstallLocation: DefaultAllUsersTargetDir=<INSTALLPATH>
+    Custom: InstallAllUsers=1 PrependPath=1
+  AppsAndFeaturesEntries:
+  - DisplayName: Python 3.13.0a2 (ARM64)
+    DisplayVersion: 3.13.102.0
+    # ProductCode:
+    # UpgradeCode:
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/p/Python/Python/3/13/3.13.0a2/Python.Python.3.13.locale.en-US.yaml
+++ b/manifests/p/Python/Python/3/13/3.13.0a2/Python.Python.3.13.locale.en-US.yaml
@@ -1,0 +1,21 @@
+# Created using wingetcreate 1.5.7.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+
+PackageIdentifier: Python.Python.3.13
+PackageVersion: 3.13.0a2
+PackageLocale: en-US
+Publisher: Python Software Foundation
+PublisherUrl: https://www.python.org/psf/
+PrivacyUrl: https://www.python.org/privacy/
+PackageName: Python 3.13.0a2
+PackageUrl: https://www.python.org/downloads/release/python-3130a2/
+License: PSF License
+LicenseUrl: https://docs.python.org/3.13/license.html#psf-license-agreement-for-python-release
+Copyright: Copyright (c) Python Software Foundation. All rights reserved.
+ShortDescription: Python is a programming language that lets you work quickly and integrate systems more effectively.
+Moniker: python3
+Tags:
+- python
+ReleaseNotesUrl: https://www.python.org/downloads/release/python-3130a2/
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/p/Python/Python/3/13/3.13.0a2/Python.Python.3.13.yaml
+++ b/manifests/p/Python/Python/3/13/3.13.0a2/Python.Python.3.13.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.5.7.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+
+PackageIdentifier: Python.Python.3.13
+PackageVersion: 3.13.0a2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0


### PR DESCRIPTION
## Description

- Resolve #131729

> [!NOTE]
>
> Comparing to `Python.Python.3.12` version `v3.12.0`, there are missing keys in the manifests. I failed to inspect them on my own.

## Checks

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- Have you tested your manifest locally with `winget install --manifest <path>`?
  - [x] `x86` architecture
  - [x] `x64` architecture
  - [ ] `arm64` architecture
- [x] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/131741)