### PR TITLE
New package: futo-org.Grayjay.Desktop version v2

### DIFF
--- a/manifests/f/futo-org/Grayjay/Desktop/v2/futo-org.Grayjay.Desktop.installer.yaml
+++ b/manifests/f/futo-org/Grayjay/Desktop/v2/futo-org.Grayjay.Desktop.installer.yaml
@@ -1,0 +1,22 @@
+# Created with komac v2.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: futo-org.Grayjay.Desktop
+PackageVersion: v2
+InstallerType: zip
+NestedInstallerType: portable
+ArchiveBinariesDependOnPath: true
+NestedInstallerFiles:
+- RelativeFilePath: Grayjay.Desktop-win-x64-v2/Grayjay.exe
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: uninstallPrevious
+ReleaseDate: 2024-12-19
+Installers:
+- Architecture: x64
+  InstallerUrl: https://updater.grayjay.app/Apps/Grayjay.Desktop/Grayjay.Desktop-win-x64.zip
+  InstallerSha256: F9A18730F17917CB8B55613EAC5EAAC895CBE778FAF39B63BE142E700C492E80
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/f/futo-org/Grayjay/Desktop/v2/futo-org.Grayjay.Desktop.locale.en-US.yaml
+++ b/manifests/f/futo-org/Grayjay/Desktop/v2/futo-org.Grayjay.Desktop.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# Created with komac v2.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: futo-org.Grayjay.Desktop
+PackageVersion: v2
+PackageLocale: en-US
+Publisher: Futo
+PublisherUrl: https://futo.org/
+PublisherSupportUrl: https://github.com/futo-org/Grayjay.Desktop/issues
+PackageName: GrayJay.Desktop
+PackageUrl: https://grayjay.app/desktop/
+License: Source First License 1.1
+LicenseUrl: https://github.com/futo-org/Grayjay.Desktop/blob/master/LICENSE.md
+ShortDescription: Follow Creators, Not Platforms
+Description: |-
+  Watch content on your own terms, ensuring you retain full ownership and control over what you
+  watch. Your content, your way.
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/f/futo-org/Grayjay/Desktop/v2/futo-org.Grayjay.Desktop.yaml
+++ b/manifests/f/futo-org/Grayjay/Desktop/v2/futo-org.Grayjay.Desktop.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: futo-org.Grayjay.Desktop
+PackageVersion: v2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## Checklist for Pull Requests

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Resolve #202148

## Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.9.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

## Manual validation

> [!WARNING]
> 
> It seems this package can't be launched via command line, even though `ArchiveBinariesDependOnPath: true` is configured.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/202156)