### PR TITLE
Remove DisplayVersion for Rustlang.Rust.MSVC version 1.64.0

### DIFF
--- a/manifests/r/Rustlang/Rust/MSVC/1.64.0/Rustlang.Rust.MSVC.installer.yaml
+++ b/manifests/r/Rustlang/Rust/MSVC/1.64.0/Rustlang.Rust.MSVC.installer.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.1.2.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: Rustlang.Rust.MSVC
 PackageVersion: 1.64.0
@@ -13,7 +13,6 @@ Installers:
   ProductCode: '{D5CE2732-42B8-44D3-96FB-64A316D0AAAF}'
   AppsAndFeaturesEntries:
   - DisplayName: Rust 1.64 (MSVC 64-bit)
-    DisplayVersion: 1.64.0.0
     ProductCode: '{D5CE2732-42B8-44D3-96FB-64A316D0AAAF}'
 - Architecture: x86
   InstallerType: wix
@@ -22,7 +21,6 @@ Installers:
   ProductCode: '{1F85CE85-B78E-4F95-801E-60D425AA7BD0}'
   AppsAndFeaturesEntries:
   - DisplayName: Rust 1.64 (MSVC)
-    DisplayVersion: 1.64.0.0
     ProductCode: '{1F85CE85-B78E-4F95-801E-60D425AA7BD0}'
 - Architecture: arm64
   InstallerType: wix
@@ -30,5 +28,5 @@ Installers:
   InstallerSha256: 8C5BD2B009BE1D6CBE6A532F144C4817FDA75BB64C726E5460DF0D20E260C069
   ProductCode: '{4C0708CF-371A-4691-9318-8E8F1ED2DA6B}'
 ManifestType: installer
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0
 

--- a/manifests/r/Rustlang/Rust/MSVC/1.64.0/Rustlang.Rust.MSVC.locale.en-US.yaml
+++ b/manifests/r/Rustlang/Rust/MSVC/1.64.0/Rustlang.Rust.MSVC.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.1.2.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: Rustlang.Rust.MSVC
 PackageVersion: 1.64.0
@@ -20,5 +20,5 @@ Tags:
 - rust
 - windows
 ManifestType: defaultLocale
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0
 

--- a/manifests/r/Rustlang/Rust/MSVC/1.64.0/Rustlang.Rust.MSVC.yaml
+++ b/manifests/r/Rustlang/Rust/MSVC/1.64.0/Rustlang.Rust.MSVC.yaml
@@ -1,8 +1,8 @@
 # Created using wingetcreate 1.1.2.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: Rustlang.Rust.MSVC
 PackageVersion: 1.64.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
For Rust MSVC, the DisplayVersion always differs by `.0` at the end from the semantic PackageVersion.
`.0` at the end plays no part in package matching and CLI treats both versions the same.
This PR removes DisplayVersion to make it easy for PR authors to author manifest for this package
and to avoid blowing up publishing pipelines in case an incorrect DisplayVersion goes through.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/182944)