### PR TITLE
Fix incorrect download links in Tyrrrz.LightBulb.installer.yaml

### DIFF
--- a/manifests/t/Tyrrrz/LightBulb/2.5.2/Tyrrrz.LightBulb.installer.yaml
+++ b/manifests/t/Tyrrrz/LightBulb/2.5.2/Tyrrrz.LightBulb.installer.yaml
@@ -8,8 +8,14 @@ InstallerSwitches:
   Custom: /NORESTART
 ReleaseDate: 2024-05-30
 Installers:
-- Architecture: x86
+- Architecture: arm64
   InstallerUrl: https://github.com/Tyrrrz/LightBulb/releases/download/2.5.2/LightBulb-Installer.win-arm64.exe
   InstallerSha256: 7588C39390958B5A5C0B9B41E2E7875A64A314210B02705E5E0A28F597A3847D
+- Architecture: x64
+  InstallerUrl: https://github.com/Tyrrrz/LightBulb/releases/download/2.5.2/LightBulb-Installer.win-x64.exe
+  InstallerSha256: 77839209237275B36CDB4FFD60CB5B7F10C30562540A001ACE5B33DBFD01D52D
+- Architecture: x86
+  InstallerUrl: https://github.com/Tyrrrz/LightBulb/releases/download/2.5.2/LightBulb-Installer.win-x86.exe
+  InstallerSha256: D7DD26A2AD6A9F00379F379CD1DECA2FDA765ADFD95797D36379FA0F0147E8F6
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/t/Tyrrrz/LightBulb/2.5.2/Tyrrrz.LightBulb.installer.yaml
+++ b/manifests/t/Tyrrrz/LightBulb/2.5.2/Tyrrrz.LightBulb.installer.yaml
@@ -13,7 +13,7 @@ Installers:
   InstallerSha256: 7588C39390958B5A5C0B9B41E2E7875A64A314210B02705E5E0A28F597A3847D
 - Architecture: x64
   InstallerUrl: https://github.com/Tyrrrz/LightBulb/releases/download/2.5.2/LightBulb-Installer.win-x64.exe
-  InstallerSha256: 77839209237275B36CDB4FFD60CB5B7F10C30562540A001ACE5B33DBFD01D52D
+  InstallerSha256: 3FE3E66731CDC2FE08342AA818A9D4A26536390117BA92E34BD6FC32F7D4E51C
 - Architecture: x86
   InstallerUrl: https://github.com/Tyrrrz/LightBulb/releases/download/2.5.2/LightBulb-Installer.win-x86.exe
   InstallerSha256: D7DD26A2AD6A9F00379F379CD1DECA2FDA765ADFD95797D36379FA0F0147E8F6


### PR DESCRIPTION
#155718 unfortunately introduced incorrect download URLs, leading `x86` users to the `arm64` download

---

Checklist for Pull Requests
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/155887)