### PR TITLE
Remove unnecessary DisplayVersion from ArduinoSA.IDE.stable version 2.1.0

### DIFF
--- a/manifests/a/ArduinoSA/IDE/stable/2.1.0/ArduinoSA.IDE.stable.installer.yaml
+++ b/manifests/a/ArduinoSA/IDE/stable/2.1.0/ArduinoSA.IDE.stable.installer.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.2.5.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: ArduinoSA.IDE.stable
 PackageVersion: 2.1.0
@@ -57,8 +57,7 @@ Installers:
   AppsAndFeaturesEntries:
   - DisplayName: Arduino IDE
     Publisher: Arduino SA
-    DisplayVersion: 2.1.0
     ProductCode: '{06BA4131-5D9D-4F96-966F-B43C942E3D76}'
     InstallerType: wix
 ManifestType: installer
-ManifestVersion: 1.4.0
+ManifestVersion: 1.6.0

--- a/manifests/a/ArduinoSA/IDE/stable/2.1.0/ArduinoSA.IDE.stable.locale.en-US.yaml
+++ b/manifests/a/ArduinoSA/IDE/stable/2.1.0/ArduinoSA.IDE.stable.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.2.5.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.4.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: ArduinoSA.IDE.stable
 PackageVersion: 2.1.0
@@ -28,4 +28,4 @@ Tags:
 - mcu
 - microcontroller
 ManifestType: defaultLocale
-ManifestVersion: 1.4.0
+ManifestVersion: 1.6.0

--- a/manifests/a/ArduinoSA/IDE/stable/2.1.0/ArduinoSA.IDE.stable.yaml
+++ b/manifests/a/ArduinoSA/IDE/stable/2.1.0/ArduinoSA.IDE.stable.yaml
@@ -1,8 +1,8 @@
 # Created using wingetcreate 1.2.5.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.4.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: ArduinoSA.IDE.stable
 PackageVersion: 2.1.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.4.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191137)