### PR TITLE
Remove unnecessary DisplayVersion from Tencent.WeType version 0.9.4.149

### DIFF
--- a/manifests/t/Tencent/WeType/0.9.4.149/Tencent.WeType.installer.yaml
+++ b/manifests/t/Tencent/WeType/0.9.4.149/Tencent.WeType.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: Tencent.WeType
 PackageVersion: 0.9.4.149
@@ -19,8 +19,7 @@ Installers:
     AppsAndFeaturesEntries:
       - DisplayName: 微信键盘
         Publisher: 腾讯科技(深圳)有限公司
-        DisplayVersion: 0.9.4.149
     ElevationRequirement: elevatesSelf
     ReleaseDate: 2023-10-23
 ManifestType: installer
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/t/Tencent/WeType/0.9.4.149/Tencent.WeType.locale.zh-CN.yaml
+++ b/manifests/t/Tencent/WeType/0.9.4.149/Tencent.WeType.locale.zh-CN.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: Tencent.WeType
 PackageVersion: 0.9.4.149
@@ -27,4 +27,4 @@ ReleaseNotes: |
   - 体验优化和问题修复
 ReleaseNotesUrl: https://z.weixin.qq.com/web/changelog/47
 ManifestType: defaultLocale
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/t/Tencent/WeType/0.9.4.149/Tencent.WeType.yaml
+++ b/manifests/t/Tencent/WeType/0.9.4.149/Tencent.WeType.yaml
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: Tencent.WeType
 PackageVersion: 0.9.4.149
 DefaultLocale: zh-CN
 ManifestType: version
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191239)