### PR TITLE
Update version: ZugferdCommunity.QubaViewer version 1.4.1

### DIFF
--- a/manifests/z/ZugferdCommunity/QubaViewer/1.4.1/ZugferdCommunity.QubaViewer.installer.yaml
+++ b/manifests/z/ZugferdCommunity/QubaViewer/1.4.1/ZugferdCommunity.QubaViewer.installer.yaml
@@ -12,7 +12,6 @@ ReleaseDate: 2024-10-30
 AppsAndFeaturesEntries:
 - DisplayName: Quba
   Publisher: Quba
-  DisplayVersion: 1.4.1.0
   ProductCode: '{97D63278-BF32-4537-B46E-EDB211CD2ACD}'
   UpgradeCode: '{972DC07A-6235-5DC4-8D77-BC4559A99103}'
 InstallationMetadata:


### PR DESCRIPTION
This PR removes the displayVersion ARP entry. Due to wingets package matching logic, it should still match `PackageVersion 1.4.1` with the ARP version `1.4.1.0`

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191462)