### PR TITLE
Remove DisplayVersion for Rustlang.Rust.MSVC version 1.81.0

### DIFF
--- a/manifests/r/Rustlang/Rust/MSVC/1.81.0/Rustlang.Rust.MSVC.installer.yaml
+++ b/manifests/r/Rustlang/Rust/MSVC/1.81.0/Rustlang.Rust.MSVC.installer.yaml
@@ -14,7 +14,6 @@ Installers:
   AppsAndFeaturesEntries:
   - DisplayName: Rust 1.81 (MSVC)
     ProductCode: '{7122E189-D3E9-4CB1-8DD1-BAAABEB11686}'
-    DisplayVersion: 1.81.0.0
 - Architecture: x86
   InstallerUrl: https://static.rust-lang.org/dist/rust-1.81.0-i686-pc-windows-msvc.msi
   InstallerSha256: DFE95F0345BA64673521FA310D33D2E5B613D21BF8419AEF92460FC56EB1423B
@@ -22,7 +21,6 @@ Installers:
   AppsAndFeaturesEntries:
   - DisplayName: Rust 1.81 (MSVC)
     ProductCode: '{AA2F05D1-3B94-4380-B503-D42EAE4006B9}'
-    DisplayVersion: 1.81.0.0
 - Architecture: x64
   InstallerUrl: https://static.rust-lang.org/dist/rust-1.81.0-x86_64-pc-windows-msvc.msi
   InstallerSha256: 2C956FB4F4A994E525FDC43D8C82FC76F89DAF5A64641E334CC02F87B2B8EAE3
@@ -30,7 +28,6 @@ Installers:
   AppsAndFeaturesEntries:
   - DisplayName: Rust 1.81 (MSVC 64-bit)
     ProductCode: '{F86ED319-B907-4A6F-866A-48373F88C5D4}'
-    DisplayVersion: 1.81.0.0
 ManifestType: installer
 ManifestVersion: 1.6.0
 


### PR DESCRIPTION
For Rust MSVC, the DisplayVersion always differs by `.0` at the end from the semantic PackageVersion.
`.0` at the end plays no part in package matching and CLI treats both versions the same.
This PR removes DisplayVersion to make it easy for PR authors to author manifest for this package
and to avoid blowing up publishing pipelines in case an incorrect DisplayVersion goes through.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/182971)