### PR TITLE
Remove unnecessary DisplayVersion from Nextcloud.NextcloudDesktop version 3.10.1

### DIFF
--- a/manifests/n/Nextcloud/NextcloudDesktop/3.10.1/Nextcloud.NextcloudDesktop.installer.yaml
+++ b/manifests/n/Nextcloud/NextcloudDesktop/3.10.1/Nextcloud.NextcloudDesktop.installer.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.5.5.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: Nextcloud.NextcloudDesktop
 PackageVersion: 3.10.1
@@ -19,11 +19,10 @@ InstallerSuccessCodes:
 UpgradeBehavior: install
 ProductCode: '{619EFCA5-B7F1-4880-BF99-CF2AA874A2DF}'
 AppsAndFeaturesEntries:
-- DisplayVersion: 3.10.1
-  UpgradeCode: '{FD2FCCA9-BB8F-4485-8F70-A0621B84A7F4}'
+- UpgradeCode: '{FD2FCCA9-BB8F-4485-8F70-A0621B84A7F4}'
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/nextcloud-releases/desktop/releases/download/v3.10.1/Nextcloud-3.10.1-x64.msi
   InstallerSha256: 26A1834B9BF1D94D30BCCE0B04FFF00AC78C335EF211D15B9B556CF8C5A55F1F
 ManifestType: installer
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/n/Nextcloud/NextcloudDesktop/3.10.1/Nextcloud.NextcloudDesktop.locale.en-US.yaml
+++ b/manifests/n/Nextcloud/NextcloudDesktop/3.10.1/Nextcloud.NextcloudDesktop.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.5.5.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: Nextcloud.NextcloudDesktop
 PackageVersion: 3.10.1
@@ -30,4 +30,4 @@ Documentations:
 - DocumentLabel: Nextcloud Desktop Client Manual
   DocumentUrl: https://docs.nextcloud.com/desktop/3.6
 ManifestType: defaultLocale
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/n/Nextcloud/NextcloudDesktop/3.10.1/Nextcloud.NextcloudDesktop.yaml
+++ b/manifests/n/Nextcloud/NextcloudDesktop/3.10.1/Nextcloud.NextcloudDesktop.yaml
@@ -1,8 +1,8 @@
 # Created using wingetcreate 1.5.5.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: Nextcloud.NextcloudDesktop
 PackageVersion: 3.10.1
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191203)