### PR TITLE
New package: Devicetree compiler version 1.6.1

### DIFF
--- a/manifests/d/Devicetree/dtc/1.6.1/Devicetree.dtc.installer.yaml
+++ b/manifests/d/Devicetree/dtc/1.6.1/Devicetree.dtc.installer.yaml
@@ -1,0 +1,16 @@
+# Created using wingetcreate 1.9.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: Devicetree.dtc
+PackageVersion: 1.6.1
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: usr\bin\dtc.exe
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/carlescufi/winget-packages/raw/refs/heads/main/packages/dtc/1.6.1/dtc-msys2-1.6.1-x86_64.zip
+  InstallerSha256: 7AAC366F989FD2450D5E641E118734653EA29D0DDB7DBFA33521D57AFE852AE3
+  ArchiveBinariesDependOnPath: true
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/d/Devicetree/dtc/1.6.1/Devicetree.dtc.locale.en-US.yaml
+++ b/manifests/d/Devicetree/dtc/1.6.1/Devicetree.dtc.locale.en-US.yaml
@@ -1,0 +1,12 @@
+# Created using wingetcreate 1.9.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: Devicetree.dtc
+PackageVersion: 1.6.1
+PackageLocale: en-US
+Publisher: Devicetree.org
+PackageName: dtc
+License: GPL-2.0
+ShortDescription: Devicetree compiler
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/d/Devicetree/dtc/1.6.1/Devicetree.dtc.yaml
+++ b/manifests/d/Devicetree/dtc/1.6.1/Devicetree.dtc.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.9.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: Devicetree.dtc
+PackageVersion: 1.6.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
This adds the Devicetree compiler (dtc) version 1.6.1.

Replaces previous attempt in #114001

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.9.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/202965)