### PR TITLE
Update manifest: RustDesk.RustDesk version 1.4.1

### DIFF
--- a/manifests/r/RustDesk/RustDesk/1.4.1/RustDesk.RustDesk.installer.yaml
+++ b/manifests/r/RustDesk/RustDesk/1.4.1/RustDesk.RustDesk.installer.yaml
@@ -1,4 +1,4 @@
-# Created with WinGet Releaser using komac v2.12.1
+# Created with komac v2.12.1
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
 
 PackageIdentifier: RustDesk.RustDesk
@@ -13,13 +13,13 @@ InstallerSwitches:
   SilentWithProgress: --silent-install
   Interactive: --install
 UpgradeBehavior: install
-ReleaseDate: 2025-07-23
+ReleaseDate: 2025-07-29
 Installers:
 - Architecture: x86
   InstallerUrl: https://github.com/rustdesk/rustdesk/releases/download/1.4.1/rustdesk-1.4.1-x86-sciter.exe
-  InstallerSha256: 7E8C9320B6D8A475198EBB87BEC2CB2372B7F6D8194383FCE331CDB8DF77B569
+  InstallerSha256: 76720E622E36BC36A1E594D706F2ABC3647931BA59709D2BA9DC15D0354314BE
 - Architecture: x64
   InstallerUrl: https://github.com/rustdesk/rustdesk/releases/download/1.4.1/rustdesk-1.4.1-x86_64.exe
-  InstallerSha256: 24D753A7E494C5234D854578BC3D8A8EC42D6A220C227A0264980893674D71E6
+  InstallerSha256: BA5AF57AFC8E97381AF7201EE35B202AA62F5B162863D9135A3A8908F32FF08A
 ManifestType: installer
 ManifestVersion: 1.10.0

--- a/manifests/r/RustDesk/RustDesk/1.4.1/RustDesk.RustDesk.locale.en-US.yaml
+++ b/manifests/r/RustDesk/RustDesk/1.4.1/RustDesk.RustDesk.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# Created with WinGet Releaser using komac v2.12.1
+# Created with komac v2.12.1
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
 
 PackageIdentifier: RustDesk.RustDesk
@@ -42,15 +42,16 @@ ReleaseNotes: |-
   Changelog
   Changelog
   Added
-  - Numberic one time password option
-  - Enable force-always-relay option in address books and accessible devices
+  - Terminal
   - UDP and IPv6 Punch
   - Stylus
-  - Terminal
+  - Numberic one time password option
+  - Enable force-always-relay option in address books and accessible devices
   Changes
   - Force secure tcp for login session rather than ignoring timeout
   - clear the accessible devices tab when retrieving accessible devices disabled #11913
   - Improve sas
+  - Shorten retry time (from 18s to 3s) for some network error in rendezvous mediator to make reboot connection faster
   Fixes
   - macOS resolution list for Retina to solve the problem of unexpected resolution change after disconnection
   - Can not input password if lock screen via RustDesk on macOS #11802
@@ -73,6 +74,7 @@ ReleaseNotes: |-
   - win, only start tray if is installed exe #11737
   - High CPU on MacOS when the service is Stop #12233
   - rustdesk.service cause high CPU usage when idle #11157
+  - Print output truncated at bottom and right side #11410
 ReleaseNotesUrl: https://github.com/rustdesk/rustdesk/releases/tag/1.4.1
 PurchaseUrl: https://rustdesk.com/pricing.html
 Documentations:

--- a/manifests/r/RustDesk/RustDesk/1.4.1/RustDesk.RustDesk.locale.zh-CN.yaml
+++ b/manifests/r/RustDesk/RustDesk/1.4.1/RustDesk.RustDesk.locale.zh-CN.yaml
@@ -1,4 +1,4 @@
-# Created with WinGet Releaser using komac v2.12.1
+# Created with komac v2.12.1
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.10.0.schema.json
 
 PackageIdentifier: RustDesk.RustDesk

--- a/manifests/r/RustDesk/RustDesk/1.4.1/RustDesk.RustDesk.yaml
+++ b/manifests/r/RustDesk/RustDesk/1.4.1/RustDesk.RustDesk.yaml
@@ -1,4 +1,4 @@
-# Created with WinGet Releaser using komac v2.12.1
+# Created with komac v2.12.1
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
 
 PackageIdentifier: RustDesk.RustDesk


### PR DESCRIPTION
## What's changed

- Update installer URLs and SHA256 checksums for both `x86` and `x64` architectures
- Correct release date from `2025-07-23` to `2025-07-29`
- Update release notes with new changes and fixes

## Checklist for Pull Requests

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Resolve #256206

## Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/278739)