### PR TITLE
Update Package: curl.curl version 8.11.1.3

### DIFF
--- a/manifests/c/cURL/cURL/8.11.1.3/cURL.cURL.installer.yaml
+++ b/manifests/c/cURL/cURL/8.11.1.3/cURL.cURL.installer.yaml
@@ -44,7 +44,7 @@ Installers:
   - RelativeFilePath: curl-8.11.1_3-win64-mingw/bin/curl.exe
   InstallerUrl: https://curl.se/windows/dl-8.11.1_3/curl-8.11.1_3-win64-mingw.zip
   InstallerSha256: D1D22A7DF2AE726DCDA82623E11824ECE48A4F335B5A855D47BC8A15C970B401
-- Architecture: neutral
+- Architecture: arm64
   NestedInstallerFiles:
   - RelativeFilePath: curl-8.11.1_3-win64a-mingw/bin/curl.exe
   InstallerUrl: https://curl.se/windows/dl-8.11.1_3/curl-8.11.1_3-win64a-mingw.zip


### PR DESCRIPTION
fix arm64 installer falsely classified as neutral
installer documentation: https://curl.se/windows/


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/228222)