### PR TITLE
GiulianoBellini.Sniffnet version 1.3.2

### DIFF
--- a/manifests/g/GiulianoBellini/Sniffnet/1.3.2/GiulianoBellini.Sniffnet.installer.yaml
+++ b/manifests/g/GiulianoBellini/Sniffnet/1.3.2/GiulianoBellini.Sniffnet.installer.yaml
@@ -13,6 +13,9 @@ Installers:
 - Architecture: x86
   InstallerUrl: https://github.com/GyulyVGC/sniffnet/releases/download/v1.3.2/Sniffnet_Windows_32-bit.msi
   InstallerSha256: 5F8FF28A38CB7AFCC8D256388D13E25BBAB9137741B9A5641BF1666E5B6DAF7F
+  Dependencies:
+    PackageDependencies:
+      - PackageIdentifier: Microsoft.VCRedist.2015+.x86
   ProductCode: '{514F546E-1543-4FF1-B759-822882A6F254}'
 ManifestType: installer
 ManifestVersion: 1.9.0

--- a/manifests/g/GiulianoBellini/Sniffnet/1.3.2/GiulianoBellini.Sniffnet.installer.yaml
+++ b/manifests/g/GiulianoBellini/Sniffnet/1.3.2/GiulianoBellini.Sniffnet.installer.yaml
@@ -1,0 +1,19 @@
+# Created using wingetcreate 1.9.4.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: GiulianoBellini.Sniffnet
+PackageVersion: 1.3.2
+InstallerLocale: en-US
+InstallerType: wix
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/GyulyVGC/sniffnet/releases/download/v1.3.2/Sniffnet_Windows_64-bit.msi
+  InstallerSha256: 90A4642B6D545877FFA2B63D4B5EB0A4305285B0B6FBF1D084EE4CD168863123
+  ProductCode: '{8D7ABD3D-5154-4494-98BA-061AE24A32DA}'
+- Architecture: x86
+  InstallerUrl: https://github.com/GyulyVGC/sniffnet/releases/download/v1.3.2/Sniffnet_Windows_32-bit.msi
+  InstallerSha256: 5F8FF28A38CB7AFCC8D256388D13E25BBAB9137741B9A5641BF1666E5B6DAF7F
+  ProductCode: '{514F546E-1543-4FF1-B759-822882A6F254}'
+ManifestType: installer
+ManifestVersion: 1.9.0
+ReleaseDate: 2025-01-06

--- a/manifests/g/GiulianoBellini/Sniffnet/1.3.2/GiulianoBellini.Sniffnet.installer.yaml
+++ b/manifests/g/GiulianoBellini/Sniffnet/1.3.2/GiulianoBellini.Sniffnet.installer.yaml
@@ -9,6 +9,9 @@ Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/GyulyVGC/sniffnet/releases/download/v1.3.2/Sniffnet_Windows_64-bit.msi
   InstallerSha256: 90A4642B6D545877FFA2B63D4B5EB0A4305285B0B6FBF1D084EE4CD168863123
+  Dependencies:
+    PackageDependencies:
+      - PackageIdentifier: Microsoft.VCRedist.2015+.x64
   ProductCode: '{8D7ABD3D-5154-4494-98BA-061AE24A32DA}'
 - Architecture: x86
   InstallerUrl: https://github.com/GyulyVGC/sniffnet/releases/download/v1.3.2/Sniffnet_Windows_32-bit.msi

--- a/manifests/g/GiulianoBellini/Sniffnet/1.3.2/GiulianoBellini.Sniffnet.locale.en-US.yaml
+++ b/manifests/g/GiulianoBellini/Sniffnet/1.3.2/GiulianoBellini.Sniffnet.locale.en-US.yaml
@@ -1,0 +1,36 @@
+# Created using wingetcreate 1.9.4.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: GiulianoBellini.Sniffnet
+PackageVersion: 1.3.2
+PackageLocale: en-US
+Publisher: Giuliano Bellini
+PublisherUrl: https://github.com/GyulyVGC
+PublisherSupportUrl: https://github.com/GyulyVGC/sniffnet/issues
+PackageName: Sniffnet
+PackageUrl: https://github.com/GyulyVGC/sniffnet
+License: Apache-2.0
+ShortDescription: "Comfortably monitor your Internet traffic \U0001F575️‍♂️"
+Tags:
+- application
+- gui
+- iced
+- linux
+- macos
+- network
+- network-analysis
+- network-monitoring
+- networking
+- packet-analyser
+- packet-capture
+- packet-sniffer
+- pcap
+- rust
+- rust-crate
+- security
+ReleaseNotesUrl: https://github.com/GyulyVGC/sniffnet/releases/tag/v1.3.2
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/GyulyVGC/sniffnet/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/g/GiulianoBellini/Sniffnet/1.3.2/GiulianoBellini.Sniffnet.yaml
+++ b/manifests/g/GiulianoBellini/Sniffnet/1.3.2/GiulianoBellini.Sniffnet.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.9.4.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: GiulianoBellini.Sniffnet
+PackageVersion: 1.3.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.9.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

I see that this application has submitted previously, but ran into some issues with it's dependencies: https://github.com/microsoft/winget-pkgs/pull/134980

I have tried specifying the Microsoft.VCRedist.2015+ x64 and x86 runtimes with MinimumVersion 14.34.31938 and Insecure.Npcap MinimumVersion: 0.86 (the latest version available in winget). This version of npcap does not work with sniffnet, but manually installing the latest version 1.80 worked and the application launched successfully in a sandbox.

But I noticed that applications like Wireshark have manifests without the npcap dependency? 
https://github.com/microsoft/winget-pkgs/blob/8cd6dc74df40d8f5fb2ac574aade5fd8e901bbed/manifests/w/WiresharkFoundation/Wireshark/4.4.3/WiresharkFoundation.Wireshark.installer.yaml
 Feel free to close this PR if we're just not shipping manifests for certain applications with an npcap dependency.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/223026)