### PR TITLE
Add recommendation for users to move away from WinDirStat

### DIFF
--- a/manifests/w/WinDirStat/WinDirStat/1.1.2/WinDirStat.WinDirStat.installer.yaml
+++ b/manifests/w/WinDirStat/WinDirStat/1.1.2/WinDirStat.WinDirStat.installer.yaml
@@ -1,5 +1,5 @@
-# Created with YamlCreate.ps1 v2.0.7 $debug=AUSU.7-2-1
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+# Created with YamlCreate.ps1 v2.4.1 $debug=AUSU.CRLF.7-4-5.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: WinDirStat.WinDirStat
 PackageVersion: 1.1.2
@@ -13,15 +13,15 @@ InstallModes:
 - silent
 UpgradeBehavior: install
 ReleaseDate: 2016-12-10
+AppsAndFeaturesEntries:
+- DisplayName: WinDirStat 1.1.2
+  Publisher:
+  DisplayVersion:
+  ProductCode: WinDirStat
 Installers:
 - Architecture: x86
-  InstallerUrl: https://sourceforge.net/projects/windirstat/files/windirstat/1.1.2%20installer%20re-release%20%28more%20languages%21%29/windirstat1_1_2_setup.exe/download
+  InstallerUrl: https://sourceforge.net/projects/windirstat/files/windirstat/1.1.2%20installer%20re-release%20(more%20languages!)/windirstat1_1_2_setup.exe/download
   InstallerSha256: 370A27A30EE57247FADDEB1F99A83933247E07C8760A07ED82E451E1CB5E5CDD
   ProductCode: WinDirStat
-  AppsAndFeaturesEntries:
-    - DisplayName: 'WinDirStat 1.1.2'
-      Publisher: ''
-      DisplayVersion: ''
-      ProductCode: WinDirStat
 ManifestType: installer
-ManifestVersion: 1.1.0
+ManifestVersion: 1.6.0

--- a/manifests/w/WinDirStat/WinDirStat/1.1.2/WinDirStat.WinDirStat.locale.en-US.yaml
+++ b/manifests/w/WinDirStat/WinDirStat/1.1.2/WinDirStat.WinDirStat.locale.en-US.yaml
@@ -12,9 +12,9 @@ Author: The WinDirStat Team
 PackageName: WinDirStat
 PackageUrl: https://windirstat.net
 License: GNU Public License, version 2 (GPLv2)
-LicenseUrl: https://sourceforge.net/p/windirstat/code/ci/default/tree/README.md
+# LicenseUrl: https://sourceforge.net/p/windirstat/code/ci/default/tree/README.md
 Copyright: Copyright © 2004-2017 WinDirStat Team (windirstat.net)
-CopyrightUrl: https://sourceforge.net/p/windirstat/code/ci/default/tree/README.md
+# CopyrightUrl: https://sourceforge.net/p/windirstat/code/ci/default/tree/README.md
 ShortDescription: WinDirStat is a disk usage statistics viewer and cleanup tool for various versions of Microsoft Windows.
 Description: |-
   WinDirStat (Windows Directory Statistics) is a disk usage statistics viewer and cleanup tool for Windows. On start up, WinDirStat reads the whole directory tree once and then presents it in three useful views:

--- a/manifests/w/WinDirStat/WinDirStat/1.1.2/WinDirStat.WinDirStat.locale.en-US.yaml
+++ b/manifests/w/WinDirStat/WinDirStat/1.1.2/WinDirStat.WinDirStat.locale.en-US.yaml
@@ -1,5 +1,5 @@
-# Created with YamlCreate.ps1 v2.0.7 $debug=AUSU.7-2-1
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+# Created with YamlCreate.ps1 v2.4.1 $debug=AUSU.CRLF.7-4-5.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: WinDirStat.WinDirStat
 PackageVersion: 1.1.2
@@ -7,7 +7,7 @@ PackageLocale: en-US
 Publisher: The WinDirStat Team
 PublisherUrl: https://windirstat.net
 PublisherSupportUrl: https://sourceforge.net/projects/windirstat/support
-# PrivacyUrl: 
+# PrivacyUrl:
 Author: The WinDirStat Team
 PackageName: WinDirStat
 PackageUrl: https://windirstat.net
@@ -16,7 +16,7 @@ LicenseUrl: https://sourceforge.net/p/windirstat/code/ci/default/tree/README.md
 Copyright: Copyright © 2004-2017 WinDirStat Team (windirstat.net)
 CopyrightUrl: https://sourceforge.net/p/windirstat/code/ci/default/tree/README.md
 ShortDescription: WinDirStat is a disk usage statistics viewer and cleanup tool for various versions of Microsoft Windows.
-Description: |- 
+Description: |-
   WinDirStat (Windows Directory Statistics) is a disk usage statistics viewer and cleanup tool for Windows. On start up, WinDirStat reads the whole directory tree once and then presents it in three useful views:
   - The directory list, which resembles the tree view of the Windows Explorer but is sorted by file/subtree size,
   - The treemap, which shows the whole contents of the directory tree straight away,
@@ -29,8 +29,15 @@ Tags:
 - organization
 - sequoiaview
 - statistics
-# Agreements: 
-# ReleaseNotes: 
-# ReleaseNotesUrl: 
+# ReleaseNotes:
+# ReleaseNotesUrl:
+# PurchaseUrl:
+InstallationNotes: >-
+  This software is no longer in active development.
+  Because this software does not write a version to the registry, WinGet is not able to determine the installed version.
+
+  For an alternative to WinDirStat with better performance and ongoing patches use:
+    winget install AntibodySoftware.WizTree
+# Documentations:
 ManifestType: defaultLocale
-ManifestVersion: 1.1.0
+ManifestVersion: 1.6.0

--- a/manifests/w/WinDirStat/WinDirStat/1.1.2/WinDirStat.WinDirStat.yaml
+++ b/manifests/w/WinDirStat/WinDirStat/1.1.2/WinDirStat.WinDirStat.yaml
@@ -1,8 +1,8 @@
-# Created with YamlCreate.ps1 v2.0.7 $debug=AUSU.7-2-1
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+# Created with YamlCreate.ps1 v2.4.1 $debug=AUSU.CRLF.7-4-5.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: WinDirStat.WinDirStat
 PackageVersion: 1.1.2
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.1.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

There have now been a few issues filed indicating confusion around the behavior of WinDirStat and the version being unknown.
* https://github.com/microsoft/winget-pkgs/issues/161769
* https://github.com/microsoft/winget-pkgs/issues/54490
* https://github.com/microsoft/winget-pkgs/issues/88994
* https://github.com/microsoft/winget-pkgs/issues/173833

Because the last release of WinDirStat was in 2016, it should be safe to assume that it is not in active development and no new updates for the package will be coming. However, another package - WizTree - provides the same functionality as WinDirStat but is newer, much faster, and is still being patched and developed upon. 

This PR adds an installation note to help reduce confusion and point users towards the newer software if they should choose to install it.

###### Related to microsoft/winget-cli#1899