### PR TITLE
Rem0o.FanControl: update manifest to fix `Installer failed with exit code: 5`

### DIFF
--- a/manifests/r/Rem0o/FanControl/226/Rem0o.FanControl.installer.yaml
+++ b/manifests/r/Rem0o/FanControl/226/Rem0o.FanControl.installer.yaml
@@ -4,6 +4,8 @@
 PackageIdentifier: Rem0o.FanControl
 PackageVersion: "226"
 InstallerType: inno
+InstallerSwitches:
+  Custom: /FORCECLOSEAPPLICATIONS
 UpgradeBehavior: install
 Dependencies:
   PackageDependencies:


### PR DESCRIPTION
https://github.com/Rem0o/FanControl.Releases/discussions/2558#discussioncomment-9723325

https://jrsoftware.org/ishelp/index.php?topic=setupcmdline

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/266130)