### PR TITLE
2dust.v2rayN version 6.55

### DIFF
--- a/manifests/2/2dust/v2rayN/6.55/2dust.v2rayN.installer.yaml
+++ b/manifests/2/2dust/v2rayN/6.55/2dust.v2rayN.installer.yaml
@@ -1,0 +1,21 @@
+# Created using wingetcreate 1.6.4.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: 2dust.v2rayN
+PackageVersion: "6.55"
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: v2rayN\v2rayUpgrade.exe
+UpgradeBehavior: deny
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.8
+RequireExplicitUpgrade: true
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/2dust/v2rayN/releases/download/6.55/v2rayN-With-Core.zip
+  InstallerSha256: 29FFE0EF176096CD22C6001D5B875E1DB94DE00176D7348D7493DEF3F80FFEF8
+ManifestType: installer
+ManifestVersion: 1.6.0
+ReleaseDate: 2024-08-05

--- a/manifests/2/2dust/v2rayN/6.55/2dust.v2rayN.installer.yaml
+++ b/manifests/2/2dust/v2rayN/6.55/2dust.v2rayN.installer.yaml
@@ -6,7 +6,7 @@ PackageVersion: "6.55"
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
-- RelativeFilePath: v2rayN\v2rayUpgrade.exe
+- RelativeFilePath: v2rayN-With-Core\v2rayUpgrade.exe
 UpgradeBehavior: deny
 Dependencies:
   PackageDependencies:

--- a/manifests/2/2dust/v2rayN/6.55/2dust.v2rayN.locale.zh-CN.yaml
+++ b/manifests/2/2dust/v2rayN/6.55/2dust.v2rayN.locale.zh-CN.yaml
@@ -1,0 +1,19 @@
+# Created using wingetcreate 1.6.4.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: 2dust.v2rayN
+PackageVersion: "6.55"
+PackageLocale: zh-CN
+Publisher: 2dust
+PublisherUrl: https://github.com/2dust
+PublisherSupportUrl: https://github.com/2dust/v2rayN/issues
+Author: 2dust
+PackageName: v2rayN
+PackageUrl: https://github.com/2dust/v2rayN
+License: GPL-3.0
+LicenseUrl: https://github.com/2dust/v2rayN/blob/master/LICENSE
+ShortDescription: A GUI client for Windows, support Xray core and v2fly core and others
+ReleaseNotes: 修复了一些已知的问题
+ReleaseNotesUrl: https://github.com/2dust/v2rayN/releases/tag/6.55
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/2/2dust/v2rayN/6.55/2dust.v2rayN.yaml
+++ b/manifests/2/2dust/v2rayN/6.55/2dust.v2rayN.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.6.4.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: 2dust.v2rayN
+PackageVersion: "6.55"
+DefaultLocale: zh-CN
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Some explanation:

```
NestedInstallerFiles:
- RelativeFilePath: v2rayN\v2rayUpgrade.exe
```
The file link to `v2rayN\v2rayN.exe` is intentionally skipped because when launching it through the link, it will seek related files from the `Links` folder and won't start properly. A link to `v2rayUpgrade.exe` is created instead as a placeholder.

```
RequireExplicitUpgrade: true
UpgradeBehavior: deny
```
The program (`v2rayN\v2rayN.exe`) has self-update functionality and saves its settings (`v2rayN\guiConfigs\*`) in the installation folder. But since all those files are inside some nested or double-nested folders, winget CLI won't record their SHA256 (let alone the settings files are absent upon installation) so when upgrading it will consider the installation "untouched" and remove everything. Therefore, upgrade is disabled to prevent accidentally overwriting user's files.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/166420)