### PR TITLE
Remove Display Version from Azul.Zulu.11.JDK

### DIFF
--- a/manifests/a/Azul/Zulu/11/JDK/11.43.21/Azul.Zulu.11.JDK.installer.yaml
+++ b/manifests/a/Azul/Zulu/11/JDK/11.43.21/Azul.Zulu.11.JDK.installer.yaml
@@ -23,14 +23,12 @@ Installers:
   InstallerSha256: 83F1ADCEE8F294897CB8B36B28E16818FD75DF4A43DF205A6D198DFAD8BBB4E5
   AppsAndFeaturesEntries:
   - DisplayName: Zulu JDK 11.43 (11.0.9), 64-bit
-    DisplayVersion: "11.43"
     ProductCode: '{E8455D89-09ED-4893-9302-2A43656079E5}'
 - Architecture: x86
   InstallerUrl: https://cdn.azul.com/zulu/bin/zulu11.43.21-ca-jdk11.0.9-win_i686.msi
   InstallerSha256: 1D4369CAE4E44E13E4D443F8A95BB6DBB74FD08B0DE42916234120B67461934A
   AppsAndFeaturesEntries:
   - DisplayName: Zulu JDK 11.43 (11.0.9), 32-bit
-    DisplayVersion: "11.43"
     ProductCode: '{F6BE14B6-D657-45F6-A6F0-FBFAE9675220}'
 ManifestType: installer
 ManifestVersion: 1.1.0


### PR DESCRIPTION
Newer versions have the proper display version. Since the ISV has had the issue fixed for some time, it seems a better course of action to remove the DisplayVersion from the relatively few manifests that have it rather than updating the manifests without it. 

* microsoft/winget-cli#4459
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/152660)