### PR TITLE
Remove DisplayVersion for Rustlang.Rust.MSVC version 1.60.0

### DIFF
--- a/manifests/r/Rustlang/Rust/MSVC/1.60.0/Rustlang.Rust.MSVC.installer.yaml
+++ b/manifests/r/Rustlang/Rust/MSVC/1.60.0/Rustlang.Rust.MSVC.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 PackageIdentifier: Rustlang.Rust.MSVC
 PackageVersion: 1.60.0
 MinimumOSVersion: 10.0.0.0
@@ -10,19 +10,17 @@ Installers:
   InstallerUrl: https://static.rust-lang.org/dist/rust-1.60.0-x86_64-pc-windows-msvc.msi
   AppsAndFeaturesEntries:
   - DisplayName: Rust 1.60 (MSVC 64-bit)
-    DisplayVersion: 1.60.0.0
     ProductCode: '{C19308FC-7FE4-4C73-9B62-829E5CA32EC9}'
 - InstallerSha256: 7EC1786F1ED530EC918343773760E0B5AFC668A1EB2697D74BB0A6967C113FD0
   Architecture: x86
   InstallerUrl: https://static.rust-lang.org/dist/rust-1.60.0-i686-pc-windows-msvc.msi
   AppsAndFeaturesEntries:
   - DisplayName: Rust 1.60 (MSVC)
-    DisplayVersion: 1.60.0.0
     ProductCode: '{689F91A4-E461-4316-AE01-96B431E6F1A9}'
 - InstallerSha256: 6EB7DA6FA5920D8B094264397EC4959C95D64F91AD0F78016557FC86F6DE0759
   Architecture: arm64
   ProductCode: '{E18E663C-AD85-4C4F-9AC2-6A30B76C0CA7}'
   InstallerUrl: https://static.rust-lang.org/dist/rust-1.60.0-aarch64-pc-windows-msvc.msi
 ManifestType: installer
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0
 

--- a/manifests/r/Rustlang/Rust/MSVC/1.60.0/Rustlang.Rust.MSVC.locale.en-US.yaml
+++ b/manifests/r/Rustlang/Rust/MSVC/1.60.0/Rustlang.Rust.MSVC.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with YamlCreate.ps1 v2.1.4 $debug=AUSU.7-2-6
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: Rustlang.Rust.MSVC
 PackageVersion: 1.60.0
@@ -29,4 +29,4 @@ Tags:
 # InstallationNotes: 
 # Documentations: 
 ManifestType: defaultLocale
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0

--- a/manifests/r/Rustlang/Rust/MSVC/1.60.0/Rustlang.Rust.MSVC.yaml
+++ b/manifests/r/Rustlang/Rust/MSVC/1.60.0/Rustlang.Rust.MSVC.yaml
@@ -1,8 +1,8 @@
 # Created with YamlCreate.ps1 v2.1.4 $debug=AUSU.7-2-6
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: Rustlang.Rust.MSVC
 PackageVersion: 1.60.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
For Rust MSVC, the DisplayVersion always differs by `.0` at the end from the semantic PackageVersion.
`.0` at the end plays no part in package matching and CLI treats both versions the same.
This PR removes DisplayVersion to make it easy for PR authors to author manifest for this package
and to avoid blowing up publishing pipelines in case an incorrect DisplayVersion goes through.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/182939)