### PR TITLE
Remove unnecessary DisplayVersion from ArduinoSA.IDE.stable version 2.3.2

### DIFF
--- a/manifests/a/ArduinoSA/IDE/stable/2.3.2/ArduinoSA.IDE.stable.installer.yaml
+++ b/manifests/a/ArduinoSA/IDE/stable/2.3.2/ArduinoSA.IDE.stable.installer.yaml
@@ -28,8 +28,7 @@ FileExtensions:
 - ixx
 ProductCode: '{245C87AB-B263-46D2-92BA-61E0F067D27E}'
 AppsAndFeaturesEntries:
-- DisplayVersion: 2.3.2
-  UpgradeCode: '{315F6168-1C48-5F6A-953D-BD5ADC41FE08}'
+- UpgradeCode: '{315F6168-1C48-5F6A-953D-BD5ADC41FE08}'
 Installers:
 - Architecture: x64
   Scope: machine


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191140)