### PR TITLE
Remove DisplayVersion for Rustlang.Rust.MSVC version 1.80.0

### DIFF
--- a/manifests/r/Rustlang/Rust/MSVC/1.80.0/Rustlang.Rust.MSVC.installer.yaml
+++ b/manifests/r/Rustlang/Rust/MSVC/1.80.0/Rustlang.Rust.MSVC.installer.yaml
@@ -14,7 +14,6 @@ Installers:
   AppsAndFeaturesEntries:
   - DisplayName: Rust 1.80 (MSVC)
     ProductCode: '{58BFB817-AE37-4A21-9BCC-D48D898B4E0B}'
-    DisplayVersion: 1.80.0.0
 - Architecture: x86
   InstallerUrl: https://static.rust-lang.org/dist/rust-1.80.0-i686-pc-windows-msvc.msi
   InstallerSha256: 2DC51FF59F5A962078501D15D567E36A50FE1096F2650A66120F177047E9CEE3
@@ -22,7 +21,6 @@ Installers:
   AppsAndFeaturesEntries:
   - DisplayName: Rust 1.80 (MSVC)
     ProductCode: '{7EEF408E-FF25-4D76-A2DD-23A5776E240D}'
-    DisplayVersion: 1.80.0.0
 - Architecture: x64
   InstallerUrl: https://static.rust-lang.org/dist/rust-1.80.0-x86_64-pc-windows-msvc.msi
   InstallerSha256: 33A947601F24FFE64445984612B3D1CB414C40DE388E2A3C1CBB77D107C52111
@@ -30,7 +28,6 @@ Installers:
   AppsAndFeaturesEntries:
   - DisplayName: Rust 1.80 (MSVC 64-bit)
     ProductCode: '{3C28C7CD-0D54-481D-9247-041E885E3951}'
-    DisplayVersion: 1.80.0.0
 ManifestType: installer
 ManifestVersion: 1.6.0
 


### PR DESCRIPTION
For Rust MSVC, the DisplayVersion always differs by `.0` at the end from the semantic PackageVersion.
`.0` at the end plays no part in package matching and CLI treats both versions the same.
This PR removes DisplayVersion to make it easy for PR authors to author manifest for this package
and to avoid blowing up publishing pipelines in case an incorrect DisplayVersion goes through.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/182969)