### PR TITLE
Update SandboxTest.ps1 to use UTF-8 on winget validate manifest

### DIFF
--- a/Tools/SandboxTest.ps1
+++ b/Tools/SandboxTest.ps1
@@ -295,8 +295,19 @@ if (!$SkipManifestValidation -and ![String]::IsNullOrWhiteSpace($Manifest)) {
         Invoke-CleanExit -ExitCode 3
     }
     Write-Information "--> Validating Manifest"
-    $validateCommandOutput = winget.exe validate $Manifest
-    switch ($LASTEXITCODE) {
+    $validateCommandOutput = 
+        & {
+            # Store current output encoding setting
+            $prevOutEnc = [Console]::OutputEncoding
+            # Set [Console]::OutputEncoding to UTF-8 since winget uses UTF-8 for output
+            [Console]::OutputEncoding = $OutputEncoding = [System.Text.Utf8Encoding]::new()
+
+            winget.exe validate $Manifest
+
+            # Reset the encoding to the previous values
+            [Console]::OutputEncoding = $prevOutEnc
+        }    
+        switch ($LASTEXITCODE) {
         '-1978335191' {
             ($validateCommandOutput | Select-Object -Skip 1 -SkipLast 1) | Write-Information # Skip the first line and the empty last line
             Write-Error -Category ParserError 'Manifest validation failed' -ErrorAction Continue


### PR DESCRIPTION
Add encoding logic to $validateCommandOutput to use UTF-8 during validation.
Restore original enoding after running winget command
![image](https://github.com/user-attachments/assets/d1213874-07c2-40f6-9e6d-3dc040d5acad)


fixes: #222295 



 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/222296)