### PR TITLE
Remove unnecessary DisplayVersion from LamantineSoftware.StickyPassword version 8.8.3.1629

### DIFF
--- a/manifests/l/LamantineSoftware/StickyPassword/8.8.3.1629/LamantineSoftware.StickyPassword.installer.yaml
+++ b/manifests/l/LamantineSoftware/StickyPassword/8.8.3.1629/LamantineSoftware.StickyPassword.installer.yaml
@@ -1,5 +1,5 @@
 # Created with YamlCreate.ps1 v2.2.10 $debug=NVS0.CRLF.5-1-19041-3570.Win32NT
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: LamantineSoftware.StickyPassword
 PackageVersion: 8.8.3.1629
@@ -15,11 +15,10 @@ InstallerSwitches:
 UpgradeBehavior: install
 ReleaseDate: 2023-11-09
 AppsAndFeaturesEntries:
-- DisplayVersion: 8.8.3.1629
-  DisplayName: Sticky Password 8.8.3.1629
+- DisplayName: Sticky Password 8.8.3.1629
 Installers:
 - Architecture: x86
   InstallerUrl: https://downloads.stickypassword.com/files/SP7/StickyPassword_rev8831629.exe
   InstallerSha256: 42895E2A88400CCDAD2676AEAE9D07340E717A79121ADE5E17A7A59233757E45
 ManifestType: installer
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/l/LamantineSoftware/StickyPassword/8.8.3.1629/LamantineSoftware.StickyPassword.locale.en-US.yaml
+++ b/manifests/l/LamantineSoftware/StickyPassword/8.8.3.1629/LamantineSoftware.StickyPassword.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with YamlCreate.ps1 v2.2.10 $debug=NVS0.CRLF.5-1-19041-3570.Win32NT
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: LamantineSoftware.StickyPassword
 PackageVersion: 8.8.3.1629
@@ -26,4 +26,4 @@ ReleaseNotesUrl: https://www.stickypassword.com/download/release-notes-windows
 # InstallationNotes:
 # Documentations:
 ManifestType: defaultLocale
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/l/LamantineSoftware/StickyPassword/8.8.3.1629/LamantineSoftware.StickyPassword.yaml
+++ b/manifests/l/LamantineSoftware/StickyPassword/8.8.3.1629/LamantineSoftware.StickyPassword.yaml
@@ -1,8 +1,8 @@
 # Created with YamlCreate.ps1 v2.2.10 $debug=NVS0.CRLF.5-1-19041-3570.Win32NT
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: LamantineSoftware.StickyPassword
 PackageVersion: 8.8.3.1629
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191186)