### PR TITLE
Add elevationRequirement to winaero.tweaker version '1.63'

### DIFF
--- a/manifests/w/winaero/tweaker/1.63/winaero.tweaker.installer.yaml
+++ b/manifests/w/winaero/tweaker/1.63/winaero.tweaker.installer.yaml
@@ -1,5 +1,5 @@
 # Created with komac v2.3.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 
 PackageIdentifier: winaero.tweaker
 PackageVersion: '1.63'
@@ -12,6 +12,7 @@ InstallModes:
 - interactive
 - silent
 - silentWithProgress
+ElevationRequirement: elevatesSelf
 UpgradeBehavior: install
 ReleaseDate: 2024-07-03
 AppsAndFeaturesEntries:
@@ -21,4 +22,4 @@ Installers:
   InstallerUrl: https://winaerotweaker.com/download/winaerotweaker.zip
   InstallerSha256: 8B46861ABB7266C798B27CD6E4CC95E6E81215870128F892236B7A27DFB02B74
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/w/winaero/tweaker/1.63/winaero.tweaker.locale.en-US.yaml
+++ b/manifests/w/winaero/tweaker/1.63/winaero.tweaker.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with komac v2.3.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 
 PackageIdentifier: winaero.tweaker
 PackageVersion: '1.63'
@@ -15,4 +15,4 @@ ShortDescription: Winaero Twеaker is essential software for every Windows 10, W
 Description: Winaero Tweaker is a free app for all versions of Windows that lets you adjust (i.e. tweak) hidden secret settings that Microsoft does not let you adjust from the user interface. In addition, it allows you to add extra value to existing Windows apps and tools with advanced context menus, options, and handy commands.
 ReleaseNotesUrl: https://winaero.com/winaero-tweaker-1-63-is-available/
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/w/winaero/tweaker/1.63/winaero.tweaker.yaml
+++ b/manifests/w/winaero/tweaker/1.63/winaero.tweaker.yaml
@@ -1,8 +1,8 @@
 # Created with komac v2.3.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
 
 PackageIdentifier: winaero.tweaker
 PackageVersion: '1.63'
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Add `elevationRequirement` to the manifest for a completer manifest & so that WinGet shows helpful output when installing the package.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/198533)