### PR TITLE
Remove unnecessary DisplayVersion from AngusJohnson.ResourceHacker version 5.2.6

### DIFF
--- a/manifests/a/AngusJohnson/ResourceHacker/5.2.6/AngusJohnson.ResourceHacker.installer.yaml
+++ b/manifests/a/AngusJohnson/ResourceHacker/5.2.6/AngusJohnson.ResourceHacker.installer.yaml
@@ -1,5 +1,5 @@
 # Automatically updated by the winget bot at 2023/Nov/18
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: AngusJohnson.ResourceHacker
 PackageVersion: 5.2.6
@@ -22,7 +22,6 @@ FileExtensions:
 - scr
 AppsAndFeaturesEntries:
 - DisplayName: Resource Hacker version 5.2.6
-  DisplayVersion: 5.2.6
   ProductCode: '{A10FDE4A-B9BB-4427-A4A2-843A960D99FA}_is1'
 Installers:
 - Architecture: x86
@@ -30,4 +29,4 @@ Installers:
   InstallerSha256: 246457363396DCEA4CC3D19CE2A431897BAC948AE1694D3E87CC0EBAF2EA39F5
   ProductCode: '{A10FDE4A-B9BB-4427-A4A2-843A960D99FA}_is1'
 ManifestType: installer
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/a/AngusJohnson/ResourceHacker/5.2.6/AngusJohnson.ResourceHacker.locale.en-US.yaml
+++ b/manifests/a/AngusJohnson/ResourceHacker/5.2.6/AngusJohnson.ResourceHacker.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Automatically updated by the winget bot at 2023/Nov/18
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: AngusJohnson.ResourceHacker
 PackageVersion: 5.2.6
@@ -20,4 +20,4 @@ Tags:
 - resource-decompiler
 - resource-editor
 ManifestType: defaultLocale
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/a/AngusJohnson/ResourceHacker/5.2.6/AngusJohnson.ResourceHacker.yaml
+++ b/manifests/a/AngusJohnson/ResourceHacker/5.2.6/AngusJohnson.ResourceHacker.yaml
@@ -1,8 +1,8 @@
 # Automatically updated by the winget bot at 2023/Nov/18
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: AngusJohnson.ResourceHacker
 PackageVersion: 5.2.6
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191136)