### PR TITLE
[Update Package] Microsoft.DotNet.HostingBundle.6: version 6.0.16: update installer URL

### DIFF
--- a/manifests/m/Microsoft/DotNet/HostingBundle/6/6.0.16/Microsoft.DotNet.HostingBundle.6.installer.yaml
+++ b/manifests/m/Microsoft/DotNet/HostingBundle/6/6.0.16/Microsoft.DotNet.HostingBundle.6.installer.yaml
@@ -11,7 +11,7 @@ InstallerSwitches:
 Installers:
 - Architecture: x86
   InstallerType: burn
-  InstallerUrl: https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/6.0.16/dotnet-hosting-6.0.16-win.exe
+  InstallerUrl: https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/6.0.16/dotnet-hosting-6.0.16-win.exe
   InstallerSha256: A6FBC64CAB98C8FB094100669F8E1F410E7BA316398C0DA99BBC8812BC568EEC
   ProductCode: '{58f3f479-fe1b-4cb4-b547-d6cb9196eac4}'
   AppsAndFeaturesEntries:
@@ -20,5 +20,5 @@ Installers:
     DisplayVersion: 6.0.16.23174
     ProductCode: '{58f3f479-fe1b-4cb4-b547-d6cb9196eac4}'
 ManifestType: installer
-ManifestVersion: 1.1.0
+ManifestVersion: 1.9.0
 

--- a/manifests/m/Microsoft/DotNet/HostingBundle/6/6.0.16/Microsoft.DotNet.HostingBundle.6.locale.en-US.yaml
+++ b/manifests/m/Microsoft/DotNet/HostingBundle/6/6.0.16/Microsoft.DotNet.HostingBundle.6.locale.en-US.yaml
@@ -28,5 +28,5 @@ Tags:
 - hosting bundle
 - IIS
 ManifestType: defaultLocale
-ManifestVersion: 1.1.0
+ManifestVersion: 1.9.0
 

--- a/manifests/m/Microsoft/DotNet/HostingBundle/6/6.0.16/Microsoft.DotNet.HostingBundle.6.yaml
+++ b/manifests/m/Microsoft/DotNet/HostingBundle/6/6.0.16/Microsoft.DotNet.HostingBundle.6.yaml
@@ -5,5 +5,5 @@ PackageIdentifier: Microsoft.DotNet.HostingBundle.6
 PackageVersion: 6.0.16
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.1.0
+ManifestVersion: 1.9.0
 


### PR DESCRIPTION
Microsoft.DotNet.HostingBundle.6: version 6.0.16: update installer URLs to new CDN.  
This PR is part of a bulk update.  
see #202037
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/202687)