### PR TITLE
Update font policy regex

### DIFF
--- a/.github/policies/labelManagement.issueOpened.yml
+++ b/.github/policies/labelManagement.issueOpened.yml
@@ -223,7 +223,7 @@ configuration:
               filesMatchPattern:
                 pattern: ^$
           - filesMatchPattern:
-                pattern: ^fonts\\.*
+                pattern: ^fonts[\/\\].*
           - not:
               activitySenderHasPermission:
                 permission: Admin


### PR DESCRIPTION
- Changes in #262057 didn't seem to work. Updating the regex to match both forward and back slashes for directory name

Targets:
- https://github.com/microsoft/winget-pkgs/issues/262005

---


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/262858)