### PR TITLE
Remove unnecessary DisplayVersion from StrawberryPerl.StrawberryPerl version 5.32.1001

### DIFF
--- a/manifests/s/StrawberryPerl/StrawberryPerl/5.32.1001/StrawberryPerl.StrawberryPerl.installer.yaml
+++ b/manifests/s/StrawberryPerl/StrawberryPerl/5.32.1001/StrawberryPerl.StrawberryPerl.installer.yaml
@@ -23,12 +23,10 @@ Installers:
   InstallerSha256: 241A881670164FEB0B91BB69D39FBBF84C981BEC0D9F8C19959F8F48FD177768
   AppsAndFeaturesEntries:
   - DisplayName: Strawberry Perl (64-bit)
-    DisplayVersion: 5.32.1001
 - Architecture: x86
   InstallerUrl: https://strawberryperl.com/download/5.32.1.1/strawberry-perl-5.32.1.1-32bit.msi
   InstallerSha256: 5D36FE3464169154C8D2D437AB368BBD54539EAFEE2C107DAB53B1A86A658F1B
   AppsAndFeaturesEntries:
   - DisplayName: Strawberry Perl
-    DisplayVersion: 5.32.1001
 ManifestType: installer
 ManifestVersion: 1.6.0


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191210)