### PR TITLE
Fix Waterfox product codes, hashes and installer types

### DIFF
--- a/manifests/w/Waterfox/Waterfox/G6.0.10/Waterfox.Waterfox.installer.yaml
+++ b/manifests/w/Waterfox/Waterfox/G6.0.10/Waterfox.Waterfox.installer.yaml
@@ -6,15 +6,12 @@ PackageVersion: G6.0.10
 Platform:
 - Windows.Desktop
 MinimumOSVersion: 7.0.0.0
-InstallerType: portable
+InstallerType: nullsoft
 Scope: machine
 InstallModes:
 - interactive
 - silent
 - silentWithProgress
-InstallerSwitches:
-  Silent: /sp- /verysilent /norestart
-  SilentWithProgress: /sp- /silent /norestart
 UpgradeBehavior: install
 Protocols:
 - file
@@ -25,11 +22,11 @@ FileExtensions:
 - html
 - pdf
 - url
-ProductCode: Waterfox 115.7.0 (x64 en-US)
+ProductCode: Waterfox 115.10.0 (x64 en-US)
 ReleaseDate: 2024-03-20
 AppsAndFeaturesEntries:
 - DisplayName: Waterfox (x64 en-US)
-  ProductCode: Waterfox 115.7.0 (x64 en-US)
+  ProductCode: Waterfox 115.10.0 (x64 en-US)
 ElevationRequirement: elevatesSelf
 Installers:
 - Architecture: x64

--- a/manifests/w/Waterfox/Waterfox/G6.0.9/Waterfox.Waterfox.installer.yaml
+++ b/manifests/w/Waterfox/Waterfox/G6.0.9/Waterfox.Waterfox.installer.yaml
@@ -6,7 +6,7 @@ PackageVersion: G6.0.9
 Platform:
 - Windows.Desktop
 MinimumOSVersion: 7.0.0.0
-InstallerType: exe
+InstallerType: nullsoft
 Scope: machine
 InstallModes:
 - interactive
@@ -22,18 +22,15 @@ FileExtensions:
 - html
 - pdf
 - url
-ProductCode: Waterfox 115.7.0 (x64 en-US)
+ProductCode: Waterfox 115.9.0 (x64 en-US)
 ReleaseDate: 2024-02-20
 AppsAndFeaturesEntries:
 - DisplayName: Waterfox (x64 en-US)
-  ProductCode: Waterfox 115.7.0 (x64 en-US)
+  ProductCode: Waterfox 115.9.0 (x64 en-US)
 ElevationRequirement: elevatesSelf
-InstallerSwitches:
-  Silent: /sp- /verysilent /norestart
-  SilentWithProgress: /sp- /silent /norestart
 Installers:
 - Architecture: x64
   InstallerUrl: https://cdn1.waterfox.net/waterfox/releases/G6.0.9/WINNT_x86_64/Waterfox%20Setup%20G6.0.9.exe
-  InstallerSha256: 28270EB3E52BF4D3BCE0E29B93B9A424F5BB5BBAC72CE45EEA851656A6396B68
+  InstallerSha256: 5044632adfe98a186cac1a646846af2aef48bfaacb668ce7a160de08ceacf57b
 ManifestType: installer
 ManifestVersion: 1.6.0


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] This PR only modifies one (1) manifest
  * It modifies two, but the changes are minimal.
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

@Exorcism0666's PRs weren't very good. The installer is a nullsoft installer, for which we have predefined flags. The installer also <em>definitely</em> isn't portable. The unchanged ProductCode slipped validation (#130391, anyone?), probably causing Winget to think my version is outdated.

The hash change wasn't their fault. Waterfox seems to have changed that download.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/145888)