### PR TITLE
Remove Display Version from Azul.Zulu.11.JDK

### DIFF
--- a/manifests/a/Azul/Zulu/11/JDK/11.39.15/Azul.Zulu.11.JDK.installer.yaml
+++ b/manifests/a/Azul/Zulu/11/JDK/11.39.15/Azul.Zulu.11.JDK.installer.yaml
@@ -23,14 +23,12 @@ Installers:
   InstallerSha256: B1A12349EAD4C8E43DEF54988AE6FF601CE55995F7765D011F1CD751B27639CD
   AppsAndFeaturesEntries:
   - DisplayName: Zulu JDK 11.39 (11.0.7), 64-bit
-    DisplayVersion: "11.39"
     ProductCode: '{1B2FFD3B-2B88-4EB2-9255-95942B1437CF}'
 - Architecture: x86
   InstallerUrl: https://cdn.azul.com/zulu/bin/zulu11.39.15-ca-jdk11.0.7-win_i686.msi
   InstallerSha256: CE9F7E9A8F6BC7AF40ACF8B72F72532927337B7D56EAA5137973C4D1E703B599
   AppsAndFeaturesEntries:
   - DisplayName: Zulu JDK 11.39 (11.0.7), 32-bit
-    DisplayVersion: "11.39"
     ProductCode: '{C6F67717-AA12-444C-ADD7-67CB65743046}'
 ManifestType: installer
 ManifestVersion: 1.1.0


### PR DESCRIPTION
Newer versions have the proper display version. Since the ISV has had the issue fixed for some time, it seems a better course of action to remove the DisplayVersion from the relatively few manifests that have it rather than updating the manifests without it. 

* microsoft/winget-cli#4459
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/152658)