### PR TITLE
Remove unnecessary DisplayName from DoltHub.Dolt version 1.31.1

### DIFF
--- a/manifests/d/DoltHub/Dolt/1.31.1/DoltHub.Dolt.installer.yaml
+++ b/manifests/d/DoltHub/Dolt/1.31.1/DoltHub.Dolt.installer.yaml
@@ -1,6 +1,6 @@
 # Created using WinGet Automation (CLI)
 
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: DoltHub.Dolt
 PackageVersion: 1.31.1
@@ -8,9 +8,8 @@ Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/dolthub/dolt/releases/download/v1.31.1/dolt-windows-amd64.msi
   InstallerSha256: 1d7eb39d3ad85228177803fd712a1ec0effc2ac1dec0419646c4d43273ad8c78
-  UpgradeCode: "{6BC40754-759D-4899-9FD3-E6BE1823CACD}"
 ManifestType: installer
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0
 InstallerLocale: en-US
 Platform:
 - Windows.Desktop
@@ -20,5 +19,4 @@ UpgradeBehavior: install
 ProductCode: '{666D28E3-7DFC-405D-AA46-9A74F6C10A64}'
 ReleaseDate: "2024-01-11"
 AppsAndFeaturesEntries:
-- DisplayName: Dolt 1.9.0
-  UpgradeCode: '{6BC40754-759D-4899-9FD3-E6BE1823CACD}'
+- UpgradeCode: '{6BC40754-759D-4899-9FD3-E6BE1823CACD}'

--- a/manifests/d/DoltHub/Dolt/1.31.1/DoltHub.Dolt.locale.en-US.yaml
+++ b/manifests/d/DoltHub/Dolt/1.31.1/DoltHub.Dolt.locale.en-US.yaml
@@ -1,6 +1,6 @@
 # Created using WinGet Automation (CLI)
 
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.4.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: DoltHub.Dolt
 PackageVersion: 1.31.1
@@ -26,5 +26,5 @@ Tags:
 - git-for-data
 - versioning
 ManifestType: defaultLocale
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0
 ReleaseNotesUrl: https://github.com/dolthub/dolt/releases/tag/v1.31.1

--- a/manifests/d/DoltHub/Dolt/1.31.1/DoltHub.Dolt.yaml
+++ b/manifests/d/DoltHub/Dolt/1.31.1/DoltHub.Dolt.yaml
@@ -1,9 +1,9 @@
 # Created using WinGet Automation (CLI)
 
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.4.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: DoltHub.Dolt
 PackageVersion: 1.31.1
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
DisplayName isn't needed as PackageName is a good match. Most manifests have an outdated value. Remove unnecessary DisplayName that would need to be updated manually in each PR.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/193332)