### PR TITLE
Remove DisplayVersion for Rustlang.Rust.MSVC version 1.57.0

### DIFF
--- a/manifests/r/Rustlang/Rust/MSVC/1.57.0/Rustlang.Rust.MSVC.installer.yaml
+++ b/manifests/r/Rustlang/Rust/MSVC/1.57.0/Rustlang.Rust.MSVC.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 PackageIdentifier: Rustlang.Rust.MSVC
 PackageVersion: 1.57.0
 MinimumOSVersion: 10.0.0.0
@@ -11,19 +11,17 @@ Installers:
   InstallerUrl: https://static.rust-lang.org/dist/rust-1.57.0-x86_64-pc-windows-msvc.msi
   AppsAndFeaturesEntries:
   - DisplayName: Rust 1.57 (MSVC 64-bit)
-    DisplayVersion: 1.57.0.0
     ProductCode: '{52AE14FB-2FD1-4BBF-8641-A5FD32071892}'
 - InstallerSha256: 8D1211D29FC3A0CCCA4E427A967D64A7B042308C3F7933BEF6293D27FE241E13
   Architecture: x86
   InstallerUrl: https://static.rust-lang.org/dist/rust-1.57.0-i686-pc-windows-msvc.msi
   AppsAndFeaturesEntries:
   - DisplayName: Rust 1.57 (MSVC)
-    DisplayVersion: 1.57.0.0
     ProductCode: '{0B085D95-22A4-49C3-99DD-E142E65B6A96}'
 - InstallerSha256: 3E63318855F6B8232B2D4B9C666C1CD73FAE76B2DE09F86D1EDB3CA04BC15A83
   Architecture: arm64
   ProductCode: '{D602AEF6-3838-4A9A-9484-D0BF4920DBF9}'
   InstallerUrl: https://static.rust-lang.org/dist/rust-1.57.0-aarch64-pc-windows-msvc.msi
 ManifestType: installer
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0
 

--- a/manifests/r/Rustlang/Rust/MSVC/1.57.0/Rustlang.Rust.MSVC.locale.en-US.yaml
+++ b/manifests/r/Rustlang/Rust/MSVC/1.57.0/Rustlang.Rust.MSVC.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with YamlCreate.ps1 v2.1.4 $debug=AUSU.7-2-6
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: Rustlang.Rust.MSVC
 PackageVersion: 1.57.0
@@ -29,4 +29,4 @@ ReleaseNotesUrl: https://github.com/rust-lang/rust/releases/tag/1.57.0
 # InstallationNotes: 
 # Documentations: 
 ManifestType: defaultLocale
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0

--- a/manifests/r/Rustlang/Rust/MSVC/1.57.0/Rustlang.Rust.MSVC.yaml
+++ b/manifests/r/Rustlang/Rust/MSVC/1.57.0/Rustlang.Rust.MSVC.yaml
@@ -1,8 +1,8 @@
 # Created with YamlCreate.ps1 v2.1.4 $debug=AUSU.7-2-6
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: Rustlang.Rust.MSVC
 PackageVersion: 1.57.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
For Rust MSVC, the DisplayVersion always differs by `.0` at the end from the semantic PackageVersion.
`.0` at the end plays no part in package matching and CLI treats both versions the same.
This PR removes DisplayVersion to make it easy for PR authors to author manifest for this package
and to avoid blowing up publishing pipelines in case an incorrect DisplayVersion goes through.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/182938)