### PR TITLE
Add elevationRequirement to Nvidia.CUDA version 12.6

### DIFF
--- a/manifests/n/Nvidia/CUDA/12.6/Nvidia.CUDA.installer.yaml
+++ b/manifests/n/Nvidia/CUDA/12.6/Nvidia.CUDA.installer.yaml
@@ -1,10 +1,11 @@
 # Created with YamlCreate.ps1 v2.4.1 Dumplings Mod $debug=QUSU.CRLF.7-4-6.Win32NT
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 
 PackageIdentifier: Nvidia.CUDA
 PackageVersion: "12.6"
 InstallerType: exe
 Scope: machine
+ElevationRequirement: elevatesSelf
 InstallModes:
 - interactive
 - silent
@@ -20,4 +21,4 @@ Installers:
   InstallerSha256: D73E937C75AAA8114DA3AFF4EEE96F9CAE03D4B9D70A30B962CCF3C9B4D7A8E1
   ProductCode: '{B2FE1952-0186-46C3-BAEC-A80AA35AC5B8}_CUDAToolkit_12.6'
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/n/Nvidia/CUDA/12.6/Nvidia.CUDA.locale.en-US.yaml
+++ b/manifests/n/Nvidia/CUDA/12.6/Nvidia.CUDA.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with YamlCreate.ps1 v2.4.1 Dumplings Mod $debug=QUSU.CRLF.7-4-6.Win32NT
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 
 PackageIdentifier: Nvidia.CUDA
 PackageVersion: "12.6"
@@ -33,4 +33,4 @@ Documentations:
 - DocumentLabel: FAQ
   DocumentUrl: https://developer.nvidia.com/cuda-faq
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/n/Nvidia/CUDA/12.6/Nvidia.CUDA.locale.zh-CN.yaml
+++ b/manifests/n/Nvidia/CUDA/12.6/Nvidia.CUDA.locale.zh-CN.yaml
@@ -1,5 +1,5 @@
 # Created with YamlCreate.ps1 v2.4.1 Dumplings Mod $debug=QUSU.CRLF.7-4-6.Win32NT
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.9.0.schema.json
 
 PackageIdentifier: Nvidia.CUDA
 PackageVersion: "12.6"
@@ -33,4 +33,4 @@ Documentations:
 - DocumentLabel: 常见问题
   DocumentUrl: https://developer.nvidia.com/cuda-faq
 ManifestType: locale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/n/Nvidia/CUDA/12.6/Nvidia.CUDA.yaml
+++ b/manifests/n/Nvidia/CUDA/12.6/Nvidia.CUDA.yaml
@@ -1,8 +1,8 @@
 # Created with YamlCreate.ps1 v2.4.1 Dumplings Mod $debug=QUSU.CRLF.7-4-6.Win32NT
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
 
 PackageIdentifier: Nvidia.CUDA
 PackageVersion: "12.6"
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Add `elevationRequirement` to the manifest for a completer manifest & so that WinGet shows helpful output when installing the package.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/198522)