### PR TITLE
Add `msedit` tag to Microsoft.Edit manifest

### DIFF
--- a/manifests/m/Microsoft/Edit/1.2.0/Microsoft.Edit.locale.en-US.yaml
+++ b/manifests/m/Microsoft/Edit/1.2.0/Microsoft.Edit.locale.en-US.yaml
@@ -21,6 +21,7 @@ Description: |-
   The goal is to provide an accessible editor that even users largely unfamiliar with terminals can easily use.
 Moniker: edit
 Tags:
+- msedit
 - code
 - code-editing
 - code-editor


### PR DESCRIPTION
msedit was chosen as the official binary name for the program on Linux (https://github.com/microsoft/edit/discussions/341) and it is also just a natural shortname / search term for the program, as searching for just "edit" yields too many results to be practical.

Also see https://github.com/microsoft/edit/issues/515

Checklist for Pull Requests
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Is there a linked Issue?
  Not in this repo but https://github.com/microsoft/edit/issues/515

Manifests
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] This PR only modifies one (1) manifest
- [X] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [X] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?
  Yes but I still left it at version 1.9.0 because that's what it was and there's no schema update required for this change.

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/268280)