### PR TITLE
Remove DisplayVersion for Screenpresso 2.1.23.0

### DIFF
--- a/manifests/l/Learnpulse/Screenpresso/2.1.23.0/Learnpulse.Screenpresso.installer.yaml
+++ b/manifests/l/Learnpulse/Screenpresso/2.1.23.0/Learnpulse.Screenpresso.installer.yaml
@@ -13,8 +13,7 @@ InstallModes:
 UpgradeBehavior: install
 ProductCode: '{32dfcb05-18bb-4a1c-81cd-5a3781358810}'
 AppsAndFeaturesEntries:
-- DisplayVersion: 2.1.23.0
-  UpgradeCode: '{35D6B64D-DD12-4513-B273-1D630B56E451}'
+- UpgradeCode: '{35D6B64D-DD12-4513-B273-1D630B56E451}'
 Installers:
 - Architecture: x64
   InstallerUrl: https://www.screenpresso.com/binaries/releases/stable/dotnet47/ScreenpressoSetup.msi

--- a/manifests/l/Learnpulse/Screenpresso/2.1.23.0/Learnpulse.Screenpresso.installer.yaml
+++ b/manifests/l/Learnpulse/Screenpresso/2.1.23.0/Learnpulse.Screenpresso.installer.yaml
@@ -16,7 +16,7 @@ AppsAndFeaturesEntries:
 - UpgradeCode: '{35D6B64D-DD12-4513-B273-1D630B56E451}'
 Installers:
 - Architecture: x64
-  InstallerUrl: https://www.screenpresso.com/binaries/releases/stable/dotnet47/ScreenpressoSetup.msi
+  InstallerUrl: https://www.screenpresso.com/binaries/releases/v2-1-23-000/dotnet47/ScreenpressoSetup.msi
   InstallerSha256: 7577D5A4B910D5B493EFE132A2D4690F044BA7FBCA378A300668588034B4DA83
 ManifestType: installer
 ManifestVersion: 1.5.0


### PR DESCRIPTION
DisplayVersion should not be used when it's equal to PackageVersion

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/140376)