### PR TITLE
Add elevationRequirement to BlenderFoundation.Blender.LTS.3.3 version 3.3.19

### DIFF
--- a/manifests/b/BlenderFoundation/Blender/LTS/3/3/3.3.19/BlenderFoundation.Blender.LTS.3.3.installer.yaml
+++ b/manifests/b/BlenderFoundation/Blender/LTS/3/3/3.3.19/BlenderFoundation.Blender.LTS.3.3.installer.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.6.1.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 
 PackageIdentifier: BlenderFoundation.Blender.LTS.3.3
 PackageVersion: 3.3.19
@@ -21,9 +21,10 @@ FileExtensions:
 - ply
 - stl
 ProductCode: '{7A6D6D72-B80A-4DB9-8CE7-855C19A11E2D}'
+ElevationRequirement: elevatesSelf
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.blender.org/release/Blender3.3/blender-3.3.19-windows-x64.msi
   InstallerSha256: 088D9AF8C5816BE358CEE0AF890757024675A27D67006422BFAE4EB96187CCF8
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/b/BlenderFoundation/Blender/LTS/3/3/3.3.19/BlenderFoundation.Blender.LTS.3.3.locale.en-US.yaml
+++ b/manifests/b/BlenderFoundation/Blender/LTS/3/3/3.3.19/BlenderFoundation.Blender.LTS.3.3.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.6.1.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 
 PackageIdentifier: BlenderFoundation.Blender.LTS.3.3
 PackageVersion: 3.3.19
@@ -25,4 +25,4 @@ Tags:
 - rigging
 - vfx
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/b/BlenderFoundation/Blender/LTS/3/3/3.3.19/BlenderFoundation.Blender.LTS.3.3.yaml
+++ b/manifests/b/BlenderFoundation/Blender/LTS/3/3/3.3.19/BlenderFoundation.Blender.LTS.3.3.yaml
@@ -1,8 +1,8 @@
 # Created using wingetcreate 1.6.1.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
 
 PackageIdentifier: BlenderFoundation.Blender.LTS.3.3
 PackageVersion: 3.3.19
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Add `elevationRequirement` to the manifest for a completer manifest & so that WinGet shows helpful output when installing the package.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/198510)