### PR TITLE
Remove unnecessary DisplayName from DoltHub.Dolt version 1.32.2

### DIFF
--- a/manifests/d/DoltHub/Dolt/1.32.2/DoltHub.Dolt.installer.yaml
+++ b/manifests/d/DoltHub/Dolt/1.32.2/DoltHub.Dolt.installer.yaml
@@ -1,5 +1,5 @@
 # Created with Komac v1.11.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: DoltHub.Dolt
 PackageVersion: 1.32.2
@@ -12,11 +12,10 @@ UpgradeBehavior: install
 ProductCode: '{D1F9AC8C-22B9-4729-BA35-FE82C6098B2F}'
 ReleaseDate: 2024-01-23
 AppsAndFeaturesEntries:
-- DisplayName: Dolt 1.32.2
-  UpgradeCode: '{6BC40754-759D-4899-9FD3-E6BE1823CACD}'
+- UpgradeCode: '{6BC40754-759D-4899-9FD3-E6BE1823CACD}'
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/dolthub/dolt/releases/download/v1.32.2/dolt-windows-amd64.msi
   InstallerSha256: E972F1CE882F5A6B50707C190E124A0ECC798A77710B46E517ABE13E6EEF188C
 ManifestType: installer
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/d/DoltHub/Dolt/1.32.2/DoltHub.Dolt.locale.en-US.yaml
+++ b/manifests/d/DoltHub/Dolt/1.32.2/DoltHub.Dolt.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with Komac v1.11.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: DoltHub.Dolt
 PackageVersion: 1.32.2
@@ -37,4 +37,4 @@ ReleaseNotes: |-
   - 7313: sql server panic when uploading table
 ReleaseNotesUrl: https://github.com/dolthub/dolt/releases/tag/v1.32.2
 ManifestType: defaultLocale
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/d/DoltHub/Dolt/1.32.2/DoltHub.Dolt.yaml
+++ b/manifests/d/DoltHub/Dolt/1.32.2/DoltHub.Dolt.yaml
@@ -1,8 +1,8 @@
 # Created with Komac v1.11.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: DoltHub.Dolt
 PackageVersion: 1.32.2
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
DisplayName isn't needed as PackageName is a good match. Most manifests have an outdated value. Remove unnecessary DisplayName that would need to be updated manually in each PR.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/193337)