### PR TITLE
Make Similarity Check stricter

### DIFF
--- a/.github/workflows/similarissues.yml
+++ b/.github/workflows/similarissues.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           issuetitle: ${{ github.event.issue.title }}
           repo: ${{ github.repository }}
-          similaritytolerance: "0.7"
+          similaritytolerance: "0.81"
   add-comment:
     needs: getSimilarIssues
     runs-on: ubuntu-latest


### PR DESCRIPTION
- [*] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?

With the number of issues that have been opened in this repository, the similarity finder is finding issues which are not usually helpful. This is evidenced by several of the comments from the workflow being 👎 by the issue authors. 

I've gone through several of the threads and found that when an issue has a similarity score of 0.80 it seems to be only tangentially related but as soon as it hits 0.82 the issues are generally similar enough to be useful. This change should make the replies from the workflow more useful by increasing the threshold. I do know that this is a big bump (and it may need to be bumped higher even), but I believe this to be a fair threshold based on what I've seen in some of the issues (linked below) 

* https://github.com/microsoft/winget-pkgs/issues/138357
* https://github.com/microsoft/winget-pkgs/issues/138153
* https://github.com/microsoft/winget-pkgs/issues/137960
* https://github.com/microsoft/winget-pkgs/issues/137602
* https://github.com/microsoft/winget-pkgs/issues/137286
* https://github.com/microsoft/winget-pkgs/issues/137157

cc @denelon
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/138375)