### PR TITLE
Support additional params of SandboxTest.ps1 in PRTest.ps1

### DIFF
--- a/Tools/PRTest.ps1
+++ b/Tools/PRTest.ps1
@@ -9,7 +9,11 @@ Param(
     [Switch] $KeepBranch = $false,
     [Switch] $Prerelease = $false,
     [Switch] $EnableExperimentalFeatures = $false,
-    [string] $WinGetVersion = $null
+    [string] $WinGetVersion = $null,
+    [string] $WinGetOptions,
+    [scriptblock] $Script = $null,
+    [string] $MapFolder = $pwd,
+    [switch] $Clean
 )
 
 $PullRequest = $PullRequest.TrimStart('#')
@@ -51,6 +55,10 @@ $params = @{
     Prerelease                 = $Prerelease
     EnableExperimentalFeatures = $EnableExperimentalFeatures
     WinGetVersion              = $WinGetVersion
+    WinGetOptions              = $WinGetOptions
+    Script                     = $Script
+    MapFolder                  = $MapFolder
+    Clean                      = $Clean
 }
 & $sandboxTestPath @params
 


### PR DESCRIPTION
Allow PRTest.ps1 script to make use of more params that SandboxTest.ps1 has to offer

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/192071)