### PR TITLE
Remove DisplayVersion for Rustlang.Rust.MSVC version 1.61.0

### DIFF
--- a/manifests/r/Rustlang/Rust/MSVC/1.61.0/Rustlang.Rust.MSVC.installer.yaml
+++ b/manifests/r/Rustlang/Rust/MSVC/1.61.0/Rustlang.Rust.MSVC.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 PackageIdentifier: Rustlang.Rust.MSVC
 PackageVersion: 1.61.0
 MinimumOSVersion: 10.0.0.0
@@ -10,19 +10,17 @@ Installers:
   InstallerUrl: https://static.rust-lang.org/dist/rust-1.61.0-x86_64-pc-windows-msvc.msi
   AppsAndFeaturesEntries:
   - DisplayName: Rust 1.61 (MSVC 64-bit)
-    DisplayVersion: 1.61.0.0
     ProductCode: '{8E32649E-ED91-47BF-A937-7921EAED5027}'
 - InstallerSha256: 6394A77FB4CF49C465A147029D62DDC005EEF71E8B36D3E89185E9C5FA26BFD7
   Architecture: x86
   InstallerUrl: https://static.rust-lang.org/dist/rust-1.61.0-i686-pc-windows-msvc.msi
   AppsAndFeaturesEntries:
   - DisplayName: Rust 1.61 (MSVC)
-    DisplayVersion: 1.61.0.0
     ProductCode: '{ACA6A6BC-F33F-42A9-9189-EFB992C32EFD}'
 - InstallerSha256: 7612A764C0C513D82C8A8960A195AB68D7E8E3325FADB93DA8560344EF769339
   Architecture: arm64
   ProductCode: '{EEFDBF67-8B17-4E9A-B9ED-F1B68529C212}'
   InstallerUrl: https://static.rust-lang.org/dist/rust-1.61.0-aarch64-pc-windows-msvc.msi
 ManifestType: installer
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0
 

--- a/manifests/r/Rustlang/Rust/MSVC/1.61.0/Rustlang.Rust.MSVC.locale.en-US.yaml
+++ b/manifests/r/Rustlang/Rust/MSVC/1.61.0/Rustlang.Rust.MSVC.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with YamlCreate.ps1 v2.1.4 $debug=AUSU.7-2-6
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: Rustlang.Rust.MSVC
 PackageVersion: 1.61.0
@@ -29,4 +29,4 @@ Tags:
 # InstallationNotes: 
 # Documentations: 
 ManifestType: defaultLocale
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0

--- a/manifests/r/Rustlang/Rust/MSVC/1.61.0/Rustlang.Rust.MSVC.yaml
+++ b/manifests/r/Rustlang/Rust/MSVC/1.61.0/Rustlang.Rust.MSVC.yaml
@@ -1,8 +1,8 @@
 # Created with YamlCreate.ps1 v2.1.4 $debug=AUSU.7-2-6
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: Rustlang.Rust.MSVC
 PackageVersion: 1.61.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
For Rust MSVC, the DisplayVersion always differs by `.0` at the end from the semantic PackageVersion.
`.0` at the end plays no part in package matching and CLI treats both versions the same.
This PR removes DisplayVersion to make it easy for PR authors to author manifest for this package
and to avoid blowing up publishing pipelines in case an incorrect DisplayVersion goes through.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/182940)