### PR TITLE
Add portable installer options for Notepad++

### DIFF
--- a/manifests/n/Notepad++/Notepad++/8.8.5/Notepad++.Notepad++.installer.yaml
+++ b/manifests/n/Notepad++/Notepad++/8.8.5/Notepad++.Notepad++.installer.yaml
@@ -3,39 +3,97 @@
 
 PackageIdentifier: Notepad++.Notepad++
 PackageVersion: 8.8.5
-InstallerLocale: en-US
-InstallerType: nullsoft
-Scope: machine
-InstallModes:
-- interactive
-- silent
-ExpectedReturnCodes:
-- InstallerReturnCode: 5
-  ReturnResponse: packageInUse
-UpgradeBehavior: install
-ProductCode: Notepad++
 ReleaseDate: 2025-08-13
-ElevationRequirement: elevatesSelf
-InstallationMetadata:
-  DefaultInstallLocation: '%ProgramFiles(x86)%\Notepad++'
 Installers:
-- Architecture: x86
+- InstallerLocale: en-US
+  Architecture: x86
+  InstallerType: nullsoft
+  Scope: machine
   InstallerUrl: https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.8.5/npp.8.8.5.Installer.exe
   InstallerSha256: 05ABC57952974D08FEAFA399D6FDB37945A3FD0A10F37833DD837A5788E421D5
+  ProductCode: Notepad++
   AppsAndFeaturesEntries:
   - DisplayName: Notepad++ (32-bit x86)
+    Publisher: Notepad++ Team
     ProductCode: Notepad++
-- Architecture: x64
+  InstallationMetadata:
+    DefaultInstallLocation: '%ProgramFiles(x86)%\Notepad++'
+  ElevationRequirement: elevatesSelf
+  InstallModes:
+  - interactive
+  - silent
+  ExpectedReturnCodes:
+  - InstallerReturnCode: 5
+    ReturnResponse: packageInUse
+  UpgradeBehavior: install
+- InstallerLocale: en-US
+  Architecture: x64
+  InstallerType: nullsoft
+  Scope: machine
   InstallerUrl: https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.8.5/npp.8.8.5.Installer.x64.exe
   InstallerSha256: C6D1E5AACBF69AA18DF4CAF1346FD69638491A5AD0085729BAE91C662D1C62BB
+  ProductCode: Notepad++
   AppsAndFeaturesEntries:
   - DisplayName: Notepad++ (64-bit x64)
+    Publisher: Notepad++ Team
     ProductCode: Notepad++
-- Architecture: arm64
+  InstallationMetadata:
+    DefaultInstallLocation: '%ProgramFiles(x86)%\Notepad++'
+  ElevationRequirement: elevatesSelf
+  InstallModes:
+  - interactive
+  - silent
+  ExpectedReturnCodes:
+  - InstallerReturnCode: 5
+    ReturnResponse: packageInUse
+  UpgradeBehavior: install
+- InstallerLocale: en-US
+  Architecture: arm64
+  InstallerType: nullsoft
+  Scope: machine
   InstallerUrl: https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.8.5/npp.8.8.5.Installer.arm64.exe
   InstallerSha256: 9E3D7A56C194CD1A1DE22CFC3B1CC6893EDC3E00657C6249E973B692BEA970FD
+  ProductCode: Notepad++
   AppsAndFeaturesEntries:
   - DisplayName: Notepad++ (ARM 64-bit)
+    Publisher: Notepad++ Team
     ProductCode: Notepad++
+  InstallationMetadata:
+    DefaultInstallLocation: '%ProgramFiles(x86)%\Notepad++'
+  ElevationRequirement: elevatesSelf
+  InstallModes:
+  - interactive
+  - silent
+  ExpectedReturnCodes:
+  - InstallerReturnCode: 5
+    ReturnResponse: packageInUse
+  UpgradeBehavior: install
+- Architecture: x86
+  InstallerType: zip
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: notepad++.exe
+    PortableCommandAlias: notepad++
+  InstallerUrl: https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.8.5/npp.8.8.5.portable.zip
+  InstallerSha256: A08A9E4D6A3610F11F1961C4C07BD0AD85B04A47AA46D96B684AC5D2A63237F5
+  ArchiveBinariesDependOnPath: true
+- Architecture: x64
+  InstallerType: zip
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: notepad++.exe
+    PortableCommandAlias: notepad++
+  InstallerUrl: https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.8.5/npp.8.8.5.portable.x64.zip
+  InstallerSha256: 372BD3A9B15566AF7793DF86212A5C213739BD57E1B09AB007A1E00CE4DE555B
+  ArchiveBinariesDependOnPath: true
+- Architecture: arm64
+  InstallerType: zip
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: notepad++.exe
+    PortableCommandAlias: notepad++
+  InstallerUrl: https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.8.5/npp.8.8.5.portable.arm64.zip
+  InstallerSha256: 0D08F428AC33235F6F8B694B9C9967023F222A22542E2A5C9FFC2A595F3F9A4A
+  ArchiveBinariesDependOnPath: true
 ManifestType: installer
 ManifestVersion: 1.10.0


### PR DESCRIPTION
Updated Notepad++ installer manifest to include portable versions for x86, x64, and arm64 architectures.

Checklist for Pull Requests
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] This PR only modifies one (1) manifest
- [X] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [X] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/292346)