### PR TITLE
Remove unnecessary DisplayVersion from RandyHollines.Objeck version 2023.12.0

### DIFF
--- a/manifests/r/RandyHollines/Objeck/2023.12.0/RandyHollines.Objeck.installer.yaml
+++ b/manifests/r/RandyHollines/Objeck/2023.12.0/RandyHollines.Objeck.installer.yaml
@@ -1,5 +1,5 @@
 # Created with Komac v1.11.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: RandyHollines.Objeck
 PackageVersion: 2023.12.0
@@ -11,11 +11,10 @@ Dependencies:
 ProductCode: '{C6FF1E2B-F4A3-420F-89D0-FBFFE7069646}'
 ReleaseDate: 2023-12-21
 AppsAndFeaturesEntries:
-- DisplayVersion: 2023.12.0
-  UpgradeCode: '{FAD125F6-CB1B-46F7-91EB-429682D927CB}'
+- UpgradeCode: '{FAD125F6-CB1B-46F7-91EB-429682D927CB}'
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/objeck/objeck-lang/releases/download/v2023.12.0/objeck-windows-x64_2023.12.0.msi
   InstallerSha256: 72FE3384B03AD867EA6C7ABF72C6D129B72AFF0544FDF172F7FA35D6E67672F9
 ManifestType: installer
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/r/RandyHollines/Objeck/2023.12.0/RandyHollines.Objeck.locale.en-US.yaml
+++ b/manifests/r/RandyHollines/Objeck/2023.12.0/RandyHollines.Objeck.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with Komac v1.11.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: RandyHollines.Objeck
 PackageVersion: 2023.12.0
@@ -48,4 +48,4 @@ ReleaseNotes: |-
   - @yyokyfo made their first contribution in #428
 ReleaseNotesUrl: https://github.com/objeck/objeck-lang/releases/tag/v2023.12.0
 ManifestType: defaultLocale
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/r/RandyHollines/Objeck/2023.12.0/RandyHollines.Objeck.yaml
+++ b/manifests/r/RandyHollines/Objeck/2023.12.0/RandyHollines.Objeck.yaml
@@ -1,8 +1,8 @@
 # Created with Komac v1.11.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: RandyHollines.Objeck
 PackageVersion: 2023.12.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191506)