### PR TITLE
Add Azure Artifacts NuGet Credential Provider

### DIFF
--- a/manifests/m/Microsoft/NuGet/CredentialProvider/DotNet/1.0.9/Microsoft.NuGet.CredentialProvider.DotNet.installer.yaml
+++ b/manifests/m/Microsoft/NuGet/CredentialProvider/DotNet/1.0.9/Microsoft.NuGet.CredentialProvider.DotNet.installer.yaml
@@ -1,0 +1,20 @@
+# Created with YamlCreate.ps1 v2.2.12 $debug=NVS0.CRLF.7-4-0.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+
+PackageIdentifier: Microsoft.NuGet.CredentialProvider.DotNet
+PackageVersion: 1.0.9
+InstallerType: zip
+ReleaseDate: 2023-07-12
+Installers:
+- Architecture: neutral
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: plugins\netcore\CredentialProvider.Microsoft\CredentialProvider.Microsoft.exe
+  InstallerUrl: https://github.com/microsoft/artifacts-credprovider/releases/download/v1.0.9/Microsoft.Net6.NuGet.CredentialProvider.zip
+  InstallerSha256: 5C866AE3106A7DC4E5C5180B884EBBC9FD122FEAC1C3BB13AB6DA13582FFCD50
+  Scope: user
+  InstallLocationRequired: true
+  UnsupportedArguments:
+  - log
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/m/Microsoft/NuGet/CredentialProvider/DotNet/1.0.9/Microsoft.NuGet.CredentialProvider.DotNet.installer.yaml
+++ b/manifests/m/Microsoft/NuGet/CredentialProvider/DotNet/1.0.9/Microsoft.NuGet.CredentialProvider.DotNet.installer.yaml
@@ -12,8 +12,8 @@ Installers:
   - RelativeFilePath: plugins\netcore\CredentialProvider.Microsoft\CredentialProvider.Microsoft.exe
   InstallerUrl: https://github.com/microsoft/artifacts-credprovider/releases/download/v1.0.9/Microsoft.Net6.NuGet.CredentialProvider.zip
   InstallerSha256: 5C866AE3106A7DC4E5C5180B884EBBC9FD122FEAC1C3BB13AB6DA13582FFCD50
-  Scope: user
   InstallLocationRequired: true
+  ElevationRequirement: elevationProhibited
   UnsupportedArguments:
   - log
 ManifestType: installer

--- a/manifests/m/Microsoft/NuGet/CredentialProvider/DotNet/1.0.9/Microsoft.NuGet.CredentialProvider.DotNet.locale.en-US.yaml
+++ b/manifests/m/Microsoft/NuGet/CredentialProvider/DotNet/1.0.9/Microsoft.NuGet.CredentialProvider.DotNet.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# Created with YamlCreate.ps1 v2.2.12 $debug=NVS0.CRLF.7-4-0.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+
+PackageIdentifier: Microsoft.NuGet.CredentialProvider.DotNet
+PackageVersion: 1.0.9
+PackageLocale: en-US
+Publisher: Microsoft Corporation
+# PublisherUrl: 
+# PublisherSupportUrl: 
+# PrivacyUrl: 
+# Author: 
+PackageName: Azure Artifacts NuGet Credential Provider
+PackageUrl: https://github.com/microsoft/artifacts-credprovider
+License: MIT
+# LicenseUrl: 
+Copyright: Copyright (c) Microsoft Corporation
+# CopyrightUrl: 
+ShortDescription: The Azure Artifacts Credential Provider automates the acquisition of credentials needed to restore NuGet packages as part of your .NET development workflow.
+Description: The Azure Artifacts Credential Provider automates the acquisition of credentials needed to restore NuGet packages as part of your .NET development workflow. It integrates with MSBuild, dotnet, and NuGet(.exe) and works on Windows, Mac, and Linux. Any time you want to use packages from an Azure Artifacts feed, the Credential Provider will automatically acquire and securely store a token on behalf of the NuGet client you're using.
+# Moniker: 
+# Tags: 
+# ReleaseNotes: 
+# ReleaseNotesUrl: 
+# PurchaseUrl: 
+# InstallationNotes: 
+# Documentations: 
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/m/Microsoft/NuGet/CredentialProvider/DotNet/1.0.9/Microsoft.NuGet.CredentialProvider.DotNet.yaml
+++ b/manifests/m/Microsoft/NuGet/CredentialProvider/DotNet/1.0.9/Microsoft.NuGet.CredentialProvider.DotNet.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.2.12 $debug=NVS0.CRLF.7-4-0.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+
+PackageIdentifier: Microsoft.NuGet.CredentialProvider.DotNet
+PackageVersion: 1.0.9
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---
Attempts to fix microsoft/artifacts-credprovider#417 but is not fully automated; requires manual input for `--location` to point to the NuGet plugin directory, and automatic addition to `PATH` environment variable is not used/discovered by NuGet.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/132585)