### PR TITLE
Exclude .github folder from Manifest-Path-Error trigger

### DIFF
--- a/.github/policies/labelManagement.issueOpened.yml
+++ b/.github/policies/labelManagement.issueOpened.yml
@@ -106,6 +106,9 @@ configuration:
           - not:
               filesMatchPattern:
                 pattern: ^.configurations/.*
+          - not:
+              filesMatchPattern:
+                pattern: ^.github/.*
           - filesMatchPattern:
               pattern: ^.*\.yaml
         then:


### PR DESCRIPTION
@denelon
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/240823)