### PR TITLE
Remove InstallerLocale field from OpenJDK 11.0.22

### DIFF
--- a/manifests/m/Microsoft/OpenJDK/11/11.0.22.7/Microsoft.OpenJDK.11.installer.yaml
+++ b/manifests/m/Microsoft/OpenJDK/11/11.0.22.7/Microsoft.OpenJDK.11.installer.yaml
@@ -3,7 +3,6 @@
 
 PackageIdentifier: Microsoft.OpenJDK.11
 PackageVersion: 11.0.22.7
-InstallerLocale: en-US
 MinimumOSVersion: 10.0.0.0
 InstallerType: wix
 Scope: machine


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

Remove the InstallerLocale field since we need to be able to run these installers outside of that locale as well as within.

![image](https://github.com/microsoft/winget-pkgs/assets/106336504/bd43372e-37ad-49ca-9a6c-dbd329126fa2)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/135899)