### PR TITLE
Remove DisplayVersion for Amazon.AWSCLI version 2.7.28

### DIFF
--- a/manifests/a/Amazon/AWSCLI/2.7.28/Amazon.AWSCLI.installer.yaml
+++ b/manifests/a/Amazon/AWSCLI/2.7.28/Amazon.AWSCLI.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 PackageIdentifier: Amazon.AWSCLI
 PackageVersion: 2.7.28
 Platform:
@@ -18,9 +18,8 @@ Installers:
   InstallerSha256: FAAFD4E45C168A299E46EF85C07F71EF8D098340758CA408E93AF99C71282546
   AppsAndFeaturesEntries:
   - DisplayName: AWS Command Line Interface v2
-    DisplayVersion: 2.7.28.0
     ProductCode: '{FD984712-3009-49FB-BB16-2198E63755CB}'
   InstallerType: wix
 ManifestType: installer
-ManifestVersion: 1.1.0
+ManifestVersion: 1.6.0
 

--- a/manifests/a/Amazon/AWSCLI/2.7.28/Amazon.AWSCLI.locale.en-US.yaml
+++ b/manifests/a/Amazon/AWSCLI/2.7.28/Amazon.AWSCLI.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultlocale.1.1.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultlocale.1.6.0.schema.json
 PackageIdentifier: Amazon.AWSCLI
 PackageVersion: 2.7.28
 PackageLocale: en-US
@@ -25,5 +25,5 @@ Tags:
 - services
 - web
 ManifestType: defaultLocale
-ManifestVersion: 1.1.0
+ManifestVersion: 1.6.0
 

--- a/manifests/a/Amazon/AWSCLI/2.7.28/Amazon.AWSCLI.yaml
+++ b/manifests/a/Amazon/AWSCLI/2.7.28/Amazon.AWSCLI.yaml
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 PackageIdentifier: Amazon.AWSCLI
 PackageVersion: 2.7.28
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.1.0
+ManifestVersion: 1.6.0
 


### PR DESCRIPTION
For AWSCLI, the DisplayVersion always differs by `.0` at the end from the semantic PackageVersion.
`.0` at the end plays no part in package matching and CLI treats both versions the same.
This PR removes DisplayVersion to make it easy for PR authors to author manifest for this package
and to avoid blowing up publishing pipelines in case an incorrect DisplayVersion goes through.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/181984)