### PR TITLE
Make Triggers more specific

### DIFF
--- a/.github/policies/labelManagement.issueOpened.yml
+++ b/.github/policies/labelManagement.issueOpened.yml
@@ -14,7 +14,11 @@ configuration:
           * Add a comment
         if:
           - payloadType: Pull_Request
-          - isOpen
+          - or:
+              - isAction:
+                  action: Opened
+              - isAction:
+                  action: Synchronize
           - filesMatchPattern:
                 pattern: ^$
         then:
@@ -31,6 +35,7 @@ configuration:
       - description: Add CodeFlow link to new PRs
         if:
           - payloadType: Pull_Request
+          - isOpen
           - isAction:
               action: Opened
         then:
@@ -57,8 +62,14 @@ configuration:
           * Add the "Needs-Author-Feedback" label
         if:
           - payloadType: Pull_Request
+          - isOpen
           - filesMatchPattern:
               pattern: DevOpsPipelineDefinitions/*
+          - or:
+              - isAction:
+                  action: Opened
+              - isAction:
+                  action: Synchronize
           - or:
               - activitySenderHasPermission:
                   permission: Read
@@ -86,6 +97,12 @@ configuration:
           * Add the "Manifest-Path-Error" label
         if:
           - payloadType: Pull_Request
+          - isOpen
+          - or:
+              - isAction:
+                  action: Opened
+              - isAction:
+                  action: Synchronize
           - not:
               filesMatchPattern:
                 pattern: ^manifests/*
@@ -157,6 +174,11 @@ configuration:
           - payloadType: Pull_Request
           - isOpen
           - or:
+              - isAction:
+                  action: Opened
+              - isAction:
+                  action: Synchronize
+          - or:
             - filesMatchPattern:
                 pattern: ^.github\\.*
             - filesMatchPattern:
@@ -181,6 +203,11 @@ configuration:
         if:
           - payloadType: Pull_Request
           - isOpen
+          - or:
+              - isAction:
+                  action: Opened
+              - isAction:
+                  action: Synchronize
           - filesMatchPattern:
                 pattern: ^.*\.validation
           - not:

--- a/.github/policies/labelManagement.issueOpened.yml
+++ b/.github/policies/labelManagement.issueOpened.yml
@@ -14,6 +14,7 @@ configuration:
           * Add a comment
         if:
           - payloadType: Pull_Request
+          - isOpen
           - or:
               - isAction:
                   action: Opened


### PR DESCRIPTION
As seen in https://github.com/microsoft/winget-pkgs/pull/180012 - the triggers for project file and author not authorized are hit even though the PR is closed. What isn't shown in the PR is that the comments for these triggers are also put onto the PR briefly, and then removed as the policy service corrects itself. 

This PR narrows the triggers to only activate when a PR is first opened or new changes are pushed. While it would be ideal to have these be run only when an issue is opened, it could be a breaking change. More investigation is needed before removing the `Synchronize` trigger.

Additionally, since rules are processed in the order they occur in the file, `isOpen` was added to each of the rules to ensure that they are not run on a PR that was already closed.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/180014)