### PR TITLE
2nd attempt at a Norwegian locale: Microsoft.MaliciousSoftwareRemovalTool version 5.134.25060.1001

### DIFF
--- a/manifests/m/Microsoft/MaliciousSoftwareRemovalTool/5.134.25060.1001/Microsoft.MaliciousSoftwareRemovalTool.locale.nb.yaml
+++ b/manifests/m/Microsoft/MaliciousSoftwareRemovalTool/5.134.25060.1001/Microsoft.MaliciousSoftwareRemovalTool.locale.nb.yaml
@@ -1,0 +1,19 @@
+# Created using wingetcreate 1.9.14.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.9.0.schema.json
+
+PackageIdentifier: Microsoft.MaliciousSoftwareRemovalTool
+PackageVersion: "5.134.25060.1001"
+PackageLocale: nb
+Publisher: Microsoft
+PackageName: Verktøy for fjerning av skadelig programvare
+License: Proprietary
+Copyright: © Microsoft Corporation. Alle rettigheter forbeholdt.
+ShortDescription: Verktøy for å manuelt kjøre Windows sine månedlige oppdateringers sjekking etter ondsinnede programmer.
+Tags:
+- malware
+- skadevare
+- antivirus
+- msrt
+- kb890830
+ManifestType: locale
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Is there a linked Issue? (#277273)

Manifests
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---
Notes from me:
* My goal was to get it to show in `winget list` with the Norwegian title. While my 1st attempt got `winget show Microsoft.MaliciousSoftwareRemovalTool` to work, it did not get `winget search Microsoft.MaliciousSoftwareRemovalTool` to work. However, I noticed by chance this morning with `Get-WinUserLanguageList` that the locale in question is apparently simply `nb` and not `nb-NO`, so here's my 2nd attempt.