### PR TITLE
[TEST MANIFEST Do Not Merge] Tgstation.Server version 6.1.999

### DIFF
--- a/manifests/t/Tgstation/Server/6.1.999/Tgstation.Server.installer.yaml
+++ b/manifests/t/Tgstation/Server/6.1.999/Tgstation.Server.installer.yaml
@@ -1,0 +1,30 @@
+# Created using wingetcreate 1.5.7.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+
+PackageIdentifier: Tgstation.Server
+PackageVersion: 6.1.999
+Installers:
+- InstallerLocale: en-US
+  Architecture: x86
+  InstallerType: burn
+  Scope: machine
+  InstallerUrl: https://github.com/tgstation/tgstation-server/releases/download/tgstation-server-v6.1.0/tgstation-server-installer.exe
+  InstallerSha256: BA859F97D6FFAA7ECF817C466B855750845072C74CCED4593041CEB8F0B7C885
+  InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.DotNet.HostingBundle.8
+  ProductCode: '{4DDF1CC6-C26C-4B6D-8172-3A5D84AF1B51}'
+  UnsupportedOSArchitectures:
+  - arm
+  - arm64
+  AppsAndFeaturesEntries:
+  - DisplayName: tgstation-server
+    Publisher: /tg/station 13
+  ElevationRequirement: elevatesSelf
+  ReleaseDate: 2023-12-28
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/t/Tgstation/Server/6.1.999/Tgstation.Server.locale.en-US.yaml
+++ b/manifests/t/Tgstation/Server/6.1.999/Tgstation.Server.locale.en-US.yaml
@@ -1,0 +1,21 @@
+# Created using wingetcreate 1.5.7.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+
+PackageIdentifier: Tgstation.Server
+PackageVersion: 6.1.999
+PackageLocale: en-US
+Publisher: /tg/station 13
+PublisherUrl: https://github.com/tgstation/tgstation-server
+PublisherSupportUrl: https://github.com/tgstation/tgstation-server/discussions/categories/q-a
+Author: Dominion/Cyberboss
+PackageName: tgstation-server
+License: AGPL-3.0
+ShortDescription: A production scale tool for BYOND server management
+Moniker: tgstation-server
+ReleaseNotesUrl: https://github.com/tgstation/tgstation-server/releases/tag/tgstation-server-v6.1.0
+PurchaseUrl: https://github.com/sponsors/Cyberboss
+Documentations:
+- DocumentLabel: README.md
+  DocumentUrl: https://github.com/tgstation/tgstation-server/blob/tgstation-server-v6.1.0/README.md
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/t/Tgstation/Server/6.1.999/Tgstation.Server.yaml
+++ b/manifests/t/Tgstation/Server/6.1.999/Tgstation.Server.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.5.7.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+
+PackageIdentifier: Tgstation.Server
+PackageVersion: 6.1.999
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0


### PR DESCRIPTION
Do not merge this pull request.

This manifest is a reversioned resubmission of Tgstation.Server.6.1.0

Recently, Tgstation.Server has begun failing winget validation (#132245, #133023, #135613). I have no reason to believe any change made to the package's code would cause this.

This PR is meant to test the last version that succeeded (#132002) against the validation pipeline to see if the problem lies in the pipeline itself.

I will close this PR on conclusion of the test.