### PR TITLE
vim.vim.nightly: fix wrong architecture for x86

### DIFF
--- a/manifests/v/vim/vim/nightly/9.1.1453/vim.vim.nightly.installer.yaml
+++ b/manifests/v/vim/vim/nightly/9.1.1453/vim.vim.nightly.installer.yaml
@@ -25,8 +25,8 @@ InstallationMetadata:
   DefaultInstallLocation: '%ProgramFiles%\Vim'
 Installers:
 - Architecture: x86
-  InstallerUrl: https://github.com/vim/vim-win32-installer/releases/download/v9.1.1453/gvim_9.1.1453_arm64.exe
-  InstallerSha256: 885FDAB007F9B3C2CD2A3154191DC8644B9A77A6D496CDABF4E0DAF915DE483A
+  InstallerUrl: https://github.com/vim/vim-win32-installer/releases/download/v9.1.1453/gvim_9.1.1453_x86.exe
+  InstallerSha256: 055818A52D26D3EAD99E2D612021BCD16B7276A28DC7F0BF977CD595F382F416
 - Architecture: x64
   InstallerUrl: https://github.com/vim/vim-win32-installer/releases/download/v9.1.1453/gvim_9.1.1453_x64.exe
   InstallerSha256: 310726D6C5BED41E3B56CA1118D1F5A8E108374A8B2E95287ECF508393A02DAF


### PR DESCRIPTION
related: vim/vim#17521

Checklist for Pull Requests
- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/265068)