### PR TITLE
Add elevationRequirement to Docker.DockerDesktop version 4.36.0

### DIFF
--- a/manifests/d/Docker/DockerDesktop/4.36.0/Docker.DockerDesktop.installer.yaml
+++ b/manifests/d/Docker/DockerDesktop/4.36.0/Docker.DockerDesktop.installer.yaml
@@ -1,5 +1,5 @@
 # Created with komac v2.6.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 
 PackageIdentifier: Docker.DockerDesktop
 PackageVersion: 4.36.0
@@ -14,6 +14,7 @@ InstallerSwitches:
   Silent: install --quiet
   SilentWithProgress: install --quiet
 UpgradeBehavior: install
+ElevationRequirement: elevatesSelf
 ReleaseDate: 2024-11-17
 Installers:
 - Architecture: x64
@@ -23,4 +24,4 @@ Installers:
   InstallerUrl: https://desktop.docker.com/win/main/arm64/175267/Docker%20Desktop%20Installer.exe
   InstallerSha256: 8EEC2A8CFD42D008024F0950F091A01C75D3F737860E123DD41DBBEBEAB0312A
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/d/Docker/DockerDesktop/4.36.0/Docker.DockerDesktop.locale.en-US.yaml
+++ b/manifests/d/Docker/DockerDesktop/4.36.0/Docker.DockerDesktop.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with komac v2.6.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 
 PackageIdentifier: Docker.DockerDesktop
 PackageVersion: 4.36.0
@@ -22,4 +22,4 @@ Tags:
 - containerization
 - virtualization
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/d/Docker/DockerDesktop/4.36.0/Docker.DockerDesktop.yaml
+++ b/manifests/d/Docker/DockerDesktop/4.36.0/Docker.DockerDesktop.yaml
@@ -1,8 +1,8 @@
 # Created with komac v2.6.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
 
 PackageIdentifier: Docker.DockerDesktop
 PackageVersion: 4.36.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Add `elevationRequirement` to the manifest for a completer manifest & so that WinGet shows helpful output when installing the package.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/198512)