### PR TITLE
Update Google.Chrome.installer.yaml

### DIFF
--- a/manifests/g/Google/Chrome/123.0.6312.106/Google.Chrome.installer.yaml
+++ b/manifests/g/Google/Chrome/123.0.6312.106/Google.Chrome.installer.yaml
@@ -42,4 +42,4 @@ Installers:
   InstallerSha256: F9F7E6211FF117BA49020B31AB84537F8CCB506AC7B3630D688ECC57613D960E
   ProductCode: '{904FCAC2-3803-3E90-8CA6-5ADB7BC38D34}'
 ManifestType: installer
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/g/Google/Chrome/123.0.6312.106/Google.Chrome.installer.yaml
+++ b/manifests/g/Google/Chrome/123.0.6312.106/Google.Chrome.installer.yaml
@@ -1,24 +1,10 @@
-# Created with YamlCreate.ps1 v2.3.4 Dumplings Mod $debug=QUSU.CRLF.7-4-1.Win32NT
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
-
 PackageIdentifier: Google.Chrome
 PackageVersion: 123.0.6312.106
-InstallerType: exe
-InstallModes:
-- silent
-InstallerSwitches:
-  Log: --verbose-logging --log-file="<LOGPATH>"
-ExpectedReturnCodes:
-- InstallerReturnCode: 3
-  ReturnResponse: alreadyInstalled
-- InstallerReturnCode: 4
-  ReturnResponse: downgrade
-- InstallerReturnCode: 22
-  ReturnResponse: cancelledByUser
-- InstallerReturnCode: 60
-  ReturnResponse: installInProgress
+InstallerLocale: en-US
+InstallerType: msi
 UpgradeBehavior: install
 Protocols:
+- ftp
 - http
 - https
 - mailto
@@ -34,49 +20,26 @@ FileExtensions:
 - xhtml
 AppsAndFeaturesEntries:
 - UpgradeCode: '{C1DFDF69-5945-32F2-A35E-EE94C99C7CF4}'
-  InstallerType: wix
 Installers:
 - Architecture: x86
   Scope: user
-  InstallerUrl: https://dl.google.com/release2/chrome/acbkb2gy36ufgyyn2nikx5vzo2cq_123.0.6312.106/123.0.6312.106_chrome_installer.exe
-  InstallerSha256: CED1038239B0706210601BD13C5B7B51D62EA5FC6A63075627DB164A049CEAC0
-  InstallerSwitches:
-    Custom: --do-not-launch-chrome
-  ProductCode: Google Chrome
+  InstallerUrl: https://dl.google.com/dl/chrome/install/googlechromestandaloneenterprise.msi
+  InstallerSha256: D9EF908E44785C8AAE7850F90F6384FDD808DD72538332E443FE5DD2B424B9FE
+  ProductCode: '{E430CF3A-8F17-3FF2-B3CA-9A1CF1B33FF0}'
 - Architecture: x86
   Scope: machine
-  InstallerUrl: https://dl.google.com/release2/chrome/acbkb2gy36ufgyyn2nikx5vzo2cq_123.0.6312.106/123.0.6312.106_chrome_installer.exe
-  InstallerSha256: CED1038239B0706210601BD13C5B7B51D62EA5FC6A63075627DB164A049CEAC0
-  InstallerSwitches:
-    Custom: --do-not-launch-chrome --system-level
-  ProductCode: Google Chrome
+  InstallerUrl: https://dl.google.com/dl/chrome/install/googlechromestandaloneenterprise.msi
+  InstallerSha256: D9EF908E44785C8AAE7850F90F6384FDD808DD72538332E443FE5DD2B424B9FE
+  ProductCode: '{E430CF3A-8F17-3FF2-B3CA-9A1CF1B33FF0}'
 - Architecture: x64
   Scope: user
-  InstallerUrl: https://dl.google.com/release2/chrome/actwpqpbckrqnxh2vvxg53plwjma_123.0.6312.106/123.0.6312.106_chrome_installer.exe
-  InstallerSha256: 9305BF74929CEE9B7214004EAB4176D4220767E382B04EF4E5948C857580C49E
-  InstallerSwitches:
-    Custom: --do-not-launch-chrome
-  ProductCode: Google Chrome
+  InstallerUrl: https://dl.google.com/dl/chrome/install/googlechromestandaloneenterprise64.msi
+  InstallerSha256: F9F7E6211FF117BA49020B31AB84537F8CCB506AC7B3630D688ECC57613D960E
+  ProductCode: '{904FCAC2-3803-3E90-8CA6-5ADB7BC38D34}'
 - Architecture: x64
   Scope: machine
-  InstallerUrl: https://dl.google.com/release2/chrome/actwpqpbckrqnxh2vvxg53plwjma_123.0.6312.106/123.0.6312.106_chrome_installer.exe
-  InstallerSha256: 9305BF74929CEE9B7214004EAB4176D4220767E382B04EF4E5948C857580C49E
-  InstallerSwitches:
-    Custom: --do-not-launch-chrome --system-level
-  ProductCode: Google Chrome
-- Architecture: arm64
-  Scope: user
-  InstallerUrl: https://dl.google.com/release2/chrome/ocanhc63k2byagkvsvltx2bpvy_123.0.6312.106/123.0.6312.106_chrome_installer.exe
-  InstallerSha256: D501AA4DA4E994723CF20A1D97DDFCCC4F86F4AE67D30EAC52A5AC29C887F963
-  InstallerSwitches:
-    Custom: --do-not-launch-chrome
-  ProductCode: Google Chrome
-- Architecture: arm64
-  Scope: machine
-  InstallerUrl: https://dl.google.com/release2/chrome/ocanhc63k2byagkvsvltx2bpvy_123.0.6312.106/123.0.6312.106_chrome_installer.exe
-  InstallerSha256: D501AA4DA4E994723CF20A1D97DDFCCC4F86F4AE67D30EAC52A5AC29C887F963
-  InstallerSwitches:
-    Custom: --do-not-launch-chrome --system-level
-  ProductCode: Google Chrome
+  InstallerUrl: https://dl.google.com/dl/chrome/install/googlechromestandaloneenterprise64.msi
+  InstallerSha256: F9F7E6211FF117BA49020B31AB84537F8CCB506AC7B3630D688ECC57613D960E
+  ProductCode: '{904FCAC2-3803-3E90-8CA6-5ADB7BC38D34}'
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.5.0


### PR DESCRIPTION
The MSI installer is standard for installing Windows software and should be used when posisble. In addition Google has a static download for future versions and winget bot will keep this up to date. Google also uses the msi in their own deployment guide: https://support.google.com/chrome/a/answer/3115278?hl=en

Checklist for Pull Requests
- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/147683)