### PR TITLE
Remove DisplayVersion from 7zip.7zip version 21.06

### DIFF
--- a/manifests/7/7zip/7zip/21.06/7zip.7zip.installer.yaml
+++ b/manifests/7/7zip/7zip/21.06/7zip.7zip.installer.yaml
@@ -1,5 +1,5 @@
 # Created with YamlCreate.ps1 v2.0.6 $debug=AUSU.5-1-19041-1320
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: 7zip.7zip
 PackageVersion: "21.06"
@@ -72,7 +72,6 @@ Installers:
   ProductCode: '{23170F69-40C1-2701-2106-000001000000}'
   AppsAndFeaturesEntries:
   - DisplayName: 7-Zip 21.06
-    DisplayVersion: 21.06.00.0
 - Architecture: x64
   InstallerType: wix
   InstallerUrl: https://www.7-zip.org/a/7z2106-x64.msi
@@ -80,6 +79,5 @@ Installers:
   ProductCode: '{23170F69-40C1-2702-2106-000001000000}'
   AppsAndFeaturesEntries:
   - DisplayName: 7-Zip 21.06 (x64 edition)
-    DisplayVersion: 21.06.00.0
 ManifestType: installer
-ManifestVersion: 1.1.0
+ManifestVersion: 1.6.0

--- a/manifests/7/7zip/7zip/21.06/7zip.7zip.locale.en-US.yaml
+++ b/manifests/7/7zip/7zip/21.06/7zip.7zip.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with YamlCreate.ps1 v2.0.6 $debug=AUSU.5-1-19041-1320
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: 7zip.7zip
 PackageVersion: "21.06"
@@ -30,4 +30,4 @@ Tags:
 # ReleaseNotes: 
 # ReleaseNotesUrl: 
 ManifestType: defaultLocale
-ManifestVersion: 1.1.0
+ManifestVersion: 1.6.0

--- a/manifests/7/7zip/7zip/21.06/7zip.7zip.locale.zh-CN.yaml
+++ b/manifests/7/7zip/7zip/21.06/7zip.7zip.locale.zh-CN.yaml
@@ -1,5 +1,5 @@
 # Created with YamlCreate.ps1 v2.0.6 $debug=AUSU.5-1-19041-1320
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.1.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
 
 PackageIdentifier: 7zip.7zip
 PackageVersion: "21.06"
@@ -23,4 +23,4 @@ ShortDescription: 7-Zip 是一款拥有极高压缩比的开源压缩软件。
 # ReleaseNotes: 
 # ReleaseNotesUrl: 
 ManifestType: locale
-ManifestVersion: 1.1.0
+ManifestVersion: 1.6.0

--- a/manifests/7/7zip/7zip/21.06/7zip.7zip.yaml
+++ b/manifests/7/7zip/7zip/21.06/7zip.7zip.yaml
@@ -1,8 +1,8 @@
 # Created with YamlCreate.ps1 v2.0.6 $debug=AUSU.5-1-19041-1320
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: 7zip.7zip
 PackageVersion: "21.06"
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.1.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
DisplayVersion differs from PackageVersion by trailing `.0`s, which do not play a part in package matching. Removing it to reduce client mapping code and avoid publish pipelines issues that could arise in case of an incorrect DisplayVersion value.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/184849)