### PR TITLE
gopass.gopass v1.15.13: remove user scope

### DIFF
--- a/manifests/g/gopass/gopass/1.15.13/gopass.gopass.installer.yaml
+++ b/manifests/g/gopass/gopass/1.15.13/gopass.gopass.installer.yaml
@@ -6,7 +6,6 @@ PackageVersion: 1.15.13
 InstallerLocale: en-US
 MinimumOSVersion: 7.0.0.0
 InstallerType: msi
-Scope: user
 UpgradeBehavior: uninstallPrevious
 ProductCode: '{5716A2AE-2D24-4CCE-AD4A-F396B5BAD080}'
 ReleaseDate: 2024-04-06


### PR DESCRIPTION
This removes the `Scope: User` setting. Otherwise an update of a previous install with machine scope is not possible.

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/152451)