### PR TITLE
Update MathWorks.MATLABRuntime.installer.yaml

### DIFF
--- a/manifests/m/MathWorks/MATLABRuntime/25.1/MathWorks.MATLABRuntime.installer.yaml
+++ b/manifests/m/MathWorks/MATLABRuntime/25.1/MathWorks.MATLABRuntime.installer.yaml
@@ -17,6 +17,7 @@ InstallerSwitches:
   InstallLocation: -destinationFolder "<INSTALLPATH>"
   Log: -outputFile "<LOGPATH>"
   Custom: -agreeToLicense yes
+RequireExplicitUpgrade: true
 ProductCode: MATLAB Runtime R2025a
 Installers:
 - Architecture: x64


### PR DESCRIPTION
New Matlab Runtime versions are not updating the installed versions, and are not needed for user's installed applications, only for future/other applications.

"RequireExplicitUpgrade" should be "true", to avoid undesired behaviour.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/273202)