### PR TITLE
Update manifest: AntiMicroX.antimicrox version 3.5.1

### DIFF
--- a/manifests/a/AntiMicroX/antimicrox/3.5.1/AntiMicroX.antimicrox.installer.yaml
+++ b/manifests/a/AntiMicroX/antimicrox/3.5.1/AntiMicroX.antimicrox.installer.yaml
@@ -1,5 +1,5 @@
 # Created with komac v2.10.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
 
 PackageIdentifier: AntiMicroX.antimicrox
 PackageVersion: 3.5.1
@@ -16,4 +16,4 @@ Installers:
   InstallerUrl: https://github.com/AntiMicroX/antimicrox/releases/download/3.5.1/antimicrox-3.5.1-Windows-AMD64.exe
   InstallerSha256: 6D24ABDC25C0D2EA35392D2EAC10F1FF52EF4C62C2518C1EEB4CF5FAEBB7EBD8
 ManifestType: installer
-ManifestVersion: 1.9.0
+ManifestVersion: 1.10.0

--- a/manifests/a/AntiMicroX/antimicrox/3.5.1/AntiMicroX.antimicrox.installer.yaml
+++ b/manifests/a/AntiMicroX/antimicrox/3.5.1/AntiMicroX.antimicrox.installer.yaml
@@ -12,7 +12,8 @@ InstallationMetadata:
   DefaultInstallLocation: '%ProgramFiles(x86)%\AntiMicroX'
 Installers:
 - Architecture: x64
+  # They bump the installer file on Mar 3rd, 2025.
   InstallerUrl: https://github.com/AntiMicroX/antimicrox/releases/download/3.5.1/antimicrox-3.5.1-Windows-AMD64.exe
-  InstallerSha256: C5BA3CF111A2BEC96CE780B7224C292085A421278E733F17CF71633F106153A0
+  InstallerSha256: 6D24ABDC25C0D2EA35392D2EAC10F1FF52EF4C62C2518C1EEB4CF5FAEBB7EBD8
 ManifestType: installer
 ManifestVersion: 1.9.0

--- a/manifests/a/AntiMicroX/antimicrox/3.5.1/AntiMicroX.antimicrox.locale.en-US.yaml
+++ b/manifests/a/AntiMicroX/antimicrox/3.5.1/AntiMicroX.antimicrox.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with komac v2.10.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
 
 PackageIdentifier: AntiMicroX.antimicrox
 PackageVersion: 3.5.1
@@ -46,4 +46,4 @@ ReleaseNotes: |-
   - Reenabled --next option #189
 ReleaseNotesUrl: https://github.com/AntiMicroX/antimicrox/releases/tag/3.5.1
 ManifestType: defaultLocale
-ManifestVersion: 1.9.0
+ManifestVersion: 1.10.0

--- a/manifests/a/AntiMicroX/antimicrox/3.5.1/AntiMicroX.antimicrox.locale.en-US.yaml
+++ b/manifests/a/AntiMicroX/antimicrox/3.5.1/AntiMicroX.antimicrox.locale.en-US.yaml
@@ -11,7 +11,9 @@ PackageName: AntiMicroX
 PackageUrl: https://github.com/AntiMicroX/antimicrox
 License: GPL-3.0
 LicenseUrl: https://github.com/AntiMicroX/antimicrox/blob/HEAD/LICENSE
-ShortDescription: Graphical program used to map keyboard buttons and mouse controls to a gamepad. Useful for playing games with no gamepad support.
+ShortDescription: >
+  Graphical program used to map keyboard buttons and mouse controls to a
+  gamepad. Useful for playing games with no gamepad support.
 Tags:
 - controller
 - gamepad
@@ -20,11 +22,15 @@ Tags:
 - gaming
 - keyboard-emulation
 ReleaseNotes: |-
-  3.5.1 (2025-01-27)
+  ## 3.5.1 (2025-01-27)
+
   Fixed bugs:
+
   - Fix appId on Wayland pull 1100 (by ReillyBrogan)
   - Wrong install dependencies on a Debian build with QT6 #1104
+
   Notable changes:
+
   - New translation: Tamil
   - Update translation for: Spanish, French, Japanese, Finnish,
   - Create deb release dor Ubuntu 24.04
@@ -34,7 +40,9 @@ ReleaseNotes: |-
   - Add proper note informing about lack of Wayland support for Auto Profiles
   - Cleanup in dependencies
   - Fix some typos and update docs (by zturtleman )
+
   Implemented enhancements:
+
   - Reenabled --next option #189
 ReleaseNotesUrl: https://github.com/AntiMicroX/antimicrox/releases/tag/3.5.1
 ManifestType: defaultLocale

--- a/manifests/a/AntiMicroX/antimicrox/3.5.1/AntiMicroX.antimicrox.yaml
+++ b/manifests/a/AntiMicroX/antimicrox/3.5.1/AntiMicroX.antimicrox.yaml
@@ -1,8 +1,8 @@
 # Created with komac v2.10.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
 
 PackageIdentifier: AntiMicroX.antimicrox
 PackageVersion: 3.5.1
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.9.0
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## What's changed?

- Bump `InstallerSha256`
- Original publisher bump the installer file on Mar 3rd, 2025
- Bump `ManifestVersion` to `1.10.0`

## Checklist for Pull Requests

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Resolve #257453 

## Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/257865)