### PR TITLE
FIX: BlenderFoundation.Blender.LTS.3.6 version 3.6.12 downloading version 3.6.2

### DIFF
--- a/manifests/b/BlenderFoundation/Blender/LTS/3/6/3.6.12/BlenderFoundation.Blender.LTS.3.6.installer.yaml
+++ b/manifests/b/BlenderFoundation/Blender/LTS/3/6/3.6.12/BlenderFoundation.Blender.LTS.3.6.installer.yaml
@@ -23,8 +23,8 @@ FileExtensions:
 ProductCode: '{74317F41-A4D5-4A90-A22E-CADBBA452983}'
 Installers:
 - Architecture: x64
-  InstallerUrl: https://download.blender.org/release/Blender3.6/blender-3.6.2-windows-x64.msi
-  InstallerSha256: E39904678DF0DDEA93E83F317B4CC9EA6803EF0ECE3D0E31FB944FBA241DEF01
+  InstallerUrl: https://download.blender.org/release/Blender3.6/blender-3.6.12-windows-x64.msi
+  InstallerSha256: D2BF006E568F4B4076331D074734D3078E4CEB0DF4EFE4D1BD63FA193C66F71A
 ManifestType: installer
 ManifestVersion: 1.6.0
-ReleaseDate: 2024-04-16
+ReleaseDate: 2024-05-21


### PR DESCRIPTION
…sion 3.6.2

The manifest file for the BlenderFoundation.Blender.LTS.3.6 version 3.6.12 was downloading the wrong version of blender

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] This PR only modifies one (1) manifest
- [X] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [X] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/157812)