### PR TITLE
Add function for checking and caching GitHub Tokens

### DIFF
--- a/Tools/SandboxTest.ps1
+++ b/Tools/SandboxTest.ps1
@@ -426,7 +426,7 @@ function Test-GithubToken {
     # If the token doesn't expire, write a special value to the file
     if (!$tokenExpiration -or [string]::IsNullOrWhiteSpace($tokenExpiration[0])) { $tokenExpiration = @([System.DateTime]::MaxValue) }
     # When datetime objects are converted to string, they have extra whitespace that should be trimmed off
-    $tokenExpiration = $tokenExpiration[0].ToLongDateString().Trim()
+    $tokenExpiration = [DateTime]::Parse($tokenExpiration[0]).ToLongDateString().Trim()
     New-Item -ItemType File -Path $script:TokenValidationCache -Name $tokenHash -Value $tokenExpiration | Out-Null
     Write-Debug "Token <$tokenHash> added to cache with content <$tokenExpiration>"
     return $true

--- a/Tools/SandboxTest.ps1
+++ b/Tools/SandboxTest.ps1
@@ -390,6 +390,11 @@ function Test-GithubToken {
                 return $false
             }
         }
+        else {
+            # Either the token was empty, or the cached token is expired. Remove the cached token so that re-validation
+            # of the token will update the date the token was cached if it is still valid
+            Invoke-FileCleanup -FilePaths $cachedToken.FullName
+        }
     }
     else {
         Write-Verbose 'Token was not found in the cache'

--- a/Tools/SandboxTest.ps1
+++ b/Tools/SandboxTest.ps1
@@ -364,7 +364,8 @@ function Test-GithubToken {
             # Since Github adds ` UTC` at the end, it needs to be stripped off. Trim is safe here since the last character should always be a digit
             $cachedExpirationForParsing = $cachedTokenContent.TrimEnd(' UTC')
             $cachedExpirationDate = [System.DateTime]::MinValue
-            [System.DateTime]::TryParse($cachedExpirationForParsing, [ref]$cachedExpirationDate)
+            # Pipe to Out-Null so that it doesn't get captured in the return output
+            [System.DateTime]::TryParse($cachedExpirationForParsing, [ref]$cachedExpirationDate) | Out-Null
 
             $tokenExpirationDays = $cachedExpirationDate - (Get-Date) | Select-Object -ExpandProperty TotalDays
 

--- a/doc/tools/SandboxTest.md
+++ b/doc/tools/SandboxTest.md
@@ -13,13 +13,17 @@ To test a manifest, simply call the script with the full path to the manifest as
 The following optional arguments are supported:
 
 | Argument | Description |
-|-------------|-------------|  
+|-------------|-------------|
+| **-Manifest** | The path to the manifest to install in the Sandbox |
 | **-Script** | Post-installation script to run in the Sandbox |
 | **-MapFolder** | The folder to map in Sandbox. Default is the current directory |
 | **-WinGetVersion** | Specify version of WinGet to use in Sandbox |
+| **-WinGetOptions** | Additional Options to be passed at the end of the `winget install` command |
+| **-GitHubToken** | The GitHub token to be used for making requests to GitHub APIs |
+| **-SkipManifestValidation** | Skip `winget validate -m <manifest>` if you have already validated the manifest |
 | **-Prerelease** | Allow preview release versions of WinGet |
 | **-EnableExperimentalFeatures** | Enable WinGet experimental features |
-| **-SkipManifestValidation** | Skip `winget validate -m <manifest>` if you have already validated the manifest |
+| **-Clean** | Forces a re-download of WinGet and all of its dependencies |
 
 ### Examples
 
@@ -41,10 +45,10 @@ Test manifest on a specified version of WinGet
 .\SandboxTest.ps1 <path-to-manifest> -WinGetVersion 1.4.2011 -Prerelease -Script {Write-Host 'The script has finished'}
 ```
 
-Install a package from the repository in Sandbox 
+Install a package from the repository in Sandbox
 
 ```raw
-.\SandboxTest.ps1 -WinGetVersion 1.5 -Script {winget install <PackageIdentifier> --accept-source-agreements}
+.\SandboxTest.ps1 -WinGetVersion 1.7 -Script {winget install <PackageIdentifier> --accept-source-agreements}
 ```
 
 # System Requirements


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Is there a linked Issue?
  * #189849

## Description
This PR re-adds authentication using GitHub tokens for `SandboxTest.ps1`

This is achieved by adding a function which caches the provided GitHub token to avoid making unnecessary calls to the GitHub API. The token cache is located inside WinGet's AppData folder so that uninstalling WinGet will also remove the cache. This also ensures that the tokens are cached in a well-known location so this function can be ported to other tools such as PRTest.ps1 and YamlCreate.

For security, the cache does not contain the users actual GitHub token, but instead contains the HASH of the token. Where possible, the expiration of the token is also cached. After a token has been in the cache for more than 30 days, it is re-validated. 

## Reviewers
* @mdanish-kh 
* @denelon
* @stephengillie 

## Watchers
* @dragon1573

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/230208)