### PR TITLE
Revert "Remove version: GnuWin32.Make version 3.81"

### DIFF
--- a/manifests/g/GnuWin32/Make/3.81/GnuWin32.Make.installer.yaml
+++ b/manifests/g/GnuWin32/Make/3.81/GnuWin32.Make.installer.yaml
@@ -1,0 +1,13 @@
+# Created with YamlCreate.ps1 v2.1.0 $debug=AUSU.5-1-19041-1320
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+
+PackageIdentifier: GnuWin32.Make
+PackageVersion: "3.81"
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Installers:
+- Architecture: x86
+  InstallerUrl: https://sourceforge.net/projects/gnuwin32/files/make/3.81/make-3.81.exe/download
+  InstallerSha256: CC55115C78A16386587C6EB90DD35E6DE820191B83A6B3058460E5661F457E3F
+ManifestType: installer
+ManifestVersion: 1.1.0

--- a/manifests/g/GnuWin32/Make/3.81/GnuWin32.Make.locale.en-US.yaml
+++ b/manifests/g/GnuWin32/Make/3.81/GnuWin32.Make.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# Created with YamlCreate.ps1 v2.1.0 $debug=AUSU.5-1-19041-1320
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+
+PackageIdentifier: GnuWin32.Make
+PackageVersion: "3.81"
+PackageLocale: en-US
+Publisher: GnuWin32
+# PublisherUrl: 
+# PublisherSupportUrl: 
+# PrivacyUrl: 
+# Author: 
+PackageName: 'GnuWin32: Make'
+PackageUrl: http://gnuwin32.sourceforge.net/packages/make.htm
+License: GnuWin License
+LicenseUrl: http://gnuwin32.sourceforge.net/license.html
+# Copyright: 
+# CopyrightUrl: 
+ShortDescription: GnuWin32.Make
+Description: Make is a tool which controls the generation of executables and other non-source files of a program from the program's source files. Make gets its knowledge of how to build your program from a file called the makefile, which lists each of the non-source files and how to compute it from other files. When you write a program, you should write a makefile for it, so that it is possible to use Make to build and install the program.
+# Moniker: 
+Tags:
+- gnuwin32
+- make
+# Agreements: 
+# ReleaseNotes: 
+# ReleaseNotesUrl: 
+ManifestType: defaultLocale
+ManifestVersion: 1.1.0

--- a/manifests/g/GnuWin32/Make/3.81/GnuWin32.Make.yaml
+++ b/manifests/g/GnuWin32/Make/3.81/GnuWin32.Make.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.1.0 $debug=AUSU.5-1-19041-1320
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+
+PackageIdentifier: GnuWin32.Make
+PackageVersion: "3.81"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.1.0


### PR DESCRIPTION
Reverts microsoft/winget-pkgs#140010
Resolves microsoft/winget-pkgs#177602

@stephengillie - The package which was added as a "replacement" is actually a different piece of software and is not from GnuWin32, as it comes from a different SourceForge project. Ref https://sourceforge.net/projects/gnuwin32/files/make/ and note that 3.81 is still the latest version
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/178042)