### PR TITLE
Update Display Version for Zoom.Zoom version 5.17.2.29988

### DIFF
--- a/manifests/z/Zoom/Zoom/5.17.2.29988/Zoom.Zoom.installer.yaml
+++ b/manifests/z/Zoom/Zoom/5.17.2.29988/Zoom.Zoom.installer.yaml
@@ -67,7 +67,7 @@ Installers:
   ProductCode: '{5B3FE6D3-5131-4262-A11F-2F6531B0BDAC}'
   AppsAndFeaturesEntries:
   - DisplayName: Zoom (32-bit)
-    DisplayVersion: 5.17.2 (29988)
+    DisplayVersion: '5.17.29988'
     ProductCode: '{5B3FE6D3-5131-4262-A11F-2F6531B0BDAC}'
     UpgradeCode: '{C819B794-A45C-4F27-9860-0C86492A52CC}'
 - Architecture: x64
@@ -78,7 +78,7 @@ Installers:
   ProductCode: '{C11BB445-1C38-4FD5-9CD1-1D075C697E3A}'
   AppsAndFeaturesEntries:
   - DisplayName: Zoom (64-bit)
-    DisplayVersion: 5.17.2 (29988)
+    DisplayVersion: '5.17.29988'
     ProductCode: '{C11BB445-1C38-4FD5-9CD1-1D075C697E3A}'
     UpgradeCode: '{C819B794-A45C-4F27-9860-0C86492A52CC}'
 - Architecture: arm64
@@ -89,7 +89,7 @@ Installers:
   ProductCode: '{C9A08007-03D2-413B-9ADD-8E40CE0394E1}'
   AppsAndFeaturesEntries:
   - DisplayName: Zoom (ARM64)
-    DisplayVersion: 5.17.2 (29988)
+    DisplayVersion: '5.17.29988'
     ProductCode: '{C9A08007-03D2-413B-9ADD-8E40CE0394E1}'
     UpgradeCode: '{C819B794-A45C-4F27-9860-0C86492A52CC}'
 ManifestType: installer


### PR DESCRIPTION
When the previous version is installed, in sandbox it matches to '> 5.17.5.31030' which indicates the package can't be mapped to a specific version. Making the display version exactly match what is installed should help

* Related to #137286
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/137363)