### PR TITLE
Remove DisplayVersion for Rustlang.Rust.MSVC version 1.52.0

### DIFF
--- a/manifests/r/Rustlang/Rust/MSVC/1.52.0/Rustlang.Rust.MSVC.installer.yaml
+++ b/manifests/r/Rustlang/Rust/MSVC/1.52.0/Rustlang.Rust.MSVC.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 PackageIdentifier: Rustlang.Rust.MSVC
 PackageVersion: 1.52.0
 MinimumOSVersion: 10.0.0.0
@@ -10,7 +10,6 @@ Installers:
   InstallerUrl: https://static.rust-lang.org/dist/rust-1.52.0-x86_64-pc-windows-msvc.msi
   AppsAndFeaturesEntries:
   - DisplayName: Rust 1.52 (MSVC 64-bit)
-    DisplayVersion: 1.52.0.0
     Publisher: The Rust Project Developers
     ProductCode: '{91E09C1B-EA96-430E-9C9C-C5C0888649D4}'
 - InstallerSha256: 258F11A477708A3513FE618B52C5681D6AA9835BD69F96EA10E055CE263ADA04
@@ -18,9 +17,8 @@ Installers:
   InstallerUrl: https://static.rust-lang.org/dist/rust-1.52.0-i686-pc-windows-msvc.msi
   AppsAndFeaturesEntries:
   - DisplayName: Rust 1.52 (MSVC)
-    DisplayVersion: 1.52.0.0
     Publisher: The Rust Project Developers
     ProductCode: '{0F4FE3C0-CFBE-4E00-8266-4A595C0D0C6D}'
 ManifestType: installer
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0
 

--- a/manifests/r/Rustlang/Rust/MSVC/1.52.0/Rustlang.Rust.MSVC.locale.en-US.yaml
+++ b/manifests/r/Rustlang/Rust/MSVC/1.52.0/Rustlang.Rust.MSVC.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with YamlCreate.ps1 v2.1.4 $debug=AUSU.7-2-6
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: Rustlang.Rust.MSVC
 PackageVersion: 1.52.0
@@ -29,4 +29,4 @@ Tags:
 # InstallationNotes: 
 # Documentations: 
 ManifestType: defaultLocale
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0

--- a/manifests/r/Rustlang/Rust/MSVC/1.52.0/Rustlang.Rust.MSVC.yaml
+++ b/manifests/r/Rustlang/Rust/MSVC/1.52.0/Rustlang.Rust.MSVC.yaml
@@ -1,8 +1,8 @@
 # Created with YamlCreate.ps1 v2.1.4 $debug=AUSU.7-2-6
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: Rustlang.Rust.MSVC
 PackageVersion: 1.52.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
For Rust MSVC, the DisplayVersion always differs by `.0` at the end from the semantic PackageVersion.
`.0` at the end plays no part in package matching and CLI treats both versions the same.
This PR removes DisplayVersion to make it easy for PR authors to author manifest for this package
and to avoid blowing up publishing pipelines in case an incorrect DisplayVersion goes through.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/182937)