### PR TITLE
Remove unnecessary DisplayVersion from UltimateGadgetLaboratories.UHKAgent version 3.1.0

### DIFF
--- a/manifests/u/UltimateGadgetLaboratories/UHKAgent/3.1.0/UltimateGadgetLaboratories.UHKAgent.installer.yaml
+++ b/manifests/u/UltimateGadgetLaboratories/UHKAgent/3.1.0/UltimateGadgetLaboratories.UHKAgent.installer.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.5.3.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: UltimateGadgetLaboratories.UHKAgent
 PackageVersion: 3.1.0
@@ -14,10 +14,9 @@ Installers:
   AppsAndFeaturesEntries:
   - DisplayName: UHK Agent 3.1.0
     Publisher: Ultimate Gadget Laboratories
-    DisplayVersion: 3.1.0
     ProductCode: 0b6dba6d-dd72-5279-b091-fcf82cfafc54
 - Architecture: neutral
   InstallerUrl: https://github.com/UltimateHackingKeyboard/agent/releases/download/v3.1.0/UHK.Agent-3.1.0-win.exe
   InstallerSha256: 7CABBD71FE2BFBBCEF7C6DC252CE872912904E474A1973F3F1C376206402F2C4
 ManifestType: installer
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/u/UltimateGadgetLaboratories/UHKAgent/3.1.0/UltimateGadgetLaboratories.UHKAgent.locale.en-US.yaml
+++ b/manifests/u/UltimateGadgetLaboratories/UHKAgent/3.1.0/UltimateGadgetLaboratories.UHKAgent.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.5.3.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: UltimateGadgetLaboratories.UHKAgent
 PackageVersion: 3.1.0
@@ -17,4 +17,4 @@ Description: Agent is the configuration application of the Ultimate Hacking Keyb
 ReleaseNotes: 'Firmware: 10.3.0 [release] | Device Protocol: 4.10.0 | User Config: 6.0.0 | Hardware Config: 1.0.0'
 ReleaseNotesUrl: https://github.com/UltimateHackingKeyboard/agent/releases/tag/v3.1.0
 ManifestType: defaultLocale
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/u/UltimateGadgetLaboratories/UHKAgent/3.1.0/UltimateGadgetLaboratories.UHKAgent.yaml
+++ b/manifests/u/UltimateGadgetLaboratories/UHKAgent/3.1.0/UltimateGadgetLaboratories.UHKAgent.yaml
@@ -1,8 +1,8 @@
 # Created using wingetcreate 1.5.3.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: UltimateGadgetLaboratories.UHKAgent
 PackageVersion: 3.1.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191243)