### PR TITLE
Add elevationRequirement to Ubisoft.Connect version 159.1.0.11430

### DIFF
--- a/manifests/u/Ubisoft/Connect/159.1.0.11430/Ubisoft.Connect.installer.yaml
+++ b/manifests/u/Ubisoft/Connect/159.1.0.11430/Ubisoft.Connect.installer.yaml
@@ -9,6 +9,7 @@ InstallModes:
 - interactive
 - silent
 UpgradeBehavior: install
+ElevationRequirement: elevatesSelf
 ProductCode: Uplay
 Installers:
 - Architecture: x86


### PR DESCRIPTION
Add `elevationRequirement` to the manifest for a completer manifest & so that WinGet shows helpful output when installing the package.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/198530)