### PR TITLE
UPDATE SCHEMA: nkdAgility.AzureDevOpsMigrationTools.16.0.9 to add ArchiveBinariesDependOnPath for Schema 1.9

### DIFF
--- a/manifests/n/nkdAgility/AzureDevOpsMigrationTools/16.0.9/nkdAgility.AzureDevOpsMigrationTools.installer.yaml
+++ b/manifests/n/nkdAgility/AzureDevOpsMigrationTools/16.0.9/nkdAgility.AzureDevOpsMigrationTools.installer.yaml
@@ -1,5 +1,5 @@
-# Created using wingetcreate 1.6.5.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# Created using wingetcreate 1.9.2.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 
 PackageIdentifier: nkdAgility.AzureDevOpsMigrationTools
 PackageVersion: 16.0.9
@@ -7,14 +7,21 @@ InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
 - RelativeFilePath: devopsmigration.exe
+  PortableCommandAlias: devopsmigration
 Dependencies:
   PackageDependencies:
   - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.8
   - PackageIdentifier: Microsoft.DotNet.Framework.DeveloperPack_4
+ArchiveBinariesDependOnPath: true
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/nkdAgility/azure-devops-migration-tools/releases/download/v16.0.9/MigrationTools-16.0.9.zip
   InstallerSha256: DAC100E9B77589666709AA4B4A6F4C9274CDD2AD78D42914F39C53F398721BD3
 ManifestType: installer
-ManifestVersion: 1.6.0
-ReleaseDate: 2024-12-04
+ManifestVersion: 1.9.0
+ReleaseDate: 2024-12-27
+
+
+
+
+

--- a/manifests/n/nkdAgility/AzureDevOpsMigrationTools/16.0.9/nkdAgility.AzureDevOpsMigrationTools.locale.en-US.yaml
+++ b/manifests/n/nkdAgility/AzureDevOpsMigrationTools/16.0.9/nkdAgility.AzureDevOpsMigrationTools.locale.en-US.yaml
@@ -24,4 +24,4 @@ Tags:
 - vsts
 ReleaseNotesUrl: https://github.com/nkdAgility/azure-devops-migration-tools/releases/tag/v16.0.9
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/n/nkdAgility/AzureDevOpsMigrationTools/16.0.9/nkdAgility.AzureDevOpsMigrationTools.yaml
+++ b/manifests/n/nkdAgility/AzureDevOpsMigrationTools/16.0.9/nkdAgility.AzureDevOpsMigrationTools.yaml
@@ -5,4 +5,4 @@ PackageIdentifier: nkdAgility.AzureDevOpsMigrationTools
 PackageVersion: 16.0.9
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0


### PR DESCRIPTION
This change adds the necessary feature from https://github.com/microsoft/winget-cli/pull/4816 to handle https://github.com/microsoft/winget-cli/issues/2711 which we suffer from.

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.9.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

This change adds the necessary feature from https://github.com/microsoft/winget-cli/pull/4816 to handle https://github.com/microsoft/winget-cli/issues/2711 which we suffer from.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/209263)