### PR TITLE
New version EclipseFoundation.EclipseIDEforJavaDevelopers 2025-03

### DIFF
--- a/manifests/e/EclipseFoundation/EclipseIDEforJavaDevelopers/2025-03/EclipseFoundation.EclipseIDEforJavaDevelopers.installer.yaml
+++ b/manifests/e/EclipseFoundation/EclipseIDEforJavaDevelopers/2025-03/EclipseFoundation.EclipseIDEforJavaDevelopers.installer.yaml
@@ -1,0 +1,17 @@
+# Created with komac v2.10.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: EclipseFoundation.EclipseIDEforJavaDevelopers
+PackageVersion: 2025-03
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: eclipse\eclipse.exe
+UpgradeBehavior: install
+ReleaseDate: 2025-03-12
+Installers:
+- Architecture: x64
+  InstallerUrl: https://ftp.halifax.rwth-aachen.de/eclipse/technology/epp/downloads/release/2025-03/R/eclipse-java-2025-03-R-win32-x86_64.zip
+  InstallerSha256: 626F2703F1E55F8C1F2F583C42B314640269793D41F718B465F5C19F3F065CD8
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/e/EclipseFoundation/EclipseIDEforJavaDevelopers/2025-03/EclipseFoundation.EclipseIDEforJavaDevelopers.locale.en-US.yaml
+++ b/manifests/e/EclipseFoundation/EclipseIDEforJavaDevelopers/2025-03/EclipseFoundation.EclipseIDEforJavaDevelopers.locale.en-US.yaml
@@ -1,0 +1,20 @@
+# Created with komac v2.10.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: EclipseFoundation.EclipseIDEforJavaDevelopers
+PackageVersion: 2025-03
+PackageLocale: en-US
+Publisher: Eclipse Foundation
+PublisherUrl: https://www.eclipse.org/
+PublisherSupportUrl: https://www.eclipse.org/projects/support/
+Author: Eclipse Foundation
+PackageName: Eclipse IDE for Java Developers
+PackageUrl: https://www.eclipse.org/downloads/packages/release/2024-12/r/eclipse-ide-java-developers
+License: EPL-2.0
+LicenseUrl: https://www.eclipse.org/legal/epl-2.0/
+Copyright: Copyright © Eclipse Foundation AISBL
+ShortDescription: The essential tools for any Java developer, including a Java IDE, a Git client, XML Editor, Maven and Gradle integration
+Description: The essential tools for any Java developer, including a Java IDE, a Git client, XML Editor, Maven and Gradle integration
+ReleaseNotesUrl: https://eclipseide.org/release/noteworthy/
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/e/EclipseFoundation/EclipseIDEforJavaDevelopers/2025-03/EclipseFoundation.EclipseIDEforJavaDevelopers.yaml
+++ b/manifests/e/EclipseFoundation/EclipseIDEforJavaDevelopers/2025-03/EclipseFoundation.EclipseIDEforJavaDevelopers.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.10.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: EclipseFoundation.EclipseIDEforJavaDevelopers
+PackageVersion: 2025-03
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Checklist for Pull Requests
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] This PR only modifies one (1) manifest
- [X] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

This adds version "4.35" again, just as version 2025-03, the problem before was that the release before had version 2024-12 and therefore 2024-12 was detected "newer" than 4.35.
We will now use the year-month versioning for all versions.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/257068)