### PR TITLE
Fix the license of `y-chan.SHAREVOX.NVIDIA` 0.2.1

### DIFF
--- a/manifests/y/y-chan/SHAREVOX/NVIDIA/0.2.1/y-chan.SHAREVOX.NVIDIA.locale.en-US.yaml
+++ b/manifests/y/y-chan/SHAREVOX/NVIDIA/0.2.1/y-chan.SHAREVOX.NVIDIA.locale.en-US.yaml
@@ -10,7 +10,7 @@ PublisherSupportUrl: https://github.com/SHAREVOX/sharevox/issues
 PackageName: SHAREVOX
 PackageUrl: https://github.com/SHAREVOX/sharevox
 License: Proprietary
-LicenseUrl: https://raw.githubusercontent.com/SHAREVOX/SHAREVOX.github.io/e32c3eb9172d09356211dbcecf9d979140d1e052/docs/terms.md
+LicenseUrl: https://www.sharevox.app/terms
 ShortDescription: 無料で使える、声を作れるテキスト読み上げソフトウェア、SHAREVOXのエディター
 ReleaseNotesUrl: https://github.com/SHAREVOX/sharevox/releases/tag/0.2.1
 ManifestType: defaultLocale

--- a/manifests/y/y-chan/SHAREVOX/NVIDIA/0.2.1/y-chan.SHAREVOX.NVIDIA.locale.en-US.yaml
+++ b/manifests/y/y-chan/SHAREVOX/NVIDIA/0.2.1/y-chan.SHAREVOX.NVIDIA.locale.en-US.yaml
@@ -9,8 +9,8 @@ PublisherUrl: https://sharevox.app
 PublisherSupportUrl: https://github.com/SHAREVOX/sharevox/issues
 PackageName: SHAREVOX
 PackageUrl: https://github.com/SHAREVOX/sharevox
-License: LGPL-3.0
-LicenseUrl: https://github.com/SHAREVOX/sharevox/blob/main/LICENSE
+License: Proprietary
+LicenseUrl: https://raw.githubusercontent.com/SHAREVOX/SHAREVOX.github.io/e32c3eb9172d09356211dbcecf9d979140d1e052/docs/terms.md
 ShortDescription: 無料で使える、声を作れるテキスト読み上げソフトウェア、SHAREVOXのエディター
 ReleaseNotesUrl: https://github.com/SHAREVOX/sharevox/releases/tag/0.2.1
 ManifestType: defaultLocale


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

Same change as #133790.

CC: @y-chan (the publisher of SHAREVOX)
CC: @Exorcism0666 (#133381)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/133792)