### PR TITLE
New package: Codebox.BitMeterOS.Experimental version 0.8.0

### DIFF
--- a/manifests/c/Codebox/BitMeterOS/Experimental/0.8.0/Codebox.BitMeterOS.Experimental.installer.yaml
+++ b/manifests/c/Codebox/BitMeterOS/Experimental/0.8.0/Codebox.BitMeterOS.Experimental.installer.yaml
@@ -1,0 +1,15 @@
+# Created using wingetcreate 1.5.7.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: Codebox.BitMeterOS.Experimental
+PackageVersion: 0.8.0
+InstallerType: zip
+NestedInstallerType: nullsoft
+NestedInstallerFiles:
+- RelativeFilePath: BitMeterOSInstaller.exe
+Installers:
+- InstallerUrl: https://codebox.org.uk/downloads/bitmeteros/080/BitMeterOSInstaller.zip
+  Architecture: x86
+  InstallerSha256: 028192C2402F26733D686B4891C8D40FB653A2F9FDFDDF7533E5870897BB6741
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/c/Codebox/BitMeterOS/Experimental/0.8.0/Codebox.BitMeterOS.Experimental.locale.en-US.yaml
+++ b/manifests/c/Codebox/BitMeterOS/Experimental/0.8.0/Codebox.BitMeterOS.Experimental.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created using wingetcreate 1.5.7.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: Codebox.BitMeterOS.Experimental
+PackageVersion: 0.8.0
+PackageLocale: en-US
+Publisher: Rob Dawson
+PublisherUrl: https://codebox.org.uk/pages/about
+PublisherSupportUrl: https://codebox.org.uk/pages/bitmeteros-faq
+PackageName: BitMeter OS
+PackageUrl: https://codebox.org.uk/pages/bitmeteros
+License: GPL-3.0 License
+LicenseUrl: http://www.gnu.org/licenses/gpl.txt
+Copyright: Copyright (c) 2004-2023 Rob Dawson
+ShortDescription: BitMeter OS is a free, open-source, bandwidth monitor that works on Windows, Linux and Mac OSX.
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/c/Codebox/BitMeterOS/Experimental/0.8.0/Codebox.BitMeterOS.Experimental.locale.zh-CN.yaml
+++ b/manifests/c/Codebox/BitMeterOS/Experimental/0.8.0/Codebox.BitMeterOS.Experimental.locale.zh-CN.yaml
@@ -1,0 +1,17 @@
+# Created using wingetcreate 1.5.7.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.9.0.schema.json
+
+PackageIdentifier: Codebox.BitMeterOS.Experimental
+PackageVersion: 0.8.0
+PackageLocale: zh-CN
+Publisher: Rob Dawson
+PublisherUrl: https://codebox.org.uk/pages/about
+PublisherSupportUrl: https://codebox.org.uk/pages/bitmeteros-faq
+PackageName: BitMeter OS
+PackageUrl: https://codebox.org.uk/pages/bitmeteros
+License: GPL-3.0 License
+LicenseUrl: http://www.gnu.org/licenses/gpl.txt
+Copyright: Copyright (c) 2004-2023 Rob Dawson
+ShortDescription: BitMeter OS 是一款免费、开源的带宽监控器，可在 Windows、Linux 和 Mac OSX 上运行。
+ManifestType: locale
+ManifestVersion: 1.9.0

--- a/manifests/c/Codebox/BitMeterOS/Experimental/0.8.0/Codebox.BitMeterOS.Experimental.yaml
+++ b/manifests/c/Codebox/BitMeterOS/Experimental/0.8.0/Codebox.BitMeterOS.Experimental.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.5.7.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: Codebox.BitMeterOS.Experimental
+PackageVersion: 0.8.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
`komac new` and `komac analyse` end with `thread 'main' has overflowed its stack` for this package...

![image](https://github.com/user-attachments/assets/8e19ee81-d9bc-4f53-91c7-fc0e81dff2ea)

- https://github.com/microsoft/winget-pkgs/pull/198730#issuecomment-2541019041