### PR TITLE
Remove unnecessary DisplayVersion from MusicBrainz.Picard version 2.12.1

### DIFF
--- a/manifests/m/MusicBrainz/Picard/2.12.1/MusicBrainz.Picard.installer.yaml
+++ b/manifests/m/MusicBrainz/Picard/2.12.1/MusicBrainz.Picard.installer.yaml
@@ -9,7 +9,6 @@ MinimumOSVersion: 10.0.17135.0
 InstallerType: nullsoft
 AppsAndFeaturesEntries:
 - Publisher: MusicBrainz
-  DisplayVersion: 2.12.1
   ProductCode: MusicBrainz Picard
 Installers:
 - Architecture: x64


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191194)