### PR TITLE
Update: Mattermost.MattermostDesktop version 5.10.0

### DIFF
--- a/manifests/m/Mattermost/MattermostDesktop/5.10.0/Mattermost.MattermostDesktop.installer.yaml
+++ b/manifests/m/Mattermost/MattermostDesktop/5.10.0/Mattermost.MattermostDesktop.installer.yaml
@@ -6,65 +6,44 @@ PackageVersion: 5.10.0
 InstallerLocale: en-US
 Platform:
 - Windows.Desktop
-InstallerType: wix
 InstallModes:
 - interactive
 - silent
 - silentWithProgress
 UpgradeBehavior: install
-ProductCode: '{95C1D261-22CB-4CD2-A091-892601E8B17E}'
 ReleaseDate: 2024-11-15
-AppsAndFeaturesEntries:
-- DisplayName: Mattermost
-  Publisher: Mattermost, Inc.
-  ProductCode: '{95C1D261-22CB-4CD2-A091-892601E8B17E}'
-  UpgradeCode: '{0F183CAA-DF79-5400-A71F-684F563AF31C}'
-InstallationMetadata:
-  DefaultInstallLocation: '%ProgramFiles%\mattermost-desktop'
 Installers:
-- Architecture: x64
+- Architecture: x86
+  InstallerType: nullsoft
   Scope: user
-  InstallerUrl: https://releases.mattermost.com/desktop/5.10.0/mattermost-desktop-5.10.0-win-x64.msi
-  InstallerSha256: BBE85376C3FF14D1FEE8467A34985DA938A051518C7E26E6BCAF371BBFFC39C1
-  ProductCode: '{A756468E-6706-4E56-869F-9FAC1E87337B}'
-  AppsAndFeaturesEntries:
-  - DisplayName: Mattermost
-    Publisher: Mattermost, Inc.
-    DisplayVersion: 5.10.0.0
-    ProductCode: '{A756468E-6706-4E56-869F-9FAC1E87337B}'
-    UpgradeCode: '{0F183CAA-DF79-5400-A71F-684F563AF31C}'
+  InstallerUrl: https://releases.mattermost.com/desktop/5.10.0/mattermost-desktop-setup-5.10.0-win.exe
+  InstallerSha256: E26BB9CAB644BBDF979915D3AF81A2DBF4938528F56D6C1813D9E246FC3C22D6
+  ProductCode: 0cc73166-b7d0-592b-8d95-6cbe304083a6
 - Architecture: x64
+  InstallerType: nullsoft
+  Scope: user
+  InstallerUrl: https://releases.mattermost.com/desktop/5.10.0/mattermost-desktop-setup-5.10.0-win.exe
+  InstallerSha256: E26BB9CAB644BBDF979915D3AF81A2DBF4938528F56D6C1813D9E246FC3C22D6
+  ProductCode: 0cc73166-b7d0-592b-8d95-6cbe304083a6
+- Architecture: x64
+  InstallerType: wix
   Scope: machine
   InstallerUrl: https://releases.mattermost.com/desktop/5.10.0/mattermost-desktop-5.10.0-win-x64.msi
   InstallerSha256: BBE85376C3FF14D1FEE8467A34985DA938A051518C7E26E6BCAF371BBFFC39C1
   ProductCode: '{A756468E-6706-4E56-869F-9FAC1E87337B}'
+  InstallationMetadata:
+    DefaultInstallLocation: '%ProgramFiles%\mattermost-desktop'
   AppsAndFeaturesEntries:
-  - DisplayName: Mattermost
-    Publisher: Mattermost, Inc.
-    DisplayVersion: 5.10.0.0
-    ProductCode: '{A756468E-6706-4E56-869F-9FAC1E87337B}'
-    UpgradeCode: '{0F183CAA-DF79-5400-A71F-684F563AF31C}'
+    - UpgradeCode: '{0F183CAA-DF79-5400-A71F-684F563AF31C}'
 - Architecture: arm64
-  Scope: user
-  InstallerUrl: https://releases.mattermost.com/desktop/5.10.0/mattermost-desktop-5.10.0-win-arm64.msi
-  InstallerSha256: 4E98AE04E3B64422CA4D222EE9CB13E8D097DD8B2FAD384782DCDAA8CBEFAC6D
-  ProductCode: '{13BBFBC7-8E4D-4988-A82E-18EE43054C6E}'
-  AppsAndFeaturesEntries:
-  - DisplayName: Mattermost
-    Publisher: Mattermost, Inc.
-    DisplayVersion: 5.10.0.0
-    ProductCode: '{13BBFBC7-8E4D-4988-A82E-18EE43054C6E}'
-    UpgradeCode: '{0F183CAA-DF79-5400-A71F-684F563AF31C}'
-- Architecture: arm64
+  InstallerType: wix
   Scope: machine
   InstallerUrl: https://releases.mattermost.com/desktop/5.10.0/mattermost-desktop-5.10.0-win-arm64.msi
   InstallerSha256: 4E98AE04E3B64422CA4D222EE9CB13E8D097DD8B2FAD384782DCDAA8CBEFAC6D
   ProductCode: '{13BBFBC7-8E4D-4988-A82E-18EE43054C6E}'
+  InstallationMetadata:
+    DefaultInstallLocation: '%ProgramFiles%\mattermost-desktop'
   AppsAndFeaturesEntries:
-  - DisplayName: Mattermost
-    Publisher: Mattermost, Inc.
-    DisplayVersion: 5.10.0.0
-    ProductCode: '{13BBFBC7-8E4D-4988-A82E-18EE43054C6E}'
-    UpgradeCode: '{0F183CAA-DF79-5400-A71F-684F563AF31C}'
+    - UpgradeCode: '{0F183CAA-DF79-5400-A71F-684F563AF31C}'
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/m/Mattermost/MattermostDesktop/5.10.0/Mattermost.MattermostDesktop.installer.yaml
+++ b/manifests/m/Mattermost/MattermostDesktop/5.10.0/Mattermost.MattermostDesktop.installer.yaml
@@ -27,22 +27,18 @@ Installers:
   ProductCode: 0cc73166-b7d0-592b-8d95-6cbe304083a6
 - Architecture: x64
   InstallerType: wix
-  Scope: machine
+  # Scope: any - Installs per-user but writes to HKLM, so WinGet detects as machine
   InstallerUrl: https://releases.mattermost.com/desktop/5.10.0/mattermost-desktop-5.10.0-win-x64.msi
   InstallerSha256: BBE85376C3FF14D1FEE8467A34985DA938A051518C7E26E6BCAF371BBFFC39C1
   ProductCode: '{A756468E-6706-4E56-869F-9FAC1E87337B}'
-  InstallationMetadata:
-    DefaultInstallLocation: '%ProgramFiles%\mattermost-desktop'
   AppsAndFeaturesEntries:
     - UpgradeCode: '{0F183CAA-DF79-5400-A71F-684F563AF31C}'
 - Architecture: arm64
   InstallerType: wix
-  Scope: machine
+  # Scope: any - Installs per-user but writes to HKLM, so WinGet detects as machine
   InstallerUrl: https://releases.mattermost.com/desktop/5.10.0/mattermost-desktop-5.10.0-win-arm64.msi
   InstallerSha256: 4E98AE04E3B64422CA4D222EE9CB13E8D097DD8B2FAD384782DCDAA8CBEFAC6D
   ProductCode: '{13BBFBC7-8E4D-4988-A82E-18EE43054C6E}'
-  InstallationMetadata:
-    DefaultInstallLocation: '%ProgramFiles%\mattermost-desktop'
   AppsAndFeaturesEntries:
     - UpgradeCode: '{0F183CAA-DF79-5400-A71F-684F563AF31C}'
 ManifestType: installer


### PR DESCRIPTION
Clean up Mattermost 5.10.0 manifest

- DisplayVersion is not needed, PackageVersion can suffice. No difference in `5.10.0` & `5.10.0.0` matching wise in the CLI logic.
- Add user scope installer
- Remove unnecesary ARP entries (DisplayName & Publisher are already exact matches of fields in default locale manifest)

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/192931)