### PR TITLE
New package: LargeAddressAware.laa version 2.0.4

### DIFF
--- a/manifests/l/LargeAddressAware/laa/2.0.4/LargeAddressAware.laa.installer.yaml
+++ b/manifests/l/LargeAddressAware/laa/2.0.4/LargeAddressAware.laa.installer.yaml
@@ -1,0 +1,17 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: LargeAddressAware.laa
+PackageVersion: 2.0.4
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: Large Address Aware.exe
+  PortableCommandAlias: largeaddressaware
+ArchiveBinariesDependOnPath: true
+Installers:
+- Architecture: x86
+  InstallerUrl: https://www.techpowerup.com/forums/attachments/laa_2_0_4-zip.34392/
+  InstallerSha256: 456336DD0B8D41DC79EE5B8766353354B0DCC2BB216845AC831149077B2D463A
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/l/LargeAddressAware/laa/2.0.4/LargeAddressAware.laa.installer.yaml
+++ b/manifests/l/LargeAddressAware/laa/2.0.4/LargeAddressAware.laa.installer.yaml
@@ -13,5 +13,8 @@ Installers:
 - Architecture: x86
   InstallerUrl: https://www.techpowerup.com/forums/attachments/laa_2_0_4-zip.34392/
   InstallerSha256: 456336DD0B8D41DC79EE5B8766353354B0DCC2BB216845AC831149077B2D463A
+Dependencies:
+  WindowsFeatures:
+  - netfx3
 ManifestType: installer
 ManifestVersion: 1.10.0

--- a/manifests/l/LargeAddressAware/laa/2.0.4/LargeAddressAware.laa.locale.en-US.yaml
+++ b/manifests/l/LargeAddressAware/laa/2.0.4/LargeAddressAware.laa.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: LargeAddressAware.laa
+PackageVersion: 2.0.4
+PackageLocale: en-US
+Publisher: FordGT90Concept on TechPowerUp
+PackageName: Large Address Aware
+PackageUrl: https://www.techpowerup.com/forums/threads/large-address-aware.112556/
+License: Unclear (Source code is publicly available but does not state a license)
+ShortDescription: An application that assists in making 32-bit programs Large Address Aware and can then access up to 4 GiB on x64 OS versions, and all memory that isn't used by the OS or other applications on x86 OS versions.
+Tags:
+- 4gb
+- 4gib
+- gamemodding
+- ram
+- randomaccessmemory
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/l/LargeAddressAware/laa/2.0.4/LargeAddressAware.laa.yaml
+++ b/manifests/l/LargeAddressAware/laa/2.0.4/LargeAddressAware.laa.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: LargeAddressAware.laa
+PackageVersion: 2.0.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Is there a linked Issue? (#277592 sort-of)

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---
Notes from me:
* While the program serves the same goal as #277592, it can somewhat more easily handle more than one EXE at once, and is also able to detect whether the "Large address aware" flag has already been turned on for an EXE previously or not.
* A handful of programs (incl. CyberLink PowerDVD 16) don't work if the flag is set to true, but I couldn't find anywhere in the manifest(s) to mention such a note.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/278583)