### PR TITLE
Remove unnecessary DisplayName from DoltHub.Dolt version 1.6.0

### DIFF
--- a/manifests/d/DoltHub/Dolt/1.6.0/DoltHub.Dolt.installer.yaml
+++ b/manifests/d/DoltHub/Dolt/1.6.0/DoltHub.Dolt.installer.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.2.6.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: DoltHub.Dolt
 PackageVersion: 1.6.0
@@ -9,8 +9,7 @@ Platform:
 Scope: machine
 UpgradeBehavior: install
 AppsAndFeaturesEntries:
-- DisplayName: Dolt 1.6.0
-  UpgradeCode: '{6BC40754-759D-4899-9FD3-E6BE1823CACD}'
+- UpgradeCode: '{6BC40754-759D-4899-9FD3-E6BE1823CACD}'
 Installers:
 - Architecture: x64
   InstallerType: wix
@@ -18,4 +17,4 @@ Installers:
   InstallerSha256: 219085EC9D72FBC9A7153984398CF25C10470E0A93BF2A20A4CE9C4105AF7258
   ProductCode: '{386CBB87-CCE6-44AE-AEDD-5F8DDE503176}'
 ManifestType: installer
-ManifestVersion: 1.4.0
+ManifestVersion: 1.6.0

--- a/manifests/d/DoltHub/Dolt/1.6.0/DoltHub.Dolt.locale.en-US.yaml
+++ b/manifests/d/DoltHub/Dolt/1.6.0/DoltHub.Dolt.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.2.6.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.4.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: DoltHub.Dolt
 PackageVersion: 1.6.0
@@ -25,4 +25,4 @@ Tags:
 - git-for-data
 - versioning
 ManifestType: defaultLocale
-ManifestVersion: 1.4.0
+ManifestVersion: 1.6.0

--- a/manifests/d/DoltHub/Dolt/1.6.0/DoltHub.Dolt.yaml
+++ b/manifests/d/DoltHub/Dolt/1.6.0/DoltHub.Dolt.yaml
@@ -1,8 +1,8 @@
 # Created using wingetcreate 1.2.6.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.4.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: DoltHub.Dolt
 PackageVersion: 1.6.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.4.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
DisplayName isn't needed as PackageName is a good match. Most manifests have an outdated value. Remove unnecessary DisplayName that would need to be updated manually in each PR.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/193417)