### PR TITLE
Remove DisplayVersion for Amazon.AWSCLI version 2.17.5

### DIFF
--- a/manifests/a/Amazon/AWSCLI/2.17.5/Amazon.AWSCLI.installer.yaml
+++ b/manifests/a/Amazon/AWSCLI/2.17.5/Amazon.AWSCLI.installer.yaml
@@ -19,7 +19,6 @@ ProductCode: '{D7FECEA9-9C24-41AF-A615-1D4B56FF235F}'
 ReleaseDate: 2024-06-28
 AppsAndFeaturesEntries:
 - DisplayName: AWS Command Line Interface v2
-  DisplayVersion: 2.17.5.0
   UpgradeCode: '{E1C1971C-384E-4D6D-8D02-F1AC48281CF8}'
 Installers:
 - Architecture: x64


### PR DESCRIPTION
For AWSCLI, the DisplayVersion always differs by `.0` at the end from the semantic PackageVersion.
`.0` at the end plays no part in package matching and CLI treats both versions the same.
This PR removes DisplayVersion to make it easy for PR authors to author manifest for this package
and to avoid blowing up publishing pipelines in case an incorrect DisplayVersion goes through.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/181886)