### PR TITLE
Update WorldTimeCLI.WorldTimeCLI to version 1.0.0.1

### DIFF
--- a/manifests/w/WorldTimeCLI/WorldTimeCLI/1.0.0.1/WorldTimeCLI.WorldTimeCLI.installer.yaml
+++ b/manifests/w/WorldTimeCLI/WorldTimeCLI/1.0.0.1/WorldTimeCLI.WorldTimeCLI.installer.yaml
@@ -1,0 +1,14 @@
+# Created using wingetcreate 1.9.4.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: WorldTimeCLI.WorldTimeCLI
+PackageVersion: 1.0.0.1
+InstallerType: exe
+Commands:
+  - wtc
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Nurbek1998/WorldTimeCLI/releases/download/v1.0.1/wtc.exe
+    InstallerSha256: B332F9FE291B2E68E891D2747D4B00222E2CB10A37D8AF9D58915C27B783F887
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/w/WorldTimeCLI/WorldTimeCLI/1.0.0.1/WorldTimeCLI.WorldTimeCLI.locale.en-US.yaml
+++ b/manifests/w/WorldTimeCLI/WorldTimeCLI/1.0.0.1/WorldTimeCLI.WorldTimeCLI.locale.en-US.yaml
@@ -1,0 +1,13 @@
+# Created using wingetcreate 1.9.4.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: WorldTimeCLI.WorldTimeCLI
+PackageVersion: 1.0.0.1
+PackageLocale: en-US
+Publisher: Nurbek Rajabov
+PackageName: World Time CLI
+License: MIT License
+ShortDescription: A CLI tool for managing and displaying world time across multiple time zones, with support for language preferences and easy installation via winget.
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0
+

--- a/manifests/w/WorldTimeCLI/WorldTimeCLI/1.0.0.1/WorldTimeCLI.WorldTimeCLI.yaml
+++ b/manifests/w/WorldTimeCLI/WorldTimeCLI/1.0.0.1/WorldTimeCLI.WorldTimeCLI.yaml
@@ -1,0 +1,9 @@
+# Created using wingetcreate 1.9.4.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: WorldTimeCLI.WorldTimeCLI
+PackageVersion: 1.0.0.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0
+


### PR DESCRIPTION
Updated WorldTimeCLI to version 1.0.0.1.
- Changed AppMoniker from `wt` to `wtc`
- Updated installer URL and SHA256

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/250794)