### PR TITLE
[Update Package] Microsoft.DotNet.HostingBundle.6: version 6.0.22: update installer URL

### DIFF
--- a/manifests/m/Microsoft/DotNet/HostingBundle/6/6.0.22/Microsoft.DotNet.HostingBundle.6.installer.yaml
+++ b/manifests/m/Microsoft/DotNet/HostingBundle/6/6.0.22/Microsoft.DotNet.HostingBundle.6.installer.yaml
@@ -11,7 +11,7 @@ InstallerSwitches:
 Installers:
 - Architecture: x86
   InstallerType: burn
-  InstallerUrl: https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/6.0.22/dotnet-hosting-6.0.22-win.exe
+  InstallerUrl: https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/6.0.22/dotnet-hosting-6.0.22-win.exe
   InstallerSha256: 2C2F091AD75915F11783F7DA4A87B3D9C6DC4504FD29C5D76A21C3AD1F07B894
   ProductCode: '{e9c5b436-c2f7-4a9e-8a63-55c9e4eb1bcb}'
   AppsAndFeaturesEntries:
@@ -20,5 +20,5 @@ Installers:
     DisplayVersion: 6.0.22.23424
     ProductCode: '{e9c5b436-c2f7-4a9e-8a63-55c9e4eb1bcb}'
 ManifestType: installer
-ManifestVersion: 1.1.0
+ManifestVersion: 1.9.0
 

--- a/manifests/m/Microsoft/DotNet/HostingBundle/6/6.0.22/Microsoft.DotNet.HostingBundle.6.locale.en-US.yaml
+++ b/manifests/m/Microsoft/DotNet/HostingBundle/6/6.0.22/Microsoft.DotNet.HostingBundle.6.locale.en-US.yaml
@@ -28,5 +28,5 @@ Tags:
 - hosting bundle
 - IIS
 ManifestType: defaultLocale
-ManifestVersion: 1.1.0
+ManifestVersion: 1.9.0
 

--- a/manifests/m/Microsoft/DotNet/HostingBundle/6/6.0.22/Microsoft.DotNet.HostingBundle.6.yaml
+++ b/manifests/m/Microsoft/DotNet/HostingBundle/6/6.0.22/Microsoft.DotNet.HostingBundle.6.yaml
@@ -5,5 +5,5 @@ PackageIdentifier: Microsoft.DotNet.HostingBundle.6
 PackageVersion: 6.0.22
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.1.0
+ManifestVersion: 1.9.0
 


### PR DESCRIPTION
Microsoft.DotNet.HostingBundle.6: version 6.0.22: update installer URLs to new CDN.  
This PR is part of a bulk update.  
see #202037
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/202692)