### PR TITLE
Remove unnecessary DisplayVersion from GitHub.GitHubDesktop version 3.3.9

### DIFF
--- a/manifests/g/GitHub/GitHubDesktop/3.3.9/GitHub.GitHubDesktop.installer.yaml
+++ b/manifests/g/GitHub/GitHubDesktop/3.3.9/GitHub.GitHubDesktop.installer.yaml
@@ -27,7 +27,6 @@ Installers:
   ProductCode: '{82F1721F-87A7-403F-8308-E25E62B74250}'
   AppsAndFeaturesEntries:
   - DisplayName: GitHub Desktop Deployment Tool
-    DisplayVersion: 3.3.9.0
     ProductCode: '{82F1721F-87A7-403F-8308-E25E62B74250}'
     UpgradeCode: '{00D8E2EE-13EA-5BEB-87F0-70EFC46A7D4A}'
     InstallerType: msi


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191170)