### PR TITLE
fix: use correct version information for Gitleaks.Gitleaks 8.18.2

### DIFF
--- a/manifests/g/Gitleaks/Gitleaks/8.18.2/Gitleaks.Gitleaks.installer.yaml
+++ b/manifests/g/Gitleaks/Gitleaks/8.18.2/Gitleaks.Gitleaks.installer.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: Gitleaks.Gitleaks
-PackageVersion: 8.12.2
+PackageVersion: 8.18.2
 InstallerLocale: en-US
 InstallerType: zip
 NestedInstallerType: portable

--- a/manifests/g/Gitleaks/Gitleaks/8.18.2/Gitleaks.Gitleaks.locale.en-US.yaml
+++ b/manifests/g/Gitleaks/Gitleaks/8.18.2/Gitleaks.Gitleaks.locale.en-US.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: Gitleaks.Gitleaks
-PackageVersion: 8.12.2
+PackageVersion: 8.18.2
 PackageLocale: en-US
 Publisher: Gitleaks LLC
 PublisherUrl: https://gitleaks.io/

--- a/manifests/g/Gitleaks/Gitleaks/8.18.2/Gitleaks.Gitleaks.yaml
+++ b/manifests/g/Gitleaks/Gitleaks/8.18.2/Gitleaks.Gitleaks.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: Gitleaks.Gitleaks
-PackageVersion: 8.12.2
+PackageVersion: 8.18.2
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.6.0


### PR DESCRIPTION
Version 8.18.2 was erraneously published within winget as 8.12.2 because of a typo. The release 8.12.2 does in fact not exist and the binaries listed in the manifest pointed to 8.18.2 as expected.

---

Sorry about that, I really wasn't paying enough attention when creating the original PR apparently :(
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/142081)