### PR TITLE
Improve Reply Notify and Assign PR Author for False Positive Resolution in labelAdded.validationDefenderError

### DIFF
--- a/.github/policies/labelAdded.validationDefenderError.yml
+++ b/.github/policies/labelAdded.validationDefenderError.yml
@@ -11,7 +11,9 @@ configuration:
       - description: >-
           When the label "Validation-Defender-Error" is added to a pull request
           * Add the PR specific reply notifying the issue author
-          * Close the PR
+          * Assign to the Author
+          * Label with Needs-Author-Feedback
+          * Remove the Needs-Attention Label
         if:
           - payloadType: Pull_Request
           - labelAdded:
@@ -22,14 +24,28 @@ configuration:
                 Hello @${issueAuthor},
 
 
-                The package manager bot was blocked from installing one of the installers listed in the url field, and cannot continue. 
+                The package manager bot was blocked from installing one of the installers listed in the url field, and cannot continue.
 
 
-                The application included in this pull request failed to pass the [Installers Scan](https://docs.microsoft.com/en-us/windows/package-manager/package/winget-validation) test. This test is designed to ensure that the application installs on all environments without warnings. For more details on this error, see [Defender errors](https://learn.microsoft.com/en-us/windows/package-manager/package/repository#error-labels). Please check to ensure the installer URL is correct and update the URL and the Hash if a change is made.
+                The application included in this pull request failed to pass the [Installers Scan](https://docs.microsoft.com/en-us/windows/package-manager/package/winget-validation) test. This test is designed to ensure that the application installs on all environments without warnings.
+
+
+                Please check to ensure the installer URL is correct and update the URL and the Hash if a change is made.
+
+
+                If the package is mistakenly flagged as malware, you can [submit the installer(s) to the Microsoft Defender team for analysis](https://www.microsoft.com/en-us/wdsi/filesubmission).
+
+
+                For more details on this error, see [Defender errors](https://learn.microsoft.com/en-us/windows/package-manager/package/repository#error-labels).
 
 
                 Template: msftbot/validationError/installers/validationDefender
-          - closeIssue
+          - assignTo:
+              author: True
+          - addLabel:
+              label: Needs-Author-Feedback
+          - removeLabel:
+              label: Needs-Attention # This will automatically assign the ICM Users
         # The policy service should trigger even when the label was added by the policy service
         triggerOnOwnActions: true
 onFailure:


### PR DESCRIPTION
## Why These Changes Were Made

### Reply notify
The current reply notify is unclear and causes confusion for some PR authors. It only mentions verifying the correctness of the URL and hash values, but **doesn't address the possibility of false positives or guide author on how to solve the problem further** .

### Closing the PR
It is more efficient to track and resolve this issue within the same PR. In the past, [@denelon suggested](https://github.com/microsoft/winget-pkgs/pull/217501#issuecomment-2619722573) that PR authors could reopen the PR themselves to trigger the pipeline validation again. However, in reality, **PR authors do not have permission to reopen a PR that has been closed by the policy service** . (For example, see [this comment](https://github.com/microsoft/winget-pkgs/pull/215274#issuecomment-2620739138)).

## What Has Been Changed
I have modified the reply notify to make it clearer. It now explicitly states that if the PR author believes this is a false positive, they can submit the installer to the Microsoft Defender team for further analysis. This will help PR authors resolve the issue faster, rather than endlessly searching through documentation.
Additionally, I had the policy service **assign the PR to the PR author** in the corresponding PR, because for this issue, more feedback from the author is needed.

### Expected Outcome
The updated error message will help PR authors better understand the next steps to take when encountering similar issues, reducing misunderstandings that could lead to incorrect conclusions.

<details>
  <summary>原文</summary>
  <h2>为什么做这些修改</h2>
  <h3>提示消息</h3>
  <p>当前的提示消息不够明确，导致一些 PR 作者难以理解。它仅简单提到确认 URL 和哈希值的正确性，并未提及误报的可能性，且没有引导用户如何进一步排查问题。</p>
  <h3>关闭 PR</h3>
  <p>在同一个 PR 中跟踪并解决此问题是更高效的。在此前，@denelon 表示 PR 作者可以自行重新打开 PR 来让管道验证重新运行，但事实是 PR 作者根本没有权限重新打开由策略服务关闭的 PR。(例如 https://github.com/microsoft/winget-pkgs/pull/215274#issuecomment-2620739138 )</p>
  <h2>修改内容</h2>
  <p>我对提示消息进行了调整，明确指出如果 PR 作者确信这是误报，可以将安装程序提交给 Microsoft Defender 团队进行分析。这将有助于 PR 作者更快速地定位问题的解决方案而不是一直在文档中翻来翻去。</p>
  <p>同时，我让策略服务在对应的 PR 中指派给 PR 作者，因为对于此问题，更多的是需要作者的反馈。</p>
  <h3>预期效果</h3>
  <p>更新后的提示消息将帮助 PR 作者在遇到类似问题时，能更清楚地知道该采取哪些后续步骤，避免误解导致错误的结论（如误认为 winget 不接受他们的软件包）。</p>
</details>

---

@denelon @Trenly @stephengillie PTAL
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/218616)