### PR TITLE
Remove unnecessary DisplayVersion from MusicBrainz.Picard version 2.10.0

### DIFF
--- a/manifests/m/MusicBrainz/Picard/2.10.0/MusicBrainz.Picard.installer.yaml
+++ b/manifests/m/MusicBrainz/Picard/2.10.0/MusicBrainz.Picard.installer.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.5.7.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: MusicBrainz.Picard
 PackageVersion: 2.10.0
@@ -13,7 +13,6 @@ Installers:
   InstallerSha256: BDE7E74AFC0A4C49E0F7851875D36EC61FEFCC6A310042118DAA7FD4501EED2C
   AppsAndFeaturesEntries:
   - Publisher: MusicBrainz
-    DisplayVersion: 2.10.0
     ProductCode: MusicBrainz Picard
 ManifestType: installer
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/m/MusicBrainz/Picard/2.10.0/MusicBrainz.Picard.locale.en-US.yaml
+++ b/manifests/m/MusicBrainz/Picard/2.10.0/MusicBrainz.Picard.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.5.7.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: MusicBrainz.Picard
 PackageVersion: 2.10.0
@@ -32,4 +32,4 @@ ReleaseNotes: |-
   - PICARD-2769 - If a tag got unset by scripting display a file's original tag value in the columns
 ReleaseNotesUrl: https://picard.musicbrainz.org/changelog/#release-2.10
 ManifestType: defaultLocale
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/m/MusicBrainz/Picard/2.10.0/MusicBrainz.Picard.yaml
+++ b/manifests/m/MusicBrainz/Picard/2.10.0/MusicBrainz.Picard.yaml
@@ -1,8 +1,8 @@
 # Created using wingetcreate 1.5.7.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: MusicBrainz.Picard
 PackageVersion: 2.10.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191191)