### PR TITLE
New package: TongHuaShun.TongHuaShun.Freeldy version 9.30.90

### DIFF
--- a/manifests/t/TongHuaShun/TongHuaShun/Freeldy/9.30.90/TongHuaShun.TongHuaShun.Freeldy.installer.yaml
+++ b/manifests/t/TongHuaShun/TongHuaShun/Freeldy/9.30.90/TongHuaShun.TongHuaShun.Freeldy.installer.yaml
@@ -1,0 +1,30 @@
+# Created with komac v2.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: TongHuaShun.TongHuaShun.Freeldy
+PackageVersion: "9.30.90"
+InstallerLocale: zh-CN
+InstallerType: inno
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+#ProductCode: 捻摯㩥䥕䝟瑥啇䑉�_is1 --> komac generates garbled code
+ReleaseDate: 2024-11-27
+#AppsAndFeaturesEntries:
+#- DisplayName: 곍ꢻ돋 --> komac generates garbled code
+#  Publisher: 궽쮺싐곍ꢻ돋에ꋏ즹�탓�ꮹ뻋 --> komac generates garbled code
+#  ProductCode: 捻摯㩥䥕䝟瑥啇䑉�_is1 --> komac generates garbled code
+# ElevationRequirement: elevatesSelf --> komac generates
+#InstallationMetadata:
+#  DefaultInstallLocation: 獻絤최뮬쮨좳볭峾곍ꢻ돋 --> komac generates garbled code
+Installers:
+- Architecture: x86
+  InstallerUrl: https://sp.thsi.cn/staticS3/mobileweb-upload-static-server.file/app_6/downloadcenter/THS_insoft_9.30.90_1127.exe
+  InstallerSha256: 0D652CB8434D8EF5189914C53AF0058489353F0E649C56ED1765B11D4EE2E5C7
+- Architecture: x64
+  InstallerUrl: https://sp.thsi.cn/staticS3/mobileweb-upload-static-server.file/app_6/downloadcenter/THS_insoft_9.30.90_1127.exe
+  InstallerSha256: 0D652CB8434D8EF5189914C53AF0058489353F0E649C56ED1765B11D4EE2E5C7
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/t/TongHuaShun/TongHuaShun/Freeldy/9.30.90/TongHuaShun.TongHuaShun.Freeldy.locale.zh-CN.yaml
+++ b/manifests/t/TongHuaShun/TongHuaShun/Freeldy/9.30.90/TongHuaShun.TongHuaShun.Freeldy.locale.zh-CN.yaml
@@ -1,0 +1,26 @@
+# Created with komac v2.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: TongHuaShun.TongHuaShun.Freeldy
+PackageVersion: "9.30.90"
+PackageLocale: zh-CN
+Publisher: 浙江核新同花顺网络信息股份有限公司
+PrivacyUrl: https://www.10jqka.com.cn/ia/pass_buck.php?bfid=mkt_20190311_free_486.btn.5
+PublisherUrl: https://www.10jqka.com.cn/
+PublisherSupportUrl: https://news.10jqka.com.cn/homepage/intro/contact-us
+Author: 浙江同花顺互联信息技术有限公司
+PackageName: 同花顺免费版 # --> komac generates "同花顺(v9.30.90)
+PackageUrl: https://mams.10jqka.com.cn/new/server/html/61557.html
+License: Proprietary
+Copyright: Copyright@1995-2024 浙江核新同花顺网络信息股份有限公司 # --> komac generates
+ShortDescription: 股票投资理财程序
+Moniker: 同花顺财经
+Tags:
+- 投资
+- 炒股
+- 理财
+- 股票
+- 财经
+ReleaseNotesUrl: https://mams.10jqka.com.cn/new/server/html/61174.html
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/t/TongHuaShun/TongHuaShun/Freeldy/9.30.90/TongHuaShun.TongHuaShun.Freeldy.yaml
+++ b/manifests/t/TongHuaShun/TongHuaShun/Freeldy/9.30.90/TongHuaShun.TongHuaShun.Freeldy.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: TongHuaShun.TongHuaShun.Freeldy
+PackageVersion: "9.30.90"
+DefaultLocale: zh-CN
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
On the domain name issue, the domain name should be correct. The domain where the software is installed can be found in the source code of the package page:
![image](https://github.com/user-attachments/assets/fea82704-8de3-4c0c-ad7e-7a4f5bab6834)

---

Manual verification failed:
![image](https://github.com/user-attachments/assets/78876f30-c315-429e-a085-2e9cd18215f7)

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/197014)