### PR TITLE
Remove unnecessary DisplayName from DoltHub.Dolt version 1.13.6

### DIFF
--- a/manifests/d/DoltHub/Dolt/1.13.6/DoltHub.Dolt.installer.yaml
+++ b/manifests/d/DoltHub/Dolt/1.13.6/DoltHub.Dolt.installer.yaml
@@ -1,5 +1,5 @@
 # Created with WinGet Automation using Komac v1.11.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: DoltHub.Dolt
 PackageVersion: 1.13.6
@@ -12,11 +12,10 @@ UpgradeBehavior: install
 ProductCode: '{26C1771A-B909-4FE1-82BF-5EF73618D09A}'
 ReleaseDate: 2023-09-01
 AppsAndFeaturesEntries:
-- DisplayName: Dolt 1.13.6
-  UpgradeCode: '{6BC40754-759D-4899-9FD3-E6BE1823CACD}'
+- UpgradeCode: '{6BC40754-759D-4899-9FD3-E6BE1823CACD}'
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/dolthub/dolt/releases/download/v1.13.6/dolt-windows-amd64.msi
   InstallerSha256: 0FF9D922CB999D1B57C8D2C9171BABE538C78245AA9AB79BCB94C2FD22EBB874
 ManifestType: installer
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/d/DoltHub/Dolt/1.13.6/DoltHub.Dolt.locale.en-US.yaml
+++ b/manifests/d/DoltHub/Dolt/1.13.6/DoltHub.Dolt.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with WinGet Automation using Komac v1.11.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: DoltHub.Dolt
 PackageVersion: 1.13.6
@@ -43,4 +43,4 @@ ReleaseNotes: |-
   - 6486: Allow pattern-matching in replicate_heads variable
 ReleaseNotesUrl: https://github.com/dolthub/dolt/releases/tag/v1.13.6
 ManifestType: defaultLocale
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/d/DoltHub/Dolt/1.13.6/DoltHub.Dolt.yaml
+++ b/manifests/d/DoltHub/Dolt/1.13.6/DoltHub.Dolt.yaml
@@ -1,8 +1,8 @@
 # Created with WinGet Automation using Komac v1.11.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: DoltHub.Dolt
 PackageVersion: 1.13.6
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
DisplayName isn't needed as PackageName is a good match. Most manifests have an outdated value. Remove unnecessary DisplayName that would need to be updated manually in each PR.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/193285)