### PR TITLE
New package: GovernmentOfThePRC.SAT.ETB.WithholdingSide version 3.1.229

### DIFF
--- a/manifests/g/GovernmentOfThePRC/SAT/ETB/WithholdingSide/3.1.229/GovernmentOfThePRC.SAT.ETB.WithholdingSide.installer.yaml
+++ b/manifests/g/GovernmentOfThePRC/SAT/ETB/WithholdingSide/3.1.229/GovernmentOfThePRC.SAT.ETB.WithholdingSide.installer.yaml
@@ -1,0 +1,24 @@
+# Created with komac v2.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: GovernmentOfThePRC.SAT.ETB.WithholdingSide
+PackageVersion: 3.1.229
+InstallerLocale: zh-CN
+InstallerType: exe
+#Scope: machine
+InstallModes:
+- interactive
+- silent
+InstallerSwitches:
+  Silent: /VerySilent
+UpgradeBehavior: install
+ReleaseDate: 2024-11-29
+Installers:
+- Architecture: x64
+  InstallerUrl: https://file.etax.chinatax.gov.cn/bbxzdownload/kjkhd/ETax.exe
+  InstallerSha256: BBAE9F7DD7885D79FFDD756DFAFE45E801D36DF62BF73EDE670A6565785FEAB8
+- Architecture: x86
+  InstallerUrl: https://file.etax.chinatax.gov.cn/bbxzdownload/kjkhd/ETax.exe
+  InstallerSha256: BBAE9F7DD7885D79FFDD756DFAFE45E801D36DF62BF73EDE670A6565785FEAB8
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/g/GovernmentOfThePRC/SAT/ETB/WithholdingSide/3.1.229/GovernmentOfThePRC.SAT.ETB.WithholdingSide.locale.zh-CN.yaml
+++ b/manifests/g/GovernmentOfThePRC/SAT/ETB/WithholdingSide/3.1.229/GovernmentOfThePRC.SAT.ETB.WithholdingSide.locale.zh-CN.yaml
@@ -1,0 +1,28 @@
+# Created with komac v2.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: GovernmentOfThePRC.SAT.ETB.WithholdingSide
+PackageVersion: 3.1.229
+PackageLocale: zh-CN
+Publisher: 中华人民共和国国家税务总局
+PublisherUrl: https://etax.chinatax.gov.cn/webstatic/
+PublisherSupportUrl: https://etax.chinatax.gov.cn/webstatic/help-center/200001
+Author: 中华人民共和国国家税务总局
+PackageName: 自然人电子税务局（扣缴端）
+PackageUrl: https://etax.chinatax.gov.cn/webstatic/download-service/100001
+License: 专有软件
+Copyright: 版权所有 (c) 国家税务总局
+ShortDescription: 自然人电子税务局（扣缴端）
+Moniker: 纳税扣缴端
+Tags:
+- 中国
+- 税务
+- 纳税
+- 税务局
+- 政务
+- 扣缴
+- 扣费
+- 缴税
+- 交税
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/g/GovernmentOfThePRC/SAT/ETB/WithholdingSide/3.1.229/GovernmentOfThePRC.SAT.ETB.WithholdingSide.locale.zh-CN.yaml
+++ b/manifests/g/GovernmentOfThePRC/SAT/ETB/WithholdingSide/3.1.229/GovernmentOfThePRC.SAT.ETB.WithholdingSide.locale.zh-CN.yaml
@@ -5,11 +5,16 @@ PackageIdentifier: GovernmentOfThePRC.SAT.ETB.WithholdingSide
 PackageVersion: 3.1.229
 PackageLocale: zh-CN
 Publisher: 中华人民共和国国家税务总局
-PublisherUrl: https://etax.chinatax.gov.cn/webstatic/
-PublisherSupportUrl: https://etax.chinatax.gov.cn/webstatic/help-center/200001
+# PublisherUrl: https://etax.chinatax.gov.cn/webstatic/
+# https://dev.azure.com/shine-oss/winget-pkgs/_build/results?buildId=36605&view=logs&j=129b3b09-7d10-5f42-7e8e-d03c270d019d&t=16eada92-7f78-5f60-1b2e-3a2ac807e0d2&l=35
+# URI: https://etax.chinatax.gov.cn/webstatic/, Validation result: Failed, Http status code: BadRequest 
+# URI: https://etax.chinatax.gov.cn/webstatic/help-center/200001, Validation result: Failed, Http status code: BadRequest 
+# URI: https://etax.chinatax.gov.cn/webstatic/download-service/100001, Validation result: Failed, Http status code: NotFound 
+# URI: https://file.etax.chinatax.gov.cn/bbxzdownload/kjkhd/ETax.exe, Validation result: Passed
+# PublisherSupportUrl: https://etax.chinatax.gov.cn/webstatic/help-center/200001
 Author: 中华人民共和国国家税务总局
 PackageName: 自然人电子税务局（扣缴端）
-PackageUrl: https://etax.chinatax.gov.cn/webstatic/download-service/100001
+# PackageUrl: https://etax.chinatax.gov.cn/webstatic/download-service/100001
 License: 专有软件
 Copyright: 版权所有 (c) 国家税务总局
 ShortDescription: 自然人电子税务局（扣缴端）

--- a/manifests/g/GovernmentOfThePRC/SAT/ETB/WithholdingSide/3.1.229/GovernmentOfThePRC.SAT.ETB.WithholdingSide.yaml
+++ b/manifests/g/GovernmentOfThePRC/SAT/ETB/WithholdingSide/3.1.229/GovernmentOfThePRC.SAT.ETB.WithholdingSide.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: GovernmentOfThePRC.SAT.ETB.WithholdingSide
+PackageVersion: 3.1.229
+DefaultLocale: zh-CN
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
I can't tell if this package is working properly because my VM blue screened when I started the package in...
This seems bound to happen... For more, see [Bing search](https://www.bing.com/search?q=ahs+protect.sys+%E7%A8%8E).
![image](https://github.com/user-attachments/assets/b9788eb1-70da-4779-aa47-50ddceda80f7)

> Stop code: KMODE EXCEPTION NOT HANDLED
> What failed: ahs protect.sys

> From [search results](https://bbs.pcbeta.com/forum.php?mod=viewthread&tid=2005361&highlight=%D7%D4%C8%BB%C8%CB%B5%E7%D7%D3%CB%B0%CE%F1%BE%D6): PS：此驱动过于老旧，数字签名未2018年。应该与26100.\*\*及以上的系统都有冲突，切记！！
> DeepL translation: PS: This driver is too old and the digital signature is not 2018. It should conflict with all systems 26100.\*\* and above, remember!

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/199082)