### PR TITLE
Update DuongDieuPhap.ImageGlass.installer.yaml version 9.3.2.520

### DIFF
--- a/manifests/d/DuongDieuPhap/ImageGlass/9.3.2.520/DuongDieuPhap.ImageGlass.installer.yaml
+++ b/manifests/d/DuongDieuPhap/ImageGlass/9.3.2.520/DuongDieuPhap.ImageGlass.installer.yaml
@@ -95,9 +95,6 @@ FileExtensions:
 - xbm
 - xpm
 - xv
-Dependencies:
-  PackageDependencies:
-  - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.8
 ProductCode: '{AFA43F26-FC77-4D80-896E-95299F313E8D}'
 AppsAndFeaturesEntries:
 - ProductCode: '{AFA43F26-FC77-4D80-896E-95299F313E8D}'


### PR DESCRIPTION
Removed .NET Desktop Runtime 8 dependency - ImageGlass now bundles it with the application itself: https://imageglass.org/news/announcing-imageglass-9-3-94
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/259283)