### PR TITLE
New package: KGSOnline.CGoban version 3.5.23

### DIFF
--- a/manifests/k/KGSOnline/CGoban/3.5.23/KGSOnline.CGoban.installer.yaml
+++ b/manifests/k/KGSOnline/CGoban/3.5.23/KGSOnline.CGoban.installer.yaml
@@ -1,0 +1,12 @@
+# Created using wingetcreate 1.9.2.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: KGSOnline.CGoban
+PackageVersion: 3.5.23
+InstallerType: inno
+Installers:
+- Architecture: x86
+  InstallerUrl: https://files.gokgs.com/javaBin/cgoban.exe
+  InstallerSha256: 623385AF77E75A6F315E7625C5AE72EE919EA064A4F57C7F9F6993A04697F0D7
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/k/KGSOnline/CGoban/3.5.23/KGSOnline.CGoban.locale.en-US.yaml
+++ b/manifests/k/KGSOnline/CGoban/3.5.23/KGSOnline.CGoban.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# Created using wingetcreate 1.9.2.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: KGSOnline.CGoban
+PackageVersion: 3.5.23
+PackageLocale: en-US
+Publisher: KGS Online
+PublisherUrl: https://www.gokgs.com
+PublisherSupportUrl: https://www.gokgs.com/help
+PrivacyUrl: https://www.gokgs.com/tos.jsp
+Author: William Shubert
+PackageName: CGoban
+PackageUrl: http://www.gokgs.com/download.jsp
+License: Freeware
+Copyright: Copyright © William Shubert
+ShortDescription: Official client of the KGS Go Server.
+Agreements:
+- AgreementLabel: KGS Terms of Service
+  AgreementUrl: https://www.gokgs.com/tos.jsp
+ReleaseNotesUrl: http://files.gokgs.com/changeLog.txt
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/k/KGSOnline/CGoban/3.5.23/KGSOnline.CGoban.yaml
+++ b/manifests/k/KGSOnline/CGoban/3.5.23/KGSOnline.CGoban.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.9.2.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: KGSOnline.CGoban
+PackageVersion: 3.5.23
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
This is the latest version of the CGoban client that was published on the website https://www.gokgs.com. This version is still functional but it warns on startup that a new version is available. A newer version of the client is published by KGS AI Services, LLC on the website https://kgsai.com/ and is the object of #196641.

---

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.9.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/196636)