### PR TITLE
New package: psf.black version 24.10.0

### DIFF
--- a/manifests/p/psf/black/24.10.0/psf.black.installer.yaml
+++ b/manifests/p/psf/black/24.10.0/psf.black.installer.yaml
@@ -1,0 +1,20 @@
+# Created with komac v2.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: psf.black
+PackageVersion: 24.10.0
+InstallerType: portable
+Commands:
+  - black
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: uninstallPrevious
+ReleaseDate: 2024-10-07
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/psf/black/releases/download/24.10.0/black_windows.exe
+  InstallerSha256: 077AC67CB5DBB804406BD4956756C16D26F4C7D87C70438078888CBEC68D27EF
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/p/psf/black/24.10.0/psf.black.locale.en-US.yaml
+++ b/manifests/p/psf/black/24.10.0/psf.black.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# Created with komac v2.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: psf.black
+PackageVersion: 24.10.0
+PackageLocale: en-US
+Publisher: Python Software Foundation
+PublisherUrl: https://python.org/psf/github
+PublisherSupportUrl: https://github.com/psf/black/issues
+Author: Łukasz Langa
+PackageName: Black
+PackageUrl: https://github.com/psf/black
+License: MIT
+LicenseUrl: https://github.com/psf/black/blob/main/LICENSE
+Copyright: Copyright (c) 2018 Łukasz Langa
+CopyrightUrl: https://github.com/psf/black/blob/main/LICENSE
+ShortDescription: The uncompromising Python code formatter
+Description: Black is the uncompromising Python code formatter. By using it, you agree to cede control over minutiae of hand-formatting.
+Tags:
+- autopep8
+- code
+- codeformatter
+- formatter
+- gofmt
+- hacktoberfest
+- pre-commit-hook
+- python
+- yapf
+ReleaseNotesUrl: https://github.com/psf/black/releases/tag/24.10.0
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/p/psf/black/24.10.0/psf.black.yaml
+++ b/manifests/p/psf/black/24.10.0/psf.black.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: psf.black
+PackageVersion: 24.10.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## Checklist for Pull Requests

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Resolve #199457

## Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.9.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

## Manual validation

<details><summary>Installation log</summary>

```text
--> Installing WinGet
--> Disabling safety warning when running installers
Tip: you can type 'Update-EnvironmentVariables' to update your environment variables, such as after installing a new software.

--> Configuring Winget
已启用管理员设置 'LocalManifestFiles'。
已启用管理员设置 'LocalArchiveMalwareScanOverride'。

--> Installing the Manifest 24.10.0

已找到 Black [psf.black] 版本 24.10.0
此应用程序由其所有者授权给你。
Microsoft 对第三方程序包概不负责，也不向第三方程序包授予任何许可证。
正在下载 https://github.com/psf/black/releases/download/24.10.0/black_windows.exe
  ██████████████████████████████  11.6 MB / 11.6 MB
已成功验证安装程序哈希
正在启动程序包安装...
添加了命令行别名： "black"
已修改路径环境变量；重启 shell 以使用新值。
已成功安装

--> Refreshing environment variables

--> Comparing ARP Entries

DisplayName DisplayVersion Publisher                  ProductCode              Scope
----------- -------------- ---------                  -----------              -----
Black       24.10.0        Python Software Foundation psf.black__DefaultSource User
```

</details>
<details><summary>Usage logs</summary>

```text
PS C:\Users\WDAGUtilityAccount\Desktop\winget-pkgs> black --version
black.exe, 24.10.0 (compiled: no)
Python (CPython) 3.12.4

PS C:\Users\WDAGUtilityAccount\Desktop\winget-pkgs> black --help
Usage: black.exe [OPTIONS] SRC ...

  The uncompromising code formatter.

Options:
  -c, --code TEXT                 Format the code passed in as a string.
  -l, --line-length INTEGER       How many characters per line to allow.
                                  [default: 88]
  -t, --target-version [py33|py34|py35|py36|py37|py38|py39|py310|py311|py312|py313]
                                  Python versions that should be supported by
                                  Black's output. You should include all
                                  versions that your code supports. By
                                  default, Black will infer target versions
                                  from the project metadata in pyproject.toml.
                                  If this does not yield conclusive results,
                                  Black will use per-file auto-detection.
  --pyi                           Format all input files like typing stubs
                                  regardless of file extension. This is useful
                                  when piping source on standard input.
  --ipynb                         Format all input files like Jupyter
                                  Notebooks regardless of file extension. This
                                  is useful when piping source on standard
                                  input.
  --python-cell-magics TEXT       When processing Jupyter Notebooks, add the
                                  given magic to the list of known python-
                                  magics (capture, prun, pypy, python,
                                  python3, time, timeit). Useful for
                                  formatting cells with custom python magics.
  -x, --skip-source-first-line    Skip the first line of the source code.
  -S, --skip-string-normalization
                                  Don't normalize string quotes or prefixes.
  -C, --skip-magic-trailing-comma
                                  Don't use trailing commas as a reason to
                                  split lines.
  --preview                       Enable potentially disruptive style changes
                                  that may be added to Black's main
                                  functionality in the next major release.
  --unstable                      Enable potentially disruptive style changes
                                  that have known bugs or are not currently
                                  expected to make it into the stable style
                                  Black's next major release. Implies
                                  --preview.
  --enable-unstable-feature [hex_codes_in_unicode_sequences|string_processing|hug_parens_with_braces_and_square_brackets|unify_docstring_detection|no_normalize_fmt_skip_whitespace|wrap_long_dict_values_in_parens|multiline_string_handling|typed_params_trailing_comma|is_simple_lookup_for_doublestar_expression|docstring_check_for_newline|remove_redundant_guard_parens|parens_for_long_if_clauses_in_case_block|pep646_typed_star_arg_type_var_tuple]
                                  Enable specific features included in the
                                  `--unstable` style. Requires `--preview`. No
                                  compatibility guarantees are provided on the
                                  behavior or existence of any unstable
                                  features.
  --check                         Don't write the files back, just return the
                                  status. Return code 0 means nothing would
                                  change. Return code 1 means some files would
                                  be reformatted. Return code 123 means there
                                  was an internal error.
  --diff                          Don't write the files back, just output a
                                  diff to indicate what changes Black would've
                                  made. They are printed to stdout so
                                  capturing them is simple.
  --color / --no-color            Show (or do not show) colored diff. Only
                                  applies when --diff is given.
  --line-ranges START-END         When specified, Black will try its best to
                                  only format these lines. This option can be
                                  specified multiple times, and a union of the
                                  lines will be formatted. Each range must be
                                  specified as two integers connected by a
                                  `-`: `<START>-<END>`. The `<START>` and
                                  `<END>` integer indices are 1-based and
                                  inclusive on both ends.
  --fast / --safe                 By default, Black performs an AST safety
                                  check after formatting your code. The --fast
                                  flag turns off this check and the --safe
                                  flag explicitly enables it. [default:
                                  --safe]
  --required-version TEXT         Require a specific version of Black to be
                                  running. This is useful for ensuring that
                                  all contributors to your project are using
                                  the same version, because different versions
                                  of Black may format code a little
                                  differently. This option can be set in a
                                  configuration file for consistent results
                                  across environments.
  --exclude TEXT                  A regular expression that matches files and
                                  directories that should be excluded on
                                  recursive searches. An empty value means no
                                  paths are excluded. Use forward slashes for
                                  directories on all platforms (Windows, too).
                                  By default, Black also ignores all paths
                                  listed in .gitignore. Changing this value
                                  will override all default exclusions.
                                  [default: /(\.direnv|\.eggs|\.git|\.hg|\.ipy
                                  nb_checkpoints|\.mypy_cache|\.nox|\.pytest_c
                                  ache|\.ruff_cache|\.tox|\.svn|\.venv|\.vscod
                                  e|__pypackages__|_build|buck-
                                  out|build|dist|venv)/]
  --extend-exclude TEXT           Like --exclude, but adds additional files
                                  and directories on top of the default values
                                  instead of overriding them.
  --force-exclude TEXT            Like --exclude, but files and directories
                                  matching this regex will be excluded even
                                  when they are passed explicitly as
                                  arguments. This is useful when invoking
                                  Black programmatically on changed files,
                                  such as in a pre-commit hook or editor
                                  plugin.
  --stdin-filename TEXT           The name of the file when passing it through
                                  stdin. Useful to make sure Black will
                                  respect the --force-exclude option on some
                                  editors that rely on using stdin.
  --include TEXT                  A regular expression that matches files and
                                  directories that should be included on
                                  recursive searches. An empty value means all
                                  files are included regardless of the name.
                                  Use forward slashes for directories on all
                                  platforms (Windows, too). Overrides all
                                  exclusions, including from .gitignore and
                                  command line options.  [default:
                                  (\.pyi?|\.ipynb)$]
  -W, --workers INTEGER RANGE     When Black formats multiple files, it may
                                  use a process pool to speed up formatting.
                                  This option controls the number of parallel
                                  workers. This can also be specified via the
                                  BLACK_NUM_WORKERS environment variable.
                                  Defaults to the number of CPUs in the
                                  system.  [x>=1]
  -q, --quiet                     Stop emitting all non-critical output. Error
                                  messages will still be emitted (which can
                                  silenced by 2>/dev/null).
  -v, --verbose                   Emit messages about files that were not
                                  changed or were ignored due to exclusion
                                  patterns. If Black is using a configuration
                                  file, a message detailing which one it is
                                  using will be emitted.
  --version                       Show the version and exit.
  --config FILE                   Read configuration options from a
                                  configuration file.
  -h, --help                      Show this message and exit.
```

</details>

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/199543)