### PR TITLE
Remove DisplayVersion for Amazon.AWSCLI version 2.7.9

### DIFF
--- a/manifests/a/Amazon/AWSCLI/2.7.9/Amazon.AWSCLI.installer.yaml
+++ b/manifests/a/Amazon/AWSCLI/2.7.9/Amazon.AWSCLI.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 PackageIdentifier: Amazon.AWSCLI
 PackageVersion: 2.7.9
 Platform:
@@ -19,7 +19,6 @@ Installers:
   InstallerSha256: CB1013FB09EF771ADB3467A4C8AE387E316EA2F288E3E4290E9911DA57A42AE4
   AppsAndFeaturesEntries:
   - DisplayName: AWS Command Line Interface v2
-    DisplayVersion: 2.7.9.0
     ProductCode: '{7A22772C-783D-4E70-B60B-5DA58BDDCA06}'
 ManifestType: installer
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0

--- a/manifests/a/Amazon/AWSCLI/2.7.9/Amazon.AWSCLI.locale.en-US.yaml
+++ b/manifests/a/Amazon/AWSCLI/2.7.9/Amazon.AWSCLI.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 PackageIdentifier: Amazon.AWSCLI
 PackageVersion: 2.7.9
 PackageLocale: en-US
@@ -28,4 +28,4 @@ Tags:
 - services
 - web
 ManifestType: defaultLocale
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0

--- a/manifests/a/Amazon/AWSCLI/2.7.9/Amazon.AWSCLI.yaml
+++ b/manifests/a/Amazon/AWSCLI/2.7.9/Amazon.AWSCLI.yaml
@@ -1,6 +1,6 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 PackageIdentifier: Amazon.AWSCLI
 PackageVersion: 2.7.9
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
For AWSCLI, the DisplayVersion always differs by `.0` at the end from the semantic PackageVersion.
`.0` at the end plays no part in package matching and CLI treats both versions the same.
This PR removes DisplayVersion to make it easy for PR authors to author manifest for this package
and to avoid blowing up publishing pipelines in case an incorrect DisplayVersion goes through.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/181998)