### PR TITLE
Add elevationRequirement to Elgato.StreamDeck version 6.8.1.21263

### DIFF
--- a/manifests/e/Elgato/StreamDeck/6.8.1.21263/Elgato.StreamDeck.installer.yaml
+++ b/manifests/e/Elgato/StreamDeck/6.8.1.21263/Elgato.StreamDeck.installer.yaml
@@ -5,6 +5,7 @@ PackageIdentifier: Elgato.StreamDeck
 PackageVersion: 6.8.1.21263
 InstallerType: wix
 Scope: machine
+ElevationRequirement: elevatesSelf
 InstallerSwitches:
   InstallLocation: INSTALL_DIR_COMPANY="<INSTALLPATH>"
 UpgradeBehavior: install


### PR DESCRIPTION
Add `elevationRequirement` to the manifest for a completer manifest & so that WinGet shows helpful output when installing the package.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/198513)