### PR TITLE
Tencent.WeType 1.2.2.630 and change some properties

### DIFF
--- a/manifests/t/Tencent/WeType/1.2.2.630/Tencent.WeType.installer.yaml
+++ b/manifests/t/Tencent/WeType/1.2.2.630/Tencent.WeType.installer.yaml
@@ -1,0 +1,26 @@
+# Created using wingetcreate 1.6.1.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: Tencent.WeType
+PackageVersion: 1.2.2.630
+InstallerLocale: zh-CN
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 6.1.7601.0
+InstallerType: exe
+Scope: machine
+InstallerSwitches:
+  Silent: /s
+  SilentWithProgress: /s
+UpgradeBehavior: deny
+AppsAndFeaturesEntries:
+- DisplayName: 微信输入法
+  Publisher: 腾讯科技(深圳)有限公司
+  DisplayVersion: 1.2.2.630
+ElevationRequirement: elevatesSelf
+Installers:
+- Architecture: x86
+  InstallerUrl: https://download.z.weixin.qq.com/app/win/WeTypeSetup_1.2.2.630_3.exe
+  InstallerSha256: AF04E13B073A993C1E16F48B6FC06DB7D24875BBE66E182A8DD64E62AB571790
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/t/Tencent/WeType/1.2.2.630/Tencent.WeType.installer.yaml
+++ b/manifests/t/Tencent/WeType/1.2.2.630/Tencent.WeType.installer.yaml
@@ -19,7 +19,7 @@ AppsAndFeaturesEntries:
   DisplayVersion: 1.2.2.630
 ElevationRequirement: elevatesSelf
 Installers:
-- Architecture: x86
+- Architecture: x64
   InstallerUrl: https://download.z.weixin.qq.com/app/win/WeTypeSetup_1.2.2.630_3.exe
   InstallerSha256: AF04E13B073A993C1E16F48B6FC06DB7D24875BBE66E182A8DD64E62AB571790
 ManifestType: installer

--- a/manifests/t/Tencent/WeType/1.2.2.630/Tencent.WeType.installer.yaml
+++ b/manifests/t/Tencent/WeType/1.2.2.630/Tencent.WeType.installer.yaml
@@ -13,10 +13,6 @@ InstallerSwitches:
   Silent: /s
   SilentWithProgress: /s
 UpgradeBehavior: deny
-AppsAndFeaturesEntries:
-- DisplayName: 微信输入法
-  Publisher: 腾讯科技(深圳)有限公司
-  DisplayVersion: 1.2.2.630
 ElevationRequirement: elevatesSelf
 Installers:
 - Architecture: x64
@@ -24,3 +20,4 @@ Installers:
   InstallerSha256: AF04E13B073A993C1E16F48B6FC06DB7D24875BBE66E182A8DD64E62AB571790
 ManifestType: installer
 ManifestVersion: 1.6.0
+ReleaseDate: 2024-07-30

--- a/manifests/t/Tencent/WeType/1.2.2.630/Tencent.WeType.locale.zh-CN.yaml
+++ b/manifests/t/Tencent/WeType/1.2.2.630/Tencent.WeType.locale.zh-CN.yaml
@@ -1,0 +1,26 @@
+# Created using wingetcreate 1.6.1.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: Tencent.WeType
+PackageVersion: 1.2.2.630
+PackageLocale: zh-CN
+Publisher: 腾讯科技(深圳)有限公司
+PublisherUrl: https://z.weixin.qq.com/
+PublisherSupportUrl: https://z.weixin.qq.com/web/feedback_h5
+PrivacyUrl: https://wxkeyboardcms-1258476243.file.myqcloud.com/page/article/index/13.html
+Author: 深圳市腾讯计算机系统有限公司
+PackageName: 微信输入法
+PackageUrl: https://z.weixin.qq.com/
+License: 免费软件
+LicenseUrl: https://wxkeyboardcms-1258476243.file.myqcloud.com/page/article/index/14.html
+Copyright: 腾讯公司 版权所有 Copyright © 1998 - 2023 Tencent. All Rights Reserved.
+CopyrightUrl: https://www.tencent.com/zh-cn/statement.html
+ShortDescription: 微信输入法是微信官方出品的中文输入法，提供高效的输入体验、精准的推荐策略、多元的创新玩法。
+Moniker: 微信输入法
+Tags:
+- 中文
+- 拼音
+- 汉语
+- 输入法
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/t/Tencent/WeType/1.2.2.630/Tencent.WeType.locale.zh-CN.yaml
+++ b/manifests/t/Tencent/WeType/1.2.2.630/Tencent.WeType.locale.zh-CN.yaml
@@ -13,14 +13,17 @@ PackageName: 微信输入法
 PackageUrl: https://z.weixin.qq.com/
 License: 免费软件
 LicenseUrl: https://wxkeyboardcms-1258476243.file.myqcloud.com/page/article/index/14.html
-Copyright: 腾讯公司 版权所有 Copyright © 1998 - 2023 Tencent. All Rights Reserved.
+Copyright: 腾讯公司 版权所有 Copyright © 1998-2024 Tencent. All Rights Reserved.
 CopyrightUrl: https://www.tencent.com/zh-cn/statement.html
 ShortDescription: 微信输入法是微信官方出品的中文输入法，提供高效的输入体验、精准的推荐策略、多元的创新玩法。
-Moniker: 微信输入法
 Tags:
 - 中文
 - 拼音
 - 汉语
 - 输入法
+ReleaseNotes: |-
+  - 支持按「v」键使用符号面板
+  - 体验优化和问题修复
+ReleaseNotesUrl: https://z.weixin.qq.com/web/change-log/87
 ManifestType: defaultLocale
 ManifestVersion: 1.6.0

--- a/manifests/t/Tencent/WeType/1.2.2.630/Tencent.WeType.yaml
+++ b/manifests/t/Tencent/WeType/1.2.2.630/Tencent.WeType.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.6.1.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: Tencent.WeType
+PackageVersion: 1.2.2.630
+DefaultLocale: zh-CN
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Upgrade behavior is changed to "deny" because the silent installation won't terminate the old version, causing the update to not take effect until the user manually reboots the computer. Instead, users should use the software's built-in updater, or run the installer interactively. "Uninstall previous" is not ideal because it clears user data.

The built-in updater uses the "/Silence" switch (and internally it terminates the old version), which has the same effect as "/s". Other switches like "/S" (default of nullsoft) or "/random" will result in an incomplete installation somehow.

---

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/165220)