### PR TITLE
New version AVRDudes.AVRDUDE version 8.0

### DIFF
--- a/manifests/a/AVRDudes/AVRDUDE/8.0/AVRDudes.AVRDUDE.installer.yaml
+++ b/manifests/a/AVRDudes/AVRDUDE/8.0/AVRDudes.AVRDUDE.installer.yaml
@@ -1,0 +1,22 @@
+# Created with komac v2.9.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: AVRDudes.AVRDUDE
+PackageVersion: '8.0'
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: avrdude.exe
+ReleaseDate: 2024-08-24
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/avrdudes/avrdude/releases/download/v8.0/avrdude-v8.0-windows-x86.zip
+  InstallerSha256: 783FFD3C62024EFDF0EA65C257EAED0F3FDC3D5F2415616F05B94F4D07112BC0
+- Architecture: x64
+  InstallerUrl: https://github.com/avrdudes/avrdude/releases/download/v8.0/avrdude-v8.0-windows-x64.zip
+  InstallerSha256: F4AA811042EF95B52C68531F6E5044C5B5A8711BCD4B495D6B9AF20F9AC41325
+- Architecture: arm64
+  InstallerUrl: https://github.com/avrdudes/avrdude/releases/download/v8.0/avrdude-v8.0-windows-arm64.zip
+  InstallerSha256: 91E17BC1064AE1AF7421FE9017CA7A2DB3DEAC478B990AC951A1DB0F22CC8971
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/a/AVRDudes/AVRDUDE/8.0/AVRDudes.AVRDUDE.locale.en-US.yaml
+++ b/manifests/a/AVRDudes/AVRDUDE/8.0/AVRDudes.AVRDUDE.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# Created with komac v2.9.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: AVRDudes.AVRDUDE
+PackageVersion: '8.0'
+PackageLocale: en-US
+Publisher: AVR Dudes
+PublisherUrl: https://github.com/avrdudes
+PublisherSupportUrl: https://github.com/avrdudes/avrdude/issues
+PackageName: AVRDUDE
+PackageUrl: https://github.com/avrdudes/avrdude
+License: GPL-2.0
+ShortDescription: AVRDUDE is software for programming Atmel AVR Microcontrollers
+Tags:
+- arduino
+- atmega
+- atmel
+- attiny
+- avr
+- avrdude
+- microchip
+ReleaseNotesUrl: https://github.com/avrdudes/avrdude/releases/tag/v8.0
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/a/AVRDudes/AVRDUDE/8.0/AVRDudes.AVRDUDE.yaml
+++ b/manifests/a/AVRDudes/AVRDUDE/8.0/AVRDudes.AVRDUDE.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.9.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: AVRDudes.AVRDUDE
+PackageVersion: '8.0'
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## Additional changes

- Additionally add "arm64" installer file.

## Checklist for Pull Requests

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Resolve #215715

## Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.9.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

## Manual validation

<details><summary>Installation logs</summary>

```text
--> Installing WinGet
--> Disabling safety warning when running installers
Tip: you can type 'Update-EnvironmentVariables' to update your environment variables, such as after installing a new software.

--> Configuring Winget
已启用管理员设置 'LocalManifestFiles'。
已启用管理员设置 'LocalArchiveMalwareScanOverride'。

--> Installing the Manifest 8.0

已找到 AVRDUDE [AVRDudes.AVRDUDE] 版本 8.0
此应用程序由其所有者授权给你。
Microsoft 对第三方程序包概不负责，也不向第三方程序包授予任何许可证。
正在下载 https://github.com/avrdudes/avrdude/releases/download/v8.0/avrdude-v8.0-windows-x64.zip
  ██████████████████████████████  3.58 MB / 3.58 MB
已成功验证安装程序哈希
正在提取存档...
已成功提取存档
正在启动程序包安装...
添加了命令行别名： "avrdude"
已修改路径环境变量；重启 shell 以使用新值。
已成功安装

--> Refreshing environment variables

--> Comparing ARP Entries

DisplayName DisplayVersion Publisher ProductCode                     Scope
----------- -------------- --------- -----------                     -----
AVRDUDE     8.0            AVR Dudes AVRDudes.AVRDUDE__DefaultSource User
```

</details>
<details><summary>Validation logs</summary>

```text
PS C:\Users\WDAGUtilityAccount\Desktop\winget-pkgs> avrdude.exe -?
Usage: avrdude [options]
Options:
  -p <partno>            Specify AVR device; -p ? lists all known parts
  -p <wildcard>/<flags>  Run developer options for matched AVR devices,
                         e.g., -p ATmega328P/s or /S for part definition
  -b <baudrate>          Override RS-232 baud rate
  -B <bitclock>          Specify bit clock period (us)
  -C <config-file>       Specify location of configuration file
  -C +<config-file>      Specify additional config file, can be repeated
  -N                     Do not load config file
  -c <programmer>        Specify programmer; -c ? and -c ?type list all
  -c <wildcard>/<flags>  Run developer options for matched programmers,
                         e.g., -c 'ur*'/s for programmer info/definition
  -A                     Disable trailing-0xff removal for file/AVR read
  -D                     Disable auto-erase for flash memory; implies -A
  -i <delay>             ISP Clock Delay [in microseconds]
  -P <port>              Connection; -P ?s or -P ?sa lists serial ones
  -r                     Reconnect to -P port after "touching" it; wait
                         400 ms for each -r; needed for some USB boards
  -F                     Override invalid signature or initial checks
  -e                     Perform a chip erase at the beginning
  -O                     Perform RC oscillator calibration (see AVR053)
  -t                     Run an interactive terminal when it is its turn
  -T <terminal cmd line> Run terminal line when it is its turn
  -U <memstr>:r|w|v:<filename>[:format]
                         Carry out memory operation when it is its turn
                         Multiple -t, -T and -U options can be specified
  -n                     Do not write to the device whilst processing -U
  -V                     Do not automatically verify during -U
  -E <exitsp>[,<exitsp>] List programmer exit specifications
  -x <extended_param>    Pass <extended_param> to programmer, see -x help
  -v                     Verbose output; -v -v for more
  -q                     Quell progress output; -q -q for less
  -l logfile             Use logfile rather than stderr for diagnostics
  -?                     Display this usage

avrdude version 8.0, https://github.com/avrdudes/avrdude
```

</details>

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/216008)