### PR TITLE
Modify: MSYS2.MSYS2 version 20240113

### DIFF
--- a/manifests/m/MSYS2/MSYS2/20240113/MSYS2.MSYS2.locale.en-US.yaml
+++ b/manifests/m/MSYS2/MSYS2/20240113/MSYS2.MSYS2.locale.en-US.yaml
@@ -8,7 +8,7 @@ Publisher: The MSYS2 Developers
 PublisherUrl: https://www.msys2.org/
 PublisherSupportUrl: https://www.msys2.org/contact/
 Author: The MSYS2 Developers
-PackageName: MSYS2
+PackageName: MSYS2 Installer
 PackageUrl: https://github.com/msys2/msys2-installer
 License: BSD-3-Clause
 LicenseUrl: https://github.com/msys2/msys2-installer/blob/main/LICENSE

--- a/manifests/m/MSYS2/MSYS2/20240113/MSYS2.MSYS2.locale.zh-CN.yaml
+++ b/manifests/m/MSYS2/MSYS2/20240113/MSYS2.MSYS2.locale.zh-CN.yaml
@@ -8,7 +8,7 @@ Publisher: The MSYS2 Developers
 PublisherUrl: https://www.msys2.org/
 PublisherSupportUrl: https://www.msys2.org/contact/
 Author: The MSYS2 Developers
-PackageName: MSYS2
+PackageName: MSYS2 Installer
 PackageUrl: https://github.com/msys2/msys2-installer
 License: BSD-3-Clause
 LicenseUrl: https://github.com/msys2/msys2-installer/blob/main/LICENSE


### PR DESCRIPTION
Currently `UpgradeBehavior: deny` does not work well with `winget upgrade --all`. Change the DisplayName back to the "wrong" one so I won't receive more complaints about MSYS2 not upgradable.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/146121)