### PR TITLE
Remove unnecessary DisplayVersion from stnkl.EverythingToolbar version 1.5.1

### DIFF
--- a/manifests/s/stnkl/EverythingToolbar/1.5.1/stnkl.EverythingToolbar.installer.yaml
+++ b/manifests/s/stnkl/EverythingToolbar/1.5.1/stnkl.EverythingToolbar.installer.yaml
@@ -18,8 +18,7 @@ Dependencies:
   - PackageIdentifier: voidtools.Everything
 ProductCode: '{5868369F-87A1-4FBA-BB53-F4121CFDDF7C}'
 AppsAndFeaturesEntries:
-- DisplayVersion: 1.5.1
-  UpgradeCode: '{744F23C4-7ADB-42FA-A781-AC940DC4B454}'
+- UpgradeCode: '{744F23C4-7ADB-42FA-A781-AC940DC4B454}'
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/srwi/EverythingToolbar/releases/download/1.5.1/EverythingToolbar-1.5.1.msi


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191510)