### PR TITLE
Remove unnecessary DisplayVersion from VideoLAN.VLC version 3.0.18

### DIFF
--- a/manifests/v/VideoLAN/VLC/3.0.18/VideoLAN.VLC.installer.yaml
+++ b/manifests/v/VideoLAN/VLC/3.0.18/VideoLAN.VLC.installer.yaml
@@ -1,5 +1,5 @@
 # Created with Komac v1.6.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: VideoLAN.VLC
 PackageVersion: 3.0.18
@@ -59,7 +59,6 @@ Installers:
   AppsAndFeaturesEntries:
   - Publisher: VideoLAN
     DisplayName: VLC media player
-    DisplayVersion: 3.0.18.0
     InstallerType: msi
 - Architecture: x86
   InstallerType: wix
@@ -69,7 +68,6 @@ Installers:
   AppsAndFeaturesEntries:
   - Publisher: VideoLAN
     DisplayName: VLC media player
-    DisplayVersion: 3.0.18.0
     InstallerType: msi
 - Architecture: x64
   InstallerType: nullsoft
@@ -88,4 +86,4 @@ Installers:
     DisplayName: VLC media player
     InstallerType: nullsoft
 ManifestType: installer
-ManifestVersion: 1.4.0
+ManifestVersion: 1.6.0

--- a/manifests/v/VideoLAN/VLC/3.0.18/VideoLAN.VLC.locale.en-US.yaml
+++ b/manifests/v/VideoLAN/VLC/3.0.18/VideoLAN.VLC.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with Komac v1.6.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.4.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: VideoLAN.VLC
 PackageVersion: 3.0.18
@@ -49,4 +49,4 @@ ReleaseNotes: |-
   And many more! Check our news file for more details!
 ReleaseNotesUrl: https://github.com/videolan/vlc/releases/tag/3.0.18
 ManifestType: defaultLocale
-ManifestVersion: 1.4.0
+ManifestVersion: 1.6.0

--- a/manifests/v/VideoLAN/VLC/3.0.18/VideoLAN.VLC.yaml
+++ b/manifests/v/VideoLAN/VLC/3.0.18/VideoLAN.VLC.yaml
@@ -1,8 +1,8 @@
 # Created with Komac v1.6.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.4.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: VideoLAN.VLC
 PackageVersion: 3.0.18
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.4.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191248)