### PR TITLE
Update hash DigitalScholar.Zotero 6.0.35

### DIFF
--- a/manifests/d/DigitalScholar/Zotero/6.0.35/DigitalScholar.Zotero.installer.yaml
+++ b/manifests/d/DigitalScholar/Zotero/6.0.35/DigitalScholar.Zotero.installer.yaml
@@ -22,6 +22,6 @@ RequireExplicitUpgrade: true
 Installers:
 - Architecture: x86
   InstallerUrl: https://download.zotero.org/client/release/6.0.35/Zotero-6.0.35_setup.exe
-  InstallerSha256: C059309FCC346E6BDF99353611B64F2414F5A031470EAB89642FD001E2C8B99F
+  InstallerSha256: 0580A8F1FF58E45530273EA140F86ACB4ED06AFFB67DAE395810EC5CCA18B9B9
 ManifestType: installer
 ManifestVersion: 1.6.0


### PR DESCRIPTION
Hash was wrong due to probably CDN caching issue? Edge, winget, PowerShell downloads a newer version of installation file with different hash.

- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/142941)