### PR TITLE
Remove unnecessary DisplayName from DoltHub.Dolt version 1.35.11

### DIFF
--- a/manifests/d/DoltHub/Dolt/1.35.11/DoltHub.Dolt.installer.yaml
+++ b/manifests/d/DoltHub/Dolt/1.35.11/DoltHub.Dolt.installer.yaml
@@ -11,8 +11,7 @@ Scope: machine
 UpgradeBehavior: install
 ProductCode: '{58A4C6FD-6BC4-49B3-93D4-D85C851EA231}'
 AppsAndFeaturesEntries:
-- DisplayName: Dolt 1.34.1
-  UpgradeCode: '{6BC40754-759D-4899-9FD3-E6BE1823CACD}'
+- UpgradeCode: '{6BC40754-759D-4899-9FD3-E6BE1823CACD}'
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/dolthub/dolt/releases/download/v1.35.11/dolt-windows-amd64.msi


### PR DESCRIPTION
DisplayName isn't needed as PackageName is a good match. Most manifests have an outdated value. Remove unnecessary DisplayName that would need to be updated manually in each PR.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/193348)