### PR TITLE
Fix for automergeTriggers.yml (resource management app)

### DIFF
--- a/.github/policies/automergeTriggers.yml
+++ b/.github/policies/automergeTriggers.yml
@@ -19,16 +19,5 @@ configuration:
         then:
           - enableAutoMerge:
               mergeMethod: Squash
-      - description: Disable Auto Merge when the "Validation-Completed" label is not present
-        if:
-          - payloadType: Pull_Request
-          - or:
-              - labelRemoved:
-                  label: Validation-Completed
-              - not:
-                  hasLabel:
-                    label: Validation-Completed
-        then:
-          - disableAutoMerge
 onFailure:
 onSuccess:


### PR DESCRIPTION
Disable logic is conflicting with enable logic since the order is not guarantee.
Kaleb try to create another label to act specifically for disabling  the auto-merge
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/164780)