### PR TITLE
Microsoft.PIX: Update 2303.30 manifest file to point to new installer locations

### DIFF
--- a/manifests/m/Microsoft/PIX/2303.30/Microsoft.PIX.installer.yaml
+++ b/manifests/m/Microsoft/PIX/2303.30/Microsoft.PIX.installer.yaml
@@ -10,10 +10,10 @@ AppsAndFeaturesEntries:
   DisplayVersion: 23.3.30.1
 Installers:
 - Architecture: x64
-  InstallerUrl: https://query.prod.cms.rt.microsoft.com/cms/api/am/binary/RW10twp
+  InstallerUrl: https://download.microsoft.com/download/d/4/c/d4ce10ac-baf3-4f59-a24b-97a93530c5d0/PIX-2303.30-Installer-x64.exe
   InstallerSha256: 777D6E5C7787479CD174EF4C966462BEF5CFB94AC7EA3A404BFEA8B14E26D797
 - Architecture: arm64
-  InstallerUrl: https://query.prod.cms.rt.microsoft.com/cms/api/am/binary/RW10H6c
+  InstallerUrl: https://download.microsoft.com/download/d/4/c/d4ce10ac-baf3-4f59-a24b-97a93530c5d0/PIX-2303.30-Installer-ARM64.exe
   InstallerSha256: 2288236F2FAF9031DBD5D3BFE645922EB9A59044DD6886E1ECEA7BFD3AACA6DC
 ManifestType: installer
 ManifestVersion: 1.6.0


### PR DESCRIPTION
Our PIX installer host is being deprecated, so we need to move the installers. This PR updates WinGet to point to the new installer locations.

https://github.com/microsoft/winget-pkgs/issues/165137
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/165143)