### PR TITLE
Remove Display Version from Azul.Zulu.11.JDK

### DIFF
--- a/manifests/a/Azul/Zulu/11/JDK/11.2.3/Azul.Zulu.11.JDK.installer.yaml
+++ b/manifests/a/Azul/Zulu/11/JDK/11.2.3/Azul.Zulu.11.JDK.installer.yaml
@@ -23,7 +23,6 @@ Installers:
   InstallerSha256: 893B8B0B4B63BE62296DFEAA7922A0127E533B8DDE6533A67678FA9F2E88B1A1
   AppsAndFeaturesEntries:
   - DisplayName: Zulu 11.2 (64-bit)
-    DisplayVersion: "11.2"
     ProductCode: '{1E49F12B-555C-4752-BB92-C3CEED818928}'
 ManifestType: installer
 ManifestVersion: 1.1.0


### PR DESCRIPTION
Newer versions have the proper display version. Since the ISV has had the issue fixed for some time, it seems a better course of action to remove the DisplayVersion from the relatively few manifests that have it rather than updating the manifests without it. 

* microsoft/winget-cli#4459
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/152653)