### PR TITLE
New package: GaijinNetwork.WarThunder.CDK version 2024.07.24

### DIFF
--- a/manifests/g/GaijinNetwork/WarThunder/CDK/2024.07.24/GaijinNetwork.WarThunder.CDK.installer.yaml
+++ b/manifests/g/GaijinNetwork/WarThunder/CDK/2024.07.24/GaijinNetwork.WarThunder.CDK.installer.yaml
@@ -18,6 +18,6 @@ Dependencies:
 Installers:
 - Architecture: x64
   InstallerUrl: https://cdk.warthunder.com/WarThunderCDK_2024_07_24__17_35.exe
-  InstallerSha256: 1B0AD20DCDA5060646FDE17779E91EBCC256CEAD5FF80BBEA1CF90F90F9FA3DF
+  InstallerSha256: 60CE5EA054DA2B0E952D3CB0BE5297E13BC9A0954FB8E19E64B42A7D6B46C007
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/g/GaijinNetwork/WarThunder/CDK/2024.07.24/GaijinNetwork.WarThunder.CDK.installer.yaml
+++ b/manifests/g/GaijinNetwork/WarThunder/CDK/2024.07.24/GaijinNetwork.WarThunder.CDK.installer.yaml
@@ -1,0 +1,23 @@
+# Created with komac v2.6.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: GaijinNetwork.WarThunder.CDK
+PackageVersion: 2024.07.24
+InstallerLocale: ru-RU
+InstallerType: inno
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{ed8deea4-29fe-1932-9612-e2122d8a62d9}}_is1'
+ReleaseDate: 2024-07-24
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: GaijinNetwork.WarThunder
+Installers:
+- Architecture: x64
+  InstallerUrl: https://cdk.warthunder.com/WarThunderCDK_2024_07_24__17_35.exe
+  InstallerSha256: 1B0AD20DCDA5060646FDE17779E91EBCC256CEAD5FF80BBEA1CF90F90F9FA3DF
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/g/GaijinNetwork/WarThunder/CDK/2024.07.24/GaijinNetwork.WarThunder.CDK.locale.en-US.yaml
+++ b/manifests/g/GaijinNetwork/WarThunder/CDK/2024.07.24/GaijinNetwork.WarThunder.CDK.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# Created with komac v2.6.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: GaijinNetwork.WarThunder.CDK
+PackageVersion: 2024.07.24
+PackageLocale: en-US
+Publisher: Gaijin Entertainment
+PublisherUrl: https://gaijin.net/
+PublisherSupportUrl: https://support.gaijin.net/hc/en-us
+PackageName: War Thunder CDK
+PackageUrl: https://wiki.warthunder.com/War_Thunder_CDK
+License: Proprietary
+Copyright: Copyright © 2011-2017 Gaijin Entertainment
+ShortDescription: A set of tools for user content creation available to every player.
+Description: |-
+  The CDK is installed in the game folder and allows the player to edit or create new unique
+  missions and locations, as well as helps create game models. Players can share created
+  content with each other on LIVE and take part in the Revenue Share program by adding their
+  content to the game and earning real money.
+ReleaseNotesUrl: https://wiki.warthunder.com/Download_War_Thunder_CDK
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/g/GaijinNetwork/WarThunder/CDK/2024.07.24/GaijinNetwork.WarThunder.CDK.yaml
+++ b/manifests/g/GaijinNetwork/WarThunder/CDK/2024.07.24/GaijinNetwork.WarThunder.CDK.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.6.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: GaijinNetwork.WarThunder.CDK
+PackageVersion: 2024.07.24
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Checklist for Pull Requests

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Resolve #189983
- [x] Waiting for #190448
  - Which will be resolved by #190449 

## Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

## Additional information

It seems this package depends on **HUGE** (from `19.6GB` minimum, to `115.8GB` top quality) game contents of _War Thunder_.

Game contents are too large for me. Appreciate if other contributors & volunteers can investigate it further. 🙏🏼

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/190452)