### PR TITLE
Remove DisplayVersion for Rustlang.Rust.MSVC version 1.62.1

### DIFF
--- a/manifests/r/Rustlang/Rust/MSVC/1.62.1/Rustlang.Rust.MSVC.installer.yaml
+++ b/manifests/r/Rustlang/Rust/MSVC/1.62.1/Rustlang.Rust.MSVC.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 PackageIdentifier: Rustlang.Rust.MSVC
 PackageVersion: 1.62.1
 MinimumOSVersion: 10.0.0.0
@@ -10,19 +10,17 @@ Installers:
   InstallerUrl: https://static.rust-lang.org/dist/rust-1.62.1-x86_64-pc-windows-msvc.msi
   AppsAndFeaturesEntries:
   - DisplayName: Rust 1.62 (MSVC 64-bit)
-    DisplayVersion: 1.62.1.0
     ProductCode: '{485172F4-E484-4E1A-957F-F4DD008A9E8B}'
 - InstallerSha256: DD3854205BD71CAF4ADD79C3C6FDBD2F745B95C0B0B7DCD1C0B38C644BE1E322
   Architecture: x86
   InstallerUrl: https://static.rust-lang.org/dist/rust-1.62.1-i686-pc-windows-msvc.msi
   AppsAndFeaturesEntries:
   - DisplayName: Rust 1.62 (MSVC)
-    DisplayVersion: 1.62.1.0
     ProductCode: '{D97D5F7D-228F-4A23-A0F0-B67372EE89F8}'
 - InstallerSha256: BD459E2405B82C03CE49E754711A0C5B15FB40FF3D68AEE58C4151786CCBDDF4
   Architecture: arm64
   ProductCode: '{EEBD6D61-2490-44CF-A173-E98148339B37}'
   InstallerUrl: https://static.rust-lang.org/dist/rust-1.62.1-aarch64-pc-windows-msvc.msi
 ManifestType: installer
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0
 

--- a/manifests/r/Rustlang/Rust/MSVC/1.62.1/Rustlang.Rust.MSVC.locale.en-US.yaml
+++ b/manifests/r/Rustlang/Rust/MSVC/1.62.1/Rustlang.Rust.MSVC.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with YamlCreate.ps1 v2.1.4 $debug=AUSU.7-2-6
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: Rustlang.Rust.MSVC
 PackageVersion: 1.62.1
@@ -29,4 +29,4 @@ Tags:
 # InstallationNotes: 
 # Documentations: 
 ManifestType: defaultLocale
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0

--- a/manifests/r/Rustlang/Rust/MSVC/1.62.1/Rustlang.Rust.MSVC.yaml
+++ b/manifests/r/Rustlang/Rust/MSVC/1.62.1/Rustlang.Rust.MSVC.yaml
@@ -1,8 +1,8 @@
 # Created with YamlCreate.ps1 v2.1.4 $debug=AUSU.7-2-6
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: Rustlang.Rust.MSVC
 PackageVersion: 1.62.1
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
For Rust MSVC, the DisplayVersion always differs by `.0` at the end from the semantic PackageVersion.
`.0` at the end plays no part in package matching and CLI treats both versions the same.
This PR removes DisplayVersion to make it easy for PR authors to author manifest for this package
and to avoid blowing up publishing pipelines in case an incorrect DisplayVersion goes through.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/182942)