### PR TITLE
MediaHuman.YouTubeToMP3Converter 3.9.14 ReleaseNotes 975340238

### DIFF
--- a/manifests/m/MediaHuman/YouTubeToMP3Converter/3.9.14/MediaHuman.YouTubeToMP3Converter.installer.yaml
+++ b/manifests/m/MediaHuman/YouTubeToMP3Converter/3.9.14/MediaHuman.YouTubeToMP3Converter.installer.yaml
@@ -7,6 +7,7 @@ InstallerType: inno
 Scope: machine
 UpgradeBehavior: install
 ProductCode: MediaHuman YouTube to MP3 Converter_is1
+ReleaseDate: 2025-06-13
 Installers:
 - Architecture: x86
   InstallerUrl: https://www.mediahuman.com/files/YouTubeToMP3.exe

--- a/manifests/m/MediaHuman/YouTubeToMP3Converter/3.9.14/MediaHuman.YouTubeToMP3Converter.locale.en-US.yaml
+++ b/manifests/m/MediaHuman/YouTubeToMP3Converter/3.9.14/MediaHuman.YouTubeToMP3Converter.locale.en-US.yaml
@@ -25,6 +25,10 @@ Tags:
 - downloader
 - soundcloud
 - youtube
+ReleaseNotes: |-
+  - fixed download from YouTube
+  - improved parsing speed of YouTube videos
+  - fixed download from Spotify
 Documentations:
 - DocumentLabel: Guides
   DocumentUrl: https://www.mediahuman.com/howto/

--- a/manifests/r/RoyalApps/RoyalTS/7/7.3.50701.0/RoyalApps.RoyalTS.7.installer.yaml
+++ b/manifests/r/RoyalApps/RoyalTS/7/7.3.50701.0/RoyalApps.RoyalTS.7.installer.yaml
@@ -3,7 +3,6 @@
 
 PackageIdentifier: RoyalApps.RoyalTS.7
 PackageVersion: 7.3.50701.0
-InstallerLocale: en-US
 InstallerType: wix
 Scope: machine
 InstallerSwitches:
@@ -17,12 +16,9 @@ FileExtensions:
 - rtsx
 - rtsz
 ProductCode: '{4959A733-614C-44E8-AC0D-3E7BCAA345AC}'
-ReleaseDate: 2025-06-19
+ReleaseDate: 2025-07-01
 AppsAndFeaturesEntries:
-- DisplayName: Royal TS V7
-  Publisher: Royal Apps GmbH
-  DisplayVersion: 7.3.50701.0
-  ProductCode: '{4959A733-614C-44E8-AC0D-3E7BCAA345AC}'
+- ProductCode: '{4959A733-614C-44E8-AC0D-3E7BCAA345AC}'
   UpgradeCode: '{4959A733-614C-44E8-AC0D-3E7B5A7375AB}'
 Installers:
 - Architecture: x64

--- a/manifests/r/RoyalApps/RoyalTS/7/7.3.50701.0/RoyalApps.RoyalTS.7.locale.en-US.yaml
+++ b/manifests/r/RoyalApps/RoyalTS/7/7.3.50701.0/RoyalApps.RoyalTS.7.locale.en-US.yaml
@@ -29,7 +29,11 @@ Tags:
 - x11
 - xorg
 - xserver
-ReleaseNotes: https://www.royalapps.com/go/kb-ts-win-v7-releasenotes
+ReleaseNotes: |-
+  Remote Desktop (Microsoft)
+  [New] Plugin settings to disable overview thumbnails
+  [Fixed] Local zoom issue
+  [Fixed] Application may freeze when sessions are resized or minimized
 PurchaseUrl: https://www.royalapps.com/ts/win/buy
 Documentations:
 - DocumentLabel: Docs


### PR DESCRIPTION
- **ReleaseNotes: RoyalApps.RoyalTS.7 version 7.3.50701.0**
- **ReleaseNotes: MediaHuman.YouTubeToMP3Converter version 3.9.14**

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/270439)