### PR TITLE
Fix dependencies status and formatting in schema docs

### DIFF
--- a/doc/manifest/schema/1.6.0/singleton.md
+++ b/doc/manifest/schema/1.6.0/singleton.md
@@ -71,10 +71,10 @@ Installers:                        # The package installer
     Commands:                      # Optional commands or aliases to run the package
     Protocols:                     # Optional list of protocols supported by the package
     FileExtensions:                # Optional list of file extensions supported by the package
-    Dependencies:                  # *Experimental* list of dependencies required by the package
+    Dependencies:                  # Optional list of dependencies required by the package
       - ExternalDependencies:      # *Not implemented* list of external dependencies
-        PackageDependencies:       # *Experimental* list of package dependencies
-        WindowsFeatures:           # *Not implemented* list of Windows feature dependencies
+        PackageDependencies:       # Optional list of package dependencies
+        WindowsFeatures:           # Optional list of Windows feature dependencies
         WindowsLibraries:          # *Not implemented* list of Windows library dependencies
     PackageFamilyName:             # Optional MSIX package family name
     Capabilities:                  # Optional list of MSIX package capabilities

--- a/doc/manifest/schema/1.7.0/installer.md
+++ b/doc/manifest/schema/1.7.0/installer.md
@@ -47,7 +47,7 @@ Installers:                        # The list of package installers
       Log:                         # Optional installer log file path
       Upgrade:                     # Optional installer switches for upgrade
       Custom:                      # Optional installer switches for custom behavior
-			Repair:											 # Optional installer switches to use when repairing the package installation
+      Repair:                      # Optional installer switches to use when repairing the package installation
     UpgradeBehavior:               # Optional upgrade method
     Commands:                      # Optional commands or aliases to run the package
     Protocols:                     # Optional list of protocols supported by the package
@@ -93,7 +93,7 @@ Installers:                        # The list of package installers
             InvocationParameter:   # Optional parameter for invocable files
             DisplayName:           # Optional display name for invocable files
     DownloadCommandProhibited:     # Optional indicator for packages which cannot be downloaded for offline installation
-		RepairBehavior:								 # Optional repair method to use with 'winget repair`
+    RepairBehavior:                # Optional repair method to use with 'winget repair`
 ManifestType: installer            # The manifest type
 ManifestVersion: 1.7.0             # The manifest syntax version
 ```

--- a/doc/manifest/schema/1.7.0/singleton.md
+++ b/doc/manifest/schema/1.7.0/singleton.md
@@ -67,15 +67,15 @@ Installers:                        # The package installer
       Log:                         # Optional installer log file path
       Upgrade:                     # Optional installer switches for upgrade
       Custom:                      # Optional installer switches for custom behavior
-			Repair:											 # Optional installer switches to use when repairing the package installation
+      Repair:                      # Optional installer switches to use when repairing the package installation
     UpgradeBehavior:               # Optional upgrade method
     Commands:                      # Optional commands or aliases to run the package
     Protocols:                     # Optional list of protocols supported by the package
     FileExtensions:                # Optional list of file extensions supported by the package
-    Dependencies:                  # *Experimental* list of dependencies required by the package
+    Dependencies:                  # Optional list of dependencies required by the package
       - ExternalDependencies:      # *Not implemented* list of external dependencies
-        PackageDependencies:       # *Experimental* list of package dependencies
-        WindowsFeatures:           # *Not implemented* list of Windows feature dependencies
+        PackageDependencies:       # Optional list of package dependencies
+        WindowsFeatures:           # Optional list of Windows feature dependencies
         WindowsLibraries:          # *Not implemented* list of Windows library dependencies
     PackageFamilyName:             # Optional MSIX package family name
     Capabilities:                  # Optional list of MSIX package capabilities
@@ -112,7 +112,7 @@ Installers:                        # The package installer
             InvocationParameter:   # Optional parameter for invocable files
             DisplayName:           # Optional display name for invocable files
     DownloadCommandProhibited:     # Optional indicator for packages which cannot be downloaded for offline installation
-		RepairBehavior:								 # Optional repair method to use with 'winget repair`
+    RepairBehavior:                # Optional repair method to use with 'winget repair`
 ManifestType: singleton            # The manifest type
 ManifestVersion: 1.7.0             # The manifest syntax version
 ```


### PR DESCRIPTION
- Update status of dependency in singleton schema docs (https://github.com/microsoft/winget-pkgs/issues/170902#issuecomment-2322865394)
- Remove hard tabs used with Repair & RepairBehavior fields in 1.7.0 docs. Hard tabs were making the markdown display look as:
![image](https://github.com/user-attachments/assets/690015b1-4c67-4641-97c4-c3a506806aa2)


---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/171087)