### PR TITLE
Update Display Version for Zoom.Zoom version 5.17.5.31030

### DIFF
--- a/manifests/z/Zoom/Zoom/5.17.5.31030/Zoom.Zoom.installer.yaml
+++ b/manifests/z/Zoom/Zoom/5.17.5.31030/Zoom.Zoom.installer.yaml
@@ -67,7 +67,7 @@ Installers:
   ProductCode: '{EC7587BB-30F4-4997-A278-4BAA1A33EC27}'
   AppsAndFeaturesEntries:
   - DisplayName: Zoom (32-bit)
-    DisplayVersion: 5.17.5 (31030)
+    DisplayVersion: '5.17.31030'
     ProductCode: '{EC7587BB-30F4-4997-A278-4BAA1A33EC27}'
     UpgradeCode: '{C819B794-A45C-4F27-9860-0C86492A52CC}'
 - Architecture: x64
@@ -78,7 +78,7 @@ Installers:
   ProductCode: '{91FD060F-B754-4A33-8DAA-093B9F095638}'
   AppsAndFeaturesEntries:
   - DisplayName: Zoom (64-bit)
-    DisplayVersion: 5.17.5 (31030)
+    DisplayVersion: '5.17.31030'
     ProductCode: '{91FD060F-B754-4A33-8DAA-093B9F095638}'
     UpgradeCode: '{C819B794-A45C-4F27-9860-0C86492A52CC}'
 - Architecture: arm64
@@ -89,6 +89,7 @@ Installers:
   ProductCode: '{B2A2F561-3735-4D42-AB87-73B6EC9FC3AB}'
   AppsAndFeaturesEntries:
   - DisplayName: Zoom (ARM64)
+    DisplayVersion: '5.17.31030'
     ProductCode: '{B2A2F561-3735-4D42-AB87-73B6EC9FC3AB}'
     UpgradeCode: '{C819B794-A45C-4F27-9860-0C86492A52CC}'
 ManifestType: installer


### PR DESCRIPTION
When the previous version is installed, in sandbox it matches to '> 5.17.5.31030' which indicates the package can't be mapped to a specific version. Making the display version exactly match what is installed should help

* Related to #137286
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/137364)