### PR TITLE
[Update Package] Microsoft.DotNet.HostingBundle.6: version 6.0.15: update installer URL

### DIFF
--- a/manifests/m/Microsoft/DotNet/HostingBundle/6/6.0.15/Microsoft.DotNet.HostingBundle.6.installer.yaml
+++ b/manifests/m/Microsoft/DotNet/HostingBundle/6/6.0.15/Microsoft.DotNet.HostingBundle.6.installer.yaml
@@ -11,7 +11,7 @@ InstallerSwitches:
 Installers:
 - Architecture: x86
   InstallerType: burn
-  InstallerUrl: https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/6.0.15/dotnet-hosting-6.0.15-win.exe
+  InstallerUrl: https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/6.0.15/dotnet-hosting-6.0.15-win.exe
   InstallerSha256: A673F81A63FEC26AFF5872A38631BC9BD8433A6C5B828C3E1B65276BD7BCBB4A
   ProductCode: '{797df013-1f2b-44e7-ada3-36623d6dccd8}'
   AppsAndFeaturesEntries:
@@ -20,5 +20,5 @@ Installers:
     DisplayVersion: 6.0.15.23124
     ProductCode: '{797df013-1f2b-44e7-ada3-36623d6dccd8}'
 ManifestType: installer
-ManifestVersion: 1.1.0
+ManifestVersion: 1.9.0
 

--- a/manifests/m/Microsoft/DotNet/HostingBundle/6/6.0.15/Microsoft.DotNet.HostingBundle.6.locale.en-US.yaml
+++ b/manifests/m/Microsoft/DotNet/HostingBundle/6/6.0.15/Microsoft.DotNet.HostingBundle.6.locale.en-US.yaml
@@ -28,5 +28,5 @@ Tags:
 - hosting bundle
 - IIS
 ManifestType: defaultLocale
-ManifestVersion: 1.1.0
+ManifestVersion: 1.9.0
 

--- a/manifests/m/Microsoft/DotNet/HostingBundle/6/6.0.15/Microsoft.DotNet.HostingBundle.6.yaml
+++ b/manifests/m/Microsoft/DotNet/HostingBundle/6/6.0.15/Microsoft.DotNet.HostingBundle.6.yaml
@@ -5,5 +5,5 @@ PackageIdentifier: Microsoft.DotNet.HostingBundle.6
 PackageVersion: 6.0.15
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.1.0
+ManifestVersion: 1.9.0
 


### PR DESCRIPTION
Microsoft.DotNet.HostingBundle.6: version 6.0.15: update installer URLs to new CDN.  
This PR is part of a bulk update.  
see #202037
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/202686)