### PR TITLE
Remove DisplayVersion for Amazon.AWSCLI version 2.13.6

### DIFF
--- a/manifests/a/Amazon/AWSCLI/2.13.6/Amazon.AWSCLI.installer.yaml
+++ b/manifests/a/Amazon/AWSCLI/2.13.6/Amazon.AWSCLI.installer.yaml
@@ -1,5 +1,5 @@
 # Created with WinGet Automation using Komac v1.10.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: Amazon.AWSCLI
 PackageVersion: 2.13.6
@@ -19,11 +19,10 @@ ProductCode: '{27CC09EF-1CD7-4290-B2AE-578224A374AA}'
 ReleaseDate: 2023-08-02
 AppsAndFeaturesEntries:
 - DisplayName: AWS Command Line Interface v2
-  DisplayVersion: 2.13.6.0
   ProductCode: '{27CC09EF-1CD7-4290-B2AE-578224A374AA}'
 Installers:
 - Architecture: x64
   InstallerUrl: https://awscli.amazonaws.com/AWSCLIV2-2.13.6.msi
   InstallerSha256: 7E67FA4A0A3DB241301413E6981687A2E2BA1D6C0EF19E0E9B186F2C8B550892
 ManifestType: installer
-ManifestVersion: 1.4.0
+ManifestVersion: 1.6.0

--- a/manifests/a/Amazon/AWSCLI/2.13.6/Amazon.AWSCLI.locale.en-US.yaml
+++ b/manifests/a/Amazon/AWSCLI/2.13.6/Amazon.AWSCLI.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with WinGet Automation using Komac v1.10.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.4.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: Amazon.AWSCLI
 PackageVersion: 2.13.6
@@ -29,4 +29,4 @@ Tags:
 - services
 - web
 ManifestType: defaultLocale
-ManifestVersion: 1.4.0
+ManifestVersion: 1.6.0

--- a/manifests/a/Amazon/AWSCLI/2.13.6/Amazon.AWSCLI.yaml
+++ b/manifests/a/Amazon/AWSCLI/2.13.6/Amazon.AWSCLI.yaml
@@ -1,8 +1,8 @@
 # Created with WinGet Automation using Komac v1.10.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.4.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: Amazon.AWSCLI
 PackageVersion: 2.13.6
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.4.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
For AWSCLI, the DisplayVersion always differs by `.0` at the end from the semantic PackageVersion.
`.0` at the end plays no part in package matching and CLI treats both versions the same.
This PR removes DisplayVersion to make it easy for PR authors to author manifest for this package
and to avoid blowing up publishing pipelines in case an incorrect DisplayVersion goes through.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/181729)