### PR TITLE
Add elevationRequirement to GnuPG.GnuPG version 2.4.7

### DIFF
--- a/manifests/g/GnuPG/GnuPG/2.4.7/GnuPG.GnuPG.installer.yaml
+++ b/manifests/g/GnuPG/GnuPG/2.4.7/GnuPG.GnuPG.installer.yaml
@@ -1,11 +1,12 @@
 # Created with YamlCreate.ps1 Dumplings Mod
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 
 PackageIdentifier: GnuPG.GnuPG
 PackageVersion: 2.4.7
 InstallerType: nullsoft
 Scope: machine
 UpgradeBehavior: install
+ElevationRequirement: elevatesSelf
 Commands:
 - dirmngr
 - dirmngr_ldap
@@ -30,4 +31,4 @@ Installers:
   InstallerUrl: https://gnupg.org/ftp/gcrypt/binary/gnupg-w32-2.4.7_20241125.exe
   InstallerSha256: CAF2904C02C02C94CBE137F01B63E5A43DBEA92D27EA66E56F0AF4AF2C70C170
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/g/GnuPG/GnuPG/2.4.7/GnuPG.GnuPG.locale.en-US.yaml
+++ b/manifests/g/GnuPG/GnuPG/2.4.7/GnuPG.GnuPG.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with YamlCreate.ps1 Dumplings Mod
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 
 PackageIdentifier: GnuPG.GnuPG
 PackageVersion: 2.4.7
@@ -38,4 +38,4 @@ Documentations:
 - DocumentLabel: Documentation
   DocumentUrl: https://gnupg.org/documentation/
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/g/GnuPG/GnuPG/2.4.7/GnuPG.GnuPG.locale.zh-CN.yaml
+++ b/manifests/g/GnuPG/GnuPG/2.4.7/GnuPG.GnuPG.locale.zh-CN.yaml
@@ -1,5 +1,5 @@
 # Created with YamlCreate.ps1 Dumplings Mod
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.9.0.schema.json
 
 PackageIdentifier: GnuPG.GnuPG
 PackageVersion: 2.4.7
@@ -34,4 +34,4 @@ Documentations:
 - DocumentLabel: 文档
   DocumentUrl: https://gnupg.org/documentation/
 ManifestType: locale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/g/GnuPG/GnuPG/2.4.7/GnuPG.GnuPG.yaml
+++ b/manifests/g/GnuPG/GnuPG/2.4.7/GnuPG.GnuPG.yaml
@@ -1,8 +1,8 @@
 # Created with YamlCreate.ps1 Dumplings Mod
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
 
 PackageIdentifier: GnuPG.GnuPG
 PackageVersion: 2.4.7
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Add `elevationRequirement` to the manifest for a completer manifest & so that WinGet shows helpful output when installing the package.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/198516)