### PR TITLE
Update CodeBlocks.CodeBlocks.installer.yaml version 20.03

### DIFF
--- a/manifests/c/CodeBlocks/CodeBlocks/20.03/CodeBlocks.CodeBlocks.installer.yaml
+++ b/manifests/c/CodeBlocks/CodeBlocks/20.03/CodeBlocks.CodeBlocks.installer.yaml
@@ -3,7 +3,7 @@
 
 PackageIdentifier: CodeBlocks.CodeBlocks
 PackageVersion: '20.03'
-UpgradeBehavior: install
+UpgradeBehavior: uninstallPrevious
 Installers:
 - Architecture: x86
   InstallerType: zip
@@ -20,6 +20,7 @@ Installers:
     PortableCommandAlias: cb_share_config
   - RelativeFilePath: cbp2make.exe
     PortableCommandAlias: cb2make
+  ArchiveBinariesDependOnPath: true
 - Architecture: x64
   InstallerType: zip
   InstallerUrl: https://sourceforge.net/projects/codeblocks/files/Binaries/20.03/Windows/codeblocks-20.03-nosetup.zip/download
@@ -35,6 +36,7 @@ Installers:
     PortableCommandAlias: cb_share_config
   - RelativeFilePath: cbp2make.exe
     PortableCommandAlias: cb2make
+  ArchiveBinariesDependOnPath: true
 - InstallerLocale: en-US
   Architecture: x86
   InstallerType: nullsoft


### PR DESCRIPTION
Fix UpgradeBehavior and add ArchiveBinariesDependOnPath for portable installations.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/253402)