### PR TITLE
Use x64-specific installer: RedHat.Podman-Desktop v1.11.1

### DIFF
--- a/manifests/r/RedHat/Podman-Desktop/1.11.1/RedHat.Podman-Desktop.installer.yaml
+++ b/manifests/r/RedHat/Podman-Desktop/1.11.1/RedHat.Podman-Desktop.installer.yaml
@@ -6,8 +6,8 @@ PackageVersion: 1.11.1
 InstallerType: nullsoft
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/containers/podman-desktop/releases/download/v1.11.1/podman-desktop-1.11.1-setup.exe
-  InstallerSha256: C1E047D8B63ECD2B3CDD94FD5ED48B6FD43A4AE73F8AF8A02E61317EFB0EB235
+  InstallerUrl: https://github.com/containers/podman-desktop/releases/download/v1.11.1/podman-desktop-1.11.1-setup-x64.exe
+  InstallerSha256: DF8DEA0EC42AF15B8C2618ED56DB16872E816A7C8467DED85F406A04106F8F1C
 - Architecture: arm64
   InstallerUrl: https://github.com/containers/podman-desktop/releases/download/v1.11.1/podman-desktop-1.11.1-setup-arm64.exe
   InstallerSha256: 035D1026AF6CEE4612A9B5557317047A00FE8F9D5985BD968F5B9EC9D40264BC


### PR DESCRIPTION
I learned recently that the installer currently specified in the manifest as x64-specific actually includes builds for multiple architectures.  This change optimizes the manifest by ensuring x64 machines only download the x64 installer.

Checklist for Pull Requests
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] This PR only modifies one (1) manifest
- [X] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [X] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/164235)