### PR TITLE
Update manifests/a/AdaLang/Alire/Portable/2.0.1/AdaLang.Alire.Portable.locale.en-US.yaml

### DIFF
--- a/manifests/a/AdaLang/Alire/Portable/2.0.1/AdaLang.Alire.Portable.locale.en-US.yaml
+++ b/manifests/a/AdaLang/Alire/Portable/2.0.1/AdaLang.Alire.Portable.locale.en-US.yaml
@@ -4,24 +4,21 @@ PackageLocale: en-US
 Publisher: The Alire Developers
 PublisherUrl: https://github.com/alire-project/
 PublisherSupportUrl: https://github.com/alire-project/alire/issues
-# PrivacyUrl: 
 Author: The Alire Developers
 PackageName: Alire
 PackageUrl: https://alire.ada.dev/
 License: GPL-3.0
 LicenseUrl: https://github.com/alire-project/alire/blob/master/LICENSE.txt
-# Copyright: 
-# CopyrightUrl:
 ShortDescription: Ada/SPARK Source Package Manager
 Description: A catalog of ready-to-use Ada libraries plus a command-line tool (alr) to obtain, build, and incorporate them into your own projects. It aims to fulfill a similar role to Rust's cargo or OCaml's opam.
-Moniker: alr
+Moniker: alr-portable
 Tags:
-  - package-manager 
-  - ada 
-  - package-management 
-  - reproducible-builds 
-  - ada-2012 
-  - package-manager-tool
+- package-manager
+- ada
+- package-management
+- reproducible-builds
+- ada-2012
+- package-manager-tool
 ReleaseNotes: |-
   This is a maintenance release to fix some issues detected in 2.0.
   Notable Fixes
@@ -29,9 +26,5 @@ ReleaseNotes: |-
   - msys2 installer updated to the latest version (#1648)
   - Fix installation of binary crates containing softlinks (#1653)
   Full Changelog: v2.0.0...v2.0.1
-# ReleaseNotesUrl: 
-# PurchaseUrl:
-# InstallationNotes:
-# Documentations:
 ManifestType: defaultLocale
 ManifestVersion: 1.6.0


### PR DESCRIPTION
Fixes an issue where this package has multiple different monikers
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/181627)