### PR TITLE
remove wrong DisplayVersion in EQAditu.AdvancedCombatTracker 3.8.2.285

### DIFF
--- a/manifests/e/EQAditu/AdvancedCombatTracker/3.8.2.285/EQAditu.AdvancedCombatTracker.installer.yaml
+++ b/manifests/e/EQAditu/AdvancedCombatTracker/3.8.2.285/EQAditu.AdvancedCombatTracker.installer.yaml
@@ -10,7 +10,6 @@ ProductCode: Advanced Combat Tracker
 ReleaseDate: 2024-10-21
 AppsAndFeaturesEntries:
 - DisplayName: Advanced Combat Tracker (remove only)
-  DisplayVersion: $INSTDIR\Advanced Combat Tracker.exe
   ProductCode: Advanced Combat Tracker
 InstallationMetadata:
   DefaultInstallLocation: '%ProgramFiles(x86)%\Advanced Combat Tracker'


### PR DESCRIPTION
Removing DisplayVersion in EQAditu.AdvancedCombatTracker version 3.8.2.285 since it is wrong/not required.

PackageVersion=DisplayVersion in ARP-Table

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/258141)