### PR TITLE
Remove unnecessary DisplayName from DoltHub.Dolt version 1.16.5

### DIFF
--- a/manifests/d/DoltHub/Dolt/1.16.5/DoltHub.Dolt.installer.yaml
+++ b/manifests/d/DoltHub/Dolt/1.16.5/DoltHub.Dolt.installer.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.5.3.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: DoltHub.Dolt
 PackageVersion: 1.16.5
@@ -11,11 +11,10 @@ Scope: machine
 UpgradeBehavior: install
 ProductCode: '{40E0B291-5EB3-458B-959E-3F89CC8459E5}'
 AppsAndFeaturesEntries:
-- DisplayName: Dolt 1.16.5
-  UpgradeCode: '{6BC40754-759D-4899-9FD3-E6BE1823CACD}'
+- UpgradeCode: '{6BC40754-759D-4899-9FD3-E6BE1823CACD}'
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/dolthub/dolt/releases/download/v1.16.5/dolt-windows-amd64.msi
   InstallerSha256: D8C1957BB4C16D0086F63B63E3B8904834AAA1188F5CD1C993085F1C31E6ED8E
 ManifestType: installer
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/d/DoltHub/Dolt/1.16.5/DoltHub.Dolt.locale.en-US.yaml
+++ b/manifests/d/DoltHub/Dolt/1.16.5/DoltHub.Dolt.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.5.3.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: DoltHub.Dolt
 PackageVersion: 1.16.5
@@ -25,4 +25,4 @@ Tags:
 - git-for-data
 - versioning
 ManifestType: defaultLocale
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/d/DoltHub/Dolt/1.16.5/DoltHub.Dolt.yaml
+++ b/manifests/d/DoltHub/Dolt/1.16.5/DoltHub.Dolt.yaml
@@ -1,8 +1,8 @@
 # Created using wingetcreate 1.5.3.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: DoltHub.Dolt
 PackageVersion: 1.16.5
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
DisplayName isn't needed as PackageName is a good match. Most manifests have an outdated value. Remove unnecessary DisplayName that would need to be updated manually in each PR.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/193295)