### PR TITLE
Remove DisplayVersion for Rustlang.Rust.MSVC version 1.77.1

### DIFF
--- a/manifests/r/Rustlang/Rust/MSVC/1.77.1/Rustlang.Rust.MSVC.installer.yaml
+++ b/manifests/r/Rustlang/Rust/MSVC/1.77.1/Rustlang.Rust.MSVC.installer.yaml
@@ -14,7 +14,6 @@ Installers:
   AppsAndFeaturesEntries:
   - DisplayName: Rust 1.77 (MSVC)
     ProductCode: '{E69E7AAC-F977-4499-8F57-4D334142B867}'
-    DisplayVersion: 1.77.1.0
 - Architecture: x86
   InstallerUrl: https://static.rust-lang.org/dist/rust-1.77.1-i686-pc-windows-msvc.msi
   InstallerSha256: 8A6EFB046B8BA68AC67791CC1CC57209662D24FE10929A74B0B606E6B5319562
@@ -22,7 +21,6 @@ Installers:
   AppsAndFeaturesEntries:
   - DisplayName: Rust 1.77 (MSVC)
     ProductCode: '{F6F0F11D-9222-4862-923A-BB7B756476FC}'
-    DisplayVersion: 1.77.1.0
 - Architecture: x64
   InstallerUrl: https://static.rust-lang.org/dist/rust-1.77.1-x86_64-pc-windows-msvc.msi
   InstallerSha256: BF92940C1674306BBF154A6C24D1F94189A4D1CE798BABB62DA92B13B4B3DD89
@@ -30,7 +28,6 @@ Installers:
   AppsAndFeaturesEntries:
   - DisplayName: Rust 1.77 (MSVC 64-bit)
     ProductCode: '{616C3829-A359-45CF-8C2D-6D46D38A222A}'
-    DisplayVersion: 1.77.1.0
 ManifestType: installer
 ManifestVersion: 1.6.0
 


### PR DESCRIPTION
For Rust MSVC, the DisplayVersion always differs by `.0` at the end from the semantic PackageVersion.
`.0` at the end plays no part in package matching and CLI treats both versions the same.
This PR removes DisplayVersion to make it easy for PR authors to author manifest for this package
and to avoid blowing up publishing pipelines in case an incorrect DisplayVersion goes through.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/182965)