### PR TITLE
fix waterfox g6.0.10 publisher

### DIFF
--- a/manifests/w/Waterfox/Waterfox/G6.0.10/Waterfox.Waterfox.locale.en-US.yaml
+++ b/manifests/w/Waterfox/Waterfox/G6.0.10/Waterfox.Waterfox.locale.en-US.yaml
@@ -4,7 +4,7 @@
 PackageIdentifier: Waterfox.Waterfox
 PackageVersion: G6.0.10
 PackageLocale: en-US
-Publisher: WaterfoxLimited
+Publisher: BrowserWorks Ltd
 PublisherUrl: https://www.waterfox.net/
 PublisherSupportUrl: https://github.com/WaterfoxCo/Waterfox/issues
 PrivacyUrl: https://www.waterfox.net/docs/policies/privacy
@@ -13,7 +13,7 @@ PackageName: Waterfox
 PackageUrl: https://www.waterfox.net/
 License: Mozilla Public License
 LicenseUrl: https://www.mozilla.org/en-US/MPL/2.0
-Copyright: © 2023 BrowserWorks Ltd
+Copyright: © 2024 BrowserWorks Ltd
 CopyrightUrl: http://www.mozilla.org/foundation/licensing.html
 ShortDescription: FOSS fork of Mozilla Firefox focused on performance, privacy and customization.
 Tags:


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---
![image](https://github.com/microsoft/winget-pkgs/assets/11874211/eea0c778-5e59-48d8-892d-a0c81dd704e2)
hopefully this is why winget still isn't recognizing correctly
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/146171)