### PR TITLE
update `Miller.Miller` to `6.10.0`

### DIFF
--- a/manifests/m/Miller/Miller/6.10.0/Miller.Miller.installer.yaml
+++ b/manifests/m/Miller/Miller/6.10.0/Miller.Miller.installer.yaml
@@ -1,0 +1,23 @@
+# Created using wingetcreate 1.5.7.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+
+PackageIdentifier: Miller.Miller
+PackageVersion: 6.10.0
+InstallerType: zip
+NestedInstallerType: portable
+UpgradeBehavior: install
+Installers:
+- Architecture: x86
+  NestedInstallerFiles:
+  - RelativeFilePath: miller-6.10.0-windows-386\mlr.exe
+    PortableCommandAlias: mlr
+  InstallerUrl: https://github.com/johnkerl/miller/releases/download/v6.10.0/miller-6.10.0-windows-386.zip
+  InstallerSha256: E5E7121C6962E0A9678F539D3C77B505D7CE4497721EAD4EF4B2B54010575D00
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: miller-6.10.0-windows-amd64\mlr.exe
+    PortableCommandAlias: mlr
+  InstallerUrl: https://github.com/johnkerl/miller/releases/download/v6.10.0/miller-6.10.0-windows-amd64.zip
+  InstallerSha256: 82F0204B3E54AB0D201CAEB6B78186710BC03941373C55272082DA473130685B
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/m/Miller/Miller/6.10.0/Miller.Miller.locale.en-US.yaml
+++ b/manifests/m/Miller/Miller/6.10.0/Miller.Miller.locale.en-US.yaml
@@ -1,0 +1,39 @@
+# Created using wingetcreate 1.5.7.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+
+PackageIdentifier: Miller.Miller
+PackageVersion: 6.10.0
+PackageLocale: en-US
+Publisher: John Kerl
+PublisherUrl: https://github.com/johnkerl
+PublisherSupportUrl: https://github.com/johnkerl/miller/issues
+Author: John Kerl
+PackageName: Miller
+PackageUrl: https://github.com/johnkerl/miller
+License: BSD-2-Clause
+LicenseUrl: https://github.com/johnkerl/miller/blob/main/LICENSE.txt
+CopyrightUrl: https://raw.githubusercontent.com/johnkerl/miller/master/LICENSE.txt
+ShortDescription: Miller is like awk, sed, cut, join, and sort for name-indexed data such as CSV, TSV, and tabular JSON
+Description: |-
+  Miller is like awk, sed, cut, join, and sort for name-indexed data such as CSV, TSV, and tabular JSON. You get to work with your data using named fields, without needing to count positional column indices.
+
+  This is something the Unix toolkit always could have done, and arguably always should have done. It operates on key-value-pair data while the familiar Unix tools operate on integer-indexed fields: if the natural data structure for the latter is the array, then Miller’s natural data structure is the insertion-ordered hash map. This encompasses a variety of data formats, including but not limited to the familiar CSV, TSV, and JSON. (Miller can handle positionally-indexed data as a special case.)
+
+  ## Features
+
+  - Miller is multi-purpose: it’s useful for data cleaning, data reduction, statistical reporting, devops, system administration, log-file processing, format conversion, and database-query post-processing.
+  - You can use Miller to snarf and munge log-file data, including selecting out relevant substreams, then produce CSV format and load that into all-in-memory/data-frame utilities for further statistical and/or graphical processing.
+  - Miller complements data-analysis tools such as R, pandas, etc.: you can use Miller to clean and prepare your data. While you can do basic statistics entirely in Miller, its streaming-data feature and single-pass algorithms enable you to reduce very large data sets.
+  - Miller complements SQL databases: you can slice, dice, and reformat data on the client side on its way into or out of a database. (Examples here and here). You can also reap some of the benefits of databases for quick, setup-free one-off tasks when you just need to query some data in disk files in a hurry.
+  - Miller also goes beyond the classic Unix tools by stepping fully into our modern, no-SQL world: its essential record-heterogeneity property allows Miller to operate on data where records with different schema (field names) are interleaved.
+  - Miller is streaming: most operations need only a single record in memory at a time, rather than ingesting all input before producing any output. For those operations which require deeper retention (sort, tac, stats1), Miller retains only as much data as needed. This means that whenever functionally possible, you can operate on files which are larger than your system’s available RAM, and you can use Miller in tail -f contexts.
+  - Miller is pipe-friendly and interoperates with the Unix toolkit
+  - Miller’s I/O formats include tabular pretty-printing, positionally indexed (Unix-toolkit style), CSV, JSON, and others
+  - Miller does conversion between formats
+  - Miller’s processing is format-aware: e.g. CSV sort and tac keep header lines first
+  - Miller has high-throughput performance on par with the Unix toolkit
+  - Not unlike jq (for JSON), Miller is written in portable, modern C, with zero runtime dependencies. You can download or compile a single binary, scp it to a faraway machine, and expect it to work.
+Moniker: miller
+ReleaseNotesUrl: https://github.com/johnkerl/miller/releases/tag/v6.10.0
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/m/Miller/Miller/6.10.0/Miller.Miller.yaml
+++ b/manifests/m/Miller/Miller/6.10.0/Miller.Miller.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.5.7.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+
+PackageIdentifier: Miller.Miller
+PackageVersion: 6.10.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0


### PR DESCRIPTION
the manifest has been created using the following command:
```bash
wingetcreate update miller.miller -v 6.10.0 -u https://github.com/johnkerl/miller/releases/download/v6.10.0/miller-6.10.0-windows-386.zip https://github.com/johnkerl/miller/releases/download/v6.10.0/miller-6.10.0-windows-amd64.zip
```

the `ReleaseNotesUrl` has been manually added as `wingetcreate update` does not yet support release notes (see also
microsoft/winget-create#497).

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/132018)