### PR TITLE
Update manifest: Spotify.Spotify version 1.2.53.440.g7b2f582a

### DIFF
--- a/manifests/s/Spotify/Spotify/1.2.53.440.g7b2f582a/Spotify.Spotify.installer.yaml
+++ b/manifests/s/Spotify/Spotify/1.2.53.440.g7b2f582a/Spotify.Spotify.installer.yaml
@@ -8,8 +8,8 @@ Scope: user
 InstallModes:
 - silent
 InstallerSwitches:
-  Silent: /silent
-  SilentWithProgress: /silent
+  Silent: /silent /skip-app-launch
+  SilentWithProgress: /silent /skip-app-launch
   Log: /log-file "<LOGPATH>"
 ExpectedReturnCodes:
 - InstallerReturnCode: 26


### PR DESCRIPTION
## What's changed

- Add more switches to suppress the default "launch after install" behavior.

## Checklist for Pull Requests

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Resolve #210640

## Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.9.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/210697)