### PR TITLE
Docs: Manifest schemas: Replace broken alert syntax usage

### DIFF
--- a/doc/manifest/schema/1.6.0/defaultLocale.md
+++ b/doc/manifest/schema/1.6.0/defaultLocale.md
@@ -82,8 +82,7 @@ ManifestVersion: 1.6.0        # The manifest syntax version
 * [Available languages for Windows]
 * [Default Input Profiles (Input Locales) in Windows][locales]
 
-  > [!NOTE]
-	This field is the key to determining which fields are required for the Microsoft community repository. The default locale specified in the version file must match with this value.
+  NOTE:	This field is the key to determining which fields are required for the Microsoft community repository. The default locale specified in the version file must match with this value.
  </details>
 
 
@@ -94,8 +93,7 @@ ManifestVersion: 1.6.0        # The manifest syntax version
 
   This key represents the name of the publisher for a given package. This field is intended to allow the full publisher's or ISV's name to be displayed as they wish.
 
-  > [!NOTE]
-	With the 1.6 release of the Windows Package Manager, this name affects how packages from a source are mapped to Apps installed in Windows 10 and Windows 11 via Add / Remove Programs (ARP) and Windows Apps & Features respectively. The best practice is to ensure this matches the entry for the package when it has been installed. The impact is associated with `winget upgrade` and `winget list`.
+  NOTE:	With the 1.6 release of the Windows Package Manager, this name affects how packages from a source are mapped to Apps installed in Windows 10 and Windows 11 via Add / Remove Programs (ARP) and Windows Apps & Features respectively. The best practice is to ensure this matches the entry for the package when it has been installed. The impact is associated with `winget upgrade` and `winget list`.
  </details>
 
 <details>
@@ -137,8 +135,7 @@ ManifestVersion: 1.6.0        # The manifest syntax version
 
   This key represents the name of the package. This field is intended to allow the full package name to be displayed as the publisher or ISV wishes.
 
-  > [!NOTE]
-	With the 1.6 release of the Windows Package Manager, this name affects how packages from a source are mapped to Apps installed in Windows 10 via Add / Remove Programs (ARP). The best practice is to ensure this matches the ARP entry for the package name when it has been installed. The impact is associated with `winget upgrade` and `winget list`.
+  NOTE:	With the 1.6 release of the Windows Package Manager, this name affects how packages from a source are mapped to Apps installed in Windows 10 via Add / Remove Programs (ARP). The best practice is to ensure this matches the ARP entry for the package name when it has been installed. The impact is associated with `winget upgrade` and `winget list`.
  </details>
 
 <details>
@@ -192,8 +189,7 @@ ManifestVersion: 1.6.0        # The manifest syntax version
 
   This key represents the description for a package. It is intended for use in `winget show` to help a user understand what the package is.
 
-  > [!NOTE]
-	This should be something descriptive about what the package does, and it should not simply state something like "&lt;package name&gt; installer" or "&lt;package name&gt; setup".
+  NOTE:	This should be something descriptive about what the package does, and it should not simply state something like "&lt;package name&gt; installer" or "&lt;package name&gt; setup".
 </details>
 
 <details>
@@ -203,8 +199,7 @@ ManifestVersion: 1.6.0        # The manifest syntax version
 
   This key represents the full or long description for a package. It is *not* currently used in the Windows Package Manager.
 
-  > [!NOTE]
-	This was included for integration with the Microsoft Store source to provide the ability to display the full package description.
+  NOTE:	This was included for integration with the Microsoft Store source to provide the ability to display the full package description.
 </details>
 
 <details>
@@ -214,8 +209,7 @@ ManifestVersion: 1.6.0        # The manifest syntax version
 
   This key represents the most common term users would search for when installing or upgrading a package. If only one package uses this moniker, then the [install], [list] and [upgrade] command may match with this package.
 
-  > [!NOTE]
-	Moniker is the third property evaluated when searching for a matching package.
+  NOTE:	Moniker is the third property evaluated when searching for a matching package.
 </details>
 
 <details>
@@ -225,8 +219,7 @@ ManifestVersion: 1.6.0        # The manifest syntax version
 
   This key represents other common term users would search for when looking for packages. Tags should be pertinent to what a user might search for when looking for a specific package.
 
-  > [!NOTE]
-	The best practice is to present these terms in all lower case with hyphens rather than spaces.
+  NOTE:	The best practice is to present these terms in all lower case with hyphens rather than spaces.
 </details>
 
 

--- a/doc/manifest/schema/1.6.0/installer.md
+++ b/doc/manifest/schema/1.6.0/installer.md
@@ -165,8 +165,7 @@ ManifestVersion: 1.6.0
 
  The Windows Package Manager client uses this version to determine if an upgrade for a package is available. In some cases, packages may be released with a marketing driven version, and that causes trouble with the [`winget upgrade`] command.
 
- > [!NOTE]
- The current best practice is to use the value reported in Add / Remove Programs when this version of the package is installed. In some cases, packages do not report a version resulting in an upgrade loop or other unwanted behavior. This practice may seem contrary to using semantic versioning, but it provides the best end to end experience for customers. It will take time for publishers and ISVs to migrate to semantic versioning, and some may intentionally choose to preserve other versioning schemes. In these cases, it is best practice to include the "AppsAndFeaturesEntries" section for each installer.
+ NOTE: The current best practice is to use the value reported in Add / Remove Programs when this version of the package is installed. In some cases, packages do not report a version resulting in an upgrade loop or other unwanted behavior. This practice may seem contrary to using semantic versioning, but it provides the best end to end experience for customers. It will take time for publishers and ISVs to migrate to semantic versioning, and some may intentionally choose to preserve other versioning schemes. In these cases, it is best practice to include the "AppsAndFeaturesEntries" section for each installer.
 </details>
 
 <details>
@@ -176,8 +175,7 @@ ManifestVersion: 1.6.0
 
  This key represents the distribution channel for a package. Examples may include "stable" or "beta".
 
- > [!NOTE]
- This key is included for future use. The Windows Package Manager currently does not have any behavior associated with this key. The intent behind this key is to help disambiguate the different channels for packages lacking support for side by side installation. Some packages support having more than one package channel available on a system simultaneously; in this case it is better to use unique packages rather than channels. This key is intended to ensure the proper channel for a package is used during install and upgrade scenarios.
+ NOTE: This key is included for future use. The Windows Package Manager currently does not have any behavior associated with this key. The intent behind this key is to help disambiguate the different channels for packages lacking support for side by side installation. Some packages support having more than one package channel available on a system simultaneously; in this case it is better to use unique packages rather than channels. This key is intended to ensure the proper channel for a package is used during install and upgrade scenarios.
 </details>
 
 <details>
@@ -187,8 +185,7 @@ ManifestVersion: 1.6.0
 
  The key represents an installer for a package.
 
- > [!IMPORTANT]
- Many of the keys related to installers may either be at the root level of the manifest, or included in an installer. Any values provided at the root level and not specified in an installer will be inherited.
+ IMPORTANT: Many of the keys related to installers may either be at the root level of the manifest, or included in an installer. Any values provided at the root level and not specified in an installer will be inherited.
 </details>
 
 <details>
@@ -214,8 +211,7 @@ ManifestVersion: 1.6.0
 
  This key represents the locale for an installer *not* the package meta-data. Some installers are compiled with locale or language specific properties. If this key is present, it is used to represent the package locale for an installer.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -225,8 +221,7 @@ ManifestVersion: 1.6.0
 
  This key represents the Windows platform targeted by the installer. The Windows Package Manager currently supports "Windows.Desktop" and "Windows.Universal". The Windows Package Manager client currently has no behavior associated with this property. It was added for future looking scenarios.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -236,8 +231,7 @@ ManifestVersion: 1.6.0
 
  This key represents the minimum version of the Windows operating system supported by the package.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -247,14 +241,11 @@ ManifestVersion: 1.6.0
 
  This key represents the installer type for the package. The Windows Package Manager supports [MSIX], [MSI], and executable installers. Some well known formats ([Inno], [Nullsoft], [WiX], and [Burn]) provide standard sets of installer switches to provide different installer experiences. Portable packages are supported as of Windows Package Manager 1.3. Zip packages are supported as of Windows Package Manager 1.5.
 
- > [!IMPORTANT]
- The Windows Package Manager 1.6 does not support loose executables with the .com file extension directly. Progressive Web Applications (PWAs) and fonts are also not supported.
+ IMPORTANT: The Windows Package Manager 1.6 does not support loose executables with the .com file extension directly. Progressive Web Applications (PWAs) and fonts are also not supported.
 
- > [!NOTE]
- The Windows Package Manager defaults to the install mode providing install progress. A best practice is to determine if one of the supported installer technologies was used to build an installer with the .exe file extension. The [Windows Package Manager Manifest Creator] tool can be used to determine if one of the known tools was used to build an installer with the .exe file extension.
+ NOTE: The Windows Package Manager defaults to the install mode providing install progress. A best practice is to determine if one of the supported installer technologies was used to build an installer with the .exe file extension. The [Windows Package Manager Manifest Creator] tool can be used to determine if one of the known tools was used to build an installer with the .exe file extension.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -272,8 +263,7 @@ ManifestVersion: 1.6.0
 
  This key represents the SHA 256 hash for the installer. It is used to confirm the installer has not been modified. The Windows Package Manager will compare the hash in the manifest with the calculated hash of the installer after it has been downloaded.
 
- > [!NOTE]
- The [Windows Package Manager Manifest Creator] can be used to determine the SHA 256 of the installer. The `winget hash &lt;pathToInstaller&gt;` command can also be used to determine the SHA 256 of the installer.
+ NOTE: The [Windows Package Manager Manifest Creator] can be used to determine the SHA 256 of the installer. The `winget hash &lt;pathToInstaller&gt;` command can also be used to determine the SHA 256 of the installer.
 </details>
 
 <details>
@@ -283,8 +273,7 @@ ManifestVersion: 1.6.0
 
  This key represents the signature file (AppxSignature.p7x) inside an MSIX installer. It is used to provide streaming install for MSIX packages.
 
- > [!IMPORTANT]
- MSIX installers must be signed to be included in the Microsoft community package repository. If the installer is an MSIX this signature should be included in the manifest. The [Windows Package Manager Manifest Creator] can be used to determine the signature SHA 256. The `winget hash <pathToInstaller> --msix` command can also be used to determine the signature SHA 256.
+ IMPORTANT: MSIX installers must be signed to be included in the Microsoft community package repository. If the installer is an MSIX this signature should be included in the manifest. The [Windows Package Manager Manifest Creator] can be used to determine the signature SHA 256. The `winget hash <pathToInstaller> --msix` command can also be used to determine the signature SHA 256.
 </details>
 
 <details>
@@ -302,8 +291,7 @@ ManifestVersion: 1.6.0
 
  This key is a list of all the installers to be executed within an archive.
 
- > [!IMPORTANT]
- This field can only contain one nested installer file unless the NestedInstallerType is 'portable'
+ IMPORTANT: This field can only contain one nested installer file unless the NestedInstallerType is 'portable'
 </details>
 
 <details>
@@ -321,8 +309,7 @@ ManifestVersion: 1.6.0
 
  The alias which is added to the PATH for calling the package from the command line.
 
- > [!IMPORTANT]
- This field is only valid when NestedInstallerType is 'portable'
+ IMPORTANT: This field is only valid when NestedInstallerType is 'portable'
 </details>
 
 <details>
@@ -332,8 +319,7 @@ ManifestVersion: 1.6.0
 
  This key represents the scope the package is installed under. The two configurations are "user" and "machine". Some installers support only one of these scopes while others support both via arguments passed to the installer using "InstallerSwitches".
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -343,11 +329,9 @@ ManifestVersion: 1.6.0
 
  This key represents the install modes supported by the installer. The Microsoft community package repository requires a package support "silent" and "silent with progress". The Windows Package Manager also supports "interactive" installers. The Windows Package Manager client does not have any behavior associated with this key.
 
- > [!IMPORTANT]
- Some installers will attempt to install missing dependencies. If these dependencies require user interaction, the package will not be allowed into the Microsoft community package repository.
+ IMPORTANT: Some installers will attempt to install missing dependencies. If these dependencies require user interaction, the package will not be allowed into the Microsoft community package repository.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -369,11 +353,9 @@ ManifestVersion: 1.6.0
 
  This key represents switches passed to the installer to provide a silent install experience. These would be used when the command `winget install <package> --silent` is executed.
 
- > [!NOTE]
- When the Windows Package Manager installs a package using the "silent" install mode, any custom switches will also be passed to the installer. If a user applies override switches via command line via the Windows Package Manager, none of the switches from the manifest will be passed to the installer.
+ NOTE: When the Windows Package Manager installs a package using the "silent" install mode, any custom switches will also be passed to the installer. If a user applies override switches via command line via the Windows Package Manager, none of the switches from the manifest will be passed to the installer.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -383,8 +365,7 @@ ManifestVersion: 1.6.0
 
  This key represents switches passed to the installer to provide a silent with progress install experience. This is intended to allow a progress indication to the user, and the indication may come from an installer UI dialogue, but it must not require user interaction to complete. The Windows Package Manager currently defaults to this install experience.
 
- > [!NOTE]
- When the Windows Package Manager installs a package using the "silent with progress" install mode, any custom switches will also be passed to the installer. If a user applies override switches via command line via the Windows Package Manager, none of the switches from the manifest will be passed to the installer.
+ NOTE: When the Windows Package Manager installs a package using the "silent with progress" install mode, any custom switches will also be passed to the installer. If a user applies override switches via command line via the Windows Package Manager, none of the switches from the manifest will be passed to the installer.
 </details>
 
 <details>
@@ -394,8 +375,7 @@ ManifestVersion: 1.6.0
 
  This key represents switches passed to the installer to provide an interactive install experience. This is intended to allow a user to interact with the installer. These would be used when the command `winget install <package> --interactive` is executed.
 
- > [!NOTE]
- When the Windows Package Manager installs a package using the "interactive" install mode, any custom switches will also be passed to the installer. If a user applies override switches via command line via the Windows Package Manager, none of the switches from the manifest will be passed to the installer.
+ NOTE: When the Windows Package Manager installs a package using the "interactive" install mode, any custom switches will also be passed to the installer. If a user applies override switches via command line via the Windows Package Manager, none of the switches from the manifest will be passed to the installer.
 </details>
 
 <details>
@@ -421,8 +401,7 @@ ManifestVersion: 1.6.0
 
  This key represents the switches to be passed to the installer during an upgrade. This will happen only if the upgrade behavior is "install".
 
- > [!NOTE]
- If a user applies override switches via command line via the Windows Package Manager, none of the switches from the manifest will be passed to the installer.
+ NOTE: If a user applies override switches via command line via the Windows Package Manager, none of the switches from the manifest will be passed to the installer.
 </details>
 
 <details>
@@ -432,8 +411,7 @@ ManifestVersion: 1.6.0
 
  This key represents any switches the Windows Package Manager will pass to the installer in addition to "Silent", "SilentWithProgress", and "Interactive".
 
- > [!NOTE]
- If a user applies override switches via command line via the Windows Package Manager, none of the switches from the manifest will be passed to the installer.
+ NOTE: If a user applies override switches via command line via the Windows Package Manager, none of the switches from the manifest will be passed to the installer.
 </details>
 
 <details>
@@ -443,8 +421,7 @@ ManifestVersion: 1.6.0
 
  This key represents what the Windows Package Manager should do regarding the currently installed package during a package upgrade. If the package should be uninstalled first, the "uninstallPrevious" value should be specified. If the package should not be upgraded through WinGet, the "deny" value should be specified.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -454,11 +431,9 @@ ManifestVersion: 1.6.0
 
  This key represents any commands or aliases used to execute the package after it has been installed.
 
- > [!IMPORTANT]
- The Windows Package Manager does not update the path during the install workflow. In those cases, the user may need to restart their shell or terminal before the command will execute the newly installed package. The Windows Package Manager does not support any behavior related to commands or aliases.
+ IMPORTANT: The Windows Package Manager does not update the path during the install workflow. In those cases, the user may need to restart their shell or terminal before the command will execute the newly installed package. The Windows Package Manager does not support any behavior related to commands or aliases.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -468,8 +443,7 @@ ManifestVersion: 1.6.0
 
  This key represents any protocols supported by the package. The Windows Package Manager does not support any behavior related to protocols handled by a package.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -479,8 +453,7 @@ ManifestVersion: 1.6.0
 
  This key represents any file extensions supported by the package. The Windows Package Manager does not support any behavior related to the file extensions supported by the package.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -490,11 +463,9 @@ ManifestVersion: 1.6.0
 
  This key represents any dependencies required to install or run the package.
 
- > [!IMPORTANT]
- External Dependencies are not supported. Package dependencies are referenced by their package identifier and must come from the same source. Windows Features may require a reboot before they are enabled. Windows Libraries are not supported.
+ IMPORTANT: External Dependencies are not supported. Package dependencies are referenced by their package identifier and must come from the same source. Windows Features may require a reboot before they are enabled. Windows Libraries are not supported.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -504,8 +475,7 @@ ManifestVersion: 1.6.0
 
  This key represents any external dependencies required to install or run the package.
 
- > [!IMPORTANT]
- The Windows Package Manager does not support any behavior related to external dependencies.
+ IMPORTANT: The Windows Package Manager does not support any behavior related to external dependencies.
 </details>
 
 <details>
@@ -515,8 +485,7 @@ ManifestVersion: 1.6.0
 
  This key represents any packages from the same source required to install or run the package.
 
- > [!IMPORTANT]
-Dependencies are referenced by their package identifier and must come from the same source.
+ IMPORTANT: Dependencies are referenced by their package identifier and must come from the same source.
 </details>
 
 <details>
@@ -534,8 +503,7 @@ Dependencies are referenced by their package identifier and must come from the s
 
  This key represents any Windows libraries required to install or run the package.
 
- > [!IMPORTANT]
- The Windows Package Manager does not support any behavior related to Windows Libraries.
+ IMPORTANT: The Windows Package Manager does not support any behavior related to Windows Libraries.
 </details>
 
 <details>
@@ -545,8 +513,7 @@ Dependencies are referenced by their package identifier and must come from the s
 
  This key represents the package family name specified in an MSIX installer. This value is used to assist with matching packages from a source to the program installed in Windows via Add / Remove Programs for list, and upgrade behavior.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -556,8 +523,7 @@ Dependencies are referenced by their package identifier and must come from the s
 
  This key represents the capabilities provided by an MSIX package. More information is available for [App capability declarations]
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -567,8 +533,7 @@ Dependencies are referenced by their package identifier and must come from the s
 
  This key represents the restricted capabilities provided by an MSIX package. More information is available for [App capability declarations]
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -578,8 +543,7 @@ Dependencies are referenced by their package identifier and must come from the s
 
  This key represents the behavior associated with installers that abort the terminal. This most often occurs when a user is performing an upgrade of the running terminal.
 
- > [!NOTE]
- Windows Terminal no longer causes this to occur as the MSIX install behavior from the Windows Package Manager is deferred registration.
+ NOTE: Windows Terminal no longer causes this to occur as the MSIX install behavior from the Windows Package Manager is deferred registration.
 </details>
 
 <details>
@@ -625,8 +589,7 @@ Dependencies are referenced by their package identifier and must come from the s
 
   This key represents any markets a package may be installed in.
 
-  > [!IMPORTANT]
-  If a market is listed in both this key and the ExcludedMarkets key, the market will be excluded. Both keys are present to reduce the need to list the larger set of markets.
+  IMPORTANT: If a market is listed in both this key and the ExcludedMarkets key, the market will be excluded. Both keys are present to reduce the need to list the larger set of markets.
 </details>
 
 <details>
@@ -636,8 +599,7 @@ Dependencies are referenced by their package identifier and must come from the s
 
   This key represents any markets a package may not be installed in.
 
-  > [!IMPORTANT]
-  If a market is listed in both this key and the Markets key, the market will be excluded. Both keys are present to reduce the need to list the larger set of markets.
+  IMPORTANT: If a market is listed in both this key and the Markets key, the market will be excluded. Both keys are present to reduce the need to list the larger set of markets.
 </details>
 
 <details>
@@ -647,11 +609,9 @@ Dependencies are referenced by their package identifier and must come from the s
 
  This key represents any status codes returned by the installer representing a success condition other than zero.
 
- > [!IMPORTANT]
- Some return codes indicate a reboot is suggested or required. The Windows Package Manager does not support the reboot behavior currently. Some installers will force a reboot, and the Windows Package Manager does not currently suppress reboot behavior.
+ IMPORTANT: Some return codes indicate a reboot is suggested or required. The Windows Package Manager does not support the reboot behavior currently. Some installers will force a reboot, and the Windows Package Manager does not currently suppress reboot behavior.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -661,11 +621,9 @@ Dependencies are referenced by their package identifier and must come from the s
 
  This key represents any status codes returned by the installer representing a condition other than zero.
 
- > [!IMPORTANT]
- Some return codes indicate a reboot is suggested or required. The Windows Package Manager does not support the reboot behavior currently. Some installers will force a reboot, and the Windows Package Manager does not currently suppress reboot behavior.
+ IMPORTANT: Some return codes indicate a reboot is suggested or required. The Windows Package Manager does not support the reboot behavior currently. Some installers will force a reboot, and the Windows Package Manager does not currently suppress reboot behavior.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -683,8 +641,7 @@ Dependencies are referenced by their package identifier and must come from the s
 
  This key represents a return response to display when an installer returns an expected return code. MSIX and MSI packages have well known return codes. This is primarily intended for executable installers that have custom or unique return codes that can be mapped to a return response.
 
- > [!NOTE]
- An enumerated list of values in the JSON schema must be specified for consistency of user experience.
+ NOTE: An enumerated list of values in the JSON schema must be specified for consistency of user experience.
 </details>
 
 <details>
@@ -694,8 +651,7 @@ Dependencies are referenced by their package identifier and must come from the s
 
  This key represents a return response URL to display when an installer returns an expected return code. MSIX and MSI packages have well known return codes. This is primarily intended for executable installers that have custom or unique return codes that can be mapped to a return response.
 
- > [!NOTE]
- An enumerated list of values in the JSON schema must be specified for consistency of user experience.
+ NOTE: An enumerated list of values in the JSON schema must be specified for consistency of user experience.
 </details>
 
 <details>
@@ -705,8 +661,7 @@ Dependencies are referenced by their package identifier and must come from the s
 
  This key represents the [product code] specified in an MSI installer. This value is used to assist with matching packages from a source to the program installed in Windows via Add / Remove Programs for list, and upgrade behavior.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -750,8 +705,7 @@ Dependencies are referenced by their package identifier and must come from the s
 
  This key represents the [product code] for a package. It is used to help correlate installed packages with manifests in configured sources.
 
- > [!NOTE]
- This key is displayed twice for completeness. When AppsAndFeaturesEntries are specified, the ProductCode should be placed both within the installer and the AppsAndFeaturesEntries
+ NOTE: This key is displayed twice for completeness. When AppsAndFeaturesEntries are specified, the ProductCode should be placed both within the installer and the AppsAndFeaturesEntries
 </details>
 
 <details>
@@ -769,8 +723,7 @@ Dependencies are referenced by their package identifier and must come from the s
 
  This key represents the installer type for the package. It is used to help correlate installed packages with manifests in configured sources. In some cases, an installer is an .exe based installer, but contains an MSI installer. This key will help the Windows Package Manager understand if upgrading an MSI should be performed when it is contained in an .exe installer.
 
- > [!NOTE]
- This key is displayed twice for completeness. When AppsAndFeaturesEntries are specified, the InstallerType should be placed within the installer only, unless the AppsAndFeaturesEntries represent a different InstallerType
+ NOTE: This key is displayed twice for completeness. When AppsAndFeaturesEntries are specified, the InstallerType should be placed within the installer only, unless the AppsAndFeaturesEntries represent a different InstallerType
 </details>
 
 <details>
@@ -789,8 +742,7 @@ Dependencies are referenced by their package identifier and must come from the s
 
 This key represents whether a warning message is displayed to the user prior to install or upgrade if the package is known to interfere with any running applications.
 
-> [!NOTE]
-The DisplayInstallWarnings behavior is not implemented in the Windows Package Manager 1.6 client.
+NOTE: The DisplayInstallWarnings behavior is not implemented in the Windows Package Manager 1.6 client.
 </details>
 
 <details>

--- a/doc/manifest/schema/1.6.0/locale.md
+++ b/doc/manifest/schema/1.6.0/locale.md
@@ -81,8 +81,7 @@ ManifestVersion: 1.6.0        # The manifest syntax version
 * [Available languages for Windows]
 * [Default Input Profiles (Input Locales) in Windows][locales]
 
-  > [!NOTE]
-	This field is the key to determining which fields are required for the Microsoft community repository. The default locale specified in the version file must match with this value.
+  NOTE:	This field is the key to determining which fields are required for the Microsoft community repository. The default locale specified in the version file must match with this value.
  </details>
 
 <details>
@@ -92,8 +91,7 @@ ManifestVersion: 1.6.0        # The manifest syntax version
 
   This key represents the name of the publisher for a given package. This field is intended to allow the full publisher's or ISV's name to be displayed as they wish.
 
-  > [!NOTE]
-	With the 1.0 release of the Windows Package Manager, this name affects how packages from a source are mapped to Apps installed in Windows 10 and Windows 11 via Add / Remove Programs (ARP). The best practice is to ensure this matches the ARP entry for the package when it has been installed. The impact is associated with `winget upgrade` and `winget list`.
+  NOTE:	With the 1.0 release of the Windows Package Manager, this name affects how packages from a source are mapped to Apps installed in Windows 10 and Windows 11 via Add / Remove Programs (ARP). The best practice is to ensure this matches the ARP entry for the package when it has been installed. The impact is associated with `winget upgrade` and `winget list`.
  </details>
 
 <details>
@@ -135,8 +133,7 @@ ManifestVersion: 1.6.0        # The manifest syntax version
 
   This key represents the name of the package. This field is intended to allow the full package name to be displayed as the publisher or ISV wishes.
 
-  > [!NOTE]
-	With the 1.0 release of the Windows Package Manager, this name affects how packages from a source are mapped to Apps installed in Windows 10 via Add / Remove Programs (ARP). The best practice is to ensure this matches the ARP entry for the package name when it has been installed. The impact is associated with `winget upgrade` and `winget list`.
+  NOTE:	With the 1.0 release of the Windows Package Manager, this name affects how packages from a source are mapped to Apps installed in Windows 10 via Add / Remove Programs (ARP). The best practice is to ensure this matches the ARP entry for the package name when it has been installed. The impact is associated with `winget upgrade` and `winget list`.
  </details>
 
 <details>
@@ -190,8 +187,7 @@ ManifestVersion: 1.6.0        # The manifest syntax version
 
   This key represents the description for a package. It is intended for use in `winget show` to help a user understand what the package is.
 
-  > [!NOTE]
-	This should be something descriptive about what the package does, and it should not simply state something like "&lt;package name&gt; installer" or "&lt;package name&gt; setup".
+  NOTE:	This should be something descriptive about what the package does, and it should not simply state something like "&lt;package name&gt; installer" or "&lt;package name&gt; setup".
  </details>
 
 <details>
@@ -201,8 +197,7 @@ ManifestVersion: 1.6.0        # The manifest syntax version
 
   This key represents the full or long description for a package. It is *not* currently used in the Windows Package Manager.
 
-  > [!NOTE]
-	This was included for future integration with the Microsoft Store source to provide the ability to display the full package description.
+  NOTE:	This was included for future integration with the Microsoft Store source to provide the ability to display the full package description.
  </details>
 
 <details>
@@ -212,8 +207,7 @@ ManifestVersion: 1.6.0        # The manifest syntax version
 
   This key represents other common term users would search for when looking for packages.
 
-  > [!NOTE]
-	The best practice is to present these terms in all lower case with hyphens rather than spaces.
+  NOTE: The best practice is to present these terms in all lower case with hyphens rather than spaces.
  </details>
 
  <details>
@@ -223,8 +217,7 @@ ManifestVersion: 1.6.0        # The manifest syntax version
 
    This key holds any agreements a user must accept prior to download and subsequent install or upgrade.
 
-   > [!IMPORTANT]
-	 In the Windows Package Manager Community Repository, these are only allowed to be submitted by verified developers.
+   IMPORTANT: In the Windows Package Manager Community Repository, these are only allowed to be submitted by verified developers.
   </details>
 
 <details>

--- a/doc/manifest/schema/1.6.0/singleton.md
+++ b/doc/manifest/schema/1.6.0/singleton.md
@@ -154,8 +154,7 @@ ManifestVersion: 1.6.0
 
  The Windows Package Manager client uses this version to determine if an upgrade for a package is available. In some cases, packages may be released with a marketing driven version, and that causes trouble with the [`winget upgrade`][upgrade] command.
 
- > [!NOTE]
- The current best practice is to use the value reported in Add / Remove Programs when this version of the package is installed. In some cases, packages do not report a version resulting in an upgrade loop or other unwanted behavior. This practice may seem contrary to using semantic versioning, but it provides the best end to end experience for customers. It will take time for publishers and ISVs to migrate to semantic versioning, and some may intentionally choose to preserve other versioning schemes. In these cases, it is best practice to include the "AppsAndFeaturesEntries" section for each installer.
+ NOTE: The current best practice is to use the value reported in Add / Remove Programs when this version of the package is installed. In some cases, packages do not report a version resulting in an upgrade loop or other unwanted behavior. This practice may seem contrary to using semantic versioning, but it provides the best end to end experience for customers. It will take time for publishers and ISVs to migrate to semantic versioning, and some may intentionally choose to preserve other versioning schemes. In these cases, it is best practice to include the "AppsAndFeaturesEntries" section for each installer.
 </details>
 
 <details>
@@ -165,8 +164,7 @@ ManifestVersion: 1.6.0
 
  This key represents the distribution channel for a package. Examples may include "stable" or "beta".
 
- > [!NOTE]
- This key is included for future use. The Windows Package Manager currently does not have any behavior associated with this key. The intent behind this key is to help disambiguate the different channels for packages lacking support for side by side installation. Some packages support having more than one package channel available on a system simultaneously; in this case it is better to use unique packages rather than channels. This key is intended to ensure the proper channel for a package is used during install and upgrade scenarios.
+ NOTE: This key is included for future use. The Windows Package Manager currently does not have any behavior associated with this key. The intent behind this key is to help disambiguate the different channels for packages lacking support for side by side installation. Some packages support having more than one package channel available on a system simultaneously; in this case it is better to use unique packages rather than channels. This key is intended to ensure the proper channel for a package is used during install and upgrade scenarios.
  </details>
 
 <details>
@@ -176,8 +174,7 @@ ManifestVersion: 1.6.0
 
   This key represents the full or long description for a package. It is *not* currently used in the Windows Package Manager.
 
-  > [!NOTE]
-  This was included for future integration with the Microsoft Store source to provide the ability to display the full package description.
+  NOTE: This was included for future integration with the Microsoft Store source to provide the ability to display the full package description.
  </details>
 
 <details>
@@ -187,7 +184,7 @@ ManifestVersion: 1.6.0
 
   This key represents the most common term users would search for when installing or upgrading a package. If only one package uses this moniker, then the [install], [list] and [upgrade] command may match with this package.
 
-  >Note:Moniker is the third property evaluated when searching for a matching package.
+  NOTE: Moniker is the third property evaluated when searching for a matching package.
 </details>
 
 <details>
@@ -197,8 +194,7 @@ ManifestVersion: 1.6.0
 
   This key represents other common term users would search for when looking for packages.
 
-  > [!NOTE]
-  The best practice is to present these terms in all lower case with hyphens rather than spaces.
+  NOTE: The best practice is to present these terms in all lower case with hyphens rather than spaces.
  </details>
 
  <details>
@@ -208,8 +204,7 @@ ManifestVersion: 1.6.0
 
    This key holds any agreements a user must accept prior to download and subsequent install or upgrade.
 
-   > [!IMPORTANT]
-   In the Windows Package Manager Community Repository, these are only allowed to be submitted by verified developers.
+   IMPORTANT: In the Windows Package Manager Community Repository, these are only allowed to be submitted by verified developers.
   </details>
 
 <details>
@@ -307,8 +302,7 @@ ManifestVersion: 1.6.0
 
  The key represents an installer for a package.
 
- > [!IMPORTANT]
- Many of the keys related to installers may either be at the root level of the manifest, or included in an installer. Any values provided at the root level and not specified in an installer will be inherited.
+ IMPORTANT: Many of the keys related to installers may either be at the root level of the manifest, or included in an installer. Any values provided at the root level and not specified in an installer will be inherited.
 </details>
 
 <details>
@@ -326,8 +320,7 @@ ManifestVersion: 1.6.0
 
  This key represents the locale for an installer *not* the package meta-data. Some installers are compiled with locale or language specific properties. If this key is present, it is used to represent the package locale for an installer.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 
 </details>
 
@@ -338,8 +331,7 @@ ManifestVersion: 1.6.0
 
  This key represents the Windows platform targeted by the installer. The Windows Package Manager currently supports "Windows.Desktop" and "Windows.Universal". The Windows Package Manager client currently has no behavior associated with this property. It was added for future looking scenarios.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -349,8 +341,7 @@ ManifestVersion: 1.6.0
 
  This key represents the minimum version of the Windows operating system supported by the package.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -360,14 +351,11 @@ ManifestVersion: 1.6.0
 
  This key represents the installer type for the package. The Windows Package Manager supports [MSIX], [MSI], and executable installers. Some well known formats ([Inno], [Nullsoft], [WiX], and [Burn]) provide standard sets of installer switches to provide different installer experiences. Portable packages are supported as of Windows Package Manager 1.3. Zip packages are supported as of Windows Package Manager 1.5.
 
- > [!IMPORTANT]
- The Windows Package Manager does not support loose executables with the .exe or .com file extension directly. Progressive Web Applications (PWAs) and fonts are also not supported.
+ IMPORTANT: The Windows Package Manager does not support loose executables with the .exe or .com file extension directly. Progressive Web Applications (PWAs) and fonts are also not supported.
 
- > [!NOTE]
- The Windows Package Manager defaults to the install mode providing install progress. A best practice is to determine if one of the supported installer technologies was used to build an installer with the .exe file extension. The [Windows Package Manager Manifest Creator] tool can be used to determine if one of the known tools was used to build an installer with the .exe file extension.
+ NOTE: The Windows Package Manager defaults to the install mode providing install progress. A best practice is to determine if one of the supported installer technologies was used to build an installer with the .exe file extension. The [Windows Package Manager Manifest Creator] tool can be used to determine if one of the known tools was used to build an installer with the .exe file extension.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -385,8 +373,7 @@ ManifestVersion: 1.6.0
 
  This key represents the SHA 256 hash for the installer. It is used to confirm the installer has not been modified. The Windows Package Manager will compare the hash in the manifest with the calculated hash of the installer after it has been downloaded.
 
- > [!NOTE]
- The [Windows Package Manager Manifest Creator] can be used to determine the SHA 256 of the installer. The `winget hash &lt;pathToInstaller&gt;` command can also be used to determine the SHA 256 of the installer.
+ NOTE: The [Windows Package Manager Manifest Creator] can be used to determine the SHA 256 of the installer. The `winget hash &lt;pathToInstaller&gt;` command can also be used to determine the SHA 256 of the installer.
 </details>
 
 <details>
@@ -396,8 +383,7 @@ ManifestVersion: 1.6.0
 
  This key represents the signature file (AppxSignature.p7x) inside an MSIX installer. It is used to provide streaming install for MSIX packages.
 
- > [!IMPORTANT]
- MSIX installers must be signed to be included in the Microsoft community package repository. If the installer is an MSIX this signature should be included in the manifest. The [Windows Package Manager Manifest Creator] can be used to determine the signature SHA 256. The `winget hash <pathToInstaller> --msix` command can also be used to determine the signature SHA 256.
+ IMPORTANT: MSIX installers must be signed to be included in the Microsoft community package repository. If the installer is an MSIX this signature should be included in the manifest. The [Windows Package Manager Manifest Creator] can be used to determine the signature SHA 256. The `winget hash <pathToInstaller> --msix` command can also be used to determine the signature SHA 256.
 </details>
 
 <details>
@@ -433,7 +419,7 @@ ManifestVersion: 1.6.0
 
  The alias which is added to the PATH for calling the package from the command line.
 
- > Note: This field is only valid when NestedInstallerType is 'portable'
+ NOTE: This field is only valid when NestedInstallerType is 'portable'
 </details>
 
 <details>
@@ -443,8 +429,7 @@ ManifestVersion: 1.6.0
 
  This key represents the scope the package is installed under. The two configurations are "user" and "machine". Some installers support only one of these scopes while others support both via arguments passed to the installer using "InstallerSwitches".
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -454,11 +439,9 @@ ManifestVersion: 1.6.0
 
  This key represents the install modes supported by the installer. The Microsoft community package repository requires a package support "silent" and "silent with progress". The Windows Package Manager also supports "interactive" installers. The Windows Package Manager client does not have any behavior associated with this key.
 
- > [!IMPORTANT]
- Some installers will attempt to install missing dependencies. If these dependencies require user interaction, the package will not be allowed into the Microsoft community package repository.
+ IMPORTANT: Some installers will attempt to install missing dependencies. If these dependencies require user interaction, the package will not be allowed into the Microsoft community package repository.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -468,8 +451,7 @@ ManifestVersion: 1.6.0
 
  This key represents the set of switches passed to installers.
 
- > [!IMPORTANT]
- The Microsoft community repository currently requires support for silent and silent with progress installation. Many custom .exe installers will require the proper switches to meet this requirement. The [Windows Package Manager Manifest Creator] tool can be used to determine if one of the known tools was used to build an installer with the .exe file extension. In the event the tool is unable to determine the tool used to build the installer, the publisher may have documentation for the proper switches.
+ IMPORTANT: The Microsoft community repository currently requires support for silent and silent with progress installation. Many custom .exe installers will require the proper switches to meet this requirement. The [Windows Package Manager Manifest Creator] tool can be used to determine if one of the known tools was used to build an installer with the .exe file extension. In the event the tool is unable to determine the tool used to build the installer, the publisher may have documentation for the proper switches.
 </details>
 
 <details>
@@ -479,11 +461,9 @@ ManifestVersion: 1.6.0
 
  This key represents switches passed to the installer to provide a silent install experience. These would be used when the command `winget install <package> --silent` is executed.
 
- > [!NOTE]
- When the Windows Package Manager installs a package using the "silent" install mode, any custom switches will also be passed to the installer. If a user applies override switches via command line via the Windows Package Manager, none of the switches from the manifest will be passed to the installer.
+ NOTE: When the Windows Package Manager installs a package using the "silent" install mode, any custom switches will also be passed to the installer. If a user applies override switches via command line via the Windows Package Manager, none of the switches from the manifest will be passed to the installer.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -493,8 +473,7 @@ ManifestVersion: 1.6.0
 
  This key represents switches passed to the installer to provide a silent with progress install experience. This is intended to allow a progress indication to the user, and the indication may come from an installer UI dialogue, but it must not require user interaction to complete. The Windows Package Manager currently defaults to this install experience.
 
- > [!NOTE]
- When the Windows Package Manager installs a package using the "silent with progress" install mode, any custom switches will also be passed to the installer. If a user applies override switches via command line via the Windows Package Manager, none of the switches from the manifest will be passed to the installer.
+ NOTE: When the Windows Package Manager installs a package using the "silent with progress" install mode, any custom switches will also be passed to the installer. If a user applies override switches via command line via the Windows Package Manager, none of the switches from the manifest will be passed to the installer.
 </details>
 
 <details>
@@ -504,8 +483,7 @@ ManifestVersion: 1.6.0
 
  This key represents switches passed to the installer to provide an interactive install experience. This is intended to allow a user to interact with the installer. These would be used when the command `winget install <package> --interactive` is executed.
 
- > [!NOTE]
- When the Windows Package Manager installs a package using the "interactive" install mode, any custom switches will also be passed to the installer. If a user applies override switches via command line via the Windows Package Manager, none of the switches from the manifest will be passed to the installer.
+ NOTE: When the Windows Package Manager installs a package using the "interactive" install mode, any custom switches will also be passed to the installer. If a user applies override switches via command line via the Windows Package Manager, none of the switches from the manifest will be passed to the installer.
 </details>
 
 <details>
@@ -531,8 +509,7 @@ ManifestVersion: 1.6.0
 
  This key represents the switches to be passed to the installer during an upgrade. This will happen only if the upgrade behavior is "install".
 
- > [!NOTE]
- If a user applies override switches via command line via the Windows Package Manager, none of the switches from the manifest will be passed to the installer.
+ NOTE: If a user applies override switches via command line via the Windows Package Manager, none of the switches from the manifest will be passed to the installer.
 </details>
 
 <details>
@@ -542,8 +519,7 @@ ManifestVersion: 1.6.0
 
  This key represents any switches the Windows Package Manager will pass to the installer in addition to "Silent", "SilentWithProgress", and "Interactive".
 
- > [!NOTE]
- If a user applies override switches via command line via the Windows Package Manager, none of the switches from the manifest will be passed to the installer.
+ NOTE: If a user applies override switches via command line via the Windows Package Manager, none of the switches from the manifest will be passed to the installer.
 </details>
 
 <details>
@@ -553,8 +529,7 @@ ManifestVersion: 1.6.0
 
  This key represents what the Windows Package Manager should do regarding the currently installed package during a package upgrade. If the package should be uninstalled first, the "uninstallPrevious" value should be specified. If the package should not be upgraded through WinGet, the "deny" value should be specified.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -564,11 +539,9 @@ ManifestVersion: 1.6.0
 
  This key represents any commands or aliases used to execute the package after it has been installed.
 
- > [!IMPORTANT]
- The Windows Package Manager does not update the path during the install workflow. In those cases, the user may need to restart their shell or terminal before the command will execute the newly installed package. The Windows Package Manager does not support any behavior related to commands or aliases.
+ IMPORTANT: The Windows Package Manager does not update the path during the install workflow. In those cases, the user may need to restart their shell or terminal before the command will execute the newly installed package. The Windows Package Manager does not support any behavior related to commands or aliases.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -578,8 +551,7 @@ ManifestVersion: 1.6.0
 
  This key represents any protocols supported by the package. The Windows Package Manager does not support any behavior related to protocols handled by a package.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -589,8 +561,7 @@ ManifestVersion: 1.6.0
 
  This key represents any file extensions supported by the package. The Windows Package Manager does not support any behavior related to the file extensions supported by the package.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -600,11 +571,9 @@ ManifestVersion: 1.6.0
 
  This key represents any dependencies required to install or run the package.
 
- > [!IMPORTANT]
- The Windows Package Manager does not support any behavior related to dependencies.
+ IMPORTANT: The Windows Package Manager does not support any behavior related to dependencies.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -614,8 +583,7 @@ ManifestVersion: 1.6.0
 
  This key represents any external dependencies required to install or run the package.
 
- > [!IMPORTANT]
- The Windows Package Manager does not support any behavior related to dependencies.
+ IMPORTANT: The Windows Package Manager does not support any behavior related to dependencies.
 </details>
 
 <details>
@@ -625,8 +593,7 @@ ManifestVersion: 1.6.0
 
  This key represents any packages from the same source required to install or run the package.
 
- > [!IMPORTANT]
- The Windows Package Manager does not support any behavior related to dependencies.
+ IMPORTANT: The Windows Package Manager does not support any behavior related to dependencies.
 </details>
 
 <details>
@@ -636,8 +603,7 @@ ManifestVersion: 1.6.0
 
  This key represents any Windows features required to install or run the package.
 
- > [!IMPORTANT]
- The Windows Package Manager does not support any behavior related to dependencies.
+ IMPORTANT: The Windows Package Manager does not support any behavior related to dependencies.
 </details>
 
 <details>
@@ -647,8 +613,7 @@ ManifestVersion: 1.6.0
 
  This key represents any Windows libraries required to install or run the package.
 
- > [!IMPORTANT]
- The Windows Package Manager does not support any behavior related to dependencies.
+ IMPORTANT: The Windows Package Manager does not support any behavior related to dependencies.
 </details>
 
 <details>
@@ -658,8 +623,7 @@ ManifestVersion: 1.6.0
 
  This key represents the package family name specified in an MSIX installer. This value is used to assist with matching packages from a source to the program installed in Windows via Add / Remove Programs for list, and upgrade behavior.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -669,8 +633,7 @@ ManifestVersion: 1.6.0
 
  This key represents the capabilities provided by an MSIX package. More information is available for [App capability declarations]
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -680,8 +643,7 @@ ManifestVersion: 1.6.0
 
  This key represents the restricted capabilities provided by an MSIX package.More information is available for [App capability declarations]
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -691,8 +653,7 @@ ManifestVersion: 1.6.0
 
  This key represents the behavior associated with installers that abort the terminal. This most often occurs when a user is performing an upgrade of the running terminal.
 
- > [!NOTE]
- Windows Terminal no longer causes this to occur as the MSIX install behavior from the Windows Package Manager is deferred registration.
+ NOTE: Windows Terminal no longer causes this to occur as the MSIX install behavior from the Windows Package Manager is deferred registration.
 </details>
 
 <details>
@@ -734,8 +695,7 @@ ManifestVersion: 1.6.0
 
   This key represents any markets a package may be installed in.
 
-  > [!IMPORTANT]
- If a market is listed in both this key and the ExcludedMarkets key, the market will be excluded. Both keys are present to reduce the need to list the larger set of markets.
+  IMPORTANT: If a market is listed in both this key and the ExcludedMarkets key, the market will be excluded. Both keys are present to reduce the need to list the larger set of markets.
 </details>
 
 <details>
@@ -745,8 +705,7 @@ ManifestVersion: 1.6.0
 
   This key represents any markets a package may not be installed in.
 
-  > [!IMPORTANT]
- If a market is listed in both this key and the Markets key, the market will be excluded. Both keys are present to reduce the need to list the larger set of markets.
+  IMPORTANT: If a market is listed in both this key and the Markets key, the market will be excluded. Both keys are present to reduce the need to list the larger set of markets.
 </details>
 
 <details>
@@ -756,11 +715,9 @@ ManifestVersion: 1.6.0
 
  This key represents any status codes returned by the installer representing a success condition other than zero.
 
- > [!IMPORTANT]
- Some return codes indicate a reboot is suggested or required. The Windows Package Manager does not support the reboot behavior currently. Some installers will force a reboot, and the Windows Package Manager does not currently suppress reboot behavior.
+ IMPORTANT: Some return codes indicate a reboot is suggested or required. The Windows Package Manager does not support the reboot behavior currently. Some installers will force a reboot, and the Windows Package Manager does not currently suppress reboot behavior.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -770,11 +727,9 @@ ManifestVersion: 1.6.0
 
  This key represents any status codes returned by the installer representing a condition other than zero.
 
- > [!IMPORTANT]
- Some return codes indicate a reboot is suggested or required. The Windows Package Manager does not support the reboot behavior currently. Some installers will force a reboot, and the Windows Package Manager does not currently suppress reboot behavior.
+ IMPORTANT: Some return codes indicate a reboot is suggested or required. The Windows Package Manager does not support the reboot behavior currently. Some installers will force a reboot, and the Windows Package Manager does not currently suppress reboot behavior.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -792,8 +747,7 @@ ManifestVersion: 1.6.0
 
  This key represents a return response to display when an installer returns an expected return code. MSIX and MSI packages have well known return codes. This is primarily intended for executable installers that have custom or unique return coes that can be mapped to a return response.
 
- > [!NOTE]
- An enumerated list of values in the JSON schema must be specified for consistency of user experience.
+ NOTE: An enumerated list of values in the JSON schema must be specified for consistency of user experience.
 </details>
 
 <details>
@@ -803,8 +757,7 @@ ManifestVersion: 1.6.0
 
  This key represents a return response URL to display when an installer returns an expected return code. MSIX and MSI packages have well known return codes. This is primarily intended for executable installers that have custom or unique return codes that can be mapped to a return response.
 
- > [!NOTE]
- An enumerated list of values in the JSON schema must be specified for consistency of user experience.
+ NOTE: An enumerated list of values in the JSON schema must be specified for consistency of user experience.
 </details>
 
 <details>
@@ -814,8 +767,7 @@ ManifestVersion: 1.6.0
 
  This key represents the product code specified in an MSI installer. This value is used to assist with matching packages from a source to the program installed in Windows via Add / Remove Programs for list, and upgrade behavior.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -859,8 +811,7 @@ ManifestVersion: 1.6.0
 
  This key represents the product code for a package. It is used to help correlate installed packages with manifests in configured sources.
 
- > [!NOTE]
- This key is displayed twice for completeness. When AppsAndFeaturesEntries are specified, the ProductCode should be placed both within the installer and the AppsAndFeaturesEntries
+ NOTE: This key is displayed twice for completeness. When AppsAndFeaturesEntries are specified, the ProductCode should be placed both within the installer and the AppsAndFeaturesEntries
 </details>
 
 <details>
@@ -878,8 +829,7 @@ ManifestVersion: 1.6.0
 
  This key represents the installer type for the package. It is used to help correlate installed packages with manifests in configured sources. In some cases, an installer is an .exe based installer, but contains an MSI installer. This key will help the Windows Package Manager understand if upgrading an MSI should be performed when it is contained in an .exe installer.
 
- > [!NOTE]
- This key is displayed twice for completeness. When AppsAndFeaturesEntries are specified, the InstallerType should be placed within the installer only, unless the AppsAndFeaturesEntries represent a different InstallerType
+ NOTE: This key is displayed twice for completeness. When AppsAndFeaturesEntries are specified, the InstallerType should be placed within the installer only, unless the AppsAndFeaturesEntries represent a different InstallerType
 </details>
 
 <details>
@@ -898,8 +848,7 @@ ManifestVersion: 1.6.0
 
 This key represents whether a warning message is displayed to the user prior to install or upgrade if the package is known to interfere with any running applications.
 
-> [!NOTE]
- The DisplayInstallWarnings behavior is not implemented in the Windows Package Manager 1.6 client.
+NOTE: The DisplayInstallWarnings behavior is not implemented in the Windows Package Manager 1.6 client.
 </details>
 
 <details>

--- a/doc/manifest/schema/1.7.0/defaultLocale.md
+++ b/doc/manifest/schema/1.7.0/defaultLocale.md
@@ -82,8 +82,7 @@ ManifestVersion: 1.7.0        # The manifest syntax version
 * [Available languages for Windows]
 * [Default Input Profiles (Input Locales) in Windows][locales]
 
-  > [!NOTE]
-	This field is the key to determining which fields are required for the Microsoft community repository. The default locale specified in the version file must match with this value.
+  NOTE:	This field is the key to determining which fields are required for the Microsoft community repository. The default locale specified in the version file must match with this value.
  </details>
 
 
@@ -94,8 +93,7 @@ ManifestVersion: 1.7.0        # The manifest syntax version
 
   This key represents the name of the publisher for a given package. This field is intended to allow the full publisher's or ISV's name to be displayed as they wish.
 
-  > [!NOTE]
-	With the 1.7 release of the Windows Package Manager, this name affects how packages from a source are mapped to Apps installed in Windows 10 and Windows 11 via Add / Remove Programs (ARP) and Windows Apps & Features respectively. The best practice is to ensure this matches the entry for the package when it has been installed. The impact is associated with `winget upgrade` and `winget list`.
+  NOTE: With the 1.7 release of the Windows Package Manager, this name affects how packages from a source are mapped to Apps installed in Windows 10 and Windows 11 via Add / Remove Programs (ARP) and Windows Apps & Features respectively. The best practice is to ensure this matches the entry for the package when it has been installed. The impact is associated with `winget upgrade` and `winget list`.
  </details>
 
 <details>
@@ -137,8 +135,7 @@ ManifestVersion: 1.7.0        # The manifest syntax version
 
   This key represents the name of the package. This field is intended to allow the full package name to be displayed as the publisher or ISV wishes.
 
-  > [!NOTE]
-	With the 1.7 release of the Windows Package Manager, this name affects how packages from a source are mapped to Apps installed in Windows 10 via Add / Remove Programs (ARP). The best practice is to ensure this matches the ARP entry for the package name when it has been installed. The impact is associated with `winget upgrade` and `winget list`.
+  NOTE:	With the 1.7 release of the Windows Package Manager, this name affects how packages from a source are mapped to Apps installed in Windows 10 via Add / Remove Programs (ARP). The best practice is to ensure this matches the ARP entry for the package name when it has been installed. The impact is associated with `winget upgrade` and `winget list`.
  </details>
 
 <details>
@@ -192,8 +189,7 @@ ManifestVersion: 1.7.0        # The manifest syntax version
 
   This key represents the description for a package. It is intended for use in `winget show` to help a user understand what the package is.
 
-  > [!NOTE]
-	This should be something descriptive about what the package does, and it should not simply state something like "&lt;package name&gt; installer" or "&lt;package name&gt; setup".
+  NOTE:	This should be something descriptive about what the package does, and it should not simply state something like "&lt;package name&gt; installer" or "&lt;package name&gt; setup".
 </details>
 
 <details>
@@ -203,8 +199,7 @@ ManifestVersion: 1.7.0        # The manifest syntax version
 
   This key represents the full or long description for a package. It is *not* currently used in the Windows Package Manager.
 
-  > [!NOTE]
-	This was included for integration with the Microsoft Store source to provide the ability to display the full package description.
+  NOTE: This was included for integration with the Microsoft Store source to provide the ability to display the full package description.
 </details>
 
 <details>
@@ -214,8 +209,7 @@ ManifestVersion: 1.7.0        # The manifest syntax version
 
   This key represents the most common term users would search for when installing or upgrading a package. If only one package uses this moniker, then the [install], [list] and [upgrade] command may match with this package.
 
-  > [!NOTE]
-	Moniker is the third property evaluated when searching for a matching package.
+  NOTE: Moniker is the third property evaluated when searching for a matching package.
 </details>
 
 <details>
@@ -225,8 +219,7 @@ ManifestVersion: 1.7.0        # The manifest syntax version
 
   This key represents other common term users would search for when looking for packages. Tags should be pertinent to what a user might search for when looking for a specific package.
 
-  > [!NOTE]
-	The best practice is to present these terms in all lower case with hyphens rather than spaces.
+  NOTE:	The best practice is to present these terms in all lower case with hyphens rather than spaces.
 </details>
 
 

--- a/doc/manifest/schema/1.7.0/installer.md
+++ b/doc/manifest/schema/1.7.0/installer.md
@@ -167,8 +167,7 @@ ManifestVersion: 1.7.0
 
  The Windows Package Manager client uses this version to determine if an upgrade for a package is available. In some cases, packages may be released with a marketing driven version, and that causes trouble with the [`winget upgrade`] command.
 
- > [!NOTE]
- The current best practice is to use the value reported in Add / Remove Programs when this version of the package is installed. In some cases, packages do not report a version resulting in an upgrade loop or other unwanted behavior. This practice may seem contrary to using semantic versioning, but it provides the best end to end experience for customers. It will take time for publishers and ISVs to migrate to semantic versioning, and some may intentionally choose to preserve other versioning schemes. In these cases, it is best practice to include the "AppsAndFeaturesEntries" section for each installer.
+ NOTE: The current best practice is to use the value reported in Add / Remove Programs when this version of the package is installed. In some cases, packages do not report a version resulting in an upgrade loop or other unwanted behavior. This practice may seem contrary to using semantic versioning, but it provides the best end to end experience for customers. It will take time for publishers and ISVs to migrate to semantic versioning, and some may intentionally choose to preserve other versioning schemes. In these cases, it is best practice to include the "AppsAndFeaturesEntries" section for each installer.
 </details>
 
 <details>
@@ -178,8 +177,7 @@ ManifestVersion: 1.7.0
 
  This key represents the distribution channel for a package. Examples may include "stable" or "beta".
 
- > [!NOTE]
- This key is included for future use. The Windows Package Manager currently does not have any behavior associated with this key. The intent behind this key is to help disambiguate the different channels for packages lacking support for side by side installation. Some packages support having more than one package channel available on a system simultaneously; in this case it is better to use unique packages rather than channels. This key is intended to ensure the proper channel for a package is used during install and upgrade scenarios.
+ NOTE: This key is included for future use. The Windows Package Manager currently does not have any behavior associated with this key. The intent behind this key is to help disambiguate the different channels for packages lacking support for side by side installation. Some packages support having more than one package channel available on a system simultaneously; in this case it is better to use unique packages rather than channels. This key is intended to ensure the proper channel for a package is used during install and upgrade scenarios.
 </details>
 
 <details>
@@ -189,8 +187,7 @@ ManifestVersion: 1.7.0
 
  The key represents an installer for a package.
 
- > [!IMPORTANT]
- Many of the keys related to installers may either be at the root level of the manifest, or included in an installer. Any values provided at the root level and not specified in an installer will be inherited.
+ IMPORTANT: Many of the keys related to installers may either be at the root level of the manifest, or included in an installer. Any values provided at the root level and not specified in an installer will be inherited.
 </details>
 
 <details>
@@ -216,8 +213,7 @@ ManifestVersion: 1.7.0
 
  This key represents the locale for an installer *not* the package meta-data. Some installers are compiled with locale or language specific properties. If this key is present, it is used to represent the package locale for an installer.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -227,8 +223,7 @@ ManifestVersion: 1.7.0
 
  This key represents the Windows platform targeted by the installer. The Windows Package Manager currently supports "Windows.Desktop" and "Windows.Universal". The Windows Package Manager client currently has no behavior associated with this property. It was added for future looking scenarios.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -238,8 +233,7 @@ ManifestVersion: 1.7.0
 
  This key represents the minimum version of the Windows operating system supported by the package.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -249,14 +243,11 @@ ManifestVersion: 1.7.0
 
  This key represents the installer type for the package. The Windows Package Manager supports [MSIX], [MSI], and executable installers. Some well known formats ([Inno], [Nullsoft], [WiX], and [Burn]) provide standard sets of installer switches to provide different installer experiences. Portable packages are supported as of Windows Package Manager 1.3. Zip packages are supported as of Windows Package Manager 1.5.
 
- > [!IMPORTANT]
- The Windows Package Manager 1.7 does not support loose executables with the .com file extension directly. Progressive Web Applications (PWAs) and fonts are also not supported.
+ IMPORTANT: The Windows Package Manager 1.7 does not support loose executables with the .com file extension directly. Progressive Web Applications (PWAs) and fonts are also not supported.
 
- > [!NOTE]
- The Windows Package Manager defaults to the install mode providing install progress. A best practice is to determine if one of the supported installer technologies was used to build an installer with the .exe file extension. The [Windows Package Manager Manifest Creator] tool can be used to determine if one of the known tools was used to build an installer with the .exe file extension.
+ NOTE: The Windows Package Manager defaults to the install mode providing install progress. A best practice is to determine if one of the supported installer technologies was used to build an installer with the .exe file extension. The [Windows Package Manager Manifest Creator] tool can be used to determine if one of the known tools was used to build an installer with the .exe file extension.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -274,8 +265,7 @@ ManifestVersion: 1.7.0
 
  This key represents the SHA 256 hash for the installer. It is used to confirm the installer has not been modified. The Windows Package Manager will compare the hash in the manifest with the calculated hash of the installer after it has been downloaded.
 
- > [!NOTE]
- The [Windows Package Manager Manifest Creator] can be used to determine the SHA 256 of the installer. The `winget hash &lt;pathToInstaller&gt;` command can also be used to determine the SHA 256 of the installer.
+ NOTE: The [Windows Package Manager Manifest Creator] can be used to determine the SHA 256 of the installer. The `winget hash &lt;pathToInstaller&gt;` command can also be used to determine the SHA 256 of the installer.
 </details>
 
 <details>
@@ -285,8 +275,7 @@ ManifestVersion: 1.7.0
 
  This key represents the signature file (AppxSignature.p7x) inside an MSIX installer. It is used to provide streaming install for MSIX packages.
 
- > [!IMPORTANT]
- MSIX installers must be signed to be included in the Microsoft community package repository. If the installer is an MSIX this signature should be included in the manifest. The [Windows Package Manager Manifest Creator] can be used to determine the signature SHA 256. The `winget hash <pathToInstaller> --msix` command can also be used to determine the signature SHA 256.
+ IMPORTANT: MSIX installers must be signed to be included in the Microsoft community package repository. If the installer is an MSIX this signature should be included in the manifest. The [Windows Package Manager Manifest Creator] can be used to determine the signature SHA 256. The `winget hash <pathToInstaller> --msix` command can also be used to determine the signature SHA 256.
 </details>
 
 <details>
@@ -304,8 +293,7 @@ ManifestVersion: 1.7.0
 
  This key is a list of all the installers to be executed within an archive.
 
- > [!IMPORTANT]
- This field can only contain one nested installer file unless the NestedInstallerType is 'portable'
+ IMPORTANT: This field can only contain one nested installer file unless the NestedInstallerType is 'portable'
 </details>
 
 <details>
@@ -323,8 +311,7 @@ ManifestVersion: 1.7.0
 
  The alias which is added to the PATH for calling the package from the command line.
 
- > [!IMPORTANT]
- This field is only valid when NestedInstallerType is 'portable'
+ IMPORTANT: This field is only valid when NestedInstallerType is 'portable'
 </details>
 
 <details>
@@ -334,8 +321,7 @@ ManifestVersion: 1.7.0
 
  This key represents the scope the package is installed under. The two configurations are "user" and "machine". Some installers support only one of these scopes while others support both via arguments passed to the installer using "InstallerSwitches".
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -345,11 +331,9 @@ ManifestVersion: 1.7.0
 
  This key represents the install modes supported by the installer. The Microsoft community package repository requires a package support "silent" and "silent with progress". The Windows Package Manager also supports "interactive" installers. The Windows Package Manager client does not have any behavior associated with this key.
 
- > [!IMPORTANT]
- Some installers will attempt to install missing dependencies. If these dependencies require user interaction, the package will not be allowed into the Microsoft community package repository.
+ IMPORTANT: Some installers will attempt to install missing dependencies. If these dependencies require user interaction, the package will not be allowed into the Microsoft community package repository.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -371,11 +355,9 @@ ManifestVersion: 1.7.0
 
  This key represents switches passed to the installer to provide a silent install experience. These would be used when the command `winget install <package> --silent` is executed.
 
- > [!NOTE]
- When the Windows Package Manager installs a package using the "silent" install mode, any custom switches will also be passed to the installer. If a user applies override switches via command line via the Windows Package Manager, none of the switches from the manifest will be passed to the installer.
+ NOTE: When the Windows Package Manager installs a package using the "silent" install mode, any custom switches will also be passed to the installer. If a user applies override switches via command line via the Windows Package Manager, none of the switches from the manifest will be passed to the installer.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -385,8 +367,7 @@ ManifestVersion: 1.7.0
 
  This key represents switches passed to the installer to provide a silent with progress install experience. This is intended to allow a progress indication to the user, and the indication may come from an installer UI dialogue, but it must not require user interaction to complete. The Windows Package Manager currently defaults to this install experience.
 
- > [!NOTE]
- When the Windows Package Manager installs a package using the "silent with progress" install mode, any custom switches will also be passed to the installer. If a user applies override switches via command line via the Windows Package Manager, none of the switches from the manifest will be passed to the installer.
+ NOTE: When the Windows Package Manager installs a package using the "silent with progress" install mode, any custom switches will also be passed to the installer. If a user applies override switches via command line via the Windows Package Manager, none of the switches from the manifest will be passed to the installer.
 </details>
 
 <details>
@@ -396,8 +377,7 @@ ManifestVersion: 1.7.0
 
  This key represents switches passed to the installer to provide an interactive install experience. This is intended to allow a user to interact with the installer. These would be used when the command `winget install <package> --interactive` is executed.
 
- > [!NOTE]
- When the Windows Package Manager installs a package using the "interactive" install mode, any custom switches will also be passed to the installer. If a user applies override switches via command line via the Windows Package Manager, none of the switches from the manifest will be passed to the installer.
+ NOTE: When the Windows Package Manager installs a package using the "interactive" install mode, any custom switches will also be passed to the installer. If a user applies override switches via command line via the Windows Package Manager, none of the switches from the manifest will be passed to the installer.
 </details>
 
 <details>
@@ -423,8 +403,7 @@ ManifestVersion: 1.7.0
 
  This key represents the switches to be passed to the installer during an upgrade. This will happen only if the upgrade behavior is "install".
 
- > [!NOTE]
- If a user applies override switches via command line via the Windows Package Manager, none of the switches from the manifest will be passed to the installer.
+ NOTE: If a user applies override switches via command line via the Windows Package Manager, none of the switches from the manifest will be passed to the installer.
 </details>
 
 <details>
@@ -434,8 +413,7 @@ ManifestVersion: 1.7.0
 
  This key represents any switches the Windows Package Manager will pass to the installer in addition to "Silent", "SilentWithProgress", and "Interactive".
 
- > [!NOTE]
- If a user applies override switches via command line via the Windows Package Manager, none of the switches from the manifest will be passed to the installer.
+ NOTE: If a user applies override switches via command line via the Windows Package Manager, none of the switches from the manifest will be passed to the installer.
 </details>
 
 <details>
@@ -445,8 +423,7 @@ ManifestVersion: 1.7.0
 
  This key represents the switches to be passed during the repair of an existing installation. This will be passed to the installer, ModifyPath ARP command, or Uninstaller ARP command depending on the RepairBehavior specified in the manifest.
 
- > [!NOTE]
- If a user applies override switches via command line via the Windows Package Manager, none of the switches from the manifest will be passed to the installer.
+ NOTE: If a user applies override switches via command line via the Windows Package Manager, none of the switches from the manifest will be passed to the installer.
 </details>
 
 <details>
@@ -456,8 +433,7 @@ ManifestVersion: 1.7.0
 
  This key represents what the Windows Package Manager should do regarding the currently installed package during a package upgrade. If the package should be uninstalled first, the "uninstallPrevious" value should be specified. If the package should not be upgraded through WinGet, the "deny" value should be specified.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -467,11 +443,9 @@ ManifestVersion: 1.7.0
 
  This key represents any commands or aliases used to execute the package after it has been installed.
 
- > [!IMPORTANT]
- The Windows Package Manager does not update the path during the install workflow. In those cases, the user may need to restart their shell or terminal before the command will execute the newly installed package. The Windows Package Manager does not support any behavior related to commands or aliases.
+ IMPORTANT: The Windows Package Manager does not update the path during the install workflow. In those cases, the user may need to restart their shell or terminal before the command will execute the newly installed package. The Windows Package Manager does not support any behavior related to commands or aliases.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -481,8 +455,7 @@ ManifestVersion: 1.7.0
 
  This key represents any protocols supported by the package. The Windows Package Manager does not support any behavior related to protocols handled by a package.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -492,8 +465,7 @@ ManifestVersion: 1.7.0
 
  This key represents any file extensions supported by the package. The Windows Package Manager does not support any behavior related to the file extensions supported by the package.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -503,11 +475,9 @@ ManifestVersion: 1.7.0
 
  This key represents any dependencies required to install or run the package.
 
- > [!IMPORTANT]
- External Dependencies are not supported. Package dependencies are referenced by their package identifier and must come from the same source. Windows Features may require a reboot before they are enabled. Windows Libraries are not supported.
+ IMPORTANT: External Dependencies are not supported. Package dependencies are referenced by their package identifier and must come from the same source. Windows Features may require a reboot before they are enabled. Windows Libraries are not supported.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -517,8 +487,7 @@ ManifestVersion: 1.7.0
 
  This key represents any external dependencies required to install or run the package.
 
- > [!IMPORTANT]
- The Windows Package Manager does not support any behavior related to external dependencies.
+ IMPORTANT: The Windows Package Manager does not support any behavior related to external dependencies.
 </details>
 
 <details>
@@ -528,8 +497,7 @@ ManifestVersion: 1.7.0
 
  This key represents any packages from the same source required to install or run the package.
 
- > [!IMPORTANT]
-Dependencies are referenced by their package identifier and must come from the same source.
+ IMPORTANT: Dependencies are referenced by their package identifier and must come from the same source.
 </details>
 
 <details>
@@ -547,8 +515,7 @@ Dependencies are referenced by their package identifier and must come from the s
 
  This key represents any Windows libraries required to install or run the package.
 
- > [!IMPORTANT]
- The Windows Package Manager does not support any behavior related to Windows Libraries.
+ IMPORTANT: The Windows Package Manager does not support any behavior related to Windows Libraries.
 </details>
 
 <details>
@@ -558,8 +525,7 @@ Dependencies are referenced by their package identifier and must come from the s
 
  This key represents the package family name specified in an MSIX installer. This value is used to assist with matching packages from a source to the program installed in Windows via Add / Remove Programs for list, and upgrade behavior.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -569,8 +535,7 @@ Dependencies are referenced by their package identifier and must come from the s
 
  This key represents the capabilities provided by an MSIX package. More information is available for [App capability declarations]
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -580,8 +545,7 @@ Dependencies are referenced by their package identifier and must come from the s
 
  This key represents the restricted capabilities provided by an MSIX package. More information is available for [App capability declarations]
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -591,8 +555,7 @@ Dependencies are referenced by their package identifier and must come from the s
 
  This key represents the behavior associated with installers that abort the terminal. This most often occurs when a user is performing an upgrade of the running terminal.
 
- > [!NOTE]
- Windows Terminal no longer causes this to occur as the MSIX install behavior from the Windows Package Manager is deferred registration.
+ NOTE: Windows Terminal no longer causes this to occur as the MSIX install behavior from the Windows Package Manager is deferred registration.
 </details>
 
 <details>
@@ -638,8 +601,7 @@ Dependencies are referenced by their package identifier and must come from the s
 
   This key represents any markets a package may be installed in.
 
-  > [!IMPORTANT]
-  If a market is listed in both this key and the ExcludedMarkets key, the market will be excluded. Both keys are present to reduce the need to list the larger set of markets.
+  IMPORTANT: If a market is listed in both this key and the ExcludedMarkets key, the market will be excluded. Both keys are present to reduce the need to list the larger set of markets.
 </details>
 
 <details>
@@ -649,8 +611,7 @@ Dependencies are referenced by their package identifier and must come from the s
 
   This key represents any markets a package may not be installed in.
 
-  > [!IMPORTANT]
-  If a market is listed in both this key and the Markets key, the market will be excluded. Both keys are present to reduce the need to list the larger set of markets.
+  IMPORTANT: If a market is listed in both this key and the Markets key, the market will be excluded. Both keys are present to reduce the need to list the larger set of markets.
 </details>
 
 <details>
@@ -660,11 +621,9 @@ Dependencies are referenced by their package identifier and must come from the s
 
  This key represents any status codes returned by the installer representing a success condition other than zero.
 
- > [!IMPORTANT]
- Some return codes indicate a reboot is suggested or required. The Windows Package Manager does not support the reboot behavior currently. Some installers will force a reboot, and the Windows Package Manager does not currently suppress reboot behavior.
+ IMPORTANT: Some return codes indicate a reboot is suggested or required. The Windows Package Manager does not support the reboot behavior currently. Some installers will force a reboot, and the Windows Package Manager does not currently suppress reboot behavior.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -674,11 +633,9 @@ Dependencies are referenced by their package identifier and must come from the s
 
  This key represents any status codes returned by the installer representing a condition other than zero.
 
- > [!IMPORTANT]
- Some return codes indicate a reboot is suggested or required. The Windows Package Manager does not support the reboot behavior currently. Some installers will force a reboot, and the Windows Package Manager does not currently suppress reboot behavior.
+ IMPORTANT: Some return codes indicate a reboot is suggested or required. The Windows Package Manager does not support the reboot behavior currently. Some installers will force a reboot, and the Windows Package Manager does not currently suppress reboot behavior.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -696,8 +653,7 @@ Dependencies are referenced by their package identifier and must come from the s
 
  This key represents a return response to display when an installer returns an expected return code. MSIX and MSI packages have well known return codes. This is primarily intended for executable installers that have custom or unique return codes that can be mapped to a return response.
 
- > [!NOTE]
- An enumerated list of values in the JSON schema must be specified for consistency of user experience.
+ NOTE: An enumerated list of values in the JSON schema must be specified for consistency of user experience.
 </details>
 
 <details>
@@ -707,8 +663,7 @@ Dependencies are referenced by their package identifier and must come from the s
 
  This key represents a return response URL to display when an installer returns an expected return code. MSIX and MSI packages have well known return codes. This is primarily intended for executable installers that have custom or unique return codes that can be mapped to a return response.
 
- > [!NOTE]
- An enumerated list of values in the JSON schema must be specified for consistency of user experience.
+ NOTE: An enumerated list of values in the JSON schema must be specified for consistency of user experience.
 </details>
 
 <details>
@@ -718,8 +673,7 @@ Dependencies are referenced by their package identifier and must come from the s
 
  This key represents the [product code] specified in an MSI installer. This value is used to assist with matching packages from a source to the program installed in Windows via Add / Remove Programs for list, and upgrade behavior.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -763,8 +717,7 @@ Dependencies are referenced by their package identifier and must come from the s
 
  This key represents the [product code] for a package. It is used to help correlate installed packages with manifests in configured sources.
 
- > [!NOTE]
- This key is displayed twice for completeness. When AppsAndFeaturesEntries are specified, the ProductCode should be placed both within the installer and the AppsAndFeaturesEntries
+ NOTE: This key is displayed twice for completeness. When AppsAndFeaturesEntries are specified, the ProductCode should be placed both within the installer and the AppsAndFeaturesEntries
 </details>
 
 <details>
@@ -782,8 +735,7 @@ Dependencies are referenced by their package identifier and must come from the s
 
  This key represents the installer type for the package. It is used to help correlate installed packages with manifests in configured sources. In some cases, an installer is an .exe based installer, but contains an MSI installer. This key will help the Windows Package Manager understand if upgrading an MSI should be performed when it is contained in an .exe installer.
 
- > [!NOTE]
- This key is displayed twice for completeness. When AppsAndFeaturesEntries are specified, the InstallerType should be placed within the installer only, unless the AppsAndFeaturesEntries represent a different InstallerType
+ NOTE: This key is displayed twice for completeness. When AppsAndFeaturesEntries are specified, the InstallerType should be placed within the installer only, unless the AppsAndFeaturesEntries represent a different InstallerType
 </details>
 
 <details>
@@ -802,8 +754,7 @@ Dependencies are referenced by their package identifier and must come from the s
 
 This key represents whether a warning message is displayed to the user prior to install or upgrade if the package is known to interfere with any running applications.
 
-> [!NOTE]
-The DisplayInstallWarnings behavior is not implemented in the Windows Package Manager 1.7 client.
+NOTE: The DisplayInstallWarnings behavior is not implemented in the Windows Package Manager 1.7 client.
 </details>
 
 <details>

--- a/doc/manifest/schema/1.7.0/locale.md
+++ b/doc/manifest/schema/1.7.0/locale.md
@@ -81,8 +81,7 @@ ManifestVersion: 1.7.0        # The manifest syntax version
 * [Available languages for Windows]
 * [Default Input Profiles (Input Locales) in Windows][locales]
 
-  > [!NOTE]
-	This field is the key to determining which fields are required for the Microsoft community repository. The default locale specified in the version file must match with this value.
+  NOTE:	This field is the key to determining which fields are required for the Microsoft community repository. The default locale specified in the version file must match with this value.
  </details>
 
 <details>
@@ -92,8 +91,7 @@ ManifestVersion: 1.7.0        # The manifest syntax version
 
   This key represents the name of the publisher for a given package. This field is intended to allow the full publisher's or ISV's name to be displayed as they wish.
 
-  > [!NOTE]
-	With the 1.0 release of the Windows Package Manager, this name affects how packages from a source are mapped to Apps installed in Windows 10 and Windows 11 via Add / Remove Programs (ARP). The best practice is to ensure this matches the ARP entry for the package when it has been installed. The impact is associated with `winget upgrade` and `winget list`.
+  NOTE:	With the 1.0 release of the Windows Package Manager, this name affects how packages from a source are mapped to Apps installed in Windows 10 and Windows 11 via Add / Remove Programs (ARP). The best practice is to ensure this matches the ARP entry for the package when it has been installed. The impact is associated with `winget upgrade` and `winget list`.
  </details>
 
 <details>
@@ -135,8 +133,7 @@ ManifestVersion: 1.7.0        # The manifest syntax version
 
   This key represents the name of the package. This field is intended to allow the full package name to be displayed as the publisher or ISV wishes.
 
-  > [!NOTE]
-	With the 1.0 release of the Windows Package Manager, this name affects how packages from a source are mapped to Apps installed in Windows 10 via Add / Remove Programs (ARP). The best practice is to ensure this matches the ARP entry for the package name when it has been installed. The impact is associated with `winget upgrade` and `winget list`.
+  NOTE:	With the 1.0 release of the Windows Package Manager, this name affects how packages from a source are mapped to Apps installed in Windows 10 via Add / Remove Programs (ARP). The best practice is to ensure this matches the ARP entry for the package name when it has been installed. The impact is associated with `winget upgrade` and `winget list`.
  </details>
 
 <details>
@@ -190,8 +187,7 @@ ManifestVersion: 1.7.0        # The manifest syntax version
 
   This key represents the description for a package. It is intended for use in `winget show` to help a user understand what the package is.
 
-  > [!NOTE]
-	This should be something descriptive about what the package does, and it should not simply state something like "&lt;package name&gt; installer" or "&lt;package name&gt; setup".
+  NOTE:	This should be something descriptive about what the package does, and it should not simply state something like "&lt;package name&gt; installer" or "&lt;package name&gt; setup".
  </details>
 
 <details>
@@ -201,8 +197,7 @@ ManifestVersion: 1.7.0        # The manifest syntax version
 
   This key represents the full or long description for a package. It is *not* currently used in the Windows Package Manager.
 
-  > [!NOTE]
-	This was included for future integration with the Microsoft Store source to provide the ability to display the full package description.
+  NOTE:	This was included for future integration with the Microsoft Store source to provide the ability to display the full package description.
  </details>
 
 <details>
@@ -212,8 +207,7 @@ ManifestVersion: 1.7.0        # The manifest syntax version
 
   This key represents other common term users would search for when looking for packages.
 
-  > [!NOTE]
-	The best practice is to present these terms in all lower case with hyphens rather than spaces.
+  NOTE:	The best practice is to present these terms in all lower case with hyphens rather than spaces.
  </details>
 
  <details>
@@ -223,8 +217,7 @@ ManifestVersion: 1.7.0        # The manifest syntax version
 
    This key holds any agreements a user must accept prior to download and subsequent install or upgrade.
 
-   > [!IMPORTANT]
-	 In the Windows Package Manager Community Repository, these are only allowed to be submitted by verified developers.
+   IMPORTANT: In the Windows Package Manager Community Repository, these are only allowed to be submitted by verified developers.
   </details>
 
 <details>

--- a/doc/manifest/schema/1.7.0/singleton.md
+++ b/doc/manifest/schema/1.7.0/singleton.md
@@ -156,8 +156,7 @@ ManifestVersion: 1.7.0
 
  The Windows Package Manager client uses this version to determine if an upgrade for a package is available. In some cases, packages may be released with a marketing driven version, and that causes trouble with the [`winget upgrade`][upgrade] command.
 
- > [!NOTE]
- The current best practice is to use the value reported in Add / Remove Programs when this version of the package is installed. In some cases, packages do not report a version resulting in an upgrade loop or other unwanted behavior. This practice may seem contrary to using semantic versioning, but it provides the best end to end experience for customers. It will take time for publishers and ISVs to migrate to semantic versioning, and some may intentionally choose to preserve other versioning schemes. In these cases, it is best practice to include the "AppsAndFeaturesEntries" section for each installer.
+ NOTE: The current best practice is to use the value reported in Add / Remove Programs when this version of the package is installed. In some cases, packages do not report a version resulting in an upgrade loop or other unwanted behavior. This practice may seem contrary to using semantic versioning, but it provides the best end to end experience for customers. It will take time for publishers and ISVs to migrate to semantic versioning, and some may intentionally choose to preserve other versioning schemes. In these cases, it is best practice to include the "AppsAndFeaturesEntries" section for each installer.
 </details>
 
 <details>
@@ -167,8 +166,7 @@ ManifestVersion: 1.7.0
 
  This key represents the distribution channel for a package. Examples may include "stable" or "beta".
 
- > [!NOTE]
- This key is included for future use. The Windows Package Manager currently does not have any behavior associated with this key. The intent behind this key is to help disambiguate the different channels for packages lacking support for side by side installation. Some packages support having more than one package channel available on a system simultaneously; in this case it is better to use unique packages rather than channels. This key is intended to ensure the proper channel for a package is used during install and upgrade scenarios.
+ NOTE: This key is included for future use. The Windows Package Manager currently does not have any behavior associated with this key. The intent behind this key is to help disambiguate the different channels for packages lacking support for side by side installation. Some packages support having more than one package channel available on a system simultaneously; in this case it is better to use unique packages rather than channels. This key is intended to ensure the proper channel for a package is used during install and upgrade scenarios.
  </details>
 
 <details>
@@ -178,8 +176,7 @@ ManifestVersion: 1.7.0
 
   This key represents the full or long description for a package. It is *not* currently used in the Windows Package Manager.
 
-  > [!NOTE]
-  This was included for future integration with the Microsoft Store source to provide the ability to display the full package description.
+  NOTE: This was included for future integration with the Microsoft Store source to provide the ability to display the full package description.
  </details>
 
 <details>
@@ -189,7 +186,7 @@ ManifestVersion: 1.7.0
 
   This key represents the most common term users would search for when installing or upgrading a package. If only one package uses this moniker, then the [install], [list] and [upgrade] command may match with this package.
 
-  >Note:Moniker is the third property evaluated when searching for a matching package.
+  NOTE: Moniker is the third property evaluated when searching for a matching package.
 </details>
 
 <details>
@@ -199,8 +196,7 @@ ManifestVersion: 1.7.0
 
   This key represents other common term users would search for when looking for packages.
 
-  > [!NOTE]
-  The best practice is to present these terms in all lower case with hyphens rather than spaces.
+  NOTE: The best practice is to present these terms in all lower case with hyphens rather than spaces.
  </details>
 
  <details>
@@ -210,8 +206,7 @@ ManifestVersion: 1.7.0
 
    This key holds any agreements a user must accept prior to download and subsequent install or upgrade.
 
-   > [!IMPORTANT]
-   In the Windows Package Manager Community Repository, these are only allowed to be submitted by verified developers.
+   IMPORTANT: In the Windows Package Manager Community Repository, these are only allowed to be submitted by verified developers.
   </details>
 
 <details>
@@ -309,8 +304,7 @@ ManifestVersion: 1.7.0
 
  The key represents an installer for a package.
 
- > [!IMPORTANT]
- Many of the keys related to installers may either be at the root level of the manifest, or included in an installer. Any values provided at the root level and not specified in an installer will be inherited.
+ IMPORTANT: Many of the keys related to installers may either be at the root level of the manifest, or included in an installer. Any values provided at the root level and not specified in an installer will be inherited.
 </details>
 
 <details>
@@ -328,8 +322,7 @@ ManifestVersion: 1.7.0
 
  This key represents the locale for an installer *not* the package meta-data. Some installers are compiled with locale or language specific properties. If this key is present, it is used to represent the package locale for an installer.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 
 </details>
 
@@ -340,8 +333,7 @@ ManifestVersion: 1.7.0
 
  This key represents the Windows platform targeted by the installer. The Windows Package Manager currently supports "Windows.Desktop" and "Windows.Universal". The Windows Package Manager client currently has no behavior associated with this property. It was added for future looking scenarios.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -351,8 +343,7 @@ ManifestVersion: 1.7.0
 
  This key represents the minimum version of the Windows operating system supported by the package.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -362,14 +353,11 @@ ManifestVersion: 1.7.0
 
  This key represents the installer type for the package. The Windows Package Manager supports [MSIX], [MSI], and executable installers. Some well known formats ([Inno], [Nullsoft], [WiX], and [Burn]) provide standard sets of installer switches to provide different installer experiences. Portable packages are supported as of Windows Package Manager 1.3. Zip packages are supported as of Windows Package Manager 1.5.
 
- > [!IMPORTANT]
- The Windows Package Manager does not support loose executables with the .exe or .com file extension directly. Progressive Web Applications (PWAs) and fonts are also not supported.
+ IMPORTANT: The Windows Package Manager does not support loose executables with the .exe or .com file extension directly. Progressive Web Applications (PWAs) and fonts are also not supported.
 
- > [!NOTE]
- The Windows Package Manager defaults to the install mode providing install progress. A best practice is to determine if one of the supported installer technologies was used to build an installer with the .exe file extension. The [Windows Package Manager Manifest Creator] tool can be used to determine if one of the known tools was used to build an installer with the .exe file extension.
+ NOTE: The Windows Package Manager defaults to the install mode providing install progress. A best practice is to determine if one of the supported installer technologies was used to build an installer with the .exe file extension. The [Windows Package Manager Manifest Creator] tool can be used to determine if one of the known tools was used to build an installer with the .exe file extension.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -387,8 +375,7 @@ ManifestVersion: 1.7.0
 
  This key represents the SHA 256 hash for the installer. It is used to confirm the installer has not been modified. The Windows Package Manager will compare the hash in the manifest with the calculated hash of the installer after it has been downloaded.
 
- > [!NOTE]
- The [Windows Package Manager Manifest Creator] can be used to determine the SHA 256 of the installer. The `winget hash &lt;pathToInstaller&gt;` command can also be used to determine the SHA 256 of the installer.
+ NOTE: The [Windows Package Manager Manifest Creator] can be used to determine the SHA 256 of the installer. The `winget hash &lt;pathToInstaller&gt;` command can also be used to determine the SHA 256 of the installer.
 </details>
 
 <details>
@@ -398,8 +385,7 @@ ManifestVersion: 1.7.0
 
  This key represents the signature file (AppxSignature.p7x) inside an MSIX installer. It is used to provide streaming install for MSIX packages.
 
- > [!IMPORTANT]
- MSIX installers must be signed to be included in the Microsoft community package repository. If the installer is an MSIX this signature should be included in the manifest. The [Windows Package Manager Manifest Creator] can be used to determine the signature SHA 256. The `winget hash <pathToInstaller> --msix` command can also be used to determine the signature SHA 256.
+ IMPORTANT: MSIX installers must be signed to be included in the Microsoft community package repository. If the installer is an MSIX this signature should be included in the manifest. The [Windows Package Manager Manifest Creator] can be used to determine the signature SHA 256. The `winget hash <pathToInstaller> --msix` command can also be used to determine the signature SHA 256.
 </details>
 
 <details>
@@ -445,8 +431,7 @@ ManifestVersion: 1.7.0
 
  This key represents the scope the package is installed under. The two configurations are "user" and "machine". Some installers support only one of these scopes while others support both via arguments passed to the installer using "InstallerSwitches".
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -456,11 +441,9 @@ ManifestVersion: 1.7.0
 
  This key represents the install modes supported by the installer. The Microsoft community package repository requires a package support "silent" and "silent with progress". The Windows Package Manager also supports "interactive" installers. The Windows Package Manager client does not have any behavior associated with this key.
 
- > [!IMPORTANT]
- Some installers will attempt to install missing dependencies. If these dependencies require user interaction, the package will not be allowed into the Microsoft community package repository.
+ IMPORTANT: Some installers will attempt to install missing dependencies. If these dependencies require user interaction, the package will not be allowed into the Microsoft community package repository.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -470,8 +453,7 @@ ManifestVersion: 1.7.0
 
  This key represents the set of switches passed to installers.
 
- > [!IMPORTANT]
- The Microsoft community repository currently requires support for silent and silent with progress installation. Many custom .exe installers will require the proper switches to meet this requirement. The [Windows Package Manager Manifest Creator] tool can be used to determine if one of the known tools was used to build an installer with the .exe file extension. In the event the tool is unable to determine the tool used to build the installer, the publisher may have documentation for the proper switches.
+ IMPORTANT: The Microsoft community repository currently requires support for silent and silent with progress installation. Many custom .exe installers will require the proper switches to meet this requirement. The [Windows Package Manager Manifest Creator] tool can be used to determine if one of the known tools was used to build an installer with the .exe file extension. In the event the tool is unable to determine the tool used to build the installer, the publisher may have documentation for the proper switches.
 </details>
 
 <details>
@@ -481,11 +463,9 @@ ManifestVersion: 1.7.0
 
  This key represents switches passed to the installer to provide a silent install experience. These would be used when the command `winget install <package> --silent` is executed.
 
- > [!NOTE]
- When the Windows Package Manager installs a package using the "silent" install mode, any custom switches will also be passed to the installer. If a user applies override switches via command line via the Windows Package Manager, none of the switches from the manifest will be passed to the installer.
+ NOTE: When the Windows Package Manager installs a package using the "silent" install mode, any custom switches will also be passed to the installer. If a user applies override switches via command line via the Windows Package Manager, none of the switches from the manifest will be passed to the installer.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -495,8 +475,7 @@ ManifestVersion: 1.7.0
 
  This key represents switches passed to the installer to provide a silent with progress install experience. This is intended to allow a progress indication to the user, and the indication may come from an installer UI dialogue, but it must not require user interaction to complete. The Windows Package Manager currently defaults to this install experience.
 
- > [!NOTE]
- When the Windows Package Manager installs a package using the "silent with progress" install mode, any custom switches will also be passed to the installer. If a user applies override switches via command line via the Windows Package Manager, none of the switches from the manifest will be passed to the installer.
+ NOTE: When the Windows Package Manager installs a package using the "silent with progress" install mode, any custom switches will also be passed to the installer. If a user applies override switches via command line via the Windows Package Manager, none of the switches from the manifest will be passed to the installer.
 </details>
 
 <details>
@@ -506,8 +485,7 @@ ManifestVersion: 1.7.0
 
  This key represents switches passed to the installer to provide an interactive install experience. This is intended to allow a user to interact with the installer. These would be used when the command `winget install <package> --interactive` is executed.
 
- > [!NOTE]
- When the Windows Package Manager installs a package using the "interactive" install mode, any custom switches will also be passed to the installer. If a user applies override switches via command line via the Windows Package Manager, none of the switches from the manifest will be passed to the installer.
+ NOTE: When the Windows Package Manager installs a package using the "interactive" install mode, any custom switches will also be passed to the installer. If a user applies override switches via command line via the Windows Package Manager, none of the switches from the manifest will be passed to the installer.
 </details>
 
 <details>
@@ -533,8 +511,7 @@ ManifestVersion: 1.7.0
 
  This key represents the switches to be passed to the installer during an upgrade. This will happen only if the upgrade behavior is "install".
 
- > [!NOTE]
- If a user applies override switches via command line via the Windows Package Manager, none of the switches from the manifest will be passed to the installer.
+ NOTE: If a user applies override switches via command line via the Windows Package Manager, none of the switches from the manifest will be passed to the installer.
 </details>
 
 <details>
@@ -544,8 +521,7 @@ ManifestVersion: 1.7.0
 
  This key represents any switches the Windows Package Manager will pass to the installer in addition to "Silent", "SilentWithProgress", and "Interactive".
 
- > [!NOTE]
- If a user applies override switches via command line via the Windows Package Manager, none of the switches from the manifest will be passed to the installer.
+ NOTE: If a user applies override switches via command line via the Windows Package Manager, none of the switches from the manifest will be passed to the installer.
 </details>
 
 <details>
@@ -555,8 +531,7 @@ ManifestVersion: 1.7.0
 
  This key represents the switches to be passed during the repair of an existing installation. This will be passed to the installer, ModifyPath ARP command, or Uninstaller ARP command depending on the RepairBehavior specified in the manifest.
 
- > [!NOTE]
- If a user applies override switches via command line via the Windows Package Manager, none of the switches from the manifest will be passed to the installer.
+ NOTE: If a user applies override switches via command line via the Windows Package Manager, none of the switches from the manifest will be passed to the installer.
 </details>
 
 <details>
@@ -566,8 +541,7 @@ ManifestVersion: 1.7.0
 
  This key represents what the Windows Package Manager should do regarding the currently installed package during a package upgrade. If the package should be uninstalled first, the "uninstallPrevious" value should be specified. If the package should not be upgraded through WinGet, the "deny" value should be specified.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -577,11 +551,9 @@ ManifestVersion: 1.7.0
 
  This key represents any commands or aliases used to execute the package after it has been installed.
 
- > [!IMPORTANT]
- The Windows Package Manager does not update the path during the install workflow. In those cases, the user may need to restart their shell or terminal before the command will execute the newly installed package. The Windows Package Manager does not support any behavior related to commands or aliases.
+ IMPORTANT: The Windows Package Manager does not update the path during the install workflow. In those cases, the user may need to restart their shell or terminal before the command will execute the newly installed package. The Windows Package Manager does not support any behavior related to commands or aliases.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -591,8 +563,7 @@ ManifestVersion: 1.7.0
 
  This key represents any protocols supported by the package. The Windows Package Manager does not support any behavior related to protocols handled by a package.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -602,8 +573,7 @@ ManifestVersion: 1.7.0
 
  This key represents any file extensions supported by the package. The Windows Package Manager does not support any behavior related to the file extensions supported by the package.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -613,11 +583,9 @@ ManifestVersion: 1.7.0
 
  This key represents any dependencies required to install or run the package.
 
- > [!IMPORTANT]
- The Windows Package Manager does not support any behavior related to dependencies.
+ IMPORTANT: The Windows Package Manager does not support any behavior related to dependencies.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -627,8 +595,7 @@ ManifestVersion: 1.7.0
 
  This key represents any external dependencies required to install or run the package.
 
- > [!IMPORTANT]
- The Windows Package Manager does not support any behavior related to dependencies.
+ IMPORTANT: The Windows Package Manager does not support any behavior related to dependencies.
 </details>
 
 <details>
@@ -638,8 +605,7 @@ ManifestVersion: 1.7.0
 
  This key represents any packages from the same source required to install or run the package.
 
- > [!IMPORTANT]
- The Windows Package Manager does not support any behavior related to dependencies.
+ IMPORTANT: The Windows Package Manager does not support any behavior related to dependencies.
 </details>
 
 <details>
@@ -649,8 +615,7 @@ ManifestVersion: 1.7.0
 
  This key represents any Windows features required to install or run the package.
 
- > [!IMPORTANT]
- The Windows Package Manager does not support any behavior related to dependencies.
+ IMPORTANT: The Windows Package Manager does not support any behavior related to dependencies.
 </details>
 
 <details>
@@ -660,8 +625,7 @@ ManifestVersion: 1.7.0
 
  This key represents any Windows libraries required to install or run the package.
 
- > [!IMPORTANT]
- The Windows Package Manager does not support any behavior related to dependencies.
+ IMPORTANT: The Windows Package Manager does not support any behavior related to dependencies.
 </details>
 
 <details>
@@ -671,8 +635,7 @@ ManifestVersion: 1.7.0
 
  This key represents the package family name specified in an MSIX installer. This value is used to assist with matching packages from a source to the program installed in Windows via Add / Remove Programs for list, and upgrade behavior.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -682,8 +645,7 @@ ManifestVersion: 1.7.0
 
  This key represents the capabilities provided by an MSIX package. More information is available for [App capability declarations]
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -693,8 +655,7 @@ ManifestVersion: 1.7.0
 
  This key represents the restricted capabilities provided by an MSIX package.More information is available for [App capability declarations]
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -704,8 +665,7 @@ ManifestVersion: 1.7.0
 
  This key represents the behavior associated with installers that abort the terminal. This most often occurs when a user is performing an upgrade of the running terminal.
 
- > [!NOTE]
- Windows Terminal no longer causes this to occur as the MSIX install behavior from the Windows Package Manager is deferred registration.
+ NOTE: Windows Terminal no longer causes this to occur as the MSIX install behavior from the Windows Package Manager is deferred registration.
 </details>
 
 <details>
@@ -747,8 +707,7 @@ ManifestVersion: 1.7.0
 
   This key represents any markets a package may be installed in.
 
-  > [!IMPORTANT]
- If a market is listed in both this key and the ExcludedMarkets key, the market will be excluded. Both keys are present to reduce the need to list the larger set of markets.
+  IMPORTANT: If a market is listed in both this key and the ExcludedMarkets key, the market will be excluded. Both keys are present to reduce the need to list the larger set of markets.
 </details>
 
 <details>
@@ -758,8 +717,7 @@ ManifestVersion: 1.7.0
 
   This key represents any markets a package may not be installed in.
 
-  > [!IMPORTANT]
- If a market is listed in both this key and the Markets key, the market will be excluded. Both keys are present to reduce the need to list the larger set of markets.
+  IMPORTANT: If a market is listed in both this key and the Markets key, the market will be excluded. Both keys are present to reduce the need to list the larger set of markets.
 </details>
 
 <details>
@@ -769,11 +727,9 @@ ManifestVersion: 1.7.0
 
  This key represents any status codes returned by the installer representing a success condition other than zero.
 
- > [!IMPORTANT]
- Some return codes indicate a reboot is suggested or required. The Windows Package Manager does not support the reboot behavior currently. Some installers will force a reboot, and the Windows Package Manager does not currently suppress reboot behavior.
+ IMPORTANT: Some return codes indicate a reboot is suggested or required. The Windows Package Manager does not support the reboot behavior currently. Some installers will force a reboot, and the Windows Package Manager does not currently suppress reboot behavior.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -783,11 +739,9 @@ ManifestVersion: 1.7.0
 
  This key represents any status codes returned by the installer representing a condition other than zero.
 
- > [!IMPORTANT]
- Some return codes indicate a reboot is suggested or required. The Windows Package Manager does not support the reboot behavior currently. Some installers will force a reboot, and the Windows Package Manager does not currently suppress reboot behavior.
+ IMPORTANT: Some return codes indicate a reboot is suggested or required. The Windows Package Manager does not support the reboot behavior currently. Some installers will force a reboot, and the Windows Package Manager does not currently suppress reboot behavior.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -805,8 +759,7 @@ ManifestVersion: 1.7.0
 
  This key represents a return response to display when an installer returns an expected return code. MSIX and MSI packages have well known return codes. This is primarily intended for executable installers that have custom or unique return coes that can be mapped to a return response.
 
- > [!NOTE]
- An enumerated list of values in the JSON schema must be specified for consistency of user experience.
+ NOTE: An enumerated list of values in the JSON schema must be specified for consistency of user experience.
 </details>
 
 <details>
@@ -816,8 +769,7 @@ ManifestVersion: 1.7.0
 
  This key represents a return response URL to display when an installer returns an expected return code. MSIX and MSI packages have well known return codes. This is primarily intended for executable installers that have custom or unique return codes that can be mapped to a return response.
 
- > [!NOTE]
- An enumerated list of values in the JSON schema must be specified for consistency of user experience.
+ NOTE: An enumerated list of values in the JSON schema must be specified for consistency of user experience.
 </details>
 
 <details>
@@ -827,8 +779,7 @@ ManifestVersion: 1.7.0
 
  This key represents the product code specified in an MSI installer. This value is used to assist with matching packages from a source to the program installed in Windows via Add / Remove Programs for list, and upgrade behavior.
 
- > [!NOTE]
- This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
+ NOTE: This key may be present in the root of the manifest as the default value for all installer nodes. This key may also be present in an individual installer node as well. If this key is in the manifest root and in an installer node, the value in the installer node will apply.
 </details>
 
 <details>
@@ -872,8 +823,7 @@ ManifestVersion: 1.7.0
 
  This key represents the product code for a package. It is used to help correlate installed packages with manifests in configured sources.
 
- > [!NOTE]
- This key is displayed twice for completeness. When AppsAndFeaturesEntries are specified, the ProductCode should be placed both within the installer and the AppsAndFeaturesEntries
+ NOTE: This key is displayed twice for completeness. When AppsAndFeaturesEntries are specified, the ProductCode should be placed both within the installer and the AppsAndFeaturesEntries
 </details>
 
 <details>
@@ -891,8 +841,7 @@ ManifestVersion: 1.7.0
 
  This key represents the installer type for the package. It is used to help correlate installed packages with manifests in configured sources. In some cases, an installer is an .exe based installer, but contains an MSI installer. This key will help the Windows Package Manager understand if upgrading an MSI should be performed when it is contained in an .exe installer.
 
- > [!NOTE]
- This key is displayed twice for completeness. When AppsAndFeaturesEntries are specified, the InstallerType should be placed within the installer only, unless the AppsAndFeaturesEntries represent a different InstallerType
+ NOTE: This key is displayed twice for completeness. When AppsAndFeaturesEntries are specified, the InstallerType should be placed within the installer only, unless the AppsAndFeaturesEntries represent a different InstallerType
 </details>
 
 <details>
@@ -911,8 +860,7 @@ ManifestVersion: 1.7.0
 
 This key represents whether a warning message is displayed to the user prior to install or upgrade if the package is known to interfere with any running applications.
 
-> [!NOTE]
- The DisplayInstallWarnings behavior is not implemented in the Windows Package Manager 1.7 client.
+NOTE: The DisplayInstallWarnings behavior is not implemented in the Windows Package Manager 1.7 client.
 </details>
 
 <details>


### PR DESCRIPTION
Per https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts
> Alerts cannot be nested within other elements.

Hence why these usages within `<details>` elements weren't rendering properly.

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/174228)