### PR TITLE
Fix for Tools/SandboxTest.ps1 to handle missing dependency files

### DIFF
--- a/Tools/SandboxTest.ps1
+++ b/Tools/SandboxTest.ps1
@@ -269,8 +269,8 @@ function Test-FileChecksum {
     )
 
     # Get the hash of the file that is currently at the expected location for the dependency; This can be $null
-    $currentHash = (Get-FileHash -Path $Path -Algorithm $Algorithm -ErrorAction SilentlyContinue).Hash
-    return ($currentHash -eq $ExpectedChecksum)
+    $currentHash = Get-FileHash -Path $Path -Algorithm $Algorithm -ErrorAction SilentlyContinue
+    return ($currentHash -and $currentHash.Hash -eq $ExpectedChecksum)
 }
 
 #### Start of main script ####


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Is there a linked Issue? #196638 

Fix just checks if the hash object is null (for missing file) or not before doing the member equality check.
---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/196640)