### PR TITLE
[YamlCreate] Remove white spaces at the end of each line

### DIFF
--- a/Tools/YamlCreate.ps1
+++ b/Tools/YamlCreate.ps1
@@ -2254,7 +2254,7 @@ Function Write-ManifestContent {
       "# yaml-language-server: `$schema=$Schema";
       '';
       # This regex looks for lines with the special character ⍰ and comments them out
-      $(ConvertTo-Yaml $YamlContent).TrimEnd() -replace "(.*)$([char]0x2370)", "# `$1"
+      $(ConvertTo-Yaml $YamlContent).TrimEnd() -replace "(.*) $([char]0x2370)", "# `$1"
     ), $Utf8NoBomEncoding)
 
   Write-Host "Yaml file created: $FilePath"

--- a/Tools/YamlCreate.ps1
+++ b/Tools/YamlCreate.ps1
@@ -2254,7 +2254,7 @@ Function Write-ManifestContent {
       "# yaml-language-server: `$schema=$Schema";
       '';
       # This regex looks for lines with the special character ⍰ and comments them out
-      $(ConvertTo-Yaml $YamlContent).TrimEnd() -replace "(.*) $([char]0x2370)", "# `$1"
+      $(ConvertTo-Yaml $YamlContent).TrimEnd() -replace "(.*)\s+$([char]0x2370)", "# `$1"
     ), $Utf8NoBomEncoding)
 
   Write-Host "Yaml file created: $FilePath"


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?

---

This PR fixes the issue that YamlCreate does not remove the white space before the special character when commenting out some lines in the locale manifests, leaving these comments ending with a white space, which contradicts with editorconfig rules:
https://github.com/microsoft/winget-pkgs/blob/8ce267285884b7601b93355571a648f61668ed21/.editorconfig#L9
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/135715)