### PR TITLE
Remove unnecessary entries from Conan manfiests

### DIFF
--- a/manifests/j/JFrog/Conan/2.10.0/JFrog.Conan.installer.yaml
+++ b/manifests/j/JFrog/Conan/2.10.0/JFrog.Conan.installer.yaml
@@ -18,8 +18,6 @@ ReleaseDate: 2024-12-03
 AppsAndFeaturesEntries:
 - ProductCode: Conan Package Manager_is1
 ElevationRequirement: elevatesSelf
-InstallationMetadata:
-  DefaultInstallLocation: '{code:DefDirRoot}\Conan'
 Installers:
 - Architecture: x86
   InstallerUrl: https://github.com/conan-io/conan/releases/download/2.10.0/conan-2.10.0-windows-i686-installer.exe

--- a/manifests/j/JFrog/Conan/2.10.1/JFrog.Conan.installer.yaml
+++ b/manifests/j/JFrog/Conan/2.10.1/JFrog.Conan.installer.yaml
@@ -18,8 +18,6 @@ ReleaseDate: 2024-12-04
 AppsAndFeaturesEntries:
 - ProductCode: Conan Package Manager_is1
 ElevationRequirement: elevatesSelf
-InstallationMetadata:
-  DefaultInstallLocation: '{code:DefDirRoot}\Conan'
 Installers:
 - Architecture: x86
   InstallerUrl: https://github.com/conan-io/conan/releases/download/2.10.1/conan-2.10.1-windows-i686-installer.exe

--- a/manifests/j/JFrog/Conan/2.10.2/JFrog.Conan.installer.yaml
+++ b/manifests/j/JFrog/Conan/2.10.2/JFrog.Conan.installer.yaml
@@ -18,8 +18,6 @@ ReleaseDate: 2024-12-10
 AppsAndFeaturesEntries:
 - ProductCode: Conan Package Manager_is1
 ElevationRequirement: elevatesSelf
-InstallationMetadata:
-  DefaultInstallLocation: '{code:DefDirRoot}\Conan'
 Installers:
 - Architecture: x86
   InstallerUrl: https://github.com/conan-io/conan/releases/download/2.10.2/conan-2.10.2-windows-i686-installer.exe

--- a/manifests/j/JFrog/Conan/2.10.3/JFrog.Conan.installer.yaml
+++ b/manifests/j/JFrog/Conan/2.10.3/JFrog.Conan.installer.yaml
@@ -18,8 +18,6 @@ ReleaseDate: 2024-12-18
 AppsAndFeaturesEntries:
 - ProductCode: Conan Package Manager_is1
 ElevationRequirement: elevatesSelf
-InstallationMetadata:
-  DefaultInstallLocation: '{code:DefDirRoot}\Conan'
 Installers:
 - Architecture: x86
   InstallerUrl: https://github.com/conan-io/conan/releases/download/2.10.3/conan-2.10.3-windows-i686-installer.exe

--- a/manifests/j/JFrog/Conan/2.11.0/JFrog.Conan.installer.yaml
+++ b/manifests/j/JFrog/Conan/2.11.0/JFrog.Conan.installer.yaml
@@ -18,8 +18,6 @@ ReleaseDate: 2024-12-18
 AppsAndFeaturesEntries:
 - ProductCode: Conan Package Manager_is1
 ElevationRequirement: elevatesSelf
-InstallationMetadata:
-  DefaultInstallLocation: '{code:DefDirRoot}\Conan'
 Installers:
 - Architecture: x86
   InstallerUrl: https://github.com/conan-io/conan/releases/download/2.11.0/conan-2.11.0-windows-i686-installer.exe


### PR DESCRIPTION
As pointed out in #202046, Conan manifests started receiving some weird entries for default installation directory. It looks like some remnant of VSCode variable.

Let's get rid of those.

Checklist for Pull Requests

**Checklist does not apply as it's a fix for existing manifests**

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/209406)