### PR TITLE
Add elevationRequirement to GnuPG.Gpg4win version 4.4.0

### DIFF
--- a/manifests/g/GnuPG/Gpg4win/4.4.0/GnuPG.Gpg4win.installer.yaml
+++ b/manifests/g/GnuPG/Gpg4win/4.4.0/GnuPG.Gpg4win.installer.yaml
@@ -1,11 +1,12 @@
 # Created with YamlCreate.ps1 Dumplings Mod
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 
 PackageIdentifier: GnuPG.Gpg4win
 PackageVersion: 4.4.0
 InstallerType: nullsoft
 Scope: machine
 UpgradeBehavior: install
+ElevationRequirement: elevatesSelf
 Commands:
 - dirmngr
 - dirmngr_ldap
@@ -50,4 +51,4 @@ Installers:
   InstallerUrl: https://files.gpg4win.org/gpg4win-4.4.0.exe
   InstallerSha256: 765673854C1503602B09C97BFA6C72B534E2414185FB2F23A0CE19CF8CECD891
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/g/GnuPG/Gpg4win/4.4.0/GnuPG.Gpg4win.locale.en-US.yaml
+++ b/manifests/g/GnuPG/Gpg4win/4.4.0/GnuPG.Gpg4win.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with YamlCreate.ps1 Dumplings Mod
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 
 PackageIdentifier: GnuPG.Gpg4win
 PackageVersion: 4.4.0
@@ -40,4 +40,4 @@ Documentations:
 - DocumentLabel: Wiki
   DocumentUrl: https://wiki.gnupg.org/
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/g/GnuPG/Gpg4win/4.4.0/GnuPG.Gpg4win.locale.zh-CN.yaml
+++ b/manifests/g/GnuPG/Gpg4win/4.4.0/GnuPG.Gpg4win.locale.zh-CN.yaml
@@ -1,5 +1,5 @@
 # Created with YamlCreate.ps1 Dumplings Mod
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.9.0.schema.json
 
 PackageIdentifier: GnuPG.Gpg4win
 PackageVersion: 4.4.0
@@ -37,4 +37,4 @@ Documentations:
 - DocumentLabel: Wiki
   DocumentUrl: https://wiki.gnupg.org/
 ManifestType: locale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/g/GnuPG/Gpg4win/4.4.0/GnuPG.Gpg4win.yaml
+++ b/manifests/g/GnuPG/Gpg4win/4.4.0/GnuPG.Gpg4win.yaml
@@ -1,8 +1,8 @@
 # Created with YamlCreate.ps1 Dumplings Mod
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
 
 PackageIdentifier: GnuPG.Gpg4win
 PackageVersion: 4.4.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Add `elevationRequirement` to the manifest for a completer manifest & so that WinGet shows helpful output when installing the package.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/198517)