### PR TITLE
Remove unnecessary DisplayVersion from Twingate.Client version 2024.99.6390

### DIFF
--- a/manifests/t/Twingate/Client/2024.99.6390/Twingate.Client.installer.yaml
+++ b/manifests/t/Twingate/Client/2024.99.6390/Twingate.Client.installer.yaml
@@ -8,11 +8,9 @@ InstallerType: msi
 InstallerSwitches:
   Silent: /qn
 ProductCode: '{11BA3B45-D8FA-4524-A085-80FB4B023483}'
-AppsAndFeaturesEntries:
-- DisplayVersion: 2024.99.6390
 Dependencies:
   PackageDependencies:
-     - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.6
+    - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.6
 Installers:
 - Architecture: x64
   InstallerUrl: https://binaries.twingate.com/client/windows/versions/2024.99.6390/TwingateWindowsInstaller.msi


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191511)