### PR TITLE
Update manifest: Oven-sh.Bun version 1.2.18

### DIFF
--- a/manifests/o/Oven-sh/Bun/1.2.18/Oven-sh.Bun.installer.yaml
+++ b/manifests/o/Oven-sh/Bun/1.2.18/Oven-sh.Bun.installer.yaml
@@ -7,6 +7,9 @@ InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
 - RelativeFilePath: bun-windows-x64/bun.exe
+  PortableCommandAlias: bun
+- RelativeFilePath: ./bun-windows-x64/bun.exe
+  PortableCommandAlias: bunx
 Dependencies:
   PackageDependencies:
   - PackageIdentifier: Microsoft.VCRedist.2015+.x64


### PR DESCRIPTION
## Checklist for Pull Requests

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Resolve #272725 

## Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

## Manual validation

<details><summary>Installation logs</summary><p>

```text
--> Injecting proxy settings from the host with Windows Registry


ProxyEnable   : 1
ProxyServer   : http://alist.dragon1573.local:57890
ProxyOverride : <local>,*.local,*.cn



--> Installing WinGet
--> Disabling safety warning when running installers
Tip: you can type 'Update-EnvironmentVariables' to update your environment variables, such as after installing a new software.

--> Configuring Winget
已启用管理员设置 'LocalManifestFiles'。
已启用管理员设置 'LocalArchiveMalwareScanOverride'。
已启用管理员设置 'ProxyCommandLineOptions'。
将管理员设置 'DefaultProxy' 设置为 'http://alist.dragon1573.local:57890'。

--> Installing the Manifest 1.2.18

已找到 Bun [Oven-sh.Bun] 版本 1.2.18
此应用程序由其所有者授权给你。
Microsoft 对第三方程序包概不负责，也不向第三方程序包授予任何许可证。
此包需要以下依赖项：
  - 程序包
      Microsoft.VCRedist.2015+.x64
(1/1) 已找到 Microsoft Visual C++ 2015-2022 Redistributable (x64) [Microsoft.VCRedist.2015+.x64] 版本 14.44.35211.0
此应用程序由其所有者授权给你。
Microsoft 对第三方程序包概不负责，也不向第三方程序包授予任何许可证。
正在下载 https://download.visualstudio.microsoft.com/download/pr/73aabf2e-9532-4f68-99f7-3247081a619c/CC0FF0EB1DC3F5188AE6300FAEF32BF5BEEBA4BDD6E8E445A9184072096B713B/VC_redist.x64.exe
  ██████████████████████████████  24.4 MB / 24.4 MB
已成功验证安装程序哈希
正在启动程序包安装...
已成功安装

正在下载 https://github.com/oven-sh/bun/releases/download/bun-v1.2.18/bun-windows-x64.zip
  ██████████████████████████████  39.0 MB / 39.0 MB
已成功验证安装程序哈希
正在提取存档...
已成功提取存档
正在启动程序包安装...
添加了命令行别名： "bun"
添加了命令行别名： "bunx"
已修改路径环境变量；重启 shell 以使用新值。
已成功安装
注意: If you face issues running the package, it might be because your CPU does not support AVX2 instruction set.
In that case, try installing the package 'Oven-sh.Bun.Baseline' instead.

--> Refreshing environment variables

--> Comparing ARP Entries


DisplayName    : Microsoft Visual C++ 2015-2022 Redistributable (x64) - 14.44.35211
DisplayVersion : 14.44.35211.0
Publisher      : Microsoft Corporation
ProductCode    : {d8bbe9f9-7c5b-42c6-b715-9ee898a2e515}
Scope          : Machine

DisplayName    : Bun
DisplayVersion : 1.2.18
Publisher      : Oven-sh
ProductCode    : Oven-sh.Bun__DefaultSource
Scope          : User
```

</p></details>
<details><summary>Validation logs</summary><p>

```text
PS C:\Users\WDAGUtilityAccount\Desktop\winget-pkgs> bun.exe --version
1.2.18

PS C:\Users\WDAGUtilityAccount\Desktop\winget-pkgs> bunx.exe --version
1.2.18
```

</p></details>

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/273437)