### PR TITLE
Add elevationRequirement to Piriform.Speccy version 1.33

### DIFF
--- a/manifests/p/Piriform/Speccy/1.33/Piriform.Speccy.installer.yaml
+++ b/manifests/p/Piriform/Speccy/1.33/Piriform.Speccy.installer.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.6.1.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 
 PackageIdentifier: Piriform.Speccy
 PackageVersion: "1.33"
@@ -7,6 +7,7 @@ InstallerLocale: en-US
 MinimumOSVersion: 10.0.0.0
 InstallerType: nullsoft
 Scope: machine
+ElevationRequirement: elevatesSelf
 InstallModes:
 - interactive
 - silent
@@ -17,4 +18,4 @@ Installers:
   InstallerUrl: https://download.ccleaner.com/spsetup133.exe
   InstallerSha256: 03C35FCB1D10CF478C0B9896699937E6E262DAA4F4A4353A7CC56B238FE86892
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/p/Piriform/Speccy/1.33/Piriform.Speccy.locale.en-US.yaml
+++ b/manifests/p/Piriform/Speccy/1.33/Piriform.Speccy.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.6.1.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 
 PackageIdentifier: Piriform.Speccy
 PackageVersion: "1.33"
@@ -23,4 +23,4 @@ Tags:
 - system
 - system-information
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/p/Piriform/Speccy/1.33/Piriform.Speccy.yaml
+++ b/manifests/p/Piriform/Speccy/1.33/Piriform.Speccy.yaml
@@ -1,8 +1,8 @@
 # Created using wingetcreate 1.6.1.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
 
 PackageIdentifier: Piriform.Speccy
 PackageVersion: "1.33"
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Add `elevationRequirement` to the manifest for a completer manifest & so that WinGet shows helpful output when installing the package.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/198527)