### PR TITLE
New version: Splunk.UniversalForwarder version 9.4.0

### DIFF
--- a/manifests/s/Splunk/UniversalForwarder/9.4.0/Splunk.UniversalForwarder.installer.yaml
+++ b/manifests/s/Splunk/UniversalForwarder/9.4.0/Splunk.UniversalForwarder.installer.yaml
@@ -1,0 +1,25 @@
+# Manual update
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: Splunk.UniversalForwarder
+PackageVersion: 9.4.0
+InstallerLocale: en-US
+MinimumOSVersion: 10.0.0.0
+InstallerType: wix
+InstallModes:
+- silent
+InstallerSwitches:
+  Silent: /q /norestart
+  Custom: AGREETOLICENSE=YES
+# NOTE: Komac are failed to analyse installer: failed to fill whole buffer
+Installers:
+- Architecture: x86
+  InstallerUrl: https://download.splunk.com/products/universalforwarder/releases/9.4.0/windows/splunkforwarder-9.4.0-251651b291fe-windows-x86.msi
+  InstallerSha256: 6d6def566400a99edbaede2d6913e59ba48564555c65502060a805a9cffef065
+  #ProductCode: '{36AB7E05-0C06-42DA-918D-8EC2C9F5C04F}'
+- Architecture: x64
+  InstallerUrl: https://download.splunk.com/products/universalforwarder/releases/9.4.0/windows/splunkforwarder-9.4.0-6b4ebe426ca6-windows-x64.msi
+  InstallerSha256: 0670d5547df889f9e0fdffabdce5c34c7ee2cbcd8bdf74e8d3350c4b26081375
+  #ProductCode: '{63436C71-C10F-4813-98AC-DA3AD4738EE8}'
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/s/Splunk/UniversalForwarder/9.4.0/Splunk.UniversalForwarder.locale.en-US.yaml
+++ b/manifests/s/Splunk/UniversalForwarder/9.4.0/Splunk.UniversalForwarder.locale.en-US.yaml
@@ -1,0 +1,16 @@
+# Manual update
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: Splunk.UniversalForwarder
+PackageVersion: 9.4.0
+PackageLocale: en-US
+Publisher: Splunk, Inc.
+PackageName: UniversalForwarder
+License: Splunk Software License Agreement
+LicenseUrl: https://www.splunk.com/en_us/legal/splunk-software-license-agreement-bah.html
+ShortDescription: The universal forwarder collects data from a data source or another forwarder and sends it to a forwarder or a Splunk deployment. With a universal forwarder, you can send data to Splunk Enterprise, Splunk Light, or Splunk Cloud.
+Agreements:
+- AgreementLabel: SPLUNK GENERAL TERMS
+  AgreementUrl: https://www.splunk.com/en_us/legal/splunk-general-terms.html
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/s/Splunk/UniversalForwarder/9.4.0/Splunk.UniversalForwarder.locale.zh-CN.yaml
+++ b/manifests/s/Splunk/UniversalForwarder/9.4.0/Splunk.UniversalForwarder.locale.zh-CN.yaml
@@ -1,0 +1,16 @@
+# Manual update
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.9.0.schema.json
+
+PackageIdentifier: Splunk.UniversalForwarder
+PackageVersion: 9.4.0
+PackageLocale: zh-CN
+Publisher: Splunk, Inc.
+PackageName: UniversalForwarder
+License: Splunk Software License Agreement
+LicenseUrl: https://www.splunk.com/en_us/legal/splunk-software-license-agreement-bah.html
+ShortDescription: Universal Forwarder 从数据源或其他转发器收集数据，并将其发送到转发器或 Splunk 部署。使用 Universal Forwarder，您可以将数据发送到 Splunk Enterprise、Splunk Light 或 Splunk Cloud。
+Agreements:
+- AgreementLabel: SPLUNK GENERAL TERMS
+  AgreementUrl: https://www.splunk.com/en_us/legal/splunk-general-terms.html
+ManifestType: locale
+ManifestVersion: 1.9.0

--- a/manifests/s/Splunk/UniversalForwarder/9.4.0/Splunk.UniversalForwarder.yaml
+++ b/manifests/s/Splunk/UniversalForwarder/9.4.0/Splunk.UniversalForwarder.yaml
@@ -1,0 +1,8 @@
+# Manual update
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: Splunk.UniversalForwarder
+PackageVersion: 9.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
I tried use Komac to update version, but I get an error:
```
> komac update Splunk.UniversalForwarder --version 9.4.0 --urls https://download.splunk.com/products/universalforwarder/releases/9.4.0/windows/splunkforwarder-9.4.0-6b4ebe426ca6-windows-x64.msi https://download.splunk.com/products/universalforwarder/releases/9.4.0/windows/splunkforwarder-9.4.0-251651b291fe-windows-x86.msi
Latest version of Splunk.UniversalForwarder: 9.2.2 Error:
   0: failed to fill whole buffer
```

- Resolve #199749

---
