### PR TITLE
Add RvToolsMerge version 1.4.2

### DIFF
--- a/manifests/r/RvToolsMerge/RvToolsMerge/1.4.2/RvToolsMerge.RvToolsMerge.installer.yaml
+++ b/manifests/r/RvToolsMerge/RvToolsMerge/1.4.2/RvToolsMerge.RvToolsMerge.installer.yaml
@@ -1,7 +1,7 @@
 # Created with winget-create
 # https://github.com/microsoft/winget-create
 PackageIdentifier: RvToolsMerge.RvToolsMerge
-PackageVersion: 1.4.2
+PackageVersion: 1.4.2.0
 Platform:
 - Windows.Desktop
 MinimumOSVersion: 10.0.17763.0

--- a/manifests/r/RvToolsMerge/RvToolsMerge/1.4.2/RvToolsMerge.RvToolsMerge.installer.yaml
+++ b/manifests/r/RvToolsMerge/RvToolsMerge/1.4.2/RvToolsMerge.RvToolsMerge.installer.yaml
@@ -36,7 +36,6 @@ Installers:
   AppsAndFeaturesEntries:
   - DisplayName: RVToolsMerge
     Publisher: Stefan Broenner
-    DisplayVersion: 1.4.2
   InstallationMetadata:
     DefaultInstallLocation: '%ProgramFiles%\RVToolsMerge'
 ManifestType: installer

--- a/manifests/r/RvToolsMerge/RvToolsMerge/1.4.2/RvToolsMerge.RvToolsMerge.installer.yaml
+++ b/manifests/r/RvToolsMerge/RvToolsMerge/1.4.2/RvToolsMerge.RvToolsMerge.installer.yaml
@@ -26,7 +26,6 @@ Installers:
   AppsAndFeaturesEntries:
   - DisplayName: RVToolsMerge
     Publisher: Stefan Broenner
-    DisplayVersion: 1.4.2
   InstallationMetadata:
     DefaultInstallLocation: '%ProgramFiles%\RVToolsMerge'
 - Architecture: arm64

--- a/manifests/r/RvToolsMerge/RvToolsMerge/1.4.2/RvToolsMerge.RvToolsMerge.installer.yaml
+++ b/manifests/r/RvToolsMerge/RvToolsMerge/1.4.2/RvToolsMerge.RvToolsMerge.installer.yaml
@@ -1,0 +1,45 @@
+# Created with winget-create
+# https://github.com/microsoft/winget-create
+PackageIdentifier: RvToolsMerge.RvToolsMerge
+PackageVersion: 1.4.2
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Protocols:
+- http
+- https
+FileExtensions:
+- xlsx
+- xls
+Installers:
+- Architecture: x64
+  InstallerType: wix
+  InstallerUrl: https://github.com/sbroenne/RVToolsMerge/releases/download/v1.4.2/RVToolsMerge-1.4.2-win-x64.msi
+  InstallerSha256: 4B0A53C61E3D8328FF583CF9385D2602D57F1A944F09FEAA15761DCA5DDA2377
+  ProductCode: '{198D93B7-15F4-469F-A6D5-E78CEA3BFCD3}'
+  AppsAndFeaturesEntries:
+  - DisplayName: RVToolsMerge
+    Publisher: Stefan Broenner
+    DisplayVersion: 1.4.2
+  InstallationMetadata:
+    DefaultInstallLocation: '%ProgramFiles%\RVToolsMerge'
+- Architecture: arm64
+  InstallerType: wix
+  InstallerUrl: https://github.com/sbroenne/RVToolsMerge/releases/download/v1.4.2/RVToolsMerge-1.4.2-win-arm64.msi
+  InstallerSha256: 1046E39605D1EB513FA7A1BDE8BB58E7F010EFD4D71A9CD191F8FB5A1B6E5A9F
+  ProductCode: '{52A81075-1A00-424E-BA3E-339E3C64162F}'
+  AppsAndFeaturesEntries:
+  - DisplayName: RVToolsMerge
+    Publisher: Stefan Broenner
+    DisplayVersion: 1.4.2
+  InstallationMetadata:
+    DefaultInstallLocation: '%ProgramFiles%\RVToolsMerge'
+ManifestType: installer
+ManifestVersion: 1.6.0
+

--- a/manifests/r/RvToolsMerge/RvToolsMerge/1.4.2/RvToolsMerge.RvToolsMerge.locale.en-US.yaml
+++ b/manifests/r/RvToolsMerge/RvToolsMerge/1.4.2/RvToolsMerge.RvToolsMerge.locale.en-US.yaml
@@ -1,7 +1,7 @@
 # Created with winget-create
 # https://github.com/microsoft/winget-create
 PackageIdentifier: RvToolsMerge.RvToolsMerge
-PackageVersion: 1.4.2
+PackageVersion: 1.4.2.0
 PackageLocale: en-US
 Publisher: Stefan Broenner
 PublisherUrl: https://github.com/sbroenne

--- a/manifests/r/RvToolsMerge/RvToolsMerge/1.4.2/RvToolsMerge.RvToolsMerge.locale.en-US.yaml
+++ b/manifests/r/RvToolsMerge/RvToolsMerge/1.4.2/RvToolsMerge.RvToolsMerge.locale.en-US.yaml
@@ -1,0 +1,59 @@
+# Created with winget-create
+# https://github.com/microsoft/winget-create
+PackageIdentifier: RvToolsMerge.RvToolsMerge
+PackageVersion: 1.4.2
+PackageLocale: en-US
+Publisher: Stefan Broenner
+PublisherUrl: https://github.com/sbroenne
+PublisherSupportUrl: https://github.com/sbroenne/RVToolsMerge/issues
+Author: Stefan Broenner
+PackageName: RVToolsMerge
+PackageUrl: https://github.com/sbroenne/RVToolsMerge
+License: MIT
+LicenseUrl: https://github.com/sbroenne/RVToolsMerge/blob/main/LICENSE
+Copyright: Copyright (c) 2025 Stefan Broenner
+CopyrightUrl: https://github.com/sbroenne/RVToolsMerge/blob/main/LICENSE
+ShortDescription: A command-line tool to merge multiple RVTools Excel files into a single consolidated file
+Description: |-
+  RVToolsMerge is a command-line application for merging one or multiple RVTools export files into a single consolidated file.
+
+  Key Features:
+
+  - Intelligent Sheet Handling: Combines multiple RVTools exports while validating required sheets and columns
+  - Flexible Processing Options: Process single files or entire directories with configurable validation rules
+  - Complete Data Anonymization: Replace sensitive identifiers (VM names, IPs, hosts, clusters) with generic equivalents while maintaining data relationships
+  - Data Protection Features: Mandatory-columns-only mode and minimal data exposure for sharing with external parties
+  - Azure Migrate Validation: Built-in validation for Azure Migrate requirements with detailed reporting
+  - Source Tracking: Optional inclusion of source file information for data lineage
+  - Advanced Filtering: Skip invalid files, ignore missing sheets, exclude empty values
+  - Rich Console Experience: Beautiful console output with progress bars, status indicators, and colorful tables
+
+  Perfect for VMware administrators managing multiple vCenter environments who need to consolidate RVTools data for reporting, analysis, and Azure migration planning through automated command-line workflows.
+Moniker: rvtoolsmerge
+Tags:
+- vmware
+- rvtools
+- excel
+- merge
+- virtualization
+- infrastructure
+- vcenter
+- consolidation
+- automation
+- anonymization
+- azure-migrate
+- data-protection
+ReleaseNotes: |-
+  See the full release notes at: https://github.com/sbroenne/RVToolsMerge/releases/tag/v1.4.2
+ReleaseNotesUrl: https://github.com/sbroenne/RVToolsMerge/releases/tag/v1.4.2
+PurchaseUrl: https://github.com/sbroenne/RVToolsMerge
+InstallationNotes: |-
+  After installation, RVToolsMerge will be available as a command-line tool. Run 'rvtoolsmerge --help' or 'RVToolsMerge --help' to see all available options including anonymization, Azure Migrate validation, and advanced processing features.
+Documentations:
+- DocumentLabel: User Guide
+  DocumentUrl: https://github.com/sbroenne/RVToolsMerge/blob/main/README.md
+- DocumentLabel: Contributing Guidelines
+  DocumentUrl: https://github.com/sbroenne/RVToolsMerge/blob/main/CONTRIBUTING.md
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0
+

--- a/manifests/r/RvToolsMerge/RvToolsMerge/1.4.2/RvToolsMerge.RvToolsMerge.yaml
+++ b/manifests/r/RvToolsMerge/RvToolsMerge/1.4.2/RvToolsMerge.RvToolsMerge.yaml
@@ -1,7 +1,7 @@
 # Created with winget-create
 # https://github.com/microsoft/winget-create
 PackageIdentifier: RvToolsMerge.RvToolsMerge
-PackageVersion: 1.4.2
+PackageVersion: 1.4.2.0
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.6.0

--- a/manifests/r/RvToolsMerge/RvToolsMerge/1.4.2/RvToolsMerge.RvToolsMerge.yaml
+++ b/manifests/r/RvToolsMerge/RvToolsMerge/1.4.2/RvToolsMerge.RvToolsMerge.yaml
@@ -1,0 +1,7 @@
+# Created with winget-create
+# https://github.com/microsoft/winget-create
+PackageIdentifier: RvToolsMerge.RvToolsMerge
+PackageVersion: 1.4.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
This submission adds RvToolsMerge version 1.4.2 to the Windows Package Manager repository.

Package ID: RvToolsMerge.RvToolsMerge
Version: 1.4.2

Release URL: https://github.com/sbroenne/RvToolsMerge/releases/tag/v1.4.2

I have now fixed the missing ProducCode information in the manifest.

Checklist for Pull Requests
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?

Manifests
- [ X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] This PR only modifies one (1) manifest
- [X] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [X] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/270687)