### PR TITLE
Remove DisplayVersion for Amazon.AWSCLI version 2.13.33

### DIFF
--- a/manifests/a/Amazon/AWSCLI/2.13.33/Amazon.AWSCLI.installer.yaml
+++ b/manifests/a/Amazon/AWSCLI/2.13.33/Amazon.AWSCLI.installer.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.5.5.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: Amazon.AWSCLI
 PackageVersion: 2.13.33
@@ -21,7 +21,6 @@ Installers:
   InstallerSha256: 2B31539015BF7542F08CF54DFFC811232C176F42F7B60EEE729C4DC231EFCB89
   AppsAndFeaturesEntries:
   - DisplayName: AWS Command Line Interface v2
-    DisplayVersion: 2.13.33.0
     ProductCode: '{91127DC3-043A-45DE-94E2-8591152908E9}'
 ManifestType: installer
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/a/Amazon/AWSCLI/2.13.33/Amazon.AWSCLI.locale.en-US.yaml
+++ b/manifests/a/Amazon/AWSCLI/2.13.33/Amazon.AWSCLI.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.5.5.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: Amazon.AWSCLI
 PackageVersion: 2.13.33
@@ -29,4 +29,4 @@ Tags:
 - services
 - web
 ManifestType: defaultLocale
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/a/Amazon/AWSCLI/2.13.33/Amazon.AWSCLI.yaml
+++ b/manifests/a/Amazon/AWSCLI/2.13.33/Amazon.AWSCLI.yaml
@@ -1,8 +1,8 @@
 # Created using wingetcreate 1.5.5.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: Amazon.AWSCLI
 PackageVersion: 2.13.33
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
For AWSCLI, the DisplayVersion always differs by `.0` at the end from the semantic PackageVersion.
`.0` at the end plays no part in package matching and CLI treats both versions the same.
This PR removes DisplayVersion to make it easy for PR authors to author manifest for this package
and to avoid blowing up publishing pipelines in case an incorrect DisplayVersion goes through.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/181719)