### PR TITLE
Update TechPowerUp.NVCleanstall to v1.19.0

### DIFF
--- a/manifests/t/TechPowerUp/NVCleanstall/1.19.0/TechPowerUp.NVCleanstall.installer.yaml
+++ b/manifests/t/TechPowerUp/NVCleanstall/1.19.0/TechPowerUp.NVCleanstall.installer.yaml
@@ -1,0 +1,43 @@
+# Created with komac v2.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: TechPowerUp.NVCleanstall
+PackageVersion: 1.19.0
+Platform:
+- Windows.Desktop
+InstallerType: inno
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: /install /VERYSILENT
+  SilentWithProgress: /install /SILENT
+UpgradeBehavior: install
+ProductCode: '{B422A5B9-1671-4E8B-BD8B-1E76A2ABFF57}}_is1'
+ReleaseDate: 2025-04-27
+ElevationRequirement: elevatesSelf
+Installers:
+- InstallerLocale: en-US
+  Architecture: x86
+  InstallerUrl: https://us1-dl.techpowerup.com/files/tzeHH0XUlEwjWiL_wq1SLA/1746218159/NVCleanstall_1.19.0.exe
+  InstallerSha256: 9DD36EF956AF927CF41FA441F91B329A7973E13965E4E7D70E6FA9C1DF1CADE6
+- InstallerLocale: en-GB
+  Architecture: x86
+  InstallerUrl: https://uk1-dl.techpowerup.com/files/1RnCgtN63fjD8HtYmqyflw/1746218140/NVCleanstall_1.19.0.exe
+  InstallerSha256: 9DD36EF956AF927CF41FA441F91B329A7973E13965E4E7D70E6FA9C1DF1CADE6
+- InstallerLocale: nl-NL
+  Architecture: x86
+  InstallerUrl: https://nl1-dl.techpowerup.com/files/bojIorwDvPV-Yk3FyjYfAA/1746218114/NVCleanstall_1.19.0.exe
+  InstallerSha256: 9DD36EF956AF927CF41FA441F91B329A7973E13965E4E7D70E6FA9C1DF1CADE6
+- InstallerLocale: de-DE
+  Architecture: x86
+  InstallerUrl: https://de2-dl.techpowerup.com/files/9KETh7o9sK9p-K9Jcx8n3A/1746218073/NVCleanstall_1.19.0.exe
+  InstallerSha256: 9DD36EF956AF927CF41FA441F91B329A7973E13965E4E7D70E6FA9C1DF1CADE6
+- InstallerLocale: en-SG
+  Architecture: x86
+  InstallerUrl: https://sg1-dl.techpowerup.com/files/bRcNYfpghv7O_SBpdaYepA/1746218175/NVCleanstall_1.19.0.exe
+  InstallerSha256: 9DD36EF956AF927CF41FA441F91B329A7973E13965E4E7D70E6FA9C1DF1CADE6
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/t/TechPowerUp/NVCleanstall/1.19.0/TechPowerUp.NVCleanstall.locale.en-US.yaml
+++ b/manifests/t/TechPowerUp/NVCleanstall/1.19.0/TechPowerUp.NVCleanstall.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# Created with komac v2.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: TechPowerUp.NVCleanstall
+PackageVersion: 1.19.0
+PackageLocale: en-US
+Publisher: TechPowerUp
+PublisherUrl: https://www.techpowerup.com/
+PublisherSupportUrl: https://www.techpowerup.com/contact/
+PrivacyUrl: https://www.techpowerup.com/privacy/
+Author: TechPowerUp
+PackageName: NVCleanstall
+PackageUrl: https://www.techpowerup.com/download/techpowerup-nvcleanstall/
+License: Proprietary
+Copyright: Copyright (c) 2018-2023 TechPowerUp
+ShortDescription: NVCleanstall lets you customize the NVIDIA GeForce Driver package by removing components that you don't need (or want). This not only keeps things tidy, but also lowers disk usage and memory footprint.
+Moniker: nvcleanstall
+Tags:
+- display-driver
+- driver-install
+- driver-installer
+- nvidia
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/t/TechPowerUp/NVCleanstall/1.19.0/TechPowerUp.NVCleanstall.yaml
+++ b/manifests/t/TechPowerUp/NVCleanstall/1.19.0/TechPowerUp.NVCleanstall.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: TechPowerUp.NVCleanstall
+PackageVersion: 1.19.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [/] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

Tested everything from above and works accordingly.
The files for version 1.18.0 however don't exist on the CDN servers of TechPowerup (or atleast not in same URLs as listed of the manifest files of v1.18.0).
Should these manifest files be removed?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/253230)