### PR TITLE
Update Cisco.WebexTeams package to support machine scope and system-wide installations

### DIFF
--- a/manifests/c/Cisco/WebexTeams/43.12.0.28111/Cisco.WebexTeams.installer.yaml
+++ b/manifests/c/Cisco/WebexTeams/43.12.0.28111/Cisco.WebexTeams.installer.yaml
@@ -10,7 +10,13 @@ AppsAndFeaturesEntries:
 - UpgradeCode: '{6FE30B47-2577-43AD-9095-1861BA25889B}'
 Installers:
 - Architecture: x64
+  Scope: user
   InstallerUrl: https://binaries.webex.com/WebexTeamsDesktop-Windows-Gold/Webex.msi
   InstallerSha256: E7991F58C26141D7660902BB7BE843BB5CF730F8D7AE8F0D89E79F740719E77C
+- Architecture: x64
+  Scope: machine
+  InstallerUrl: https://binaries.webex.com/WebexTeamsDesktop-Windows-Gold/Webex.msi
+  InstallerSha256: E7991F58C26141D7660902BB7BE843BB5CF730F8D7AE8F0D89E79F740719E77C
+    Custom: ALLUSERS=1
 ManifestType: installer
 ManifestVersion: 1.5.0

--- a/manifests/c/Cisco/WebexTeams/43.12.0.28111/Cisco.WebexTeams.installer.yaml
+++ b/manifests/c/Cisco/WebexTeams/43.12.0.28111/Cisco.WebexTeams.installer.yaml
@@ -17,6 +17,7 @@ Installers:
   Scope: machine
   InstallerUrl: https://binaries.webex.com/WebexTeamsDesktop-Windows-Gold/Webex.msi
   InstallerSha256: E7991F58C26141D7660902BB7BE843BB5CF730F8D7AE8F0D89E79F740719E77C
+  InstallerSwitches:
     Custom: ALLUSERS=1
 ManifestType: installer
 ManifestVersion: 1.5.0


### PR DESCRIPTION
Updates the Cisco.WebexTeams package manifest to support machine scope for system-wide installations. The current package manifest only supports installing in the current user profile, making updates difficult to perform on multi-user systems.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/132154)