### PR TITLE
Remove unnecessary DisplayVersion from ColonyLabs.ScribeDesktopCapture version 3.3.5.0

### DIFF
--- a/manifests/c/ColonyLabs/ScribeDesktopCapture/3.3.5.0/ColonyLabs.ScribeDesktopCapture.installer.yaml
+++ b/manifests/c/ColonyLabs/ScribeDesktopCapture/3.3.5.0/ColonyLabs.ScribeDesktopCapture.installer.yaml
@@ -18,7 +18,6 @@ ReleaseDate: 2024-07-19
 AppsAndFeaturesEntries:
 - DisplayName: Scribe
   Publisher: Colony Labs, Inc
-  DisplayVersion: 3.3.5.0
   ProductCode: '{920A62BB-31C2-4FA2-ADB5-E2788ABAE742}'
   UpgradeCode: '{351EF756-3AF5-4117-8697-53AB61427040}'
 InstallationMetadata:

--- a/manifests/c/ColonyLabs/ScribeDesktopCapture/3.3.5.0/ColonyLabs.ScribeDesktopCapture.locale.en-US.yaml
+++ b/manifests/c/ColonyLabs/ScribeDesktopCapture/3.3.5.0/ColonyLabs.ScribeDesktopCapture.locale.en-US.yaml
@@ -6,7 +6,6 @@ PackageVersion: 3.3.5.0
 PackageLocale: en-US
 Publisher: Colony Labs, Inc
 PublisherUrl: https://scribehow.com/
-PublisherSupportUrl: https://support.scribehow.com/hc/en-us/requests/new
 Author: Colony Labs, Inc
 PackageName: Scribe Desktop Capture
 PackageUrl: https://scribehow.com/get-desktop


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191143)