### PR TITLE
Remove unnecessary DisplayVersion from johnlng.slickcmd version 2.0.0

### DIFF
--- a/manifests/j/johnlng/slickcmd/2.0.0/johnlng.slickcmd.installer.yaml
+++ b/manifests/j/johnlng/slickcmd/2.0.0/johnlng.slickcmd.installer.yaml
@@ -8,8 +8,6 @@ NestedInstallerType: portable
 NestedInstallerFiles:
 - RelativeFilePath: slickcmd.exe
   PortableCommandAlias: slickcmd
-AppsAndFeaturesEntries:
-- DisplayVersion: 2.0.0
 Installers:
 - InstallerUrl: https://github.com/johnlng/slickcmd/releases/download/v2.0.0/slickcmd-2.0.0-x86_64-pc-windows-msvc.zip
   Architecture: x64


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191183)