### PR TITLE
Update manifest: Ghisler.TotalCommander version 11.02

### DIFF
--- a/manifests/g/Ghisler/TotalCommander/11.02/Ghisler.TotalCommander.installer.yaml
+++ b/manifests/g/Ghisler/TotalCommander/11.02/Ghisler.TotalCommander.installer.yaml
@@ -4,16 +4,35 @@
 PackageIdentifier: Ghisler.TotalCommander
 PackageVersion: "11.02"
 InstallerType: exe
-InstallerSwitches:
-  Silent: /AH
-  SilentWithProgress: /AH
 UpgradeBehavior: install
 Installers:
 - Architecture: x64
   InstallerUrl: https://totalcommander.ch/win/tcmd1102x64.exe
   InstallerSha256: 07CDF2D51CB04EE3148AE3399978FC609829908B538C49CABF1953015857987B
+  Scope: user
+  InstallerSwitches:
+    Silent: /AH
+    SilentWithProgress: /AH
 - Architecture: x86
   InstallerUrl: https://totalcommander.ch/win/tcmd1102x32.exe
   InstallerSha256: 25C4706EF4519664E5101A8BDC3AFF813B6DD76F05883279608667E25752DF36
+  Scope: user
+  InstallerSwitches:
+    Silent: /AH
+    SilentWithProgress: /AH
+- Architecture: x64
+  InstallerUrl: https://totalcommander.ch/win/tcmd1102x64.exe
+  InstallerSha256: 07CDF2D51CB04EE3148AE3399978FC609829908B538C49CABF1953015857987B
+  Scope: machine
+  InstallerSwitches:
+    Silent: /AHFN
+    SilentWithProgress: /AHFN
+- Architecture: x86
+  InstallerUrl: https://totalcommander.ch/win/tcmd1102x32.exe
+  InstallerSha256: 25C4706EF4519664E5101A8BDC3AFF813B6DD76F05883279608667E25752DF36
+  Scope: machine
+  InstallerSwitches:
+    Silent: /AHFN
+    SilentWithProgress: /AHFN
 ManifestType: installer
 ManifestVersion: 1.5.0


### PR DESCRIPTION
## Description

- Resolve #138570
- Seperate `user` and `machine` scopes with different `InstallerSwitches`

## Checks

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/138659)