### PR TITLE
Remove Display Version from Azul.Zulu.11.JDK

### DIFF
--- a/manifests/a/Azul/Zulu/11/JDK/11.33.15/Azul.Zulu.11.JDK.installer.yaml
+++ b/manifests/a/Azul/Zulu/11/JDK/11.33.15/Azul.Zulu.11.JDK.installer.yaml
@@ -23,7 +23,6 @@ Installers:
   InstallerSha256: 09B70B37B142B756E15DDD2494DA832EF065D7F2CF7B05065C2B2FCC69308CEF
   AppsAndFeaturesEntries:
   - DisplayName: Zulu 11.33 (64-bit)
-    DisplayVersion: "11.33"
     ProductCode: '{D1998142-B1A5-4BDF-B293-3553C9B054BB}'
 ManifestType: installer
 ManifestVersion: 1.1.0


### PR DESCRIPTION
Newer versions have the proper display version. Since the ISV has had the issue fixed for some time, it seems a better course of action to remove the DisplayVersion from the relatively few manifests that have it rather than updating the manifests without it. 

* microsoft/winget-cli#4459
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/152655)