### PR TITLE
[Docs] Locale manifest schemas: PackageName & Publisher field details

### DIFF
--- a/doc/manifest/schema/1.6.0/defaultLocale.md
+++ b/doc/manifest/schema/1.6.0/defaultLocale.md
@@ -6,6 +6,7 @@
 [install]:                                          https://docs.microsoft.com/windows/package-manager/winget/install
 [list]:                                             https://docs.microsoft.com/windows/package-manager/winget/list
 [upgrade]:                                          https://docs.microsoft.com/windows/package-manager/winget/upgrade
+[uninstall-registry]:                               https://learn.microsoft.com/en-us/windows/win32/msi/uninstall-registry-key
 
 # Windows Package Manager
 ## Manifest Schema v1.6.0 Default Locale File
@@ -93,7 +94,7 @@ ManifestVersion: 1.6.0        # The manifest syntax version
 
   This key represents the name of the publisher for a given package. This field is intended to allow the full publisher's or ISV's name to be displayed as they wish.
 
-  NOTE:	With the 1.6 release of the Windows Package Manager, this name affects how packages from a source are mapped to Apps installed in Windows 10 and Windows 11 via Add / Remove Programs (ARP) and Windows Apps & Features respectively. The best practice is to ensure this matches the entry for the package when it has been installed. The impact is associated with `winget upgrade` and `winget list`.
+  NOTE:	With the 1.6 release of the Windows Package Manager, this name affects how packages from a source are mapped to Apps installed in Windows 10 and Windows 11 via Add / Remove Programs (ARP) and Windows Apps & Features respectively. The best practice is to ensure this matches the entry for the package when it has been installed. This should be the value of the `Publisher` subkey for the package in the [Windows registry][uninstall-registry]. The impact is associated with `winget upgrade` and `winget list`.
  </details>
 
 <details>
@@ -135,7 +136,7 @@ ManifestVersion: 1.6.0        # The manifest syntax version
 
   This key represents the name of the package. This field is intended to allow the full package name to be displayed as the publisher or ISV wishes.
 
-  NOTE:	With the 1.6 release of the Windows Package Manager, this name affects how packages from a source are mapped to Apps installed in Windows 10 via Add / Remove Programs (ARP). The best practice is to ensure this matches the ARP entry for the package name when it has been installed. The impact is associated with `winget upgrade` and `winget list`.
+  NOTE:	With the 1.6 release of the Windows Package Manager, this name affects how packages from a source are mapped to Apps installed in Windows 10 via Add / Remove Programs (ARP). The best practice is to ensure this matches the ARP entry for the package name when it has been installed. This should be the value of the `DisplayName` subkey for the package in the [Windows registry][uninstall-registry]. The impact is associated with `winget upgrade` and `winget list`.
  </details>
 
 <details>

--- a/doc/manifest/schema/1.6.0/locale.md
+++ b/doc/manifest/schema/1.6.0/locale.md
@@ -6,6 +6,7 @@
 [install]:                                          https://docs.microsoft.com/windows/package-manager/winget/install
 [list]:                                             https://docs.microsoft.com/windows/package-manager/winget/list
 [upgrade]:                                          https://docs.microsoft.com/windows/package-manager/winget/upgrade
+[uninstall-registry]:                               https://learn.microsoft.com/en-us/windows/win32/msi/uninstall-registry-key
 
 # Windows Package Manager
 ## Manifest Schema v1.6.0 Locale File
@@ -91,7 +92,7 @@ ManifestVersion: 1.6.0        # The manifest syntax version
 
   This key represents the name of the publisher for a given package. This field is intended to allow the full publisher's or ISV's name to be displayed as they wish.
 
-  NOTE:	With the 1.6 release of the Windows Package Manager, this name affects how packages from a source are mapped to Apps installed in Windows 10 and Windows 11 via Add / Remove Programs (ARP). The best practice is to ensure this matches the ARP entry for the package when it has been installed. The impact is associated with `winget upgrade` and `winget list`.
+  NOTE:	With the 1.6 release of the Windows Package Manager, this name affects how packages from a source are mapped to Apps installed in Windows 10 and Windows 11 via Add / Remove Programs (ARP). The best practice is to ensure this matches the ARP entry for the package when it has been installed. This should be the value of the `Publisher` subkey for the package in the [Windows registry][uninstall-registry]. The impact is associated with `winget upgrade` and `winget list`.
  </details>
 
 <details>
@@ -133,7 +134,7 @@ ManifestVersion: 1.6.0        # The manifest syntax version
 
   This key represents the name of the package. This field is intended to allow the full package name to be displayed as the publisher or ISV wishes.
 
-  NOTE:	With the 1.6 release of the Windows Package Manager, this name affects how packages from a source are mapped to Apps installed in Windows 10 via Add / Remove Programs (ARP). The best practice is to ensure this matches the ARP entry for the package name when it has been installed. The impact is associated with `winget upgrade` and `winget list`.
+  NOTE:	With the 1.6 release of the Windows Package Manager, this name affects how packages from a source are mapped to Apps installed in Windows 10 via Add / Remove Programs (ARP). The best practice is to ensure this matches the ARP entry for the package name when it has been installed. This should be the value of the `DisplayName` subkey for the package in the [Windows registry][uninstall-registry]. The impact is associated with `winget upgrade` and `winget list`.
  </details>
 
 <details>

--- a/doc/manifest/schema/1.7.0/defaultLocale.md
+++ b/doc/manifest/schema/1.7.0/defaultLocale.md
@@ -6,6 +6,7 @@
 [install]:                                          https://docs.microsoft.com/windows/package-manager/winget/install
 [list]:                                             https://docs.microsoft.com/windows/package-manager/winget/list
 [upgrade]:                                          https://docs.microsoft.com/windows/package-manager/winget/upgrade
+[uninstall-registry]:                               https://learn.microsoft.com/en-us/windows/win32/msi/uninstall-registry-key
 
 # Windows Package Manager
 ## Manifest Schema v1.7.0 Default Locale File
@@ -93,7 +94,7 @@ ManifestVersion: 1.7.0        # The manifest syntax version
 
   This key represents the name of the publisher for a given package. This field is intended to allow the full publisher's or ISV's name to be displayed as they wish.
 
-  NOTE: With the 1.7 release of the Windows Package Manager, this name affects how packages from a source are mapped to Apps installed in Windows 10 and Windows 11 via Add / Remove Programs (ARP) and Windows Apps & Features respectively. The best practice is to ensure this matches the entry for the package when it has been installed. The impact is associated with `winget upgrade` and `winget list`.
+  NOTE: With the 1.7 release of the Windows Package Manager, this name affects how packages from a source are mapped to Apps installed in Windows 10 and Windows 11 via Add / Remove Programs (ARP) and Windows Apps & Features respectively. The best practice is to ensure this matches the entry for the package when it has been installed. This should be the value of the `Publisher` subkey for the package in the [Windows registry][uninstall-registry]. The impact is associated with `winget upgrade` and `winget list`.
  </details>
 
 <details>
@@ -135,7 +136,7 @@ ManifestVersion: 1.7.0        # The manifest syntax version
 
   This key represents the name of the package. This field is intended to allow the full package name to be displayed as the publisher or ISV wishes.
 
-  NOTE:	With the 1.7 release of the Windows Package Manager, this name affects how packages from a source are mapped to Apps installed in Windows 10 via Add / Remove Programs (ARP). The best practice is to ensure this matches the ARP entry for the package name when it has been installed. The impact is associated with `winget upgrade` and `winget list`.
+  NOTE:	With the 1.7 release of the Windows Package Manager, this name affects how packages from a source are mapped to Apps installed in Windows 10 via Add / Remove Programs (ARP). The best practice is to ensure this matches the ARP entry for the package name when it has been installed. This should be the value of the `DisplayName` subkey for the package in the [Windows registry][uninstall-registry]. The impact is associated with `winget upgrade` and `winget list`.
  </details>
 
 <details>

--- a/doc/manifest/schema/1.7.0/locale.md
+++ b/doc/manifest/schema/1.7.0/locale.md
@@ -6,6 +6,7 @@
 [install]:                                          https://docs.microsoft.com/windows/package-manager/winget/install
 [list]:                                             https://docs.microsoft.com/windows/package-manager/winget/list
 [upgrade]:                                          https://docs.microsoft.com/windows/package-manager/winget/upgrade
+[uninstall-registry]:                               https://learn.microsoft.com/en-us/windows/win32/msi/uninstall-registry-key
 
 # Windows Package Manager
 ## Manifest Schema v1.7.0 Locale File
@@ -91,7 +92,7 @@ ManifestVersion: 1.7.0        # The manifest syntax version
 
   This key represents the name of the publisher for a given package. This field is intended to allow the full publisher's or ISV's name to be displayed as they wish.
 
-  NOTE:	With the 1.7 release of the Windows Package Manager, this name affects how packages from a source are mapped to Apps installed in Windows 10 and Windows 11 via Add / Remove Programs (ARP). The best practice is to ensure this matches the ARP entry for the package when it has been installed. The impact is associated with `winget upgrade` and `winget list`.
+  NOTE:	With the 1.7 release of the Windows Package Manager, this name affects how packages from a source are mapped to Apps installed in Windows 10 and Windows 11 via Add / Remove Programs (ARP). The best practice is to ensure this matches the ARP entry for the package when it has been installed. This should be the value of the `Publisher` subkey for the package in the [Windows registry][uninstall-registry]. The impact is associated with `winget upgrade` and `winget list`.
  </details>
 
 <details>
@@ -133,7 +134,7 @@ ManifestVersion: 1.7.0        # The manifest syntax version
 
   This key represents the name of the package. This field is intended to allow the full package name to be displayed as the publisher or ISV wishes.
 
-  NOTE:	With the 1.7 release of the Windows Package Manager, this name affects how packages from a source are mapped to Apps installed in Windows 10 via Add / Remove Programs (ARP). The best practice is to ensure this matches the ARP entry for the package name when it has been installed. The impact is associated with `winget upgrade` and `winget list`.
+  NOTE:	With the 1.7 release of the Windows Package Manager, this name affects how packages from a source are mapped to Apps installed in Windows 10 via Add / Remove Programs (ARP). The best practice is to ensure this matches the ARP entry for the package name when it has been installed. This should be the value of the `DisplayName` subkey for the package in the [Windows registry][uninstall-registry]. The impact is associated with `winget upgrade` and `winget list`.
  </details>
 
 <details>


### PR DESCRIPTION
Explain how `PackageName` & `Publisher` fields of winget `locale` & `defaultLocale` manifests correspond to respective keys in the Windows registry, by linking to relevant Windows Installer docs page.

X-Ref: #174151, but that was for installer schemas.

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/174415)