### PR TITLE
Remove unnecessary DisplayVersion from Tencent.WeType version 0.9.0.69

### DIFF
--- a/manifests/t/Tencent/WeType/0.9.0.69/Tencent.WeType.installer.yaml
+++ b/manifests/t/Tencent/WeType/0.9.0.69/Tencent.WeType.installer.yaml
@@ -1,5 +1,5 @@
 # Created with YamlCreate.ps1 v2.2.8 $debug=AUSU.CRLF.5-1-19041-3031.Win32NT
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: Tencent.WeType
 PackageVersion: 0.9.0.69
@@ -13,7 +13,6 @@ UpgradeBehavior: install
 ReleaseDate: 2023-05-25
 AppsAndFeaturesEntries:
 - DisplayName: 微信键盘
-  DisplayVersion: 0.9.0.69
   Publisher: 腾讯科技(深圳)有限公司
 ElevationRequirement: elevatesSelf
 Installers:
@@ -21,4 +20,4 @@ Installers:
   InstallerUrl: https://wetype.wxqcloud.qq.com/app/win/WeTypeSetup_0.9.0.69.exe
   InstallerSha256: F9BBDEA98B211409584D40A22307F41E861470804D2B0F97D3385B0DC36E5C17
 ManifestType: installer
-ManifestVersion: 1.4.0
+ManifestVersion: 1.6.0

--- a/manifests/t/Tencent/WeType/0.9.0.69/Tencent.WeType.locale.zh-CN.yaml
+++ b/manifests/t/Tencent/WeType/0.9.0.69/Tencent.WeType.locale.zh-CN.yaml
@@ -1,5 +1,5 @@
 # Created with YamlCreate.ps1 v2.2.8 $debug=AUSU.CRLF.5-1-19041-3031.Win32NT
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.4.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: Tencent.WeType
 PackageVersion: 0.9.0.69
@@ -29,4 +29,4 @@ ReleaseNotesUrl: https://z.weixin.qq.com/web/changelog/21
 # InstallationNotes:
 # Documentations:
 ManifestType: defaultLocale
-ManifestVersion: 1.4.0
+ManifestVersion: 1.6.0

--- a/manifests/t/Tencent/WeType/0.9.0.69/Tencent.WeType.yaml
+++ b/manifests/t/Tencent/WeType/0.9.0.69/Tencent.WeType.yaml
@@ -1,8 +1,8 @@
 # Created with YamlCreate.ps1 v2.2.8 $debug=AUSU.CRLF.5-1-19041-3031.Win32NT
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.4.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: Tencent.WeType
 PackageVersion: 0.9.0.69
 DefaultLocale: zh-CN
 ManifestType: version
-ManifestVersion: 1.4.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191236)