### PR TITLE
Update kitty to 0.9.0

### DIFF
--- a/manifests/a/avborup/kitty/0.9.0/avborup.kitty.installer.yaml
+++ b/manifests/a/avborup/kitty/0.9.0/avborup.kitty.installer.yaml
@@ -7,7 +7,7 @@ InstallerType: portable
 Commands:
 - kitty
 Installers:
-- Architecture: x64
+- Architecture: x86
   InstallerUrl: https://github.com/avborup/kitty/releases/download/v0.9.0/kitty-x86_64-pc-windows-msvc.exe
   InstallerSha256: 18EE635BB2D3FACF1CF4D28CCAF8901CAFC2882D405DC9D3FAB0531BB5A02812
   Dependencies:

--- a/manifests/a/avborup/kitty/0.9.0/avborup.kitty.installer.yaml
+++ b/manifests/a/avborup/kitty/0.9.0/avborup.kitty.installer.yaml
@@ -1,0 +1,24 @@
+# Created using wingetcreate 1.6.5.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: avborup.kitty
+PackageVersion: 0.9.0
+InstallerType: portable
+Commands:
+- kitty
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/avborup/kitty/releases/download/v0.9.0/kitty-x86_64-pc-windows-msvc.exe
+  InstallerSha256: 18EE635BB2D3FACF1CF4D28CCAF8901CAFC2882D405DC9D3FAB0531BB5A02812
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x86
+- Architecture: x64
+  InstallerUrl: https://github.com/avborup/kitty/releases/download/v0.9.0/kitty-x86_64-pc-windows-msvc.exe
+  InstallerSha256: 18EE635BB2D3FACF1CF4D28CCAF8901CAFC2882D405DC9D3FAB0531BB5A02812
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+ManifestType: installer
+ManifestVersion: 1.6.0
+ReleaseDate: 2024-09-16

--- a/manifests/a/avborup/kitty/0.9.0/avborup.kitty.locale.en-US.yaml
+++ b/manifests/a/avborup/kitty/0.9.0/avborup.kitty.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# Created using wingetcreate 1.6.5.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: avborup.kitty
+PackageVersion: 0.9.0
+PackageLocale: en-US
+Publisher: avborup
+PublisherUrl: https://github.com/avborup
+PublisherSupportUrl: https://github.com/avborup/kitty/issues
+PackageName: Kitty Kattis Cli
+PackageUrl: https://github.com/avborup/kitty
+License: MIT License
+ShortDescription: Kattis challenge cli manager
+Tags:
+- cli
+- kattis
+ReleaseNotesUrl: https://github.com/avborup/kitty/releases/tag/v0.9.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/a/avborup/kitty/0.9.0/avborup.kitty.yaml
+++ b/manifests/a/avborup/kitty/0.9.0/avborup.kitty.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.6.5.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: avborup.kitty
+PackageVersion: 0.9.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
    - It fails with  Duplicate installer entry found
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
    - It works fine 
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

The package install works as it should. I'm not sure if it was a mistake that I added both x86 and x64. But the program runs as expected on both architectures, so there shouldn't be an issue.
If a mod sees this. Is there a proper way this should have been done, or will I just have to do the package update manually every time?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/173963)