### PR TITLE
Update manifest: ClashVergeRev.ClashVergeRev version 2.4.1

### DIFF
--- a/manifests/c/ClashVergeRev/ClashVergeRev/2.4.1/ClashVergeRev.ClashVergeRev.installer.yaml
+++ b/manifests/c/ClashVergeRev/ClashVergeRev/2.4.1/ClashVergeRev.ClashVergeRev.installer.yaml
@@ -5,7 +5,7 @@ PackageIdentifier: ClashVergeRev.ClashVergeRev
 PackageVersion: 2.4.1
 InstallerLocale: en-US
 InstallerType: nullsoft
-Scope: machine
+Scope: user
 UpgradeBehavior: install
 FileExtensions:
 - clash


### PR DESCRIPTION
## For what?

- Switching `Scope` of this package
  - This package DOES NOT provide machine scope installation anymore.

## Checklist for Pull Requests

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Resolve #288991 
  - [x] Also resolve clash-verge-rev/clash-verge-rev#4524

## Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

## Manual validation

- (Simplified Chinese Only) See https://github.com/clash-verge-rev/clash-verge-rev/issues/4524#issuecomment-3242195776

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/288992)