### PR TITLE
Fix the license of `HiroshibaKazuyuki.VOICEVOX.CPU` 0.14.10

### DIFF
--- a/manifests/h/HiroshibaKazuyuki/VOICEVOX/CPU/0.14.10/HiroshibaKazuyuki.VOICEVOX.CPU.locale.en-US.yaml
+++ b/manifests/h/HiroshibaKazuyuki/VOICEVOX/CPU/0.14.10/HiroshibaKazuyuki.VOICEVOX.CPU.locale.en-US.yaml
@@ -10,7 +10,7 @@ PublisherSupportUrl: https://github.com/VOICEVOX/voicevox/issues
 PackageName: VOICEVOX
 PackageUrl: https://github.com/VOICEVOX/voicevox
 License: Proprietary
-LicenseUrl: https://raw.githubusercontent.com/VOICEVOX/voicevox_blog/4a33d321d292071152633a650a59006b21d16a61/src/markdowns/softwareReadme.md
+LicenseUrl: https://voicevox.hiroshiba.jp/term/
 ShortDescription: 無料で使える中品質なテキスト読み上げソフトウェア、VOICEVOXのエディター
 ReleaseNotes: |-
   - Windows

--- a/manifests/h/HiroshibaKazuyuki/VOICEVOX/CPU/0.14.10/HiroshibaKazuyuki.VOICEVOX.CPU.locale.en-US.yaml
+++ b/manifests/h/HiroshibaKazuyuki/VOICEVOX/CPU/0.14.10/HiroshibaKazuyuki.VOICEVOX.CPU.locale.en-US.yaml
@@ -9,8 +9,8 @@ PublisherUrl: https://voicevox.hiroshiba.jp
 PublisherSupportUrl: https://github.com/VOICEVOX/voicevox/issues
 PackageName: VOICEVOX
 PackageUrl: https://github.com/VOICEVOX/voicevox
-License: LGPL-3.0 license
-LicenseUrl: https://github.com/VOICEVOX/voicevox/blob/main/LICENSE
+License: Proprietary
+LicenseUrl: https://raw.githubusercontent.com/VOICEVOX/voicevox_blog/4a33d321d292071152633a650a59006b21d16a61/src/markdowns/softwareReadme.md
 ShortDescription: 無料で使える中品質なテキスト読み上げソフトウェア、VOICEVOXのエディター
 ReleaseNotes: |-
   - Windows


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

Same change as #133664.

CC: @Hiroshiba ("Hiroshiba Kazuyuki", the publisher of VOICEVOX)
CC: @Exorcism0666 (#133053)