### PR TITLE
Fix Betterbird.Betterbird 115.8.0-bb24 installers

### DIFF
--- a/manifests/b/Betterbird/Betterbird/115.8.0-bb24/Betterbird.Betterbird.installer.yaml
+++ b/manifests/b/Betterbird/Betterbird/115.8.0-bb24/Betterbird.Betterbird.installer.yaml
@@ -44,7 +44,7 @@ Installers:
     InstallerSha256: d8893d55440f2b1b7c3d2dbbfaac8f1c9af2d68fc116c864b9e3f52cdfb5c915
   - InstallerLocale: pt-BR
     Architecture: x64
-    InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.8.0-bb24.pt.win64.installer.exe
+    InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.8.0-bb24.pt-BR.win64.installer.exe
     InstallerSha256: d7b38f8e3edf58bdad3e5a2aa8233916bffae49fd07031bb9937017d3d9abb26
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/b/Betterbird/Betterbird/115.8.0-bb24/Betterbird.Betterbird.installer.yaml
+++ b/manifests/b/Betterbird/Betterbird/115.8.0-bb24/Betterbird.Betterbird.installer.yaml
@@ -28,23 +28,23 @@ Installers:
     InstallerSha256: 5a7a5aeaa729a906be0c8f3105c36edf8f7ea348a6a4796bb500df77b90ae95e
   - InstallerLocale: fr-FR
     Architecture: x64
-    InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.8.0-bb24.fr-FR.win64.installer.exe
+    InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.8.0-bb24.fr.win64.installer.exe
     InstallerSha256: 8080424e2298dca04332544eeaf940a265109f9451bb9b58b5e873b230a100ba
   - InstallerLocale: it-IT
     Architecture: x64
-    InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.8.0-bb24.it-IT.win64.installer.exe
+    InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.8.0-bb24.it.win64.installer.exe
     InstallerSha256: 58E792ABF486BA6FB0373D029806759708C16F02D48E38453A9DEF94C8523529
   - InstallerLocale: ja-JP
     Architecture: x64
-    InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.8.0-bb24.ja-JP.win64.installer.exe
+    InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.8.0-bb24.ja.win64.installer.exe
     InstallerSha256: 25a487d60422231f6ed8dbff6f9eb228c0aa02513074002797d07c65b8fb6576
   - InstallerLocale: nl-NL
     Architecture: x64
-    InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.8.0-bb24.nl-NL.win64.installer.exe
+    InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.8.0-bb24.nl.win64.installer.exe
     InstallerSha256: d8893d55440f2b1b7c3d2dbbfaac8f1c9af2d68fc116c864b9e3f52cdfb5c915
   - InstallerLocale: pt-BR
     Architecture: x64
-    InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.8.0-bb24.pt-BR.win64.installer.exe
+    InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.8.0-bb24.pt.win64.installer.exe
     InstallerSha256: d7b38f8e3edf58bdad3e5a2aa8233916bffae49fd07031bb9937017d3d9abb26
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/b/Betterbird/Betterbird/115.8.0-bb24/Betterbird.Betterbird.installer.yaml
+++ b/manifests/b/Betterbird/Betterbird/115.8.0-bb24/Betterbird.Betterbird.installer.yaml
@@ -12,38 +12,39 @@ UpgradeBehavior: install
 ReleaseDate: 2024-02-21
 AppsAndFeaturesEntries:
 - DisplayVersion: 115.8.0
+ElevationRequirement: elevatesSelf
 Installers:
-- InstallerLocale: de-DE
-  Architecture: x64
-  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.8.0-bb24.it.win64.installer.exe
-  InstallerSha256: 58E792ABF486BA6FB0373D029806759708C16F02D48E38453A9DEF94C8523529
-- InstallerLocale: en-US
-  Architecture: x64
-  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.8.0-bb24.it.win64.installer.exe
-  InstallerSha256: 58E792ABF486BA6FB0373D029806759708C16F02D48E38453A9DEF94C8523529
-- InstallerLocale: es-AR
-  Architecture: x64
-  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.8.0-bb24.it.win64.installer.exe
-  InstallerSha256: 58E792ABF486BA6FB0373D029806759708C16F02D48E38453A9DEF94C8523529
-- InstallerLocale: fr-FR
-  Architecture: x64
-  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.8.0-bb24.it.win64.installer.exe
-  InstallerSha256: 58E792ABF486BA6FB0373D029806759708C16F02D48E38453A9DEF94C8523529
-- InstallerLocale: it-IT
-  Architecture: x64
-  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.8.0-bb24.it.win64.installer.exe
-  InstallerSha256: 58E792ABF486BA6FB0373D029806759708C16F02D48E38453A9DEF94C8523529
-- InstallerLocale: ja-JP
-  Architecture: x64
-  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.8.0-bb24.it.win64.installer.exe
-  InstallerSha256: 58E792ABF486BA6FB0373D029806759708C16F02D48E38453A9DEF94C8523529
-- InstallerLocale: nl-NL
-  Architecture: x64
-  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.8.0-bb24.it.win64.installer.exe
-  InstallerSha256: 58E792ABF486BA6FB0373D029806759708C16F02D48E38453A9DEF94C8523529
-- InstallerLocale: pt-BR
-  Architecture: x64
-  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.8.0-bb24.it.win64.installer.exe
-  InstallerSha256: 58E792ABF486BA6FB0373D029806759708C16F02D48E38453A9DEF94C8523529
+  - InstallerLocale: de-DE
+    Architecture: x64
+    InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.8.0-bb24.de.win64.installer.exe
+    InstallerSha256: 6e32b0c0f3be6db0f816ac91391fe00dd272c53f19dc6a359c0a988b57df0ce7
+  - InstallerLocale: en-US
+    Architecture: x64
+    InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.8.0-bb24.en-US.win64.installer.exe
+    InstallerSha256: 0e40b14fb44705b68ddc025715fa977fd0814bcd38dd3922e283e14359550ade
+  - InstallerLocale: es-AR
+    Architecture: x64
+    InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.8.0-bb24.es-AR.win64.installer.exe
+    InstallerSha256: 5a7a5aeaa729a906be0c8f3105c36edf8f7ea348a6a4796bb500df77b90ae95e
+  - InstallerLocale: fr-FR
+    Architecture: x64
+    InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.8.0-bb24.fr-FR.win64.installer.exe
+    InstallerSha256: 8080424e2298dca04332544eeaf940a265109f9451bb9b58b5e873b230a100ba
+  - InstallerLocale: it-IT
+    Architecture: x64
+    InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.8.0-bb24.it-IT.win64.installer.exe
+    InstallerSha256: 58E792ABF486BA6FB0373D029806759708C16F02D48E38453A9DEF94C8523529
+  - InstallerLocale: ja-JP
+    Architecture: x64
+    InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.8.0-bb24.ja-JP.win64.installer.exe
+    InstallerSha256: 25a487d60422231f6ed8dbff6f9eb228c0aa02513074002797d07c65b8fb6576
+  - InstallerLocale: nl-NL
+    Architecture: x64
+    InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.8.0-bb24.nl-NL.win64.installer.exe
+    InstallerSha256: d8893d55440f2b1b7c3d2dbbfaac8f1c9af2d68fc116c864b9e3f52cdfb5c915
+  - InstallerLocale: pt-BR
+    Architecture: x64
+    InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.8.0-bb24.pt-BR.win64.installer.exe
+    InstallerSha256: d7b38f8e3edf58bdad3e5a2aa8233916bffae49fd07031bb9937017d3d9abb26
 ManifestType: installer
 ManifestVersion: 1.6.0


### PR DESCRIPTION
Komac stupid, it doesn't respect installer links for different locales. This affected the last version and made the world Italian. I apologize for my lingual genocide

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/142781)