### PR TITLE
Update Package: curl.curl version 8.11.1.2

### DIFF
--- a/manifests/c/cURL/cURL/8.11.1.2/cURL.cURL.installer.yaml
+++ b/manifests/c/cURL/cURL/8.11.1.2/cURL.cURL.installer.yaml
@@ -44,7 +44,7 @@ Installers:
   - RelativeFilePath: curl-8.11.1_2-win64-mingw/bin/curl.exe
   InstallerUrl: https://curl.se/windows/dl-8.11.1_2/curl-8.11.1_2-win64-mingw.zip
   InstallerSha256: 2FE6CC59AB5549A04009D81D07F371C7AE5A66162FAFA0E894F66B987FBBEB88
-- Architecture: neutral
+- Architecture: arm64
   NestedInstallerFiles:
   - RelativeFilePath: curl-8.11.1_2-win64a-mingw/bin/curl.exe
   InstallerUrl: https://curl.se/windows/dl-8.11.1_2/curl-8.11.1_2-win64a-mingw.zip


### PR DESCRIPTION
fix arm64 installer falsely classified as neutral
installer documentation: https://curl.se/windows/


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/228220)