### PR TITLE
New Feature: Load PAT from environment variables

### DIFF
--- a/Tools/SandboxTest.ps1
+++ b/Tools/SandboxTest.ps1
@@ -90,12 +90,12 @@ function Get-Release {
   # First query an endpoint to see if credentials are valid.
   $isValidCredential = $false
   $requestParameters = @{
-    Uri = 'https://api.github.com/octocat'
+    Uri = 'https://api.github.com/rate_limit'
   }
   if ($env:GITHUB_TOKEN) {
     $requestParameters.Add('Authentication', 'Bearer')
     $requestParameters.Add('Token', $(ConvertTo-SecureString "$env:GITHUB_TOKEN" -AsPlainText))
-    $isValidCredential = ([Int16](Invoke-WebRequest @requestParameters).Headers["X-RateLimit-Limit"][0]) -eq 60
+    $isValidCredential = (ConvertFrom-Json (Invoke-WebRequest @requestParameters).Headers["X-RateLimit-Limit"]).resources.core.limit -ne 60
   }
 
   # Query version information of microsoft/winget-cli

--- a/Tools/SandboxTest.ps1
+++ b/Tools/SandboxTest.ps1
@@ -116,7 +116,7 @@ function Get-Release {
   else {
     <# Use original Powershell `Invoke-WebRequest` and `Invoke-RestMethod` without authentication. #>
 
-    Write-Warning 'WARNING: $env.GITHUB_TOKEN not set! You may encounter "API rate limit exeeded" error!'
+    Write-Warning 'WARNING: $env.GITHUB_TOKEN not set! You may encounter "API rate limit exceeded" error!'
     Write-Warning "TIPS: Please consider adding GITHUB_TOKEN to your environment variable."
 
     $releasesAPIResponse = Invoke-RestMethod -Uri 'https://api.github.com/repos/microsoft/winget-cli/releases?per_page=100'


### PR DESCRIPTION
## What's changed

Before querying GitHub REST API for getting release information of `winget.exe`, ...

1. Load `$env:GITHUB_TOKEN` from _Windows Environment Variables_.
2. Check if `$env:GITHUB_TOKEN` begins with `ghp_`, since GitHub REST API uses PAT for authentication.
3. If above 2 steps passed, perform an authorized request.
4. Otherwise, perform unauthorized request as this script used to be.

## Checklist for Pull Requests

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- Resolve #167997

> [!NOTE]
>
> This pull request is about PowerShell scripts in `Tools/` folder instead of manifests.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/168000)