### PR TITLE
Use different PackageName for non-stable releases of terraform

### DIFF
--- a/manifests/h/Hashicorp/Terraform/Beta/1.6.0-beta1/Hashicorp.Terraform.Beta.locale.en-US.yaml
+++ b/manifests/h/Hashicorp/Terraform/Beta/1.6.0-beta1/Hashicorp.Terraform.Beta.locale.en-US.yaml
@@ -9,7 +9,7 @@ PublisherUrl: https://www.hashicorp.com/
 PublisherSupportUrl: https://github.com/hashicorp/terraform/issues
 PrivacyUrl: https://www.hashicorp.com/privacy?product_intent=terraform
 Author: Mitchell Hashimoto
-PackageName: Hashicorp Terraform
+PackageName: Hashicorp Terraform Beta
 PackageUrl: https://www.terraform.io/
 License: Business Source License 1.1
 LicenseUrl: https://github.com/hashicorp/terraform/blob/v1.6.0-beta1/LICENSE


### PR DESCRIPTION
Same PackageName is used across HashiCorp.Terraform, HashiCorp.Terraform.Alpha, HashiCorp.Terraform.Beta & HashiCorp.Terraform.RC which can cause multiple correlations issue for the CLI. Change to using unique PackageName across different packages
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/183242)