### PR TITLE
Move Microsoft.WindowsSDK.10.0.x to correct PackageVersion with DisplayVersion

### DIFF
--- a/manifests/m/Microsoft/WindowsSDK/10/0/26100/10.0.26100.1742/Microsoft.WindowsSDK.10.0.26100.installer.yaml
+++ b/manifests/m/Microsoft/WindowsSDK/10/0/26100/10.0.26100.1742/Microsoft.WindowsSDK.10.0.26100.installer.yaml
@@ -1,0 +1,20 @@
+# Created with YamlCreate.ps1 v2.4.6 $debug=AUSU.CRLF.7-5-2.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: Microsoft.WindowsSDK.10.0.26100
+PackageVersion: 10.0.26100.1742
+MinimumOSVersion: 10.0.0.0
+InstallerType: burn
+InstallerSwitches:
+  Silent: /q
+  SilentWithProgress: /q
+  Log: ' '
+UpgradeBehavior: uninstallPrevious
+AppsAndFeaturesEntries:
+- DisplayVersion: 10.1.26100.1742
+Installers:
+- Architecture: x86
+  InstallerUrl: https://download.microsoft.com/download/e/b/3/eb320eb1-b21e-4e6e-899e-d6aec552ecb0/KIT_BUNDLE_WINDOWSSDK_MEDIACREATION/winsdksetup.exe
+  InstallerSha256: A8E6B6CC2DCEC9FDD4C35553A4CBF288C9CE5E4761D7A2762F06A3A95F1E530D
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/m/Microsoft/WindowsSDK/10/0/26100/10.0.26100.1742/Microsoft.WindowsSDK.10.0.26100.locale.en-US.yaml
+++ b/manifests/m/Microsoft/WindowsSDK/10/0/26100/10.0.26100.1742/Microsoft.WindowsSDK.10.0.26100.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# Created with YamlCreate.ps1 v2.4.6 $debug=AUSU.CRLF.7-5-2.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: Microsoft.WindowsSDK.10.0.26100
+PackageVersion: 10.0.26100.1742
+PackageLocale: en-US
+Publisher: Microsoft Corporation
+PublisherUrl: https://www.microsoft.com/en-us/
+PublisherSupportUrl: https://support.microsoft.com/en-us
+PrivacyUrl: https://privacy.microsoft.com/en-us/privacystatement
+Author: Microsoft Corporation
+PackageName: Windows Software Development Kit - Windows 10.0.26100.1742
+# PackageUrl:
+License: Proprietary
+# LicenseUrl:
+Copyright: Copyright (c) Microsoft Corporation. All rights reserved.
+# CopyrightUrl:
+ShortDescription: The Windows Software Development Kit (10.1.26100.1742) for Windows 11 provides the latest headers, libraries, metadata, and tools for building Windows apps.
+# Description:
+# Moniker:
+# Tags:
+# ReleaseNotes:
+# ReleaseNotesUrl:
+# PurchaseUrl:
+# InstallationNotes:
+# Documentations:
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/m/Microsoft/WindowsSDK/10/0/26100/10.0.26100.1742/Microsoft.WindowsSDK.10.0.26100.yaml
+++ b/manifests/m/Microsoft/WindowsSDK/10/0/26100/10.0.26100.1742/Microsoft.WindowsSDK.10.0.26100.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.4.6 $debug=AUSU.CRLF.7-5-2.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: Microsoft.WindowsSDK.10.0.26100
+PackageVersion: 10.0.26100.1742
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?
  - Fixes an issue noticed by @denelon

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

```
PS E:\winget-pkgs> Get-ARPTable | ? { $_.DisplayName -match 'Windows Software Development' } | ft

DisplayName                                                DisplayVersion  Publisher             ProductCode                            Scope
-----------                                                --------------  ---------             -----------                            -----
Windows Software Development Kit - Windows 10.0.26100.1742 10.1.26100.1742 Microsoft Corporation {8f220346-a8e7-401e-81b8-a0c5d7308086} Machine
```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/272139)