### PR TITLE
Fix SandboxTest for Windows 24H2 (26100.2454)

### DIFF
--- a/Tools/SandboxTest.ps1
+++ b/Tools/SandboxTest.ps1
@@ -460,6 +460,7 @@ foreach ($dependency in $script:AppInstallerDependencies) {
 
 # Kill the active running sandbox, if it exists, otherwise the test data folder can't be removed
 Stop-NamedProcess -ProcessName 'WindowsSandboxClient'
+Stop-NamedProcess -ProcessName 'WindowsSandboxRemoteSession'
 Start-Sleep -Milliseconds 5000 # Wait for the lock on the file to be released
 
 # Remove the test data folder if it exists. We will rebuild it with new test data


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

On Windows 11 24H2 (26100.2454) the sandbox team apparently renamed the service from `WindowsSandboxClient` to `WindowsSandboxRemoteSession`. This breaks `SandboxTest.ps1`, since if the sandbox is not closed, the test files can't be overwritten from one test to the next. 

This PR makes it so that either process name will be killed, ensuring compatibility with both newer and older versions of Windows.

@denelon
@mdanish-kh

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/193559)