### PR TITLE
Remove unnecessary DisplayVersion from GlennDelahoy.SnappyDriverInstallerOrigin version 1.13.4.771

### DIFF
--- a/manifests/g/GlennDelahoy/SnappyDriverInstallerOrigin/1.13.4.771/GlennDelahoy.SnappyDriverInstallerOrigin.installer.yaml
+++ b/manifests/g/GlennDelahoy/SnappyDriverInstallerOrigin/1.13.4.771/GlennDelahoy.SnappyDriverInstallerOrigin.installer.yaml
@@ -7,8 +7,6 @@ InstallerType: zip
 NestedInstallerType: portable
 ReleaseDate: 2024-09-12
 UpgradeBehavior: uninstallPrevious
-AppsAndFeaturesEntries:
-- DisplayVersion: 1.13.4.771
 Installers:
 - Architecture: x86
   NestedInstallerFiles:


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191180)