### PR TITLE
Remove unnecessary entries from Conan 2.10.1

### DIFF
--- a/manifests/j/JFrog/Conan/2.10.1/JFrog.Conan.installer.yaml
+++ b/manifests/j/JFrog/Conan/2.10.1/JFrog.Conan.installer.yaml
@@ -18,8 +18,6 @@ ReleaseDate: 2024-12-04
 AppsAndFeaturesEntries:
 - ProductCode: Conan Package Manager_is1
 ElevationRequirement: elevatesSelf
-InstallationMetadata:
-  DefaultInstallLocation: '{code:DefDirRoot}\Conan'
 Installers:
 - Architecture: x86
   InstallerUrl: https://github.com/conan-io/conan/releases/download/2.10.1/conan-2.10.1-windows-i686-installer.exe


### PR DESCRIPTION
As pointed out in #202046, Conan manifests started receiving some weird entries for default installation directory. It looks like some remnant of VSCode variable.

Let's get rid of those.

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.9.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/210097)