### PR TITLE
New version: Audient.EVO version 4.3.18.0

### DIFF
--- a/manifests/a/Audient/EVO/4.3.18.0/Audient.EVO.installer.yaml
+++ b/manifests/a/Audient/EVO/4.3.18.0/Audient.EVO.installer.yaml
@@ -1,0 +1,13 @@
+# Created using wingetcreate 1.5.7.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+
+PackageIdentifier: Audient.EVO
+PackageVersion: 4.3.18.0
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+Installers:
+- Architecture: x86
+  InstallerUrl: https://d9w4fhj63j193.cloudfront.net/2023/EVO%20Drivers/EVO-v4.3.18a.exe
+  InstallerSha256: 98E501DF8EFCC5435796B5EA015AEF129DB358FE308AF4B03FB16427E9019E61
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/a/Audient/EVO/4.3.18.0/Audient.EVO.locale.en-US.yaml
+++ b/manifests/a/Audient/EVO/4.3.18.0/Audient.EVO.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# Created using wingetcreate 1.5.7.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+
+PackageIdentifier: Audient.EVO
+PackageVersion: 4.3.18.0
+PackageLocale: en-US
+Publisher: Audient
+PublisherUrl: https://audient.com
+PublisherSupportUrl: https://support.audient.com
+PrivacyUrl: https://www.iubenda.com/privacy-policy/76513121
+PackageName: EVO
+PackageUrl: https://evo.audio/products/audio-interfaces/evo-4/downloads/
+License: Proprietary
+Copyright: Copyright © 2022 Audient Ltd
+ShortDescription: Driver for the Audient EVO Audio Interfaces
+Moniker: audient-evo
+Tags:
+- audient
+- audio
+- audio-interface
+- control
+- driver
+- evo
+- loop-back-mixer
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/a/Audient/EVO/4.3.18.0/Audient.EVO.yaml
+++ b/manifests/a/Audient/EVO/4.3.18.0/Audient.EVO.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.5.7.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+
+PackageIdentifier: Audient.EVO
+PackageVersion: 4.3.18.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0


### PR DESCRIPTION
## Description

- Resolve #133070
- Update `PackageUrl`

> [!NOTE]
>
> There are only `v4.3.18a` in the download page. I can't find the installer of `v4.3.19a`.

## Checks

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/133227)