### PR TITLE
Remove DisplayVersion for Rustlang.Rust.MSVC version 1.65.0

### DIFF
--- a/manifests/r/Rustlang/Rust/MSVC/1.65.0/Rustlang.Rust.MSVC.installer.yaml
+++ b/manifests/r/Rustlang/Rust/MSVC/1.65.0/Rustlang.Rust.MSVC.installer.yaml
@@ -1,5 +1,5 @@
 # Created with YamlCreate.ps1 v2.2.1 $debug=QUSU.CRLF.5-1-19041-1682.Win32NT
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: Rustlang.Rust.MSVC
 PackageVersion: 1.65.0
@@ -14,7 +14,6 @@ Installers:
   AppsAndFeaturesEntries:
   - DisplayName: Rust 1.65 (MSVC)
     ProductCode: '{161A0B9B-880A-4BF8-96F2-ED83CA18AB66}'
-    DisplayVersion: 1.65.0.0
 - Architecture: x86
   InstallerUrl: https://static.rust-lang.org/dist/rust-1.65.0-i686-pc-windows-msvc.msi
   InstallerSha256: 1776B141EF6BA76AA34290AEE6B9816FCD4614E713D852CC3171472FAF977463
@@ -22,7 +21,6 @@ Installers:
   AppsAndFeaturesEntries:
   - DisplayName: Rust 1.65 (MSVC)
     ProductCode: '{005CC509-035B-4BC2-B2A2-0B9ECC9301DD}'
-    DisplayVersion: 1.65.0.0
 - Architecture: x64
   InstallerUrl: https://static.rust-lang.org/dist/rust-1.65.0-x86_64-pc-windows-msvc.msi
   InstallerSha256: 9425A225C484BE4CD68386F6CEAB1DB8A5A8FFE9992A14D47983607A9766FC24
@@ -30,6 +28,5 @@ Installers:
   AppsAndFeaturesEntries:
   - DisplayName: Rust 1.65 (MSVC 64-bit)
     ProductCode: '{D773EB4D-6913-4C04-9441-8317E61FE9E4}'
-    DisplayVersion: 1.65.0.0
 ManifestType: installer
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0

--- a/manifests/r/Rustlang/Rust/MSVC/1.65.0/Rustlang.Rust.MSVC.locale.en-US.yaml
+++ b/manifests/r/Rustlang/Rust/MSVC/1.65.0/Rustlang.Rust.MSVC.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with YamlCreate.ps1 v2.2.1 $debug=QUSU.CRLF.5-1-19041-1682.Win32NT
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: Rustlang.Rust.MSVC
 PackageVersion: 1.65.0
@@ -29,4 +29,4 @@ Tags:
 # InstallationNotes:
 # Documentations:
 ManifestType: defaultLocale
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0

--- a/manifests/r/Rustlang/Rust/MSVC/1.65.0/Rustlang.Rust.MSVC.yaml
+++ b/manifests/r/Rustlang/Rust/MSVC/1.65.0/Rustlang.Rust.MSVC.yaml
@@ -1,8 +1,8 @@
 # Created with YamlCreate.ps1 v2.2.1 $debug=QUSU.CRLF.5-1-19041-1682.Win32NT
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: Rustlang.Rust.MSVC
 PackageVersion: 1.65.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
For Rust MSVC, the DisplayVersion always differs by `.0` at the end from the semantic PackageVersion.
`.0` at the end plays no part in package matching and CLI treats both versions the same.
This PR removes DisplayVersion to make it easy for PR authors to author manifest for this package
and to avoid blowing up publishing pipelines in case an incorrect DisplayVersion goes through.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/182945)