### PR TITLE
Add elevationRequirement to WiresharkFoundation.Wireshark version 4.4.2

### DIFF
--- a/manifests/w/WiresharkFoundation/Wireshark/4.4.2/WiresharkFoundation.Wireshark.installer.yaml
+++ b/manifests/w/WiresharkFoundation/Wireshark/4.4.2/WiresharkFoundation.Wireshark.installer.yaml
@@ -1,5 +1,5 @@
 # Created with komac v2.6.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 
 PackageIdentifier: WiresharkFoundation.Wireshark
 PackageVersion: 4.4.2
@@ -11,6 +11,7 @@ InstallModes:
 - silent
 - silentWithProgress
 UpgradeBehavior: install
+ElevationRequirement: elevatesSelf
 ReleaseDate: 2024-11-20
 Installers:
 - Architecture: x64
@@ -35,4 +36,4 @@ Installers:
   InstallationMetadata:
     DefaultInstallLocation: '%ProgramFiles%\Wireshark'
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/w/WiresharkFoundation/Wireshark/4.4.2/WiresharkFoundation.Wireshark.locale.en-US.yaml
+++ b/manifests/w/WiresharkFoundation/Wireshark/4.4.2/WiresharkFoundation.Wireshark.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with komac v2.6.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 
 PackageIdentifier: WiresharkFoundation.Wireshark
 PackageVersion: 4.4.2
@@ -28,4 +28,4 @@ Tags:
 - protocol
 - sniffer
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/w/WiresharkFoundation/Wireshark/4.4.2/WiresharkFoundation.Wireshark.yaml
+++ b/manifests/w/WiresharkFoundation/Wireshark/4.4.2/WiresharkFoundation.Wireshark.yaml
@@ -1,8 +1,8 @@
 # Created with komac v2.6.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
 
 PackageIdentifier: WiresharkFoundation.Wireshark
 PackageVersion: 4.4.2
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Add `elevationRequirement` to the manifest for a completer manifest & so that WinGet shows helpful output when installing the package.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/198532)