### PR TITLE
New package: Jamovi.Desktop.Legacy version 2.3.28

### DIFF
--- a/manifests/j/Jamovi/Desktop/Legacy/2.3.28/Jamovi.Desktop.Legacy.installer.yaml
+++ b/manifests/j/Jamovi/Desktop/Legacy/2.3.28/Jamovi.Desktop.Legacy.installer.yaml
@@ -1,0 +1,26 @@
+# Created with komac v2.11.2
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: Jamovi.Desktop.Legacy
+PackageVersion: 2.3.28
+InstallerLocale: en-US
+InstallerType: nullsoft
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ProductCode: jamovi 2.3.28.0
+ReleaseDate: 2023-05-25
+AppsAndFeaturesEntries:
+- DisplayName: jamovi 2.3.28.0
+  DisplayVersion: 2.3.28.0
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles%\jamovi 2.3.28.0'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://dl.jamovi.org/jamovi-2.3.28.0-win64.exe
+  InstallerSha256: 7D6EA7E8DE693A51234254A231644CE89D367A9A03B2B893513E9C63EB6D0E89
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/j/Jamovi/Desktop/Legacy/2.3.28/Jamovi.Desktop.Legacy.locale.en-US.yaml
+++ b/manifests/j/Jamovi/Desktop/Legacy/2.3.28/Jamovi.Desktop.Legacy.locale.en-US.yaml
@@ -1,0 +1,18 @@
+# Created with komac v2.11.2
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: Jamovi.Desktop.Legacy
+PackageVersion: 2.3.28
+PackageLocale: en-US
+Publisher: The jamovi Project
+PublisherUrl: https://www.jamovi.org/about.html
+PublisherSupportUrl: https://docs.jamovi.org/
+PackageName: jamovi 2.3.28.0
+PackageUrl: https://www.jamovi.org/download.html
+License: AGPL-3.0
+Copyright: jamovi (C) 2017
+ShortDescription: Open statistical software for the desktop and cloud
+ReleaseNotes: General bug-fixes and improvements
+ReleaseNotesUrl: https://www.jamovi.org/release-notes.html
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/j/Jamovi/Desktop/Legacy/2.3.28/Jamovi.Desktop.Legacy.yaml
+++ b/manifests/j/Jamovi/Desktop/Legacy/2.3.28/Jamovi.Desktop.Legacy.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.11.2
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: Jamovi.Desktop.Legacy
+PackageVersion: 2.3.28
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## Checklist for Pull Requests

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Resolve #250151

## Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

## Additional information

> [!IMPORTANT]
> 
> **Jamovi Desktop** split their releases into 3 series - "current", "solid" and "legacy". I want to split them into 3 new package identifiers.

## Manual validation

![Image](https://github.com/user-attachments/assets/1a44f59b-8684-4838-a7fa-76a9cd6acdd3)
![Image](https://github.com/user-attachments/assets/a6708f20-379a-4b8b-ae40-d8704d0d78bf)

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/250173)