### PR TITLE
Remove unnecessary DisplayVersion from Elgato.CameraHub version 1.5.1.887

### DIFF
--- a/manifests/e/Elgato/CameraHub/1.5.1.887/Elgato.CameraHub.installer.yaml
+++ b/manifests/e/Elgato/CameraHub/1.5.1.887/Elgato.CameraHub.installer.yaml
@@ -1,5 +1,5 @@
 # Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-7
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: Elgato.CameraHub
 PackageVersion: 1.5.1.887
@@ -13,12 +13,10 @@ InstallModes:
 - silent
 - silentWithProgress
 UpgradeBehavior: install
-AppsAndFeaturesEntries:
-- DisplayVersion: 1.5.1.887
 Installers:
 - Architecture: x64
   InstallerUrl: https://edge.elgato.com/egc/windows/echw/1.5.1/CameraHub_1.5.1.887_x64.msi
   InstallerSha256: 00188737641507C7BDCEC0086349ECBA9DFFE2DF3F1A9FA0116A0F250155EBC6
   ProductCode: '{F55CBAB3-5E4B-49CF-957B-1AF4EFC6C108}'
 ManifestType: installer
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0

--- a/manifests/e/Elgato/CameraHub/1.5.1.887/Elgato.CameraHub.locale.en-US.yaml
+++ b/manifests/e/Elgato/CameraHub/1.5.1.887/Elgato.CameraHub.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-7
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: Elgato.CameraHub
 PackageVersion: 1.5.1.887
@@ -32,4 +32,4 @@ Tags:
 # InstallationNotes:
 # Documentations:
 ManifestType: defaultLocale
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0

--- a/manifests/e/Elgato/CameraHub/1.5.1.887/Elgato.CameraHub.yaml
+++ b/manifests/e/Elgato/CameraHub/1.5.1.887/Elgato.CameraHub.yaml
@@ -1,8 +1,8 @@
 # Created with YamlCreate.ps1 v2.2.0 using InputObject 🤖 $debug=QUSU.CRLF..7-2-7
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: Elgato.CameraHub
 PackageVersion: 1.5.1.887
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191146)