### PR TITLE
New package: Veracode.CLI version 2.37.0

### DIFF
--- a/manifests/v/Veracode/CLI/2.37.0/Veracode.CLI.installer.yaml
+++ b/manifests/v/Veracode/CLI/2.37.0/Veracode.CLI.installer.yaml
@@ -1,0 +1,27 @@
+# Created with komac v2.11.2
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: Veracode.CLI
+PackageVersion: 2.37.0
+InstallerType: wix
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{7C6A96BF-5E7D-435C-956E-04EA90857712}'
+ReleaseDate: 2025-01-13
+AppsAndFeaturesEntries:
+- DisplayName: veracode
+  Publisher: veracode
+  ProductCode: '{7C6A96BF-5E7D-435C-956E-04EA90857712}'
+  UpgradeCode: '{A033A3AC-2826-4D8A-8867-B0155EDCEEBE}'
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles(x86)%\veracode\veracode'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://tools.veracode.com/veracode-cli/veracode_v2.37.0_windows_386.msi
+  InstallerSha256: A5C3963AE46C4154545BE622AD95CD17F6F0065B4F795F0C96CBE97A23EEE8A0
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/v/Veracode/CLI/2.37.0/Veracode.CLI.locale.en-US.yaml
+++ b/manifests/v/Veracode/CLI/2.37.0/Veracode.CLI.locale.en-US.yaml
@@ -19,6 +19,18 @@ Description: >
   You use the Veracode CLI to run security scans of development containers. The
   CLI helps developers prevent comprehensive exploits before runtime and
   provides visibility into their container pipeline security posture.
+ReleaseNotes: |-
+  This update includes the following improvements:
+
+  - You can now install the CLI on Windows using a signed Microsoft Standard Installer (MSI) file.
+  - The CLI now prompts you when a new version of the CLI is available.
+  - The CLI now displays a progress indicator when commands are running.
+  - The veracode package command includes:
+    - Auto-packaging for .NET MAUI framework, .NET Blazor WebAssembly, Azure functions
+      in .NET projects, and .publishproj file types in .NET frameworks.
+    - Improved logging.
+  - The veracode scan command no longer generates extraneous files in the working directory.
+ReleaseNotesUrl: https://docs.veracode.com/updates/r/Veracode_CLI_Updates#veracode-cli-v2370
 Moniker: veracode-cli
 ManifestType: defaultLocale
 ManifestVersion: 1.9.0

--- a/manifests/v/Veracode/CLI/2.37.0/Veracode.CLI.locale.en-US.yaml
+++ b/manifests/v/Veracode/CLI/2.37.0/Veracode.CLI.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# Created with komac v2.11.2
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: Veracode.CLI
+PackageVersion: 2.37.0
+PackageLocale: en-US
+Publisher: Veracode
+PublisherUrl: https://www.veracode.com/about/
+PublisherSupportUrl: https://www.veracode.com/contact-us/
+PrivacyUrl: https://www.veracode.com/legal-privacy/privacy-statement
+PackageName: Veracode CLI
+PackageUrl: https://docs.veracode.com/r/Install_a_specific_version_of_the_CLI?install-options=msi
+License: Proprietary
+LicenseUrl: https://www.veracode.com/legal-privacy/terms-of-use
+Copyright: Copyright © 2025 Veracode
+CopyrightUrl: https://www.veracode.com/legal-privacy/terms-of-use
+ShortDescription: Veracode CLI
+Description: >
+  You use the Veracode CLI to run security scans of development containers. The
+  CLI helps developers prevent comprehensive exploits before runtime and
+  provides visibility into their container pipeline security posture.
+Moniker: veracode-cli
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/v/Veracode/CLI/2.37.0/Veracode.CLI.yaml
+++ b/manifests/v/Veracode/CLI/2.37.0/Veracode.CLI.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.11.2
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: Veracode.CLI
+PackageVersion: 2.37.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## Checklist for Pull Requests

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Resolve #249249

## Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

## Manual validation

```text
--> Installing WinGet
--> Disabling safety warning when running installers
Tip: you can type 'Update-EnvironmentVariables' to update your environment variables, such as after installing a new software.

--> Configuring Winget
已启用管理员设置 'LocalManifestFiles'。
已启用管理员设置 'LocalArchiveMalwareScanOverride'。
已启用管理员设置 'ProxyCommandLineOptions'。
将管理员设置 'DefaultProxy' 设置为 'http://alist.dragon1573.local:57890'。

--> Installing the Manifest 2.37.0

已找到 Veracode CLI [Veracode.CLI] 版本 2.37.0
此应用程序由其所有者授权给你。
Microsoft 对第三方程序包概不负责，也不向第三方程序包授予任何许可证。
正在下载 https://tools.veracode.com/veracode-cli/veracode_v2.37.0_windows_386.msi
  ██████████████████████████████  32.3 MB / 32.3 MB
已成功验证安装程序哈希
正在启动程序包安装...
已成功安装

--> Refreshing environment variables

--> Comparing ARP Entries

DisplayName DisplayVersion Publisher ProductCode                            Scope
----------- -------------- --------- -----------                            -----
veracode    2.37.0         veracode  {7C6A96BF-5E7D-435C-956E-04EA90857712} Machine

PS C:\Users\WDAGUtilityAccount\Desktop\winget-pkgs> veracode version
Veracode CLI v2.37.0 -- b63fe5c
A new version is available: 2.37.0 -> 2.39.0. Visit https://docs.veracode.com/updates/r/Veracode_CLI_Updates for more info

PS C:\Users\WDAGUtilityAccount\Desktop\winget-pkgs> veracode --help
A CLI for integrating with the Veracode Platform.

Use the help command for more information.

Usage:
  veracode [command]

Available Commands:
  cache       Clearing of cache directory.
  configure   Configure credentials for the Veracode CLI
  dynamic     Provides Veracode Dynamic Analysis commands
  fix         Generate a fix for a flaw
  help        Help about any command
  package     Package application artifacts suitable for Static analysis.
  policy      Get policy/policies
  repository  Source code repository management commands.
  sbom        Generate a Software Bill Of Materials (SBOM) of an image, repo, archive or directory
  scan        Generate Vulnerabilities and Policy results for an image, repo, archive or directory.
  static      Provides Veracode Static Analysis commands
  version     Return the Veracode CLI version.

Flags:
  -h, --help              help for veracode
      --no-update-check   Enable verbose output
  -v, --verbose           Enable verbose output

Use "veracode [command] --help" for more information about a command.
```

-----
