### PR TITLE
Remove Display Version from Azul.Zulu.11.JDK

### DIFF
--- a/manifests/a/Azul/Zulu/11/JDK/11.45.27/Azul.Zulu.11.JDK.installer.yaml
+++ b/manifests/a/Azul/Zulu/11/JDK/11.45.27/Azul.Zulu.11.JDK.installer.yaml
@@ -23,14 +23,12 @@ Installers:
   InstallerSha256: 133D79339F6A981A25A0D812A5C33B48D700D160F0CAD9A50FE930E51D0D9DF8
   AppsAndFeaturesEntries:
   - DisplayName: Zulu JDK 11.45 (11.0.10), 64-bit
-    DisplayVersion: "11.45"
     ProductCode: '{000FC15D-583C-4679-91FC-A92374F58970}'
 - Architecture: x86
   InstallerUrl: https://cdn.azul.com/zulu/bin/zulu11.45.27-ca-jdk11.0.10-win_i686.msi
   InstallerSha256: 2DBCD769C2876AB749A5157ED7DB1C78BB356DA73EE4423A13095D9131909A2A
   AppsAndFeaturesEntries:
   - DisplayName: Zulu JDK 11.45 (11.0.10), 32-bit
-    DisplayVersion: "11.45"
     ProductCode: '{5BEDAD86-6F8A-4B4A-B847-279F1FA1889C}'
 ManifestType: installer
 ManifestVersion: 1.1.0


### PR DESCRIPTION
Newer versions have the proper display version. Since the ISV has had the issue fixed for some time, it seems a better course of action to remove the DisplayVersion from the relatively few manifests that have it rather than updating the manifests without it. 

* microsoft/winget-cli#4459
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/152661)