### PR TITLE
Remove unnecessary DisplayName from DoltHub.Dolt version 1.12.0

### DIFF
--- a/manifests/d/DoltHub/Dolt/1.12.0/DoltHub.Dolt.installer.yaml
+++ b/manifests/d/DoltHub/Dolt/1.12.0/DoltHub.Dolt.installer.yaml
@@ -1,5 +1,5 @@
 # Created with WinGet Automation using Komac v1.10.1
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: DoltHub.Dolt
 PackageVersion: 1.12.0
@@ -12,11 +12,10 @@ UpgradeBehavior: install
 ProductCode: '{B6C98FDB-53D4-47CD-93DB-5A10518ECE7B}'
 ReleaseDate: 2023-08-18
 AppsAndFeaturesEntries:
-- DisplayName: Dolt 1.12.0
-  UpgradeCode: '{6BC40754-759D-4899-9FD3-E6BE1823CACD}'
+- UpgradeCode: '{6BC40754-759D-4899-9FD3-E6BE1823CACD}'
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/dolthub/dolt/releases/download/v1.12.0/dolt-windows-amd64.msi
   InstallerSha256: DEA1732785E7FFA53E4CC20DE2B114AD52E33BF63D6386F6BDC01888C5552B8E
 ManifestType: installer
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/d/DoltHub/Dolt/1.12.0/DoltHub.Dolt.locale.en-US.yaml
+++ b/manifests/d/DoltHub/Dolt/1.12.0/DoltHub.Dolt.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with WinGet Automation using Komac v1.10.1
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: DoltHub.Dolt
 PackageVersion: 1.12.0
@@ -59,4 +59,4 @@ ReleaseNotes: |-
   - 6305: XCA Tool shows no records when Dolt is used instead of MySQL
 ReleaseNotesUrl: https://github.com/dolthub/dolt/releases/tag/v1.12.0
 ManifestType: defaultLocale
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/d/DoltHub/Dolt/1.12.0/DoltHub.Dolt.yaml
+++ b/manifests/d/DoltHub/Dolt/1.12.0/DoltHub.Dolt.yaml
@@ -1,8 +1,8 @@
 # Created with WinGet Automation using Komac v1.10.1
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: DoltHub.Dolt
 PackageVersion: 1.12.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
DisplayName isn't needed as PackageName is a good match. Most manifests have an outdated value. Remove unnecessary DisplayName that would need to be updated manually in each PR.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/193278)