### PR TITLE
Improve install switches in WinsiderSS.SystemInformer

### DIFF
--- a/manifests/w/WinsiderSS/SystemInformer/3.2.25099.1530/WinsiderSS.SystemInformer.installer.yaml
+++ b/manifests/w/WinsiderSS/SystemInformer/3.2.25099.1530/WinsiderSS.SystemInformer.installer.yaml
@@ -10,8 +10,8 @@ InstallModes:
 - silent
 - silentWithProgress
 InstallerSwitches:
-  Silent: -install -silent
-  SilentWithProgress: -install -silent
+  Silent: -install -unattended -nostart
+  SilentWithProgress: -install -unattended -nostart
   Interactive: -install
   Upgrade: -update -silent
 ProductCode: SystemInformer


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

This pull request updates the install switches for the latest manifest of WinsiderSS.SystemInformer to add the `-nostart` options that prevents the opening of System Informer at installation completed and renames the `-silent` switch to `-unattend` as recommended by the maintainers of the application

The available switches are documented here:

https://github.com/winsiderss/systeminformer/blob/master/tools/CustomSetupTool/main.c#L451-L477
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/255536)