### PR TITLE
Update Package: curl.curl version 8.12.0.1

### DIFF
--- a/manifests/c/cURL/cURL/8.12.0.1/cURL.cURL.installer.yaml
+++ b/manifests/c/cURL/cURL/8.12.0.1/cURL.cURL.installer.yaml
@@ -44,7 +44,7 @@ Installers:
   - RelativeFilePath: curl-8.12.0_1-win64-mingw/bin/curl.exe
   InstallerUrl: https://curl.se/windows/dl-8.12.0_1/curl-8.12.0_1-win64-mingw.zip
   InstallerSha256: 030F8BD879E800FFD0C3C88506766DA24EB2DF64C574AA386EF92F7E1874C458
-- Architecture: neutral
+- Architecture: arm64
   NestedInstallerFiles:
   - RelativeFilePath: curl-8.12.0_1-win64a-mingw/bin/curl.exe
   InstallerUrl: https://curl.se/windows/dl-8.12.0_1/curl-8.12.0_1-win64a-mingw.zip


### PR DESCRIPTION
fix arm64 installer falsely classified as neutral
installer documentation: https://curl.se/windows/


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/228223)