### PR TITLE
Remove unnecessary DisplayVersion from FileCloud.FileCloudDrive version 23.241.1.8881

### DIFF
--- a/manifests/f/FileCloud/FileCloudDrive/23.241.1.8881/FileCloud.FileCloudDrive.installer.yaml
+++ b/manifests/f/FileCloud/FileCloudDrive/23.241.1.8881/FileCloud.FileCloudDrive.installer.yaml
@@ -8,7 +8,6 @@ InstallModes:
 - silent
 - silentWithProgress
 UpgradeBehavior: install
-ReleaseDate: 2024-08-14
 Installers:
 - Architecture: x64
   InstallerType: inno
@@ -22,11 +21,7 @@ Installers:
   InstallerSha256: F7C826B998C413448101377A8601509AE84781C747201F26DB5E4CB461B5D768
   ProductCode: '{497AF6C2-D536-4B1E-8708-86CBCE6CDF7E}'
   AppsAndFeaturesEntries:
-  - DisplayName: FileCloud Drive
-    Publisher: CodeLathe Technologies Inc
-    DisplayVersion: 23.241.1.8881
-    ProductCode: '{67A9EC03-B6E5-4CCE-894B-7664896640DB}'
-    UpgradeCode: '{A1C1C780-AF9F-4935-ADCF-E0DEC824E3B1}'
+  - UpgradeCode: '{A1C1C780-AF9F-4935-ADCF-E0DEC824E3B1}'
   InstallationMetadata:
     DefaultInstallLocation: '%ProgramFiles%\[BZ.COMPANYNAME]'
 ManifestType: installer


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191147)