### PR TITLE
Set `ArchiveBinariesDependOnPath` for 2dust.v2rayN

### DIFF
--- a/manifests/2/2dust/v2rayN/7.10.4/2dust.v2rayN.installer.yaml
+++ b/manifests/2/2dust/v2rayN/7.10.4/2dust.v2rayN.installer.yaml
@@ -10,7 +10,7 @@ NestedInstallerFiles:
 Dependencies:
   PackageDependencies:
   - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.8
-RequireExplicitUpgrade: true
+ArchiveBinariesDependOnPath: true
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/2dust/v2rayN/releases/download/7.10.4/v2rayN-windows-64.zip


### PR DESCRIPTION
See discussion in https://github.com/2dust/v2rayN/issues/6803.

`RequireExplicitUpgrade` is removed since the self-upgrade function is off by default.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/240903)