### PR TITLE
[Agreements] NI.ni-pxiplatformservices version 23.8.0

### DIFF
--- a/manifests/n/NI/ni-pxiplatformservices/23.8.0/NI.ni-pxiplatformservices.installer.yaml
+++ b/manifests/n/NI/ni-pxiplatformservices/23.8.0/NI.ni-pxiplatformservices.installer.yaml
@@ -1,0 +1,30 @@
+# Created using wingetcreate 1.6.1.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: NI.ni-pxiplatformservices
+PackageVersion: 23.8.0
+MinimumOSVersion: 10.0.0.0
+InstallerType: exe
+Scope: machine
+InstallModes:
+- interactive
+- silent
+InstallerSwitches:
+  Silent: --quiet --accept-eulas --prevent-reboot
+  SilentWithProgress: --language=en --passive --accept-eulas --prevent-reboot
+InstallerSuccessCodes:
+- 4294842225
+UpgradeBehavior: install
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+  - PackageIdentifier: Microsoft.VCRedist.2015+.x86
+  - PackageIdentifier: NI.ni-packagemanager
+    MinimumVersion: 23.8.0
+InstallLocationRequired: false
+Installers:
+- Architecture: x64
+  InstallerUrl: https://download.ni.com/support/nipkg/products/ni-p/ni-pxiplatformservices/23.8/online/ni-pxiplatformservices_23.8_online.exe
+  InstallerSha256: 094C4B37039EEF5B44ABFB51E325143D38B8BB69FC2FB10CADC731018EAF4510
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/n/NI/ni-pxiplatformservices/23.8.0/NI.ni-pxiplatformservices.locale.en-US.yaml
+++ b/manifests/n/NI/ni-pxiplatformservices/23.8.0/NI.ni-pxiplatformservices.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created using wingetcreate 1.6.1.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: NI.ni-pxiplatformservices
+PackageVersion: 23.8.0
+PackageLocale: en-US
+Publisher: National Instruments Corporation
+PackageName: NI PXI Platform Services
+License: NI General Purpose Software License Agreement
+LicenseUrl: https://www.ni.com/en/about-ni/legal/software-license-agreement.html
+Copyright: Copyright © 2000-2023 National Instruments Corporation. All Rights Reserved.
+ShortDescription: NI PXI Platform Services
+Agreements:
+- AgreementLabel: End User License Agreement (EULA)
+  AgreementUrl: https://www.ni.com/content/dam/web/pdfs/legal/software_license_agreement_en.pdf
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/n/NI/ni-pxiplatformservices/23.8.0/NI.ni-pxiplatformservices.yaml
+++ b/manifests/n/NI/ni-pxiplatformservices/23.8.0/NI.ni-pxiplatformservices.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.6.1.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: NI.ni-pxiplatformservices
+PackageVersion: 23.8.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
New package, but same license and agreement as NI.ni-packagemanager:
https://github.com/microsoft/winget-pkgs/pull/139458

---

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/140233)