### PR TITLE
Atlassian.Sourcetree 3.4.21: change machine scope installer to msi

### DIFF
--- a/manifests/a/Atlassian/Sourcetree/3.4.21/Atlassian.Sourcetree.installer.yaml
+++ b/manifests/a/Atlassian/Sourcetree/3.4.21/Atlassian.Sourcetree.installer.yaml
@@ -1,10 +1,9 @@
-# Created with komac v2.6.0
+# Created with YamlCreate.ps1 v2.4.1 $debug=QUSU.CRLF.7-4-6.Win32NT
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: Atlassian.Sourcetree
 PackageVersion: 3.4.21
 InstallerLocale: en-US
-InstallerType: exe
 InstallModes:
 - interactive
 - silent
@@ -13,14 +12,17 @@ UpgradeBehavior: install
 ReleaseDate: 2024-11-13
 Installers:
 - Architecture: x86
+  InstallerType: exe
   Scope: user
   InstallerUrl: https://product-downloads.atlassian.com/software/sourcetree/windows/ga/SourceTreeSetup-3.4.21.exe
   InstallerSha256: 503D4C1FBAD714ACDA48B76DBBBFC7F1CF64F3BD73FB3BAE887F8024CD93C8EE
 - Architecture: x64
+  InstallerType: wix
   Scope: machine
-  InstallerUrl: https://product-downloads.atlassian.com/software/sourcetree/windows/ga/SourceTreeSetup-3.4.21.exe
-  InstallerSha256: 503D4C1FBAD714ACDA48B76DBBBFC7F1CF64F3BD73FB3BAE887F8024CD93C8EE
+  InstallerUrl: https://product-downloads.atlassian.com/software/sourcetree/windows/ga/SourcetreeEnterpriseSetup_3.4.21.msi
+  InstallerSha256: 7AEC40FFA4E28210C49467C56B5679934094E4B861557EC71B6776F419B0E125
   InstallerSwitches:
     Custom: ACCEPTEULA=1
+  ProductCode: '{8A756017-B20E-444E-A184-2DFF6CEA85FF}'
 ManifestType: installer
 ManifestVersion: 1.6.0


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

Previous manifest version used the msi installer for the machine scope. Now this has been (needlessly) changed to exe, possibly due to [this komac bug](https://github.com/russellbanks/Komac/issues/488). This PR corrects this.