### PR TITLE
Fix YamlCreate

### DIFF
--- a/Tools/YamlCreate.ps1
+++ b/Tools/YamlCreate.ps1
@@ -1,9 +1,9 @@
 ﻿#Requires -Version 5
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'This script is not intended to have any outputs piped')]
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'Preserve', Justification = 'The variable is used in a conditional but ScriptAnalyser does not recognize the scope')]
-[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', Scope = 'Function', Target = 'Read-AppsAndFeaturesEntries',
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Scope = 'Function', Target = 'Read-AppsAndFeaturesEntries',
   Justification = 'Ths function is a wrapper which calls the singular Read-AppsAndFeaturesEntry as many times as necessary. It corresponds exactly to a pluralized manifest field')]
-[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', Scope = 'Function', Target = '*Metadata',
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Scope = 'Function', Target = '*Metadata',
   Justification = 'Metadata is used as a mass noun and is therefore singular in the cases used in this script')]
 
 Param


### PR DESCRIPTION
```
MethodException: D:\Git\winget-pkgs\Tools\YamlCreate.ps1:6
Line |
   6 |  [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNoun …
     |  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Cannot find an overload for ".ctor" and the argument count: "1".
```

https://github.com/pester/Pester/issues/2106