### PR TITLE
Update manifests: karakun.OpenWebStart version 1.10.1

### DIFF
--- a/manifests/k/karakun/OpenWebStart/1.10.1/karakun.OpenWebStart.installer.yaml
+++ b/manifests/k/karakun/OpenWebStart/1.10.1/karakun.OpenWebStart.installer.yaml
@@ -1,10 +1,10 @@
-# Created with komac v2.2.1
+# Created with komac v2.3.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: karakun.OpenWebStart
 PackageVersion: 1.10.1
 InstallerLocale: en-US
-InstallerType: portable
+InstallerType: exe
 Scope: machine
 InstallModes:
 - interactive

--- a/manifests/k/karakun/OpenWebStart/1.10.1/karakun.OpenWebStart.locale.en-US.yaml
+++ b/manifests/k/karakun/OpenWebStart/1.10.1/karakun.OpenWebStart.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# Created with komac v2.2.1
+# Created with komac v2.3.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: karakun.OpenWebStart
@@ -21,7 +21,8 @@ Tags:
 - jre
 - web
 ReleaseNotes: |-
-  This release that provides the following fixes:- Fix Desktop Shortcuts creation on macOS Aarch64
+  This release that provides the following fixes:
+  - Fix Desktop Shortcuts creation on macOS Aarch64
   - Fix code signature for macOS installer and apps: 580
   - Fix NoClassDefFoundError when using PAC: 583
   - Fix Direct start of Jnlp on macOS: 586

--- a/manifests/k/karakun/OpenWebStart/1.10.1/karakun.OpenWebStart.yaml
+++ b/manifests/k/karakun/OpenWebStart/1.10.1/karakun.OpenWebStart.yaml
@@ -1,4 +1,4 @@
-# Created with komac v2.2.1
+# Created with komac v2.3.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: karakun.OpenWebStart


### PR DESCRIPTION
## Details

- Change `InstallerType` of the package
- Issue seems introduced by Komac, since it detects the package as "portable" instead of "exe"

## Checklist for Pull Requests

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- Resolve #159914
- Related #158925

## Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/159915)