### PR TITLE
Remove incorrect portable node from Microsoft.AzureCLI version 2.63.0

### DIFF
--- a/manifests/m/Microsoft/AzureCLI/2.63.0/Microsoft.AzureCLI.installer.yaml
+++ b/manifests/m/Microsoft/AzureCLI/2.63.0/Microsoft.AzureCLI.installer.yaml
@@ -1,18 +1,10 @@
 # Created with komac v2.3.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 
 PackageIdentifier: Microsoft.AzureCLI
 PackageVersion: 2.63.0
 ReleaseDate: 2024-07-31
 Installers:
-  - Architecture: x64
-    InstallerType: zip
-    NestedInstallerType: portable
-    NestedInstallerFiles:
-      - RelativeFilePath: python.exe
-        PortableCommandAlias: az
-    InstallerUrl: https://github.com/Azure/azure-cli/releases/download/azure-cli-2.63.0/azure-cli-2.63.0-x64.zip
-    InstallerSha256: FB3359EF37D11A4197F8B9C4C8629C821A91760785BE3B1849B9BC9B590150DD
   - InstallerLocale: en-US
     Architecture: x86
     InstallerType: wix
@@ -34,4 +26,4 @@ Installers:
       - DisplayName: Microsoft Azure CLI (64-bit)
         UpgradeCode: '{90762FEC-9554-4729-A107-C6A8EA316698}'
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/m/Microsoft/AzureCLI/2.63.0/Microsoft.AzureCLI.locale.en-US.yaml
+++ b/manifests/m/Microsoft/AzureCLI/2.63.0/Microsoft.AzureCLI.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with komac v2.3.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 
 PackageIdentifier: Microsoft.AzureCLI
 PackageVersion: 2.63.0
@@ -20,4 +20,4 @@ Tags:
 - cli
 InstallationNotes: 'Winget installs the 64-bit CLI on 64-bit OS by default now. If you have used the 32-bit CLI before, please follow this guide to migrate to 64-bit version: https://learn.microsoft.com/cli/azure/install-azure-cli-windows#migrate-to-64-bit-azure-cli'
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/m/Microsoft/AzureCLI/2.63.0/Microsoft.AzureCLI.yaml
+++ b/manifests/m/Microsoft/AzureCLI/2.63.0/Microsoft.AzureCLI.yaml
@@ -1,8 +1,8 @@
 # Created with komac v2.3.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
 
 PackageIdentifier: Microsoft.AzureCLI
 PackageVersion: 2.63.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0


### PR DESCRIPTION
The portable node renames python.exe to \az which is incorrect. There is an \az.cmd present in the zip file, but
we can not use that as scripted installers are blocked by policy. This PR removes the portable installer from the manifest.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/241751)