### PR TITLE
New package: NETGEAR.DiscoveryTool version 2.0.7

### DIFF
--- a/manifests/n/NETGEAR/DiscoveryTool/2.0.7/NETGEAR.DiscoveryTool.installer.yaml
+++ b/manifests/n/NETGEAR/DiscoveryTool/2.0.7/NETGEAR.DiscoveryTool.installer.yaml
@@ -1,0 +1,15 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: NETGEAR.DiscoveryTool
+PackageVersion: 2.0.7
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: NETGEAR-Discovery-Tool-2.0.7.exe
+Installers:
+- Architecture: x86
+  InstallerUrl: https://www.downloads.netgear.com/files/GDC/NDT/NETGEAR_Discovery_Tool_Windows-V2.0.7.zip
+  InstallerSha256: 754803D3A94885984A314712C761B1E78793EDE476A9CAA72413A0ECB27850E4
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/n/NETGEAR/DiscoveryTool/2.0.7/NETGEAR.DiscoveryTool.locale.en-US.yaml
+++ b/manifests/n/NETGEAR/DiscoveryTool/2.0.7/NETGEAR.DiscoveryTool.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: NETGEAR.DiscoveryTool
+PackageVersion: 2.0.7
+PackageLocale: en-US
+Publisher: NETGEAR
+PackageName: NETGEAR Discovery Tool
+PackageUrl: https://www.netgear.com/support/product/netgear-discovery-tool/
+License: Proprietary
+ShortDescription: Helps finding NETGEAR "Smart Managed" switches on the LAN network.
+Tags:
+- smartmanagedpro
+- smartmanagedplus
+- netgearswitchdiscoverytool
+- ndt
+- nsdt
+- gs808e
+- s8000
+- gs810emx
+- sx10
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/n/NETGEAR/DiscoveryTool/2.0.7/NETGEAR.DiscoveryTool.yaml
+++ b/manifests/n/NETGEAR/DiscoveryTool/2.0.7/NETGEAR.DiscoveryTool.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: NETGEAR.DiscoveryTool
+PackageVersion: 2.0.7
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---
Notes from me:
* Wingetcreate seemingly incorrectly auto-detects the .exe as a Nullsoft installer, but setting `nullsoft` as the `NestedInstallerType` causes the fully functional program to launch in the midst of when Wingetcreate waits to see if it has been "installed" correctly.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/286241)