### PR TITLE
Remove unnecessary DisplayName from DoltHub.Dolt version 1.41.4

### DIFF
--- a/manifests/d/DoltHub/Dolt/1.41.4/DoltHub.Dolt.installer.yaml
+++ b/manifests/d/DoltHub/Dolt/1.41.4/DoltHub.Dolt.installer.yaml
@@ -10,8 +10,6 @@ InstallerType: wix
 Scope: machine
 UpgradeBehavior: install
 ProductCode: '{96B5B30E-C802-433C-B51C-697663B0C19C}'
-AppsAndFeaturesEntries:
-- DisplayName: Dolt 1.41.0
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/dolthub/dolt/releases/download/v1.41.4/dolt-windows-amd64.msi


### PR DESCRIPTION
DisplayName isn't needed as PackageName is a good match. Most manifests have an outdated value. Remove unnecessary DisplayName that would need to be updated manually in each PR.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/193379)