### PR TITLE
New Package: charmbracelet.vhs version 0.7.1

### DIFF
--- a/manifests/c/charmbracelet/vhs/0.7.1/charmbracelet.vhs.installer.yaml
+++ b/manifests/c/charmbracelet/vhs/0.7.1/charmbracelet.vhs.installer.yaml
@@ -1,0 +1,29 @@
+# Created with YamlCreate.ps1 v2.3.4 $debug=NVS1.CRLF.7-4-1.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: charmbracelet.vhs
+PackageVersion: 0.7.1
+InstallerLocale: en-US
+InstallerType: zip
+ReleaseDate: 2023-12-12
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Gyan.FFmpeg
+  - PackageIdentifier: tsl0922.ttyd
+Installers:
+- Architecture: x86
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: vhs.exe
+    PortableCommandAlias: vhs.exe
+  InstallerUrl: https://github.com/charmbracelet/vhs/releases/download/v0.7.1/vhs_0.7.1_Windows_i386.zip
+  InstallerSha256: FAFA1FC1BA3022F51E67D26C00477A1E0CC492A6A3F765D07A98327065BC41AE
+- Architecture: x64
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: vhs.exe
+    PortableCommandAlias: vhs.exe
+  InstallerUrl: https://github.com/charmbracelet/vhs/releases/download/v0.7.1/vhs_0.7.1_Windows_x86_64.zip
+  InstallerSha256: F1D6B58E4575DD79D04909C9359A0E51819F5DBDA77B4C2D96A72DA9A51C4973
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/c/charmbracelet/vhs/0.7.1/charmbracelet.vhs.locale.en-US.yaml
+++ b/manifests/c/charmbracelet/vhs/0.7.1/charmbracelet.vhs.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# Created with YamlCreate.ps1 v2.3.4 $debug=NVS1.CRLF.7-4-1.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: charmbracelet.vhs
+PackageVersion: 0.7.1
+PackageLocale: en-US
+Publisher: charmbracelet
+PublisherUrl: https://charm.sh/
+# PublisherSupportUrl:
+# PrivacyUrl:
+# Author:
+PackageName: vhs
+PackageUrl: https://github.com/charmbracelet/vhs
+License: MIT
+LicenseUrl: https://raw.githubusercontent.com/charmbracelet/vhs/main/LICENSE
+# Copyright:
+# CopyrightUrl:
+ShortDescription: Write terminal GIFs as code for integration testing and demoing your CLI tools.
+# Description:
+Moniker: vhs
+# Tags:
+# ReleaseNotes:
+ReleaseNotesUrl: https://github.com/charmbracelet/vhs/releases/tag/v0.7.1
+# PurchaseUrl:
+# InstallationNotes:
+# Documentations:
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/c/charmbracelet/vhs/0.7.1/charmbracelet.vhs.yaml
+++ b/manifests/c/charmbracelet/vhs/0.7.1/charmbracelet.vhs.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.3.4 $debug=NVS1.CRLF.7-4-1.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: charmbracelet.vhs
+PackageVersion: 0.7.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Previous PR(s) That're Similar to This PR
* https://github.com/microsoft/winget-pkgs/pull/107392
* https://github.com/microsoft/winget-pkgs/pull/112696
* https://github.com/microsoft/winget-pkgs/pull/130244

### Reason for Failing Validation Tests
This new Package (called `vhs` published by `charmbracelet`) depends on `FFmpeg` and `ttyd` to be installed and available in `PATH` (User's or Machine's `PATH`), the later one, `ttyd`, wasn't available as a Package in `winget-pkgs` repo, this unavailability issue was resolved in [this PR](https://github.com/microsoft/winget-pkgs/pull/142883).

-----

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/142995)