### PR TITLE
Set GeoID in sandbox to prevent msstore source errors

### DIFF
--- a/Tools/SandboxTest.ps1
+++ b/Tools/SandboxTest.ps1
@@ -22,6 +22,7 @@ $ErrorActionPreference = 'Stop'
 
 $useNuGetForMicrosoftUIXaml = $false
 $mapFolder = (Resolve-Path -Path $MapFolder).Path
+$geoID = (Get-WinHomeLocation).GeoID
 
 if (-Not (Test-Path -Path $mapFolder -PathType Container)) {
   Write-Error -Category InvalidArgument -Message 'The provided MapFolder is not a folder.'
@@ -305,6 +306,7 @@ winget settings --Enable LocalManifestFiles
 winget settings --Enable LocalArchiveMalwareScanOverride
 copy -Path $settingsPathInSandbox -Destination C:\Users\WDAGUtilityAccount\AppData\Local\Packages\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe\LocalState\settings.json
 `$originalARP = Get-ARPTable
+Set-WinHomeLocation -GeoID $geoID
 Write-Host @'
 
 

--- a/Tools/SandboxTest.ps1
+++ b/Tools/SandboxTest.ps1
@@ -309,7 +309,6 @@ copy -Path $settingsPathInSandbox -Destination C:\Users\WDAGUtilityAccount\AppDa
 Set-WinHomeLocation -GeoID $geoID
 Write-Host @'
 
-
 --> Installing the Manifest $manifestFileName
 
 '@
@@ -326,7 +325,6 @@ Write-Host @'
 --> Comparing ARP Entries
 '@
 (Compare-Object (Get-ARPTable) `$originalARP -Property DisplayName,DisplayVersion,Publisher,ProductCode,Scope)| Select-Object -Property * -ExcludeProperty SideIndicator | Format-Table
-
 "@
 }
 
@@ -347,10 +345,6 @@ $Script
 
 "@
 }
-
-$bootstrapPs1Content += @'
-Write-Host
-'@
 
 $bootstrapPs1FileName = 'Bootstrap.ps1'
 $bootstrapPs1Content | Out-File (Join-Path -Path $tempFolder -ChildPath $bootstrapPs1FileName)


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Is there a linked Issue?
  - microsoft/winget-cli#4328

This PR makes it so that the GeoID of the sandbox is set to the same GeoID of the host machine when using the sandbox test script

Manifests
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

@denelon @stephengillie

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/160554)