### PR TITLE
Remove DisplayVersion for Rustlang.Rust.MSVC version 1.78.0

### DIFF
--- a/manifests/r/Rustlang/Rust/MSVC/1.78.0/Rustlang.Rust.MSVC.installer.yaml
+++ b/manifests/r/Rustlang/Rust/MSVC/1.78.0/Rustlang.Rust.MSVC.installer.yaml
@@ -14,7 +14,6 @@ Installers:
   AppsAndFeaturesEntries:
   - DisplayName: Rust 1.78 (MSVC)
     ProductCode: '{120FED31-8FC6-4259-AEBA-C41C34C16EC6}'
-    DisplayVersion: 1.78.0.0
 - Architecture: x86
   InstallerUrl: https://static.rust-lang.org/dist/rust-1.78.0-i686-pc-windows-msvc.msi
   InstallerSha256: 9D24D15FBF7482EA9A9629A1D0677AA47BAA21AB3C3B15BE7CBA950074D7F7E8
@@ -22,7 +21,6 @@ Installers:
   AppsAndFeaturesEntries:
   - DisplayName: Rust 1.78 (MSVC)
     ProductCode: '{8415621A-294B-4356-88CF-E13A43DFE0DB}'
-    DisplayVersion: 1.78.0.0
 - Architecture: x64
   InstallerUrl: https://static.rust-lang.org/dist/rust-1.78.0-x86_64-pc-windows-msvc.msi
   InstallerSha256: 7C9B34402B4D26FBC80C8ACAE9F82C52708BDF2C547135E74D499A3D4AED5124
@@ -30,7 +28,6 @@ Installers:
   AppsAndFeaturesEntries:
   - DisplayName: Rust 1.78 (MSVC 64-bit)
     ProductCode: '{E8D6BC55-CF5F-474E-8CB5-3CAA61A537ED}'
-    DisplayVersion: 1.78.0.0
 ManifestType: installer
 ManifestVersion: 1.6.0
 


### PR DESCRIPTION
For Rust MSVC, the DisplayVersion always differs by `.0` at the end from the semantic PackageVersion.
`.0` at the end plays no part in package matching and CLI treats both versions the same.
This PR removes DisplayVersion to make it easy for PR authors to author manifest for this package
and to avoid blowing up publishing pipelines in case an incorrect DisplayVersion goes through.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/182967)