### PR TITLE
New version: Mozilla.Thunderbird version 128.1.0esr

### DIFF
--- a/manifests/m/Mozilla/Thunderbird/128.1.0esr/Mozilla.Thunderbird.installer.yaml
+++ b/manifests/m/Mozilla/Thunderbird/128.1.0esr/Mozilla.Thunderbird.installer.yaml
@@ -1,0 +1,756 @@
+PackageIdentifier: Mozilla.Thunderbird
+PackageVersion: 128.1.0esr
+Scope: machine
+InstallModes:
+- silent
+- interactive
+InstallerSwitches:
+  Silent: /S /PreventRebootRequired=true
+  SilentWithProgress: /S /PreventRebootRequired=true
+  InstallLocation: /InstallDirectoryPath="<INSTALLPATH>"
+UpgradeBehavior: install
+Protocols:
+- mailto
+- mid
+- webcal
+- webcals
+FileExtensions:
+- eml
+- ics
+- wdseml
+ReleaseDate: 2024-08-06
+Installers:
+- InstallerLocale: af
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/af/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 48084fa0bd2f7c7c92ce0d30c8ec30993e4cd13a3c5cd6fbf82cd68634ddb94a
+  ProductCode: Mozilla Thunderbird x86 af
+- InstallerLocale: ar
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/ar/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: e3d09341940ae012121a61600311e7f8f30a1ce4466176fa82d81c95fb8bf0f1
+  ProductCode: Mozilla Thunderbird x86 ar
+- InstallerLocale: be
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/be/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 6d52cd4e1ee6db4dad4af3e8c54389e8d9c721079367a0a834903d467f61d097
+  ProductCode: Mozilla Thunderbird x86 be
+- InstallerLocale: bg
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/bg/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 85f41513f2bdd67b5b5ef606d2dc0a4518fd7f1c716bc2435b3dfbd290d34356
+  ProductCode: Mozilla Thunderbird x86 bg
+- InstallerLocale: br
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/br/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 81486db80af9628cb81e138a5d897ce9dd55db0fabd792442e313cc63a2ca6fa
+  ProductCode: Mozilla Thunderbird x86 br
+- InstallerLocale: ca
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/ca/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 749fd1b7b924642946e5dfa4700924e081d49426961399881c2170d31c9ebff9
+  ProductCode: Mozilla Thunderbird x86 ca
+- InstallerLocale: cs
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/cs/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 89e622df72123489ba1f6254241ea85d383d2dc2efa02411d241ee26512f2a25
+  ProductCode: Mozilla Thunderbird x86 cs
+- InstallerLocale: cy
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/cy/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 9682d4728743ab7622d8f342c44f1c9be045220e8d2f1f9414c2bf0e5b89b174
+  ProductCode: Mozilla Thunderbird x86 cy
+- InstallerLocale: da
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/da/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: f8075e3bb623275887383d4890d193a15508ee6efb0b5ed2eadabd011080f8d1
+  ProductCode: Mozilla Thunderbird x86 da
+- InstallerLocale: de
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/de/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 36ccdb4c2e6112a853773120ad1b84fe990a763166f4d1e2df41fe686cc255ee
+  ProductCode: Mozilla Thunderbird x86 de
+- InstallerLocale: el
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/el/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 3c613aff7a56482dd79734ca13e25933237b2d3e9dbce4760e81f65acf0e15f8
+  ProductCode: Mozilla Thunderbird x86 el
+- InstallerLocale: en-CA
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/en-CA/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: d4a4a96181d92f762038ab3cc28c90f014971c41562144ffe63732f1621b7daf
+  ProductCode: Mozilla Thunderbird x86 en-CA
+- InstallerLocale: en-GB
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/en-GB/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: cf4785af8fd4c987d7cc8bb4c2cb85026dcd1d5f970d3c573f2fdecc9694cb6f
+  ProductCode: Mozilla Thunderbird x86 en-GB
+- InstallerLocale: en-US
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/en-US/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 8fed4013dd04ec4e3e836782e0faa3ea6c4770d68624d30f65a4e124714adbea
+  ProductCode: Mozilla Thunderbird x86 en-US
+- InstallerLocale: es-AR
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/es-AR/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: b424bc71973855bb9f4fb2c8e850a5ae6e4298358771f8fcaafd9d9efe445dc9
+  ProductCode: Mozilla Thunderbird x86 es-AR
+- InstallerLocale: es-ES
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/es-ES/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: b85f9bf07e7d80d9deec22c942ed80529470064ff7f7c192f7b7d90977834652
+  ProductCode: Mozilla Thunderbird x86 es-ES
+- InstallerLocale: es-MX
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/es-MX/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: bcbe5389cb90e8ea3f4b2c098bee491852b20cfd367ef9b1ea4ba67bf2191fb8
+  ProductCode: Mozilla Thunderbird x86 es-MX
+- InstallerLocale: et
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/et/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 638dd44cc91b6e6d109c916cebc4b01251ae72e24811621f21b39f6bc1af90a4
+  ProductCode: Mozilla Thunderbird x86 et
+- InstallerLocale: eu
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/eu/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: cc5a01e39fbfa5a6f3c9706c29649ac26b8a3e3f38df47179827c7efb3ae4c41
+  ProductCode: Mozilla Thunderbird x86 eu
+- InstallerLocale: fi
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/fi/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 26f75c4869d4764445fe1d32fbd2010eef9a0f973fe11d5c38e496710d5ffcbd
+  ProductCode: Mozilla Thunderbird x86 fi
+- InstallerLocale: fr
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/fr/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: f143f01c50f6b7f827f9ea88d03fdeb96723ec8c5ed1b2dd62900787d68bd6f3
+  ProductCode: Mozilla Thunderbird x86 fr
+- InstallerLocale: fy-NL
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/fy-NL/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 6ae143bb9518a103215c7a854a4b48f0ed4870134d2cbcbf3d6377df6f7acd51
+  ProductCode: Mozilla Thunderbird x86 fy-NL
+- InstallerLocale: ga-IE
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/ga-IE/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 481f5008af856eb759a7bfdc2b50d9b69d12b7504aa716a6ffa6617b85fda70c
+  ProductCode: Mozilla Thunderbird x86 ga-IE
+- InstallerLocale: gd
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/gd/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: c1f7410ef1865a872c599fb71a8ebc35b578e8a092ea34054cbb2858e26a85f1
+  ProductCode: Mozilla Thunderbird x86 gd
+- InstallerLocale: gl
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/gl/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 06026a8a736baf47d14db6099d4da73e6354341cd55ae6c615b31ad197462ebc
+  ProductCode: Mozilla Thunderbird x86 gl
+- InstallerLocale: he
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/he/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 9b1e3b23258187c7386acbe6cb00d045580a940f3da6a909a350dbd4211761e7
+  ProductCode: Mozilla Thunderbird x86 he
+- InstallerLocale: hr
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/hr/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: da2814953bd498dc29a9b4571cabeeec37186e89683adc330dcb9bedf058fa83
+  ProductCode: Mozilla Thunderbird x86 hr
+- InstallerLocale: hu
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/hu/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: a6422fe323b13991c9e2349ea6d4eaf46fa9d865192971b778be5e88847aa834
+  ProductCode: Mozilla Thunderbird x86 hu
+- InstallerLocale: hy-AM
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/hy-AM/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 81a2546b32ffb161384cf241f5a437e9e1dbdf0b951911f6ef1651be86430aa6
+  ProductCode: Mozilla Thunderbird x86 hy-AM
+- InstallerLocale: id
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/id/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 6c2c0b445352e48f10d6b2ffe97f049d605f67c8a1e2e55b8fa57afea11e0053
+  ProductCode: Mozilla Thunderbird x86 id
+- InstallerLocale: is
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/is/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: e738634cd0f1cbf6e8214dbb39408a0fc2bd3cb840756763073d628804893282
+  ProductCode: Mozilla Thunderbird x86 is
+- InstallerLocale: it
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/it/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 3f4262666bb2e023d2a152463241979e47ccaaf2b5e04503776dd12cbc87052b
+  ProductCode: Mozilla Thunderbird x86 it
+- InstallerLocale: ja
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/ja/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 6cef192d4bb6aefee05083529aed355b06b1fa2130c372298576a3c7d4ed47c6
+  ProductCode: Mozilla Thunderbird x86 ja
+- InstallerLocale: ka
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/ka/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: ff34262418b83e3bc7d9db22141864078f54f57d4ad9d2869eff1792923f5b7d
+  ProductCode: Mozilla Thunderbird x86 ka
+- InstallerLocale: kk
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/kk/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: fc90dea1a08394e1a8120505355654dc5ec5cc996c3168b1d7f5df46b2217edc
+  ProductCode: Mozilla Thunderbird x86 kk
+- InstallerLocale: ko
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/ko/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 8dd017c99a7e2274d08737ff6f14b0eb384b0a54b935974a6036e820676ac92d
+  ProductCode: Mozilla Thunderbird x86 ko
+- InstallerLocale: lt
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/lt/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 40d871ea8f972170d6041aea878c5dc48d39e718c56de8550795de16e348f73b
+  ProductCode: Mozilla Thunderbird x86 lt
+- InstallerLocale: lv
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/lv/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: adbc15c243f123f32542b9b5493ffe6f8f61ab263fbc09b12fcea949abe4ca87
+  ProductCode: Mozilla Thunderbird x86 lv
+- InstallerLocale: ms
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/ms/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 3266012124f46a9354703a19273a0ae8e3621ba732ea6837e0e34b463abeb418
+  ProductCode: Mozilla Thunderbird x86 ms
+- InstallerLocale: nb-NO
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/nb-NO/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: ae938fa4ab3dd565a5321480e39c8c1dff61789e68ca7ac4b49537dbe68e3eb6
+  ProductCode: Mozilla Thunderbird x86 nb-NO
+- InstallerLocale: nl
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/nl/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 70b7fdfbb85998f41d1bb1bb70905dfb38d83c6d1aff76b5a56dd6a90144564b
+  ProductCode: Mozilla Thunderbird x86 nl
+- InstallerLocale: nn-NO
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/nn-NO/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: f044224cf56ac702e492cf5e1e54dc003bf53dda696d762b63a10361bc2de406
+  ProductCode: Mozilla Thunderbird x86 nn-NO
+- InstallerLocale: pa-IN
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/pa-IN/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 313f4927448727d7144278806514703973b5c343c7e3d57c6975d5f5864b7f72
+  ProductCode: Mozilla Thunderbird x86 pa-IN
+- InstallerLocale: pl
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/pl/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 81c3dcf61c6a19af2271e09fc4030519be02bf0b3ae42463c2c240918bc1f517
+  ProductCode: Mozilla Thunderbird x86 pl
+- InstallerLocale: pt-BR
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/pt-BR/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 5912e02906469fff107fe265838d27bdad392f298444c8b0cebb625af1c0958d
+  ProductCode: Mozilla Thunderbird x86 pt-BR
+- InstallerLocale: pt-PT
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/pt-PT/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 746bbba6abc5920ec33347a3ac7345bb5a935acb1ed12e7a85e3e089effbbea2
+  ProductCode: Mozilla Thunderbird x86 pt-PT
+- InstallerLocale: rm
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/rm/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 623261d4b7c0e74c46985e6694db176005230ab1b22920860845e70b670c77fe
+  ProductCode: Mozilla Thunderbird x86 rm
+- InstallerLocale: ro
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/ro/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 3ec52a6f88a5a4ff472dd0696a8563a3c75161cd6929de45e3cc26381205e8f2
+  ProductCode: Mozilla Thunderbird x86 ro
+- InstallerLocale: ru
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/ru/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: ff1f4ab4b2d774c7e3b6fea6ffdd60edacda94bd1f89ebf9417c63bc22d40c39
+  ProductCode: Mozilla Thunderbird x86 ru
+- InstallerLocale: sk
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/sk/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 89316eb4b391e3b11d100e491e8b2d840051de759ca8e3aef3c8831ffe8c5fbf
+  ProductCode: Mozilla Thunderbird x86 sk
+- InstallerLocale: sl
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/sl/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: ca11ea6e3f3d092b1df23bc02d01288ca4f2e444f2902d810205197f2908b78f
+  ProductCode: Mozilla Thunderbird x86 sl
+- InstallerLocale: sq
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/sq/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 72110775e0986e70912d589c08b6efe6310377ac7545ddeff38ede8d70e60b7c
+  ProductCode: Mozilla Thunderbird x86 sq
+- InstallerLocale: sr
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/sr/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: f96ee910c60f6cacb24bd6aac67696cc056fdc56bbdc957c66d90636fc42f745
+  ProductCode: Mozilla Thunderbird x86 sr
+- InstallerLocale: sv-SE
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/sv-SE/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: da6a89211bc5a68777227837426cf8ee74958dc321a65bc4c5e70aab3b0b2f0a
+  ProductCode: Mozilla Thunderbird x86 sv-SE
+- InstallerLocale: th
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/th/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 5cb7d52d236e2481d4ad869702e7e3a9413f6c7b4097a5b2ca470aac46152410
+  ProductCode: Mozilla Thunderbird x86 th
+- InstallerLocale: tr
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/tr/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 0f69f7195c7e95691bdedf3b65c8589643b067766473a51b52bf046a9e1fb5e2
+  ProductCode: Mozilla Thunderbird x86 tr
+- InstallerLocale: uk
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/uk/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 772009821d708a34468d79eaf8ca63ee6e3c53c381f62c11000e655307573ae6
+  ProductCode: Mozilla Thunderbird x86 uk
+- InstallerLocale: uz
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/uz/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 816e6244ce6679541f83fca4bac0f868fd59a4ea18f0e1b7609de5679d7c5105
+  ProductCode: Mozilla Thunderbird x86 uz
+- InstallerLocale: vi
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/vi/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 3ecf69f4cfa673aacb166568311fe4b3ee10c8e81a8261685a16bcc4ca222081
+  ProductCode: Mozilla Thunderbird x86 vi
+- InstallerLocale: zh-CN
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/zh-CN/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: a743d5a3f51a35b6ec54b89749110fd4c6743038f0ae34c2cd3c36f176adc59a
+  ProductCode: Mozilla Thunderbird x86 zh-CN
+- InstallerLocale: zh-TW
+  Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win32/zh-TW/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 68bbd86b158ad4da6e924d56ebf3483e6037ce34e40170afdb5f4a0b9812ecf4
+  ProductCode: Mozilla Thunderbird x86 zh-TW
+- InstallerLocale: af
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/af/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 6cccc39ee8267ed4169857dceebcf41e7c2dcfc4e7e155259316a2421f8398cb
+  ProductCode: Mozilla Thunderbird x64 af
+- InstallerLocale: ar
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/ar/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 06944f78974f14c8457d0ca4bee87b7e81e3539f728a1a3a2de80577fc390cb3
+  ProductCode: Mozilla Thunderbird x64 ar
+- InstallerLocale: be
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/be/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 77fda74c8d1b5bcba2601e682e22450393625b9da67a95fcf96bc4ded19b4a8f
+  ProductCode: Mozilla Thunderbird x64 be
+- InstallerLocale: bg
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/bg/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 710e33c4e49640ce5ef8c88bbba4894b3f30f5185f6c6e6ef180f0fd0a70e0bf
+  ProductCode: Mozilla Thunderbird x64 bg
+- InstallerLocale: br
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/br/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 6e5733a3b9670834022af070bf935c6762b7ba3ef800969db80e65238596dea8
+  ProductCode: Mozilla Thunderbird x64 br
+- InstallerLocale: ca
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/ca/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 875204ebd90f77b6569c0b3c7b59e941ec619257a4261c622500a6175663a89a
+  ProductCode: Mozilla Thunderbird x64 ca
+- InstallerLocale: cs
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/cs/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 198450cdb9b0f81e0d413d5fe8285c0bb375572823af0ee4c2430d2cf104ddf9
+  ProductCode: Mozilla Thunderbird x64 cs
+- InstallerLocale: cy
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/cy/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 3329e378fd16a1e7e938d3aed5f60273f750f7716079568842d11eca433d6ae6
+  ProductCode: Mozilla Thunderbird x64 cy
+- InstallerLocale: da
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/da/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: bd885890e824c2c94ce0302a36a5ac182d326f2a0b8e3f4644c64cfb3a6f6e47
+  ProductCode: Mozilla Thunderbird x64 da
+- InstallerLocale: de
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/de/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 6a4ed6f1c452e4e65b633760abad8e958278926a26772c0c99e1e6e7f4fe1ba4
+  ProductCode: Mozilla Thunderbird x64 de
+- InstallerLocale: el
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/el/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 5b64660b30ec32e16efc1bffd6713867133d3e0abe6de1aad362ca66e4be3050
+  ProductCode: Mozilla Thunderbird x64 el
+- InstallerLocale: en-CA
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/en-CA/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 4d6a413c369a5309ce91f9bf6c38b8f6033894ff704075af0887c0514c9c0723
+  ProductCode: Mozilla Thunderbird x64 en-CA
+- InstallerLocale: en-GB
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/en-GB/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: dac9b437009c0a6e7eb36a4d4ecacbd9032c649b14dd42cd070444a9f271feea
+  ProductCode: Mozilla Thunderbird x64 en-GB
+- InstallerLocale: en-US
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/en-US/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 178c28c5dc2b91424d6f133ae68becf725620a473d655d836f666da730a46c95
+  ProductCode: Mozilla Thunderbird x64 en-US
+- InstallerLocale: es-AR
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/es-AR/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: ece2e0b122f8282a99d748acf47642d8688838602e2108213c23e29b258d0a52
+  ProductCode: Mozilla Thunderbird x64 es-AR
+- InstallerLocale: es-ES
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/es-ES/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: f7c063f46e348ad71e222c39d0b1ae4eae66e952a1437574c481f0faa202440b
+  ProductCode: Mozilla Thunderbird x64 es-ES
+- InstallerLocale: es-MX
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/es-MX/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 7665f514d939e70006e1558506dd0f68f45d9ddc0f0f5e716847bcedb792f286
+  ProductCode: Mozilla Thunderbird x64 es-MX
+- InstallerLocale: et
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/et/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: e5eb4cbfbd09866c6bae64948757a771890e0a1d67eb9745147ab97284c2179b
+  ProductCode: Mozilla Thunderbird x64 et
+- InstallerLocale: eu
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/eu/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: f6c78a96139cfe727dcb7c600de1fd6b180753e2c3a34aa0e41e429d1290bd5e
+  ProductCode: Mozilla Thunderbird x64 eu
+- InstallerLocale: fi
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/fi/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 5d49195e9593756675c21683eee487e1a339e926b46595881ba2b4bc0a5e1a7c
+  ProductCode: Mozilla Thunderbird x64 fi
+- InstallerLocale: fr
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/fr/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 5886a5d57080e65f28c8c628773149b005afd643e1ae08132b9e627e2dcd4fb8
+  ProductCode: Mozilla Thunderbird x64 fr
+- InstallerLocale: fy-NL
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/fy-NL/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 3c0fb8c5de77b60a615c9b01312e4bb0b57b36b6b849e41b39346d8437727c70
+  ProductCode: Mozilla Thunderbird x64 fy-NL
+- InstallerLocale: ga-IE
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/ga-IE/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 8032ed96d6e3de03da511c5a94014026fe98f3d503fd3ff9644e696db34fa5e2
+  ProductCode: Mozilla Thunderbird x64 ga-IE
+- InstallerLocale: gd
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/gd/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: d5b9dc85e005951c2a19d8d0013b5db3338838c6d7d124d55b55ce6e2a8d450c
+  ProductCode: Mozilla Thunderbird x64 gd
+- InstallerLocale: gl
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/gl/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: b59a1b50f6a10fa2d12cbc57ad767de16e73c5442e41d402c8f63c2471f4817a
+  ProductCode: Mozilla Thunderbird x64 gl
+- InstallerLocale: he
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/he/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: ef2ef706f4693c45616b2c920ad1a9002d7fd5323f827e342b22b8729a0f0548
+  ProductCode: Mozilla Thunderbird x64 he
+- InstallerLocale: hr
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/hr/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: fee34c08470d8181639f30f2b718680a9bc75c3c81b84dee1b48286830ee4044
+  ProductCode: Mozilla Thunderbird x64 hr
+- InstallerLocale: hu
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/hu/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 60de1a719082587c8b37c652d1c3b23b043712583cb9782621cacc907c639d92
+  ProductCode: Mozilla Thunderbird x64 hu
+- InstallerLocale: hy-AM
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/hy-AM/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 3fed69f485e0c887751f68f39e42b452ea8304820e0cc9520cada0aa10fa9a2b
+  ProductCode: Mozilla Thunderbird x64 hy-AM
+- InstallerLocale: id
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/id/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 1b857adb51da1206721e2db0c30b84431dfcf4bdec17b2ef9383a36f398b60b4
+  ProductCode: Mozilla Thunderbird x64 id
+- InstallerLocale: is
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/is/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 4fa5c4ddf1374de1885cd7eaf2cd6b35e94c5152bfbea8591c19449f1d18f549
+  ProductCode: Mozilla Thunderbird x64 is
+- InstallerLocale: it
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/it/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: ec1ee874627e7606b50b32c4b00a13e33a3acffa1a2064ac18949f8664f6eebc
+  ProductCode: Mozilla Thunderbird x64 it
+- InstallerLocale: ja
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/ja/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 07fe8a63dc783d046ec66f7dc7f4b1cd9d1b842d8b3b65c86b36509a39fc488e
+  ProductCode: Mozilla Thunderbird x64 ja
+- InstallerLocale: ka
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/ka/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 4209599e983800d45911fbfb1b9b306f4c7b9f3d259d773f1a6cf6565fb9e913
+  ProductCode: Mozilla Thunderbird x64 ka
+- InstallerLocale: kk
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/kk/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 11baf8076cf9cfc71e0444c8d95444d71bb7209ce2783d5c0733f84c6be21ccb
+  ProductCode: Mozilla Thunderbird x64 kk
+- InstallerLocale: ko
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/ko/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 94a926babaa4b4730b73defa8a42d18172d1c30ff371ae9c1f7815a9fd28eb32
+  ProductCode: Mozilla Thunderbird x64 ko
+- InstallerLocale: lt
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/lt/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 85cfdf0a2dc1bd1e5d9fe3387aefa47afa4a81204a96746a975a42df0ae67710
+  ProductCode: Mozilla Thunderbird x64 lt
+- InstallerLocale: lv
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/lv/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 635f0fe6d08384032e07d196d4e65b7ae14740e314de9979dd9fdf2758b07b14
+  ProductCode: Mozilla Thunderbird x64 lv
+- InstallerLocale: ms
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/ms/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 604631e997c63757c697d730c89f98ccfd023e53f0e7bddca1e90a419b16a712
+  ProductCode: Mozilla Thunderbird x64 ms
+- InstallerLocale: nb-NO
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/nb-NO/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: b99d7e4bff9dcc65deda192ba0aa4819d00fc4471b90c1be867626b791b459d3
+  ProductCode: Mozilla Thunderbird x64 nb-NO
+- InstallerLocale: nl
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/nl/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 805efddf8aac1bc2d836583f8c7a7f01f63403ef728e4f22f62d639707b181a5
+  ProductCode: Mozilla Thunderbird x64 nl
+- InstallerLocale: nn-NO
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/nn-NO/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 3bb861cc257389f71158e549063d52f3cec027dc794afcc3ae6f5638790b6747
+  ProductCode: Mozilla Thunderbird x64 nn-NO
+- InstallerLocale: pa-IN
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/pa-IN/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 08f1caa7b9b96dabe34c0e9f2292974a6184f6c9a706f24d4d9c33afeb2efaac
+  ProductCode: Mozilla Thunderbird x64 pa-IN
+- InstallerLocale: pl
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/pl/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 5fc617f5b30a5bf4cd0731baa4e494e9a222c21db292fa3f2ecf94bf4650eee4
+  ProductCode: Mozilla Thunderbird x64 pl
+- InstallerLocale: pt-BR
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/pt-BR/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 87249ed4de1987fd2de7bb27a235587d239eb98c0f841de05ac16316e8b996b5
+  ProductCode: Mozilla Thunderbird x64 pt-BR
+- InstallerLocale: pt-PT
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/pt-PT/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 7dbbcc5dc3cf6f7ed55b8b71c968fbae6eed0e6793156c56ae023411375c2db9
+  ProductCode: Mozilla Thunderbird x64 pt-PT
+- InstallerLocale: rm
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/rm/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 232acca5feaa0ec0ba45b6beb56bf4e6d865eee773654f9d59283c6d2c5f7dce
+  ProductCode: Mozilla Thunderbird x64 rm
+- InstallerLocale: ro
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/ro/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: cb43aef31463973280f391921fb62995f1420f8c6fe90d6d1bcc6ff96f039dd7
+  ProductCode: Mozilla Thunderbird x64 ro
+- InstallerLocale: ru
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/ru/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 81fd098917ea1f643360f5d30bd534a5c09bb01d0efcd9200c8470ea5ed8e1ff
+  ProductCode: Mozilla Thunderbird x64 ru
+- InstallerLocale: sk
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/sk/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: e505658cfed67ae662eca8b1c05336ec0a6fbca5232fcc9eb54d3603aeb8e151
+  ProductCode: Mozilla Thunderbird x64 sk
+- InstallerLocale: sl
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/sl/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 51add5bea7354113e36f0ef503c0fdef1d81c85a0a0b01784ccecdd0b3515e1a
+  ProductCode: Mozilla Thunderbird x64 sl
+- InstallerLocale: sq
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/sq/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: d89e07be013000433eb4ed1dd63c8fe06439196979c19f1cc1fb3ee5dc630f83
+  ProductCode: Mozilla Thunderbird x64 sq
+- InstallerLocale: sr
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/sr/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: e88c9457ff6fd13d063379d093f066f3e43fe105472feb75e67b094cf13aecce
+  ProductCode: Mozilla Thunderbird x64 sr
+- InstallerLocale: sv-SE
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/sv-SE/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: eff4f978ce22fe0c42499b8eb54c34033b5f93b4552d2f6f69e982314b8ecc51
+  ProductCode: Mozilla Thunderbird x64 sv-SE
+- InstallerLocale: th
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/th/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 719d7208291e9746d122a57f42a0f5d99320a70e8aa6c6e49240facd935c83c1
+  ProductCode: Mozilla Thunderbird x64 th
+- InstallerLocale: tr
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/tr/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: e4274a3d6f7053f0bb1feb9984628bd3eeb05c2c6cea0172cc9fc50b37ca11f4
+  ProductCode: Mozilla Thunderbird x64 tr
+- InstallerLocale: uk
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/uk/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 136e9d0a26cc07b63198e3f5db0df57f9cc8d971cd746f149146f2b5652f42f8
+  ProductCode: Mozilla Thunderbird x64 uk
+- InstallerLocale: uz
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/uz/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 06b7f933228e3d4f30b157fc7cb465ee258effcec40173cd6998176f609cf8e9
+  ProductCode: Mozilla Thunderbird x64 uz
+- InstallerLocale: vi
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/vi/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 031577c4ecc8e2f82c20461a4379d8cd6c968e6f5460b5c4c847864a0652c267
+  ProductCode: Mozilla Thunderbird x64 vi
+- InstallerLocale: zh-CN
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/zh-CN/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: 01b1ab9209bd96176cb3aad66a2a0c832546dd85739b76044cbff4919ec5d27c
+  ProductCode: Mozilla Thunderbird x64 zh-CN
+- InstallerLocale: zh-TW
+  Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/128.1.0esr/win64/zh-TW/Thunderbird%20Setup%20128.1.0esr.exe
+  InstallerSha256: e7207e545b551338a26941ae0b2cf214dc1ed77b306b8b4f40849aafe6342ea0
+  ProductCode: Mozilla Thunderbird x64 zh-TW
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/Mozilla/Thunderbird/128.1.0esr/Mozilla.Thunderbird.locale.en-US.yaml
+++ b/manifests/m/Mozilla/Thunderbird/128.1.0esr/Mozilla.Thunderbird.locale.en-US.yaml
@@ -1,0 +1,44 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: Mozilla.Thunderbird
+PackageVersion: 128.1.0esr
+PackageLocale: en-US
+Publisher: Mozilla
+PublisherUrl: https://www.mozilla.org/
+PublisherSupportUrl: https://support.mozilla.org/
+PrivacyUrl: https://www.mozilla.org/privacy/thunderbird/
+Author: Mozilla Foundation
+PackageName: Mozilla Thunderbird
+PackageUrl: https://www.thunderbird.net/
+License: MPL-2.0
+LicenseUrl: https://www.mozilla.org/MPL/2.0
+# Copyright:
+CopyrightUrl: https://www.mozilla.org/foundation/trademarks/policy
+ShortDescription: Thunderbird is a free email application that is easy to set up and customize - and it's loaded with great features!
+Description: Thunderbird is a free and open source email, newsfeed, chat, and calendaring client, that’s easy to set up and customize. One of the core principles of Thunderbird is the use and promotion of open standards - this focus is a rejection of our world of closed platforms and services that can’t communicate with each other. We want our users to have freedom and choice in how they communicate.
+Moniker: thunderbird
+Tags:
+- email
+- mail
+ReleaseNotes: |-
+  Could not add override for a certificate with the wrong hostname
+  Auto-detection of CalDAV calendars and CardDAV address books failed in certain scenarios
+  Potential memory leak in local folder repair
+  Selecting messages and then switching to a new folder with no selected messages did not clear selected messages count
+  When using an external installation of GnuPG, Thunderbird occassionally sent/received corrupted messages
+  Users of external GnuPG were unable to decrypt incorrectly encoded messages
+  UTF-8 encoded messages became garbled when encrypted using inline OpenPGP
+  Could not access the contents of an S/MIME encrypted message wrapped in a digital signature
+  Occasional crash occurred shortly after startup
+  Flatpak created a duplicate unpinned icon in Linux dock after launching Thunderbird
+  Flatpak release notes URL was incorrect
+  Spell checker dictionary was not available for Flatpak install
+  Digital signatures on signed-only OpenPGP messages were broken with some providers
+  Visual and UX improvements
+  Security fixes
+ReleaseNotesUrl: https://www.thunderbird.net/en-US/thunderbird/128.1.0esr/releasenotes/
+# PurchaseUrl:
+# InstallationNotes:
+# Documentations:
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/Mozilla/Thunderbird/128.1.0esr/Mozilla.Thunderbird.locale.zh-CN.yaml
+++ b/manifests/m/Mozilla/Thunderbird/128.1.0esr/Mozilla.Thunderbird.locale.zh-CN.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
+
+PackageIdentifier: Mozilla.Thunderbird
+PackageVersion: 128.1.0esr
+PackageLocale: zh-CN
+Publisher: Mozilla
+PublisherUrl: https://www.mozilla.org/zh-CN/
+PublisherSupportUrl: https://support.mozilla.org/zh-CN/
+PrivacyUrl: https://www.mozilla.org/privacy/thunderbird/
+Author: Mozilla 基金会
+PackageName: Mozilla Thunderbird
+PackageUrl: https://www.thunderbird.net/zh-CN/
+License: MPL-2.0
+LicenseUrl: https://www.mozilla.org/MPL/2.0
+# Copyright:
+CopyrightUrl: https://www.mozilla.org/foundation/trademarks/policy
+ShortDescription: Thunderbird 是一款免费的邮件应用程序，配置简单、定制自由、功能强大！
+Description: Thunderbird 是一款免费开源的电子邮件、新闻订阅、即时通信、日历客户端，配置简单，定制自由。Thunderbird 的核心准则之一是使用和推广开放标准——重点就是拒绝世界上我们无法相互通信的封闭平台和服务。我们希望我们的用户在沟通方式上拥有自由和选择。
+# Moniker:
+Tags:
+- 电子邮件
+- 邮件
+# ReleaseNotes:
+ReleaseNotesUrl: https://www.thunderbird.net/thunderbird/128.1.0esr/releasenotes/
+# PurchaseUrl:
+# InstallationNotes:
+# Documentations:
+ManifestType: locale
+ManifestVersion: 1.6.0

--- a/manifests/m/Mozilla/Thunderbird/128.1.0esr/Mozilla.Thunderbird.yaml
+++ b/manifests/m/Mozilla/Thunderbird/128.1.0esr/Mozilla.Thunderbird.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: Mozilla.Thunderbird
+PackageVersion: 128.1.0esr
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
There is a [new version format](https://www.thunderbird.net/en-US/thunderbird/releases/) since the [last manifest](https://github.com/microsoft/winget-pkgs/tree/master/manifests/m/Mozilla/Thunderbird/115.14.0) ( from `115.14.0` to `128.1.0esr` ).

- Resolves https://github.com/microsoft/winget-pkgs/issues/167084
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/167172)