### PR TITLE
New package: bloodrock.pkg-config-lite version 0.28-1

### DIFF
--- a/manifests/b/bloodrock/pkg-config-lite/0.28-1/bloodrock.pkg-config-lite.installer.yaml
+++ b/manifests/b/bloodrock/pkg-config-lite/0.28-1/bloodrock.pkg-config-lite.installer.yaml
@@ -1,0 +1,16 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: bloodrock.pkg-config-lite
+PackageVersion: 0.28-1
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: pkg-config-lite-0.28-1\bin\pkg-config.exe
+Installers:
+- Architecture: x86
+  InstallerUrl: https://sourceforge.net/projects/pkgconfiglite/files/0.28-1/pkg-config-lite-0.28-1_bin-win32.zip/download
+  InstallerSha256: 2038C49D23B5CA19E2218CA89F06DF18FE6D870B4C6B54C0498548EF88771F6F
+ManifestType: installer
+ManifestVersion: 1.10.0
+ReleaseDate: 2013-01-26

--- a/manifests/b/bloodrock/pkg-config-lite/0.28-1/bloodrock.pkg-config-lite.locale.en-US.yaml
+++ b/manifests/b/bloodrock/pkg-config-lite/0.28-1/bloodrock.pkg-config-lite.locale.en-US.yaml
@@ -1,0 +1,18 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: bloodrock.pkg-config-lite
+PackageVersion: 0.28-1
+PackageLocale: en-US
+Publisher: bloodrock
+PublisherUrl: https://sourceforge.net/u/bloodrock/profile/
+PublisherSupportUrl: https://sourceforge.net/projects/pkgconfiglite/support
+Author: bloodrock
+PackageName: Pkg Config Lite
+PackageUrl: https://sourceforge.net/projects/pkgconfiglite/
+License: GPLv2
+ShortDescription: pkg-config-lite is based on pkg-config, but is built with a glib code snippet which eliminates the glib dependency, so it is possible once again to build and run pkg-config without dependencies.
+ReleaseNotes: Applied all changes from pkg-config-0.28 (see NEWS).
+ReleaseNotesUrl: https://sourceforge.net/projects/pkgconfiglite/files/0.28-1/
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/b/bloodrock/pkg-config-lite/0.28-1/bloodrock.pkg-config-lite.yaml
+++ b/manifests/b/bloodrock/pkg-config-lite/0.28-1/bloodrock.pkg-config-lite.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: bloodrock.pkg-config-lite
+PackageVersion: 0.28-1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Revert "Remove version: bloodrock.pkg-config-lite version 0.28-1 (#181625)"

This reverts commit 85beb94f9140834be1aabdd7ed2d7bcb7d858990.

With InstallerUrl update to
https://sourceforge.net/projects/pkgconfiglite/files/0.28-1/pkg-config-lite-0.28-1_bin-win32.zip/download

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---
Closes: https://github.com/microsoft/winget-pkgs/issues/123550
Building mesa needs this.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/284186)