### PR TITLE
[PHP] Add new version `PHP.PHP.8.1` - `8.1.32`

### DIFF
--- a/manifests/p/PHP/PHP/8/1/8.1.32/PHP.PHP.8.1.installer.yaml
+++ b/manifests/p/PHP/PHP/8/1/8.1.32/PHP.PHP.8.1.installer.yaml
@@ -1,0 +1,32 @@
+# Created with PHPWatch/winget-pkgs - https://github.com/PHPWatch/php-winget-manifest
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: PHP.PHP.8.1
+PackageVersion: 8.1.32
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: php.exe
+    PortableCommandAlias: php
+Commands:
+  - php
+  - php81
+UpgradeBehavior: install
+ReleaseDate: 2025-03-12
+ArchiveBinariesDependOnPath: true
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://windows.php.net/downloads/releases/php-8.1.32-Win32-vs16-x64.zip
+    InstallerSha256: 6729ee58a364b5176360ce826678840a54c55e6036d11499330383cd6689f8e4
+    Dependencies:
+      PackageDependencies:
+        - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+  - Architecture: x86
+    InstallerUrl: https://windows.php.net/downloads/releases/php-8.1.32-Win32-vs16-x86.zip
+    InstallerSha256: 1b1dd346ee0b329e7b92a984f2f3dc6c987a300289ff112f978dfcce30565893
+    Dependencies:
+      PackageDependencies:
+        - PackageIdentifier: Microsoft.VCRedist.2015+.x86
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/p/PHP/PHP/8/1/8.1.32/PHP.PHP.8.1.locale.en-US.yaml
+++ b/manifests/p/PHP/PHP/8/1/8.1.32/PHP.PHP.8.1.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# Created with PHPWatch/winget-pkgs - https://github.com/PHPWatch/php-winget-manifest
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: PHP.PHP.8.1
+Description: "PHP (recursive acronym for PHP: Hypertext Preprocessor) is a widely-used open source general-purpose scripting language that is especially suited for web development and can be embedded into HTML."
+ShortDescription: PHP 8.1
+PackageVersion: 8.1.32
+ReleaseNotesUrl: https://www.php.net/ChangeLog-8.php#8.1.32
+PackageLocale: en-US
+Publisher: PHP Group
+PublisherUrl: https://php.net
+PublisherSupportUrl: https://www.php.net/docs.php
+Author: PHP Group
+PackageName: PHP 8.1
+PackageUrl: https://php.net
+License: PHP License v3.01
+LicenseUrl: https://www.php.net/license/3_01.txt
+Copyright: (c) PHP Group
+CopyrightUrl: https://www.php.net/credits.php
+Moniker: php8.1
+Tags:
+  - php
+  - php81
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/p/PHP/PHP/8/1/8.1.32/PHP.PHP.8.1.yaml
+++ b/manifests/p/PHP/PHP/8/1/8.1.32/PHP.PHP.8.1.yaml
@@ -1,0 +1,8 @@
+# Created with PHPWatch/winget-pkgs - https://github.com/PHPWatch/php-winget-manifest
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: PHP.PHP.8.1
+PackageVersion: 8.1.32
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Updates `PHP.PHP.8.1` to PHP `8.1.32`

---

**PHP 8.1.32**
x86 zip Download: https://windows.php.net/downloads/releases/php-8.1.32-Win32-vs16-x86.zip
x86 zip checksum: `1b1dd346ee0b329e7b92a984f2f3dc6c987a300289ff112f978dfcce30565893`
x64 zip Download: https://windows.php.net/downloads/releases/php-8.1.32-Win32-vs16-x64.zip
x64 zip Checksum: `6729ee58a364b5176360ce826678840a54c55e6036d11499330383cd6689f8e4`

Info: [PHP 8.1](https://windows.php.net/download#php-8.1) - [PHP 8.1.32](https://php.watch/versions/8.1/releases/8.1.32#download-windows) - [php/php-src 8.1.32](https://github.com/php/php-src/releases/tag/php-8.1.32)

---

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.9.0)?

---

###### Manifest built [automatically](https://github.com/PHPWatch/php-winget-manifest/actions/runs/13810342689) and [attested](https://github.com/PHPWatch/php-winget-manifest/attestations/5517160) by [PHPWatch/php-winget-manifest](https://github.com/PHPWatch/php-winget-manifest/).


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/236889)