### PR TITLE
Remove unnecessary DisplayVersion from ArduinoSA.IDE.stable version 2.3.3

### DIFF
--- a/manifests/a/ArduinoSA/IDE/stable/2.3.3/ArduinoSA.IDE.stable.installer.yaml
+++ b/manifests/a/ArduinoSA/IDE/stable/2.3.3/ArduinoSA.IDE.stable.installer.yaml
@@ -29,8 +29,7 @@ FileExtensions:
 - ixx
 ProductCode: '{F341EC28-63DC-448E-9C6D-28FA5D8F0CA5}'
 AppsAndFeaturesEntries:
-- DisplayVersion: 2.3.3
-  UpgradeCode: '{315F6168-1C48-5F6A-953D-BD5ADC41FE08}'
+- UpgradeCode: '{315F6168-1C48-5F6A-953D-BD5ADC41FE08}'
 Installers:
 - Architecture: x64
   Scope: machine


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191141)