### PR TITLE
Fixed Incorrect Architecture Installer URL

### DIFF
--- a/manifests/a/AppByTroye/KoodoReader/2.1.1/AppByTroye.KoodoReader.installer.yaml
+++ b/manifests/a/AppByTroye/KoodoReader/2.1.1/AppByTroye.KoodoReader.installer.yaml
@@ -22,15 +22,16 @@ ReleaseDate: 2025-08-17
 Installers:
 - Architecture: x64
   Scope: user
-  InstallerUrl: https://dl.koodoreader.com/v2.1.1/Koodo-Reader-2.1.1-arm64.exe
-  InstallerSha256: D10910529B99FDE4452927AA4A6FCE7012D744A9939E82906052F811C1B94104
+  InstallerUrl: https://dl.koodoreader.com/v2.1.1/Koodo-Reader-2.1.1-x64.exe
+  InstallerSha256: 5BBA9B874C1E0370836171ECA76ED6BE125BF3C9E89F596A44E751714A9526F7
   InstallerSwitches:
     Custom: /currentuser
 - Architecture: x64
   Scope: machine
-  InstallerUrl: https://dl.koodoreader.com/v2.1.1/Koodo-Reader-2.1.1-arm64.exe
-  InstallerSha256: D10910529B99FDE4452927AA4A6FCE7012D744A9939E82906052F811C1B94104
+  InstallerUrl: https://dl.koodoreader.com/v2.1.1/Koodo-Reader-2.1.1-x64.exe
+  InstallerSha256: 5BBA9B874C1E0370836171ECA76ED6BE125BF3C9E89F596A44E751714A9526F7
   InstallerSwitches:
     Custom: /allusers
 ManifestType: installer
 ManifestVersion: 1.10.0
+


### PR DESCRIPTION
The installer URL for x64 points to the ARM64 installer which will cause crash after installation.

Since the issue is caused by an automated action, I think this issue should be ultimately fixed by the build script author 
@spectopo @ItzLevvie @stephengillie

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/285503)