### PR TITLE
Remove Display Version from Azul.Zulu.11.JDK

### DIFF
--- a/manifests/a/Azul/Zulu/11/JDK/11.31.11/Azul.Zulu.11.JDK.installer.yaml
+++ b/manifests/a/Azul/Zulu/11/JDK/11.31.11/Azul.Zulu.11.JDK.installer.yaml
@@ -23,7 +23,6 @@ Installers:
   InstallerSha256: 58F830ED4AE0130FC537AFE5A746BD48A667A4C01D48B7926A2A71D2F93486E9
   AppsAndFeaturesEntries:
   - DisplayName: Zulu 11.31 (64-bit)
-    DisplayVersion: "11.31"
     ProductCode: '{F52DFA9B-97BD-45FC-A048-670F4EE5CC04}'
 ManifestType: installer
 ManifestVersion: 1.1.0


### PR DESCRIPTION
Newer versions have the proper display version. Since the ISV has had the issue fixed for some time, it seems a better course of action to remove the DisplayVersion from the relatively few manifests that have it rather than updating the manifests without it. 

* microsoft/winget-cli#4459
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/152654)