### PR TITLE
Add elevationRequirement to RARLab.WinRAR version 7.01.0

### DIFF
--- a/manifests/r/RARLab/WinRAR/7.01.0/RARLab.WinRAR.installer.yaml
+++ b/manifests/r/RARLab/WinRAR/7.01.0/RARLab.WinRAR.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 
 PackageIdentifier: RARLab.WinRAR
 PackageVersion: 7.01.0
@@ -14,6 +14,7 @@ InstallerSwitches:
   Silent: /S
   SilentWithProgress: /S
 UpgradeBehavior: install
+ElevationRequirement: elevatesSelf
 Commands:
 - winrar
 FileExtensions:
@@ -329,4 +330,4 @@ Installers:
   InstallerUrl: https://www.rarlab.com/rar/winrar-x32-701vn.exe
   InstallerSha256: 387a74d36243f8254b95aa90458e3323aab0ab36aaffa76099927dbf38edd9b0
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/r/RARLab/WinRAR/7.01.0/RARLab.WinRAR.installer.yaml
+++ b/manifests/r/RARLab/WinRAR/7.01.0/RARLab.WinRAR.installer.yaml
@@ -84,11 +84,11 @@ Installers:
 - InstallerLocale: zh-CN
   Architecture: x64
   InstallerUrl: https://www.rarlab.com/rar/winrar-x64-701sc.exe
-  InstallerSha256: bf66ff1181ec95a383bcefbaf28388230ae77aadc656ed0ac5fec6b8197afb95
+  InstallerSha256: 07316498B0E82392A52C2603147A395401E87D41E3EEB67B856641E7F5DFF16E
 - InstallerLocale: zh-CN
   Architecture: x86
   InstallerUrl: https://www.rarlab.com/rar/winrar-x32-701sc.exe
-  InstallerSha256: dbed3a9fb4de3e247ea22299c565eaecf938f87ee4f2f6269e41b96318159682
+  InstallerSha256: CB966343B293C0DB31ADB6D2C5C98261B9C59C7A2B3A5AB71C4A7F5A54F866B2
 - InstallerLocale: zh-TW
   Architecture: x64
   InstallerUrl: https://www.rarlab.com/rar/winrar-x64-701tc.exe
@@ -172,11 +172,11 @@ Installers:
 - InstallerLocale: el-GR
   Architecture: x64
   InstallerUrl: https://www.rarlab.com/rar/winrar-x64-701el.exe
-  InstallerSha256: b497a39703349c0954b3ebaf09f94ab5ea7c0d8fb3298720b57703d6e1a7422e
+  InstallerSha256: FCD9A1BF632058AD2707154245A5800907B6C547228C1E323A058077543AB5D9
 - InstallerLocale: el-GR
   Architecture: x86
   InstallerUrl: https://www.rarlab.com/rar/winrar-x32-701el.exe
-  InstallerSha256: 83e6aa87cae3964c666ffc79c6c6939504d7632fd0a2adab39e526dcc46b4f91
+  InstallerSha256: D7B8E3B2439B87EA1012533597A9BB9CA7A59384725E69A2F8E1A4A8DBBE8187
 - InstallerLocale: hu-HU
   Architecture: x64
   InstallerUrl: https://www.rarlab.com/rar/winrar-x64-701hu.exe

--- a/manifests/r/RARLab/WinRAR/7.01.0/RARLab.WinRAR.locale.de.yaml
+++ b/manifests/r/RARLab/WinRAR/7.01.0/RARLab.WinRAR.locale.de.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.9.0.schema.json
 
 PackageIdentifier: RARLab.WinRAR
 PackageVersion: 7.01.0
@@ -21,4 +21,4 @@ Tags:
 - rar
 - winrar
 ManifestType: locale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/r/RARLab/WinRAR/7.01.0/RARLab.WinRAR.locale.en.yaml
+++ b/manifests/r/RARLab/WinRAR/7.01.0/RARLab.WinRAR.locale.en.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 
 PackageIdentifier: RARLab.WinRAR
 PackageVersion: 7.01.0
@@ -22,4 +22,4 @@ Tags:
 - rar
 - winrar
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/r/RARLab/WinRAR/7.01.0/RARLab.WinRAR.yaml
+++ b/manifests/r/RARLab/WinRAR/7.01.0/RARLab.WinRAR.yaml
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
 
 PackageIdentifier: RARLab.WinRAR
 PackageVersion: 7.01.0
 DefaultLocale: en
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Add `elevationRequirement` to the manifest for a completer manifest & so that WinGet shows helpful output when installing the package.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/198528)