### PR TITLE
Update Oracle.VirtualBox.installer.yaml version 7.2.0

### DIFF
--- a/manifests/o/Oracle/VirtualBox/7.2.0/Oracle.VirtualBox.installer.yaml
+++ b/manifests/o/Oracle/VirtualBox/7.2.0/Oracle.VirtualBox.installer.yaml
@@ -17,7 +17,7 @@ InstallerSwitches:
   Custom: -msiparams REBOOT=ReallySuppress
 InstallerSuccessCodes:
 - 3010
-UpgradeBehavior: uninstallPrevious
+UpgradeBehavior: install
 FileExtensions:
 - ova
 - ovf
@@ -38,4 +38,5 @@ Installers:
   InstallerSha256: 536F0ED5D99E8406A3D3B4B304C641507A581DFEBD1BC249C1C5323A873AF0BC
 ManifestType: installer
 ManifestVersion: 1.10.0
+
 


### PR DESCRIPTION
`uninstallPrevious` is not necessary for this package. The `--uninstall-previous` option for `winget install`/`winget upgrade` should be used instead.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/291439)