### PR TITLE
Update manifests/e/Eugeny/Tabby/1.0.197/Eugeny.Tabby.locale.en-US.yaml

### DIFF
--- a/manifests/e/Eugeny/Tabby/1.0.197/Eugeny.Tabby.locale.en-US.yaml
+++ b/manifests/e/Eugeny/Tabby/1.0.197/Eugeny.Tabby.locale.en-US.yaml
@@ -1,6 +1,3 @@
-# Created with WinGet Automation using Komac v1.7.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.4.0.schema.json
-
 PackageIdentifier: Eugeny.Tabby
 PackageVersion: 1.0.197
 PackageLocale: en-US
@@ -16,6 +13,7 @@ Copyright: Copyright (c) 2021 Eugene Pankov
 CopyrightUrl: https://raw.githubusercontent.com/Eugeny/tabby/master/LICENSE
 ShortDescription: A terminal for a more modern age.
 Description: Tabby is a highly configurable terminal emulator, SSH and serial client for Windows, macOS and Linux
+Moniker: tabby
 Tags:
 - cli
 - command-line


### PR DESCRIPTION
Fixes an issue where this package has multiple different monikers
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/180944)