### PR TITLE
Remove unnecessary DisplayVersion from Tencent.WeCom version 4.1.6.6017

### DIFF
--- a/manifests/t/Tencent/WeCom/4.1.6.6017/Tencent.WeCom.installer.yaml
+++ b/manifests/t/Tencent/WeCom/4.1.6.6017/Tencent.WeCom.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: Tencent.WeCom
 PackageVersion: 4.1.6.6017
@@ -14,6 +14,5 @@ Installers:
   AppsAndFeaturesEntries:
   - DisplayName: 企业微信
     Publisher: 腾讯科技(深圳)有限公司
-    DisplayVersion: 4.1.6.6017
 ManifestType: installer
-ManifestVersion: 1.4.0
+ManifestVersion: 1.6.0

--- a/manifests/t/Tencent/WeCom/4.1.6.6017/Tencent.WeCom.locale.en-US.yaml
+++ b/manifests/t/Tencent/WeCom/4.1.6.6017/Tencent.WeCom.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.4.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
 
 PackageIdentifier: Tencent.WeCom
 PackageVersion: 4.1.6.6017
@@ -106,4 +106,4 @@ ReleaseNotes: |
   - Companies can submit documents and activate accounts quickly via API.
 ReleaseNotesUrl: https://work.weixin.qq.com/nl/act/p/e166b083be6d4c46?ver=4.1.6&lang=en
 ManifestType: locale
-ManifestVersion: 1.4.0
+ManifestVersion: 1.6.0

--- a/manifests/t/Tencent/WeCom/4.1.6.6017/Tencent.WeCom.locale.zh-CN.yaml
+++ b/manifests/t/Tencent/WeCom/4.1.6.6017/Tencent.WeCom.locale.zh-CN.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.4.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: Tencent.WeCom
 PackageVersion: 4.1.6.6017
@@ -106,4 +106,4 @@ ReleaseNotes: |
   - 企业可通过接口快速递交材料，更方便的开号了。
 ReleaseNotesUrl: https://work.weixin.qq.com/nl/act/p/e166b083be6d4c46?ver=4.1.6&lang=zh
 ManifestType: defaultLocale
-ManifestVersion: 1.4.0
+ManifestVersion: 1.6.0

--- a/manifests/t/Tencent/WeCom/4.1.6.6017/Tencent.WeCom.yaml
+++ b/manifests/t/Tencent/WeCom/4.1.6.6017/Tencent.WeCom.yaml
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.4.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: Tencent.WeCom
 PackageVersion: 4.1.6.6017
 DefaultLocale: zh-CN
 ManifestType: version
-ManifestVersion: 1.4.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191234)