### PR TITLE
New package: HomeDev.PatchCleanerPortable version 1.4.2.0

### DIFF
--- a/manifests/h/HomeDev/PatchCleanerPortable/1.4.2.0/HomeDev.PatchCleanerPortable.installer.yaml
+++ b/manifests/h/HomeDev/PatchCleanerPortable/1.4.2.0/HomeDev.PatchCleanerPortable.installer.yaml
@@ -7,7 +7,7 @@ InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
 - RelativeFilePath: PatchCleanerPortable_1_4_2_0\PatchCleaner\PatchCleaner.exe
-  PortableCommandAlias: patchcleanerportable
+  PortableCommandAlias: patchcleaner
 ArchiveBinariesDependOnPath: true
 Installers:
 - Architecture: x86

--- a/manifests/h/HomeDev/PatchCleanerPortable/1.4.2.0/HomeDev.PatchCleanerPortable.installer.yaml
+++ b/manifests/h/HomeDev/PatchCleanerPortable/1.4.2.0/HomeDev.PatchCleanerPortable.installer.yaml
@@ -1,0 +1,17 @@
+# Created using wingetcreate 1.9.14.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: HomeDev.PatchCleanerPortable
+PackageVersion: 1.4.2.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: PatchCleanerPortable_1_4_2_0\PatchCleaner\PatchCleaner.exe
+  PortableCommandAlias: patchcleanerportable
+ArchiveBinariesDependOnPath: true
+Installers:
+- Architecture: x86
+  InstallerUrl: https://deac-riga.dl.sourceforge.net/project/patchcleaner/PatchCleaner_Portable/v1.4.2.0/PatchCleanerPortable_1_4_2_0.zip
+  InstallerSha256: 62EAF79C146D35862329CA1ADEDD089CC08BA554DBDFF440E08657F9814CE3B8
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/h/HomeDev/PatchCleanerPortable/1.4.2.0/HomeDev.PatchCleanerPortable.locale.en-US.yaml
+++ b/manifests/h/HomeDev/PatchCleanerPortable/1.4.2.0/HomeDev.PatchCleanerPortable.locale.en-US.yaml
@@ -1,0 +1,20 @@
+# Created using wingetcreate 1.9.14.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: HomeDev.PatchCleanerPortable
+PackageVersion: 1.4.2.0
+PackageLocale: en-US
+Publisher: HomeDev
+PackageName: PatchCleaner Portable
+PackageUrl: https://www.homedev.com.au/Free/PatchCleaner
+License: Proprietary
+ShortDescription: (Re)Moves orphaned .msi files from the C:\Windows\Installer folder to free up disk space.
+Tags:
+- msi
+- cleanup
+- diskspace
+- storagespace
+- harddrive
+- harddisk
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/h/HomeDev/PatchCleanerPortable/1.4.2.0/HomeDev.PatchCleanerPortable.yaml
+++ b/manifests/h/HomeDev/PatchCleanerPortable/1.4.2.0/HomeDev.PatchCleanerPortable.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.9.14.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: HomeDev.PatchCleanerPortable
+PackageVersion: 1.4.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---
Notes from me:
* For the inevitable "Validation-Unapproved-URL" label: Yes, it is hosted on SourceForge. No, the program's developer did not provide any other download locations.
* There also exists an installable version of PatchCleaner (which is why I added Portable to this manifest's name to distinguish the two), but wingetcreate was unable to make a manifest of it, seemingly as it is a self-extracting 7Z (but don't take my word for it).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/268936)