### PR TITLE
Completing the merger of the Motorola.ReadyForAssistant and Lenovo.SmartConnect packages.

### DIFF
--- a/manifests/m/Motorola/ReadyForAssistant/8.0.0.114.001/Motorola.ReadyForAssistant.locale.en-US.yaml
+++ b/manifests/m/Motorola/ReadyForAssistant/8.0.0.114.001/Motorola.ReadyForAssistant.locale.en-US.yaml
@@ -5,9 +5,25 @@ PackageIdentifier: Motorola.ReadyForAssistant
 PackageVersion: 8.0.0.114.001
 PackageLocale: en-US
 Publisher: Motorola
-PackageName: Ready For Assistant
-License: None
-Copyright: (C) Motorola
-ShortDescription: Connect your ready for supported device to your pc
+PackageName: Ready For Assistant / Smart Connect
+PackageUrl: https://www.lenovo.com/gb/en/software/smart-connect/
+Documentations:
+  - DocumentUrl: https://en-gb.support.motorola.com/app/answers/detail/a_id/182071/~/smart-connect---pair-devices
+License: Proprietary
+Copyright: © Motorola / Lenovo
+ShortDescription: Connect your "Ready For"-supported Motorola or Lenovo device to your PC.
+Tags:
+- android
+- smartconnect
+- mobilephoneconnection
+- cellphones
+- tablets
+- xp8jrf5sxv03zm
+- smartconnectextinstaller
+- webcamera
+- lenovodriverhid.inf
+- lenovodisplay.inf
+- lenovodriveraudio.inf
+- usb-c
 ManifestType: defaultLocale
 ManifestVersion: 1.10.0


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Is there a linked Issue? #291739 *de facto*

Manifests
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---
Notes from me:
* I had planned this for months, ever since I realised a day or so after the Lenovo.SmartConnect package had originally been merged, but I had put it off since creating new packages and adding tags felt more important. But from how I understand #291739 and how it removed one of the 2 clone packages (Solid thumbs up to Dragon1573 for it), I felt the time was right for me to handle the last bits.
* `xp8jrf5sxv03zm` is the name of its Microsoft Store listing's URL tag thing, so I added it as a tag for this package for easier searching, especially for people who have previously downloaded Smart Connect through the `msstore` source.

Key aspects of those 2 points are highlighted in purple in the screenshot below:

<img width="943" height="672" alt="image" src="https://github.com/user-attachments/assets/c17c19e8-14a8-4313-9dbb-665f3cecfb77" />

* For reasons I'm less sure about, downloading from the `msstore` source also lists a `SmartConnectExtInstaller` v1.0.0.0 in the registry and thus in `winget list`; but since that listing does not show up in the list of installed apps in Geek Uninstaller (i.e. `GeekUninstaller.GeekUninstaller`), it shouldn't be of concern. I've added `smartconnectextinstaller` as a tag just in case.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/292395)