### PR TITLE
Discord.Discord 1.0.9158 and disable upgrades

### DIFF
--- a/manifests/d/Discord/Discord/1.0.9158/Discord.Discord.installer.yaml
+++ b/manifests/d/Discord/Discord/1.0.9158/Discord.Discord.installer.yaml
@@ -1,0 +1,20 @@
+# Created using wingetcreate 1.6.4.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: Discord.Discord
+PackageVersion: 1.0.9158
+InstallerType: exe
+Scope: user
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+Protocols:
+- discord
+Installers:
+- Architecture: x64
+  InstallerUrl: https://dl.discordapp.net/distro/app/stable/win/x64/1.0.9158/DiscordSetup.exe
+  InstallerSha256: 8D5C5C4AA33C9BAE3F6F2D82E27BD7246389B490081434BA735A926FB63F6380
+  ProductCode: Discord
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/d/Discord/Discord/1.0.9158/Discord.Discord.installer.yaml
+++ b/manifests/d/Discord/Discord/1.0.9158/Discord.Discord.installer.yaml
@@ -8,9 +8,10 @@ Scope: user
 InstallModes:
 - interactive
 - silent
-UpgradeBehavior: install
+UpgradeBehavior: deny
 Protocols:
 - discord
+RequireExplicitUpgrade: true
 Installers:
 - Architecture: x64
   InstallerUrl: https://dl.discordapp.net/distro/app/stable/win/x64/1.0.9158/DiscordSetup.exe

--- a/manifests/d/Discord/Discord/1.0.9158/Discord.Discord.locale.en-US.yaml
+++ b/manifests/d/Discord/Discord/1.0.9158/Discord.Discord.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# Created using wingetcreate 1.6.4.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: Discord.Discord
+PackageVersion: 1.0.9158
+PackageLocale: en-US
+Publisher: Discord Inc.
+PublisherUrl: https://discord.com/
+PublisherSupportUrl: https://support.discord.com/
+PrivacyUrl: https://discord.com/privacy
+Author: Discord Inc.
+PackageName: Discord
+PackageUrl: https://discord.com/download
+License: Proprietary
+LicenseUrl: https://discord.com/terms
+Copyright: Copyright (c) 2024 Discord Inc. All rights reserved.
+ShortDescription: Your Place to Talk and Hang Out
+Description: |-
+  Discord is the easiest way to talk over voice, video, and text.
+  Talk, chat, hang out, and stay close with your friends and communities.
+Moniker: discord
+Tags:
+- chat
+- community
+- gaming
+- hang-out
+- talk
+- video
+- voice
+- voice-chat
+PurchaseUrl: https://discord.com/nitro
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/d/Discord/Discord/1.0.9158/Discord.Discord.locale.pt-BR.yaml
+++ b/manifests/d/Discord/Discord/1.0.9158/Discord.Discord.locale.pt-BR.yaml
@@ -1,0 +1,31 @@
+# Created using wingetcreate 1.6.4.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
+
+PackageIdentifier: Discord.Discord
+PackageVersion: 1.0.9158
+PackageLocale: pt-BR
+Publisher: Discord Inc.
+PublisherUrl: https://discord.com/
+PublisherSupportUrl: https://support.discord.com/
+PrivacyUrl: https://discord.com/privacy
+Author: Discord Inc.
+PackageName: Discord
+PackageUrl: https://discord.com/download
+License: Proprietary
+LicenseUrl: https://discord.com/terms
+Copyright: Copyright (c) 2024 Discord Inc. All rights reserved.
+ShortDescription: Seu Lugar para Papear e Ficar De Boa
+Description: |-
+  O Discord é a forma mais fácil de falar por voz, vídeo e texto.
+  Fale, converse, saia e mantenha-se próximo dos seus amigos e comunidades.
+Tags:
+- conversa
+- conversar
+- conversação-por-voz
+- jogos
+- voz
+PurchaseUrl: https://discord.com/nitro
+Documentations:
+- DocumentLabel: Support
+ManifestType: locale
+ManifestVersion: 1.6.0

--- a/manifests/d/Discord/Discord/1.0.9158/Discord.Discord.locale.zh-CN.yaml
+++ b/manifests/d/Discord/Discord/1.0.9158/Discord.Discord.locale.zh-CN.yaml
@@ -1,0 +1,29 @@
+# Created using wingetcreate 1.6.4.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
+
+PackageIdentifier: Discord.Discord
+PackageVersion: 1.0.9158
+PackageLocale: zh-CN
+Publisher: Discord Inc.
+PublisherUrl: https://discord.com/
+PublisherSupportUrl: https://support.discord.com/
+PrivacyUrl: https://discord.com/privacy
+Author: Discord Inc.
+PackageName: Discord
+PackageUrl: https://discord.com/download
+License: 专有软件
+LicenseUrl: https://discord.com/terms
+Copyright: Copyright (c) 2024 Discord Inc. All rights reserved.
+ShortDescription: 玩耍聊天的地方
+Description: |-
+  Discord 是最简单易用的通讯工具，兼具语音、视频以及文字信息功能。
+  您可以聊聊天，拉拉家常，一起玩耍，与好友和社区保持紧密联系。
+Tags:
+- 开黑
+- 游戏
+- 聊天
+- 语音
+- 语音聊天
+PurchaseUrl: https://discord.com/nitro
+ManifestType: locale
+ManifestVersion: 1.6.0

--- a/manifests/d/Discord/Discord/1.0.9158/Discord.Discord.yaml
+++ b/manifests/d/Discord/Discord/1.0.9158/Discord.Discord.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.6.4.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: Discord.Discord
+PackageVersion: 1.0.9158
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
> Discord.Discord - does self-updates and does not update the version number in the registry when doing so, applying an update via winget will break/override the user preferences and forcefully enable auto-start on system boot #90642

_Originally posted by @R-Adrian in https://github.com/microsoft/winget-cli/issues/3482#issuecomment-1722437239_

Added the flags back in this PR:
- `UpgradeBehavior: deny` - because Discord "will break/override the user preferences and forcefully enable auto-start on system boot"
- `RequireExplicitUpgrade: true` - because Discord "does not update the version number in the registry"

The flags were initially removed in #157519 without discussion.

See also:
- https://github.com/microsoft/winget-pkgs/pulls?q=%22Make+Discord+UpgradeBehavior+Deny%22
- https://github.com/microsoft/winget-pkgs/issues/137934#issuecomment-1928412289
- https://github.com/microsoft/winget-pkgs/issues/136960

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/167864)