### PR TITLE
Update manifests/e/Eugeny/Tabby/1.0.143/Eugeny.Tabby.locale.en-US.yaml

### DIFF
--- a/manifests/e/Eugeny/Tabby/1.0.143/Eugeny.Tabby.locale.en-US.yaml
+++ b/manifests/e/Eugeny/Tabby/1.0.143/Eugeny.Tabby.locale.en-US.yaml
@@ -1,13 +1,9 @@
-# Created using YamlCreate.ps1
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultlocale.1.0.0.schema.json
-
 PackageIdentifier: Eugeny.Tabby
 PackageVersion: 1.0.143
 PackageLocale: en-US
 Publisher: Eugene Pankov
 PublisherUrl: https://github.com/Eugeny/Tabby
 PublisherSupportUrl: https://github.com/Eugeny/Tabby/issues
-#PrivacyUrl: 
 Author: Eugene Pankov
 PackageName: Terminus
 PackageUrl: https://eugeny.github.io/terminus/
@@ -17,7 +13,7 @@ Copyright: Copyright (c) 2017 Eugene Pankov
 CopyrightUrl: https://raw.githubusercontent.com/Eugeny/Tabby/master/LICENSE
 ShortDescription: A terminal for a more modern age.
 Description: Terminus is a highly configurable terminal emulator, SSH and serial client for Windows, macOS and Linux
-Moniker: terminus
+Moniker: tabby
 Tags:
 - terminal
 - console
@@ -27,4 +23,3 @@ Tags:
 - cross-platform
 ManifestType: defaultLocale
 ManifestVersion: 1.0.0
-


### PR DESCRIPTION
Fixes an issue where this package has multiple different monikers
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/180918)