### PR TITLE
Remove unnecessary DisplayVersion from GitHub.GitHubDesktop version 3.4.7

### DIFF
--- a/manifests/g/GitHub/GitHubDesktop/3.4.7/GitHub.GitHubDesktop.installer.yaml
+++ b/manifests/g/GitHub/GitHubDesktop/3.4.7/GitHub.GitHubDesktop.installer.yaml
@@ -22,8 +22,6 @@ Installers:
     Silent: --silent
     SilentWithProgress: --silent
   ProductCode: GitHubDesktop
-  AppsAndFeaturesEntries:
-  - DisplayVersion: 3.4.7
 - Architecture: x64
   InstallerType: wix
   Scope: machine
@@ -32,7 +30,6 @@ Installers:
   ProductCode: '{BBAD118E-6D02-4C8F-9CC7-0F50C8A0E591}'
   AppsAndFeaturesEntries:
   - DisplayName: GitHub Desktop Deployment Tool
-    DisplayVersion: 3.4.7.0
     ProductCode: '{BBAD118E-6D02-4C8F-9CC7-0F50C8A0E591}'
     UpgradeCode: '{00D8E2EE-13EA-5BEB-87F0-70EFC46A7D4A}'
 ManifestType: installer


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191178)