### PR TITLE
Remove DisplayVersion for Amazon.AWSCLI version 2.11.21

### DIFF
--- a/manifests/a/Amazon/AWSCLI/2.11.21/Amazon.AWSCLI.installer.yaml
+++ b/manifests/a/Amazon/AWSCLI/2.11.21/Amazon.AWSCLI.installer.yaml
@@ -1,5 +1,5 @@
 # Created with Komac v1.6.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: Amazon.AWSCLI
 PackageVersion: 2.11.21
@@ -18,7 +18,6 @@ Commands:
 ReleaseDate: 2023-05-19
 AppsAndFeaturesEntries:
 - DisplayName: AWS Command Line Interface v2
-  DisplayVersion: 2.11.21.0
   ProductCode: '{AC6D1704-C385-4602-971F-CF5DF8C672D8}'
   UpgradeCode: '{E1C1971C-384E-4D6D-8D02-F1AC48281CF8}'
 Installers:
@@ -27,4 +26,4 @@ Installers:
   InstallerSha256: B2CFADF81929D833041C372A9E789645BFD0D3791CEA86D65F58001F1AD06BD1
   ProductCode: '{AC6D1704-C385-4602-971F-CF5DF8C672D8}'
 ManifestType: installer
-ManifestVersion: 1.4.0
+ManifestVersion: 1.6.0

--- a/manifests/a/Amazon/AWSCLI/2.11.21/Amazon.AWSCLI.locale.en-US.yaml
+++ b/manifests/a/Amazon/AWSCLI/2.11.21/Amazon.AWSCLI.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with Komac v1.6.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.4.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: Amazon.AWSCLI
 PackageVersion: 2.11.21
@@ -29,4 +29,4 @@ Tags:
 - services
 - web
 ManifestType: defaultLocale
-ManifestVersion: 1.4.0
+ManifestVersion: 1.6.0

--- a/manifests/a/Amazon/AWSCLI/2.11.21/Amazon.AWSCLI.yaml
+++ b/manifests/a/Amazon/AWSCLI/2.11.21/Amazon.AWSCLI.yaml
@@ -1,8 +1,8 @@
 # Created with Komac v1.6.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.4.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: Amazon.AWSCLI
 PackageVersion: 2.11.21
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.4.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
For AWSCLI, the DisplayVersion always differs by `.0` at the end from the semantic PackageVersion.
`.0` at the end plays no part in package matching and CLI treats both versions the same.
This PR removes DisplayVersion to make it easy for PR authors to author manifest for this package
and to avoid blowing up publishing pipelines in case an incorrect DisplayVersion goes through.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/181665)