### PR TITLE
Update hash value for April 2025 GDK zip

### DIFF
--- a/manifests/m/Microsoft/Gaming/GDK/2504.0.4020/Microsoft.Gaming.GDK.installer.yaml
+++ b/manifests/m/Microsoft/Gaming/GDK/2504.0.4020/Microsoft.Gaming.GDK.installer.yaml
@@ -15,7 +15,7 @@ Installers:
   NestedInstallerType: burn
   NestedInstallerFiles:
   - RelativeFilePath: GDK-April_2025\PGDK.exe
-  InstallerSha256: CC67C2C3E752D175E14EDD775CD75C39B105164AD383167C41F9B334CE601DE3
+  InstallerSha256: FE0B9DCC0AFB844E265A3ACA5F31803941BCE4D882023EB6858D5B360110C00D
   ProductCode: '{0b28b918-e992-48b9-bf94-a0fd570830fb}'
 AppsAndFeaturesEntries:
   - DisplayName: Microsoft Game Development Kit - 250400 (April 2025)


### PR DESCRIPTION
Update hash value for April 2025 GDK zip

I recreated the GitHub release which inadvertently invalidated the zip hash value. This PR fixes that so the WinGet package for Microsoft.Gaming.GDK version 2504.0.4020 will work again.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/255964)