### PR TITLE
GAI.GAI update version 1.2.1, date:250726

### DIFF
--- a/manifests/g/GAI/GAI/1.2.1/GAI.GAI.installer.yaml
+++ b/manifests/g/GAI/GAI/1.2.1/GAI.GAI.installer.yaml
@@ -1,0 +1,28 @@
+# Created with komac v2.10.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: GAI.GAI
+PackageVersion: 1.2.1
+InstallerLocale: en-US
+InstallerType: inno
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Custom: /ALLUSERS
+UpgradeBehavior: install
+ProductCode: '{59470D0E-4D60-465A-A8A4-D04521F250B2}_is1'
+ReleaseDate: 2025-07-27
+AppsAndFeaturesEntries:
+- ProductCode: '{59470D0E-4D60-465A-A8A4-D04521F250B2}_is1'
+ElevationRequirement: elevatesSelf
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles%\Gai'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://webpath.iche2.com/release/Gai-1.2.1-Setup.exe
+  InstallerSha256: 579a60d78cc4400eb7a616ad5feedc1db426eedda503a1c107bd9c844795373c
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/g/GAI/GAI/1.2.1/GAI.GAI.locale.en-US.yaml
+++ b/manifests/g/GAI/GAI/1.2.1/GAI.GAI.locale.en-US.yaml
@@ -1,0 +1,40 @@
+# Created with komac v2.10.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: GAI.GAI
+PackageVersion: 1.2.1
+PackageLocale: en-US
+Publisher: Heshan Aisipai E-commerce Co., Ltd.
+PublisherUrl: https://webpath.iche2.com/gaidoc/en/
+PackageName: Gai
+PackageUrl: https://webpath.iche2.com/app/gai/download_en.html
+License: Proprietary
+ShortDescription: Generative-AI Tools For Beginner
+Description: |-
+  No ads, No registration, No other permissions required. Internet connection only.
+
+  - Multimodal conversations: Text, images, videos – easily get the content you need.
+  - User-friendly interface: Conveniently manage prompts, instructions, parameters, and input/output.
+  - Scheduled Tasks: Pre-set time, automatically generate content.
+  - Private prompt libraries: Support offline/online prompt libraries.
+  - Multiple output options: Local logs or your private network server.
+
+  Full-featured, customizable, and easy to master!
+# Moniker:
+Tags:
+- ai
+- openai
+- gpt
+- chatgpt
+- gemini
+- imagen
+ReleaseNotes: |-
+  - upgrade model imagen-3.0-generate-001 to 002.
+  - support Gemini 2.5 Flash dynamic thinking.
+  - support Gemini 2.0 Flash preview image generation.
+  - http job, new option, sendmail on task failure only.
+  - fix bug http job auto-start on app launch.
+  - fix bug history attachment save to local direcotry.
+  - fix bug imagen save to local file.
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/g/GAI/GAI/1.2.1/GAI.GAI.locale.zh-CN.yaml
+++ b/manifests/g/GAI/GAI/1.2.1/GAI.GAI.locale.zh-CN.yaml
@@ -1,0 +1,40 @@
+# Created with komac v2.10.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: GAI.GAI
+PackageVersion: 1.2.1
+PackageLocale: zh-CN
+Publisher: Heshan Aisipai E-commerce Co., Ltd.
+PublisherUrl: https://webpath.iche2.com/gaidoc/zh/
+PackageName: Gai
+PackageUrl: https://webpath.iche2.com/app/gai/download_zh.html
+License: Proprietary
+ShortDescription: Generative-AI Tools For Beginner
+Description: |-
+  无广告、免注册、零权限，联网即用。
+
+  - 多模态对话：文本、图像、音视频，轻松获取所需内容。
+  - 界面友好：便捷管理提示词、指令、参数及输入输出。
+  - 定时任务：预设时间，自动生成内容。
+  - 私有提示词库：支持离线/联网提示词库。
+  - 多种输出方式：本地日志或私有网络服务器。
+
+  全功能开放，调参自由，轻松进阶！
+# Moniker:
+Tags:
+- ai
+- openai
+- gpt
+- chatgpt
+- gemini
+- imagen
+ReleaseNotes: |-
+  - upgrade model imagen-3.0-generate-001 to 002.
+  - support Gemini 2.5 Flash dynamic thinking.
+  - support Gemini 2.0 Flash preview image generation.
+  - http job, new option, sendmail on task failure only.
+  - fix bug http job auto-start on app launch.
+  - fix bug history attachment save to local direcotry.
+  - fix bug imagen save to local file.
+ManifestType: locale
+ManifestVersion: 1.9.0

--- a/manifests/g/GAI/GAI/1.2.1/GAI.GAI.yaml
+++ b/manifests/g/GAI/GAI/1.2.1/GAI.GAI.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.10.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: GAI.GAI
+PackageVersion: 1.2.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
  - upgrade model imagen-3.0-generate-001 to 002.
  - support Gemini 2.5 Flash dynamic thinking.
  - support Gemini 2.0 Flash preview image generation.
  - http job, new option, sendmail on task failure only.
  - fix bug http job auto-start on app launch.
  - fix bug history attachment save to local direcotry.
  - fix bug imagen save to local file.

Checklist for Pull Requests
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] This PR only modifies one (1) manifest
- [X] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [X] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/278017)