### PR TITLE
Remove DisplayVersion from 7zip.7zip version '24.05'

### DIFF
--- a/manifests/7/7zip/7zip/24.05/7zip.7zip.installer.yaml
+++ b/manifests/7/7zip/7zip/24.05/7zip.7zip.installer.yaml
@@ -84,7 +84,6 @@ Installers:
   ProductCode: '{23170F69-40C1-2701-2405-000001000000}'
   AppsAndFeaturesEntries:
   - DisplayName: 7-Zip 24.05
-    DisplayVersion: 24.05.00.0
     UpgradeCode: '{23170F69-40C1-2701-0000-000004000000}'
   ElevationRequirement: elevatesSelf
 - InstallerLocale: en-US
@@ -95,7 +94,6 @@ Installers:
   ProductCode: '{23170F69-40C1-2702-2405-000001000000}'
   AppsAndFeaturesEntries:
   - DisplayName: 7-Zip 24.05 (x64 edition)
-    DisplayVersion: 24.05.00.0
     UpgradeCode: '{23170F69-40C1-2702-0000-000004000000}'
   ElevationRequirement: elevatesSelf
 ManifestType: installer


### PR DESCRIPTION
DisplayVersion differs from PackageVersion by trailing `.0`s, which do not play a part in package matching. Removing it to reduce client mapping code and avoid publish pipelines issues that could arise in case of an incorrect DisplayVersion value.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/184858)