### PR TITLE
Remove unnecessary DisplayVersion from UltimateGadgetLaboratories.UHKAgent version 4.2.1

### DIFF
--- a/manifests/u/UltimateGadgetLaboratories/UHKAgent/4.2.1/UltimateGadgetLaboratories.UHKAgent.installer.yaml
+++ b/manifests/u/UltimateGadgetLaboratories/UHKAgent/4.2.1/UltimateGadgetLaboratories.UHKAgent.installer.yaml
@@ -15,7 +15,6 @@ Installers:
   AppsAndFeaturesEntries:
   - DisplayName: UHK Agent 4.2.1
     Publisher: Ultimate Gadget Laboratories
-    DisplayVersion: 4.2.1
     ProductCode: 0b6dba6d-dd72-5279-b091-fcf82cfafc54
 - Architecture: neutral
   InstallerUrl: https://github.com/UltimateHackingKeyboard/agent/releases/download/v4.2.1/UHK.Agent-4.2.1-win.exe


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191245)