### PR TITLE
Remove unnecessary DisplayVersion from GitExtensionsTeam.GitExtensions version 4.0.0.15569

### DIFF
--- a/manifests/g/GitExtensionsTeam/GitExtensions/4.0.0.15569/GitExtensionsTeam.GitExtensions.installer.yaml
+++ b/manifests/g/GitExtensionsTeam/GitExtensions/4.0.0.15569/GitExtensionsTeam.GitExtensions.installer.yaml
@@ -1,5 +1,5 @@
 # Created with YamlCreate.ps1 v2.2.1 $debug=MDSU.CRLF.7-3-0.Win32NT
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: GitExtensionsTeam.GitExtensions
 PackageVersion: 4.0.0.15569
@@ -26,9 +26,8 @@ Installers:
         - PackageIdentifier: Git.Git
     AppsAndFeaturesEntries:
       - DisplayName: Git Extensions 4.0.0.15569
-        DisplayVersion: 4.0.0.15569
         Publisher: Git Extensions Team
         ProductCode: "{491CFDF0-5096-42D2-A2F4-51C0F9BD219C}"
         InstallerType: msi
 ManifestType: installer
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0

--- a/manifests/g/GitExtensionsTeam/GitExtensions/4.0.0.15569/GitExtensionsTeam.GitExtensions.locale.en-US.yaml
+++ b/manifests/g/GitExtensionsTeam/GitExtensions/4.0.0.15569/GitExtensionsTeam.GitExtensions.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with YamlCreate.ps1 v2.2.1 $debug=MDSU.CRLF.7-3-0.Win32NT
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: GitExtensionsTeam.GitExtensions
 PackageVersion: 4.0.0.15569
@@ -30,4 +30,4 @@ ReleaseNotesUrl: https://github.com/gitextensions/gitextensions/blob/release/4.0
 InstallationNotes: This package also requires .Net Desktop Runtime 6 (Microsoft.DotNet.DesktopRuntime.6) and git (Git.Git) to work.
 # Documentations:
 ManifestType: defaultLocale
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0

--- a/manifests/g/GitExtensionsTeam/GitExtensions/4.0.0.15569/GitExtensionsTeam.GitExtensions.yaml
+++ b/manifests/g/GitExtensionsTeam/GitExtensions/4.0.0.15569/GitExtensionsTeam.GitExtensions.yaml
@@ -1,8 +1,8 @@
 # Created with YamlCreate.ps1 v2.2.1 $debug=MDSU.CRLF.7-3-0.Win32NT
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: GitExtensionsTeam.GitExtensions
 PackageVersion: 4.0.0.15569
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.2.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191504)