### PR TITLE
New package: Rustlang.mdBook version 0.4.43

### DIFF
--- a/manifests/r/Rustlang/mdBook/0.4.43/Rustlang.mdBook.installer.yaml
+++ b/manifests/r/Rustlang/mdBook/0.4.43/Rustlang.mdBook.installer.yaml
@@ -1,0 +1,26 @@
+# Created with komac v2.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: Rustlang.mdBook
+PackageVersion: 0.4.43
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: mdbook.exe
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: uninstallPrevious
+FileExtensions:
+- md
+ReleaseDate: 2024-11-25
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/rust-lang/mdBook/releases/download/v0.4.43/mdbook-v0.4.43-x86_64-pc-windows-msvc.zip
+  InstallerSha256: A8BBC1920E43DC88D2D10D0E3A271AF863BB6F76545C6CDECC35DD1B30852A86
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/r/Rustlang/mdBook/0.4.43/Rustlang.mdBook.locale.en-US.yaml
+++ b/manifests/r/Rustlang/mdBook/0.4.43/Rustlang.mdBook.locale.en-US.yaml
@@ -1,0 +1,18 @@
+# Created with komac v2.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: Rustlang.mdBook
+PackageVersion: 0.4.43
+PackageLocale: en-US
+Publisher: The Rust Programming Language
+PublisherUrl: https://www.rust-lang.org/
+PublisherSupportUrl: https://github.com/rust-lang/mdBook/issues
+PackageName: mdBook
+PackageUrl: https://github.com/rust-lang/mdBook
+License: MPL-2.0
+LicenseUrl: https://github.com/rust-lang/mdBook/blob/master/LICENSE
+ShortDescription: Create book from markdown files. Like Gitbook but implemented in Rust.
+Description: mdBook is a utility to create modern online books from Markdown files.
+ReleaseNotesUrl: https://github.com/rust-lang/mdBook/blob/master/CHANGELOG.md#mdbook-0443
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/r/Rustlang/mdBook/0.4.43/Rustlang.mdBook.yaml
+++ b/manifests/r/Rustlang/mdBook/0.4.43/Rustlang.mdBook.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: Rustlang.mdBook
+PackageVersion: 0.4.43
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## Checklist for Pull Requests

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Resolve #202702

## Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.9.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

## Manual validation

<details><summary>Installation logs</summary>

```text
--> Installing WinGet
--> Disabling safety warning when running installers
Tip: you can type 'Update-EnvironmentVariables' to update your environment variables, such as after installing a new software.

--> Configuring Winget
Enabled admin setting 'LocalManifestFiles'.
Enabled admin setting 'LocalArchiveMalwareScanOverride'.

--> Installing the Manifest 0.4.43

Found mdBook [Rustlang.mdBook] Version 0.4.43
This application is licensed to you by its owner.
Microsoft is not responsible for, nor does it grant any licenses to, third-party packages.
This package requires the following dependencies:
  - Packages
      Microsoft.VCRedist.2015+.x64
(1/1) Found Microsoft Visual C++ 2015-2022 Redistributable (x64) [Microsoft.VCRedist.2015+.x64] Version 14.42.34433.0
This application is licensed to you by its owner.
Microsoft is not responsible for, nor does it grant any licenses to, third-party packages.
Downloading https://download.visualstudio.microsoft.com/download/pr/c7dac50a-e3e8-40f6-bbb2-9cc4e3dfcabe/1821577409C35B2B9505AC833E246376CC68A8262972100444010B57226F0940/VC_redist.x64.exe
  ██████████████████████████████  24.4 MB / 24.4 MB
Successfully verified installer hash
Starting package install...
Successfully installed

Downloading https://github.com/rust-lang/mdBook/releases/download/v0.4.43/mdbook-v0.4.43-x86_64-pc-windows-msvc.zip
  ██████████████████████████████  4.12 MB / 4.12 MB
Successfully verified installer hash
Extracting archive...
Successfully extracted archive
Starting package install...
Command line alias added: "mdbook"
Path environment variable modified; restart your shell to use the new value.
Successfully installed

--> Refreshing environment variables

--> Comparing ARP Entries

DisplayName                                                        DisplayVersion Publisher                     ProductCode                            Scope
-----------                                                        -------------- ---------                     -----------                            -----
Microsoft Visual C++ 2015-2022 Redistributable (x64) - 14.42.34433 14.42.34433.0  Microsoft Corporation         {804e7d66-ccc2-4c12-84ba-476da31d103d} Machine
mdBook                                                             0.4.43         The Rust Programming Language Rustlang.mdBook__DefaultSource         User
```

</details>
<details><summary>Validation logs</summary>

```text
PS C:\Users\WDAGUtilityAccount\Desktop\winget-pkgs> mdbook.exe --version
mdbook v0.4.43
PS C:\Users\WDAGUtilityAccount\Desktop\winget-pkgs> mdbook.exe --help
Creates a book from markdown files

Usage: mdbook.exe [COMMAND]

Commands:
  init         Creates the boilerplate structure and files for a new book
  build        Builds a book from its markdown files
  test         Tests that a book's Rust code samples compile
  clean        Deletes a built book
  completions  Generate shell completions for your shell to stdout
  watch        Watches a book's files and rebuilds it on changes
  serve        Serves a book at http://localhost:3000, and rebuilds it on changes
  help         Print this message or the help of the given subcommand(s)

Options:
  -h, --help     Print help
  -V, --version  Print version

For more information about a specific command, try `mdbook <command> --help`
The source code for mdBook is available at: https://github.com/rust-lang/mdBook
```

</details>

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/202772)