### PR TITLE
MullvadVPN.MullvadVPN.beta version 2024.5-beta1

### DIFF
--- a/manifests/m/MullvadVPN/MullvadVPN/beta/2024.5-beta1/MullvadVPN.MullvadVPN.beta.installer.yaml
+++ b/manifests/m/MullvadVPN/MullvadVPN/beta/2024.5-beta1/MullvadVPN.MullvadVPN.beta.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: MullvadVPN.MullvadVPN.beta
+PackageVersion: "2024.5-beta1"
+Platform:
+- Windows.Desktop
+InstallerType: nullsoft
+Scope: machine
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+ReleaseDate: 2024-08-20
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/mullvad/mullvadvpn-app/releases/download/2024.5-beta1/MullvadVPN-2024.5-beta1.exe
+  InstallerSha256: f1b6c17803f44c1a736f7a2a32f0137fdda43dc80fb0b4e39701ad6b21edb4b1
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/MullvadVPN/MullvadVPN/beta/2024.5-beta1/MullvadVPN.MullvadVPN.beta.installer.yaml
+++ b/manifests/m/MullvadVPN/MullvadVPN/beta/2024.5-beta1/MullvadVPN.MullvadVPN.beta.installer.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: MullvadVPN.MullvadVPN.beta
-PackageVersion: "2024.5-beta1"
+PackageVersion: 2024.5-beta1
 Platform:
 - Windows.Desktop
 InstallerType: nullsoft
@@ -15,5 +15,7 @@ Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/mullvad/mullvadvpn-app/releases/download/2024.5-beta1/MullvadVPN-2024.5-beta1.exe
   InstallerSha256: f1b6c17803f44c1a736f7a2a32f0137fdda43dc80fb0b4e39701ad6b21edb4b1
+  AppsAndFeaturesEntries:
+  - DisplayVersion: 2024.5.0-beta1
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/m/MullvadVPN/MullvadVPN/beta/2024.5-beta1/MullvadVPN.MullvadVPN.beta.locale.en-US.yaml
+++ b/manifests/m/MullvadVPN/MullvadVPN/beta/2024.5-beta1/MullvadVPN.MullvadVPN.beta.locale.en-US.yaml
@@ -1,0 +1,51 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: MullvadVPN.MullvadVPN.beta
+PackageVersion: "2024.5-beta1"
+PackageLocale: en-US
+Publisher: Mullvad VPN
+PublisherUrl: https://mullvad.net
+PublisherSupportUrl: https://mullvad.net/help
+PrivacyUrl: https://mullvad.net/en/help/privacy-policy
+Author: Mullvad VPN
+PackageName: Mullvad VPN
+PackageUrl: https://mullvad.net
+License: GPL-3.0
+LicenseUrl: https://raw.githubusercontent.com/mullvad/mullvadvpn-app/master/LICENSE.md
+Copyright: Copyright (C) 2007 Free Software Foundation, Inc.
+CopyrightUrl: https://raw.githubusercontent.com/mullvad/mullvadvpn-app/master/LICENSE.md
+ShortDescription: Mullvad is an open-source commercial virtual private network service based in Sweden.
+Description: Mullvad is an open-source commercial virtual private network service based in Sweden.
+# Moniker:
+Tags:
+- network
+- open-source
+- privacy
+- private
+- private-network
+- security
+- vpn
+ReleaseNotes: |-
+  This release is for desktop only.
+  Here is a list of all changes since last stable release 2024.4.
+
+  Added
+  - Add DAITA (Defence against AI-guided Traffic Analysis) setting for Linux and macOS.
+  - Add --json flag to mullvad status CLI.
+
+  Changed
+  - Ignore obfuscation protocol constraints when the obfuscation mode is set to auto.
+  macOS
+  - Enable quantum resistant tunnels by default (when set to auto).
+
+  Fixed
+  - Fix mullvad cli bug causing mullvad status listen command to miss events if they occurred too quickly.
+  - Fix bug causing app to enter blocked state when toggling DAITA on and off.
+  macOS
+  - Fix intermittent failures to connect with PQ enabled.
+ReleaseNotesUrl: https://github.com/mullvad/mullvadvpn-app/releases/tag/2024.5-beta1
+# PurchaseUrl:
+# InstallationNotes:
+# Documentations:
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/MullvadVPN/MullvadVPN/beta/2024.5-beta1/MullvadVPN.MullvadVPN.beta.yaml
+++ b/manifests/m/MullvadVPN/MullvadVPN/beta/2024.5-beta1/MullvadVPN.MullvadVPN.beta.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: MullvadVPN.MullvadVPN.beta
+PackageVersion: "2024.5-beta1"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Moves beta releases into their own identifier so it doesn't propose a beta version by default (#137814) but folks who want them (like me) can still install them through WinGet.

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/168551)