### PR TITLE
PowerShell Preview 7.4.0.5: Correct msix installer URL

### DIFF
--- a/manifests/m/Microsoft/PowerShell/Preview/7.4.0.5/Microsoft.PowerShell.Preview.installer.yaml
+++ b/manifests/m/Microsoft/PowerShell/Preview/7.4.0.5/Microsoft.PowerShell.Preview.installer.yaml
@@ -37,7 +37,7 @@ Installers:
   Platform:
   - Windows.Universal
   InstallerType: msix
-  InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.4.0-preview.4/PowerShell-7.4.0-preview.4-win.msixbundle
+  InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.4.0-preview.5/PowerShell-7.4.0-preview.5-win.msixbundle
   InstallerSha256: 3D8608AA1C8D345E7D992FD1EA56F537B9CF5270154732CA3C52ECB28A4158E9
   SignatureSha256: F1E919A76A37E5BAB41D435570FD5954F71BE65818440202150B80B474314A25
   PackageFamilyName: Microsoft.PowerShellPreview_8wekyb3d8bbwe
@@ -46,7 +46,7 @@ Installers:
   Platform:
   - Windows.Universal
   InstallerType: msix
-  InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.4.0-preview.4/PowerShell-7.4.0-preview.4-win.msixbundle
+  InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.4.0-preview.5/PowerShell-7.4.0-preview.5-win.msixbundle
   InstallerSha256: 3D8608AA1C8D345E7D992FD1EA56F537B9CF5270154732CA3C52ECB28A4158E9
   SignatureSha256: F1E919A76A37E5BAB41D435570FD5954F71BE65818440202150B80B474314A25
   PackageFamilyName: Microsoft.PowerShell_8wekyb3d8bbwe


### PR DESCRIPTION
Due to a typo with incorrect installer URL (but correct hashes) the hash doesn't match the installer and wingetbot created a PR to remove this installer entirely. Instead this PR, fixes the installer URL so that it now matches the hashes.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/131926)