### PR TITLE
Update: univrsal.input-overlay 5.0.6.

### DIFF
--- a/manifests/u/univrsal/input-overlay/5.0.6/univrsal.input-overlay.installer.yaml
+++ b/manifests/u/univrsal/input-overlay/5.0.6/univrsal.input-overlay.installer.yaml
@@ -1,0 +1,17 @@
+# Created using wingetcreate 1.9.14.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: univrsal.input-overlay
+PackageVersion: 5.0.6
+InstallerType: inno
+UpgradeBehavior: install
+ReleaseDate: 2024-10-25
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/univrsal/input-overlay/releases/download/5.0.6/input-overlay-5.0.6-windows-x64-Installer.exe
+  InstallerSha256: 4440662160379af26623798a493a167276caa9703eb3b12041699d6b7d3df28d
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/u/univrsal/input-overlay/5.0.6/univrsal.input-overlay.locale.en-US.yaml
+++ b/manifests/u/univrsal/input-overlay/5.0.6/univrsal.input-overlay.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created using wingetcreate 1.9.14.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: univrsal.input-overlay
+PackageVersion: 5.0.6
+PackageLocale: en-US
+Publisher: univrsal
+PublisherUrl: https://github.com/univrsal
+PublisherSupportUrl: https://github.com/univrsal/input-overlay/issues
+PackageName: input-overlay
+PackageUrl: https://github.com/univrsal/input-overlay
+License: GPL-2.0
+LicenseUrl: https://github.com/univrsal/input-overlay/blob/master/LICENSE
+ShortDescription: Show keyboard, gamepad and mouse input on stream
+ReleaseNotesUrl: https://github.com/univrsal/input-overlay/releases/tag/5.0.6
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/u/univrsal/input-overlay/5.0.6/univrsal.input-overlay.yaml
+++ b/manifests/u/univrsal/input-overlay/5.0.6/univrsal.input-overlay.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.9.14.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: univrsal.input-overlay
+PackageVersion: 5.0.6
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Note: x86 installer is dropped in this version.

---

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/272037)