### PR TITLE
Remove DisplayVersion for Amazon.AWSCLI version 2.14.0

### DIFF
--- a/manifests/a/Amazon/AWSCLI/2.14.0/Amazon.AWSCLI.installer.yaml
+++ b/manifests/a/Amazon/AWSCLI/2.14.0/Amazon.AWSCLI.installer.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.5.7.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: Amazon.AWSCLI
 PackageVersion: 2.14.0
@@ -21,7 +21,6 @@ Installers:
   InstallerSha256: 2FDAA7AB4B8B91A2CEF2F14CA27F662952341A5CDF09C3FDCF266EE839A56E76
   AppsAndFeaturesEntries:
   - DisplayName: AWS Command Line Interface v2
-    DisplayVersion: 2.14.0
     ProductCode: '{0AC6A03D-222D-4AB6-9ADF-597EA9E1EFD5}'
 ManifestType: installer
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/a/Amazon/AWSCLI/2.14.0/Amazon.AWSCLI.locale.en-US.yaml
+++ b/manifests/a/Amazon/AWSCLI/2.14.0/Amazon.AWSCLI.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.5.7.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: Amazon.AWSCLI
 PackageVersion: 2.14.0
@@ -29,4 +29,4 @@ Tags:
 - services
 - web
 ManifestType: defaultLocale
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/a/Amazon/AWSCLI/2.14.0/Amazon.AWSCLI.yaml
+++ b/manifests/a/Amazon/AWSCLI/2.14.0/Amazon.AWSCLI.yaml
@@ -1,8 +1,8 @@
 # Created using wingetcreate 1.5.7.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: Amazon.AWSCLI
 PackageVersion: 2.14.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
For AWSCLI, the DisplayVersion always differs by `.0` at the end from the semantic PackageVersion.
`.0` at the end plays no part in package matching and CLI treats both versions the same.
This PR removes DisplayVersion to make it easy for PR authors to author manifest for this package
and to avoid blowing up publishing pipelines in case an incorrect DisplayVersion goes through.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/181733)