### PR TITLE
Add elevationRequirement to BlenderFoundation.Blender version 4.3.1

### DIFF
--- a/manifests/b/BlenderFoundation/Blender/4.3.1/BlenderFoundation.Blender.installer.yaml
+++ b/manifests/b/BlenderFoundation/Blender/4.3.1/BlenderFoundation.Blender.installer.yaml
@@ -8,6 +8,7 @@ Scope: machine
 InstallerSwitches:
   InstallLocation: INSTALL_ROOT="<INSTALLPATH>"
 UpgradeBehavior: uninstallPrevious
+ElevationRequirement: elevatesSelf
 FileExtensions:
 - blend
 ProductCode: '{79C77119-CFC9-4914-B1CA-4CD2045780FB}'


### PR DESCRIPTION
Add `elevationRequirement` to the manifest for a completer manifest & so that WinGet shows helpful output when installing the package.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/198509)