### PR TITLE
Add additional labels for moderators to use

### DIFF
--- a/.github/policies/moderatorTriggers.yml
+++ b/.github/policies/moderatorTriggers.yml
@@ -413,20 +413,6 @@ configuration:
                       label: Moderator-Approved
                   - removeLabel:
                       label: Changes-Requested
-                  - removeLabel:
-                      label: Last-Version-Remaining
-                  - removeLabel:
-                      label: License-Blocks-Install
-                  - removeLabel:
-                      label: Scripted-Application
-                  - removeLabel:
-                      label: DriverInstall
-                  - removeLabel:
-                      label: Network-Blocker
-                  - removeLabel:
-                      label: Manifest-Metadata-Consistency
-                  - removeLabel:
-                      label: Version-Parameter-Mismatch
               # Reset-Labels
               - if:
                   - commentContains:

--- a/.github/policies/moderatorTriggers.yml
+++ b/.github/policies/moderatorTriggers.yml
@@ -76,6 +76,14 @@ configuration:
                 then:
                   - addLabel:
                       label: Needs-CLA
+              # Needs-Review
+              - if:
+                  - commentContains:
+                      pattern: '\[[Pp]olicy\]\s+[Nn]eeds[\s-][Rr]eview'
+                      isRegex: True
+                then:
+                  - addLabel:
+                      label: Needs-Review
               # Dependencies
               - if:
                   - commentContains:
@@ -100,6 +108,14 @@ configuration:
                 then:
                   - addLabel:
                       label: portable-archive
+              # portable-jar
+              - if:
+                  - commentContains:
+                      pattern: '\[[Pp]olicy\]\s+[pP]ortable[\s-][jJ][aA][rR]'
+                      isRegex: True
+                then:
+                  - addLabel:
+                      label: portable-jar
               # Area-External
               - if:
                   - commentContains:
@@ -150,6 +166,22 @@ configuration:
                 then:
                   - addLabel:
                       label: Area-Bots
+              # Area-Bots
+              - if:
+                  - commentContains:
+                      pattern: '\[[Pp]olicy\]\s+[aA]rea[\s-][cC]lient'
+                      isRegex: True
+                then:
+                  - addLabel:
+                      label: Area-Client
+              # Area-Manifest
+              - if:
+                  - commentContains:
+                      pattern: '\[[Pp]olicy\]\s+[aA]rea[\s-][mM]anifest'
+                      isRegex: True
+                then:
+                  - addLabel:
+                      label: Area-Manifest
               # Area-Matching
               - if:
                   - commentContains:
@@ -158,6 +190,14 @@ configuration:
                 then:
                   - addLabel:
                       label: Area-Matching
+              # Area-Scope
+              - if:
+                  - commentContains:
+                      pattern: '\[[Pp]olicy\]\s+[aA]rea[\s-][sS]cope'
+                      isRegex: True
+                then:
+                  - addLabel:
+                      label: Area-Scope
               # Area-Validation-Pipeline
               - if:
                   - commentContains:
@@ -239,6 +279,22 @@ configuration:
                 then:
                   - addLabel:
                       label: Scripted-Application
+              # Testing
+              - if:
+                  - commentContains:
+                      pattern: '\[[Pp]olicy\]\s+[tT]est(ing)?'
+                      isRegex: True
+                then:
+                  - addLabel:
+                      label: Testing
+              # Upgrade-Issue
+              - if:
+                  - commentContains:
+                      pattern: '\[[Pp]olicy\]\s+[uU]pgrade[\s-][iI]ssue'
+                      isRegex: True
+                then:
+                  - addLabel:
+                      label: Upgrade-Issue
               # DriverInstall
               - if:
                   - commentContains:
@@ -247,6 +303,22 @@ configuration:
                 then:
                   - addLabel:
                       label: DriverInstall
+              # DSC
+              - if:
+                  - commentContains:
+                      pattern: '\[[Pp]olicy\]\s+[Dd][Ss][Cc]'
+                      isRegex: True
+                then:
+                  - addLabel:
+                      label: DSC
+              # In-PR
+              - if:
+                  - commentContains:
+                      pattern: '\[[Pp]olicy\]\s+[Ii]n[\s-][Pp][Rr]'
+                      isRegex: True
+                then:
+                  - addLabel:
+                      label: In-PR
               # Network-Blocker
               - if:
                   - commentContains:
@@ -255,6 +327,22 @@ configuration:
                 then:
                   - addLabel:
                       label: Network-Blocker
+              # Package-Request
+              - if:
+                  - commentContains:
+                      pattern: '\[[Pp]olicy\]\s+[pP]ackage[\s-][rR]equest'
+                      isRegex: True
+                then:
+                  - addLabel:
+                      label: Package-Request
+              # Package-Update
+              - if:
+                  - commentContains:
+                      pattern: '\[[Pp]olicy\]\s+[pP]ackage[\s-][uU]pdate'
+                      isRegex: True
+                then:
+                  - addLabel:
+                      label: Package-Update
               # Version-Parameter-Mismatch
               - if:
                   - commentContains:
@@ -287,6 +375,14 @@ configuration:
                 then:
                   - addLabel:
                       label: Issue-Bug
+              # Issue-Docs
+              - if:
+                  - commentContains:
+                      pattern: '\[[Pp]olicy\]\s+[iI]ssue[\s-][dD]ocs'
+                      isRegex: True
+                then:
+                  - addLabel:
+                      label: Issue-Docs
               # Issue-Feature
               - if:
                   - commentContains:
@@ -329,6 +425,98 @@ configuration:
                       label: Network-Blocker
                   - removeLabel:
                       label: Manifest-Metadata-Consistency
+                  - removeLabel:
+                      label: Version-Parameter-Mismatch
+              # Reset-Labels
+              - if:
+                  - commentContains:
+                      pattern: '\[[Pp]olicy\]\s+[rR]eset[\s-]+[lL]abels'
+                      isRegex: True
+                then:
+                  - removeLabel:
+                      label: Area-Bots
+                  - removeLabel:
+                      label: Area-Client
+                  - removeLabel:
+                      label: Area-External
+                  - removeLabel:
+                      label: Area-Manifest
+                  - removeLabel:
+                      label: Area-Matching
+                  - removeLabel:
+                      label: Area-Scope
+                  - removeLabel:
+                      label: Area-Validation-Pipeline
+                  - removeLabel:
+                      label: Blocking-Issue
+                  - removeLabel:
+                      label: Changes-Requested
+                  - removeLabel:
+                      label: Dependencies
+                  - removeLabel:
+                      label: DriverInstall
+                  - removeLabel:
+                      label: DSC
+                  - removeLabel:
+                      label: Hardware
+                  - removeLabel:
+                      label: In-PR
+                  - removeLabel:
+                      label: Installer-Issue
+                  - removeLabel:
+                      label: Interactive-Only-Installer
+                  - removeLabel:
+                      label: Issue-Bug
+                  - removeLabel:
+                      label: Issue-Docs
+                  - removeLabel:
+                      label: Issue-Feature
+                  - removeLabel:
+                      label: Last-Version-Remaining
+                  - removeLabel:
+                      label: License-Blocks-Install
+                  - removeLabel:
+                      label: Manifest-Content-Incomplete
+                  - removeLabel:
+                      label: Manifest-Metadata-Consistency
+                  - removeLabel:
+                      label: Manifest-Version-Deprecated
+                  - removeLabel:
+                      label: Moderator-Approved
+                  - removeLabel:
+                      label: Needs-Attention
+                  - removeLabel:
+                      label: Needs-Author-Feedback
+                  - removeLabel:
+                      label: Needs-CLA
+                  - removeLabel:
+                      label: Needs-Review
+                  - removeLabel:
+                      label: Network-Blocker
+                  - removeLabel:
+                      label: Package-Request
+                  - removeLabel:
+                      label: Package-Update
+                  - removeLabel:
+                      label: portable-archive
+                  - removeLabel:
+                      label: portable-jar
+                  - removeLabel:
+                      label: Possible-Duplicate
+                  - removeLabel:
+                      label: Project-File
+                  - removeLabel:
+                      label: Public-Service-Announcement
+                  - removeLabel:
+                      label: Scripted-Application
+                  - removeLabel:
+                      label: Testing
+                  - removeLabel:
+                      label: Upgrade-Issue
+                  - removeLabel:
+                      label: WindowsFeatures
+                  - removeLabel:
+                      label: zip-binary
                   ## TODO: Dismiss All Pull Request Reviews
               # Duplicate of #
               - if:

--- a/.github/policies/moderatorTriggers.yml
+++ b/.github/policies/moderatorTriggers.yml
@@ -56,108 +56,6 @@ configuration:
             then:
               - removeLabel:
                   label: Needs-Triage
-              # Blocking-Issue
-              - if:
-                  - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[bB]locking[\s-][iI]ssue'
-                      isRegex: True
-                then:
-                  - removeLabel:
-                      label: Needs-Author-Feedback
-                  - removeLabel:
-                      label: Needs-Attention
-                  - addLabel:
-                      label: Blocking-Issue
-              # Needs-CLA
-              - if:
-                  - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[Nn]eeds[\s-][Cc][Ll][Aa]'
-                      isRegex: True
-                then:
-                  - addLabel:
-                      label: Needs-CLA
-              # Needs-Review
-              - if:
-                  - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[Nn]eeds[\s-][Rr]eview'
-                      isRegex: True
-                then:
-                  - addLabel:
-                      label: Needs-Review
-              # Dependencies
-              - if:
-                  - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[dD]ependencies'
-                      isRegex: True
-                then:
-                  - addLabel:
-                      label: Dependencies
-              # Windows Features
-              - if:
-                  - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[wW]indows[\s-]?[fF]eature(s)?'
-                      isRegex: True
-                then:
-                  - addLabel:
-                      label: WindowsFeatures
-              # portable-archive
-              - if:
-                  - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[pP]ortable[\s-][aA]rchive'
-                      isRegex: True
-                then:
-                  - addLabel:
-                      label: portable-archive
-              # portable-jar
-              - if:
-                  - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[pP]ortable[\s-][jJ][aA][rR]'
-                      isRegex: True
-                then:
-                  - addLabel:
-                      label: portable-jar
-              # Area-External
-              - if:
-                  - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[aA]rea[\s-][eE]xternal'
-                      isRegex: True
-                then:
-                  - addLabel:
-                      label: Area-External
-              # Installer-Issue
-              - if:
-                  - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[iI]nstaller[\s-][iI]ssue'
-                      isRegex: True
-                then:
-                  - addLabel:
-                      label: Installer-Issue
-                  - addLabel:
-                      label: Area-External
-              # Interactive-Only-Installer
-              - if:
-                  - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[iI]nteractive[\s-][oO]nly([\s-][iI]nstaller)?'
-                      isRegex: True
-                then:
-                  - addLabel:
-                      label: Interactive-Only-Installer
-              # Zip-Binary
-              - if:
-                  - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[zZ]ip[\s-][bB]inary'
-                      isRegex: True
-                then:
-                  - addLabel:
-                      label: zip-binary
-              # Hardware
-              - if:
-                  - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[hH]ardware'
-                      isRegex: True
-                then:
-                  - addLabel:
-                      label: Hardware
               # Area-Bots
               - if:
                   - commentContains:
@@ -166,7 +64,7 @@ configuration:
                 then:
                   - addLabel:
                       label: Area-Bots
-              # Area-Bots
+              # Area-Client
               - if:
                   - commentContains:
                       pattern: '\[[Pp]olicy\]\s+[aA]rea[\s-][cC]lient'
@@ -174,6 +72,14 @@ configuration:
                 then:
                   - addLabel:
                       label: Area-Client
+              # Area-External
+              - if:
+                  - commentContains:
+                      pattern: '\[[Pp]olicy\]\s+[aA]rea[\s-][eE]xternal'
+                      isRegex: True
+                then:
+                  - addLabel:
+                      label: Area-External
               # Area-Manifest
               - if:
                   - commentContains:
@@ -206,14 +112,132 @@ configuration:
                 then:
                   - addLabel:
                       label: Area-Validation-Pipeline
-              # Needs-Author-Feedback
+              # Blocking-Issue
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[Nn]eeds[\s-][Aa]uthor[\s-][fF]eedback'
+                      pattern: '\[[Pp]olicy\]\s+[bB]locking[\s-][iI]ssue'
+                      isRegex: True
+                then:
+                  - removeLabel:
+                      label: Needs-Author-Feedback
+                  - removeLabel:
+                      label: Needs-Attention
+                  - addLabel:
+                      label: Blocking-Issue
+              # Dependencies
+              - if:
+                  - commentContains:
+                      pattern: '\[[Pp]olicy\]\s+[dD]ependencies'
                       isRegex: True
                 then:
                   - addLabel:
-                      label: Needs-Author-Feedback
+                      label: Dependencies
+              # DriverInstall
+              - if:
+                  - commentContains:
+                      pattern: '\[[Pp]olicy\]\s+[Dd]river[\s-][Ii]nstall'
+                      isRegex: True
+                then:
+                  - addLabel:
+                      label: DriverInstall
+              # DSC
+              - if:
+                  - commentContains:
+                      pattern: '\[[Pp]olicy\]\s+[Dd][Ss][Cc]'
+                      isRegex: True
+                then:
+                  - addLabel:
+                      label: DSC
+              # Hardware
+              - if:
+                  - commentContains:
+                      pattern: '\[[Pp]olicy\]\s+[hH]ardware'
+                      isRegex: True
+                then:
+                  - addLabel:
+                      label: Hardware
+              # Help-Wanted
+              - if:
+                  - commentContains:
+                      pattern: '\[[Pp]olicy\]\s+[hH]elp[\s-][wW]anted'
+                      isRegex: True
+                then:
+                  - addLabel:
+                      label: Help-Wanted
+              # In-PR
+              - if:
+                  - commentContains:
+                      pattern: '\[[Pp]olicy\]\s+[Ii]n[\s-][Pp][Rr]'
+                      isRegex: True
+                then:
+                  - addLabel:
+                      label: In-PR
+              # Installer-Issue
+              - if:
+                  - commentContains:
+                      pattern: '\[[Pp]olicy\]\s+[iI]nstaller[\s-][iI]ssue'
+                      isRegex: True
+                then:
+                  - addLabel:
+                      label: Installer-Issue
+                  - addLabel:
+                      label: Area-External
+              # Interactive-Only-Installer
+              - if:
+                  - commentContains:
+                      pattern: '\[[Pp]olicy\]\s+[iI]nteractive[\s-][oO]nly([\s-][iI]nstaller)?'
+                      isRegex: True
+                then:
+                  - addLabel:
+                      label: Interactive-Only-Installer
+              # Issue-Bug
+              - if:
+                  - commentContains:
+                      pattern: '\[[Pp]olicy\]\s+[iI]ssue[\s-][bB]ug'
+                      isRegex: True
+                then:
+                  - addLabel:
+                      label: Issue-Bug
+              # Issue-Docs
+              - if:
+                  - commentContains:
+                      pattern: '\[[Pp]olicy\]\s+[iI]ssue[\s-][dD]ocs'
+                      isRegex: True
+                then:
+                  - addLabel:
+                      label: Issue-Docs
+              # Issue-Feature
+              - if:
+                  - commentContains:
+                      pattern: '\[[Pp]olicy\]\s+[iI]ssue[\s-][fF]eature'
+                      isRegex: True
+                then:
+                  - addLabel:
+                      label: Issue-Feature
+              # Last-Version-Remaining
+              - if:
+                  - commentContains:
+                      pattern: '\[[Pp]olicy\]\s+[Ll]ast[\s-][Vv]ersion([\s-][Rr]emaining)?'
+                      isRegex: True
+                then:
+                  - addLabel:
+                      label: Last-Version-Remaining
+              # License-Blocks-Install
+              - if:
+                  - commentContains:
+                      pattern: '\[[Pp]olicy\]\s+[Ll]icense[\s-][Bb]locks([\s-][Ii]nstall)?'
+                      isRegex: True
+                then:
+                  - addLabel:
+                      label: License-Blocks-Install
+              # Manifest-Content-Incomplete
+              - if:
+                  - commentContains:
+                      pattern: '\[[Pp]olicy\]\s+([Mm]anifest[\s-])?[Cc]ontent[\s-][Ii]ncomplete'
+                      isRegex: True
+                then:
+                  - addLabel:
+                      label: Manifest-Content-Incomplete
               # Moderator-Approved
               - if:
                   - commentContains:
@@ -239,6 +263,22 @@ configuration:
 
 
                         Template: msftbot/manualReview
+              # Needs-Author-Feedback
+              - if:
+                  - commentContains:
+                      pattern: '\[[Pp]olicy\]\s+[Nn]eeds[\s-][Aa]uthor[\s-][fF]eedback'
+                      isRegex: True
+                then:
+                  - addLabel:
+                      label: Needs-Author-Feedback
+              # Needs-CLA
+              - if:
+                  - commentContains:
+                      pattern: '\[[Pp]olicy\]\s+[Nn]eeds[\s-][Cc][Ll][Aa]'
+                      isRegex: True
+                then:
+                  - addLabel:
+                      label: Needs-CLA
               # Needs-Manual-Merge
               - if:
                   - commentContains:
@@ -247,78 +287,14 @@ configuration:
                 then:
                   - addLabel:
                       label: Needs-Manual-Merge
-              # Manifest-Content-Incomplete
+              # Needs-Review
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+([Mm]anifest[\s-])?[Cc]ontent[\s-][Ii]ncomplete'
+                      pattern: '\[[Pp]olicy\]\s+[Nn]eeds[\s-][Rr]eview'
                       isRegex: True
                 then:
                   - addLabel:
-                      label: Manifest-Content-Incomplete
-              # Last-Version-Remaining
-              - if:
-                  - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[Ll]ast[\s-][Vv]ersion([\s-][Rr]emaining)?'
-                      isRegex: True
-                then:
-                  - addLabel:
-                      label: Last-Version-Remaining
-              # License-Blocks-Install
-              - if:
-                  - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[Ll]icense[\s-][Bb]locks([\s-][Ii]nstall)?'
-                      isRegex: True
-                then:
-                  - addLabel:
-                      label: License-Blocks-Install
-              # Scripted-Application
-              - if:
-                  - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[Ss]cript(ed)?[\s-][Aa]pplication'
-                      isRegex: True
-                then:
-                  - addLabel:
-                      label: Scripted-Application
-              # Testing
-              - if:
-                  - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[tT]est(ing)?'
-                      isRegex: True
-                then:
-                  - addLabel:
-                      label: Testing
-              # Upgrade-Issue
-              - if:
-                  - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[uU]pgrade[\s-][iI]ssue'
-                      isRegex: True
-                then:
-                  - addLabel:
-                      label: Upgrade-Issue
-              # DriverInstall
-              - if:
-                  - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[Dd]river[\s-][Ii]nstall'
-                      isRegex: True
-                then:
-                  - addLabel:
-                      label: DriverInstall
-              # DSC
-              - if:
-                  - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[Dd][Ss][Cc]'
-                      isRegex: True
-                then:
-                  - addLabel:
-                      label: DSC
-              # In-PR
-              - if:
-                  - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[Ii]n[\s-][Pp][Rr]'
-                      isRegex: True
-                then:
-                  - addLabel:
-                      label: In-PR
+                      label: Needs-Review
               # Network-Blocker
               - if:
                   - commentContains:
@@ -343,22 +319,22 @@ configuration:
                 then:
                   - addLabel:
                       label: Package-Update
-              # Version-Parameter-Mismatch
+              # portable-archive
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[vV]ersion[\s-][pP]arameter[\s-][mM]ismatch'
+                      pattern: '\[[Pp]olicy\]\s+[pP]ortable[\s-][aA]rchive'
                       isRegex: True
                 then:
                   - addLabel:
-                      label: Version-Parameter-Mismatch
-              # Unblocked
+                      label: portable-archive
+              # portable-jar
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[uU]nblocked'
+                      pattern: '\[[Pp]olicy\]\s+[pP]ortable[\s-][jJ][aA][rR]'
                       isRegex: True
                 then:
-                  - removeLabel:
-                      label: Blocking-Issue
+                  - addLabel:
+                      label: portable-jar
               # PSA
               - if:
                   - commentContains:
@@ -367,38 +343,62 @@ configuration:
                 then:
                   - addLabel:
                       label: Public-Service-Announcement
-              # Issue-Bug
+              # Scripted-Application
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[iI]ssue[\s-][bB]ug'
+                      pattern: '\[[Pp]olicy\]\s+[Ss]cript(ed)?[\s-][Aa]pplication'
                       isRegex: True
                 then:
                   - addLabel:
-                      label: Issue-Bug
-              # Issue-Docs
+                      label: Scripted-Application
+              # Testing
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[iI]ssue[\s-][dD]ocs'
+                      pattern: '\[[Pp]olicy\]\s+[tT]est(ing)?'
                       isRegex: True
                 then:
                   - addLabel:
-                      label: Issue-Docs
-              # Issue-Feature
+                      label: Testing
+              # Upgrade-Issue
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[iI]ssue[\s-][fF]eature'
+                      pattern: '\[[Pp]olicy\]\s+[uU]pgrade[\s-][iI]ssue'
                       isRegex: True
                 then:
                   - addLabel:
-                      label: Issue-Feature
-              # Package-Update
+                      label: Upgrade-Issue
+              # Version-Parameter-Mismatch
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[pP]ackage[\s-][uU]pdate'
+                      pattern: '\[[Pp]olicy\]\s+[vV]ersion[\s-][pP]arameter[\s-][mM]ismatch'
                       isRegex: True
                 then:
                   - addLabel:
-                      label: Package-Update
+                      label: Version-Parameter-Mismatch
+              # Windows Features
+              - if:
+                  - commentContains:
+                      pattern: '\[[Pp]olicy\]\s+[wW]indows[\s-]?[fF]eature(s)?'
+                      isRegex: True
+                then:
+                  - addLabel:
+                      label: WindowsFeatures
+              # Zip-Binary
+              - if:
+                  - commentContains:
+                      pattern: '\[[Pp]olicy\]\s+[zZ]ip[\s-][bB]inary'
+                      isRegex: True
+                then:
+                  - addLabel:
+                      label: zip-binary
+              # Unblocked
+              - if:
+                  - commentContains:
+                      pattern: '\[[Pp]olicy\]\s+[uU]nblocked'
+                      isRegex: True
+                then:
+                  - removeLabel:
+                      label: Blocking-Issue
               # Reset-Feedback
               - if:
                   - commentContains:
@@ -459,6 +459,8 @@ configuration:
                       label: DSC
                   - removeLabel:
                       label: Hardware
+                  - removeLabel:
+                      label: Help-Wanted
                   - removeLabel:
                       label: In-PR
                   - removeLabel:

--- a/.github/policies/moderatorTriggers.yml
+++ b/.github/policies/moderatorTriggers.yml
@@ -148,6 +148,14 @@ configuration:
                 then:
                   - addLabel:
                       label: DSC
+              # Error-Hash-Mismatch
+              - if:
+                  - commentContains:
+                      pattern: '\[[Pp]olicy\]\s+[eE]rror[\s-][hH]ash[\s-][mM]ismatch'
+                      isRegex: True
+                then:
+                  - addLabel:
+                      label: Error-Hash-Mismatch
               # Hardware
               - if:
                   - commentContains:
@@ -443,6 +451,8 @@ configuration:
                       label: DriverInstall
                   - removeLabel:
                       label: DSC
+                  - removeLabel:
+                      label: Error-Hash-Mismatch
                   - removeLabel:
                       label: Hardware
                   - removeLabel:

--- a/doc/Moderation.md
+++ b/doc/Moderation.md
@@ -57,6 +57,12 @@ Occasionally the automatic validation runs into an issue which is transient, or 
 
 The bots which help keep the repository clean sometimes make mistakes or or sometimes a moderator misclicks and accidentally requests changes. This can add the `Needs-Author-Feedback` or `Needs-Attention` labels to pull requests that don't need them. Moderators can remove these labels without re-running the pipelines to allow for the PR to be re-reviewed and merged.
 
+### Removing Labels
+
+> Trigger: Comment `[Policy] Reset Labels` on a pull request or issue
+
+Sometimes a label is misapplied or needs to be removed to keep things clean. This trigger will remove all labels that moderators have access to as well as some non-blocking pipeline labels such as `Possible-Duplicate`. After using this trigger, the applicable labels should be re-added using the triggers below.
+
 ### Closing or Re-opening Pull Requests and Issues
 
 > Trigger: Comment `Close with reason: <reason>;` on a pull request or issue
@@ -81,16 +87,22 @@ When duplicate issues are raised, moderators are able to use this special variat
 Moderators are often the first to see and triage new issues, and so they have the ability to apply certain labels to pull requests and issues. Below is a list of labels that moderators can apply:
 
 * `Area-Bots`
+* `Area-Client`
 * `Area-External`
 * `Area-Matching`
+* `Area-Scope`
 * `Area-Validation-Pipeline`
 * `Blocking-Issue`
 * `Dependencies`
 * `DriverInstall`
+* `DSC`
 * `Hardware`
+* `Help-Wanted`
+* `In-PR`
 * `Installer-Issue`
 * `Interactive-Only-Installer`
 * `Issue-Bug`
+* `Issue-Docs`
 * `Issue-Feature`
 * `Last-Version-Remaining`
 * `License-Blocks-Install`
@@ -100,13 +112,18 @@ Moderators are often the first to see and triage new issues, and so they have th
 * `Needs-Author-Feedback`
 * `Needs-CLA`
 * `Needs-Manual-Merge`
+* `Needs-Review`
 * `Network-Blocker`
+* `Package-Request`
 * `Package-Update`
 * `Portable-Archive`
+* `Portable-JAR`
 * `PSA`
 * `Scripted-Application`
-* `Windows-Features`
+* `Testing`
+* `Upgrade-Issue`
 * `Version-Parameter-Mismatch`
+* `Windows-Features`
 * `Zip-Binary`
 
 > [!NOTE]

--- a/doc/Moderation.md
+++ b/doc/Moderation.md
@@ -96,6 +96,7 @@ Moderators are often the first to see and triage new issues, and so they have th
 * `Dependencies`
 * `DriverInstall`
 * `DSC`
+* `Error-Hash-Mismatch`
 * `Hardware`
 * `Help-Wanted`
 * `In-PR`


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

This PR adds missing triggers for some of the labels moderators should have access to. It also adds the `[Policy] Reset Labels` trigger from winget-cli to ensure that everything can be kept clean. Finally, it organizes all the triggers by the name of the label to make it easier to maintain as new labels are added or removed at the repo

@denelon

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/146532)