### PR TITLE
Use different PackageName for non-stable releases of terraform

### DIFF
--- a/manifests/h/Hashicorp/Terraform/Alpha/1.10.0-alpha20240807/Hashicorp.Terraform.Alpha.locale.en-US.yaml
+++ b/manifests/h/Hashicorp/Terraform/Alpha/1.10.0-alpha20240807/Hashicorp.Terraform.Alpha.locale.en-US.yaml
@@ -9,7 +9,7 @@ PublisherUrl: https://www.hashicorp.com/
 PublisherSupportUrl: https://github.com/hashicorp/terraform/issues
 PrivacyUrl: https://www.hashicorp.com/privacy?product_intent=terraform
 Author: Mitchell Hashimoto
-PackageName: Hashicorp Terraform
+PackageName: Hashicorp Terraform Alpha
 PackageUrl: https://www.terraform.io/
 License: BUSL 1.1
 LicenseUrl: https://github.com/hashicorp/terraform/blob/main/LICENSE


### PR DESCRIPTION
Same PackageName is used across HashiCorp.Terraform, HashiCorp.Terraform.Alpha, HashiCorp.Terraform.Beta & HashiCorp.Terraform.RC which can cause multiple correlations issue for the CLI. Change to using unique PackageName across different packages
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/183227)