### PR TITLE
Added 1 tag: RODE.RODECasterVirtualDeviceDriver version 1.0.1

### DIFF
--- a/manifests/r/RODE/RODECasterVirtualDeviceDriver/1.0.1/RODE.RODECasterVirtualDeviceDriver.locale.en-US.yaml
+++ b/manifests/r/RODE/RODECasterVirtualDeviceDriver/1.0.1/RODE.RODECasterVirtualDeviceDriver.locale.en-US.yaml
@@ -8,5 +8,7 @@ Publisher: RØDE Microphones
 PackageName: RØDECaster Virtual Device Driver
 License: Proprietary
 ShortDescription: Driver for the virtual devices of the Rodecaster.
+Tags:
+- rodecastervad.inf
 ManifestType: defaultLocale
 ManifestVersion: 1.9.0


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---
Notes from me:
* The logic behind adding the extra tag, is that when people search for the driver's INF name (`rodecastervad.inf`) in search engines (Bing, Qwant, etc.), there'll be a non-zero chance that Winget-related pages will show up higher in search results.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/270782)