### PR TITLE
Update manifests/m/Mozilla/Firefox/ESR/91.7.1/Mozilla.Firefox.ESR.locale.en-US.yaml

### DIFF
--- a/manifests/m/Mozilla/Firefox/ESR/91.7.1/Mozilla.Firefox.ESR.locale.en-US.yaml
+++ b/manifests/m/Mozilla/Firefox/ESR/91.7.1/Mozilla.Firefox.ESR.locale.en-US.yaml
@@ -1,6 +1,3 @@
-# Created using wingetcreate 0.5.0.1
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.0.0.schema.json
-
 PackageIdentifier: Mozilla.Firefox.ESR
 PackageVersion: 91.7.1
 PackageLocale: en-US
@@ -10,7 +7,7 @@ PackageUrl: https://www.mozilla.org/en-US/firefox/enterprise/
 License: Mozilla Public License V2.0
 LicenseUrl: https://www.mozilla.org/en-US/MPL/2.0/
 ShortDescription: Firefox Extended Support Release (ESR) is a web browser developed by the Mozilla Foundation, designed for large organisations. Although Firefox ESR lacks the most recent features, it does contain the most recent security and stability fixes.
-Moniker: firefoxesr
+Moniker: firefox-esr
 Tags:
 - browser
 - firefox
@@ -18,4 +15,3 @@ Tags:
 - esr
 ManifestType: defaultLocale
 ManifestVersion: 1.0.0
-


### PR DESCRIPTION
Fixes an issue where this package has multiple different monikers
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/181007)