### PR TITLE
Remove unnecessary DisplayVersion from MusicBrainz.Picard version 2.9.0.0

### DIFF
--- a/manifests/m/MusicBrainz/Picard/2.9.0.0/MusicBrainz.Picard.installer.yaml
+++ b/manifests/m/MusicBrainz/Picard/2.9.0.0/MusicBrainz.Picard.installer.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.2.8.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: MusicBrainz.Picard
 PackageVersion: 2.9.0.0
@@ -22,7 +22,6 @@ Installers:
   InstallerSha256: E01F1DC0BFB867BB3016B1397C8F4EDF19F25EB20CBE75882E38351B07A33DBA
   AppsAndFeaturesEntries:
   - Publisher: MusicBrainz
-    DisplayVersion: 2.9.0
     ProductCode: MusicBrainz Picard
 ManifestType: installer
-ManifestVersion: 1.4.0
+ManifestVersion: 1.6.0

--- a/manifests/m/MusicBrainz/Picard/2.9.0.0/MusicBrainz.Picard.locale.en-US.yaml
+++ b/manifests/m/MusicBrainz/Picard/2.9.0.0/MusicBrainz.Picard.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with WinGet Automation using Komac v1.10.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.4.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: MusicBrainz.Picard
 PackageVersion: 2.9.0.0
@@ -32,4 +32,4 @@ ReleaseNotes: |-
   - PICARD-2681 - Revise wording of first use and file save confirmation dialogs
 ReleaseNotesUrl: https://github.com/metabrainz/picard/releases/tag/release-2.9
 ManifestType: defaultLocale
-ManifestVersion: 1.4.0
+ManifestVersion: 1.6.0

--- a/manifests/m/MusicBrainz/Picard/2.9.0.0/MusicBrainz.Picard.yaml
+++ b/manifests/m/MusicBrainz/Picard/2.9.0.0/MusicBrainz.Picard.yaml
@@ -1,8 +1,8 @@
 # Created with WinGet Automation using Komac v1.10.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.4.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: MusicBrainz.Picard
 PackageVersion: 2.9.0.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.4.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191199)