### PR TITLE
Add moniker keeper to KeeperSecurity.KeeperDesktop

### DIFF
--- a/manifests/k/KeeperSecurity/KeeperDesktop/16.11.3.0/KeeperSecurity.KeeperDesktop.locale.en-US.yaml
+++ b/manifests/k/KeeperSecurity/KeeperDesktop/16.11.3.0/KeeperSecurity.KeeperDesktop.locale.en-US.yaml
@@ -23,3 +23,4 @@ Tags:
 - security
 ManifestType: defaultLocale
 ManifestVersion: 1.5.0
+Moniker: keeper


### PR DESCRIPTION
Note `KeeperSecurity.Commander` also has moniker `keeper`, but people probably prefer installing `KeeperSecurity.KeeperDesktop` when running `winget install keeper`. Hence simply adding the moniker here so both are listed.

By the way, is it possible to include multiple monikers? like `keeper, keeper-desktop`

https://github.com/microsoft/winget-pkgs/blob/544a60f3ad64fe54d099429c5ac3fd1db0bdc5ca/manifests/k/KeeperSecurity/Commander/16.11.8/KeeperSecurity.Commander.locale.en-US.yaml#L17

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191463)