### PR TITLE
Remove DisplayVersion for Rustlang.Rust.MSVC version 1.62.0

### DIFF
--- a/manifests/r/Rustlang/Rust/MSVC/1.62.0/Rustlang.Rust.MSVC.installer.yaml
+++ b/manifests/r/Rustlang/Rust/MSVC/1.62.0/Rustlang.Rust.MSVC.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 PackageIdentifier: Rustlang.Rust.MSVC
 PackageVersion: 1.62.0
 MinimumOSVersion: 10.0.0.0
@@ -10,19 +10,17 @@ Installers:
   InstallerUrl: https://static.rust-lang.org/dist/rust-1.62.0-x86_64-pc-windows-msvc.msi
   AppsAndFeaturesEntries:
   - DisplayName: Rust 1.62 (MSVC 64-bit)
-    DisplayVersion: 1.62.0.0
     ProductCode: '{1328D7EF-8D77-49D4-AF98-F6199CC05162}'
 - InstallerSha256: 1D0FDE5E380A492AC0CB7FECA87849D9CCAE918C0AF8429B23D9EFF3B22B59DD
   Architecture: x86
   InstallerUrl: https://static.rust-lang.org/dist/rust-1.62.0-i686-pc-windows-msvc.msi
   AppsAndFeaturesEntries:
   - DisplayName: Rust 1.62 (MSVC)
-    DisplayVersion: 1.62.0.0
     ProductCode: '{03AB9F77-CE6D-4F49-B4D1-E5B282CB9E09}'
 - InstallerSha256: 9F49AA2BC28DAE4F5A9F4A7DEAC117BE82851F4B871C07EE4998F7C78B318A05
   Architecture: arm64
   ProductCode: '{E6ACC02A-AC7E-4B26-8FE3-3B07BA890B0F}'
   InstallerUrl: https://static.rust-lang.org/dist/rust-1.62.0-aarch64-pc-windows-msvc.msi
 ManifestType: installer
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0
 

--- a/manifests/r/Rustlang/Rust/MSVC/1.62.0/Rustlang.Rust.MSVC.locale.en-US.yaml
+++ b/manifests/r/Rustlang/Rust/MSVC/1.62.0/Rustlang.Rust.MSVC.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with YamlCreate.ps1 v2.1.4 $debug=AUSU.7-2-6
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: Rustlang.Rust.MSVC
 PackageVersion: 1.62.0
@@ -29,4 +29,4 @@ Tags:
 # InstallationNotes: 
 # Documentations: 
 ManifestType: defaultLocale
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0

--- a/manifests/r/Rustlang/Rust/MSVC/1.62.0/Rustlang.Rust.MSVC.yaml
+++ b/manifests/r/Rustlang/Rust/MSVC/1.62.0/Rustlang.Rust.MSVC.yaml
@@ -1,8 +1,8 @@
 # Created with YamlCreate.ps1 v2.1.4 $debug=AUSU.7-2-6
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: Rustlang.Rust.MSVC
 PackageVersion: 1.62.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
For Rust MSVC, the DisplayVersion always differs by `.0` at the end from the semantic PackageVersion.
`.0` at the end plays no part in package matching and CLI treats both versions the same.
This PR removes DisplayVersion to make it easy for PR authors to author manifest for this package
and to avoid blowing up publishing pipelines in case an incorrect DisplayVersion goes through.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/182941)