### PR TITLE
Remove DisplayVersion from 7zip.7zip version 24.08

### DIFF
--- a/manifests/7/7zip/7zip/24.08/7zip.7zip.installer.yaml
+++ b/manifests/7/7zip/7zip/24.08/7zip.7zip.installer.yaml
@@ -63,8 +63,6 @@ Installers:
     SilentWithProgress: /S
     InstallLocation: /D="<INSTALLPATH>"
   ProductCode: 7-Zip
-  AppsAndFeaturesEntries:
-  - DisplayVersion: "24.08"
 - Architecture: x64
   InstallerType: exe
   InstallerUrl: https://7-zip.org/a/7z2408-x64.exe
@@ -77,8 +75,6 @@ Installers:
     SilentWithProgress: /S
     InstallLocation: /D="<INSTALLPATH>"
   ProductCode: 7-Zip
-  AppsAndFeaturesEntries:
-  - DisplayVersion: "24.08"
 - Architecture: arm
   InstallerType: exe
   InstallerUrl: https://7-zip.org/a/7z2408-arm.exe
@@ -91,8 +87,6 @@ Installers:
     SilentWithProgress: /S
     InstallLocation: /D="<INSTALLPATH>"
   ProductCode: 7-Zip
-  AppsAndFeaturesEntries:
-  - DisplayVersion: "24.08"
 - Architecture: arm64
   InstallerType: exe
   InstallerUrl: https://7-zip.org/a/7z2408-arm64.exe
@@ -105,8 +99,6 @@ Installers:
     SilentWithProgress: /S
     InstallLocation: /D="<INSTALLPATH>"
   ProductCode: 7-Zip
-  AppsAndFeaturesEntries:
-  - DisplayVersion: "24.08"
 - Architecture: x86
   InstallerType: wix
   InstallerUrl: https://7-zip.org/a/7z2408.msi
@@ -115,8 +107,7 @@ Installers:
     InstallLocation: INSTALLDIR="<INSTALLPATH>"
   ProductCode: '{23170F69-40C1-2701-2408-000001000000}'
   AppsAndFeaturesEntries:
-  - DisplayVersion: 24.08.00.0
-    ProductCode: '{23170F69-40C1-2701-2408-000001000000}'
+  - ProductCode: '{23170F69-40C1-2701-2408-000001000000}'
     UpgradeCode: '{23170F69-40C1-2701-0000-000004000000}'
 - Architecture: x64
   InstallerType: wix
@@ -126,8 +117,7 @@ Installers:
     InstallLocation: INSTALLDIR="<INSTALLPATH>"
   ProductCode: '{23170F69-40C1-2702-2408-000001000000}'
   AppsAndFeaturesEntries:
-  - DisplayVersion: 24.08.00.0
-    ProductCode: '{23170F69-40C1-2702-2408-000001000000}'
+  - ProductCode: '{23170F69-40C1-2702-2408-000001000000}'
     UpgradeCode: '{23170F69-40C1-2702-0000-000004000000}'
 ManifestType: installer
 ManifestVersion: 1.6.0


### PR DESCRIPTION
DisplayVersion differs from PackageVersion by trailing `.0`s, which do not play a part in package matching. Removing it to reduce client mapping code and avoid publish pipelines issues that could arise in case of an incorrect DisplayVersion value.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/184861)