### PR TITLE
Remove unnecessary DisplayName from DoltHub.Dolt version 1.17.1

### DIFF
--- a/manifests/d/DoltHub/Dolt/1.17.1/DoltHub.Dolt.installer.yaml
+++ b/manifests/d/DoltHub/Dolt/1.17.1/DoltHub.Dolt.installer.yaml
@@ -1,5 +1,5 @@
 # Created with WinGet Automation using Komac v1.11.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: DoltHub.Dolt
 PackageVersion: 1.17.1
@@ -12,11 +12,10 @@ UpgradeBehavior: install
 ProductCode: '{9FDA5CD6-9AEC-4872-AF6D-4B65E4629A8E}'
 ReleaseDate: 2023-09-29
 AppsAndFeaturesEntries:
-- DisplayName: Dolt 1.17.1
-  UpgradeCode: '{6BC40754-759D-4899-9FD3-E6BE1823CACD}'
+- UpgradeCode: '{6BC40754-759D-4899-9FD3-E6BE1823CACD}'
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/dolthub/dolt/releases/download/v1.17.1/dolt-windows-amd64.msi
   InstallerSha256: C47F5F234BEBABC755CFB690F1C92B2BF1077D309B3BE1A623BE1F3EF4AB44C6
 ManifestType: installer
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/d/DoltHub/Dolt/1.17.1/DoltHub.Dolt.locale.en-US.yaml
+++ b/manifests/d/DoltHub/Dolt/1.17.1/DoltHub.Dolt.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with WinGet Automation using Komac v1.11.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: DoltHub.Dolt
 PackageVersion: 1.17.1
@@ -60,4 +60,4 @@ ReleaseNotes: |-
   - 1782: Error 1105: -128 out of range for BIGINT UNSIGNED
 ReleaseNotesUrl: https://github.com/dolthub/dolt/releases/tag/v1.17.1
 ManifestType: defaultLocale
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/d/DoltHub/Dolt/1.17.1/DoltHub.Dolt.yaml
+++ b/manifests/d/DoltHub/Dolt/1.17.1/DoltHub.Dolt.yaml
@@ -1,8 +1,8 @@
 # Created with WinGet Automation using Komac v1.11.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: DoltHub.Dolt
 PackageVersion: 1.17.1
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
DisplayName isn't needed as PackageName is a good match. Most manifests have an outdated value. Remove unnecessary DisplayName that would need to be updated manually in each PR.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/193297)