### PR TITLE
Remove unnecessary DisplayVersion from Argotronic.ArgusMonitor version 7.1.3.2793

### DIFF
--- a/manifests/a/Argotronic/ArgusMonitor/7.1.3.2793/Argotronic.ArgusMonitor.installer.yaml
+++ b/manifests/a/Argotronic/ArgusMonitor/7.1.3.2793/Argotronic.ArgusMonitor.installer.yaml
@@ -1,5 +1,5 @@
 # Automatically updated by the winget bot at 2024/Oct/15
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: Argotronic.ArgusMonitor
 PackageVersion: 7.1.3.2793
@@ -9,10 +9,9 @@ InstallerType: nullsoft
 UpgradeBehavior: install
 AppsAndFeaturesEntries:
 - ProductCode: ArgusMonitor
-  DisplayVersion: 7.1.3.2793
 Installers:
 - Architecture: x86
   InstallerUrl: https://www.argusmonitor.com/downloads/ArgusMonitor_Setup.exe
   InstallerSha256: 93E1C2EA99A9B47A688586D1F562DC93C161FDE29EB41D00B60728277B3BA4CA
 ManifestType: installer
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/a/Argotronic/ArgusMonitor/7.1.3.2793/Argotronic.ArgusMonitor.locale.en-US.yaml
+++ b/manifests/a/Argotronic/ArgusMonitor/7.1.3.2793/Argotronic.ArgusMonitor.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Automatically updated by the winget bot at 2024/Oct/15
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: Argotronic.ArgusMonitor
 PackageVersion: 7.1.3.2793
@@ -31,4 +31,4 @@ Documentations:
 - DocumentLabel: FAQ
   DocumentUrl: https://www.argusmonitor.com/faq.php
 ManifestType: defaultLocale
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/a/Argotronic/ArgusMonitor/7.1.3.2793/Argotronic.ArgusMonitor.yaml
+++ b/manifests/a/Argotronic/ArgusMonitor/7.1.3.2793/Argotronic.ArgusMonitor.yaml
@@ -1,8 +1,8 @@
 # Automatically updated by the winget bot at 2024/Oct/15
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: Argotronic.ArgusMonitor
 PackageVersion: 7.1.3.2793
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191142)