### PR TITLE
Resolve MullvadVPN manifest problems

### DIFF
--- a/manifests/m/MullvadVPN/MullvadVPN/2024.5/MullvadVPN.MullvadVPN.installer.yaml
+++ b/manifests/m/MullvadVPN/MullvadVPN/2024.5/MullvadVPN.MullvadVPN.installer.yaml
@@ -1,8 +1,7 @@
-# Created with komac v2.6.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: MullvadVPN.MullvadVPN
-PackageVersion: '2024.5'
+PackageVersion: "2024.5"
 Platform:
 - Windows.Desktop
 InstallerType: nullsoft
@@ -15,6 +14,8 @@ ReleaseDate: 2024-09-03
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/mullvad/mullvadvpn-app/releases/download/2024.5/MullvadVPN-2024.5.exe
-  InstallerSha256: 5411FEF047ADADB03E49AB2B9F5B5EFD0B1AB4F8C544DD4842582444895462C8
+  InstallerSha256: 5411fef047adadb03e49ab2b9f5b5efd0b1ab4f8c544dd4842582444895462c8
+  AppsAndFeaturesEntries:
+  - DisplayVersion: 2024.5.0
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/m/MullvadVPN/MullvadVPN/2024.5/MullvadVPN.MullvadVPN.locale.en-US.yaml
+++ b/manifests/m/MullvadVPN/MullvadVPN/2024.5/MullvadVPN.MullvadVPN.locale.en-US.yaml
@@ -1,20 +1,19 @@
-# Created with komac v2.6.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: MullvadVPN.MullvadVPN
-PackageVersion: '2024.5'
+PackageVersion: "2024.5"
 PackageLocale: en-US
 Publisher: Mullvad VPN
-PublisherUrl: https://mullvad.net/
+PublisherUrl: https://mullvad.net
 PublisherSupportUrl: https://mullvad.net/help
 PrivacyUrl: https://mullvad.net/en/help/privacy-policy
 Author: Mullvad VPN
 PackageName: Mullvad VPN
-PackageUrl: https://mullvad.net/
+PackageUrl: https://mullvad.net
 License: GPL-3.0
-LicenseUrl: https://github.com/mullvad/mullvadvpn-app/blob/HEAD/LICENSE.md
-Copyright: Copyright (C) 2007 Free Software Foundation, Inc.
-CopyrightUrl: https://raw.githubusercontent.com/mullvad/mullvadvpn-app/master/LICENSE.md
+LicenseUrl: https://github.com/mullvad/mullvadvpn-app/blob/main/LICENSE.md
+Copyright: Copyright (C) 2024 Mullvad VPN AB
+CopyrightUrl: https://github.com/mullvad/mullvadvpn-app/blob/main/README.md
 ShortDescription: Mullvad is an open-source commercial virtual private network service based in Sweden.
 Description: Mullvad is an open-source commercial virtual private network service based in Sweden.
 Tags:
@@ -26,20 +25,25 @@ Tags:
 - security
 - vpn
 ReleaseNotes: |-
-  This release is for desktop only.Here is a list of all changes since last stable release 2024.4:Added
+  This release is for desktop only.
+  Here is a list of all changes since last stable release 2024.4.
+
+  Added
   - Add DAITA (Defence against AI-guided Traffic Analysis) setting for Linux and macOS.
   - Add --json flag to mullvad status CLI.
+
   Changed
   - Ignore obfuscation protocol constraints when the obfuscation mode is set to auto.
   macOS
   - Enable quantum resistant tunnels by default (when set to auto).
+
   Fixed
-  - Fix mullvad cli bug causing mullvad status listen command to miss events if they occurred
-  too quickly.
+  - Fix mullvad cli bug causing mullvad status listen command to miss events if they occurred too quickly.
   - Fix bug causing app to enter blocked state when toggling DAITA on and off.
   - macOS and Linux: Fix potential crash when disconnecting with DAITA enabled.
   macOS
   - Fix intermittent failures to connect with PQ enabled.
 ReleaseNotesUrl: https://github.com/mullvad/mullvadvpn-app/releases/tag/2024.5
+PurchaseUrl: https://mullvad.net/en/account/create
 ManifestType: defaultLocale
 ManifestVersion: 1.6.0

--- a/manifests/m/MullvadVPN/MullvadVPN/2024.5/MullvadVPN.MullvadVPN.yaml
+++ b/manifests/m/MullvadVPN/MullvadVPN/2024.5/MullvadVPN.MullvadVPN.yaml
@@ -1,8 +1,7 @@
-# Created with komac v2.6.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: MullvadVPN.MullvadVPN
-PackageVersion: '2024.5'
+PackageVersion: "2024.5"
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.6.0


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

Split up from #171489, resolves various mistakes in the `MullvadVPN.MullvadVPN` manifest. Quick overview:

- Adds a `DisplayVersion` tag in line with what the app writes to the registry
- Corrects the copyright notice to point to the package copyright instead of the FSF copyright of the GPL-3.0 licence.
- Adds a purchase URL as you can't do anything without a (paid) Mullvad account
- Makes the release notes a bit nicer
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/171663)