### PR TITLE
Revert "Revert "New package: StreetPea.chiaki-ng version 1.9.1""

### DIFF
--- a/manifests/s/StreetPea/chiaki-ng/1.9.1/StreetPea.chiaki-ng.installer.yaml
+++ b/manifests/s/StreetPea/chiaki-ng/1.9.1/StreetPea.chiaki-ng.installer.yaml
@@ -1,0 +1,19 @@
+# Created using wingetcreate 1.6.5.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: StreetPea.chiaki-ng
+PackageVersion: 1.9.1
+InstallerType: inno
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+    - PackageIdentifier: KhronosGroup.VulkanRT
+Installers:
+- InstallerUrl: https://github.com/streetpea/chiaki-ng/releases/download/v1.9.1/chiaki-ng-windows-installer.exe
+  Architecture: x64
+  InstallerSha256: 42B9AE0FAB026BC8387C0345BDA04EA17ABE24340A89699D75ECCFCBE7712D1F
+ManifestType: installer
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+ManifestVersion: 1.6.0

--- a/manifests/s/StreetPea/chiaki-ng/1.9.1/StreetPea.chiaki-ng.locale.en-US.yaml
+++ b/manifests/s/StreetPea/chiaki-ng/1.9.1/StreetPea.chiaki-ng.locale.en-US.yaml
@@ -1,0 +1,12 @@
+# Created using wingetcreate 1.6.5.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: StreetPea.chiaki-ng
+PackageVersion: 1.9.1
+PackageLocale: en-US
+Publisher: Street Pea
+PackageName: chiaki-ng
+License: AGPL-3.0 license
+ShortDescription: Open Source PlayStation Remote Play
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/StreetPea/chiaki-ng/1.9.1/StreetPea.chiaki-ng.yaml
+++ b/manifests/s/StreetPea/chiaki-ng/1.9.1/StreetPea.chiaki-ng.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.6.5.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: StreetPea.chiaki-ng
+PackageVersion: 1.9.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Reverts microsoft/winget-pkgs#198174 as the offending package was removed in #198168. Once that change clears the [publishing pipeline](https://dev.azure.com/shine-oss/winget-pkgs/_build/results?buildId=35892&view=results), this change should be safe to merge in
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/198555)