### PR TITLE
SSMS21: Making the PackageIdentifier unique (Preview manifest)

### DIFF
--- a/manifests/m/Microsoft/SQLServerManagementStudio/Preview/21.0/Microsoft.SQLServerManagementStudio.Preview.installer.yaml
+++ b/manifests/m/Microsoft/SQLServerManagementStudio/Preview/21.0/Microsoft.SQLServerManagementStudio.Preview.installer.yaml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
-PackageIdentifier: Microsoft.SQLServerManagementStudio.Preview
+PackageIdentifier: Microsoft.SQLServerManagementStudio.21.Preview
 PackageVersion: 21.0
 InstallerLocale: en-US
 InstallerType: exe

--- a/manifests/m/Microsoft/SQLServerManagementStudio/Preview/21.0/Microsoft.SQLServerManagementStudio.Preview.locale.en-US.yaml
+++ b/manifests/m/Microsoft/SQLServerManagementStudio/Preview/21.0/Microsoft.SQLServerManagementStudio.Preview.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
-PackageIdentifier: Microsoft.SQLServerManagementStudio.Preview
+PackageIdentifier: Microsoft.SQLServerManagementStudio.21.Preview
 PackageVersion: 21.0
 PackageLocale: en-US
 Publisher: Microsoft Corporation

--- a/manifests/m/Microsoft/SQLServerManagementStudio/Preview/21.0/Microsoft.SQLServerManagementStudio.Preview.yaml
+++ b/manifests/m/Microsoft/SQLServerManagementStudio/Preview/21.0/Microsoft.SQLServerManagementStudio.Preview.yaml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
-PackageIdentifier: Microsoft.SQLServerManagementStudio.Preview
+PackageIdentifier: Microsoft.SQLServerManagementStudio.21.Preview
 PackageVersion: 21.0
 DefaultLocale: en-US
 ManifestType: version


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---
This has been a hidden problem for years, but it finally surfaced to us as an SSMS feedback ticket

We should have versioned a unique package identifier a long time ago.

I'm not going back in time to fix older version of SSMS, but we should start doing the right thing for SSMS 21, even if that may cause some confusion in some users (manifest as or should probably be immutable for the most part, right?)

Note: this is the same thing as https://github.com/microsoft/winget-pkgs/pull/262844, only for the SSMS 21 Preview manifest.



 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/262851)