### PR TITLE
Fix incorrect hash for QuadSpinner.Gaea 2.0.4.0

### DIFF
--- a/manifests/q/QuadSpinner/Gaea/2.0.4.0/QuadSpinner.Gaea.installer.yaml
+++ b/manifests/q/QuadSpinner/Gaea/2.0.4.0/QuadSpinner.Gaea.installer.yaml
@@ -13,7 +13,7 @@ ReleaseDate: 2024-09-11
 Installers:
 - Architecture: x64
   InstallerUrl: https://get.gaea.app/Release/Gaea-2.0.4.0.exe
-  InstallerSha256: 6299E37954FAC417844E2E7FF944A3F0CA18237BEA5F836EFED64382018BACEE
+  InstallerSha256: E5E51F60817A224EC34A8E03E27EE8221428E231C7E0A5430511453AA8DB5EE5
   ProductCode: QuadSpinner Gaea 2_is1
 ManifestType: installer
 ManifestVersion: 1.6.0


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---


The hash for the installer was incorrect as the installer was changed after the `dumpling` bot (not sure what that is?!) generated this manifest for our application. (I'm the owner of the `QuadSpinner.Gaea` application). We reissued the installer on our server but this manifest was generated before we could manually submit our own. This is to fix the bad hash. All else is fine.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/173367)