### PR TITLE
Add AppsAndFeaturesEntries InstallerType for nested installer

### DIFF
--- a/manifests/s/SlackTechnologies/Slack/4.39.89/SlackTechnologies.Slack.installer.yaml
+++ b/manifests/s/SlackTechnologies/Slack/4.39.89/SlackTechnologies.Slack.installer.yaml
@@ -22,6 +22,8 @@ Installers:
 - InstallerLocale: en-US
   Architecture: x64
   InstallerType: wix
+  AppsAndFeaturesEntries:
+    - InstallerType: exe
   Scope: machine
   InstallerUrl: https://downloads.slack-edge.com/desktop-releases/windows/x64/4.39.89/slack-standalone-4.39.89.0.msi
   InstallerSha256: 55C0FCD87B65C997A9ADF8D4B4B72CF09F0818142B9622684B5464E4AEC1E52A


### PR DESCRIPTION
The package is an EXE bundled in a WiX installer. From my local winget upgrade log

```
[CLI ] Installer [X64,wix,Machine,en-US] not applicable: Installed package type 'exe' is not compatible with installer type wix
```

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/162351)