### PR TITLE
Remove DisplayVersion for Rustlang.Rust.MSVC version 1.79.0

### DIFF
--- a/manifests/r/Rustlang/Rust/MSVC/1.79.0/Rustlang.Rust.MSVC.installer.yaml
+++ b/manifests/r/Rustlang/Rust/MSVC/1.79.0/Rustlang.Rust.MSVC.installer.yaml
@@ -14,7 +14,6 @@ Installers:
   AppsAndFeaturesEntries:
   - DisplayName: Rust 1.79 (MSVC)
     ProductCode: '{9430CFC3-229E-49F6-A060-9FD6A9AAB83A}'
-    DisplayVersion: 1.79.0.0
 - Architecture: x86
   InstallerUrl: https://static.rust-lang.org/dist/rust-1.79.0-i686-pc-windows-msvc.msi
   InstallerSha256: 77A47CC9DFA23346747D65F534569D0893832A6AEA015F0E4D5FBB5D3E6E8946
@@ -22,7 +21,6 @@ Installers:
   AppsAndFeaturesEntries:
   - DisplayName: Rust 1.79 (MSVC)
     ProductCode: '{35E660C2-976E-4C50-B898-BA0CD101014D}'
-    DisplayVersion: 1.79.0.0
 - Architecture: x64
   InstallerUrl: https://static.rust-lang.org/dist/rust-1.79.0-x86_64-pc-windows-msvc.msi
   InstallerSha256: BB9077C65C3D3A77127B45C4DFC83811915133E6C7A5535AC9A958AED2CA64C5
@@ -30,7 +28,6 @@ Installers:
   AppsAndFeaturesEntries:
   - DisplayName: Rust 1.79 (MSVC 64-bit)
     ProductCode: '{A499A938-55C1-4357-9D9D-2C0130A2E41C}'
-    DisplayVersion: 1.79.0.0
 ManifestType: installer
 ManifestVersion: 1.6.0
 


### PR DESCRIPTION
For Rust MSVC, the DisplayVersion always differs by `.0` at the end from the semantic PackageVersion.
`.0` at the end plays no part in package matching and CLI treats both versions the same.
This PR removes DisplayVersion to make it easy for PR authors to author manifest for this package
and to avoid blowing up publishing pipelines in case an incorrect DisplayVersion goes through.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/182968)