### PR TITLE
New package: x64dbg.x64dbg version 2025.08.19

### DIFF
--- a/manifests/x/x64dbg/x64dbg/2025.08.19/x64dbg.x64dbg.installer.yaml
+++ b/manifests/x/x64dbg/x64dbg/2025.08.19/x64dbg.x64dbg.installer.yaml
@@ -1,0 +1,39 @@
+# Created with komac v2.10.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: x64dbg.x64dbg
+PackageVersion: 2025.08.19
+InstallerType: zip
+NestedInstallerType: portable
+ArchiveBinariesDependOnPath: true
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Commands:
+  - x96dbg
+  - x32dbg
+  - x64dbg
+ReleaseDate: 2025-08-19
+Installers:
+  - Architecture: x86
+    InstallerUrl: https://github.com/x64dbg/x64dbg/releases/download/2025.08.19/snapshot_2025-08-19_19-40.zip
+    InstallerSha256: CC614CAF34F9FE1EC156F045129DB3A513C35593FF1EE647BC819A352DC12271
+    NestedInstallerFiles:
+      - RelativeFilePath: release\x96dbg.exe
+        PortableCommandAlias: x96dbg
+      - RelativeFilePath: release\x32\x32dbg.exe
+        PortableCommandAlias: x32dbg
+  - Architecture: x64
+    InstallerUrl: https://github.com/x64dbg/x64dbg/releases/download/2025.08.19/snapshot_2025-08-19_19-40.zip
+    InstallerSha256: CC614CAF34F9FE1EC156F045129DB3A513C35593FF1EE647BC819A352DC12271
+    NestedInstallerFiles:
+      - RelativeFilePath: release\x96dbg.exe
+        PortableCommandAlias: x96dbg
+      - RelativeFilePath: release\x32\x32dbg.exe
+        PortableCommandAlias: x32dbg
+      - RelativeFilePath: release\x64\x64dbg.exe
+        PortableCommandAlias: x64dbg
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/x/x64dbg/x64dbg/2025.08.19/x64dbg.x64dbg.locale.en-US.yaml
+++ b/manifests/x/x64dbg/x64dbg/2025.08.19/x64dbg.x64dbg.locale.en-US.yaml
@@ -1,0 +1,18 @@
+# Created with komac v2.10.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: x64dbg.x64dbg
+PackageVersion: 2025.08.19
+PackageLocale: en-US
+Publisher: x64dbg
+PublisherUrl: https://github.com/x64dbg
+PublisherSupportUrl: https://github.com/x64dbg/x64dbg/issues
+PackageName: x64dbg
+PackageUrl: https://github.com/x64dbg/x64dbg
+License: GPL-3.0 (Modified)
+LicenseUrl: https://github.com/x64dbg/x64dbg/blob/development/LICENSE
+ShortDescription: An open-source user mode debugger for Windows. Optimized for reverse engineering and malware analysis.
+Description: An open-source binary debugger for Windows, aimed at malware analysis and reverse engineering of executables you do not have the source code for.
+ReleaseNotesUrl: https://github.com/x64dbg/x64dbg/releases/tag/2025.08.19
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/x/x64dbg/x64dbg/2025.08.19/x64dbg.x64dbg.yaml
+++ b/manifests/x/x64dbg/x64dbg/2025.08.19/x64dbg.x64dbg.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.10.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: x64dbg.x64dbg
+PackageVersion: 2025.08.19
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

This has been adjusted based on https://github.com/microsoft/winget-pkgs/pull/233392, but that PR was missing the `x32dbg` and `x96dbg` commands when installing on amd64.