### PR TITLE
 VulkanSDK: Add actual ARM64 installer support

### DIFF
--- a/manifests/k/KhronosGroup/VulkanSDK/1.4.304.1/KhronosGroup.VulkanSDK.installer.yaml
+++ b/manifests/k/KhronosGroup/VulkanSDK/1.4.304.1/KhronosGroup.VulkanSDK.installer.yaml
@@ -15,12 +15,18 @@ InstallerSwitches:
 UpgradeBehavior: install
 ReleaseDate: 2025-02-06
 ElevationRequirement: elevationRequired
-Dependencies:
-  PackageDependencies:
-  - PackageIdentifier: Microsoft.VCRedist.2015+.x64
 Installers:
 - Architecture: x64
   InstallerUrl: https://sdk.lunarg.com/sdk/download/1.4.304.1/windows/VulkanSDK-1.4.304.1-Installer.exe
   InstallerSha256: 19cc78a4ba59fcd9339d83958e09662f8396a320e4a3e73660ed382627952bfb
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+- Architecture: arm64
+  InstallerUrl: https://sdk.lunarg.com/sdk/download/1.4.304.1/warm/InstallVulkanARM64-1.4.304.1.exe
+  InstallerSha256: cd3ab7b0bea5b385c056bc5eede0be32c0f4b44f244a207a31db049abd2cfec6
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.arm64
 ManifestType: installer
 ManifestVersion: 1.9.0

--- a/manifests/k/KhronosGroup/VulkanSDK/1.4.304.1/KhronosGroup.VulkanSDK.locale.en-US.yaml
+++ b/manifests/k/KhronosGroup/VulkanSDK/1.4.304.1/KhronosGroup.VulkanSDK.locale.en-US.yaml
@@ -11,14 +11,14 @@ PrivacyUrl: https://vulkan.lunarg.com/sdk/home#content/popup/privacy/lg
 PackageName: Vulkan SDK
 PackageUrl: https://vulkan.lunarg.com/sdk/home
 License: MIT
-LicenseUrl: https://vulkan.lunarg.com/software/license/vulkan-1.3.296.0-windows-license-summary.txt
+LicenseUrl: https://vulkan.lunarg.com/software/license/vulkan-1.4.304.1-windows-license-summary.txt
 Copyright: Copyright (c) 2015-2022 LunarG, Inc.
-CopyrightUrl: https://vulkan.lunarg.com/software/license/vulkan-1.3.296.0-windows-license-summary.txt
+CopyrightUrl: https://vulkan.lunarg.com/software/license/vulkan-1.4.304.1-windows-license-summary.txt
 ShortDescription: The Vulkan SDK provides Vulkan application developers with essential tools to accelerate the development process.
 Moniker: vulkansdk
 Tags:
 - vulkan-api
 Agreements:
-- AgreementUrl: https://vulkan.lunarg.com/software/license/vulkan-1.3.296.0-windows-license-summary.txt
+- AgreementUrl: https://vulkan.lunarg.com/software/license/vulkan-1.4.304.1-windows-license-summary.txt
 ManifestType: defaultLocale
 ManifestVersion: 1.9.0


### PR DESCRIPTION
When #230915 got merged to close #230914, it didn't actually add the installer for ARM64 but only used the existing `x64` one (and proceeded to use the old license links, likely copied from an older release too).

Strangely `winget` didn't complain about this and seemed to continue to install the `x64` version of both the `VCRedist` dependency and the Vulkan SDK itself (was everything being emulated?).

I could run `vkcube.exe` from the SDK just fine, yet a native Aarch64 app calling `LoadLibraryEx()` for `C:\Windows\System32\vulkan-1.dll` failed with it not being a "valid win32 application" (in my Dutch locale).

After adding and running with the correct installer, my app could once again load `vulkan-1.dll` without errors.