### PR TITLE
Remove: Martchus.syncthingtray `.validation`

### DIFF
--- a/manifests/m/Martchus/syncthingtray/.validation
+++ b/manifests/m/Martchus/syncthingtray/.validation
@@ -1,1 +1,0 @@
-{"ValidationVersion":"1.0.0","Waivers":[{"WaiverId":"b00f6fee-bdc3-460f-a317-4ba0d3e3dec4","TestPlan":"Validation-Executable-Error","PackagePath":"manifests/m/Martchus/syncthingtray/1.3.3","CommitId":"9131d6609f9588031373b74adc11d7279a99f4dd"}]}


### PR DESCRIPTION
Removes `manifests/m/Martchus/syncthingtray/.validation`.

- https://github.com/microsoft/winget-pkgs/pull/196517#issuecomment-2520065535

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/196886)