### PR TITLE
chore: add latest HashiCorp Vault

### DIFF
--- a/manifests/h/Hashicorp/Vault/1.16.1/Hashicorp.Vault.installer.yaml
+++ b/manifests/h/Hashicorp/Vault/1.16.1/Hashicorp.Vault.installer.yaml
@@ -1,0 +1,25 @@
+# Created with YamlCreate.ps1 v2.4.1 $debug=NVS1.CRLF.7-4-1.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: Hashicorp.Vault
+PackageVersion: 1.16.1
+InstallerLocale: en-US
+InstallerType: zip
+ReleaseDate: 2024-04-04
+Installers:
+- Architecture: x64
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: ./vault.exe
+    PortableCommandAlias: vault
+  InstallerUrl: https://releases.hashicorp.com/vault/1.16.1/vault_1.16.1_windows_amd64.zip
+  InstallerSha256: 1E56F46B292F0A034F50C4B82D98CE8A845B42F1C13CA8E282C5604AAC5699F7
+- Architecture: x86
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: ./vault.exe
+    PortableCommandAlias: vault
+  InstallerUrl: https://releases.hashicorp.com/vault/1.16.1/vault_1.16.1_windows_386.zip
+  InstallerSha256: C98A0C8EB527EFB8EEC7C109165E5857AA1F2D0230F0DCAC211D9EC7053C8BA5
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/h/Hashicorp/Vault/1.16.1/Hashicorp.Vault.locale.en-US.yaml
+++ b/manifests/h/Hashicorp/Vault/1.16.1/Hashicorp.Vault.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# Created with YamlCreate.ps1 v2.4.1 $debug=NVS1.CRLF.7-4-1.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: Hashicorp.Vault
+PackageVersion: 1.16.1
+PackageLocale: en-US
+Publisher: HashiCorp
+PublisherUrl: https://www.hashicorp.com/
+PublisherSupportUrl: https://github.com/hashicorp/vault/issues
+PrivacyUrl: https://www.hashicorp.com/privacy?product_intent=vault
+Author: Mitchell Hashimoto
+PackageName: HashiCorp Vault
+PackageUrl: https://www.vaultproject.io/
+License: Business Source License 1.1
+LicenseUrl: https://github.com/hashicorp/vault/blob/main/LICENSE
+Copyright: Copyright (c) HashiCorp
+CopyrightUrl: https://github.com/hashicorp/vault/blob/main/LICENSE
+ShortDescription: Vault is an identity-based secrets and encryption management system.
+# Description:
+Moniker: vault
+Tags:
+- hashicorp
+- vault
+# ReleaseNotes:
+ReleaseNotesUrl: https://github.com/hashicorp/vault/blob/main/CHANGELOG.md#1161
+# PurchaseUrl:
+# InstallationNotes:
+# Documentations:
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/h/Hashicorp/Vault/1.16.1/Hashicorp.Vault.yaml
+++ b/manifests/h/Hashicorp/Vault/1.16.1/Hashicorp.Vault.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.4.1 $debug=NVS1.CRLF.7-4-1.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: Hashicorp.Vault
+PackageVersion: 1.16.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
This PR is to add the latest available version of HashiCorp Vault as it has not been updated in the WinGet repo for about nine months. Straightforward new version add, but do note there was a license change by HashiCorp since the last version available in WinGet.

Checklist for Pull Requests
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] This PR only modifies one (1) manifest
- [X] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

---
