### PR TITLE
Remove DisplayVersion from PowerBI 2.124.2028.0 manifest

### DIFF
--- a/manifests/m/Microsoft/PowerBI/2.124.2028.0/Microsoft.PowerBI.installer.yaml
+++ b/manifests/m/Microsoft/PowerBI/2.124.2028.0/Microsoft.PowerBI.installer.yaml
@@ -24,7 +24,6 @@ UpgradeBehavior: install
 AppsAndFeaturesEntries:
 - DisplayName: Microsoft PowerBI Desktop (x64)
   Publisher: Microsoft Corporation
-  DisplayVersion: 2.124.2028.0
   ProductCode: '{035c1474-8dc2-474f-8f0f-6edad420b959}'
   InstallerType: burn
 ElevationRequirement: elevatesSelf


### PR DESCRIPTION
DisplayVersion should not be used when it's equal to PackageVersion

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/139132)