### PR TITLE
Remove unnecessary DisplayVersion from MusicBrainz.Picard version 2.11.0

### DIFF
--- a/manifests/m/MusicBrainz/Picard/2.11.0/MusicBrainz.Picard.installer.yaml
+++ b/manifests/m/MusicBrainz/Picard/2.11.0/MusicBrainz.Picard.installer.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.5.7.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: MusicBrainz.Picard
 PackageVersion: 2.11.0
@@ -16,7 +16,6 @@ Installers:
   InstallerSha256: 57970F147CF4A383701699728D7C6BFE3069E3BA37EA00E6B49529D89F444541
   AppsAndFeaturesEntries:
   - Publisher: MusicBrainz
-    DisplayVersion: 2.11
     ProductCode: MusicBrainz Picard
 ManifestType: installer
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/m/MusicBrainz/Picard/2.11.0/MusicBrainz.Picard.locale.en-US.yaml
+++ b/manifests/m/MusicBrainz/Picard/2.11.0/MusicBrainz.Picard.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.5.7.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: MusicBrainz.Picard
 PackageVersion: 2.11.0
@@ -38,4 +38,4 @@ ReleaseNotes: |-
   - PICARD-2813 - AcoustID lookup on recoverable decoding errors
 ReleaseNotesUrl: https://picard.musicbrainz.org/changelog/#release-2.10
 ManifestType: defaultLocale
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/m/MusicBrainz/Picard/2.11.0/MusicBrainz.Picard.yaml
+++ b/manifests/m/MusicBrainz/Picard/2.11.0/MusicBrainz.Picard.yaml
@@ -1,8 +1,8 @@
 # Created using wingetcreate 1.5.7.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: MusicBrainz.Picard
 PackageVersion: 2.11.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191192)