### PR TITLE
Remove unnecessary DisplayVersion from GeoGebra.Classic version 6.0.857

### DIFF
--- a/manifests/g/GeoGebra/Classic/6.0.857/GeoGebra.Classic.installer.yaml
+++ b/manifests/g/GeoGebra/Classic/6.0.857/GeoGebra.Classic.installer.yaml
@@ -19,8 +19,6 @@ Installers:
     SilentWithProgress: --silent
   UpgradeBehavior: install
   ProductCode: GeoGebra_6
-  AppsAndFeaturesEntries:
-  - DisplayVersion: 6.0.857
 - Architecture: x86
   InstallerType: wix
   Scope: machine
@@ -31,8 +29,7 @@ Installers:
   UpgradeBehavior: uninstallPrevious
   ProductCode: '{4748282E-2448-11E8-81BC-53A8D56EE868}'
   AppsAndFeaturesEntries:
-  - DisplayVersion: 6.0.857.0
-    ProductCode: '{4748282E-2448-11E8-81BC-53A8D56EE868}'
+  - ProductCode: '{4748282E-2448-11E8-81BC-53A8D56EE868}'
     UpgradeCode: '{27555540-BDD5-486C-94BF-D367BC812CEF}'
 ManifestType: installer
 ManifestVersion: 1.6.0


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191149)