### PR TITLE
New version: MeinbergGlobal.NTP version 4.2.8p18

### DIFF
--- a/manifests/m/MeinbergGlobal/NTP/4.2.8p18/MeinbergGlobal.NTP.installer.yaml
+++ b/manifests/m/MeinbergGlobal/NTP/4.2.8p18/MeinbergGlobal.NTP.installer.yaml
@@ -9,5 +9,7 @@ Installers:
   InstallerUrl: https://www.meinbergglobal.com/download/ntp/windows/ntp-4.2.8p18-win32-setup.exe
   InstallerSha256: 96CCAFC1582320DF3A135280ACDDA8AF4092DC248A553469EA30EE0B9CDB80ED
   ProductCode: NTP
+InstallerSuccessCodes:
+- 2
 ManifestType: installer
 ManifestVersion: 1.10.0

--- a/manifests/m/MeinbergGlobal/NTP/4.2.8p18/MeinbergGlobal.NTP.installer.yaml
+++ b/manifests/m/MeinbergGlobal/NTP/4.2.8p18/MeinbergGlobal.NTP.installer.yaml
@@ -1,0 +1,13 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: MeinbergGlobal.NTP
+PackageVersion: 4.2.8p18
+InstallerType: nullsoft
+Installers:
+- Architecture: x86
+  InstallerUrl: https://www.meinbergglobal.com/download/ntp/windows/ntp-4.2.8p18-win32-setup.exe
+  InstallerSha256: 96CCAFC1582320DF3A135280ACDDA8AF4092DC248A553469EA30EE0B9CDB80ED
+  ProductCode: NTP
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/m/MeinbergGlobal/NTP/4.2.8p18/MeinbergGlobal.NTP.locale.en-US.yaml
+++ b/manifests/m/MeinbergGlobal/NTP/4.2.8p18/MeinbergGlobal.NTP.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: MeinbergGlobal.NTP
+PackageVersion: 4.2.8p18
+PackageLocale: en-US
+Publisher: Meinberg Global
+PublisherUrl: https://www.meinbergglobal.com/
+PublisherSupportUrl: https://www.meinbergglobal.com/english/support/
+PrivacyUrl: https://www.meinbergglobal.com/english/privacy.htm
+PackageName: Network Time Protocol
+PackageUrl: https://www.meinbergglobal.com/english/sw/ntp.htm
+License: Proprietary
+ShortDescription: Provides a GUI setup program for Windows which installs the NTP service and associated executable programs that have been compiled from the original public NTP source code available at the NTP download page at ntp.org
+Tags:
+- ntpserver
+- ntptimesync
+- ntptimeserver
+- clocksynchronize
+- clocksynchronise
+- clockserver
+- ntppool
+- networktimeprotocol
+Moniker: meinberg-ntp
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/m/MeinbergGlobal/NTP/4.2.8p18/MeinbergGlobal.NTP.yaml
+++ b/manifests/m/MeinbergGlobal/NTP/4.2.8p18/MeinbergGlobal.NTP.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: MeinbergGlobal.NTP
+PackageVersion: 4.2.8p18
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---
Notes from me:
* Wingetcreate incorrectly claimed *"Installer failed with exit code: 2"*, despite the program being fully installed by that point. Accordingly, I've added "2" as a success exit code.
* The manifest for 4.2.8p15a claims that a full reinstall of NTP is needed. I've debunked that during testing of 4.2.8p18.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/292317)