### PR TITLE
Microsoft.PIX: Update 2403.08 manifest file to point to new installer locations

### DIFF
--- a/manifests/m/Microsoft/PIX/2403.08/Microsoft.PIX.installer.yaml
+++ b/manifests/m/Microsoft/PIX/2403.08/Microsoft.PIX.installer.yaml
@@ -10,10 +10,10 @@ AppsAndFeaturesEntries:
     DisplayVersion: 24.3.8.1
 Installers:
 - Architecture: x64
-  InstallerUrl: https://query.prod.cms.rt.microsoft.com/cms/api/am/binary/RW1j4DU
+  InstallerUrl: https://download.microsoft.com/download/4/0/c/40c26ec0-048c-49b4-a2ac-d27fccd666f8/PIX-2403.08-Installer-x64.exe
   InstallerSha256: 52FCEF1E1C4316549E4FC1B7D6EAAB1219FA8EFB238002247EC5543FB7BA8012
 - Architecture: arm64
-  InstallerUrl: https://query.prod.cms.rt.microsoft.com/cms/api/am/binary/RW1j20K
+  InstallerUrl: https://download.microsoft.com/download/4/0/c/40c26ec0-048c-49b4-a2ac-d27fccd666f8/PIX-2403.08-Installer-ARM64.exe
   InstallerSha256: A2756E23CCEAFCC508B10A6539F49125E6B11418EE1E67357987EB2E1799F3AC
 ManifestType: installer
 ManifestVersion: 1.6.0


### PR DESCRIPTION
Our PIX installer host is being deprecated, so we need to move the installers. This PR updates WinGet to point to the new installer locations.

https://github.com/microsoft/winget-pkgs/issues/165137
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/165142)