### PR TITLE
New version: GodotEngine.GodotEngine version 4.4.1

### DIFF
--- a/manifests/g/GodotEngine/GodotEngine/4.4.1/GodotEngine.GodotEngine.installer.yaml
+++ b/manifests/g/GodotEngine/GodotEngine/4.4.1/GodotEngine.GodotEngine.installer.yaml
@@ -1,0 +1,35 @@
+# Created with komac v2.11.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: GodotEngine.GodotEngine
+PackageVersion: 4.4.1
+InstallerType: zip
+NestedInstallerType: portable
+ReleaseDate: 2025-03-26
+Installers:
+- Architecture: x86
+  NestedInstallerFiles:
+  - RelativeFilePath: Godot_v4.4.1-stable_win32.exe
+    PortableCommandAlias: godot
+  - RelativeFilePath: Godot_v4.4.1-stable_win32_console.exe
+    PortableCommandAlias: godot_console
+  InstallerUrl: https://github.com/godotengine/godot/releases/download/4.4.1-stable/Godot_v4.4.1-stable_win32.exe.zip
+  InstallerSha256: F26EC321388B537A568DCC97D2D43902E2AFF4AFA308D81AF6605103E5EC5C9C
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: Godot_v4.4.1-stable_win64.exe
+    PortableCommandAlias: godot
+  - RelativeFilePath: Godot_v4.4.1-stable_win64_console.exe
+    PortableCommandAlias: godot_console
+  InstallerUrl: https://github.com/godotengine/godot/releases/download/4.4.1-stable/Godot_v4.4.1-stable_win64.exe.zip
+  InstallerSha256: 1C729738F42E43036A7147838AA9FA56D62101CF90884F315E1AB525E8E69D61
+- Architecture: arm64
+  NestedInstallerFiles:
+  - RelativeFilePath: Godot_v4.4.1-stable_windows_arm64.exe
+    PortableCommandAlias: godot
+  - RelativeFilePath: Godot_v4.4.1-stable_windows_arm64_console.exe
+    PortableCommandAlias: godot_console
+  InstallerUrl: https://github.com/godotengine/godot/releases/download/4.4.1-stable/Godot_v4.4.1-stable_windows_arm64.exe.zip
+  InstallerSha256: 81D259F24DE16549445BAEB77A2CA7797AA531F552A03C479316D0542F9F298E
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/g/GodotEngine/GodotEngine/4.4.1/GodotEngine.GodotEngine.locale.en-US.yaml
+++ b/manifests/g/GodotEngine/GodotEngine/4.4.1/GodotEngine.GodotEngine.locale.en-US.yaml
@@ -1,0 +1,55 @@
+# Created with komac v2.11.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: GodotEngine.GodotEngine
+PackageVersion: 4.4.1
+PackageLocale: en-US
+Publisher: Godot Engine
+PublisherUrl: https://godotengine.org/
+PublisherSupportUrl: https://github.com/godotengine/godot/issues
+PrivacyUrl: https://godotengine.org/privacy-policy
+Author: Godot Engine
+PackageName: Godot Engine
+PackageUrl: https://godotengine.org/download/windows
+License: MIT
+LicenseUrl: https://github.com/godotengine/godot/blob/HEAD/LICENSE.txt
+Copyright: |-
+  Copyright (c) 2014-present Godot Engine contributors.
+  Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.
+CopyrightUrl: https://godotengine.org/license
+ShortDescription: Multi-platform 2D and 3D game engine
+Description: |-
+  Godot Engine is a feature-packed, cross-platform game engine to create 2D and 3D games from a unified interface.
+  It provides a comprehensive set of common tools, so that users can focus on making games without having to
+  reinvent the wheel. Games can be exported with one click to a number of platforms, including the major desktop
+  platforms (Linux, macOS, Windows), mobile platforms (Android, iOS), as well as Web-based platforms and consoles.
+Moniker: godot
+Tags:
+- game-development
+- game-engine
+- gamedev
+- godot
+- godotengine
+- hacktoberfest
+- multi-platform
+- open-source
+ReleaseNotes: |-
+  Godot 4.4.1 is a maintenance release addressing stability and usability issues, and fixing all sorts of bugs. Maintenance releases are compatible with previous releases and are recommended for adoption.
+  Report bugs on GitHub after checking that they haven't been reported:
+  - https://github.com/godotengine/godot/issues
+  - Release notes
+  - Complete changelog
+  - Curated changelog
+  - Download (GitHub): Expand Assets below
+ReleaseNotesUrl: https://github.com/godotengine/godot/releases/tag/4.4.1-stable
+InstallationNotes: |-
+  Note when running WinGet to Install This Package *Without Admin Privileges*:
+  WinGet *Can Not* Create Command Line Alias(es) unless Admin Privileges are provided, as without Admin Privileges Winget *Can Not* Create Symbolic Links for those Command Lines Aliases.
+  More Details:
+    https://github.com/microsoft/winget-cli/issues/549
+    https://github.com/microsoft/winget-cli/issues/361
+Documentations:
+- DocumentLabel: Godot Engine 4.4 documentation in English
+  DocumentUrl: https://docs.godotengine.org/en/4.4/
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/g/GodotEngine/GodotEngine/4.4.1/GodotEngine.GodotEngine.yaml
+++ b/manifests/g/GodotEngine/GodotEngine/4.4.1/GodotEngine.GodotEngine.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.11.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: GodotEngine.GodotEngine
+PackageVersion: 4.4.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## Checklist for Pull Requests

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Resolve #243251

## Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?
  - [x] Or does it conform to the [1.9 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.9.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

## Manual validation

```text
--> Disabling safety warning when running installers
Tip: you can type 'Update-EnvironmentVariables' to update your environment variables, such as after installing a new software.

--> Configuring Winget
已启用管理员设置 'LocalManifestFiles'。
已启用管理员设置 'LocalArchiveMalwareScanOverride'。
已启用管理员设置 'ProxyCommandLineOptions'。
将管理员设置 'DefaultProxy' 设置为 'http://alist.dragon1573.local:57890'。

--> Installing the Manifest 4.4.1

已找到 Godot Engine [GodotEngine.GodotEngine] 版本 4.4.1
此应用程序由其所有者授权给你。
Microsoft 对第三方程序包概不负责，也不向第三方程序包授予任何许可证。
正在下载 https://github.com/godotengine/godot/releases/download/4.4.1-stable/Godot_v4.4.1-stable_win64.exe.zip
  ██████████████████████████████  65.8 MB / 65.8 MB
已成功验证安装程序哈希
正在提取存档...
已成功提取存档
正在启动程序包安装...
添加了命令行别名： "godot"
添加了命令行别名： "godot_console"
已修改路径环境变量；重启 shell 以使用新值。
已成功安装
注意: Note when running WinGet to Install This Package *Without Admin Privileges*:
WinGet *Can Not* Create Command Line Alias(es) unless Admin Privileges are provided, as without Admin Privileges Winget *Can Not* Create Symbolic Links for those Command Lines Aliases.
More Details:
  https://github.com/microsoft/winget-cli/issues/549
  https://github.com/microsoft/winget-cli/issues/361

--> Refreshing environment variables

--> Comparing ARP Entries

DisplayName  DisplayVersion Publisher    ProductCode                            Scope
-----------  -------------- ---------    -----------                            -----
Godot Engine 4.4.1          Godot Engine GodotEngine.GodotEngine__DefaultSource User

PS C:\Users\WDAGUtilityAccount\Desktop\winget-pkgs> godot_console --version
4.4.1.stable.official.49a5bc7b6
```

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/243271)