### PR TITLE
Update Betterbird.Betterbird to 115.8.1-bb25

### DIFF
--- a/manifests/b/Betterbird/Betterbird/115.8.1-bb25/Betterbird.Betterbird.installer.yaml
+++ b/manifests/b/Betterbird/Betterbird/115.8.1-bb25/Betterbird.Betterbird.installer.yaml
@@ -1,0 +1,69 @@
+# Created with komac v2.1.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: Betterbird.Betterbird
+PackageVersion: 115.8.1-bb25
+InstallerType: exe
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+  InstallLocation: /InstallDirectoryPath=<INSTALLPATH>
+UpgradeBehavior: install
+ReleaseDate: 2024-03-05
+AppsAndFeaturesEntries:
+  - DisplayVersion: 115.8.0
+Installers:
+  - InstallerLocale: de-DE
+    Architecture: x64
+    InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.8.1-bb25.de.win64.installer.exe
+    InstallerSha256: e5721f48efa3b62680f17e70f5ff8f6eeaad123d6c4c415099e37d9278389818
+  - InstallerLocale: de-DE
+    Architecture: x64
+    InstallerType: portable
+    InstallerUrl: https://www.betterbird.eu/downloads/WindowsPortable/BetterbirdPortable-115.8.1-bb25.de.win64.zip
+    InstallerSha256: ab1902e8d5d856e5cab4e1d408a3d7e4793da3d159c9e6427b23799463525951
+  - InstallerLocale: en-US
+    Architecture: x64
+    InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.8.1-bb25.en-US.win64.installer.exe
+    InstallerSha256: 07c5bba633087df515dc1fe1fa9049a59556f79376569a1e8f365d62f6a783b5
+  - InstallerLocale: en-US
+    Architecture: x64
+    InstallerType: portable
+    InstallerUrl: https://www.betterbird.eu/downloads/WindowsPortable/BetterbirdPortable-115.8.1-bb25.en-US.win64.zip
+    InstallerSha256: 1ec2527fc70c51c7d97a7d67e43ce99e15c253ed5633bf5de798d296b8b4c7c0
+  - InstallerLocale: es-AR
+    Architecture: x64
+    InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.8.1-bb25.es-AR.win64.installer.exe
+    InstallerSha256: 374029e54c87e8e573ca96e99584fc7aac75b33962d343f408735ba6ca0d977d
+  - InstallerLocale: es-AR
+    Architecture: x64
+    InstallerType: portable
+    InstallerUrl: https://www.betterbird.eu/downloads/WindowsPortable/BetterbirdPortable-115.8.1-bb25.es-AR.win64.zip
+    InstallerSha256: ba003cd8c47a940362080d0e2bdce317ec26d14b3af840b6d250769e54ba99d4
+  - InstallerLocale: fr-FR
+    Architecture: x64
+    InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.8.1-bb25.fr.win64.installer.exe
+    InstallerSha256: ADD20F5B8730B3E80DF253A24309A003CC3F5C6F0EBB643F2DD6691DC3ED3E54
+  - InstallerLocale: fr-FR
+    Architecture: x64
+    InstallerType: portable
+    InstallerUrl: https://www.betterbird.eu/downloads/WindowsPortable/BetterbirdPortable-115.8.1-bb25.fr.win64.zip
+    InstallerSha256: 0c2d1ad926388a98157e4f931a8bd46b18de3decfbf8fe047cb4db4d94fed198
+  - InstallerLocale: it-IT
+    Architecture: x64
+    InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.8.1-bb25.it.win64.installer.exe
+    InstallerSha256: 67f82f0d657ade06091cae524ae2b4284dd12a2d861baa831ba55c331c6f81cc
+  - InstallerLocale: ja-JP
+    Architecture: x64
+    InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.8.1-bb25.ja.win64.installer.exe
+    InstallerSha256: ef19b6da39e608b3b04d726303d140c67ec4432b076ca3bc69a79c00661181a4
+  - InstallerLocale: nl-NL
+    Architecture: x64
+    InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.8.1-bb25.nl.win64.installer.exe
+    InstallerSha256: 5343f1cd87ebe446f70e6769f3b4ba17860cbffa7eac98fb412bf1f578a76139
+  - InstallerLocale: pt-BR
+    Architecture: x64
+    InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.8.1-bb25.pt-BR.win64.installer.exe
+    InstallerSha256: 1f20eee27dbf3db3c11c37161658e5c1d5aef4c69e91a022a8ce0682b96749e4
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/b/Betterbird/Betterbird/115.8.1-bb25/Betterbird.Betterbird.installer.yaml
+++ b/manifests/b/Betterbird/Betterbird/115.8.1-bb25/Betterbird.Betterbird.installer.yaml
@@ -12,6 +12,7 @@ UpgradeBehavior: install
 ReleaseDate: 2024-03-05
 AppsAndFeaturesEntries:
   - DisplayVersion: 115.8.0
+ElevationRequirement: elevatesSelf
 Installers:
   - InstallerLocale: de-DE
     Architecture: x64

--- a/manifests/b/Betterbird/Betterbird/115.8.1-bb25/Betterbird.Betterbird.installer.yaml
+++ b/manifests/b/Betterbird/Betterbird/115.8.1-bb25/Betterbird.Betterbird.installer.yaml
@@ -11,7 +11,7 @@ InstallerSwitches:
 UpgradeBehavior: install
 ReleaseDate: 2024-03-05
 AppsAndFeaturesEntries:
-  - DisplayVersion: 115.8.0
+  - DisplayVersion: 115.8.1
 ElevationRequirement: elevatesSelf
 Installers:
   - InstallerLocale: de-DE

--- a/manifests/b/Betterbird/Betterbird/115.8.1-bb25/Betterbird.Betterbird.locale.de.yaml
+++ b/manifests/b/Betterbird/Betterbird/115.8.1-bb25/Betterbird.Betterbird.locale.de.yaml
@@ -1,0 +1,9 @@
+# Created with komac v2.1.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
+
+PackageIdentifier: Betterbird.Betterbird
+PackageVersion: 115.8.1-bb25
+PackageLocale: de
+ShortDescription: Betterbird ist eine Variante (Fork) von Mozilla Thunderbird, der zusätzliche Features und Bugfixes enthält.
+ManifestType: locale
+ManifestVersion: 1.6.0

--- a/manifests/b/Betterbird/Betterbird/115.8.1-bb25/Betterbird.Betterbird.locale.en-US.yaml
+++ b/manifests/b/Betterbird/Betterbird/115.8.1-bb25/Betterbird.Betterbird.locale.en-US.yaml
@@ -1,0 +1,92 @@
+# Created with komac v2.1.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: Betterbird.Betterbird
+PackageVersion: 115.8.1-bb25
+PackageLocale: en-US
+Publisher: Betterbird Project
+PublisherUrl: https://www.betterbird.eu/
+PublisherSupportUrl: https://www.betterbird.eu/support/index.html
+PrivacyUrl: https://www.betterbird.eu/legal/index.html
+PackageName: Betterbird
+License: Mozilla Public License Version 2.0
+LicenseUrl: https://www.mozilla.org/MPL/2.0
+CopyrightUrl: https://www.betterbird.eu/legal/index.html
+ShortDescription: Betterbird is a fork of Mozilla Thunderbird with additional features and bugfixes.
+Moniker: betterbird
+Tags:
+  - e-mail
+  - fork
+  - mail
+  - mozilla
+  - thunderbird
+Documentations:
+  - DocumentLabel: FAQ
+    DocumentUrl: https://betterbird.eu/faq/index.html
+ReleaseNotes: |
+  Fixed in this version:
+
+  NEW - Editing of message headers. The Edit Headers menu item is found in the message toolbar More Actions menu.
+  By default the message subject is editable, use pref mail.messageEditor.editableHeaders to allow for more headers.
+  NEW - Message rethreading via drag & drop or the keyboard. See this paragraph for details.
+  FIXED - The additional total count in the status bar not always updating when a folder is entered or threads are collapsed or expanded
+  FIXED - Issue when using Quick Filter Bar with untagged messages (was broken in 115.8.0)
+
+
+  Fixed in Betterbird, not fixed in Thunderbird 115.8.1 yet:
+  Fixes provided by the Betterbird project and integrated into Thunderbird to be released later
+
+  FIXED - Multiple spellcheck dictionaries not reliably set in new composition and not restored when editing draft (fixed in 102.6.1!!) - 
+  Bug 1790746
+  FIXED - A sound was sometimes played for new feed messages even if disabled with pref mail.feed.play_sound. New prefs
+  mail.feed.play_sound.type and mail.feed.play_sound.url to configure feed notification sounds if desired (fixed in 115.6.1) -
+  Bug 1871493
+
+
+  Various minor fixes that Thunderbird isn't shipping yet:
+
+  FIXED - Wrong counts in Group-By-Sort headers (and related issues) -
+  Bug 646168  the-big-crash-part1 
+  Bug 1866951  break-secondary-sort-group-by-etc 
+  Bug 1873353  fix-secondary-sort-by-date-in-grouped-by-sort 
+  Other: 
+  Bug 522768   prettyPath 
+  Bug 531319   open-conversation-standalone 
+  Bug 956446   fix-shift-delete-context-menu 
+  Bug 1368011  disable-watch-thread-where-not-working 
+  Bug 1427546  fix-expand-thread-invisible-children 
+  Bug 1678057  copy-cut-typo 
+  Bug 1799368  dont-add-duplicate-ML-entries 
+  Bug 1811214  fix-add-on-install 
+  Bug 1812726  clear-details-on-AB-search 
+  Bug 1823024  improve-activity-manager-when-indexing 
+  Bug 1837152  get-messages-unified-toolbar 
+  Bug 1843221  icons-unthreaded-view 
+  Bug 1851975  sort-order-synch-view 
+  Bug 1859271  fix-theme-numbering 
+  Bug 1861200  fix-ignore-thread-single-folder-search, disable-ignore-thread-where-not-working 
+  Bug 1862519  fix-chat-init 
+  Bug 1862521  fix-GetSelectedMsgFolders-eml 
+  Bug 1862978  open-add-on-manager-from-toolbar 
+  Bug 1863820  mark_message_read_servertype 
+  Bug 1864924  limit-number-messages-per-connection 
+  Bug 1865598  fix-imap-descending-uids 
+  Bug 1867091  fix-get-selected-partial-messages 
+  Bug 1868094  folder-pane-kb-nav 
+  Bug 1868718  fix-mac-menus-no-window 
+  Bug 1870873  ab-scroll 
+  Bug 1873282  fix-imap-threads 
+  Bug 1873313  dont-select-dummy-group-headers 
+  Bug 1873607  fix-chat-init 
+  Bug 1875577  unified-grouped-perf 
+  Bug 1876431  fix-pop3-error-report 
+  Bug 1876662  fix-get-messages-standalone-message 
+  Bug 1877774  fix-secondary-sort 
+  Bug 1877962  fix-open-msg-in-containing-folder 
+  Bug 1878543  arrow-keys-gloda-search-box 
+  Bug 1879735  disable-fields-filter 
+  Bug 1880043  fix-wrong-imap-status 
+  Bug 1881124  fix numeric tags
+ReleaseNotesUrl: https://www.betterbird.eu/releasenotes/index.html
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/b/Betterbird/Betterbird/115.8.1-bb25/Betterbird.Betterbird.locale.es-AR.yaml
+++ b/manifests/b/Betterbird/Betterbird/115.8.1-bb25/Betterbird.Betterbird.locale.es-AR.yaml
@@ -1,0 +1,9 @@
+# Created with komac v2.1.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
+
+PackageIdentifier: Betterbird.Betterbird
+PackageVersion: 115.8.1-bb25
+PackageLocale: es-AR
+ShortDescription: Betterbird es una bifurcación de Mozilla Thunderbird con funciones y correcciones de errores adicionales.
+ManifestType: locale
+ManifestVersion: 1.6.0

--- a/manifests/b/Betterbird/Betterbird/115.8.1-bb25/Betterbird.Betterbird.locale.fr.yaml
+++ b/manifests/b/Betterbird/Betterbird/115.8.1-bb25/Betterbird.Betterbird.locale.fr.yaml
@@ -1,0 +1,9 @@
+# Created with komac v2.1.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
+
+PackageIdentifier: Betterbird.Betterbird
+PackageVersion: 115.8.1-bb25
+PackageLocale: fr
+ShortDescription: Betterbird est un fork de Mozilla Thunderbird avec des fonctionnalités et des corrections de bogues supplémentaires.
+ManifestType: locale
+ManifestVersion: 1.6.0

--- a/manifests/b/Betterbird/Betterbird/115.8.1-bb25/Betterbird.Betterbird.locale.it.yaml
+++ b/manifests/b/Betterbird/Betterbird/115.8.1-bb25/Betterbird.Betterbird.locale.it.yaml
@@ -1,0 +1,9 @@
+# Created with komac v2.1.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
+
+PackageIdentifier: Betterbird.Betterbird
+PackageVersion: 115.8.1-bb25
+PackageLocale: it
+ShortDescription: Betterbird è un fork di Mozilla Thunderbird con funzioni e correzioni di bug aggiuntive.
+ManifestType: locale
+ManifestVersion: 1.6.0

--- a/manifests/b/Betterbird/Betterbird/115.8.1-bb25/Betterbird.Betterbird.locale.nl.yaml
+++ b/manifests/b/Betterbird/Betterbird/115.8.1-bb25/Betterbird.Betterbird.locale.nl.yaml
@@ -1,0 +1,9 @@
+# Created with komac v2.1.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
+
+PackageIdentifier: Betterbird.Betterbird
+PackageVersion: 115.8.1-bb25
+PackageLocale: nl
+ShortDescription: Betterbird is een afsplitsing van Mozilla Thunderbird met extra functies en bugfixes.
+ManifestType: locale
+ManifestVersion: 1.6.0

--- a/manifests/b/Betterbird/Betterbird/115.8.1-bb25/Betterbird.Betterbird.locale.pt-BR.yaml
+++ b/manifests/b/Betterbird/Betterbird/115.8.1-bb25/Betterbird.Betterbird.locale.pt-BR.yaml
@@ -1,0 +1,9 @@
+# Created with komac v2.1.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
+
+PackageIdentifier: Betterbird.Betterbird
+PackageVersion: 115.8.1-bb25
+PackageLocale: pt-BR
+ShortDescription: Betterbird é um fork do Mozilla Thunderbird com recursos e correções de bugs adicionais.
+ManifestType: locale
+ManifestVersion: 1.6.0

--- a/manifests/b/Betterbird/Betterbird/115.8.1-bb25/Betterbird.Betterbird.yaml
+++ b/manifests/b/Betterbird/Betterbird/115.8.1-bb25/Betterbird.Betterbird.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.1.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: Betterbird.Betterbird
+PackageVersion: 115.8.1-bb25
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Komac stupid, it doesn't respect installer links for different locales. This affected the last version and made the world Italian. I'll fix that soon

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/142779)