### PR TITLE
Fix the license of `HiroshibaKazuyuki.VOICEVOX` 0.14.10

### DIFF
--- a/manifests/h/HiroshibaKazuyuki/VOICEVOX/0.14.10/HiroshibaKazuyuki.VOICEVOX.locale.en-US.yaml
+++ b/manifests/h/HiroshibaKazuyuki/VOICEVOX/0.14.10/HiroshibaKazuyuki.VOICEVOX.locale.en-US.yaml
@@ -9,8 +9,8 @@ PublisherUrl: https://voicevox.hiroshiba.jp
 PublisherSupportUrl: https://github.com/VOICEVOX/voicevox/issues
 PackageName: VOICEVOX
 PackageUrl: https://github.com/VOICEVOX/voicevox
-License: LGPL-3.0 license
-LicenseUrl: https://github.com/VOICEVOX/voicevox/blob/main/LICENSE
+License: Proprietary
+LicenseUrl: https://raw.githubusercontent.com/VOICEVOX/voicevox_blog/4a33d321d292071152633a650a59006b21d16a61/src/markdowns/softwareReadme.md
 ShortDescription: 無料で使える中品質なテキスト読み上げソフトウェア、VOICEVOXのエディター
 ReleaseNotes: |-
   - Windows


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

The license of `HiroshibaKazuyuki.VOICEVOX` should not be LGPL-3.0. 

First, **as described in the [current `LicenseUrl`](https://github.com/VOICEVOX/voicevox/blob/main/LICENSE)**, github.com/VOICEVOX/voicevox is dual-licensed. The second (2.) proprietary license is applied for published binaries.

(edit) Plus, the releases contain additional proprietary resources.

The correct license for releases is the EULA written in <https://voicevox.hiroshiba.jp/term/>. I also changed the `LicenseUrl` to the EULA text.

CC: @Hiroshiba ("Hiroshiba Kazuyuki", the publisher of VOICEVOX)
CC: @Exorcism0666 (#133385)

FYI, the following packages have the same problem.

- #133053
- #133054
- #133056
- #133381

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/133664)