### PR TITLE
Fix versions: Use Storj Uplink 1.22.10 correct binary

### DIFF
--- a/manifests/s/Storj/Uplink/1.122.10/Storj.Uplink.installer.yaml
+++ b/manifests/s/Storj/Uplink/1.122.10/Storj.Uplink.installer.yaml
@@ -7,12 +7,12 @@ InstallerLocale: en-US
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
-- RelativeFilePath: storagenode.exe
+- RelativeFilePath: uplink.exe
 UpgradeBehavior: uninstallPrevious
 ReleaseDate: 2025-02-20
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/storj/storj/releases/download/v1.122.10/storagenode_windows_amd64.zip
-  InstallerSha256: 7EC30DA781AE8DAA941C7C4A7F4D9578D1F37FE79BD009144471FCE1FBB1D9AC
+  InstallerUrl: https://github.com/storj/storj/releases/download/v1.122.10/uplink_windows_amd64.zip
+  InstallerSha256: EDDE7715C968DBEB9AE16E3211D9F73A653B0202F5BF169EBA085A4AF5929B14
 ManifestType: installer
 ManifestVersion: 1.9.0


### PR DESCRIPTION
Fix versions: Use Storj Uplink 1.22.10 correct binary
The Storj Uplink v1.122.10 was not downloading the correct binary. It
was downloading the storagenode binary instead of uplink.

This commit fixes the URL and updates the binary name and the ZIP file
check sum.

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Is there a linked Issue?

Manifests
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/252601)