### PR TITLE
PowerToys fixing 82.1 release

### DIFF
--- a/manifests/m/Microsoft/PowerToys/0.82.1/Microsoft.PowerToys.installer.yaml
+++ b/manifests/m/Microsoft/PowerToys/0.82.1/Microsoft.PowerToys.installer.yaml
@@ -1,0 +1,32 @@
+# Created using wingetcreate 1.6.1.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: Microsoft.PowerToys
+PackageVersion: 0.82.1
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17134.0
+InstallerType: burn
+InstallerSwitches:
+  Silent: /quiet /norestart
+  SilentWithProgress: /quiet /norestart
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  Scope: user
+  InstallerUrl: https://github.com/microsoft/PowerToys/releases/download/V0.82.1/PowerToysUserSetup-0.82.1-x64.exe
+  InstallerSha256: B594C9A32125079186DCE776431E2DC77B896774D2AEE2ACF51BAB8791683485
+- Architecture: x64
+  Scope: machine
+  InstallerUrl: https://github.com/microsoft/PowerToys/releases/download/V0.82.1/PowerToysSetup-0.82.1-x64.exe
+  InstallerSha256: B8FA7E7C8F88B69E070E234F561D32807634E2E9D782EDBB9DC35F3A454F2264
+- Architecture: arm64
+  Scope: user
+  InstallerUrl: https://github.com/microsoft/PowerToys/releases/download/V0.82.1/PowerToysUserSetup-0.82.1-arm64.exe
+  InstallerSha256: 41C1D9C0E8FA7EFFCE6F605C92C143AE933F8C999A2933A4D9D1115B16F14F67
+- Architecture: arm64
+  Scope: machine
+  InstallerUrl: https://github.com/microsoft/PowerToys/releases/download/V0.82.1/PowerToysSetup-0.82.1-arm64.exe
+  InstallerSha256: 58F22306F22CF9878C6DDE6AC128388DF4DFF78B76165E38A695490E55B3C8C4
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/Microsoft/PowerToys/0.82.1/Microsoft.PowerToys.locale.en-US.yaml
+++ b/manifests/m/Microsoft/PowerToys/0.82.1/Microsoft.PowerToys.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# Created using wingetcreate 1.6.1.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: Microsoft.PowerToys
+PackageVersion: 0.82.1
+PackageLocale: en-US
+Publisher: Microsoft Corporation
+PublisherUrl: https://github.com/microsoft/PowerToys
+PublisherSupportUrl: https://github.com/microsoft/PowerToys/issues
+PrivacyUrl: https://privacy.microsoft.com/en-us/privacystatement
+Author: Microsoft Corporation
+PackageName: PowerToys (Preview)
+PackageUrl: https://github.com/microsoft/PowerToys
+License: MIT
+LicenseUrl: https://github.com/microsoft/PowerToys/blob/master/LICENSE
+Copyright: Copyright (c) Microsoft Corporation. All rights reserved.
+CopyrightUrl: https://github.com/microsoft/PowerToys/blob/main/LICENSE
+ShortDescription: Microsoft PowerToys is a set of utilities for power users to tune and streamline their Windows experience for greater productivity.
+Description: |-
+  Microsoft PowerToys is a set of utilities for power users to tune and streamline their Windows experience for greater productivity.
+  Inspired by the Windows 95 era PowerToys project, this reboot provides power users with ways to squeeze more efficiency out of the Windows 10 shell and customize it for individual workflows.
+Moniker: powertoys
+Tags:
+- colorpicker
+- fancyzones
+- fileexplorer
+- imageresizer
+- keyboardmanager
+- power-toys
+- powerrename
+- powertoys
+- powertoys-run
+- windows-key-shortcut-guide
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/Microsoft/PowerToys/0.82.1/Microsoft.PowerToys.yaml
+++ b/manifests/m/Microsoft/PowerToys/0.82.1/Microsoft.PowerToys.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.6.1.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: Microsoft.PowerToys
+PackageVersion: 0.82.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
@mdanish-kh called out a great oops on my part creating the tag and our script didn't do it correctly.

The script put it in the wrong folder an version number was screwed up

Checklist for Pull Requests
- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/162735)