### PR TITLE
feat: add MullvadVPN.MullvadVPN.beta version 2025.4

### DIFF
--- a/manifests/m/MullvadVPN/MullvadVPN/beta/2025.4/MullvadVPN.MullvadVPN.beta.installer.yaml
+++ b/manifests/m/MullvadVPN/MullvadVPN/beta/2025.4/MullvadVPN.MullvadVPN.beta.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: MullvadVPN.MullvadVPN.beta
+PackageVersion: "2025.4"
+Platform:
+- Windows.Desktop
+InstallerType: nullsoft
+Scope: machine
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+ReleaseDate: 2025-02-12
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/mullvad/mullvadvpn-app/releases/download/2025.4/MullvadVPN-2025.4_x64.exe
+  InstallerSha256: 860399c8b144deae0f09b2a404a17feb46c5626be96411ffe22e6eb16961040e
+- Architecture: arm64
+  InstallerUrl: https://github.com/mullvad/mullvadvpn-app/releases/download/2025.4/MullvadVPN-2025.4_arm64.exe
+  InstallerSha256: a5a3d65bbdce8aa8e818f17f71710bf077bb9257e8d89522818c8e7c6834eace
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/m/MullvadVPN/MullvadVPN/beta/2025.4/MullvadVPN.MullvadVPN.beta.locale.en-US.yaml
+++ b/manifests/m/MullvadVPN/MullvadVPN/beta/2025.4/MullvadVPN.MullvadVPN.beta.locale.en-US.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: MullvadVPN.MullvadVPN.beta
+PackageVersion: "2025.4"
+PackageLocale: en-US
+Publisher: Mullvad VPN
+PublisherUrl: https://mullvad.net
+PublisherSupportUrl: https://mullvad.net/help
+PrivacyUrl: https://mullvad.net/en/help/privacy-policy
+Author: Mullvad VPN
+PackageName: Mullvad VPN
+PackageUrl: https://mullvad.net
+License: GPL-3.0
+LicenseUrl: https://github.com/mullvad/mullvadvpn-app/blob/main/LICENSE.md
+Copyright: Copyright (C) 2024 Mullvad VPN AB
+CopyrightUrl: https://github.com/mullvad/mullvadvpn-app/blob/main/README.md
+ShortDescription: Mullvad is an open-source commercial virtual private network service based in Sweden.
+Description: Mullvad is an open-source commercial virtual private network service based in Sweden.
+# Moniker:
+Tags:
+- network
+- open-source
+- privacy
+- private
+- private-network
+- security
+- vpn
+ReleaseNotes: |-
+  This release is for desktop only.
+  This release is identical to 2025.4-beta1.
+  Here is a list of all changes since last stable release 2025.3.
+
+  Changed
+  Windows
+  - Fix GUI crashing at launch on some systems.
+ReleaseNotesUrl: https://github.com/mullvad/mullvadvpn-app/releases/tag/2025.4
+PurchaseUrl: https://mullvad.net/en/account/create
+# InstallationNotes:
+# Documentations:
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/m/MullvadVPN/MullvadVPN/beta/2025.4/MullvadVPN.MullvadVPN.beta.yaml
+++ b/manifests/m/MullvadVPN/MullvadVPN/beta/2025.4/MullvadVPN.MullvadVPN.beta.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: MullvadVPN.MullvadVPN.beta
+PackageVersion: "2025.4"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
I'm experimenting with splitting up the installer based on architecture, which should drastically reduce network usage. x64: 209 MB → 102 MB, arm64: 209 MB → 107 MB. Not sure if I should add the all-in-one installer as a 'neutral' architecture still, don't think that'd have any purpose.

---

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.9.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/230048)