### PR TITLE
Add PlebOne.nos version 1.1.3

### DIFF
--- a/manifests/p/PlebOne/nos/1.1.3/PlebOne.nos.installer.yaml
+++ b/manifests/p/PlebOne/nos/1.1.3/PlebOne.nos.installer.yaml
@@ -1,0 +1,24 @@
+# Created using winget-create 1.6.0.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.8.0.schema.json
+
+PackageIdentifier: PlebOne.nos
+PackageVersion: 1.1.3
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: exe
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/PlebOne/nos/releases/download/v1.1.3/nos-1.1.3-windows-amd64.exe
+  InstallerSha256: 8517b5008f84dc4e00bcd03d1e9b611c5513cce38ce03c151226f55a9e6a17f0
+  InstallerSwitches:
+    Silent: ""
+    SilentWithProgress: ""
+- Architecture: arm64
+  InstallerUrl: https://github.com/PlebOne/nos/releases/download/v1.1.3/nos-1.1.3-windows-arm64.exe
+  InstallerSha256: 128a9154bee9c9929797a0e2e594b9d1532f467eb4a4ec481e3a529b68b0a063
+  InstallerSwitches:
+    Silent: ""
+    SilentWithProgress: ""
+ManifestType: installer
+ManifestVersion: 1.8.0

--- a/manifests/p/PlebOne/nos/1.1.3/PlebOne.nos.installer.yaml
+++ b/manifests/p/PlebOne/nos/1.1.3/PlebOne.nos.installer.yaml
@@ -1,5 +1,5 @@
 # Created using winget-create 1.6.0.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.8.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
 
 PackageIdentifier: PlebOne.nos
 PackageVersion: 1.1.3
@@ -21,4 +21,4 @@ Installers:
     Silent: ""
     SilentWithProgress: ""
 ManifestType: installer
-ManifestVersion: 1.8.0
+ManifestVersion: 1.10.0

--- a/manifests/p/PlebOne/nos/1.1.3/PlebOne.nos.installer.yaml
+++ b/manifests/p/PlebOne/nos/1.1.3/PlebOne.nos.installer.yaml
@@ -6,19 +6,13 @@ PackageVersion: 1.1.3
 Platform:
 - Windows.Desktop
 MinimumOSVersion: 10.0.0.0
-InstallerType: exe
+InstallerType: portable
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/PlebOne/nos/releases/download/v1.1.3/nos-1.1.3-windows-amd64.exe
   InstallerSha256: 8517b5008f84dc4e00bcd03d1e9b611c5513cce38ce03c151226f55a9e6a17f0
-  InstallerSwitches:
-    Silent: ""
-    SilentWithProgress: ""
 - Architecture: arm64
   InstallerUrl: https://github.com/PlebOne/nos/releases/download/v1.1.3/nos-1.1.3-windows-arm64.exe
   InstallerSha256: 128a9154bee9c9929797a0e2e594b9d1532f467eb4a4ec481e3a529b68b0a063
-  InstallerSwitches:
-    Silent: ""
-    SilentWithProgress: ""
 ManifestType: installer
 ManifestVersion: 1.10.0

--- a/manifests/p/PlebOne/nos/1.1.3/PlebOne.nos.installer.yaml
+++ b/manifests/p/PlebOne/nos/1.1.3/PlebOne.nos.installer.yaml
@@ -10,9 +10,9 @@ InstallerType: portable
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/PlebOne/nos/releases/download/v1.1.3/nos-1.1.3-windows-amd64.exe
-  InstallerSha256: 8517b5008f84dc4e00bcd03d1e9b611c5513cce38ce03c151226f55a9e6a17f0
+  InstallerSha256: 7d49eac8ef6538bd4ceff0b8efa9aece392a9e444756ff2ff66afd9ad4b67a63
 - Architecture: arm64
   InstallerUrl: https://github.com/PlebOne/nos/releases/download/v1.1.3/nos-1.1.3-windows-arm64.exe
-  InstallerSha256: 128a9154bee9c9929797a0e2e594b9d1532f467eb4a4ec481e3a529b68b0a063
+  InstallerSha256: ce2c79d1dafe4c95712fb2d626dc36b51c7f4fcf8b8863f40f4e12ac93f5837f
 ManifestType: installer
 ManifestVersion: 1.10.0

--- a/manifests/p/PlebOne/nos/1.1.3/PlebOne.nos.locale.en-US.yaml
+++ b/manifests/p/PlebOne/nos/1.1.3/PlebOne.nos.locale.en-US.yaml
@@ -1,0 +1,37 @@
+# Created using winget-create 1.6.0.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.8.0.schema.json
+
+PackageIdentifier: PlebOne.nos
+PackageVersion: 1.1.1
+PackageLocale: en-US
+Publisher: PlebOne
+PublisherUrl: https://github.com/PlebOne
+PublisherSupportUrl: https://github.com/PlebOne/nos/issues
+Author: PlebOne
+PackageName: nos
+PackageUrl: https://github.com/PlebOne/nos
+License: MIT
+LicenseUrl: https://raw.githubusercontent.com/PlebOne/nos/main/LICENSE
+Copyright: Copyright (c) 2024 PlebOne
+ShortDescription: A beautiful command-line client for posting to Nostr
+Description: |-
+  nos is a command-line client for Nostr, a decentralized social network protocol.
+  It provides a beautiful and easy-to-use interface for posting messages, viewing feeds,
+  and interacting with the Nostr network directly from your terminal.
+  
+  Features:
+  - Post messages to Nostr relays
+  - Beautiful command-line interface
+  - Cross-platform support (Windows, macOS, Linux)
+  - Fast and lightweight
+Tags:
+- nostr
+- social-network
+- cli
+- command-line
+- decentralized
+ReleaseNotes: |-
+  Release v1.1.1 includes automated winget support and improved release pipeline.
+ReleaseNotesUrl: https://github.com/PlebOne/nos/releases/tag/v1.1.1
+ManifestType: defaultLocale
+ManifestVersion: 1.8.0

--- a/manifests/p/PlebOne/nos/1.1.3/PlebOne.nos.locale.en-US.yaml
+++ b/manifests/p/PlebOne/nos/1.1.3/PlebOne.nos.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created using winget-create 1.6.0.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.8.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
 
 PackageIdentifier: PlebOne.nos
 PackageVersion: 1.1.1
@@ -34,4 +34,4 @@ ReleaseNotes: |-
   Release v1.1.1 includes automated winget support and improved release pipeline.
 ReleaseNotesUrl: https://github.com/PlebOne/nos/releases/tag/v1.1.1
 ManifestType: defaultLocale
-ManifestVersion: 1.8.0
+ManifestVersion: 1.10.0

--- a/manifests/p/PlebOne/nos/1.1.3/PlebOne.nos.locale.en-US.yaml
+++ b/manifests/p/PlebOne/nos/1.1.3/PlebOne.nos.locale.en-US.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
 
 PackageIdentifier: PlebOne.nos
-PackageVersion: 1.1.1
+PackageVersion: 1.1.3
 PackageLocale: en-US
 Publisher: PlebOne
 PublisherUrl: https://github.com/PlebOne
@@ -31,7 +31,7 @@ Tags:
 - command-line
 - decentralized
 ReleaseNotes: |-
-  Release v1.1.1 includes automated winget support and improved release pipeline.
-ReleaseNotesUrl: https://github.com/PlebOne/nos/releases/tag/v1.1.1
+  Release v1.1.3 includes automated winget support and improved release pipeline.
+ReleaseNotesUrl: https://github.com/PlebOne/nos/releases/tag/v1.1.3
 ManifestType: defaultLocale
 ManifestVersion: 1.10.0

--- a/manifests/p/PlebOne/nos/1.1.3/PlebOne.nos.yaml
+++ b/manifests/p/PlebOne/nos/1.1.3/PlebOne.nos.yaml
@@ -1,0 +1,8 @@
+# Created using winget-create 1.6.0.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.8.0.schema.json
+
+PackageIdentifier: PlebOne.nos
+PackageVersion: 1.1.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.8.0

--- a/manifests/p/PlebOne/nos/1.1.3/PlebOne.nos.yaml
+++ b/manifests/p/PlebOne/nos/1.1.3/PlebOne.nos.yaml
@@ -1,8 +1,8 @@
 # Created using winget-create 1.6.0.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.8.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
 
 PackageIdentifier: PlebOne.nos
 PackageVersion: 1.1.3
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.8.0
+ManifestVersion: 1.10.0


### PR DESCRIPTION
### Package Information
- **Package Name**: PlebOne.nos
- **Package Version**: 1.1.3
- **Package Description**: A beautiful command-line client for posting to Nostr
- **Package License**: MIT
- **Package Homepage**: https://github.com/PlebOne/nos

### Installer Information
- **Installer Type**: exe (direct executable)
- **Architectures**: x64, arm64
- **Silent Install**: Supported
- **Install Location**: User profile

### Changes in this Version
- Direct .exe installers for improved Microsoft Store compliance
- Multi-architecture support (x64 and arm64)
- Automated release process with GitHub Actions
- Enhanced winget manifest generation

### Testing
- [x] Package installs successfully via winget
- [x] Package uninstalls cleanly
- [x] All manifest files follow winget schema requirements
- [x] SHA256 checksums verified

### Additional Notes
This is a new package submission for nos, a command-line Nostr client. The package provides direct .exe installers that are compatible with Microsoft's winget requirements and supports both x64 and arm64 architectures.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/288169)