### PR TITLE
Make Sandbox script work in PowerShell 5

### DIFF
--- a/Tools/SandboxTest.ps1
+++ b/Tools/SandboxTest.ps1
@@ -239,8 +239,6 @@ function Get-RemoteContent {
     # Mark the file for cleanup when the script ends if the raw data was requested
     if ($Raw) {
         $script:CleanupPaths += @($localFile.FullName)
-    } else {
-        $script:CleanupPaths += @()
     }
     try {
         $downloadTask = $script:HttpClient.GetByteArrayAsync($URL)


### PR DESCRIPTION
List of stuff not supported in PS5:


- Ternary operator (?)
- `-AdditionalPath` param for `Join-Path` cmdlet
- Doesn't support piping into Write-Information
- Requires the assembly to be loaded before using it (either with `using assembly System.Net.Http` or `Add-Type`)


Manually validated that the script works with the changes.

- Closes #247863  (if that doesn't get merged first :D) 

cc @Trenly @jedieaston

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/247924)