### PR TITLE
Update AresEmulator.Ares.locale.en-US.yaml version 141

### DIFF
--- a/manifests/a/AresEmulator/Ares/141/AresEmulator.Ares.locale.en-US.yaml
+++ b/manifests/a/AresEmulator/Ares/141/AresEmulator.Ares.locale.en-US.yaml
@@ -9,7 +9,7 @@ PublisherUrl: https://github.com/ares-emulator
 PublisherSupportUrl: https://github.com/ares-emulator/ares/issues
 PackageName: Ares
 PackageUrl: https://github.com/ares-emulator/ares
-License: Proprietary
+License: ISC
 LicenseUrl: https://github.com/ares-emulator/ares/blob/HEAD/LICENSE
 Copyright: Copyright (c) 2004-2024 ares team, Near et al
 CopyrightUrl: https://github.com/ares-emulator/ares/raw/master/LICENSE


### PR DESCRIPTION
Corrected license listing from proprietary to ISC.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/252765)