### PR TITLE
Identifier Change: Keeper.KeeperDesktop -> KeeperSecurityInc.KeeperDesktop (readd)

### DIFF
--- a/manifests/k/KeeperSecurity/KeeperDesktop/16.11.1.0/KeeperSecurity.KeeperDesktop.installer.yaml
+++ b/manifests/k/KeeperSecurity/KeeperDesktop/16.11.1.0/KeeperSecurity.KeeperDesktop.installer.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+
+PackageIdentifier: KeeperSecurity.KeeperDesktop
+PackageVersion: 16.11.1.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.15063.0
+InstallerType: msix
+Scope: user
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+PackageFamilyName: KeeperSecurityInc.KeeperPasswordManager_26bb6b95qhpkr
+Installers:
+- Architecture: x86
+  InstallerUrl: https://keepersecurity.com/desktop_electron/packages/KeeperPasswordManager.msixbundle
+  InstallerSha256: 841850D3917AB86CDBBECD318818A115AC843EE4F13C1576C1681B20535D172E
+  SignatureSha256: CA3C66AFE7B57D50F25F5E2E6E94E218E65C2B3E57B331E8867E9F3BB61ADA50
+- Architecture: x64
+  InstallerUrl: https://keepersecurity.com/desktop_electron/packages/KeeperPasswordManager.msixbundle
+  InstallerSha256: 841850D3917AB86CDBBECD318818A115AC843EE4F13C1576C1681B20535D172E
+  SignatureSha256: CA3C66AFE7B57D50F25F5E2E6E94E218E65C2B3E57B331E8867E9F3BB61ADA50
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/k/KeeperSecurity/KeeperDesktop/16.11.1.0/KeeperSecurity.KeeperDesktop.locale.en-US.yaml
+++ b/manifests/k/KeeperSecurity/KeeperDesktop/16.11.1.0/KeeperSecurity.KeeperDesktop.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+
+PackageIdentifier: KeeperSecurity.KeeperDesktop
+PackageVersion: 16.11.1.0
+PackageLocale: en-US
+Publisher: Keeper Security Inc
+PublisherUrl: https://www.keepersecurity.com
+PublisherSupportUrl: https://www.keepersecurity.com/support.html
+PrivacyUrl: https://www.keepersecurity.com/privacypolicy.html
+Author: Keeper Security Inc
+PackageName: Keeper® Password Manager
+PackageUrl: https://www.keepersecurity.com
+License: Proprietary
+LicenseUrl: https://www.keepersecurity.com/termsofuse.html
+Copyright: © 2022 Keeper Security, Inc.
+CopyrightUrl: https://www.keepersecurity.com/termsofuse.html
+ShortDescription: Keeper is the top-rated password manager for protecting you, your family and your business from password-related data breaches and cyberthreats.
+Tags:
+- manager
+- password
+- password-manager
+- security
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/k/KeeperSecurity/KeeperDesktop/16.11.1.0/KeeperSecurity.KeeperDesktop.yaml
+++ b/manifests/k/KeeperSecurity/KeeperDesktop/16.11.1.0/KeeperSecurity.KeeperDesktop.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+
+PackageIdentifier: KeeperSecurity.KeeperDesktop
+PackageVersion: 16.11.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0


### PR DESCRIPTION
The offical Publisher is KeeperSecurity Inc and KeeperSecurity.Commander is also already in the package index.
Therefore both applications should be in the same publisher folder.

This PR **adds** the package under the new identifier.

Removal PR of old identifier: #165671
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/165672)