### PR TITLE
Remove unnecessary DisplayVersion from MusicBrainz.Picard version 2.9.1000.0

### DIFF
--- a/manifests/m/MusicBrainz/Picard/2.9.1000.0/MusicBrainz.Picard.installer.yaml
+++ b/manifests/m/MusicBrainz/Picard/2.9.1000.0/MusicBrainz.Picard.installer.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.5.2.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: MusicBrainz.Picard
 PackageVersion: 2.9.1000.0
@@ -19,7 +19,6 @@ Installers:
   InstallerSha256: 370E0E494C6BDD22D218412871E3E73C29416B277B51A9F3F4C4788A422BBF6A
   AppsAndFeaturesEntries:
   - Publisher: MusicBrainz
-    DisplayVersion: 2.9.1
     ProductCode: MusicBrainz Picard
 ManifestType: installer
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/m/MusicBrainz/Picard/2.9.1000.0/MusicBrainz.Picard.locale.en-US.yaml
+++ b/manifests/m/MusicBrainz/Picard/2.9.1000.0/MusicBrainz.Picard.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.5.2.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: MusicBrainz.Picard
 PackageVersion: 2.9.1000.0
@@ -44,4 +44,4 @@ ReleaseNotes: |-
   - PICARD-2691 - Provide code signed source archives
 ReleaseNotesUrl: https://github.com/metabrainz/picard/releases/tag/release-2.9.1
 ManifestType: defaultLocale
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/m/MusicBrainz/Picard/2.9.1000.0/MusicBrainz.Picard.yaml
+++ b/manifests/m/MusicBrainz/Picard/2.9.1000.0/MusicBrainz.Picard.yaml
@@ -1,8 +1,8 @@
 # Created using wingetcreate 1.5.2.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: MusicBrainz.Picard
 PackageVersion: 2.9.1000.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191200)