### PR TITLE
[Metadata]: GodotEngine.GodotEngine version 3.1.x Copyright Notice Update

### DIFF
--- a/manifests/g/GodotEngine/GodotEngine/3.1.1/GodotEngine.GodotEngine.locale.en-US.yaml
+++ b/manifests/g/GodotEngine/GodotEngine/3.1.1/GodotEngine.GodotEngine.locale.en-US.yaml
@@ -13,7 +13,9 @@ PackageName: Godot Engine
 PackageUrl: https://godotengine.org/download/windows
 License: MIT License
 LicenseUrl: https://godotengine.org/license
-Copyright: Copyright (c) 2007-2018 Juan Linietsky, Ariel Manzur & Godot Contributors.
+Copyright: |-
+  Copyright (c) 2014-2019 Godot Engine Contributors.
+  Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.
 CopyrightUrl: https://godotengine.org/license
 ShortDescription: Multi-platform 2D and 3D game engine
 Description: |-

--- a/manifests/g/GodotEngine/GodotEngine/3.1.2/GodotEngine.GodotEngine.locale.en-US.yaml
+++ b/manifests/g/GodotEngine/GodotEngine/3.1.2/GodotEngine.GodotEngine.locale.en-US.yaml
@@ -13,7 +13,9 @@ PackageName: Godot Engine
 PackageUrl: https://godotengine.org/download/windows
 License: MIT License
 LicenseUrl: https://godotengine.org/license
-Copyright: Copyright (c) 2007-2018 Juan Linietsky, Ariel Manzur & Godot Contributors.
+Copyright: |-
+  Copyright (c) 2014-2019 Godot Engine Contributors.
+  Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.
 CopyrightUrl: https://godotengine.org/license
 ShortDescription: Multi-platform 2D and 3D game engine
 Description: |-

--- a/manifests/g/GodotEngine/GodotEngine/3.1/GodotEngine.GodotEngine.locale.en-US.yaml
+++ b/manifests/g/GodotEngine/GodotEngine/3.1/GodotEngine.GodotEngine.locale.en-US.yaml
@@ -13,7 +13,9 @@ PackageName: Godot Engine
 PackageUrl: https://godotengine.org/download/windows
 License: MIT License
 LicenseUrl: https://godotengine.org/license
-Copyright: Copyright (c) 2007-2018 Juan Linietsky, Ariel Manzur & Godot Contributors.
+Copyright: |-
+  Copyright (c) 2014-2019 Godot Engine Contributors.
+  Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.
 CopyrightUrl: https://godotengine.org/license
 ShortDescription: Multi-platform 2D and 3D game engine
 Description: |-


### PR DESCRIPTION
### Description
A follow-up PR to those which've added versions 3.1, 3.1.1, and 3.1.2 of GodotEngine.GodotEngine Package. _[read more in 3.0.x Copyright Update PR](https://github.com/microsoft/winget-pkgs/pull/141726)_

> [!NOTE]
> This PR changes Manifest's `Copyright` Field in multiple versions of GodotEngine.GodotEngine Package, If it's possible to accept this kind of PR (a PR that changes multiple manifests), then It'll save alot of headaches and time for both me & the maintainers.
> If not, then I guess the only way to do this is by splitting these changes into 3 PRs.

-----

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/141728)