### PR TITLE
Fix 403 in KDE.Okular by updating installer to latest build

### DIFF
--- a/manifests/k/KDE/Okular/23.08.4/KDE.Okular.installer.yaml
+++ b/manifests/k/KDE/Okular/23.08.4/KDE.Okular.installer.yaml
@@ -8,14 +8,14 @@ ReleaseDate: 2024-01-12
 Installers:
 - Architecture: x64
   Scope: user
-  InstallerUrl: https://binary-factory.kde.org/view/Windows%2064-bit/job/Okular_Release_win64/1638/artifact/okular-23.08.4-1638-windows-cl-msvc2019-x86_64.exe
-  InstallerSha256: 6BDEF090C693353BA26F41237E410D2CB3E656544265D50C3078EA81011E5EA3
+  InstallerUrl: https://binary-factory.kde.org/view/Windows%2064-bit/job/Okular_Release_win64/1649/artifact/okular-23.08.4-1649-windows-cl-msvc2019-x86_64.exe
+  InstallerSha256: 3371b476c28aace664fc3a69385394a91cb001701c4aae5185d07a58bb4db774
   InstallerSwitches:
     Custom: /CURRENTUSER
 - Architecture: x64
   Scope: machine
-  InstallerUrl: https://binary-factory.kde.org/view/Windows%2064-bit/job/Okular_Release_win64/1638/artifact/okular-23.08.4-1638-windows-cl-msvc2019-x86_64.exe
-  InstallerSha256: 6BDEF090C693353BA26F41237E410D2CB3E656544265D50C3078EA81011E5EA3
+  InstallerUrl: https://binary-factory.kde.org/view/Windows%2064-bit/job/Okular_Release_win64/1649/artifact/okular-23.08.4-1649-windows-cl-msvc2019-x86_64.exe
+  InstallerSha256: 3371b476c28aace664fc3a69385394a91cb001701c4aae5185d07a58bb4db774
   InstallerSwitches:
     Custom: /ALLUSERS
 ManifestType: installer


### PR DESCRIPTION
KDE's installer URLs are notoriously unstable and need to be updated frequently as only the last few builds are kept.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

The previously occuring 403 issue fixed by this change:

```
(1/1) Found Okular [KDE.Okular] Version 23.08.4
This application is licensed to you by its owner.
Microsoft is not responsible for, nor does it grant any licenses to, third-party packages.
Downloading https://binary-factory.kde.org/view/Windows%2064-bit/job/Okular_Release_win64/1638/artifact/okular-23.08.4-1638-windows-cl-msvc2019-x86_64.exe
An unexpected error occurred while executing the command:
Download request status is not success.
0x80190193 : unknown error
```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/135850)