### PR TITLE
Remove unnecessary DisplayName from DoltHub.Dolt version 1.43.8

### DIFF
--- a/manifests/d/DoltHub/Dolt/1.43.8/DoltHub.Dolt.installer.yaml
+++ b/manifests/d/DoltHub/Dolt/1.43.8/DoltHub.Dolt.installer.yaml
@@ -10,8 +10,6 @@ InstallerType: wix
 Scope: machine
 UpgradeBehavior: install
 ProductCode: '{0833791C-A9B3-45AE-9029-2C16BA9A2CD1}'
-AppsAndFeaturesEntries:
-- DisplayName: Dolt 1.42.20
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/dolthub/dolt/releases/download/v1.43.8/dolt-windows-amd64.msi


### PR DESCRIPTION
DisplayName isn't needed as PackageName is a good match. Most manifests have an outdated value. Remove unnecessary DisplayName that would need to be updated manually in each PR.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/193415)