### PR TITLE
Add elevationRequirement to FlipperDevicesInc.qFlipper version 1.3.3

### DIFF
--- a/manifests/f/FlipperDevicesInc/qFlipper/1.3.3/FlipperDevicesInc.qFlipper.installer.yaml
+++ b/manifests/f/FlipperDevicesInc/qFlipper/1.3.3/FlipperDevicesInc.qFlipper.installer.yaml
@@ -1,12 +1,14 @@
 # Created using wingetcreate 1.5.7.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 
 PackageIdentifier: FlipperDevicesInc.qFlipper
 PackageVersion: 1.3.3
 InstallerType: nullsoft
+Scope: machine
+ElevationRequirement: elevatesSelf
 Installers:
 - Architecture: x64
   InstallerUrl: https://update.flipperzero.one/builds/qFlipper/1.3.3/qFlipperSetup-64bit-1.3.3.exe
   InstallerSha256: 0AD49533997A8FEDFEC9525CE2F0BE1860D66D5AE8625164717059CF03512BBA
 ManifestType: installer
-ManifestVersion: 1.5.0
+ManifestVersion: 1.9.0

--- a/manifests/f/FlipperDevicesInc/qFlipper/1.3.3/FlipperDevicesInc.qFlipper.locale.en-US.yaml
+++ b/manifests/f/FlipperDevicesInc/qFlipper/1.3.3/FlipperDevicesInc.qFlipper.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.5.7.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 
 PackageIdentifier: FlipperDevicesInc.qFlipper
 PackageVersion: 1.3.3
@@ -10,4 +10,4 @@ License: GPL-3.0
 Copyright: (C) Flipper Devices Inc.
 ShortDescription: qFlipper Windows Installer
 ManifestType: defaultLocale
-ManifestVersion: 1.5.0
+ManifestVersion: 1.9.0

--- a/manifests/f/FlipperDevicesInc/qFlipper/1.3.3/FlipperDevicesInc.qFlipper.yaml
+++ b/manifests/f/FlipperDevicesInc/qFlipper/1.3.3/FlipperDevicesInc.qFlipper.yaml
@@ -1,8 +1,8 @@
 # Created using wingetcreate 1.5.7.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
 
 PackageIdentifier: FlipperDevicesInc.qFlipper
 PackageVersion: 1.3.3
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.5.0
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Add `elevationRequirement` to the manifest for a completer manifest & so that WinGet shows helpful output when installing the package.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/198515)