### PR TITLE
Fix PackageFamilyName for Microsoft.WindowsAppRuntime.1.5

### DIFF
--- a/manifests/m/Microsoft/WindowsAppRuntime/1/5/1.5.0/Microsoft.WindowsAppRuntime.1.5.installer.yaml
+++ b/manifests/m/Microsoft/WindowsAppRuntime/1/5/1.5.0/Microsoft.WindowsAppRuntime.1.5.installer.yaml
@@ -13,17 +13,16 @@ AppsAndFeaturesEntries:
   - InstallerType: msix
     DisplayVersion: 5001.58.448.0
 ElevationRequirement: elevationRequired
+PackageFamilyName: Microsoft.WindowsAppRuntime.1.5_8wekyb3d8bbwe
 UpgradeBehavior: install
 ReleaseDate: 2024-02-29
 Installers:
 - Architecture: x64
   InstallerUrl: https://aka.ms/windowsappsdk/1.5/1.5.240227000/windowsappruntimeinstall-x64.exe
   InstallerSha256: D6A7967F7CBA217E4AEFED048234C6FF089C226FDAA6B625470B12BE41DCF8C7
-  PackageFamilyName: Microsoft.WinAppRuntime.DDLM.5001.58.448.0-x6_8wekyb3d8bbwe
 - Architecture: x86
   InstallerUrl: https://aka.ms/windowsappsdk/1.5/1.5.240227000/windowsappruntimeinstall-x86.exe
   InstallerSha256: DFEA69F8A683082DB36EB56784DDDEEBC265D51C1EB670F89C66BCE972812360
-  PackageFamilyName: Microsoft.WinAppRuntime.DDLM.5001.58.448.0-x8_8wekyb3d8bbwe
 - Architecture: arm64
   InstallerUrl: https://aka.ms/windowsappsdk/1.5/1.5.240227000/windowsappruntimeinstall-arm64.exe
   InstallerSha256: BF989687C31D8DC45C7CA24AB832119BB950C2D5E3E8E6FFC6F75BB9E92BE242


### PR DESCRIPTION
I appeared to have used `PackageFullName` instead of `PackageFamilyName` in a previous PR

- Related: https://github.com/microsoft/winget-cli/pull/3391

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/144311)