### PR TITLE
Add elevationRequirement to VideoLAN.VLC version 3.0.21

### DIFF
--- a/manifests/v/VideoLAN/VLC/3.0.21/VideoLAN.VLC.installer.yaml
+++ b/manifests/v/VideoLAN/VLC/3.0.21/VideoLAN.VLC.installer.yaml
@@ -1,10 +1,11 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 PackageIdentifier: VideoLAN.VLC
 PackageVersion: 3.0.21
 Platform:
 - Windows.Desktop
 MinimumOSVersion: 6.1.7600
 Scope: machine
+ElevationRequirement: elevatesSelf
 InstallModes:
 - interactive
 - silent
@@ -66,4 +67,4 @@ Installers:
     Publisher: VideoLAN
     InstallerType: nullsoft
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/v/VideoLAN/VLC/3.0.21/VideoLAN.VLC.locale.en-US.yaml
+++ b/manifests/v/VideoLAN/VLC/3.0.21/VideoLAN.VLC.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 PackageIdentifier: VideoLAN.VLC
 PackageVersion: 3.0.21
 PackageLocale: en-US
@@ -76,4 +76,4 @@ ReleaseNotes: |-
    * Fix security integer overflow in MMS module
 ReleaseNotesUrl: https://www.videolan.org/vlc/releases/3.0.21.html
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/v/VideoLAN/VLC/3.0.21/VideoLAN.VLC.yaml
+++ b/manifests/v/VideoLAN/VLC/3.0.21/VideoLAN.VLC.yaml
@@ -1,6 +1,6 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
 PackageIdentifier: VideoLAN.VLC
 PackageVersion: 3.0.21
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Add `elevationRequirement` to the manifest for a completer manifest & so that WinGet shows helpful output when installing the package.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/198531)