### PR TITLE
Remove DisplayVersion for Amazon.AWSCLI version 2.8.7

### DIFF
--- a/manifests/a/Amazon/AWSCLI/2.8.7/Amazon.AWSCLI.installer.yaml
+++ b/manifests/a/Amazon/AWSCLI/2.8.7/Amazon.AWSCLI.installer.yaml
@@ -1,5 +1,5 @@
 # Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-7
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: Amazon.AWSCLI
 PackageVersion: 2.8.7
@@ -17,7 +17,6 @@ Commands:
 - aws
 AppsAndFeaturesEntries:
 - DisplayName: AWS Command Line Interface v2
-  DisplayVersion: 2.8.7.0
   ProductCode: '{35FFDCCC-294D-4082-8496-0CBB6E47A2AF}'
 Installers:
 - Architecture: x64
@@ -25,4 +24,4 @@ Installers:
   InstallerSha256: 4CC6D7A4C662B0FDA0C94633D3FD02463A5F169B3710BC4433DABCF8717B94D6
   ProductCode: '{35FFDCCC-294D-4082-8496-0CBB6E47A2AF}'
 ManifestType: installer
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0

--- a/manifests/a/Amazon/AWSCLI/2.8.7/Amazon.AWSCLI.locale.en-US.yaml
+++ b/manifests/a/Amazon/AWSCLI/2.8.7/Amazon.AWSCLI.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-7
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: Amazon.AWSCLI
 PackageVersion: 2.8.7
@@ -35,4 +35,4 @@ Tags:
 # InstallationNotes:
 # Documentations:
 ManifestType: defaultLocale
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0

--- a/manifests/a/Amazon/AWSCLI/2.8.7/Amazon.AWSCLI.yaml
+++ b/manifests/a/Amazon/AWSCLI/2.8.7/Amazon.AWSCLI.yaml
@@ -1,8 +1,8 @@
 # Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-7
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: Amazon.AWSCLI
 PackageVersion: 2.8.7
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
For AWSCLI, the DisplayVersion always differs by `.0` at the end from the semantic PackageVersion.
`.0` at the end plays no part in package matching and CLI treats both versions the same.
This PR removes DisplayVersion to make it easy for PR authors to author manifest for this package
and to avoid blowing up publishing pipelines in case an incorrect DisplayVersion goes through.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/182010)