### PR TITLE
Bumping schema version to 1.6.x; updating a few URIs

### DIFF
--- a/manifests/m/Microsoft/SQLServerManagementStudio/20.0/Microsoft.SQLServerManagementStudio.installer.yaml
+++ b/manifests/m/Microsoft/SQLServerManagementStudio/20.0/Microsoft.SQLServerManagementStudio.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 PackageIdentifier: Microsoft.SQLServerManagementStudio
 PackageVersion: '20.0'
 Platform:
@@ -135,4 +135,4 @@ Installers:
     DisplayVersion: 20.0.70.0
     ProductCode: '{41ea79b7-65c9-48fc-949d-682d0642a797}'
 ManifestType: installer
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0

--- a/manifests/m/Microsoft/SQLServerManagementStudio/20.0/Microsoft.SQLServerManagementStudio.locale.de-DE.yaml
+++ b/manifests/m/Microsoft/SQLServerManagementStudio/20.0/Microsoft.SQLServerManagementStudio.locale.de-DE.yaml
@@ -1,25 +1,25 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
 PackageIdentifier: Microsoft.SQLServerManagementStudio
 PackageVersion: '20.0'
 PackageLocale: de-DE
 Publisher: Microsoft Corporation
 PublisherUrl: https://www.microsoft.com/
-PublisherSupportUrl: https://support.microsoft.com/
+PublisherSupportUrl: https://aka.ms/ssms-feedback/
 PrivacyUrl: https://privacy.microsoft.com/
 Author: Microsoft
 PackageName: Microsoft SQL Server Management Studio
-PackageUrl: https://docs.microsoft.com/de-DE/sql/ssms/download-sql-server-management-studio-ssms
+PackageUrl: https://learn.microsoft.com/de-DE/sql/ssms/download-sql-server-management-studio-ssms
 License: Proprietary
-# LicenseUrl: 
+LicenseUrl: https://learn.microsoft.com/de-DE/Legal/sql/sql-server-management-studio-license-terms
 Copyright: Urheberrecht (c) Microsoft Corporation
 # CopyrightUrl: 
 ShortDescription: SQL Server Management Studio (SSMS) ist eine integrierte Umgebung zum Verwalten jeder beliebigen SQL-Infrastruktur, von SQL Server bis hin zur Azure SQL-Datenbank
 Description: SQL Server Management Studio (SSMS) ist eine integrierte Umgebung zum Verwalten jeder beliebigen SQL-Infrastruktur, von SQL Server bis hin zur Azure SQL-Datenbank. SSMS stellt Tools zum Konfigurieren, Überwachen und Verwalten von Instanzen von SQL Server und Datenbanken zur Verfügung. Verwenden Sie SSMS, um Abfragen und Skripts zu erstellen sowie die Datenebenenkomponenten bereitzustellen, zu überwachen und zu aktualisieren, die von Ihren Anwendungen verwendet werden.
 # Agreements: 
 # ReleaseNotes: 
-ReleaseNotesUrl: https://docs.microsoft.com/de-DE/sql/ssms/release-notes-ssms?view=sql-server-ver15#200
+ReleaseNotesUrl: https://learn.microsoft.com/de-DE/sql/ssms/release-notes-ssms#200
 # PurchaseUrl: 
 # InstallationNotes: 
 # Documentations: 
 ManifestType: locale
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0

--- a/manifests/m/Microsoft/SQLServerManagementStudio/20.0/Microsoft.SQLServerManagementStudio.locale.en-US.yaml
+++ b/manifests/m/Microsoft/SQLServerManagementStudio/20.0/Microsoft.SQLServerManagementStudio.locale.en-US.yaml
@@ -1,16 +1,16 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
 PackageIdentifier: Microsoft.SQLServerManagementStudio
 PackageVersion: '20.0'
 PackageLocale: en-US
 Publisher: Microsoft Corporation
 PublisherUrl: https://www.microsoft.com/
-PublisherSupportUrl: https://support.microsoft.com/
+PublisherSupportUrl: https://aka.ms/ssms-feedback/
 PrivacyUrl: https://privacy.microsoft.com/
 Author: Microsoft
 PackageName: Microsoft SQL Server Management Studio
-PackageUrl: https://docs.microsoft.com/en-US/sql/ssms/download-sql-server-management-studio-ssms
+PackageUrl: https://learn.microsoft.com/en-US/sql/ssms/download-sql-server-management-studio-ssms
 License: Proprietary
-# LicenseUrl: 
+LicenseUrl: https://learn.microsoft.com/en-US/Legal/sql/sql-server-management-studio-license-terms
 Copyright: Copyright (c) Microsoft Corporation
 # CopyrightUrl: 
 ShortDescription: SQL Server Management Studio (SSMS) is an integrated environment for managing any SQL infrastructure
@@ -24,9 +24,9 @@ Tags:
 - ssms
 # Agreements: 
 # ReleaseNotes: 
-ReleaseNotesUrl: https://docs.microsoft.com/en-US/sql/ssms/release-notes-ssms?view=sql-server-ver15#200
+ReleaseNotesUrl: https://learn.microsoft.com/en-US/sql/ssms/release-notes-ssms#200
 # PurchaseUrl: 
 # InstallationNotes: 
 # Documentations: 
 ManifestType: defaultLocale
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0

--- a/manifests/m/Microsoft/SQLServerManagementStudio/20.0/Microsoft.SQLServerManagementStudio.locale.es-ES.yaml
+++ b/manifests/m/Microsoft/SQLServerManagementStudio/20.0/Microsoft.SQLServerManagementStudio.locale.es-ES.yaml
@@ -1,25 +1,25 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
 PackageIdentifier: Microsoft.SQLServerManagementStudio
 PackageVersion: '20.0'
 PackageLocale: es-ES
 Publisher: Microsoft Corporation
 PublisherUrl: https://www.microsoft.com/
-PublisherSupportUrl: https://support.microsoft.com/
+PublisherSupportUrl: https://aka.ms/ssms-feedback/
 PrivacyUrl: https://privacy.microsoft.com/
 Author: Microsoft
 PackageName: Microsoft SQL Server Management Studio
-PackageUrl: https://docs.microsoft.com/es-ES/sql/ssms/download-sql-server-management-studio-ssms
+PackageUrl: https://learn.microsoft.com/es-ES/sql/ssms/download-sql-server-management-studio-ssms
 License: Proprietary
-# LicenseUrl: 
+LicenseUrl: https://learn.microsoft.com/es-ES/Legal/sql/sql-server-management-studio-license-terms
 Copyright: Copyright (c) Microsoft Corporation
 # CopyrightUrl: 
 ShortDescription: SQL Server Management Studio (SSMS) es un entorno integrado para administrar cualquier infraestructura de SQL, desde SQL Server a Azure SQL Database
 Description: SQL Server Management Studio (SSMS) es un entorno integrado para administrar cualquier infraestructura de SQL, desde SQL Server a Azure SQL Database. SSMS proporciona herramientas para configurar, supervisar y administrar instancias de SQL Server y bases de datos. Use SSMS para implementar, supervisar y actualizar los componentes de nivel de datos que usan las aplicaciones, además de compilar consultas y scripts.
 # Agreements: 
 # ReleaseNotes: 
-ReleaseNotesUrl: https://docs.microsoft.com/es-ES/sql/ssms/release-notes-ssms?view=sql-server-ver15#200
+ReleaseNotesUrl: https://learn.microsoft.com/es-ES/sql/ssms/release-notes-ssms#200
 # PurchaseUrl: 
 # InstallationNotes: 
 # Documentations: 
 ManifestType: locale
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0

--- a/manifests/m/Microsoft/SQLServerManagementStudio/20.0/Microsoft.SQLServerManagementStudio.locale.fr-FR.yaml
+++ b/manifests/m/Microsoft/SQLServerManagementStudio/20.0/Microsoft.SQLServerManagementStudio.locale.fr-FR.yaml
@@ -1,25 +1,25 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
 PackageIdentifier: Microsoft.SQLServerManagementStudio
 PackageVersion: '20.0'
 PackageLocale: fr-FR
 Publisher: Microsoft Corporation
 PublisherUrl: https://www.microsoft.com/
-PublisherSupportUrl: https://support.microsoft.com/
+PublisherSupportUrl: https://aka.ms/ssms-feedback/
 PrivacyUrl: https://privacy.microsoft.com/
 Author: Microsoft
 PackageName: Microsoft SQL Server Management Studio
-PackageUrl: https://docs.microsoft.com/fr-FR/sql/ssms/download-sql-server-management-studio-ssms
+PackageUrl: https://learn.microsoft.com/fr-FR/sql/ssms/download-sql-server-management-studio-ssms
 License: Proprietary
-# LicenseUrl: 
+LicenseUrl: https://learn.microsoft.com/fr-FR/Legal/sql/sql-server-management-studio-license-terms
 Copyright: Copyright (c) Microsoft Corporation
 # CopyrightUrl: 
 ShortDescription: SQL Server Management Studio (SSMS) est un environnement intégré pour la gestion des infrastructures SQL, de SQL Server à Azure SQL Database
 Description: SQL Server Management Studio (SSMS) est un environnement intégré pour la gestion des infrastructures SQL, de SQL Server à Azure SQL Database. SSMS fournit des outils permettant de configurer, de superviser et d’administrer des instances de SQL Server et des bases de données. Utilisez SSMS pour déployer, superviser et mettre à niveau les composants de la couche Données utilisés par vos applications, ainsi que pour créer des requêtes et des scripts.
 # Agreements: 
 # ReleaseNotes: 
-ReleaseNotesUrl: https://docs.microsoft.com/fr-FR/sql/ssms/release-notes-ssms?view=sql-server-ver15#200
+ReleaseNotesUrl: https://learn.microsoft.com/fr-FR/sql/ssms/release-notes-ssms#200
 # PurchaseUrl: 
 # InstallationNotes: 
 # Documentations: 
 ManifestType: locale
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0

--- a/manifests/m/Microsoft/SQLServerManagementStudio/20.0/Microsoft.SQLServerManagementStudio.locale.it-IT.yaml
+++ b/manifests/m/Microsoft/SQLServerManagementStudio/20.0/Microsoft.SQLServerManagementStudio.locale.it-IT.yaml
@@ -1,25 +1,25 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
 PackageIdentifier: Microsoft.SQLServerManagementStudio
 PackageVersion: '20.0'
 PackageLocale: it-IT
 Publisher: Microsoft Corporation
 PublisherUrl: https://www.microsoft.com/
-PublisherSupportUrl: https://support.microsoft.com/
+PublisherSupportUrl: https://aka.ms/ssms-feedback/
 PrivacyUrl: https://privacy.microsoft.com/
 Author: Microsoft
 PackageName: Microsoft SQL Server Management Studio
-PackageUrl: https://docs.microsoft.com/it-IT/sql/ssms/download-sql-server-management-studio-ssms
+PackageUrl: https://learn.microsoft.com/it-IT/sql/ssms/download-sql-server-management-studio-ssms
 License: Proprietary
-# LicenseUrl: 
+LicenseUrl: https://learn.microsoft.com/it-IT/Legal/sql/sql-server-management-studio-license-terms
 Copyright: Copyright (c) Microsoft Corporation
 # CopyrightUrl: 
 ShortDescription: SQL Server Management Studio (SSMS) è un ambiente integrato per la gestione di qualsiasi infrastruttura SQL, da SQL Server al database SQL di Azure
 Description: SQL Server Management Studio (SSMS) è un ambiente integrato per la gestione di qualsiasi infrastruttura SQL, da SQL Server al database SQL di Azure. SSMS offre gli strumenti per configurare, monitorare e amministrare le istanze di SQL Server e i database. Usare SSMS per distribuire, monitorare e aggiornare i componenti del livello dati usati dalle applicazioni, nonché per creare query e script.
 # Agreements: 
 # ReleaseNotes: 
-ReleaseNotesUrl: https://docs.microsoft.com/it-IT/sql/ssms/release-notes-ssms?view=sql-server-ver15#200
+ReleaseNotesUrl: https://learn.microsoft.com/it-IT/sql/ssms/release-notes-ssms#200
 # PurchaseUrl: 
 # InstallationNotes: 
 # Documentations: 
 ManifestType: locale
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0

--- a/manifests/m/Microsoft/SQLServerManagementStudio/20.0/Microsoft.SQLServerManagementStudio.locale.ja-JP.yaml
+++ b/manifests/m/Microsoft/SQLServerManagementStudio/20.0/Microsoft.SQLServerManagementStudio.locale.ja-JP.yaml
@@ -1,25 +1,25 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
 PackageIdentifier: Microsoft.SQLServerManagementStudio
 PackageVersion: '20.0'
 PackageLocale: ja-JP
 Publisher: Microsoft Corporation
 PublisherUrl: https://www.microsoft.com/
-PublisherSupportUrl: https://support.microsoft.com/
+PublisherSupportUrl: https://aka.ms/ssms-feedback/
 PrivacyUrl: https://privacy.microsoft.com/
 Author: Microsoft
 PackageName: Microsoft SQL Server Management Studio
-PackageUrl: https://docs.microsoft.com/ja-JP/sql/ssms/download-sql-server-management-studio-ssms
+PackageUrl: https://learn.microsoft.com/ja-JP/sql/ssms/download-sql-server-management-studio-ssms
 License: Proprietary
-# LicenseUrl: 
+LicenseUrl: https://learn.microsoft.com/ja-JP/Legal/sql/sql-server-management-studio-license-terms
 Copyright: Copyright (c) Microsoft Corporation
 # CopyrightUrl: 
 ShortDescription: SQL Server Management Studio (SSMS) は、SQL Server から Azure SQL Database まで、SQL インフラストラクチャを管理するための統合環境です
 Description: SQL Server Management Studio (SSMS) は、SQL Server から Azure SQL Database まで、SQL インフラストラクチャを管理するための統合環境です。 SSMS には、SQL Server とデータベースのインスタンスを構成、監視、および管理するためのツールが備わっています。 SSMS を使用して、ご利用のアプリケーションで使われるデータ層コンポーネントを配置、監視、アップグレードしたり、クエリとスクリプトを作成したりすることができます。
 # Agreements: 
 # ReleaseNotes: 
-ReleaseNotesUrl: https://docs.microsoft.com/ja-JP/sql/ssms/release-notes-ssms?view=sql-server-ver15#200
+ReleaseNotesUrl: https://learn.microsoft.com/ja-JP/sql/ssms/release-notes-ssms#200
 # PurchaseUrl: 
 # InstallationNotes: 
 # Documentations: 
 ManifestType: locale
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0

--- a/manifests/m/Microsoft/SQLServerManagementStudio/20.0/Microsoft.SQLServerManagementStudio.locale.ko-KR.yaml
+++ b/manifests/m/Microsoft/SQLServerManagementStudio/20.0/Microsoft.SQLServerManagementStudio.locale.ko-KR.yaml
@@ -1,25 +1,25 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
 PackageIdentifier: Microsoft.SQLServerManagementStudio
 PackageVersion: '20.0'
 PackageLocale: ko-KR
 Publisher: Microsoft Corporation
 PublisherUrl: https://www.microsoft.com/
-PublisherSupportUrl: https://support.microsoft.com/
+PublisherSupportUrl: https://aka.ms/ssms-feedback/
 PrivacyUrl: https://privacy.microsoft.com/
 Author: Microsoft
 PackageName: Microsoft SQL Server Management Studio
-PackageUrl: https://docs.microsoft.com/ko-KR/sql/ssms/download-sql-server-management-studio-ssms
+PackageUrl: https://learn.microsoft.com/ko-KR/sql/ssms/download-sql-server-management-studio-ssms
 License: Proprietary
-# LicenseUrl: 
+LicenseUrl: https://learn.microsoft.com/ko-KR/Legal/sql/sql-server-management-studio-license-terms
 Copyright: 저작권 (c) Microsoft Corporation
 # CopyrightUrl: 
 ShortDescription: SSMS(SQL Server Management Studio)는 SQL Server에서 Azure SQL Database까지 모든 SQL 인프라를 관리하기 위한 통합 환경입니다
 Description: SSMS(SQL Server Management Studio)는 SQL Server에서 Azure SQL Database까지 모든 SQL 인프라를 관리하기 위한 통합 환경입니다. SSMS는 SQL Server 및 데이터베이스의 인스턴스를 구성, 모니터링 및 관리하는 도구를 제공합니다. SSMS를 사용하면 애플리케이션에 사용되는 데이터 계층 구성 요소를 배포, 모니터링 및 업그레이드하고 쿼리 및 스크립트를 작성할 수 있습니다.
 # Agreements: 
 # ReleaseNotes: 
-ReleaseNotesUrl: https://docs.microsoft.com/ko-KR/sql/ssms/release-notes-ssms?view=sql-server-ver15#200
+ReleaseNotesUrl: https://learn.microsoft.com/ko-KR/sql/ssms/release-notes-ssms#200
 # PurchaseUrl: 
 # InstallationNotes: 
 # Documentations: 
 ManifestType: locale
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0

--- a/manifests/m/Microsoft/SQLServerManagementStudio/20.0/Microsoft.SQLServerManagementStudio.locale.pt-BR.yaml
+++ b/manifests/m/Microsoft/SQLServerManagementStudio/20.0/Microsoft.SQLServerManagementStudio.locale.pt-BR.yaml
@@ -1,25 +1,25 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
 PackageIdentifier: Microsoft.SQLServerManagementStudio
 PackageVersion: '20.0'
 PackageLocale: pt-BR
 Publisher: Microsoft Corporation
 PublisherUrl: https://www.microsoft.com/
-PublisherSupportUrl: https://support.microsoft.com/
+PublisherSupportUrl: https://aka.ms/ssms-feedback/
 PrivacyUrl: https://privacy.microsoft.com/
 Author: Microsoft
 PackageName: Microsoft SQL Server Management Studio
-PackageUrl: https://docs.microsoft.com/pt-BR/sql/ssms/download-sql-server-management-studio-ssms
+PackageUrl: https://learn.microsoft.com/pt-BR/sql/ssms/download-sql-server-management-studio-ssms
 License: Proprietary
-# LicenseUrl: 
+LicenseUrl: https://learn.microsoft.com/pt-BR/Legal/sql/sql-server-management-studio-license-terms
 Copyright: Direitos autorais (c) Microsoft Corporation
 # CopyrightUrl: 
 ShortDescription: O SSMS (SQL Server Management Studio) é um ambiente integrado para gerenciar qualquer infraestrutura de SQL, do SQL Server para o Banco de Dados SQL do Azure
 Description: O SSMS (SQL Server Management Studio) é um ambiente integrado para gerenciar qualquer infraestrutura de SQL, do SQL Server para o Banco de Dados SQL do Azure. O SSMS fornece ferramentas para configurar, monitorar e administrar instâncias do SQL Server e bancos de dados. Use o SSMS para implantar, monitorar e atualizar os componentes da camada de dados usados pelos seus aplicativos, além de criar consultas e scripts.
 # Agreements: 
 # ReleaseNotes: 
-ReleaseNotesUrl: https://docs.microsoft.com/pt-BR/sql/ssms/release-notes-ssms?view=sql-server-ver15#200
+ReleaseNotesUrl: https://learn.microsoft.com/pt-BR/sql/ssms/release-notes-ssms#200
 # PurchaseUrl: 
 # InstallationNotes: 
 # Documentations: 
 ManifestType: locale
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0

--- a/manifests/m/Microsoft/SQLServerManagementStudio/20.0/Microsoft.SQLServerManagementStudio.locale.ru-RU.yaml
+++ b/manifests/m/Microsoft/SQLServerManagementStudio/20.0/Microsoft.SQLServerManagementStudio.locale.ru-RU.yaml
@@ -1,25 +1,25 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
 PackageIdentifier: Microsoft.SQLServerManagementStudio
 PackageVersion: '20.0'
 PackageLocale: ru-RU
 Publisher: Microsoft Corporation
 PublisherUrl: https://www.microsoft.com/
-PublisherSupportUrl: https://support.microsoft.com/
+PublisherSupportUrl: https://aka.ms/ssms-feedback/
 PrivacyUrl: https://privacy.microsoft.com/
 Author: Microsoft
 PackageName: Microsoft SQL Server Management Studio
-PackageUrl: https://docs.microsoft.com/ru-RU/sql/ssms/download-sql-server-management-studio-ssms
+PackageUrl: https://learn.microsoft.com/ru-RU/sql/ssms/download-sql-server-management-studio-ssms
 License: Proprietary
-# LicenseUrl: 
+LicenseUrl: https://learn.microsoft.com/ru-RU/Legal/sql/sql-server-management-studio-license-terms
 Copyright: Авторское право (c) Microsoft Corporation
 # CopyrightUrl: 
 ShortDescription: SQL Server Management Studio (SSMS) — это интегрированная среда для управления любой инфраструктурой SQL, от SQL Server до баз данных SQL Azure
 Description: SQL Server Management Studio (SSMS) — это интегрированная среда для управления любой инфраструктурой SQL, от SQL Server до баз данных SQL Azure. SSMS предоставляет средства для настройки, наблюдения и администрирования экземпляров SQL Server и баз данных. С помощью SSMS можно развертывать, отслеживать и обновлять компоненты уровня данных, используемые вашими приложениями, а также создавать запросы и скрипты.
 # Agreements: 
 # ReleaseNotes: 
-ReleaseNotesUrl: https://docs.microsoft.com/ru-RU/sql/ssms/release-notes-ssms?view=sql-server-ver15#200
+ReleaseNotesUrl: https://learn.microsoft.com/ru-RU/sql/ssms/release-notes-ssms#200
 # PurchaseUrl: 
 # InstallationNotes: 
 # Documentations: 
 ManifestType: locale
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0

--- a/manifests/m/Microsoft/SQLServerManagementStudio/20.0/Microsoft.SQLServerManagementStudio.locale.zh-CN.yaml
+++ b/manifests/m/Microsoft/SQLServerManagementStudio/20.0/Microsoft.SQLServerManagementStudio.locale.zh-CN.yaml
@@ -1,25 +1,25 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
 PackageIdentifier: Microsoft.SQLServerManagementStudio
 PackageVersion: '20.0'
 PackageLocale: zh-CN
 Publisher: Microsoft Corporation
 PublisherUrl: https://www.microsoft.com/
-PublisherSupportUrl: https://support.microsoft.com/
+PublisherSupportUrl: https://aka.ms/ssms-feedback/
 PrivacyUrl: https://privacy.microsoft.com/
 Author: Microsoft
 PackageName: Microsoft SQL Server Management Studio
-PackageUrl: https://docs.microsoft.com/zh-CN/sql/ssms/download-sql-server-management-studio-ssms
+PackageUrl: https://learn.microsoft.com/zh-CN/sql/ssms/download-sql-server-management-studio-ssms
 License: Proprietary
-# LicenseUrl: 
+LicenseUrl: https://learn.microsoft.com/zh-CN/Legal/sql/sql-server-management-studio-license-terms
 Copyright: 版权所有 (c) Microsoft Corporation
 # CopyrightUrl: 
 ShortDescription: SQL Server Management Studio 是一个集成环境，用于访问、配置、管理和开发 SQL Server 的所有组件
 Description: SQL Server Management Studio (SSMS) 是一种集成环境，用于管理从 SQL Server 到 Azure SQL 数据库的任何 SQL 基础结构。 SSMS 提供用于配置、监视和管理 SQL Server 和数据库实例的工具。 使用 SSMS 部署、监视和升级应用程序使用的数据层组件，以及生成查询和脚本。
 # Agreements: 
 # ReleaseNotes: 
-ReleaseNotesUrl: https://docs.microsoft.com/zh-CN/sql/ssms/release-notes-ssms?view=sql-server-ver15#200
+ReleaseNotesUrl: https://learn.microsoft.com/zh-CN/sql/ssms/release-notes-ssms#200
 # PurchaseUrl: 
 # InstallationNotes: 
 # Documentations: 
 ManifestType: locale
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0

--- a/manifests/m/Microsoft/SQLServerManagementStudio/20.0/Microsoft.SQLServerManagementStudio.locale.zh-HK.yaml
+++ b/manifests/m/Microsoft/SQLServerManagementStudio/20.0/Microsoft.SQLServerManagementStudio.locale.zh-HK.yaml
@@ -1,25 +1,25 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
 PackageIdentifier: Microsoft.SQLServerManagementStudio
 PackageVersion: '20.0'
 PackageLocale: zh-HK
 Publisher: Microsoft Corporation
 PublisherUrl: https://www.microsoft.com/
-PublisherSupportUrl: https://support.microsoft.com/
+PublisherSupportUrl: https://aka.ms/ssms-feedback/
 PrivacyUrl: https://privacy.microsoft.com/
 Author: Microsoft
 PackageName: Microsoft SQL Server Management Studio
-PackageUrl: https://docs.microsoft.com/zh-HK/sql/ssms/download-sql-server-management-studio-ssms
+PackageUrl: https://learn.microsoft.com/zh-HK/sql/ssms/download-sql-server-management-studio-ssms
 License: Proprietary
-# LicenseUrl: 
+LicenseUrl: https://learn.microsoft.com/zh-HK/Legal/sql/sql-server-management-studio-license-terms
 Copyright: 版權所有 (c) Microsoft Corporation
 # CopyrightUrl: 
 ShortDescription: SQL Server Management Studio (SSMS) 是整合式環境，可用於管理任何 SQL 基礎結構，從 SQL Sever 到 Azure SQL Database 皆適用
 Description: SQL Server Management Studio (SSMS) 是整合式環境，可用於管理任何 SQL 基礎結構，從 SQL Sever 到 Azure SQL Database 皆適用。 SSMS 提供工具來設定、監視以及管理 SQL Server 執行個體和資料庫。 使用 SSMS，即可部署、監視和升級應用程式所使用的資料層元件，以及建置查詢和指令碼。
 # Agreements: 
 # ReleaseNotes: 
-ReleaseNotesUrl: https://docs.microsoft.com/zh-HK/sql/ssms/release-notes-ssms?view=sql-server-ver15#200
+ReleaseNotesUrl: https://learn.microsoft.com/zh-HK/sql/ssms/release-notes-ssms#200
 # PurchaseUrl: 
 # InstallationNotes: 
 # Documentations: 
 ManifestType: locale
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0

--- a/manifests/m/Microsoft/SQLServerManagementStudio/20.0/Microsoft.SQLServerManagementStudio.locale.zh-TW.yaml
+++ b/manifests/m/Microsoft/SQLServerManagementStudio/20.0/Microsoft.SQLServerManagementStudio.locale.zh-TW.yaml
@@ -1,25 +1,25 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
 PackageIdentifier: Microsoft.SQLServerManagementStudio
 PackageVersion: '20.0'
 PackageLocale: zh-TW
 Publisher: Microsoft Corporation
 PublisherUrl: https://www.microsoft.com/
-PublisherSupportUrl: https://support.microsoft.com/
+PublisherSupportUrl: https://aka.ms/ssms-feedback/
 PrivacyUrl: https://privacy.microsoft.com/
 Author: Microsoft
 PackageName: Microsoft SQL Server Management Studio
-PackageUrl: https://docs.microsoft.com/zh-TW/sql/ssms/download-sql-server-management-studio-ssms
+PackageUrl: https://learn.microsoft.com/zh-TW/sql/ssms/download-sql-server-management-studio-ssms
 License: Proprietary
-# LicenseUrl: 
+LicenseUrl: https://learn.microsoft.com/zh-TW/Legal/sql/sql-server-management-studio-license-terms
 Copyright: 版權所有 (c) Microsoft Corporation
 # CopyrightUrl: 
 ShortDescription: SQL Server Management Studio (SSMS) 是整合式環境，可用於管理任何 SQL 基礎結構，從 SQL Sever 到 Azure SQL Database 皆適用
 Description: SQL Server Management Studio (SSMS) 是整合式環境，可用於管理任何 SQL 基礎結構，從 SQL Sever 到 Azure SQL Database 皆適用。 SSMS 提供工具來設定、監視以及管理 SQL Server 執行個體和資料庫。 使用 SSMS，即可部署、監視和升級應用程式所使用的資料層元件，以及建置查詢和指令碼。
 # Agreements: 
 # ReleaseNotes: 
-ReleaseNotesUrl: https://docs.microsoft.com/zh-TW/sql/ssms/release-notes-ssms?view=sql-server-ver15#200
+ReleaseNotesUrl: https://learn.microsoft.com/zh-TW/sql/ssms/release-notes-ssms#200
 # PurchaseUrl: 
 # InstallationNotes: 
 # Documentations: 
 ManifestType: locale
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0

--- a/manifests/m/Microsoft/SQLServerManagementStudio/20.0/Microsoft.SQLServerManagementStudio.yaml
+++ b/manifests/m/Microsoft/SQLServerManagementStudio/20.0/Microsoft.SQLServerManagementStudio.yaml
@@ -1,6 +1,6 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 PackageIdentifier: Microsoft.SQLServerManagementStudio
 PackageVersion: '20.0'
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
I did not see anything obviously different in going from 1.2.0 to 1.6.0.

Also, I'm not really using any of the new features introduced in later minor updates of the schema.

Just silencing the bot that complains about me be using an older schema version.

-------

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---
