### PR TITLE
Ottomated.CrewLink: remove wrong moniker

### DIFF
--- a/manifests/o/Ottomated/CrewLink/2.0.1/Ottomated.CrewLink.locale.en-US.yaml
+++ b/manifests/o/Ottomated/CrewLink/2.0.1/Ottomated.CrewLink.locale.en-US.yaml
@@ -11,7 +11,6 @@ PackageUrl: https://github.com/ottomated/CrewLink
 License: Copyright © 2020 Ottomated
 LicenseUrl: https://github.com/ottomated/CrewLink/blob/master/LICENSE
 ShortDescription: Free, open, Among Us proximity voice chat
-Moniker: tcmd
 Tags:
 - game
 - voice


### PR DESCRIPTION
This moniker is already in use by total commander package https://github.com/microsoft/winget-pkgs/blob/6aaef132dce12d7f9e8a29728878cecb9c07bf1b/manifests/g/Ghisler/TotalCommander/11.03/Ghisler.TotalCommander.locale.en-US.yaml#L18

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/166015)