### PR TITLE
New package: KhronosGroup.VulkanSDK version 1.3.268.0

### DIFF
--- a/manifests/k/KhronosGroup/VulkanSDK/1.3.268.0/KhronosGroup.VulkanSDK.installer.yaml
+++ b/manifests/k/KhronosGroup/VulkanSDK/1.3.268.0/KhronosGroup.VulkanSDK.installer.yaml
@@ -1,0 +1,28 @@
+# Created using wingetcreate 1.5.5.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+
+PackageIdentifier: KhronosGroup.VulkanSDK
+PackageVersion: 1.3.268.0
+InstallerLocale: en-US
+MinimumOSVersion: 10.0.0.0
+InstallerType: exe
+Scope: machine
+InstallModes:
+- interactive
+- silent
+InstallerSwitches:
+  Silent: --accept-licenses --default-answer --confirm-command install
+  SilentWithProgress: --accept-licenses --default-answer --confirm-command install
+UpgradeBehavior: install
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+  - PackageIdentifier: KhronosGroup.VulkanRT
+    MinimumVersion: 1.3.268.0
+ElevationRequirement: elevationRequired
+Installers:
+- Architecture: x64
+  InstallerUrl: https://sdk.lunarg.com/sdk/download/1.3.268.0/windows/VulkanSDK-1.3.268.0-Installer.exe
+  InstallerSha256: 8459EF49BD06B697115DDD3D97C9AEC729E849CD775F5BE70897718A9B3B9DB5
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/k/KhronosGroup/VulkanSDK/1.3.268.0/KhronosGroup.VulkanSDK.locale.en-US.yaml
+++ b/manifests/k/KhronosGroup/VulkanSDK/1.3.268.0/KhronosGroup.VulkanSDK.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# Created using wingetcreate 1.5.5.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+
+PackageIdentifier: KhronosGroup.VulkanSDK
+PackageVersion: 1.3.268.0
+PackageLocale: en-US
+Publisher: LunarG Inc.
+PublisherUrl: https://www.lunarg.com/
+PublisherSupportUrl: https://vulkan.lunarg.com/issue/home
+PrivacyUrl: https://vulkan.lunarg.com/sdk/home#content/popup/privacy/lg
+PackageName: Vulkan SDK
+PackageUrl: https://vulkan.lunarg.com/sdk/home
+License: MIT
+LicenseUrl: https://vulkan.lunarg.com/software/license/vulkan-1.3.268.0-windows-license-summary.txt
+Copyright: Copyright (c) 2015-2023 LunarG, Inc.
+CopyrightUrl: https://vulkan.lunarg.com/software/license/vulkan-1.3.268.0-windows-license-summary.txt
+ShortDescription: The Vulkan SDK provides Vulkan application developers with essential tools to accelerate the development process.
+Moniker: vulkansdk
+Tags:
+- vulkan-api
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0
+Agreements:
+  - AgreementLabel: LunarG Inc. Vulkan SDK License Agreement
+    Agreement: |
+      Copyright 2016-2023 LunarG Inc.
+
+      The Vulkan SDK is comprised of 100% open-source components. The majority of the materials are MIT or Apache 2.0 licenses. The Vulkan SDK licensing registry (found at vulkan.lunarg.com) discloses all components in the SDK and their corresponding open source license. The SDK itself is not licensed because to do so would re-attribute licenses to all the things included in the SDK.
+
+      ALL INFORMATION HERE IS PROVIDED "AS IS." LUNARG MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, WITH REGARD TO THIS LIST OR ITS ACCURACY OR COMPLETENESS, OR WITH RESPECT TO ANY RESULTS TO BE OBTAINED FROM USE OR DISTRIBUTION OF THE LIST. BY USING OR DISTRIBUTING THIS LIST, YOU AGREE THAT IN NO EVENT SHALL LUNARG BE HELD LIABLE FOR ANY DAMAGES WHATSOEVER RESULTING FROM ANY USE OR DISTRIBUTION OF THIS LIST, INCLUDING, WITHOUT LIMITATION, ANY SPECIAL, CONSEQUENTIAL, INCIDENTAL OR OTHER DIRECT OR INDIRECT DAMAGES.

--- a/manifests/k/KhronosGroup/VulkanSDK/1.3.268.0/KhronosGroup.VulkanSDK.yaml
+++ b/manifests/k/KhronosGroup/VulkanSDK/1.3.268.0/KhronosGroup.VulkanSDK.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.5.5.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+
+PackageIdentifier: KhronosGroup.VulkanSDK
+PackageVersion: 1.3.268.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

Now that we have VulkanRT #133065 we can use this as a dependency for this package to make sure you can test with apps like vkcube.exe that is installed in a sandbox.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/133387)