### PR TITLE
Modify: wire.wire version 3.31.4421

### DIFF
--- a/manifests/w/wire/wire/3.31.4421/wire.wire.installer.yaml
+++ b/manifests/w/wire/wire/3.31.4421/wire.wire.installer.yaml
@@ -1,5 +1,5 @@
 # Created with WinGet Automation using Komac v1.10.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 
 PackageIdentifier: wire.wire
 PackageVersion: 3.31.4421
@@ -7,14 +7,12 @@ InstallerType: exe
 Scope: user
 InstallModes:
 - silent
-- silentWithProgress
 InstallerSwitches:
   Silent: --silent
-  SilentWithProgress: ' '
 ReleaseDate: 2023-05-16
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/wireapp/wire-desktop/releases/download/windows/3.31.4421/Wire-Setup.exe
   InstallerSha256: 20DFF70BB15B8F8BC8B9D44F939A684FCA9C31122CFD9254BD4E4CC64C28F8D3
 ManifestType: installer
-ManifestVersion: 1.5.0
+ManifestVersion: 1.9.0

--- a/manifests/w/wire/wire/3.31.4421/wire.wire.locale.en-US.yaml
+++ b/manifests/w/wire/wire/3.31.4421/wire.wire.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with WinGet Automation using Komac v1.10.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 
 PackageIdentifier: wire.wire
 PackageVersion: 3.31.4421
@@ -23,4 +23,4 @@ ReleaseNotes: |-
   - Screen sharing requires now minimum webapp >= 2022-06-30
 ReleaseNotesUrl: https://github.com/wireapp/wire-desktop/releases/tag/windows/3.31.4421
 ManifestType: defaultLocale
-ManifestVersion: 1.5.0
+ManifestVersion: 1.9.0

--- a/manifests/w/wire/wire/3.31.4421/wire.wire.yaml
+++ b/manifests/w/wire/wire/3.31.4421/wire.wire.yaml
@@ -1,8 +1,8 @@
 # Created with WinGet Automation using Komac v1.10.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
 
 PackageIdentifier: wire.wire
 PackageVersion: 3.31.4421
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.5.0
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Removes incorrect "silent with progress" installation switch. Update to Manifest version 1.9.0

---

清单验证成功，但出现警告。
Manifest Warning: Silent and SilentWithProgress switches are not specified for InstallerType exe. Please make sure the installer can run unattended.

Checklist for Pull Requests
- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.9.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/196504)