### PR TITLE
OlegShparber.Zeal: add moniker

### DIFF
--- a/manifests/o/OlegShparber/Zeal/0.7.2/OlegShparber.Zeal.locale.en-US.yaml
+++ b/manifests/o/OlegShparber/Zeal/0.7.2/OlegShparber.Zeal.locale.en-US.yaml
@@ -8,6 +8,7 @@ Publisher: Oleg Shparber
 PublisherUrl: https://github.com/zealdocs
 PublisherSupportUrl: https://github.com/zealdocs/zeal/issues
 PackageName: Zeal
+Moniker: zeal
 License: GPL-3.0
 ShortDescription: Offline documentation browser inspired by Dash.
 Tags:


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

Zeal is known as `zeal` to pretty much every package manager ([repology](https://repology.org/project/zeal/versions)). This PR adds a matching moniker.