### PR TITLE
Remove unnecessary DisplayVersion from Sylpheed.Sylpheed version 3.2

### DIFF
--- a/manifests/s/Sylpheed/Sylpheed/3.2/Sylpheed.Sylpheed.installer.yaml
+++ b/manifests/s/Sylpheed/Sylpheed/3.2/Sylpheed.Sylpheed.installer.yaml
@@ -4,8 +4,6 @@
 PackageIdentifier: Sylpheed.Sylpheed
 PackageVersion: "3.2"
 InstallerType: nullsoft
-AppsAndFeaturesEntries:
-- DisplayVersion: "3.2"
 Installers:
 - Architecture: x86
   InstallerUrl: https://sylpheed.sraoss.jp/sylpheed/win32/Sylpheed-3.2_setup.exe


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191222)