### PR TITLE
Remove Manifest-Path-Error on PR re-run and changes pushed

### DIFF
--- a/.github/policies/labelManagement.issueUpdated.yml
+++ b/.github/policies/labelManagement.issueUpdated.yml
@@ -293,6 +293,8 @@ configuration:
           - removeLabel:
               label: Manifest-Metadata-Consistency
           - removeLabel:
+              label: Manifest-Path-Error
+          - removeLabel:
               label: Manifest-Validation-Error
           - removeLabel:
               label: Manifest-Version-Deprecated
@@ -443,6 +445,8 @@ configuration:
               label: Manifest-Dependencies-Error
           - removeLabel:
               label: Manifest-Installer-Validation-Error
+          - removeLabel:
+              label: Manifest-Path-Error
           - removeLabel:
               label: Manifest-Validation-Error
           - removeLabel:

--- a/.github/policies/labelManagement.issueUpdated.yml
+++ b/.github/policies/labelManagement.issueUpdated.yml
@@ -243,77 +243,73 @@ configuration:
               action: Synchronize
         then:
           - removeLabel:
-              label: Validation-Completed
-          - removeLabel:
               label: Azure-Pipeline-Passed
-          - removeLabel:
-              label: Validation-Hash-Verification-Failed
-          - removeLabel:
-              label: Manifest-Version-Error
-          - removeLabel:
-              label: Manifest-Dependencies-Error
-          - removeLabel:
-              label: PullRequest-Error
-          - removeLabel:
-              label: Manifest-Validation-Error
-          - removeLabel:
-              label: Manifest-Installer-Validation-Error
-          - removeLabel:
-              label: URL-Validation-Error
           - removeLabel:
               label: Binary-Validation-Error
           - removeLabel:
-              label: Error-Analysis-Timeout
+              label: Blocking-Issue
           - removeLabel:
-              label: Error-Installer-Availability
+              label: Changes-Requested
+          - removeLabel:
+              label: EULA-Install
+          - removeLabel:
+              label: Error-Analysis-Timeout
           - removeLabel:
               label: Error-Hash-Mismatch
           - removeLabel:
+              label: Error-Installer-Availability
+          - removeLabel:
               label: Internal-Error
-          - removeLabel:
-              label: Internal-Error-PR
-          - removeLabel:
-              label: Internal-Error-Manifest
-          - removeLabel:
-              label: Internal-Error-URL
           - removeLabel:
               label: Internal-Error-Domain
           - removeLabel:
-              label: Internal-Error-Keyword-Policy
-          - removeLabel:
-              label: Internal-Error-Static-Scan
-          - removeLabel:
               label: Internal-Error-Dynamic-Scan
           - removeLabel:
-              label: Validation-Installation-Error
+              label: Internal-Error-Keyword-Policy
+          - removeLabel:
+              label: Internal-Error-Manifest
           - removeLabel:
               label: Internal-Error-NoArchitectures
           - removeLabel:
               label: Internal-Error-NoSupportedArchitectures
           - removeLabel:
-              label: Validation-Executable-Error
+              label: Internal-Error-PR
           - removeLabel:
-              label: Validation-Defender-Error
+              label: Internal-Error-Static-Scan
           - removeLabel:
-              label: Validation-Unapproved-URL
+              label: Internal-Error-URL
           - removeLabel:
-              label: Validation-Forbidden-URL-Error
-          - removeLabel:
-              label: Validation-Domain
-          - removeLabel:
-              label: Validation-Missing-Dependency
-          - removeLabel:
-              label: Blocking-Issue
-          - removeLabel:
-              label: Needs-SmartScreen-Investigation
-          - removeLabel:
-              label: Needs-Attention
-          - removeLabel:
-              label: EULA-Install
+              label: Last-Version-Remaining
           - removeLabel:
               label: MSFT-Verified
           - removeLabel:
-              label: Validation-Unattended-Failed
+              label: Manifest-AppsAndFeaturesVersion-Error
+          - removeLabel:
+              label: Manifest-Content-Incomplete
+          - removeLabel:
+              label: Manifest-Dependencies-Error
+          - removeLabel:
+              label: Manifest-Installer-Validation-Error
+          - removeLabel:
+              label: Manifest-Metadata-Consistency
+          - removeLabel:
+              label: Manifest-Validation-Error
+          - removeLabel:
+              label: Manifest-Version-Deprecated
+          - removeLabel:
+              label: Manifest-Version-Error
+          - removeLabel:
+              label: Moderator-Approved
+          - removeLabel:
+              label: Needs-Attention
+          - removeLabel:
+              label: Needs-Author-Feedback
+          - removeLabel:
+              label: Needs-SmartScreen-Investigation
+          - removeLabel:
+              label: New-Manifest
+          - removeLabel:
+              label: New-Package
           - removeLabel:
               label: Policy-Test-1.1.A
           - removeLabel:
@@ -345,39 +341,43 @@ configuration:
           - removeLabel:
               label: Policy-Test-2.9
           - removeLabel:
-              label: Validation-No-Executables
+              label: PullRequest-Error
           - removeLabel:
-              label: Needs-Author-Feedback
-          - removeLabel:
-              label: Moderator-Approved
-          - removeLabel:
-              label: Changes-Requested
+              label: URL-Validation-Error
           - removeLabel:
               label: Unexpected-File
           - removeLabel:
+              label: Validation-Completed
+          - removeLabel:
+              label: Validation-Defender-Error
+          - removeLabel:
+              label: Validation-Domain
+          - removeLabel:
+              label: Validation-Executable-Error
+          - removeLabel:
+              label: Validation-Forbidden-URL-Error
+          - removeLabel:
+              label: Validation-Hash-Verification-Failed
+          - removeLabel:
+              label: Validation-Installation-Error
+          - removeLabel:
+              label: Validation-Line-Endings-Error
+          - removeLabel:
               label: Validation-Merge-Conflict
           - removeLabel:
-              label: Manifest-AppsAndFeaturesVersion-Error
+              label: Validation-Missing-Dependency
           - removeLabel:
-              label: Validation-Shell-Execute
-          - removeLabel:
-              label: Manifest-Content-Incomplete
+              label: Validation-No-Executables
           - removeLabel:
               label: Validation-Open-Url-Failed
           - removeLabel:
-              label: Last-Version-Remaining
+              label: Validation-Shell-Execute
           - removeLabel:
-              label: New-Manifest
+              label: Validation-Unapproved-URL
           - removeLabel:
-              label: New-Package
-          - removeLabel:
-              label: Manifest-Metadata-Consistency
-          - removeLabel:
-              label: Manifest-Version-Deprecated
+              label: Validation-Unattended-Failed
           - removeLabel:
               label: Version-Parameter-Mismatch
-          - removeLabel:
-              label: Validation-Line-Endings-Error
       - description: Remove status labels when a PR is re-run
         if:
           - payloadType: Issue_Comment
@@ -400,77 +400,59 @@ configuration:
         then:
           # Don't remove Changes-Requested here because it is just a re-run, no new commits have been added
           - removeLabel:
-              label: Validation-Completed
+              label: Author-Not-Authorized
           - removeLabel:
               label: Azure-Pipeline-Passed
           - removeLabel:
-              label: Validation-Hash-Verification-Failed
-          - removeLabel:
-              label: Validation-Merge-Conflict
-          - removeLabel:
-              label: PullRequest-Error
-          - removeLabel:
-              label: Manifest-Version-Error
-          - removeLabel:
-              label: Manifest-Dependencies-Error
-          - removeLabel:
-              label: Manifest-Validation-Error
-          - removeLabel:
-              label: Manifest-Installer-Validation-Error
-          - removeLabel:
-              label: URL-Validation-Error
-          - removeLabel:
               label: Binary-Validation-Error
+          - removeLabel:
+              label: Blocking-Issue
+          - removeLabel:
+              label: EULA-Install
           - removeLabel:
               label: Error-Analysis-Timeout
           - removeLabel:
-              label: Error-Installer-Availability
-          - removeLabel:
               label: Error-Hash-Mismatch
+          - removeLabel:
+              label: Error-Installer-Availability
           - removeLabel:
               label: Internal-Error
           - removeLabel:
-              label: Internal-Error-PR
-          - removeLabel:
-              label: Internal-Error-Manifest
-          - removeLabel:
-              label: Internal-Error-URL
-          - removeLabel:
               label: Internal-Error-Domain
-          - removeLabel:
-              label: Internal-Error-Keyword-Policy
-          - removeLabel:
-              label: Internal-Error-Static-Scan
           - removeLabel:
               label: Internal-Error-Dynamic-Scan
           - removeLabel:
-              label: Validation-Installation-Error
+              label: Internal-Error-Keyword-Policy
+          - removeLabel:
+              label: Internal-Error-Manifest
           - removeLabel:
               label: Internal-Error-NoArchitectures
           - removeLabel:
               label: Internal-Error-NoSupportedArchitectures
           - removeLabel:
-              label: Validation-Executable-Error
+              label: Internal-Error-PR
           - removeLabel:
-              label: Validation-Defender-Error
+              label: Internal-Error-Static-Scan
           - removeLabel:
-              label: Validation-Unapproved-URL
-          - removeLabel:
-              label: Validation-Domain
-          - removeLabel:
-              label: Validation-Missing-Dependency
-          - removeLabel:
-              label: Blocking-Issue
-          - removeLabel:
-              label: Needs-SmartScreen-Investigation
-          - removeLabel:
-              label: Needs-Attention
-          - removeLabel:
-              label: EULA-Install
+              label: Internal-Error-URL
           - removeLabel:
               label: MSFT-Verified
           - removeLabel:
-              label: Validation-Unattended-Failed
+              label: Manifest-AppsAndFeaturesVersion-Error
+          - removeLabel:
+              label: Manifest-Dependencies-Error
+          - removeLabel:
+              label: Manifest-Installer-Validation-Error
+          - removeLabel:
+              label: Manifest-Validation-Error
+          - removeLabel:
+              label: Manifest-Version-Error
+          - removeLabel:
+              label: Needs-Attention
+          - removeLabel:
+              label: Needs-Author-Feedback
+          - removeLabel:
+              label: Needs-SmartScreen-Investigation
           - removeLabel:
               label: Policy-Test-1.1.A
           - removeLabel:
@@ -502,22 +484,40 @@ configuration:
           - removeLabel:
               label: Policy-Test-2.9
           - removeLabel:
-              label: Validation-No-Executables
-          - removeLabel:
-              label: Needs-Author-Feedback
-          - removeLabel:
-              label: Unexpected-File
-          - removeLabel:
-              label: Manifest-AppsAndFeaturesVersion-Error
-          - removeLabel:
-              label: Validation-Shell-Execute
-          - removeLabel:
-              label: Validation-Open-Url-Failed
-          - removeLabel:
               label: Possible-Duplicate
           - removeLabel:
               label: Project-File
           - removeLabel:
-              label: Author-Not-Authorized
+              label: PullRequest-Error
+          - removeLabel:
+              label: URL-Validation-Error
+          - removeLabel:
+              label: Unexpected-File
+          - removeLabel:
+              label: Validation-Completed
+          - removeLabel:
+              label: Validation-Defender-Error
+          - removeLabel:
+              label: Validation-Domain
+          - removeLabel:
+              label: Validation-Executable-Error
+          - removeLabel:
+              label: Validation-Hash-Verification-Failed
+          - removeLabel:
+              label: Validation-Installation-Error
+          - removeLabel:
+              label: Validation-Merge-Conflict
+          - removeLabel:
+              label: Validation-Missing-Dependency
+          - removeLabel:
+              label: Validation-No-Executables
+          - removeLabel:
+              label: Validation-Open-Url-Failed
+          - removeLabel:
+              label: Validation-Shell-Execute
+          - removeLabel:
+              label: Validation-Unapproved-URL
+          - removeLabel:
+              label: Validation-Unattended-Failed
 onFailure:
 onSuccess:


### PR DESCRIPTION
Example PR: https://github.com/microsoft/winget-pkgs/pull/148606

The first commit sorts the existing keys in lexicographic order for ease of add in the future. The second commit adds `Manifest-Path-Error` in the list
