### PR TITLE
New package: Microsoft.VisualStudio.2017.Enterprise version 15.9.70

### DIFF
--- a/manifests/m/Microsoft/VisualStudio/2017/Enterprise/15.9.70/Microsoft.VisualStudio.2017.Enterprise.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2017/Enterprise/15.9.70/Microsoft.VisualStudio.2017.Enterprise.installer.yaml
@@ -1,0 +1,93 @@
+# Created with komac v2.11.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: Microsoft.VisualStudio.2017.Enterprise
+PackageVersion: 15.9.70
+MinimumOSVersion: 10.0.0.0
+InstallerType: exe
+Scope: machine
+InstallerSwitches:
+  Silent: --quiet
+  SilentWithProgress: --passive
+  Upgrade: update
+  Custom: --wait
+ExpectedReturnCodes:
+  - InstallerReturnCode: -2146233083
+    ReturnResponse: custom
+    ReturnResponseUrl: https://learn.microsoft.com/en-us/troubleshoot/developer/visualstudio/installation/issues-workarounds-visual-studio-setup
+  - InstallerReturnCode: -1073720687
+    ReturnResponse: noNetwork
+    ReturnResponseUrl: https://learn.microsoft.com/en-us/troubleshoot/developer/visualstudio/installation/issues-workarounds-visual-studio-setup
+  - InstallerReturnCode: 740
+    ReturnResponse: custom
+    ReturnResponseUrl: https://learn.microsoft.com/en-us/troubleshoot/developer/visualstudio/installation/issues-workarounds-visual-studio-setup
+  - InstallerReturnCode: 1001
+    ReturnResponse: installInProgress
+    ReturnResponseUrl: https://learn.microsoft.com/en-us/troubleshoot/developer/visualstudio/installation/issues-workarounds-visual-studio-setup
+  - InstallerReturnCode: 1003
+    ReturnResponse: fileInUse
+    ReturnResponseUrl: https://learn.microsoft.com/en-us/troubleshoot/developer/visualstudio/installation/issues-workarounds-visual-studio-setup
+  - InstallerReturnCode: 1618
+    ReturnResponse: installInProgress
+    ReturnResponseUrl: https://learn.microsoft.com/en-us/troubleshoot/developer/visualstudio/installation/issues-workarounds-visual-studio-setup
+  - InstallerReturnCode: 1641
+    ReturnResponse: rebootInitiated
+    ReturnResponseUrl: https://learn.microsoft.com/en-us/troubleshoot/developer/visualstudio/installation/issues-workarounds-visual-studio-setup
+  - InstallerReturnCode: 3010
+    ReturnResponse: rebootRequiredToFinish
+    ReturnResponseUrl: https://learn.microsoft.com/en-us/troubleshoot/developer/visualstudio/installation/issues-workarounds-visual-studio-setup
+  - InstallerReturnCode: 5001
+    ReturnResponse: custom
+    ReturnResponseUrl: https://learn.microsoft.com/en-us/troubleshoot/developer/visualstudio/installation/issues-workarounds-visual-studio-setup
+  - InstallerReturnCode: 5002
+    ReturnResponse: custom
+    ReturnResponseUrl: https://learn.microsoft.com/en-us/troubleshoot/developer/visualstudio/installation/issues-workarounds-visual-studio-setup
+  - InstallerReturnCode: 5003
+    ReturnResponse: custom
+    ReturnResponseUrl: https://learn.microsoft.com/en-us/troubleshoot/developer/visualstudio/installation/issues-workarounds-visual-studio-setup
+  - InstallerReturnCode: 5004
+    ReturnResponse: cancelledByUser
+    ReturnResponseUrl: https://learn.microsoft.com/en-us/troubleshoot/developer/visualstudio/installation/issues-workarounds-visual-studio-setup
+  - InstallerReturnCode: 5005
+    ReturnResponse: custom
+    ReturnResponseUrl: https://learn.microsoft.com/en-us/troubleshoot/developer/visualstudio/installation/issues-workarounds-visual-studio-setup
+  - InstallerReturnCode: 5007
+    ReturnResponse: custom
+    ReturnResponseUrl: https://learn.microsoft.com/en-us/troubleshoot/developer/visualstudio/installation/issues-workarounds-visual-studio-setup
+  - InstallerReturnCode: 5008
+    ReturnResponse: custom
+    ReturnResponseUrl: https://learn.microsoft.com/en-us/troubleshoot/developer/visualstudio/installation/issues-workarounds-visual-studio-setup
+  - InstallerReturnCode: 8001
+    ReturnResponse: blockedByPolicy
+    ReturnResponseUrl: https://learn.microsoft.com/en-us/troubleshoot/developer/visualstudio/installation/issues-workarounds-visual-studio-setup
+  - InstallerReturnCode: 8002
+    ReturnResponse: blockedByPolicy
+    ReturnResponseUrl: https://learn.microsoft.com/en-us/troubleshoot/developer/visualstudio/installation/issues-workarounds-visual-studio-setup
+  - InstallerReturnCode: 8003
+    ReturnResponse: blockedByPolicy
+    ReturnResponseUrl: https://learn.microsoft.com/en-us/troubleshoot/developer/visualstudio/installation/issues-workarounds-visual-studio-setup
+  - InstallerReturnCode: 8004
+    ReturnResponse: blockedByPolicy
+    ReturnResponseUrl: https://learn.microsoft.com/en-us/troubleshoot/developer/visualstudio/installation/issues-workarounds-visual-studio-setup
+  - InstallerReturnCode: 8005
+    ReturnResponse: blockedByPolicy
+    ReturnResponseUrl: https://learn.microsoft.com/en-us/troubleshoot/developer/visualstudio/installation/issues-workarounds-visual-studio-setup
+  - InstallerReturnCode: 8006
+    ReturnResponse: custom
+    ReturnResponseUrl: https://learn.microsoft.com/en-us/troubleshoot/developer/visualstudio/installation/issues-workarounds-visual-studio-setup
+  - InstallerReturnCode: 8007
+    ReturnResponse: blockedByPolicy
+    ReturnResponseUrl: https://learn.microsoft.com/en-us/troubleshoot/developer/visualstudio/installation/issues-workarounds-visual-studio-setup
+  - InstallerReturnCode: 8008
+    ReturnResponse: blockedByPolicy
+    ReturnResponseUrl: https://learn.microsoft.com/en-us/troubleshoot/developer/visualstudio/installation/issues-workarounds-visual-studio-setup
+  - InstallerReturnCode: 8009
+    ReturnResponse: blockedByPolicy
+    ReturnResponseUrl: https://learn.microsoft.com/en-us/troubleshoot/developer/visualstudio/installation/issues-workarounds-visual-studio-setup
+ReleaseDate: 2025-01-27
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/0062cf19-350e-4e71-9d4d-af0557a5b273/5394bc024756c12652a9510ff7b68819780cf21f4c498babd1d85ba4f12ff94d/vs_Enterprise.exe
+    InstallerSha256: 5394BC024756C12652A9510FF7B68819780CF21F4C498BABD1D85BA4F12FF94D
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/m/Microsoft/VisualStudio/2017/Enterprise/15.9.70/Microsoft.VisualStudio.2017.Enterprise.locale.en-US.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2017/Enterprise/15.9.70/Microsoft.VisualStudio.2017.Enterprise.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# Created with komac v2.11.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: Microsoft.VisualStudio.2017.Enterprise
+PackageVersion: 15.9.70
+PackageLocale: en-US
+Publisher: Microsoft Corporation
+PackageName: Visual Studio Enterprise 2017
+PackageUrl: https://visualstudio.microsoft.com/
+License: Proprietary
+LicenseUrl: https://visualstudio.microsoft.com/license-terms/
+Copyright: Copyright (c) Microsoft Corporation. All rights reserved.
+ShortDescription: >
+  An integrated, end-to-end solution for developers looking for high productivity and seamless
+  coordination across teams of any size.
+Moniker: vs2017-enterprise
+Tags:
+  - c#
+  - c++
+  - vs
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/m/Microsoft/VisualStudio/2017/Enterprise/15.9.70/Microsoft.VisualStudio.2017.Enterprise.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2017/Enterprise/15.9.70/Microsoft.VisualStudio.2017.Enterprise.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.11.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: Microsoft.VisualStudio.2017.Enterprise
+PackageVersion: 15.9.70
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## Checklist for Pull Requests

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Resolve #234895

## Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.9.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

## Manual validation

<details><summary>Console logs</summary>

```text
22:18:32 D:\...\winget-pkgs  [issues/234895/15.9.70 ≡] 0ms pwsh$ .\Tools\SandboxTest.ps1 -Verbose -GitHubToken $(gh auth token) `
> -Manifest .\manifests\m\Microsoft\VisualStudio\2017\Enterprise\15.9.70\ -WinGetOptions '--interactive'
--> Validating Manifest
清单验证成功。
VERBOSE: Fetching release details from https://api.github.com/repos/microsoft/winget-cli/releases?per_page=100; Filters: {Prerelease=False; Version~=}
VERBOSE: Hashing GitHub Token
VERBOSE: Token was found in the cache
VERBOSE: Attempting to fetch token expiration from cache
VERBOSE: The cached token contained content. It is set to never expire
VERBOSE: Adding Bearer Token Authentication to Releases API Request
VERBOSE: Requested HTTP/1.1 GET with 0-byte payload
VERBOSE: Received HTTP/1.1 response of content type application/json of unknown size
VERBOSE: Content encoding: utf-8
VERBOSE: Parsing Release Information
VERBOSE: Fetching file hash information
VERBOSE: Requested HTTP/1.1 HEAD with 0-byte payload
VERBOSE: Received HTTP/1.1 64-byte response of content type application/octet-stream
VERBOSE: Requested HTTP/1.1 HEAD with 0-byte payload
VERBOSE: Received HTTP/1.1 64-byte response of content type application/octet-stream
VERBOSE: Building Dependency List
--> Checking Dependencies
VERBOSE: Checking the hash of C:\Users\Dragon1573\AppData\Local\Packages\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe\bin\v1.10.340\DesktopAppInstaller_Dependencies.zip
VERBOSE: Checking the hash of C:\Users\Dragon1573\AppData\Local\Packages\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe\bin\v1.10.340\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle
VERBOSE: Cleaning up previous test data
VERBOSE: Copying assets into C:\Users\Dragon1573\AppData\Local\Packages\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe\SandboxTest
VERBOSE: Creating the script for bootstrapping the sandbox
VERBOSE: Creating WSB file for launching the sandbox
--> Starting Windows Sandbox, and:
    - Mounting the following directories:
      - C:\Users\Dragon1573\AppData\Local\Packages\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe\SandboxTest as read-and-write
      - D:\Repository\winget-pkgs as read-and-write
    - Installing WinGet
    - Configuring Winget
      - Installing the Manifest 15.9.70
      - Refreshing environment variables
      - Comparing ARP Entries
VERBOSE: Invoking the sandbox using C:\Users\Dragon1573\AppData\Local\Packages\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe\SandboxTest\SandboxTest.wsb
```

</details>
<details><summary>Screenshots</summary>

![image](https://github.com/user-attachments/assets/d6a5e32f-8be4-43ea-9806-bd36af9c90f8)

</details>

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/236317)