### PR TITLE
Modify: wire.wire version 3.36.4913

### DIFF
--- a/manifests/w/wire/wire/3.36.4913/wire.wire.installer.yaml
+++ b/manifests/w/wire/wire/3.36.4913/wire.wire.installer.yaml
@@ -1,5 +1,5 @@
 # Created with komac v2.6.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 
 PackageIdentifier: wire.wire
 PackageVersion: 3.36.4913
@@ -7,14 +7,12 @@ InstallerType: exe
 Scope: user
 InstallModes:
 - silent
-- silentWithProgress
 InstallerSwitches:
   Silent: --silent
-  SilentWithProgress: ' '
 ReleaseDate: 2024-11-05
 Installers:
 - Architecture: x86
   InstallerUrl: https://github.com/wireapp/wire-desktop/releases/download/windows/3.36.4913/Wire-Setup.exe
   InstallerSha256: 7E9D011C6DAC2C4523F223F66A9EF58C2B00962A9EC0BAF1D35D004C2C2E681D
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/w/wire/wire/3.36.4913/wire.wire.installer.yaml
+++ b/manifests/w/wire/wire/3.36.4913/wire.wire.installer.yaml
@@ -14,8 +14,5 @@ Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/wireapp/wire-desktop/releases/download/windows/3.36.4913/Wire-Setup.exe
   InstallerSha256: 7E9D011C6DAC2C4523F223F66A9EF58C2B00962A9EC0BAF1D35D004C2C2E681D
-- Architecture: x86
-  InstallerUrl: https://github.com/wireapp/wire-desktop/releases/download/windows/3.36.4913/Wire-Setup.exe
-  InstallerSha256: 7E9D011C6DAC2C4523F223F66A9EF58C2B00962A9EC0BAF1D35D004C2C2E681D
 ManifestType: installer
 ManifestVersion: 1.9.0

--- a/manifests/w/wire/wire/3.36.4913/wire.wire.installer.yaml
+++ b/manifests/w/wire/wire/3.36.4913/wire.wire.installer.yaml
@@ -11,6 +11,9 @@ InstallerSwitches:
   Silent: --silent
 ReleaseDate: 2024-11-05
 Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/wireapp/wire-desktop/releases/download/windows/3.36.4913/Wire-Setup.exe
+  InstallerSha256: 7E9D011C6DAC2C4523F223F66A9EF58C2B00962A9EC0BAF1D35D004C2C2E681D
 - Architecture: x86
   InstallerUrl: https://github.com/wireapp/wire-desktop/releases/download/windows/3.36.4913/Wire-Setup.exe
   InstallerSha256: 7E9D011C6DAC2C4523F223F66A9EF58C2B00962A9EC0BAF1D35D004C2C2E681D

--- a/manifests/w/wire/wire/3.36.4913/wire.wire.locale.en-US.yaml
+++ b/manifests/w/wire/wire/3.36.4913/wire.wire.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with komac v2.6.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 
 PackageIdentifier: wire.wire
 PackageVersion: 3.36.4913
@@ -21,4 +21,4 @@ Tags:
 - wire
 ReleaseNotesUrl: https://github.com/wireapp/wire-desktop/releases/tag/windows/3.36.4913
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/w/wire/wire/3.36.4913/wire.wire.locale.en-US.yaml
+++ b/manifests/w/wire/wire/3.36.4913/wire.wire.locale.en-US.yaml
@@ -19,6 +19,11 @@ Tags:
 - electron
 - hacktoberfest
 - wire
+ReleaseNotes: |
+  Whats New
+    - Support for hardware acceleration for calling improvements
+    - Updated shortcuts for the top menu
+    - Security Improvements
 ReleaseNotesUrl: https://github.com/wireapp/wire-desktop/releases/tag/windows/3.36.4913
 ManifestType: defaultLocale
 ManifestVersion: 1.9.0

--- a/manifests/w/wire/wire/3.36.4913/wire.wire.locale.zh-CN.yaml
+++ b/manifests/w/wire/wire/3.36.4913/wire.wire.locale.zh-CN.yaml
@@ -1,0 +1,28 @@
+# Created with komac v2.6.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.9.0.schema.json
+
+PackageIdentifier: wire.wire
+PackageVersion: 3.36.4913
+PackageLocale: zh-CN
+Publisher: Wire
+PublisherUrl: https://github.com/wireapp/wire-desktop
+PublisherSupportUrl: https://github.com/wireapp/wire-desktop/issues
+Author: Wire
+PackageName: Wire
+PackageUrl: https://github.com/wireapp/wire-desktop
+License: GPL-3.0
+LicenseUrl: https://github.com/wireapp/wire-desktop/blob/HEAD/LICENSE
+CopyrightUrl: https://github.com/wireapp/wire-desktop/blob/dev/LICENSE
+ShortDescription: 最安全的协作平台。
+Tags:
+- 桌面
+- electron
+- hacktoberfest
+- wire
+ReleaseNotes: |
+  - 支持硬件加速以提升呼叫性能
+  - 更新了顶部菜单的快捷键
+  - 安全性改进
+ReleaseNotesUrl: https://github.com/wireapp/wire-desktop/releases/tag/windows/3.36.4913
+ManifestType: locale
+ManifestVersion: 1.9.0

--- a/manifests/w/wire/wire/3.36.4913/wire.wire.yaml
+++ b/manifests/w/wire/wire/3.36.4913/wire.wire.yaml
@@ -1,8 +1,8 @@
 # Created with komac v2.6.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
 
 PackageIdentifier: wire.wire
 PackageVersion: 3.36.4913
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Removes incorrect "silent with progress" installation switch. Update to Manifest version 1.9.0

---

清单验证成功，但出现警告。
Manifest Warning: Silent and SilentWithProgress switches are not specified for InstallerType exe. Please make sure the installer can run unattended.

Checklist for Pull Requests
- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.9.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/196499)