### PR TITLE
change mortenn.BrowserPicker: switch to native installer and add dependency

### DIFF
--- a/manifests/m/mortenn/BrowserPicker/2.2.3/mortenn.BrowserPicker.installer.yaml
+++ b/manifests/m/mortenn/BrowserPicker/2.2.3/mortenn.BrowserPicker.installer.yaml
@@ -1,6 +1,6 @@
-# Created with WinGet Updater using komac v2.11.2
+# Created with komac v2.11.2
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
-
+ 
 PackageIdentifier: mortenn.BrowserPicker
 PackageVersion: 2.2.3
 InstallerLocale: en-US
@@ -11,17 +11,20 @@ InstallModes:
 - silent
 - silentWithProgress
 UpgradeBehavior: install
-ProductCode: '{D708BB2C-C1CD-4A40-8A29-71495A29B86E}'
+ProductCode: '{C9E2B2BA-112D-475B-8C8B-611D5C06A65B}'
+Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.9
 ReleaseDate: 2025-04-03
 AppsAndFeaturesEntries:
 - DisplayName: BrowserPicker
-  ProductCode: '{D708BB2C-C1CD-4A40-8A29-71495A29B86E}'
+  ProductCode: '{C9E2B2BA-112D-475B-8C8B-611D5C06A65B}'
   UpgradeCode: '{31E74D4E-57DD-4786-BEB8-B9B8188F2764}'
 InstallationMetadata:
-  DefaultInstallLocation: '%ProgramFiles%/BrowserPicker'
+  DefaultInstallLocation: '%ProgramFiles%\BrowserPicker'                         
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/mortenn/BrowserPicker/releases/download/v2.2.3/BrowserPicker-Portable.msi
-  InstallerSha256: C056797F5831CB384F4CF3ADEAB76EE63E0B0653C149CEA908A484187A2E9913
+  InstallerUrl: https://github.com/mortenn/BrowserPicker/releases/download/v2.2.3/BrowserPicker.msi
+  InstallerSha256: 8051D31353489DFD7D755A2B819B0A7176D2321A5871DE1DE1035C74A185021D
 ManifestType: installer
 ManifestVersion: 1.9.0


### PR DESCRIPTION
Even though the "Portable" is still some sort of installation (it just brings all the dependencies) the native installer seems to be preferable:
![image](https://github.com/user-attachments/assets/074134e2-1497-427c-afa0-111df136ac01)

Sandbox:
![image](https://github.com/user-attachments/assets/b6a67c5f-0f48-4d2f-b14a-dd78eeef02af)

resolves #246176
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/246452)