### PR TITLE
Remove unnecessary DisplayName from DoltHub.Dolt version 1.29.1

### DIFF
--- a/manifests/d/DoltHub/Dolt/1.29.1/DoltHub.Dolt.installer.yaml
+++ b/manifests/d/DoltHub/Dolt/1.29.1/DoltHub.Dolt.installer.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.5.7.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: DoltHub.Dolt
 PackageVersion: 1.29.1
@@ -11,11 +11,10 @@ Scope: machine
 UpgradeBehavior: install
 ProductCode: '{C5B55A03-8914-4846-94E0-5BB51CCDDAE4}'
 AppsAndFeaturesEntries:
-- DisplayName: Dolt 1.29.1
-  UpgradeCode: '{6BC40754-759D-4899-9FD3-E6BE1823CACD}'
+- UpgradeCode: '{6BC40754-759D-4899-9FD3-E6BE1823CACD}'
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/dolthub/dolt/releases/download/v1.29.1/dolt-windows-amd64.msi
   InstallerSha256: A75E8BCB69ACE6B2390786E675314CD94848FD097D28179F78E4DA8A4C7B85D6
 ManifestType: installer
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/d/DoltHub/Dolt/1.29.1/DoltHub.Dolt.locale.en-US.yaml
+++ b/manifests/d/DoltHub/Dolt/1.29.1/DoltHub.Dolt.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.5.7.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: DoltHub.Dolt
 PackageVersion: 1.29.1
@@ -25,4 +25,4 @@ Tags:
 - git-for-data
 - versioning
 ManifestType: defaultLocale
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/d/DoltHub/Dolt/1.29.1/DoltHub.Dolt.yaml
+++ b/manifests/d/DoltHub/Dolt/1.29.1/DoltHub.Dolt.yaml
@@ -1,8 +1,8 @@
 # Created using wingetcreate 1.5.7.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: DoltHub.Dolt
 PackageVersion: 1.29.1
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
DisplayName isn't needed as PackageName is a good match. Most manifests have an outdated value. Remove unnecessary DisplayName that would need to be updated manually in each PR.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/193319)