### PR TITLE
Remove Display Version from Azul.Zulu.11.JDK

### DIFF
--- a/manifests/a/Azul/Zulu/11/JDK/11.35.13/Azul.Zulu.11.JDK.installer.yaml
+++ b/manifests/a/Azul/Zulu/11/JDK/11.35.13/Azul.Zulu.11.JDK.installer.yaml
@@ -23,7 +23,6 @@ Installers:
   InstallerSha256: 602438074CD6EFDE9691CDF32C0EB2DE280E06D92729B7C25FD2E017984D57BF
   AppsAndFeaturesEntries:
   - DisplayName: Zulu JDK 11.35 (64-bit)
-    DisplayVersion: "11.35"
     ProductCode: '{CB12C524-B9ED-4C5E-B775-5C987A2F18C5}'
 ManifestType: installer
 ManifestVersion: 1.1.0


### PR DESCRIPTION
Newer versions have the proper display version. Since the ISV has had the issue fixed for some time, it seems a better course of action to remove the DisplayVersion from the relatively few manifests that have it rather than updating the manifests without it. 

* microsoft/winget-cli#4459
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/152656)