### PR TITLE
Remove unnecessary DisplayVersion from SaaSGroup.Tower version 3.4.405

### DIFF
--- a/manifests/s/SaaSGroup/Tower/3.4.405/SaaSGroup.Tower.installer.yaml
+++ b/manifests/s/SaaSGroup/Tower/3.4.405/SaaSGroup.Tower.installer.yaml
@@ -18,8 +18,6 @@ Installers:
     Silent: --silent
     SilentWithProgress: --silent
   ProductCode: Tower
-  AppsAndFeaturesEntries:
-  - DisplayVersion: 3.4.405
 - Architecture: x64
   InstallerType: wix
   Scope: machine
@@ -30,7 +28,6 @@ Installers:
   ProductCode: '{BE3287CE-ACF3-4034-B71E-D2AFF5EDAEEE}'
   AppsAndFeaturesEntries:
   - DisplayName: Tower Deployment Tool
-    DisplayVersion: 3.4.405.0
     ProductCode: '{BE3287CE-ACF3-4034-B71E-D2AFF5EDAEEE}'
     UpgradeCode: '{3B1FBA9F-260D-5585-9DF1-C642CA263F35}'
 ManifestType: installer


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191208)