### PR TITLE
Update manifests/e/Eugeny/Tabby/1.0.141/Eugeny.Tabby.locale.en-US.yaml

### DIFF
--- a/manifests/e/Eugeny/Tabby/1.0.141/Eugeny.Tabby.locale.en-US.yaml
+++ b/manifests/e/Eugeny/Tabby/1.0.141/Eugeny.Tabby.locale.en-US.yaml
@@ -1,6 +1,3 @@
-# Created using wingetcreate 0.2.0.29
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.0.0.schema.json
-
 PackageIdentifier: Eugeny.Tabby
 PackageVersion: 1.0.141
 PackageLocale: en-US
@@ -11,12 +8,10 @@ PackageUrl: https://eugeny.github.io/terminus/
 License: MIT License
 LicenseUrl: https://github.com/Eugeny/Tabby/blob/master/LICENSE
 ShortDescription: A terminal for a more modern age.
-Moniker: terminus
+Moniker: tabby
 Tags:
 - terminal
 - console
 - command line
 ManifestType: defaultLocale
 ManifestVersion: 1.0.0
-
-


### PR DESCRIPTION
Fixes an issue where this package has multiple different monikers
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/180915)