### PR TITLE
Remove unnecessary DisplayVersion from Nextcloud.NextcloudDesktop version 3.9.1

### DIFF
--- a/manifests/n/Nextcloud/NextcloudDesktop/3.9.1/Nextcloud.NextcloudDesktop.installer.yaml
+++ b/manifests/n/Nextcloud/NextcloudDesktop/3.9.1/Nextcloud.NextcloudDesktop.installer.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.2.8.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: Nextcloud.NextcloudDesktop
 PackageVersion: 3.9.1
@@ -17,8 +17,7 @@ InstallerSuccessCodes:
 - 3010
 UpgradeBehavior: install
 AppsAndFeaturesEntries:
-- DisplayVersion: 3.9.1
-  UpgradeCode: '{FD2FCCA9-BB8F-4485-8F70-A0621B84A7F4}'
+- UpgradeCode: '{FD2FCCA9-BB8F-4485-8F70-A0621B84A7F4}'
 Installers:
 - Architecture: x64
   InstallerType: wix
@@ -26,4 +25,4 @@ Installers:
   InstallerSha256: 28CBAB97C7568A782244B34A5A8220CC90B0F7EC72A77CF5001C80F5452106ED
   ProductCode: '{FA5B6B23-0F34-4FBF-A054-45FD3084D913}'
 ManifestType: installer
-ManifestVersion: 1.4.0
+ManifestVersion: 1.6.0

--- a/manifests/n/Nextcloud/NextcloudDesktop/3.9.1/Nextcloud.NextcloudDesktop.locale.en-US.yaml
+++ b/manifests/n/Nextcloud/NextcloudDesktop/3.9.1/Nextcloud.NextcloudDesktop.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.2.8.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.4.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: Nextcloud.NextcloudDesktop
 PackageVersion: 3.9.1
@@ -30,4 +30,4 @@ Documentations:
 - DocumentLabel: Nextcloud Desktop Client Manual
   DocumentUrl: https://docs.nextcloud.com/desktop/3.6
 ManifestType: defaultLocale
-ManifestVersion: 1.4.0
+ManifestVersion: 1.6.0

--- a/manifests/n/Nextcloud/NextcloudDesktop/3.9.1/Nextcloud.NextcloudDesktop.yaml
+++ b/manifests/n/Nextcloud/NextcloudDesktop/3.9.1/Nextcloud.NextcloudDesktop.yaml
@@ -1,8 +1,8 @@
 # Created using wingetcreate 1.2.8.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.4.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: Nextcloud.NextcloudDesktop
 PackageVersion: 3.9.1
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.4.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191205)