### PR TITLE
New version: BRL-CAD.brlcad version 7.38.0

### DIFF
--- a/manifests/b/BRL-CAD/brlcad/7.38.0/BRL-CAD.brlcad.installer.yaml
+++ b/manifests/b/BRL-CAD/brlcad/7.38.0/BRL-CAD.brlcad.installer.yaml
@@ -1,0 +1,14 @@
+# Created using wingetcreate 1.5.7.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+
+PackageIdentifier: BRL-CAD.brlcad
+PackageVersion: 7.38.0
+InstallerLocale: en-US
+InstallerType: nullsoft
+ProductCode: '{2186D7C6-1612-4567-B3B2-EF962895A9C5}'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/BRL-CAD/brlcad/releases/download/rel-7-38-0/BRL-CAD_7.38.0_win64.exe
+  InstallerSha256: A0C76AACC8D553D1E9FD9E0F778F826A9A1523CC3BC5F405A1ED320ADD56A736
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/b/BRL-CAD/brlcad/7.38.0/BRL-CAD.brlcad.locale.en-US.yaml
+++ b/manifests/b/BRL-CAD/brlcad/7.38.0/BRL-CAD.brlcad.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# Created using wingetcreate 1.5.7.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+
+PackageIdentifier: BRL-CAD.brlcad
+PackageVersion: 7.38.0
+PackageLocale: en-US
+Publisher: BRL-CAD Development Team
+PublisherUrl: https://github.com/BRL-CAD
+PublisherSupportUrl: https://github.com/BRL-CAD/brlcad/issues
+Author: BRL-CAD Development Team
+PackageName: BRLCAD
+PackageUrl: https://github.com/BRL-CAD/brlcad
+License: LGPL License
+LicenseUrl: https://github.com/BRL-CAD/brlcad/blob/main/COPYING
+Copyright: Copyright (c) 1984-2023 United States Government as represented by the U.S. Army Research Laboratory.
+CopyrightUrl: https://github.com/BRL-CAD/brlcad/blob/main/COPYING
+ShortDescription: BRL-CAD is a powerful cross-platform open source combinatorial solid modeling system.
+Moniker: brlcad
+Tags:
+- cad
+ReleaseNotesUrl: https://github.com/BRL-CAD/brlcad/releases/tag/rel-7-38-0
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/b/BRL-CAD/brlcad/7.38.0/BRL-CAD.brlcad.yaml
+++ b/manifests/b/BRL-CAD/brlcad/7.38.0/BRL-CAD.brlcad.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.5.7.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+
+PackageIdentifier: BRL-CAD.brlcad
+PackageVersion: 7.38.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0


### PR DESCRIPTION
## Description

- Resolve #132972

> [!IMPORTANT]
>
> Official team has changed the installer file extension from `*.msi` to `*.exe`, and changed the installer technology from `wix` to `nullsoft`.

## Checks

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/135821)