### PR TITLE
Update manifests/e/Eugeny/Tabby/1.0.214/Eugeny.Tabby.locale.en-US.yaml

### DIFF
--- a/manifests/e/Eugeny/Tabby/1.0.214/Eugeny.Tabby.locale.en-US.yaml
+++ b/manifests/e/Eugeny/Tabby/1.0.214/Eugeny.Tabby.locale.en-US.yaml
@@ -1,20 +1,15 @@
-# Created with YamlCreate.ps1 v2.4.1 Dumplings Mod $debug=QUSU.CRLF.7-4-5.Win32NT
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
-
 PackageIdentifier: Eugeny.Tabby
 PackageVersion: 1.0.214
 PackageLocale: en-US
 Publisher: Eugene Pankov
 PublisherUrl: https://github.com/Eugeny
 PublisherSupportUrl: https://github.com/Eugeny/tabby/issues
-# PrivacyUrl:
 Author: Eugene Pankov
 PackageName: Tabby
 PackageUrl: https://tabby.sh/
 License: MIT
 LicenseUrl: https://github.com/Eugeny/tabby/blob/master/LICENSE
 Copyright: Copyright (c) 2024 Eugene Pankov
-# CopyrightUrl:
 ShortDescription: A terminal for a more modern age.
 Description: |-
   Tabby (formerly Terminus) is a highly configurable terminal emulator, SSH and serial client for Windows 10, macOS and Linux
@@ -31,7 +26,7 @@ Description: |-
   - Proper shell experience on Windows including tab completion (via Clink)
   - Integrated encrypted container for SSH secrets and configuration
   - SSH, SFTP and Telnet client available as a web app (also self-hosted)
-# Moniker:
+Moniker: tabby
 Tags:
 - command-line
 - console
@@ -43,8 +38,5 @@ ReleaseNotes: |-
   - 1c07714: fixed #9955 - host key checking race
   Tabby would incorrectly prompt for credentials / send saved password while the host key verification prompt is still visible, leading to credentials leakage if your session is intercepted in a MitM attack.
 ReleaseNotesUrl: https://github.com/Eugeny/tabby/releases/tag/v1.0.214
-# PurchaseUrl:
-# InstallationNotes:
-# Documentations:
 ManifestType: defaultLocale
 ManifestVersion: 1.6.0


### PR DESCRIPTION
Fixes an issue where this package has multiple different monikers
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/180963)