### PR TITLE
Correct capitalization of CodeBlocks.CodeBlocks

### DIFF
--- a/manifests/c/CodeBlocks/CodeBlocks/.validation
+++ b/manifests/c/CodeBlocks/CodeBlocks/.validation
@@ -1,0 +1,1 @@
+{"ValidationVersion":"1.0.0","Waivers":[{"WaiverId":"af63852b-69cc-446c-8c4f-a01f56357fdd","TestPlan":"Validation-Unapproved-URL","PackagePath":"manifests/c/Codeblocks/Codeblocks/20.03","CommitId":"870be33b4f7d2c386bc24557e059359da8fd6996"}]}

--- a/manifests/c/CodeBlocks/CodeBlocks/.validation
+++ b/manifests/c/CodeBlocks/CodeBlocks/.validation
@@ -1,1 +1,0 @@
-{"ValidationVersion":"1.0.0","Waivers":[{"WaiverId":"af63852b-69cc-446c-8c4f-a01f56357fdd","TestPlan":"Validation-Unapproved-URL","PackagePath":"manifests/c/Codeblocks/Codeblocks/20.03","CommitId":"870be33b4f7d2c386bc24557e059359da8fd6996"}]}

--- a/manifests/c/CodeBlocks/CodeBlocks/20.03/CodeBlocks.CodeBlocks.installer.yaml
+++ b/manifests/c/CodeBlocks/CodeBlocks/20.03/CodeBlocks.CodeBlocks.installer.yaml
@@ -1,7 +1,7 @@
 # Created with komac v2.11.2
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 
-PackageIdentifier: Codeblocks.Codeblocks
+PackageIdentifier: CodeBlocks.CodeBlocks
 PackageVersion: '20.03'
 InstallerLocale: en-US
 ReleaseDate: 2020-04-03
@@ -50,6 +50,6 @@ Installers:
   - RelativeFilePath: cb_share_config.exe
     PortableCommandAlias: cb_share_config
   - RelativeFilePath: cbp2make.exe
-    PortableCommandAlias: cb2make 
+    PortableCommandAlias: cb2make
 ManifestType: installer
 ManifestVersion: 1.9.0

--- a/manifests/c/CodeBlocks/CodeBlocks/20.03/CodeBlocks.CodeBlocks.installer.yaml
+++ b/manifests/c/CodeBlocks/CodeBlocks/20.03/CodeBlocks.CodeBlocks.installer.yaml
@@ -12,6 +12,16 @@ AppsAndFeaturesEntries:
 InstallationMetadata:
   DefaultInstallLocation: '%ProgramFiles%\CodeBlocks'
 ArchiveBinariesDependOnPath: true
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: codeblocks.exe
+  PortableCommandAlias: codeblocks
+- RelativeFilePath: CbLauncher.exe
+  PortableCommandAlias: CbLauncher
+- RelativeFilePath: cb_share_config.exe
+  PortableCommandAlias: cb_share_config
+- RelativeFilePath: cbp2make.exe
+  PortableCommandAlias: cb2make
 Installers:
 - Architecture: x64
   InstallerType: nullsoft
@@ -22,16 +32,6 @@ Installers:
   InstallerType: zip
   InstallerUrl: https://sourceforge.net/projects/codeblocks/files/Binaries/20.03/Windows/codeblocks-20.03mingw-nosetup.zip/download
   InstallerSha256: D74520E1A50A2B345C4AC57CA5E1C651BC26BCDE22214517EA052383B49A90AD
-  NestedInstallerType: portable
-  NestedInstallerFiles:
-  - RelativeFilePath: codeblocks.exe
-    PortableCommandAlias: codeblocks
-  - RelativeFilePath: CbLauncher.exe
-    PortableCommandAlias: CbLauncher
-  - RelativeFilePath: cb_share_config.exe
-    PortableCommandAlias: cb_share_config
-  - RelativeFilePath: cbp2make.exe
-    PortableCommandAlias: cb2make
 - Architecture: x86
   InstallerType: nullsoft
   Scope: machine
@@ -41,15 +41,5 @@ Installers:
   InstallerType: zip
   InstallerUrl: https://sourceforge.net/projects/codeblocks/files/Binaries/20.03/Windows/32bit/codeblocks-20.03-32bit-mingw-32bit-nosetup.zip/download
   InstallerSha256: 1242E424104B929D87741633DCDEA63C5812CCE65D7EB76AE1BAE208D9951A69
-  NestedInstallerType: portable
-  NestedInstallerFiles:
-  - RelativeFilePath: codeblocks.exe
-    PortableCommandAlias: codeblocks
-  - RelativeFilePath: CbLauncher.exe
-    PortableCommandAlias: CbLauncher
-  - RelativeFilePath: cb_share_config.exe
-    PortableCommandAlias: cb_share_config
-  - RelativeFilePath: cbp2make.exe
-    PortableCommandAlias: cb2make
 ManifestType: installer
 ManifestVersion: 1.9.0

--- a/manifests/c/CodeBlocks/CodeBlocks/20.03/CodeBlocks.CodeBlocks.locale.en-US.yaml
+++ b/manifests/c/CodeBlocks/CodeBlocks/20.03/CodeBlocks.CodeBlocks.locale.en-US.yaml
@@ -1,7 +1,7 @@
 # Created with komac v2.11.2
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 
-PackageIdentifier: Codeblocks.Codeblocks
+PackageIdentifier: CodeBlocks.CodeBlocks
 PackageVersion: '20.03'
 PackageLocale: en-US
 Publisher: The Code::Blocks Team

--- a/manifests/c/CodeBlocks/CodeBlocks/20.03/CodeBlocks.CodeBlocks.yaml
+++ b/manifests/c/CodeBlocks/CodeBlocks/20.03/CodeBlocks.CodeBlocks.yaml
@@ -1,7 +1,7 @@
 # Created with komac v2.11.2
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
 
-PackageIdentifier: Codeblocks.Codeblocks
+PackageIdentifier: CodeBlocks.CodeBlocks
 PackageVersion: '20.03'
 DefaultLocale: en-US
 ManifestType: version

--- a/manifests/c/Codeblocks/Codeblocks/.validation
+++ b/manifests/c/Codeblocks/Codeblocks/.validation
@@ -1,1 +1,0 @@
-{"ValidationVersion":"1.0.0","Waivers":[{"WaiverId":"af63852b-69cc-446c-8c4f-a01f56357fdd","TestPlan":"Validation-Unapproved-URL","PackagePath":"manifests/c/Codeblocks/Codeblocks/20.03","CommitId":"870be33b4f7d2c386bc24557e059359da8fd6996"}]}


### PR DESCRIPTION
This is the capitalization that is used when the stylized title (Code::Blocks) is not available, evident by Start menu shortcuts and default installation folder.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/249001)