### PR TITLE
Remove unnecessary DisplayVersion from Sylpheed.Sylpheed version 2.7.0

### DIFF
--- a/manifests/s/Sylpheed/Sylpheed/2.7.0/Sylpheed.Sylpheed.installer.yaml
+++ b/manifests/s/Sylpheed/Sylpheed/2.7.0/Sylpheed.Sylpheed.installer.yaml
@@ -4,8 +4,6 @@
 PackageIdentifier: Sylpheed.Sylpheed
 PackageVersion: 2.7.0
 InstallerType: nullsoft
-AppsAndFeaturesEntries:
-- DisplayVersion: 2.7.0
 Installers:
 - Architecture: x86
   InstallerUrl: https://sylpheed.sraoss.jp/sylpheed/win32/2.x/Sylpheed-2.7.0_setup.exe


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191211)