### PR TITLE
Add Machine Scope to DotNet Runtime Installer

### DIFF
--- a/manifests/m/Microsoft/DotNet/Runtime/8/8.0.8/Microsoft.DotNet.Runtime.8.installer.yaml
+++ b/manifests/m/Microsoft/DotNet/Runtime/8/8.0.8/Microsoft.DotNet.Runtime.8.installer.yaml
@@ -4,6 +4,7 @@
 PackageIdentifier: Microsoft.DotNet.Runtime.8
 PackageVersion: 8.0.8
 MinimumOSVersion: 6.1.7601
+Scope: machine
 InstallerSwitches:
   Silent: /quiet
   SilentWithProgress: /passive

--- a/manifests/m/Microsoft/DotNet/SDK/8/8.0.413/Microsoft.DotNet.SDK.8.installer.yaml
+++ b/manifests/m/Microsoft/DotNet/SDK/8/8.0.413/Microsoft.DotNet.SDK.8.installer.yaml
@@ -4,7 +4,6 @@
 PackageIdentifier: Microsoft.DotNet.SDK.8
 PackageVersion: 8.0.413
 MinimumOSVersion: 6.1.7601
-Scope: machine
 InstallerSwitches:
   Silent: /quiet
   SilentWithProgress: /passive

--- a/manifests/m/Microsoft/DotNet/SDK/8/8.0.413/Microsoft.DotNet.SDK.8.installer.yaml
+++ b/manifests/m/Microsoft/DotNet/SDK/8/8.0.413/Microsoft.DotNet.SDK.8.installer.yaml
@@ -4,6 +4,7 @@
 PackageIdentifier: Microsoft.DotNet.SDK.8
 PackageVersion: 8.0.413
 MinimumOSVersion: 6.1.7601
+Scope: machine
 InstallerSwitches:
   Silent: /quiet
   SilentWithProgress: /passive


### PR DESCRIPTION
Allows for installation with `--scope machine` argument.

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/284182)