### PR TITLE
Update manifests/m/Mozilla/Firefox/ESR/78.8.0esr/Mozilla.Firefox.ESR.locale.en-US.yaml

### DIFF
--- a/manifests/m/Mozilla/Firefox/ESR/78.8.0esr/Mozilla.Firefox.ESR.locale.en-US.yaml
+++ b/manifests/m/Mozilla/Firefox/ESR/78.8.0esr/Mozilla.Firefox.ESR.locale.en-US.yaml
@@ -1,20 +1,17 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultlocale.1.0.0.schema.json
 PackageIdentifier: Mozilla.Firefox.ESR
 PackageVersion: 78.8.0esr
 PackageLocale: en-US
+Publisher: Mozilla
+PackageName: Firefox ESR
+PackageUrl: https://www.mozilla.org/en-US/firefox/enterprise/
+License: Mozilla Public License V2.0
 LicenseUrl: https://www.mozilla.org/en-US/MPL/2.0/
-Moniker: firefoxesr
+ShortDescription: Get unmatched data protection on the release cadence that suits you with Firefox for enterprise.
+Moniker: firefox-esr
 Tags:
 - browser
 - firefox
 - mozilla
 - esr
-PackageUrl: https://www.mozilla.org/en-US/firefox/enterprise/
-Publisher: Mozilla
-PackageName: Firefox ESR
-License: Mozilla Public License V2.0
-ShortDescription: Get unmatched data protection on the release cadence that suits you with Firefox for enterprise.
 ManifestType: defaultLocale
 ManifestVersion: 1.0.0
-
-


### PR DESCRIPTION
Fixes an issue where this package has multiple different monikers
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/180995)