### PR TITLE
Try separate comment and reply

### DIFF
--- a/.github/policies/superModeratorTriggers.yml
+++ b/.github/policies/superModeratorTriggers.yml
@@ -50,7 +50,7 @@ configuration:
                       A Microsoft-authorized representative is forcibly merging this PR
 
 
-                      Template: msftbot/validationCompleted
+                      Template: msftbot/microsoft/merge
                   - enableAutoMerge:
                       mergeMethod: Squash
               # Manually-Validated

--- a/.github/policies/superModeratorTriggers.yml
+++ b/.github/policies/superModeratorTriggers.yml
@@ -40,18 +40,19 @@ configuration:
                       isRegex: True
                   - isPullRequest
                 then:
-                  - approvePullRequest:
-                      comment: >-
-                        A Microsoft-authorized representative is forcibly merging this PR
-
-
-                        Template: msftbot/microsoft/merge
-                  - enableAutoMerge:
-                      mergeMethod: Squash
                   - removeLabel:
                       label: Needs-Attention
                   - removeLabel:
                       label: Needs-Author-Feedback
+                  - approvePullRequest:
+                      comment: ""
+                  - addReply: >-
+                      A Microsoft-authorized representative is forcibly merging this PR
+
+
+                      Template: msftbot/validationCompleted
+                  - enableAutoMerge:
+                      mergeMethod: Squash
               # Manually-Validated
               - if:
                   - commentContains:
@@ -61,7 +62,7 @@ configuration:
                 then:
                   - addReply:
                       reply:  >-
-                        A Microsoft-authorized representative has manually validated this pull requests to conform with the security requirements of this repository. This package may be exempt from additional pipeline runs.
+                        A Microsoft-authorized representative has manually validated this pull request to conform with the security requirements of this repository. This package may be exempt from additional pipeline runs.
 
 
                         Template: msftbot/microsoft/validated


### PR DESCRIPTION
The force-merge policy for MSFT representatives is not working; Since it isn't clear what portion isn't working, this PR tries separating out the steps of approving and commenting, and moves the label removal before enabling auto-merge
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/139164)