### PR TITLE
Update manifests: hluk.CopyQ version 8.0.0

### DIFF
--- a/manifests/h/hluk/CopyQ/8.0.0/hluk.CopyQ.installer.yaml
+++ b/manifests/h/hluk/CopyQ/8.0.0/hluk.CopyQ.installer.yaml
@@ -5,6 +5,7 @@ PackageIdentifier: hluk.CopyQ
 PackageVersion: 8.0.0
 InstallerType: inno
 ReleaseDate: 2024-03-14
+ElevationRequirement: elevationRequired
 Installers:
 - Architecture: x64
   Scope: machine


### PR DESCRIPTION
## Summary

- Package default to install in `C:/Program Files/CopyQ/`
- Creating such a directory requires administrator privileges
- This is the default behavior no matter if user install it to user or machine scope.

## Checklist for Pull Requests

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Resolve #174495

## Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/175278)