### PR TITLE
Add elevationRequirement to Obsidian.Obsidian version 1.7.7

### DIFF
--- a/manifests/o/Obsidian/Obsidian/1.7.7/Obsidian.Obsidian.installer.yaml
+++ b/manifests/o/Obsidian/Obsidian/1.7.7/Obsidian.Obsidian.installer.yaml
@@ -1,5 +1,5 @@
 # Created with komac v2.6.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 
 PackageIdentifier: Obsidian.Obsidian
 PackageVersion: 1.7.7
@@ -25,6 +25,7 @@ Installers:
   InstallerSha256: F8097C934D0A4A1022611213255FD11FD0F7BF20A13DB47882DE2D9C25566AE1
   InstallerSwitches:
     Custom: /allusers
+  ElevationRequirement: elevatesSelf
 - Architecture: x64
   Scope: user
   InstallerUrl: https://github.com/obsidianmd/obsidian-releases/releases/download/v1.7.7/Obsidian-1.7.7.exe
@@ -37,6 +38,7 @@ Installers:
   InstallerSha256: F8097C934D0A4A1022611213255FD11FD0F7BF20A13DB47882DE2D9C25566AE1
   InstallerSwitches:
     Custom: /allusers
+  ElevationRequirement: elevatesSelf
 - Architecture: arm64
   Scope: user
   InstallerUrl: https://github.com/obsidianmd/obsidian-releases/releases/download/v1.7.7/Obsidian-1.7.7.exe
@@ -49,5 +51,6 @@ Installers:
   InstallerSha256: F8097C934D0A4A1022611213255FD11FD0F7BF20A13DB47882DE2D9C25566AE1
   InstallerSwitches:
     Custom: /allusers
+  ElevationRequirement: elevatesSelf
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/o/Obsidian/Obsidian/1.7.7/Obsidian.Obsidian.locale.en-US.yaml
+++ b/manifests/o/Obsidian/Obsidian/1.7.7/Obsidian.Obsidian.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with komac v2.6.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 
 PackageIdentifier: Obsidian.Obsidian
 PackageVersion: 1.7.7
@@ -40,4 +40,4 @@ ReleaseNotes: |-
 ReleaseNotesUrl: https://github.com/obsidianmd/obsidian-releases/releases/tag/v1.7.7
 PurchaseUrl: https://obsidian.md/pricing
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/o/Obsidian/Obsidian/1.7.7/Obsidian.Obsidian.locale.zh-CN.yaml
+++ b/manifests/o/Obsidian/Obsidian/1.7.7/Obsidian.Obsidian.locale.zh-CN.yaml
@@ -1,5 +1,5 @@
 # Created with komac v2.6.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.9.0.schema.json
 
 PackageIdentifier: Obsidian.Obsidian
 PackageVersion: 1.7.7
@@ -35,4 +35,4 @@ Tags:
 ReleaseNotesUrl: https://github.com/obsidianmd/obsidian-releases/releases/tag/v1.7.7
 PurchaseUrl: https://obsidian.md/pricing
 ManifestType: locale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/o/Obsidian/Obsidian/1.7.7/Obsidian.Obsidian.yaml
+++ b/manifests/o/Obsidian/Obsidian/1.7.7/Obsidian.Obsidian.yaml
@@ -1,8 +1,8 @@
 # Created with komac v2.6.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
 
 PackageIdentifier: Obsidian.Obsidian
 PackageVersion: 1.7.7
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Add `elevationRequirement` to the manifest for a completer manifest & so that WinGet shows helpful output when installing the package.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/198524)