### PR TITLE
Remove DisplayVersion for Rustlang.Rust.MSVC version 1.77.0

### DIFF
--- a/manifests/r/Rustlang/Rust/MSVC/1.77.0/Rustlang.Rust.MSVC.installer.yaml
+++ b/manifests/r/Rustlang/Rust/MSVC/1.77.0/Rustlang.Rust.MSVC.installer.yaml
@@ -14,7 +14,6 @@ Installers:
   AppsAndFeaturesEntries:
   - DisplayName: Rust 1.77 (MSVC)
     ProductCode: '{EBE956C2-1121-4C2F-98F3-19748D037AC9}'
-    DisplayVersion: 1.77.0.0
 - Architecture: x86
   InstallerUrl: https://static.rust-lang.org/dist/rust-1.77.0-i686-pc-windows-msvc.msi
   InstallerSha256: 3E767050ED77571A8B268D19860A8B9081E3C38BA9DFAF209DA5A438756B8F36
@@ -22,7 +21,6 @@ Installers:
   AppsAndFeaturesEntries:
   - DisplayName: Rust 1.77 (MSVC)
     ProductCode: '{31438511-B399-4750-BFB7-2B00244C899C}'
-    DisplayVersion: 1.77.0.0
 - Architecture: x64
   InstallerUrl: https://static.rust-lang.org/dist/rust-1.77.0-x86_64-pc-windows-msvc.msi
   InstallerSha256: C1F2A843B492D36785596DA5B0F0B4D1140431F312E748052C966C990311475B
@@ -30,7 +28,6 @@ Installers:
   AppsAndFeaturesEntries:
   - DisplayName: Rust 1.77 (MSVC 64-bit)
     ProductCode: '{D354AAC1-079B-4D73-B38F-6DF94FAB661C}'
-    DisplayVersion: 1.77.0.0
 ManifestType: installer
 ManifestVersion: 1.6.0
 


### PR DESCRIPTION
For Rust MSVC, the DisplayVersion always differs by `.0` at the end from the semantic PackageVersion.
`.0` at the end plays no part in package matching and CLI treats both versions the same.
This PR removes DisplayVersion to make it easy for PR authors to author manifest for this package
and to avoid blowing up publishing pipelines in case an incorrect DisplayVersion goes through.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/182964)