### PR TITLE
Modify: wire.wire version 3.27.4223

### DIFF
--- a/manifests/w/wire/wire/3.27.4223/wire.wire.installer.yaml
+++ b/manifests/w/wire/wire/3.27.4223/wire.wire.installer.yaml
@@ -1,5 +1,5 @@
 # Created with YamlCreate.ps1 v2.1.2 $debug=QUSU.7-2-2
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 
 PackageIdentifier: wire.wire
 PackageVersion: 3.27.4223
@@ -8,14 +8,12 @@ InstallerType: exe
 Scope: user
 InstallerSwitches:
   Silent: --silent
-  SilentWithProgress: ' '
 InstallModes:
   - silent
-  - silentWithProgress
 ReleaseDate: 2022-04-12
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/wireapp/wire-desktop/releases/download/windows%2F3.27.4223/Wire-Setup.exe
   InstallerSha256: 3D335159E8FD2C05431C0E66D0252616B448301AD95B261F8D93C9EF3B8B6D2D
 ManifestType: installer
-ManifestVersion: 1.1.0
+ManifestVersion: 1.9.0

--- a/manifests/w/wire/wire/3.27.4223/wire.wire.locale.en-US.yaml
+++ b/manifests/w/wire/wire/3.27.4223/wire.wire.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with YamlCreate.ps1 v2.1.2 $debug=QUSU.7-2-2
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 
 PackageIdentifier: wire.wire
 PackageVersion: 3.27.4223
@@ -32,4 +32,4 @@ ReleaseNotes: |-
   • Fix default backend config (Windows versions were not affected)
 ReleaseNotesUrl: https://github.com/wireapp/wire-desktop/releases/tag/windows%2F3.27.4223
 ManifestType: defaultLocale
-ManifestVersion: 1.1.0
+ManifestVersion: 1.9.0

--- a/manifests/w/wire/wire/3.27.4223/wire.wire.yaml
+++ b/manifests/w/wire/wire/3.27.4223/wire.wire.yaml
@@ -1,8 +1,8 @@
 # Created with YamlCreate.ps1 v2.1.2 $debug=QUSU.7-2-2
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
 
 PackageIdentifier: wire.wire
 PackageVersion: 3.27.4223
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.1.0
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Removes incorrect "silent with progress" installation switch. Update to Manifest version 1.9.0

---

清单验证成功，但出现警告。
Manifest Warning: Silent and SilentWithProgress switches are not specified for InstallerType exe. Please make sure the installer can run unattended.

Checklist for Pull Requests
- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.9.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/196508)