### PR TITLE
New version: stevencohn.OneMore version 6.7.1

### DIFF
--- a/manifests/s/stevencohn/OneMore/6.7.1/stevencohn.OneMore.installer.yaml
+++ b/manifests/s/stevencohn/OneMore/6.7.1/stevencohn.OneMore.installer.yaml
@@ -1,0 +1,31 @@
+# Created using wingetcreate 1.9.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: stevencohn.OneMore
+PackageVersion: 6.7.1
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+InstallerType: msi
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.EdgeWebView2Runtime
+ProductCode: '{99676656-16B8-483C-9BF8-2DC2C251755C}'
+AppsAndFeaturesEntries:
+- UpgradeCode: '{058F6D04-E0D0-4984-B6B7-7FE0C581680E}'
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/stevencohn/OneMore/releases/download/6.7.1/OneMore_6.7.1_Setupx86.msi
+  InstallerSha256: 88DB6B3273F7086BDB62E830A0D8307A6A13A04F177B21EEB64FE04E3EAFECAB
+- Architecture: x64
+  InstallerUrl: https://github.com/stevencohn/OneMore/releases/download/6.7.1/OneMore_6.7.1_Setupx64.msi
+  InstallerSha256: 538BCCFF9084A0FCB330FF03A7BFC969DDF7CE07235584E30B121C8641DC761D
+ManifestType: installer
+ManifestVersion: 1.9.0
+ReleaseDate: 2025-01-02

--- a/manifests/s/stevencohn/OneMore/6.7.1/stevencohn.OneMore.locale.en-US.yaml
+++ b/manifests/s/stevencohn/OneMore/6.7.1/stevencohn.OneMore.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# Created using wingetcreate 1.9.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: stevencohn.OneMore
+PackageVersion: 6.7.1
+PackageLocale: en-US
+Publisher: River
+PublisherUrl: https://stevencohn.net
+PublisherSupportUrl: https://github.com/stevencohn/OneMore/issues
+Author: Steven M. Cohn
+PackageName: OneMoreAddIn
+PackageUrl: https://github.com/stevencohn/OneMore
+License: MPL-2.0
+LicenseUrl: https://raw.githubusercontent.com/stevencohn/OneMore/main/LICENSE
+ShortDescription: A OneNote add-in with simple, yet powerful and useful features
+Tags:
+- extension
+- hotkey
+- note
+- office
+- onenote
+- plugin
+ReleaseNotesUrl: https://github.com/stevencohn/OneMore/releases/tag/6.7.1
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/s/stevencohn/OneMore/6.7.1/stevencohn.OneMore.yaml
+++ b/manifests/s/stevencohn/OneMore/6.7.1/stevencohn.OneMore.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.9.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: stevencohn.OneMore
+PackageVersion: 6.7.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION

## Notice:
This package has a dependency on `Microsoft OneNote`. As we don't want to dictate the specific dependency used, the dependency is omitted in the manifest. The package therefore needs a manual validation with manual installation of the dependency.

See https://github.com/microsoft/winget-pkgs/issues/178311#issuecomment-2400447708

resolves #178311
resolves #210064
