### PR TITLE
Remove DisplayVersion from 7zip.7zip version 16.04

### DIFF
--- a/manifests/7/7zip/7zip/16.04/7zip.7zip.installer.yaml
+++ b/manifests/7/7zip/7zip/16.04/7zip.7zip.installer.yaml
@@ -1,5 +1,5 @@
 # Created with YamlCreate.ps1 v2.0.6 $debug=AUSU.7-2-1
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: 7zip.7zip
 PackageVersion: "16.04"
@@ -21,7 +21,6 @@ Installers:
   AppsAndFeaturesEntries:
   - DisplayName: 7-Zip 16.04
     Publisher: Igor Pavlov
-    DisplayVersion: 16.04.00.0
 - Architecture: x64
   InstallerType: wix
   InstallerUrl: https://www.7-zip.org/a/7z1604-x64.msi
@@ -30,6 +29,5 @@ Installers:
   AppsAndFeaturesEntries:
   - DisplayName: 7-Zip 16.04 (x64 edition)
     Publisher: Igor Pavlov
-    DisplayVersion: 16.04.00.0
 ManifestType: installer
-ManifestVersion: 1.1.0
+ManifestVersion: 1.6.0

--- a/manifests/7/7zip/7zip/16.04/7zip.7zip.locale.en-US.yaml
+++ b/manifests/7/7zip/7zip/16.04/7zip.7zip.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with YamlCreate.ps1 v2.0.6 $debug=AUSU.7-2-1
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: 7zip.7zip
 PackageVersion: "16.04"
@@ -29,4 +29,4 @@ Tags:
 # ReleaseNotes: 
 # ReleaseNotesUrl: 
 ManifestType: defaultLocale
-ManifestVersion: 1.1.0
+ManifestVersion: 1.6.0

--- a/manifests/7/7zip/7zip/16.04/7zip.7zip.yaml
+++ b/manifests/7/7zip/7zip/16.04/7zip.7zip.yaml
@@ -1,8 +1,8 @@
 # Created with YamlCreate.ps1 v2.0.6 $debug=AUSU.7-2-1
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: 7zip.7zip
 PackageVersion: "16.04"
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.1.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
DisplayVersion differs from PackageVersion by trailing `.0`s, which do not play a part in package matching. Removing it to reduce client mapping code and avoid publish pipelines issues that could arise in case of an incorrect DisplayVersion value.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/184848)