### PR TITLE
Remove unnecessary DisplayVersion from Musescore.Musescore version 4.0.0.223472200

### DIFF
--- a/manifests/m/Musescore/Musescore/4.0.0.223472200/Musescore.Musescore.installer.yaml
+++ b/manifests/m/Musescore/Musescore/4.0.0.223472200/Musescore.Musescore.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: Musescore.Musescore
 PackageVersion: 4.0.0.223472200
@@ -25,7 +25,6 @@ Installers:
   ProductCode: '{0146EF2D-5111-4414-8818-4D293AF5E154}'
   AppsAndFeaturesEntries:
   - DisplayName: MuseScore 4
-    DisplayVersion: 4.0.0.223472200
     ProductCode: '{0146EF2D-5111-4414-8818-4D293AF5E154}'
 ManifestType: installer
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0

--- a/manifests/m/Musescore/Musescore/4.0.0.223472200/Musescore.Musescore.locale.en-US.yaml
+++ b/manifests/m/Musescore/Musescore/4.0.0.223472200/Musescore.Musescore.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: Musescore.Musescore
 PackageVersion: 4.0.0.223472200
@@ -26,4 +26,4 @@ Tags:
 - sheet-music
 ReleaseNotesUrl: https://musescore.org/en/4.0
 ManifestType: defaultLocale
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0

--- a/manifests/m/Musescore/Musescore/4.0.0.223472200/Musescore.Musescore.locale.en-US.yaml
+++ b/manifests/m/Musescore/Musescore/4.0.0.223472200/Musescore.Musescore.locale.en-US.yaml
@@ -11,7 +11,7 @@ Author: Werner Schweer
 PackageName: MuseScore
 PackageUrl: https://musescore.org/en
 License: GPL-3.0 License
-LicenseUrl: https://github.com/musescore/MuseScore/blob/master/LICENSE.GPL
+LicenseUrl: https://github.com/musescore/MuseScore/blob/master/LICENSE.txt
 Copyright: Copyright (c) 1999-2022 MuseScore BVBA and others
 CopyrightUrl: https://musescore.com/legal/dmca
 ShortDescription: Create, play back and print beautiful sheet music with free and easy to use music notation software MuseScore.

--- a/manifests/m/Musescore/Musescore/4.0.0.223472200/Musescore.Musescore.yaml
+++ b/manifests/m/Musescore/Musescore/4.0.0.223472200/Musescore.Musescore.yaml
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: Musescore.Musescore
 PackageVersion: 4.0.0.223472200
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191189)