### PR TITLE
Remove unnecessary DisplayVersion from GitHub.GitHubDesktop version 3.3.12

### DIFF
--- a/manifests/g/GitHub/GitHubDesktop/3.3.12/GitHub.GitHubDesktop.installer.yaml
+++ b/manifests/g/GitHub/GitHubDesktop/3.3.12/GitHub.GitHubDesktop.installer.yaml
@@ -26,7 +26,6 @@ Installers:
   ProductCode: '{73DDE5D2-79DC-432F-9309-6B4BEF09D04B}'
   AppsAndFeaturesEntries:
   - DisplayName: GitHub Desktop Deployment Tool
-    DisplayVersion: 3.3.12.0
     ProductCode: '{73DDE5D2-79DC-432F-9309-6B4BEF09D04B}'
     UpgradeCode: '{00D8E2EE-13EA-5BEB-87F0-70EFC46A7D4A}'
     InstallerType: msi


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191159)