### PR TITLE
Add missing Mumble Client vcredist dependency

### DIFF
--- a/manifests/m/Mumble/Mumble/Client/1.5.634/Mumble.Mumble.Client.installer.yaml
+++ b/manifests/m/Mumble/Mumble/Client/1.5.634/Mumble.Mumble.Client.installer.yaml
@@ -11,6 +11,9 @@ InstallModes:
 - silentWithProgress
 UpgradeBehavior: install
 ReleaseDate: 2024-05-19
+Dependencies:
+  PackageDependencies:
+     - PackageIdentifier: Microsoft.VCRedist.2015+.x64
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/mumble-voip/mumble/releases/download/v1.5.634/mumble_client-1.5.634.x64.msi


### PR DESCRIPTION
Tested in Windows Sandbox via `.\Tools\SandboxTest.ps1`. Fails to launch before. Now launches.

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/154583)