### PR TITLE
Microsoft.PIX: Update 2405.15 manifest file to point to new installer locations

### DIFF
--- a/manifests/m/Microsoft/PIX/2405.15/Microsoft.PIX.installer.yaml
+++ b/manifests/m/Microsoft/PIX/2405.15/Microsoft.PIX.installer.yaml
@@ -10,10 +10,10 @@ AppsAndFeaturesEntries:
     DisplayVersion: 24.5.15.2
 Installers:
 - Architecture: x64
-  InstallerUrl: https://query.prod.cms.rt.microsoft.com/cms/api/am/binary/RW1lmoH
+  InstallerUrl: https://download.microsoft.com/download/9/8/3/9839adc3-8bb8-4e27-8b42-b85edc517fd6/PIX-2405.15.002-OneBranch_release-Installer-x64.exe
   InstallerSha256: C3ED910C1699FE8DC9C21986D88251909D11FC5B3D81E1955AB6EEF56F9B501D
 - Architecture: arm64
-  InstallerUrl: https://query.prod.cms.rt.microsoft.com/cms/api/am/binary/RW1lmoG
+  InstallerUrl: https://download.microsoft.com/download/9/8/3/9839adc3-8bb8-4e27-8b42-b85edc517fd6/PIX-2405.15.002-OneBranch_release-Installer-ARM64.exe
   InstallerSha256: 907951A8555A78727DEDA63D8F41D859D6D36DEC85EBA478266F672F88DAC06B
 ManifestType: installer
 ManifestVersion: 1.6.0


### PR DESCRIPTION
Our PIX installer host is being deprecated, so we need to move the installers. This PR updates WinGet to point to the new installer locations.

https://github.com/microsoft/winget-pkgs/issues/165137
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/165141)