### PR TITLE
Fix installer URL for Cloudflare.Warp with the version-specific address

### DIFF
--- a/manifests/c/Cloudflare/Warp/24.12.760.0/Cloudflare.Warp.installer.yaml
+++ b/manifests/c/Cloudflare/Warp/24.12.760.0/Cloudflare.Warp.installer.yaml
@@ -24,7 +24,7 @@ AppsAndFeaturesEntries:
 - UpgradeCode: '{1BF42825-7B65-4CA9-AFFF-B7B5E1CE27B4}'
 Installers:
 - Architecture: x64
-  InstallerUrl: https://1111-releases.cloudflareclient.com/windows/Cloudflare_WARP_Release-x64.msi
+  InstallerUrl: https://downloads.cloudflareclient.com/v1/download/windows/version/2024.12.760.0
   InstallerSha256: 632246671D77CA806A172FDC355D0299D8C42157EDCA89E9DD123C5847B4DBA4
 ManifestType: installer
 ManifestVersion: 1.6.0


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.9.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

Fixes #213643

I got the URL from https://github.com/cloudflare/cloudflare-docs/tree/84eb1ed98a6991608742c51cccb64d6339aeb0b5/src/content/warp-releases/windows/ga

And I have checked the hash on WSL2 as below

```console
> curl -o fixed-url https://downloads.cloudflareclient.com/v1/download/windows/version/2024.12.760.0
> curl -L -o unstable-url https://1111-releases.cloudflareclient.com/windows/Cloudflare_WARP_Release-x64.msi
> sha256sum *
632246671d77ca806a172fdc355d0299d8c42157edca89e9dd123c5847b4dba4  fixed-url
632246671d77ca806a172fdc355d0299d8c42157edca89e9dd123c5847b4dba4  unstable-url
```

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/213644)