### PR TITLE
Update version: Martchus.syncthingtray version 1.4.10

### DIFF
--- a/manifests/m/Martchus/syncthingtray/1.4.10/Martchus.syncthingtray.installer.yaml
+++ b/manifests/m/Martchus/syncthingtray/1.4.10/Martchus.syncthingtray.installer.yaml
@@ -12,12 +12,6 @@ Installers:
     PortableCommandAlias: syncthingtray
   InstallerUrl: https://github.com/Martchus/syncthingtray/releases/download/v1.4.10/syncthingtray-1.4.10-x86_64-w64-mingw32.exe.zip
   InstallerSha256: 2F6452356A3457FDB67A930D9FA536CE7DE1ADD2E9BA140A2B54928D3D68B632
-- Architecture: x86
-  NestedInstallerFiles:
-  - RelativeFilePath: syncthingctl-qt5-1.4.10-i686-w64-mingw32.exe
-    PortableCommandAlias: syncthingtray
-  InstallerUrl: https://github.com/Martchus/syncthingtray/releases/download/v1.4.10/syncthingctl-qt5-1.4.10-i686-w64-mingw32.exe.zip
-  InstallerSha256: 5D35EE76B0996E21509AF262AFDFEBBB4D5C7445AD9D1882900FCCB47DE7AA9B
 ManifestType: installer
 ManifestVersion: 1.5.0
 ReleaseDate: 2023-12-05


### PR DESCRIPTION
from https://github.com/Martchus/syncthingtray/releases/tag/v1.4.10

> The i686-w64-mingw32 builds are currently broken (see [#220](https://github.com/Martchus/syncthingtray/issues/220)). Supposedly the GCC update to 13.1.0 broke it. For now, use the builds from v1.4.9 on 32-bit Windows.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/171287)