### PR TITLE
Remove new manifest labels on changes pushed

### DIFF
--- a/.github/policies/labelManagement.issueUpdated.yml
+++ b/.github/policies/labelManagement.issueUpdated.yml
@@ -368,6 +368,14 @@ configuration:
               label: Validation-Open-Url-Failed
           - removeLabel:
               label: Last-Version-Remaining
+          - removeLabel:
+              label: New-Manifest
+          - removeLabel:
+              label: New-Package
+          - removeLabel:
+              label: Manifest-Metadata-Consistency
+          - removeLabel:
+              label: Manifest-Version-Deprecated
       - description: Remove status labels when a PR is re-run
         if:
           - payloadType: Issue_Comment

--- a/.github/policies/moderatorTriggers.yml
+++ b/.github/policies/moderatorTriggers.yml
@@ -287,6 +287,8 @@ configuration:
                       label: DriverInstall
                   - removeLabel:
                       label: Network-Blocker
+                  - removeLabel:
+                      label: Manifest-Metadata-Consistency
                   ## TODO: Dismiss All Pull Request Reviews
               # Duplicate of #
               - if:


### PR DESCRIPTION
cc @Trenly @denelon

These don't appear to get auto-removed by wingetbot. See https://github.com/microsoft/winget-pkgs/pull/139070

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/139076)