### PR TITLE
Add elevationRequirement to Telerik.Fiddler.Classic version 5.0.20245.10105

### DIFF
--- a/manifests/t/Telerik/Fiddler/Classic/5.0.20245.10105/Telerik.Fiddler.Classic.installer.yaml
+++ b/manifests/t/Telerik/Fiddler/Classic/5.0.20245.10105/Telerik.Fiddler.Classic.installer.yaml
@@ -1,10 +1,11 @@
 # Created with YamlCreate.ps1 v2.4.1 Dumplings Mod $debug=QUSU.CRLF.7-4-5.Win32NT
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 
 PackageIdentifier: Telerik.Fiddler.Classic
 PackageVersion: 5.0.20245.10105
 InstallerType: nullsoft
 Scope: user
+ElevationRequirement: elevatesSelf
 UpgradeBehavior: install
 FileExtensions:
 - saz
@@ -19,4 +20,4 @@ Installers:
   InstallerSha256: 588024037B1E5929B1F2A741FFF52A207BCAB17F0650EC7CB0CD3CB78051998D
   ProductCode: Fiddler2
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/t/Telerik/Fiddler/Classic/5.0.20245.10105/Telerik.Fiddler.Classic.locale.en-US.yaml
+++ b/manifests/t/Telerik/Fiddler/Classic/5.0.20245.10105/Telerik.Fiddler.Classic.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with YamlCreate.ps1 v2.4.1 Dumplings Mod $debug=QUSU.CRLF.7-4-5.Win32NT
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 
 PackageIdentifier: Telerik.Fiddler.Classic
 PackageVersion: 5.0.20245.10105
@@ -41,4 +41,4 @@ ReleaseNotes: |-
 # InstallationNotes:
 # Documentations:
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/t/Telerik/Fiddler/Classic/5.0.20245.10105/Telerik.Fiddler.Classic.locale.zh-CN.yaml
+++ b/manifests/t/Telerik/Fiddler/Classic/5.0.20245.10105/Telerik.Fiddler.Classic.locale.zh-CN.yaml
@@ -1,5 +1,5 @@
 # Created with YamlCreate.ps1 v2.4.1 Dumplings Mod $debug=QUSU.CRLF.7-4-5.Win32NT
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.9.0.schema.json
 
 PackageIdentifier: Telerik.Fiddler.Classic
 PackageVersion: 5.0.20245.10105
@@ -36,4 +36,4 @@ Tags:
 # InstallationNotes:
 # Documentations:
 ManifestType: locale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/t/Telerik/Fiddler/Classic/5.0.20245.10105/Telerik.Fiddler.Classic.yaml
+++ b/manifests/t/Telerik/Fiddler/Classic/5.0.20245.10105/Telerik.Fiddler.Classic.yaml
@@ -1,8 +1,8 @@
 # Created with YamlCreate.ps1 v2.4.1 Dumplings Mod $debug=QUSU.CRLF.7-4-5.Win32NT
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
 
 PackageIdentifier: Telerik.Fiddler.Classic
 PackageVersion: 5.0.20245.10105
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Add `elevationRequirement` to the manifest for a completer manifest & so that WinGet shows helpful output when installing the package.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/198529)