### PR TITLE
Remove DisplayName from Kopia.KopiaUI

### DIFF
--- a/manifests/k/Kopia/KopiaUI/0.18.2/Kopia.KopiaUI.installer.yaml
+++ b/manifests/k/Kopia/KopiaUI/0.18.2/Kopia.KopiaUI.installer.yaml
@@ -12,8 +12,6 @@ InstallModes:
 - silent
 UpgradeBehavior: install
 ReleaseDate: 2024-11-21
-AppsAndFeaturesEntries:
-- DisplayName: KopiaUI 0.18.1
 Installers:
 - Architecture: x64
   Scope: user


### PR DESCRIPTION
DisplayName not needed for this package as PackageName is a good match. This doesn't get updated automatically by manifest creation tools so removing it to make manifest creation easier and prevent old values from getting carried forward

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/192775)