### PR TITLE
Add different label when changes are requested

### DIFF
--- a/.github/policies/labelAdded.changesRequested.yml
+++ b/.github/policies/labelAdded.changesRequested.yml
@@ -1,0 +1,37 @@
+id: labelAdded.changesRequested
+name: GitOps.PullRequestIssueManagement
+description: Handlers when "Changes-Requested" label is added
+owner:
+resource: repository
+disabled: false
+where:
+configuration:
+  resourceManagementConfiguration:
+    eventResponderTasks:
+      - description: >-
+          When the label "Changes-Requested" is added to a pull request
+          * Add the PR specific reply notifying the issue author
+          * Assign to the Author
+          * Label with Needs-Author-Feedback
+        if:
+          - payloadType: Pull_Request
+          - labelAdded:
+              label: Changes-Requested
+        then:
+          - addReply:
+              reply: >-
+                Hello @${issueAuthor},
+
+
+                The package manager bot determined changes have been requested to your PR.
+
+
+                Template: msftbot/changesRequested
+          - assignTo:
+              author: True
+          - addLabel:
+              label: Needs-Author-Feedback
+        # The policy service should trigger even when the label was added by the policy service
+        triggerOnOwnActions: true
+onFailure:
+onSuccess:

--- a/.github/policies/labelManagement.issueUpdated.yml
+++ b/.github/policies/labelManagement.issueUpdated.yml
@@ -51,6 +51,9 @@ configuration:
               - not:
                   hasLabel:
                     label: Needs-Author-Feedback
+              - not:
+                  hasLabel:
+                    label: Changes-Requested
         then:
           - enableAutoMerge:
               mergeMethod: Squash
@@ -77,6 +80,9 @@ configuration:
               - not:
                   hasLabel:
                     label: Needs-Author-Feedback
+              - not:
+                  hasLabel:
+                    label: Changes-Requested
         then:
           - enableAutoMerge:
               mergeMethod: Squash
@@ -112,6 +118,9 @@ configuration:
               - not:
                   hasLabel:
                     label: Needs-Attention
+              - not:
+                  hasLabel:
+                    label: Changes-Requested
         then:
           - approvePullRequest:
               comment: ""
@@ -196,9 +205,7 @@ configuration:
       - description: >-
           When changes are requested on a pull request
           * Disable automerge
-          * Add a reply notifying the issue author
-          * Assign to the author
-          * Label with Needs-Author-Feedback
+          * Label with Changes-Requested
         if:
           - payloadType: Pull_Request_Review
           - isAction:
@@ -207,19 +214,8 @@ configuration:
               reviewState: Changes_requested
         then:
           - disableAutoMerge
-          - addReply:
-              reply: >-
-                Hello @${issueAuthor},
-
-
-                The package manager bot determined changes have been requested to your PR.
-
-
-                Template: msftbot/changesRequested
-          - assignTo:
-              author: True
           - addLabel:
-              label: Needs-Author-Feedback
+              label: Changes-Requested
       - description: >-
           If static analysis has timed out, and the retry has timed out
           * Add a reply notifying the issue author
@@ -355,6 +351,8 @@ configuration:
           - removeLabel:
               label: Moderator-Approved
           - removeLabel:
+              label: Changes-Requested
+          - removeLabel:
               label: Unexpected-File
           - removeLabel:
               label: Validation-Merge-Conflict
@@ -386,6 +384,7 @@ configuration:
               - activitySenderHasPermission:
                   permission: Write
         then:
+          # Don't remove Changes-Requested here beacause it is just a re-run, no new commits have been added
           - removeLabel:
               label: Validation-Completed
           - removeLabel:

--- a/.github/policies/moderatorTriggers.yml
+++ b/.github/policies/moderatorTriggers.yml
@@ -205,6 +205,8 @@ configuration:
                       label: Needs-Attention
                   - removeLabel:
                       label: Moderator-Approved
+                  - removeLabel:
+                      label: Changes-Requested
                   ## TODO: Dismiss All Pull Request Reviews
               # Duplicate of #
               - if:


### PR DESCRIPTION
- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/132430)