### PR TITLE
Fix mesonbuild.meson command name

### DIFF
--- a/manifests/m/mesonbuild/meson/0.58.1/mesonbuild.meson.installer.yaml
+++ b/manifests/m/mesonbuild/meson/0.58.1/mesonbuild.meson.installer.yaml
@@ -11,7 +11,7 @@ InstallModes:
 - silentWithProgress
 UpgradeBehavior: install
 Commands:
-- meseon
+- meson
 ReleaseDate: 2021-07-07
 Installers:
 - Architecture: x64

--- a/manifests/m/mesonbuild/meson/0.59.0/mesonbuild.meson.installer.yaml
+++ b/manifests/m/mesonbuild/meson/0.59.0/mesonbuild.meson.installer.yaml
@@ -11,7 +11,7 @@ InstallModes:
 - silentWithProgress
 UpgradeBehavior: install
 Commands:
-- meseon
+- meson
 ReleaseDate: 2021-07-18
 Installers:
 - Architecture: x64

--- a/manifests/m/mesonbuild/meson/0.59.1/mesonbuild.meson.installer.yaml
+++ b/manifests/m/mesonbuild/meson/0.59.1/mesonbuild.meson.installer.yaml
@@ -11,7 +11,7 @@ InstallModes:
 - silentWithProgress
 UpgradeBehavior: install
 Commands:
-- meseon
+- meson
 ReleaseDate: 2021-08-18
 Installers:
 - Architecture: x64

--- a/manifests/m/mesonbuild/meson/0.59.2/mesonbuild.meson.installer.yaml
+++ b/manifests/m/mesonbuild/meson/0.59.2/mesonbuild.meson.installer.yaml
@@ -11,7 +11,7 @@ InstallModes:
 - silentWithProgress
 UpgradeBehavior: install
 Commands:
-- meseon
+- meson
 ReleaseDate: 2021-09-28
 Installers:
 - Architecture: x64

--- a/manifests/m/mesonbuild/meson/0.59.3/mesonbuild.meson.installer.yaml
+++ b/manifests/m/mesonbuild/meson/0.59.3/mesonbuild.meson.installer.yaml
@@ -11,7 +11,7 @@ InstallModes:
 - silentWithProgress
 UpgradeBehavior: install
 Commands:
-- meseon
+- meson
 ReleaseDate: 2021-10-23
 Installers:
 - Architecture: x64

--- a/manifests/m/mesonbuild/meson/0.59.4/mesonbuild.meson.installer.yaml
+++ b/manifests/m/mesonbuild/meson/0.59.4/mesonbuild.meson.installer.yaml
@@ -11,7 +11,7 @@ InstallModes:
 - silentWithProgress
 UpgradeBehavior: install
 Commands:
-- meseon
+- meson
 ReleaseDate: 2021-10-28
 Installers:
 - Architecture: x64

--- a/manifests/m/mesonbuild/meson/0.60.0/mesonbuild.meson.installer.yaml
+++ b/manifests/m/mesonbuild/meson/0.60.0/mesonbuild.meson.installer.yaml
@@ -11,7 +11,7 @@ InstallModes:
 - silentWithProgress
 UpgradeBehavior: install
 Commands:
-- meseon
+- meson
 ReleaseDate: 2021-10-24
 Installers:
 - Architecture: x64

--- a/manifests/m/mesonbuild/meson/0.60.1/mesonbuild.meson.installer.yaml
+++ b/manifests/m/mesonbuild/meson/0.60.1/mesonbuild.meson.installer.yaml
@@ -11,7 +11,7 @@ InstallModes:
 - silentWithProgress
 UpgradeBehavior: install
 Commands:
-- meseon
+- meson
 ReleaseDate: 2021-11-02
 Installers:
 - Architecture: x64

--- a/manifests/m/mesonbuild/meson/0.60.2/mesonbuild.meson.installer.yaml
+++ b/manifests/m/mesonbuild/meson/0.60.2/mesonbuild.meson.installer.yaml
@@ -11,7 +11,7 @@ InstallModes:
 - silentWithProgress
 UpgradeBehavior: install
 Commands:
-- meseon
+- meson
 ReleaseDate: 2021-11-25
 Installers:
 - Architecture: x64

--- a/manifests/m/mesonbuild/meson/0.60.3/mesonbuild.meson.installer.yaml
+++ b/manifests/m/mesonbuild/meson/0.60.3/mesonbuild.meson.installer.yaml
@@ -11,7 +11,7 @@ InstallModes:
 - silentWithProgress
 UpgradeBehavior: install
 Commands:
-- meseon
+- meson
 ReleaseDate: 2021-12-22
 Installers:
 - Architecture: x64

--- a/manifests/m/mesonbuild/meson/0.61.0/mesonbuild.meson.installer.yaml
+++ b/manifests/m/mesonbuild/meson/0.61.0/mesonbuild.meson.installer.yaml
@@ -12,7 +12,7 @@ InstallModes:
 - silentWithProgress
 UpgradeBehavior: install
 Commands:
-- meseon
+- meson
 ReleaseDate: 2022-01-10
 Installers:
 - Architecture: x64

--- a/manifests/m/mesonbuild/meson/0.61.1/mesonbuild.meson.installer.yaml
+++ b/manifests/m/mesonbuild/meson/0.61.1/mesonbuild.meson.installer.yaml
@@ -12,7 +12,7 @@ InstallModes:
 - silentWithProgress
 UpgradeBehavior: install
 Commands:
-- meseon
+- meson
 ReleaseDate: 2022-01-17
 Installers:
 - Architecture: x64

--- a/manifests/m/mesonbuild/meson/0.61.2/mesonbuild.meson.installer.yaml
+++ b/manifests/m/mesonbuild/meson/0.61.2/mesonbuild.meson.installer.yaml
@@ -13,7 +13,7 @@ InstallModes:
 - silentWithProgress
 UpgradeBehavior: install
 Commands:
-- meseon
+- meson
 ReleaseDate: 2022-02-14
 Installers:
 - Architecture: x64

--- a/manifests/m/mesonbuild/meson/0.61.3/mesonbuild.meson.installer.yaml
+++ b/manifests/m/mesonbuild/meson/0.61.3/mesonbuild.meson.installer.yaml
@@ -13,7 +13,7 @@ InstallModes:
 - silentWithProgress
 UpgradeBehavior: install
 Commands:
-- meseon
+- meson
 ReleaseDate: 2022-03-14
 Installers:
 - Architecture: x64

--- a/manifests/m/mesonbuild/meson/0.61.4/mesonbuild.meson.installer.yaml
+++ b/manifests/m/mesonbuild/meson/0.61.4/mesonbuild.meson.installer.yaml
@@ -13,7 +13,7 @@ InstallModes:
 - silentWithProgress
 UpgradeBehavior: install
 Commands:
-- meseon
+- meson
 ReleaseDate: 2022-03-25
 Installers:
 - Architecture: x64

--- a/manifests/m/mesonbuild/meson/0.62.0/mesonbuild.meson.installer.yaml
+++ b/manifests/m/mesonbuild/meson/0.62.0/mesonbuild.meson.installer.yaml
@@ -13,7 +13,7 @@ InstallModes:
 - silentWithProgress
 UpgradeBehavior: install
 Commands:
-- meseon
+- meson
 ReleaseDate: 2022-03-21
 Installers:
 - Architecture: x64

--- a/manifests/m/mesonbuild/meson/0.62.1/mesonbuild.meson.installer.yaml
+++ b/manifests/m/mesonbuild/meson/0.62.1/mesonbuild.meson.installer.yaml
@@ -13,7 +13,7 @@ InstallModes:
 - silentWithProgress
 UpgradeBehavior: install
 Commands:
-- meseon
+- meson
 ReleaseDate: 2022-04-23
 Installers:
 - Architecture: x64

--- a/manifests/m/mesonbuild/meson/0.63.0/mesonbuild.meson.installer.yaml
+++ b/manifests/m/mesonbuild/meson/0.63.0/mesonbuild.meson.installer.yaml
@@ -13,7 +13,7 @@ InstallModes:
 - silentWithProgress
 UpgradeBehavior: install
 Commands:
-- meseon
+- meson
 ReleaseDate: 2022-07-03
 Installers:
 - Architecture: x64

--- a/manifests/m/mesonbuild/meson/0.63.1/mesonbuild.meson.installer.yaml
+++ b/manifests/m/mesonbuild/meson/0.63.1/mesonbuild.meson.installer.yaml
@@ -13,7 +13,7 @@ InstallModes:
 - silentWithProgress
 UpgradeBehavior: install
 Commands:
-- meseon
+- meson
 ReleaseDate: 2022-08-13
 Installers:
 - Architecture: x64

--- a/manifests/m/mesonbuild/meson/0.63.2/mesonbuild.meson.installer.yaml
+++ b/manifests/m/mesonbuild/meson/0.63.2/mesonbuild.meson.installer.yaml
@@ -13,7 +13,7 @@ InstallModes:
 - silentWithProgress
 UpgradeBehavior: install
 Commands:
-- meseon
+- meson
 ReleaseDate: 2022-09-03
 Installers:
 - Architecture: x64

--- a/manifests/m/mesonbuild/meson/0.63.3/mesonbuild.meson.installer.yaml
+++ b/manifests/m/mesonbuild/meson/0.63.3/mesonbuild.meson.installer.yaml
@@ -13,7 +13,7 @@ InstallModes:
 - silentWithProgress
 UpgradeBehavior: install
 Commands:
-- meseon
+- meson
 ReleaseDate: 2022-10-05
 Installers:
 - Architecture: x64

--- a/manifests/m/mesonbuild/meson/0.64.0/mesonbuild.meson.installer.yaml
+++ b/manifests/m/mesonbuild/meson/0.64.0/mesonbuild.meson.installer.yaml
@@ -13,7 +13,7 @@ InstallModes:
 - silentWithProgress
 UpgradeBehavior: install
 Commands:
-- meseon
+- meson
 ReleaseDate: 2022-11-06
 Installers:
 - Architecture: x64

--- a/manifests/m/mesonbuild/meson/0.64.1/mesonbuild.meson.installer.yaml
+++ b/manifests/m/mesonbuild/meson/0.64.1/mesonbuild.meson.installer.yaml
@@ -13,7 +13,7 @@ InstallModes:
 - silentWithProgress
 UpgradeBehavior: install
 Commands:
-- meseon
+- meson
 ReleaseDate: 2022-11-22
 Installers:
 - Architecture: x64

--- a/manifests/m/mesonbuild/meson/1.0.0/mesonbuild.meson.installer.yaml
+++ b/manifests/m/mesonbuild/meson/1.0.0/mesonbuild.meson.installer.yaml
@@ -13,7 +13,7 @@ InstallModes:
 - silentWithProgress
 UpgradeBehavior: install
 Commands:
-- meseon
+- meson
 ReleaseDate: 2022-12-23
 Installers:
 - Architecture: x64

--- a/manifests/m/mesonbuild/meson/1.0.1/mesonbuild.meson.installer.yaml
+++ b/manifests/m/mesonbuild/meson/1.0.1/mesonbuild.meson.installer.yaml
@@ -13,7 +13,7 @@ InstallModes:
 - silentWithProgress
 UpgradeBehavior: install
 Commands:
-- meseon
+- meson
 ReleaseDate: 2023-02-23
 Installers:
 - Architecture: x64

--- a/manifests/m/mesonbuild/meson/1.1.0/mesonbuild.meson.installer.yaml
+++ b/manifests/m/mesonbuild/meson/1.1.0/mesonbuild.meson.installer.yaml
@@ -13,7 +13,7 @@ InstallModes:
 - silentWithProgress
 UpgradeBehavior: install
 Commands:
-- meseon
+- meson
 ReleaseDate: 2023-04-10
 Installers:
 - Architecture: x64

--- a/manifests/m/mesonbuild/meson/1.1.1/mesonbuild.meson.installer.yaml
+++ b/manifests/m/mesonbuild/meson/1.1.1/mesonbuild.meson.installer.yaml
@@ -12,7 +12,7 @@ InstallModes:
 - silentWithProgress
 UpgradeBehavior: install
 Commands:
-- meseon
+- meson
 ReleaseDate: 2023-05-25
 AppsAndFeaturesEntries:
 - UpgradeCode: '{141527EE-E28A-4D14-97A4-92E6075D28B2}'

--- a/manifests/m/mesonbuild/meson/1.2.0/mesonbuild.meson.installer.yaml
+++ b/manifests/m/mesonbuild/meson/1.2.0/mesonbuild.meson.installer.yaml
@@ -12,7 +12,7 @@ InstallModes:
 - silentWithProgress
 UpgradeBehavior: install
 Commands:
-- meseon
+- meson
 ProductCode: '{3DF7FB93-1766-411E-B976-FDEC0C44430E}'
 ReleaseDate: 2023-07-16
 AppsAndFeaturesEntries:

--- a/manifests/m/mesonbuild/meson/1.2.1/mesonbuild.meson.installer.yaml
+++ b/manifests/m/mesonbuild/meson/1.2.1/mesonbuild.meson.installer.yaml
@@ -12,7 +12,7 @@ InstallModes:
 - silentWithProgress
 UpgradeBehavior: install
 Commands:
-- meseon
+- meson
 ProductCode: '{5DEB0D5F-DCCB-49A3-974D-2EC43942C5ED}'
 ReleaseDate: 2023-08-08
 AppsAndFeaturesEntries:

--- a/manifests/m/mesonbuild/meson/1.2.2/mesonbuild.meson.installer.yaml
+++ b/manifests/m/mesonbuild/meson/1.2.2/mesonbuild.meson.installer.yaml
@@ -12,7 +12,7 @@ InstallModes:
 - silentWithProgress
 UpgradeBehavior: install
 Commands:
-- meseon
+- meson
 ProductCode: '{FF361687-E25C-43C4-877A-8A50A218FF6B}'
 ReleaseDate: 2023-09-29
 AppsAndFeaturesEntries:

--- a/manifests/m/mesonbuild/meson/1.4.0/mesonbuild.meson.installer.yaml
+++ b/manifests/m/mesonbuild/meson/1.4.0/mesonbuild.meson.installer.yaml
@@ -12,7 +12,7 @@ InstallModes:
 - silentWithProgress
 UpgradeBehavior: install
 Commands:
-- meseon
+- meson
 ProductCode: '{3DE65131-5503-4A06-B2A4-9F87E17CAA84}'
 AppsAndFeaturesEntries:
 - UpgradeCode: '{141527EE-E28A-4D14-97A4-92E6075D28B2}'


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

Seems the command name is accidentally misspelled for all Meson versions.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/154170)