### PR TITLE
Update manifest: SublimeHQ.SublimeMerge version 2102

### DIFF
--- a/manifests/s/SublimeHQ/SublimeMerge/2102/SublimeHQ.SublimeMerge.installer.yaml
+++ b/manifests/s/SublimeHQ/SublimeMerge/2102/SublimeHQ.SublimeMerge.installer.yaml
@@ -1,5 +1,5 @@
 # Created with komac v2.6.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 
 PackageIdentifier: SublimeHQ.SublimeMerge
 PackageVersion: '2102'
@@ -20,6 +20,7 @@ Installers:
     PortableCommandAlias: smerge
   - RelativeFilePath: sublime_merge.exe
     PortableCommandAlias: sublime_merge
+  ArchiveBinariesDependOnPath: true
   InstallerUrl: https://download.sublimetext.com/sublime_merge_build_2102_x64.zip
   InstallerSha256: 8A6E7CDEC39456CA6FADFD17CCFC86D29E52A611EEC4405CCAF743C42CCB1F97
 - InstallerLocale: en-US
@@ -39,4 +40,4 @@ Installers:
     ProductCode: Sublime Merge_is1
   ElevationRequirement: elevatesSelf
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/s/SublimeHQ/SublimeMerge/2102/SublimeHQ.SublimeMerge.locale.en-US.yaml
+++ b/manifests/s/SublimeHQ/SublimeMerge/2102/SublimeHQ.SublimeMerge.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with komac v2.6.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 
 PackageIdentifier: SublimeHQ.SublimeMerge
 PackageVersion: '2102'
@@ -31,4 +31,4 @@ Documentations:
 - DocumentLabel: Official Sublime Merge Documentation
   DocumentUrl: https://www.sublimemerge.com/docs/
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/s/SublimeHQ/SublimeMerge/2102/SublimeHQ.SublimeMerge.yaml
+++ b/manifests/s/SublimeHQ/SublimeMerge/2102/SublimeHQ.SublimeMerge.yaml
@@ -1,8 +1,8 @@
 # Created with komac v2.6.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
 
 PackageIdentifier: SublimeHQ.SublimeMerge
 PackageVersion: '2102'
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## What's changed

- Bump manifest version to `v1.9.0`
- Add `ArchiveBinariesDependOnPath` for zip installer

## Checklist for Pull Requests

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Resolve #199187

## Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.9.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

## Manual validation

![image](https://github.com/user-attachments/assets/84579529-d8c1-4762-b5a3-d4164353b9de)

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/199290)