### PR TITLE
Switch trigger from AZP run to wingetbot run

### DIFF
--- a/.github/policies/labelManagement.issueUpdated.yml
+++ b/.github/policies/labelManagement.issueUpdated.yml
@@ -383,13 +383,14 @@ configuration:
       - description: Remove status labels when a PR is re-run
         if:
           - payloadType: Issue_Comment
+          - isOpen
           - or:
               - commentContains:
-                  pattern: '\/[a|A][z|Z][p|P] [r|R][u|U][n|N]'
-                  isRegex: True
+                  pattern: 'Validation Pipeline Run'
+                  isRegex: false
               - commentContains:
-                  pattern: '\/[a|A][z|Z][u|U][r|R][e|E][p|P][i|I][p|P][e|E][l|L][i|I][n|N][e|E][s|S] [r|R][u|U][n|N]'
-                  isRegex: True
+                  pattern: '@[Ww]ingetbot\s[Rr]un'
+                  isRegex: true
           - not:
               isActivitySender:
                 user: microsoft-github-policy-service[bot]
@@ -399,6 +400,26 @@ configuration:
                   permission: Admin
               - activitySenderHasPermission:
                   permission: Write
+              - isActivitySender:
+                  user: stephengillie
+              - isActivitySender:
+                  user: ImJoakim
+              - isActivitySender:
+                  user: ItzLevvie
+              - isActivitySender:
+                  user: jedieaston
+              - isActivitySender:
+                  user: KaranKad
+              - isActivitySender:
+                  user: OfficialEsco
+              - isActivitySender:
+                  user: quhxl
+              - isActivitySender:
+                  user: Trenly
+              - isActivitySender:
+                  user: mdanish-kh
+              - isActivitySender:
+                  user: russellbanks
         then:
           # Don't remove Changes-Requested here because it is just a re-run, no new commits have been added
           - removeLabel:


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Since the pipelines no longer use `/azp run` for re-runs, this PR updates the logic.
* If wingetbot comments that a new pipeline run has been started - volatile labels will be reset
* If an admin or moderator comments for wingetbot to rerun - volatile labels will be reset. This is necessary to address cases where a rerun has been requested but not yet been started
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/243067)