### PR TITLE
New package: ClassicOldSong.Apollo version 0.2.9-alpha.1

### DIFF
--- a/manifests/c/ClassicOldSong/Apollo/0.2.9-alpha.1/ClassicOldSong.Apollo.installer.yaml
+++ b/manifests/c/ClassicOldSong/Apollo/0.2.9-alpha.1/ClassicOldSong.Apollo.installer.yaml
@@ -1,0 +1,22 @@
+# Created with komac v2.9.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: ClassicOldSong.Apollo
+PackageVersion: 0.2.9-alpha.1
+InstallerLocale: en-US
+InstallerType: nullsoft
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2025-01-24
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles%\Apollo'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/ClassicOldSong/Apollo/releases/download/v0.2.9-alpha.1/Apollo.exe
+  InstallerSha256: 46BE4FD0E003112A985019A7C83165565A6DD2970D96ED820AE0296E140734D0
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/c/ClassicOldSong/Apollo/0.2.9-alpha.1/ClassicOldSong.Apollo.locale.en-US.yaml
+++ b/manifests/c/ClassicOldSong/Apollo/0.2.9-alpha.1/ClassicOldSong.Apollo.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# Created with komac v2.9.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: ClassicOldSong.Apollo
+PackageVersion: 0.2.9-alpha.1
+PackageLocale: en-US
+Publisher: Yukino Song
+PublisherUrl: https://github.com/ClassicOldSong
+PublisherSupportUrl: https://github.com/ClassicOldSong/Apollo/issues
+Author: Yukino Song
+PackageName: Apollo
+PackageUrl: https://github.com/ClassicOldSong/Apollo
+License: GPL-3.0
+LicenseUrl: https://github.com/ClassicOldSong/Apollo/blob/master/LICENSE
+ShortDescription: |-
+  Sunshine fork - The easiest way to stream with the native resolution of your client device.
+Description: |-
+  Apollo is a self-hosted desktop stream host for Artemis(Moonlight Noir). Offering low latency,
+  native client resolution, cloud gaming server capabilities with support for AMD, Intel, and
+  Nvidia GPUs for hardware encoding. Software encoding is also available. A web UI is provided to
+  allow configuration and client pairing from your favorite web browser. Pair from the local server
+  or any mobile device.
+ReleaseNotesUrl: https://github.com/ClassicOldSong/Apollo/releases/tag/v0.2.9-alpha.1
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/c/ClassicOldSong/Apollo/0.2.9-alpha.1/ClassicOldSong.Apollo.yaml
+++ b/manifests/c/ClassicOldSong/Apollo/0.2.9-alpha.1/ClassicOldSong.Apollo.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.9.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: ClassicOldSong.Apollo
+PackageVersion: 0.2.9-alpha.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## Checklist for Pull Requests

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Resolve #217076

## Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.9.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

## Manual validation

<details><summary>Installation logs</summary>

```text
--> Installing WinGet
--> Disabling safety warning when running installers
Tip: you can type 'Update-EnvironmentVariables' to update your environment variables, such as after installing a new software.

--> Configuring Winget
已启用管理员设置 'LocalManifestFiles'。
已启用管理员设置 'LocalArchiveMalwareScanOverride'。

--> Installing the Manifest 0.2.9-alpha.1

已找到 Apollo [ClassicOldSong.Apollo] 版本 0.2.9-alpha.1
此应用程序由其所有者授权给你。
Microsoft 对第三方程序包概不负责，也不向第三方程序包授予任何许可证。
正在下载 http://alist.dragon1573.local/d/programs/Apollo.exe
  ██████████████████████████████  12.0 MB / 12.0 MB
已成功验证安装程序哈希
正在启动程序包安装...
已成功安装

--> Refreshing environment variables

--> Comparing ARP Entries

DisplayName DisplayVersion Publisher ProductCode Scope
----------- -------------- --------- ----------- -----
Apollo      0.2.9-alpha.1  SudoMaker Apollo      Machine
```

</details>
<details><summary>Launch logs</summary>

```text
[server_cmd] -- [[{"name":"Bubbles","cmd":"bubbles.scr","elevated":false}]]
[2025-01-28 00:07:20.793]: Info: Apollo version: v0.2.9-alpha.1
[2025-01-28 00:07:20.794]: Info: Package Publisher: SudoMaker
[2025-01-28 00:07:20.794]: Info: Publisher Website: https://www.sudomaker.com
[2025-01-28 00:07:20.795]: Info: Get support: https://github.com/ClassicOldSong/Apollo/issues
[2025-01-28 00:07:20.795]: Info: Provided workaround settings for SettingsManager:
{
  "hdr_blank_delay": null
}
[2025-01-28 00:07:20.798]: Error: [code: 2, message: 系统找不到指定的文件。
] "RegQueryValueExW" failed when getting size.
[2025-01-28 00:07:20.799]: Error: [code: 2, message: 系统找不到指定的文件。
] "RegQueryValueExW" failed when getting size.
[2025-01-28 00:07:20.804]: Error: [code: 2, message: 系统找不到指定的文件。
] "RegQueryValueExW" failed when getting size.
[2025-01-28 00:07:20.805]: Error: [code: 2, message: 系统找不到指定的文件。
] "RegQueryValueExW" failed when getting size.
[2025-01-28 00:07:20.805]: Error: [code: 2, message: 系统找不到指定的文件。
] "RegQueryValueExW" failed when getting size.
[2025-01-28 00:07:20.805]: Error: [code: 2, message: 系统找不到指定的文件。
] "RegQueryValueExW" failed when getting size.
[2025-01-28 00:07:20.806]: Error: [code: 2, message: 系统找不到指定的文件。
] "RegQueryValueExW" failed when getting size.
[2025-01-28 00:07:20.806]: Error: [code: 2, message: 系统找不到指定的文件。
] "RegQueryValueExW" failed when getting size.
[2025-01-28 00:07:20.806]: Error: [code: 2, message: 系统找不到指定的文件。
] "RegQueryValueExW" failed when getting size.
[2025-01-28 00:07:20.806]: Error: [code: 2, message: 系统找不到指定的文件。
] "RegQueryValueExW" failed when getting size.
[2025-01-28 00:07:20.807]: Error: [code: 2, message: 系统找不到指定的文件。
] "RegQueryValueExW" failed when getting size.
[2025-01-28 00:07:20.807]: Error: [code: 2, message: 系统找不到指定的文件。
] "RegQueryValueExW" failed when getting size.
[2025-01-28 00:07:20.808]: Error: [code: 2, message: 系统找不到指定的文件。
] "RegQueryValueExW" failed when getting size.
[2025-01-28 00:07:20.808]: Error: [code: 2, message: 系统找不到指定的文件。
] "RegQueryValueExW" failed when getting size.
[2025-01-28 00:07:20.809]: Error: [code: 2, message: 系统找不到指定的文件。
] "RegQueryValueExW" failed when getting size.
[2025-01-28 00:07:20.809]: Error: [code: 2, message: 系统找不到指定的文件。
] "RegQueryValueExW" failed when getting size.
[SUDOVDA] Watchdog: Timeout 3, Countdown 3
[2025-01-28 00:07:20.810]: Info: Currently available display devices:
[
  {
    "device_id": "{915c9a45-9a73-5589-8938-f54837e3eaa1}",
    "display_name": "\\\\.\\DISPLAY1",
    "friendly_name": "",
    "info": {
      "hdr_state": "Disabled",
      "origin_point": {
        "x": 0,
        "y": 0
      },
      "primary": true,
      "refresh_rate": {
        "type": "rational",
        "value": {
          "denominator": 1,
          "numerator": 32
        }
      },
      "resolution": {
        "height": 1529,
        "width": 2374
      },
      "resolution_scale": {
        "type": "rational",
        "value": {
          "denominator": 100,
          "numerator": 200
        }
      }
    }
  }
]
[2025-01-28 00:07:20.815]: Error: [code: 2, message: 系统找不到指定的文件。
] "RegQueryValueExW" failed when getting size.
[2025-01-28 00:07:20.822]: Error: [code: 2, message: 系统找不到指定的文件。
] "RegQueryValueExW" failed when getting size.
[2025-01-28 00:07:20.822]: Error: [code: 2, message: 系统找不到指定的文件。
] "RegQueryValueExW" failed when getting size.
[2025-01-28 00:07:20.823]: Error: [code: 2, message: 系统找不到指定的文件。
] "RegQueryValueExW" failed when getting size.
[2025-01-28 00:07:20.823]: Error: [code: 2, message: 系统找不到指定的文件。
] "RegQueryValueExW" failed when getting size.
[2025-01-28 00:07:20.823]: Error: [code: 2, message: 系统找不到指定的文件。
] "RegQueryValueExW" failed when getting size.
[2025-01-28 00:07:20.824]: Error: [code: 2, message: 系统找不到指定的文件。
] "RegQueryValueExW" failed when getting size.
[2025-01-28 00:07:20.824]: Error: [code: 2, message: 系统找不到指定的文件。
] "RegQueryValueExW" failed when getting size.
[2025-01-28 00:07:20.825]: Error: [code: 2, message: 系统找不到指定的文件。
] "RegQueryValueExW" failed when getting size.
[2025-01-28 00:07:20.825]: Error: [code: 2, message: 系统找不到指定的文件。
] "RegQueryValueExW" failed when getting size.
[2025-01-28 00:07:20.826]: Error: [code: 2, message: 系统找不到指定的文件。
] "RegQueryValueExW" failed when getting size.
[2025-01-28 00:07:20.826]: Error: [code: 2, message: 系统找不到指定的文件。
] "RegQueryValueExW" failed when getting size.
[2025-01-28 00:07:20.826]: Error: [code: 2, message: 系统找不到指定的文件。
] "RegQueryValueExW" failed when getting size.
[2025-01-28 00:07:20.827]: Error: [code: 2, message: 系统找不到指定的文件。
] "RegQueryValueExW" failed when getting size.
[2025-01-28 00:07:20.827]: Error: [code: 2, message: 系统找不到指定的文件。
] "RegQueryValueExW" failed when getting size.
[2025-01-28 00:07:20.828]: Error: [code: 2, message: 系统找不到指定的文件。
] "RegQueryValueExW" failed when getting size.
[2025-01-28 00:07:20.828]: Info: nvprefs: NvAPI_Initialize() failed, ignore if you don't have NVIDIA video card
[2025-01-28 00:07:20.828]: Info: Compiling shaders...
[2025-01-28 00:07:20.835]: Info: System tray created
[2025-01-28 00:07:20.937]: Info: Compiled shaders
[2025-01-28 00:07:20.952]: Fatal: ViGEmBus is not installed or running. You must install ViGEmBus for gamepad support!
[2025-01-28 00:07:20.953]: Info: // Testing for available encoders, this may generate errors. You can safely ignore those errors. //
[2025-01-28 00:07:20.954]: Info: Trying encoder [nvenc]
[2025-01-28 00:07:21.092]: Info:
Device Description : Intel(R) Iris(R) Xe Graphics
Device Vendor ID   : 0x00008086
Device Device ID   : 0x00009A49
Device Video Mem   : 128 MiB
Device Sys Mem     : 0 MiB
Share Sys Mem      : 8091 MiB
Feature Level      : 0x0000B100
Capture size       : 2374x1529
Offset             : 0x0
Virtual Desktop    : 2374x1529
[2025-01-28 00:07:21.093]: Info: Active GPU has HAGS disabled
[2025-01-28 00:07:21.093]: Info: Using realtime GPU priority
[2025-01-28 00:07:21.094]: Info:
Colorspace         : DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709
Bits Per Color     : 8
Red Primary        : [0,0]
Green Primary      : [0,0]
Blue Primary       : [0,0]
White Point        : [0,0]
Min Luminance      : 0 nits
Max Luminance      : 0 nits
Max Full Luminance : 0 nits
[2025-01-28 00:07:21.094]: Info: Desktop resolution [2374x1529]
[2025-01-28 00:07:21.095]: Info: Desktop format [DXGI_FORMAT_B8G8R8A8_UNORM]
[2025-01-28 00:07:21.096]: Info: Display refresh rate [60.0004Hz]
[2025-01-28 00:07:21.096]: Info: Requested frame rate [60fps]
[2025-01-28 00:07:21.097]: Info: Encoder [nvenc] is not supported on this GPU
[2025-01-28 00:07:21.107]: Info: Trying encoder [quicksync]
[2025-01-28 00:07:21.225]: Info:
Device Description : Intel(R) Iris(R) Xe Graphics
Device Vendor ID   : 0x00008086
Device Device ID   : 0x00009A49
Device Video Mem   : 128 MiB
Device Sys Mem     : 0 MiB
Share Sys Mem      : 8091 MiB
Feature Level      : 0x0000B100
Capture size       : 2374x1529
Offset             : 0x0
Virtual Desktop    : 2374x1529
[2025-01-28 00:07:21.226]: Info: Active GPU has HAGS disabled
[2025-01-28 00:07:21.226]: Info: Using realtime GPU priority
[2025-01-28 00:07:21.227]: Info:
Colorspace         : DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709
Bits Per Color     : 8
Red Primary        : [0,0]
Green Primary      : [0,0]
Blue Primary       : [0,0]
White Point        : [0,0]
Min Luminance      : 0 nits
Max Luminance      : 0 nits
Max Full Luminance : 0 nits
[2025-01-28 00:07:21.227]: Info: Desktop resolution [2374x1529]
[2025-01-28 00:07:21.228]: Info: Desktop format [DXGI_FORMAT_B8G8R8A8_UNORM]
[2025-01-28 00:07:21.228]: Info: Display refresh rate [60.0004Hz]
[2025-01-28 00:07:21.228]: Info: Requested frame rate [60fps]
[2025-01-28 00:07:21.229]: Info: Client dynamicRange: 0, Display is HDR: false
[2025-01-28 00:07:21.229]: Info: Creating encoder [h264_qsv]
[2025-01-28 00:07:21.230]: Info: Color coding: SDR (Rec. 601)
[2025-01-28 00:07:21.231]: Info: Color depth: 8-bit
[2025-01-28 00:07:21.231]: Info: Color range: JPEG
[2025-01-28 00:07:21.602]: Info: Client dynamicRange: 0, Display is HDR: false
[2025-01-28 00:07:21.603]: Info: Creating encoder [hevc_qsv]
[2025-01-28 00:07:21.603]: Info: Color coding: SDR (Rec. 601)
[2025-01-28 00:07:21.604]: Info: Color depth: 8-bit
[2025-01-28 00:07:21.604]: Info: Color range: JPEG
[2025-01-28 00:07:22.299]: Info: Client dynamicRange: 0, Display is HDR: false
[2025-01-28 00:07:22.299]: Info: Creating encoder [av1_qsv]
[2025-01-28 00:07:22.300]: Info: Color coding: SDR (Rec. 601)
[2025-01-28 00:07:22.300]: Info: Color depth: 8-bit
[2025-01-28 00:07:22.300]: Info: Color range: JPEG
[2025-01-28 00:07:22.546]: Error: [av1_qsv @ 0000028a212cbb40] This version of runtime doesn't support AV1 encoding
[2025-01-28 00:07:22.548]: Error: Could not open codec [av1_qsv]: Unknown error occurred
[2025-01-28 00:07:22.689]: Info:
Device Description : Intel(R) Iris(R) Xe Graphics
Device Vendor ID   : 0x00008086
Device Device ID   : 0x00009A49
Device Video Mem   : 128 MiB
Device Sys Mem     : 0 MiB
Share Sys Mem      : 8091 MiB
Feature Level      : 0x0000B100
Capture size       : 2374x1529
Offset             : 0x0
Virtual Desktop    : 2374x1529
[2025-01-28 00:07:22.690]: Info: Active GPU has HAGS disabled
[2025-01-28 00:07:22.691]: Info: Using realtime GPU priority
[2025-01-28 00:07:22.691]: Info:
Colorspace         : DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709
Bits Per Color     : 8
Red Primary        : [0,0]
Green Primary      : [0,0]
Blue Primary       : [0,0]
White Point        : [0,0]
Min Luminance      : 0 nits
Max Luminance      : 0 nits
Max Full Luminance : 0 nits
[2025-01-28 00:07:22.691]: Info: Desktop resolution [2374x1529]
[2025-01-28 00:07:22.692]: Info: Desktop format [DXGI_FORMAT_B8G8R8A8_UNORM]
[2025-01-28 00:07:22.692]: Info: Display refresh rate [60.0004Hz]
[2025-01-28 00:07:22.693]: Info: Requested frame rate [60fps]
[2025-01-28 00:07:22.693]: Info: Client dynamicRange: 1, Display is HDR: false
[2025-01-28 00:07:22.694]: Info: Creating encoder [hevc_qsv]
[2025-01-28 00:07:22.694]: Info: Color coding: SDR (Rec. 709)
[2025-01-28 00:07:22.695]: Info: Color depth: 10-bit
[2025-01-28 00:07:22.695]: Info: Color range: JPEG
[2025-01-28 00:07:23.447]: Info:
[2025-01-28 00:07:23.447]: Info: // Ignore any errors mentioned above, they are not relevant. //
[2025-01-28 00:07:23.448]: Info:
[2025-01-28 00:07:23.449]: Info: Found H.264 encoder: h264_qsv [quicksync]
[2025-01-28 00:07:23.449]: Info: Found HEVC encoder: hevc_qsv [quicksync]
[2025-01-28 00:07:23.450]: Info: Open the Web UI to set your new username and password and getting started
[2025-01-28 00:07:23.451]: Info: File C:\Program Files\Apollo\config\sunshine_state.json doesn't exist
[2025-01-28 00:07:23.456]: Info: Configuration UI available at [https://localhost:47990]
[2025-01-28 00:07:24.222]: Info: Registered Apollo mDNS service
```

</details>
<details><summary>Screenshots</summary>

![Image](https://github.com/user-attachments/assets/6e18f395-7909-4c49-b095-f4b78c412be4)

</details>

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/217337)