### PR TITLE
Remove unnecessary DisplayVersion from Tencent.WeType version 1.0.5.376

### DIFF
--- a/manifests/t/Tencent/WeType/1.0.5.376/Tencent.WeType.installer.yaml
+++ b/manifests/t/Tencent/WeType/1.0.5.376/Tencent.WeType.installer.yaml
@@ -16,7 +16,6 @@ UpgradeBehavior: install
 AppsAndFeaturesEntries:
 - DisplayName: 微信键盘
   Publisher: 腾讯科技(深圳)有限公司
-  DisplayVersion: 1.0.5.376
 ElevationRequirement: elevatesSelf
 Installers:
 - Architecture: x86


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191242)