### PR TITLE
Add elevationRequirement to OpenShot.OpenShot version 3.2.1

### DIFF
--- a/manifests/o/OpenShot/OpenShot/3.2.1/OpenShot.OpenShot.installer.yaml
+++ b/manifests/o/OpenShot/OpenShot/3.2.1/OpenShot.OpenShot.installer.yaml
@@ -1,11 +1,12 @@
 # Created with komac v2.3.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 
 PackageIdentifier: OpenShot.OpenShot
 PackageVersion: 3.2.1
 InstallerLocale: en-US
 InstallerType: inno
 Scope: machine
+ElevationRequirement: elevatesSelf
 InstallModes:
 - interactive
 - silent
@@ -22,4 +23,4 @@ Installers:
   InstallerUrl: https://github.com/OpenShot/openshot-qt/releases/download/v3.2.1/OpenShot-v3.2.1-x86_64.exe
   InstallerSha256: FA13E2E48E0B4C25C3AE38F1418D90B967001BEEDBC8891B6CCFCB9D54118630
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/o/OpenShot/OpenShot/3.2.1/OpenShot.OpenShot.locale.en-US.yaml
+++ b/manifests/o/OpenShot/OpenShot/3.2.1/OpenShot.OpenShot.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with komac v2.3.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 
 PackageIdentifier: OpenShot.OpenShot
 PackageVersion: 3.2.1
@@ -87,4 +87,4 @@ ReleaseNotes: |-
   - 8418a372  2024-06-24 Jonathan Thomas          Merge pull request #5543 from OpenShot/release-20240619
 ReleaseNotesUrl: https://github.com/OpenShot/openshot-qt/releases/tag/v3.2.1
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/o/OpenShot/OpenShot/3.2.1/OpenShot.OpenShot.yaml
+++ b/manifests/o/OpenShot/OpenShot/3.2.1/OpenShot.OpenShot.yaml
@@ -1,8 +1,8 @@
 # Created with komac v2.3.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
 
 PackageIdentifier: OpenShot.OpenShot
 PackageVersion: 3.2.1
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Add `elevationRequirement` to the manifest for a completer manifest & so that WinGet shows helpful output when installing the package.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/198525)