### PR TITLE
Possible BugFix for gnif.LookingGlass version B6

### DIFF
--- a/manifests/g/gnif/LookingGlass/B6/gnif.LookingGlass.installer.yaml
+++ b/manifests/g/gnif/LookingGlass/B6/gnif.LookingGlass.installer.yaml
@@ -12,7 +12,6 @@ InstallModes:
 InstallerSwitches:
   Silent: /S
   SilentWithProgress: /S
-  Custom: /noservice
 UpgradeBehavior: install
 ReleaseDate: 2022-12-09
 Installers:


### PR DESCRIPTION
### Description
In the [PR for gnif.LookingGlass](https://github.com/microsoft/winget-pkgs/pull/141514), there were a `custom` Sub-Field added under `InstallerSwitches`, at the time for that PR, I added it for testing, to see if the `Exited with code 80` would go away, but that wasn't the case, of course that code value could be for successful installation, or successful install but User needs to restart their system, but I can't confirm on that end. The project is Open Source, you can look around [the LookingGlass Repo](https://github.com/gnif/LookingGlass) if you want to.

After looking into [LookingGlass version B6 official documentation](https://looking-glass.io/docs/B6), it turns out that adding `/noservice` switch to the installer was going to add confusion and frustration to Users who're following the Docs, so I've removed this custom switch to fix this Possible Bug. _[further reading](https://looking-glass.io/docs/B6/install/#installing-the-looking-glass-service)_

**Note**: the `/noservice` does what's titled as, which's instructing the Installer to not add a `Looking Glass Host` service to Windows Services, which by default, most users don't want this switch, everything else works just fine, I've double checked using `winget validate` & `winget install`, before and after this change.

-----

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/141718)