### PR TITLE
Add elevationRequirement to mIRC.mIRC version 7.78

### DIFF
--- a/manifests/m/mIRC/mIRC/7.78/mIRC.mIRC.installer.yaml
+++ b/manifests/m/mIRC/mIRC/7.78/mIRC.mIRC.installer.yaml
@@ -1,10 +1,11 @@
 # Created using wingetcreate 1.6.5.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 
 PackageIdentifier: mIRC.mIRC
 PackageVersion: "7.78"
 MinimumOSVersion: 10.0.0.0
 InstallerType: nullsoft
+ElevationRequirement: elevatesSelf
 InstallerSuccessCodes:
 - 1223
 Installers:
@@ -12,4 +13,4 @@ Installers:
   InstallerUrl: https://www.mirc.com/downloads/mirc/45/mirc778.exe
   InstallerSha256: 0938A619D654860257C2C4F022AC3BB5B6B06230663322FC448FAA2FED0B6ED3
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/m/mIRC/mIRC/7.78/mIRC.mIRC.locale.en-US.yaml
+++ b/manifests/m/mIRC/mIRC/7.78/mIRC.mIRC.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.6.5.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 
 PackageIdentifier: mIRC.mIRC
 PackageVersion: "7.78"
@@ -20,4 +20,4 @@ Tags:
 - chat
 - irc
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/m/mIRC/mIRC/7.78/mIRC.mIRC.yaml
+++ b/manifests/m/mIRC/mIRC/7.78/mIRC.mIRC.yaml
@@ -1,8 +1,8 @@
 # Created using wingetcreate 1.6.5.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
 
 PackageIdentifier: mIRC.mIRC
 PackageVersion: "7.78"
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Add `elevationRequirement` to the manifest for a completer manifest & so that WinGet shows helpful output when installing the package.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/198521)