### PR TITLE
Update manifest: Vendicated.Vencord version 1.4.0

### DIFF
--- a/manifests/v/Vendicated/Vencord/1.4.0/Vendicated.Vencord.installer.yaml
+++ b/manifests/v/Vendicated/Vencord/1.4.0/Vendicated.Vencord.installer.yaml
@@ -1,5 +1,5 @@
-# Created with Komac v1.11.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+# Created with komac v2.11.2
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
 
 PackageIdentifier: Vendicated.Vencord
 PackageVersion: 1.4.0
@@ -12,11 +12,11 @@ InstallerSwitches:
 Dependencies:
   PackageDependencies:
   - PackageIdentifier: Discord.Discord
-ReleaseDate: 2024-01-23
+ReleaseDate: 2024-02-24
+RequireExplicitUpgrade: true
 Installers:
 - Architecture: x86
   InstallerUrl: https://github.com/Vencord/Installer/releases/download/v1.4.0/VencordInstallerCli.exe
-  InstallerSha256: F33967CDC61D0F2E720C335880FB3350DFEAADB68E8A9FDD16787E94CD22C8DE
-  RequireExplicitUpgrade: true
+  InstallerSha256: 466D2A0BE1F380DDFFED052DF3CC132125FA34DC1AF29312E14F13F358C8D2A2
 ManifestType: installer
-ManifestVersion: 1.5.0
+ManifestVersion: 1.10.0

--- a/manifests/v/Vendicated/Vencord/1.4.0/Vendicated.Vencord.installer.yaml
+++ b/manifests/v/Vendicated/Vencord/1.4.0/Vendicated.Vencord.installer.yaml
@@ -15,7 +15,7 @@ Dependencies:
 ReleaseDate: 2024-02-24
 RequireExplicitUpgrade: true
 Installers:
-- Architecture: x86
+- Architecture: x64
   InstallerUrl: https://github.com/Vencord/Installer/releases/download/v1.4.0/VencordInstallerCli.exe
   InstallerSha256: 466D2A0BE1F380DDFFED052DF3CC132125FA34DC1AF29312E14F13F358C8D2A2
 ManifestType: installer

--- a/manifests/v/Vendicated/Vencord/1.4.0/Vendicated.Vencord.locale.en-US.yaml
+++ b/manifests/v/Vendicated/Vencord/1.4.0/Vendicated.Vencord.locale.en-US.yaml
@@ -1,5 +1,5 @@
-# Created with Komac v1.11.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+# Created with komac v2.11.2
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
 
 PackageIdentifier: Vendicated.Vencord
 PackageVersion: 1.4.0
@@ -10,20 +10,22 @@ PublisherSupportUrl: https://discord.gg/D9uwnFnqmd
 Author: Vendicated
 PackageName: Vencord
 PackageUrl: https://github.com/Vendicated/Vencord
-License: GNU General Public License v3.0
+License: GPL-3.0
 LicenseUrl: https://github.com/Vendicated/Vencord/blob/main/LICENSE
 Copyright: N/A
 ShortDescription: The cutest Discord client mod
 ReleaseNotes: |-
-  What changed
+  ## What changed
+
   - Cli UX has been considerably improved
   - Gui UX has been improved
   - Added automatic self updating on Windows & Linux
   - Some error messages have been made more user friendly
   - no longer warns you about running as Admin on windows
   - fixes some issues with the OpenAsar integration
-  - fixed flashing a terminal window on Windows (this was due to using powershell to kill Discord)
+  - fixed flashing a terminal window on Windows (this was due to using powershell
+    to kill Discord)
   - patcher now writes a proper app.asar file instead of using a folder
 ReleaseNotesUrl: https://github.com/Vencord/Installer/releases/tag/v1.4.0
 ManifestType: defaultLocale
-ManifestVersion: 1.5.0
+ManifestVersion: 1.10.0

--- a/manifests/v/Vendicated/Vencord/1.4.0/Vendicated.Vencord.yaml
+++ b/manifests/v/Vendicated/Vencord/1.4.0/Vendicated.Vencord.yaml
@@ -1,8 +1,8 @@
-# Created with Komac v1.11.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+# Created with komac v2.11.2
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
 
 PackageIdentifier: Vendicated.Vencord
 PackageVersion: 1.4.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.5.0
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## What's changed?

- Bump manifest version: `1.5.0` -> `1.10.0`
- Update installer hash value
- Prettify some properties

## Checklist for Pull Requests

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Resolve #262961 

## Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

## Manual validation

> [!WARNING]
> 
> The first black console will automatically pop up during installation. It might block the "unattended" install process of the package and might cause https://github.com/microsoft/winget-pkgs/labels/Validation-Unattended-Failed.

![Image](https://github.com/user-attachments/assets/cd3d7e21-31e2-49c4-81a8-72f1358f6acf)
![Image](https://github.com/user-attachments/assets/8ea0a685-a292-4c7a-bc51-f97f4057599c)
![Image](https://github.com/user-attachments/assets/2e6f374f-93b1-448a-9fd7-77a803b6a1e9)

> [!IMPORTANT]
> 
> Users HAVE TO login to _Discord Client_ to see effects of _Vencord_.

-----


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/264074)