### PR TITLE
2dust.v2rayN version 6.53

### DIFF
--- a/manifests/2/2dust/v2rayN/6.53/2dust.v2rayN.installer.yaml
+++ b/manifests/2/2dust/v2rayN/6.53/2dust.v2rayN.installer.yaml
@@ -6,7 +6,7 @@ PackageVersion: "6.53"
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
-- RelativeFilePath: v2rayN\v2rayUpgrade.exe
+- RelativeFilePath: v2rayN-With-Core\v2rayUpgrade.exe
 UpgradeBehavior: deny
 Dependencies:
   PackageDependencies:

--- a/manifests/2/2dust/v2rayN/6.53/2dust.v2rayN.installer.yaml
+++ b/manifests/2/2dust/v2rayN/6.53/2dust.v2rayN.installer.yaml
@@ -1,0 +1,26 @@
+# Created using wingetcreate 1.6.4.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: 2dust.v2rayN
+PackageVersion: "6.53"
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: v2rayN\v2rayN.exe
+  PortableCommandAlias: v2rayN
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.8
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/2dust/v2rayN/releases/download/6.53/v2rayN.zip
+  InstallerSha256: 2B4178FD02B927EC34E74ABBE23110768F55999EB3A7A0A8CBC209FD9C481AA4
+- Architecture: x86
+  InstallerUrl: https://github.com/2dust/v2rayN/releases/download/6.53/v2rayN-32.zip
+  InstallerSha256: 4C5EA13C2B166FFACBDFBFACAC7192977C7B91A7C7CEA006BB0380A781DA7F45
+- Architecture: arm64
+  InstallerUrl: https://github.com/2dust/v2rayN/releases/download/6.53/v2rayN-arm64.zip
+  InstallerSha256: DFF94BDBABE216837C77222D412A520BD9D15967DA95D6AAA3E9B47585092AF5
+ManifestType: installer
+ManifestVersion: 1.6.0
+ReleaseDate: 2024-07-26

--- a/manifests/2/2dust/v2rayN/6.53/2dust.v2rayN.installer.yaml
+++ b/manifests/2/2dust/v2rayN/6.53/2dust.v2rayN.installer.yaml
@@ -6,21 +6,16 @@ PackageVersion: "6.53"
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
-- RelativeFilePath: v2rayN\v2rayN.exe
-  PortableCommandAlias: v2rayN
+- RelativeFilePath: v2rayN\v2rayUpgrade.exe
+UpgradeBehavior: deny
 Dependencies:
   PackageDependencies:
   - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.8
+RequireExplicitUpgrade: true
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/2dust/v2rayN/releases/download/6.53/v2rayN.zip
-  InstallerSha256: 2B4178FD02B927EC34E74ABBE23110768F55999EB3A7A0A8CBC209FD9C481AA4
-- Architecture: x86
-  InstallerUrl: https://github.com/2dust/v2rayN/releases/download/6.53/v2rayN-32.zip
-  InstallerSha256: 4C5EA13C2B166FFACBDFBFACAC7192977C7B91A7C7CEA006BB0380A781DA7F45
-- Architecture: arm64
-  InstallerUrl: https://github.com/2dust/v2rayN/releases/download/6.53/v2rayN-arm64.zip
-  InstallerSha256: DFF94BDBABE216837C77222D412A520BD9D15967DA95D6AAA3E9B47585092AF5
+  InstallerUrl: https://github.com/2dust/v2rayN/releases/download/6.53/v2rayN-With-Core.zip
+  InstallerSha256: AD96E94E276F224C25F303464531CB591A7038DB9C871DDE1E507EA34CF1BFDE
 ManifestType: installer
 ManifestVersion: 1.6.0
 ReleaseDate: 2024-07-26

--- a/manifests/2/2dust/v2rayN/6.53/2dust.v2rayN.locale.zh-CN.yaml
+++ b/manifests/2/2dust/v2rayN/6.53/2dust.v2rayN.locale.zh-CN.yaml
@@ -1,0 +1,18 @@
+# Created using wingetcreate 1.6.4.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: 2dust.v2rayN
+PackageVersion: "6.53"
+PackageLocale: zh-CN
+Publisher: 2dust
+PublisherUrl: https://github.com/2dust
+PublisherSupportUrl: https://github.com/2dust/v2rayN/issues
+Author: 2dust
+PackageName: v2rayN
+PackageUrl: https://github.com/2dust/v2rayN
+License: GPL-3.0
+LicenseUrl: https://github.com/2dust/v2rayN/blob/master/LICENSE
+ShortDescription: A GUI client for Windows, support Xray core and v2fly core and others
+ReleaseNotesUrl: https://github.com/2dust/v2rayN/releases/tag/6.53
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/2/2dust/v2rayN/6.53/2dust.v2rayN.locale.zh-CN.yaml
+++ b/manifests/2/2dust/v2rayN/6.53/2dust.v2rayN.locale.zh-CN.yaml
@@ -13,6 +13,14 @@ PackageUrl: https://github.com/2dust/v2rayN
 License: GPL-3.0
 LicenseUrl: https://github.com/2dust/v2rayN/blob/master/LICENSE
 ShortDescription: A GUI client for Windows, support Xray core and v2fly core and others
+ReleaseNotes: |-
+  - 增加功能多服务器最低延迟 (多选) ，使用sing-box 实现，可使用clash api #5405
+  - 增加功能多服务器负载均衡 (多选) ，使用xray 实现（不支持Hy2，Tuic，Wg)
+  - 重构主界面布局，可设置主界面布局方向
+  - 延迟测试改进，多次测试取最低值
+  - 增加Outbound域名解析地址
+  - sing-box 默认DNS改成白名单，和V2ray一致
+  - 修复一些已知问题 #5394 #5400
 ReleaseNotesUrl: https://github.com/2dust/v2rayN/releases/tag/6.53
 ManifestType: defaultLocale
 ManifestVersion: 1.6.0

--- a/manifests/2/2dust/v2rayN/6.53/2dust.v2rayN.yaml
+++ b/manifests/2/2dust/v2rayN/6.53/2dust.v2rayN.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.6.4.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: 2dust.v2rayN
+PackageVersion: "6.53"
+DefaultLocale: zh-CN
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Some explanation:

```
NestedInstallerFiles:
- RelativeFilePath: v2rayN\v2rayUpgrade.exe
```
The file link to `v2rayN\v2rayN.exe` is intentionally skipped because when launching it through the link, it will seek related files from the `Links` folder and won't start properly. A link to `v2rayUpgrade.exe` is created instead as a placeholder.

```
RequireExplicitUpgrade: true
UpgradeBehavior: deny
```
The program (`v2rayN\v2rayN.exe`) has self-update functionality and saves its settings (`v2rayN\guiConfigs\*`) in the installation folder. But since all those files are inside some nested or double-nested folders, winget CLI won't record their SHA256 (let alone the settings files are absent upon installation) so when upgrading it will consider the installation "untouched" and remove everything. Therefore, upgrade is disabled to prevent accidentally overwriting user's files.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/166409)