### PR TITLE
Remove incorrect portable node from Microsoft.AzureCLI version 2.65.0

### DIFF
--- a/manifests/m/Microsoft/AzureCLI/2.65.0/Microsoft.AzureCLI.installer.yaml
+++ b/manifests/m/Microsoft/AzureCLI/2.65.0/Microsoft.AzureCLI.installer.yaml
@@ -1,18 +1,10 @@
 # Created with komac v2.5.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 
 PackageIdentifier: Microsoft.AzureCLI
 PackageVersion: 2.65.0
 ReleaseDate: 2024-10-08
 Installers:
-- Architecture: x64
-  InstallerType: zip
-  NestedInstallerType: portable
-  NestedInstallerFiles:
-  - RelativeFilePath: python.exe
-    PortableCommandAlias: az
-  InstallerUrl: https://github.com/Azure/azure-cli/releases/download/azure-cli-2.65.0/azure-cli-2.65.0-x64.zip
-  InstallerSha256: E30C6838FD2AF64CC1FE2B09787575A39B724BB16858C23E84B8CEB93B75C7FC
 - InstallerLocale: en-US
   Architecture: x86
   InstallerType: wix
@@ -42,4 +34,4 @@ Installers:
   InstallationMetadata:
     DefaultInstallLocation: '%ProgramFiles%\Microsoft SDKs\Azure\CLI2'
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/m/Microsoft/AzureCLI/2.65.0/Microsoft.AzureCLI.locale.en-US.yaml
+++ b/manifests/m/Microsoft/AzureCLI/2.65.0/Microsoft.AzureCLI.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with komac v2.5.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 
 PackageIdentifier: Microsoft.AzureCLI
 PackageVersion: 2.65.0
@@ -21,4 +21,4 @@ Tags:
 ReleaseNotesUrl: https://github.com/Azure/azure-cli/releases/tag/azure-cli-2.65.0
 InstallationNotes: 'Winget installs the 64-bit CLI on 64-bit OS by default now. If you have used the 32-bit CLI before, please follow this guide to migrate to 64-bit version: https://learn.microsoft.com/cli/azure/install-azure-cli-windows#migrate-to-64-bit-azure-cli'
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/m/Microsoft/AzureCLI/2.65.0/Microsoft.AzureCLI.yaml
+++ b/manifests/m/Microsoft/AzureCLI/2.65.0/Microsoft.AzureCLI.yaml
@@ -1,8 +1,8 @@
 # Created with komac v2.5.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
 
 PackageIdentifier: Microsoft.AzureCLI
 PackageVersion: 2.65.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0


### PR DESCRIPTION
The portable node renames python.exe to \az which is incorrect. There is an \az.cmd present in the zip file, but
we can not use that as scripted installers are blocked by policy. This PR removes the portable installer from the manifest.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/241753)