### PR TITLE
New package: accellence.vimacc.enterprise.2_2_15 version 2.2.15.4

### DIFF
--- a/manifests/a/accellence/vimacc.enterprise.2_2_15/2.2.15.4/accellence.vimacc.enterprise.2_2_15.installer.yaml
+++ b/manifests/a/accellence/vimacc.enterprise.2_2_15/2.2.15.4/accellence.vimacc.enterprise.2_2_15.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: accellence.vimacc.enterprise.2_2_15
+PackageVersion: 2.2.15.4
+MinimumOSVersion: 10.0.10240.0
+InstallerType: inno
+Scope: machine
+InstallerSwitches:
+      Silent: /VERYSILENT /NORESTART
+      SilentWithProgress: /SILENT /NORESTART
+      Interactive: ""
+      Log: /LOG="{log}"
+      InstallLocation: /DIR="{installPath}"
+      Custom: "{custom}"
+UpgradeBehavior: install
+ProductCode: "{FB2456E5-2EB8-42A4-B5B8-7AD1E4BCB8EE}_is1"
+ReleaseDate: 2025-07-11
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://wg.accellence.eu/vimacc/2_2_15/vimaccEnterprise_2.2.15.4_x64_sign.exe
+    InstallerSha256: 9ae48d3eff77fb1c3017013f8fe8029735477b8f17975feaaf5b992293ad4579
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/a/accellence/vimacc.enterprise.2_2_15/2.2.15.4/accellence.vimacc.enterprise.2_2_15.locale.de-DE.yaml
+++ b/manifests/a/accellence/vimacc.enterprise.2_2_15/2.2.15.4/accellence.vimacc.enterprise.2_2_15.locale.de-DE.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.10.0.schema.json
+
+PackageIdentifier: accellence.vimacc.enterprise.2_2_15
+PackageVersion: 2.2.15.4
+PackageLocale: de-DE
+PackageName: vimacc Enterprise IPVMS
+ShortDescription: vimacc – Das Datenschutz-zertifizierte Videomanagement system.
+Description: |
+  vimacc ist eine plattformunabhängige, leistungsstarke und skalierbare Software für das professionelle Videomanagement.
+  Sie unterstützt verschlüsselte Kommunikation, flexible Kameraanbindung, Videoanalyse sowie datenschutzkonforme Funktionen gemäß DSGVO.
+  Ideal für KRITIS, öffentliche Sicherheit und Unternehmenslösungen.
+Publisher: Accellence Technologies GmbH
+PublisherUrl: https://vimacc.de
+PublisherSupportUrl: https://www.vimacc.de/kontakt
+Author: accellence
+License: Kommerziell
+PrivacyUrl: https://www.accellence.de/datenschutz
+Copyright: Copyright © 2012-2025 Accellence Technologies GmbH, Hannover, Germany
+Tags:
+  - IPVMS
+Agreements:
+  - AgreementLabel: Endbenutzervereinbarung (EULA)
+    AgreementUrl: https://wg.accellence.eu/vimacc/accellence_vimacc_EULA_DE.md
+ReleaseNotesUrl: https://wg.accellence.eu/vimacc/2_2_15/vimacc2.2.15_ReleaseNotes.txt
+ManifestType: locale
+ManifestVersion: 1.10.0

--- a/manifests/a/accellence/vimacc.enterprise.2_2_15/2.2.15.4/accellence.vimacc.enterprise.2_2_15.locale.en-US.yaml
+++ b/manifests/a/accellence/vimacc.enterprise.2_2_15/2.2.15.4/accellence.vimacc.enterprise.2_2_15.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: accellence.vimacc.enterprise.2_2_15
+PackageVersion: 2.2.15.4
+PackageLocale: en-US
+PackageName: vimacc Enterprise IPVMS
+ShortDescription: vimacc – The data privacy certified video management system.
+Description: |
+  vimacc is a high-performing, platform-independent, scalable software solution for professional video management.
+  It supports encrypted communication, flexible camera integration, video analytics, and GDPR-compliant privacy protection features.
+  Ideal for critical infrastructure, public safety, and enterprise deployments.
+Publisher: Accellence Technologies GmbH
+PublisherUrl: https://vimacc.de
+PublisherSupportUrl: https://www.vimacc.de/en/contact
+Author: accellence
+License: Commercial
+PrivacyUrl: https://www.accellence.de/en/privacy-statement
+Copyright: Copyright © 2012-2025 Accellence Technologies GmbH, Hannover, Germany
+Tags:
+  - IPVMS
+Agreements:
+  - AgreementLabel: End User License Agreement (EULA)
+    AgreementUrl: https://wg.accellence.eu/vimacc/accellence_vimacc_EULA_EN.md
+ReleaseNotesUrl: https://wg.accellence.eu/vimacc/2_2_15/vimacc2.2.15_ReleaseNotes.txt
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/a/accellence/vimacc.enterprise.2_2_15/2.2.15.4/accellence.vimacc.enterprise.2_2_15.yaml
+++ b/manifests/a/accellence/vimacc.enterprise.2_2_15/2.2.15.4/accellence.vimacc.enterprise.2_2_15.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: accellence.vimacc.enterprise.2_2_15
+PackageVersion: 2.2.15.4
+DefaultLocale: en-US
+Publisher: Accellence Technologies GmbH
+PublisherUrl: https://vimacc.de
+PublisherSupportUrl: https://www.vimacc.de/en/contact
+Author: accellence
+Moniker: vimacc-enterprise-2_2_15
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Adding release 2.2.15.4 of vimacc Enterprise for WinGet. Intentional hash reuse across vimacc, vimacc.enterprise and vimacc.enterprise.2_2_15 (multi-track version support).

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/285510)