### PR TITLE
Added x86 version: yt-dlp.yt-dlp version 2024.03.10

### DIFF
--- a/manifests/y/yt-dlp/yt-dlp/2024.03.10/yt-dlp.yt-dlp.installer.yaml
+++ b/manifests/y/yt-dlp/yt-dlp/2024.03.10/yt-dlp.yt-dlp.installer.yaml
@@ -6,9 +6,6 @@ PackageVersion: 2024.03.10
 InstallerType: portable
 Commands:
 - yt-dlp
-Dependencies:
-  PackageDependencies:
-  - PackageIdentifier: Gyan.FFmpeg
 ReleaseDate: 2024-03-10
 Installers:
 - Architecture: x86
@@ -17,5 +14,8 @@ Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/yt-dlp/yt-dlp/releases/download/2024.03.10/yt-dlp.exe
   InstallerSha256: 0E1854AA6EED3FAA52C0D46B3630C6AFAF2E16C27287A3DD605A7012EDD203C7
+  Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Gyan.FFmpeg
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/y/yt-dlp/yt-dlp/2024.03.10/yt-dlp.yt-dlp.installer.yaml
+++ b/manifests/y/yt-dlp/yt-dlp/2024.03.10/yt-dlp.yt-dlp.installer.yaml
@@ -11,6 +11,9 @@ Dependencies:
   - PackageIdentifier: Gyan.FFmpeg
 ReleaseDate: 2024-03-10
 Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/yt-dlp/yt-dlp/releases/download/2024.03.10/yt-dlp_x86.exe
+  InstallerSha256: CBAC37AED7E36835A1E7CB605B32B3A7E84271EEFF2E3E7D6E4BCA993D9724E3
 - Architecture: x64
   InstallerUrl: https://github.com/yt-dlp/yt-dlp/releases/download/2024.03.10/yt-dlp.exe
   InstallerSha256: 0E1854AA6EED3FAA52C0D46B3630C6AFAF2E16C27287A3DD605A7012EDD203C7


### PR DESCRIPTION
Added missing x86 release for yt-dlp version 2024.03.10

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/144419)