### PR TITLE
Remove unnecessary DisplayVersion from Musescore.Musescore version 4.0.1.230121751

### DIFF
--- a/manifests/m/Musescore/Musescore/4.0.1.230121751/Musescore.Musescore.installer.yaml
+++ b/manifests/m/Musescore/Musescore/4.0.1.230121751/Musescore.Musescore.installer.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.1.2.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: Musescore.Musescore
 PackageVersion: 4.0.1.230121751
@@ -25,8 +25,7 @@ Installers:
   ProductCode: '{0A7FE0EB-6049-4FE5-8C61-122149891EAE}'
   AppsAndFeaturesEntries:
   - DisplayName: MuseScore 4
-    DisplayVersion: 4.0.1.230121751
     ProductCode: '{0A7FE0EB-6049-4FE5-8C61-122149891EAE}'
 ManifestType: installer
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0
 

--- a/manifests/m/Musescore/Musescore/4.0.1.230121751/Musescore.Musescore.locale.en-US.yaml
+++ b/manifests/m/Musescore/Musescore/4.0.1.230121751/Musescore.Musescore.locale.en-US.yaml
@@ -12,7 +12,7 @@ Author: Werner Schweer
 PackageName: MuseScore
 PackageUrl: https://musescore.org/en
 License: GPL-3.0 License
-LicenseUrl: https://github.com/musescore/MuseScore/blob/master/LICENSE.GPL
+LicenseUrl: https://github.com/musescore/MuseScore/blob/master/LICENSE.txt
 Copyright: Copyright (c) 1999-2023 MuseScore BVBA and others
 CopyrightUrl: https://musescore.com/legal/dmca
 ShortDescription: Create, play back and print beautiful sheet music with free and easy to use music notation software MuseScore.

--- a/manifests/m/Musescore/Musescore/4.0.1.230121751/Musescore.Musescore.locale.en-US.yaml
+++ b/manifests/m/Musescore/Musescore/4.0.1.230121751/Musescore.Musescore.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.1.2.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: Musescore.Musescore
 PackageVersion: 4.0.1.230121751
@@ -27,5 +27,5 @@ Tags:
 - sheet-music
 ReleaseNotesUrl: https://github.com/musescore/MuseScore/releases/tag/v4.0.1
 ManifestType: defaultLocale
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0
 

--- a/manifests/m/Musescore/Musescore/4.0.1.230121751/Musescore.Musescore.yaml
+++ b/manifests/m/Musescore/Musescore/4.0.1.230121751/Musescore.Musescore.yaml
@@ -1,9 +1,9 @@
 # Created using wingetcreate 1.1.2.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: Musescore.Musescore
 PackageVersion: 4.0.1.230121751
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0
 


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191190)