### PR TITLE
Modify: DuckStudio.FufuDevTools version 2025.02.03.2358

### DIFF
--- a/manifests/d/DuckStudio/FufuDevTools/2025.02.03.2358/DuckStudio.FufuDevTools.installer.yaml
+++ b/manifests/d/DuckStudio/FufuDevTools/2025.02.03.2358/DuckStudio.FufuDevTools.installer.yaml
@@ -1,4 +1,4 @@
-# Created with komac v2.10.0
+# Created with DuckDuckStudio's Automation.
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 
 PackageIdentifier: DuckStudio.FufuDevTools
@@ -15,13 +15,19 @@ Commands:
 Protocols:
 - https
 ReleaseDate: 2025-02-03
-# AppsAndFeaturesEntries:
-# - Publisher: DuckStudio
-#   ProductCode: 芙芙工具箱开发工具包_is1
 InstallationMetadata:
   DefaultInstallLocation: '%ProgramFiles%\Fufu_Dev_Tools'
 Installers:
-- Architecture: neutral  # This is a bundle that supports ANY CPU, "neutral" there might be better.
+- Architecture: x64
+  InstallerUrl: https://github.com/DuckDuckStudio/Fufu_Dev_Tools/releases/download/2025.02.03.2358/Fufu_Dev_Tools_Setup_2025.02.03.2358.exe
+  InstallerSha256: 2C6AAAD6C4EA1AC5EB8B8916442E0056ADD454D2577AF5D00E60B6D67F0781A1
+- Architecture: x86
+  InstallerUrl: https://github.com/DuckDuckStudio/Fufu_Dev_Tools/releases/download/2025.02.03.2358/Fufu_Dev_Tools_Setup_2025.02.03.2358.exe
+  InstallerSha256: 2C6AAAD6C4EA1AC5EB8B8916442E0056ADD454D2577AF5D00E60B6D67F0781A1
+- Architecture: arm
+  InstallerUrl: https://github.com/DuckDuckStudio/Fufu_Dev_Tools/releases/download/2025.02.03.2358/Fufu_Dev_Tools_Setup_2025.02.03.2358.exe
+  InstallerSha256: 2C6AAAD6C4EA1AC5EB8B8916442E0056ADD454D2577AF5D00E60B6D67F0781A1
+- Architecture: arm64
   InstallerUrl: https://github.com/DuckDuckStudio/Fufu_Dev_Tools/releases/download/2025.02.03.2358/Fufu_Dev_Tools_Setup_2025.02.03.2358.exe
   InstallerSha256: 2C6AAAD6C4EA1AC5EB8B8916442E0056ADD454D2577AF5D00E60B6D67F0781A1
 ManifestType: installer

--- a/manifests/d/DuckStudio/FufuDevTools/2025.02.03.2358/DuckStudio.FufuDevTools.locale.en-GB.yaml
+++ b/manifests/d/DuckStudio/FufuDevTools/2025.02.03.2358/DuckStudio.FufuDevTools.locale.en-GB.yaml
@@ -1,0 +1,37 @@
+# Created with DuckDuckStudio's Automation.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.9.0.schema.json
+
+PackageIdentifier: DuckStudio.FufuDevTools
+PackageVersion: 2025.02.03.2358
+PackageLocale: en-GB
+Publisher: Duck Studio
+PublisherUrl: https://duckduckstudio.github.io/yazicbs.github.io/
+PublisherSupportUrl: https://github.com/DuckDuckStudio/Fufu_Dev_Tools/issues
+# PrivacyUrl:
+Author: 鸭鸭「カモ」
+PackageName: Fufu Tools Independent Development Kit
+PackageUrl: https://github.com/DuckDuckStudio/Fufu_Dev_Tools
+License: 芙芙工具箱许可文件
+LicenseUrl: https://github.com/DuckDuckStudio/Fufu_Tools/blob/HEAD/LICENSE
+Copyright: Copyright (c) 鸭鸭「カモ」
+# CopyrightUrl:
+ShortDescription: Fufu Tools Independent Development Kit
+Description: Fufu Tools Independent Development Kit is a console development kit specifically designed for developers.
+# Moniker:
+Tags:
+- command
+- console
+- develop
+- devtools
+- fufutools
+- kit
+- tools
+# ReleaseNotes:
+ReleaseNotesUrl: https://github.com/DuckDuckStudio/Fufu_Dev_Tools/releases/tag/2025.02.03.2358
+# PurchaseUrl:
+# InstallationNotes:
+Documentations:
+- DocumentLabel: 芙芙工具箱开发工具说明
+  DocumentUrl: https://duckduckstudio.github.io/yazicbs.github.io/Tools/Fufu_Tools/wiki/Dev/
+ManifestType: locale
+ManifestVersion: 1.9.0

--- a/manifests/d/DuckStudio/FufuDevTools/2025.02.03.2358/DuckStudio.FufuDevTools.locale.en-US.yaml
+++ b/manifests/d/DuckStudio/FufuDevTools/2025.02.03.2358/DuckStudio.FufuDevTools.locale.en-US.yaml
@@ -1,0 +1,37 @@
+# Created with DuckDuckStudio's Automation.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.9.0.schema.json
+
+PackageIdentifier: DuckStudio.FufuDevTools
+PackageVersion: 2025.02.03.2358
+PackageLocale: en-US
+Publisher: Duck Studio
+PublisherUrl: https://duckduckstudio.github.io/yazicbs.github.io/
+PublisherSupportUrl: https://github.com/DuckDuckStudio/Fufu_Dev_Tools/issues
+# PrivacyUrl:
+Author: 鸭鸭「カモ」
+PackageName: Fufu Tools Independent Development Kit
+PackageUrl: https://github.com/DuckDuckStudio/Fufu_Dev_Tools
+License: 芙芙工具箱许可文件
+LicenseUrl: https://github.com/DuckDuckStudio/Fufu_Tools/blob/HEAD/LICENSE
+Copyright: Copyright (c) 鸭鸭「カモ」
+# CopyrightUrl:
+ShortDescription: Fufu Tools Independent Development Kit
+Description: Fufu Tools Independent Development Kit is a console development kit specifically designed for developers.
+# Moniker:
+Tags:
+- command
+- console
+- develop
+- devtools
+- fufutools
+- kit
+- tools
+# ReleaseNotes:
+ReleaseNotesUrl: https://github.com/DuckDuckStudio/Fufu_Dev_Tools/releases/tag/2025.02.03.2358
+# PurchaseUrl:
+# InstallationNotes:
+Documentations:
+- DocumentLabel: 芙芙工具箱开发工具说明
+  DocumentUrl: https://duckduckstudio.github.io/yazicbs.github.io/Tools/Fufu_Tools/wiki/Dev/
+ManifestType: locale
+ManifestVersion: 1.9.0

--- a/manifests/d/DuckStudio/FufuDevTools/2025.02.03.2358/DuckStudio.FufuDevTools.locale.ja-JP.yaml
+++ b/manifests/d/DuckStudio/FufuDevTools/2025.02.03.2358/DuckStudio.FufuDevTools.locale.ja-JP.yaml
@@ -1,0 +1,38 @@
+# Created with DuckDuckStudio's Automation.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.9.0.schema.json
+
+PackageIdentifier: DuckStudio.FufuDevTools
+PackageVersion: 2025.02.03.2358
+PackageLocale: ja-JP
+Publisher: Duck Studio
+PublisherUrl: https://duckduckstudio.github.io/yazicbs.github.io/
+PublisherSupportUrl: https://github.com/DuckDuckStudio/Fufu_Dev_Tools/issues
+# PrivacyUrl:
+Author: 鸭鸭「カモ」
+PackageName: 芙芙ツールボックス独立開発キット
+PackageUrl: https://github.com/DuckDuckStudio/Fufu_Dev_Tools
+License: 芙芙工具箱许可文件
+LicenseUrl: https://github.com/DuckDuckStudio/Fufu_Tools/blob/HEAD/LICENSE
+Copyright: Copyright (c) 鸭鸭「カモ」
+# CopyrightUrl:
+ShortDescription: 芙芙ツールボックス独立開発キット
+Description: 芙芙工具箱独立開発キットは、開発者向けに特化したコンソール開発キットです。
+# Moniker:
+Tags:
+- キット
+- コマンド
+- コンソール
+- ツール
+- 芙芙ツールボックス
+- 芙芙工具箱
+- 開発
+- 開発ツール
+# ReleaseNotes:
+ReleaseNotesUrl: https://github.com/DuckDuckStudio/Fufu_Dev_Tools/releases/tag/2025.02.03.2358
+# PurchaseUrl:
+# InstallationNotes:
+Documentations:
+- DocumentLabel: 芙芙工具箱開発ツール説明（中国語）
+  DocumentUrl: https://duckduckstudio.github.io/yazicbs.github.io/Tools/Fufu_Tools/wiki/Dev/
+ManifestType: locale
+ManifestVersion: 1.9.0

--- a/manifests/d/DuckStudio/FufuDevTools/2025.02.03.2358/DuckStudio.FufuDevTools.locale.zh-CN.yaml
+++ b/manifests/d/DuckStudio/FufuDevTools/2025.02.03.2358/DuckStudio.FufuDevTools.locale.zh-CN.yaml
@@ -1,4 +1,4 @@
-# Created with komac v2.10.0
+# Created with DuckDuckStudio's Automation.
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 
 PackageIdentifier: DuckStudio.FufuDevTools

--- a/manifests/d/DuckStudio/FufuDevTools/2025.02.03.2358/DuckStudio.FufuDevTools.locale.zh-TW.yaml
+++ b/manifests/d/DuckStudio/FufuDevTools/2025.02.03.2358/DuckStudio.FufuDevTools.locale.zh-TW.yaml
@@ -1,0 +1,37 @@
+# Created with DuckDuckStudio's Automation.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.9.0.schema.json
+
+PackageIdentifier: DuckStudio.FufuDevTools
+PackageVersion: 2025.02.03.2358
+PackageLocale: zh-TW
+Publisher: Duck Studio
+PublisherUrl: https://duckduckstudio.github.io/yazicbs.github.io/
+PublisherSupportUrl: https://github.com/DuckDuckStudio/Fufu_Dev_Tools/issues
+# PrivacyUrl:
+Author: 鸭鸭「カモ」
+PackageName: 芙芙工具箱獨立開發套件
+PackageUrl: https://github.com/DuckDuckStudio/Fufu_Dev_Tools
+License: 芙芙工具箱許可文件（簡體）
+LicenseUrl: https://github.com/DuckDuckStudio/Fufu_Tools/blob/HEAD/LICENSE
+Copyright: Copyright (c) 鸭鸭「カモ」
+# CopyrightUrl:
+ShortDescription: 芙芙工具箱獨立開發套件
+Description: 芙芙工具箱獨立開發套件是一個專為開發者設計的控制台開發套件。
+# Moniker:
+Tags:
+- 命令行
+- 套件
+- 工具
+- 控制台
+- 芙芙工具箱
+- 開發
+- 開發工具
+# ReleaseNotes:
+ReleaseNotesUrl: https://github.com/DuckDuckStudio/Fufu_Dev_Tools/releases/tag/2025.02.03.2358
+# PurchaseUrl:
+# InstallationNotes:
+Documentations:
+- DocumentLabel: 芙芙工具箱開發工具說明（簡體）
+  DocumentUrl: https://duckduckstudio.github.io/yazicbs.github.io/Tools/Fufu_Tools/wiki/Dev/
+ManifestType: locale
+ManifestVersion: 1.9.0

--- a/manifests/d/DuckStudio/FufuDevTools/2025.02.03.2358/DuckStudio.FufuDevTools.yaml
+++ b/manifests/d/DuckStudio/FufuDevTools/2025.02.03.2358/DuckStudio.FufuDevTools.yaml
@@ -1,4 +1,4 @@
-# Created with komac v2.10.0
+# Created with DuckDuckStudio's Automation.
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
 
 PackageIdentifier: DuckStudio.FufuDevTools


### PR DESCRIPTION
CC @Dragon1573 (https://github.com/microsoft/winget-pkgs/pull/223485#issue-2833498427) ,
On x64 architecture devices:
```pwsh
> winget update DuckStudio.FufuDevTools --source winget
找不到适用的升级。
较新的包版本在配置的源中可用，但不适用于你的系统或要求。
```

---
