### PR TITLE
fix: broken betterbird download links

### DIFF
--- a/manifests/b/Betterbird/Betterbird/115.18.0/Betterbird.Betterbird.installer.yaml
+++ b/manifests/b/Betterbird/Betterbird/115.18.0/Betterbird.Betterbird.installer.yaml
@@ -22,42 +22,42 @@ FileExtensions:
 Installers:
 - InstallerLocale: en-US
   Architecture: x64
-  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.18.0-bb36.en-US.win64.installer.exe
+  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.18.0-bb36-build3.en-US.win64.installer.exe
   InstallerSha256: BA2EB309C2469C0D09DB32BDD6522B95EF03636C87B542E067FCA05B50F938B0
   ProductCode: Betterbird 115.18.0 (x64 en-US)
 - InstallerLocale: de
   Architecture: x64
-  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.18.0-bb36.de.win64.installer.exe
+  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.18.0-bb36-build3.de.win64.installer.exe
   InstallerSha256: DC3BDCAEDD977C240C528597D0A4813A4EB03DCC5D6F904676CA938C73E9F049
   ProductCode: Betterbird 115.18.0 (x64 de)
 - InstallerLocale: es-AR
   Architecture: x64
-  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.18.0-bb36.es-AR.win64.installer.exe
+  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.18.0-bb36-build3.es-AR.win64.installer.exe
   InstallerSha256: FD0A5346E0E6C7F85C934309296DD85B7D319416DEBF0848148A6F565A440C0A
   ProductCode: Betterbird 115.18.0 (x64 es-AR)
 - InstallerLocale: fr
   Architecture: x64
-  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.18.0-bb36.fr.win64.installer.exe
+  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.18.0-bb36-build3.fr.win64.installer.exe
   InstallerSha256: 137914BC5391E546267EE7077A77C250440F50BCB0CE51C7832C67712715817E
   ProductCode: Betterbird 115.18.0 (x64 fr)
 - InstallerLocale: it
   Architecture: x64
-  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.18.0-bb36.it.win64.installer.exe
+  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.18.0-bb36-build3.it.win64.installer.exe
   InstallerSha256: 3DA59BF6F4152A72F2B7E805457C25656DCE2A1F3D178E6A1DDC23C08FE83A2B
   ProductCode: Betterbird 115.18.0 (x64 it)
 - InstallerLocale: ja
   Architecture: x64
-  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.18.0-bb36.ja.win64.installer.exe
+  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.18.0-bb36-build3.ja.win64.installer.exe
   InstallerSha256: ADA8B3A31BF5174B458537DA651FED553FB6B0299EEF71A8F732D2B073FD0331
   ProductCode: Betterbird 115.18.0 (x64 ja)
 - InstallerLocale: nl
   Architecture: x64
-  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.18.0-bb36.nl.win64.installer.exe
+  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.18.0-bb36-build3.nl.win64.installer.exe
   InstallerSha256: D0CCD3C12791F2AD40197CE17E652135087F58C91D63479176CD33D8BCA5E412
   ProductCode: Betterbird 115.18.0 (x64 nl)
 - InstallerLocale: pt-BR
   Architecture: x64
-  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.18.0-bb36.pt-BR.win64.installer.exe
+  InstallerUrl: https://www.betterbird.eu/downloads/WindowsInstaller/betterbird-115.18.0-bb36-build3.pt-BR.win64.installer.exe
   InstallerSha256: ADC015C51F16009DEC404442C1209906FFB553154CD854F0B266F667252F45E0
   ProductCode: Betterbird 115.18.0 (x64 pt-BR)
 ManifestType: installer


### PR DESCRIPTION
According to https://www.betterbird.eu/downloads/index.php, build3 will be available 27 Nov. 2024.

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/194612)