### PR TITLE
New package: Salesforce.sf-cli version 2.21.8.0

### DIFF
--- a/manifests/s/Salesforce/sf-cli/2.21.8.0/Salesforce.sf-cli.installer.yaml
+++ b/manifests/s/Salesforce/sf-cli/2.21.8.0/Salesforce.sf-cli.installer.yaml
@@ -1,0 +1,15 @@
+# Created using wingetcreate 1.5.7.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+
+PackageIdentifier: Salesforce.sf-cli
+PackageVersion: 2.21.8.0
+InstallerType: nullsoft
+Installers:
+- InstallerUrl: https://developer.salesforce.com/media/salesforce-cli/sf/channels/stable/sf-x64.exe
+  Architecture: x64
+  InstallerSha256: 7590EB7CBBF73143F3E9CEC5F855502CEE343228E41CA303FDE9D0C8203FF8E6
+- InstallerUrl: https://developer.salesforce.com/media/salesforce-cli/sf/channels/stable/sf-x86.exe
+  Architecture: x86
+  InstallerSha256: 1D5492251594B76BD82C77CE2F6773D45CCC4F68C186E2D2F39C486C11DAB04E
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/s/Salesforce/sf-cli/2.21.8.0/Salesforce.sf-cli.locale.en-US.yaml
+++ b/manifests/s/Salesforce/sf-cli/2.21.8.0/Salesforce.sf-cli.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# Created using wingetcreate 1.5.7.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+
+PackageIdentifier: Salesforce.sf-cli
+PackageVersion: 2.21.8.0
+PackageLocale: en-US
+Publisher: Salesforce
+PublisherUrl: https://www.salesforce.com
+PublisherSupportUrl: https://github.com/forcedotcom/cli/issues
+PrivacyUrl: https://www.salesforce.com/company/privacy
+PackageName: '@salesforce/cli'
+PackageUrl: https://developer.salesforce.com/tools/salesforcecli
+License: BSD 3-Clause "New" or "Revised" License
+LicenseUrl: https://github.com/forcedotcom/cli/blob/main/LICENSE.txt
+Copyright: Copyright (c) 2023, Salesforce.com, Inc.
+CopyrightUrl: https://github.com/forcedotcom/cli/blob/main/LICENSE.txt
+ShortDescription: |-
+  The Salesforce CLI is a powerful command line interface that simplifies
+  development and build automation when working with your Salesforce org.
+Moniker: sf
+Tags:
+- salesforce-cli
+- sf
+- sf-cli
+Documentations:
+- DocumentLabel: Command Reference
+  DocumentUrl: https://developer.salesforce.com/docs/atlas.en-us.sfdx_cli_reference.meta/sfdx_cli_reference/cli_reference_top.htm
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/s/Salesforce/sf-cli/2.21.8.0/Salesforce.sf-cli.yaml
+++ b/manifests/s/Salesforce/sf-cli/2.21.8.0/Salesforce.sf-cli.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.5.7.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+
+PackageIdentifier: Salesforce.sf-cli
+PackageVersion: 2.21.8.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0


### PR DESCRIPTION
## Description

This package is changed from `sfdx` v7 to `sf` v2. The package identifier should be changed.

- Resolve #132209
- Related #132027

## Checks

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/132224)