### PR TITLE
New version: GrangerHub.Tremulous version 1.3.0.14

### DIFF
--- a/manifests/g/GrangerHub/Tremulous/1.3.0.14/GrangerHub.Tremulous.installer.yaml
+++ b/manifests/g/GrangerHub/Tremulous/1.3.0.14/GrangerHub.Tremulous.installer.yaml
@@ -1,0 +1,25 @@
+# Created with komac v2.10.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: GrangerHub.Tremulous
+PackageVersion: 1.3.0.14
+InstallerType: zip
+NestedInstallerType: portable
+ArchiveBinariesDependOnPath: true
+NestedInstallerFiles:
+  - RelativeFilePath: tremulous.exe
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: uninstallPrevious
+ReleaseDate: 2019-09-14
+Installers:
+  - Architecture: x86
+    InstallerUrl: https://github.com/GrangerHub/tremulous/releases/download/v1.3.0-alpha.0.14/release-mingw32-x86.zip
+    InstallerSha256: A74C51C4582BA52E3200427E252F6806D92CA1E3EE155BEF4375FB564B63ACF0
+  - Architecture: x64
+    InstallerUrl: https://github.com/GrangerHub/tremulous/releases/download/v1.3.0-alpha.0.14/release-mingw32-x86_64.zip
+    InstallerSha256: 1BAAFDC4298A8CE38405B4465EC883FD1E7C3EDA4B91869B7C1E32436A1C5D0E
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/g/GrangerHub/Tremulous/1.3.0.14/GrangerHub.Tremulous.locale.en-US.yaml
+++ b/manifests/g/GrangerHub/Tremulous/1.3.0.14/GrangerHub.Tremulous.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# Created with komac v2.10.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: GrangerHub.Tremulous
+PackageVersion: 1.3.0.14
+PackageLocale: en-US
+Publisher: GrangerHub
+PublisherUrl: https://github.com/GrangerHub
+PublisherSupportUrl: https://github.com/GrangerHub/tremulous/issues
+Author: Cengiz Gunay
+PackageName: Tremulous
+PackageUrl: https://github.com/GrangerHub/tremulous
+License: Tremulous License
+LicenseUrl: https://github.com/GrangerHub/tremulous/blob/master/COPYING
+Copyright: |-
+  Copyright (C) 2015-2019 GrangerHub
+  Copyright (C) 2005-2009 darklegion development
+ShortDescription: |-
+  Free and open source asymmetric team-based first-person shooter with real-time strategy elements.
+Description: |-
+  The game features two opposing teams: humans and aliens. Each team must attack the enemy’s base
+  and team members while defending their own base.
+ReleaseNotesUrl: https://github.com/GrangerHub/tremulous/releases/tag/v1.3.0-alpha.0.14
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/g/GrangerHub/Tremulous/1.3.0.14/GrangerHub.Tremulous.yaml
+++ b/manifests/g/GrangerHub/Tremulous/1.3.0.14/GrangerHub.Tremulous.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.10.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: GrangerHub.Tremulous
+PackageVersion: 1.3.0.14
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.9.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

As mentioned [here](https://github.com/microsoft/winget-pkgs/pull/225196#issuecomment-2645847330), the latest version 1.3.0.15 is quite buggy. Let's also add the older version 1.3.0.14 to allow users to choose between the newer one which has the latest features but its stability is not ideal, or this older one, which does not have the latest features but is stable and tested.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/225743)