### PR TITLE
Update manifest: Asus.ArmouryCreate version 5.8.9.0

### DIFF
--- a/manifests/a/Asus/ArmouryCrate/5.8.9.0/Asus.ArmouryCrate.installer.yaml
+++ b/manifests/a/Asus/ArmouryCrate/5.8.9.0/Asus.ArmouryCrate.installer.yaml
@@ -1,17 +1,18 @@
-# Created using wingetcreate 1.6.1.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# Created with komac v2.11.2
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
 
 PackageIdentifier: Asus.ArmouryCrate
 PackageVersion: 5.8.9.0
 InstallerType: zip
 NestedInstallerType: exe
 NestedInstallerFiles:
-- RelativeFilePath: ArmouryCrateInstaller_3.2.11.2\ArmouryCrateInstaller.exe
+- RelativeFilePath: ArmouryCrateInstaller_3.3.1.0/ArmouryCrateInstaller.exe
 InstallerSwitches:
   Silent: /SILENT
+ReleaseDate: 2025-03-05
 Installers:
 - Architecture: neutral
   InstallerUrl: https://dlcdnets.asus.com/pub/ASUS/mb/14Utilities/ArmouryCrateInstallTool.zip
-  InstallerSha256: E365596C8B51835DCEA310AF6603707A4C87BDA046E476FCFEB3A82869E6132E
+  InstallerSha256: BBCD8B2F6DA29C43C26356502DCDE4313FC7BB2720DA1A081763AC0C426A5F6B
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.10.0

--- a/manifests/a/Asus/ArmouryCrate/5.8.9.0/Asus.ArmouryCrate.locale.en-US.yaml
+++ b/manifests/a/Asus/ArmouryCrate/5.8.9.0/Asus.ArmouryCrate.locale.en-US.yaml
@@ -1,5 +1,5 @@
-# Created using wingetcreate 1.6.1.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# Created with komac v2.11.2
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
 
 PackageIdentifier: Asus.ArmouryCrate
 PackageVersion: 5.8.9.0
@@ -7,6 +7,8 @@ PackageLocale: en-US
 Publisher: Asus
 PackageName: ArmouryCrate
 License: Proprietary
-ShortDescription: A program that allows you to unify the configuration and control of all ASUS and ROG software and gear.
+ShortDescription: >
+  A program that allows you to unify the configuration and control of all ASUS
+  and ROG software and gear.
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.10.0

--- a/manifests/a/Asus/ArmouryCrate/5.8.9.0/Asus.ArmouryCrate.yaml
+++ b/manifests/a/Asus/ArmouryCrate/5.8.9.0/Asus.ArmouryCrate.yaml
@@ -1,8 +1,8 @@
-# Created using wingetcreate 1.6.1.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# Created with komac v2.11.2
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
 
 PackageIdentifier: Asus.ArmouryCrate
 PackageVersion: 5.8.9.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## What's changed

- Update `RelativeFilePath` since version of installer itself has bumped (`3.2.11.2` -> `3.3.1.0`).
- Update `InstallerSha256` to match the new installer version.
- Bump `ManifestVersion`: `1.6.0` -> `1.10.0`.

## Checklist for Pull Requests

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Resolve #257482 

## Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

## Manual validation

> [!CAUTION]
> 
> It seems this package can't be properly installed. No entries are written to the Apps and Remove Panel.

![image](https://github.com/user-attachments/assets/e3e1f268-ae2b-407f-8170-2840be746fba)

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/257875)