### PR TITLE
Update manifest: Gabia.HiworksMessenger version 3.0

### DIFF
--- a/manifests/g/Gabia/HiworksMessenger/3.0/Gabia.HiworksMessenger.installer.yaml
+++ b/manifests/g/Gabia/HiworksMessenger/3.0/Gabia.HiworksMessenger.installer.yaml
@@ -1,17 +1,19 @@
-# Created using wingetcreate 1.6.5.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# Created with komac v2.11.2
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
 
 PackageIdentifier: Gabia.HiworksMessenger
-PackageVersion: "3.0"
+PackageVersion: '3.0'
+InstallerLocale: ko-KR
 InstallerType: nullsoft
+Scope: machine
 InstallerSuccessCodes:
 - 1223
+ReleaseDate: 2025-01-06
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles(x86)%\Hiworks\Messenger'
 Installers:
 - Architecture: x86
   InstallerUrl: https://update.hiworks.com/messenger/HiworksMessengerSetup.exe
-  InstallerSha256: 6DB198AFB20E564F702267D7A445D2A3C55409D00C680F894C867F18BBC94A1B
-  AppsAndFeaturesEntries: 
-  - Publisher: Gabia, Inc.
-    ProductCode: 하이웍스 메신저
+  InstallerSha256: EEEBE41434009C08C3E19444B034783EF187F5C4D81F787863708472D5D0F285
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.10.0

--- a/manifests/g/Gabia/HiworksMessenger/3.0/Gabia.HiworksMessenger.locale.en-US.yaml
+++ b/manifests/g/Gabia/HiworksMessenger/3.0/Gabia.HiworksMessenger.locale.en-US.yaml
@@ -1,8 +1,8 @@
-# Created using wingetcreate 1.6.5.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# Created with komac v2.11.2
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
 
 PackageIdentifier: Gabia.HiworksMessenger
-PackageVersion: "3.0"
+PackageVersion: '3.0'
 PackageLocale: en-US
 Publisher: Gabia Inc.
 PublisherUrl: https://company.gabia.com/
@@ -15,4 +15,4 @@ Copyright: (c) Gabia Inc. All Rights Reserved.
 ShortDescription: Groupware messenger by Gabia Inc.
 Moniker: hiworks-messenger
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.10.0

--- a/manifests/g/Gabia/HiworksMessenger/3.0/Gabia.HiworksMessenger.yaml
+++ b/manifests/g/Gabia/HiworksMessenger/3.0/Gabia.HiworksMessenger.yaml
@@ -1,8 +1,8 @@
-# Created using wingetcreate 1.6.5.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# Created with komac v2.11.2
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
 
 PackageIdentifier: Gabia.HiworksMessenger
-PackageVersion: "3.0"
+PackageVersion: '3.0'
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## What's changed?

- Update hash value of the installer.
- Fill more fields of the manifest.

## Checklist for Pull Requests

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Resolve #258995 

## Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

## Manual validation

![Image](https://github.com/user-attachments/assets/4780682d-a101-4b12-9c8d-f9d3a11123a8)
![Image](https://github.com/user-attachments/assets/df84d2bf-ae54-4710-ade2-c19351c0b34f)

> [!WARNING]
> 
> There's NO `DisplayVersion` written into _Windows Registry_. There's neither "about" panel of the application. Can't figure out if they bumped the version of the package. 😕 

-----


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/259675)