### PR TITLE
Update DuongDieuPhap.ImageGlass.installer.yaml version 9.3.0.514

### DIFF
--- a/manifests/d/DuongDieuPhap/ImageGlass/9.3.0.514/DuongDieuPhap.ImageGlass.installer.yaml
+++ b/manifests/d/DuongDieuPhap/ImageGlass/9.3.0.514/DuongDieuPhap.ImageGlass.installer.yaml
@@ -95,9 +95,6 @@ FileExtensions:
 - xbm
 - xpm
 - xv
-Dependencies:
-  PackageDependencies:
-  - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.8
 ProductCode: '{1B4E998D-C873-49F9-ADB6-60DD09F137CC}'
 ReleaseDate: 2025-05-12
 AppsAndFeaturesEntries:


### PR DESCRIPTION
Removed .NET Desktop Runtime 8 dependency - ImageGlass now bundles it with the application itself: https://imageglass.org/news/announcing-imageglass-9-3-94
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/259281)