### PR TITLE
Update labelAdded.manifestValidationError.yml

### DIFF
--- a/.github/policies/labelAdded.manifestValidationError.yml
+++ b/.github/policies/labelAdded.manifestValidationError.yml
@@ -24,7 +24,7 @@ configuration:
                 Hello @${issueAuthor},
 
 
-                Please verify the manifest file is compliant with the package manager [1.0 manifest specification](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.0.0), [1.1 manifest specification](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.1.0), [1.2 manifest specification](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.2.0), or [1.4 manifest specification](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.4.0).
+                Please verify the manifest file is compliant with the package manager [1.5 manifest specification](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0) or [1.6 manifest specification](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0).
 
 
                 Make sure the ID is of the form publisher.appname and that the folder structure is manifests\partition\publisher\appname\version.


### PR DESCRIPTION
Updating the error message to point toward the most recent schemas. Makes it similar to another trigger:

https://github.com/microsoft/winget-pkgs/blob/9d0ce389e005dea243e246f3042be79a5b170168/.github/policies/labelAdded.manifestVersionError.yml#L22-L33

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/138442)