### PR TITLE
Remove arm64 installer node for OpenJS.NodeJS.LTS 12.22.9

### DIFF
--- a/manifests/o/OpenJS/NodeJS/LTS/12.22.9/OpenJS.NodeJS.LTS.installer.yaml
+++ b/manifests/o/OpenJS/NodeJS/LTS/12.22.9/OpenJS.NodeJS.LTS.installer.yaml
@@ -25,9 +25,5 @@ Installers:
   InstallerUrl: https://nodejs.org/dist/v12.22.9/node-v12.22.9-x64.msi
   InstallerSha256: A289F3AA81C72A0C0D0F835D7AB6892534E112D1052771582CC0C8B77E1C7267
   ProductCode: '{C1B586E6-C075-42F3-B7E4-0DE4222DEEC0}'
-- Architecture: arm64
-  InstallerUrl: https://nodejs.org/dist/v12.22.9/node-v12.22.9-x86.msi
-  InstallerSha256: C0C8D61293DE67C867B5180856B18ADC2788E69BD74C1585341BAFE62CC542C5
-  ProductCode: '{31545B2C-89E3-4F0C-A940-6B5B0DCC8DE2}'
 ManifestType: installer
 ManifestVersion: 1.6.0


### PR DESCRIPTION
Reason: `arm64` native URL does not exist for this version.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/145091)