### PR TITLE
Remove DisplayVersion for Rustlang.Rust.MSVC version 1.80.1

### DIFF
--- a/manifests/r/Rustlang/Rust/MSVC/1.80.1/Rustlang.Rust.MSVC.installer.yaml
+++ b/manifests/r/Rustlang/Rust/MSVC/1.80.1/Rustlang.Rust.MSVC.installer.yaml
@@ -14,7 +14,6 @@ Installers:
   AppsAndFeaturesEntries:
   - DisplayName: Rust 1.80 (MSVC)
     ProductCode: '{5D9E502C-C8B6-4305-87D1-000966C341C6}'
-    DisplayVersion: 1.80.1.0
 - Architecture: x86
   InstallerUrl: https://static.rust-lang.org/dist/rust-1.80.1-i686-pc-windows-msvc.msi
   InstallerSha256: 287877D182BC7731C8A831E8B0687B9791D895715BA9F40065B5FA6A42D9507A
@@ -22,7 +21,6 @@ Installers:
   AppsAndFeaturesEntries:
   - DisplayName: Rust 1.80 (MSVC)
     ProductCode: '{DBC67A5F-1E5F-40B0-A5BC-BC22F9CBAE5E}'
-    DisplayVersion: 1.80.1.0
 - Architecture: x64
   InstallerUrl: https://static.rust-lang.org/dist/rust-1.80.1-x86_64-pc-windows-msvc.msi
   InstallerSha256: 06FE8305A2F3CAA0415E9CBEDC237DE6EF4AD018D36012D6C5BAADE076411637
@@ -30,7 +28,6 @@ Installers:
   AppsAndFeaturesEntries:
   - DisplayName: Rust 1.80 (MSVC 64-bit)
     ProductCode: '{ABF4D498-80F9-41D7-ACF5-61D5A811CF98}'
-    DisplayVersion: 1.80.1.0
 ManifestType: installer
 ManifestVersion: 1.6.0
 


### PR DESCRIPTION
For Rust MSVC, the DisplayVersion always differs by `.0` at the end from the semantic PackageVersion.
`.0` at the end plays no part in package matching and CLI treats both versions the same.
This PR removes DisplayVersion to make it easy for PR authors to author manifest for this package
and to avoid blowing up publishing pipelines in case an incorrect DisplayVersion goes through.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/182970)