### PR TITLE
Remove unnecessary DisplayVersion from GitExtensionsTeam.GitExtensions version 5.0

### DIFF
--- a/manifests/g/GitExtensionsTeam/GitExtensions/5.0/GitExtensionsTeam.GitExtensions.installer.yaml
+++ b/manifests/g/GitExtensionsTeam/GitExtensions/5.0/GitExtensionsTeam.GitExtensions.installer.yaml
@@ -27,8 +27,6 @@ Installers:
     ReleaseDate: "2024-09-06"
     AppsAndFeaturesEntries:
       - DisplayName: Git Extensions 5.0
-        DisplayVersion: 5.0
-        ProductCode: '{99DA7AAC-1F6B-43B4-A847-A5588C7CFFD2}'
         UpgradeCode: '{140E80EA-5053-42DC-AB0E-6FF0E49E6BCF}'
         InstallerType: msi
 ManifestType: installer

--- a/manifests/g/GitExtensionsTeam/GitExtensions/5.0/GitExtensionsTeam.GitExtensions.installer.yaml
+++ b/manifests/g/GitExtensionsTeam/GitExtensions/5.0/GitExtensionsTeam.GitExtensions.installer.yaml
@@ -3,7 +3,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: GitExtensionsTeam.GitExtensions
-PackageVersion: 5.0
+PackageVersion: '5.0'
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/gitextensions/gitextensions/releases/download/v5.0/GitExtensions-x64-5.0.0.17897-2a3b78b86.msi

--- a/manifests/g/GitExtensionsTeam/GitExtensions/5.0/GitExtensionsTeam.GitExtensions.locale.en-US.yaml
+++ b/manifests/g/GitExtensionsTeam/GitExtensions/5.0/GitExtensionsTeam.GitExtensions.locale.en-US.yaml
@@ -3,7 +3,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: GitExtensionsTeam.GitExtensions
-PackageVersion: 5.0
+PackageVersion: '5.0'
 PackageLocale: en-US
 Publisher: Git Extensions Team
 PublisherUrl: https://github.com/gitextensions/gitextensions

--- a/manifests/g/GitExtensionsTeam/GitExtensions/5.0/GitExtensionsTeam.GitExtensions.yaml
+++ b/manifests/g/GitExtensionsTeam/GitExtensions/5.0/GitExtensionsTeam.GitExtensions.yaml
@@ -3,7 +3,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: GitExtensionsTeam.GitExtensions
-PackageVersion: 5.0
+PackageVersion: '5.0'
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.6.0


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191505)