### PR TITLE
[CODEOWNERS] its `doc/`, not `.doc/*`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,13 +16,14 @@ SECURITY.md @microsoft/windows-package-manager-packages-admins @denelon
 schemas/* @microsoft/windows-package-manager-packages-admins @denelon
 
 # These files should be reviewed by any Microsoft FTE, but may not require careful review
+
+doc/* @microsoft/windows-package-manager-packages-admins @denelon
+Tools/* @microsoft/windows-package-manager-packages-admins @denelon
 .configurations/* @microsoft/windows-package-manager-packages-admins @denelon
 .vscode/* @microsoft/windows-package-manager-packages-admins @denelon
-.doc/* @microsoft/windows-package-manager-packages-admins @denelon
 .editorconfig @microsoft/windows-package-manager-packages-admins @denelon
 .gitattributes @microsoft/windows-package-manager-packages-admins @denelon
 .gitignore @microsoft/windows-package-manager-packages-admins @denelon
 README.md @microsoft/windows-package-manager-packages-admins @denelon
 CONTRIBUTING.md @microsoft/windows-package-manager-packages-admins @denelon
 SUPPORT.md @microsoft/windows-package-manager-packages-admins @denelon
-Tools/* @microsoft/windows-package-manager-packages-admins @denelon


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Is there a linked Issue?
  - I discovered this typo when @denelon and the team weren't automatically requested for review on https://github.com/microsoft/winget-pkgs/pull/148006 by GitHub CODEOWNERS functionality

Manifests
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/148008)