### PR TITLE
Remove unnecessary DisplayVersion from Microsoft.WindowsSDK.10.0.22621 version 10.1.22621.2428

### DIFF
--- a/manifests/m/Microsoft/WindowsSDK/10/0/22621/10.1.22621.2428/Microsoft.WindowsSDK.10.0.22621.installer.yaml
+++ b/manifests/m/Microsoft/WindowsSDK/10/0/22621/10.1.22621.2428/Microsoft.WindowsSDK.10.0.22621.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: Microsoft.WindowsSDK.10.0.22621
 PackageVersion: 10.1.22621.2428
@@ -11,7 +11,6 @@ UpgradeBehavior: uninstallPrevious
 AppsAndFeaturesEntries:
 - DisplayName: Windows Software Development Kit - Windows 10.0.22621.2428
   Publisher: Microsoft Corporation
-  DisplayVersion: 10.1.22621.2428
   ProductCode: '{7645bd51-e95b-48cd-bf4b-0e9ab7ef33b0}'
 Installers:
 - Architecture: x86
@@ -19,4 +18,4 @@ Installers:
   InstallerSha256: 3F73F59566B0CF3EDDDDAF61AD72BB0C6E4588A5D9E004ABF68115B752EBBBD8
   ProductCode: '{7645bd51-e95b-48cd-bf4b-0e9ab7ef33b0}'
 ManifestType: installer
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/m/Microsoft/WindowsSDK/10/0/22621/10.1.22621.2428/Microsoft.WindowsSDK.10.0.22621.locale.en-US.yaml
+++ b/manifests/m/Microsoft/WindowsSDK/10/0/22621/10.1.22621.2428/Microsoft.WindowsSDK.10.0.22621.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: Microsoft.WindowsSDK.10.0.22621
 PackageVersion: 10.1.22621.2428
@@ -13,4 +13,4 @@ License: Proprietary
 Copyright: Copyright (c) Microsoft Corporation. All rights reserved.
 ShortDescription: The Windows Software Development Kit (10.1.22621.2428) for Windows 11 provides the latest headers, libraries, metadata, and tools for building Windows apps.
 ManifestType: defaultLocale
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/m/Microsoft/WindowsSDK/10/0/22621/10.1.22621.2428/Microsoft.WindowsSDK.10.0.22621.yaml
+++ b/manifests/m/Microsoft/WindowsSDK/10/0/22621/10.1.22621.2428/Microsoft.WindowsSDK.10.0.22621.yaml
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: Microsoft.WindowsSDK.10.0.22621
 PackageVersion: 10.1.22621.2428
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191188)