### PR TITLE
Add elevationRequirement to Microsoft.PowerToys version 0.86.0

### DIFF
--- a/manifests/m/Microsoft/PowerToys/0.86.0/Microsoft.PowerToys.installer.yaml
+++ b/manifests/m/Microsoft/PowerToys/0.86.0/Microsoft.PowerToys.installer.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.6.5.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 
 PackageIdentifier: Microsoft.PowerToys
 PackageVersion: 0.86.0
@@ -18,6 +18,7 @@ Installers:
   InstallerSha256: CFB9608B28B8FF12C9A7C9814A6EF981636EB5AB261DC278C28EC93FD959CCE2
 - Architecture: x64
   Scope: machine
+  ElevationRequirement: elevatesSelf
   InstallerUrl: https://github.com/microsoft/PowerToys/releases/download/v0.86.0/PowerToysSetup-0.86.0-x64.exe
   InstallerSha256: 857DE9DC5938D9602F82DFD6183DB5E6823B875A412AEC59B4BE93617E27E9CD
 - Architecture: arm64
@@ -26,8 +27,9 @@ Installers:
   InstallerSha256: 861CEDBFDCDA993D1D1056E3280319D5EA45D142CA3C737AB1FB4FABD651A5F5
 - Architecture: arm64
   Scope: machine
+  ElevationRequirement: elevatesSelf
   InstallerUrl: https://github.com/microsoft/PowerToys/releases/download/v0.86.0/PowerToysSetup-0.86.0-arm64.exe
   InstallerSha256: 6F37192534C195A02A80AAE1E449DF61C894C50763096A06195581801943FA31
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0
 ReleaseDate: 2024-11-04

--- a/manifests/m/Microsoft/PowerToys/0.86.0/Microsoft.PowerToys.locale.en-US.yaml
+++ b/manifests/m/Microsoft/PowerToys/0.86.0/Microsoft.PowerToys.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.6.5.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 
 PackageIdentifier: Microsoft.PowerToys
 PackageVersion: 0.86.0
@@ -36,4 +36,4 @@ Documentations:
 - DocumentLabel: Wiki
   DocumentUrl: https://github.com/microsoft/PowerToys/wiki
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/m/Microsoft/PowerToys/0.86.0/Microsoft.PowerToys.yaml
+++ b/manifests/m/Microsoft/PowerToys/0.86.0/Microsoft.PowerToys.yaml
@@ -1,8 +1,8 @@
 # Created using wingetcreate 1.6.5.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
 
 PackageIdentifier: Microsoft.PowerToys
 PackageVersion: 0.86.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Add `elevationRequirement` to the manifest for a completer manifest & so that WinGet shows helpful output when installing the package.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/198519)