### PR TITLE
Remove DisplayVersion for Amazon.AWSCLI version 2.17.57

### DIFF
--- a/manifests/a/Amazon/AWSCLI/2.17.57/Amazon.AWSCLI.installer.yaml
+++ b/manifests/a/Amazon/AWSCLI/2.17.57/Amazon.AWSCLI.installer.yaml
@@ -20,7 +20,6 @@ ReleaseDate: 2024-09-23
 AppsAndFeaturesEntries:
 - DisplayName: AWS Command Line Interface v2
   Publisher: Amazon Web Services
-  DisplayVersion: 2.17.57.0
   ProductCode: '{A9A9C51A-CF41-4588-8A8C-B78FAEF9334B}'
   UpgradeCode: '{E1C1971C-384E-4D6D-8D02-F1AC48281CF8}'
 InstallationMetadata:


### PR DESCRIPTION
For AWSCLI, the DisplayVersion always differs by `.0` at the end from the semantic PackageVersion.
`.0` at the end plays no part in package matching and CLI treats both versions the same.
This PR removes DisplayVersion to make it easy for PR authors to author manifest for this package
and to avoid blowing up publishing pipelines in case an incorrect DisplayVersion goes through.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/181894)