### PR TITLE
Remove unnecessary DisplayVersion from VideoLAN.VLC version 3.0.20

### DIFF
--- a/manifests/v/VideoLAN/VLC/3.0.20/VideoLAN.VLC.installer.yaml
+++ b/manifests/v/VideoLAN/VLC/3.0.20/VideoLAN.VLC.installer.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.5.7.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: VideoLAN.VLC
 PackageVersion: 3.0.20
@@ -61,7 +61,6 @@ Installers:
   AppsAndFeaturesEntries:
   - DisplayName: VLC media player
     Publisher: VideoLAN
-    DisplayVersion: 3.0.20.0
     InstallerType: msi
 - Architecture: x86
   InstallerType: wix
@@ -74,7 +73,6 @@ Installers:
   AppsAndFeaturesEntries:
   - DisplayName: VLC media player
     Publisher: VideoLAN
-    DisplayVersion: 3.0.20.0
     InstallerType: msi
 - Architecture: x64
   InstallerType: nullsoft
@@ -93,4 +91,4 @@ Installers:
     Publisher: VideoLAN
     InstallerType: nullsoft
 ManifestType: installer
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/v/VideoLAN/VLC/3.0.20/VideoLAN.VLC.locale.en-US.yaml
+++ b/manifests/v/VideoLAN/VLC/3.0.20/VideoLAN.VLC.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.5.7.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: VideoLAN.VLC
 PackageVersion: 3.0.20
@@ -35,4 +35,4 @@ Tags:
 - video
 - video-player
 ManifestType: defaultLocale
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/v/VideoLAN/VLC/3.0.20/VideoLAN.VLC.yaml
+++ b/manifests/v/VideoLAN/VLC/3.0.20/VideoLAN.VLC.yaml
@@ -1,8 +1,8 @@
 # Created using wingetcreate 1.5.7.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: VideoLAN.VLC
 PackageVersion: 3.0.20
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191250)