### PR TITLE
SSMS 21.2.5: fixing the 'Upgrade'

### DIFF
--- a/manifests/m/Microsoft/SQLServerManagementStudio/21/21.2.5/Microsoft.SQLServerManagementStudio.21.installer.yaml
+++ b/manifests/m/Microsoft/SQLServerManagementStudio/21/21.2.5/Microsoft.SQLServerManagementStudio.21.installer.yaml
@@ -10,9 +10,10 @@ InstallModes:
 - silent
 - silentWithProgress
 InstallerSwitches:
-  Silent: --quiet --norestart --wait
-  SilentWithProgress: --passive --norestart --wait
-  Interactive: --wait
+  Silent: --quiet
+  SilentWithProgress: --passive
+  Upgrade: update
+  Custom: --wait
   InstallLocation: --installPath <INSTALLPATH>
 ExpectedReturnCodes:
 - InstallerReturnCode: 1001


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---
The 'Upgrade' entry was missing from the manifest. I'm adding it + I'm cleaning up the other options.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/265054)