### PR TITLE
Remove unnecessary DisplayVersion from sylikc.JPEGView version 1.1.41.1

### DIFF
--- a/manifests/s/sylikc/JPEGView/1.1.41.1/sylikc.JPEGView.installer.yaml
+++ b/manifests/s/sylikc/JPEGView/1.1.41.1/sylikc.JPEGView.installer.yaml
@@ -1,12 +1,10 @@
 # Created using wingetcreate 1.1.2.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: sylikc.JPEGView
 PackageVersion: 1.1.41.1
 InstallerLocale: en-US
 MinimumOSVersion: 10.0.0.0
-AppsAndFeaturesEntries:
-- DisplayVersion: 1.1.41.1
 Installers:
 - Architecture: x64
   InstallerType: wix
@@ -19,5 +17,5 @@ Installers:
   InstallerSha256: 761935CDA45AC7AFBE2311F4EC86F27B7B6FD42D3F6233058C5637A0232FC5C4
   ProductCode: '{9184BA37-6242-4031-AC30-DBD390FF05A8}'
 ManifestType: installer
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0
 

--- a/manifests/s/sylikc/JPEGView/1.1.41.1/sylikc.JPEGView.locale.en-US.yaml
+++ b/manifests/s/sylikc/JPEGView/1.1.41.1/sylikc.JPEGView.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.1.2.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: sylikc.JPEGView
 PackageVersion: 1.1.41.1
@@ -18,5 +18,5 @@ Copyright: |-
 CopyrightUrl: https://github.com/sylikc/jpegview/blob/master/LICENSE.txt
 ShortDescription: JPEGView is a lean, fast and highly configurable viewer/editor for JPEG, BMP, PNG, WEBP, TGA, GIF and TIFF images with a minimal GUI. Basic on-the-fly image processing is provided.
 ManifestType: defaultLocale
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0
 

--- a/manifests/s/sylikc/JPEGView/1.1.41.1/sylikc.JPEGView.yaml
+++ b/manifests/s/sylikc/JPEGView/1.1.41.1/sylikc.JPEGView.yaml
@@ -1,9 +1,9 @@
 # Created using wingetcreate 1.1.2.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: sylikc.JPEGView
 PackageVersion: 1.1.41.1
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0
 


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191233)