### PR TITLE
Remove unnecessary DisplayVersion from Webrox.Regedix version 2.0.0.0

### DIFF
--- a/manifests/w/Webrox/Regedix/2.0.0.0/Webrox.Regedix.installer.yaml
+++ b/manifests/w/Webrox/Regedix/2.0.0.0/Webrox.Regedix.installer.yaml
@@ -12,7 +12,6 @@ Commands:
 - Regedix
 AppsAndFeaturesEntries:
 - DisplayName: Regedix
-  DisplayVersion: 2.0.0.0
   ProductCode: Webrox.Regedix
 Installers:
 - Architecture: x86


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/191512)