### PR TITLE
Remove Display Version from Azul.Zulu.11.JDK

### DIFF
--- a/manifests/a/Azul/Zulu/11/JDK/11.37.17/Azul.Zulu.11.JDK.installer.yaml
+++ b/manifests/a/Azul/Zulu/11/JDK/11.37.17/Azul.Zulu.11.JDK.installer.yaml
@@ -23,14 +23,12 @@ Installers:
   InstallerSha256: BD334571691B3D41612EC74A88E9BAF01F5F3126B73D51052378D1F7892922C1
   AppsAndFeaturesEntries:
   - DisplayName: Zulu JDK 11.37 (11.0.6), 64-bit
-    DisplayVersion: "11.37"
     ProductCode: '{6A7A39EA-EBC9-4F8A-A02C-E6D5B30A426A}'
 - Architecture: x86
   InstallerUrl: https://cdn.azul.com/zulu/bin/zulu11.37.17-ca-jdk11.0.6-win_i686.msi
   InstallerSha256: 153CD7A0887890C27C660C0E7E361266048E4714D06D226A590D76DAC81EC196
   AppsAndFeaturesEntries:
   - DisplayName: Zulu JDK 11.37 (11.0.6), 32-bit
-    DisplayVersion: "11.37"
     ProductCode: '{D20C1545-F30D-46B1-9D22-BA19D5FA1703}'
 ManifestType: installer
 ManifestVersion: 1.1.0


### PR DESCRIPTION
Newer versions have the proper display version. Since the ISV has had the issue fixed for some time, it seems a better course of action to remove the DisplayVersion from the relatively few manifests that have it rather than updating the manifests without it. 

* microsoft/winget-cli#4459
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/152657)