### PR TITLE
Remove unnecessary DisplayVersion from GitHub.GitHubDesktop version 3.3.4

### DIFF
--- a/manifests/g/GitHub/GitHubDesktop/3.3.4/GitHub.GitHubDesktop.installer.yaml
+++ b/manifests/g/GitHub/GitHubDesktop/3.3.4/GitHub.GitHubDesktop.installer.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.5.3.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: GitHub.GitHubDesktop
 PackageVersion: 3.3.4
@@ -27,9 +27,8 @@ Installers:
   ProductCode: '{092ED4F6-C7AF-4032-8DF8-6F53FE80637E}'
   AppsAndFeaturesEntries:
   - DisplayName: GitHub Desktop Deployment Tool
-    DisplayVersion: 3.3.4.0
     ProductCode: '{092ED4F6-C7AF-4032-8DF8-6F53FE80637E}'
     UpgradeCode: '{00D8E2EE-13EA-5BEB-87F0-70EFC46A7D4A}'
     InstallerType: msi
 ManifestType: installer
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/g/GitHub/GitHubDesktop/3.3.4/GitHub.GitHubDesktop.locale.en-US.yaml
+++ b/manifests/g/GitHub/GitHubDesktop/3.3.4/GitHub.GitHubDesktop.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.5.3.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: GitHub.GitHubDesktop
 PackageVersion: 3.3.4
@@ -25,4 +25,4 @@ Tags:
 - git
 - typescript
 ManifestType: defaultLocale
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/g/GitHub/GitHubDesktop/3.3.4/GitHub.GitHubDesktop.yaml
+++ b/manifests/g/GitHub/GitHubDesktop/3.3.4/GitHub.GitHubDesktop.yaml
@@ -1,8 +1,8 @@
 # Created using wingetcreate 1.5.3.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: GitHub.GitHubDesktop
 PackageVersion: 3.3.4
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191167)