### PR TITLE
Remove unnecessary DisplayVersion from MusicBrainz.Picard version 2.8.30000.0

### DIFF
--- a/manifests/m/MusicBrainz/Picard/2.8.30000.0/MusicBrainz.Picard.installer.yaml
+++ b/manifests/m/MusicBrainz/Picard/2.8.30000.0/MusicBrainz.Picard.installer.yaml
@@ -1,5 +1,5 @@
 # Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: MusicBrainz.Picard
 PackageVersion: 2.8.30000.0
@@ -19,8 +19,7 @@ Installers:
   InstallerUrl: https://github.com/metabrainz/picard/releases/download/release-2.8.3/picard-setup-2.8.3.exe
   InstallerSha256: 10E68E883B2DC19CBCE46DFE1EC538B5C53A7F618AFD38389658BBF56B091CE9
   AppsAndFeaturesEntries:
-  - DisplayVersion: 2.8.3
-    Publisher: MusicBrainz
+  - Publisher: MusicBrainz
     ProductCode: MusicBrainz Picard
 ManifestType: installer
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0

--- a/manifests/m/MusicBrainz/Picard/2.8.30000.0/MusicBrainz.Picard.locale.en-US.yaml
+++ b/manifests/m/MusicBrainz/Picard/2.8.30000.0/MusicBrainz.Picard.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: MusicBrainz.Picard
 PackageVersion: 2.8.30000.0
@@ -33,4 +33,4 @@ ReleaseNotesUrl: https://github.com/metabrainz/picard/releases/tag/release-2.8.3
 # InstallationNotes: 
 # Documentations: 
 ManifestType: defaultLocale
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0

--- a/manifests/m/MusicBrainz/Picard/2.8.30000.0/MusicBrainz.Picard.yaml
+++ b/manifests/m/MusicBrainz/Picard/2.8.30000.0/MusicBrainz.Picard.yaml
@@ -1,8 +1,8 @@
 # Created with YamlCreate.ps1 v2.1.3 using InputObject 🤖 $debug=QUSU.7-2-6
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: MusicBrainz.Picard
 PackageVersion: 2.8.30000.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191197)