### PR TITLE
Ensure SandboxTest falls back correctly

### DIFF
--- a/Tools/SandboxTest.ps1
+++ b/Tools/SandboxTest.ps1
@@ -232,10 +232,7 @@ Write-Host @'
 '@
 `$ProgressPreference = 'SilentlyContinue'
 try {
-  Add-AppxPackage -Path '$($desktopAppInstaller.pathInSandbox)' -DependencyPath '$($vcLibsUwp.pathInSandbox)','$($uiLibsUwp.pathInSandbox)' -ErrorAction SilentlyContinue
-  if (!(Get-Command winget -ErrorAction SilentlyContinue)) {
-    throw
-  }
+  Add-AppxPackage -Path '$($desktopAppInstaller.pathInSandbox)' -DependencyPath '$($vcLibsUwp.pathInSandbox)','$($uiLibsUwp.pathInSandbox)' -ErrorAction Stop
 } catch {
   Write-Host -ForegroundColor Red 'Could not install from cached packages. Falling back to Repair-WinGetPackageManager cmdlet'
   try {

--- a/Tools/SandboxTest.ps1
+++ b/Tools/SandboxTest.ps1
@@ -232,7 +232,10 @@ Write-Host @'
 '@
 `$ProgressPreference = 'SilentlyContinue'
 try {
-  Add-AppxPackage -Path '$($desktopAppInstaller.pathInSandbox)' -DependencyPath '$($vcLibsUwp.pathInSandbox)','$($uiLibsUwp.pathInSandbox)'
+  Add-AppxPackage -Path '$($desktopAppInstaller.pathInSandbox)' -DependencyPath '$($vcLibsUwp.pathInSandbox)','$($uiLibsUwp.pathInSandbox)' -ErrorAction SilentlyContinue
+  if (!(Get-Command winget -ErrorAction SilentlyContinue)) {
+    throw
+  }
 } catch {
   Write-Host -ForegroundColor Red 'Could not install from cached packages. Falling back to Repair-WinGetPackageManager cmdlet'
   try {


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?

If there is an error during the deployment of the dependencies, the try-catch will accurately fall back to Repair-WinGetPackageManager. However, if there is an error in the deployment of the AppInstaller package after the dependencies are deployed, it will not be caught correctly. This change makes it so that any errors in the deployment of winget will fall back to the PowerShell cmdlet regardless of whether they occur at the dependencies stage or the package deployment stage

@mdanish-kh @denelon
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/141251)