### PR TITLE
Fix: Fill AppsAndFeaturesEntries in Google.JapaneseIME old version

### DIFF
--- a/manifests/g/Google/JapaneseIME/2.28.4650.0/Google.JapaneseIME.installer.yaml
+++ b/manifests/g/Google/JapaneseIME/2.28.4650.0/Google.JapaneseIME.installer.yaml
@@ -5,6 +5,9 @@ PackageIdentifier: Google.JapaneseIME
 PackageVersion: 2.28.4650.0
 MinimumOSVersion: 10.0.0.0
 InstallerType: wix
+AppsAndFeaturesEntries:
+- DisplayName: Google 日本語入力
+  UpgradeCode: '{C1A818AF-6EC9-49EF-ADCF-35A40475D156}'
 Installers:
 - Architecture: x64
   InstallerUrl: https://www.google.com/dl/release2/mwbfzwv776vr5mu3j7emky7tqi_2.28.4650.0/GoogleJapaneseInput64-2.28.4650.0.msi #https://tools.google.com/dlpage/japaneseinput/eula.html?platform=win


### PR DESCRIPTION
According to what was pointed out in https://github.com/microsoft/winget-pkgs/pull/144281#issuecomment-1998835532

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

- I have checked the generated `AppsAndFeaturesEntries` by [Komac](https://github.com/russellbanks/Komac/releases/tag/v2.1.0) is same as `2.29.5370.0`
- Keeping the schema version with current v1.1.0, [it already has `AppsAndFeaturesEntries`](https://github.com/microsoft/winget-cli/blob/7cea3d9582f9bd68a4406c73f07309b1df79f120/schemas/JSON/manifests/v1.1.0/manifest.installer.1.1.0.json#L386-L427)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/144449)