### PR TITLE
Update manifests/p/Piriform/CCleaner/5.91/Piriform.CCleaner.locale.en-US.yaml

### DIFF
--- a/manifests/p/Piriform/CCleaner/5.91/Piriform.CCleaner.locale.en-US.yaml
+++ b/manifests/p/Piriform/CCleaner/5.91/Piriform.CCleaner.locale.en-US.yaml
@@ -1,12 +1,8 @@
-# Created with YamlCreate.ps1 v2.1.1 $debug=AUSU.7-2-1
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
-
 PackageIdentifier: Piriform.CCleaner
 PackageVersion: "5.91"
 PackageLocale: en-US
 Publisher: Piriform
 PublisherUrl: https://www.ccleaner.com
-# PublisherSupportUrl: 
 PrivacyUrl: https://www.ccleaner.com/legal/general-privacy-policy
 Author: Piriform Software Ltd
 PackageName: CCleaner
@@ -17,14 +13,13 @@ Copyright: Copyright © 2005-2021 Piriform Software Ltd
 CopyrightUrl: https://www.ccleaner.com/about/terms-of-use
 ShortDescription: CCleaner is a utility used to clean potentially unwanted files and invalid Windows Registry entries from a computer.
 Description: CCleaner is a utility used to clean potentially unwanted files and invalid Windows Registry entries from a computer.
-Moniker: ccleaner
+Moniker: ccleaner-free
 Tags:
 - ccleaner
 - cleanup
 - registry
 - system
 - trail
-# Agreements: 
 ReleaseNotes: |-
   Maintaining cleaning reliability
   • We’re now cleaning Google syndication cookies fully in Google Chrome


### PR DESCRIPTION
Fixes an issue where this package has multiple different monikers
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/181130)