### PR TITLE
SSMS21: Using a unique PackageIdentifier for major version 21 (Part 2, add new manifests)

### DIFF
--- a/manifests/m/Microsoft/SQLServerManagementStudio/21/21.0.0/Microsoft.SQLServerManagementStudio.21.installer.yaml
+++ b/manifests/m/Microsoft/SQLServerManagementStudio/21/21.0.0/Microsoft.SQLServerManagementStudio.21.installer.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Microsoft.SQLServerManagementStudio.21
+PackageVersion: 21.0.0
+MinimumOSVersion: 10.0.0.0
+InstallerLocale: en-US
+InstallerType: exe
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: --quiet --norestart --wait
+  SilentWithProgress: --passive --norestart --wait
+  Interactive: --wait
+  InstallLocation: --installPath <INSTALLPATH>
+ExpectedReturnCodes:
+- InstallerReturnCode: 1001
+  ReturnResponse: installInProgress
+- InstallerReturnCode: 1003
+  ReturnResponse: fileInUse
+- InstallerReturnCode: 1641
+  ReturnResponse: rebootInitiated
+- InstallerReturnCode: 3010
+  ReturnResponse: rebootRequiredToFinish
+- InstallerReturnCode: -1073720687
+  ReturnResponse: noNetwork
+ElevationRequirement: elevatesSelf
+UpgradeBehavior: install
+Commands:
+- SSMS
+FileExtensions:
+- SQL
+Installers:
+- Architecture: x64
+  InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/f50ab15d-99d5-43aa-b0b4-496b6cb1e574/15f9b6305340d6ac2ec0181d00b7b1cc1f7c6605650bf42cb1da81ca443152d9/vs_SSMS.exe
+  InstallerSha256: 15F9B6305340D6AC2EC0181D00B7B1CC1F7C6605650BF42CB1DA81CA443152D9
+ReleaseDate: 2025-05-19
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/Microsoft/SQLServerManagementStudio/21/21.0.0/Microsoft.SQLServerManagementStudio.21.locale.en-US.yaml
+++ b/manifests/m/Microsoft/SQLServerManagementStudio/21/21.0.0/Microsoft.SQLServerManagementStudio.21.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
+PackageIdentifier: Microsoft.SQLServerManagementStudio.21
+PackageVersion: 21.0.0
+PackageLocale: en-US
+Publisher: Microsoft Corporation
+PublisherUrl: https://www.microsoft.com/
+PublisherSupportUrl: https://aka.ms/ssms-feedback/
+PrivacyUrl: https://privacy.microsoft.com/
+Author: Microsoft
+PackageName: Microsoft SQL Server Management Studio 21
+PackageUrl: https://learn.microsoft.com/sql/ssms/download-sql-server-management-studio-ssms
+License: Microsoft Release Software License
+LicenseUrl: https://aka.ms/ssms-license
+Copyright: Copyright (c) Microsoft Corporation. All rights reserved.
+ShortDescription: SQL Server Management Studio (SSMS) is an integrated environment for managing any SQL infrastructure
+Description: SQL Server Management Studio (SSMS) is an integrated environment for managing any SQL infrastructure, from SQL Server to Azure SQL Database. SSMS provides tools to configure, monitor, and administer instances of SQL Server and databases. Use SSMS to deploy, monitor, and upgrade the data-tier components used by your applications, and build queries and scripts.
+Moniker: ssms
+Tags:
+- management-studio
+- sql
+- sql-management-studio
+- sql-server
+- ssms
+# Agreements: 
+# ReleaseNotes: 
+ReleaseNotesUrl: https://aka.ms/SSMSReleaseNotes-21#2100
+# PurchaseUrl: 
+# InstallationNotes: 
+# Documentations: 
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/Microsoft/SQLServerManagementStudio/21/21.0.0/Microsoft.SQLServerManagementStudio.21.yaml
+++ b/manifests/m/Microsoft/SQLServerManagementStudio/21/21.0.0/Microsoft.SQLServerManagementStudio.21.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Microsoft.SQLServerManagementStudio.21
+PackageVersion: 21.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

I accidentally reused the same PackageIdentifier over the years for the same MAJOR version of the product. That was not a bright idea, in retrospective. So, starting with SSMS 21, I'm going to include the MAJOR version in the package identified so avoid issues when doing updates, like in https://developercommunity.visualstudio.com/t/Winget-keeps-triggering-upgrade-to-SSMS2/10913077

This PR is the 2nd of 2:

- Deletion of the OLD manifests   <- [PR 263818](https://github.com/microsoft/winget-pkgs/pull/263818)
- Addition of the NEW manifests   <- This PR (similar to [PR 263560](https://github.com/microsoft/winget-pkgs/pull/263560))
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/263831)