### PR TITLE
Remove unnecessary DisplayVersion from GitHub.GitHubDesktop version 3.4.2

### DIFF
--- a/manifests/g/GitHub/GitHubDesktop/3.4.2/GitHub.GitHubDesktop.installer.yaml
+++ b/manifests/g/GitHub/GitHubDesktop/3.4.2/GitHub.GitHubDesktop.installer.yaml
@@ -22,8 +22,6 @@ Installers:
     Silent: --silent
     SilentWithProgress: --silent
   ProductCode: GitHubDesktop
-  AppsAndFeaturesEntries:
-  - DisplayVersion: 3.4.2
 - Architecture: x64
   InstallerType: wix
   Scope: machine
@@ -32,7 +30,6 @@ Installers:
   ProductCode: '{C53BD05C-8BC7-4437-8000-BABD9084A8A5}'
   AppsAndFeaturesEntries:
   - DisplayName: GitHub Desktop Deployment Tool
-    DisplayVersion: 3.4.2.0
     ProductCode: '{C53BD05C-8BC7-4437-8000-BABD9084A8A5}'
     UpgradeCode: '{00D8E2EE-13EA-5BEB-87F0-70EFC46A7D4A}'
 ManifestType: installer


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191173)