### PR TITLE
Remove unnecessary DisplayVersion from SaaSGroup.Tower version 7.1.483

### DIFF
--- a/manifests/s/SaaSGroup/Tower/7.1.483/SaaSGroup.Tower.installer.yaml
+++ b/manifests/s/SaaSGroup/Tower/7.1.483/SaaSGroup.Tower.installer.yaml
@@ -21,8 +21,6 @@ Installers:
     Silent: --silent
     SilentWithProgress: --silent
   ProductCode: Tower
-  AppsAndFeaturesEntries:
-  - DisplayVersion: 7.1.483
 - Architecture: x64
   InstallerType: wix
   Scope: machine
@@ -33,7 +31,6 @@ Installers:
   ProductCode: '{81D164FB-FA26-4922-B5E1-95AAE522EB99}'
   AppsAndFeaturesEntries:
   - DisplayName: Tower Deployment Tool
-    DisplayVersion: 7.1.483.0
     ProductCode: '{81D164FB-FA26-4922-B5E1-95AAE522EB99}'
     UpgradeCode: '{3B1FBA9F-260D-5585-9DF1-C642CA263F35}'
 ManifestType: installer


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191507)