### PR TITLE
Remove portable installers from Microsoft.DSC.Preview 3.0.12.0

### DIFF
--- a/manifests/m/Microsoft/DSC/Preview/3.0.12.0/Microsoft.DSC.Preview.installer.yaml
+++ b/manifests/m/Microsoft/DSC/Preview/3.0.12.0/Microsoft.DSC.Preview.installer.yaml
@@ -4,52 +4,24 @@
 PackageIdentifier: Microsoft.DSC.Preview
 PackageVersion: 3.0.12.0
 ReleaseDate: 2024-12-10
+MinimumOSVersion: 10.0.17763.0
+InstallerType: msix
+PackageFamilyName: Microsoft.DesiredStateConfiguration-Preview_8wekyb3d8bbwe
+Platform:
+  - Windows.Universal
+# Both can be shown for PowerToys CommandNotFound module
 Commands:
-- dsc
+  - dsc
+  - dsc-preview
+# Portable installers for this version do not work when invoked via symlink. See https://github.com/PowerShell/DSC/issues/618
 Installers:
 - Architecture: x64
-  Platform:
-    - Windows.Universal
-  MinimumOSVersion: 10.0.17763.0
-  InstallerType: msix
   InstallerUrl: https://github.com/PowerShell/DSC/releases/download/v3.0.0-preview.12/DSC-3.0.0-preview.12-Win.msixbundle
   InstallerSha256: A4818A8840263A4D9FDAFEB980F8D9AC2B07CE1FAA8AD8377F2521CCAEF55BEE
   SignatureSha256: AD0C429D7AEEFA7BEB0D2E26584547EB0165A93531DAD0E16732DC306E61134D
-  PackageFamilyName: Microsoft.DesiredStateConfiguration-Preview_8wekyb3d8bbwe
 - Architecture: arm64
-  Platform:
-    - Windows.Universal
-  MinimumOSVersion: 10.0.17763.0
-  InstallerType: msix
   InstallerUrl: https://github.com/PowerShell/DSC/releases/download/v3.0.0-preview.12/DSC-3.0.0-preview.12-Win.msixbundle
   InstallerSha256: A4818A8840263A4D9FDAFEB980F8D9AC2B07CE1FAA8AD8377F2521CCAEF55BEE
   SignatureSha256: AD0C429D7AEEFA7BEB0D2E26584547EB0165A93531DAD0E16732DC306E61134D
-  PackageFamilyName: Microsoft.DesiredStateConfiguration-Preview_8wekyb3d8bbwe
-- Architecture: x64
-  Dependencies:
-    PackageDependencies:
-    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
-  InstallerType: zip
-  NestedInstallerType: portable
-  NestedInstallerFiles:
-  - RelativeFilePath: dsc.exe
-    PortableCommandAlias: dsc
-  AppsAndFeaturesEntries:
-    - DisplayVersion: 3.0.0-preview.12
-  InstallerUrl: https://github.com/PowerShell/DSC/releases/download/v3.0.0-preview.12/DSC-3.0.0-preview.12-x86_64-pc-windows-msvc.zip
-  InstallerSha256: 8CDBBD0E5B004C2D54A0EBCB066CA74D5BCB86CD530DFBE8D3C91589F8AB8CEC
-- Architecture: arm64
-  Dependencies:
-    PackageDependencies:
-    - PackageIdentifier: Microsoft.VCRedist.2015+.arm64
-  InstallerType: zip
-  NestedInstallerType: portable
-  NestedInstallerFiles:
-  - RelativeFilePath: dsc.exe
-    PortableCommandAlias: dsc
-  AppsAndFeaturesEntries:
-    - DisplayVersion: 3.0.0-preview.12
-  InstallerUrl: https://github.com/PowerShell/DSC/releases/download/v3.0.0-preview.12/DSC-3.0.0-preview.12-aarch64-pc-windows-msvc.zip
-  InstallerSha256: A618C29FF4D3C92F45E85BE0AAD7827F46493F70FCF257E19D8BF17D0BDD12BD
 ManifestType: installer
 ManifestVersion: 1.9.0

--- a/manifests/m/Microsoft/DSC/Preview/3.0.12.0/Microsoft.DSC.Preview.locale.en-US.yaml
+++ b/manifests/m/Microsoft/DSC/Preview/3.0.12.0/Microsoft.DSC.Preview.locale.en-US.yaml
@@ -7,7 +7,7 @@ PackageLocale: en-US
 Publisher: Microsoft Corporation
 PublisherUrl: https://www.microsoft.com/
 PublisherSupportUrl: https://support.microsoft.com/
-PackageName: DSC v3
+PackageName: DSC v3 Preview
 PackageUrl: https://github.com/PowerShell/DSC
 License: MIT
 LicenseUrl: https://github.com/PowerShell/DSC/blob/main/LICENSE
@@ -27,6 +27,7 @@ Description: |-
 Tags:
 - dsc
 - dscv3
+- dscv3-preview
 - configuration-as-code
 - config-as-code
 - configuration
@@ -35,7 +36,7 @@ Tags:
 Moniker: dscv3-preview
 ReleaseNotesUrl: https://github.com/PowerShell/DSC/releases/tag/v3.0.0-preview.12
 Documentations:
-- DocumentLabel: Wiki
-  DocumentUrl: https://github.com/PowerShell/DSC/wiki
+- DocumentLabel: Microsoft Learn
+  DocumentUrl: https://learn.microsoft.com/en-us/powershell/dsc/overview?view=dsc-3.0
 ManifestType: defaultLocale
 ManifestVersion: 1.9.0


### PR DESCRIPTION
Portable installers for this version do not work when invoked via symlink. 

- See https://github.com/PowerShell/DSC/issues/618

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/242499)