### PR TITLE
PowerShell 7.5.0.0: Remove .zip installers added that are causing breaking change

### DIFF
--- a/manifests/m/Microsoft/PowerShell/7.5.0.0/Microsoft.PowerShell.installer.yaml
+++ b/manifests/m/Microsoft/PowerShell/7.5.0.0/Microsoft.PowerShell.installer.yaml
@@ -1,93 +1,35 @@
+# Created with YamlCreate.ps1 v2.4.3 $debug=NVS1.CRLF.7-4-6.Win32NT
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 
 PackageIdentifier: Microsoft.PowerShell
 PackageVersion: 7.5.0.0
 MinimumOSVersion: 10.0.17763.0
+InstallerType: wix
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Commands:
+- pwsh
 ReleaseDate: 2025-01-22
 Installers:
-  - Architecture: x64
-    InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.5.0/PowerShell-7.5.0-win-x64.zip
-    InstallerSha256: C270F392D63D4297D78730FBFFC0FEFA2AA7FB39C80307C3105D22CD7FC9040E
-    InstallerType: zip
-    NestedInstallerType: portable
-    NestedInstallerFiles:
-      - RelativeFilePath: pwsh.exe
-        PortableCommandAlias: pwsh
-  - Architecture: x64
-    InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.5.0/PowerShell-7.5.0-win-x64.msi
-    InstallerSha256: 6B988B7E236A8E1CF1166D3BE289D3A20AA344499153BDAADD2F9FEDFFC6EDA9
-    InstallerType: wix
-    Scope: machine
-    ProductCode: '{D012DCD1-67EA-4627-938F-19FD677FC03A}'
-    InstallModes:
-      - interactive
-      - silent
-      - silentWithProgress
-    UpgradeBehavior: install
-    Commands:
-      - pwsh
-  - Architecture: x86
-    InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.5.0/PowerShell-7.5.0-win-x86.zip
-    InstallerSha256: C8CCA1D070788DA89B10796C4CC4352C945E56C3F9E21ECD4AE4A972C865859E
-    InstallerType: zip
-    NestedInstallerType: portable
-    NestedInstallerFiles:
-      - RelativeFilePath: pwsh.exe
-        PortableCommandAlias: pwsh
-  - Architecture: x86
-    InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.5.0/PowerShell-7.5.0-win-x86.msi
-    InstallerSha256: 25BDF464E4050B7DD0E6034F2AE34D1111596A4A497EAA89862D0B5928825F58
-    InstallerType: wix
-    Scope: machine
-    ProductCode: '{57413274-F91F-4B8E-B61A-A13FE70D4072}'
-    InstallModes:
-      - interactive
-      - silent
-      - silentWithProgress
-    UpgradeBehavior: install
-    Commands:
-      - pwsh
-  - Architecture: arm
-    InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.5.0/PowerShell-7.5.0-win-arm64.zip
-    InstallerSha256: 5CF346F196A7BA862772F7FE0BF5DC98A08632BAAE74C36DCA26DE386203A142
-    InstallerType: zip
-    NestedInstallerType: portable
-    NestedInstallerFiles:
-      - RelativeFilePath: pwsh.exe
-        PortableCommandAlias: pwsh
-  - Architecture: arm
-    InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.5.0/PowerShell-7.5.0-win-arm64.msi
-    InstallerSha256: E5625771D0708A1192ED207640918117573C20C8FEB9355F2AA2891796B7C408
-    InstallerType: wix
-    Scope: machine
-    ProductCode: '{36718E61-5626-4B3C-B32B-2BA07707D714}'
-    InstallModes:
-      - interactive
-      - silent
-      - silentWithProgress
-    UpgradeBehavior: install
-    Commands:
-      - pwsh
-  - Architecture: arm64
-    InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.5.0/PowerShell-7.5.0-win-arm64.zip
-    InstallerSha256: 5CF346F196A7BA862772F7FE0BF5DC98A08632BAAE74C36DCA26DE386203A142
-    InstallerType: zip
-    NestedInstallerType: portable
-    NestedInstallerFiles:
-      - RelativeFilePath: pwsh.exe
-        PortableCommandAlias: pwsh
-  - Architecture: arm64
-    InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.5.0/PowerShell-7.5.0-win-arm64.msi
-    InstallerSha256: E5625771D0708A1192ED207640918117573C20C8FEB9355F2AA2891796B7C408
-    InstallerType: wix
-    Scope: machine
-    ProductCode: '{36718E61-5626-4B3C-B32B-2BA07707D714}'
-    InstallModes:
-      - interactive
-      - silent
-      - silentWithProgress
-    UpgradeBehavior: install
-    Commands:
-      - pwsh
+- Architecture: x64
+  InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.5.0/PowerShell-7.5.0-win-x64.msi
+  InstallerSha256: 6B988B7E236A8E1CF1166D3BE289D3A20AA344499153BDAADD2F9FEDFFC6EDA9
+  ProductCode: '{D012DCD1-67EA-4627-938F-19FD677FC03A}'
+- Architecture: x86
+  InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.5.0/PowerShell-7.5.0-win-x86.msi
+  InstallerSha256: 25BDF464E4050B7DD0E6034F2AE34D1111596A4A497EAA89862D0B5928825F58
+  ProductCode: '{57413274-F91F-4B8E-B61A-A13FE70D4072}'
+- Architecture: arm
+  InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.5.0/PowerShell-7.5.0-win-arm64.msi
+  InstallerSha256: E5625771D0708A1192ED207640918117573C20C8FEB9355F2AA2891796B7C408
+  ProductCode: '{36718E61-5626-4B3C-B32B-2BA07707D714}'
+- Architecture: arm64
+  InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.5.0/PowerShell-7.5.0-win-arm64.msi
+  InstallerSha256: E5625771D0708A1192ED207640918117573C20C8FEB9355F2AA2891796B7C408
+  ProductCode: '{36718E61-5626-4B3C-B32B-2BA07707D714}'
 ManifestType: installer
 ManifestVersion: 1.9.0


### PR DESCRIPTION
Revert this change: https://github.com/microsoft/winget-pkgs/pull/231998
which is causing breaking changes detailed here: https://github.com/PowerShell/PowerShell/issues/25068

The default installation with winget should not be to install with portable zip, but to install with msi

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.9.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/232947)