### PR TITLE
Use different PackageName for non-stable releases of terraform

### DIFF
--- a/manifests/h/Hashicorp/Terraform/RC/1.8.0-rc1/Hashicorp.Terraform.RC.locale.en-US.yaml
+++ b/manifests/h/Hashicorp/Terraform/RC/1.8.0-rc1/Hashicorp.Terraform.RC.locale.en-US.yaml
@@ -6,7 +6,7 @@ PackageVersion: 1.8.0-rc1
 PackageLocale: en-US
 Publisher: Hashicorp
 PublisherUrl: https://www.hashicorp.com/
-PackageName: Hashicorp Terraform
+PackageName: Hashicorp Terraform RC
 PackageUrl: https://www.terraform.io/
 License: Business Source License 1.1
 LicenseUrl: https://github.com/hashicorp/terraform/blob/v1.8.0-rc1/LICENSE


### PR DESCRIPTION
Same PackageName is used across HashiCorp.Terraform, HashiCorp.Terraform.Alpha, HashiCorp.Terraform.Beta & HashiCorp.Terraform.RC which can cause multiple correlations issue for the CLI. Change to using unique PackageName across different packages
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/183245)