### PR TITLE
Update: ghdl.ghdl.ucrt64 4.1.0 bugfix

### DIFF
--- a/manifests/g/ghdl/ghdl/ucrt64/4.1.0/ghdl.ghdl.ucrt64.installer.yaml
+++ b/manifests/g/ghdl/ghdl/ucrt64/4.1.0/ghdl.ghdl.ucrt64.installer.yaml
@@ -16,6 +16,7 @@ UpgradeBehavior: uninstallPrevious
 Commands:
 - ghdl
 ReleaseDate: 2024-04-14
+ArchiveBinariesDependOnPath: true
 Installers:
 - Architecture: x86
   InstallerUrl: https://github.com/ghdl/ghdl/releases/download/v4.1.0/ghdl-UCRT64.zip


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.9.0)?
---

Adds the `ArchiveBinariesDependOnPath` field to the installer manifold.

Resolves #232775 and ghdl/ghdl#2771
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/232776)