### PR TITLE
Update manifests/e/Eugeny/Tabby/1.0.169/Eugeny.Tabby.locale.en-US.yaml

### DIFF
--- a/manifests/e/Eugeny/Tabby/1.0.169/Eugeny.Tabby.locale.en-US.yaml
+++ b/manifests/e/Eugeny/Tabby/1.0.169/Eugeny.Tabby.locale.en-US.yaml
@@ -1,13 +1,9 @@
-# Created with YamlCreate.ps1 v2.0.4 $debug=QUSU.7-2-1
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
-
 PackageIdentifier: Eugeny.Tabby
 PackageVersion: 1.0.169
 PackageLocale: en-US
 Publisher: Eugene Pankov
 PublisherUrl: https://github.com/Eugeny/
 PublisherSupportUrl: https://github.com/Eugeny/tabby/issues
-# PrivacyUrl: 
 Author: Eugene Pankov
 PackageName: Tabby
 PackageUrl: https://github.com/Eugeny/tabby
@@ -17,7 +13,7 @@ Copyright: Copyright (c) 2021 Eugene Pankov
 CopyrightUrl: https://raw.githubusercontent.com/Eugeny/tabby/master/LICENSE
 ShortDescription: A terminal for a more modern age.
 Description: Tabby is a highly configurable terminal emulator, SSH and serial client for Windows, macOS and Linux
-# Moniker: 
+Moniker: tabby
 Tags:
 - cli
 - command-line
@@ -26,8 +22,5 @@ Tags:
 - electron
 - open-source
 - terminal
-# Agreements: 
-# ReleaseNotes: 
-# ReleaseNotesUrl: 
 ManifestType: defaultLocale
 ManifestVersion: 1.1.0


### PR DESCRIPTION
Fixes an issue where this package has multiple different monikers
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/180924)