### PR TITLE
Remove unnecessary DisplayVersion from ArduinoSA.IDE.stable version 2.2.1

### DIFF
--- a/manifests/a/ArduinoSA/IDE/stable/2.2.1/ArduinoSA.IDE.stable.installer.yaml
+++ b/manifests/a/ArduinoSA/IDE/stable/2.2.1/ArduinoSA.IDE.stable.installer.yaml
@@ -1,5 +1,5 @@
 # Created with Komac v1.11.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: ArduinoSA.IDE.stable
 PackageVersion: 2.2.1
@@ -62,7 +62,6 @@ Installers:
   - ixx
   ProductCode: '{CE3A4D22-4A86-4CA8-AB93-E843B3E38533}'
   AppsAndFeaturesEntries:
-  - DisplayVersion: 2.2.1
-    UpgradeCode: '{315F6168-1C48-5F6A-953D-BD5ADC41FE08}'
+  - UpgradeCode: '{315F6168-1C48-5F6A-953D-BD5ADC41FE08}'
 ManifestType: installer
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/a/ArduinoSA/IDE/stable/2.2.1/ArduinoSA.IDE.stable.locale.en-US.yaml
+++ b/manifests/a/ArduinoSA/IDE/stable/2.2.1/ArduinoSA.IDE.stable.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with Komac v1.11.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: ArduinoSA.IDE.stable
 PackageVersion: 2.2.1
@@ -28,4 +28,4 @@ Tags:
 - mcu
 - microcontroller
 ManifestType: defaultLocale
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/a/ArduinoSA/IDE/stable/2.2.1/ArduinoSA.IDE.stable.yaml
+++ b/manifests/a/ArduinoSA/IDE/stable/2.2.1/ArduinoSA.IDE.stable.yaml
@@ -1,8 +1,8 @@
 # Created with Komac v1.11.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: ArduinoSA.IDE.stable
 PackageVersion: 2.2.1
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191139)