### PR TITLE
Update manifests/m/Mozilla/Firefox/ESR/78.15.0/Mozilla.Firefox.ESR.locale.en-US.yaml

### DIFF
--- a/manifests/m/Mozilla/Firefox/ESR/78.15.0/Mozilla.Firefox.ESR.locale.en-US.yaml
+++ b/manifests/m/Mozilla/Firefox/ESR/78.15.0/Mozilla.Firefox.ESR.locale.en-US.yaml
@@ -1,4 +1,3 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultlocale.1.0.0.schema.json
 PackageIdentifier: Mozilla.Firefox.ESR
 PackageVersion: 78.15.0
 PackageLocale: en-US
@@ -13,7 +12,7 @@ License: Mozilla Public License V2.0
 LicenseUrl: https://www.mozilla.org/en-US/MPL/2.0/
 ShortDescription: Get unmatched data protection on the release cadence that suits you with Firefox for enterprise.
 Description: Get unmatched data protection on the release cadence that suits you with Firefox for enterprise.
-Moniker: firefoxesr
+Moniker: firefox-esr
 Tags:
 - mozilla
 - firefox
@@ -24,5 +23,3 @@ Tags:
 - cross-platform
 ManifestType: defaultLocale
 ManifestVersion: 1.0.0
-
-


### PR DESCRIPTION
Fixes an issue where this package has multiple different monikers
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/180987)