### PR TITLE
Add elevationRequirement to BlenderFoundation.Blender.LTS.3.6 version 3.6.12

### DIFF
--- a/manifests/b/BlenderFoundation/Blender/LTS/3/6/3.6.12/BlenderFoundation.Blender.LTS.3.6.installer.yaml
+++ b/manifests/b/BlenderFoundation/Blender/LTS/3/6/3.6.12/BlenderFoundation.Blender.LTS.3.6.installer.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.6.1.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 
 PackageIdentifier: BlenderFoundation.Blender.LTS.3.6
 PackageVersion: 3.6.12
@@ -21,10 +21,11 @@ FileExtensions:
 - ply
 - stl
 ProductCode: '{74317F41-A4D5-4A90-A22E-CADBBA452983}'
+ElevationRequirement: elevatesSelf
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.blender.org/release/Blender3.6/blender-3.6.12-windows-x64.msi
   InstallerSha256: D2BF006E568F4B4076331D074734D3078E4CEB0DF4EFE4D1BD63FA193C66F71A
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0
 ReleaseDate: 2024-05-21

--- a/manifests/b/BlenderFoundation/Blender/LTS/3/6/3.6.12/BlenderFoundation.Blender.LTS.3.6.locale.en-US.yaml
+++ b/manifests/b/BlenderFoundation/Blender/LTS/3/6/3.6.12/BlenderFoundation.Blender.LTS.3.6.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.6.1.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 
 PackageIdentifier: BlenderFoundation.Blender.LTS.3.6
 PackageVersion: 3.6.12
@@ -18,4 +18,4 @@ Tags:
 - rigging
 - vfx
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/b/BlenderFoundation/Blender/LTS/3/6/3.6.12/BlenderFoundation.Blender.LTS.3.6.yaml
+++ b/manifests/b/BlenderFoundation/Blender/LTS/3/6/3.6.12/BlenderFoundation.Blender.LTS.3.6.yaml
@@ -1,8 +1,8 @@
 # Created using wingetcreate 1.6.1.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
 
 PackageIdentifier: BlenderFoundation.Blender.LTS.3.6
 PackageVersion: 3.6.12
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Add `elevationRequirement` to the manifest for a completer manifest & so that WinGet shows helpful output when installing the package.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/198511)