### PR TITLE
Remove Display Version from Azul.Zulu.11.JDK

### DIFF
--- a/manifests/a/Azul/Zulu/11/JDK/11.41.23/Azul.Zulu.11.JDK.installer.yaml
+++ b/manifests/a/Azul/Zulu/11/JDK/11.41.23/Azul.Zulu.11.JDK.installer.yaml
@@ -23,14 +23,12 @@ Installers:
   InstallerSha256: F1C0F0C8DD4621CCE9CC753FC7AE2450DB49B327FCAC15297DD869F7E9F77800
   AppsAndFeaturesEntries:
   - DisplayName: Zulu JDK 11.41 (11.0.8), 64-bit
-    DisplayVersion: "11.41"
     ProductCode: '{32FE03CF-CA3A-42B4-B0B7-D081A912FD9E}'
 - Architecture: x86
   InstallerUrl: https://cdn.azul.com/zulu/bin/zulu11.41.23-ca-jdk11.0.8-win_i686.msi
   InstallerSha256: 963B9505CB949B54C4CB521E8F2295C496950254A6FA418B846033BC9A3A1959
   AppsAndFeaturesEntries:
   - DisplayName: Zulu JDK 11.41 (11.0.8), 32-bit
-    DisplayVersion: "11.41"
     ProductCode: '{79A464CA-A552-40C1-A526-0F5D25CD91CA}'
 ManifestType: installer
 ManifestVersion: 1.1.0


### PR DESCRIPTION
Newer versions have the proper display version. Since the ISV has had the issue fixed for some time, it seems a better course of action to remove the DisplayVersion from the relatively few manifests that have it rather than updating the manifests without it. 

* microsoft/winget-cli#4459
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/152659)