### PR TITLE
Add elevationRequirement to OBSProject.OBSStudio version 31.0.0

### DIFF
--- a/manifests/o/OBSProject/OBSStudio/31.0.0/OBSProject.OBSStudio.installer.yaml
+++ b/manifests/o/OBSProject/OBSStudio/31.0.0/OBSProject.OBSStudio.installer.yaml
@@ -1,5 +1,5 @@
 # Created with komac v2.7.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 
 PackageIdentifier: OBSProject.OBSStudio
 PackageVersion: 31.0.0
@@ -15,6 +15,7 @@ ExpectedReturnCodes:
 - InstallerReturnCode: 6
   ReturnResponse: packageInUseByApplication
 UpgradeBehavior: install
+ElevationRequirement: elevatesSelf
 Dependencies:
   PackageDependencies:
   - PackageIdentifier: Microsoft.VCRedist.2015+.x64
@@ -29,4 +30,4 @@ Installers:
   InstallerUrl: https://github.com/obsproject/obs-studio/releases/download/31.0.0/OBS-Studio-31.0.0-Windows-Installer.exe
   InstallerSha256: 786DBF97F558A9190A30D6C86D7215DFBDCB9D2AAABB8000E3610B2BE19F3F89
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/o/OBSProject/OBSStudio/31.0.0/OBSProject.OBSStudio.locale.en-US.yaml
+++ b/manifests/o/OBSProject/OBSStudio/31.0.0/OBSProject.OBSStudio.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with komac v2.7.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 
 PackageIdentifier: OBSProject.OBSStudio
 PackageVersion: 31.0.0
@@ -109,4 +109,4 @@ ReleaseNotes: |-
   OBS-Studio-31.0.0-macOS-Intel.dmg: 029ae118f8c02d9319cdb29880c65edb674932e2ef2331237091416b50a5f1ba
 ReleaseNotesUrl: https://github.com/obsproject/obs-studio/releases/tag/31.0.0
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/o/OBSProject/OBSStudio/31.0.0/OBSProject.OBSStudio.yaml
+++ b/manifests/o/OBSProject/OBSStudio/31.0.0/OBSProject.OBSStudio.yaml
@@ -1,8 +1,8 @@
 # Created with komac v2.7.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
 
 PackageIdentifier: OBSProject.OBSStudio
 PackageVersion: 31.0.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Add `elevationRequirement` to the manifest for a completer manifest & so that WinGet shows helpful output when installing the package.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/198523)