### PR TITLE
New version: CertifyTheWeb.CertifySSLManager version 6.1.4

### DIFF
--- a/manifests/c/CertifyTheWeb/CertifySSLManager/6.1.4/CertifyTheWeb.CertifySSLManager.installer.yaml
+++ b/manifests/c/CertifyTheWeb/CertifySSLManager/6.1.4/CertifyTheWeb.CertifySSLManager.installer.yaml
@@ -1,0 +1,21 @@
+# Created with komac v2.11.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: CertifyTheWeb.CertifySSLManager
+PackageVersion: 6.1.4
+InstallerLocale: en-US
+InstallerType: inno
+Scope: machine
+ProductCode: Certify The Web_is1
+ReleaseDate: 2025-03-18
+AppsAndFeaturesEntries:
+  - ProductCode: Certify The Web_is1
+ElevationRequirement: elevatesSelf
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles%\CertifyTheWeb'
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://certifytheweb.s3.amazonaws.com/downloads/archive/CertifyTheWebSetup_V6.1.4.exe
+    InstallerSha256: A8BE4AB7BAEB6BAA46C8A8A01FF21BA0EC3FB0590D97DEAF156FCEEC068435DC
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/c/CertifyTheWeb/CertifySSLManager/6.1.4/CertifyTheWeb.CertifySSLManager.locale.en-US.yaml
+++ b/manifests/c/CertifyTheWeb/CertifySSLManager/6.1.4/CertifyTheWeb.CertifySSLManager.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# Created with komac v2.11.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: CertifyTheWeb.CertifySSLManager
+PackageVersion: 6.1.4
+PackageLocale: en-US
+Publisher: Webprofusion Pty Ltd
+PackageName: Certify The Web
+PackageUrl: https://certifytheweb.com/
+License: GPL
+ShortDescription: |
+  Easily install and auto-renew free SSL/TLS certificates from letsencrypt.org and other ACME Certificate Authorities for your IIS/Windows servers. Setting up https has never been easier.
+Moniker: certifysslmanager
+Tags:
+  - certificate
+  - https
+  - ssl
+ReleaseNotes: |-
+  6.1.4 : 2025/03/18
+
+  - Enhancements:
+    - DNS: WEDOS DNS provider via Posh-ACME.
+  - Fixes:
+    - Tasks: Deploy to Generic Server, Apache, nginx, Tomcat and Export Certificate - fix issue with non-user accessible path setting causing issues with some exported components (e.g. full chain).
+    - ACME: Remove log warning if acme profile not selected, add DisableARIChecks setting for users who require a specific renewal interval.
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/c/CertifyTheWeb/CertifySSLManager/6.1.4/CertifyTheWeb.CertifySSLManager.yaml
+++ b/manifests/c/CertifyTheWeb/CertifySSLManager/6.1.4/CertifyTheWeb.CertifySSLManager.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.11.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: CertifyTheWeb.CertifySSLManager
+PackageVersion: 6.1.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## Checklist for Pull Requests

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Resolve #240977

## Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.9.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

## Manual validation

> [!NOTE]
> 
> A local "cache" server was used below for speeding up download and install process. The original installer file was downloaded externally with _Motrix_. The server was provided by an _AList_ instance.

```text
00:19:47 D:\...\winget-pkgs  [master ≡ +1 ~0 -0 !] 1ms pwsh$ gsudo { winget upgrade -m .\manifests\c\CertifyTheWeb\CertifySSLManager\6.1.4\ }       
已找到 Certify The Web [CertifyTheWeb.CertifySSLManager] 版本 6.1.4
此应用程序由其所有者授权给你。
Microsoft 对第三方程序包概不负责，也不向第三方程序包授予任何许可证。
正在下载 http://alist.dragon1573.local/d/CertifyTheWebSetup_V6.1.4.exe
  ██████████████████████████████  12.2 MB / 12.2 MB
已成功验证安装程序哈希
正在启动程序包安装...
已成功安装
```

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/240981)