### PR TITLE
Use different PackageName for non-stable releases of terraform

### DIFF
--- a/manifests/h/Hashicorp/Terraform/Alpha/1.6.0-alpha20230816/Hashicorp.Terraform.Alpha.installer.yaml
+++ b/manifests/h/Hashicorp/Terraform/Alpha/1.6.0-alpha20230816/Hashicorp.Terraform.Alpha.installer.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.2.8.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: Hashicorp.Terraform.Alpha
 PackageVersion: 1.6.0-alpha20230816
@@ -22,4 +22,4 @@ Installers:
   InstallerUrl: https://releases.hashicorp.com/terraform/1.6.0-alpha20230816/terraform_1.6.0-alpha20230816_windows_amd64.zip
   InstallerSha256: D614C3A22DCAFD2B94FD39E0736CF10EF6B359D1E5FF3C12B0E6985287D2B103
 ManifestType: installer
-ManifestVersion: 1.4.0
+ManifestVersion: 1.6.0

--- a/manifests/h/Hashicorp/Terraform/Alpha/1.6.0-alpha20230816/Hashicorp.Terraform.Alpha.locale.en-US.yaml
+++ b/manifests/h/Hashicorp/Terraform/Alpha/1.6.0-alpha20230816/Hashicorp.Terraform.Alpha.locale.en-US.yaml
@@ -9,7 +9,7 @@ PublisherUrl: https://www.hashicorp.com/
 PublisherSupportUrl: https://github.com/hashicorp/terraform/issues
 PrivacyUrl: https://www.hashicorp.com/privacy?product_intent=terraform
 Author: Mitchell Hashimoto
-PackageName: Hashicorp Terraform
+PackageName: Hashicorp Terraform Alpha
 PackageUrl: https://www.terraform.io/
 License: BUSL 1.1
 LicenseUrl: https://github.com/hashicorp/terraform/blob/main/LICENSE

--- a/manifests/h/Hashicorp/Terraform/Alpha/1.6.0-alpha20230816/Hashicorp.Terraform.Alpha.locale.en-US.yaml
+++ b/manifests/h/Hashicorp/Terraform/Alpha/1.6.0-alpha20230816/Hashicorp.Terraform.Alpha.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.2.8.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.4.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: Hashicorp.Terraform.Alpha
 PackageVersion: 1.6.0-alpha20230816
@@ -21,4 +21,4 @@ Tags:
 - hashicorp
 - terraform
 ManifestType: defaultLocale
-ManifestVersion: 1.4.0
+ManifestVersion: 1.6.0

--- a/manifests/h/Hashicorp/Terraform/Alpha/1.6.0-alpha20230816/Hashicorp.Terraform.Alpha.yaml
+++ b/manifests/h/Hashicorp/Terraform/Alpha/1.6.0-alpha20230816/Hashicorp.Terraform.Alpha.yaml
@@ -1,8 +1,8 @@
 # Created using wingetcreate 1.2.8.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.4.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: Hashicorp.Terraform.Alpha
 PackageVersion: 1.6.0-alpha20230816
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.4.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Same PackageName is used across HashiCorp.Terraform, HashiCorp.Terraform.Alpha, HashiCorp.Terraform.Beta & HashiCorp.Terraform.RC which can cause multiple correlations issue for the CLI. Change to using unique PackageName across different packages
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/183232)