### PR TITLE
Remove DisplayVersion for Amazon.AWSCLI version 2.11.10

### DIFF
--- a/manifests/a/Amazon/AWSCLI/2.11.10/Amazon.AWSCLI.installer.yaml
+++ b/manifests/a/Amazon/AWSCLI/2.11.10/Amazon.AWSCLI.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 PackageIdentifier: Amazon.AWSCLI
 PackageVersion: 2.11.10
 Platform:
@@ -19,8 +19,7 @@ Installers:
   InstallerType: wix
   AppsAndFeaturesEntries:
   - DisplayName: AWS Command Line Interface v2
-    DisplayVersion: 2.11.10.0
     ProductCode: '{66483EFC-F3C4-45C7-A3A0-E2F8C678C4B2}'
 ManifestType: installer
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0
 

--- a/manifests/a/Amazon/AWSCLI/2.11.10/Amazon.AWSCLI.locale.en-US.yaml
+++ b/manifests/a/Amazon/AWSCLI/2.11.10/Amazon.AWSCLI.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultlocale.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultlocale.1.6.0.schema.json
 PackageIdentifier: Amazon.AWSCLI
 PackageVersion: 2.11.10
 PackageLocale: en-US
@@ -25,5 +25,5 @@ Tags:
 - services
 - web
 ManifestType: defaultLocale
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0
 

--- a/manifests/a/Amazon/AWSCLI/2.11.10/Amazon.AWSCLI.yaml
+++ b/manifests/a/Amazon/AWSCLI/2.11.10/Amazon.AWSCLI.yaml
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 PackageIdentifier: Amazon.AWSCLI
 PackageVersion: 2.11.10
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0
 


### PR DESCRIPTION
For AWSCLI, the DisplayVersion always differs by `.0` at the end from the semantic PackageVersion.
`.0` at the end plays no part in package matching and CLI treats both versions the same.
This PR removes DisplayVersion to make it easy for PR authors to author manifest for this package
and to avoid blowing up publishing pipelines in case an incorrect DisplayVersion goes through.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/181652)