### PR TITLE
[Docs] Manifest schemas: Clarify format of date fields

### DIFF
--- a/doc/manifest/schema/1.6.0/installer.md
+++ b/doc/manifest/schema/1.6.0/installer.md
@@ -751,7 +751,7 @@ NOTE: The DisplayInstallWarnings behavior is not implemented in the Windows Pack
 
   **Optional Field**
 
-  This key represents the release date for a package.
+  This key represents the release date for a package, in RFC 3339 / ISO 8601 format, i.e. "YYYY-MM-DD".
 </details>
 
 <details>

--- a/doc/manifest/schema/1.6.0/singleton.md
+++ b/doc/manifest/schema/1.6.0/singleton.md
@@ -260,7 +260,7 @@ ManifestVersion: 1.6.0
 
   **Optional Field**
 
-  This key represents the release date for a package.
+  This key represents the release date for a package, in RFC 3339 / ISO 8601 format, i.e. "YYYY-MM-DD".
 </details>
 
 <details>

--- a/doc/manifest/schema/1.7.0/installer.md
+++ b/doc/manifest/schema/1.7.0/installer.md
@@ -763,7 +763,7 @@ NOTE: The DisplayInstallWarnings behavior is not implemented in the Windows Pack
 
   **Optional Field**
 
-  This key represents the release date for a package.
+  This key represents the release date for a package, in RFC 3339 / ISO 8601 format, i.e. "YYYY-MM-DD".
 </details>
 
 <details>

--- a/doc/manifest/schema/1.7.0/singleton.md
+++ b/doc/manifest/schema/1.7.0/singleton.md
@@ -262,7 +262,7 @@ ManifestVersion: 1.7.0
 
   **Optional Field**
 
-  This key represents the release date for a package.
+  This key represents the release date for a package, in RFC 3339 / ISO 8601 format, i.e. "YYYY-MM-DD".
 </details>
 
 <details>


### PR DESCRIPTION
`ReleaseDate` is the only temporal field. [Its format is "date"](https://github.com/microsoft/winget-cli/blob/7650384a3f457532aa7df8ea3455280cb93b8c13/schemas/JSON/manifests/v1.6.0/manifest.installer.1.6.0.json#L427), which translates to YYYY-MM-DD
per https://json-schema.org/understanding-json-schema/reference/string#dates-and-times

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/174394)