### PR TITLE
Remove unnecessary DisplayVersion from GitHub.GitHubDesktop version 3.3.13

### DIFF
--- a/manifests/g/GitHub/GitHubDesktop/3.3.13/GitHub.GitHubDesktop.installer.yaml
+++ b/manifests/g/GitHub/GitHubDesktop/3.3.13/GitHub.GitHubDesktop.installer.yaml
@@ -26,7 +26,6 @@ Installers:
   ProductCode: '{64F0A174-3677-49C8-93F7-7252F8EA46B3}'
   AppsAndFeaturesEntries:
   - DisplayName: GitHub Desktop Deployment Tool
-    DisplayVersion: 3.3.13.0
     ProductCode: '{64F0A174-3677-49C8-93F7-7252F8EA46B3}'
     UpgradeCode: '{00D8E2EE-13EA-5BEB-87F0-70EFC46A7D4A}'
     InstallerType: msi


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191160)