### PR TITLE
Remove DisplayVersion from 7zip.7zip version 23.01

### DIFF
--- a/manifests/7/7zip/7zip/23.01/7zip.7zip.installer.yaml
+++ b/manifests/7/7zip/7zip/23.01/7zip.7zip.installer.yaml
@@ -1,5 +1,5 @@
 # Created with YamlCreate.ps1 v2.2.8 $debug=QUSU.CRLF.7-3-4.Win32NT
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: 7zip.7zip
 PackageVersion: "23.01"
@@ -89,7 +89,6 @@ Installers:
   AppsAndFeaturesEntries:
   - DisplayName: 7-Zip 23.01
     Publisher: Igor Pavlov
-    DisplayVersion: 23.01.00.0
   ElevationRequirement: elevatesSelf
 - InstallerLocale: en-US
   Architecture: x64
@@ -100,7 +99,6 @@ Installers:
   AppsAndFeaturesEntries:
   - DisplayName: 7-Zip 23.01 (x64 edition)
     Publisher: Igor Pavlov
-    DisplayVersion: 23.01.00.0
   ElevationRequirement: elevatesSelf
 ManifestType: installer
-ManifestVersion: 1.4.0
+ManifestVersion: 1.6.0

--- a/manifests/7/7zip/7zip/23.01/7zip.7zip.locale.en-US.yaml
+++ b/manifests/7/7zip/7zip/23.01/7zip.7zip.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with YamlCreate.ps1 v2.2.8 $debug=QUSU.CRLF.7-3-4.Win32NT
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.4.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: 7zip.7zip
 PackageVersion: "23.01"
@@ -32,4 +32,4 @@ Tags:
 # InstallationNotes:
 # Documentations:
 ManifestType: defaultLocale
-ManifestVersion: 1.4.0
+ManifestVersion: 1.6.0

--- a/manifests/7/7zip/7zip/23.01/7zip.7zip.locale.zh-CN.yaml
+++ b/manifests/7/7zip/7zip/23.01/7zip.7zip.locale.zh-CN.yaml
@@ -1,5 +1,5 @@
 # Created with YamlCreate.ps1 v2.2.8 $debug=QUSU.CRLF.7-3-4.Win32NT
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.4.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
 
 PackageIdentifier: 7zip.7zip
 PackageVersion: "23.01"
@@ -25,4 +25,4 @@ ShortDescription: 7-Zip 是一款拥有极高压缩比的开源压缩软件。
 # InstallationNotes:
 # Documentations:
 ManifestType: locale
-ManifestVersion: 1.4.0
+ManifestVersion: 1.6.0

--- a/manifests/7/7zip/7zip/23.01/7zip.7zip.yaml
+++ b/manifests/7/7zip/7zip/23.01/7zip.7zip.yaml
@@ -1,8 +1,8 @@
 # Created with YamlCreate.ps1 v2.2.8 $debug=QUSU.CRLF.7-3-4.Win32NT
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.4.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: 7zip.7zip
 PackageVersion: "23.01"
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.4.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
DisplayVersion differs from PackageVersion by trailing `.0`s, which do not play a part in package matching. Removing it to reduce client mapping code and avoid publish pipelines issues that could arise in case of an incorrect DisplayVersion value.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/184853)