### PR TITLE
Update manifests/a/AppbyTroye/KoodoReader/1.4.0/AppbyTroye.KoodoReader.locale.en-US.yaml

### DIFF
--- a/manifests/a/AppbyTroye/KoodoReader/1.4.0/AppbyTroye.KoodoReader.locale.en-US.yaml
+++ b/manifests/a/AppbyTroye/KoodoReader/1.4.0/AppbyTroye.KoodoReader.locale.en-US.yaml
@@ -4,7 +4,7 @@ PackageLocale: en-US
 Publisher: App by Troye
 PublisherUrl: https://github.com/troyeguo/koodo-reader
 PublisherSupportUrl: https://github.com/troyeguo/koodo-reader/issues
-PrivacyUrl: https://troyeguo.notion.site/Koodo-Reader-Document-9c767af3d66c459db996bdd08a34c34b
+# PrivacyUrl: https://troyeguo.notion.site/Koodo-Reader-Document-9c767af3d66c459db996bdd08a34c34b
 Author: Troye
 PackageName: Koodo Reader
 PackageUrl: https://github.com/troyeguo/koodo-reader/releases

--- a/manifests/a/AppbyTroye/KoodoReader/1.4.0/AppbyTroye.KoodoReader.locale.en-US.yaml
+++ b/manifests/a/AppbyTroye/KoodoReader/1.4.0/AppbyTroye.KoodoReader.locale.en-US.yaml
@@ -1,6 +1,3 @@
-# Created using wingetcreate 0.4.4.1
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
-
 PackageIdentifier: AppbyTroye.KoodoReader
 PackageVersion: 1.4.0
 PackageLocale: en-US
@@ -17,7 +14,7 @@ Copyright: Copyright (c) 2020-2021 App by Troye
 CopyrightUrl: https://koodo.960960.xyz
 ShortDescription: A cross-platform ebook reader
 Description: Koodo Reader is an all-in-one ebook reader that can help you better manage and study your ebooks. It's free and open-source.
-Moniker: KoodoReader
+Moniker: koodoreader
 Tags:
 - reader
 - ebook
@@ -26,4 +23,3 @@ Tags:
 - epub
 ManifestType: defaultLocale
 ManifestVersion: 1.1.0
-

--- a/manifests/a/AppbyTroye/KoodoReader/1.4.0/AppbyTroye.KoodoReader.locale.zh-CN.yaml
+++ b/manifests/a/AppbyTroye/KoodoReader/1.4.0/AppbyTroye.KoodoReader.locale.zh-CN.yaml
@@ -7,7 +7,7 @@ PackageLocale: zh-CN
 Publisher: App by Troye
 PublisherUrl: https://github.com/troyeguo/koodo-reader
 PublisherSupportUrl: https://github.com/troyeguo/koodo-reader/issues
-PrivacyUrl: https://troyeguo.notion.site/Koodo-Reader-Document-9c767af3d66c459db996bdd08a34c34b
+# PrivacyUrl: https://troyeguo.notion.site/Koodo-Reader-Document-9c767af3d66c459db996bdd08a34c34b
 Author: Troye
 PackageName: Koodo Reader
 PackageUrl: https://github.com/troyeguo/koodo-reader/releases


### PR DESCRIPTION
Fixes an issue where this package has multiple different monikers
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/180814)