### PR TITLE
Fix version: Betterbird.Betterbird version 115.15.0-bb32 

### DIFF
--- a/manifests/b/Betterbird/Betterbird/115.15.0-bb32/Betterbird.Betterbird.installer.yaml
+++ b/manifests/b/Betterbird/Betterbird/115.15.0-bb32/Betterbird.Betterbird.installer.yaml
@@ -8,7 +8,7 @@ InstallerSwitches:
   SilentWithProgress: /S
   InstallLocation: /InstallDirectoryPath=<INSTALLPATH>
 UpgradeBehavior: install
-ReleaseDate: 2024-09-03
+ReleaseDate: 2024-09-08
 AppsAndFeaturesEntries:
 - DisplayVersion: 115.15.0
 ElevationRequirement: elevatesSelf
@@ -16,62 +16,62 @@ Installers:
 - InstallerLocale: de-DE
   Architecture: x64
   InstallerType: exe
-  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.15.0-bb32.de.win64.installer.exe
-  InstallerSha256: e017b62e967ac8ef20192e01bc1d9986249211d53b09609dd18445d7085735f6
+  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.15.0-bb32-build2.de.win64.installer.exe
+  InstallerSha256: FF85DCA70CBEDAD3C9B013AF74B497D7999576B585B617E9212F6CEB156539A5
 - InstallerLocale: de-DE
   Architecture: x64
   InstallerType: portable
-  InstallerUrl: https://www.betterbird.eu/downloads/WindowsPortable/BetterbirdPortable-115.15.0-bb32.de.win64.zip
-  InstallerSha256: ffe0f87951cb45330595d9b23065e5ac27abc1dfcda2249f8db7c213e195692b
+  InstallerUrl: https://www.betterbird.eu/downloads/WindowsPortable/BetterbirdPortable-115.15.0-bb32-build2.de.win64.zip
+  InstallerSha256: F9C9C53B1C7A68B94669838A8B910594BD53EBEC4D0D43A7C4DE8BDAAE4E9EDF
 - InstallerLocale: en-US
   Architecture: x64
   InstallerType: exe
-  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.15.0-bb32.en-US.win64.installer.exe
-  InstallerSha256: bfb6237f13bfd1a3efb886d6bf79a0173bd1ad92ee3e1275f342e433581225b5
+  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.15.0-bb32-build2.en-US.win64.installer.exe
+  InstallerSha256: AF11FCF10A8E0D8B7C50603385A4BA6001374CB26F8C6C0B826A4EBAECBB672E
 - InstallerLocale: en-US
   Architecture: x64
   InstallerType: portable
-  InstallerUrl: https://www.betterbird.eu/downloads/WindowsPortable/BetterbirdPortable-115.15.0-bb32.en-US.win64.zip
-  InstallerSha256: f7399bed9961f0e0416f8b15b8beffd1ff96e51df64ee42158308cd5bd935240
+  InstallerUrl: https://www.betterbird.eu/downloads/WindowsPortable/BetterbirdPortable-115.15.0-bb32-build2.en-US.win64.zip
+  InstallerSha256: 6361437300E9593DD117FAC3AF44C871D4572401950E607E29315FE360BE27BA
 - InstallerLocale: es-AR
   Architecture: x64
   InstallerType: exe
-  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.15.0-bb32.es-AR.win64.installer.exe
-  InstallerSha256: 1067474ab63cea6ad88fe775c53d7aae72c5a16c293d69063b872a4a1628697d
+  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.15.0-bb32-build2.es-AR.win64.installer.exe
+  InstallerSha256: 435FE2430BE44F3466E1A77244138A76157E5C6670F7BF95380E0FFAE58C1E15
 - InstallerLocale: es-AR
   Architecture: x64
   InstallerType: portable
-  InstallerUrl: https://www.betterbird.eu/downloads/WindowsPortable/BetterbirdPortable-115.15.0-bb32.es-AR.win64.zip
-  InstallerSha256: 074e10d529ff5688bee8770ae9c9a130294aa56ae6723f40bbbac71ce8cf62ef
+  InstallerUrl: https://www.betterbird.eu/downloads/WindowsPortable/BetterbirdPortable-115.15.0-bb32-build2.es-AR.win64.zip
+  InstallerSha256: FB3FC0E6623225D2CF16771646436C95482EBF221403D54431C9E8E906793803
 - InstallerLocale: fr-FR
   Architecture: x64
   InstallerType: exe
-  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.15.0-bb32.fr.win64.installer.exe
-  InstallerSha256: d959fd5ffe9b5c5efd7f3bf4fc8bbbd57dacbf7c2b4e449d9e2bab5a4ed5cb31
+  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.15.0-bb32-build2.fr.win64.installer.exe
+  InstallerSha256: 95C7FC7FCD6055692DDDF2BEE0A864B552680DA3E033B9D4AE5A963BC876E7C9
 - InstallerLocale: fr-FR
   Architecture: x64
   InstallerType: portable
-  InstallerUrl: https://www.betterbird.eu/downloads/WindowsPortable/BetterbirdPortable-115.15.0-bb32.fr.win64.zip
-  InstallerSha256: 3b9a0f2da0270bf9e4ef74676723ee9535321739407088fee87ee35346026bad
+  InstallerUrl: https://www.betterbird.eu/downloads/WindowsPortable/BetterbirdPortable-115.15.0-bb32-build2.fr.win64.zip
+  InstallerSha256: 702C422412E1FC194D0DD83500B3AD326061F3CFD11BDD1AEB36936D61207488
 - InstallerLocale: it-IT
   Architecture: x64
   InstallerType: exe
-  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.15.0-bb32.it.win64.installer.exe
-  InstallerSha256: e3f4aadc50568c6567ccb6b470dea7cb48cb20d52ab0b171219e794fe5ad8458
+  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.15.0-bb32-build2.it.win64.installer.exe
+  InstallerSha256: D02263AA9150E5253585204D778A49F1D731DBADB0A5C212F105DD45EE33233B
 - InstallerLocale: ja-JP
   Architecture: x64
   InstallerType: exe
-  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.15.0-bb32.ja.win64.installer.exe
-  InstallerSha256: d5cb4028ecb24fdbdfeccc96a687cac0a5ee1773f09503befbb06aa321542035
+  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.15.0-bb32-build2.ja.win64.installer.exe
+  InstallerSha256: 5D2E9DA1E093A3F243F43D0CAF8392D21091EEA2196EAE0411CCFF6DCD1AC671
 - InstallerLocale: nl-NL
   Architecture: x64
   InstallerType: exe
-  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.15.0-bb32.nl.win64.installer.exe
-  InstallerSha256: 64991e47652a68f6aefdfa321e2e3558cb0992a74c8862c17032c1764e5173c2
+  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.15.0-bb32-build2.nl.win64.installer.exe
+  InstallerSha256: F938C4DC15E80B695F77D179A1C9D76B1011C3A423A876F15143C5E96FB63247
 - InstallerLocale: pt-BR
   Architecture: x64
   InstallerType: exe
-  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.15.0-bb32.pt-BR.win64.installer.exe
-  InstallerSha256: e88157505edb0fd1799c6fe9d55b5237c0196f3878f12f6c09bce59b52ae1fbc
+  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.15.0-bb32-build2.pt-BR.win64.installer.exe
+  InstallerSha256: 7D45E599BC330C85DA37FBB4EF774B79C0A2B7E95367DFC109B5E09E4F5451BF
 ManifestType: installer
 ManifestVersion: 1.6.0


### PR DESCRIPTION
As of 2024-09-17, in the [official page](https://www.betterbird.eu/downloads/index.php),
> Betterbird 115.15.0-bb32 "Superstar" (3 September 2024)
> Version 115.15.0-bb32 replaced with "build 2" on 8 September 2024.

- Resolves https://github.com/microsoft/winget-pkgs/issues/173892
- Resolves https://github.com/microsoft/winget-pkgs/pull/172491
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/173925)