### PR TITLE
Remove unnecessary DisplayVersion from VideoComparer.VideoComparer version 1.7.12

### DIFF
--- a/manifests/v/VideoComparer/VideoComparer/1.7.12/VideoComparer.VideoComparer.installer.yaml
+++ b/manifests/v/VideoComparer/VideoComparer/1.7.12/VideoComparer.VideoComparer.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 # Note that despite the x86 and x64 version having different DisplayName and ProductCode,
 # side-by-side installation is not supported.
@@ -13,7 +13,6 @@ Installers:
     AppsAndFeaturesEntries:
       - DisplayName: Video Comparer Win64
         Publisher: Video Comparer
-        DisplayVersion: 1.7.12
         ProductCode: "{b632f39f-fe78-4ea9-aab8-f5e5629b575e}"
   - InstallerUrl: https://www.video-comparer.com/download/VideoComparer_Win32_1.07.012.exe
     Architecture: x86
@@ -21,7 +20,6 @@ Installers:
     AppsAndFeaturesEntries:
       - DisplayName: Video Comparer Win32
         Publisher: Video Comparer
-        DisplayVersion: 1.7.12
         ProductCode: "{7fcbf6ba-0671-4381-a98a-4c7f5de03ca9}"
 ManifestType: installer
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/v/VideoComparer/VideoComparer/1.7.12/VideoComparer.VideoComparer.locale.en-US.yaml
+++ b/manifests/v/VideoComparer/VideoComparer/1.7.12/VideoComparer.VideoComparer.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: VideoComparer.VideoComparer
 PackageVersion: 1.7.12
@@ -15,4 +15,4 @@ ReleaseNotes: Improved the software stability.
 ReleaseNotesUrl: https://www.video-comparer.com/download-release-history.php
 PurchaseUrl: https://www.video-comparer.com/register-login.php
 ManifestType: defaultLocale
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/v/VideoComparer/VideoComparer/1.7.12/VideoComparer.VideoComparer.yaml
+++ b/manifests/v/VideoComparer/VideoComparer/1.7.12/VideoComparer.VideoComparer.yaml
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: VideoComparer.VideoComparer
 PackageVersion: 1.7.12
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191247)