### PR TITLE
Set elevationRequired for Windhawk

### DIFF
--- a/manifests/r/RamenSoftware/Windhawk/1.5.1/RamenSoftware.Windhawk.installer.yaml
+++ b/manifests/r/RamenSoftware/Windhawk/1.5.1/RamenSoftware.Windhawk.installer.yaml
@@ -8,6 +8,7 @@ InstallerType: nullsoft
 InstallerSwitches:
   Silent: /S /STANDARD
   SilentWithProgress: /S /STANDARD
+ElevationRequirement: elevationRequired
 UpgradeBehavior: install
 Protocols:
 - windhawk


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

If not running as administrator, the Windhawk setup relaunches itself as administrator, and then exits. This causes winget to report that installation is completed right away, before it actually completes. Using `elevationRequired` fixes that.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/183472)