### PR TITLE
Update manifests/s/Stoplight/Spectral/6.6.0/Stoplight.Spectral.locale.en-US.yaml

### DIFF
--- a/manifests/s/Stoplight/Spectral/6.6.0/Stoplight.Spectral.locale.en-US.yaml
+++ b/manifests/s/Stoplight/Spectral/6.6.0/Stoplight.Spectral.locale.en-US.yaml
@@ -1,6 +1,3 @@
-# Created using wingetcreate 1.1.2.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
-
 PackageIdentifier: Stoplight.Spectral
 PackageVersion: 6.6.0
 PackageLocale: en-US
@@ -14,10 +11,9 @@ License: Apache License 2.0
 LicenseUrl: https://github.com/stoplightio/spectral/blob/develop/LICENSE
 Copyright: Stoplight, Inc.
 ShortDescription: A flexible JSON/YAML linter for creating automated style guides, with baked in support for OpenAPI v3.1, v3.0, and v2.0 as well as AsyncAPI v2.x.
-Moniker: Spectral
+Moniker: spectral
 ReleaseNotesUrl: https://github.com/stoplightio/spectral/releases/tag/v6.6.0
 Documentations:
 - DocumentUrl: https://meta.stoplight.io/docs/spectral/a630feff97e3a-concepts
 ManifestType: defaultLocale
 ManifestVersion: 1.2.0
-


### PR DESCRIPTION
Fixes an issue where this package has multiple different monikers
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/182247)