### PR TITLE
Modify: KeeperSecurity.Commander version v16.11.0

### DIFF
--- a/manifests/k/KeeperSecurity/Commander/v16.11.0/KeeperSecurity.Commander.installer.yaml
+++ b/manifests/k/KeeperSecurity/Commander/v16.11.0/KeeperSecurity.Commander.installer.yaml
@@ -1,5 +1,5 @@
-# Created with komac v2.2.1
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# Created with DuckDuckStudio's Automation.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 
 PackageIdentifier: KeeperSecurity.Commander
 PackageVersion: v16.11.0
@@ -13,8 +13,8 @@ Commands:
 - keeper
 ReleaseDate: 2024-05-17
 Installers:
-- Architecture: x64
+- Architecture: x86
   InstallerUrl: https://github.com/Keeper-Security/Commander/releases/download/v16.11.0/keeper-commander-windows-v16.11.0.exe
   InstallerSha256: 69821455E1387CFCAF9976C80BBAD96D810558262138A996CE093F2509CA3EE8
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/k/KeeperSecurity/Commander/v16.11.0/KeeperSecurity.Commander.locale.en-US.yaml
+++ b/manifests/k/KeeperSecurity/Commander/v16.11.0/KeeperSecurity.Commander.locale.en-US.yaml
@@ -1,5 +1,5 @@
-# Created with komac v2.2.1
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# Created with DuckDuckStudio's Automation.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 
 PackageIdentifier: KeeperSecurity.Commander
 PackageVersion: v16.11.0
@@ -7,7 +7,7 @@ PackageLocale: en-US
 Publisher: Keeper Security, Inc.
 PublisherUrl: https://www.keepersecurity.com/
 PackageName: Keeper Commander
-PackageUrl: https://github.com/Keeper-Security/Commander
+PackageUrl: https://www.keepersecurity.com/commander.html
 License: MIT
 LicenseUrl: https://github.com/Keeper-Security/Commander/blob/master/LICENSE
 Copyright: Copyright (c) Keeper Security, Inc.
@@ -21,6 +21,6 @@ Tags:
 - password-manager
 - secrets
 - security-tools
-ReleaseNotesUrl: https://github.com/Keeper-Security/Commander/releases
+ReleaseNotesUrl: https://github.com/Keeper-Security/Commander/releases/tag/v16.11.0
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/k/KeeperSecurity/Commander/v16.11.0/KeeperSecurity.Commander.locale.zh-CN.yaml
+++ b/manifests/k/KeeperSecurity/Commander/v16.11.0/KeeperSecurity.Commander.locale.zh-CN.yaml
@@ -1,0 +1,29 @@
+# Created with DuckDuckStudio's Automation.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.9.0.schema.json
+
+PackageIdentifier: KeeperSecurity.Commander
+PackageVersion: v16.11.0
+PackageLocale: zh-CN
+Publisher: Keeper Security, Inc.
+PublisherUrl: https://www.keepersecurity.com/zh_CN/
+PackageName: Keeper Commander
+PackageUrl: https://www.keepersecurity.com/zh_CN/commander.html
+License: MIT
+LicenseUrl: https://github.com/Keeper-Security/Commander/blob/master/LICENSE
+Copyright: Copyright (c) Keeper Security, Inc.
+CopyrightUrl: https://github.com/Keeper-Security/Commander/blob/master/LICENSE
+ShortDescription: 通过强大的命令行界面实现对 Keeper Enterprise 环境的细粒度控制。
+Description: Keeper Commander 由一项开源的 Python SDK 提供支持，其可在 Keeper 系统中执行基本的保管库和管理功能。Commander 可用于访问和控制您的 Keeper 保管库、执行管理功能、启动远程会话、轮换密码、消除硬编码密码等。
+Tags:
+- cli
+- 密码
+- 秘密
+- 机密
+- 密钥
+- 安全工具
+- 管理器
+- 机密管理器
+- 密钥管理器
+ReleaseNotesUrl: https://github.com/Keeper-Security/Commander/releases/tag/v16.11.0
+ManifestType: locale
+ManifestVersion: 1.9.0

--- a/manifests/k/KeeperSecurity/Commander/v16.11.0/KeeperSecurity.Commander.yaml
+++ b/manifests/k/KeeperSecurity/Commander/v16.11.0/KeeperSecurity.Commander.yaml
@@ -1,8 +1,8 @@
-# Created with komac v2.2.1
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# Created with DuckDuckStudio's Automation.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
 
 PackageIdentifier: KeeperSecurity.Commander
 PackageVersion: v16.11.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0


### PR DESCRIPTION
See https://github.com/russellbanks/Komac/issues/967#issuecomment-2546336134 to know why change `Architecture` (`x64` → `x86`).

Manually validate the domain(s):
![image](https://github.com/user-attachments/assets/c69931a9-c572-4193-bf8e-a0733e2b8d08)
![image](https://github.com/user-attachments/assets/7a957255-2e84-41ce-8756-e86149657d58)
![image](https://github.com/user-attachments/assets/7dfa7239-a28d-41cf-8d48-37ed111d76ac)

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/210828)