### PR TITLE
New version: CCTV.CBox version 6.0.3.1

### DIFF
--- a/manifests/c/CCTV/CBox/6.0.3.1/CCTV.CBox.installer.yaml
+++ b/manifests/c/CCTV/CBox/6.0.3.1/CCTV.CBox.installer.yaml
@@ -1,0 +1,16 @@
+# Created with YamlCreate.ps1 v2.4.1 Dumplings Mod $debug=QUSU.CRLF.7-4-5.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: CCTV.CBox
+PackageVersion: 6.0.3.1
+InstallerType: nullsoft
+Scope: machine
+UpgradeBehavior: install
+#ReleaseDate: 2024-07-26
+Installers:
+- Architecture: x64
+  InstallerUrl: https://download.cntv.cn/cbox/v6/ysyy_v6.0.3.1_1001_setup_x64.exe
+  InstallerSha256: 2D2F70349F7DD365A9C6A858EB5650523D1CD1375F4D2180DA80CDEB0AFE4FCF
+  #ProductCode: '{07F79EE3-1012-40BF-BEE7-A07EE6C284DC}_is1'
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/c/CCTV/CBox/6.0.3.1/CCTV.CBox.locale.en-US.yaml
+++ b/manifests/c/CCTV/CBox/6.0.3.1/CCTV.CBox.locale.en-US.yaml
@@ -1,8 +1,8 @@
 # Created with YamlCreate.ps1 v2.4.1 Dumplings Mod $debug=QUSU.CRLF.7-4-5.Win32NT
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.9.0.schema.json
 
 PackageIdentifier: CCTV.CBox
-PackageVersion: 6.0.3.0
+PackageVersion: 6.0.3.1
 PackageLocale: en-US
 Publisher: 中国网络电视台
 PublisherUrl: https://www.cctv.com
@@ -38,5 +38,5 @@ Tags:
 # PurchaseUrl:
 # InstallationNotes:
 # Documentations:
-ManifestType: defaultLocale
+ManifestType: locale
 ManifestVersion: 1.9.0

--- a/manifests/c/CCTV/CBox/6.0.3.1/CCTV.CBox.locale.en-US.yaml
+++ b/manifests/c/CCTV/CBox/6.0.3.1/CCTV.CBox.locale.en-US.yaml
@@ -1,0 +1,42 @@
+# Created with YamlCreate.ps1 v2.4.1 Dumplings Mod $debug=QUSU.CRLF.7-4-5.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: CCTV.CBox
+PackageVersion: 6.0.3.0
+PackageLocale: en-US
+Publisher: 中国网络电视台
+PublisherUrl: https://www.cctv.com
+PublisherSupportUrl: https://help.cctv.com/new_erji/index.shtml
+PrivacyUrl: https://www.cctv.com/special/guanyunew/PAGE1381887126760260/index.shtml
+Author: CCTV International Network Co., Ltd.
+PackageName: 央视影音
+PackageUrl: https://app.cctv.com
+License: Proprietary
+# LicenseUrl:
+Copyright: China Internet TV (CNTV). All rights reserved.
+CopyrightUrl: https://www.cctv.com/special/guanyunew/PAGE13818868795101878/index.shtml
+ShortDescription: A streaming platform by China Central Television
+Description: |-
+  CBox is a streaming platform by China Central Television that supports live broadcasting of all CCTV channels and providing rich and high-quality TV programs, sports events, films, shows and many other kinds of videos.
+  It aims to create high-quality watching experience and allow users to watch TV at their own pace.
+# Moniker:
+Tags:
+- cartoon
+- cctv
+- documentary
+- film
+- live
+- movie
+- news
+- serial
+- series
+- show
+- tv
+- video
+# ReleaseNotes:
+# ReleaseNotesUrl:
+# PurchaseUrl:
+# InstallationNotes:
+# Documentations:
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/c/CCTV/CBox/6.0.3.1/CCTV.CBox.locale.zh-CN.yaml
+++ b/manifests/c/CCTV/CBox/6.0.3.1/CCTV.CBox.locale.zh-CN.yaml
@@ -1,5 +1,5 @@
 # Created with YamlCreate.ps1 v2.4.1 Dumplings Mod $debug=QUSU.CRLF.7-4-5.Win32NT
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.9.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 
 PackageIdentifier: CCTV.CBox
 PackageVersion: 6.0.3.1
@@ -37,5 +37,5 @@ Tags:
 # PurchaseUrl:
 # InstallationNotes:
 # Documentations:
-ManifestType: locale
+ManifestType: defaultLocale
 ManifestVersion: 1.9.0

--- a/manifests/c/CCTV/CBox/6.0.3.1/CCTV.CBox.locale.zh-CN.yaml
+++ b/manifests/c/CCTV/CBox/6.0.3.1/CCTV.CBox.locale.zh-CN.yaml
@@ -1,0 +1,41 @@
+# Created with YamlCreate.ps1 v2.4.1 Dumplings Mod $debug=QUSU.CRLF.7-4-5.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.9.0.schema.json
+
+PackageIdentifier: CCTV.CBox
+PackageVersion: 6.0.3.1
+PackageLocale: zh-CN
+Publisher: 中国网络电视台
+PublisherUrl: https://www.cctv.com
+PublisherSupportUrl: https://help.cctv.com/new_erji/index.shtml
+PrivacyUrl: https://www.cctv.com/special/guanyunew/PAGE1381887126760260/index.shtml
+Author: 央视国际网络有限公司
+PackageName: 央视影音
+PackageUrl: https://app.cctv.com
+License: 专有软件
+# LicenseUrl:
+Copyright: 中国网络电视台 CNTV 版权所有
+CopyrightUrl: https://www.cctv.com/special/guanyunew/PAGE13818868795101878/index.shtml
+ShortDescription: 新闻体育人文影视高清平台
+Description: 央视影音是央视网为全球移动用户倾力打造的电视直播应用，支持覆盖央视全部频道直播，提供丰富优质的电视栏目、体育赛事、影视综艺等海量视频，努力打造优质的观看体验，让用户做到随心所欲看电视。
+# Moniker:
+Tags:
+- 中央电视台
+- 卡通
+- 央视
+- 少儿
+- 新闻
+- 电影
+- 电视
+- 电视剧
+- 直播
+- 视频
+- 纪录片
+- 综艺
+- 连续剧
+# ReleaseNotes:
+# ReleaseNotesUrl:
+# PurchaseUrl:
+# InstallationNotes:
+# Documentations:
+ManifestType: locale
+ManifestVersion: 1.9.0

--- a/manifests/c/CCTV/CBox/6.0.3.1/CCTV.CBox.yaml
+++ b/manifests/c/CCTV/CBox/6.0.3.1/CCTV.CBox.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.4.1 Dumplings Mod $debug=QUSU.CRLF.7-4-5.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: CCTV.CBox
+PackageVersion: 6.0.3.1
+DefaultLocale: zh-CN
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
I tried using komac to update the manifest, but I get the 403 return code:

```
Error:
   0: https://download.cntv.cn/cbox/v6/ysyy_v6.0.3.1_1001_setup_x64.exe returned 403 Forbidden
```

I also tried downloading the previous version using winget and it still returns 403:

```
执行此命令时发生意外错误：
Download request status is not success.
0x80190193 : 已禁止(403)。
```

I tried to download it manually from the official website and it downloaded successfully. Got the same link as in the manifest. But when I access the installer url directly from the manifest, I get the `ERR_INVALID_RESPONSE` error in Edge.

I'm not sure if I should remove all versions of this package or if this is only a problem in some areas?

Removes the pull request for this package:
- #198740 
- #198741 
- #198742 
- #198743 
- #198744 
- #198745 
- #198746 
- #198747 
- #198748 
- #198749 
- #198750 
- #198751 
- #198753 
- #198754 
- #198755 
- #198756 
- #198757 
- #198758 

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/198735)