### PR TITLE
Remove unnecessary DisplayName from DoltHub.Dolt version 1.16.2

### DIFF
--- a/manifests/d/DoltHub/Dolt/1.16.2/DoltHub.Dolt.installer.yaml
+++ b/manifests/d/DoltHub/Dolt/1.16.2/DoltHub.Dolt.installer.yaml
@@ -1,5 +1,5 @@
 # Created with WinGet Automation using Komac v1.11.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: DoltHub.Dolt
 PackageVersion: 1.16.2
@@ -12,11 +12,10 @@ UpgradeBehavior: install
 ProductCode: '{0D249593-1F6B-4FE4-A089-01739E3AA39F}'
 ReleaseDate: 2023-09-21
 AppsAndFeaturesEntries:
-- DisplayName: Dolt 1.16.2
-  UpgradeCode: '{6BC40754-759D-4899-9FD3-E6BE1823CACD}'
+- UpgradeCode: '{6BC40754-759D-4899-9FD3-E6BE1823CACD}'
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/dolthub/dolt/releases/download/v1.16.2/dolt-windows-amd64.msi
   InstallerSha256: D6FDDCCCD34D3141FEA7205474453D0263C81F4F13D59BD6B011E6DC920C8D7F
 ManifestType: installer
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/d/DoltHub/Dolt/1.16.2/DoltHub.Dolt.locale.en-US.yaml
+++ b/manifests/d/DoltHub/Dolt/1.16.2/DoltHub.Dolt.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with WinGet Automation using Komac v1.11.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: DoltHub.Dolt
 PackageVersion: 1.16.2
@@ -44,4 +44,4 @@ ReleaseNotes: |-
   - 6683: Selecting from a view shows column names as all lowercase
 ReleaseNotesUrl: https://github.com/dolthub/dolt/releases/tag/v1.16.2
 ManifestType: defaultLocale
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/d/DoltHub/Dolt/1.16.2/DoltHub.Dolt.yaml
+++ b/manifests/d/DoltHub/Dolt/1.16.2/DoltHub.Dolt.yaml
@@ -1,8 +1,8 @@
 # Created with WinGet Automation using Komac v1.11.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: DoltHub.Dolt
 PackageVersion: 1.16.2
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
DisplayName isn't needed as PackageName is a good match. Most manifests have an outdated value. Remove unnecessary DisplayName that would need to be updated manually in each PR.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/193292)