### PR TITLE
Remove DisplayVersion for Amazon.AWSCLI version 2.10.3

### DIFF
--- a/manifests/a/Amazon/AWSCLI/2.10.3/Amazon.AWSCLI.installer.yaml
+++ b/manifests/a/Amazon/AWSCLI/2.10.3/Amazon.AWSCLI.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 PackageIdentifier: Amazon.AWSCLI
 PackageVersion: 2.10.3
 Platform:
@@ -19,8 +19,7 @@ Installers:
   InstallerType: wix
   AppsAndFeaturesEntries:
   - DisplayName: AWS Command Line Interface v2
-    DisplayVersion: 2.10.3.0
     ProductCode: '{21CFED1D-2229-4742-A415-2DB61BF47851}'
 ManifestType: installer
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0
 

--- a/manifests/a/Amazon/AWSCLI/2.10.3/Amazon.AWSCLI.locale.en-US.yaml
+++ b/manifests/a/Amazon/AWSCLI/2.10.3/Amazon.AWSCLI.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultlocale.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultlocale.1.6.0.schema.json
 PackageIdentifier: Amazon.AWSCLI
 PackageVersion: 2.10.3
 PackageLocale: en-US
@@ -25,5 +25,5 @@ Tags:
 - services
 - web
 ManifestType: defaultLocale
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0
 

--- a/manifests/a/Amazon/AWSCLI/2.10.3/Amazon.AWSCLI.yaml
+++ b/manifests/a/Amazon/AWSCLI/2.10.3/Amazon.AWSCLI.yaml
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 PackageIdentifier: Amazon.AWSCLI
 PackageVersion: 2.10.3
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0
 


### PR DESCRIPTION
For AWSCLI, the DisplayVersion always differs by `.0` at the end from the semantic PackageVersion.
`.0` at the end plays no part in package matching and CLI treats both versions the same.
This PR removes DisplayVersion to make it easy for PR authors to author manifest for this package
and to avoid blowing up publishing pipelines in case an incorrect DisplayVersion goes through.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/181649)