### PR TITLE
Update manifests/x/xpipe-io/xpipe/portable/1.5.3/xpipe-io.xpipe.portable.locale.en-US.yaml

### DIFF
--- a/manifests/x/xpipe-io/xpipe/portable/1.5.3/xpipe-io.xpipe.portable.locale.en-US.yaml
+++ b/manifests/x/xpipe-io/xpipe/portable/1.5.3/xpipe-io.xpipe.portable.locale.en-US.yaml
@@ -1,6 +1,3 @@
-# Created using wingetcreate 1.5.2.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
-
 PackageIdentifier: xpipe-io.xpipe.portable
 PackageVersion: 1.5.3
 PackageLocale: en-US
@@ -15,7 +12,7 @@ License: Apache License 2.0
 LicenseUrl: https://github.com/xpipe-io/xpipe/blob/master/LICENSE.md
 ShortDescription: A brand-new shell connection hub and remote file manager
 Description: XPipe is a new type of shell connection hub and remote file manager that allows you to access your entire sever infrastructure from your local machine. It works on top of your installed command-line programs that you normally use to connect and does not require any setup on your remote systems.
-Moniker: xpipe
+Moniker: xpipe-portable
 Tags:
 - remote
 ReleaseNotesUrl: https://github.com/xpipe-io/xpipe/blob/master/dist/changelogs/1.5.3.md

--- a/manifests/x/xpipe-io/xpipe/portable/1.5.3/xpipe-io.xpipe.portable.locale.en-US.yaml
+++ b/manifests/x/xpipe-io/xpipe/portable/1.5.3/xpipe-io.xpipe.portable.locale.en-US.yaml
@@ -4,7 +4,7 @@ PackageLocale: en-US
 Publisher: XPipe-io
 PublisherUrl: https://github.com/xpipe-io
 PublisherSupportUrl: https://github.com/xpipe-io/xpipe/issues
-PrivacyUrl: https://github.com/xpipe-io/xpipe/blob/master/PRIVACY.md
+# PrivacyUrl: https://github.com/xpipe-io/xpipe/blob/master/PRIVACY.md
 Author: crschnick
 PackageName: XPipe Portable
 PackageUrl: https://github.com/xpipe-io/xpipe


### PR DESCRIPTION
Fixes an issue where this package has multiple different monikers
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/182286)