### PR TITLE
Update manifests/c/calendulish/SteamToolsNG/3.0.1/calendulish.SteamToolsNG.locale.en-US.yaml

### DIFF
--- a/manifests/c/calendulish/SteamToolsNG/3.0.1/calendulish.SteamToolsNG.locale.en-US.yaml
+++ b/manifests/c/calendulish/SteamToolsNG/3.0.1/calendulish.SteamToolsNG.locale.en-US.yaml
@@ -1,6 +1,3 @@
-# Created using wingetcreate 1.2.5.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.4.0.schema.json
-
 PackageIdentifier: calendulish.SteamToolsNG
 PackageVersion: 3.0.1
 PackageLocale: en-US
@@ -15,7 +12,7 @@ LicenseUrl: https://raw.githubusercontent.com/calendulish/steam-tools-ng/master/
 Copyright: Lara Maia <dev@lara.monster> 2023
 ShortDescription: Useful tools for Steam
 Description: Some useful tools to use with steam client or compatible programs and websites
-Moniker: steam tools
+Moniker: steamtools-ng
 Tags:
 - steam
 - valve

--- a/manifests/c/calendulish/SteamToolsNG/3.0.1/calendulish.SteamToolsNG.locale.en-US.yaml
+++ b/manifests/c/calendulish/SteamToolsNG/3.0.1/calendulish.SteamToolsNG.locale.en-US.yaml
@@ -2,7 +2,7 @@ PackageIdentifier: calendulish.SteamToolsNG
 PackageVersion: 3.0.1
 PackageLocale: en-US
 Publisher: calendulish
-PublisherUrl: https://lara.monster
+# PublisherUrl: https://lara.monster
 PublisherSupportUrl: https://github.com/calendulish/steam-tools-ng/issues/new/choose
 Author: Lara Maia
 PackageName: Steam Tools NG


### PR DESCRIPTION
Fixes an issue where this package has multiple different monikers
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/180850)