### PR TITLE
Remove link to script in portable package

### DIFF
--- a/manifests/l/LesFerch/WinSetView/2.77/LesFerch.WinSetView.installer.yaml
+++ b/manifests/l/LesFerch/WinSetView/2.77/LesFerch.WinSetView.installer.yaml
@@ -8,8 +8,6 @@ NestedInstallerType: portable
 NestedInstallerFiles:
 - RelativeFilePath: WinSetView-2.77/WinSetView.exe
   PortableCommandAlias: WinSetView
-- RelativeFilePath: WinSetView-2.77/WinSetView.ps1
-  PortableCommandAlias: WinSetView.ps1
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/LesFerch/WinSetView/archive/refs/tags/2.77.zip


### PR DESCRIPTION
* Remove link to script because it is a script
* It's broken anyways - the symlink opens the PS1 in notepad

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/133550)