### PR TITLE
Update moniker for Python 3.12.0

### DIFF
--- a/manifests/p/Python/Python/3/12/3.12.0/Python.Python.3.12.locale.en-US.yaml
+++ b/manifests/p/Python/Python/3/12/3.12.0/Python.Python.3.12.locale.en-US.yaml
@@ -21,7 +21,7 @@ Copyright: |-
 CopyrightUrl: https://www.python.org/about/legal/
 ShortDescription: Python is a programming language that lets you work more quickly and integrate your systems more effectively.
 # Description:
-Moniker: python3
+Moniker: python3.12
 Tags:
 - language
 - programming


### PR DESCRIPTION
3.13.0 is a stable release of python so the `python3` moniker is shifted to Python.Python.3.13 in #179376

Checklist for Pull Requests
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] This PR only modifies one (1) manifest
- [X] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [X] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/179378)