### PR TITLE
Add back DisplayVersion for arch1t3cht.Aegisub

### DIFF
--- a/manifests/a/arch1t3cht/Aegisub/9706--cibuilds-20caaabc0/arch1t3cht.Aegisub.installer.yaml
+++ b/manifests/a/arch1t3cht/Aegisub/9706--cibuilds-20caaabc0/arch1t3cht.Aegisub.installer.yaml
@@ -17,7 +17,7 @@ FileExtensions:
 - vpy
 AppsAndFeaturesEntries:
 - DisplayName: Aegisub 9706-cibuilds-20caaabc0
-  # DisplayVersion: 3.2.2 # Display Version overlaps with previous builds
+  DisplayVersion: 3.2.2
   ProductCode: '{24BC8B57-716C-444F-B46B-A3349B9164C5}_is1'
 Installers:
 - Architecture: x64


### PR DESCRIPTION
There are no previous builds in the repo, so it's safe to add back DisplayVersion. While users on older installed builds that share the same `3.2.2` DisplayVersion may not get this version as an upgrade, I believe this change is a better option to avoid users on the latest version getting stuck in an upgrade loop


Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Is there a linked Issue?
	- Resolves #162841


Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/162852)