### PR TITLE
Remove DisplayVersion equal to DisplayVersion in Guru3D.Afterburner 

### DIFF
--- a/manifests/g/Guru3D/Afterburner/4.6.5/Guru3D.Afterburner.installer.yaml
+++ b/manifests/g/Guru3D/Afterburner/4.6.5/Guru3D.Afterburner.installer.yaml
@@ -1,5 +1,4 @@
-# Created using wingetcreate 1.2.5.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: Guru3D.Afterburner
 PackageVersion: 4.6.5
@@ -21,6 +20,5 @@ Installers:
   UpgradeBehavior: install
   AppsAndFeaturesEntries:
   - DisplayName: MSI Afterburner 4.6.5
-    DisplayVersion: 4.6.5
 ManifestType: installer
-ManifestVersion: 1.4.0
+ManifestVersion: 1.6.0

--- a/manifests/g/Guru3D/Afterburner/4.6.5/Guru3D.Afterburner.locale.en-US.yaml
+++ b/manifests/g/Guru3D/Afterburner/4.6.5/Guru3D.Afterburner.locale.en-US.yaml
@@ -1,16 +1,15 @@
-# Created using wingetcreate 1.2.5.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.4.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: Guru3D.Afterburner
 PackageVersion: 4.6.5
 PackageLocale: en-US
 Publisher: MSI Co., LTD
 PublisherUrl: https://www.msi.com/Landing/afterburner/graphics-cards
-PackageName: Afterburner
+PrivacyUrl: https://www.msi.com/page/privacy-policy
+PackageName: MSI Afterburner
 License: Freeware
 ShortDescription: MSI Afterburner monitoring and GPU overclocking tool
 ManifestType: defaultLocale
-ManifestVersion: 1.4.0
 Moniker: afterburner
 Tags:
   - gpu
@@ -36,3 +35,4 @@ ReleaseNotes: |-
   - Update server location changed to new URL inside update checking system
   - RivaTuner Statistics Server upgraded to v7.3.4 with more than 100 compatibility enhancements, changes and new features, including improved OverlayEditor plugin and upgraded DesktopOverlayHost utility.
 ReleaseNotesUrl: https://www.guru3d.com/news-story/version-4-6-5-of-msi-afterburner-now-available-for-download.html
+ManifestVersion: 1.6.0

--- a/manifests/g/Guru3D/Afterburner/4.6.5/Guru3D.Afterburner.yaml
+++ b/manifests/g/Guru3D/Afterburner/4.6.5/Guru3D.Afterburner.yaml
@@ -1,8 +1,7 @@
-# Created using wingetcreate 1.2.5.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.4.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: Guru3D.Afterburner
 PackageVersion: 4.6.5
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.4.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
DisplayVersion should not be used when it's equal to PackageVersion. This creates unnecessary version mapping on the client side and can lead to infinite upgrade problems.



Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/157597)