### PR TITLE
Microsoft.DotNet.AspNetCore.6 version 6.0.31

### DIFF
--- a/manifests/m/Microsoft/DotNet/AspNetCore/6/6.0.31/Microsoft.DotNet.AspNetCore.6.installer.yaml
+++ b/manifests/m/Microsoft/DotNet/AspNetCore/6/6.0.31/Microsoft.DotNet.AspNetCore.6.installer.yaml
@@ -12,7 +12,7 @@ Installers:
 - Architecture: x64
   InstallerType: burn
   InstallerUrl: https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/6.0.31/aspnetcore-runtime-6.0.31-win-x64.exe
-  InstallerSha256: AD0AA75D250050F7569907AB3EE92298649AB9EDDE6298CC1241FB363A19057E
+  InstallerSha256: 368E52BCB6787AAB1895B7E0300ED028DCDD6D02BEF7F83AB79C9E26CF2C1FCF
   ProductCode: '{13742479-a663-4fb5-8e7d-38d026d78a02}'
   AppsAndFeaturesEntries:
   - DisplayName: Microsoft ASP.NET Core 6.0.31 - Shared Framework (x64)
@@ -22,7 +22,7 @@ Installers:
 - Architecture: x86
   InstallerType: burn
   InstallerUrl: https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/6.0.31/aspnetcore-runtime-6.0.31-win-x86.exe
-  InstallerSha256: EFB37B6BE3FB80FF05EFFF9B16906624741006184531857CB636B1446CC1701C
+  InstallerSha256: B3E126F814993851FDC591F29276F72377AC042D6EC49127A8E82AAB05E50DCF
   ProductCode: '{ce0df0a0-9639-404a-ae53-46a6d0ffca5a}'
   AppsAndFeaturesEntries:
   - DisplayName: Microsoft ASP.NET Core 6.0.31 - Shared Framework (x86)


### PR DESCRIPTION
Updates Microsoft.DotNet.AspNetCore.6 version 6.0.31 with the correct SHAs.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/156525)