### PR TITLE
[Update Package] Microsoft.DotNet.HostingBundle.6: version 6.0.32: update installer URL

### DIFF
--- a/manifests/m/Microsoft/DotNet/HostingBundle/6/6.0.32/Microsoft.DotNet.HostingBundle.6.installer.yaml
+++ b/manifests/m/Microsoft/DotNet/HostingBundle/6/6.0.32/Microsoft.DotNet.HostingBundle.6.installer.yaml
@@ -11,7 +11,7 @@ InstallerSwitches:
 Installers:
 - Architecture: x86
   InstallerType: burn
-  InstallerUrl: https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/6.0.32/dotnet-hosting-6.0.32-win.exe
+  InstallerUrl: https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/6.0.32/dotnet-hosting-6.0.32-win.exe
   InstallerSha256: 8E18603AECC3819EBA74F222914BAB7952348A205C60259E5BE4E41387872DD5
   ProductCode: '{6ea69693-b3f5-4c76-97ef-c8394d55fe67}'
   AppsAndFeaturesEntries:
@@ -20,5 +20,5 @@ Installers:
     DisplayVersion: 6.0.32.24314
     ProductCode: '{6ea69693-b3f5-4c76-97ef-c8394d55fe67}'
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0
 

--- a/manifests/m/Microsoft/DotNet/HostingBundle/6/6.0.32/Microsoft.DotNet.HostingBundle.6.locale.en-US.yaml
+++ b/manifests/m/Microsoft/DotNet/HostingBundle/6/6.0.32/Microsoft.DotNet.HostingBundle.6.locale.en-US.yaml
@@ -28,5 +28,5 @@ Tags:
 - hosting bundle
 - IIS
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0
 

--- a/manifests/m/Microsoft/DotNet/HostingBundle/6/6.0.32/Microsoft.DotNet.HostingBundle.6.yaml
+++ b/manifests/m/Microsoft/DotNet/HostingBundle/6/6.0.32/Microsoft.DotNet.HostingBundle.6.yaml
@@ -5,5 +5,5 @@ PackageIdentifier: Microsoft.DotNet.HostingBundle.6
 PackageVersion: 6.0.32
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0
 


### PR DESCRIPTION
Microsoft.DotNet.HostingBundle.6: version 6.0.32: update installer URLs to new CDN.  
This PR is part of a bulk update.  
see #202037
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/202701)