### PR TITLE
Remove DisplayVersion for Amazon.AWSCLI version 2.15.2

### DIFF
--- a/manifests/a/Amazon/AWSCLI/2.15.2/Amazon.AWSCLI.installer.yaml
+++ b/manifests/a/Amazon/AWSCLI/2.15.2/Amazon.AWSCLI.installer.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.5.7.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: Amazon.AWSCLI
 PackageVersion: 2.15.2
@@ -18,7 +18,6 @@ Commands:
 ProductCode: '{5421E8D7-8794-4A5D-BE3B-25E8F05A3DA4}'
 AppsAndFeaturesEntries:
 - DisplayName: AWS Command Line Interface v2
-  DisplayVersion: 2.15.2.0
   ProductCode: '{5421E8D7-8794-4A5D-BE3B-25E8F05A3DA4}'
   UpgradeCode: '{E1C1971C-384E-4D6D-8D02-F1AC48281CF8}'
 Installers:
@@ -26,4 +25,4 @@ Installers:
   InstallerUrl: https://awscli.amazonaws.com/AWSCLIV2-2.15.2.msi
   InstallerSha256: 87104FEB3633DED42B666EE0D251445DFDFD17487CE4405C8F894ECB50F58608
 ManifestType: installer
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/a/Amazon/AWSCLI/2.15.2/Amazon.AWSCLI.locale.en-US.yaml
+++ b/manifests/a/Amazon/AWSCLI/2.15.2/Amazon.AWSCLI.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.5.7.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: Amazon.AWSCLI
 PackageVersion: 2.15.2
@@ -29,4 +29,4 @@ Tags:
 - services
 - web
 ManifestType: defaultLocale
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/a/Amazon/AWSCLI/2.15.2/Amazon.AWSCLI.yaml
+++ b/manifests/a/Amazon/AWSCLI/2.15.2/Amazon.AWSCLI.yaml
@@ -1,8 +1,8 @@
 # Created using wingetcreate 1.5.7.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: Amazon.AWSCLI
 PackageVersion: 2.15.2
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
For AWSCLI, the DisplayVersion always differs by `.0` at the end from the semantic PackageVersion.
`.0` at the end plays no part in package matching and CLI treats both versions the same.
This PR removes DisplayVersion to make it easy for PR authors to author manifest for this package
and to avoid blowing up publishing pipelines in case an incorrect DisplayVersion goes through.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/181756)