### PR TITLE
Add workflow for running ScriptAnalyzer

### DIFF
--- a/.github/workflows/scriptAnalyzer.yaml
+++ b/.github/workflows/scriptAnalyzer.yaml
@@ -1,0 +1,40 @@
+name: PSScriptAnalyzer
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - "**/*.ps1"
+  push:
+    paths:
+      - "**/*.ps1"
+
+permissions:
+  contents: read # Needed to check out the code
+  pull-requests: read # Needed to read pull request details
+
+jobs:
+  analyze:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Install PSScriptAnalyzer
+        run: |
+          Install-Module -Name PSScriptAnalyzer -Force -SkipPublisherCheck -Scope CurrentUser
+      - name: Run PSScriptAnalyzer
+        run: |
+          # Run PSScriptAnalyzer on all PowerShell scripts
+          $results = Get-ChildItem -Recurse -Filter *.ps1 | Invoke-ScriptAnalyzer
+          if ($results) {
+            Write-Output $results | Format-List -GroupBy ScriptName
+          }
+
+          # If errors are found, exit with a non-zero exit code to fail the job
+          if ($results.where({$_.Severity-eq 'Error'})) {
+            Write-Host "Found script issues (errors)."
+            exit 1  # Exit with a non-zero status to fail the job
+          } else {
+            Write-Host "No blocking detections."
+          }

--- a/Tools/YamlCreate.ps1
+++ b/Tools/YamlCreate.ps1
@@ -1635,8 +1635,6 @@ Function Read-InstallerMetadataValue {
 # If a key does not exist, it sets the value to a special character to be removed / commented later
 # Returns the result as a new object
 Function Restore-YamlKeyOrder {
-  [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'InputObject', Justification = 'The variable is used inside a conditional but ScriptAnalyser does not recognize the scope')]
-  [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'NoComments', Justification = 'The variable is used inside a conditional but ScriptAnalyser does not recognize the scope')]
   Param
   (
     [Parameter(Mandatory = $true, Position = 0)]


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Is there a linked Issue?
  * #236267 

This PR makes it so ScriptAnalyzer errors are identified by a workflow. Warnings and Informational items are still output in the workflow logs, but are non-blocking. This workflow should only trigger when a PowerShell script is added or modified

Once added, the repository rules should make this a required check

cc @denelon / @mdanish-kh / @stephengillie   

![image](https://github.com/user-attachments/assets/2ee250fa-53f0-478c-ae8b-df2e36630487)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/236464)