### PR TITLE
Update policies to handle GitOps tagging behavior

### DIFF
--- a/.github/policies/flaggedPackages.yml
+++ b/.github/policies/flaggedPackages.yml
@@ -117,7 +117,7 @@ configuration:
               label: Package-Flagged
           - addReply:
               reply: >-
-                @${issueAuthor},
+                ${issueAuthor},
 
 
                 The package in your PR appears to be flagged. See the table below for more information. If it is not clear why you are seeing this message, please open a [new issue](https://github.com/microsoft/winget-pkgs/issues/new) inquiring about the status of the package.

--- a/.github/policies/labelAdded.authorNotAuthorized.yml
+++ b/.github/policies/labelAdded.authorNotAuthorized.yml
@@ -19,9 +19,6 @@ configuration:
         then:
           - addReply:
               reply: >-
-                ${issueAuthor},
-
-
                 Changes to one or more files in your PR require authorization to modify. This PR has been assigned to our on call staff to evaluate.
 
 

--- a/.github/policies/labelAdded.binaryValidationError.yml
+++ b/.github/policies/labelAdded.binaryValidationError.yml
@@ -21,7 +21,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 The package manager bot determined there was an issue with one of the installers listed in the url field, and cannot continue.

--- a/.github/policies/labelAdded.changesRequested.yml
+++ b/.github/policies/labelAdded.changesRequested.yml
@@ -20,7 +20,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 The package manager bot determined changes have been requested to your PR.

--- a/.github/policies/labelAdded.driverInstall.yml
+++ b/.github/policies/labelAdded.driverInstall.yml
@@ -21,7 +21,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 This package appears to require user interaction to install.
@@ -55,7 +55,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 This package appears to require user interaction to install.

--- a/.github/policies/labelAdded.errorHashMismatch.yml
+++ b/.github/policies/labelAdded.errorHashMismatch.yml
@@ -25,7 +25,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 I am sorry to report that the Sha256 Hash does not match the installer. This may be caused by using a vanity URL rather than a URL directly to the binary.

--- a/.github/policies/labelAdded.errorInstallerAvailability.yml
+++ b/.github/policies/labelAdded.errorInstallerAvailability.yml
@@ -22,7 +22,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 When processing this package, the URL to the installer returned a 404 error or was determined to be invalid.

--- a/.github/policies/labelAdded.hardware.yml
+++ b/.github/policies/labelAdded.hardware.yml
@@ -22,7 +22,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 This package appears to require specific hardware.
@@ -58,7 +58,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 This package appears to require specific hardware.

--- a/.github/policies/labelAdded.highestVersionRemoval.yml
+++ b/.github/policies/labelAdded.highestVersionRemoval.yml
@@ -20,7 +20,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 This PR removes the highest available version of the package from the repository.

--- a/.github/policies/labelAdded.interactiveOnlyInstaller.yml
+++ b/.github/policies/labelAdded.interactiveOnlyInstaller.yml
@@ -21,7 +21,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 This package appears to require user interaction to install.
@@ -55,7 +55,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 This package appears to require user interaction to install.

--- a/.github/policies/labelAdded.internalError_Any.yml
+++ b/.github/policies/labelAdded.internalError_Any.yml
@@ -35,9 +35,6 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello ${issueAuthor},
-
-
                 The pull request encountered an internal error and has been assigned to a developer to investigate.
 
 

--- a/.github/policies/labelAdded.lastVersionRemoval.yml
+++ b/.github/policies/labelAdded.lastVersionRemoval.yml
@@ -20,7 +20,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 This PR removes the last version of this package in the repository, meaning it will completely remove this package from WinGet.

--- a/.github/policies/labelAdded.licenseBlocksInstall.yml
+++ b/.github/policies/labelAdded.licenseBlocksInstall.yml
@@ -21,7 +21,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 This package appears to require user to accept a license agreement before installation.
@@ -52,7 +52,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 This package appears to require user to accept a license agreement before installation.

--- a/.github/policies/labelAdded.manifestAppsAndFeaturesVersionError.yml
+++ b/.github/policies/labelAdded.manifestAppsAndFeaturesVersionError.yml
@@ -21,9 +21,6 @@ configuration:
         then:
           - addReply:
               reply: >-
-                ${issueAuthor},
-
-
                 During validation one or more entries for "AppsAndFeatures" did not match what was detected during validation. Please make the appropriate changes to the manifest.
 
 

--- a/.github/policies/labelAdded.manifestContentIncomplete.yml
+++ b/.github/policies/labelAdded.manifestContentIncomplete.yml
@@ -21,7 +21,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                @${issueAuthor},
+                ${issueAuthor},
 
 
                 Your manifest appears to contain one or more issues with the content. Please ensure it meets the contribution guidelines.

--- a/.github/policies/labelAdded.manifestInstallerValidationError.yml
+++ b/.github/policies/labelAdded.manifestInstallerValidationError.yml
@@ -21,7 +21,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 During validation, the MSIX package was evaluated. There were either inconsistencies or values not present in the manifest.

--- a/.github/policies/labelAdded.manifestSingletonDeprecated.yml
+++ b/.github/policies/labelAdded.manifestSingletonDeprecated.yml
@@ -21,7 +21,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 The package manager bot determined that your submission uses a `Singleton` Manifest, which been deprecated in this repository. Please update your submission to use the newer multi-manifest format. If you built your manifest by hand, a tool like [WingetCreate](https://github.com/microsoft/winget-create) or [YamlCreate](https://github.com/microsoft/winget-pkgs/blob/master/doc/tools/YamlCreate.md) can help you build the multi-manifest.

--- a/.github/policies/labelAdded.manifestValidationError.yml
+++ b/.github/policies/labelAdded.manifestValidationError.yml
@@ -21,7 +21,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 Please verify the manifest file is compliant with the package manager [1.10.0 manifest specification](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0).

--- a/.github/policies/labelAdded.manifestVersionDeprecated.yml
+++ b/.github/policies/labelAdded.manifestVersionDeprecated.yml
@@ -21,7 +21,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 The package manager bot determined that the Manifest Version used in your submission has been deprecated in this repository. Please update your submission to use a newer manifest version. If you have used a tool like [WingetCreate](https://github.com/microsoft/winget-create) or [YamlCreate](https://github.com/microsoft/winget-pkgs/blob/master/doc/tools/YamlCreate.md), you may need to update to the latest version of the tool.

--- a/.github/policies/labelAdded.manifestVersionError.yml
+++ b/.github/policies/labelAdded.manifestVersionError.yml
@@ -21,7 +21,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 The package manager bot determined that the ManifestVersion key does not match any version currently approved for release. Please verify the manifest file is compliant with the package manager [1.10.0 manifest specification](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0).

--- a/.github/policies/labelAdded.needsCLA.yml
+++ b/.github/policies/labelAdded.needsCLA.yml
@@ -18,7 +18,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 This PR cannot be merged until you sign the Contributor License Agreement (CLA). More information on this process can be found on the [Microsoft Open Source](https://opensource.microsoft.com/cla/) website.

--- a/.github/policies/labelAdded.networkBlocker.yml
+++ b/.github/policies/labelAdded.networkBlocker.yml
@@ -21,7 +21,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 The URLs provided were not reachable by the validation pipelines. This may be due to the publisher blocking the IP ranges used during validation or some other network blocker. This PR cannot be validated until the publisher adds WinGet to an allow list or removes the issue blocking the network connection. Please reach out to the publisher regarding this issue.

--- a/.github/policies/labelAdded.noRecentActivity.yml
+++ b/.github/policies/labelAdded.noRecentActivity.yml
@@ -18,7 +18,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 This pull request has been automatically marked as stale because it has been marked as requiring author feedback but has not had any recent activity. It will be closed if no further activity occurs **within 3 days of this comment**.
@@ -37,7 +37,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 This issue has been automatically marked as stale because it has been marked as requiring author feedback but has not had any recent activity. It will be closed if no further activity occurs **within 3 days of this comment**.

--- a/.github/policies/labelAdded.portableArchive.yml
+++ b/.github/policies/labelAdded.portableArchive.yml
@@ -21,7 +21,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 This package appears to require support for archive extraction.
@@ -55,7 +55,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 This package appears to require support for archive extraction.

--- a/.github/policies/labelAdded.portableJar.yml
+++ b/.github/policies/labelAdded.portableJar.yml
@@ -21,7 +21,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 This package appears to require support for non-EXE files packaged inside an archive.
@@ -55,7 +55,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 This package appears to require support for non-EXE files packaged inside an archive.

--- a/.github/policies/labelAdded.projectFile.yml
+++ b/.github/policies/labelAdded.projectFile.yml
@@ -19,9 +19,6 @@ configuration:
         then:
           - addReply:
               reply: >-
-                ${issueAuthor},
-
-
                 Changes to one or more files in your PR require authorization to modify. This PR has been assigned to our on call staff to evaluate.
 
 

--- a/.github/policies/labelAdded.pullRequestError.yml
+++ b/.github/policies/labelAdded.pullRequestError.yml
@@ -20,7 +20,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 The package manager bot determined there was an issue with the pull request. Make sure the manifest files are under the manifests\partition\publisher\appname\version directory and only one package version is being modified in your PR. The partition of the path must be the first letter of the publisher in lower-case.

--- a/.github/policies/labelAdded.scriptedApplication.yml
+++ b/.github/policies/labelAdded.scriptedApplication.yml
@@ -21,7 +21,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 This application was identified as having a script as either the executable or the installer. The policies of this repository do not allow scripts such as `.bat`, `.ps1`, `.sh`, et cetera. This package cannot be included in this repository until the publisher removes the script or moves to a compiled binary such as an exe, msi, or appx.

--- a/.github/policies/labelAdded.urlValidationError.yml
+++ b/.github/policies/labelAdded.urlValidationError.yml
@@ -22,7 +22,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 The package manager bot determined there was an issue with some of the URLs included in the manifest file. Please check the pull request for more details and make sure the urls are correct.

--- a/.github/policies/labelAdded.validation404Error.yml
+++ b/.github/policies/labelAdded.validation404Error.yml
@@ -22,7 +22,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 When processing this package, the URL to the installer returned a 404 error. It appears this URL is no longer valid.

--- a/.github/policies/labelAdded.validationCompleted.yml
+++ b/.github/policies/labelAdded.validationCompleted.yml
@@ -25,9 +25,6 @@ configuration:
         then:
           - addReply:
               reply: >-
-                ${issueAuthor},
-
-
                 The check-in policies require a moderator to approve PRs from the community.
 
 

--- a/.github/policies/labelAdded.validationDefenderError.yml
+++ b/.github/policies/labelAdded.validationDefenderError.yml
@@ -21,7 +21,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 The package manager bot was blocked from installing one of the installers listed in the url field, and cannot continue.

--- a/.github/policies/labelAdded.validationDomain.yml
+++ b/.github/policies/labelAdded.validationDomain.yml
@@ -21,7 +21,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 One or more of the installer URLs doesn't appear valid.

--- a/.github/policies/labelAdded.validationError.yml
+++ b/.github/policies/labelAdded.validationError.yml
@@ -22,7 +22,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 An issue was identified during the manual review, and the PR request cannot be approved. Please see comments for more information.

--- a/.github/policies/labelAdded.validationHttpError.yml
+++ b/.github/policies/labelAdded.validationHttpError.yml
@@ -22,7 +22,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 The validation code has detected one of the URLs in the manifest is not using the HTTPS protocol. Please update all URLs in the manifest to use HTTPS instead.

--- a/.github/policies/labelAdded.validationIndirectUrl.yml
+++ b/.github/policies/labelAdded.validationIndirectUrl.yml
@@ -22,7 +22,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 This URL in this manifest is not a direct URL. It is using the provided URL as a parameter and passing that URL to a different website. This pattern is not supported. Please update the manifest to use a direct link for the URL.

--- a/.github/policies/labelAdded.validationInstallationError.yml
+++ b/.github/policies/labelAdded.validationInstallationError.yml
@@ -22,7 +22,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 The package manager bot determined there was an issue with installing the application correctly. Please check the application installs correctly. Once repaired, please push an update to your pull request.

--- a/.github/policies/labelAdded.validationMergeConflict.yml
+++ b/.github/policies/labelAdded.validationMergeConflict.yml
@@ -22,7 +22,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 The PR could not be validated because there is a merge conflict which adds bad characters to the manifest. Please address the merge conflict and resubmit.

--- a/.github/policies/labelAdded.validationMissingDependency.yml
+++ b/.github/policies/labelAdded.validationMissingDependency.yml
@@ -23,7 +23,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 The validation pipeline could not locate a specified dependency. Please review the spelling and check whether the dependency is associated with a different identifier.

--- a/.github/policies/labelAdded.validationOpenUrlFailed.yml
+++ b/.github/policies/labelAdded.validationOpenUrlFailed.yml
@@ -22,7 +22,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 The package manager bot determined there was an issue with some of the URLs included in the manifest file. Please check the pull request for more details and make sure the urls are correct.

--- a/.github/policies/labelAdded.validationShellExecute.yml
+++ b/.github/policies/labelAdded.validationShellExecute.yml
@@ -21,7 +21,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 The package manager bot determined there was an issue with one of the installers listed in the url field, and cannot continue.

--- a/.github/policies/labelAdded.validationSmartScreen.yml
+++ b/.github/policies/labelAdded.validationSmartScreen.yml
@@ -20,7 +20,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 During installation testing, this app triggered a Microsoft Defender SmartScreen error.

--- a/.github/policies/labelAdded.validationUnattendedFailed.yml
+++ b/.github/policies/labelAdded.validationUnattendedFailed.yml
@@ -22,7 +22,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 During installation testing, this application failed to install without user input. Did you forget to add Silent or SilentWithProgress switches?

--- a/.github/policies/labelAdded.validationUninstallError.yml
+++ b/.github/policies/labelAdded.validationUninstallError.yml
@@ -22,7 +22,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 The package manager bot detected that the application did not uninstall correctly. Please make sure the SystemAppId is correct and the application uninstalls correctly. Once repaired, please push an update to your pull request.

--- a/.github/policies/labelAdded.validationVirusScanError.yml
+++ b/.github/policies/labelAdded.validationVirusScanError.yml
@@ -22,7 +22,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 The package manager bot the installation failed a virus scan. Please check the application installs correctly and there are not viruses associated with the tool. Once repaired, please push an update to your pull request.

--- a/.github/policies/labelAdded.windowsFeatures.yml
+++ b/.github/policies/labelAdded.windowsFeatures.yml
@@ -21,7 +21,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 This package appears to have dependencies on one or more Windows Feature(s).
@@ -55,7 +55,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 This package appears to have dependencies on one or more Windows Feature(s).

--- a/.github/policies/labelAdded.zipBinary.yml
+++ b/.github/policies/labelAdded.zipBinary.yml
@@ -20,7 +20,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 This package appears to depend on .dlls that aren't available via symlink. Support for this form of zipped binaries was implemented in:

--- a/.github/policies/labelManagement.issueOpened.yml
+++ b/.github/policies/labelManagement.issueOpened.yml
@@ -25,7 +25,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 This pull request does not update any files. Please review your commit history and resubmit.
@@ -78,7 +78,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 Sorry we cannot process ${number} because you are changing validation-pipeline.yaml. Please remove that file from your PR. If you would like to discuss changes to validation-pipeline.yml, please file an issue.
@@ -117,7 +117,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 It looks like this pull request is missing the manifests folder. For example: manifests\<first letter of the publisher in lower-case>\<publisher>\<application>\<version>\*.yaml

--- a/.github/policies/labelManagement.issueUpdated.yml
+++ b/.github/policies/labelManagement.issueUpdated.yml
@@ -123,8 +123,6 @@ configuration:
           - approvePullRequest:
               comment: ""
           - addReply: >-
-              Hello ${issueAuthor},
-
               Validation has completed.
 
 
@@ -225,9 +223,6 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello ${issueAuthor},
-
-
                 Static analysis has timed out. The PR has been assigned to a developer to investigate.
 
 

--- a/.github/policies/labelManagement.needsFeedbackHub.yml
+++ b/.github/policies/labelManagement.needsFeedbackHub.yml
@@ -35,7 +35,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 Please send us feedback with the [Feedback Hub](https://aka.ms/winget-feedback) with this issue and paste the link here so we can more easily find your crash information on the back end.

--- a/.github/policies/moderatorTriggers.yml
+++ b/.github/policies/moderatorTriggers.yml
@@ -328,9 +328,6 @@ configuration:
                       label: Needs-Attention
                   - addReply:
                       reply: >-
-                        Hello ${issueAuthor},
-
-
                         Your pull request requires attention from a repository administrator. It has been assigned to a developer for review.
 
 
@@ -624,7 +621,7 @@ configuration:
                 then:
                   - addReply:
                       reply: >-
-                        Hello @${issueAuthor},
+                        Hello ${issueAuthor},
 
 
                         We've identified this as a duplicate of another issue or PR that already exists. This specific instance is being closed in favor of the linked issue. Please add your 👍 to the other issue to raise its priority. Thanks for your contribution!

--- a/.github/policies/scheduledSearch.closeAreaExternal.yml
+++ b/.github/policies/scheduledSearch.closeAreaExternal.yml
@@ -30,7 +30,7 @@ configuration:
         actions:
           - addReply:
                 reply: >-
-                  Hello @${issueAuthor},
+                  Hello ${issueAuthor},
 
 
                   This Pull Request has been identified as requiring a fix from a third party or external repository. Since there has been no recent activity on this PR, it will be automatically closed.
@@ -60,7 +60,7 @@ configuration:
         actions:
           - addReply:
                 reply: >-
-                  Hello @${issueAuthor},
+                  Hello ${issueAuthor},
 
 
                   This issue has been identified as requiring a fix from a third party or external repository. Since there has been no recent activity on this issue, it will be automatically closed.

--- a/.github/policies/scheduledSearch.closeBlockingIssue.yml
+++ b/.github/policies/scheduledSearch.closeBlockingIssue.yml
@@ -30,7 +30,7 @@ configuration:
         actions:
           - addReply:
                 reply: >-
-                  Hello @${issueAuthor},
+                  Hello ${issueAuthor},
 
 
                   Thank you for your contribution. This Pull Request has been identified as being blocked by a known issue. Since there has been no recent activity on this PR, it will be automatically closed. Please re-submit your PR with the necessary changes once the blocking issue is resolved. If an issue has not been linked, please tag whomever added the Blocking-Issue label for additional information.


### PR DESCRIPTION
There appears to be a recent breaking change in the GitOps API for handling `${issueAuthor}`. See https://github.com/microsoft/winget-pkgs/issues/247286.

Updating the policy files to:
- Remove instances of `${issueAuthor}` where we did not intend to tag users
- Remove `@` preceding `${issueAuthor}` where we did intend to tag, as GitOps just does automatically now

cc @Trenly 


This should alleviate _some annoyance_ of issue #261419, though I'm thinking maybe we should have a `Pause-Notifications` label to handle that correctly and update policy files to not send a message when a PR/issue has that label...

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/261467)