### PR TITLE
Powershell 7.4.6.0: Provide msix for arm instead of msi

### DIFF
--- a/manifests/m/Microsoft/PowerShell/7.4.6.0/Microsoft.PowerShell.installer.yaml
+++ b/manifests/m/Microsoft/PowerShell/7.4.6.0/Microsoft.PowerShell.installer.yaml
@@ -14,10 +14,14 @@ Commands:
 ReleaseDate: 2024-10-22
 Installers:
 - Architecture: x64
+  InstallerType: wix
+  Scope: machine
   InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.4.6/PowerShell-7.4.6-win-x64.msi
   InstallerSha256: ED331A04679B83D4C013705282D1F3F8D8300485EB04C081F36E11EAF1148BD0
   ProductCode: '{AA89DEED-9030-494E-9F28-53A4D9B55D12}'
 - Architecture: x86
+  InstallerType: wix
+  Scope: machine
   InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.4.6/PowerShell-7.4.6-win-x86.msi
   InstallerSha256: A3F17465BA4B0838B37B5B6F93D03EFEBC49B065CE5A93D51F1A9BD364DF3E30
   ProductCode: '{1E0DA27E-792E-4909-A1EE-BBEC76EFDF79}'

--- a/manifests/m/Microsoft/PowerShell/7.4.6.0/Microsoft.PowerShell.installer.yaml
+++ b/manifests/m/Microsoft/PowerShell/7.4.6.0/Microsoft.PowerShell.installer.yaml
@@ -4,8 +4,6 @@
 PackageIdentifier: Microsoft.PowerShell
 PackageVersion: 7.4.6.0
 MinimumOSVersion: 10.0.17763.0
-InstallerType: wix
-Scope: machine
 InstallModes:
 - interactive
 - silent
@@ -23,9 +21,25 @@ Installers:
   InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.4.6/PowerShell-7.4.6-win-x86.msi
   InstallerSha256: A3F17465BA4B0838B37B5B6F93D03EFEBC49B065CE5A93D51F1A9BD364DF3E30
   ProductCode: '{1E0DA27E-792E-4909-A1EE-BBEC76EFDF79}'
+- Architecture: arm
+  MinimumOSVersion: 10.0.17763.0
+  Platform:
+  - Windows.Universal
+  InstallerType: msix
+  Scope: user
+  InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.4.6/PowerShell-7.4.6-win.msixbundle
+  InstallerSha256: 55587D2D6F3A5B1F3320524141E752DFB7D7CFACAE18A1D644E4CF0FE813C416
+  SignatureSha256: 0BA89D4526AAF46BC04A0DDBE764DC5E43024DC0EEA84DD34494A86070B7C5D2
+  PackageFamilyName: Microsoft.PowerShell_8wekyb3d8bbwe
 - Architecture: arm64
-  InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.4.6/PowerShell-7.4.6-win-Arm64.msi
-  InstallerSha256: 16A649D1F47E0020D38D893AF1C5037EAED7DFCE76ED420675C589CD54E3A079
-  ProductCode: '{308FEE22-3045-45F9-A35F-D9B45048341F}'
+  MinimumOSVersion: 10.0.17763.0
+  Platform:
+  - Windows.Universal
+  InstallerType: msix
+  Scope: user
+  InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.4.6/PowerShell-7.4.6-win.msixbundle
+  InstallerSha256: 55587D2D6F3A5B1F3320524141E752DFB7D7CFACAE18A1D644E4CF0FE813C416
+  SignatureSha256: 0BA89D4526AAF46BC04A0DDBE764DC5E43024DC0EEA84DD34494A86070B7C5D2
+  PackageFamilyName: Microsoft.PowerShell_8wekyb3d8bbwe
 ManifestType: installer
 ManifestVersion: 1.6.0


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Is there a linked Issue?

While the msi for arm is available on PowerShell's GitHub page, it's not intended to be made available via winget for 7.4 releases as we had previously been including the msix and we don't want to break upgrade behavior of users going from msix to msi within this release version.

PR https://github.com/microsoft/winget-pkgs/pull/186064 had included the arm msi for 7.4.6, and this PR will change that to msix.

The msi may be causing upgrade issue as reported on this issue: https://github.com/PowerShell/PowerShell/issues/24499
An engineer on our team was able to repro for arm only.
Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.9.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/197580)