### PR TITLE
New version: Bitvise.SSH.Client version 9.42

### DIFF
--- a/manifests/b/Bitvise/SSH/Client/9.42/Bitvise.SSH.Client.installer.yaml
+++ b/manifests/b/Bitvise/SSH/Client/9.42/Bitvise.SSH.Client.installer.yaml
@@ -1,0 +1,26 @@
+# Created with komac v2.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: Bitvise.SSH.Client
+PackageVersion: '9.42'
+InstallerLocale: en-US
+InstallerType: exe
+InstallModes:
+- silentWithProgress
+InstallerSwitches:
+  Silent: -acceptEULA
+  SilentWithProgress: -acceptEULA
+UpgradeBehavior: uninstallPrevious
+Protocols:
+- ssh
+FileExtensions:
+- bscp
+- tlp
+ProductCode: '{CF8E6E00-9C03-4440-81C0-21FACB921A6B}'
+ReleaseDate: 2024-12-09
+Installers:
+- Architecture: x86
+  InstallerUrl: https://dl.bitvise.com/BvSshClient-Inst.exe
+  InstallerSha256: 016B1918C0F8EB4977276590F7889C2E2129E5DCB69C7CDEF9A70640202E7C7E
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/b/Bitvise/SSH/Client/9.42/Bitvise.SSH.Client.locale.en-US.yaml
+++ b/manifests/b/Bitvise/SSH/Client/9.42/Bitvise.SSH.Client.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# Created with komac v2.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: Bitvise.SSH.Client
+PackageVersion: '9.42'
+PackageLocale: en-US
+Publisher: Bitvise Limited
+PublisherUrl: https://www.bitvise.com/
+PublisherSupportUrl: https://www.bitvise.com/contact
+PrivacyUrl: https://www.bitvise.com/privacy-policy
+PackageName: Bitvise SSH Client
+PackageUrl: https://www.bitvise.com/ssh-client
+License: Proprietary
+LicenseUrl: https://www.bitvise.com/ssh-client-license
+Copyright: Copyright (c) 2001-2022 by Bitvise Limited. All rights reserved.
+ShortDescription: A Free and Flexible SSH Client
+Moniker: bitvisessh
+Tags:
+- bvterm
+- file-transfer
+- files
+- forwarding
+- remote-desktop-forwarding
+- sftp
+- ssh
+- terminal
+- tunneling
+- vt100
+- xterm
+Agreements:
+- AgreementLabel: End User License Agreement (EULA)
+  AgreementUrl: https://www.bitvise.com/files/license/BvSshClient-EULA-20221111.pdf
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/b/Bitvise/SSH/Client/9.42/Bitvise.SSH.Client.yaml
+++ b/manifests/b/Bitvise/SSH/Client/9.42/Bitvise.SSH.Client.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: Bitvise.SSH.Client
+PackageVersion: '9.42'
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## Checklist for Pull Requests

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Resolve #198832

## Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.9.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

## Manual validation

<details><summary>Console logs</summary>

```text
15:19:13 D:\...\winget-pkgs  [master ≡ +1 ~0 -0 !] 109ms pwsh> .\Tools\SandboxTest.ps1 .\manifests\b\Bitvise\SSH\Client\9.42\
--> Validating Manifest
清单验证成功。
--> Checking Dependencies
--> Starting Windows Sandbox, and:
    - Mounting the following directories:
      - C:\Users\Administrator\AppData\Local\Packages\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe\SandboxTest as read-and-write
      - D:\Workloads\winget-pkgs as read-and-write
    - Installing WinGet
    - Configuring Winget
      - Installing the Manifest 9.42
      - Refreshing environment variables
      - Comparing ARP Entries
```

```text
--> Installing WinGet
--> Disabling safety warning when running installers
Tip: you can type 'Update-EnvironmentVariables' to update your environment variables, such as after installing a new software.

--> Configuring Winget
已启用管理员设置 'LocalManifestFiles'。
已启用管理员设置 'LocalArchiveMalwareScanOverride'。

--> Installing the Manifest 9.42

已找到 Bitvise SSH Client [Bitvise.SSH.Client] 版本 9.42
此应用程序由其所有者授权给你。
Microsoft 对第三方程序包概不负责，也不向第三方程序包授予任何许可证。
的协议 Bitvise SSH Client [Bitvise.SSH.Client] 版本 9.42
版本: 9.42
发布者: Bitvise Limited
发布服务器 URL: https://www.bitvise.com/
发布服务器支持 URL: https://www.bitvise.com/contact
主页: https://www.bitvise.com/ssh-client
许可证: Proprietary
许可证 URL: https://www.bitvise.com/ssh-client-license
隐私 URL: https://www.bitvise.com/privacy-policy
版权所有: Copyright (c) 2001-2022 by Bitvise Limited. All rights reserved.
协议：
  End User License Agreement (EULA): https://www.bitvise.com/files/license/BvSshClient-EULA-20221111.pdf

正在下载 https://dl.bitvise.com/BvSshClient-Inst.exe
  ██████████████████████████████  25.5 MB / 25.5 MB
已成功验证安装程序哈希
正在启动程序包安装...
已成功安装

--> Refreshing environment variables

--> Comparing ARP Entries

DisplayName                                          DisplayVersion Publisher       ProductCode Scope
-----------                                          -------------- ---------       ----------- -----
Bitvise SSH Client 9.42 (remove only)                9.42           Bitvise Limited BvSshClient Machine
WinFsp installed by Bitvise SSH Client (remove only) 2.0.23075      Bitvise Limited BvWinFsp    Machine
```

</details>
<details><summary>Screenshots</summary>

![image](https://github.com/user-attachments/assets/e9922e1f-e132-4485-9560-3c511eb2bdae)

</details>

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/198957)