### PR TITLE
[Update Package] Microsoft.DotNet.HostingBundle.6: version 6.0.25: update installer URL

### DIFF
--- a/manifests/m/Microsoft/DotNet/HostingBundle/6/6.0.25/Microsoft.DotNet.HostingBundle.6.installer.yaml
+++ b/manifests/m/Microsoft/DotNet/HostingBundle/6/6.0.25/Microsoft.DotNet.HostingBundle.6.installer.yaml
@@ -11,7 +11,7 @@ InstallerSwitches:
 Installers:
 - Architecture: x86
   InstallerType: burn
-  InstallerUrl: https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/6.0.25/dotnet-hosting-6.0.25-win.exe
+  InstallerUrl: https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/6.0.25/dotnet-hosting-6.0.25-win.exe
   InstallerSha256: 029B5E840F0BF0B473BE86A247879BE6F854B563269792CD1534BF9A950DE731
   ProductCode: '{b4a5e26c-84fd-4b01-8d3f-42022169595a}'
   AppsAndFeaturesEntries:
@@ -20,5 +20,5 @@ Installers:
     DisplayVersion: 6.0.25.23523
     ProductCode: '{b4a5e26c-84fd-4b01-8d3f-42022169595a}'
 ManifestType: installer
-ManifestVersion: 1.1.0
+ManifestVersion: 1.9.0
 

--- a/manifests/m/Microsoft/DotNet/HostingBundle/6/6.0.25/Microsoft.DotNet.HostingBundle.6.locale.en-US.yaml
+++ b/manifests/m/Microsoft/DotNet/HostingBundle/6/6.0.25/Microsoft.DotNet.HostingBundle.6.locale.en-US.yaml
@@ -28,5 +28,5 @@ Tags:
 - hosting bundle
 - IIS
 ManifestType: defaultLocale
-ManifestVersion: 1.1.0
+ManifestVersion: 1.9.0
 

--- a/manifests/m/Microsoft/DotNet/HostingBundle/6/6.0.25/Microsoft.DotNet.HostingBundle.6.yaml
+++ b/manifests/m/Microsoft/DotNet/HostingBundle/6/6.0.25/Microsoft.DotNet.HostingBundle.6.yaml
@@ -5,5 +5,5 @@ PackageIdentifier: Microsoft.DotNet.HostingBundle.6
 PackageVersion: 6.0.25
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.1.0
+ManifestVersion: 1.9.0
 


### PR DESCRIPTION
Microsoft.DotNet.HostingBundle.6: version 6.0.25: update installer URLs to new CDN.  
This PR is part of a bulk update.  
see #202037
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/202695)