### PR TITLE
voidtools.Everything.Cli: rename moniker to `everything-cli` to avoid…

### DIFF
--- a/manifests/v/voidtools/Everything/Cli/1.1.0.27/voidtools.Everything.Cli.locale.en-US.yaml
+++ b/manifests/v/voidtools/Everything/Cli/1.1.0.27/voidtools.Everything.Cli.locale.en-US.yaml
@@ -14,7 +14,7 @@ Copyright: Copyright (C) 2022 David Carpenter
 CopyrightUrl: https://www.voidtools.com/License.txt
 ShortDescription: Locate files and folders by name instantly.
 Description: Everything is search engine that locates files and folders by filename instantly for Windows. Unlike Windows search Everything initially displays every file and folder on your computer (hence the name Everything). You type in a search filter to limit what files and folders are displayed.
-Moniker: everything
+Moniker: everything-cli
 Tags:
 - file-search
 - filesystem


### PR DESCRIPTION
… collision with everything moniker

Two packages cannot have same monikers.

Checklist for Pull Requests
- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/166016)