### PR TITLE
Update manifests/e/Eugeny/Tabby/1.0.117/Eugeny.Tabby.locale.en-US.yaml

### DIFF
--- a/manifests/e/Eugeny/Tabby/1.0.117/Eugeny.Tabby.locale.en-US.yaml
+++ b/manifests/e/Eugeny/Tabby/1.0.117/Eugeny.Tabby.locale.en-US.yaml
@@ -1,29 +1,16 @@
-# Created with YamlCreate.ps1 v2.1.0 $debug=AUSU.5-1-19041-1320
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
-
 PackageIdentifier: Eugeny.Tabby
 PackageVersion: 1.0.117
 PackageLocale: en-US
 Publisher: Eugeny
-# PublisherUrl: 
-# PublisherSupportUrl: 
-# PrivacyUrl: 
-# Author: 
 PackageName: Terminus
 PackageUrl: https://eugeny.github.io/terminus/
 License: MIT License
 LicenseUrl: https://github.com/Eugeny/Tabby/blob/master/LICENSE
-# Copyright: 
-# CopyrightUrl: 
 ShortDescription: A terminal for a more modern age.
-# Description: 
-Moniker: terminus
+Moniker: tabby
 Tags:
 - command-line
 - console
 - terminal
-# Agreements: 
-# ReleaseNotes: 
-# ReleaseNotesUrl: 
 ManifestType: defaultLocale
 ManifestVersion: 1.1.0


### PR DESCRIPTION
Fixes an issue where this package has multiple different monikers
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/180907)