### PR TITLE
Remove unnecessary DisplayVersion from MusicBrainz.Picard version 2.8.50000.0

### DIFF
--- a/manifests/m/MusicBrainz/Picard/2.8.50000.0/MusicBrainz.Picard.installer.yaml
+++ b/manifests/m/MusicBrainz/Picard/2.8.50000.0/MusicBrainz.Picard.installer.yaml
@@ -1,5 +1,5 @@
 # Created with YamlCreate.ps1 v2.2.1 $debug=QUSU.CRLF.5-1-19041-1682.Win32NT
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: MusicBrainz.Picard
 PackageVersion: 2.8.50000.0
@@ -18,8 +18,7 @@ Installers:
   InstallerUrl: https://github.com/metabrainz/picard/releases/download/release-2.8.5/picard-setup-2.8.5.exe
   InstallerSha256: D89223178501FFA13B9485586B547CD40C62FF19EBD635828CB5C4B4840D9F5D
   AppsAndFeaturesEntries:
-  - DisplayVersion: 2.8.5
-    Publisher: MusicBrainz
+  - Publisher: MusicBrainz
     ProductCode: MusicBrainz Picard
 ManifestType: installer
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0

--- a/manifests/m/MusicBrainz/Picard/2.8.50000.0/MusicBrainz.Picard.locale.en-US.yaml
+++ b/manifests/m/MusicBrainz/Picard/2.8.50000.0/MusicBrainz.Picard.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with YamlCreate.ps1 v2.2.1 $debug=QUSU.CRLF.5-1-19041-1682.Win32NT
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: MusicBrainz.Picard
 PackageVersion: 2.8.50000.0
@@ -33,4 +33,4 @@ Tags:
 # InstallationNotes:
 # Documentations:
 ManifestType: defaultLocale
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0

--- a/manifests/m/MusicBrainz/Picard/2.8.50000.0/MusicBrainz.Picard.yaml
+++ b/manifests/m/MusicBrainz/Picard/2.8.50000.0/MusicBrainz.Picard.yaml
@@ -1,8 +1,8 @@
 # Created with YamlCreate.ps1 v2.2.1 $debug=QUSU.CRLF.5-1-19041-1682.Win32NT
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: MusicBrainz.Picard
 PackageVersion: 2.8.50000.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191198)