### PR TITLE
Revert non-applicable scope changes to Rufus.Rufus.installer.yaml

### DIFF
--- a/manifests/r/Rufus/Rufus/4.6/Rufus.Rufus.installer.yaml
+++ b/manifests/r/Rufus/Rufus/4.6/Rufus.Rufus.installer.yaml
@@ -3,55 +3,22 @@
 
 PackageIdentifier: Rufus.Rufus
 PackageVersion: '4.6'
+InstallerType: portable
+Commands:
+- rufus
 ReleaseDate: 2024-10-21
 Installers:
-  - Architecture: x86
-    InstallerType: exe
-    Scope: machine
-    InstallerUrl: https://github.com/pbatard/rufus/releases/download/v4.6/rufus-4.6_x86.exe
-    InstallerSha256: 1C3EDD36BDB686DE09E3A0AD6507D52B9F91FA3AE2A24658FB0F7C157C2C8DCF
-  - Architecture: x64
-    InstallerType: exe
-    Scope: machine
-    InstallerUrl: https://github.com/pbatard/rufus/releases/download/v4.6/rufus-4.6.exe
-    InstallerSha256: 8279696C1D78B14618500E9135886A3667B9DECC65946F3729002E4BFDBB20AB
-  - Architecture: arm
-    InstallerType: exe
-    Scope: machine
-    InstallerUrl: https://github.com/pbatard/rufus/releases/download/v4.6/rufus-4.6_arm.exe
-    InstallerSha256: 72EEE5AAA819B442AEE34AEA7B075B0FB478A8DA189A57EE2936520707D41A2F
-  - Architecture: arm64
-    InstallerType: exe
-    Scope: machine
-    InstallerUrl: https://github.com/pbatard/rufus/releases/download/v4.6/rufus-4.6_arm64.exe
-    InstallerSha256: 318F89696B36BE6667B1D70EAF211851B8289020BD61CDAA57EBC3A1500436E1
-  - Architecture: x86
-    InstallerType: portable
-    Scope: user
-    InstallerUrl: https://github.com/pbatard/rufus/releases/download/v4.6/rufus-4.6p.exe
-    InstallerSha256: 8279696C1D78B14618500E9135886A3667B9DECC65946F3729002E4BFDBB20AB
-    Commands:
-      - rufus
-  - Architecture: x64
-    InstallerType: portable
-    Scope: user
-    InstallerUrl: https://github.com/pbatard/rufus/releases/download/v4.6/rufus-4.6p.exe
-    InstallerSha256: 8279696C1D78B14618500E9135886A3667B9DECC65946F3729002E4BFDBB20AB
-    Commands:
-      - rufus
-  - Architecture: arm
-    InstallerType: portable
-    Scope: user
-    InstallerUrl: https://github.com/pbatard/rufus/releases/download/v4.6/rufus-4.6p.exe
-    InstallerSha256: 8279696C1D78B14618500E9135886A3667B9DECC65946F3729002E4BFDBB20AB
-    Commands:
-      - rufus
-  - Architecture: arm64
-    InstallerType: portable
-    Scope: user
-    InstallerUrl: https://github.com/pbatard/rufus/releases/download/v4.6/rufus-4.6p.exe
-    InstallerSha256: 8279696C1D78B14618500E9135886A3667B9DECC65946F3729002E4BFDBB20AB
-    Commands:
-      - rufus
+- Architecture: x86
+  InstallerUrl: https://github.com/pbatard/rufus/releases/download/v4.6/rufus-4.6.exe
+  InstallerSha256: 8279696C1D78B14618500E9135886A3667B9DECC65946F3729002E4BFDBB20AB
+- Architecture: x64
+  InstallerUrl: https://github.com/pbatard/rufus/releases/download/v4.6/rufus-4.6.exe
+  InstallerSha256: 8279696C1D78B14618500E9135886A3667B9DECC65946F3729002E4BFDBB20AB
+- Architecture: arm
+  InstallerUrl: https://github.com/pbatard/rufus/releases/download/v4.6/rufus-4.6.exe
+  InstallerSha256: 8279696C1D78B14618500E9135886A3667B9DECC65946F3729002E4BFDBB20AB
+- Architecture: arm64
+  InstallerUrl: https://github.com/pbatard/rufus/releases/download/v4.6/rufus-4.6.exe
+  InstallerSha256: 8279696C1D78B14618500E9135886A3667B9DECC65946F3729002E4BFDBB20AB
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/r/Rufus/Rufus/4.6/Rufus.Rufus.installer.yaml
+++ b/manifests/r/Rufus/Rufus/4.6/Rufus.Rufus.installer.yaml
@@ -9,16 +9,16 @@ Commands:
 ReleaseDate: 2024-10-21
 Installers:
 - Architecture: x86
-  InstallerUrl: https://github.com/pbatard/rufus/releases/download/v4.6/rufus-4.6.exe
-  InstallerSha256: 8279696C1D78B14618500E9135886A3667B9DECC65946F3729002E4BFDBB20AB
+  InstallerUrl: https://github.com/pbatard/rufus/releases/download/v4.6/rufus-4.6_x86.exe
+  InstallerSha256: 1C3EDD36BDB686DE09E3A0AD6507D52B9F91FA3AE2A24658FB0F7C157C2C8DCF
 - Architecture: x64
   InstallerUrl: https://github.com/pbatard/rufus/releases/download/v4.6/rufus-4.6.exe
   InstallerSha256: 8279696C1D78B14618500E9135886A3667B9DECC65946F3729002E4BFDBB20AB
 - Architecture: arm
-  InstallerUrl: https://github.com/pbatard/rufus/releases/download/v4.6/rufus-4.6.exe
-  InstallerSha256: 8279696C1D78B14618500E9135886A3667B9DECC65946F3729002E4BFDBB20AB
+  InstallerUrl: https://github.com/pbatard/rufus/releases/download/v4.6/rufus-4.6_arm.exe
+  InstallerSha256: 72EEE5AAA819B442AEE34AEA7B075B0FB478A8DA189A57EE2936520707D41A2F
 - Architecture: arm64
-  InstallerUrl: https://github.com/pbatard/rufus/releases/download/v4.6/rufus-4.6.exe
-  InstallerSha256: 8279696C1D78B14618500E9135886A3667B9DECC65946F3729002E4BFDBB20AB
+  InstallerUrl: https://github.com/pbatard/rufus/releases/download/v4.6/rufus-4.6_arm64.exe
+  InstallerSha256: 318F89696B36BE6667B1D70EAF211851B8289020BD61CDAA57EBC3A1500436E1
 ManifestType: installer
 ManifestVersion: 1.6.0


### PR DESCRIPTION
The scope field is completely ignored for portable applications - these changes were unnecessary.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/247747)