### PR TITLE
Fix AGSProjectTeam.AdventureGameStudio 3.6.1.23 hash

### DIFF
--- a/manifests/a/AGSProjectTeam/AdventureGameStudio/3.6.1.23/AGSProjectTeam.AdventureGameStudio.installer.yaml
+++ b/manifests/a/AGSProjectTeam/AdventureGameStudio/3.6.1.23/AGSProjectTeam.AdventureGameStudio.installer.yaml
@@ -11,7 +11,7 @@ AppsAndFeaturesEntries:
 Installers:
 - Architecture: x86
   InstallerUrl: https://github.com/adventuregamestudio/ags/releases/download/v3.6.1.23/AGS-3.6.1.23-P1.exe
-  InstallerSha256: 3D8EBD96B3A8E5549EAD93A2FFD8B64C22CBC69536D0E2AA5A65F09193D3C978
+  InstallerSha256: 300D857552CEBA738CFEC54045AF08DBBE637CD82AB458448C7F999165B36854
   ProductCode: 6fcbc804-4887-4786-bcf6-b0786e1e983d_is1
 ManifestType: installer
 ManifestVersion: 1.6.0


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

The installer file has been replaced and so the hash is now incorrect.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/148232)