### PR TITLE
Add GlennDelahoy.SnappyDriverInstallerOrigin version 1.15.1.813

### DIFF
--- a/manifests/g/GlennDelahoy/SnappyDriverInstallerOrigin/1.15.1.813/GlennDelahoy.SnappyDriverInstallerOrigin.installer.yaml
+++ b/manifests/g/GlennDelahoy/SnappyDriverInstallerOrigin/1.15.1.813/GlennDelahoy.SnappyDriverInstallerOrigin.installer.yaml
@@ -1,0 +1,25 @@
+# Created with komac v2.11.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: GlennDelahoy.SnappyDriverInstallerOrigin
+PackageVersion: 1.15.1.813
+InstallerType: zip
+NestedInstallerType: portable
+UpgradeBehavior: uninstallPrevious
+ReleaseDate: 2025-02-28
+Installers:
+- Architecture: x86
+  InstallerUrl: https://www.glenn.delahoy.com/downloads/sdio/SDIO_1.15.1.813.zip
+  InstallerSha256: 83F65065DE223C3F2AA371B0AE14C8DAA2C6AE42E28F8ACD54A919E44CE4FC55
+  NestedInstallerFiles:
+  - RelativeFilePath: SDIO_R813.exe
+    PortableCommandAlias: SDIO
+- Architecture: x64
+  InstallerUrl: https://www.glenn.delahoy.com/downloads/sdio/SDIO_1.15.1.813.zip
+  InstallerSha256: 83F65065DE223C3F2AA371B0AE14C8DAA2C6AE42E28F8ACD54A919E44CE4FC55
+  NestedInstallerFiles:
+  - RelativeFilePath: SDIO_x64_R813.exe
+    PortableCommandAlias: SDIO
+ReleaseNotesUrl: https://www.glenn.delahoy.com/downloads/sdio/changelog.txt
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/g/GlennDelahoy/SnappyDriverInstallerOrigin/1.15.1.813/GlennDelahoy.SnappyDriverInstallerOrigin.locale.en-US.yaml
+++ b/manifests/g/GlennDelahoy/SnappyDriverInstallerOrigin/1.15.1.813/GlennDelahoy.SnappyDriverInstallerOrigin.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# Created with komac v2.11.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: GlennDelahoy.SnappyDriverInstallerOrigin
+PackageVersion: 1.15.1.813
+PackageLocale: en-US
+Publisher: Glenn Delahoy
+PublisherUrl: https://www.glenn.delahoy.com/
+PublisherSupportUrl: https://www.glenn.delahoy.com/sdio-faq/
+Author: Glenn Delahoy
+PackageName: Snappy Driver Installer Origin
+PackageUrl: https://glenn.delahoy.com/downloads/sdio/SDIO_1.15.1.813.zip
+License: GPLv3
+LicenseUrl: https://www.glenn.delahoy.com/snappy-driver-installer-origin/
+ShortDescription: Install Missing Drivers and Update Old Drivers
+Moniker: sdio
+Tags:
+- drivers
+- installer
+- update
+ReleaseNotesUrl: https://www.glenn.delahoy.com/downloads/sdio/changelog.txt
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0
+

--- a/manifests/g/GlennDelahoy/SnappyDriverInstallerOrigin/1.15.1.813/GlennDelahoy.SnappyDriverInstallerOrigin.yaml
+++ b/manifests/g/GlennDelahoy/SnappyDriverInstallerOrigin/1.15.1.813/GlennDelahoy.SnappyDriverInstallerOrigin.yaml
@@ -1,0 +1,9 @@
+# Created with komac v2.11.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: GlennDelahoy.SnappyDriverInstallerOrigin
+PackageVersion: 1.15.1.813
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0
+


### PR DESCRIPTION
### Summary
Added new version 1.15.1.813 of Snappy Driver Installer Origin.

### Changes
- Updated InstallerUrl and SHA256 hash
- Defined NestedInstallerFiles for x86 and x64
- Added ReleaseNotesUrl: https://www.glenn.delahoy.com/downloads/sdio/changelog.txt
- Verified with `winget validate` and Komac

### Validation
- [x] Manifest schema 1.9.0 compliant
- [x] Validated locally with `winget validate`
- [x] Installer files and URLs verified

Thanks!

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/236852)