### PR TITLE
Add WiFiman Desktop for Windows productversion 0.3.1

### DIFF
--- a/manifests/u/UbiquitiInc/WiFimanDesktop/0.3.1/UbiquitiInc.WiFimanDesktop.installer.yaml
+++ b/manifests/u/UbiquitiInc/WiFimanDesktop/0.3.1/UbiquitiInc.WiFimanDesktop.installer.yaml
@@ -1,0 +1,15 @@
+# Created using wingetcreate 1.5.7.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+
+PackageIdentifier: UbiquitiInc.WiFimanDesktop
+PackageVersion: 0.3.1
+InstallerType: nullsoft
+InstallModes:
+- interactive
+- silent
+Installers:
+- InstallerUrl: https://desktop.wifiman.com/wifiman-desktop-0.3.1-win-x64.exe
+  Architecture: x64
+  InstallerSha256: 5E329F892BDC6C6BEABC637D2F50FC8351D0E4CCBF130C8400B771E57D07531A
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/u/UbiquitiInc/WiFimanDesktop/0.3.1/UbiquitiInc.WiFimanDesktop.locale.en-US.yaml
+++ b/manifests/u/UbiquitiInc/WiFimanDesktop/0.3.1/UbiquitiInc.WiFimanDesktop.locale.en-US.yaml
@@ -1,0 +1,15 @@
+# Created using wingetcreate 1.5.7.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+
+PackageIdentifier: UbiquitiInc.WiFimanDesktop
+PackageVersion: 0.3.1
+PackageLocale: en-US
+Publisher: Ubiquiti Inc.
+PackageName: WiFiman Desktop
+License: Proprietary
+Copyright: Copyright © 2023 Ubiquiti Inc.
+ShortDescription: WiFiman is a desktop app which can scan local network for active devices and configure them.
+ReleaseNotes: Initial release of WiFiman Desktop application for Windows.
+ReleaseNotesUrl: https://community.ui.com/releases/WiFiman-Desktop-0-3-1-for-Windows-0-3-1/978e9a73-6d86-4274-a553-a1e9ce170766
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/u/UbiquitiInc/WiFimanDesktop/0.3.1/UbiquitiInc.WiFimanDesktop.yaml
+++ b/manifests/u/UbiquitiInc/WiFimanDesktop/0.3.1/UbiquitiInc.WiFimanDesktop.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.5.7.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+
+PackageIdentifier: UbiquitiInc.WiFimanDesktop
+PackageVersion: 0.3.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

Adding version 0.3.1 since that is the _productversion_ of this release. Otherwise winget upgrade wil keep flagging this for an upgrade. The _fileversion_ is indeed 0.3.1.6 as previously added, will need to remove version 0.3.1.6 after this one merges.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/132634)