### PR TITLE
fix Rufus installer by architecture & support machine wide installer

### DIFF
--- a/manifests/r/Rufus/Rufus/4.6/Rufus.Rufus.installer.yaml
+++ b/manifests/r/Rufus/Rufus/4.6/Rufus.Rufus.installer.yaml
@@ -3,22 +3,55 @@
 
 PackageIdentifier: Rufus.Rufus
 PackageVersion: '4.6'
-InstallerType: portable
-Commands:
-- rufus
 ReleaseDate: 2024-10-21
 Installers:
-- Architecture: x86
-  InstallerUrl: https://github.com/pbatard/rufus/releases/download/v4.6/rufus-4.6.exe
-  InstallerSha256: 8279696C1D78B14618500E9135886A3667B9DECC65946F3729002E4BFDBB20AB
-- Architecture: x64
-  InstallerUrl: https://github.com/pbatard/rufus/releases/download/v4.6/rufus-4.6.exe
-  InstallerSha256: 8279696C1D78B14618500E9135886A3667B9DECC65946F3729002E4BFDBB20AB
-- Architecture: arm
-  InstallerUrl: https://github.com/pbatard/rufus/releases/download/v4.6/rufus-4.6.exe
-  InstallerSha256: 8279696C1D78B14618500E9135886A3667B9DECC65946F3729002E4BFDBB20AB
-- Architecture: arm64
-  InstallerUrl: https://github.com/pbatard/rufus/releases/download/v4.6/rufus-4.6.exe
-  InstallerSha256: 8279696C1D78B14618500E9135886A3667B9DECC65946F3729002E4BFDBB20AB
+  - Architecture: x86
+    InstallerType: exe
+    Scope: machine
+    InstallerUrl: https://github.com/pbatard/rufus/releases/download/v4.6/rufus-4.6_x86.exe
+    InstallerSha256: 1C3EDD36BDB686DE09E3A0AD6507D52B9F91FA3AE2A24658FB0F7C157C2C8DCF
+  - Architecture: x64
+    InstallerType: exe
+    Scope: machine
+    InstallerUrl: https://github.com/pbatard/rufus/releases/download/v4.6/rufus-4.6.exe
+    InstallerSha256: 8279696C1D78B14618500E9135886A3667B9DECC65946F3729002E4BFDBB20AB
+  - Architecture: arm
+    InstallerType: exe
+    Scope: machine
+    InstallerUrl: https://github.com/pbatard/rufus/releases/download/v4.6/rufus-4.6_arm.exe
+    InstallerSha256: 72EEE5AAA819B442AEE34AEA7B075B0FB478A8DA189A57EE2936520707D41A2F
+  - Architecture: arm64
+    InstallerType: exe
+    Scope: machine
+    InstallerUrl: https://github.com/pbatard/rufus/releases/download/v4.6/rufus-4.6_arm64.exe
+    InstallerSha256: 318F89696B36BE6667B1D70EAF211851B8289020BD61CDAA57EBC3A1500436E1
+  - Architecture: x86
+    InstallerType: portable
+    Scope: user
+    InstallerUrl: https://github.com/pbatard/rufus/releases/download/v4.6/rufus-4.6p.exe
+    InstallerSha256: 8279696C1D78B14618500E9135886A3667B9DECC65946F3729002E4BFDBB20AB
+    Commands:
+      - rufus
+  - Architecture: x64
+    InstallerType: portable
+    Scope: user
+    InstallerUrl: https://github.com/pbatard/rufus/releases/download/v4.6/rufus-4.6p.exe
+    InstallerSha256: 8279696C1D78B14618500E9135886A3667B9DECC65946F3729002E4BFDBB20AB
+    Commands:
+      - rufus
+  - Architecture: arm
+    InstallerType: portable
+    Scope: user
+    InstallerUrl: https://github.com/pbatard/rufus/releases/download/v4.6/rufus-4.6p.exe
+    InstallerSha256: 8279696C1D78B14618500E9135886A3667B9DECC65946F3729002E4BFDBB20AB
+    Commands:
+      - rufus
+  - Architecture: arm64
+    InstallerType: portable
+    Scope: user
+    InstallerUrl: https://github.com/pbatard/rufus/releases/download/v4.6/rufus-4.6p.exe
+    InstallerSha256: 8279696C1D78B14618500E9135886A3667B9DECC65946F3729002E4BFDBB20AB
+    Commands:
+      - rufus
 ManifestType: installer
 ManifestVersion: 1.6.0


### PR DESCRIPTION
Checklist for Pull Requests
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] This PR only modifies one (1) manifest
- [X] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

PR #191556 by @SomeStreamsandMaybePanels has overwritten the functionality to correctly install rufus by its architecture, there always x64 version would have been installed on all architectures.
Also this PR adds support for machine wide and user scope installers.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/193739)