### PR TITLE
Remove unnecessary DisplayVersion from Microsoft.WindowsSDK.10.0.20348 version 10.1.20348.1

### DIFF
--- a/manifests/m/Microsoft/WindowsSDK/10/0/20348/10.1.20348.1/Microsoft.WindowsSDK.10.0.20348.installer.yaml
+++ b/manifests/m/Microsoft/WindowsSDK/10/0/20348/10.1.20348.1/Microsoft.WindowsSDK.10.0.20348.installer.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.5.5.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: Microsoft.WindowsSDK.10.0.20348
 PackageVersion: 10.1.20348.1
@@ -13,11 +13,10 @@ ProductCode: '{63ca8fb0-603f-4442-aa8b-48659a9338f5}'
 AppsAndFeaturesEntries:
 - DisplayName: Windows Software Development Kit - Windows 10.0.20348.1
   Publisher: Microsoft Corporation
-  DisplayVersion: 10.1.20348.1
   UpgradeCode: '{DD38DE23-AA03-2E43-4BEF-397FA57E368F}'
 Installers:
 - Architecture: x86
   InstallerUrl: https://download.microsoft.com/download/9/7/9/97982c1d-d687-41be-9dd3-6d01e52ceb68/windowssdk/winsdksetup.exe
   InstallerSha256: BC73435923977350AC92420A06C0D5A7DB3A966CE66393C3218ACCC6B1B4076D
 ManifestType: installer
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/m/Microsoft/WindowsSDK/10/0/20348/10.1.20348.1/Microsoft.WindowsSDK.10.0.20348.locale.en-US.yaml
+++ b/manifests/m/Microsoft/WindowsSDK/10/0/20348/10.1.20348.1/Microsoft.WindowsSDK.10.0.20348.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.5.5.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: Microsoft.WindowsSDK.10.0.20348
 PackageVersion: 10.1.20348.1
@@ -12,4 +12,4 @@ PackageUrl: https://developer.microsoft.com/windows/downloads/windows-sdk/
 License: Copyright (c) Microsoft Corporation. All rights reserved.
 ShortDescription: The Windows SDK (10.1.20348.1) for Windows 10 provides the latest headers, libraries, metadata, and tools for building Windows apps.
 ManifestType: defaultLocale
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/m/Microsoft/WindowsSDK/10/0/20348/10.1.20348.1/Microsoft.WindowsSDK.10.0.20348.yaml
+++ b/manifests/m/Microsoft/WindowsSDK/10/0/20348/10.1.20348.1/Microsoft.WindowsSDK.10.0.20348.yaml
@@ -1,8 +1,8 @@
 # Created using wingetcreate 1.5.5.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: Microsoft.WindowsSDK.10.0.20348
 PackageVersion: 10.1.20348.1
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191187)