### PR TITLE
Microsoft.DotNet.SDK.6 version 6.0.423

### DIFF
--- a/manifests/m/Microsoft/DotNet/SDK/6/6.0.423/Microsoft.DotNet.SDK.6.installer.yaml
+++ b/manifests/m/Microsoft/DotNet/SDK/6/6.0.423/Microsoft.DotNet.SDK.6.installer.yaml
@@ -1,0 +1,44 @@
+# Created using wingetcreate 1.0.4.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: Microsoft.DotNet.SDK.6
+PackageVersion: 6.0.423
+MinimumOSVersion: 6.1.7601
+InstallerSwitches:
+  Silent: /quiet
+  SilentWithProgress: /passive
+  Custom: /norestart
+Installers:
+- Architecture: arm64
+  InstallerType: burn
+  InstallerUrl: https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.423/dotnet-sdk-6.0.423-win-arm64.exe
+  InstallerSha256: 6B37EFE20B5E76C1CEEAB4EF717E3CAD820B119AEFDB39A57B9C15A51688423F
+  ProductCode: '{f09675ba-8cad-40fb-8e57-ce2570dc54c3}'
+  AppsAndFeaturesEntries:
+  - DisplayName: Microsoft .NET SDK 6.0.423 (arm64)
+    Publisher: Microsoft Corporation
+    DisplayVersion: 6.4.2324.27026
+    ProductCode: '{f09675ba-8cad-40fb-8e57-ce2570dc54c3}'
+- Architecture: x64
+  InstallerType: burn
+  InstallerUrl: https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.423/dotnet-sdk-6.0.423-win-x64.exe
+  InstallerSha256: 304AE842BA21CE5166827268591660FAC6E29BE9413587617C519FB3882F9104
+  ProductCode: '{3c490016-1c7d-43ba-b0b7-a9d25b431c3c}'
+  AppsAndFeaturesEntries:
+  - DisplayName: Microsoft .NET SDK 6.0.423 (x64)
+    Publisher: Microsoft Corporation
+    DisplayVersion: 6.4.2324.27026
+    ProductCode: '{3c490016-1c7d-43ba-b0b7-a9d25b431c3c}'
+- Architecture: x86
+  InstallerType: burn
+  InstallerUrl: https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.423/dotnet-sdk-6.0.423-win-x86.exe
+  InstallerSha256: D6457A281A0C9AD9CEC42382567848D8259AEC819977F912C9C2EAB7BC9601C4
+  ProductCode: '{f4ce9de4-9fed-490b-ab4d-3eda659d3126}'
+  AppsAndFeaturesEntries:
+  - DisplayName: Microsoft .NET SDK 6.0.423 (x86)
+    Publisher: Microsoft Corporation
+    DisplayVersion: 6.4.2324.27026
+    ProductCode: '{f4ce9de4-9fed-490b-ab4d-3eda659d3126}'
+ManifestType: installer
+ManifestVersion: 1.6.0
+

--- a/manifests/m/Microsoft/DotNet/SDK/6/6.0.423/Microsoft.DotNet.SDK.6.locale.en-US.yaml
+++ b/manifests/m/Microsoft/DotNet/SDK/6/6.0.423/Microsoft.DotNet.SDK.6.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# Created using wingetcreate 1.0.4.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: Microsoft.DotNet.SDK.6
+PackageVersion: 6.0.423
+PackageLocale: en-US
+Publisher: Microsoft Corporation
+PackageName: Microsoft .NET SDK 6.0
+PackageUrl: https://dotnet.microsoft.com
+License: MIT
+ShortDescription: .NET is a free, cross-platform, open-source developer platform for building many different types of applications.
+Moniker: dotnet-sdk-6
+Tags:
+- .NET
+- .NET Core
+- dotnet
+- net
+- C#
+- csharp
+- F#
+- fsharp
+- VB
+- Visual Basic
+- SDK
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0
+

--- a/manifests/m/Microsoft/DotNet/SDK/6/6.0.423/Microsoft.DotNet.SDK.6.yaml
+++ b/manifests/m/Microsoft/DotNet/SDK/6/6.0.423/Microsoft.DotNet.SDK.6.yaml
@@ -1,0 +1,9 @@
+# Created using wingetcreate 1.0.4.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: Microsoft.DotNet.SDK.6
+PackageVersion: 6.0.423
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0
+


### PR DESCRIPTION
Restores Microsoft.DotNet.SDK.6 version 6.0.423 with the correct checksums after its deletion in https://github.com/microsoft/winget-pkgs/pull/155820.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/156521)