### PR TITLE
Remove unnecessary DisplayVersion from GitHub.GitHubDesktop version 3.4.1

### DIFF
--- a/manifests/g/GitHub/GitHubDesktop/3.4.1/GitHub.GitHubDesktop.installer.yaml
+++ b/manifests/g/GitHub/GitHubDesktop/3.4.1/GitHub.GitHubDesktop.installer.yaml
@@ -28,7 +28,6 @@ Installers:
   ProductCode: '{7EA57A90-6052-4F44-B0D8-987C335638B5}'
   AppsAndFeaturesEntries:
   - DisplayName: GitHub Desktop Deployment Tool
-    DisplayVersion: 3.4.1.0
     UpgradeCode: '{00D8E2EE-13EA-5BEB-87F0-70EFC46A7D4A}'
 ManifestType: installer
 ManifestVersion: 1.6.0


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191172)