### PR TITLE
Revert "Add function for checking and caching GitHub Tokens"

### DIFF
--- a/Tools/SandboxTest.ps1
+++ b/Tools/SandboxTest.ps1
@@ -32,10 +32,6 @@ Param(
     # WinGetOptions
     [Parameter(HelpMessage = 'Additional options for WinGet')]
     [string] $WinGetOptions,
-    # GitHubToken
-    [Parameter(HelpMessage = 'Token for GitHub API Requests')]
-    # It is possible that the environment variable may not exist, in which case this may be null
-    [string] $GitHubToken = $env:GITHUB_TOKEN,
     # Switches
     [switch] $SkipManifestValidation,
     [switch] $Prerelease,
@@ -50,7 +46,7 @@ enum DependencySources {
 
 # Script Behaviors
 $ProgressPreference = 'SilentlyContinue'
-$ErrorActionPreference = 'Stop' # This gets overridden most places, but is set explicitly here to help catch errors
+$ErrorActionPreference = 'Stop' # This gets overriden most places, but is set explicitly here to help catch errors
 if ($PSBoundParameters.Keys -notcontains 'InformationAction') { $InformationPreference = 'Continue' } # If the user didn't explicitly set an InformationAction, Override their preference
 $script:OnMappedFolderWarning = ($PSBoundParameters.Keys -contains 'WarningAction') ? $PSBoundParameters.WarningAction : 'Inquire'
 $script:UseNuGetForMicrosoftUIXaml = $false
@@ -60,7 +56,6 @@ $script:DependenciesBaseName = 'DesktopAppInstaller_Dependencies'
 $script:ReleasesApiUrl = 'https://api.github.com/repos/microsoft/winget-cli/releases?per_page=100'
 $script:DependencySource = [DependencySources]::InRelease
 $script:UsePowerShellModuleForInstall = $false
-$script:CachedTokenExpiration = 30 # Days
 
 # File Names
 $script:AppInstallerMsixFileName = "$script:AppInstallerPFN.msixbundle" # This should exactly match the name of the file in the CLI GitHub Release
@@ -80,7 +75,6 @@ $script:UiLibsHash_NuGet = '6B62BD3C277F55518C3738121B77585AC5E171C154936EC58D87
 
 # File Paths
 $script:AppInstallerDataFolder = Join-Path -Path $env:LOCALAPPDATA -ChildPath 'Packages' -AdditionalChildPath $script:AppInstallerPFN
-$script:TokenValidationCache = Join-Path -Path $script:AppInstallerDataFolder -ChildPath 'TokenValidationCache'
 $script:DependenciesCacheFolder = Join-Path -Path $script:AppInstallerDataFolder -ChildPath "$script:ScriptName.Dependencies"
 $script:TestDataFolder = Join-Path -Path $script:AppInstallerDataFolder -ChildPath $script:ScriptName
 $script:PrimaryMappedFolder = (Resolve-Path -Path $MapFolder).Path
@@ -153,37 +147,11 @@ function Initialize-Folder {
 
 ####
 # Description: Gets the details for a specific WinGet CLI release
-# Inputs: Nullable GitHub API Token
+# Inputs: None
 # Outputs: Nullable Object containing GitHub release details
 ####
 function Get-Release {
-    param (
-        [Parameter()]
-        [AllowEmptyString()]
-        [String] $GitHubToken
-    )
-
-    # Build up the API request parameters here so the authentication can be added if the user's token is valid
-    $requestParameters = @{
-        Uri = $script:ReleasesApiUrl
-    }
-
-    if (Test-GithubToken -Token $GitHubToken) {
-        # The validation function will return True only if the provided token is valid
-        Write-Verbose 'Adding Bearer Token Authentication to Releases API Request'
-        $requestParameters.Add('Authentication', 'Bearer')
-        $requestParameters.Add('Token', $(ConvertTo-SecureString $GitHubToken -AsPlainText))
-    }
-    else {
-        # No token was provided or the token has expired
-        # If an invalid token was provided, an exception will have been thrown before this code is reached
-        Write-Warning @"
-A valid GitHub token was not provided. You may encounter API rate limits.
-Please consider using the `-GitHubToken` option or adding the `GITHUB_TOKEN` environment variable.
-"@
-    }
-
-    $releasesAPIResponse = Invoke-RestMethod @requestParameters
+    $releasesAPIResponse = Invoke-RestMethod $script:ReleasesApiUrl
     if (!$script:Prerelease) {
         $releasesAPIResponse = $releasesAPIResponse.Where({ !$_.prerelease })
     }
@@ -305,133 +273,6 @@ function Test-FileChecksum {
     return ($currentHash -and $currentHash.Hash -eq $ExpectedChecksum)
 }
 
-####
-# Description: Checks that a provided GitHub token is valid
-# Inputs: Token
-# Outputs: Boolean
-# Notes:
-#   This function hashes the provided GitHub token. If the provided token is valid, a file is added to the token cache with
-#   the name of the hashed token and the token expiration date. To avoid making unnecessary calls to the GitHub APIs, this
-#   function checks the token cache for the existence of the file. If the file is older than 30 days, it is removed and the
-#   token is re-checked. If the file has content, the date is checked to see if the token is expired. This can't catch every
-#   edge case, but it should catch a majority of the use cases.
-####
-function Test-GithubToken {
-    param (
-        [Parameter(Mandatory = $true)]
-        [AllowEmptyString()]
-        [String] $Token
-    )
-
-    # If the token is empty, there is no way that it can be valid
-    if ([string]::IsNullOrWhiteSpace($Token)) { return $false }
-
-    Write-Verbose 'Hashing GitHub Token'
-    $_memoryStream = [System.IO.MemoryStream]::new()
-    $_streamWriter = [System.IO.StreamWriter]::new($_memoryStream)
-    $_streamWriter.Write($Token)
-    $_streamWriter.Flush()
-    $_memoryStream.Position = 0
-
-    $tokenHash = Get-FileHash -InputStream $_memoryStream | Select-Object -ExpandProperty Hash
-
-    # Dispose of the reader and writer for hashing the token to ensure they cannot be accessed outside of the intended scope
-    Write-Debug 'Disposing of hashing components'
-    $_streamWriter.DisposeAsync() 1> $null
-    $_memoryStream.DisposeAsync() 1> $null
-
-    # Check for the cached token file
-    Initialize-Folder -FolderPath $script:TokenValidationCache | Out-Null
-    $cachedToken = Get-ChildItem -Path $script:TokenValidationCache -Filter $tokenHash -ErrorAction SilentlyContinue
-
-    if ($cachedToken) {
-        Write-Verbose 'Token was found in the cache'
-        # Check the age of the cached file
-        $cachedTokenAge = (Get-Date) - $cachedToken.LastWriteTime | Select-Object -ExpandProperty TotalDays
-        $cachedTokenAge = [Math]::Round($cachedTokenAge, 2) # We don't need all the precision the system provides
-        Write-Debug "Token has been in the cache for $cachedTokenAge days"
-        $cacheIsExpired = $cachedTokenAge -ge $script:CachedTokenExpiration
-        $cachedTokenContent = (Get-Content $cachedToken -Raw).Trim() # Ensure any trailing whitespace is ignored
-        $cachedTokenIsEmpty = [string]::IsNullOrWhiteSpace($cachedTokenContent)
-
-        # It is possible for a token to be both empty and expired. Since these are debug and verbose messages, showing both doesn't hurt
-        if ($cachedTokenIsEmpty) { Write-Verbose 'Cached token had no content. It will be re-validated' }
-        if ($cacheIsExpired) { Write-Verbose "Cached token is older than $script:CachedTokenExpiration days. It will be re-validated" }
-
-        if (!$cacheIsExpired -and !$cachedTokenIsEmpty) {
-            # Check the content of the cached file in case the actual token expiration is known
-            Write-Verbose 'Attempting to fetch token expiration from cache'
-            # Since Github adds ` UTC` at the end, it needs to be stripped off. Trim is safe here since the last character should always be a digit
-            $cachedExpirationForParsing = $cachedTokenContent.TrimEnd(' UTC')
-            $cachedExpirationDate = [System.DateTime]::MinValue
-            # Pipe to Out-Null so that it doesn't get captured in the return output
-            [System.DateTime]::TryParse($cachedExpirationForParsing, [ref]$cachedExpirationDate) | Out-Null
-
-            $tokenExpirationDays = $cachedExpirationDate - (Get-Date) | Select-Object -ExpandProperty TotalDays
-
-            if ($cachedExpirationForParsing -eq [System.DateTime]::MaxValue.ToLongDateString().Trim()) {
-                Write-Verbose "The cached token contained content. It is set to never expire"
-                return $true
-            }
-
-            if ($tokenExpirationDays -gt 0) {
-                Write-Verbose "The cached token contained content. It should expire in $tokenExpirationDays days"
-                return $true
-            }
-            # If the parsing failed, the expiration should still be at the minimum value
-            elseif ($cachedExpirationDate -eq [System.DateTime]::MinValue) {
-                Write-Verbose 'The cached token contained content, but it could not be parsed as a date. It will be re-validated'
-                Invoke-FileCleanup -FilePaths $cachedToken.FullName
-                # Do not return anything, since the token will need to be re-validated
-            }
-            else {
-                Write-Verbose "The cached token contained content, but the token expired $([Math]::Abs($tokenExpirationDays)) days ago"
-                # Leave the cached token so that it doesn't throw script exceptions in the future
-                # Invoke-FileCleanup -FilePaths $cachedToken.FullName
-                return $false
-            }
-        }
-        else {
-            # Either the token was empty, or the cached token is expired. Remove the cached token so that re-validation
-            # of the token will update the date the token was cached if it is still valid
-            Invoke-FileCleanup -FilePaths $cachedToken.FullName
-        }
-    }
-    else {
-        Write-Verbose 'Token was not found in the cache'
-    }
-
-    # To get here either the token was not in the cache or it needs to be re-validated
-
-    $requestParameters = @{
-        Uri            = 'https://api.github.com/rate_limit'
-        Authentication = 'Bearer'
-        Token          = $(ConvertTo-SecureString "$Token" -AsPlainText)
-    }
-
-    Write-Verbose "Checking Token against $($requestParameters.Uri)"
-    $apiResponse = Invoke-WebRequest @requestParameters # This will return an exception if the token is not valid; It is intentionally not caught
-    # The headers can sometimes be a single string, or an array of strings. Cast them into an array anyways just for safety
-    $rateLimit = @($apiResponse.Headers['X-RateLimit-Limit'])
-    $tokenExpiration = @($apiResponse.Headers['github-authentication-token-expiration']) # This could be null if the token is set to never expire
-    Write-Debug "API responded with Rate Limit ($rateLimit) and Expiration ($tokenExpiration)"
-
-    if (!$rateLimit) { return $false } # Something went horribly wrong, and the rate limit isn't known. Assume the token is not valid
-    if ([int]$rateLimit[0] -le 60) {
-        # Authenticated users typically have a limit that is much higher than 60
-        return $false
-    }
-
-    Write-Verbose 'Token validated successfully. Adding to cache'
-    # If the token doesn't expire, write a special value to the file
-    if (!$tokenExpiration -or [string]::IsNullOrWhiteSpace($tokenExpiration[0])) { $tokenExpiration = @([System.DateTime]::MaxValue) }
-    # When datetime objects are converted to string, they have extra whitespace that should be trimmed off
-    $tokenExpiration = [DateTime]::Parse($tokenExpiration[0]).ToLongDateString().Trim()
-    New-Item -ItemType File -Path $script:TokenValidationCache -Name $tokenHash -Value $tokenExpiration | Out-Null
-    Write-Debug "Token <$tokenHash> added to cache with content <$tokenExpiration>"
-    return $true
-}
-
 #### Start of main script ####
 
 # Check if Windows Sandbox is enabled
@@ -450,11 +291,11 @@ $ Enable-WindowsOptionalFeature -Online -FeatureName 'Containers-DisposableClien
 if (!$SkipManifestValidation -and ![String]::IsNullOrWhiteSpace($Manifest)) {
     # Check that WinGet is Installed
     if (!(Get-Command 'winget.exe' -ErrorAction SilentlyContinue)) {
-        Write-Error -Category NotInstalled 'WinGet is not installed. Manifest cannot be validated' -ErrorAction Continue
+        Write-Error -Category NotInstalled "WinGet is not installed. Manifest cannot be validated" -ErrorAction Continue
         Invoke-CleanExit -ExitCode 3
     }
     Write-Information "--> Validating Manifest"
-    $validateCommandOutput =
+    $validateCommandOutput = 
         & {
             # Store current output encoding setting
             $prevOutEnc = [Console]::OutputEncoding
@@ -465,7 +306,7 @@ if (!$SkipManifestValidation -and ![String]::IsNullOrWhiteSpace($Manifest)) {
 
             # Reset the encoding to the previous values
             [Console]::OutputEncoding = $prevOutEnc
-        }
+        }    
         switch ($LASTEXITCODE) {
         '-1978335191' {
             ($validateCommandOutput | Select-Object -Skip 1 -SkipLast 1) | Write-Information # Skip the first line and the empty last line
@@ -474,7 +315,7 @@ if (!$SkipManifestValidation -and ![String]::IsNullOrWhiteSpace($Manifest)) {
         }
         '-1978335192' {
             ($validateCommandOutput | Select-Object -Skip 1 -SkipLast 1) | Write-Information # Skip the first line and the empty last line
-            Write-Warning 'Manifest validation succeeded with warnings'
+            Write-Warning "Manifest validation succeeded with warnings"
             Start-Sleep -Seconds 5 # Allow the user 5 seconds to read the warnings before moving on
         }
         Default {
@@ -485,7 +326,7 @@ if (!$SkipManifestValidation -and ![String]::IsNullOrWhiteSpace($Manifest)) {
 
 # Get the details for the version of WinGet that was requested
 Write-Verbose "Fetching release details from $script:ReleasesApiUrl; Filters: {Prerelease=$script:Prerelease; Version~=$script:WinGetVersion}"
-$script:WinGetReleaseDetails = Get-Release -GitHubToken $script:GitHubToken
+$script:WinGetReleaseDetails = Get-Release
 if (!$script:WinGetReleaseDetails) {
     Write-Error -Category ObjectNotFound 'No WinGet releases found matching criteria' -ErrorAction Continue
     Invoke-CleanExit -ExitCode 1
@@ -495,7 +336,7 @@ if (!$script:WinGetReleaseDetails.assets) {
     Invoke-CleanExit -ExitCode 1
 }
 
-Write-Verbose 'Parsing Release Information'
+Write-Verbose "Parsing Release Information"
 # Parse the needed URLs out of the release. It is entirely possible that these could end up being $null
 $script:AppInstallerMsixShaDownloadUrl = $script:WinGetReleaseDetails.assets.Where({ $_.name -eq "$script:AppInstallerPFN.txt" }).browser_download_url
 $script:AppInstallerMsixDownloadUrl = $script:WinGetReleaseDetails.assets.Where({ $_.name -eq $script:AppInstallerMsixFileName }).browser_download_url
@@ -515,7 +356,7 @@ $script:AppInstallerParsedVersion = [System.Version]($script:AppInstallerRelease
 Write-Debug "Using Release version $script:AppinstallerReleaseTag ($script:AppInstallerParsedVersion)"
 
 # Get the hashes for the files that change with each release version
-Write-Verbose 'Fetching file hash information'
+Write-Verbose "Fetching file hash information"
 $script:AppInstallerMsixHash = Get-RemoteContent -URL $script:AppInstallerMsixShaDownloadUrl -Raw
 $script:DependenciesZipHash = Get-RemoteContent -URL $script:DependenciesShaDownloadUrl -Raw
 Write-Debug @"
@@ -528,7 +369,7 @@ Write-Debug @"
 $script:AppInstallerReleaseAssetsFolder = Join-Path $script:AppInstallerDataFolder -ChildPath 'bin' -AdditionalChildPath $script:AppInstallerReleaseTag
 
 # Build the dependency information
-Write-Verbose 'Building Dependency List'
+Write-Verbose "Building Dependency List"
 $script:AppInstallerDependencies = @()
 if ($script:AppInstallerParsedVersion -ge [System.Version]'1.9.25180') {
     # As of WinGet 1.9.25180, VCLibs no longer publishes to the public URL and must be downloaded from the WinGet release
@@ -544,7 +385,7 @@ if ($script:AppInstallerParsedVersion -ge [System.Version]'1.9.25180') {
 else {
     $script:DependencySource = [DependencySources]::Legacy
     # Add the VCLibs to the dependencies
-    Write-Debug 'Adding VCLibs UWP to dependency list'
+    Write-Debug "Adding VCLibs UWP to dependency list"
     $script:AppInstallerDependencies += @{
         DownloadUrl = $script:VcLibsDownloadUrl
         Checksum    = $script:VcLibsHash
@@ -553,7 +394,7 @@ else {
     }
     if ($script:UseNuGetForMicrosoftUIXaml) {
         # Add the NuGet file to the dependencies
-        Write-Debug 'Adding Microsoft.UI.Xaml (NuGet) to dependency list'
+        Write-Debug "Adding Microsoft.UI.Xaml (NuGet) to dependency list"
         $script:AppInstallerDependencies += @{
             DownloadUrl = $script:UiLibsDownloadUrl_NuGet
             Checksum    = $script:UiLibsHash_NuGet
@@ -564,7 +405,7 @@ else {
     # As of WinGet 1.7.10514 (https://github.com/microsoft/winget-cli/pull/4218), the dependency on uiLibsUwP was bumped from version 2.7.3 to version 2.8.6
     elseif ($script:AppInstallerParsedVersion -lt [System.Version]'1.7.10514') {
         # Add Xaml 2.7 to the dependencies
-        Write-Debug 'Adding Microsoft.UI.Xaml (v2.7) to dependency list'
+        Write-Debug "Adding Microsoft.UI.Xaml (v2.7) to dependency list"
         $script:AppInstallerDependencies += @{
             DownloadUrl = $script:UiLibsDownloadUrl_v2_7
             Checksum    = $script:UiLibsHash_v2_7
@@ -574,7 +415,7 @@ else {
     }
     else {
         # Add Xaml 2.8 to the dependencies
-        Write-Debug 'Adding Microsoft.UI.Xaml (v2.8) to dependency list'
+        Write-Debug "Adding Microsoft.UI.Xaml (v2.8) to dependency list"
         $script:AppInstallerDependencies += @{
             DownloadUrl = $script:UiLibsDownloadUrl_v2_8
             Checksum    = $script:UiLibsHash_v2_8
@@ -602,7 +443,7 @@ if ($script:UsePowerShellModuleForInstall) {
 }
 
 # Process the dependency list
-Write-Information '--> Checking Dependencies'
+Write-Information "--> Checking Dependencies"
 foreach ($dependency in $script:AppInstallerDependencies) {
     # On a clean install, remove the existing files
     if ($Clean) { Invoke-FileCleanup -FilePaths $dependency.SaveTo }
@@ -634,7 +475,7 @@ Stop-NamedProcess -ProcessName 'WindowsSandboxRemoteSession'
 Start-Sleep -Milliseconds 5000 # Wait for the lock on the file to be released
 
 # Remove the test data folder if it exists. We will rebuild it with new test data
-Write-Verbose 'Cleaning up previous test data'
+Write-Verbose "Cleaning up previous test data"
 Invoke-FileCleanup -FilePaths $script:TestDataFolder
 
 # Create the paths if they don't exist
@@ -643,7 +484,7 @@ if (!(Initialize-Folder $script:DependenciesCacheFolder)) { throw 'Could not cre
 
 # Set Experimental Features to be Enabled, If requested
 if ($EnableExperimentalFeatures) {
-    Write-Debug 'Setting Experimental Features to Enabled'
+    Write-Debug "Setting Experimental Features to Enabled"
     $experimentalFeatures = @($script:SandboxWinGetSettings.experimentalFeatures.Keys)
     foreach ($feature in $experimentalFeatures) {
         $script:SandboxWinGetSettings.experimentalFeatures[$feature] = $true
@@ -663,7 +504,7 @@ if (-Not [String]::IsNullOrWhiteSpace($Script)) {
 }
 
 # Create the bootstrapping script
-Write-Verbose 'Creating the script for bootstrapping the sandbox'
+Write-Verbose "Creating the script for bootstrapping the sandbox"
 @"
 function Update-EnvironmentVariables {
     foreach(`$level in "Machine","User") {
@@ -771,7 +612,7 @@ Pop-Location
 
 # Create the WSB file
 # Although this could be done using the native XML processor, it's easier to just write the content directly as a string
-Write-Verbose 'Creating WSB file for launching the sandbox'
+Write-Verbose "Creating WSB file for launching the sandbox"
 @"
 <Configuration>
   <Networking>Enable</Networking>

--- a/doc/tools/SandboxTest.md
+++ b/doc/tools/SandboxTest.md
@@ -13,17 +13,13 @@ To test a manifest, simply call the script with the full path to the manifest as
 The following optional arguments are supported:
 
 | Argument | Description |
-|-------------|-------------|
-| **-Manifest** | The path to the manifest to install in the Sandbox |
+|-------------|-------------|  
 | **-Script** | Post-installation script to run in the Sandbox |
 | **-MapFolder** | The folder to map in Sandbox. Default is the current directory |
 | **-WinGetVersion** | Specify version of WinGet to use in Sandbox |
-| **-WinGetOptions** | Additional Options to be passed at the end of the `winget install` command |
-| **-GitHubToken** | The GitHub token to be used for making requests to GitHub APIs |
-| **-SkipManifestValidation** | Skip `winget validate -m <manifest>` if you have already validated the manifest |
 | **-Prerelease** | Allow preview release versions of WinGet |
 | **-EnableExperimentalFeatures** | Enable WinGet experimental features |
-| **-Clean** | Forces a re-download of WinGet and all of its dependencies |
+| **-SkipManifestValidation** | Skip `winget validate -m <manifest>` if you have already validated the manifest |
 
 ### Examples
 
@@ -45,10 +41,10 @@ Test manifest on a specified version of WinGet
 .\SandboxTest.ps1 <path-to-manifest> -WinGetVersion 1.4.2011 -Prerelease -Script {Write-Host 'The script has finished'}
 ```
 
-Install a package from the repository in Sandbox
+Install a package from the repository in Sandbox 
 
 ```raw
-.\SandboxTest.ps1 -WinGetVersion 1.7 -Script {winget install <PackageIdentifier> --accept-source-agreements}
+.\SandboxTest.ps1 -WinGetVersion 1.5 -Script {winget install <PackageIdentifier> --accept-source-agreements}
 ```
 
 # System Requirements


### PR DESCRIPTION
- Reverts microsoft/winget-pkgs#230208


Publish pipeline is down due to the use of `ConvertTo-SecureString` with `-AsPlainText` option. See the [AvoidUsingConvertToSecureStringWithPlainText](https://learn.microsoft.com/en-us/powershell/utility-modules/psscriptanalyzer/rules/avoidusingconverttosecurestringwithplaintext) PSScriptAnalyzer check

![image](https://github.com/user-attachments/assets/7b2c168a-3961-46b5-9617-ad072ff84bc4)

For future prevention we should look at:
- https://github.com/microsoft/winget-pkgs/issues/236267

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/236266)