### PR TITLE
EpicGames.EpicGamesLauncher version 1.3.93.0: Remove InstallerLocale

### DIFF
--- a/manifests/e/EpicGames/EpicGamesLauncher/1.3.93.0/EpicGames.EpicGamesLauncher.installer.yaml
+++ b/manifests/e/EpicGames/EpicGamesLauncher/1.3.93.0/EpicGames.EpicGamesLauncher.installer.yaml
@@ -3,7 +3,6 @@
 
 PackageIdentifier: EpicGames.EpicGamesLauncher
 PackageVersion: 1.3.93.0
-InstallerLocale: en-US
 InstallerType: wix
 Scope: machine
 InstallModes:


### PR DESCRIPTION
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

Fixes an issue that was already fixed in #124201 (and which I'm sorry to say I had to fix again with the new installer configuration list), where specifying InstallerLocale would prevent upgrades or new installations in language regions that were not in the list. For EpicGames.EpicGamesLauncher specifically, which is itself a multilingual installer, **there is no need to specify the InstallerLocale parameter.**
The current configuration file results in "A newer version of the package is available in the configured source, but does not apply to your system or requirements." when upgrading EpicGamesLauncher on a non-en-US machine. The following error is reported within the log:

```
2024-03-17 13:11:05.307 [CLI ] Installer [X86,wix,Machine,en-US] not applicable: Installer locale does not match required locale: en- USRequired locales: [] Or does not satisfy compatible match for Preferred Locales: [en-US].
```
This issue can be resolved by merging this pull request.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/144934)