### PR TITLE
Remove incorrect portable node from Microsoft.AzureCLI version 2.69.0

### DIFF
--- a/manifests/m/Microsoft/AzureCLI/2.69.0/Microsoft.AzureCLI.installer.yaml
+++ b/manifests/m/Microsoft/AzureCLI/2.69.0/Microsoft.AzureCLI.installer.yaml
@@ -29,13 +29,5 @@ Installers:
         UpgradeCode: '{90762FEC-9554-4729-A107-C6A8EA316698}'
     InstallationMetadata:
       DefaultInstallLocation: '%ProgramFiles%\Microsoft SDKs\Azure\CLI2'
-  - Architecture: x64
-    InstallerUrl: https://github.com/Azure/azure-cli/releases/download/azure-cli-2.69.0/azure-cli-2.69.0-x64.zip
-    InstallerSha256: 4748680e5a3806940b41b30175ddc088c4ec24b1c4b136e2a6b255510242500a
-    InstallerType: zip
-    NestedInstallerType: portable
-    NestedInstallerFiles:
-      - RelativeFilePath: python.exe
-        PortableCommandAlias: az
 ManifestType: installer
 ManifestVersion: 1.9.0


### PR DESCRIPTION
The portable node renames python.exe to \az which is incorrect. There is an \az.cmd present in the zip file, but
we can not use that as scripted installers are blocked by policy. This PR removes the portable installer from the manifest.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/241754)