### PR TITLE
PRTest: specify remote repository for gh cli

### DIFF
--- a/Tools/PRTest.ps1
+++ b/Tools/PRTest.ps1
@@ -34,7 +34,7 @@ if (-Not (Get-Command 'git' -ErrorAction 'SilentlyContinue')) {
     return
 }
 
-gh pr checkout $PullRequest $(if (!$KeepBranch) { '--detach' }) -f | Out-Null
+gh pr checkout $PullRequest $(if (!$KeepBranch) { '--detach' }) -f -R $repositoryRoot | Out-Null
 
 if ($LASTEXITCODE -ne 0) {
     Write-Host "There was an error checking out the PR. Make sure you're logged into GitHub via 'gh auth login' and come back here!" -ForegroundColor Red


### PR DESCRIPTION
This PR fixes an error case when the gh cli was not able to checkout the PR which causes the whole script to exist.  
The error occurs when the gh cli tries to checkout the PR and returns `"No default remote repository has been set for this directory."`  
This usually occurs when the local repository has multiple remotes and no default repository was explicitly set for the gh cli.  The error can be fixed by supplying the repository to the gh cli.  
  
![image](https://github.com/user-attachments/assets/75c6c297-3c9f-4d9d-9efc-9e8a80ad49ab)
  
![image](https://github.com/user-attachments/assets/372cac54-b1bb-4584-9cb2-fc84068586a6)
  
![image](https://github.com/user-attachments/assets/682ac791-f1cd-4354-b464-d1d49656020b)
  
![image](https://github.com/user-attachments/assets/fe6c95f6-5ea6-4021-80bc-5a879d8b4c21)


---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/216668)