### PR TITLE
Remove DisplayVersion for Rustlang.Rust.MSVC version 1.77.2

### DIFF
--- a/manifests/r/Rustlang/Rust/MSVC/1.77.2/Rustlang.Rust.MSVC.installer.yaml
+++ b/manifests/r/Rustlang/Rust/MSVC/1.77.2/Rustlang.Rust.MSVC.installer.yaml
@@ -14,7 +14,6 @@ Installers:
   AppsAndFeaturesEntries:
   - DisplayName: Rust 1.77 (MSVC)
     ProductCode: '{E7A95A6E-18C4-44D2-9924-886BA629E729}'
-    DisplayVersion: 1.77.2.0
 - Architecture: x86
   InstallerUrl: https://static.rust-lang.org/dist/rust-1.77.2-i686-pc-windows-msvc.msi
   InstallerSha256: 05617C8DFA09F9B7A3565BB7E01E2DB2E39AA6AF85C29AE9603832076A34CEFF
@@ -22,7 +21,6 @@ Installers:
   AppsAndFeaturesEntries:
   - DisplayName: Rust 1.77 (MSVC)
     ProductCode: '{CD6DC01C-9B3B-490C-B076-464BA5A219D1}'
-    DisplayVersion: 1.77.2.0
 - Architecture: x64
   InstallerUrl: https://static.rust-lang.org/dist/rust-1.77.2-x86_64-pc-windows-msvc.msi
   InstallerSha256: E7EE2132379B2B6A38D160356B400D7FC0CD3055B1C506166325F4E33D8C45BC
@@ -30,7 +28,6 @@ Installers:
   AppsAndFeaturesEntries:
   - DisplayName: Rust 1.77 (MSVC 64-bit)
     ProductCode: '{0F018F36-167D-4529-B6A0-709668922B9E}'
-    DisplayVersion: 1.77.2.0
 ManifestType: installer
 ManifestVersion: 1.6.0
 


### PR DESCRIPTION
For Rust MSVC, the DisplayVersion always differs by `.0` at the end from the semantic PackageVersion.
`.0` at the end plays no part in package matching and CLI treats both versions the same.
This PR removes DisplayVersion to make it easy for PR authors to author manifest for this package
and to avoid blowing up publishing pipelines in case an incorrect DisplayVersion goes through.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/182966)