### PR TITLE
RiotGames.LeagueOfLegends.KR: add ko-KR locale

### DIFF
--- a/manifests/r/RiotGames/LeagueOfLegends/KR/88.0.1.1613/RiotGames.LeagueOfLegends.KR.locale.ko-KR.yaml
+++ b/manifests/r/RiotGames/LeagueOfLegends/KR/88.0.1.1613/RiotGames.LeagueOfLegends.KR.locale.ko-KR.yaml
@@ -1,0 +1,22 @@
+# Automatically updated by the winget bot at 2024/Jun/10
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: RiotGames.LeagueOfLegends.KR
+PackageVersion: 88.0.1.1613
+PackageLocale: ko-KR
+Publisher: Riot Games, Inc
+PublisherUrl: https://www.riotgames.com/
+PublisherSupportUrl: https://support.riotgames.com/
+PrivacyUrl: https://legal.kr.riotgames.com/privacy
+Author: Riot Games, Inc.
+PackageName: 리그 오브 레전드 (한국 서버)
+PackageUrl: https://www.leagueoflegends.com/
+License: Proprietary
+LicenseUrl: https://legal.kr.riotgames.com/tos
+Copyright: Copyright © 2024 Riot Games
+ShortDescription: 140개 이상의 챔피언과 함께하는 전설적인 플레이를 위한 팀 기반 게임
+Tags:
+- 게임
+ReleaseNotesUrl: https://www.leagueoflegends.com/en-us/news/tags/patch-notes/
+ManifestType: locale
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

>[!NOTE]
>
> I'm not sure if ko-KR should be the default locale (given this is KR client and KR server is segregated from rest of the world ([Account transfer "Not applicable for KR server"](https://support-leagueoflegends.riotgames.com/hc/ko/articles/201751924-%EA%B3%84%EC%A0%95-%EC%9D%B4%EC%A0%84-FAQ), ["KR server has regional ID requirement"](https://leagueoflegends.fandom.com/wiki/Servers#Transferring_to_another_server)),
> but I am not making the determination here.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/158362)