### PR TITLE
Remove unnecessary DisplayVersion from Tencent.WeCom version 4.1.9.6038

### DIFF
--- a/manifests/t/Tencent/WeCom/4.1.9.6038/Tencent.WeCom.installer.yaml
+++ b/manifests/t/Tencent/WeCom/4.1.9.6038/Tencent.WeCom.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: Tencent.WeCom
 PackageVersion: 4.1.9.6038
@@ -14,6 +14,5 @@ Installers:
   AppsAndFeaturesEntries:
   - DisplayName: 企业微信
     Publisher: 腾讯科技(深圳)有限公司
-    DisplayVersion: 4.1.9.6038
 ManifestType: installer
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/t/Tencent/WeCom/4.1.9.6038/Tencent.WeCom.locale.en-US.yaml
+++ b/manifests/t/Tencent/WeCom/4.1.9.6038/Tencent.WeCom.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
 
 PackageIdentifier: Tencent.WeCom
 PackageVersion: 4.1.9.6038
@@ -127,4 +127,4 @@ ReleaseNotes: |
   - Chinese and English are supported for third-party app message menus.
 ReleaseNotesUrl: https://work.weixin.qq.com/nl/act/p/9d66dfedafad4c61?ver=4.1.8&lang=en
 ManifestType: locale
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/t/Tencent/WeCom/4.1.9.6038/Tencent.WeCom.locale.zh-CN.yaml
+++ b/manifests/t/Tencent/WeCom/4.1.9.6038/Tencent.WeCom.locale.zh-CN.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: Tencent.WeCom
 PackageVersion: 4.1.9.6038
@@ -127,4 +127,4 @@ ReleaseNotes: |
   - 第三方应用消息菜单支持设置中英文。
 ReleaseNotesUrl: https://work.weixin.qq.com/nl/act/p/9d66dfedafad4c61?ver=4.1.8&lang=zh
 ManifestType: defaultLocale
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/t/Tencent/WeCom/4.1.9.6038/Tencent.WeCom.yaml
+++ b/manifests/t/Tencent/WeCom/4.1.9.6038/Tencent.WeCom.yaml
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: Tencent.WeCom
 PackageVersion: 4.1.9.6038
 DefaultLocale: zh-CN
 ManifestType: version
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191235)