### PR TITLE
Microsoft.AzureCLI v2.63.0 - Change URLs to GitHub releases for much greater download speeds

### DIFF
--- a/manifests/m/Microsoft/AzureCLI/2.63.0/Microsoft.AzureCLI.installer.yaml
+++ b/manifests/m/Microsoft/AzureCLI/2.63.0/Microsoft.AzureCLI.installer.yaml
@@ -19,19 +19,19 @@ Installers:
     Scope: machine
     InstallerUrl: https://github.com/Azure/azure-cli/releases/download/azure-cli-2.63.0/azure-cli-2.63.0.msi
     InstallerSha256: CF054BF567EA710DF4D7319C150CEF162A4F2AF4193D595F2810531F04370428
-    ProductCode: "{150FBBE6-C1C8-41BF-9651-BF0BE588D957}"
+    ProductCode: '{150FBBE6-C1C8-41BF-9651-BF0BE588D957}'
     AppsAndFeaturesEntries:
       - DisplayName: Microsoft Azure CLI (32-bit)
-        UpgradeCode: "{DFF82AF0-3F95-4AC9-8EFD-948604FDB028}"
+        UpgradeCode: '{DFF82AF0-3F95-4AC9-8EFD-948604FDB028}'
   - InstallerLocale: en-US
     Architecture: x64
     InstallerType: wix
     Scope: machine
     InstallerUrl: https://github.com/Azure/azure-cli/releases/download/azure-cli-2.63.0/azure-cli-2.63.0-x64.zip
     InstallerSha256: 21CEB34D5EF1CB0072B57D787BE59BFA75A463936FAFD08D3D4A60D1F726D58E
-    ProductCode: "{A4F370AC-6E82-439F-AB2E-FEFBEAD735FE}"
+    ProductCode: '{A4F370AC-6E82-439F-AB2E-FEFBEAD735FE}'
     AppsAndFeaturesEntries:
       - DisplayName: Microsoft Azure CLI (64-bit)
-        UpgradeCode: "{90762FEC-9554-4729-A107-C6A8EA316698}"
+        UpgradeCode: '{90762FEC-9554-4729-A107-C6A8EA316698}'
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/m/Microsoft/AzureCLI/2.63.0/Microsoft.AzureCLI.installer.yaml
+++ b/manifests/m/Microsoft/AzureCLI/2.63.0/Microsoft.AzureCLI.installer.yaml
@@ -5,33 +5,33 @@ PackageIdentifier: Microsoft.AzureCLI
 PackageVersion: 2.63.0
 ReleaseDate: 2024-07-31
 Installers:
-- Architecture: x64
-  InstallerType: zip
-  NestedInstallerType: portable
-  NestedInstallerFiles:
-  - RelativeFilePath: python.exe
-    PortableCommandAlias: az
-  InstallerUrl: https://azcliprod.blob.core.windows.net/zip/azure-cli-2.63.0-x64.zip
-  InstallerSha256: FB3359EF37D11A4197F8B9C4C8629C821A91760785BE3B1849B9BC9B590150DD
-- InstallerLocale: en-US
-  Architecture: x86
-  InstallerType: wix
-  Scope: machine
-  InstallerUrl: https://azcliprod.blob.core.windows.net/msi/azure-cli-2.63.0.msi
-  InstallerSha256: CF054BF567EA710DF4D7319C150CEF162A4F2AF4193D595F2810531F04370428
-  ProductCode: '{150FBBE6-C1C8-41BF-9651-BF0BE588D957}'
-  AppsAndFeaturesEntries:
-  - DisplayName: Microsoft Azure CLI (32-bit)
-    UpgradeCode: '{DFF82AF0-3F95-4AC9-8EFD-948604FDB028}'
-- InstallerLocale: en-US
-  Architecture: x64
-  InstallerType: wix
-  Scope: machine
-  InstallerUrl: https://azcliprod.blob.core.windows.net/msi/azure-cli-2.63.0-x64.msi
-  InstallerSha256: 21CEB34D5EF1CB0072B57D787BE59BFA75A463936FAFD08D3D4A60D1F726D58E
-  ProductCode: '{A4F370AC-6E82-439F-AB2E-FEFBEAD735FE}'
-  AppsAndFeaturesEntries:
-  - DisplayName: Microsoft Azure CLI (64-bit)
-    UpgradeCode: '{90762FEC-9554-4729-A107-C6A8EA316698}'
+  - Architecture: x64
+    InstallerType: zip
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: python.exe
+        PortableCommandAlias: az
+    InstallerUrl: https://github.com/Azure/azure-cli/releases/download/azure-cli-2.63.0/azure-cli-2.63.0-x64.msi
+    InstallerSha256: FB3359EF37D11A4197F8B9C4C8629C821A91760785BE3B1849B9BC9B590150DD
+  - InstallerLocale: en-US
+    Architecture: x86
+    InstallerType: wix
+    Scope: machine
+    InstallerUrl: https://github.com/Azure/azure-cli/releases/download/azure-cli-2.63.0/azure-cli-2.63.0.msi
+    InstallerSha256: CF054BF567EA710DF4D7319C150CEF162A4F2AF4193D595F2810531F04370428
+    ProductCode: "{150FBBE6-C1C8-41BF-9651-BF0BE588D957}"
+    AppsAndFeaturesEntries:
+      - DisplayName: Microsoft Azure CLI (32-bit)
+        UpgradeCode: "{DFF82AF0-3F95-4AC9-8EFD-948604FDB028}"
+  - InstallerLocale: en-US
+    Architecture: x64
+    InstallerType: wix
+    Scope: machine
+    InstallerUrl: https://github.com/Azure/azure-cli/releases/download/azure-cli-2.63.0/azure-cli-2.63.0-x64.zip
+    InstallerSha256: 21CEB34D5EF1CB0072B57D787BE59BFA75A463936FAFD08D3D4A60D1F726D58E
+    ProductCode: "{A4F370AC-6E82-439F-AB2E-FEFBEAD735FE}"
+    AppsAndFeaturesEntries:
+      - DisplayName: Microsoft Azure CLI (64-bit)
+        UpgradeCode: "{90762FEC-9554-4729-A107-C6A8EA316698}"
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/m/Microsoft/AzureCLI/2.63.0/Microsoft.AzureCLI.installer.yaml
+++ b/manifests/m/Microsoft/AzureCLI/2.63.0/Microsoft.AzureCLI.installer.yaml
@@ -11,7 +11,7 @@ Installers:
     NestedInstallerFiles:
       - RelativeFilePath: python.exe
         PortableCommandAlias: az
-    InstallerUrl: https://github.com/Azure/azure-cli/releases/download/azure-cli-2.63.0/azure-cli-2.63.0-x64.msi
+    InstallerUrl: https://github.com/Azure/azure-cli/releases/download/azure-cli-2.63.0/azure-cli-2.63.0-x64.zip
     InstallerSha256: FB3359EF37D11A4197F8B9C4C8629C821A91760785BE3B1849B9BC9B590150DD
   - InstallerLocale: en-US
     Architecture: x86
@@ -27,7 +27,7 @@ Installers:
     Architecture: x64
     InstallerType: wix
     Scope: machine
-    InstallerUrl: https://github.com/Azure/azure-cli/releases/download/azure-cli-2.63.0/azure-cli-2.63.0-x64.zip
+    InstallerUrl: https://github.com/Azure/azure-cli/releases/download/azure-cli-2.63.0/azure-cli-2.63.0-x64.msi
     InstallerSha256: 21CEB34D5EF1CB0072B57D787BE59BFA75A463936FAFD08D3D4A60D1F726D58E
     ProductCode: '{A4F370AC-6E82-439F-AB2E-FEFBEAD735FE}'
     AppsAndFeaturesEntries:


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

This changes download URLs to GitHub releases for much improved download speeds. All relevant packages is not added to GitHub releases since v2.63.0, ref:

* <https://github.com/Azure/azure-cli/issues/28856>

Previously artifacts were available through a non-georedundant Azure Storage Account blob storage with abysmal throughput and latency, especually for non-US users. Ref:

* <https://github.com/Azure/azure-cli/issues/19447>
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/166604)