### PR TITLE
Remove unnecessary DisplayName from DoltHub.Dolt version 1.29.0

### DIFF
--- a/manifests/d/DoltHub/Dolt/1.29.0/DoltHub.Dolt.installer.yaml
+++ b/manifests/d/DoltHub/Dolt/1.29.0/DoltHub.Dolt.installer.yaml
@@ -1,5 +1,5 @@
 # Created with WinGet Automation using Komac v1.11.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: DoltHub.Dolt
 PackageVersion: 1.29.0
@@ -12,11 +12,10 @@ UpgradeBehavior: install
 ProductCode: '{0F69F0CB-D0D7-4956-93F1-CA2E28E0B92B}'
 ReleaseDate: 2023-12-01
 AppsAndFeaturesEntries:
-- DisplayName: Dolt 1.29.0
-  UpgradeCode: '{6BC40754-759D-4899-9FD3-E6BE1823CACD}'
+- UpgradeCode: '{6BC40754-759D-4899-9FD3-E6BE1823CACD}'
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/dolthub/dolt/releases/download/v1.29.0/dolt-windows-amd64.msi
   InstallerSha256: 20F8F779F853AF2B94DB72E0F297D28CD62E0A9C7D3255BB4874722AFE436BD6
 ManifestType: installer
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/d/DoltHub/Dolt/1.29.0/DoltHub.Dolt.locale.en-US.yaml
+++ b/manifests/d/DoltHub/Dolt/1.29.0/DoltHub.Dolt.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with WinGet Automation using Komac v1.11.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: DoltHub.Dolt
 PackageVersion: 1.29.0
@@ -54,4 +54,4 @@ ReleaseNotes: |-
   - 2159: VSCode debug Build Error
 ReleaseNotesUrl: https://github.com/dolthub/dolt/releases/tag/v1.29.0
 ManifestType: defaultLocale
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/d/DoltHub/Dolt/1.29.0/DoltHub.Dolt.yaml
+++ b/manifests/d/DoltHub/Dolt/1.29.0/DoltHub.Dolt.yaml
@@ -1,8 +1,8 @@
 # Created with WinGet Automation using Komac v1.11.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: DoltHub.Dolt
 PackageVersion: 1.29.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
DisplayName isn't needed as PackageName is a good match. Most manifests have an outdated value. Remove unnecessary DisplayName that would need to be updated manually in each PR.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/193318)