### PR TITLE
Remove unnecessary DisplayVersion from Kopia.KopiaUI version 0.12.0

### DIFF
--- a/manifests/k/Kopia/KopiaUI/0.12.0/Kopia.KopiaUI.installer.yaml
+++ b/manifests/k/Kopia/KopiaUI/0.12.0/Kopia.KopiaUI.installer.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.1.2.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: Kopia.KopiaUI
 PackageVersion: 0.12.0
@@ -15,7 +15,6 @@ UpgradeBehavior: install
 AppsAndFeaturesEntries:
 - DisplayName: KopiaUI 0.12.0
   Publisher: Kopia Authors
-  DisplayVersion: 0.12.0
 Installers:
 - Architecture: x64
   Scope: user
@@ -30,6 +29,6 @@ Installers:
   InstallerSwitches:
     Custom: /ALLUSERS
 ManifestType: installer
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0
 ReleaseDate: 2022-09-28
 

--- a/manifests/k/Kopia/KopiaUI/0.12.0/Kopia.KopiaUI.locale.en-US.yaml
+++ b/manifests/k/Kopia/KopiaUI/0.12.0/Kopia.KopiaUI.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.1.2.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: Kopia.KopiaUI
 PackageVersion: 0.12.0
@@ -28,5 +28,5 @@ Documentations:
 - DocumentLabel: What is Kopia?
   DocumentUrl: https://kopia.io/docs/
 ManifestType: defaultLocale
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0
 

--- a/manifests/k/Kopia/KopiaUI/0.12.0/Kopia.KopiaUI.yaml
+++ b/manifests/k/Kopia/KopiaUI/0.12.0/Kopia.KopiaUI.yaml
@@ -1,9 +1,9 @@
 # Created using wingetcreate 1.1.2.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: Kopia.KopiaUI
 PackageVersion: 0.12.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0
 


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191184)