### PR TITLE
Remove unnecessary DisplayVersion from CrystalDewWorld.CrystalDiskMark version 8.0.5

### DIFF
--- a/manifests/c/CrystalDewWorld/CrystalDiskMark/8.0.5/CrystalDewWorld.CrystalDiskMark.installer.yaml
+++ b/manifests/c/CrystalDewWorld/CrystalDiskMark/8.0.5/CrystalDewWorld.CrystalDiskMark.installer.yaml
@@ -11,7 +11,6 @@ InstallModes:
 - silentWithProgress
 AppsAndFeaturesEntries:
 - DisplayName: CrystalDiskMark 8.0.5
-  DisplayVersion: 8.0.5
 UpgradeBehavior: install
 ReleaseDate: 2024-02-25
 Installers:


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191144)