### PR TITLE
Fix versions: Use Storj Uplink 1.125.2 correct binary

### DIFF
--- a/manifests/s/Storj/Uplink/1.125.2/Storj.Uplink.installer.yaml
+++ b/manifests/s/Storj/Uplink/1.125.2/Storj.Uplink.installer.yaml
@@ -7,12 +7,12 @@ InstallerLocale: en-US
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
-- RelativeFilePath: storagenode.exe
+- RelativeFilePath: uplink.exe
 UpgradeBehavior: uninstallPrevious
 ReleaseDate: 2025-03-24
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/storj/storj/releases/download/v1.125.2/storagenode_windows_amd64.zip
-  InstallerSha256: BBDF2A4BDD9AB8270522A65A7285EB0C83B1EC9A3485ED3BAE2C0BA8992123F0
+  InstallerUrl: https://github.com/storj/storj/releases/download/v1.125.2/uplink_windows_amd64.zip
+  InstallerSha256: 802D749340C4EE8400FB7881C95E67CC62ED546D9A56858CFCA34711521093A0
 ManifestType: installer
 ManifestVersion: 1.9.0


### PR DESCRIPTION
The Storj Uplink v1.125.2 was not downloading the correct binary. It was downloading the storagenode binary instead of uplink.

This commit fixes the URL and updates the binary name and the ZIP file check sum.

Checklist for Pull Requests
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Is there a linked Issue?

Manifests
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/252609)