### PR TITLE
Fix version number of Lazarus 3.0

### DIFF
--- a/manifests/l/Lazarus/Lazarus/3.0/Lazarus.Lazarus.installer.yaml
+++ b/manifests/l/Lazarus/Lazarus/3.0/Lazarus.Lazarus.installer.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: Lazarus.Lazarus
-PackageVersion: 3.2.2
+PackageVersion: 3.0
 InstallerType: inno
 ReleaseDate: 2023-12-17
 Installers:

--- a/manifests/l/Lazarus/Lazarus/3.0/Lazarus.Lazarus.locale.en-US.yaml
+++ b/manifests/l/Lazarus/Lazarus/3.0/Lazarus.Lazarus.locale.en-US.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: Lazarus.Lazarus
-PackageVersion: 3.2.2
+PackageVersion: 3.0
 PackageLocale: en-US
 Publisher: Lazarus Team
 # PublisherUrl:

--- a/manifests/l/Lazarus/Lazarus/3.0/Lazarus.Lazarus.yaml
+++ b/manifests/l/Lazarus/Lazarus/3.0/Lazarus.Lazarus.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: Lazarus.Lazarus
-PackageVersion: 3.2.2
+PackageVersion: 3.0
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.6.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

The "3.2.2" in the installer file name actually refers to its compiler version: fpc 3.2.2, not the version of Lazarus itself.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/141571)