### PR TITLE
New package: badboy.mdbook-toc version 0.14.2

### DIFF
--- a/manifests/b/badboy/mdbook-toc/0.14.2/badboy.mdbook-toc.installer.yaml
+++ b/manifests/b/badboy/mdbook-toc/0.14.2/badboy.mdbook-toc.installer.yaml
@@ -1,0 +1,26 @@
+# Created with komac v2.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: badboy.mdbook-toc
+PackageVersion: 0.14.2
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: mdbook-toc.exe
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: uninstallPrevious
+FileExtensions:
+- md
+ReleaseDate: 2023-12-13
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Rustlang.mdBook
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/badboy/mdbook-toc/releases/download/0.14.2/mdbook-toc-0.14.2-x86_64-pc-windows-msvc.zip
+  InstallerSha256: 1083DA7227126E230E9B281A23E0C936EEFD8AF3A27D3E2E2704945CED9EC654
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/b/badboy/mdbook-toc/0.14.2/badboy.mdbook-toc.locale.en-US.yaml
+++ b/manifests/b/badboy/mdbook-toc/0.14.2/badboy.mdbook-toc.locale.en-US.yaml
@@ -1,0 +1,18 @@
+# Created with komac v2.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: badboy.mdbook-toc
+PackageVersion: 0.14.2
+PackageLocale: en-US
+Publisher: Jan-Erik Rediger
+PublisherUrl: https://github.com/badboy
+PublisherSupportUrl: https://github.com/badboy/mdbook-toc/issues
+Author: Jan-Erik Rediger
+PackageName: mdbook-toc
+PackageUrl: https://github.com/badboy/mdbook-toc
+License: MPL-2.0
+LicenseUrl: https://github.com/badboy/mdbook-toc/blob/main/LICENSE
+ShortDescription: A preprocessor for mdbook to add inline Table of Contents support.
+ReleaseNotesUrl: https://github.com/badboy/mdbook-toc/releases/tag/0.14.2
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/b/badboy/mdbook-toc/0.14.2/badboy.mdbook-toc.yaml
+++ b/manifests/b/badboy/mdbook-toc/0.14.2/badboy.mdbook-toc.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: badboy.mdbook-toc
+PackageVersion: 0.14.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## Checklist for Pull Requests

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Resolve #202859

## Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.9.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

## Manual validation

<details><summary>Installation logs</summary>

```text
--> Installing WinGet
--> Disabling safety warning when running installers
Tip: you can type 'Update-EnvironmentVariables' to update your environment variables, such as after installing a new software.

--> Configuring Winget
已启用管理员设置 'LocalManifestFiles'。
已启用管理员设置 'LocalArchiveMalwareScanOverride'。

--> Installing the Manifest 0.14.2

已找到 mdbook-toc [badboy.mdbook-toc] 版本 0.14.2
此应用程序由其所有者授权给你。
Microsoft 对第三方程序包概不负责，也不向第三方程序包授予任何许可证。
此包需要以下依赖项：
  - 程序包
      Rustlang.mdBook
(1/2) 已找到 Microsoft Visual C++ 2015-2022 Redistributable (x64) [Microsoft.VCRedist.2015+.x64] 版本 14.42.34433.0
此应用程序由其所有者授权给你。
Microsoft 对第三方程序包概不负责，也不向第三方程序包授予任何许可证。
正在下载 https://download.visualstudio.microsoft.com/download/pr/c7dac50a-e3e8-40f6-bbb2-9cc4e3dfcabe/1821577409C35B2B9505AC833E246376CC68A8262972100444010B57226F0940/VC_redist.x64.exe
  ██████████████████████████████  24.4 MB / 24.4 MB
已成功验证安装程序哈希
正在启动程序包安装...
已成功安装

(2/2) 已找到 mdBook [Rustlang.mdBook] 版本 0.4.43
此应用程序由其所有者授权给你。
Microsoft 对第三方程序包概不负责，也不向第三方程序包授予任何许可证。
正在下载 https://github.com/rust-lang/mdBook/releases/download/v0.4.43/mdbook-v0.4.43-x86_64-pc-windows-msvc.zip
  ██████████████████████████████  4.12 MB / 4.12 MB
已成功验证安装程序哈希
正在提取存档...
已成功提取存档
正在启动程序包安装...
添加了命令行别名： "mdbook"
已修改路径环境变量；重启 shell 以使用新值。
已成功安装

正在下载 https://github.com/badboy/mdbook-toc/releases/download/0.14.2/mdbook-toc-0.14.2-x86_64-pc-windows-msvc.zip
  ██████████████████████████████   465 KB /  465 KB
已成功验证安装程序哈希
正在提取存档...
已成功提取存档
正在启动程序包安装...
添加了命令行别名： "mdbook-toc"
已成功安装

--> Refreshing environment variables

--> Comparing ARP Entries

DisplayName                                                        DisplayVersion Publisher                     ProductCode
-----------                                                        -------------- ---------                     -----------
Microsoft Visual C++ 2015-2022 Redistributable (x64) - 14.42.34433 14.42.34433.0  Microsoft Corporation         {804e7d66-c...
mdbook-toc                                                         0.14.2         Jan-Erik Rediger              badboy.mdbo...
mdBook                                                             0.4.43         The Rust Programming Language Rustlang.md...


PS C:\Users\WDAGUtilityAccount\Desktop\winget-pkgs> Get-ARPTable | Format-Table

DisplayName                                                        DisplayVersion Publisher                     ProductCode
-----------                                                        -------------- ---------                     -----------
Microsoft Edge                                                     131.0.2903.99  Microsoft Corporation         Microsoft Edge
Microsoft Edge Update                                              1.3.195.39                                   Microsoft Edge Update
Microsoft Visual C++ 2015-2022 Redistributable (x64) - 14.42.34433 14.42.34433.0  Microsoft Corporation         {804e7d66-ccc2-4c12-84ba-476da31d103d}
mdbook-toc                                                         0.14.2         Jan-Erik Rediger              badboy.mdbook-toc__DefaultSource
mdBook                                                             0.4.43         The Rust Programming Language Rustlang.mdBook_Microsoft.Winget.Source_...
```

</details>
<details><summary>Validation logs</summary>

```text
PS C:\Users\WDAGUtilityAccount\Desktop\winget-pkgs> mdbook-toc.exe --help
mdbook preprocessor to add Table of Contents

Usage: mdbook-toc.exe [COMMAND]

Commands:
  supports  Check whether a renderer is supported by this preprocessor
  help      Print this message or the help of the given subcommand(s)

Options:
  -h, --help     Print help
  -V, --version  Print version
PS C:\Users\WDAGUtilityAccount\Desktop\winget-pkgs> mdbook-toc.exe --version
mdbook-toc 0.14.2
```

</details>

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/202934)