### PR TITLE
[PHP] Add PHP 8.1

### DIFF
--- a/manifests/p/PHP/PHP/8/1/8.1.31/PHP.PHP.8.1.installer.yaml
+++ b/manifests/p/PHP/PHP/8/1/8.1.31/PHP.PHP.8.1.installer.yaml
@@ -1,0 +1,32 @@
+# Created with PHPWatch/winget-pkgs - https://github.com/PHPWatch/php-winget-manifest
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: PHP.PHP.8.1
+PackageVersion: 8.1.31
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: php.exe
+    PortableCommandAlias: php
+Commands:
+  - php
+  - php81
+UpgradeBehavior: install
+ReleaseDate: 2024-11-19
+ArchiveBinariesDependOnPath: true
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://windows.php.net/downloads/releases/php-8.1.31-Win32-vs16-x64.zip
+    InstallerSha256: 3f558f92d687945fcbbaf0e6495a5d3845574e50c41ef6d0d45a87d6b258950c
+    Dependencies:
+      PackageDependencies:
+        - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+  - Architecture: x86
+    InstallerUrl: https://windows.php.net/downloads/releases/php-8.1.31-Win32-vs16-x86.zip
+    InstallerSha256: 57ae2fb8c6894466dda2a12890a6e7a1d2ab1d7888ebb8f45d74e7387bf5066e
+    Dependencies:
+      PackageDependencies:
+        - PackageIdentifier: Microsoft.VCRedist.2015+.x86
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/p/PHP/PHP/8/1/8.1.31/PHP.PHP.8.1.locale.en-US.yaml
+++ b/manifests/p/PHP/PHP/8/1/8.1.31/PHP.PHP.8.1.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# Created with PHPWatch/winget-pkgs - https://github.com/PHPWatch/php-winget-manifest
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: PHP.PHP.8.1
+Description: "PHP (recursive acronym for PHP: Hypertext Preprocessor) is a widely-used open source general-purpose scripting language that is especially suited for web development and can be embedded into HTML."
+ShortDescription: PHP 8.1
+PackageVersion: 8.1.31
+ReleaseNotesUrl: https://www.php.net/ChangeLog-8.php#8.1.31
+PackageLocale: en-US
+Publisher: PHP Group
+PublisherUrl: https://php.net
+PublisherSupportUrl: https://www.php.net/docs.php
+Author: PHP Group
+PackageName: PHP 8.1
+PackageUrl: https://php.net
+License: PHP License v3.01
+LicenseUrl: http://www.php.net/license/3_01.txt
+Copyright: (c) PHP Group
+CopyrightUrl: https://www.php.net/credits.php
+Moniker: php8.1
+Tags:
+  - php
+  - php81
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/p/PHP/PHP/8/1/8.1.31/PHP.PHP.8.1.yaml
+++ b/manifests/p/PHP/PHP/8/1/8.1.31/PHP.PHP.8.1.yaml
@@ -1,0 +1,8 @@
+# Created with PHPWatch/winget-pkgs - https://github.com/PHPWatch/php-winget-manifest
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: PHP.PHP.8.1
+PackageVersion: 8.1.31
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Follow-up to #196185 (PHP 8.4), #196728 (PHP 8.3), and #196743 (PHP 8.2)

This PR requests to add PHP 8.1.

PHP 8.1 is currently the oldest supported PHP version, reaching EOL on [2025 December](https://www.php.net/supported-versions.php).

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.9.0)?

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/196759)