### PR TITLE
New package: oschwartz10612.Poppler version 24.08.0-0

### DIFF
--- a/manifests/o/oschwartz10612/Poppler/24.08.0-0/oschwartz10612.Poppler.installer.yaml
+++ b/manifests/o/oschwartz10612/Poppler/24.08.0-0/oschwartz10612.Poppler.installer.yaml
@@ -1,0 +1,43 @@
+# Created with komac v2.11.2
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: oschwartz10612.Poppler
+PackageVersion: 24.08.0-0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: poppler-24.08.0\Library\bin\pdfattach.exe
+- RelativeFilePath: poppler-24.08.0\Library\bin\pdfdetach.exe
+- RelativeFilePath: poppler-24.08.0\Library\bin\pdffonts.exe
+- RelativeFilePath: poppler-24.08.0\Library\bin\pdfimages.exe
+- RelativeFilePath: poppler-24.08.0\Library\bin\pdfinfo.exe
+- RelativeFilePath: poppler-24.08.0\Library\bin\pdfseparate.exe
+- RelativeFilePath: poppler-24.08.0\Library\bin\pdftocairo.exe
+- RelativeFilePath: poppler-24.08.0\Library\bin\pdftohtml.exe
+- RelativeFilePath: poppler-24.08.0\Library\bin\pdftoppm.exe
+- RelativeFilePath: poppler-24.08.0\Library\bin\pdftops.exe
+- RelativeFilePath: poppler-24.08.0\Library\bin\pdftotext.exe
+- RelativeFilePath: poppler-24.08.0\Library\bin\pdfunite.exe
+- RelativeFilePath: poppler-24.08.0\Library\bin\zstd.exe
+ArchiveBinariesDependOnPath: true
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: uninstallPrevious
+ReleaseDate: 2024-10-06
+Installers:
+- Architecture: x86
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x86
+  InstallerUrl: https://github.com/oschwartz10612/poppler-windows/releases/download/v24.08.0-0/Release-24.08.0-0.zip
+  InstallerSha256: 58A6F9AE269756231D2F9AA6CBA39D75FEC6DEACAF3C4A50683383B5F3D5A527
+- Architecture: x64
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+  InstallerUrl: https://github.com/oschwartz10612/poppler-windows/releases/download/v24.08.0-0/Release-24.08.0-0.zip
+  InstallerSha256: 58A6F9AE269756231D2F9AA6CBA39D75FEC6DEACAF3C4A50683383B5F3D5A527
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/o/oschwartz10612/Poppler/24.08.0-0/oschwartz10612.Poppler.locale.en-US.yaml
+++ b/manifests/o/oschwartz10612/Poppler/24.08.0-0/oschwartz10612.Poppler.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# Created with komac v2.11.2
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: oschwartz10612.Poppler
+PackageVersion: 24.08.0-0
+PackageLocale: en-US
+Publisher: Owen Schwartz
+PublisherUrl: https://github.com/oschwartz10612
+PublisherSupportUrl: https://github.com/oschwartz10612/poppler-windows/issues
+Author: Owen Schwartz
+PackageName: Poppler
+PackageUrl: https://github.com/oschwartz10612/poppler-windows
+License: MIT
+LicenseUrl: https://github.com/oschwartz10612/poppler-windows/blob/master/LICENSE
+Copyright: Copyright (c) 2020 Owen Schwartz
+CopyrightUrl: https://github.com/oschwartz10612/poppler-windows/blob/master/LICENSE
+ShortDescription: Download Poppler binaries packaged for Windows with dependencies
+Description: >
+  Download the latest Poppler prebuilt-binaries packaged with dependencies for
+  Windows. Built with the help of conda-forge and poppler-feedstock. Includes
+  the latest poppler-data.
+Tags:
+- poppler
+- poppler-data
+- poppler-feedstock
+- windows
+ReleaseNotesUrl: https://github.com/oschwartz10612/poppler-windows/releases/tag/v24.08.0-0
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/o/oschwartz10612/Poppler/24.08.0-0/oschwartz10612.Poppler.yaml
+++ b/manifests/o/oschwartz10612/Poppler/24.08.0-0/oschwartz10612.Poppler.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.11.2
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: oschwartz10612.Poppler
+PackageVersion: 24.08.0-0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Checklist for Pull Requests

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Resolve #262798 

## Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

## Manual validation

<details><summary>Installation</summary><p>

```text
--> Injecting proxy settings from the host
    --> Injecting with WinHTTP

Current WinHTTP proxy settings:

    Proxy Server(s) :  http://alist.dragon1573.local:57890
    Bypass List     :  <local>,*.local,*.cn

    --> Injecting with Windows Registry


ProxyEnable   : 1
ProxyServer   : http://alist.dragon1573.local:57890
ProxyOverride : <local>,*.local,*.cn



--> Installing WinGet
--> Disabling safety warning when running installers
Tip: you can type 'Update-EnvironmentVariables' to update your environment variables, such as after installing a new software.

--> Configuring Winget
已启用管理员设置 'LocalManifestFiles'。
已启用管理员设置 'LocalArchiveMalwareScanOverride'。
已启用管理员设置 'ProxyCommandLineOptions'。
将管理员设置 'DefaultProxy' 设置为 'http://alist.dragon1573.local:57890'。

--> Installing the Manifest 24.08.0-0

已找到 Poppler [oschwartz10612.Poppler] 版本 24.08.0-0
此应用程序由其所有者授权给你。
Microsoft 对第三方程序包概不负责，也不向第三方程序包授予任何许可证。
此包需要以下依赖项：
  - 程序包
      Microsoft.VCRedist.2015+.x64
(1/1) 已找到 Microsoft Visual C++ 2015-2022 Redistributable (x64) [Microsoft.VCRedist.2015+.x64] 版本 14.44.35208.0
此应用程序由其所有者授权给你。
Microsoft 对第三方程序包概不负责，也不向第三方程序包授予任何许可证。
正在下载 https://download.visualstudio.microsoft.com/download/pr/40b59c73-1480-4caf-ab5b-4886f176bf71/D62841375B90782B1829483AC75695CCEF680A8F13E7DE569B992EF33C6CD14A/VC_redist.x64.exe
  ██████████████████████████████  24.4 MB / 24.4 MB
已成功验证安装程序哈希
正在启动程序包安装...
已成功安装

正在下载 https://github.com/oschwartz10612/poppler-windows/releases/download/v24.08.0-0/Release-24.08.0-0.zip
  ██████████████████████████████  14.3 MB / 14.3 MB
已成功验证安装程序哈希
正在提取存档...
已成功提取存档
正在启动程序包安装...
已修改路径环境变量；重启 shell 以使用新值。
添加了命令行别名： "pdfattach"
添加了命令行别名： "pdfdetach"
添加了命令行别名： "pdffonts"
添加了命令行别名： "pdfimages"
添加了命令行别名： "pdfinfo"
添加了命令行别名： "pdfseparate"
添加了命令行别名： "pdftocairo"
添加了命令行别名： "pdftohtml"
添加了命令行别名： "pdftoppm"
添加了命令行别名： "pdftops"
添加了命令行别名： "pdftotext"
添加了命令行别名： "pdfunite"
添加了命令行别名： "zstd"
已成功安装

--> Refreshing environment variables

--> Comparing ARP Entries

DisplayName                                                        DisplayVersion Publisher             ProductCode
-----------                                                        -------------- ---------             -----------
Microsoft Visual C++ 2015-2022 Redistributable (x64) - 14.44.35208 14.44.35208.0  Microsoft Corporation {9387bec2-2f2b-48d1-a0ce-692c5df...
Poppler                                                            24.08.0-0      Owen Schwartz         oschwartz10612.Poppler__DefaultS...
```

</p></details>
<details><summary>Validation</summary><p>

```text
PS C:\Users\WDAGUtilityAccount\Desktop\winget-pkgs> pdfattach.exe
pdfattach version 24.08.0
Copyright 2005-2024 The Poppler Developers - http://poppler.freedesktop.org
Copyright 1996-2011, 2022 Glyph & Cog, LLC
Usage: pdfattach [options] <input-PDF-file> <file-to-attach> <output-PDF-file>
  -replace         : replace embedded file with same name (if it exists)
  -v               : print copyright and version info
  -h               : print usage information
  -help            : print usage information
  --help           : print usage information
  -?               : print usage information

PS C:\Users\WDAGUtilityAccount\Desktop\winget-pkgs> pdfdetach
pdfdetach version 24.08.0
Copyright 2005-2024 The Poppler Developers - http://poppler.freedesktop.org
Copyright 1996-2011, 2022 Glyph & Cog, LLC
Usage: pdfdetach [options] <PDF-file>
  -list             : list all embedded files
  -save <int>       : save the specified embedded file (file number)
  -savefile <string>: save the specified embedded file (file name)
  -saveall          : save all embedded files
  -o <string>       : file name for the saved embedded file
  -enc <string>     : output text encoding name
  -opw <string>     : owner password (for encrypted files)
  -upw <string>     : user password (for encrypted files)
  -v                : print copyright and version info
  -h                : print usage information
  -help             : print usage information
  --help            : print usage information
  -?                : print usage information

PS C:\Users\WDAGUtilityAccount\Desktop\winget-pkgs> pdffonts
pdffonts version 24.08.0
Copyright 2005-2024 The Poppler Developers - http://poppler.freedesktop.org
Copyright 1996-2011, 2022 Glyph & Cog, LLC
Usage: pdffonts [options] <PDF-file>
  -f <int>       : first page to examine
  -l <int>       : last page to examine
  -subst         : show font substitutions
  -opw <string>  : owner password (for encrypted files)
  -upw <string>  : user password (for encrypted files)
  -v             : print copyright and version info
  -h             : print usage information
  -help          : print usage information
  --help         : print usage information
  -?             : print usage information

PS C:\Users\WDAGUtilityAccount\Desktop\winget-pkgs> pdfimages
pdfimages version 24.08.0
Copyright 2005-2024 The Poppler Developers - http://poppler.freedesktop.org
Copyright 1996-2011, 2022 Glyph & Cog, LLC
Usage: pdfimages [options] <PDF-file> <image-root>
  -f <int>                 : first page to convert
  -l <int>                 : last page to convert
  -png                     : change the default output format to PNG
  -tiff                    : change the default output format to TIFF
  -j                       : write JPEG images as JPEG files
  -jp2                     : write JPEG2000 images as JP2 files
  -jbig2                   : write JBIG2 images as JBIG2 files
  -ccitt                   : write CCITT images as CCITT files
  -all                     : equivalent to -png -tiff -j -jp2 -jbig2 -ccitt
  -list                    : print list of images instead of saving
  -opw <string>            : owner password (for encrypted files)
  -upw <string>            : user password (for encrypted files)
  -p                       : include page numbers in output file names
  -print-filenames         : print image filenames to stdout
  -q                       : don't print any messages or errors
  -v                       : print copyright and version info
  -h                       : print usage information
  -help                    : print usage information
  --help                   : print usage information
  -?                       : print usage information

PS C:\Users\WDAGUtilityAccount\Desktop\winget-pkgs> pdfinfo
pdfinfo version 24.08.0
Copyright 2005-2024 The Poppler Developers - http://poppler.freedesktop.org
Copyright 1996-2011, 2022 Glyph & Cog, LLC
Usage: pdfinfo [options] <PDF-file>
  -f <int>             : first page to convert
  -l <int>             : last page to convert
  -box                 : print the page bounding boxes
  -meta                : print the document metadata (XML)
  -custom              : print both custom and standard metadata
  -js                  : print all JavaScript in the PDF
  -struct              : print the logical document structure (for tagged files)
  -struct-text         : print text contents along with document structure (for tagged files)
  -isodates            : print the dates in ISO-8601 format
  -rawdates            : print the undecoded date strings directly from the PDF file
  -dests               : print all named destinations in the PDF
  -url                 : print all URLs inside PDF objects (does not scan text content)
  -enc <string>        : output text encoding name
  -listenc             : list available encodings
  -opw <string>        : owner password (for encrypted files)
  -upw <string>        : user password (for encrypted files)
  -v                   : print copyright and version info
  -h                   : print usage information
  -help                : print usage information
  --help               : print usage information
  -?                   : print usage information

PS C:\Users\WDAGUtilityAccount\Desktop\winget-pkgs> pdfseparate
pdfseparate version 24.08.0
Copyright 2005-2024 The Poppler Developers - http://poppler.freedesktop.org
Copyright 1996-2011, 2022 Glyph & Cog, LLC
Usage: pdfseparate [options] <PDF-sourcefile> <PDF-pattern-destfile>
  -f <int>       : first page to extract
  -l <int>       : last page to extract
  -v             : print copyright and version info
  -h             : print usage information
  -help          : print usage information
  --help         : print usage information
  -?             : print usage information

PS C:\Users\WDAGUtilityAccount\Desktop\winget-pkgs> pdftocairo
pdftocairo version 24.08.0
Copyright 2005-2024 The Poppler Developers - http://poppler.freedesktop.org
Copyright 1996-2011, 2022 Glyph & Cog, LLC
Usage: pdftocairo [options] <PDF-file> [<output-file>]
  -png                     : generate a PNG file
  -jpeg                    : generate a JPEG file
  -jpegopt <string>        : jpeg options, with format <opt1>=<val1>[,<optN>=<valN>]*
  -tiff                    : generate a TIFF file
  -tiffcompression <string>: set TIFF compression: none, packbits, jpeg, lzw, deflate
  -ps                      : generate PostScript file
  -eps                     : generate Encapsulated PostScript (EPS)
  -pdf                     : generate a PDF file
  -svg                     : generate a Scalable Vector Graphics (SVG) file
  -print                   : print to a Windows printer
  -printdlg                : show Windows print dialog and print
  -printer <string>        : printer name or use default if this option is not specified
  -printopt <string>       : printer options, with format <opt1>=<val1>[,<optN>=<valN>]*
  -setupdlg                : show printer setup dialog before printing
  -f <int>                 : first page to print
  -l <int>                 : last page to print
  -o                       : print only odd pages
  -e                       : print only even pages
  -singlefile              : write only the first page and do not add digits
  -r <fp>                  : resolution, in PPI (default is 150)
  -rx <fp>                 : X resolution, in PPI (default is 150)
  -ry <fp>                 : Y resolution, in PPI (default is 150)
  -scale-to <int>          : scales each page to fit within scale-to*scale-to pixel box
  -scale-to-x <int>        : scales each page horizontally to fit in scale-to-x pixels
  -scale-to-y <int>        : scales each page vertically to fit in scale-to-y pixels
  -x <int>                 : x-coordinate of the crop area top left corner
  -y <int>                 : y-coordinate of the crop area top left corner
  -W <int>                 : width of crop area in pixels (default is 0)
  -H <int>                 : height of crop area in pixels (default is 0)
  -sz <int>                : size of crop square in pixels (sets W and H)
  -cropbox                 : use the crop box rather than media box
  -mono                    : generate a monochrome image file (PNG, JPEG)
  -gray                    : generate a grayscale image file (PNG, JPEG)
  -transp                  : use a transparent background instead of white (PNG)
  -antialias <string>      : set cairo antialias option
  -icc <string>            : ICC color profile to use
  -level2                  : generate Level 2 PostScript (PS, EPS)
  -level3                  : generate Level 3 PostScript (PS, EPS)
  -origpagesizes           : conserve original page sizes (PS, PDF, SVG)
  -paper <string>          : paper size (letter, legal, A4, A3, match)
  -paperw <int>            : paper width, in points
  -paperh <int>            : paper height, in points
  -nocrop                  : don't crop pages to CropBox
  -expand                  : expand pages smaller than the paper size
  -noshrink                : don't shrink pages larger than the paper size
  -nocenter                : don't center pages smaller than the paper size
  -duplex                  : enable duplex printing
  -struct                  : enable logical document structure
  -opw <string>            : owner password (for encrypted files)
  -upw <string>            : user password (for encrypted files)
  -q                       : don't print any messages or errors
  -v                       : print copyright and version info
  -h                       : print usage information
  -help                    : print usage information
  --help                   : print usage information
  -?                       : print usage information

PS C:\Users\WDAGUtilityAccount\Desktop\winget-pkgs> pdftohtml
pdftohtml version 24.08.0
Copyright 2005-2024 The Poppler Developers - http://poppler.freedesktop.org
Copyright 1999-2003 Gueorgui Ovtcharov and Rainer Dorsch
Copyright 1996-2011, 2022 Glyph & Cog, LLC

Usage: pdftohtml [options] <PDF-file> [<html-file> <xml-file>]
  -f <int>              : first page to convert
  -l <int>              : last page to convert
  -q                    : don't print any messages or errors
  -h                    : print usage information
  -?                    : print usage information
  -help                 : print usage information
  --help                : print usage information
  -p                    : exchange .pdf links by .html
  -c                    : generate complex document
  -s                    : generate single document that includes all pages
  -i                    : ignore images
  -noframes             : generate no frames
  -stdout               : use standard output
  -zoom <fp>            : zoom the pdf document (default 1.5)
  -xml                  : output for XML post-processing
  -noroundcoord         : do not round coordinates (with XML output only)
  -hidden               : output hidden text
  -nomerge              : do not merge paragraphs
  -enc <string>         : output text encoding name
  -fmt <string>         : image file format for Splash output (png or jpg)
  -v                    : print copyright and version info
  -opw <string>         : owner password (for encrypted files)
  -upw <string>         : user password (for encrypted files)
  -nodrm                : override document DRM settings
  -wbt <fp>             : word break threshold (default 10 percent)
  -fontfullname         : outputs font full name

PS C:\Users\WDAGUtilityAccount\Desktop\winget-pkgs> pdftoppm
Syntax Error: Document stream is empty

PS C:\Users\WDAGUtilityAccount\Desktop\winget-pkgs> pdftops
pdftops version 24.08.0
Copyright 2005-2024 The Poppler Developers - http://poppler.freedesktop.org
Copyright 1996-2011, 2022 Glyph & Cog, LLC
Usage: pdftops [options] <PDF-file> [<PS-file>]
  -f <int>                       : first page to print
  -l <int>                       : last page to print
  -level1                        : generate Level 1 PostScript
  -level1sep                     : generate Level 1 separable PostScript
  -level2                        : generate Level 2 PostScript
  -level2sep                     : generate Level 2 separable PostScript
  -level3                        : generate Level 3 PostScript
  -level3sep                     : generate Level 3 separable PostScript
  -origpagesizes                 : conserve original page sizes
  -eps                           : generate Encapsulated PostScript (EPS)
  -form                          : generate a PostScript form
  -opi                           : generate OPI comments
  -r <int>                       : resolution for rasterization, in DPI (default is 300)
  -binary                        : write binary data in Level 1 PostScript
  -noembt1                       : don't embed Type 1 fonts
  -noembtt                       : don't embed TrueType fonts
  -noembcidps                    : don't embed CID PostScript fonts
  -noembcidtt                    : don't embed CID TrueType fonts
  -passfonts                     : don't substitute missing fonts
  -aaRaster <string>             : enable anti-aliasing on rasterization: yes, no
  -rasterize <string>            : control rasterization: always, never, whenneeded
  -processcolorformat <string>   : color format that is used during rasterization and transparency reduction: MONO8, RGB8, CMYK8
  -processcolorprofile <string>  : ICC color profile to use as the process color profile during rasterization and transparency reduction
  -defaultgrayprofile <string>   : ICC color profile to use as the DefaultGray color space
  -defaultrgbprofile <string>    : ICC color profile to use as the DefaultRGB color space
  -defaultcmykprofile <string>   : ICC color profile to use as the DefaultCMYK color space
  -optimizecolorspace            : convert gray RGB images to gray color space
  -passlevel1customcolor         : pass custom color in level1sep
  -preload                       : preload images and forms
  -paper <string>                : paper size (letter, legal, A4, A3, match)
  -paperw <int>                  : paper width, in points
  -paperh <int>                  : paper height, in points
  -nocrop                        : don't crop pages to CropBox
  -expand                        : expand pages smaller than the paper size
  -noshrink                      : don't shrink pages larger than the paper size
  -nocenter                      : don't center pages smaller than the paper size
  -duplex                        : enable duplex printing
  -opw <string>                  : owner password (for encrypted files)
  -upw <string>                  : user password (for encrypted files)
  -overprint                     : enable overprint emulation during rasterization
  -q                             : don't print any messages or errors
  -v                             : print copyright and version info
  -h                             : print usage information
  -help                          : print usage information
  --help                         : print usage information
  -?                             : print usage information

PS C:\Users\WDAGUtilityAccount\Desktop\winget-pkgs> pdftotext
pdftotext version 24.08.0
Copyright 2005-2024 The Poppler Developers - http://poppler.freedesktop.org
Copyright 1996-2011, 2022 Glyph & Cog, LLC
Usage: pdftotext [options] <PDF-file> [<text-file>]
  -f <int>             : first page to convert
  -l <int>             : last page to convert
  -r <fp>              : resolution, in DPI (default is 72)
  -x <int>             : x-coordinate of the crop area top left corner
  -y <int>             : y-coordinate of the crop area top left corner
  -W <int>             : width of crop area in pixels (default is 0)
  -H <int>             : height of crop area in pixels (default is 0)
  -layout              : maintain original physical layout
  -fixed <fp>          : assume fixed-pitch (or tabular) text
  -raw                 : keep strings in content stream order
  -nodiag              : discard diagonal text
  -htmlmeta            : generate a simple HTML file, including the meta information
  -tsv                 : generate a simple TSV file, including the meta information for bounding boxes
  -enc <string>        : output text encoding name
  -listenc             : list available encodings
  -eol <string>        : output end-of-line convention (unix, dos, or mac)
  -nopgbrk             : don't insert page breaks between pages
  -bbox                : output bounding box for each word and page size to html. Sets -htmlmeta
  -bbox-layout         : like -bbox but with extra layout bounding box data.  Sets -htmlmeta
  -cropbox             : use the crop box rather than media box
  -colspacing <fp>     : how much spacing we allow after a word before considering adjacent text to be a new column, as a fraction of the font size (default is 0.7, old releases had a 0.3 default)
  -opw <string>        : owner password (for encrypted files)
  -upw <string>        : user password (for encrypted files)
  -q                   : don't print any messages or errors
  -v                   : print copyright and version info
  -h                   : print usage information
  -help                : print usage information
  --help               : print usage information
  -?                   : print usage information

PS C:\Users\WDAGUtilityAccount\Desktop\winget-pkgs> pdfunite
pdfunite version 24.08.0
Copyright 2005-2024 The Poppler Developers - http://poppler.freedesktop.org
Copyright 1996-2011, 2022 Glyph & Cog, LLC
Usage: pdfunite [options] <PDF-sourcefile-1>..<PDF-sourcefile-n> <PDF-destfile>
  -v             : print copyright and version info
  -h             : print usage information
  -help          : print usage information
  --help         : print usage information
  -?             : print usage information

PS C:\Users\WDAGUtilityAccount\Desktop\winget-pkgs> zstd
stdin is a console, aborting
```

</p></details>

-----


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/263920)