### PR TITLE
Remove DisplayVersion for Rustlang.Rust.MSVC version 1.63.0

### DIFF
--- a/manifests/r/Rustlang/Rust/MSVC/1.63.0/Rustlang.Rust.MSVC.installer.yaml
+++ b/manifests/r/Rustlang/Rust/MSVC/1.63.0/Rustlang.Rust.MSVC.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 PackageIdentifier: Rustlang.Rust.MSVC
 PackageVersion: 1.63.0
 MinimumOSVersion: 10.0.0.0
@@ -10,19 +10,17 @@ Installers:
   InstallerUrl: https://static.rust-lang.org/dist/rust-1.63.0-x86_64-pc-windows-msvc.msi
   AppsAndFeaturesEntries:
   - DisplayName: Rust 1.63 (MSVC 64-bit)
-    DisplayVersion: 1.63.0.0
     ProductCode: '{F89628A9-D84F-486B-83F5-092007FA03C9}'
 - InstallerSha256: D8F3D382D5696DB236DF046E48D8F332D5941CF4D93B575CA3EACAE5F6D2EDF1
   Architecture: x86
   InstallerUrl: https://static.rust-lang.org/dist/rust-1.63.0-i686-pc-windows-msvc.msi
   AppsAndFeaturesEntries:
   - DisplayName: Rust 1.63 (MSVC)
-    DisplayVersion: 1.63.0.0
     ProductCode: '{FBAC7273-35AB-4942-8B6A-A3407C4558C2}'
 - InstallerSha256: A7CECC41B7346E85E904983A36F8D84970C72FCB42278BF7D20EA5F480F4E464
   Architecture: arm64
   ProductCode: '{4205D4CC-DCFE-4A97-9B95-E9B46D3FED71}'
   InstallerUrl: https://static.rust-lang.org/dist/rust-1.63.0-aarch64-pc-windows-msvc.msi
 ManifestType: installer
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0
 

--- a/manifests/r/Rustlang/Rust/MSVC/1.63.0/Rustlang.Rust.MSVC.locale.en-US.yaml
+++ b/manifests/r/Rustlang/Rust/MSVC/1.63.0/Rustlang.Rust.MSVC.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with YamlCreate.ps1 v2.1.4 $debug=AUSU.7-2-6
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: Rustlang.Rust.MSVC
 PackageVersion: 1.63.0
@@ -29,4 +29,4 @@ Tags:
 # InstallationNotes: 
 # Documentations: 
 ManifestType: defaultLocale
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0

--- a/manifests/r/Rustlang/Rust/MSVC/1.63.0/Rustlang.Rust.MSVC.yaml
+++ b/manifests/r/Rustlang/Rust/MSVC/1.63.0/Rustlang.Rust.MSVC.yaml
@@ -1,8 +1,8 @@
 # Created with YamlCreate.ps1 v2.1.4 $debug=AUSU.7-2-6
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: Rustlang.Rust.MSVC
 PackageVersion: 1.63.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
For Rust MSVC, the DisplayVersion always differs by `.0` at the end from the semantic PackageVersion.
`.0` at the end plays no part in package matching and CLI treats both versions the same.
This PR removes DisplayVersion to make it easy for PR authors to author manifest for this package
and to avoid blowing up publishing pipelines in case an incorrect DisplayVersion goes through.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/182943)