### PR TITLE
Remove unnecessary DisplayName from DoltHub.Dolt version 1.34.1

### DIFF
--- a/manifests/d/DoltHub/Dolt/1.34.1/DoltHub.Dolt.installer.yaml
+++ b/manifests/d/DoltHub/Dolt/1.34.1/DoltHub.Dolt.installer.yaml
@@ -12,8 +12,7 @@ UpgradeBehavior: install
 ProductCode: '{79244490-02BC-413A-B0D3-ABA9F8AA4355}'
 ReleaseDate: 2024-02-16
 AppsAndFeaturesEntries:
-- DisplayName: Dolt 1.34.1
-  UpgradeCode: '{6BC40754-759D-4899-9FD3-E6BE1823CACD}'
+- UpgradeCode: '{6BC40754-759D-4899-9FD3-E6BE1823CACD}'
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/dolthub/dolt/releases/download/v1.34.1/dolt-windows-amd64.msi


### PR DESCRIPTION
DisplayName isn't needed as PackageName is a good match. Most manifests have an outdated value. Remove unnecessary DisplayName that would need to be updated manually in each PR.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/193344)