### PR TITLE
Remove DisplayVersion for Amazon.AWSCLI version 2.15.36

### DIFF
--- a/manifests/a/Amazon/AWSCLI/2.15.36/Amazon.AWSCLI.installer.yaml
+++ b/manifests/a/Amazon/AWSCLI/2.15.36/Amazon.AWSCLI.installer.yaml
@@ -18,7 +18,6 @@ Commands:
 ProductCode: '{5A96071E-5CE1-4750-96DF-83B01B6CBF1C}'
 AppsAndFeaturesEntries:
 - DisplayName: AWS Command Line Interface v2
-  DisplayVersion: 2.15.36.0
   ProductCode: '{5A96071E-5CE1-4750-96DF-83B01B6CBF1C}'
 Installers:
 - Architecture: x64


### PR DESCRIPTION
For AWSCLI, the DisplayVersion always differs by `.0` at the end from the semantic PackageVersion.
`.0` at the end plays no part in package matching and CLI treats both versions the same.
This PR removes DisplayVersion to make it easy for PR authors to author manifest for this package
and to avoid blowing up publishing pipelines in case an incorrect DisplayVersion goes through.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/181778)