### PR TITLE
Add version: accellence.vimaccProfessional version 2.2.15.5

### DIFF
--- a/manifests/a/accellence/vimaccProfessional/2.2.15.5/accellence.vimaccProfessional.installer.yaml
+++ b/manifests/a/accellence/vimaccProfessional/2.2.15.5/accellence.vimaccProfessional.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: accellence.vimaccProfessional
+PackageVersion: 2.2.15.5
+MinimumOSVersion: 10.0.10240.0
+InstallerType: inno
+Scope: machine
+InstallerSwitches:
+      Silent: /VERYSILENT /NORESTART
+      SilentWithProgress: /SILENT /NORESTART
+      Interactive: ""
+      Log: /LOG="{log}"
+      InstallLocation: /DIR="{installPath}"
+      Custom: "{custom}"
+UpgradeBehavior: install
+ProductCode: "{D778127E-43AC-4E44-99F3-A27AF3297C02}_is1"
+ReleaseDate: 2025-07-11
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://wg.accellence.eu/vimacc/2_2_15/vimaccProfessional_2.2.15.5_x64_sign.exe 
+    InstallerSha256: e092f8066262a55f9b94574af16eb61c175089ce6c20980d281c4061842709de
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/a/accellence/vimaccProfessional/2.2.15.5/accellence.vimaccProfessional.locale.de-DE.yaml
+++ b/manifests/a/accellence/vimaccProfessional/2.2.15.5/accellence.vimaccProfessional.locale.de-DE.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.10.0.schema.json
+
+PackageIdentifier: accellence.vimaccProfessional
+PackageVersion: 2.2.15.5
+PackageLocale: de-DE
+PackageName: vimacc Professional IPVMS
+ShortDescription: vimacc – Das Datenschutz-zertifizierte Videomanagement system.
+Description: |
+  vimacc ist eine plattformunabhängige, leistungsstarke und skalierbare Software für das professionelle Videomanagement.
+  Sie unterstützt verschlüsselte Kommunikation, flexible Kameraanbindung, Videoanalyse sowie datenschutzkonforme Funktionen gemäß DSGVO.
+  Ideal für KRITIS, öffentliche Sicherheit und Unternehmenslösungen.
+Publisher: Accellence Technologies GmbH
+PublisherUrl: https://vimacc.de
+PublisherSupportUrl: https://www.vimacc.de/kontakt
+Author: accellence
+License: Kommerziell
+PrivacyUrl: https://www.accellence.de/datenschutz
+Copyright: Copyright © 2012-2025 Accellence Technologies GmbH, Hannover, Germany
+Tags:
+  - IPVMS
+Agreements:
+  - AgreementLabel: Endbenutzervereinbarung (EULA)
+    AgreementUrl: https://wg.accellence.eu/vimacc/accellence_vimacc_EULA_DE.md
+ReleaseNotesUrl: https://wg.accellence.eu/vimacc/2_2_15/vimacc2.2.15_ReleaseNotes.txt
+ManifestType: locale
+ManifestVersion: 1.10.0

--- a/manifests/a/accellence/vimaccProfessional/2.2.15.5/accellence.vimaccProfessional.locale.en-US.yaml
+++ b/manifests/a/accellence/vimaccProfessional/2.2.15.5/accellence.vimaccProfessional.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: accellence.vimaccProfessional
+PackageVersion: 2.2.15.5
+PackageLocale: en-US
+PackageName: vimacc Professional IPVMS
+ShortDescription: vimacc – The data privacy certified video management system.
+Description: |
+  vimacc is a high-performing, platform-independent, scalable software solution for professional video management.
+  It supports encrypted communication, flexible camera integration, video analytics, and GDPR-compliant privacy protection features.
+  Ideal for critical infrastructure, public safety, and professional deployments.
+Publisher: Accellence Technologies GmbH
+PublisherUrl: https://vimacc.de
+PublisherSupportUrl: https://www.vimacc.de/en/contact
+Author: accellence
+License: Commercial
+PrivacyUrl: https://www.accellence.de/en/privacy-statement
+Copyright: Copyright © 2012-2025 Accellence Technologies GmbH, Hannover, Germany
+Tags:
+  - IPVMS
+Agreements:
+  - AgreementLabel: End User License Agreement (EULA)
+    AgreementUrl: https://wg.accellence.eu/vimacc/accellence_vimacc_EULA_EN.md
+ReleaseNotesUrl: https://wg.accellence.eu/vimacc/2_2_15/vimacc2.2.15_ReleaseNotes.txt
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/a/accellence/vimaccProfessional/2.2.15.5/accellence.vimaccProfessional.yaml
+++ b/manifests/a/accellence/vimaccProfessional/2.2.15.5/accellence.vimaccProfessional.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: accellence.vimaccProfessional
+PackageVersion: 2.2.15.5
+DefaultLocale: en-US
+Publisher: Accellence Technologies GmbH
+PublisherUrl: https://vimacc.de
+PublisherSupportUrl: https://www.vimacc.de/en/contact
+Author: accellence
+Moniker: vimacc-professional
+ManifestType: version
+ManifestVersion: 1.10.0

--- a/manifests/a/accellence/{log}
+++ b/manifests/a/accellence/{log}
@@ -1,0 +1,8246 @@
+﻿2025-09-12 08:34:20.168   Log opened. (Time zone: UTC+02:00)
+2025-09-12 08:34:20.168   Setup version: Inno Setup version 5.5.9 (u)
+2025-09-12 08:34:20.168   Original Setup EXE: C:\Users\lilienthal.ACCELLENCE\AppData\Local\Temp\WinGet\accellence.vimaccProfessional.2.2.15.5\vimaccProfessional_2.2.15.5_x64_sign.exe
+2025-09-12 08:34:20.168   Setup command line: /SL5="$190D88,275788152,177664,C:\Users\lilienthal.ACCELLENCE\AppData\Local\Temp\WinGet\accellence.vimaccProfessional.2.2.15.5\vimaccProfessional_2.2.15.5_x64_sign.exe" /SPAWNWND=$240F08 /NOTIFYWND=$36103A /SILENT /NORESTART /LOG="{log}" {custom}
+2025-09-12 08:34:20.168   Windows version: 10.0.26100  (NT platform: Yes)
+2025-09-12 08:34:20.168   64-bit Windows: Yes
+2025-09-12 08:34:20.168   Processor architecture: x64
+2025-09-12 08:34:20.177   User privileges: Administrative
+2025-09-12 08:34:20.182   64-bit install mode: Yes
+2025-09-12 08:34:20.185   Created temporary directory: C:\Users\LILIEN~1.ACC\AppData\Local\Temp\is-LU1I8.tmp
+2025-09-12 08:34:20.303   Starting the installation process.
+2025-09-12 08:34:20.307   Creating directory: C:\vimacc
+2025-09-12 08:34:20.307   Creating directory: C:\vimacc\bin
+2025-09-12 08:34:20.307   Creating directory: C:\vimacc\log
+2025-09-12 08:34:20.307   Creating directory: C:\vimacc\config
+2025-09-12 08:34:20.307   Creating directory: C:\vimacc\config\import
+2025-09-12 08:34:20.307   Creating directory: C:\vimacc\data
+2025-09-12 08:34:20.308   Creating directory: C:\vimacc\data\about
+2025-09-12 08:34:20.308   Creating directory: C:\vimacc\data\certificates
+2025-09-12 08:34:20.308   Creating directory: C:\vimacc\data\configTemplates
+2025-09-12 08:34:20.308   Creating directory: C:\vimacc\data\Stylesheet
+2025-09-12 08:34:20.317   Creating directory: C:\vimacc\data\maps
+2025-09-12 08:34:20.317   Creating directory: C:\vimacc\data\featuresDatabase
+2025-09-12 08:34:20.317   Creating directory: C:\vimacc\data\featuresDatabase\import
+2025-09-12 08:34:20.317   Creating directory: C:\vimacc\data\plugins
+2025-09-12 08:34:20.317   Creating directory: C:\vimacc\data\plugins\imageformats
+2025-09-12 08:34:20.317   Creating directory: C:\vimacc\data\plugins\iconengines
+2025-09-12 08:34:20.317   Creating directory: C:\vimacc\bin\plugins
+2025-09-12 08:34:20.317   Creating directory: C:\vimacc\bin\plugins\opcua
+2025-09-12 08:34:20.318   Creating directory: C:\vimacc\data\pki
+2025-09-12 08:34:20.318   Creating directory: C:\vimacc\data\pki\own
+2025-09-12 08:34:20.318   Creating directory: C:\vimacc\data\pki\own\certs
+2025-09-12 08:34:20.318   Creating directory: C:\vimacc\data\pki\own\private
+2025-09-12 08:34:20.318   Creating directory: C:\vimacc\data\pki\issuers
+2025-09-12 08:34:20.318   Creating directory: C:\vimacc\data\pki\issuers\certs
+2025-09-12 08:34:20.318   Creating directory: C:\vimacc\data\pki\issuers\crl
+2025-09-12 08:34:20.318   Creating directory: C:\vimacc\data\pki\trusted
+2025-09-12 08:34:20.318   Creating directory: C:\vimacc\data\pki\trusted\certs
+2025-09-12 08:34:20.319   Creating directory: C:\vimacc\data\pki\trusted\crl
+2025-09-12 08:34:20.319   Creating directory: C:\vimacc\data\maps\H_Garbsen
+2025-09-12 08:34:20.319   Creating directory: C:\vimacc\data\maps\H_Garbsen\icons
+2025-09-12 08:34:20.319   Creating directory: C:\vimacc\data\maps\H_Garbsen\maps
+2025-09-12 08:34:20.322   Directory for uninstall files: C:\vimacc
+2025-09-12 08:34:20.322   Creating new uninstall log: C:\vimacc\unins000.dat
+2025-09-12 08:34:20.323   -- File entry --
+2025-09-12 08:34:20.323   Dest filename: C:\vimacc\unins000.exe
+2025-09-12 08:34:20.323   Non-default bitness: 32-bit
+2025-09-12 08:34:20.324   Time stamp of our file: 2025-09-12 08:34:19.858
+2025-09-12 08:34:20.325   Installing the file.
+2025-09-12 08:34:20.328   Uninstaller requires administrator: Yes
+2025-09-12 08:34:20.328   Successfully installed the file.
+2025-09-12 08:34:20.328   -- File entry --
+2025-09-12 08:34:20.329   Dest filename: C:\Users\LILIEN~1.ACC\AppData\Local\Temp\is-LU1I8.tmp\vc_redist.x64.exe
+2025-09-12 08:34:20.329   Time stamp of our file: 2024-05-29 00:34:12.000
+2025-09-12 08:34:20.329   Installing the file.
+2025-09-12 08:34:20.532   Successfully installed the file.
+2025-09-12 08:34:20.533   Setting permissions on file: C:\Users\LILIEN~1.ACC\AppData\Local\Temp\is-LU1I8.tmp\vc_redist.x64.exe
+2025-09-12 08:34:20.533   Starting 64-bit helper process.
+2025-09-12 08:34:20.553   Helper process PID: 34504
+2025-09-12 08:34:20.569   -- File entry --
+2025-09-12 08:34:20.569   Dest filename: C:\vimacc\bin\AccVmsSupport.exe
+2025-09-12 08:34:20.569   Time stamp of our file: 2025-05-05 13:06:36.000
+2025-09-12 08:34:20.569   Installing the file.
+2025-09-12 08:34:20.598   Successfully installed the file.
+2025-09-12 08:34:20.599   -- File entry --
+2025-09-12 08:34:20.599   Dest filename: C:\vimacc\bin\pskill.exe
+2025-09-12 08:34:20.599   Time stamp of our file: 2025-05-05 13:06:36.000
+2025-09-12 08:34:20.599   Installing the file.
+2025-09-12 08:34:20.606   Successfully installed the file.
+2025-09-12 08:34:20.606   -- File entry --
+2025-09-12 08:34:20.606   Dest filename: C:\vimacc\bin\StartWindowApp.exe
+2025-09-12 08:34:20.606   Time stamp of our file: 2025-05-05 13:06:42.000
+2025-09-12 08:34:20.606   Installing the file.
+2025-09-12 08:34:20.610   Successfully installed the file.
+2025-09-12 08:34:20.610   -- File entry --
+2025-09-12 08:34:20.610   Dest filename: C:\vimacc\bin\AccSvsCtrl.exe
+2025-09-12 08:34:20.610   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:20.610   Installing the file.
+2025-09-12 08:34:20.616   Successfully installed the file.
+2025-09-12 08:34:20.616   -- File entry --
+2025-09-12 08:34:20.616   Dest filename: C:\vimacc\bin\vimaccStartApplications.bat
+2025-09-12 08:34:20.616   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:20.616   Installing the file.
+2025-09-12 08:34:20.617   Successfully installed the file.
+2025-09-12 08:34:20.617   -- File entry --
+2025-09-12 08:34:20.617   Dest filename: C:\vimacc\bin\vimaccStartServices.bat
+2025-09-12 08:34:20.617   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:20.617   Installing the file.
+2025-09-12 08:34:20.618   Successfully installed the file.
+2025-09-12 08:34:20.618   -- File entry --
+2025-09-12 08:34:20.618   Dest filename: C:\vimacc\bin\vimaccStopServices.bat
+2025-09-12 08:34:20.618   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:20.618   Installing the file.
+2025-09-12 08:34:20.619   Successfully installed the file.
+2025-09-12 08:34:20.619   -- File entry --
+2025-09-12 08:34:20.619   Dest filename: C:\vimacc\bin\vimaccStopApplications.bat
+2025-09-12 08:34:20.619   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:20.619   Installing the file.
+2025-09-12 08:34:20.620   Successfully installed the file.
+2025-09-12 08:34:20.620   -- File entry --
+2025-09-12 08:34:20.620   Dest filename: C:\vimacc\bin\vimaccStart1WSp4DSP.bat
+2025-09-12 08:34:20.620   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:20.620   Installing the file.
+2025-09-12 08:34:20.621   Successfully installed the file.
+2025-09-12 08:34:20.621   -- File entry --
+2025-09-12 08:34:20.622   Dest filename: C:\vimacc\bin\vimaccStart1WSp4DS_2Monitore.bat
+2025-09-12 08:34:20.622   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:20.622   Installing the file.
+2025-09-12 08:34:20.623   Successfully installed the file.
+2025-09-12 08:34:20.623   -- File entry --
+2025-09-12 08:34:20.623   Dest filename: C:\vimacc\bin\vimaccStart1WSp4DSP_5Monitore.bat
+2025-09-12 08:34:20.623   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:20.623   Installing the file.
+2025-09-12 08:34:20.623   Successfully installed the file.
+2025-09-12 08:34:20.624   -- File entry --
+2025-09-12 08:34:20.624   Dest filename: C:\vimacc\bin\vimaccService_48x48.ico
+2025-09-12 08:34:20.624   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:20.624   Installing the file.
+2025-09-12 08:34:20.625   Successfully installed the file.
+2025-09-12 08:34:20.625   -- File entry --
+2025-09-12 08:34:20.625   Dest filename: C:\vimacc\bin\vimaccWorkstation_4_DPS_48x48.ico
+2025-09-12 08:34:20.625   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:20.625   Installing the file.
+2025-09-12 08:34:20.626   Successfully installed the file.
+2025-09-12 08:34:20.626   -- File entry --
+2025-09-12 08:34:20.626   Dest filename: C:\vimacc\bin\Qt5Core.dll
+2025-09-12 08:34:20.626   Time stamp of our file: 2024-05-25 08:03:46.000
+2025-09-12 08:34:20.626   Installing the file.
+2025-09-12 08:34:20.719   Successfully installed the file.
+2025-09-12 08:34:20.719   -- File entry --
+2025-09-12 08:34:20.719   Dest filename: C:\vimacc\bin\Qt5PrintSupport.dll
+2025-09-12 08:34:20.719   Time stamp of our file: 2024-05-25 08:41:32.000
+2025-09-12 08:34:20.719   Installing the file.
+2025-09-12 08:34:20.725   Successfully installed the file.
+2025-09-12 08:34:20.725   -- File entry --
+2025-09-12 08:34:20.726   Dest filename: C:\vimacc\bin\Qt5Gui.dll
+2025-09-12 08:34:20.726   Time stamp of our file: 2024-05-25 08:23:16.000
+2025-09-12 08:34:20.726   Installing the file.
+2025-09-12 08:34:20.819   Successfully installed the file.
+2025-09-12 08:34:20.819   -- File entry --
+2025-09-12 08:34:20.820   Dest filename: C:\vimacc\bin\Qt5Widgets.dll
+2025-09-12 08:34:20.820   Time stamp of our file: 2024-05-25 08:39:26.000
+2025-09-12 08:34:20.820   Installing the file.
+2025-09-12 08:34:20.910   Successfully installed the file.
+2025-09-12 08:34:20.910   -- File entry --
+2025-09-12 08:34:20.910   Dest filename: C:\vimacc\bin\Qt5Network.dll
+2025-09-12 08:34:20.910   Time stamp of our file: 2024-05-25 08:19:24.000
+2025-09-12 08:34:20.910   Installing the file.
+2025-09-12 08:34:20.936   Successfully installed the file.
+2025-09-12 08:34:20.936   -- File entry --
+2025-09-12 08:34:20.936   Dest filename: C:\vimacc\bin\Qt5Sql.dll
+2025-09-12 08:34:20.936   Time stamp of our file: 2024-05-25 08:07:56.000
+2025-09-12 08:34:20.936   Installing the file.
+2025-09-12 08:34:20.940   Successfully installed the file.
+2025-09-12 08:34:20.940   -- File entry --
+2025-09-12 08:34:20.940   Dest filename: C:\vimacc\bin\Qt5Svg.dll
+2025-09-12 08:34:20.940   Time stamp of our file: 2024-05-25 09:00:02.000
+2025-09-12 08:34:20.940   Installing the file.
+2025-09-12 08:34:20.946   Successfully installed the file.
+2025-09-12 08:34:20.946   -- File entry --
+2025-09-12 08:34:20.946   Dest filename: C:\vimacc\bin\Qt5Xml.dll
+2025-09-12 08:34:20.946   Time stamp of our file: 2024-05-25 08:05:00.000
+2025-09-12 08:34:20.947   Installing the file.
+2025-09-12 08:34:20.950   Successfully installed the file.
+2025-09-12 08:34:20.950   -- File entry --
+2025-09-12 08:34:20.951   Dest filename: C:\vimacc\bin\Qt5XmlPatterns.dll
+2025-09-12 08:34:20.951   Time stamp of our file: 2024-05-25 11:00:16.000
+2025-09-12 08:34:20.951   Installing the file.
+2025-09-12 08:34:20.986   Successfully installed the file.
+2025-09-12 08:34:20.986   -- File entry --
+2025-09-12 08:34:20.987   Dest filename: C:\vimacc\bin\Qt5Concurrent.dll
+2025-09-12 08:34:20.987   Time stamp of our file: 2024-05-25 08:06:56.000
+2025-09-12 08:34:20.987   Installing the file.
+2025-09-12 08:34:20.988   Successfully installed the file.
+2025-09-12 08:34:20.988   -- File entry --
+2025-09-12 08:34:20.988   Dest filename: C:\vimacc\bin\Qt5SerialPort.dll
+2025-09-12 08:34:20.988   Time stamp of our file: 2024-05-25 08:59:04.000
+2025-09-12 08:34:20.988   Installing the file.
+2025-09-12 08:34:20.990   Successfully installed the file.
+2025-09-12 08:34:20.990   -- File entry --
+2025-09-12 08:34:20.990   Dest filename: C:\vimacc\bin\Qt5SerialBus.dll
+2025-09-12 08:34:20.990   Time stamp of our file: 2024-05-25 09:02:06.000
+2025-09-12 08:34:20.990   Installing the file.
+2025-09-12 08:34:20.994   Successfully installed the file.
+2025-09-12 08:34:20.994   -- File entry --
+2025-09-12 08:34:20.994   Dest filename: C:\vimacc\bin\Qt5Script.dll
+2025-09-12 08:34:20.994   Time stamp of our file: 2024-05-25 13:46:34.000
+2025-09-12 08:34:20.994   Installing the file.
+2025-09-12 08:34:21.012   Successfully installed the file.
+2025-09-12 08:34:21.013   -- File entry --
+2025-09-12 08:34:21.013   Dest filename: C:\vimacc\bin\platforms\qwindows.dll
+2025-09-12 08:34:21.013   Time stamp of our file: 2024-05-25 08:55:56.000
+2025-09-12 08:34:21.013   Installing the file.
+2025-09-12 08:34:21.013   Creating directory: C:\vimacc\bin\platforms
+2025-09-12 08:34:21.039   Successfully installed the file.
+2025-09-12 08:34:21.039   -- File entry --
+2025-09-12 08:34:21.039   Dest filename: C:\vimacc\bin\styles\qwindowsvistastyle.dll
+2025-09-12 08:34:21.039   Time stamp of our file: 2024-05-25 08:50:44.000
+2025-09-12 08:34:21.039   Installing the file.
+2025-09-12 08:34:21.039   Creating directory: C:\vimacc\bin\styles
+2025-09-12 08:34:21.043   Successfully installed the file.
+2025-09-12 08:34:21.043   -- File entry --
+2025-09-12 08:34:21.043   Dest filename: C:\vimacc\bin\libEGL.dll
+2025-09-12 08:34:21.043   Time stamp of our file: 2024-05-25 08:01:48.000
+2025-09-12 08:34:21.043   Installing the file.
+2025-09-12 08:34:21.044   Successfully installed the file.
+2025-09-12 08:34:21.044   -- File entry --
+2025-09-12 08:34:21.044   Dest filename: C:\vimacc\bin\libGLESv2.dll
+2025-09-12 08:34:21.044   Time stamp of our file: 2024-05-25 08:01:00.000
+2025-09-12 08:34:21.044   Installing the file.
+2025-09-12 08:34:21.089   Successfully installed the file.
+2025-09-12 08:34:21.090   -- File entry --
+2025-09-12 08:34:21.090   Dest filename: C:\vimacc\bin\opengl32sw.dll
+2025-09-12 08:34:21.090   Time stamp of our file: 2025-05-05 13:06:28.000
+2025-09-12 08:34:21.090   Installing the file.
+2025-09-12 08:34:21.312   Successfully installed the file.
+2025-09-12 08:34:21.312   -- File entry --
+2025-09-12 08:34:21.313   Dest filename: C:\vimacc\bin\Qt5Quick.dll
+2025-09-12 08:34:21.313   Time stamp of our file: 2024-05-25 09:38:32.000
+2025-09-12 08:34:21.313   Installing the file.
+2025-09-12 08:34:21.374   Successfully installed the file.
+2025-09-12 08:34:21.374   -- File entry --
+2025-09-12 08:34:21.374   Dest filename: C:\vimacc\bin\Qt5QuickControls2.dll
+2025-09-12 08:34:21.375   Time stamp of our file: 2024-05-25 11:49:36.000
+2025-09-12 08:34:21.375   Installing the file.
+2025-09-12 08:34:21.378   Successfully installed the file.
+2025-09-12 08:34:21.378   -- File entry --
+2025-09-12 08:34:21.378   Dest filename: C:\vimacc\bin\Qt5QuickTemplates2.dll
+2025-09-12 08:34:21.378   Time stamp of our file: 2024-05-25 11:34:20.000
+2025-09-12 08:34:21.378   Installing the file.
+2025-09-12 08:34:21.392   Successfully installed the file.
+2025-09-12 08:34:21.392   -- File entry --
+2025-09-12 08:34:21.393   Dest filename: C:\vimacc\bin\Qt5PositioningQuick.dll
+2025-09-12 08:34:21.393   Time stamp of our file: 2024-05-25 12:42:06.000
+2025-09-12 08:34:21.393   Installing the file.
+2025-09-12 08:34:21.394   Successfully installed the file.
+2025-09-12 08:34:21.395   -- File entry --
+2025-09-12 08:34:21.395   Dest filename: C:\vimacc\bin\Qt5Positioning.dll
+2025-09-12 08:34:21.395   Time stamp of our file: 2024-05-25 12:35:54.000
+2025-09-12 08:34:21.395   Installing the file.
+2025-09-12 08:34:21.400   Successfully installed the file.
+2025-09-12 08:34:21.400   -- File entry --
+2025-09-12 08:34:21.401   Dest filename: C:\vimacc\bin\Qt5Location.dll
+2025-09-12 08:34:21.401   Time stamp of our file: 2024-05-25 13:26:40.000
+2025-09-12 08:34:21.401   Installing the file.
+2025-09-12 08:34:21.420   Successfully installed the file.
+2025-09-12 08:34:21.420   -- File entry --
+2025-09-12 08:34:21.420   Dest filename: C:\vimacc\bin\Qt5Qml.dll
+2025-09-12 08:34:21.421   Time stamp of our file: 2024-05-25 09:18:08.000
+2025-09-12 08:34:21.421   Installing the file.
+2025-09-12 08:34:21.472   Successfully installed the file.
+2025-09-12 08:34:21.472   -- File entry --
+2025-09-12 08:34:21.472   Dest filename: C:\vimacc\bin\Qt5QmlModels.dll
+2025-09-12 08:34:21.472   Time stamp of our file: 2024-05-25 09:19:20.000
+2025-09-12 08:34:21.472   Installing the file.
+2025-09-12 08:34:21.479   Successfully installed the file.
+2025-09-12 08:34:21.479   -- File entry --
+2025-09-12 08:34:21.479   Dest filename: C:\vimacc\bin\Qt5QmlWorkerScript.dll
+2025-09-12 08:34:21.479   Time stamp of our file: 2024-05-25 09:19:52.000
+2025-09-12 08:34:21.479   Installing the file.
+2025-09-12 08:34:21.481   Successfully installed the file.
+2025-09-12 08:34:21.481   -- File entry --
+2025-09-12 08:34:21.482   Dest filename: C:\vimacc\data\plugins\geoservices\qtgeoservices_osm.dll
+2025-09-12 08:34:21.482   Time stamp of our file: 2024-05-25 13:39:06.000
+2025-09-12 08:34:21.482   Installing the file.
+2025-09-12 08:34:21.482   Creating directory: C:\vimacc\data\plugins\geoservices
+2025-09-12 08:34:21.485   Successfully installed the file.
+2025-09-12 08:34:21.485   -- File entry --
+2025-09-12 08:34:21.485   Dest filename: C:\vimacc\bin\QtLocation\qmldir
+2025-09-12 08:34:21.485   Time stamp of our file: 2023-10-11 15:01:34.000
+2025-09-12 08:34:21.485   Installing the file.
+2025-09-12 08:34:21.486   Creating directory: C:\vimacc\bin\QtLocation
+2025-09-12 08:34:21.486   Successfully installed the file.
+2025-09-12 08:34:21.486   -- File entry --
+2025-09-12 08:34:21.487   Dest filename: C:\vimacc\bin\QtLocation\plugins.qmltypes
+2025-09-12 08:34:21.487   Time stamp of our file: 2023-10-11 15:01:34.000
+2025-09-12 08:34:21.487   Installing the file.
+2025-09-12 08:34:21.488   Successfully installed the file.
+2025-09-12 08:34:21.488   -- File entry --
+2025-09-12 08:34:21.488   Dest filename: C:\vimacc\bin\QtLocation\declarative_location.dll
+2025-09-12 08:34:21.488   Time stamp of our file: 2024-05-25 13:30:26.000
+2025-09-12 08:34:21.488   Installing the file.
+2025-09-12 08:34:21.491   Successfully installed the file.
+2025-09-12 08:34:21.491   -- File entry --
+2025-09-12 08:34:21.491   Dest filename: C:\vimacc\bin\QtPositioning\qmldir
+2025-09-12 08:34:21.491   Time stamp of our file: 2023-10-11 15:01:34.000
+2025-09-12 08:34:21.491   Installing the file.
+2025-09-12 08:34:21.491   Creating directory: C:\vimacc\bin\QtPositioning
+2025-09-12 08:34:21.491   Successfully installed the file.
+2025-09-12 08:34:21.491   -- File entry --
+2025-09-12 08:34:21.493   Dest filename: C:\vimacc\bin\QtPositioning\plugins.qmltypes
+2025-09-12 08:34:21.493   Time stamp of our file: 2023-10-11 15:01:34.000
+2025-09-12 08:34:21.493   Installing the file.
+2025-09-12 08:34:21.493   Successfully installed the file.
+2025-09-12 08:34:21.493   -- File entry --
+2025-09-12 08:34:21.494   Dest filename: C:\vimacc\bin\QtPositioning\declarative_positioning.dll
+2025-09-12 08:34:21.494   Time stamp of our file: 2024-05-25 13:32:04.000
+2025-09-12 08:34:21.494   Installing the file.
+2025-09-12 08:34:21.495   Successfully installed the file.
+2025-09-12 08:34:21.495   -- File entry --
+2025-09-12 08:34:21.495   Dest filename: C:\vimacc\bin\QtQuick.2\qmldir
+2025-09-12 08:34:21.495   Time stamp of our file: 2023-10-11 15:01:30.000
+2025-09-12 08:34:21.495   Installing the file.
+2025-09-12 08:34:21.496   Creating directory: C:\vimacc\bin\QtQuick.2
+2025-09-12 08:34:21.496   Successfully installed the file.
+2025-09-12 08:34:21.496   -- File entry --
+2025-09-12 08:34:21.496   Dest filename: C:\vimacc\bin\QtQuick.2\plugins.qmltypes
+2025-09-12 08:34:21.497   Time stamp of our file: 2024-05-25 09:37:54.000
+2025-09-12 08:34:21.497   Installing the file.
+2025-09-12 08:34:21.498   Successfully installed the file.
+2025-09-12 08:34:21.498   -- File entry --
+2025-09-12 08:34:21.499   Dest filename: C:\vimacc\bin\QtQuick.2\qtquick2plugin.dll
+2025-09-12 08:34:21.499   Time stamp of our file: 2024-05-25 09:53:44.000
+2025-09-12 08:34:21.499   Installing the file.
+2025-09-12 08:34:21.499   Successfully installed the file.
+2025-09-12 08:34:21.500   -- File entry --
+2025-09-12 08:34:21.500   Dest filename: C:\vimacc\bin\QtQuick\Layouts\qmldir
+2025-09-12 08:34:21.500   Time stamp of our file: 2023-10-11 15:01:30.000
+2025-09-12 08:34:21.500   Installing the file.
+2025-09-12 08:34:21.500   Creating directory: C:\vimacc\bin\QtQuick
+2025-09-12 08:34:21.500   Creating directory: C:\vimacc\bin\QtQuick\Layouts
+2025-09-12 08:34:21.501   Successfully installed the file.
+2025-09-12 08:34:21.501   -- File entry --
+2025-09-12 08:34:21.501   Dest filename: C:\vimacc\bin\QtQuick\Layouts\plugins.qmltypes
+2025-09-12 08:34:21.501   Time stamp of our file: 2024-05-25 09:56:36.000
+2025-09-12 08:34:21.501   Installing the file.
+2025-09-12 08:34:21.502   Successfully installed the file.
+2025-09-12 08:34:21.502   -- File entry --
+2025-09-12 08:34:21.502   Dest filename: C:\vimacc\bin\QtQuick\Layouts\qquicklayoutsplugin.dll
+2025-09-12 08:34:21.502   Time stamp of our file: 2024-05-25 09:57:10.000
+2025-09-12 08:34:21.502   Installing the file.
+2025-09-12 08:34:21.504   Successfully installed the file.
+2025-09-12 08:34:21.504   -- File entry --
+2025-09-12 08:34:21.504   Dest filename: C:\vimacc\bin\QtQuick\Shapes\qmldir
+2025-09-12 08:34:21.504   Time stamp of our file: 2023-10-11 15:01:30.000
+2025-09-12 08:34:21.504   Installing the file.
+2025-09-12 08:34:21.504   Creating directory: C:\vimacc\bin\QtQuick\Shapes
+2025-09-12 08:34:21.505   Successfully installed the file.
+2025-09-12 08:34:21.505   -- File entry --
+2025-09-12 08:34:21.505   Dest filename: C:\vimacc\bin\QtQuick\Shapes\plugins.qmltypes
+2025-09-12 08:34:21.505   Time stamp of our file: 2024-05-25 09:39:22.000
+2025-09-12 08:34:21.505   Installing the file.
+2025-09-12 08:34:21.506   Successfully installed the file.
+2025-09-12 08:34:21.506   -- File entry --
+2025-09-12 08:34:21.506   Dest filename: C:\vimacc\bin\QtQuick\Shapes\qmlshapesplugin.dll
+2025-09-12 08:34:21.507   Time stamp of our file: 2024-05-25 09:56:36.000
+2025-09-12 08:34:21.507   Installing the file.
+2025-09-12 08:34:21.508   Successfully installed the file.
+2025-09-12 08:34:21.508   -- File entry --
+2025-09-12 08:34:21.508   Dest filename: C:\vimacc\bin\QtQuick\Templates.2\qmldir
+2025-09-12 08:34:21.508   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.508   Installing the file.
+2025-09-12 08:34:21.508   Creating directory: C:\vimacc\bin\QtQuick\Templates.2
+2025-09-12 08:34:21.509   Successfully installed the file.
+2025-09-12 08:34:21.509   -- File entry --
+2025-09-12 08:34:21.509   Dest filename: C:\vimacc\bin\QtQuick\Templates.2\plugins.qmltypes
+2025-09-12 08:34:21.509   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.509   Installing the file.
+2025-09-12 08:34:21.510   Successfully installed the file.
+2025-09-12 08:34:21.511   -- File entry --
+2025-09-12 08:34:21.511   Dest filename: C:\vimacc\bin\QtQuick\Templates.2\qtquicktemplates2plugin.dll
+2025-09-12 08:34:21.511   Time stamp of our file: 2024-05-25 11:56:10.000
+2025-09-12 08:34:21.511   Installing the file.
+2025-09-12 08:34:21.514   Successfully installed the file.
+2025-09-12 08:34:21.514   -- File entry --
+2025-09-12 08:34:21.514   Dest filename: C:\vimacc\bin\QtQuick\Window.2\qmldir
+2025-09-12 08:34:21.515   Time stamp of our file: 2023-10-11 15:01:30.000
+2025-09-12 08:34:21.515   Installing the file.
+2025-09-12 08:34:21.515   Creating directory: C:\vimacc\bin\QtQuick\Window.2
+2025-09-12 08:34:21.515   Successfully installed the file.
+2025-09-12 08:34:21.515   -- File entry --
+2025-09-12 08:34:21.516   Dest filename: C:\vimacc\bin\QtQuick\Window.2\plugins.qmltypes
+2025-09-12 08:34:21.516   Time stamp of our file: 2024-05-25 09:55:10.000
+2025-09-12 08:34:21.516   Installing the file.
+2025-09-12 08:34:21.516   Successfully installed the file.
+2025-09-12 08:34:21.516   -- File entry --
+2025-09-12 08:34:21.517   Dest filename: C:\vimacc\bin\QtQuick\Window.2\windowplugin.dll
+2025-09-12 08:34:21.517   Time stamp of our file: 2024-05-25 09:55:40.000
+2025-09-12 08:34:21.517   Installing the file.
+2025-09-12 08:34:21.518   Successfully installed the file.
+2025-09-12 08:34:21.518   -- File entry --
+2025-09-12 08:34:21.518   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\qmldir
+2025-09-12 08:34:21.518   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.518   Installing the file.
+2025-09-12 08:34:21.518   Creating directory: C:\vimacc\bin\QtQuick\Controls.2
+2025-09-12 08:34:21.519   Successfully installed the file.
+2025-09-12 08:34:21.519   -- File entry --
+2025-09-12 08:34:21.519   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\plugins.qmltypes
+2025-09-12 08:34:21.519   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.519   Installing the file.
+2025-09-12 08:34:21.520   Successfully installed the file.
+2025-09-12 08:34:21.520   -- File entry --
+2025-09-12 08:34:21.520   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\qtquickcontrols2plugin.dll
+2025-09-12 08:34:21.520   Time stamp of our file: 2024-05-25 12:25:16.000
+2025-09-12 08:34:21.520   Installing the file.
+2025-09-12 08:34:21.524   Successfully installed the file.
+2025-09-12 08:34:21.524   -- File entry --
+2025-09-12 08:34:21.524   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\AbstractButton.qml
+2025-09-12 08:34:21.524   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.524   Installing the file.
+2025-09-12 08:34:21.525   Successfully installed the file.
+2025-09-12 08:34:21.525   -- File entry --
+2025-09-12 08:34:21.525   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\Action.qml
+2025-09-12 08:34:21.526   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.526   Installing the file.
+2025-09-12 08:34:21.526   Successfully installed the file.
+2025-09-12 08:34:21.526   -- File entry --
+2025-09-12 08:34:21.526   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\ActionGroup.qml
+2025-09-12 08:34:21.527   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.527   Installing the file.
+2025-09-12 08:34:21.527   Successfully installed the file.
+2025-09-12 08:34:21.527   -- File entry --
+2025-09-12 08:34:21.527   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\ApplicationWindow.qml
+2025-09-12 08:34:21.528   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.528   Installing the file.
+2025-09-12 08:34:21.528   Successfully installed the file.
+2025-09-12 08:34:21.528   -- File entry --
+2025-09-12 08:34:21.528   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\BusyIndicator.qml
+2025-09-12 08:34:21.529   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.529   Installing the file.
+2025-09-12 08:34:21.529   Successfully installed the file.
+2025-09-12 08:34:21.529   -- File entry --
+2025-09-12 08:34:21.529   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\Button.qml
+2025-09-12 08:34:21.530   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.530   Installing the file.
+2025-09-12 08:34:21.530   Successfully installed the file.
+2025-09-12 08:34:21.530   -- File entry --
+2025-09-12 08:34:21.530   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\ButtonGroup.qml
+2025-09-12 08:34:21.531   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.531   Installing the file.
+2025-09-12 08:34:21.531   Successfully installed the file.
+2025-09-12 08:34:21.531   -- File entry --
+2025-09-12 08:34:21.531   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\CheckBox.qml
+2025-09-12 08:34:21.532   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.532   Installing the file.
+2025-09-12 08:34:21.532   Successfully installed the file.
+2025-09-12 08:34:21.532   -- File entry --
+2025-09-12 08:34:21.532   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\CheckDelegate.qml
+2025-09-12 08:34:21.533   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.533   Installing the file.
+2025-09-12 08:34:21.533   Successfully installed the file.
+2025-09-12 08:34:21.533   -- File entry --
+2025-09-12 08:34:21.533   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\ComboBox.qml
+2025-09-12 08:34:21.534   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.534   Installing the file.
+2025-09-12 08:34:21.534   Successfully installed the file.
+2025-09-12 08:34:21.534   -- File entry --
+2025-09-12 08:34:21.534   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\Container.qml
+2025-09-12 08:34:21.535   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.535   Installing the file.
+2025-09-12 08:34:21.535   Successfully installed the file.
+2025-09-12 08:34:21.535   -- File entry --
+2025-09-12 08:34:21.535   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\Control.qml
+2025-09-12 08:34:21.536   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.536   Installing the file.
+2025-09-12 08:34:21.536   Successfully installed the file.
+2025-09-12 08:34:21.536   -- File entry --
+2025-09-12 08:34:21.536   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\DelayButton.qml
+2025-09-12 08:34:21.537   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.537   Installing the file.
+2025-09-12 08:34:21.537   Successfully installed the file.
+2025-09-12 08:34:21.537   -- File entry --
+2025-09-12 08:34:21.537   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\Dial.qml
+2025-09-12 08:34:21.537   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.537   Installing the file.
+2025-09-12 08:34:21.539   Successfully installed the file.
+2025-09-12 08:34:21.539   -- File entry --
+2025-09-12 08:34:21.539   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\Dialog.qml
+2025-09-12 08:34:21.539   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.539   Installing the file.
+2025-09-12 08:34:21.540   Successfully installed the file.
+2025-09-12 08:34:21.540   -- File entry --
+2025-09-12 08:34:21.540   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\DialogButtonBox.qml
+2025-09-12 08:34:21.540   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.540   Installing the file.
+2025-09-12 08:34:21.541   Successfully installed the file.
+2025-09-12 08:34:21.541   -- File entry --
+2025-09-12 08:34:21.541   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\Drawer.qml
+2025-09-12 08:34:21.541   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.541   Installing the file.
+2025-09-12 08:34:21.542   Successfully installed the file.
+2025-09-12 08:34:21.542   -- File entry --
+2025-09-12 08:34:21.542   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\Frame.qml
+2025-09-12 08:34:21.542   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.542   Installing the file.
+2025-09-12 08:34:21.543   Successfully installed the file.
+2025-09-12 08:34:21.543   -- File entry --
+2025-09-12 08:34:21.543   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\GroupBox.qml
+2025-09-12 08:34:21.543   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.543   Installing the file.
+2025-09-12 08:34:21.543   Successfully installed the file.
+2025-09-12 08:34:21.543   -- File entry --
+2025-09-12 08:34:21.544   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\HorizontalHeaderView.qml
+2025-09-12 08:34:21.544   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.544   Installing the file.
+2025-09-12 08:34:21.544   Successfully installed the file.
+2025-09-12 08:34:21.544   -- File entry --
+2025-09-12 08:34:21.545   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\ItemDelegate.qml
+2025-09-12 08:34:21.545   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.545   Installing the file.
+2025-09-12 08:34:21.546   Successfully installed the file.
+2025-09-12 08:34:21.546   -- File entry --
+2025-09-12 08:34:21.546   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\Label.qml
+2025-09-12 08:34:21.546   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.546   Installing the file.
+2025-09-12 08:34:21.547   Successfully installed the file.
+2025-09-12 08:34:21.547   -- File entry --
+2025-09-12 08:34:21.547   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\Menu.qml
+2025-09-12 08:34:21.547   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.547   Installing the file.
+2025-09-12 08:34:21.548   Successfully installed the file.
+2025-09-12 08:34:21.548   -- File entry --
+2025-09-12 08:34:21.548   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\MenuBar.qml
+2025-09-12 08:34:21.548   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.548   Installing the file.
+2025-09-12 08:34:21.549   Successfully installed the file.
+2025-09-12 08:34:21.549   -- File entry --
+2025-09-12 08:34:21.550   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\MenuBarItem.qml
+2025-09-12 08:34:21.550   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.550   Installing the file.
+2025-09-12 08:34:21.550   Successfully installed the file.
+2025-09-12 08:34:21.550   -- File entry --
+2025-09-12 08:34:21.551   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\MenuItem.qml
+2025-09-12 08:34:21.551   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.551   Installing the file.
+2025-09-12 08:34:21.551   Successfully installed the file.
+2025-09-12 08:34:21.551   -- File entry --
+2025-09-12 08:34:21.552   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\MenuSeparator.qml
+2025-09-12 08:34:21.552   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.552   Installing the file.
+2025-09-12 08:34:21.552   Successfully installed the file.
+2025-09-12 08:34:21.552   -- File entry --
+2025-09-12 08:34:21.553   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\Page.qml
+2025-09-12 08:34:21.553   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.553   Installing the file.
+2025-09-12 08:34:21.553   Successfully installed the file.
+2025-09-12 08:34:21.553   -- File entry --
+2025-09-12 08:34:21.553   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\PageIndicator.qml
+2025-09-12 08:34:21.553   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.553   Installing the file.
+2025-09-12 08:34:21.555   Successfully installed the file.
+2025-09-12 08:34:21.555   -- File entry --
+2025-09-12 08:34:21.555   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\Pane.qml
+2025-09-12 08:34:21.555   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.555   Installing the file.
+2025-09-12 08:34:21.556   Successfully installed the file.
+2025-09-12 08:34:21.556   -- File entry --
+2025-09-12 08:34:21.556   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\plugins.qmltypes
+2025-09-12 08:34:21.556   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.556   Dest file exists.
+2025-09-12 08:34:21.556   Time stamp of existing file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.556   Installing the file.
+2025-09-12 08:34:21.568   Successfully installed the file.
+2025-09-12 08:34:21.568   -- File entry --
+2025-09-12 08:34:21.569   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\Popup.qml
+2025-09-12 08:34:21.569   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.569   Installing the file.
+2025-09-12 08:34:21.569   Successfully installed the file.
+2025-09-12 08:34:21.569   -- File entry --
+2025-09-12 08:34:21.570   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\ProgressBar.qml
+2025-09-12 08:34:21.570   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.570   Installing the file.
+2025-09-12 08:34:21.570   Successfully installed the file.
+2025-09-12 08:34:21.570   -- File entry --
+2025-09-12 08:34:21.571   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\RadioButton.qml
+2025-09-12 08:34:21.571   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.571   Installing the file.
+2025-09-12 08:34:21.571   Successfully installed the file.
+2025-09-12 08:34:21.571   -- File entry --
+2025-09-12 08:34:21.572   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\RadioDelegate.qml
+2025-09-12 08:34:21.572   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.572   Installing the file.
+2025-09-12 08:34:21.573   Successfully installed the file.
+2025-09-12 08:34:21.573   -- File entry --
+2025-09-12 08:34:21.573   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\RangeSlider.qml
+2025-09-12 08:34:21.573   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.573   Installing the file.
+2025-09-12 08:34:21.574   Successfully installed the file.
+2025-09-12 08:34:21.574   -- File entry --
+2025-09-12 08:34:21.574   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\RoundButton.qml
+2025-09-12 08:34:21.574   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.574   Installing the file.
+2025-09-12 08:34:21.574   Successfully installed the file.
+2025-09-12 08:34:21.574   -- File entry --
+2025-09-12 08:34:21.574   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\ScrollBar.qml
+2025-09-12 08:34:21.576   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.576   Installing the file.
+2025-09-12 08:34:21.576   Successfully installed the file.
+2025-09-12 08:34:21.576   -- File entry --
+2025-09-12 08:34:21.577   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\ScrollIndicator.qml
+2025-09-12 08:34:21.577   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.577   Installing the file.
+2025-09-12 08:34:21.577   Successfully installed the file.
+2025-09-12 08:34:21.577   -- File entry --
+2025-09-12 08:34:21.577   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\ScrollView.qml
+2025-09-12 08:34:21.578   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.578   Installing the file.
+2025-09-12 08:34:21.578   Successfully installed the file.
+2025-09-12 08:34:21.578   -- File entry --
+2025-09-12 08:34:21.578   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\Slider.qml
+2025-09-12 08:34:21.579   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.579   Installing the file.
+2025-09-12 08:34:21.579   Successfully installed the file.
+2025-09-12 08:34:21.579   -- File entry --
+2025-09-12 08:34:21.579   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\SpinBox.qml
+2025-09-12 08:34:21.580   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.580   Installing the file.
+2025-09-12 08:34:21.580   Successfully installed the file.
+2025-09-12 08:34:21.580   -- File entry --
+2025-09-12 08:34:21.580   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\SplitView.qml
+2025-09-12 08:34:21.581   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.581   Installing the file.
+2025-09-12 08:34:21.581   Successfully installed the file.
+2025-09-12 08:34:21.581   -- File entry --
+2025-09-12 08:34:21.581   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\StackView.qml
+2025-09-12 08:34:21.582   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.582   Installing the file.
+2025-09-12 08:34:21.582   Successfully installed the file.
+2025-09-12 08:34:21.582   -- File entry --
+2025-09-12 08:34:21.583   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\SwipeDelegate.qml
+2025-09-12 08:34:21.583   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.583   Installing the file.
+2025-09-12 08:34:21.583   Successfully installed the file.
+2025-09-12 08:34:21.583   -- File entry --
+2025-09-12 08:34:21.584   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\SwipeView.qml
+2025-09-12 08:34:21.584   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.584   Installing the file.
+2025-09-12 08:34:21.584   Successfully installed the file.
+2025-09-12 08:34:21.584   -- File entry --
+2025-09-12 08:34:21.585   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\Switch.qml
+2025-09-12 08:34:21.585   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.585   Installing the file.
+2025-09-12 08:34:21.585   Successfully installed the file.
+2025-09-12 08:34:21.585   -- File entry --
+2025-09-12 08:34:21.585   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\SwitchDelegate.qml
+2025-09-12 08:34:21.585   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.585   Installing the file.
+2025-09-12 08:34:21.586   Successfully installed the file.
+2025-09-12 08:34:21.586   -- File entry --
+2025-09-12 08:34:21.586   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\TabBar.qml
+2025-09-12 08:34:21.586   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.586   Installing the file.
+2025-09-12 08:34:21.587   Successfully installed the file.
+2025-09-12 08:34:21.587   -- File entry --
+2025-09-12 08:34:21.587   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\TabButton.qml
+2025-09-12 08:34:21.587   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.587   Installing the file.
+2025-09-12 08:34:21.588   Successfully installed the file.
+2025-09-12 08:34:21.588   -- File entry --
+2025-09-12 08:34:21.588   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\TextArea.qml
+2025-09-12 08:34:21.588   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.588   Installing the file.
+2025-09-12 08:34:21.589   Successfully installed the file.
+2025-09-12 08:34:21.589   -- File entry --
+2025-09-12 08:34:21.589   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\TextField.qml
+2025-09-12 08:34:21.589   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.589   Installing the file.
+2025-09-12 08:34:21.590   Successfully installed the file.
+2025-09-12 08:34:21.590   -- File entry --
+2025-09-12 08:34:21.590   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\ToolBar.qml
+2025-09-12 08:34:21.590   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.590   Installing the file.
+2025-09-12 08:34:21.591   Successfully installed the file.
+2025-09-12 08:34:21.591   -- File entry --
+2025-09-12 08:34:21.591   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\ToolButton.qml
+2025-09-12 08:34:21.591   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.591   Installing the file.
+2025-09-12 08:34:21.592   Successfully installed the file.
+2025-09-12 08:34:21.592   -- File entry --
+2025-09-12 08:34:21.592   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\ToolSeparator.qml
+2025-09-12 08:34:21.592   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.592   Installing the file.
+2025-09-12 08:34:21.593   Successfully installed the file.
+2025-09-12 08:34:21.593   -- File entry --
+2025-09-12 08:34:21.593   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\ToolTip.qml
+2025-09-12 08:34:21.593   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.593   Installing the file.
+2025-09-12 08:34:21.594   Successfully installed the file.
+2025-09-12 08:34:21.594   -- File entry --
+2025-09-12 08:34:21.594   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\Tumbler.qml
+2025-09-12 08:34:21.594   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.594   Installing the file.
+2025-09-12 08:34:21.595   Successfully installed the file.
+2025-09-12 08:34:21.595   -- File entry --
+2025-09-12 08:34:21.595   Dest filename: C:\vimacc\bin\QtQuick\Controls.2\VerticalHeaderView.qml
+2025-09-12 08:34:21.595   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.595   Installing the file.
+2025-09-12 08:34:21.595   Successfully installed the file.
+2025-09-12 08:34:21.597   -- File entry --
+2025-09-12 08:34:21.597   Dest filename: C:\vimacc\bin\QtQuick\Controls\qmldir
+2025-09-12 08:34:21.597   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.597   Installing the file.
+2025-09-12 08:34:21.597   Creating directory: C:\vimacc\bin\QtQuick\Controls
+2025-09-12 08:34:21.598   Successfully installed the file.
+2025-09-12 08:34:21.598   -- File entry --
+2025-09-12 08:34:21.598   Dest filename: C:\vimacc\bin\QtQuick\Controls\plugins.qmltypes
+2025-09-12 08:34:21.598   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.598   Installing the file.
+2025-09-12 08:34:21.600   Successfully installed the file.
+2025-09-12 08:34:21.600   -- File entry --
+2025-09-12 08:34:21.600   Dest filename: C:\vimacc\bin\QtQuick\Controls\qtquickcontrolsplugin.dll
+2025-09-12 08:34:21.600   Time stamp of our file: 2024-05-25 11:10:58.000
+2025-09-12 08:34:21.600   Installing the file.
+2025-09-12 08:34:21.605   Successfully installed the file.
+2025-09-12 08:34:21.605   -- File entry --
+2025-09-12 08:34:21.605   Dest filename: C:\vimacc\bin\QtQuick\Controls\ApplicationWindow.qml
+2025-09-12 08:34:21.605   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.605   Installing the file.
+2025-09-12 08:34:21.605   Successfully installed the file.
+2025-09-12 08:34:21.607   -- File entry --
+2025-09-12 08:34:21.607   Dest filename: C:\vimacc\bin\QtQuick\Controls\BusyIndicator.qml
+2025-09-12 08:34:21.607   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.607   Installing the file.
+2025-09-12 08:34:21.607   Successfully installed the file.
+2025-09-12 08:34:21.607   -- File entry --
+2025-09-12 08:34:21.608   Dest filename: C:\vimacc\bin\QtQuick\Controls\Button.qml
+2025-09-12 08:34:21.608   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.608   Installing the file.
+2025-09-12 08:34:21.608   Successfully installed the file.
+2025-09-12 08:34:21.608   -- File entry --
+2025-09-12 08:34:21.609   Dest filename: C:\vimacc\bin\QtQuick\Controls\Calendar.qml
+2025-09-12 08:34:21.609   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.609   Installing the file.
+2025-09-12 08:34:21.609   Successfully installed the file.
+2025-09-12 08:34:21.610   -- File entry --
+2025-09-12 08:34:21.610   Dest filename: C:\vimacc\bin\QtQuick\Controls\CheckBox.qml
+2025-09-12 08:34:21.610   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.610   Installing the file.
+2025-09-12 08:34:21.610   Successfully installed the file.
+2025-09-12 08:34:21.611   -- File entry --
+2025-09-12 08:34:21.611   Dest filename: C:\vimacc\bin\QtQuick\Controls\ComboBox.qml
+2025-09-12 08:34:21.611   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.611   Installing the file.
+2025-09-12 08:34:21.612   Successfully installed the file.
+2025-09-12 08:34:21.612   -- File entry --
+2025-09-12 08:34:21.612   Dest filename: C:\vimacc\bin\QtQuick\Controls\GroupBox.qml
+2025-09-12 08:34:21.612   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.612   Installing the file.
+2025-09-12 08:34:21.613   Successfully installed the file.
+2025-09-12 08:34:21.613   -- File entry --
+2025-09-12 08:34:21.613   Dest filename: C:\vimacc\bin\QtQuick\Controls\Label.qml
+2025-09-12 08:34:21.613   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.613   Installing the file.
+2025-09-12 08:34:21.614   Successfully installed the file.
+2025-09-12 08:34:21.614   -- File entry --
+2025-09-12 08:34:21.614   Dest filename: C:\vimacc\bin\QtQuick\Controls\Menu.qml
+2025-09-12 08:34:21.614   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.614   Installing the file.
+2025-09-12 08:34:21.615   Successfully installed the file.
+2025-09-12 08:34:21.615   -- File entry --
+2025-09-12 08:34:21.615   Dest filename: C:\vimacc\bin\QtQuick\Controls\MenuBar.qml
+2025-09-12 08:34:21.615   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.615   Installing the file.
+2025-09-12 08:34:21.616   Successfully installed the file.
+2025-09-12 08:34:21.616   -- File entry --
+2025-09-12 08:34:21.616   Dest filename: C:\vimacc\bin\QtQuick\Controls\plugins.qmltypes
+2025-09-12 08:34:21.617   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.617   Dest file exists.
+2025-09-12 08:34:21.617   Time stamp of existing file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.617   Installing the file.
+2025-09-12 08:34:21.631   Successfully installed the file.
+2025-09-12 08:34:21.631   -- File entry --
+2025-09-12 08:34:21.632   Dest filename: C:\vimacc\bin\QtQuick\Controls\ProgressBar.qml
+2025-09-12 08:34:21.632   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.632   Installing the file.
+2025-09-12 08:34:21.632   Successfully installed the file.
+2025-09-12 08:34:21.632   -- File entry --
+2025-09-12 08:34:21.634   Dest filename: C:\vimacc\bin\QtQuick\Controls\RadioButton.qml
+2025-09-12 08:34:21.634   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.634   Installing the file.
+2025-09-12 08:34:21.634   Successfully installed the file.
+2025-09-12 08:34:21.635   -- File entry --
+2025-09-12 08:34:21.635   Dest filename: C:\vimacc\bin\QtQuick\Controls\ScrollView.qml
+2025-09-12 08:34:21.635   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.635   Installing the file.
+2025-09-12 08:34:21.636   Successfully installed the file.
+2025-09-12 08:34:21.636   -- File entry --
+2025-09-12 08:34:21.636   Dest filename: C:\vimacc\bin\QtQuick\Controls\Slider.qml
+2025-09-12 08:34:21.636   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.636   Installing the file.
+2025-09-12 08:34:21.637   Successfully installed the file.
+2025-09-12 08:34:21.637   -- File entry --
+2025-09-12 08:34:21.637   Dest filename: C:\vimacc\bin\QtQuick\Controls\SpinBox.qml
+2025-09-12 08:34:21.637   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.637   Installing the file.
+2025-09-12 08:34:21.637   Successfully installed the file.
+2025-09-12 08:34:21.637   -- File entry --
+2025-09-12 08:34:21.638   Dest filename: C:\vimacc\bin\QtQuick\Controls\SplitView.qml
+2025-09-12 08:34:21.638   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.638   Installing the file.
+2025-09-12 08:34:21.639   Successfully installed the file.
+2025-09-12 08:34:21.639   -- File entry --
+2025-09-12 08:34:21.639   Dest filename: C:\vimacc\bin\QtQuick\Controls\StackView.qml
+2025-09-12 08:34:21.639   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.639   Installing the file.
+2025-09-12 08:34:21.640   Successfully installed the file.
+2025-09-12 08:34:21.640   -- File entry --
+2025-09-12 08:34:21.641   Dest filename: C:\vimacc\bin\QtQuick\Controls\StackViewDelegate.qml
+2025-09-12 08:34:21.641   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.641   Installing the file.
+2025-09-12 08:34:21.641   Successfully installed the file.
+2025-09-12 08:34:21.641   -- File entry --
+2025-09-12 08:34:21.642   Dest filename: C:\vimacc\bin\QtQuick\Controls\StackViewTransition.qml
+2025-09-12 08:34:21.642   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.642   Installing the file.
+2025-09-12 08:34:21.642   Successfully installed the file.
+2025-09-12 08:34:21.642   -- File entry --
+2025-09-12 08:34:21.643   Dest filename: C:\vimacc\bin\QtQuick\Controls\StatusBar.qml
+2025-09-12 08:34:21.643   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.643   Installing the file.
+2025-09-12 08:34:21.643   Successfully installed the file.
+2025-09-12 08:34:21.643   -- File entry --
+2025-09-12 08:34:21.644   Dest filename: C:\vimacc\bin\QtQuick\Controls\Switch.qml
+2025-09-12 08:34:21.644   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.644   Installing the file.
+2025-09-12 08:34:21.644   Successfully installed the file.
+2025-09-12 08:34:21.645   -- File entry --
+2025-09-12 08:34:21.645   Dest filename: C:\vimacc\bin\QtQuick\Controls\Tab.qml
+2025-09-12 08:34:21.645   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.645   Installing the file.
+2025-09-12 08:34:21.645   Successfully installed the file.
+2025-09-12 08:34:21.646   -- File entry --
+2025-09-12 08:34:21.646   Dest filename: C:\vimacc\bin\QtQuick\Controls\TableView.qml
+2025-09-12 08:34:21.646   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.646   Installing the file.
+2025-09-12 08:34:21.647   Successfully installed the file.
+2025-09-12 08:34:21.647   -- File entry --
+2025-09-12 08:34:21.647   Dest filename: C:\vimacc\bin\QtQuick\Controls\TableViewColumn.qml
+2025-09-12 08:34:21.647   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.647   Installing the file.
+2025-09-12 08:34:21.647   Successfully installed the file.
+2025-09-12 08:34:21.647   -- File entry --
+2025-09-12 08:34:21.649   Dest filename: C:\vimacc\bin\QtQuick\Controls\TabView.qml
+2025-09-12 08:34:21.649   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.649   Installing the file.
+2025-09-12 08:34:21.649   Successfully installed the file.
+2025-09-12 08:34:21.649   -- File entry --
+2025-09-12 08:34:21.650   Dest filename: C:\vimacc\bin\QtQuick\Controls\TextArea.qml
+2025-09-12 08:34:21.650   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.650   Installing the file.
+2025-09-12 08:34:21.651   Successfully installed the file.
+2025-09-12 08:34:21.651   -- File entry --
+2025-09-12 08:34:21.651   Dest filename: C:\vimacc\bin\QtQuick\Controls\TextField.qml
+2025-09-12 08:34:21.651   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.651   Installing the file.
+2025-09-12 08:34:21.652   Successfully installed the file.
+2025-09-12 08:34:21.652   -- File entry --
+2025-09-12 08:34:21.653   Dest filename: C:\vimacc\bin\QtQuick\Controls\ToolBar.qml
+2025-09-12 08:34:21.653   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.653   Installing the file.
+2025-09-12 08:34:21.653   Successfully installed the file.
+2025-09-12 08:34:21.653   -- File entry --
+2025-09-12 08:34:21.654   Dest filename: C:\vimacc\bin\QtQuick\Controls\ToolButton.qml
+2025-09-12 08:34:21.654   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.654   Installing the file.
+2025-09-12 08:34:21.654   Successfully installed the file.
+2025-09-12 08:34:21.654   -- File entry --
+2025-09-12 08:34:21.655   Dest filename: C:\vimacc\bin\QtQuick\Controls\TreeView.qml
+2025-09-12 08:34:21.655   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.655   Installing the file.
+2025-09-12 08:34:21.656   Successfully installed the file.
+2025-09-12 08:34:21.656   -- File entry --
+2025-09-12 08:34:21.656   Dest filename: C:\vimacc\bin\QtQuick\Controls\Private\qmldir
+2025-09-12 08:34:21.656   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.656   Installing the file.
+2025-09-12 08:34:21.656   Creating directory: C:\vimacc\bin\QtQuick\Controls\Private
+2025-09-12 08:34:21.657   Successfully installed the file.
+2025-09-12 08:34:21.657   -- File entry --
+2025-09-12 08:34:21.657   Dest filename: C:\vimacc\bin\QtQuick\Controls\Private\AbstractCheckable.qml
+2025-09-12 08:34:21.657   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.657   Installing the file.
+2025-09-12 08:34:21.658   Successfully installed the file.
+2025-09-12 08:34:21.658   -- File entry --
+2025-09-12 08:34:21.658   Dest filename: C:\vimacc\bin\QtQuick\Controls\Private\BasicButton.qml
+2025-09-12 08:34:21.658   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.658   Installing the file.
+2025-09-12 08:34:21.658   Successfully installed the file.
+2025-09-12 08:34:21.658   -- File entry --
+2025-09-12 08:34:21.659   Dest filename: C:\vimacc\bin\QtQuick\Controls\Private\BasicTableView.qml
+2025-09-12 08:34:21.659   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.659   Installing the file.
+2025-09-12 08:34:21.660   Successfully installed the file.
+2025-09-12 08:34:21.660   -- File entry --
+2025-09-12 08:34:21.660   Dest filename: C:\vimacc\bin\QtQuick\Controls\Private\CalendarHeaderModel.qml
+2025-09-12 08:34:21.660   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.660   Installing the file.
+2025-09-12 08:34:21.661   Successfully installed the file.
+2025-09-12 08:34:21.661   -- File entry --
+2025-09-12 08:34:21.661   Dest filename: C:\vimacc\bin\QtQuick\Controls\Private\ColumnMenuContent.qml
+2025-09-12 08:34:21.661   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.661   Installing the file.
+2025-09-12 08:34:21.662   Successfully installed the file.
+2025-09-12 08:34:21.662   -- File entry --
+2025-09-12 08:34:21.662   Dest filename: C:\vimacc\bin\QtQuick\Controls\Private\ContentItem.qml
+2025-09-12 08:34:21.662   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.662   Installing the file.
+2025-09-12 08:34:21.663   Successfully installed the file.
+2025-09-12 08:34:21.663   -- File entry --
+2025-09-12 08:34:21.663   Dest filename: C:\vimacc\bin\QtQuick\Controls\Private\Control.qml
+2025-09-12 08:34:21.663   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.663   Installing the file.
+2025-09-12 08:34:21.664   Successfully installed the file.
+2025-09-12 08:34:21.664   -- File entry --
+2025-09-12 08:34:21.664   Dest filename: C:\vimacc\bin\QtQuick\Controls\Private\EditMenu.qml
+2025-09-12 08:34:21.664   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.664   Installing the file.
+2025-09-12 08:34:21.665   Successfully installed the file.
+2025-09-12 08:34:21.665   -- File entry --
+2025-09-12 08:34:21.665   Dest filename: C:\vimacc\bin\QtQuick\Controls\Private\EditMenu_base.qml
+2025-09-12 08:34:21.665   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.665   Installing the file.
+2025-09-12 08:34:21.666   Successfully installed the file.
+2025-09-12 08:34:21.666   -- File entry --
+2025-09-12 08:34:21.666   Dest filename: C:\vimacc\bin\QtQuick\Controls\Private\FastGlow.qml
+2025-09-12 08:34:21.666   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.666   Installing the file.
+2025-09-12 08:34:21.666   Successfully installed the file.
+2025-09-12 08:34:21.668   -- File entry --
+2025-09-12 08:34:21.668   Dest filename: C:\vimacc\bin\QtQuick\Controls\Private\FocusFrame.qml
+2025-09-12 08:34:21.668   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.668   Installing the file.
+2025-09-12 08:34:21.668   Successfully installed the file.
+2025-09-12 08:34:21.668   -- File entry --
+2025-09-12 08:34:21.669   Dest filename: C:\vimacc\bin\QtQuick\Controls\Private\HoverButton.qml
+2025-09-12 08:34:21.669   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.669   Installing the file.
+2025-09-12 08:34:21.669   Successfully installed the file.
+2025-09-12 08:34:21.669   -- File entry --
+2025-09-12 08:34:21.670   Dest filename: C:\vimacc\bin\QtQuick\Controls\Private\MenuContentItem.qml
+2025-09-12 08:34:21.670   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.670   Installing the file.
+2025-09-12 08:34:21.670   Successfully installed the file.
+2025-09-12 08:34:21.671   -- File entry --
+2025-09-12 08:34:21.671   Dest filename: C:\vimacc\bin\QtQuick\Controls\Private\MenuContentScroller.qml
+2025-09-12 08:34:21.671   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.671   Installing the file.
+2025-09-12 08:34:21.671   Successfully installed the file.
+2025-09-12 08:34:21.672   -- File entry --
+2025-09-12 08:34:21.672   Dest filename: C:\vimacc\bin\QtQuick\Controls\Private\MenuItemSubControls.qml
+2025-09-12 08:34:21.672   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.672   Installing the file.
+2025-09-12 08:34:21.673   Successfully installed the file.
+2025-09-12 08:34:21.673   -- File entry --
+2025-09-12 08:34:21.673   Dest filename: C:\vimacc\bin\QtQuick\Controls\Private\ModalPopupBehavior.qml
+2025-09-12 08:34:21.673   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.673   Installing the file.
+2025-09-12 08:34:21.674   Successfully installed the file.
+2025-09-12 08:34:21.674   -- File entry --
+2025-09-12 08:34:21.674   Dest filename: C:\vimacc\bin\QtQuick\Controls\Private\ScrollBar.qml
+2025-09-12 08:34:21.674   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.674   Installing the file.
+2025-09-12 08:34:21.675   Successfully installed the file.
+2025-09-12 08:34:21.675   -- File entry --
+2025-09-12 08:34:21.675   Dest filename: C:\vimacc\bin\QtQuick\Controls\Private\ScrollViewHelper.qml
+2025-09-12 08:34:21.675   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.675   Installing the file.
+2025-09-12 08:34:21.676   Successfully installed the file.
+2025-09-12 08:34:21.676   -- File entry --
+2025-09-12 08:34:21.676   Dest filename: C:\vimacc\bin\QtQuick\Controls\Private\SourceProxy.qml
+2025-09-12 08:34:21.676   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.676   Installing the file.
+2025-09-12 08:34:21.677   Successfully installed the file.
+2025-09-12 08:34:21.677   -- File entry --
+2025-09-12 08:34:21.677   Dest filename: C:\vimacc\bin\QtQuick\Controls\Private\StackViewSlideDelegate.qml
+2025-09-12 08:34:21.678   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.678   Installing the file.
+2025-09-12 08:34:21.678   Successfully installed the file.
+2025-09-12 08:34:21.678   -- File entry --
+2025-09-12 08:34:21.678   Dest filename: C:\vimacc\bin\QtQuick\Controls\Private\Style.qml
+2025-09-12 08:34:21.678   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.678   Installing the file.
+2025-09-12 08:34:21.680   Successfully installed the file.
+2025-09-12 08:34:21.680   -- File entry --
+2025-09-12 08:34:21.680   Dest filename: C:\vimacc\bin\QtQuick\Controls\Private\SystemPaletteSingleton.qml
+2025-09-12 08:34:21.680   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.680   Installing the file.
+2025-09-12 08:34:21.681   Successfully installed the file.
+2025-09-12 08:34:21.681   -- File entry --
+2025-09-12 08:34:21.681   Dest filename: C:\vimacc\bin\QtQuick\Controls\Private\TabBar.qml
+2025-09-12 08:34:21.681   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.681   Installing the file.
+2025-09-12 08:34:21.682   Successfully installed the file.
+2025-09-12 08:34:21.682   -- File entry --
+2025-09-12 08:34:21.682   Dest filename: C:\vimacc\bin\QtQuick\Controls\Private\TableViewItemDelegateLoader.qml
+2025-09-12 08:34:21.682   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.682   Installing the file.
+2025-09-12 08:34:21.683   Successfully installed the file.
+2025-09-12 08:34:21.683   -- File entry --
+2025-09-12 08:34:21.683   Dest filename: C:\vimacc\bin\QtQuick\Controls\Private\TableViewSelection.qml
+2025-09-12 08:34:21.684   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.684   Installing the file.
+2025-09-12 08:34:21.684   Successfully installed the file.
+2025-09-12 08:34:21.684   -- File entry --
+2025-09-12 08:34:21.684   Dest filename: C:\vimacc\bin\QtQuick\Controls\Private\TextHandle.qml
+2025-09-12 08:34:21.685   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.685   Installing the file.
+2025-09-12 08:34:21.685   Successfully installed the file.
+2025-09-12 08:34:21.685   -- File entry --
+2025-09-12 08:34:21.686   Dest filename: C:\vimacc\bin\QtQuick\Controls\Private\TextInputWithHandles.qml
+2025-09-12 08:34:21.686   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.686   Installing the file.
+2025-09-12 08:34:21.686   Successfully installed the file.
+2025-09-12 08:34:21.686   -- File entry --
+2025-09-12 08:34:21.687   Dest filename: C:\vimacc\bin\QtQuick\Controls\Private\TextSingleton.qml
+2025-09-12 08:34:21.687   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.687   Installing the file.
+2025-09-12 08:34:21.687   Successfully installed the file.
+2025-09-12 08:34:21.687   -- File entry --
+2025-09-12 08:34:21.688   Dest filename: C:\vimacc\bin\QtQuick\Controls\Private\ToolMenuButton.qml
+2025-09-12 08:34:21.688   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.688   Installing the file.
+2025-09-12 08:34:21.688   Successfully installed the file.
+2025-09-12 08:34:21.688   -- File entry --
+2025-09-12 08:34:21.688   Dest filename: C:\vimacc\bin\QtQuick\Controls\Private\TreeViewItemDelegateLoader.qml
+2025-09-12 08:34:21.688   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.688   Installing the file.
+2025-09-12 08:34:21.689   Successfully installed the file.
+2025-09-12 08:34:21.689   -- File entry --
+2025-09-12 08:34:21.689   Dest filename: C:\vimacc\bin\QtQuick\Controls\Private\CalendarUtils.js
+2025-09-12 08:34:21.690   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.690   Installing the file.
+2025-09-12 08:34:21.691   Successfully installed the file.
+2025-09-12 08:34:21.691   -- File entry --
+2025-09-12 08:34:21.691   Dest filename: C:\vimacc\bin\QtQuick\Controls\Private\StackView.js
+2025-09-12 08:34:21.691   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.691   Installing the file.
+2025-09-12 08:34:21.692   Successfully installed the file.
+2025-09-12 08:34:21.692   -- File entry --
+2025-09-12 08:34:21.692   Dest filename: C:\vimacc\bin\QtQuick\Controls\Private\style.js
+2025-09-12 08:34:21.692   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.692   Installing the file.
+2025-09-12 08:34:21.693   Successfully installed the file.
+2025-09-12 08:34:21.693   -- File entry --
+2025-09-12 08:34:21.693   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\qmldir
+2025-09-12 08:34:21.693   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.693   Installing the file.
+2025-09-12 08:34:21.693   Creating directory: C:\vimacc\bin\QtQuick\Controls\Styles
+2025-09-12 08:34:21.694   Successfully installed the file.
+2025-09-12 08:34:21.694   -- File entry --
+2025-09-12 08:34:21.694   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\ApplicationWindowStyle.qml
+2025-09-12 08:34:21.694   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.694   Installing the file.
+2025-09-12 08:34:21.694   Creating directory: C:\vimacc\bin\QtQuick\Controls\Styles\Base
+2025-09-12 08:34:21.694   Successfully installed the file.
+2025-09-12 08:34:21.694   -- File entry --
+2025-09-12 08:34:21.695   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\BasicTableViewStyle.qml
+2025-09-12 08:34:21.695   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.695   Installing the file.
+2025-09-12 08:34:21.695   Successfully installed the file.
+2025-09-12 08:34:21.695   -- File entry --
+2025-09-12 08:34:21.696   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\BusyIndicatorStyle.qml
+2025-09-12 08:34:21.696   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.696   Installing the file.
+2025-09-12 08:34:21.697   Successfully installed the file.
+2025-09-12 08:34:21.697   -- File entry --
+2025-09-12 08:34:21.697   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\ButtonStyle.qml
+2025-09-12 08:34:21.697   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.697   Installing the file.
+2025-09-12 08:34:21.698   Successfully installed the file.
+2025-09-12 08:34:21.698   -- File entry --
+2025-09-12 08:34:21.699   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\CalendarStyle.qml
+2025-09-12 08:34:21.699   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.699   Installing the file.
+2025-09-12 08:34:21.699   Successfully installed the file.
+2025-09-12 08:34:21.699   -- File entry --
+2025-09-12 08:34:21.700   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\CheckBoxStyle.qml
+2025-09-12 08:34:21.700   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.700   Installing the file.
+2025-09-12 08:34:21.700   Successfully installed the file.
+2025-09-12 08:34:21.700   -- File entry --
+2025-09-12 08:34:21.701   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\CircularButtonStyle.qml
+2025-09-12 08:34:21.701   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.701   Installing the file.
+2025-09-12 08:34:21.701   Successfully installed the file.
+2025-09-12 08:34:21.702   -- File entry --
+2025-09-12 08:34:21.702   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\CircularGaugeStyle.qml
+2025-09-12 08:34:21.702   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.702   Installing the file.
+2025-09-12 08:34:21.703   Successfully installed the file.
+2025-09-12 08:34:21.703   -- File entry --
+2025-09-12 08:34:21.703   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\CircularTickmarkLabelStyle.qml
+2025-09-12 08:34:21.703   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.703   Installing the file.
+2025-09-12 08:34:21.704   Successfully installed the file.
+2025-09-12 08:34:21.704   -- File entry --
+2025-09-12 08:34:21.704   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\ComboBoxStyle.qml
+2025-09-12 08:34:21.704   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.704   Installing the file.
+2025-09-12 08:34:21.705   Successfully installed the file.
+2025-09-12 08:34:21.705   -- File entry --
+2025-09-12 08:34:21.705   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\CommonStyleHelper.qml
+2025-09-12 08:34:21.705   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.705   Installing the file.
+2025-09-12 08:34:21.706   Successfully installed the file.
+2025-09-12 08:34:21.706   -- File entry --
+2025-09-12 08:34:21.706   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\DelayButtonStyle.qml
+2025-09-12 08:34:21.706   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.706   Installing the file.
+2025-09-12 08:34:21.707   Successfully installed the file.
+2025-09-12 08:34:21.707   -- File entry --
+2025-09-12 08:34:21.707   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\DialStyle.qml
+2025-09-12 08:34:21.707   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.707   Installing the file.
+2025-09-12 08:34:21.708   Successfully installed the file.
+2025-09-12 08:34:21.708   -- File entry --
+2025-09-12 08:34:21.709   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\FocusFrameStyle.qml
+2025-09-12 08:34:21.709   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.709   Installing the file.
+2025-09-12 08:34:21.709   Successfully installed the file.
+2025-09-12 08:34:21.709   -- File entry --
+2025-09-12 08:34:21.709   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\GaugeStyle.qml
+2025-09-12 08:34:21.709   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.709   Installing the file.
+2025-09-12 08:34:21.711   Successfully installed the file.
+2025-09-12 08:34:21.711   -- File entry --
+2025-09-12 08:34:21.711   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\GroupBoxStyle.qml
+2025-09-12 08:34:21.711   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.711   Installing the file.
+2025-09-12 08:34:21.712   Successfully installed the file.
+2025-09-12 08:34:21.712   -- File entry --
+2025-09-12 08:34:21.712   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\HandleStyle.qml
+2025-09-12 08:34:21.712   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.712   Installing the file.
+2025-09-12 08:34:21.713   Successfully installed the file.
+2025-09-12 08:34:21.713   -- File entry --
+2025-09-12 08:34:21.713   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\HandleStyleHelper.qml
+2025-09-12 08:34:21.714   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.714   Installing the file.
+2025-09-12 08:34:21.714   Successfully installed the file.
+2025-09-12 08:34:21.714   -- File entry --
+2025-09-12 08:34:21.715   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\MenuBarStyle.qml
+2025-09-12 08:34:21.715   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.715   Installing the file.
+2025-09-12 08:34:21.715   Successfully installed the file.
+2025-09-12 08:34:21.715   -- File entry --
+2025-09-12 08:34:21.716   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\MenuStyle.qml
+2025-09-12 08:34:21.716   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.716   Installing the file.
+2025-09-12 08:34:21.716   Successfully installed the file.
+2025-09-12 08:34:21.717   -- File entry --
+2025-09-12 08:34:21.717   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\PieMenuStyle.qml
+2025-09-12 08:34:21.717   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.717   Installing the file.
+2025-09-12 08:34:21.718   Successfully installed the file.
+2025-09-12 08:34:21.718   -- File entry --
+2025-09-12 08:34:21.718   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\ProgressBarStyle.qml
+2025-09-12 08:34:21.718   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.718   Installing the file.
+2025-09-12 08:34:21.719   Successfully installed the file.
+2025-09-12 08:34:21.719   -- File entry --
+2025-09-12 08:34:21.719   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\RadioButtonStyle.qml
+2025-09-12 08:34:21.719   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.719   Installing the file.
+2025-09-12 08:34:21.720   Successfully installed the file.
+2025-09-12 08:34:21.720   -- File entry --
+2025-09-12 08:34:21.720   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\ScrollViewStyle.qml
+2025-09-12 08:34:21.720   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.720   Installing the file.
+2025-09-12 08:34:21.721   Successfully installed the file.
+2025-09-12 08:34:21.721   -- File entry --
+2025-09-12 08:34:21.721   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\SliderStyle.qml
+2025-09-12 08:34:21.721   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.721   Installing the file.
+2025-09-12 08:34:21.722   Successfully installed the file.
+2025-09-12 08:34:21.722   -- File entry --
+2025-09-12 08:34:21.722   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\SpinBoxStyle.qml
+2025-09-12 08:34:21.722   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.722   Installing the file.
+2025-09-12 08:34:21.723   Successfully installed the file.
+2025-09-12 08:34:21.723   -- File entry --
+2025-09-12 08:34:21.723   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\StatusBarStyle.qml
+2025-09-12 08:34:21.723   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.723   Installing the file.
+2025-09-12 08:34:21.724   Successfully installed the file.
+2025-09-12 08:34:21.724   -- File entry --
+2025-09-12 08:34:21.724   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\StatusIndicatorStyle.qml
+2025-09-12 08:34:21.724   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.724   Installing the file.
+2025-09-12 08:34:21.725   Successfully installed the file.
+2025-09-12 08:34:21.725   -- File entry --
+2025-09-12 08:34:21.726   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\SwitchStyle.qml
+2025-09-12 08:34:21.726   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.726   Installing the file.
+2025-09-12 08:34:21.726   Successfully installed the file.
+2025-09-12 08:34:21.726   -- File entry --
+2025-09-12 08:34:21.727   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\TableViewStyle.qml
+2025-09-12 08:34:21.727   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.727   Installing the file.
+2025-09-12 08:34:21.727   Successfully installed the file.
+2025-09-12 08:34:21.727   -- File entry --
+2025-09-12 08:34:21.728   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\TabViewStyle.qml
+2025-09-12 08:34:21.728   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.728   Installing the file.
+2025-09-12 08:34:21.728   Successfully installed the file.
+2025-09-12 08:34:21.728   -- File entry --
+2025-09-12 08:34:21.729   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\TextAreaStyle.qml
+2025-09-12 08:34:21.729   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.729   Installing the file.
+2025-09-12 08:34:21.729   Successfully installed the file.
+2025-09-12 08:34:21.729   -- File entry --
+2025-09-12 08:34:21.730   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\TextFieldStyle.qml
+2025-09-12 08:34:21.730   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.730   Installing the file.
+2025-09-12 08:34:21.731   Successfully installed the file.
+2025-09-12 08:34:21.731   -- File entry --
+2025-09-12 08:34:21.740   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\ToggleButtonStyle.qml
+2025-09-12 08:34:21.740   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.740   Installing the file.
+2025-09-12 08:34:21.741   Successfully installed the file.
+2025-09-12 08:34:21.741   -- File entry --
+2025-09-12 08:34:21.742   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\ToolBarStyle.qml
+2025-09-12 08:34:21.742   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.742   Installing the file.
+2025-09-12 08:34:21.742   Successfully installed the file.
+2025-09-12 08:34:21.742   -- File entry --
+2025-09-12 08:34:21.743   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\ToolButtonStyle.qml
+2025-09-12 08:34:21.743   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.743   Installing the file.
+2025-09-12 08:34:21.743   Successfully installed the file.
+2025-09-12 08:34:21.744   -- File entry --
+2025-09-12 08:34:21.744   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\TreeViewStyle.qml
+2025-09-12 08:34:21.744   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.744   Installing the file.
+2025-09-12 08:34:21.745   Successfully installed the file.
+2025-09-12 08:34:21.745   -- File entry --
+2025-09-12 08:34:21.745   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\TumblerStyle.qml
+2025-09-12 08:34:21.745   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.745   Installing the file.
+2025-09-12 08:34:21.746   Successfully installed the file.
+2025-09-12 08:34:21.746   -- File entry --
+2025-09-12 08:34:21.746   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\images\arrow-down.png
+2025-09-12 08:34:21.746   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.746   Installing the file.
+2025-09-12 08:34:21.746   Creating directory: C:\vimacc\bin\QtQuick\Controls\Styles\Base\images
+2025-09-12 08:34:21.747   Successfully installed the file.
+2025-09-12 08:34:21.747   -- File entry --
+2025-09-12 08:34:21.747   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\images\arrow-down@2x.png
+2025-09-12 08:34:21.748   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.748   Installing the file.
+2025-09-12 08:34:21.748   Successfully installed the file.
+2025-09-12 08:34:21.748   -- File entry --
+2025-09-12 08:34:21.749   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\images\arrow-left.png
+2025-09-12 08:34:21.749   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.749   Installing the file.
+2025-09-12 08:34:21.749   Successfully installed the file.
+2025-09-12 08:34:21.749   -- File entry --
+2025-09-12 08:34:21.750   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\images\arrow-left@2x.png
+2025-09-12 08:34:21.750   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.750   Installing the file.
+2025-09-12 08:34:21.750   Successfully installed the file.
+2025-09-12 08:34:21.750   -- File entry --
+2025-09-12 08:34:21.751   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\images\arrow-right.png
+2025-09-12 08:34:21.751   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.751   Installing the file.
+2025-09-12 08:34:21.751   Successfully installed the file.
+2025-09-12 08:34:21.751   -- File entry --
+2025-09-12 08:34:21.752   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\images\arrow-right@2x.png
+2025-09-12 08:34:21.752   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.752   Installing the file.
+2025-09-12 08:34:21.752   Successfully installed the file.
+2025-09-12 08:34:21.753   -- File entry --
+2025-09-12 08:34:21.753   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\images\arrow-up.png
+2025-09-12 08:34:21.753   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.753   Installing the file.
+2025-09-12 08:34:21.753   Successfully installed the file.
+2025-09-12 08:34:21.754   -- File entry --
+2025-09-12 08:34:21.754   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\images\arrow-up@2x.png
+2025-09-12 08:34:21.754   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.754   Installing the file.
+2025-09-12 08:34:21.755   Successfully installed the file.
+2025-09-12 08:34:21.755   -- File entry --
+2025-09-12 08:34:21.755   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\images\button.png
+2025-09-12 08:34:21.755   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.755   Installing the file.
+2025-09-12 08:34:21.756   Successfully installed the file.
+2025-09-12 08:34:21.756   -- File entry --
+2025-09-12 08:34:21.756   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\images\button_down.png
+2025-09-12 08:34:21.756   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.756   Installing the file.
+2025-09-12 08:34:21.757   Successfully installed the file.
+2025-09-12 08:34:21.757   -- File entry --
+2025-09-12 08:34:21.757   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\images\check.png
+2025-09-12 08:34:21.757   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.757   Installing the file.
+2025-09-12 08:34:21.758   Successfully installed the file.
+2025-09-12 08:34:21.758   -- File entry --
+2025-09-12 08:34:21.758   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\images\check@2x.png
+2025-09-12 08:34:21.758   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.758   Installing the file.
+2025-09-12 08:34:21.759   Successfully installed the file.
+2025-09-12 08:34:21.759   -- File entry --
+2025-09-12 08:34:21.759   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\images\editbox.png
+2025-09-12 08:34:21.759   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.759   Installing the file.
+2025-09-12 08:34:21.760   Successfully installed the file.
+2025-09-12 08:34:21.760   -- File entry --
+2025-09-12 08:34:21.760   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\images\focusframe.png
+2025-09-12 08:34:21.760   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.760   Installing the file.
+2025-09-12 08:34:21.760   Successfully installed the file.
+2025-09-12 08:34:21.760   -- File entry --
+2025-09-12 08:34:21.761   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\images\groupbox.png
+2025-09-12 08:34:21.761   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.761   Installing the file.
+2025-09-12 08:34:21.762   Successfully installed the file.
+2025-09-12 08:34:21.762   -- File entry --
+2025-09-12 08:34:21.762   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\images\header.png
+2025-09-12 08:34:21.763   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.763   Installing the file.
+2025-09-12 08:34:21.766   Successfully installed the file.
+2025-09-12 08:34:21.766   -- File entry --
+2025-09-12 08:34:21.767   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\images\knob.png
+2025-09-12 08:34:21.767   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.767   Installing the file.
+2025-09-12 08:34:21.767   Successfully installed the file.
+2025-09-12 08:34:21.768   -- File entry --
+2025-09-12 08:34:21.768   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\images\leftanglearrow.png
+2025-09-12 08:34:21.768   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.768   Installing the file.
+2025-09-12 08:34:21.769   Successfully installed the file.
+2025-09-12 08:34:21.769   -- File entry --
+2025-09-12 08:34:21.769   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\images\needle.png
+2025-09-12 08:34:21.769   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.769   Installing the file.
+2025-09-12 08:34:21.770   Successfully installed the file.
+2025-09-12 08:34:21.770   -- File entry --
+2025-09-12 08:34:21.770   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\images\progress-indeterminate.png
+2025-09-12 08:34:21.770   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.770   Installing the file.
+2025-09-12 08:34:21.771   Successfully installed the file.
+2025-09-12 08:34:21.771   -- File entry --
+2025-09-12 08:34:21.771   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\images\rightanglearrow.png
+2025-09-12 08:34:21.771   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.771   Installing the file.
+2025-09-12 08:34:21.771   Successfully installed the file.
+2025-09-12 08:34:21.772   -- File entry --
+2025-09-12 08:34:21.772   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\images\scrollbar-handle-horizontal.png
+2025-09-12 08:34:21.772   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.772   Installing the file.
+2025-09-12 08:34:21.773   Successfully installed the file.
+2025-09-12 08:34:21.773   -- File entry --
+2025-09-12 08:34:21.773   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\images\scrollbar-handle-transient.png
+2025-09-12 08:34:21.773   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.773   Installing the file.
+2025-09-12 08:34:21.774   Successfully installed the file.
+2025-09-12 08:34:21.774   -- File entry --
+2025-09-12 08:34:21.774   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\images\scrollbar-handle-vertical.png
+2025-09-12 08:34:21.774   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.774   Installing the file.
+2025-09-12 08:34:21.775   Successfully installed the file.
+2025-09-12 08:34:21.775   -- File entry --
+2025-09-12 08:34:21.775   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\images\slider-groove.png
+2025-09-12 08:34:21.775   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.775   Installing the file.
+2025-09-12 08:34:21.776   Successfully installed the file.
+2025-09-12 08:34:21.776   -- File entry --
+2025-09-12 08:34:21.776   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\images\slider-handle.png
+2025-09-12 08:34:21.776   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.776   Installing the file.
+2025-09-12 08:34:21.777   Successfully installed the file.
+2025-09-12 08:34:21.777   -- File entry --
+2025-09-12 08:34:21.778   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\images\spinner_large.png
+2025-09-12 08:34:21.778   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.778   Installing the file.
+2025-09-12 08:34:21.779   Successfully installed the file.
+2025-09-12 08:34:21.779   -- File entry --
+2025-09-12 08:34:21.779   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\images\spinner_medium.png
+2025-09-12 08:34:21.779   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.779   Installing the file.
+2025-09-12 08:34:21.780   Successfully installed the file.
+2025-09-12 08:34:21.780   -- File entry --
+2025-09-12 08:34:21.780   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\images\spinner_small.png
+2025-09-12 08:34:21.780   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.780   Installing the file.
+2025-09-12 08:34:21.781   Successfully installed the file.
+2025-09-12 08:34:21.781   -- File entry --
+2025-09-12 08:34:21.781   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\images\tab.png
+2025-09-12 08:34:21.781   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.781   Installing the file.
+2025-09-12 08:34:21.781   Successfully installed the file.
+2025-09-12 08:34:21.783   -- File entry --
+2025-09-12 08:34:21.783   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Base\images\tab_selected.png
+2025-09-12 08:34:21.783   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.783   Installing the file.
+2025-09-12 08:34:21.784   Successfully installed the file.
+2025-09-12 08:34:21.784   -- File entry --
+2025-09-12 08:34:21.784   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Desktop\ApplicationWindowStyle.qml
+2025-09-12 08:34:21.784   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.784   Installing the file.
+2025-09-12 08:34:21.784   Creating directory: C:\vimacc\bin\QtQuick\Controls\Styles\Desktop
+2025-09-12 08:34:21.785   Successfully installed the file.
+2025-09-12 08:34:21.785   -- File entry --
+2025-09-12 08:34:21.785   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Desktop\BusyIndicatorStyle.qml
+2025-09-12 08:34:21.785   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.785   Installing the file.
+2025-09-12 08:34:21.786   Successfully installed the file.
+2025-09-12 08:34:21.786   -- File entry --
+2025-09-12 08:34:21.786   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Desktop\ButtonStyle.qml
+2025-09-12 08:34:21.786   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.786   Installing the file.
+2025-09-12 08:34:21.787   Successfully installed the file.
+2025-09-12 08:34:21.787   -- File entry --
+2025-09-12 08:34:21.787   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Desktop\CalendarStyle.qml
+2025-09-12 08:34:21.787   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.787   Installing the file.
+2025-09-12 08:34:21.788   Successfully installed the file.
+2025-09-12 08:34:21.788   -- File entry --
+2025-09-12 08:34:21.788   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Desktop\CheckBoxStyle.qml
+2025-09-12 08:34:21.788   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.788   Installing the file.
+2025-09-12 08:34:21.789   Successfully installed the file.
+2025-09-12 08:34:21.789   -- File entry --
+2025-09-12 08:34:21.789   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Desktop\ComboBoxStyle.qml
+2025-09-12 08:34:21.789   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.790   Installing the file.
+2025-09-12 08:34:21.790   Successfully installed the file.
+2025-09-12 08:34:21.790   -- File entry --
+2025-09-12 08:34:21.791   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Desktop\FocusFrameStyle.qml
+2025-09-12 08:34:21.791   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.791   Installing the file.
+2025-09-12 08:34:21.791   Successfully installed the file.
+2025-09-12 08:34:21.791   -- File entry --
+2025-09-12 08:34:21.792   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Desktop\GroupBoxStyle.qml
+2025-09-12 08:34:21.792   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.792   Installing the file.
+2025-09-12 08:34:21.792   Successfully installed the file.
+2025-09-12 08:34:21.792   -- File entry --
+2025-09-12 08:34:21.793   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Desktop\MenuBarStyle.qml
+2025-09-12 08:34:21.793   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.793   Installing the file.
+2025-09-12 08:34:21.793   Successfully installed the file.
+2025-09-12 08:34:21.793   -- File entry --
+2025-09-12 08:34:21.793   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Desktop\MenuStyle.qml
+2025-09-12 08:34:21.794   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.794   Installing the file.
+2025-09-12 08:34:21.794   Successfully installed the file.
+2025-09-12 08:34:21.794   -- File entry --
+2025-09-12 08:34:21.795   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Desktop\ProgressBarStyle.qml
+2025-09-12 08:34:21.795   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.795   Installing the file.
+2025-09-12 08:34:21.795   Successfully installed the file.
+2025-09-12 08:34:21.796   -- File entry --
+2025-09-12 08:34:21.796   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Desktop\RadioButtonStyle.qml
+2025-09-12 08:34:21.796   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.796   Installing the file.
+2025-09-12 08:34:21.796   Successfully installed the file.
+2025-09-12 08:34:21.797   -- File entry --
+2025-09-12 08:34:21.797   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Desktop\RowItemSingleton.qml
+2025-09-12 08:34:21.797   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.797   Installing the file.
+2025-09-12 08:34:21.797   Successfully installed the file.
+2025-09-12 08:34:21.798   -- File entry --
+2025-09-12 08:34:21.798   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Desktop\ScrollViewStyle.qml
+2025-09-12 08:34:21.798   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.798   Installing the file.
+2025-09-12 08:34:21.799   Successfully installed the file.
+2025-09-12 08:34:21.799   -- File entry --
+2025-09-12 08:34:21.799   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Desktop\SliderStyle.qml
+2025-09-12 08:34:21.799   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.799   Installing the file.
+2025-09-12 08:34:21.800   Successfully installed the file.
+2025-09-12 08:34:21.800   -- File entry --
+2025-09-12 08:34:21.800   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Desktop\SpinBoxStyle.qml
+2025-09-12 08:34:21.800   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.800   Installing the file.
+2025-09-12 08:34:21.801   Successfully installed the file.
+2025-09-12 08:34:21.801   -- File entry --
+2025-09-12 08:34:21.801   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Desktop\StatusBarStyle.qml
+2025-09-12 08:34:21.801   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.801   Installing the file.
+2025-09-12 08:34:21.802   Successfully installed the file.
+2025-09-12 08:34:21.802   -- File entry --
+2025-09-12 08:34:21.802   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Desktop\SwitchStyle.qml
+2025-09-12 08:34:21.802   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.802   Installing the file.
+2025-09-12 08:34:21.802   Successfully installed the file.
+2025-09-12 08:34:21.802   -- File entry --
+2025-09-12 08:34:21.804   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Desktop\TableViewStyle.qml
+2025-09-12 08:34:21.804   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.804   Installing the file.
+2025-09-12 08:34:21.804   Successfully installed the file.
+2025-09-12 08:34:21.805   -- File entry --
+2025-09-12 08:34:21.805   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Desktop\TabViewStyle.qml
+2025-09-12 08:34:21.805   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.805   Installing the file.
+2025-09-12 08:34:21.806   Successfully installed the file.
+2025-09-12 08:34:21.806   -- File entry --
+2025-09-12 08:34:21.806   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Desktop\TextAreaStyle.qml
+2025-09-12 08:34:21.806   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.806   Installing the file.
+2025-09-12 08:34:21.806   Successfully installed the file.
+2025-09-12 08:34:21.806   -- File entry --
+2025-09-12 08:34:21.807   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Desktop\TextFieldStyle.qml
+2025-09-12 08:34:21.807   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.807   Installing the file.
+2025-09-12 08:34:21.807   Successfully installed the file.
+2025-09-12 08:34:21.807   -- File entry --
+2025-09-12 08:34:21.808   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Desktop\ToolBarStyle.qml
+2025-09-12 08:34:21.808   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.808   Installing the file.
+2025-09-12 08:34:21.808   Successfully installed the file.
+2025-09-12 08:34:21.808   -- File entry --
+2025-09-12 08:34:21.809   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Desktop\ToolButtonStyle.qml
+2025-09-12 08:34:21.809   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.809   Installing the file.
+2025-09-12 08:34:21.809   Successfully installed the file.
+2025-09-12 08:34:21.809   -- File entry --
+2025-09-12 08:34:21.810   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Desktop\TreeViewStyle.qml
+2025-09-12 08:34:21.810   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.810   Installing the file.
+2025-09-12 08:34:21.810   Successfully installed the file.
+2025-09-12 08:34:21.810   -- File entry --
+2025-09-12 08:34:21.811   Dest filename: C:\vimacc\bin\QtQuick\Controls\Styles\Desktop\qmldir
+2025-09-12 08:34:21.811   Time stamp of our file: 2023-10-11 15:01:42.000
+2025-09-12 08:34:21.811   Installing the file.
+2025-09-12 08:34:21.811   Successfully installed the file.
+2025-09-12 08:34:21.812   -- File entry --
+2025-09-12 08:34:21.812   Dest filename: C:\vimacc\bin\Qt5WebEngineCore.dll
+2025-09-12 08:34:21.812   Time stamp of our file: 2024-05-27 12:08:34.000
+2025-09-12 08:34:21.812   Installing the file.
+2025-09-12 08:34:23.531   Successfully installed the file.
+2025-09-12 08:34:23.531   -- File entry --
+2025-09-12 08:34:23.532   Dest filename: C:\vimacc\bin\Qt5WebEngineWidgets.dll
+2025-09-12 08:34:23.532   Time stamp of our file: 2024-05-27 12:17:16.000
+2025-09-12 08:34:23.532   Installing the file.
+2025-09-12 08:34:23.535   Successfully installed the file.
+2025-09-12 08:34:23.535   -- File entry --
+2025-09-12 08:34:23.536   Dest filename: C:\vimacc\bin\Qt5Pdf.dll
+2025-09-12 08:34:23.536   Time stamp of our file: 2024-05-27 12:40:28.000
+2025-09-12 08:34:23.536   Installing the file.
+2025-09-12 08:34:23.590   Successfully installed the file.
+2025-09-12 08:34:23.590   -- File entry --
+2025-09-12 08:34:23.590   Dest filename: C:\vimacc\bin\Qt5WebChannel.dll
+2025-09-12 08:34:23.590   Time stamp of our file: 2024-05-25 10:32:04.000
+2025-09-12 08:34:23.590   Installing the file.
+2025-09-12 08:34:23.593   Successfully installed the file.
+2025-09-12 08:34:23.593   -- File entry --
+2025-09-12 08:34:23.593   Dest filename: C:\vimacc\bin\Qt5QuickWidgets.dll
+2025-09-12 08:34:23.593   Time stamp of our file: 2024-05-25 09:43:10.000
+2025-09-12 08:34:23.593   Installing the file.
+2025-09-12 08:34:23.595   Successfully installed the file.
+2025-09-12 08:34:23.595   -- File entry --
+2025-09-12 08:34:23.595   Dest filename: C:\vimacc\bin\QtWebEngineProcess.exe
+2025-09-12 08:34:23.595   Time stamp of our file: 2024-05-27 12:10:56.000
+2025-09-12 08:34:23.596   Installing the file.
+2025-09-12 08:34:23.606   Successfully installed the file.
+2025-09-12 08:34:23.606   -- File entry --
+2025-09-12 08:34:23.607   Dest filename: C:\vimacc\bin\qtwebengine_devtools_resources.pak
+2025-09-12 08:34:23.607   Time stamp of our file: 2024-05-27 08:30:04.000
+2025-09-12 08:34:23.607   Installing the file.
+2025-09-12 08:34:23.630   Successfully installed the file.
+2025-09-12 08:34:23.630   -- File entry --
+2025-09-12 08:34:23.631   Dest filename: C:\vimacc\bin\qtwebengine_resources.pak
+2025-09-12 08:34:23.631   Time stamp of our file: 2024-05-27 08:30:06.000
+2025-09-12 08:34:23.631   Installing the file.
+2025-09-12 08:34:23.668   Successfully installed the file.
+2025-09-12 08:34:23.669   -- File entry --
+2025-09-12 08:34:23.669   Dest filename: C:\vimacc\bin\qtwebengine_resources_100p.pak
+2025-09-12 08:34:23.669   Time stamp of our file: 2024-05-27 08:30:02.000
+2025-09-12 08:34:23.669   Installing the file.
+2025-09-12 08:34:23.684   Successfully installed the file.
+2025-09-12 08:34:23.684   -- File entry --
+2025-09-12 08:34:23.684   Dest filename: C:\vimacc\bin\qtwebengine_resources_200p.pak
+2025-09-12 08:34:23.684   Time stamp of our file: 2024-05-27 08:30:04.000
+2025-09-12 08:34:23.684   Installing the file.
+2025-09-12 08:34:23.690   Successfully installed the file.
+2025-09-12 08:34:23.690   -- File entry --
+2025-09-12 08:34:23.691   Dest filename: C:\vimacc\bin\icudtl.dat
+2025-09-12 08:34:23.691   Time stamp of our file: 2022-12-08 17:31:50.000
+2025-09-12 08:34:23.691   Installing the file.
+2025-09-12 08:34:23.845   Successfully installed the file.
+2025-09-12 08:34:23.845   -- File entry --
+2025-09-12 08:34:23.846   Dest filename: C:\vimacc\bin\libcrypto-3-x64.dll
+2025-09-12 08:34:23.846   Time stamp of our file: 2025-08-13 12:28:16.000
+2025-09-12 08:34:23.846   Installing the file.
+2025-09-12 08:34:23.913   Successfully installed the file.
+2025-09-12 08:34:23.913   -- File entry --
+2025-09-12 08:34:23.913   Dest filename: C:\vimacc\bin\libssl-3-x64.dll
+2025-09-12 08:34:23.913   Time stamp of our file: 2025-08-13 12:28:16.000
+2025-09-12 08:34:23.913   Installing the file.
+2025-09-12 08:34:23.924   Successfully installed the file.
+2025-09-12 08:34:23.924   -- File entry --
+2025-09-12 08:34:23.924   Dest filename: C:\vimacc\bin\QtSolutions_Service_2.6.dll
+2025-09-12 08:34:23.924   Time stamp of our file: 2025-08-13 12:28:26.000
+2025-09-12 08:34:23.924   Installing the file.
+2025-09-12 08:34:23.925   Successfully installed the file.
+2025-09-12 08:34:23.925   -- File entry --
+2025-09-12 08:34:23.926   Dest filename: C:\vimacc\bin\liblz4.dll
+2025-09-12 08:34:23.926   Time stamp of our file: 2025-08-13 12:28:16.000
+2025-09-12 08:34:23.926   Installing the file.
+2025-09-12 08:34:23.928   Successfully installed the file.
+2025-09-12 08:34:23.928   -- File entry --
+2025-09-12 08:34:23.928   Dest filename: C:\vimacc\bin\AccVimaccUtil.dll
+2025-09-12 08:34:23.928   Time stamp of our file: 2025-08-13 12:28:10.000
+2025-09-12 08:34:23.928   Installing the file.
+2025-09-12 08:34:23.944   Successfully installed the file.
+2025-09-12 08:34:23.945   -- File entry --
+2025-09-12 08:34:23.945   Dest filename: C:\vimacc\bin\AccVimaccCrypto.dll
+2025-09-12 08:34:23.945   Time stamp of our file: 2025-08-13 12:27:56.000
+2025-09-12 08:34:23.945   Installing the file.
+2025-09-12 08:34:23.949   Successfully installed the file.
+2025-09-12 08:34:23.949   -- File entry --
+2025-09-12 08:34:23.950   Dest filename: C:\vimacc\bin\AccVimaccCore.dll
+2025-09-12 08:34:23.950   Time stamp of our file: 2025-08-13 12:27:56.000
+2025-09-12 08:34:23.950   Installing the file.
+2025-09-12 08:34:23.984   Successfully installed the file.
+2025-09-12 08:34:23.984   -- File entry --
+2025-09-12 08:34:23.984   Dest filename: C:\vimacc\bin\AccVimaccScripting.dll
+2025-09-12 08:34:23.984   Time stamp of our file: 2025-08-13 12:28:06.000
+2025-09-12 08:34:23.984   Installing the file.
+2025-09-12 08:34:23.988   Successfully installed the file.
+2025-09-12 08:34:23.988   -- File entry --
+2025-09-12 08:34:23.988   Dest filename: C:\vimacc\bin\AccVimaccMixer.dll
+2025-09-12 08:34:23.988   Time stamp of our file: 2025-08-13 12:28:02.000
+2025-09-12 08:34:23.988   Installing the file.
+2025-09-12 08:34:23.993   Successfully installed the file.
+2025-09-12 08:34:23.993   -- File entry --
+2025-09-12 08:34:23.994   Dest filename: C:\vimacc\bin\AccVimaccStreaming.dll
+2025-09-12 08:34:23.994   Time stamp of our file: 2025-08-13 12:28:08.000
+2025-09-12 08:34:23.994   Installing the file.
+2025-09-12 08:34:24.014   Successfully installed the file.
+2025-09-12 08:34:24.014   -- File entry --
+2025-09-12 08:34:24.014   Dest filename: C:\vimacc\bin\AccVimaccVideoPresentation.dll
+2025-09-12 08:34:24.015   Time stamp of our file: 2025-08-13 12:28:10.000
+2025-09-12 08:34:24.015   Installing the file.
+2025-09-12 08:34:24.019   Successfully installed the file.
+2025-09-12 08:34:24.019   -- File entry --
+2025-09-12 08:34:24.020   Dest filename: C:\vimacc\bin\AccVimaccIndex.dll
+2025-09-12 08:34:24.020   Time stamp of our file: 2025-08-13 12:28:00.000
+2025-09-12 08:34:24.020   Installing the file.
+2025-09-12 08:34:24.046   Successfully installed the file.
+2025-09-12 08:34:24.046   -- File entry --
+2025-09-12 08:34:24.046   Dest filename: C:\vimacc\bin\AccVimaccPlayerToolbox.dll
+2025-09-12 08:34:24.046   Time stamp of our file: 2025-08-13 12:28:04.000
+2025-09-12 08:34:24.046   Installing the file.
+2025-09-12 08:34:24.217   Successfully installed the file.
+2025-09-12 08:34:24.217   -- File entry --
+2025-09-12 08:34:24.217   Dest filename: C:\vimacc\bin\AccVimaccMapToolbox.dll
+2025-09-12 08:34:24.217   Time stamp of our file: 2025-08-13 12:28:02.000
+2025-09-12 08:34:24.217   Installing the file.
+2025-09-12 08:34:24.223   Successfully installed the file.
+2025-09-12 08:34:24.223   -- File entry --
+2025-09-12 08:34:24.224   Dest filename: C:\vimacc\bin\AccVimaccBurnTools.dll
+2025-09-12 08:34:24.224   Time stamp of our file: 2025-08-13 12:27:54.000
+2025-09-12 08:34:24.224   Installing the file.
+2025-09-12 08:34:24.225   Successfully installed the file.
+2025-09-12 08:34:24.225   -- File entry --
+2025-09-12 08:34:24.225   Dest filename: C:\vimacc\bin\AccVimaccConfigurationCommon.dll
+2025-09-12 08:34:24.225   Time stamp of our file: 2025-08-13 12:27:54.000
+2025-09-12 08:34:24.225   Installing the file.
+2025-09-12 08:34:24.244   Successfully installed the file.
+2025-09-12 08:34:24.244   -- File entry --
+2025-09-12 08:34:24.245   Dest filename: C:\vimacc\bin\AccVimaccWebWidgets.dll
+2025-09-12 08:34:24.245   Time stamp of our file: 2025-08-13 12:28:12.000
+2025-09-12 08:34:24.245   Installing the file.
+2025-09-12 08:34:24.335   Successfully installed the file.
+2025-09-12 08:34:24.335   -- File entry --
+2025-09-12 08:34:24.335   Dest filename: C:\vimacc\bin\AccVimaccPluginWebWidgets.dll
+2025-09-12 08:34:24.335   Time stamp of our file: 2025-08-13 12:28:04.000
+2025-09-12 08:34:24.335   Installing the file.
+2025-09-12 08:34:24.346   Successfully installed the file.
+2025-09-12 08:34:24.346   -- File entry --
+2025-09-12 08:34:24.346   Dest filename: C:\vimacc\bin\AccVimaccVideoAnalytics.dll
+2025-09-12 08:34:24.346   Time stamp of our file: 2025-08-13 12:28:10.000
+2025-09-12 08:34:24.346   Installing the file.
+2025-09-12 08:34:24.351   Successfully installed the file.
+2025-09-12 08:34:24.351   -- File entry --
+2025-09-12 08:34:24.351   Dest filename: C:\vimacc\bin\AccVimaccOnvifWrapper.dll
+2025-09-12 08:34:24.351   Time stamp of our file: 2025-08-13 12:28:02.000
+2025-09-12 08:34:24.351   Installing the file.
+2025-09-12 08:34:24.358   Successfully installed the file.
+2025-09-12 08:34:24.358   -- File entry --
+2025-09-12 08:34:24.358   Dest filename: C:\vimacc\bin\AccVimaccReporting.dll
+2025-09-12 08:34:24.359   Time stamp of our file: 2025-08-13 12:28:06.000
+2025-09-12 08:34:24.359   Installing the file.
+2025-09-12 08:34:24.377   Successfully installed the file.
+2025-09-12 08:34:24.377   -- File entry --
+2025-09-12 08:34:24.378   Dest filename: C:\vimacc\bin\AccVimaccAlarmHandling.dll
+2025-09-12 08:34:24.378   Time stamp of our file: 2025-08-13 12:27:52.000
+2025-09-12 08:34:24.378   Installing the file.
+2025-09-12 08:34:24.381   Successfully installed the file.
+2025-09-12 08:34:24.381   -- File entry --
+2025-09-12 08:34:24.381   Dest filename: C:\vimacc\data\plugins\imageformats\qgif.dll
+2025-09-12 08:34:24.382   Time stamp of our file: 2024-05-25 08:46:06.000
+2025-09-12 08:34:24.382   Installing the file.
+2025-09-12 08:34:24.383   Successfully installed the file.
+2025-09-12 08:34:24.383   -- File entry --
+2025-09-12 08:34:24.383   Dest filename: C:\vimacc\data\plugins\imageformats\qico.dll
+2025-09-12 08:34:24.383   Time stamp of our file: 2024-05-25 08:43:54.000
+2025-09-12 08:34:24.383   Installing the file.
+2025-09-12 08:34:24.384   Successfully installed the file.
+2025-09-12 08:34:24.384   -- File entry --
+2025-09-12 08:34:24.384   Dest filename: C:\vimacc\data\plugins\imageformats\qjpeg.dll
+2025-09-12 08:34:24.385   Time stamp of our file: 2024-05-25 08:45:06.000
+2025-09-12 08:34:24.385   Installing the file.
+2025-09-12 08:34:24.390   Successfully installed the file.
+2025-09-12 08:34:24.391   -- File entry --
+2025-09-12 08:34:24.391   Dest filename: C:\vimacc\data\plugins\imageformats\qsvg.dll
+2025-09-12 08:34:24.391   Time stamp of our file: 2024-05-25 09:01:10.000
+2025-09-12 08:34:24.391   Installing the file.
+2025-09-12 08:34:24.392   Successfully installed the file.
+2025-09-12 08:34:24.392   -- File entry --
+2025-09-12 08:34:24.392   Dest filename: C:\vimacc\data\plugins\imageformats\qtiff.dll
+2025-09-12 08:34:24.392   Time stamp of our file: 2024-05-25 08:59:30.000
+2025-09-12 08:34:24.392   Installing the file.
+2025-09-12 08:34:24.398   Successfully installed the file.
+2025-09-12 08:34:24.398   -- File entry --
+2025-09-12 08:34:24.399   Dest filename: C:\vimacc\data\plugins\iconengines\qsvgicon.dll
+2025-09-12 08:34:24.399   Time stamp of our file: 2024-05-25 09:01:22.000
+2025-09-12 08:34:24.399   Installing the file.
+2025-09-12 08:34:24.400   Successfully installed the file.
+2025-09-12 08:34:24.400   -- File entry --
+2025-09-12 08:34:24.401   Dest filename: C:\vimacc\data\plugins\printsupport\windowsprintersupport.dll
+2025-09-12 08:34:24.401   Time stamp of our file: 2024-05-25 08:46:26.000
+2025-09-12 08:34:24.401   Installing the file.
+2025-09-12 08:34:24.401   Creating directory: C:\vimacc\data\plugins\printsupport
+2025-09-12 08:34:24.403   Successfully installed the file.
+2025-09-12 08:34:24.403   -- File entry --
+2025-09-12 08:34:24.403   Dest filename: C:\vimacc\bin\jpeg8.dll
+2025-09-12 08:34:24.403   Time stamp of our file: 2025-08-13 12:28:16.000
+2025-09-12 08:34:24.403   Installing the file.
+2025-09-12 08:34:24.412   Successfully installed the file.
+2025-09-12 08:34:24.412   -- File entry --
+2025-09-12 08:34:24.412   Dest filename: C:\vimacc\bin\turbojpeg.dll
+2025-09-12 08:34:24.413   Time stamp of our file: 2025-08-13 12:28:28.000
+2025-09-12 08:34:24.413   Installing the file.
+2025-09-12 08:34:24.431   Successfully installed the file.
+2025-09-12 08:34:24.431   -- File entry --
+2025-09-12 08:34:24.431   Dest filename: C:\vimacc\bin\avcodec_AccVimacc-58.dll
+2025-09-12 08:34:24.431   Time stamp of our file: 2025-08-13 12:28:12.000
+2025-09-12 08:34:24.431   Installing the file.
+2025-09-12 08:34:24.676   Successfully installed the file.
+2025-09-12 08:34:24.676   -- File entry --
+2025-09-12 08:34:24.677   Dest filename: C:\vimacc\bin\avdevice_AccVimacc-58.dll
+2025-09-12 08:34:24.677   Time stamp of our file: 2025-08-13 12:28:12.000
+2025-09-12 08:34:24.677   Installing the file.
+2025-09-12 08:34:24.685   Successfully installed the file.
+2025-09-12 08:34:24.685   -- File entry --
+2025-09-12 08:34:24.685   Dest filename: C:\vimacc\bin\avfilter_AccVimacc-7.dll
+2025-09-12 08:34:24.685   Time stamp of our file: 2025-08-13 12:28:12.000
+2025-09-12 08:34:24.685   Installing the file.
+2025-09-12 08:34:24.737   Successfully installed the file.
+2025-09-12 08:34:24.738   -- File entry --
+2025-09-12 08:34:24.738   Dest filename: C:\vimacc\bin\avformat_AccVimacc-58.dll
+2025-09-12 08:34:24.738   Time stamp of our file: 2025-08-13 12:28:12.000
+2025-09-12 08:34:24.738   Installing the file.
+2025-09-12 08:34:24.787   Successfully installed the file.
+2025-09-12 08:34:24.787   -- File entry --
+2025-09-12 08:34:24.787   Dest filename: C:\vimacc\bin\avutil_AccVimacc-56.dll
+2025-09-12 08:34:24.787   Time stamp of our file: 2025-08-13 12:28:12.000
+2025-09-12 08:34:24.787   Installing the file.
+2025-09-12 08:34:24.804   Successfully installed the file.
+2025-09-12 08:34:24.804   -- File entry --
+2025-09-12 08:34:24.804   Dest filename: C:\vimacc\bin\swresample_AccVimacc-3.dll
+2025-09-12 08:34:24.804   Time stamp of our file: 2025-08-13 12:28:26.000
+2025-09-12 08:34:24.804   Installing the file.
+2025-09-12 08:34:24.810   Successfully installed the file.
+2025-09-12 08:34:24.810   -- File entry --
+2025-09-12 08:34:24.811   Dest filename: C:\vimacc\bin\swscale_AccVimacc-5.dll
+2025-09-12 08:34:24.811   Time stamp of our file: 2025-08-13 12:28:26.000
+2025-09-12 08:34:24.811   Installing the file.
+2025-09-12 08:34:24.823   Successfully installed the file.
+2025-09-12 08:34:24.823   -- File entry --
+2025-09-12 08:34:24.823   Dest filename: C:\vimacc\bin\opencv_core470.dll
+2025-09-12 08:34:24.823   Time stamp of our file: 2025-08-13 12:28:18.000
+2025-09-12 08:34:24.823   Installing the file.
+2025-09-12 08:34:25.067   Successfully installed the file.
+2025-09-12 08:34:25.067   -- File entry --
+2025-09-12 08:34:25.068   Dest filename: C:\vimacc\bin\opencv_imgproc470.dll
+2025-09-12 08:34:25.068   Time stamp of our file: 2025-08-13 12:28:20.000
+2025-09-12 08:34:25.068   Installing the file.
+2025-09-12 08:34:25.423   Successfully installed the file.
+2025-09-12 08:34:25.424   -- File entry --
+2025-09-12 08:34:25.424   Dest filename: C:\vimacc\bin\opencv_highgui470.dll
+2025-09-12 08:34:25.424   Time stamp of our file: 2025-08-13 12:28:20.000
+2025-09-12 08:34:25.424   Installing the file.
+2025-09-12 08:34:25.439   Successfully installed the file.
+2025-09-12 08:34:25.439   -- File entry --
+2025-09-12 08:34:25.440   Dest filename: C:\vimacc\bin\opencv_imgcodecs470.dll
+2025-09-12 08:34:25.441   Time stamp of our file: 2025-08-13 12:28:20.000
+2025-09-12 08:34:25.441   Installing the file.
+2025-09-12 08:34:25.483   Successfully installed the file.
+2025-09-12 08:34:25.483   -- File entry --
+2025-09-12 08:34:25.483   Dest filename: C:\vimacc\bin\opencv_videoio470.dll
+2025-09-12 08:34:25.484   Time stamp of our file: 2025-08-13 12:28:22.000
+2025-09-12 08:34:25.484   Installing the file.
+2025-09-12 08:34:25.495   Successfully installed the file.
+2025-09-12 08:34:25.496   -- File entry --
+2025-09-12 08:34:25.501   Dest filename: C:\vimacc\data\plugins\sqldrivers\qsqlite.dll
+2025-09-12 08:34:25.501   Time stamp of our file: 2024-05-25 08:47:32.000
+2025-09-12 08:34:25.501   Installing the file.
+2025-09-12 08:34:25.501   Creating directory: C:\vimacc\data\plugins\sqldrivers
+2025-09-12 08:34:25.555   Successfully installed the file.
+2025-09-12 08:34:25.555   -- File entry --
+2025-09-12 08:34:25.555   Dest filename: C:\vimacc\bin\abouts\CurlLicense.json
+2025-09-12 08:34:25.555   Time stamp of our file: 2025-08-13 12:32:44.000
+2025-09-12 08:34:25.555   Installing the file.
+2025-09-12 08:34:25.555   Creating directory: C:\vimacc\bin\abouts
+2025-09-12 08:34:25.556   Successfully installed the file.
+2025-09-12 08:34:25.556   -- File entry --
+2025-09-12 08:34:25.556   Dest filename: C:\vimacc\bin\abouts\FFmpegLicenseJSON.json
+2025-09-12 08:34:25.557   Time stamp of our file: 2025-08-13 12:32:44.000
+2025-09-12 08:34:25.557   Installing the file.
+2025-09-12 08:34:25.558   Successfully installed the file.
+2025-09-12 08:34:25.558   -- File entry --
+2025-09-12 08:34:25.559   Dest filename: C:\vimacc\bin\abouts\gammuLicenseJSON.json
+2025-09-12 08:34:25.559   Time stamp of our file: 2025-08-13 12:32:44.000
+2025-09-12 08:34:25.559   Installing the file.
+2025-09-12 08:34:25.569   Successfully installed the file.
+2025-09-12 08:34:25.569   -- File entry --
+2025-09-12 08:34:25.569   Dest filename: C:\vimacc\bin\abouts\h264license.json
+2025-09-12 08:34:25.569   Time stamp of our file: 2025-08-13 12:32:44.000
+2025-09-12 08:34:25.569   Installing the file.
+2025-09-12 08:34:25.570   Successfully installed the file.
+2025-09-12 08:34:25.570   -- File entry --
+2025-09-12 08:34:25.570   Dest filename: C:\vimacc\bin\abouts\jsonata_About.json
+2025-09-12 08:34:25.570   Time stamp of our file: 2025-08-13 12:32:44.000
+2025-09-12 08:34:25.570   Installing the file.
+2025-09-12 08:34:25.571   Successfully installed the file.
+2025-09-12 08:34:25.571   -- File entry --
+2025-09-12 08:34:25.571   Dest filename: C:\vimacc\bin\abouts\licenseIJGJSON.json
+2025-09-12 08:34:25.571   Time stamp of our file: 2025-08-13 12:32:44.000
+2025-09-12 08:34:25.571   Installing the file.
+2025-09-12 08:34:25.571   Successfully installed the file.
+2025-09-12 08:34:25.571   -- File entry --
+2025-09-12 08:34:25.572   Dest filename: C:\vimacc\bin\abouts\licenseLibJpegTurboJSON.json
+2025-09-12 08:34:25.572   Time stamp of our file: 2025-08-13 12:32:44.000
+2025-09-12 08:34:25.572   Installing the file.
+2025-09-12 08:34:25.572   Successfully installed the file.
+2025-09-12 08:34:25.573   -- File entry --
+2025-09-12 08:34:25.573   Dest filename: C:\vimacc\bin\abouts\LicenseOpenCVjson.json
+2025-09-12 08:34:25.573   Time stamp of our file: 2025-08-13 12:32:44.000
+2025-09-12 08:34:25.573   Installing the file.
+2025-09-12 08:34:25.574   Successfully installed the file.
+2025-09-12 08:34:25.574   -- File entry --
+2025-09-12 08:34:25.574   Dest filename: C:\vimacc\bin\abouts\LicenseOpenSSLJSON.json
+2025-09-12 08:34:25.574   Time stamp of our file: 2025-08-13 12:32:44.000
+2025-09-12 08:34:25.574   Installing the file.
+2025-09-12 08:34:25.575   Successfully installed the file.
+2025-09-12 08:34:25.575   -- File entry --
+2025-09-12 08:34:25.575   Dest filename: C:\vimacc\bin\abouts\LicenseQTserviceJSON.json
+2025-09-12 08:34:25.575   Time stamp of our file: 2025-08-13 12:32:44.000
+2025-09-12 08:34:25.575   Installing the file.
+2025-09-12 08:34:25.576   Successfully installed the file.
+2025-09-12 08:34:25.576   -- File entry --
+2025-09-12 08:34:25.576   Dest filename: C:\vimacc\bin\abouts\licenseSNMPppJSON.json
+2025-09-12 08:34:25.576   Time stamp of our file: 2025-08-13 12:32:44.000
+2025-09-12 08:34:25.576   Installing the file.
+2025-09-12 08:34:25.577   Successfully installed the file.
+2025-09-12 08:34:25.577   -- File entry --
+2025-09-12 08:34:25.577   Dest filename: C:\vimacc\bin\abouts\LicenseSQlite3JSON.json
+2025-09-12 08:34:25.577   Time stamp of our file: 2025-08-13 12:32:44.000
+2025-09-12 08:34:25.577   Installing the file.
+2025-09-12 08:34:25.577   Successfully installed the file.
+2025-09-12 08:34:25.577   -- File entry --
+2025-09-12 08:34:25.579   Dest filename: C:\vimacc\bin\abouts\License_open62541_JSON.json
+2025-09-12 08:34:25.579   Time stamp of our file: 2025-08-13 12:32:44.000
+2025-09-12 08:34:25.579   Installing the file.
+2025-09-12 08:34:25.579   Successfully installed the file.
+2025-09-12 08:34:25.580   -- File entry --
+2025-09-12 08:34:25.580   Dest filename: C:\vimacc\bin\abouts\License_QTOPCUA_JSON.json
+2025-09-12 08:34:25.580   Time stamp of our file: 2025-08-13 12:32:44.000
+2025-09-12 08:34:25.580   Installing the file.
+2025-09-12 08:34:25.581   Successfully installed the file.
+2025-09-12 08:34:25.581   -- File entry --
+2025-09-12 08:34:25.581   Dest filename: C:\vimacc\bin\abouts\mpegla4License.json
+2025-09-12 08:34:25.581   Time stamp of our file: 2025-08-13 12:32:44.000
+2025-09-12 08:34:25.581   Installing the file.
+2025-09-12 08:34:25.582   Successfully installed the file.
+2025-09-12 08:34:25.582   -- File entry --
+2025-09-12 08:34:25.582   Dest filename: C:\vimacc\bin\abouts\pugixml_About.json
+2025-09-12 08:34:25.582   Time stamp of our file: 2025-08-13 12:32:44.000
+2025-09-12 08:34:25.582   Installing the file.
+2025-09-12 08:34:25.582   Successfully installed the file.
+2025-09-12 08:34:25.583   -- File entry --
+2025-09-12 08:34:25.583   Dest filename: C:\vimacc\bin\abouts\QCodeEditor_About.json
+2025-09-12 08:34:25.583   Time stamp of our file: 2025-08-13 12:32:44.000
+2025-09-12 08:34:25.583   Installing the file.
+2025-09-12 08:34:25.584   Successfully installed the file.
+2025-09-12 08:34:25.584   -- File entry --
+2025-09-12 08:34:25.584   Dest filename: C:\vimacc\bin\abouts\QJsonModel_About.json
+2025-09-12 08:34:25.584   Time stamp of our file: 2025-08-13 12:32:44.000
+2025-09-12 08:34:25.584   Installing the file.
+2025-09-12 08:34:25.585   Successfully installed the file.
+2025-09-12 08:34:25.585   -- File entry --
+2025-09-12 08:34:25.585   Dest filename: C:\vimacc\bin\abouts\QTLicense.json
+2025-09-12 08:34:25.585   Time stamp of our file: 2025-08-13 12:32:44.000
+2025-09-12 08:34:25.585   Installing the file.
+2025-09-12 08:34:25.586   Successfully installed the file.
+2025-09-12 08:34:25.586   -- File entry --
+2025-09-12 08:34:25.586   Dest filename: C:\vimacc\bin\abouts\SimpleBrowserExample_About.json
+2025-09-12 08:34:25.586   Time stamp of our file: 2025-08-13 12:32:44.000
+2025-09-12 08:34:25.586   Installing the file.
+2025-09-12 08:34:25.587   Successfully installed the file.
+2025-09-12 08:34:25.587   -- File entry --
+2025-09-12 08:34:25.587   Dest filename: C:\vimacc\bin\abouts\SVG-edit_About.json
+2025-09-12 08:34:25.587   Time stamp of our file: 2025-08-13 12:32:44.000
+2025-09-12 08:34:25.587   Installing the file.
+2025-09-12 08:34:25.588   Successfully installed the file.
+2025-09-12 08:34:25.588   -- File entry --
+2025-09-12 08:34:25.588   Dest filename: C:\vimacc\bin\abouts\TangoGFXLicenseJSON.json
+2025-09-12 08:34:25.588   Time stamp of our file: 2025-08-13 12:32:44.000
+2025-09-12 08:34:25.588   Installing the file.
+2025-09-12 08:34:25.588   Successfully installed the file.
+2025-09-12 08:34:25.588   -- File entry --
+2025-09-12 08:34:25.589   Dest filename: C:\vimacc\bin\abouts\vimaccEULA.json
+2025-09-12 08:34:25.589   Time stamp of our file: 2025-08-13 12:32:44.000
+2025-09-12 08:34:25.589   Installing the file.
+2025-09-12 08:34:25.589   Successfully installed the file.
+2025-09-12 08:34:25.590   -- File entry --
+2025-09-12 08:34:25.590   Dest filename: C:\vimacc\data\i18n\AccVimaccAlarmHandling_fr.qm
+2025-09-12 08:34:25.590   Time stamp of our file: 2025-08-13 12:20:42.000
+2025-09-12 08:34:25.590   Installing the file.
+2025-09-12 08:34:25.590   Creating directory: C:\vimacc\data\i18n
+2025-09-12 08:34:25.591   Successfully installed the file.
+2025-09-12 08:34:25.591   -- File entry --
+2025-09-12 08:34:25.591   Dest filename: C:\vimacc\data\i18n\AccVimaccAlarmHandling_de.qm
+2025-09-12 08:34:25.591   Time stamp of our file: 2025-08-13 12:20:42.000
+2025-09-12 08:34:25.591   Installing the file.
+2025-09-12 08:34:25.592   Successfully installed the file.
+2025-09-12 08:34:25.592   -- File entry --
+2025-09-12 08:34:25.592   Dest filename: C:\vimacc\data\i18n\AccVimaccAlarmHandling_en.qm
+2025-09-12 08:34:25.592   Time stamp of our file: 2025-08-13 12:20:42.000
+2025-09-12 08:34:25.592   Installing the file.
+2025-09-12 08:34:25.593   Successfully installed the file.
+2025-09-12 08:34:25.593   -- File entry --
+2025-09-12 08:34:25.593   Dest filename: C:\vimacc\data\i18n\AccVimaccPlayerToolbox_fr.qm
+2025-09-12 08:34:25.593   Time stamp of our file: 2025-08-13 12:22:28.000
+2025-09-12 08:34:25.593   Installing the file.
+2025-09-12 08:34:25.595   Successfully installed the file.
+2025-09-12 08:34:25.595   -- File entry --
+2025-09-12 08:34:25.595   Dest filename: C:\vimacc\data\i18n\AccVimaccPlayerToolbox_de.qm
+2025-09-12 08:34:25.595   Time stamp of our file: 2025-08-13 12:22:28.000
+2025-09-12 08:34:25.595   Installing the file.
+2025-09-12 08:34:25.597   Successfully installed the file.
+2025-09-12 08:34:25.597   -- File entry --
+2025-09-12 08:34:25.597   Dest filename: C:\vimacc\data\i18n\AccVimaccPlayerToolbox_en.qm
+2025-09-12 08:34:25.597   Time stamp of our file: 2025-08-13 12:22:28.000
+2025-09-12 08:34:25.598   Installing the file.
+2025-09-12 08:34:25.598   Successfully installed the file.
+2025-09-12 08:34:25.598   -- File entry --
+2025-09-12 08:34:25.598   Dest filename: C:\vimacc\data\i18n\AccVimaccBurnTools_fr.qm
+2025-09-12 08:34:25.598   Time stamp of our file: 2025-08-13 12:20:42.000
+2025-09-12 08:34:25.598   Installing the file.
+2025-09-12 08:34:25.598   Successfully installed the file.
+2025-09-12 08:34:25.600   -- File entry --
+2025-09-12 08:34:25.600   Dest filename: C:\vimacc\data\i18n\AccVimaccBurnTools_de.qm
+2025-09-12 08:34:25.600   Time stamp of our file: 2025-08-13 12:20:42.000
+2025-09-12 08:34:25.600   Installing the file.
+2025-09-12 08:34:25.600   Successfully installed the file.
+2025-09-12 08:34:25.601   -- File entry --
+2025-09-12 08:34:25.601   Dest filename: C:\vimacc\data\i18n\AccVimaccBurnTools_en.qm
+2025-09-12 08:34:25.601   Time stamp of our file: 2025-08-13 12:20:42.000
+2025-09-12 08:34:25.601   Installing the file.
+2025-09-12 08:34:25.601   Successfully installed the file.
+2025-09-12 08:34:25.602   -- File entry --
+2025-09-12 08:34:25.602   Dest filename: C:\vimacc\data\i18n\AccVimaccCore_de.qm
+2025-09-12 08:34:25.602   Time stamp of our file: 2025-08-13 12:20:26.000
+2025-09-12 08:34:25.602   Installing the file.
+2025-09-12 08:34:25.603   Successfully installed the file.
+2025-09-12 08:34:25.603   -- File entry --
+2025-09-12 08:34:25.603   Dest filename: C:\vimacc\data\i18n\AccVimaccCore_en.qm
+2025-09-12 08:34:25.603   Time stamp of our file: 2025-08-13 12:20:26.000
+2025-09-12 08:34:25.603   Installing the file.
+2025-09-12 08:34:25.604   Successfully installed the file.
+2025-09-12 08:34:25.604   -- File entry --
+2025-09-12 08:34:25.604   Dest filename: C:\vimacc\data\i18n\AccVimaccReporting_fr.qm
+2025-09-12 08:34:25.604   Time stamp of our file: 2025-08-13 12:20:42.000
+2025-09-12 08:34:25.604   Installing the file.
+2025-09-12 08:34:25.605   Successfully installed the file.
+2025-09-12 08:34:25.605   -- File entry --
+2025-09-12 08:34:25.605   Dest filename: C:\vimacc\data\i18n\AccVimaccReporting_de.qm
+2025-09-12 08:34:25.605   Time stamp of our file: 2025-08-13 12:20:42.000
+2025-09-12 08:34:25.605   Installing the file.
+2025-09-12 08:34:25.606   Successfully installed the file.
+2025-09-12 08:34:25.606   -- File entry --
+2025-09-12 08:34:25.607   Dest filename: C:\vimacc\data\i18n\AccVimaccReporting_en.qm
+2025-09-12 08:34:25.607   Time stamp of our file: 2025-08-13 12:20:42.000
+2025-09-12 08:34:25.607   Installing the file.
+2025-09-12 08:34:25.607   Successfully installed the file.
+2025-09-12 08:34:25.607   -- File entry --
+2025-09-12 08:34:25.607   Dest filename: C:\vimacc\data\i18n\AccVimaccConfigurationCommon_de.qm
+2025-09-12 08:34:25.608   Time stamp of our file: 2025-08-13 12:20:42.000
+2025-09-12 08:34:25.608   Installing the file.
+2025-09-12 08:34:25.608   Successfully installed the file.
+2025-09-12 08:34:25.608   -- File entry --
+2025-09-12 08:34:25.609   Dest filename: C:\vimacc\data\i18n\AccVimaccConfigurationCommon_en.qm
+2025-09-12 08:34:25.609   Time stamp of our file: 2025-08-13 12:20:42.000
+2025-09-12 08:34:25.609   Installing the file.
+2025-09-12 08:34:25.609   Successfully installed the file.
+2025-09-12 08:34:25.609   -- File entry --
+2025-09-12 08:34:25.610   Dest filename: C:\vimacc\data\i18n\AccVimaccWebWidgets_de.qm
+2025-09-12 08:34:25.610   Time stamp of our file: 2025-08-13 12:20:42.000
+2025-09-12 08:34:25.610   Installing the file.
+2025-09-12 08:34:25.611   Successfully installed the file.
+2025-09-12 08:34:25.611   -- File entry --
+2025-09-12 08:34:25.611   Dest filename: C:\vimacc\data\i18n\AccVimaccWebWidgets_en.qm
+2025-09-12 08:34:25.612   Time stamp of our file: 2025-08-13 12:20:42.000
+2025-09-12 08:34:25.612   Installing the file.
+2025-09-12 08:34:25.612   Successfully installed the file.
+2025-09-12 08:34:25.612   -- File entry --
+2025-09-12 08:34:25.612   Dest filename: C:\vimacc\data\i18n\AccVimaccPluginWebWidgets_de.qm
+2025-09-12 08:34:25.612   Time stamp of our file: 2025-08-13 12:21:28.000
+2025-09-12 08:34:25.612   Installing the file.
+2025-09-12 08:34:25.612   Successfully installed the file.
+2025-09-12 08:34:25.613   -- File entry --
+2025-09-12 08:34:25.613   Dest filename: C:\vimacc\data\i18n\AccVimaccPluginWebWidgets_en.qm
+2025-09-12 08:34:25.613   Time stamp of our file: 2025-08-13 12:21:28.000
+2025-09-12 08:34:25.613   Installing the file.
+2025-09-12 08:34:25.613   Successfully installed the file.
+2025-09-12 08:34:25.614   -- File entry --
+2025-09-12 08:34:25.614   Dest filename: C:\vimacc\data\i18n\AccVimaccMapToolbox_fr.qm
+2025-09-12 08:34:25.614   Time stamp of our file: 2025-08-13 12:21:50.000
+2025-09-12 08:34:25.614   Installing the file.
+2025-09-12 08:34:25.614   Successfully installed the file.
+2025-09-12 08:34:25.615   -- File entry --
+2025-09-12 08:34:25.615   Dest filename: C:\vimacc\data\i18n\AccVimaccMapToolbox_de.qm
+2025-09-12 08:34:25.615   Time stamp of our file: 2025-08-13 12:21:50.000
+2025-09-12 08:34:25.615   Installing the file.
+2025-09-12 08:34:25.615   Successfully installed the file.
+2025-09-12 08:34:25.615   -- File entry --
+2025-09-12 08:34:25.616   Dest filename: C:\vimacc\data\i18n\AccVimaccMapToolbox_en.qm
+2025-09-12 08:34:25.616   Time stamp of our file: 2025-08-13 12:21:50.000
+2025-09-12 08:34:25.616   Installing the file.
+2025-09-12 08:34:25.616   Successfully installed the file.
+2025-09-12 08:34:25.616   -- File entry --
+2025-09-12 08:34:25.617   Dest filename: C:\vimacc\data\i18n\qt_en.qm
+2025-09-12 08:34:25.617   Time stamp of our file: 2024-05-25 13:47:06.000
+2025-09-12 08:34:25.617   Installing the file.
+2025-09-12 08:34:25.617   Successfully installed the file.
+2025-09-12 08:34:25.617   -- File entry --
+2025-09-12 08:34:25.618   Dest filename: C:\vimacc\data\i18n\qt_de.qm
+2025-09-12 08:34:25.618   Time stamp of our file: 2024-05-25 13:43:38.000
+2025-09-12 08:34:25.618   Installing the file.
+2025-09-12 08:34:25.618   Successfully installed the file.
+2025-09-12 08:34:25.618   -- File entry --
+2025-09-12 08:34:25.619   Dest filename: C:\vimacc\data\i18n\qt_fr.qm
+2025-09-12 08:34:25.619   Time stamp of our file: 2024-05-25 13:44:04.000
+2025-09-12 08:34:25.619   Installing the file.
+2025-09-12 08:34:25.619   Successfully installed the file.
+2025-09-12 08:34:25.619   -- File entry --
+2025-09-12 08:34:25.619   Dest filename: C:\vimacc\data\i18n\qtbase_en.qm
+2025-09-12 08:34:25.619   Time stamp of our file: 2024-05-25 13:47:08.000
+2025-09-12 08:34:25.619   Installing the file.
+2025-09-12 08:34:25.621   Successfully installed the file.
+2025-09-12 08:34:25.621   -- File entry --
+2025-09-12 08:34:25.621   Dest filename: C:\vimacc\data\i18n\qtbase_de.qm
+2025-09-12 08:34:25.621   Time stamp of our file: 2024-05-25 13:46:10.000
+2025-09-12 08:34:25.621   Installing the file.
+2025-09-12 08:34:25.624   Successfully installed the file.
+2025-09-12 08:34:25.624   -- File entry --
+2025-09-12 08:34:25.624   Dest filename: C:\vimacc\data\i18n\qtbase_fr.qm
+2025-09-12 08:34:25.624   Time stamp of our file: 2024-05-25 13:46:14.000
+2025-09-12 08:34:25.624   Installing the file.
+2025-09-12 08:34:25.626   Successfully installed the file.
+2025-09-12 08:34:25.627   -- File entry --
+2025-09-12 08:34:25.627   Dest filename: C:\vimacc\data\i18n\qtdeclarative_en.qm
+2025-09-12 08:34:25.627   Time stamp of our file: 2024-05-25 13:47:08.000
+2025-09-12 08:34:25.627   Installing the file.
+2025-09-12 08:34:25.627   Successfully installed the file.
+2025-09-12 08:34:25.627   -- File entry --
+2025-09-12 08:34:25.628   Dest filename: C:\vimacc\data\i18n\qtdeclarative_de.qm
+2025-09-12 08:34:25.628   Time stamp of our file: 2024-05-25 13:46:32.000
+2025-09-12 08:34:25.628   Installing the file.
+2025-09-12 08:34:25.629   Successfully installed the file.
+2025-09-12 08:34:25.629   -- File entry --
+2025-09-12 08:34:25.630   Dest filename: C:\vimacc\data\i18n\qtdeclarative_fr.qm
+2025-09-12 08:34:25.630   Time stamp of our file: 2024-05-25 13:46:32.000
+2025-09-12 08:34:25.630   Installing the file.
+2025-09-12 08:34:25.630   Successfully installed the file.
+2025-09-12 08:34:25.630   -- File entry --
+2025-09-12 08:34:25.630   Dest filename: C:\vimacc\data\i18n\qtlocation_en.qm
+2025-09-12 08:34:25.630   Time stamp of our file: 2024-05-25 13:47:08.000
+2025-09-12 08:34:25.630   Installing the file.
+2025-09-12 08:34:25.631   Successfully installed the file.
+2025-09-12 08:34:25.631   -- File entry --
+2025-09-12 08:34:25.631   Dest filename: C:\vimacc\data\i18n\qtlocation_de.qm
+2025-09-12 08:34:25.631   Time stamp of our file: 2024-05-25 13:46:36.000
+2025-09-12 08:34:25.631   Installing the file.
+2025-09-12 08:34:25.632   Successfully installed the file.
+2025-09-12 08:34:25.632   -- File entry --
+2025-09-12 08:34:25.633   Dest filename: C:\vimacc\data\i18n\qtlocation_fr.qm
+2025-09-12 08:34:25.633   Time stamp of our file: 2024-05-25 13:46:36.000
+2025-09-12 08:34:25.633   Installing the file.
+2025-09-12 08:34:25.633   Successfully installed the file.
+2025-09-12 08:34:25.633   -- File entry --
+2025-09-12 08:34:25.634   Dest filename: C:\vimacc\data\i18n\qtscript_en.qm
+2025-09-12 08:34:25.634   Time stamp of our file: 2024-05-25 13:47:08.000
+2025-09-12 08:34:25.634   Installing the file.
+2025-09-12 08:34:25.634   Successfully installed the file.
+2025-09-12 08:34:25.634   -- File entry --
+2025-09-12 08:34:25.635   Dest filename: C:\vimacc\data\i18n\qtscript_de.qm
+2025-09-12 08:34:25.635   Time stamp of our file: 2024-05-25 13:46:52.000
+2025-09-12 08:34:25.635   Installing the file.
+2025-09-12 08:34:25.635   Successfully installed the file.
+2025-09-12 08:34:25.635   -- File entry --
+2025-09-12 08:34:25.635   Dest filename: C:\vimacc\data\i18n\qtscript_fr.qm
+2025-09-12 08:34:25.635   Time stamp of our file: 2024-05-25 13:46:54.000
+2025-09-12 08:34:25.635   Installing the file.
+2025-09-12 08:34:25.637   Successfully installed the file.
+2025-09-12 08:34:25.637   -- File entry --
+2025-09-12 08:34:25.637   Dest filename: C:\vimacc\data\i18n\qtxmlpatterns_en.qm
+2025-09-12 08:34:25.637   Time stamp of our file: 2024-05-25 13:47:10.000
+2025-09-12 08:34:25.637   Installing the file.
+2025-09-12 08:34:25.638   Successfully installed the file.
+2025-09-12 08:34:25.638   -- File entry --
+2025-09-12 08:34:25.638   Dest filename: C:\vimacc\data\i18n\qtxmlpatterns_de.qm
+2025-09-12 08:34:25.639   Time stamp of our file: 2024-05-25 13:47:02.000
+2025-09-12 08:34:25.639   Installing the file.
+2025-09-12 08:34:25.640   Successfully installed the file.
+2025-09-12 08:34:25.640   -- File entry --
+2025-09-12 08:34:25.640   Dest filename: C:\vimacc\data\i18n\qtxmlpatterns_fr.qm
+2025-09-12 08:34:25.641   Time stamp of our file: 2024-05-25 13:47:02.000
+2025-09-12 08:34:25.641   Installing the file.
+2025-09-12 08:34:25.642   Successfully installed the file.
+2025-09-12 08:34:25.642   -- File entry --
+2025-09-12 08:34:25.642   Dest filename: C:\vimacc\data\i18n\qtwebengine_en.qm
+2025-09-12 08:34:25.642   Time stamp of our file: 2024-05-25 13:47:08.000
+2025-09-12 08:34:25.642   Installing the file.
+2025-09-12 08:34:25.642   Successfully installed the file.
+2025-09-12 08:34:25.643   -- File entry --
+2025-09-12 08:34:25.643   Dest filename: C:\vimacc\data\i18n\qtwebengine_de.qm
+2025-09-12 08:34:25.643   Time stamp of our file: 2024-05-25 13:47:00.000
+2025-09-12 08:34:25.643   Installing the file.
+2025-09-12 08:34:25.644   Successfully installed the file.
+2025-09-12 08:34:25.644   -- File entry --
+2025-09-12 08:34:25.644   Dest filename: C:\vimacc\data\Stylesheet\style.conf
+2025-09-12 08:34:25.644   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:25.644   Installing the file.
+2025-09-12 08:34:25.645   Successfully installed the file.
+2025-09-12 08:34:25.645   -- File entry --
+2025-09-12 08:34:25.645   Dest filename: C:\vimacc\data\Stylesheet\stylesheet.qss.template
+2025-09-12 08:34:25.645   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:25.645   Installing the file.
+2025-09-12 08:34:25.646   Successfully installed the file.
+2025-09-12 08:34:25.646   -- File entry --
+2025-09-12 08:34:25.646   Dest filename: C:\vimacc\data\vimaccLogo_dummy.png
+2025-09-12 08:34:25.646   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:25.646   Installing the file.
+2025-09-12 08:34:25.647   Successfully installed the file.
+2025-09-12 08:34:25.647   -- File entry --
+2025-09-12 08:34:25.648   Dest filename: C:\vimacc\data\vimacc_WallPaper2025_VLZII.png
+2025-09-12 08:34:25.648   Time stamp of our file: 2025-08-13 12:07:28.000
+2025-09-12 08:34:25.648   Installing the file.
+2025-09-12 08:34:25.737   Successfully installed the file.
+2025-09-12 08:34:25.737   -- File entry --
+2025-09-12 08:34:25.738   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\MAP_A2.png
+2025-09-12 08:34:25.738   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:25.738   Installing the file.
+2025-09-12 08:34:25.747   Successfully installed the file.
+2025-09-12 08:34:25.747   -- File entry --
+2025-09-12 08:34:25.748   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\MAP_A2_HL.png
+2025-09-12 08:34:25.748   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:25.748   Installing the file.
+2025-09-12 08:34:25.760   Successfully installed the file.
+2025-09-12 08:34:25.760   -- File entry --
+2025-09-12 08:34:25.760   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\MAP_CONTI.png
+2025-09-12 08:34:25.760   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:25.760   Installing the file.
+2025-09-12 08:34:25.765   Successfully installed the file.
+2025-09-12 08:34:25.766   -- File entry --
+2025-09-12 08:34:25.766   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\MAP_CONTI_HL.png
+2025-09-12 08:34:25.766   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:25.766   Installing the file.
+2025-09-12 08:34:25.771   Successfully installed the file.
+2025-09-12 08:34:25.771   -- File entry --
+2025-09-12 08:34:25.771   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\MAP_SBAHN.png
+2025-09-12 08:34:25.771   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:25.771   Installing the file.
+2025-09-12 08:34:25.774   Successfully installed the file.
+2025-09-12 08:34:25.775   -- File entry --
+2025-09-12 08:34:25.775   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\MAP_SBAHN_HL.png
+2025-09-12 08:34:25.775   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:25.775   Installing the file.
+2025-09-12 08:34:25.778   Successfully installed the file.
+2025-09-12 08:34:25.778   -- File entry --
+2025-09-12 08:34:25.779   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\MAP_SHELL.png
+2025-09-12 08:34:25.779   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:25.779   Installing the file.
+2025-09-12 08:34:25.781   Successfully installed the file.
+2025-09-12 08:34:25.781   -- File entry --
+2025-09-12 08:34:25.781   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\MAP_SHELL_HL.png
+2025-09-12 08:34:25.781   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:25.781   Installing the file.
+2025-09-12 08:34:25.783   Successfully installed the file.
+2025-09-12 08:34:25.784   -- File entry --
+2025-09-12 08:34:25.784   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\MAP_SICAN.png
+2025-09-12 08:34:25.784   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:25.784   Installing the file.
+2025-09-12 08:34:25.786   Successfully installed the file.
+2025-09-12 08:34:25.786   -- File entry --
+2025-09-12 08:34:25.786   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\MAP_SICAN_B0.png
+2025-09-12 08:34:25.787   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:25.787   Installing the file.
+2025-09-12 08:34:25.787   Successfully installed the file.
+2025-09-12 08:34:25.787   -- File entry --
+2025-09-12 08:34:25.787   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\MAP_SICAN_B0_HL.png
+2025-09-12 08:34:25.787   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:25.787   Installing the file.
+2025-09-12 08:34:25.788   Successfully installed the file.
+2025-09-12 08:34:25.788   -- File entry --
+2025-09-12 08:34:25.788   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\MAP_SICAN_HL.png
+2025-09-12 08:34:25.788   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:25.788   Installing the file.
+2025-09-12 08:34:25.790   Successfully installed the file.
+2025-09-12 08:34:25.790   -- File entry --
+2025-09-12 08:34:25.791   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\SICAN_DOWN.png
+2025-09-12 08:34:25.791   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:25.791   Installing the file.
+2025-09-12 08:34:25.791   Successfully installed the file.
+2025-09-12 08:34:25.791   -- File entry --
+2025-09-12 08:34:25.791   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\SICAN_UP.png
+2025-09-12 08:34:25.791   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:25.791   Installing the file.
+2025-09-12 08:34:25.793   Successfully installed the file.
+2025-09-12 08:34:25.793   -- File entry --
+2025-09-12 08:34:25.793   Dest filename: C:\vimacc\data\maps\H_Garbsen\maps\H_Garbsen.png
+2025-09-12 08:34:25.793   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:25.793   Installing the file.
+2025-09-12 08:34:25.798   Successfully installed the file.
+2025-09-12 08:34:25.798   -- File entry --
+2025-09-12 08:34:25.798   Dest filename: C:\vimacc\data\maps\H_Garbsen\maps\MAP_A2.png
+2025-09-12 08:34:25.798   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:25.798   Installing the file.
+2025-09-12 08:34:25.802   Successfully installed the file.
+2025-09-12 08:34:25.802   -- File entry --
+2025-09-12 08:34:25.803   Dest filename: C:\vimacc\data\maps\H_Garbsen\maps\MAP_CONTI.png
+2025-09-12 08:34:25.803   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:25.803   Installing the file.
+2025-09-12 08:34:25.821   Successfully installed the file.
+2025-09-12 08:34:25.821   -- File entry --
+2025-09-12 08:34:25.821   Dest filename: C:\vimacc\data\maps\H_Garbsen\maps\MAP_SBAHN.png
+2025-09-12 08:34:25.821   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:25.821   Installing the file.
+2025-09-12 08:34:25.828   Successfully installed the file.
+2025-09-12 08:34:25.828   -- File entry --
+2025-09-12 08:34:25.829   Dest filename: C:\vimacc\data\maps\H_Garbsen\maps\MAP_SHELL.png
+2025-09-12 08:34:25.829   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:25.829   Installing the file.
+2025-09-12 08:34:25.839   Successfully installed the file.
+2025-09-12 08:34:25.839   -- File entry --
+2025-09-12 08:34:25.839   Dest filename: C:\vimacc\data\maps\H_Garbsen\maps\MAP_SICAN.png
+2025-09-12 08:34:25.839   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:25.839   Installing the file.
+2025-09-12 08:34:25.843   Successfully installed the file.
+2025-09-12 08:34:25.843   -- File entry --
+2025-09-12 08:34:25.844   Dest filename: C:\vimacc\data\maps\H_Garbsen\maps\MAP_SICAN_B0.png
+2025-09-12 08:34:25.844   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:25.844   Installing the file.
+2025-09-12 08:34:25.845   Successfully installed the file.
+2025-09-12 08:34:25.845   -- File entry --
+2025-09-12 08:34:25.845   Dest filename: C:\vimacc\data\maps\H_Garbsen\maps\MAP_SICAN_B1.png
+2025-09-12 08:34:25.845   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:25.845   Installing the file.
+2025-09-12 08:34:25.846   Successfully installed the file.
+2025-09-12 08:34:25.846   -- File entry --
+2025-09-12 08:34:25.846   Dest filename: C:\vimacc\data\maps\H_Garbsen\maps\MAP_SICAN_B2.png
+2025-09-12 08:34:25.846   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:25.846   Installing the file.
+2025-09-12 08:34:25.847   Successfully installed the file.
+2025-09-12 08:34:25.847   -- File entry --
+2025-09-12 08:34:25.848   Dest filename: C:\vimacc\data\Workstation\12p1Grid.png
+2025-09-12 08:34:25.848   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:25.848   Installing the file.
+2025-09-12 08:34:25.848   Creating directory: C:\vimacc\data\Workstation
+2025-09-12 08:34:25.848   Successfully installed the file.
+2025-09-12 08:34:25.848   -- File entry --
+2025-09-12 08:34:25.849   Dest filename: C:\vimacc\data\Workstation\12p1Grid_flash.png
+2025-09-12 08:34:25.849   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:25.849   Installing the file.
+2025-09-12 08:34:25.849   Successfully installed the file.
+2025-09-12 08:34:25.849   -- File entry --
+2025-09-12 08:34:25.850   Dest filename: C:\vimacc\data\Workstation\1p11Grid.png
+2025-09-12 08:34:25.850   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:25.850   Installing the file.
+2025-09-12 08:34:25.850   Successfully installed the file.
+2025-09-12 08:34:25.850   -- File entry --
+2025-09-12 08:34:25.851   Dest filename: C:\vimacc\data\Workstation\1p11Grid_flash.png
+2025-09-12 08:34:25.851   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:25.851   Installing the file.
+2025-09-12 08:34:25.852   Successfully installed the file.
+2025-09-12 08:34:25.852   -- File entry --
+2025-09-12 08:34:25.852   Dest filename: C:\vimacc\data\Workstation\1p1x2Grid.png
+2025-09-12 08:34:25.852   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:25.852   Installing the file.
+2025-09-12 08:34:25.853   Successfully installed the file.
+2025-09-12 08:34:25.853   -- File entry --
+2025-09-12 08:34:25.853   Dest filename: C:\vimacc\data\Workstation\1p1x2Grid_flash.png
+2025-09-12 08:34:25.853   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:25.853   Installing the file.
+2025-09-12 08:34:25.854   Successfully installed the file.
+2025-09-12 08:34:25.854   -- File entry --
+2025-09-12 08:34:25.854   Dest filename: C:\vimacc\data\Workstation\1p1x4Grid.png
+2025-09-12 08:34:25.854   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:25.854   Installing the file.
+2025-09-12 08:34:25.854   Successfully installed the file.
+2025-09-12 08:34:25.855   -- File entry --
+2025-09-12 08:34:25.855   Dest filename: C:\vimacc\data\Workstation\1p1x4Grid_flash.png
+2025-09-12 08:34:25.855   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:25.855   Installing the file.
+2025-09-12 08:34:25.856   Successfully installed the file.
+2025-09-12 08:34:25.856   -- File entry --
+2025-09-12 08:34:25.856   Dest filename: C:\vimacc\data\Workstation\1p2Grid.png
+2025-09-12 08:34:25.856   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:25.856   Installing the file.
+2025-09-12 08:34:25.857   Successfully installed the file.
+2025-09-12 08:34:25.857   -- File entry --
+2025-09-12 08:34:25.857   Dest filename: C:\vimacc\data\Workstation\1p2Grid_flash.png
+2025-09-12 08:34:25.857   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:25.857   Installing the file.
+2025-09-12 08:34:25.858   Successfully installed the file.
+2025-09-12 08:34:25.858   -- File entry --
+2025-09-12 08:34:25.858   Dest filename: C:\vimacc\data\Workstation\1p5Grid.png
+2025-09-12 08:34:25.858   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:25.858   Installing the file.
+2025-09-12 08:34:25.859   Successfully installed the file.
+2025-09-12 08:34:25.859   -- File entry --
+2025-09-12 08:34:25.859   Dest filename: C:\vimacc\data\Workstation\1p5Grid_flash.png
+2025-09-12 08:34:25.859   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:25.859   Installing the file.
+2025-09-12 08:34:25.860   Successfully installed the file.
+2025-09-12 08:34:25.860   -- File entry --
+2025-09-12 08:34:25.860   Dest filename: C:\vimacc\data\Workstation\1p6Grid.png
+2025-09-12 08:34:25.860   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:25.860   Installing the file.
+2025-09-12 08:34:25.860   Successfully installed the file.
+2025-09-12 08:34:25.860   -- File entry --
+2025-09-12 08:34:25.862   Dest filename: C:\vimacc\data\Workstation\1p6Grid_flash.png
+2025-09-12 08:34:25.862   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:25.862   Installing the file.
+2025-09-12 08:34:25.862   Successfully installed the file.
+2025-09-12 08:34:25.863   -- File entry --
+2025-09-12 08:34:25.863   Dest filename: C:\vimacc\data\Workstation\1x3Grid.png
+2025-09-12 08:34:25.863   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:25.863   Installing the file.
+2025-09-12 08:34:25.864   Successfully installed the file.
+2025-09-12 08:34:25.864   -- File entry --
+2025-09-12 08:34:25.864   Dest filename: C:\vimacc\data\Workstation\1x3Grid_flash.png
+2025-09-12 08:34:25.864   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:25.864   Installing the file.
+2025-09-12 08:34:25.865   Successfully installed the file.
+2025-09-12 08:34:25.865   -- File entry --
+2025-09-12 08:34:25.865   Dest filename: C:\vimacc\data\Workstation\26p1Grid.png
+2025-09-12 08:34:25.865   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:25.865   Installing the file.
+2025-09-12 08:34:25.866   Successfully installed the file.
+2025-09-12 08:34:25.866   -- File entry --
+2025-09-12 08:34:25.866   Dest filename: C:\vimacc\data\Workstation\26p1Grid_flash.png
+2025-09-12 08:34:25.866   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:25.866   Installing the file.
+2025-09-12 08:34:25.867   Successfully installed the file.
+2025-09-12 08:34:25.867   -- File entry --
+2025-09-12 08:34:25.867   Dest filename: C:\vimacc\data\Workstation\2p1Grid.png
+2025-09-12 08:34:25.867   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:25.867   Installing the file.
+2025-09-12 08:34:25.868   Successfully installed the file.
+2025-09-12 08:34:25.868   -- File entry --
+2025-09-12 08:34:25.868   Dest filename: C:\vimacc\data\Workstation\2p1Grid_flash.png
+2025-09-12 08:34:25.868   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:25.868   Installing the file.
+2025-09-12 08:34:25.869   Successfully installed the file.
+2025-09-12 08:34:25.869   -- File entry --
+2025-09-12 08:34:25.869   Dest filename: C:\vimacc\data\Workstation\2x1Grid.png
+2025-09-12 08:34:25.869   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:25.869   Installing the file.
+2025-09-12 08:34:25.870   Successfully installed the file.
+2025-09-12 08:34:25.870   -- File entry --
+2025-09-12 08:34:25.870   Dest filename: C:\vimacc\data\Workstation\2x1Grid_flash.png
+2025-09-12 08:34:25.870   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:25.870   Installing the file.
+2025-09-12 08:34:25.871   Successfully installed the file.
+2025-09-12 08:34:25.871   -- File entry --
+2025-09-12 08:34:25.871   Dest filename: C:\vimacc\data\Workstation\2x3p4Grid.png
+2025-09-12 08:34:25.871   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:25.871   Installing the file.
+2025-09-12 08:34:25.871   Successfully installed the file.
+2025-09-12 08:34:25.871   -- File entry --
+2025-09-12 08:34:25.872   Dest filename: C:\vimacc\data\Workstation\2x3p4Grid_flash.png
+2025-09-12 08:34:25.872   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:25.872   Installing the file.
+2025-09-12 08:34:25.872   Successfully installed the file.
+2025-09-12 08:34:25.872   -- File entry --
+2025-09-12 08:34:25.873   Dest filename: C:\vimacc\data\Workstation\2x4Grid.png
+2025-09-12 08:34:25.873   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:25.873   Installing the file.
+2025-09-12 08:34:25.873   Successfully installed the file.
+2025-09-12 08:34:25.873   -- File entry --
+2025-09-12 08:34:25.874   Dest filename: C:\vimacc\data\Workstation\2x4Grid_flash.png
+2025-09-12 08:34:25.874   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:25.874   Installing the file.
+2025-09-12 08:34:25.874   Successfully installed the file.
+2025-09-12 08:34:25.874   -- File entry --
+2025-09-12 08:34:25.875   Dest filename: C:\vimacc\data\Workstation\2x4p2Grid.png
+2025-09-12 08:34:25.875   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:25.875   Installing the file.
+2025-09-12 08:34:25.875   Successfully installed the file.
+2025-09-12 08:34:25.875   -- File entry --
+2025-09-12 08:34:25.876   Dest filename: C:\vimacc\data\Workstation\2x4p2Grid_flash.png
+2025-09-12 08:34:25.876   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:25.876   Installing the file.
+2025-09-12 08:34:25.876   Successfully installed the file.
+2025-09-12 08:34:25.876   -- File entry --
+2025-09-12 08:34:25.877   Dest filename: C:\vimacc\data\Workstation\2x4p5Grid.png
+2025-09-12 08:34:25.877   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:25.877   Installing the file.
+2025-09-12 08:34:25.877   Successfully installed the file.
+2025-09-12 08:34:25.878   -- File entry --
+2025-09-12 08:34:25.878   Dest filename: C:\vimacc\data\Workstation\2x4p5Grid_flash.png
+2025-09-12 08:34:25.878   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:25.878   Installing the file.
+2025-09-12 08:34:25.878   Successfully installed the file.
+2025-09-12 08:34:25.879   -- File entry --
+2025-09-12 08:34:25.879   Dest filename: C:\vimacc\data\Workstation\3p1x2Grid.png
+2025-09-12 08:34:25.879   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:25.879   Installing the file.
+2025-09-12 08:34:25.879   Successfully installed the file.
+2025-09-12 08:34:25.879   -- File entry --
+2025-09-12 08:34:25.880   Dest filename: C:\vimacc\data\Workstation\3p1x2Grid_flash.png
+2025-09-12 08:34:25.880   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:25.880   Installing the file.
+2025-09-12 08:34:25.880   Successfully installed the file.
+2025-09-12 08:34:25.881   -- File entry --
+2025-09-12 08:34:25.881   Dest filename: C:\vimacc\data\Workstation\3p2Grid.png
+2025-09-12 08:34:25.881   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:25.881   Installing the file.
+2025-09-12 08:34:25.881   Successfully installed the file.
+2025-09-12 08:34:25.881   -- File entry --
+2025-09-12 08:34:25.882   Dest filename: C:\vimacc\data\Workstation\3p2Grid_flash.png
+2025-09-12 08:34:25.882   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:25.882   Installing the file.
+2025-09-12 08:34:25.883   Successfully installed the file.
+2025-09-12 08:34:25.883   -- File entry --
+2025-09-12 08:34:25.883   Dest filename: C:\vimacc\data\Workstation\3x3Grid.png
+2025-09-12 08:34:25.883   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:25.883   Installing the file.
+2025-09-12 08:34:25.884   Successfully installed the file.
+2025-09-12 08:34:25.884   -- File entry --
+2025-09-12 08:34:25.884   Dest filename: C:\vimacc\data\Workstation\3x3Grid_flash.png
+2025-09-12 08:34:25.884   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:25.884   Installing the file.
+2025-09-12 08:34:25.885   Successfully installed the file.
+2025-09-12 08:34:25.885   -- File entry --
+2025-09-12 08:34:25.885   Dest filename: C:\vimacc\data\Workstation\4x4Grid.png
+2025-09-12 08:34:25.885   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:25.885   Installing the file.
+2025-09-12 08:34:25.885   Successfully installed the file.
+2025-09-12 08:34:25.885   -- File entry --
+2025-09-12 08:34:25.886   Dest filename: C:\vimacc\data\Workstation\4x4Grid_flash.png
+2025-09-12 08:34:25.886   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:25.886   Installing the file.
+2025-09-12 08:34:25.886   Successfully installed the file.
+2025-09-12 08:34:25.887   -- File entry --
+2025-09-12 08:34:25.887   Dest filename: C:\vimacc\data\Workstation\4x8Grid.png
+2025-09-12 08:34:25.887   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:25.887   Installing the file.
+2025-09-12 08:34:25.888   Successfully installed the file.
+2025-09-12 08:34:25.888   -- File entry --
+2025-09-12 08:34:25.888   Dest filename: C:\vimacc\data\Workstation\4x8Grid_flash.png
+2025-09-12 08:34:25.888   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:25.888   Installing the file.
+2025-09-12 08:34:25.889   Successfully installed the file.
+2025-09-12 08:34:25.889   -- File entry --
+2025-09-12 08:34:25.889   Dest filename: C:\vimacc\data\Workstation\5p1Grid.png
+2025-09-12 08:34:25.889   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:25.889   Installing the file.
+2025-09-12 08:34:25.890   Successfully installed the file.
+2025-09-12 08:34:25.890   -- File entry --
+2025-09-12 08:34:25.890   Dest filename: C:\vimacc\data\Workstation\5p1Grid_flash.png
+2025-09-12 08:34:25.890   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:25.890   Installing the file.
+2025-09-12 08:34:25.891   Successfully installed the file.
+2025-09-12 08:34:25.891   -- File entry --
+2025-09-12 08:34:25.891   Dest filename: C:\vimacc\data\Workstation\5p2x4Grid.png
+2025-09-12 08:34:25.891   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:25.891   Installing the file.
+2025-09-12 08:34:25.892   Successfully installed the file.
+2025-09-12 08:34:25.892   -- File entry --
+2025-09-12 08:34:25.893   Dest filename: C:\vimacc\data\Workstation\5p2x4Grid_flash.png
+2025-09-12 08:34:25.893   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:25.893   Installing the file.
+2025-09-12 08:34:25.893   Successfully installed the file.
+2025-09-12 08:34:25.893   -- File entry --
+2025-09-12 08:34:25.893   Dest filename: C:\vimacc\data\Workstation\5x6Grid.png
+2025-09-12 08:34:25.893   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:25.893   Installing the file.
+2025-09-12 08:34:25.894   Successfully installed the file.
+2025-09-12 08:34:25.894   -- File entry --
+2025-09-12 08:34:25.894   Dest filename: C:\vimacc\data\Workstation\5x6Grid_flash.png
+2025-09-12 08:34:25.895   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:25.895   Installing the file.
+2025-09-12 08:34:25.895   Successfully installed the file.
+2025-09-12 08:34:25.895   -- File entry --
+2025-09-12 08:34:25.895   Dest filename: C:\vimacc\config\AccVimaccConfig_workstation.conf
+2025-09-12 08:34:25.896   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:25.896   Installing the file.
+2025-09-12 08:34:25.896   Successfully installed the file.
+2025-09-12 08:34:25.896   -- File entry --
+2025-09-12 08:34:25.896   Dest filename: C:\vimacc\config\AccVimaccGui_workstation.conf
+2025-09-12 08:34:25.897   Time stamp of our file: 2025-08-13 12:07:28.000
+2025-09-12 08:34:25.897   Installing the file.
+2025-09-12 08:34:25.897   Successfully installed the file.
+2025-09-12 08:34:25.897   -- File entry --
+2025-09-12 08:34:25.897   Dest filename: C:\vimacc\config\AccVimaccStreaming_workstation.conf
+2025-09-12 08:34:25.898   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:25.898   Installing the file.
+2025-09-12 08:34:25.898   Successfully installed the file.
+2025-09-12 08:34:25.898   -- File entry --
+2025-09-12 08:34:25.898   Dest filename: C:\vimacc\data\about\accellence.png
+2025-09-12 08:34:25.898   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:25.898   Installing the file.
+2025-09-12 08:34:25.899   Successfully installed the file.
+2025-09-12 08:34:25.899   -- File entry --
+2025-09-12 08:34:25.899   Dest filename: C:\vimacc\data\about\supportpage.html
+2025-09-12 08:34:25.899   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:25.899   Installing the file.
+2025-09-12 08:34:25.900   Successfully installed the file.
+2025-09-12 08:34:25.900   -- File entry --
+2025-09-12 08:34:25.900   Dest filename: C:\vimacc\data\about\teletrust.png
+2025-09-12 08:34:25.900   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:25.900   Installing the file.
+2025-09-12 08:34:25.901   Successfully installed the file.
+2025-09-12 08:34:25.901   -- File entry --
+2025-09-12 08:34:25.901   Dest filename: C:\vimacc\data\about\vimacc.png
+2025-09-12 08:34:25.901   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:25.901   Installing the file.
+2025-09-12 08:34:25.903   Successfully installed the file.
+2025-09-12 08:34:25.903   -- File entry --
+2025-09-12 08:34:25.903   Dest filename: C:\vimacc\data\about\AnnotationTool\accellence.png
+2025-09-12 08:34:25.903   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:25.903   Installing the file.
+2025-09-12 08:34:25.903   Creating directory: C:\vimacc\data\about\AnnotationTool
+2025-09-12 08:34:25.904   Successfully installed the file.
+2025-09-12 08:34:25.904   -- File entry --
+2025-09-12 08:34:25.904   Dest filename: C:\vimacc\data\about\AnnotationTool\supportpage.html
+2025-09-12 08:34:25.904   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:25.904   Installing the file.
+2025-09-12 08:34:25.905   Successfully installed the file.
+2025-09-12 08:34:25.905   -- File entry --
+2025-09-12 08:34:25.905   Dest filename: C:\vimacc\data\about\AnnotationTool\teletrust.png
+2025-09-12 08:34:25.905   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:25.905   Installing the file.
+2025-09-12 08:34:25.906   Successfully installed the file.
+2025-09-12 08:34:25.906   -- File entry --
+2025-09-12 08:34:25.906   Dest filename: C:\vimacc\data\configTemplates\network-workgroup.png
+2025-09-12 08:34:25.907   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:25.907   Installing the file.
+2025-09-12 08:34:25.907   Successfully installed the file.
+2025-09-12 08:34:25.907   -- File entry --
+2025-09-12 08:34:25.907   Dest filename: C:\vimacc\data\configTemplates\stylesheet.qss
+2025-09-12 08:34:25.908   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:25.908   Installing the file.
+2025-09-12 08:34:25.908   Successfully installed the file.
+2025-09-12 08:34:25.908   -- File entry --
+2025-09-12 08:34:25.909   Dest filename: C:\vimacc\data\configTemplates\default\0000 DEMO (single host).vicx
+2025-09-12 08:34:25.909   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:25.909   Installing the file.
+2025-09-12 08:34:25.909   Creating directory: C:\vimacc\data\configTemplates\default
+2025-09-12 08:34:25.910   Successfully installed the file.
+2025-09-12 08:34:25.910   -- File entry --
+2025-09-12 08:34:25.911   Dest filename: C:\vimacc\data\configTemplates\default\0001 Single Host Basic.vicx
+2025-09-12 08:34:25.911   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:25.911   Installing the file.
+2025-09-12 08:34:25.911   Successfully installed the file.
+2025-09-12 08:34:25.912   -- File entry --
+2025-09-12 08:34:25.912   Dest filename: C:\vimacc\data\configTemplates\default\1000 Multi Host Basic_01.vicx
+2025-09-12 08:34:25.912   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:25.912   Installing the file.
+2025-09-12 08:34:25.912   Successfully installed the file.
+2025-09-12 08:34:25.913   -- File entry --
+2025-09-12 08:34:25.913   Dest filename: C:\vimacc\data\configTemplates\default\general.def
+2025-09-12 08:34:25.913   Time stamp of our file: 2025-07-11 13:18:10.000
+2025-09-12 08:34:25.913   Installing the file.
+2025-09-12 08:34:25.914   Successfully installed the file.
+2025-09-12 08:34:25.914   -- File entry --
+2025-09-12 08:34:25.914   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\ADDAC_AUDIO_DEVICE.template
+2025-09-12 08:34:25.914   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:25.914   Installing the file.
+2025-09-12 08:34:25.914   Creating directory: C:\vimacc\data\configTemplates\default\devTemplates
+2025-09-12 08:34:25.915   Successfully installed the file.
+2025-09-12 08:34:25.915   -- File entry --
+2025-09-12 08:34:25.915   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\ALLIEDTELISIS_ATx31026FP.template
+2025-09-12 08:34:25.915   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:25.915   Installing the file.
+2025-09-12 08:34:25.916   Successfully installed the file.
+2025-09-12 08:34:25.916   -- File entry --
+2025-09-12 08:34:25.916   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\ALLIEDTELISIS_ATx55018XSQ.template
+2025-09-12 08:34:25.916   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:25.916   Installing the file.
+2025-09-12 08:34:25.916   Successfully installed the file.
+2025-09-12 08:34:25.918   -- File entry --
+2025-09-12 08:34:25.918   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\ANY_AUDIO_DEVICE.template
+2025-09-12 08:34:25.918   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:25.918   Installing the file.
+2025-09-12 08:34:25.919   Successfully installed the file.
+2025-09-12 08:34:25.919   -- File entry --
+2025-09-12 08:34:25.919   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\ANY_VIDEO_DEVICE.template
+2025-09-12 08:34:25.919   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:25.919   Installing the file.
+2025-09-12 08:34:25.920   Successfully installed the file.
+2025-09-12 08:34:25.920   -- File entry --
+2025-09-12 08:34:25.921   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\ASSEMBLYELEMENT_LEDBUTTON.template
+2025-09-12 08:34:25.921   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:25.921   Installing the file.
+2025-09-12 08:34:25.921   Successfully installed the file.
+2025-09-12 08:34:25.921   -- File entry --
+2025-09-12 08:34:25.922   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\ASSEMBLYELEMENT_LEDBUTTON_IODEVICE.template
+2025-09-12 08:34:25.922   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:25.922   Installing the file.
+2025-09-12 08:34:25.922   Successfully installed the file.
+2025-09-12 08:34:25.922   -- File entry --
+2025-09-12 08:34:25.922   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\ASSEMBLYELEMENT_LEDBUTTON_IODEVICE_BASIC.include
+2025-09-12 08:34:25.922   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:25.922   Installing the file.
+2025-09-12 08:34:25.923   Successfully installed the file.
+2025-09-12 08:34:25.923   -- File entry --
+2025-09-12 08:34:25.924   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\ASSEMBLYELEMENT_LEDBUTTON_IODEVICE_WITH_REG_VALUE.template
+2025-09-12 08:34:25.924   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:25.924   Installing the file.
+2025-09-12 08:34:25.924   Successfully installed the file.
+2025-09-12 08:34:25.924   -- File entry --
+2025-09-12 08:34:25.925   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\ASSEMBLYTASK_GATE.template
+2025-09-12 08:34:25.925   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:25.925   Installing the file.
+2025-09-12 08:34:25.925   Successfully installed the file.
+2025-09-12 08:34:25.925   -- File entry --
+2025-09-12 08:34:25.925   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\ASSEMBLYTASK_LEDBUTTONS.template
+2025-09-12 08:34:25.925   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:25.925   Installing the file.
+2025-09-12 08:34:25.927   Successfully installed the file.
+2025-09-12 08:34:25.927   -- File entry --
+2025-09-12 08:34:25.927   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\AVERMEDIA_NH_VIDEO_DEVICE.template
+2025-09-12 08:34:25.927   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:25.927   Installing the file.
+2025-09-12 08:34:25.928   Successfully installed the file.
+2025-09-12 08:34:25.928   -- File entry --
+2025-09-12 08:34:25.928   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\AXIS_AUDIO_DEVICE.template
+2025-09-12 08:34:25.928   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:25.928   Installing the file.
+2025-09-12 08:34:25.929   Successfully installed the file.
+2025-09-12 08:34:25.929   -- File entry --
+2025-09-12 08:34:25.929   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\CMDBASE_ALARMRECORDING.include
+2025-09-12 08:34:25.929   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:25.929   Installing the file.
+2025-09-12 08:34:25.930   Successfully installed the file.
+2025-09-12 08:34:25.930   -- File entry --
+2025-09-12 08:34:25.930   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\CMDBASE_CLEARDIALOG.include
+2025-09-12 08:34:25.930   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:25.930   Installing the file.
+2025-09-12 08:34:25.931   Successfully installed the file.
+2025-09-12 08:34:25.931   -- File entry --
+2025-09-12 08:34:25.931   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\CMDBASE_DEACTIVATEPRIVACYZONES.include
+2025-09-12 08:34:25.932   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:25.932   Installing the file.
+2025-09-12 08:34:25.932   Successfully installed the file.
+2025-09-12 08:34:25.932   -- File entry --
+2025-09-12 08:34:25.932   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\CMDBASE_FTPUPLOADSTART.include
+2025-09-12 08:34:25.932   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:25.932   Installing the file.
+2025-09-12 08:34:25.934   Successfully installed the file.
+2025-09-12 08:34:25.934   -- File entry --
+2025-09-12 08:34:25.934   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\CMDBASE_FTPUPLOADSTOP.include
+2025-09-12 08:34:25.934   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:25.934   Installing the file.
+2025-09-12 08:34:25.935   Successfully installed the file.
+2025-09-12 08:34:25.935   -- File entry --
+2025-09-12 08:34:25.935   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\CMDBASE_FTP_LIVE_UPLOADSTART.include
+2025-09-12 08:34:25.935   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:25.935   Installing the file.
+2025-09-12 08:34:25.936   Successfully installed the file.
+2025-09-12 08:34:25.936   -- File entry --
+2025-09-12 08:34:25.936   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\CMDBASE_FTP_LIVE_UPLOADSTOP.include
+2025-09-12 08:34:25.936   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:25.936   Installing the file.
+2025-09-12 08:34:25.937   Successfully installed the file.
+2025-09-12 08:34:25.937   -- File entry --
+2025-09-12 08:34:25.937   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\CMDBASE_GOTOPRESET.include
+2025-09-12 08:34:25.937   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:25.937   Installing the file.
+2025-09-12 08:34:25.938   Successfully installed the file.
+2025-09-12 08:34:25.938   -- File entry --
+2025-09-12 08:34:25.938   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\CMDBASE_HOST_REBOOT.include
+2025-09-12 08:34:25.938   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:25.938   Installing the file.
+2025-09-12 08:34:25.939   Successfully installed the file.
+2025-09-12 08:34:25.939   -- File entry --
+2025-09-12 08:34:25.939   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\CMDBASE_RECSYNCBASE.include
+2025-09-12 08:34:25.939   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:25.939   Installing the file.
+2025-09-12 08:34:25.940   Successfully installed the file.
+2025-09-12 08:34:25.940   -- File entry --
+2025-09-12 08:34:25.940   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\CMDBASE_RECSYNCSTART.include
+2025-09-12 08:34:25.940   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:25.940   Installing the file.
+2025-09-12 08:34:25.941   Successfully installed the file.
+2025-09-12 08:34:25.941   -- File entry --
+2025-09-12 08:34:25.941   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\CMDBASE_RECSYNCSTOP.include
+2025-09-12 08:34:25.941   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:25.941   Installing the file.
+2025-09-12 08:34:25.942   Successfully installed the file.
+2025-09-12 08:34:25.942   -- File entry --
+2025-09-12 08:34:25.942   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\CMDBASE_SENDEMAIL.include
+2025-09-12 08:34:25.942   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:25.942   Installing the file.
+2025-09-12 08:34:25.943   Successfully installed the file.
+2025-09-12 08:34:25.943   -- File entry --
+2025-09-12 08:34:25.943   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\CMDBASE_SENDEMAIL_SCRIPTED.include
+2025-09-12 08:34:25.943   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:25.943   Installing the file.
+2025-09-12 08:34:25.944   Successfully installed the file.
+2025-09-12 08:34:25.944   -- File entry --
+2025-09-12 08:34:25.944   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\CMDBASE_SETBOOKMARK.include
+2025-09-12 08:34:25.944   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:25.944   Installing the file.
+2025-09-12 08:34:25.944   Successfully installed the file.
+2025-09-12 08:34:25.945   -- File entry --
+2025-09-12 08:34:25.945   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\CMDBASE_SETBOOKMARK_SCRIPTED.include
+2025-09-12 08:34:25.945   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:25.945   Installing the file.
+2025-09-12 08:34:25.946   Successfully installed the file.
+2025-09-12 08:34:25.946   -- File entry --
+2025-09-12 08:34:25.946   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\CMDBASE_SETGRID.include
+2025-09-12 08:34:25.946   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:25.946   Installing the file.
+2025-09-12 08:34:25.947   Successfully installed the file.
+2025-09-12 08:34:25.947   -- File entry --
+2025-09-12 08:34:25.947   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\CMDBASE_SHOWCONTROLAREA.include
+2025-09-12 08:34:25.947   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:25.947   Installing the file.
+2025-09-12 08:34:25.948   Successfully installed the file.
+2025-09-12 08:34:25.948   -- File entry --
+2025-09-12 08:34:25.948   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\CMDBASE_SHOWMAP.include
+2025-09-12 08:34:25.948   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:25.948   Installing the file.
+2025-09-12 08:34:25.949   Successfully installed the file.
+2025-09-12 08:34:25.949   -- File entry --
+2025-09-12 08:34:25.949   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\CMDBASE_SHOWNAVIGATIONAREA.include
+2025-09-12 08:34:25.949   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:25.949   Installing the file.
+2025-09-12 08:34:25.950   Successfully installed the file.
+2025-09-12 08:34:25.950   -- File entry --
+2025-09-12 08:34:25.950   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\CMDBASE_SHOWPLAYBACKS.include
+2025-09-12 08:34:25.950   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:25.950   Installing the file.
+2025-09-12 08:34:25.951   Successfully installed the file.
+2025-09-12 08:34:25.951   -- File entry --
+2025-09-12 08:34:25.951   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\CMDBASE_SHOWSCENARIO.include
+2025-09-12 08:34:25.951   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:25.951   Installing the file.
+2025-09-12 08:34:25.952   Successfully installed the file.
+2025-09-12 08:34:25.952   -- File entry --
+2025-09-12 08:34:25.952   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\CMDBASE_SHOWSEQUENCE.include
+2025-09-12 08:34:25.952   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:25.952   Installing the file.
+2025-09-12 08:34:25.952   Successfully installed the file.
+2025-09-12 08:34:25.954   -- File entry --
+2025-09-12 08:34:25.954   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\CMDBASE_SHOWSTREAMS.include
+2025-09-12 08:34:25.954   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:25.954   Installing the file.
+2025-09-12 08:34:25.955   Successfully installed the file.
+2025-09-12 08:34:25.955   -- File entry --
+2025-09-12 08:34:25.955   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\CMDBASE_SHOWTOOLBAR.include
+2025-09-12 08:34:25.955   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:25.955   Installing the file.
+2025-09-12 08:34:25.956   Successfully installed the file.
+2025-09-12 08:34:25.956   -- File entry --
+2025-09-12 08:34:25.957   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\CMDBASE_SWITCHRECORDING.include
+2025-09-12 08:34:25.957   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:25.957   Installing the file.
+2025-09-12 08:34:25.957   Successfully installed the file.
+2025-09-12 08:34:25.957   -- File entry --
+2025-09-12 08:34:25.958   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\CTRL_ENTRY.template
+2025-09-12 08:34:25.958   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:25.958   Installing the file.
+2025-09-12 08:34:25.958   Successfully installed the file.
+2025-09-12 08:34:25.958   -- File entry --
+2025-09-12 08:34:25.959   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\CTRL_ENTRY_ASSEMBLYMGR.template
+2025-09-12 08:34:25.959   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:25.959   Installing the file.
+2025-09-12 08:34:25.959   Successfully installed the file.
+2025-09-12 08:34:25.959   -- File entry --
+2025-09-12 08:34:25.960   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\CTRL_ENTRY_DIGIO.template
+2025-09-12 08:34:25.960   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:25.960   Installing the file.
+2025-09-12 08:34:25.960   Successfully installed the file.
+2025-09-12 08:34:25.960   -- File entry --
+2025-09-12 08:34:25.961   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\CTRL_ENTRY_ELISE.template
+2025-09-12 08:34:25.961   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:25.961   Installing the file.
+2025-09-12 08:34:25.961   Successfully installed the file.
+2025-09-12 08:34:25.961   -- File entry --
+2025-09-12 08:34:25.962   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\CTRL_ENTRY_EMAILSENDER.template
+2025-09-12 08:34:25.962   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:25.962   Installing the file.
+2025-09-12 08:34:25.962   Successfully installed the file.
+2025-09-12 08:34:25.962   -- File entry --
+2025-09-12 08:34:25.963   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\CTRL_ENTRY_EVENTMGR.template
+2025-09-12 08:34:25.963   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:25.963   Installing the file.
+2025-09-12 08:34:25.963   Successfully installed the file.
+2025-09-12 08:34:25.963   -- File entry --
+2025-09-12 08:34:25.963   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\CTRL_ENTRY_FTPDUPLOADER.template
+2025-09-12 08:34:25.963   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:25.963   Installing the file.
+2025-09-12 08:34:25.964   Successfully installed the file.
+2025-09-12 08:34:25.964   -- File entry --
+2025-09-12 08:34:25.964   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\CTRL_ENTRY_INTERFACE.template
+2025-09-12 08:34:25.965   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:25.965   Installing the file.
+2025-09-12 08:34:25.965   Successfully installed the file.
+2025-09-12 08:34:25.965   -- File entry --
+2025-09-12 08:34:25.966   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\CTRL_ENTRY_INTERFACE_PROXY.template
+2025-09-12 08:34:25.966   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:25.966   Installing the file.
+2025-09-12 08:34:25.966   Successfully installed the file.
+2025-09-12 08:34:25.966   -- File entry --
+2025-09-12 08:34:25.967   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\CTRL_ENTRY_MOTION_DETECTOR.template
+2025-09-12 08:34:25.967   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:25.967   Installing the file.
+2025-09-12 08:34:25.967   Successfully installed the file.
+2025-09-12 08:34:25.967   -- File entry --
+2025-09-12 08:34:25.968   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\CTRL_ENTRY_NETWORKDEVICE.template
+2025-09-12 08:34:25.968   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:25.968   Installing the file.
+2025-09-12 08:34:25.968   Successfully installed the file.
+2025-09-12 08:34:25.968   -- File entry --
+2025-09-12 08:34:25.969   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\CTRL_ENTRY_OPC_CLIENT.template
+2025-09-12 08:34:25.969   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:25.969   Installing the file.
+2025-09-12 08:34:25.969   Successfully installed the file.
+2025-09-12 08:34:25.969   -- File entry --
+2025-09-12 08:34:25.970   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\CTRL_ENTRY_PLAYBACK_PROXY.template
+2025-09-12 08:34:25.970   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:25.970   Installing the file.
+2025-09-12 08:34:25.970   Successfully installed the file.
+2025-09-12 08:34:25.970   -- File entry --
+2025-09-12 08:34:25.971   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\CTRL_ENTRY_SCHEDULER.template
+2025-09-12 08:34:25.971   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:25.971   Installing the file.
+2025-09-12 08:34:25.971   Successfully installed the file.
+2025-09-12 08:34:25.971   -- File entry --
+2025-09-12 08:34:25.972   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\CTRL_ENTRY_SERIALIO.template
+2025-09-12 08:34:25.972   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:25.972   Installing the file.
+2025-09-12 08:34:25.972   Successfully installed the file.
+2025-09-12 08:34:25.973   -- File entry --
+2025-09-12 08:34:25.973   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\CTRL_ENTRY_SERVER.template
+2025-09-12 08:34:25.973   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:25.973   Installing the file.
+2025-09-12 08:34:25.973   Successfully installed the file.
+2025-09-12 08:34:25.973   -- File entry --
+2025-09-12 08:34:25.973   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\CTRL_ENTRY_SERVER_SYNC.template
+2025-09-12 08:34:25.975   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:25.975   Installing the file.
+2025-09-12 08:34:25.975   Successfully installed the file.
+2025-09-12 08:34:25.975   -- File entry --
+2025-09-12 08:34:25.976   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\CTRL_ENTRY_SNMPAGENT.template
+2025-09-12 08:34:25.976   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:25.976   Installing the file.
+2025-09-12 08:34:25.976   Successfully installed the file.
+2025-09-12 08:34:25.976   -- File entry --
+2025-09-12 08:34:25.977   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\CTRL_ENTRY_SPSFT.template
+2025-09-12 08:34:25.977   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:25.977   Installing the file.
+2025-09-12 08:34:25.977   Successfully installed the file.
+2025-09-12 08:34:25.977   -- File entry --
+2025-09-12 08:34:25.978   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\DIGITUS_AUDIO_DEVICE.template
+2025-09-12 08:34:25.978   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:25.978   Installing the file.
+2025-09-12 08:34:25.978   Successfully installed the file.
+2025-09-12 08:34:25.978   -- File entry --
+2025-09-12 08:34:25.979   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\DIGITUS_VIDEO_DEVICE.template
+2025-09-12 08:34:25.979   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:25.979   Installing the file.
+2025-09-12 08:34:25.979   Successfully installed the file.
+2025-09-12 08:34:25.979   -- File entry --
+2025-09-12 08:34:25.979   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\DONGLE_ENTRY.template
+2025-09-12 08:34:25.979   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:25.979   Installing the file.
+2025-09-12 08:34:25.980   Successfully installed the file.
+2025-09-12 08:34:25.980   -- File entry --
+2025-09-12 08:34:25.980   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EIZO_IPSECMONITOR_DSPINTERFACE.template
+2025-09-12 08:34:25.980   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:25.980   Installing the file.
+2025-09-12 08:34:25.981   Successfully installed the file.
+2025-09-12 08:34:25.981   -- File entry --
+2025-09-12 08:34:25.981   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\ELISE_DEVICE.template
+2025-09-12 08:34:25.981   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:25.981   Installing the file.
+2025-09-12 08:34:25.982   Successfully installed the file.
+2025-09-12 08:34:25.982   -- File entry --
+2025-09-12 08:34:25.982   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTACTION_ALARMREC_START.template
+2025-09-12 08:34:25.982   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:25.982   Installing the file.
+2025-09-12 08:34:25.983   Successfully installed the file.
+2025-09-12 08:34:25.983   -- File entry --
+2025-09-12 08:34:25.983   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTACTION_ALARMREC_STOP.template
+2025-09-12 08:34:25.984   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:25.984   Installing the file.
+2025-09-12 08:34:25.984   Successfully installed the file.
+2025-09-12 08:34:25.984   -- File entry --
+2025-09-12 08:34:25.985   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTACTION_CLEARDIALOG.template
+2025-09-12 08:34:25.985   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:25.985   Installing the file.
+2025-09-12 08:34:25.985   Successfully installed the file.
+2025-09-12 08:34:25.985   -- File entry --
+2025-09-12 08:34:25.986   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTACTION_DEACTIVATEPRIVACYZONES.template
+2025-09-12 08:34:25.986   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:25.986   Installing the file.
+2025-09-12 08:34:25.986   Successfully installed the file.
+2025-09-12 08:34:25.986   -- File entry --
+2025-09-12 08:34:25.987   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTACTION_DEFINEEVENTSCENARIO_AUTO.template
+2025-09-12 08:34:25.987   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:25.987   Installing the file.
+2025-09-12 08:34:25.987   Successfully installed the file.
+2025-09-12 08:34:25.987   -- File entry --
+2025-09-12 08:34:25.988   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTACTION_DEFINEEVENTSCENARIO_PRECONF.template
+2025-09-12 08:34:25.988   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:25.988   Installing the file.
+2025-09-12 08:34:25.988   Successfully installed the file.
+2025-09-12 08:34:25.988   -- File entry --
+2025-09-12 08:34:25.989   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTACTION_EXPORTCAMREPORT.template
+2025-09-12 08:34:25.989   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:25.989   Installing the file.
+2025-09-12 08:34:25.989   Successfully installed the file.
+2025-09-12 08:34:25.989   -- File entry --
+2025-09-12 08:34:25.990   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTACTION_FTPUPLOADSTART.template
+2025-09-12 08:34:25.990   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:25.990   Installing the file.
+2025-09-12 08:34:25.990   Successfully installed the file.
+2025-09-12 08:34:25.990   -- File entry --
+2025-09-12 08:34:25.991   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTACTION_FTPUPLOADSTOP.template
+2025-09-12 08:34:25.991   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:25.991   Installing the file.
+2025-09-12 08:34:25.992   Successfully installed the file.
+2025-09-12 08:34:25.992   -- File entry --
+2025-09-12 08:34:25.992   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTACTION_FTP_LIVE_UPLOADSTART.template
+2025-09-12 08:34:25.992   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:25.992   Installing the file.
+2025-09-12 08:34:25.993   Successfully installed the file.
+2025-09-12 08:34:25.993   -- File entry --
+2025-09-12 08:34:25.993   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTACTION_FTP_LIVE_UPLOADSTOP.template
+2025-09-12 08:34:25.993   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:25.993   Installing the file.
+2025-09-12 08:34:25.994   Successfully installed the file.
+2025-09-12 08:34:25.994   -- File entry --
+2025-09-12 08:34:25.994   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTACTION_GOTOPRESET.template
+2025-09-12 08:34:25.994   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:25.994   Installing the file.
+2025-09-12 08:34:25.995   Successfully installed the file.
+2025-09-12 08:34:25.995   -- File entry --
+2025-09-12 08:34:25.996   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTACTION_HOST_REBOOT.template
+2025-09-12 08:34:25.996   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:25.996   Installing the file.
+2025-09-12 08:34:25.996   Successfully installed the file.
+2025-09-12 08:34:25.996   -- File entry --
+2025-09-12 08:34:25.997   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTACTION_RECDEFAULT.template
+2025-09-12 08:34:25.997   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:25.997   Installing the file.
+2025-09-12 08:34:25.997   Successfully installed the file.
+2025-09-12 08:34:25.997   -- File entry --
+2025-09-12 08:34:25.998   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTACTION_RECSTART.template
+2025-09-12 08:34:25.998   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:25.998   Installing the file.
+2025-09-12 08:34:25.998   Successfully installed the file.
+2025-09-12 08:34:25.998   -- File entry --
+2025-09-12 08:34:25.999   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTACTION_RECSTOP.template
+2025-09-12 08:34:25.999   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:25.999   Installing the file.
+2025-09-12 08:34:25.999   Successfully installed the file.
+2025-09-12 08:34:25.999   -- File entry --
+2025-09-12 08:34:26.000   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTACTION_RECSYNCBASE.include
+2025-09-12 08:34:26.000   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.000   Installing the file.
+2025-09-12 08:34:26.000   Successfully installed the file.
+2025-09-12 08:34:26.000   -- File entry --
+2025-09-12 08:34:26.001   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTACTION_RECSYNCSTART.template
+2025-09-12 08:34:26.001   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.001   Installing the file.
+2025-09-12 08:34:26.001   Successfully installed the file.
+2025-09-12 08:34:26.001   -- File entry --
+2025-09-12 08:34:26.002   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTACTION_RECSYNCSTOP.template
+2025-09-12 08:34:26.002   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.002   Installing the file.
+2025-09-12 08:34:26.002   Successfully installed the file.
+2025-09-12 08:34:26.002   -- File entry --
+2025-09-12 08:34:26.003   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTACTION_SENDEMAIL.template
+2025-09-12 08:34:26.003   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.003   Installing the file.
+2025-09-12 08:34:26.003   Successfully installed the file.
+2025-09-12 08:34:26.004   -- File entry --
+2025-09-12 08:34:26.004   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTACTION_SENDEMAIL_SCRIPTED.template
+2025-09-12 08:34:26.004   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.004   Installing the file.
+2025-09-12 08:34:26.004   Successfully installed the file.
+2025-09-12 08:34:26.005   -- File entry --
+2025-09-12 08:34:26.005   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTACTION_SETBOOKMARK.template
+2025-09-12 08:34:26.005   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.005   Installing the file.
+2025-09-12 08:34:26.005   Successfully installed the file.
+2025-09-12 08:34:26.006   -- File entry --
+2025-09-12 08:34:26.006   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTACTION_SETBOOKMARK_SCRIPTED.template
+2025-09-12 08:34:26.006   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.006   Installing the file.
+2025-09-12 08:34:26.006   Successfully installed the file.
+2025-09-12 08:34:26.006   -- File entry --
+2025-09-12 08:34:26.006   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTACTION_SETGRID.template
+2025-09-12 08:34:26.007   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.007   Installing the file.
+2025-09-12 08:34:26.007   Successfully installed the file.
+2025-09-12 08:34:26.007   -- File entry --
+2025-09-12 08:34:26.008   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTACTION_SETOVERLAYTEXT.template
+2025-09-12 08:34:26.008   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.008   Installing the file.
+2025-09-12 08:34:26.008   Successfully installed the file.
+2025-09-12 08:34:26.008   -- File entry --
+2025-09-12 08:34:26.009   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTACTION_SETOVERLAYTEXT_SCRIPTED.template
+2025-09-12 08:34:26.009   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.009   Installing the file.
+2025-09-12 08:34:26.009   Successfully installed the file.
+2025-09-12 08:34:26.009   -- File entry --
+2025-09-12 08:34:26.010   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTACTION_SET_OUTPUT.template
+2025-09-12 08:34:26.010   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.010   Installing the file.
+2025-09-12 08:34:26.010   Successfully installed the file.
+2025-09-12 08:34:26.010   -- File entry --
+2025-09-12 08:34:26.011   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTACTION_SET_OUTPUT_VALUE.template
+2025-09-12 08:34:26.011   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.011   Installing the file.
+2025-09-12 08:34:26.011   Successfully installed the file.
+2025-09-12 08:34:26.013   -- File entry --
+2025-09-12 08:34:26.013   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTACTION_SHOWCONTROLAREA.template
+2025-09-12 08:34:26.013   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.013   Installing the file.
+2025-09-12 08:34:26.013   Successfully installed the file.
+2025-09-12 08:34:26.013   -- File entry --
+2025-09-12 08:34:26.014   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTACTION_SHOWMAP.template
+2025-09-12 08:34:26.014   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.014   Installing the file.
+2025-09-12 08:34:26.014   Successfully installed the file.
+2025-09-12 08:34:26.014   -- File entry --
+2025-09-12 08:34:26.015   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTACTION_SHOWNAVIGATIONAREA.template
+2025-09-12 08:34:26.015   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.015   Installing the file.
+2025-09-12 08:34:26.015   Successfully installed the file.
+2025-09-12 08:34:26.015   -- File entry --
+2025-09-12 08:34:26.016   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTACTION_SHOWPLAYBACKS.template
+2025-09-12 08:34:26.016   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.016   Installing the file.
+2025-09-12 08:34:26.017   Successfully installed the file.
+2025-09-12 08:34:26.017   -- File entry --
+2025-09-12 08:34:26.017   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTACTION_SHOWSCENARIO.template
+2025-09-12 08:34:26.017   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.017   Installing the file.
+2025-09-12 08:34:26.018   Successfully installed the file.
+2025-09-12 08:34:26.018   -- File entry --
+2025-09-12 08:34:26.018   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTACTION_SHOWSEQUENCE.template
+2025-09-12 08:34:26.018   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.018   Installing the file.
+2025-09-12 08:34:26.019   Successfully installed the file.
+2025-09-12 08:34:26.019   -- File entry --
+2025-09-12 08:34:26.019   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTACTION_SHOWSTREAMS.template
+2025-09-12 08:34:26.020   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.020   Installing the file.
+2025-09-12 08:34:26.020   Successfully installed the file.
+2025-09-12 08:34:26.020   -- File entry --
+2025-09-12 08:34:26.021   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTACTION_SHOWTOOLBAR.template
+2025-09-12 08:34:26.021   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.021   Installing the file.
+2025-09-12 08:34:26.021   Successfully installed the file.
+2025-09-12 08:34:26.021   -- File entry --
+2025-09-12 08:34:26.022   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTACTION_SWITCH_OPMODE.template
+2025-09-12 08:34:26.022   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.022   Installing the file.
+2025-09-12 08:34:26.022   Successfully installed the file.
+2025-09-12 08:34:26.022   -- File entry --
+2025-09-12 08:34:26.023   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTACTION_WAIT.template
+2025-09-12 08:34:26.023   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.023   Installing the file.
+2025-09-12 08:34:26.023   Successfully installed the file.
+2025-09-12 08:34:26.024   -- File entry --
+2025-09-12 08:34:26.024   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTACTION_WRITE_DP.template
+2025-09-12 08:34:26.024   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.024   Installing the file.
+2025-09-12 08:34:26.024   Successfully installed the file.
+2025-09-12 08:34:26.025   -- File entry --
+2025-09-12 08:34:26.025   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTACTION_WRITE_DP_SCRIPTED.template
+2025-09-12 08:34:26.025   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.025   Installing the file.
+2025-09-12 08:34:26.026   Successfully installed the file.
+2025-09-12 08:34:26.026   -- File entry --
+2025-09-12 08:34:26.026   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTLNK_TRIGGER_CONFIGVALUE.template
+2025-09-12 08:34:26.027   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.027   Installing the file.
+2025-09-12 08:34:26.027   Successfully installed the file.
+2025-09-12 08:34:26.027   -- File entry --
+2025-09-12 08:34:26.028   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTLNK_TRIGGER_STREAMREQUESTED.template
+2025-09-12 08:34:26.028   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.028   Installing the file.
+2025-09-12 08:34:26.028   Successfully installed the file.
+2025-09-12 08:34:26.028   -- File entry --
+2025-09-12 08:34:26.029   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTTASK_CONFIGVALUE.template
+2025-09-12 08:34:26.029   Time stamp of our file: 2025-08-13 12:07:22.000
+2025-09-12 08:34:26.029   Installing the file.
+2025-09-12 08:34:26.029   Successfully installed the file.
+2025-09-12 08:34:26.029   -- File entry --
+2025-09-12 08:34:26.030   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTTASK_FTPALARM.template
+2025-09-12 08:34:26.030   Time stamp of our file: 2025-07-11 13:18:10.000
+2025-09-12 08:34:26.030   Installing the file.
+2025-09-12 08:34:26.030   Successfully installed the file.
+2025-09-12 08:34:26.030   -- File entry --
+2025-09-12 08:34:26.031   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTTASK_IO.template
+2025-09-12 08:34:26.031   Time stamp of our file: 2025-07-11 13:18:10.000
+2025-09-12 08:34:26.031   Installing the file.
+2025-09-12 08:34:26.031   Successfully installed the file.
+2025-09-12 08:34:26.031   -- File entry --
+2025-09-12 08:34:26.032   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTTASK_IO_VALUE.template
+2025-09-12 08:34:26.032   Time stamp of our file: 2025-07-11 13:18:10.000
+2025-09-12 08:34:26.032   Installing the file.
+2025-09-12 08:34:26.032   Successfully installed the file.
+2025-09-12 08:34:26.032   -- File entry --
+2025-09-12 08:34:26.033   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTTASK_IO_VALUE_SCRIPTED.template
+2025-09-12 08:34:26.033   Time stamp of our file: 2025-07-11 13:18:10.000
+2025-09-12 08:34:26.033   Installing the file.
+2025-09-12 08:34:26.033   Successfully installed the file.
+2025-09-12 08:34:26.034   -- File entry --
+2025-09-12 08:34:26.034   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTTASK_IPALARM.template
+2025-09-12 08:34:26.034   Time stamp of our file: 2025-07-11 13:18:10.000
+2025-09-12 08:34:26.034   Installing the file.
+2025-09-12 08:34:26.035   Successfully installed the file.
+2025-09-12 08:34:26.035   -- File entry --
+2025-09-12 08:34:26.035   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTTASK_LINKEDSOURCES.template
+2025-09-12 08:34:26.035   Time stamp of our file: 2025-07-11 13:18:10.000
+2025-09-12 08:34:26.035   Installing the file.
+2025-09-12 08:34:26.036   Successfully installed the file.
+2025-09-12 08:34:26.036   -- File entry --
+2025-09-12 08:34:26.036   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTTASK_MOTION.template
+2025-09-12 08:34:26.036   Time stamp of our file: 2025-07-11 13:18:10.000
+2025-09-12 08:34:26.036   Installing the file.
+2025-09-12 08:34:26.037   Successfully installed the file.
+2025-09-12 08:34:26.037   -- File entry --
+2025-09-12 08:34:26.037   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTTASK_SCHEDULER.template
+2025-09-12 08:34:26.037   Time stamp of our file: 2025-07-11 13:18:10.000
+2025-09-12 08:34:26.037   Installing the file.
+2025-09-12 08:34:26.037   Successfully installed the file.
+2025-09-12 08:34:26.037   -- File entry --
+2025-09-12 08:34:26.038   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EVNTTASK_VCAALARM.template
+2025-09-12 08:34:26.038   Time stamp of our file: 2025-07-11 13:18:10.000
+2025-09-12 08:34:26.038   Installing the file.
+2025-09-12 08:34:26.038   Successfully installed the file.
+2025-09-12 08:34:26.038   -- File entry --
+2025-09-12 08:34:26.039   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\EYEVIS_EYEUNIFYLINK_DSPINTERFACE.template
+2025-09-12 08:34:26.039   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.039   Installing the file.
+2025-09-12 08:34:26.039   Successfully installed the file.
+2025-09-12 08:34:26.039   -- File entry --
+2025-09-12 08:34:26.040   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\GENERIC_DEVICE.template
+2025-09-12 08:34:26.040   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.040   Installing the file.
+2025-09-12 08:34:26.040   Successfully installed the file.
+2025-09-12 08:34:26.041   -- File entry --
+2025-09-12 08:34:26.041   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\GENERIC_DEVICE_ARGS.template
+2025-09-12 08:34:26.041   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.041   Installing the file.
+2025-09-12 08:34:26.041   Successfully installed the file.
+2025-09-12 08:34:26.041   -- File entry --
+2025-09-12 08:34:26.041   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\GEVISCOPE_VIDEO_DEVICE.template
+2025-09-12 08:34:26.043   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.043   Installing the file.
+2025-09-12 08:34:26.043   Successfully installed the file.
+2025-09-12 08:34:26.043   -- File entry --
+2025-09-12 08:34:26.044   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\HEITEL_WEBAPI.template
+2025-09-12 08:34:26.044   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.044   Installing the file.
+2025-09-12 08:34:26.044   Successfully installed the file.
+2025-09-12 08:34:26.044   -- File entry --
+2025-09-12 08:34:26.045   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\HIDDEF_CLEARDLG.template
+2025-09-12 08:34:26.045   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.045   Installing the file.
+2025-09-12 08:34:26.045   Successfully installed the file.
+2025-09-12 08:34:26.046   -- File entry --
+2025-09-12 08:34:26.046   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\HIDDEF_GOTOPRESET.template
+2025-09-12 08:34:26.046   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.046   Installing the file.
+2025-09-12 08:34:26.046   Successfully installed the file.
+2025-09-12 08:34:26.047   -- File entry --
+2025-09-12 08:34:26.047   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\HIDDEF_INPUTTEXT.template
+2025-09-12 08:34:26.047   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.047   Installing the file.
+2025-09-12 08:34:26.047   Successfully installed the file.
+2025-09-12 08:34:26.048   -- File entry --
+2025-09-12 08:34:26.048   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\HIDDEF_MOVEBUTTONS.template
+2025-09-12 08:34:26.048   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.048   Installing the file.
+2025-09-12 08:34:26.049   Successfully installed the file.
+2025-09-12 08:34:26.049   -- File entry --
+2025-09-12 08:34:26.049   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\HIDDEF_NEXTDLG.template
+2025-09-12 08:34:26.049   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.049   Installing the file.
+2025-09-12 08:34:26.050   Successfully installed the file.
+2025-09-12 08:34:26.050   -- File entry --
+2025-09-12 08:34:26.050   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\HIDDEF_PLAYBACK_PLAY_PAUSE.template
+2025-09-12 08:34:26.050   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.050   Installing the file.
+2025-09-12 08:34:26.051   Successfully installed the file.
+2025-09-12 08:34:26.051   -- File entry --
+2025-09-12 08:34:26.051   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\HIDDEF_PLAYBACK_SPAN_MARKER.template
+2025-09-12 08:34:26.051   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.051   Installing the file.
+2025-09-12 08:34:26.052   Successfully installed the file.
+2025-09-12 08:34:26.052   -- File entry --
+2025-09-12 08:34:26.052   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\HIDDEF_PREVDLG.template
+2025-09-12 08:34:26.052   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.052   Installing the file.
+2025-09-12 08:34:26.053   Successfully installed the file.
+2025-09-12 08:34:26.053   -- File entry --
+2025-09-12 08:34:26.053   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\HIDDEF_SELECTTREEVIEW.template
+2025-09-12 08:34:26.053   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.053   Installing the file.
+2025-09-12 08:34:26.054   Successfully installed the file.
+2025-09-12 08:34:26.054   -- File entry --
+2025-09-12 08:34:26.054   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\HIDDEF_SETBOOKMARK.template
+2025-09-12 08:34:26.054   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.054   Installing the file.
+2025-09-12 08:34:26.055   Successfully installed the file.
+2025-09-12 08:34:26.055   -- File entry --
+2025-09-12 08:34:26.055   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\HIDDEF_SETGRID.template
+2025-09-12 08:34:26.055   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.055   Installing the file.
+2025-09-12 08:34:26.056   Successfully installed the file.
+2025-09-12 08:34:26.056   -- File entry --
+2025-09-12 08:34:26.056   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\HIDDEF_SHOWPLAYBACKS.template
+2025-09-12 08:34:26.056   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.056   Installing the file.
+2025-09-12 08:34:26.057   Successfully installed the file.
+2025-09-12 08:34:26.057   -- File entry --
+2025-09-12 08:34:26.057   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\HIDDEF_SHOWSCENARIO.template
+2025-09-12 08:34:26.057   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.057   Installing the file.
+2025-09-12 08:34:26.058   Successfully installed the file.
+2025-09-12 08:34:26.058   -- File entry --
+2025-09-12 08:34:26.058   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\HIDDEF_SHOWSTREAM.template
+2025-09-12 08:34:26.058   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.058   Installing the file.
+2025-09-12 08:34:26.059   Successfully installed the file.
+2025-09-12 08:34:26.059   -- File entry --
+2025-09-12 08:34:26.059   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\HIDDEF_STOREPRESET.template
+2025-09-12 08:34:26.059   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.059   Installing the file.
+2025-09-12 08:34:26.060   Successfully installed the file.
+2025-09-12 08:34:26.060   -- File entry --
+2025-09-12 08:34:26.060   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\HIDDEF_WRITE_DP.template
+2025-09-12 08:34:26.060   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.060   Installing the file.
+2025-09-12 08:34:26.061   Successfully installed the file.
+2025-09-12 08:34:26.061   -- File entry --
+2025-09-12 08:34:26.061   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\HIDDEF_WRITE_DP_SCRIPTED.template
+2025-09-12 08:34:26.061   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.061   Installing the file.
+2025-09-12 08:34:26.062   Successfully installed the file.
+2025-09-12 08:34:26.062   -- File entry --
+2025-09-12 08:34:26.062   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\HIKVISION_VIDEO_DEVICE.template
+2025-09-12 08:34:26.062   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.062   Installing the file.
+2025-09-12 08:34:26.063   Successfully installed the file.
+2025-09-12 08:34:26.063   -- File entry --
+2025-09-12 08:34:26.063   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\HOST_ENTRY.template
+2025-09-12 08:34:26.063   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.063   Installing the file.
+2025-09-12 08:34:26.064   Successfully installed the file.
+2025-09-12 08:34:26.064   -- File entry --
+2025-09-12 08:34:26.065   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\ICM_INTERFACE.template
+2025-09-12 08:34:26.065   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.065   Installing the file.
+2025-09-12 08:34:26.065   Successfully installed the file.
+2025-09-12 08:34:26.065   -- File entry --
+2025-09-12 08:34:26.066   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\ICXITEM_EVENT.template
+2025-09-12 08:34:26.066   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.066   Installing the file.
+2025-09-12 08:34:26.066   Successfully installed the file.
+2025-09-12 08:34:26.066   -- File entry --
+2025-09-12 08:34:26.067   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\ICXITEM_EVENTACTION_REPORTERROR.template
+2025-09-12 08:34:26.067   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.067   Installing the file.
+2025-09-12 08:34:26.067   Successfully installed the file.
+2025-09-12 08:34:26.067   -- File entry --
+2025-09-12 08:34:26.068   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\ICXITEM_EVENTACTION_REPORTINFO.template
+2025-09-12 08:34:26.068   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.068   Installing the file.
+2025-09-12 08:34:26.068   Successfully installed the file.
+2025-09-12 08:34:26.068   -- File entry --
+2025-09-12 08:34:26.068   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\ICXITEM_EVENTACTION_REPORTWARNING.template
+2025-09-12 08:34:26.068   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.068   Installing the file.
+2025-09-12 08:34:26.069   Successfully installed the file.
+2025-09-12 08:34:26.069   -- File entry --
+2025-09-12 08:34:26.070   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\ICXITEM_EVENTACTION_SHOWSCENARIO.template
+2025-09-12 08:34:26.070   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.070   Installing the file.
+2025-09-12 08:34:26.070   Successfully installed the file.
+2025-09-12 08:34:26.070   -- File entry --
+2025-09-12 08:34:26.071   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\ICXITEM_EVENTACTION_SIGNALCALL.template
+2025-09-12 08:34:26.071   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.071   Installing the file.
+2025-09-12 08:34:26.071   Successfully installed the file.
+2025-09-12 08:34:26.071   -- File entry --
+2025-09-12 08:34:26.072   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\ICXITEM_GATE.template
+2025-09-12 08:34:26.072   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.072   Installing the file.
+2025-09-12 08:34:26.073   Successfully installed the file.
+2025-09-12 08:34:26.073   -- File entry --
+2025-09-12 08:34:26.074   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\ICXITEM_TERMINAL.template
+2025-09-12 08:34:26.074   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.074   Installing the file.
+2025-09-12 08:34:26.075   Successfully installed the file.
+2025-09-12 08:34:26.075   -- File entry --
+2025-09-12 08:34:26.075   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\ICX_INTERFACE.template
+2025-09-12 08:34:26.075   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.075   Installing the file.
+2025-09-12 08:34:26.076   Successfully installed the file.
+2025-09-12 08:34:26.076   -- File entry --
+2025-09-12 08:34:26.076   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_ALPR.include
+2025-09-12 08:34:26.076   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.076   Installing the file.
+2025-09-12 08:34:26.077   Successfully installed the file.
+2025-09-12 08:34:26.077   -- File entry --
+2025-09-12 08:34:26.077   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_ASSEMBLYTASK_BASICS.include
+2025-09-12 08:34:26.077   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.077   Installing the file.
+2025-09-12 08:34:26.078   Successfully installed the file.
+2025-09-12 08:34:26.078   -- File entry --
+2025-09-12 08:34:26.079   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_ASSEMBLY_COULDASSIGNED.include
+2025-09-12 08:34:26.079   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.079   Installing the file.
+2025-09-12 08:34:26.080   Successfully installed the file.
+2025-09-12 08:34:26.080   -- File entry --
+2025-09-12 08:34:26.080   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_ASSIGNED_ASSEMBLIES.include
+2025-09-12 08:34:26.080   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.080   Installing the file.
+2025-09-12 08:34:26.081   Successfully installed the file.
+2025-09-12 08:34:26.081   -- File entry --
+2025-09-12 08:34:26.081   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_AUDIO_ASSOCIATION.include
+2025-09-12 08:34:26.081   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.081   Installing the file.
+2025-09-12 08:34:26.082   Successfully installed the file.
+2025-09-12 08:34:26.082   -- File entry --
+2025-09-12 08:34:26.082   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_AUDIO_ISDEVICE.include
+2025-09-12 08:34:26.082   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.082   Installing the file.
+2025-09-12 08:34:26.083   Successfully installed the file.
+2025-09-12 08:34:26.083   -- File entry --
+2025-09-12 08:34:26.083   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_CONTROLLER.include
+2025-09-12 08:34:26.083   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.083   Installing the file.
+2025-09-12 08:34:26.084   Successfully installed the file.
+2025-09-12 08:34:26.084   -- File entry --
+2025-09-12 08:34:26.084   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_DEVICEEVENTS.include
+2025-09-12 08:34:26.084   Time stamp of our file: 2025-05-05 16:01:38.000
+2025-09-12 08:34:26.084   Installing the file.
+2025-09-12 08:34:26.084   Successfully installed the file.
+2025-09-12 08:34:26.085   -- File entry --
+2025-09-12 08:34:26.085   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_EMAIL_SENDER_ISDEVICE.include
+2025-09-12 08:34:26.085   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.085   Installing the file.
+2025-09-12 08:34:26.086   Successfully installed the file.
+2025-09-12 08:34:26.086   -- File entry --
+2025-09-12 08:34:26.086   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_EVENTTASK_BASICS.include
+2025-09-12 08:34:26.086   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.086   Installing the file.
+2025-09-12 08:34:26.087   Successfully installed the file.
+2025-09-12 08:34:26.087   -- File entry --
+2025-09-12 08:34:26.087   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_EVENTTASK_PTZ_PROPS.include
+2025-09-12 08:34:26.087   Time stamp of our file: 2025-07-11 13:18:10.000
+2025-09-12 08:34:26.087   Installing the file.
+2025-09-12 08:34:26.088   Successfully installed the file.
+2025-09-12 08:34:26.088   -- File entry --
+2025-09-12 08:34:26.089   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_EVENTTASK_QUEUE_PROPS.include
+2025-09-12 08:34:26.089   Time stamp of our file: 2025-07-11 13:18:10.000
+2025-09-12 08:34:26.089   Installing the file.
+2025-09-12 08:34:26.089   Successfully installed the file.
+2025-09-12 08:34:26.089   -- File entry --
+2025-09-12 08:34:26.090   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_EVENT_AUTO_END.include
+2025-09-12 08:34:26.090   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.090   Installing the file.
+2025-09-12 08:34:26.090   Successfully installed the file.
+2025-09-12 08:34:26.090   -- File entry --
+2025-09-12 08:34:26.091   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_EVENT_AUTO_START.include
+2025-09-12 08:34:26.091   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.091   Installing the file.
+2025-09-12 08:34:26.091   Successfully installed the file.
+2025-09-12 08:34:26.091   -- File entry --
+2025-09-12 08:34:26.091   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_EXPORT_REPORT_ISDEVICE.include
+2025-09-12 08:34:26.091   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.091   Installing the file.
+2025-09-12 08:34:26.092   Successfully installed the file.
+2025-09-12 08:34:26.092   -- File entry --
+2025-09-12 08:34:26.092   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_GLOBAL_ADEPTSETTINGS.include
+2025-09-12 08:34:26.093   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.093   Installing the file.
+2025-09-12 08:34:26.093   Successfully installed the file.
+2025-09-12 08:34:26.094   -- File entry --
+2025-09-12 08:34:26.094   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_GLOBAL_AUDIOINPUTS.include
+2025-09-12 08:34:26.094   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.094   Installing the file.
+2025-09-12 08:34:26.095   Successfully installed the file.
+2025-09-12 08:34:26.095   -- File entry --
+2025-09-12 08:34:26.095   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_GLOBAL_CAMERAS.include
+2025-09-12 08:34:26.095   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.095   Installing the file.
+2025-09-12 08:34:26.096   Successfully installed the file.
+2025-09-12 08:34:26.096   -- File entry --
+2025-09-12 08:34:26.096   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_GLOBAL_GROUPS.include
+2025-09-12 08:34:26.096   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.096   Installing the file.
+2025-09-12 08:34:26.097   Successfully installed the file.
+2025-09-12 08:34:26.097   -- File entry --
+2025-09-12 08:34:26.097   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_GLOBAL_IFPROXY.include
+2025-09-12 08:34:26.097   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.097   Installing the file.
+2025-09-12 08:34:26.097   Successfully installed the file.
+2025-09-12 08:34:26.097   -- File entry --
+2025-09-12 08:34:26.098   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_GLOBAL_MULTICAST.include
+2025-09-12 08:34:26.098   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.098   Installing the file.
+2025-09-12 08:34:26.098   Successfully installed the file.
+2025-09-12 08:34:26.098   -- File entry --
+2025-09-12 08:34:26.099   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_GLOBAL_SRVPROXY.include
+2025-09-12 08:34:26.099   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.099   Installing the file.
+2025-09-12 08:34:26.099   Successfully installed the file.
+2025-09-12 08:34:26.099   -- File entry --
+2025-09-12 08:34:26.100   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_GLOBAL_STREAMING.include
+2025-09-12 08:34:26.100   Time stamp of our file: 2025-08-13 12:07:22.000
+2025-09-12 08:34:26.100   Installing the file.
+2025-09-12 08:34:26.100   Successfully installed the file.
+2025-09-12 08:34:26.101   -- File entry --
+2025-09-12 08:34:26.101   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_GLOBAL_WEB_CONFIG.include
+2025-09-12 08:34:26.101   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.101   Installing the file.
+2025-09-12 08:34:26.102   Successfully installed the file.
+2025-09-12 08:34:26.102   -- File entry --
+2025-09-12 08:34:26.102   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_HAS_IO.include
+2025-09-12 08:34:26.102   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.102   Installing the file.
+2025-09-12 08:34:26.103   Successfully installed the file.
+2025-09-12 08:34:26.103   -- File entry --
+2025-09-12 08:34:26.103   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_INTERFACE_PROXY_ISDEVICE.include
+2025-09-12 08:34:26.103   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.103   Installing the file.
+2025-09-12 08:34:26.104   Successfully installed the file.
+2025-09-12 08:34:26.104   -- File entry --
+2025-09-12 08:34:26.104   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_IS_AUDIOPTT.include
+2025-09-12 08:34:26.104   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.104   Installing the file.
+2025-09-12 08:34:26.105   Successfully installed the file.
+2025-09-12 08:34:26.105   -- File entry --
+2025-09-12 08:34:26.106   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_IS_DIGIO.include
+2025-09-12 08:34:26.106   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.106   Installing the file.
+2025-09-12 08:34:26.106   Successfully installed the file.
+2025-09-12 08:34:26.106   -- File entry --
+2025-09-12 08:34:26.107   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_IS_MOTIONDETECTIONZONE.include
+2025-09-12 08:34:26.107   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.107   Installing the file.
+2025-09-12 08:34:26.107   Successfully installed the file.
+2025-09-12 08:34:26.107   -- File entry --
+2025-09-12 08:34:26.108   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_IS_NETWORKDEVICE.include
+2025-09-12 08:34:26.108   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.108   Installing the file.
+2025-09-12 08:34:26.108   Successfully installed the file.
+2025-09-12 08:34:26.109   -- File entry --
+2025-09-12 08:34:26.109   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_METAINFORMATION.include
+2025-09-12 08:34:26.109   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.109   Installing the file.
+2025-09-12 08:34:26.109   Successfully installed the file.
+2025-09-12 08:34:26.109   -- File entry --
+2025-09-12 08:34:26.110   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_MOBOTIX_ISAUDIOSRC.include
+2025-09-12 08:34:26.110   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.110   Installing the file.
+2025-09-12 08:34:26.111   Successfully installed the file.
+2025-09-12 08:34:26.111   -- File entry --
+2025-09-12 08:34:26.111   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_MODBUS_IO_DEVICE_ANALOG_INPUTS.include
+2025-09-12 08:34:26.111   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.111   Installing the file.
+2025-09-12 08:34:26.112   Successfully installed the file.
+2025-09-12 08:34:26.112   -- File entry --
+2025-09-12 08:34:26.112   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_MODBUS_IO_DEVICE_ANALOG_OUTPUTS.include
+2025-09-12 08:34:26.112   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.112   Installing the file.
+2025-09-12 08:34:26.113   Successfully installed the file.
+2025-09-12 08:34:26.113   -- File entry --
+2025-09-12 08:34:26.113   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_MODBUS_IO_DEVICE_BASE.include
+2025-09-12 08:34:26.113   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.113   Installing the file.
+2025-09-12 08:34:26.114   Successfully installed the file.
+2025-09-12 08:34:26.114   -- File entry --
+2025-09-12 08:34:26.114   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_MODBUS_IO_DEVICE_DIGITAL_INPUTS.include
+2025-09-12 08:34:26.114   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.114   Installing the file.
+2025-09-12 08:34:26.115   Successfully installed the file.
+2025-09-12 08:34:26.115   -- File entry --
+2025-09-12 08:34:26.115   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_MODBUS_IO_DEVICE_DIGITAL_OUTPUTS.include
+2025-09-12 08:34:26.115   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.115   Installing the file.
+2025-09-12 08:34:26.116   Successfully installed the file.
+2025-09-12 08:34:26.116   -- File entry --
+2025-09-12 08:34:26.116   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_MOTIONDETECTION.include
+2025-09-12 08:34:26.116   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.116   Installing the file.
+2025-09-12 08:34:26.117   Successfully installed the file.
+2025-09-12 08:34:26.117   -- File entry --
+2025-09-12 08:34:26.117   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_MTND_GLOBAL_GROUPS.include
+2025-09-12 08:34:26.117   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.117   Installing the file.
+2025-09-12 08:34:26.118   Successfully installed the file.
+2025-09-12 08:34:26.118   -- File entry --
+2025-09-12 08:34:26.118   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_MTND_MOTIONZONE_BASICS.include
+2025-09-12 08:34:26.118   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.119   Installing the file.
+2025-09-12 08:34:26.119   Successfully installed the file.
+2025-09-12 08:34:26.120   -- File entry --
+2025-09-12 08:34:26.120   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_MTND_MOTIONZONE_SIMPLE.include
+2025-09-12 08:34:26.120   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.120   Installing the file.
+2025-09-12 08:34:26.120   Successfully installed the file.
+2025-09-12 08:34:26.121   -- File entry --
+2025-09-12 08:34:26.121   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_MTND_SMARTDETECT_CLASSES.include
+2025-09-12 08:34:26.121   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.121   Installing the file.
+2025-09-12 08:34:26.122   Successfully installed the file.
+2025-09-12 08:34:26.122   -- File entry --
+2025-09-12 08:34:26.122   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_MTND_SMARTDETECT_PROPS.include
+2025-09-12 08:34:26.122   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.122   Installing the file.
+2025-09-12 08:34:26.123   Successfully installed the file.
+2025-09-12 08:34:26.123   -- File entry --
+2025-09-12 08:34:26.123   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_NETDEV_ASSOCIATION.include
+2025-09-12 08:34:26.123   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.123   Installing the file.
+2025-09-12 08:34:26.124   Successfully installed the file.
+2025-09-12 08:34:26.124   -- File entry --
+2025-09-12 08:34:26.124   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_PERMITTOKEN_BASICS.include
+2025-09-12 08:34:26.124   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.124   Installing the file.
+2025-09-12 08:34:26.125   Successfully installed the file.
+2025-09-12 08:34:26.125   -- File entry --
+2025-09-12 08:34:26.125   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_PLAYBACK_PROXY_ISDEVICE.include
+2025-09-12 08:34:26.125   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.125   Installing the file.
+2025-09-12 08:34:26.127   Successfully installed the file.
+2025-09-12 08:34:26.127   -- File entry --
+2025-09-12 08:34:26.127   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_PRINT_RTP_STATS.include
+2025-09-12 08:34:26.127   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.127   Installing the file.
+2025-09-12 08:34:26.128   Successfully installed the file.
+2025-09-12 08:34:26.128   -- File entry --
+2025-09-12 08:34:26.128   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_PRIVACYZONES.include
+2025-09-12 08:34:26.128   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.128   Installing the file.
+2025-09-12 08:34:26.128   Successfully installed the file.
+2025-09-12 08:34:26.128   -- File entry --
+2025-09-12 08:34:26.129   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_PRVC_GLOBAL_GROUPS.include
+2025-09-12 08:34:26.129   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.129   Installing the file.
+2025-09-12 08:34:26.129   Successfully installed the file.
+2025-09-12 08:34:26.129   -- File entry --
+2025-09-12 08:34:26.130   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_PRVC_IS_FEATUREPRIVACYZONE.include
+2025-09-12 08:34:26.130   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.130   Installing the file.
+2025-09-12 08:34:26.130   Successfully installed the file.
+2025-09-12 08:34:26.130   -- File entry --
+2025-09-12 08:34:26.131   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_PRVC_IS_OVERLAY.include
+2025-09-12 08:34:26.131   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.131   Installing the file.
+2025-09-12 08:34:26.131   Successfully installed the file.
+2025-09-12 08:34:26.131   -- File entry --
+2025-09-12 08:34:26.132   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_PRVC_IS_STRONGPRIVACYZONE.include
+2025-09-12 08:34:26.132   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.132   Installing the file.
+2025-09-12 08:34:26.133   Successfully installed the file.
+2025-09-12 08:34:26.133   -- File entry --
+2025-09-12 08:34:26.133   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_PRVC_PRIVACYZONE_BASICS.include
+2025-09-12 08:34:26.133   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.133   Installing the file.
+2025-09-12 08:34:26.134   Successfully installed the file.
+2025-09-12 08:34:26.134   -- File entry --
+2025-09-12 08:34:26.134   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_PRVC_SMARTDETECT_CLASSES.include
+2025-09-12 08:34:26.134   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.134   Installing the file.
+2025-09-12 08:34:26.135   Successfully installed the file.
+2025-09-12 08:34:26.135   -- File entry --
+2025-09-12 08:34:26.135   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_PRVC_SMARTDETECT_PROPS.include
+2025-09-12 08:34:26.135   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.135   Installing the file.
+2025-09-12 08:34:26.136   Successfully installed the file.
+2025-09-12 08:34:26.136   -- File entry --
+2025-09-12 08:34:26.137   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_PRVC_STRONGPRIVACYZONE_PERMITS.include
+2025-09-12 08:34:26.137   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.137   Installing the file.
+2025-09-12 08:34:26.137   Successfully installed the file.
+2025-09-12 08:34:26.138   -- File entry --
+2025-09-12 08:34:26.138   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_PTTAUDIO.include
+2025-09-12 08:34:26.138   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.138   Installing the file.
+2025-09-12 08:34:26.138   Successfully installed the file.
+2025-09-12 08:34:26.139   -- File entry --
+2025-09-12 08:34:26.139   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_PTZ_INTERNAL.include
+2025-09-12 08:34:26.139   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.139   Installing the file.
+2025-09-12 08:34:26.140   Successfully installed the file.
+2025-09-12 08:34:26.140   -- File entry --
+2025-09-12 08:34:26.140   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_PTZ_ISDEVICE.include
+2025-09-12 08:34:26.140   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.140   Installing the file.
+2025-09-12 08:34:26.140   Successfully installed the file.
+2025-09-12 08:34:26.140   -- File entry --
+2025-09-12 08:34:26.141   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_PTZ_PRESETS_DEVICE.include
+2025-09-12 08:34:26.141   Time stamp of our file: 2025-07-11 13:18:10.000
+2025-09-12 08:34:26.141   Installing the file.
+2025-09-12 08:34:26.141   Successfully installed the file.
+2025-09-12 08:34:26.141   -- File entry --
+2025-09-12 08:34:26.142   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_PTZ_PRESETS_FOR_ENUM.include
+2025-09-12 08:34:26.142   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.142   Installing the file.
+2025-09-12 08:34:26.142   Successfully installed the file.
+2025-09-12 08:34:26.142   -- File entry --
+2025-09-12 08:34:26.143   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_PTZ_PROPERTIES.include
+2025-09-12 08:34:26.143   Time stamp of our file: 2025-07-11 13:18:10.000
+2025-09-12 08:34:26.143   Installing the file.
+2025-09-12 08:34:26.144   Successfully installed the file.
+2025-09-12 08:34:26.144   -- File entry --
+2025-09-12 08:34:26.144   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_RECORDING.include
+2025-09-12 08:34:26.144   Time stamp of our file: 2025-08-13 12:07:22.000
+2025-09-12 08:34:26.144   Installing the file.
+2025-09-12 08:34:26.145   Successfully installed the file.
+2025-09-12 08:34:26.145   -- File entry --
+2025-09-12 08:34:26.145   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_RECORDING_REPLAY.include
+2025-09-12 08:34:26.145   Time stamp of our file: 2025-08-13 12:07:22.000
+2025-09-12 08:34:26.145   Installing the file.
+2025-09-12 08:34:26.146   Successfully installed the file.
+2025-09-12 08:34:26.146   -- File entry --
+2025-09-12 08:34:26.146   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_RECORDING_REPLAY.js
+2025-09-12 08:34:26.146   Time stamp of our file: 2025-08-13 12:07:22.000
+2025-09-12 08:34:26.146   Installing the file.
+2025-09-12 08:34:26.147   Successfully installed the file.
+2025-09-12 08:34:26.147   -- File entry --
+2025-09-12 08:34:26.147   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_SORHEA_SOLARIS_COLUMNS.include
+2025-09-12 08:34:26.147   Time stamp of our file: 2025-07-11 13:18:10.000
+2025-09-12 08:34:26.147   Installing the file.
+2025-09-12 08:34:26.148   Successfully installed the file.
+2025-09-12 08:34:26.148   -- File entry --
+2025-09-12 08:34:26.148   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_SORHEA_SOLARIS_COLUMN_ENTRY_BASE.include
+2025-09-12 08:34:26.149   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.149   Installing the file.
+2025-09-12 08:34:26.149   Successfully installed the file.
+2025-09-12 08:34:26.149   -- File entry --
+2025-09-12 08:34:26.149   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_SORHEA_SOLARIS_GEN.js
+2025-09-12 08:34:26.150   Time stamp of our file: 2025-07-11 13:18:10.000
+2025-09-12 08:34:26.150   Installing the file.
+2025-09-12 08:34:26.151   Successfully installed the file.
+2025-09-12 08:34:26.151   -- File entry --
+2025-09-12 08:34:26.151   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_SORHEA_SOLARIS_GEN_PATCHACTIONS.js
+2025-09-12 08:34:26.151   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.151   Installing the file.
+2025-09-12 08:34:26.152   Successfully installed the file.
+2025-09-12 08:34:26.152   -- File entry --
+2025-09-12 08:34:26.152   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_SORHEA_SOLARIS_INTRUSION.include
+2025-09-12 08:34:26.152   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.152   Installing the file.
+2025-09-12 08:34:26.153   Successfully installed the file.
+2025-09-12 08:34:26.153   -- File entry --
+2025-09-12 08:34:26.153   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_SORHEA_SOLARIS_MANIPULATION.include
+2025-09-12 08:34:26.154   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.154   Installing the file.
+2025-09-12 08:34:26.154   Successfully installed the file.
+2025-09-12 08:34:26.154   -- File entry --
+2025-09-12 08:34:26.155   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_SORHEA_SOLARIS_TECFAULT.include
+2025-09-12 08:34:26.155   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.155   Installing the file.
+2025-09-12 08:34:26.155   Successfully installed the file.
+2025-09-12 08:34:26.155   -- File entry --
+2025-09-12 08:34:26.156   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_STREAM_ON_DEMAND.include
+2025-09-12 08:34:26.156   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.156   Installing the file.
+2025-09-12 08:34:26.156   Successfully installed the file.
+2025-09-12 08:34:26.156   -- File entry --
+2025-09-12 08:34:26.156   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_VIMACC_HID_BASE.include
+2025-09-12 08:34:26.156   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.156   Installing the file.
+2025-09-12 08:34:26.157   Successfully installed the file.
+2025-09-12 08:34:26.157   -- File entry --
+2025-09-12 08:34:26.157   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_VIMACC_SCHEDULER_PATROL_EVENT_ACTION.js
+2025-09-12 08:34:26.157   Time stamp of our file: 2025-07-11 13:18:10.000
+2025-09-12 08:34:26.157   Installing the file.
+2025-09-12 08:34:26.158   Successfully installed the file.
+2025-09-12 08:34:26.158   -- File entry --
+2025-09-12 08:34:26.158   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INC_VIMACC_SCHEDULER_PATROL_GEN.js
+2025-09-12 08:34:26.158   Time stamp of our file: 2025-07-11 13:18:10.000
+2025-09-12 08:34:26.158   Installing the file.
+2025-09-12 08:34:26.159   Successfully installed the file.
+2025-09-12 08:34:26.159   -- File entry --
+2025-09-12 08:34:26.159   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\INDIGOVISION_IV_VIDEO_DEVICE.template
+2025-09-12 08:34:26.160   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.160   Installing the file.
+2025-09-12 08:34:26.160   Successfully installed the file.
+2025-09-12 08:34:26.161   -- File entry --
+2025-09-12 08:34:26.161   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\MOBOTIX_AUDIO_DEVICE.template
+2025-09-12 08:34:26.161   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.161   Installing the file.
+2025-09-12 08:34:26.162   Successfully installed the file.
+2025-09-12 08:34:26.162   -- File entry --
+2025-09-12 08:34:26.162   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\MOBOTIX_VIDEO_DEVICE.template
+2025-09-12 08:34:26.162   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.162   Installing the file.
+2025-09-12 08:34:26.163   Successfully installed the file.
+2025-09-12 08:34:26.163   -- File entry --
+2025-09-12 08:34:26.163   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\MODBUS_IO_DEVICE.template
+2025-09-12 08:34:26.163   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.163   Installing the file.
+2025-09-12 08:34:26.164   Successfully installed the file.
+2025-09-12 08:34:26.164   -- File entry --
+2025-09-12 08:34:26.164   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\MODBUS_IO_DEVICE_ADAM6015.template
+2025-09-12 08:34:26.164   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.164   Installing the file.
+2025-09-12 08:34:26.165   Successfully installed the file.
+2025-09-12 08:34:26.165   -- File entry --
+2025-09-12 08:34:26.165   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\MODBUS_IO_DEVICE_ADAM6017.template
+2025-09-12 08:34:26.165   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.165   Installing the file.
+2025-09-12 08:34:26.166   Successfully installed the file.
+2025-09-12 08:34:26.166   -- File entry --
+2025-09-12 08:34:26.166   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\MODBUS_IO_DEVICE_ADAM6018.template
+2025-09-12 08:34:26.166   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.166   Installing the file.
+2025-09-12 08:34:26.166   Successfully installed the file.
+2025-09-12 08:34:26.166   -- File entry --
+2025-09-12 08:34:26.167   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\MODBUS_IO_DEVICE_ADAM6018plus.template
+2025-09-12 08:34:26.167   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.167   Installing the file.
+2025-09-12 08:34:26.167   Successfully installed the file.
+2025-09-12 08:34:26.167   -- File entry --
+2025-09-12 08:34:26.168   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\MODBUS_IO_DEVICE_ADAM6024.template
+2025-09-12 08:34:26.168   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.168   Installing the file.
+2025-09-12 08:34:26.168   Successfully installed the file.
+2025-09-12 08:34:26.169   -- File entry --
+2025-09-12 08:34:26.169   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\MODBUS_IO_DEVICE_ADAM6050.template
+2025-09-12 08:34:26.169   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.169   Installing the file.
+2025-09-12 08:34:26.169   Successfully installed the file.
+2025-09-12 08:34:26.169   -- File entry --
+2025-09-12 08:34:26.169   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\MODBUS_IO_DEVICE_ADAM6051.template
+2025-09-12 08:34:26.171   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.171   Installing the file.
+2025-09-12 08:34:26.171   Successfully installed the file.
+2025-09-12 08:34:26.171   -- File entry --
+2025-09-12 08:34:26.172   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\MODBUS_IO_DEVICE_ADAM6052.template
+2025-09-12 08:34:26.172   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.172   Installing the file.
+2025-09-12 08:34:26.173   Successfully installed the file.
+2025-09-12 08:34:26.173   -- File entry --
+2025-09-12 08:34:26.173   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\MODBUS_IO_DEVICE_ADAM6060_ADAM6066.template
+2025-09-12 08:34:26.173   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.173   Installing the file.
+2025-09-12 08:34:26.174   Successfully installed the file.
+2025-09-12 08:34:26.174   -- File entry --
+2025-09-12 08:34:26.174   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\MODBUS_IO_DEVICE_PATLITE_LA6_SIGNAL_TOWER.template
+2025-09-12 08:34:26.175   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.175   Installing the file.
+2025-09-12 08:34:26.175   Successfully installed the file.
+2025-09-12 08:34:26.175   -- File entry --
+2025-09-12 08:34:26.176   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\MODBUS_IO_DEVICE_SORHEA_MAXIBUS_UNIV_GFENCE3000.template
+2025-09-12 08:34:26.176   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.176   Installing the file.
+2025-09-12 08:34:26.176   Successfully installed the file.
+2025-09-12 08:34:26.177   -- File entry --
+2025-09-12 08:34:26.177   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\MODBUS_IO_DEVICE_SORHEA_MAXIBUS_UNIV_SOLARIS.template
+2025-09-12 08:34:26.177   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.177   Installing the file.
+2025-09-12 08:34:26.178   Successfully installed the file.
+2025-09-12 08:34:26.178   -- File entry --
+2025-09-12 08:34:26.178   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\MODBUS_IO_DEVICE_WT_WEBIO40-57838.template
+2025-09-12 08:34:26.178   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.178   Installing the file.
+2025-09-12 08:34:26.179   Successfully installed the file.
+2025-09-12 08:34:26.179   -- File entry --
+2025-09-12 08:34:26.179   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\MOXA_IO_DEVICE.template
+2025-09-12 08:34:26.179   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.179   Installing the file.
+2025-09-12 08:34:26.180   Successfully installed the file.
+2025-09-12 08:34:26.180   -- File entry --
+2025-09-12 08:34:26.180   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\MOXA_IO_E1K_DEVICE.template
+2025-09-12 08:34:26.180   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.180   Installing the file.
+2025-09-12 08:34:26.180   Successfully installed the file.
+2025-09-12 08:34:26.180   -- File entry --
+2025-09-12 08:34:26.181   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\MOXA_VIDEO_DEVICE.template
+2025-09-12 08:34:26.181   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.181   Installing the file.
+2025-09-12 08:34:26.181   Successfully installed the file.
+2025-09-12 08:34:26.181   -- File entry --
+2025-09-12 08:34:26.182   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\MTND_MOTIONZONE.template
+2025-09-12 08:34:26.182   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.182   Installing the file.
+2025-09-12 08:34:26.182   Successfully installed the file.
+2025-09-12 08:34:26.182   -- File entry --
+2025-09-12 08:34:26.183   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\MTND_MOTIONZONE_MODEL_CUSTOM1.template
+2025-09-12 08:34:26.183   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.183   Installing the file.
+2025-09-12 08:34:26.183   Successfully installed the file.
+2025-09-12 08:34:26.183   -- File entry --
+2025-09-12 08:34:26.184   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\MTND_MOTIONZONE_MODEL_CUSTOM2.template
+2025-09-12 08:34:26.184   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.184   Installing the file.
+2025-09-12 08:34:26.184   Successfully installed the file.
+2025-09-12 08:34:26.184   -- File entry --
+2025-09-12 08:34:26.185   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\MTND_MOTIONZONE_MODEL_CUSTOM3.template
+2025-09-12 08:34:26.185   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.185   Installing the file.
+2025-09-12 08:34:26.185   Successfully installed the file.
+2025-09-12 08:34:26.186   -- File entry --
+2025-09-12 08:34:26.186   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\MTND_MOTIONZONE_OBJECT.template
+2025-09-12 08:34:26.186   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.186   Installing the file.
+2025-09-12 08:34:26.186   Successfully installed the file.
+2025-09-12 08:34:26.187   -- File entry --
+2025-09-12 08:34:26.187   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\ONVIF_VIDEO_DEVICE.template
+2025-09-12 08:34:26.187   Time stamp of our file: 2025-08-13 12:07:22.000
+2025-09-12 08:34:26.187   Installing the file.
+2025-09-12 08:34:26.188   Successfully installed the file.
+2025-09-12 08:34:26.188   -- File entry --
+2025-09-12 08:34:26.188   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\OP_MODE.template
+2025-09-12 08:34:26.189   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.189   Installing the file.
+2025-09-12 08:34:26.189   Successfully installed the file.
+2025-09-12 08:34:26.189   -- File entry --
+2025-09-12 08:34:26.190   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\PERMITTOKEN_IODEVICE.template
+2025-09-12 08:34:26.190   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.190   Installing the file.
+2025-09-12 08:34:26.190   Successfully installed the file.
+2025-09-12 08:34:26.190   -- File entry --
+2025-09-12 08:34:26.190   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\PRVC_OVERLAY.template
+2025-09-12 08:34:26.190   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.190   Installing the file.
+2025-09-12 08:34:26.191   Successfully installed the file.
+2025-09-12 08:34:26.191   -- File entry --
+2025-09-12 08:34:26.191   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\PRVC_PRIVACYZONE.template
+2025-09-12 08:34:26.191   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.191   Installing the file.
+2025-09-12 08:34:26.192   Successfully installed the file.
+2025-09-12 08:34:26.192   -- File entry --
+2025-09-12 08:34:26.193   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\PRVC_PRIVACYZONE_FACE.template
+2025-09-12 08:34:26.193   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.193   Installing the file.
+2025-09-12 08:34:26.193   Successfully installed the file.
+2025-09-12 08:34:26.194   -- File entry --
+2025-09-12 08:34:26.194   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\PRVC_PRIVACYZONE_MODEL_CUSTOM1.template
+2025-09-12 08:34:26.194   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.194   Installing the file.
+2025-09-12 08:34:26.195   Successfully installed the file.
+2025-09-12 08:34:26.195   -- File entry --
+2025-09-12 08:34:26.195   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\PRVC_PRIVACYZONE_MODEL_CUSTOM2.template
+2025-09-12 08:34:26.195   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.195   Installing the file.
+2025-09-12 08:34:26.196   Successfully installed the file.
+2025-09-12 08:34:26.196   -- File entry --
+2025-09-12 08:34:26.196   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\PRVC_PRIVACYZONE_MODEL_CUSTOM3.template
+2025-09-12 08:34:26.196   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.196   Installing the file.
+2025-09-12 08:34:26.197   Successfully installed the file.
+2025-09-12 08:34:26.197   -- File entry --
+2025-09-12 08:34:26.197   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\PRVC_PRIVACYZONE_OBJECT.template
+2025-09-12 08:34:26.197   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.197   Installing the file.
+2025-09-12 08:34:26.198   Successfully installed the file.
+2025-09-12 08:34:26.198   -- File entry --
+2025-09-12 08:34:26.198   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\PRVC_PRIVACYZONE_PERSON.template
+2025-09-12 08:34:26.198   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.198   Installing the file.
+2025-09-12 08:34:26.199   Successfully installed the file.
+2025-09-12 08:34:26.199   -- File entry --
+2025-09-12 08:34:26.199   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\PRVC_STRONGPRIVACYZONE.template
+2025-09-12 08:34:26.199   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.199   Installing the file.
+2025-09-12 08:34:26.199   Successfully installed the file.
+2025-09-12 08:34:26.201   -- File entry --
+2025-09-12 08:34:26.201   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\PRVC_STRONGPRIVACYZONE_FACE.template
+2025-09-12 08:34:26.201   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.201   Installing the file.
+2025-09-12 08:34:26.202   Successfully installed the file.
+2025-09-12 08:34:26.202   -- File entry --
+2025-09-12 08:34:26.202   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\PRVC_STRONGPRIVACYZONE_OBJECT.template
+2025-09-12 08:34:26.202   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.202   Installing the file.
+2025-09-12 08:34:26.202   Successfully installed the file.
+2025-09-12 08:34:26.202   -- File entry --
+2025-09-12 08:34:26.203   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\PRVC_STRONGPRIVACYZONE_PERSON.template
+2025-09-12 08:34:26.203   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.203   Installing the file.
+2025-09-12 08:34:26.203   Successfully installed the file.
+2025-09-12 08:34:26.203   -- File entry --
+2025-09-12 08:34:26.204   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\RCPP_VIDEO_DEVICE.template
+2025-09-12 08:34:26.204   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.204   Installing the file.
+2025-09-12 08:34:26.205   Successfully installed the file.
+2025-09-12 08:34:26.205   -- File entry --
+2025-09-12 08:34:26.205   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SERIAL_RCPP_CLIENT.template
+2025-09-12 08:34:26.206   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.206   Installing the file.
+2025-09-12 08:34:26.206   Successfully installed the file.
+2025-09-12 08:34:26.206   -- File entry --
+2025-09-12 08:34:26.207   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SERIAL_TCP_CLIENT.template
+2025-09-12 08:34:26.207   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.207   Installing the file.
+2025-09-12 08:34:26.207   Successfully installed the file.
+2025-09-12 08:34:26.207   -- File entry --
+2025-09-12 08:34:26.208   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SERIAL_TCP_CLIENT_WUT.template
+2025-09-12 08:34:26.208   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.208   Installing the file.
+2025-09-12 08:34:26.208   Successfully installed the file.
+2025-09-12 08:34:26.208   -- File entry --
+2025-09-12 08:34:26.209   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SIEMENS_SISTORE_CX_DEVICE.template
+2025-09-12 08:34:26.209   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.209   Installing the file.
+2025-09-12 08:34:26.209   Successfully installed the file.
+2025-09-12 08:34:26.209   -- File entry --
+2025-09-12 08:34:26.210   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SONY_VIDEO_DEVICE.template
+2025-09-12 08:34:26.210   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.210   Installing the file.
+2025-09-12 08:34:26.210   Successfully installed the file.
+2025-09-12 08:34:26.210   -- File entry --
+2025-09-12 08:34:26.211   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_01.template
+2025-09-12 08:34:26.211   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.211   Installing the file.
+2025-09-12 08:34:26.212   Successfully installed the file.
+2025-09-12 08:34:26.212   -- File entry --
+2025-09-12 08:34:26.212   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_02.template
+2025-09-12 08:34:26.212   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.212   Installing the file.
+2025-09-12 08:34:26.213   Successfully installed the file.
+2025-09-12 08:34:26.213   -- File entry --
+2025-09-12 08:34:26.213   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_03.template
+2025-09-12 08:34:26.213   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.213   Installing the file.
+2025-09-12 08:34:26.213   Successfully installed the file.
+2025-09-12 08:34:26.214   -- File entry --
+2025-09-12 08:34:26.214   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_04.template
+2025-09-12 08:34:26.214   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.214   Installing the file.
+2025-09-12 08:34:26.215   Successfully installed the file.
+2025-09-12 08:34:26.215   -- File entry --
+2025-09-12 08:34:26.215   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_05.template
+2025-09-12 08:34:26.215   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.215   Installing the file.
+2025-09-12 08:34:26.216   Successfully installed the file.
+2025-09-12 08:34:26.216   -- File entry --
+2025-09-12 08:34:26.216   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_06.template
+2025-09-12 08:34:26.216   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.216   Installing the file.
+2025-09-12 08:34:26.217   Successfully installed the file.
+2025-09-12 08:34:26.217   -- File entry --
+2025-09-12 08:34:26.217   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_07.template
+2025-09-12 08:34:26.218   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.218   Installing the file.
+2025-09-12 08:34:26.218   Successfully installed the file.
+2025-09-12 08:34:26.218   -- File entry --
+2025-09-12 08:34:26.219   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_08.template
+2025-09-12 08:34:26.219   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.219   Installing the file.
+2025-09-12 08:34:26.220   Successfully installed the file.
+2025-09-12 08:34:26.220   -- File entry --
+2025-09-12 08:34:26.221   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_09.template
+2025-09-12 08:34:26.221   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.221   Installing the file.
+2025-09-12 08:34:26.221   Successfully installed the file.
+2025-09-12 08:34:26.221   -- File entry --
+2025-09-12 08:34:26.222   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_10.template
+2025-09-12 08:34:26.222   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.222   Installing the file.
+2025-09-12 08:34:26.222   Successfully installed the file.
+2025-09-12 08:34:26.222   -- File entry --
+2025-09-12 08:34:26.223   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_11.template
+2025-09-12 08:34:26.223   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.223   Installing the file.
+2025-09-12 08:34:26.223   Successfully installed the file.
+2025-09-12 08:34:26.223   -- File entry --
+2025-09-12 08:34:26.224   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_12.template
+2025-09-12 08:34:26.224   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.224   Installing the file.
+2025-09-12 08:34:26.224   Successfully installed the file.
+2025-09-12 08:34:26.224   -- File entry --
+2025-09-12 08:34:26.225   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_13.template
+2025-09-12 08:34:26.225   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.225   Installing the file.
+2025-09-12 08:34:26.225   Successfully installed the file.
+2025-09-12 08:34:26.226   -- File entry --
+2025-09-12 08:34:26.226   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_14.template
+2025-09-12 08:34:26.226   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.226   Installing the file.
+2025-09-12 08:34:26.227   Successfully installed the file.
+2025-09-12 08:34:26.227   -- File entry --
+2025-09-12 08:34:26.228   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_15.template
+2025-09-12 08:34:26.228   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.228   Installing the file.
+2025-09-12 08:34:26.228   Successfully installed the file.
+2025-09-12 08:34:26.228   -- File entry --
+2025-09-12 08:34:26.229   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_16.template
+2025-09-12 08:34:26.229   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.229   Installing the file.
+2025-09-12 08:34:26.230   Successfully installed the file.
+2025-09-12 08:34:26.230   -- File entry --
+2025-09-12 08:34:26.230   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_17.template
+2025-09-12 08:34:26.230   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.230   Installing the file.
+2025-09-12 08:34:26.232   Successfully installed the file.
+2025-09-12 08:34:26.232   -- File entry --
+2025-09-12 08:34:26.232   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_18.template
+2025-09-12 08:34:26.232   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.232   Installing the file.
+2025-09-12 08:34:26.233   Successfully installed the file.
+2025-09-12 08:34:26.233   -- File entry --
+2025-09-12 08:34:26.233   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_19.template
+2025-09-12 08:34:26.233   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.233   Installing the file.
+2025-09-12 08:34:26.234   Successfully installed the file.
+2025-09-12 08:34:26.234   -- File entry --
+2025-09-12 08:34:26.234   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_20.template
+2025-09-12 08:34:26.234   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.234   Installing the file.
+2025-09-12 08:34:26.236   Successfully installed the file.
+2025-09-12 08:34:26.236   -- File entry --
+2025-09-12 08:34:26.236   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_21.template
+2025-09-12 08:34:26.236   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.236   Installing the file.
+2025-09-12 08:34:26.237   Successfully installed the file.
+2025-09-12 08:34:26.237   -- File entry --
+2025-09-12 08:34:26.237   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_22.template
+2025-09-12 08:34:26.237   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.237   Installing the file.
+2025-09-12 08:34:26.238   Successfully installed the file.
+2025-09-12 08:34:26.238   -- File entry --
+2025-09-12 08:34:26.239   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_23.template
+2025-09-12 08:34:26.239   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.239   Installing the file.
+2025-09-12 08:34:26.239   Successfully installed the file.
+2025-09-12 08:34:26.239   -- File entry --
+2025-09-12 08:34:26.240   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_24.template
+2025-09-12 08:34:26.240   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.240   Installing the file.
+2025-09-12 08:34:26.240   Successfully installed the file.
+2025-09-12 08:34:26.241   -- File entry --
+2025-09-12 08:34:26.241   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_25.template
+2025-09-12 08:34:26.241   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.241   Installing the file.
+2025-09-12 08:34:26.241   Successfully installed the file.
+2025-09-12 08:34:26.241   -- File entry --
+2025-09-12 08:34:26.242   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_26.template
+2025-09-12 08:34:26.242   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.242   Installing the file.
+2025-09-12 08:34:26.242   Successfully installed the file.
+2025-09-12 08:34:26.242   -- File entry --
+2025-09-12 08:34:26.243   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_27.template
+2025-09-12 08:34:26.243   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.243   Installing the file.
+2025-09-12 08:34:26.244   Successfully installed the file.
+2025-09-12 08:34:26.244   -- File entry --
+2025-09-12 08:34:26.244   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_28.template
+2025-09-12 08:34:26.244   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.244   Installing the file.
+2025-09-12 08:34:26.245   Successfully installed the file.
+2025-09-12 08:34:26.245   -- File entry --
+2025-09-12 08:34:26.245   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_29.template
+2025-09-12 08:34:26.245   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.245   Installing the file.
+2025-09-12 08:34:26.246   Successfully installed the file.
+2025-09-12 08:34:26.246   -- File entry --
+2025-09-12 08:34:26.246   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_30.template
+2025-09-12 08:34:26.246   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.246   Installing the file.
+2025-09-12 08:34:26.247   Successfully installed the file.
+2025-09-12 08:34:26.247   -- File entry --
+2025-09-12 08:34:26.247   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_31.template
+2025-09-12 08:34:26.247   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.247   Installing the file.
+2025-09-12 08:34:26.248   Successfully installed the file.
+2025-09-12 08:34:26.248   -- File entry --
+2025-09-12 08:34:26.249   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_32.template
+2025-09-12 08:34:26.249   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.249   Installing the file.
+2025-09-12 08:34:26.249   Successfully installed the file.
+2025-09-12 08:34:26.249   -- File entry --
+2025-09-12 08:34:26.250   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_33.template
+2025-09-12 08:34:26.250   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.250   Installing the file.
+2025-09-12 08:34:26.251   Successfully installed the file.
+2025-09-12 08:34:26.251   -- File entry --
+2025-09-12 08:34:26.251   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_34.template
+2025-09-12 08:34:26.251   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.251   Installing the file.
+2025-09-12 08:34:26.252   Successfully installed the file.
+2025-09-12 08:34:26.252   -- File entry --
+2025-09-12 08:34:26.252   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_35.template
+2025-09-12 08:34:26.253   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.253   Installing the file.
+2025-09-12 08:34:26.253   Successfully installed the file.
+2025-09-12 08:34:26.253   -- File entry --
+2025-09-12 08:34:26.254   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_36.template
+2025-09-12 08:34:26.254   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.254   Installing the file.
+2025-09-12 08:34:26.254   Successfully installed the file.
+2025-09-12 08:34:26.255   -- File entry --
+2025-09-12 08:34:26.255   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_37.template
+2025-09-12 08:34:26.255   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.255   Installing the file.
+2025-09-12 08:34:26.256   Successfully installed the file.
+2025-09-12 08:34:26.256   -- File entry --
+2025-09-12 08:34:26.256   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_38.template
+2025-09-12 08:34:26.256   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.256   Installing the file.
+2025-09-12 08:34:26.257   Successfully installed the file.
+2025-09-12 08:34:26.257   -- File entry --
+2025-09-12 08:34:26.257   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_39.template
+2025-09-12 08:34:26.257   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.257   Installing the file.
+2025-09-12 08:34:26.258   Successfully installed the file.
+2025-09-12 08:34:26.258   -- File entry --
+2025-09-12 08:34:26.259   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_40.template
+2025-09-12 08:34:26.259   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.259   Installing the file.
+2025-09-12 08:34:26.259   Successfully installed the file.
+2025-09-12 08:34:26.260   -- File entry --
+2025-09-12 08:34:26.260   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_41.template
+2025-09-12 08:34:26.260   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.260   Installing the file.
+2025-09-12 08:34:26.261   Successfully installed the file.
+2025-09-12 08:34:26.261   -- File entry --
+2025-09-12 08:34:26.261   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_42.template
+2025-09-12 08:34:26.261   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.261   Installing the file.
+2025-09-12 08:34:26.263   Successfully installed the file.
+2025-09-12 08:34:26.263   -- File entry --
+2025-09-12 08:34:26.263   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_43.template
+2025-09-12 08:34:26.263   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.263   Installing the file.
+2025-09-12 08:34:26.264   Successfully installed the file.
+2025-09-12 08:34:26.264   -- File entry --
+2025-09-12 08:34:26.265   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_44.template
+2025-09-12 08:34:26.265   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.265   Installing the file.
+2025-09-12 08:34:26.265   Successfully installed the file.
+2025-09-12 08:34:26.266   -- File entry --
+2025-09-12 08:34:26.267   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_45.template
+2025-09-12 08:34:26.267   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.267   Installing the file.
+2025-09-12 08:34:26.267   Successfully installed the file.
+2025-09-12 08:34:26.268   -- File entry --
+2025-09-12 08:34:26.268   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_46.template
+2025-09-12 08:34:26.268   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.268   Installing the file.
+2025-09-12 08:34:26.269   Successfully installed the file.
+2025-09-12 08:34:26.269   -- File entry --
+2025-09-12 08:34:26.269   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_47.template
+2025-09-12 08:34:26.269   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.269   Installing the file.
+2025-09-12 08:34:26.270   Successfully installed the file.
+2025-09-12 08:34:26.270   -- File entry --
+2025-09-12 08:34:26.270   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_48.template
+2025-09-12 08:34:26.270   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.270   Installing the file.
+2025-09-12 08:34:26.271   Successfully installed the file.
+2025-09-12 08:34:26.271   -- File entry --
+2025-09-12 08:34:26.271   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_49.template
+2025-09-12 08:34:26.272   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.272   Installing the file.
+2025-09-12 08:34:26.272   Successfully installed the file.
+2025-09-12 08:34:26.272   -- File entry --
+2025-09-12 08:34:26.272   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_50.template
+2025-09-12 08:34:26.272   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.272   Installing the file.
+2025-09-12 08:34:26.274   Successfully installed the file.
+2025-09-12 08:34:26.274   -- File entry --
+2025-09-12 08:34:26.274   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_51.template
+2025-09-12 08:34:26.275   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.275   Installing the file.
+2025-09-12 08:34:26.275   Successfully installed the file.
+2025-09-12 08:34:26.275   -- File entry --
+2025-09-12 08:34:26.276   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_52.template
+2025-09-12 08:34:26.276   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.276   Installing the file.
+2025-09-12 08:34:26.276   Successfully installed the file.
+2025-09-12 08:34:26.276   -- File entry --
+2025-09-12 08:34:26.277   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_53.template
+2025-09-12 08:34:26.277   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.277   Installing the file.
+2025-09-12 08:34:26.277   Successfully installed the file.
+2025-09-12 08:34:26.278   -- File entry --
+2025-09-12 08:34:26.278   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_54.template
+2025-09-12 08:34:26.278   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.278   Installing the file.
+2025-09-12 08:34:26.279   Successfully installed the file.
+2025-09-12 08:34:26.279   -- File entry --
+2025-09-12 08:34:26.279   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_55.template
+2025-09-12 08:34:26.279   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.279   Installing the file.
+2025-09-12 08:34:26.280   Successfully installed the file.
+2025-09-12 08:34:26.280   -- File entry --
+2025-09-12 08:34:26.280   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_56.template
+2025-09-12 08:34:26.281   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.281   Installing the file.
+2025-09-12 08:34:26.281   Successfully installed the file.
+2025-09-12 08:34:26.281   -- File entry --
+2025-09-12 08:34:26.282   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_57.template
+2025-09-12 08:34:26.282   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.282   Installing the file.
+2025-09-12 08:34:26.282   Successfully installed the file.
+2025-09-12 08:34:26.282   -- File entry --
+2025-09-12 08:34:26.282   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_58.template
+2025-09-12 08:34:26.282   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.282   Installing the file.
+2025-09-12 08:34:26.284   Successfully installed the file.
+2025-09-12 08:34:26.284   -- File entry --
+2025-09-12 08:34:26.284   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_59.template
+2025-09-12 08:34:26.284   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.284   Installing the file.
+2025-09-12 08:34:26.285   Successfully installed the file.
+2025-09-12 08:34:26.285   -- File entry --
+2025-09-12 08:34:26.286   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_60.template
+2025-09-12 08:34:26.286   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.286   Installing the file.
+2025-09-12 08:34:26.286   Successfully installed the file.
+2025-09-12 08:34:26.286   -- File entry --
+2025-09-12 08:34:26.287   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_61.template
+2025-09-12 08:34:26.287   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.287   Installing the file.
+2025-09-12 08:34:26.288   Successfully installed the file.
+2025-09-12 08:34:26.288   -- File entry --
+2025-09-12 08:34:26.288   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_62.template
+2025-09-12 08:34:26.288   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.288   Installing the file.
+2025-09-12 08:34:26.289   Successfully installed the file.
+2025-09-12 08:34:26.289   -- File entry --
+2025-09-12 08:34:26.289   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_63.template
+2025-09-12 08:34:26.289   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.289   Installing the file.
+2025-09-12 08:34:26.290   Successfully installed the file.
+2025-09-12 08:34:26.290   -- File entry --
+2025-09-12 08:34:26.290   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_64.template
+2025-09-12 08:34:26.291   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.291   Installing the file.
+2025-09-12 08:34:26.291   Successfully installed the file.
+2025-09-12 08:34:26.291   -- File entry --
+2025-09-12 08:34:26.292   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SORHEA_SOLARIS_TARGET_ENTRY_CAMERA.template
+2025-09-12 08:34:26.292   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.292   Installing the file.
+2025-09-12 08:34:26.292   Successfully installed the file.
+2025-09-12 08:34:26.292   -- File entry --
+2025-09-12 08:34:26.293   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SPSFT_DEVICE.template
+2025-09-12 08:34:26.293   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.293   Installing the file.
+2025-09-12 08:34:26.293   Successfully installed the file.
+2025-09-12 08:34:26.293   -- File entry --
+2025-09-12 08:34:26.294   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\SQL_GENERIC.template
+2025-09-12 08:34:26.294   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.294   Installing the file.
+2025-09-12 08:34:26.294   Successfully installed the file.
+2025-09-12 08:34:26.294   -- File entry --
+2025-09-12 08:34:26.295   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\TEST_DSPINTERFACE.template
+2025-09-12 08:34:26.295   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.295   Installing the file.
+2025-09-12 08:34:26.295   Successfully installed the file.
+2025-09-12 08:34:26.295   -- File entry --
+2025-09-12 08:34:26.296   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\VAPIX_MJPEG_DEVICE.template
+2025-09-12 08:34:26.296   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.296   Installing the file.
+2025-09-12 08:34:26.296   Successfully installed the file.
+2025-09-12 08:34:26.297   -- File entry --
+2025-09-12 08:34:26.297   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\VAPIX_RTSP_DEVICE.template
+2025-09-12 08:34:26.297   Time stamp of our file: 2025-08-13 12:07:22.000
+2025-09-12 08:34:26.297   Installing the file.
+2025-09-12 08:34:26.297   Successfully installed the file.
+2025-09-12 08:34:26.297   -- File entry --
+2025-09-12 08:34:26.298   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\VIMACC_ASSEMBLIES_MANAGER.template
+2025-09-12 08:34:26.298   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.298   Installing the file.
+2025-09-12 08:34:26.298   Successfully installed the file.
+2025-09-12 08:34:26.298   -- File entry --
+2025-09-12 08:34:26.299   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\VIMACC_AUDIO_DEVICE.template
+2025-09-12 08:34:26.299   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.299   Installing the file.
+2025-09-12 08:34:26.299   Successfully installed the file.
+2025-09-12 08:34:26.300   -- File entry --
+2025-09-12 08:34:26.300   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\VIMACC_CTRL_INTERFACE.template
+2025-09-12 08:34:26.300   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.300   Installing the file.
+2025-09-12 08:34:26.301   Successfully installed the file.
+2025-09-12 08:34:26.301   -- File entry --
+2025-09-12 08:34:26.301   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\VIMACC_DEMO.template
+2025-09-12 08:34:26.301   Time stamp of our file: 2025-08-13 12:07:22.000
+2025-09-12 08:34:26.301   Installing the file.
+2025-09-12 08:34:26.302   Successfully installed the file.
+2025-09-12 08:34:26.302   -- File entry --
+2025-09-12 08:34:26.302   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\VIMACC_EMAIL_SENDER.template
+2025-09-12 08:34:26.302   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.302   Installing the file.
+2025-09-12 08:34:26.302   Successfully installed the file.
+2025-09-12 08:34:26.304   -- File entry --
+2025-09-12 08:34:26.304   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\VIMACC_EVENT_MANAGER.template
+2025-09-12 08:34:26.304   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.304   Installing the file.
+2025-09-12 08:34:26.304   Successfully installed the file.
+2025-09-12 08:34:26.305   -- File entry --
+2025-09-12 08:34:26.305   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\VIMACC_EXPORT_REPORT_SERVICE.template
+2025-09-12 08:34:26.305   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.305   Installing the file.
+2025-09-12 08:34:26.306   Successfully installed the file.
+2025-09-12 08:34:26.306   -- File entry --
+2025-09-12 08:34:26.306   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\VIMACC_EXPORT_SERVICE.template
+2025-09-12 08:34:26.306   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.306   Installing the file.
+2025-09-12 08:34:26.307   Successfully installed the file.
+2025-09-12 08:34:26.307   -- File entry --
+2025-09-12 08:34:26.307   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\VIMACC_FTP_ALARMRECV.template
+2025-09-12 08:34:26.307   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.307   Installing the file.
+2025-09-12 08:34:26.308   Successfully installed the file.
+2025-09-12 08:34:26.308   -- File entry --
+2025-09-12 08:34:26.308   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\VIMACC_FTP_UPLOADER.template
+2025-09-12 08:34:26.308   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.308   Installing the file.
+2025-09-12 08:34:26.309   Successfully installed the file.
+2025-09-12 08:34:26.309   -- File entry --
+2025-09-12 08:34:26.309   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\VIMACC_HID.template
+2025-09-12 08:34:26.309   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.309   Installing the file.
+2025-09-12 08:34:26.310   Successfully installed the file.
+2025-09-12 08:34:26.310   -- File entry --
+2025-09-12 08:34:26.310   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\VIMACC_HID_AXIS_T8312_KEYPAD.template
+2025-09-12 08:34:26.310   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.310   Installing the file.
+2025-09-12 08:34:26.311   Successfully installed the file.
+2025-09-12 08:34:26.311   -- File entry --
+2025-09-12 08:34:26.311   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\VIMACC_HID_AXIS_T8313_JOGDIAL.template
+2025-09-12 08:34:26.311   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.311   Installing the file.
+2025-09-12 08:34:26.312   Successfully installed the file.
+2025-09-12 08:34:26.312   -- File entry --
+2025-09-12 08:34:26.312   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\VIMACC_HID_AXIS_TU9002_JOYSTICK.template
+2025-09-12 08:34:26.312   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.312   Installing the file.
+2025-09-12 08:34:26.313   Successfully installed the file.
+2025-09-12 08:34:26.313   -- File entry --
+2025-09-12 08:34:26.314   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\VIMACC_HID_AXIS_TU9003_KEYPAD.template
+2025-09-12 08:34:26.314   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.314   Installing the file.
+2025-09-12 08:34:26.314   Successfully installed the file.
+2025-09-12 08:34:26.314   -- File entry --
+2025-09-12 08:34:26.315   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\VIMACC_HTTP_SERVER.template
+2025-09-12 08:34:26.315   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.315   Installing the file.
+2025-09-12 08:34:26.315   Successfully installed the file.
+2025-09-12 08:34:26.316   -- File entry --
+2025-09-12 08:34:26.316   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\VIMACC_INTERFACE_PROXY.template
+2025-09-12 08:34:26.316   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.316   Installing the file.
+2025-09-12 08:34:26.317   Successfully installed the file.
+2025-09-12 08:34:26.317   -- File entry --
+2025-09-12 08:34:26.317   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\VIMACC_OPC_CLIENT.template
+2025-09-12 08:34:26.317   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.317   Installing the file.
+2025-09-12 08:34:26.318   Successfully installed the file.
+2025-09-12 08:34:26.318   -- File entry --
+2025-09-12 08:34:26.318   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\VIMACC_PLAYBACK_PROXY.template
+2025-09-12 08:34:26.318   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.318   Installing the file.
+2025-09-12 08:34:26.319   Successfully installed the file.
+2025-09-12 08:34:26.319   -- File entry --
+2025-09-12 08:34:26.319   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\VIMACC_RECORDED_STREAM.template
+2025-09-12 08:34:26.319   Time stamp of our file: 2025-08-13 12:07:22.000
+2025-09-12 08:34:26.319   Installing the file.
+2025-09-12 08:34:26.320   Successfully installed the file.
+2025-09-12 08:34:26.320   -- File entry --
+2025-09-12 08:34:26.320   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\VIMACC_REPORT_SERVER.template
+2025-09-12 08:34:26.320   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.320   Installing the file.
+2025-09-12 08:34:26.321   Successfully installed the file.
+2025-09-12 08:34:26.321   -- File entry --
+2025-09-12 08:34:26.321   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\VIMACC_RTSP_SERVER.template
+2025-09-12 08:34:26.321   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.321   Installing the file.
+2025-09-12 08:34:26.322   Successfully installed the file.
+2025-09-12 08:34:26.322   -- File entry --
+2025-09-12 08:34:26.322   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\VIMACC_SCHEDULER.template
+2025-09-12 08:34:26.322   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.322   Installing the file.
+2025-09-12 08:34:26.323   Successfully installed the file.
+2025-09-12 08:34:26.323   -- File entry --
+2025-09-12 08:34:26.323   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\VIMACC_SCHEDULER_PATROL.template
+2025-09-12 08:34:26.324   Time stamp of our file: 2025-07-11 13:18:10.000
+2025-09-12 08:34:26.324   Installing the file.
+2025-09-12 08:34:26.324   Successfully installed the file.
+2025-09-12 08:34:26.324   -- File entry --
+2025-09-12 08:34:26.324   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\VIMACC_SCHEDULER_PATROL_ACTION_GOTOPRESET.template
+2025-09-12 08:34:26.324   Time stamp of our file: 2025-07-11 13:18:10.000
+2025-09-12 08:34:26.324   Installing the file.
+2025-09-12 08:34:26.325   Successfully installed the file.
+2025-09-12 08:34:26.325   -- File entry --
+2025-09-12 08:34:26.325   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\VIMACC_SCHEDULER_PULSE.template
+2025-09-12 08:34:26.325   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.325   Installing the file.
+2025-09-12 08:34:26.325   Successfully installed the file.
+2025-09-12 08:34:26.325   -- File entry --
+2025-09-12 08:34:26.327   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\VIMACC_SCREEN2RTSP_VIDEO_DEVICE.template
+2025-09-12 08:34:26.327   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.327   Installing the file.
+2025-09-12 08:34:26.328   Successfully installed the file.
+2025-09-12 08:34:26.328   -- File entry --
+2025-09-12 08:34:26.329   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\VIMACC_SERVER_SYNC.template
+2025-09-12 08:34:26.329   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.329   Installing the file.
+2025-09-12 08:34:26.329   Successfully installed the file.
+2025-09-12 08:34:26.329   -- File entry --
+2025-09-12 08:34:26.330   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\VIMACC_SMS_GATEWAY.template
+2025-09-12 08:34:26.330   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.330   Installing the file.
+2025-09-12 08:34:26.330   Successfully installed the file.
+2025-09-12 08:34:26.330   -- File entry --
+2025-09-12 08:34:26.331   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\VIMACC_SNMP_AGENT.template
+2025-09-12 08:34:26.331   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.331   Installing the file.
+2025-09-12 08:34:26.331   Successfully installed the file.
+2025-09-12 08:34:26.332   -- File entry --
+2025-09-12 08:34:26.332   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\VIMACC_STREAMING_DEVICE.template
+2025-09-12 08:34:26.332   Time stamp of our file: 2025-08-13 12:07:22.000
+2025-09-12 08:34:26.332   Installing the file.
+2025-09-12 08:34:26.333   Successfully installed the file.
+2025-09-12 08:34:26.333   -- File entry --
+2025-09-12 08:34:26.333   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\VIMACC_STREAMING_SERVER.template
+2025-09-12 08:34:26.333   Time stamp of our file: 2025-08-13 12:07:22.000
+2025-09-12 08:34:26.333   Installing the file.
+2025-09-12 08:34:26.334   Successfully installed the file.
+2025-09-12 08:34:26.334   -- File entry --
+2025-09-12 08:34:26.334   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\VIMACC_STREAMING_SERVER_ADV.template
+2025-09-12 08:34:26.334   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.334   Installing the file.
+2025-09-12 08:34:26.335   Successfully installed the file.
+2025-09-12 08:34:26.335   -- File entry --
+2025-09-12 08:34:26.335   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\VIMACC_STREAMING_SERVER_REDU.template
+2025-09-12 08:34:26.335   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.335   Installing the file.
+2025-09-12 08:34:26.335   Successfully installed the file.
+2025-09-12 08:34:26.336   -- File entry --
+2025-09-12 08:34:26.336   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\VIMACC_SYSTEM_MONITORING.template
+2025-09-12 08:34:26.336   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.336   Installing the file.
+2025-09-12 08:34:26.336   Successfully installed the file.
+2025-09-12 08:34:26.337   -- File entry --
+2025-09-12 08:34:26.337   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\VIMACC_TEST.template
+2025-09-12 08:34:26.337   Time stamp of our file: 2025-08-13 12:07:22.000
+2025-09-12 08:34:26.337   Installing the file.
+2025-09-12 08:34:26.338   Successfully installed the file.
+2025-09-12 08:34:26.338   -- File entry --
+2025-09-12 08:34:26.338   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\VIMACC_TESTAUDIO.template
+2025-09-12 08:34:26.338   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.338   Installing the file.
+2025-09-12 08:34:26.339   Successfully installed the file.
+2025-09-12 08:34:26.339   -- File entry --
+2025-09-12 08:34:26.339   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\VIMACC_USB_TEST.template
+2025-09-12 08:34:26.339   Time stamp of our file: 2025-05-05 13:05:54.000
+2025-09-12 08:34:26.339   Installing the file.
+2025-09-12 08:34:26.340   Successfully installed the file.
+2025-09-12 08:34:26.340   -- File entry --
+2025-09-12 08:34:26.340   Dest filename: C:\vimacc\data\configTemplates\default\devTemplates\VIMACC_WORKSTATION_DEVICE.template
+2025-09-12 08:34:26.340   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.340   Installing the file.
+2025-09-12 08:34:26.341   Successfully installed the file.
+2025-09-12 08:34:26.341   -- File entry --
+2025-09-12 08:34:26.341   Dest filename: C:\vimacc\data\configTemplates\de_DE\general.def
+2025-09-12 08:34:26.341   Time stamp of our file: 2025-07-11 13:18:10.000
+2025-09-12 08:34:26.341   Installing the file.
+2025-09-12 08:34:26.341   Creating directory: C:\vimacc\data\configTemplates\de_DE
+2025-09-12 08:34:26.342   Successfully installed the file.
+2025-09-12 08:34:26.342   -- File entry --
+2025-09-12 08:34:26.342   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\ADDAC_AUDIO_DEVICE.template
+2025-09-12 08:34:26.342   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.342   Installing the file.
+2025-09-12 08:34:26.342   Creating directory: C:\vimacc\data\configTemplates\de_DE\devTemplates
+2025-09-12 08:34:26.344   Successfully installed the file.
+2025-09-12 08:34:26.344   -- File entry --
+2025-09-12 08:34:26.344   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\ANY_AUDIO_DEVICE.template
+2025-09-12 08:34:26.344   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.344   Installing the file.
+2025-09-12 08:34:26.345   Successfully installed the file.
+2025-09-12 08:34:26.345   -- File entry --
+2025-09-12 08:34:26.345   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\ANY_VIDEO_DEVICE.template
+2025-09-12 08:34:26.345   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.345   Installing the file.
+2025-09-12 08:34:26.345   Successfully installed the file.
+2025-09-12 08:34:26.345   -- File entry --
+2025-09-12 08:34:26.345   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\ASSEMBLYELEMENT_LEDBUTTON.template
+2025-09-12 08:34:26.345   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.345   Installing the file.
+2025-09-12 08:34:26.346   Successfully installed the file.
+2025-09-12 08:34:26.346   -- File entry --
+2025-09-12 08:34:26.346   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\ASSEMBLYELEMENT_LEDBUTTON_IODEVICE.template
+2025-09-12 08:34:26.346   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.346   Installing the file.
+2025-09-12 08:34:26.347   Successfully installed the file.
+2025-09-12 08:34:26.347   -- File entry --
+2025-09-12 08:34:26.348   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\ASSEMBLYELEMENT_LEDBUTTON_IODEVICE_BASIC.include
+2025-09-12 08:34:26.348   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.348   Installing the file.
+2025-09-12 08:34:26.348   Successfully installed the file.
+2025-09-12 08:34:26.348   -- File entry --
+2025-09-12 08:34:26.349   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\ASSEMBLYELEMENT_LEDBUTTON_IODEVICE_WITH_REG_VALUE.template
+2025-09-12 08:34:26.349   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.349   Installing the file.
+2025-09-12 08:34:26.349   Successfully installed the file.
+2025-09-12 08:34:26.349   -- File entry --
+2025-09-12 08:34:26.350   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\ASSEMBLYTASK_GATE.template
+2025-09-12 08:34:26.350   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.350   Installing the file.
+2025-09-12 08:34:26.350   Successfully installed the file.
+2025-09-12 08:34:26.350   -- File entry --
+2025-09-12 08:34:26.351   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\ASSEMBLYTASK_LEDBUTTONS.template
+2025-09-12 08:34:26.351   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.351   Installing the file.
+2025-09-12 08:34:26.351   Successfully installed the file.
+2025-09-12 08:34:26.351   -- File entry --
+2025-09-12 08:34:26.352   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\AVERMEDIA_NH_VIDEO_DEVICE.template
+2025-09-12 08:34:26.352   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.352   Installing the file.
+2025-09-12 08:34:26.352   Successfully installed the file.
+2025-09-12 08:34:26.353   -- File entry --
+2025-09-12 08:34:26.353   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\AXIS_AUDIO_DEVICE.template
+2025-09-12 08:34:26.353   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.353   Installing the file.
+2025-09-12 08:34:26.353   Successfully installed the file.
+2025-09-12 08:34:26.353   -- File entry --
+2025-09-12 08:34:26.353   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\CMDBASE_ALARMRECORDING.include
+2025-09-12 08:34:26.353   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.353   Installing the file.
+2025-09-12 08:34:26.355   Successfully installed the file.
+2025-09-12 08:34:26.355   -- File entry --
+2025-09-12 08:34:26.355   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\CMDBASE_CLEARDIALOG.include
+2025-09-12 08:34:26.355   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.355   Installing the file.
+2025-09-12 08:34:26.356   Successfully installed the file.
+2025-09-12 08:34:26.356   -- File entry --
+2025-09-12 08:34:26.357   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\CMDBASE_DEACTIVATEPRIVACYZONES.include
+2025-09-12 08:34:26.357   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.357   Installing the file.
+2025-09-12 08:34:26.357   Successfully installed the file.
+2025-09-12 08:34:26.357   -- File entry --
+2025-09-12 08:34:26.358   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\CMDBASE_FTPUPLOADSTART.include
+2025-09-12 08:34:26.358   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.358   Installing the file.
+2025-09-12 08:34:26.359   Successfully installed the file.
+2025-09-12 08:34:26.359   -- File entry --
+2025-09-12 08:34:26.359   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\CMDBASE_FTPUPLOADSTOP.include
+2025-09-12 08:34:26.359   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.359   Installing the file.
+2025-09-12 08:34:26.360   Successfully installed the file.
+2025-09-12 08:34:26.360   -- File entry --
+2025-09-12 08:34:26.361   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\CMDBASE_FTP_LIVE_UPLOADSTART.include
+2025-09-12 08:34:26.361   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.361   Installing the file.
+2025-09-12 08:34:26.362   Successfully installed the file.
+2025-09-12 08:34:26.362   -- File entry --
+2025-09-12 08:34:26.362   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\CMDBASE_FTP_LIVE_UPLOADSTOP.include
+2025-09-12 08:34:26.363   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.363   Installing the file.
+2025-09-12 08:34:26.363   Successfully installed the file.
+2025-09-12 08:34:26.363   -- File entry --
+2025-09-12 08:34:26.364   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\CMDBASE_GOTOPRESET.include
+2025-09-12 08:34:26.364   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.364   Installing the file.
+2025-09-12 08:34:26.364   Successfully installed the file.
+2025-09-12 08:34:26.364   -- File entry --
+2025-09-12 08:34:26.365   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\CMDBASE_SENDEMAIL.include
+2025-09-12 08:34:26.365   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.365   Installing the file.
+2025-09-12 08:34:26.365   Successfully installed the file.
+2025-09-12 08:34:26.365   -- File entry --
+2025-09-12 08:34:26.365   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\CMDBASE_SENDEMAIL_SCRIPTED.include
+2025-09-12 08:34:26.365   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.365   Installing the file.
+2025-09-12 08:34:26.366   Successfully installed the file.
+2025-09-12 08:34:26.366   -- File entry --
+2025-09-12 08:34:26.366   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\CMDBASE_SETBOOKMARK.include
+2025-09-12 08:34:26.366   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.366   Installing the file.
+2025-09-12 08:34:26.367   Successfully installed the file.
+2025-09-12 08:34:26.367   -- File entry --
+2025-09-12 08:34:26.367   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\CMDBASE_SETBOOKMARK_SCRIPTED.include
+2025-09-12 08:34:26.367   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.367   Installing the file.
+2025-09-12 08:34:26.368   Successfully installed the file.
+2025-09-12 08:34:26.368   -- File entry --
+2025-09-12 08:34:26.368   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\CMDBASE_SETGRID.include
+2025-09-12 08:34:26.368   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.368   Installing the file.
+2025-09-12 08:34:26.369   Successfully installed the file.
+2025-09-12 08:34:26.369   -- File entry --
+2025-09-12 08:34:26.369   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\CMDBASE_SHOWCONTROLAREA.include
+2025-09-12 08:34:26.369   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.370   Installing the file.
+2025-09-12 08:34:26.370   Successfully installed the file.
+2025-09-12 08:34:26.370   -- File entry --
+2025-09-12 08:34:26.370   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\CMDBASE_SHOWMAP.include
+2025-09-12 08:34:26.370   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.370   Installing the file.
+2025-09-12 08:34:26.371   Successfully installed the file.
+2025-09-12 08:34:26.371   -- File entry --
+2025-09-12 08:34:26.371   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\CMDBASE_SHOWNAVIGATIONAREA.include
+2025-09-12 08:34:26.372   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.372   Installing the file.
+2025-09-12 08:34:26.372   Successfully installed the file.
+2025-09-12 08:34:26.372   -- File entry --
+2025-09-12 08:34:26.372   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\CMDBASE_SHOWPLAYBACKS.include
+2025-09-12 08:34:26.373   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.373   Installing the file.
+2025-09-12 08:34:26.373   Successfully installed the file.
+2025-09-12 08:34:26.373   -- File entry --
+2025-09-12 08:34:26.373   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\CMDBASE_SHOWSCENARIO.include
+2025-09-12 08:34:26.374   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.374   Installing the file.
+2025-09-12 08:34:26.374   Successfully installed the file.
+2025-09-12 08:34:26.374   -- File entry --
+2025-09-12 08:34:26.375   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\CMDBASE_SHOWSEQUENCE.include
+2025-09-12 08:34:26.375   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.375   Installing the file.
+2025-09-12 08:34:26.376   Successfully installed the file.
+2025-09-12 08:34:26.376   -- File entry --
+2025-09-12 08:34:26.376   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\CMDBASE_SHOWSTREAMS.include
+2025-09-12 08:34:26.376   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.376   Installing the file.
+2025-09-12 08:34:26.377   Successfully installed the file.
+2025-09-12 08:34:26.377   -- File entry --
+2025-09-12 08:34:26.378   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\CMDBASE_SHOWTOOLBAR.include
+2025-09-12 08:34:26.378   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.378   Installing the file.
+2025-09-12 08:34:26.378   Successfully installed the file.
+2025-09-12 08:34:26.378   -- File entry --
+2025-09-12 08:34:26.379   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\CMDBASE_SWITCHRECORDING.include
+2025-09-12 08:34:26.379   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.379   Installing the file.
+2025-09-12 08:34:26.380   Successfully installed the file.
+2025-09-12 08:34:26.380   -- File entry --
+2025-09-12 08:34:26.380   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\CTRL_ENTRY.template
+2025-09-12 08:34:26.380   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.380   Installing the file.
+2025-09-12 08:34:26.381   Successfully installed the file.
+2025-09-12 08:34:26.381   -- File entry --
+2025-09-12 08:34:26.381   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\CTRL_ENTRY_ASSEMBLYMGR.template
+2025-09-12 08:34:26.381   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.381   Installing the file.
+2025-09-12 08:34:26.382   Successfully installed the file.
+2025-09-12 08:34:26.382   -- File entry --
+2025-09-12 08:34:26.382   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\CTRL_ENTRY_DIGIO.template
+2025-09-12 08:34:26.382   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.382   Installing the file.
+2025-09-12 08:34:26.383   Successfully installed the file.
+2025-09-12 08:34:26.383   -- File entry --
+2025-09-12 08:34:26.383   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\CTRL_ENTRY_ELISE.template
+2025-09-12 08:34:26.383   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.383   Installing the file.
+2025-09-12 08:34:26.384   Successfully installed the file.
+2025-09-12 08:34:26.384   -- File entry --
+2025-09-12 08:34:26.384   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\CTRL_ENTRY_EMAILSENDER.template
+2025-09-12 08:34:26.384   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.384   Installing the file.
+2025-09-12 08:34:26.385   Successfully installed the file.
+2025-09-12 08:34:26.385   -- File entry --
+2025-09-12 08:34:26.385   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\CTRL_ENTRY_EVENTMGR.template
+2025-09-12 08:34:26.385   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.385   Installing the file.
+2025-09-12 08:34:26.386   Successfully installed the file.
+2025-09-12 08:34:26.386   -- File entry --
+2025-09-12 08:34:26.386   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\CTRL_ENTRY_FTPDUPLOADER.template
+2025-09-12 08:34:26.386   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.386   Installing the file.
+2025-09-12 08:34:26.386   Successfully installed the file.
+2025-09-12 08:34:26.387   -- File entry --
+2025-09-12 08:34:26.387   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\CTRL_ENTRY_INTERFACE.template
+2025-09-12 08:34:26.387   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.387   Installing the file.
+2025-09-12 08:34:26.387   Successfully installed the file.
+2025-09-12 08:34:26.388   -- File entry --
+2025-09-12 08:34:26.388   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\CTRL_ENTRY_INTERFACE_PROXY.template
+2025-09-12 08:34:26.388   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.388   Installing the file.
+2025-09-12 08:34:26.389   Successfully installed the file.
+2025-09-12 08:34:26.389   -- File entry --
+2025-09-12 08:34:26.389   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\CTRL_ENTRY_MOTION_DETECTOR.template
+2025-09-12 08:34:26.389   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.389   Installing the file.
+2025-09-12 08:34:26.390   Successfully installed the file.
+2025-09-12 08:34:26.390   -- File entry --
+2025-09-12 08:34:26.391   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\CTRL_ENTRY_SCHEDULER.template
+2025-09-12 08:34:26.391   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.391   Installing the file.
+2025-09-12 08:34:26.391   Successfully installed the file.
+2025-09-12 08:34:26.391   -- File entry --
+2025-09-12 08:34:26.392   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\CTRL_ENTRY_SERIALIO.template
+2025-09-12 08:34:26.392   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.392   Installing the file.
+2025-09-12 08:34:26.392   Successfully installed the file.
+2025-09-12 08:34:26.392   -- File entry --
+2025-09-12 08:34:26.393   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\CTRL_ENTRY_SNMPAGENT.template
+2025-09-12 08:34:26.393   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.393   Installing the file.
+2025-09-12 08:34:26.393   Successfully installed the file.
+2025-09-12 08:34:26.393   -- File entry --
+2025-09-12 08:34:26.394   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\CTRL_ENTRY_SPSFT.template
+2025-09-12 08:34:26.394   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.394   Installing the file.
+2025-09-12 08:34:26.394   Successfully installed the file.
+2025-09-12 08:34:26.394   -- File entry --
+2025-09-12 08:34:26.395   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\DIGITUS_AUDIO_DEVICE.template
+2025-09-12 08:34:26.395   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.395   Installing the file.
+2025-09-12 08:34:26.395   Successfully installed the file.
+2025-09-12 08:34:26.396   -- File entry --
+2025-09-12 08:34:26.396   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\DIGITUS_VIDEO_DEVICE.template
+2025-09-12 08:34:26.397   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.397   Installing the file.
+2025-09-12 08:34:26.397   Successfully installed the file.
+2025-09-12 08:34:26.397   -- File entry --
+2025-09-12 08:34:26.398   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\DONGLE_ENTRY.template
+2025-09-12 08:34:26.398   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.398   Installing the file.
+2025-09-12 08:34:26.398   Successfully installed the file.
+2025-09-12 08:34:26.398   -- File entry --
+2025-09-12 08:34:26.399   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\ELISE_DEVICE.template
+2025-09-12 08:34:26.399   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.399   Installing the file.
+2025-09-12 08:34:26.399   Successfully installed the file.
+2025-09-12 08:34:26.399   -- File entry --
+2025-09-12 08:34:26.400   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\EVNTACTION_ALARMREC_START.template
+2025-09-12 08:34:26.400   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.400   Installing the file.
+2025-09-12 08:34:26.400   Successfully installed the file.
+2025-09-12 08:34:26.400   -- File entry --
+2025-09-12 08:34:26.401   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\EVNTACTION_ALARMREC_STOP.template
+2025-09-12 08:34:26.401   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.401   Installing the file.
+2025-09-12 08:34:26.401   Successfully installed the file.
+2025-09-12 08:34:26.401   -- File entry --
+2025-09-12 08:34:26.402   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\EVNTACTION_CLEARDIALOG.template
+2025-09-12 08:34:26.402   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.402   Installing the file.
+2025-09-12 08:34:26.402   Successfully installed the file.
+2025-09-12 08:34:26.402   -- File entry --
+2025-09-12 08:34:26.403   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\EVNTACTION_DEACTIVATEPRIVACYZONES.template
+2025-09-12 08:34:26.403   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.403   Installing the file.
+2025-09-12 08:34:26.403   Successfully installed the file.
+2025-09-12 08:34:26.403   -- File entry --
+2025-09-12 08:34:26.404   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\EVNTACTION_DEFINEEVENTSCENARIO_AUTO.template
+2025-09-12 08:34:26.404   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.404   Installing the file.
+2025-09-12 08:34:26.404   Successfully installed the file.
+2025-09-12 08:34:26.405   -- File entry --
+2025-09-12 08:34:26.405   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\EVNTACTION_DEFINEEVENTSCENARIO_PRECONF.template
+2025-09-12 08:34:26.405   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.405   Installing the file.
+2025-09-12 08:34:26.405   Successfully installed the file.
+2025-09-12 08:34:26.406   -- File entry --
+2025-09-12 08:34:26.406   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\EVNTACTION_EXPORTCAMREPORT.template
+2025-09-12 08:34:26.406   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.406   Installing the file.
+2025-09-12 08:34:26.407   Successfully installed the file.
+2025-09-12 08:34:26.407   -- File entry --
+2025-09-12 08:34:26.407   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\EVNTACTION_FTPUPLOADSTART.template
+2025-09-12 08:34:26.407   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.407   Installing the file.
+2025-09-12 08:34:26.408   Successfully installed the file.
+2025-09-12 08:34:26.408   -- File entry --
+2025-09-12 08:34:26.408   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\EVNTACTION_FTPUPLOADSTOP.template
+2025-09-12 08:34:26.408   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.408   Installing the file.
+2025-09-12 08:34:26.409   Successfully installed the file.
+2025-09-12 08:34:26.409   -- File entry --
+2025-09-12 08:34:26.409   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\EVNTACTION_FTP_LIVE_UPLOADSTART.template
+2025-09-12 08:34:26.409   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.409   Installing the file.
+2025-09-12 08:34:26.410   Successfully installed the file.
+2025-09-12 08:34:26.410   -- File entry --
+2025-09-12 08:34:26.410   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\EVNTACTION_FTP_LIVE_UPLOADSTOP.template
+2025-09-12 08:34:26.410   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.410   Installing the file.
+2025-09-12 08:34:26.411   Successfully installed the file.
+2025-09-12 08:34:26.411   -- File entry --
+2025-09-12 08:34:26.411   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\EVNTACTION_GOTOPRESET.template
+2025-09-12 08:34:26.411   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.411   Installing the file.
+2025-09-12 08:34:26.412   Successfully installed the file.
+2025-09-12 08:34:26.412   -- File entry --
+2025-09-12 08:34:26.412   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\EVNTACTION_RECDEFAULT.template
+2025-09-12 08:34:26.412   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.412   Installing the file.
+2025-09-12 08:34:26.413   Successfully installed the file.
+2025-09-12 08:34:26.413   -- File entry --
+2025-09-12 08:34:26.413   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\EVNTACTION_RECSTART.template
+2025-09-12 08:34:26.413   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.413   Installing the file.
+2025-09-12 08:34:26.414   Successfully installed the file.
+2025-09-12 08:34:26.414   -- File entry --
+2025-09-12 08:34:26.414   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\EVNTACTION_RECSTOP.template
+2025-09-12 08:34:26.414   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.414   Installing the file.
+2025-09-12 08:34:26.415   Successfully installed the file.
+2025-09-12 08:34:26.415   -- File entry --
+2025-09-12 08:34:26.415   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\EVNTACTION_SENDEMAIL.template
+2025-09-12 08:34:26.415   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.415   Installing the file.
+2025-09-12 08:34:26.415   Successfully installed the file.
+2025-09-12 08:34:26.415   -- File entry --
+2025-09-12 08:34:26.415   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\EVNTACTION_SENDEMAIL_SCRIPTED.template
+2025-09-12 08:34:26.415   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.415   Installing the file.
+2025-09-12 08:34:26.417   Successfully installed the file.
+2025-09-12 08:34:26.417   -- File entry --
+2025-09-12 08:34:26.417   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\EVNTACTION_SETBOOKMARK.template
+2025-09-12 08:34:26.417   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.417   Installing the file.
+2025-09-12 08:34:26.418   Successfully installed the file.
+2025-09-12 08:34:26.418   -- File entry --
+2025-09-12 08:34:26.418   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\EVNTACTION_SETBOOKMARK_SCRIPTED.template
+2025-09-12 08:34:26.418   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.419   Installing the file.
+2025-09-12 08:34:26.419   Successfully installed the file.
+2025-09-12 08:34:26.419   -- File entry --
+2025-09-12 08:34:26.420   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\EVNTACTION_SETGRID.template
+2025-09-12 08:34:26.420   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.420   Installing the file.
+2025-09-12 08:34:26.420   Successfully installed the file.
+2025-09-12 08:34:26.420   -- File entry --
+2025-09-12 08:34:26.421   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\EVNTACTION_SETOVERLAYTEXT.template
+2025-09-12 08:34:26.421   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.421   Installing the file.
+2025-09-12 08:34:26.421   Successfully installed the file.
+2025-09-12 08:34:26.421   -- File entry --
+2025-09-12 08:34:26.421   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\EVNTACTION_SETOVERLAYTEXT_SCRIPTED.template
+2025-09-12 08:34:26.421   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.421   Installing the file.
+2025-09-12 08:34:26.422   Successfully installed the file.
+2025-09-12 08:34:26.422   -- File entry --
+2025-09-12 08:34:26.422   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\EVNTACTION_SET_OUTPUT.template
+2025-09-12 08:34:26.422   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.422   Installing the file.
+2025-09-12 08:34:26.423   Successfully installed the file.
+2025-09-12 08:34:26.423   -- File entry --
+2025-09-12 08:34:26.423   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\EVNTACTION_SET_OUTPUT_VALUE.template
+2025-09-12 08:34:26.423   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.423   Installing the file.
+2025-09-12 08:34:26.424   Successfully installed the file.
+2025-09-12 08:34:26.424   -- File entry --
+2025-09-12 08:34:26.424   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\EVNTACTION_SHOWCONTROLAREA.template
+2025-09-12 08:34:26.425   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.425   Installing the file.
+2025-09-12 08:34:26.425   Successfully installed the file.
+2025-09-12 08:34:26.425   -- File entry --
+2025-09-12 08:34:26.425   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\EVNTACTION_SHOWMAP.template
+2025-09-12 08:34:26.425   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.425   Installing the file.
+2025-09-12 08:34:26.427   Successfully installed the file.
+2025-09-12 08:34:26.427   -- File entry --
+2025-09-12 08:34:26.427   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\EVNTACTION_SHOWNAVIGATIONAREA.template
+2025-09-12 08:34:26.427   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.427   Installing the file.
+2025-09-12 08:34:26.428   Successfully installed the file.
+2025-09-12 08:34:26.428   -- File entry --
+2025-09-12 08:34:26.428   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\EVNTACTION_SHOWPLAYBACKS.template
+2025-09-12 08:34:26.428   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.428   Installing the file.
+2025-09-12 08:34:26.429   Successfully installed the file.
+2025-09-12 08:34:26.429   -- File entry --
+2025-09-12 08:34:26.429   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\EVNTACTION_SHOWSCENARIO.template
+2025-09-12 08:34:26.429   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.429   Installing the file.
+2025-09-12 08:34:26.430   Successfully installed the file.
+2025-09-12 08:34:26.430   -- File entry --
+2025-09-12 08:34:26.430   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\EVNTACTION_SHOWSEQUENCE.template
+2025-09-12 08:34:26.431   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.431   Installing the file.
+2025-09-12 08:34:26.431   Successfully installed the file.
+2025-09-12 08:34:26.431   -- File entry --
+2025-09-12 08:34:26.431   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\EVNTACTION_SHOWSTREAMS.template
+2025-09-12 08:34:26.432   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.432   Installing the file.
+2025-09-12 08:34:26.432   Successfully installed the file.
+2025-09-12 08:34:26.432   -- File entry --
+2025-09-12 08:34:26.433   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\EVNTACTION_SHOWTOOLBAR.template
+2025-09-12 08:34:26.433   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.433   Installing the file.
+2025-09-12 08:34:26.434   Successfully installed the file.
+2025-09-12 08:34:26.434   -- File entry --
+2025-09-12 08:34:26.434   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\EVNTACTION_SWITCH_OPMODE.template
+2025-09-12 08:34:26.434   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.434   Installing the file.
+2025-09-12 08:34:26.435   Successfully installed the file.
+2025-09-12 08:34:26.435   -- File entry --
+2025-09-12 08:34:26.435   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\EVNTACTION_WAIT.template
+2025-09-12 08:34:26.435   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.436   Installing the file.
+2025-09-12 08:34:26.436   Successfully installed the file.
+2025-09-12 08:34:26.436   -- File entry --
+2025-09-12 08:34:26.436   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\EVNTACTION_WRITE_DP.template
+2025-09-12 08:34:26.436   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.436   Installing the file.
+2025-09-12 08:34:26.436   Successfully installed the file.
+2025-09-12 08:34:26.437   -- File entry --
+2025-09-12 08:34:26.438   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\EVNTACTION_WRITE_DP_SCRIPTED.template
+2025-09-12 08:34:26.438   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.438   Installing the file.
+2025-09-12 08:34:26.438   Successfully installed the file.
+2025-09-12 08:34:26.438   -- File entry --
+2025-09-12 08:34:26.439   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\EVNTLNK_TRIGGER_CONFIGVALUE.template
+2025-09-12 08:34:26.439   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.439   Installing the file.
+2025-09-12 08:34:26.439   Successfully installed the file.
+2025-09-12 08:34:26.439   -- File entry --
+2025-09-12 08:34:26.440   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\EVNTLNK_TRIGGER_STREAMREQUESTED.template
+2025-09-12 08:34:26.440   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.440   Installing the file.
+2025-09-12 08:34:26.441   Successfully installed the file.
+2025-09-12 08:34:26.441   -- File entry --
+2025-09-12 08:34:26.441   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\EVNTTASK_CONFIGVALUE.template
+2025-09-12 08:34:26.441   Time stamp of our file: 2025-07-11 13:18:10.000
+2025-09-12 08:34:26.441   Installing the file.
+2025-09-12 08:34:26.442   Successfully installed the file.
+2025-09-12 08:34:26.442   -- File entry --
+2025-09-12 08:34:26.442   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\EVNTTASK_FTPALARM.template
+2025-09-12 08:34:26.442   Time stamp of our file: 2025-07-11 13:18:10.000
+2025-09-12 08:34:26.442   Installing the file.
+2025-09-12 08:34:26.443   Successfully installed the file.
+2025-09-12 08:34:26.443   -- File entry --
+2025-09-12 08:34:26.443   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\EVNTTASK_IO.template
+2025-09-12 08:34:26.443   Time stamp of our file: 2025-07-11 13:18:10.000
+2025-09-12 08:34:26.443   Installing the file.
+2025-09-12 08:34:26.444   Successfully installed the file.
+2025-09-12 08:34:26.444   -- File entry --
+2025-09-12 08:34:26.444   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\EVNTTASK_IO_VALUE.template
+2025-09-12 08:34:26.444   Time stamp of our file: 2025-07-11 13:18:10.000
+2025-09-12 08:34:26.444   Installing the file.
+2025-09-12 08:34:26.445   Successfully installed the file.
+2025-09-12 08:34:26.445   -- File entry --
+2025-09-12 08:34:26.445   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\EVNTTASK_IO_VALUE_SCRIPTED.template
+2025-09-12 08:34:26.445   Time stamp of our file: 2025-07-11 13:18:10.000
+2025-09-12 08:34:26.446   Installing the file.
+2025-09-12 08:34:26.446   Successfully installed the file.
+2025-09-12 08:34:26.446   -- File entry --
+2025-09-12 08:34:26.446   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\EVNTTASK_IPALARM.template
+2025-09-12 08:34:26.447   Time stamp of our file: 2025-07-11 13:18:10.000
+2025-09-12 08:34:26.447   Installing the file.
+2025-09-12 08:34:26.447   Successfully installed the file.
+2025-09-12 08:34:26.447   -- File entry --
+2025-09-12 08:34:26.447   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\EVNTTASK_LINKEDSOURCES.template
+2025-09-12 08:34:26.448   Time stamp of our file: 2025-07-11 13:18:10.000
+2025-09-12 08:34:26.448   Installing the file.
+2025-09-12 08:34:26.448   Successfully installed the file.
+2025-09-12 08:34:26.448   -- File entry --
+2025-09-12 08:34:26.448   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\EVNTTASK_MOTION.template
+2025-09-12 08:34:26.448   Time stamp of our file: 2025-07-11 13:18:10.000
+2025-09-12 08:34:26.448   Installing the file.
+2025-09-12 08:34:26.448   Successfully installed the file.
+2025-09-12 08:34:26.449   -- File entry --
+2025-09-12 08:34:26.449   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\EVNTTASK_SCHEDULER.template
+2025-09-12 08:34:26.449   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.449   Installing the file.
+2025-09-12 08:34:26.450   Successfully installed the file.
+2025-09-12 08:34:26.450   -- File entry --
+2025-09-12 08:34:26.450   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\EVNTTASK_VCAALARM.template
+2025-09-12 08:34:26.450   Time stamp of our file: 2025-07-11 13:18:10.000
+2025-09-12 08:34:26.450   Installing the file.
+2025-09-12 08:34:26.451   Successfully installed the file.
+2025-09-12 08:34:26.451   -- File entry --
+2025-09-12 08:34:26.451   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\GENERIC_DEVICE.template
+2025-09-12 08:34:26.451   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.451   Installing the file.
+2025-09-12 08:34:26.452   Successfully installed the file.
+2025-09-12 08:34:26.452   -- File entry --
+2025-09-12 08:34:26.452   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\GENERIC_DEVICE_ARGS.template
+2025-09-12 08:34:26.452   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.452   Installing the file.
+2025-09-12 08:34:26.453   Successfully installed the file.
+2025-09-12 08:34:26.453   -- File entry --
+2025-09-12 08:34:26.454   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\GEVISCOPE_VIDEO_DEVICE.template
+2025-09-12 08:34:26.454   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.454   Installing the file.
+2025-09-12 08:34:26.454   Successfully installed the file.
+2025-09-12 08:34:26.454   -- File entry --
+2025-09-12 08:34:26.455   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\HEITEL_WEBAPI.template
+2025-09-12 08:34:26.455   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.455   Installing the file.
+2025-09-12 08:34:26.455   Successfully installed the file.
+2025-09-12 08:34:26.455   -- File entry --
+2025-09-12 08:34:26.456   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\HIDDEF_CLEARDLG.template
+2025-09-12 08:34:26.456   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.456   Installing the file.
+2025-09-12 08:34:26.456   Successfully installed the file.
+2025-09-12 08:34:26.456   -- File entry --
+2025-09-12 08:34:26.457   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\HIDDEF_GOTOPRESET.template
+2025-09-12 08:34:26.457   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.457   Installing the file.
+2025-09-12 08:34:26.458   Successfully installed the file.
+2025-09-12 08:34:26.458   -- File entry --
+2025-09-12 08:34:26.458   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\HIDDEF_INPUTTEXT.template
+2025-09-12 08:34:26.458   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.458   Installing the file.
+2025-09-12 08:34:26.459   Successfully installed the file.
+2025-09-12 08:34:26.459   -- File entry --
+2025-09-12 08:34:26.459   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\HIDDEF_MOVEBUTTONS.template
+2025-09-12 08:34:26.459   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.459   Installing the file.
+2025-09-12 08:34:26.460   Successfully installed the file.
+2025-09-12 08:34:26.460   -- File entry --
+2025-09-12 08:34:26.460   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\HIDDEF_NEXTDLG.template
+2025-09-12 08:34:26.460   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.460   Installing the file.
+2025-09-12 08:34:26.461   Successfully installed the file.
+2025-09-12 08:34:26.461   -- File entry --
+2025-09-12 08:34:26.461   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\HIDDEF_PLAYBACK_PLAY_PAUSE.template
+2025-09-12 08:34:26.461   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.461   Installing the file.
+2025-09-12 08:34:26.462   Successfully installed the file.
+2025-09-12 08:34:26.462   -- File entry --
+2025-09-12 08:34:26.462   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\HIDDEF_PLAYBACK_SPAN_MARKER.template
+2025-09-12 08:34:26.462   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.462   Installing the file.
+2025-09-12 08:34:26.463   Successfully installed the file.
+2025-09-12 08:34:26.463   -- File entry --
+2025-09-12 08:34:26.463   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\HIDDEF_PREVDLG.template
+2025-09-12 08:34:26.463   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.463   Installing the file.
+2025-09-12 08:34:26.464   Successfully installed the file.
+2025-09-12 08:34:26.464   -- File entry --
+2025-09-12 08:34:26.464   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\HIDDEF_SELECTTREEVIEW.template
+2025-09-12 08:34:26.464   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.464   Installing the file.
+2025-09-12 08:34:26.465   Successfully installed the file.
+2025-09-12 08:34:26.465   -- File entry --
+2025-09-12 08:34:26.465   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\HIDDEF_SETBOOKMARK.template
+2025-09-12 08:34:26.465   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.465   Installing the file.
+2025-09-12 08:34:26.466   Successfully installed the file.
+2025-09-12 08:34:26.466   -- File entry --
+2025-09-12 08:34:26.466   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\HIDDEF_SETGRID.template
+2025-09-12 08:34:26.466   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.466   Installing the file.
+2025-09-12 08:34:26.467   Successfully installed the file.
+2025-09-12 08:34:26.467   -- File entry --
+2025-09-12 08:34:26.467   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\HIDDEF_SHOWPLAYBACKS.template
+2025-09-12 08:34:26.467   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.467   Installing the file.
+2025-09-12 08:34:26.467   Successfully installed the file.
+2025-09-12 08:34:26.467   -- File entry --
+2025-09-12 08:34:26.468   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\HIDDEF_SHOWSCENARIO.template
+2025-09-12 08:34:26.468   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.468   Installing the file.
+2025-09-12 08:34:26.469   Successfully installed the file.
+2025-09-12 08:34:26.469   -- File entry --
+2025-09-12 08:34:26.469   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\HIDDEF_SHOWSTREAM.template
+2025-09-12 08:34:26.469   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.469   Installing the file.
+2025-09-12 08:34:26.470   Successfully installed the file.
+2025-09-12 08:34:26.470   -- File entry --
+2025-09-12 08:34:26.470   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\HIDDEF_STOREPRESET.template
+2025-09-12 08:34:26.470   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.470   Installing the file.
+2025-09-12 08:34:26.471   Successfully installed the file.
+2025-09-12 08:34:26.471   -- File entry --
+2025-09-12 08:34:26.471   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\HIDDEF_WRITE_DP.template
+2025-09-12 08:34:26.472   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.472   Installing the file.
+2025-09-12 08:34:26.472   Successfully installed the file.
+2025-09-12 08:34:26.472   -- File entry --
+2025-09-12 08:34:26.472   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\HIDDEF_WRITE_DP_SCRIPTED.template
+2025-09-12 08:34:26.472   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.472   Installing the file.
+2025-09-12 08:34:26.473   Successfully installed the file.
+2025-09-12 08:34:26.473   -- File entry --
+2025-09-12 08:34:26.473   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\HIKVISION_VIDEO_DEVICE.template
+2025-09-12 08:34:26.473   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.473   Installing the file.
+2025-09-12 08:34:26.474   Successfully installed the file.
+2025-09-12 08:34:26.474   -- File entry --
+2025-09-12 08:34:26.474   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\HOST_ENTRY.template
+2025-09-12 08:34:26.474   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.474   Installing the file.
+2025-09-12 08:34:26.475   Successfully installed the file.
+2025-09-12 08:34:26.475   -- File entry --
+2025-09-12 08:34:26.475   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_ALPR.include
+2025-09-12 08:34:26.475   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.475   Installing the file.
+2025-09-12 08:34:26.476   Successfully installed the file.
+2025-09-12 08:34:26.476   -- File entry --
+2025-09-12 08:34:26.476   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_ASSEMBLYTASK_BASICS.include
+2025-09-12 08:34:26.476   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.476   Installing the file.
+2025-09-12 08:34:26.477   Successfully installed the file.
+2025-09-12 08:34:26.477   -- File entry --
+2025-09-12 08:34:26.477   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_ASSEMBLY_COULDASSIGNED.include
+2025-09-12 08:34:26.477   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.477   Installing the file.
+2025-09-12 08:34:26.478   Successfully installed the file.
+2025-09-12 08:34:26.478   -- File entry --
+2025-09-12 08:34:26.479   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_ASSIGNED_ASSEMBLIES.include
+2025-09-12 08:34:26.479   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.479   Installing the file.
+2025-09-12 08:34:26.479   Successfully installed the file.
+2025-09-12 08:34:26.479   -- File entry --
+2025-09-12 08:34:26.479   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_AUDIO_ASSOCIATION.include
+2025-09-12 08:34:26.479   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.479   Installing the file.
+2025-09-12 08:34:26.480   Successfully installed the file.
+2025-09-12 08:34:26.480   -- File entry --
+2025-09-12 08:34:26.481   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_AUDIO_ISDEVICE.include
+2025-09-12 08:34:26.481   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.481   Installing the file.
+2025-09-12 08:34:26.481   Successfully installed the file.
+2025-09-12 08:34:26.481   -- File entry --
+2025-09-12 08:34:26.482   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_CONTROLLER.include
+2025-09-12 08:34:26.482   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.482   Installing the file.
+2025-09-12 08:34:26.482   Successfully installed the file.
+2025-09-12 08:34:26.482   -- File entry --
+2025-09-12 08:34:26.483   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_DEVICEEVENTS.include
+2025-09-12 08:34:26.483   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.483   Installing the file.
+2025-09-12 08:34:26.484   Successfully installed the file.
+2025-09-12 08:34:26.484   -- File entry --
+2025-09-12 08:34:26.485   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_EMAIL_SENDER_ISDEVICE.include
+2025-09-12 08:34:26.485   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.485   Installing the file.
+2025-09-12 08:34:26.485   Successfully installed the file.
+2025-09-12 08:34:26.485   -- File entry --
+2025-09-12 08:34:26.486   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_EVENTTASK_BASICS.include
+2025-09-12 08:34:26.486   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.486   Installing the file.
+2025-09-12 08:34:26.487   Successfully installed the file.
+2025-09-12 08:34:26.487   -- File entry --
+2025-09-12 08:34:26.487   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_EVENTTASK_PTZ_PROPS.include
+2025-09-12 08:34:26.487   Time stamp of our file: 2025-07-11 13:18:10.000
+2025-09-12 08:34:26.487   Installing the file.
+2025-09-12 08:34:26.487   Successfully installed the file.
+2025-09-12 08:34:26.487   -- File entry --
+2025-09-12 08:34:26.488   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_EVENTTASK_QUEUE_PROPS.include
+2025-09-12 08:34:26.488   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.488   Installing the file.
+2025-09-12 08:34:26.488   Successfully installed the file.
+2025-09-12 08:34:26.489   -- File entry --
+2025-09-12 08:34:26.489   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_EVENT_AUTO_END.include
+2025-09-12 08:34:26.489   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.489   Installing the file.
+2025-09-12 08:34:26.490   Successfully installed the file.
+2025-09-12 08:34:26.490   -- File entry --
+2025-09-12 08:34:26.490   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_EVENT_AUTO_START.include
+2025-09-12 08:34:26.490   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.490   Installing the file.
+2025-09-12 08:34:26.491   Successfully installed the file.
+2025-09-12 08:34:26.491   -- File entry --
+2025-09-12 08:34:26.492   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_EXPORT_REPORT_ISDEVICE.include
+2025-09-12 08:34:26.492   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.492   Installing the file.
+2025-09-12 08:34:26.493   Successfully installed the file.
+2025-09-12 08:34:26.493   -- File entry --
+2025-09-12 08:34:26.493   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_GLOBAL_ADEPTSETTINGS.include
+2025-09-12 08:34:26.493   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.493   Installing the file.
+2025-09-12 08:34:26.494   Successfully installed the file.
+2025-09-12 08:34:26.494   -- File entry --
+2025-09-12 08:34:26.494   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_GLOBAL_AUDIOINPUTS.include
+2025-09-12 08:34:26.494   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.494   Installing the file.
+2025-09-12 08:34:26.495   Successfully installed the file.
+2025-09-12 08:34:26.495   -- File entry --
+2025-09-12 08:34:26.495   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_GLOBAL_CAMERAS.include
+2025-09-12 08:34:26.495   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.495   Installing the file.
+2025-09-12 08:34:26.496   Successfully installed the file.
+2025-09-12 08:34:26.496   -- File entry --
+2025-09-12 08:34:26.496   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_GLOBAL_GROUPS.include
+2025-09-12 08:34:26.496   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.496   Installing the file.
+2025-09-12 08:34:26.497   Successfully installed the file.
+2025-09-12 08:34:26.497   -- File entry --
+2025-09-12 08:34:26.497   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_GLOBAL_IFPROXY.include
+2025-09-12 08:34:26.497   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.497   Installing the file.
+2025-09-12 08:34:26.497   Successfully installed the file.
+2025-09-12 08:34:26.499   -- File entry --
+2025-09-12 08:34:26.499   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_GLOBAL_MULTICAST.include
+2025-09-12 08:34:26.499   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.499   Installing the file.
+2025-09-12 08:34:26.499   Successfully installed the file.
+2025-09-12 08:34:26.499   -- File entry --
+2025-09-12 08:34:26.500   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_GLOBAL_SRVPROXY.include
+2025-09-12 08:34:26.500   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.500   Installing the file.
+2025-09-12 08:34:26.500   Successfully installed the file.
+2025-09-12 08:34:26.500   -- File entry --
+2025-09-12 08:34:26.501   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_GLOBAL_STREAMING.include
+2025-09-12 08:34:26.501   Time stamp of our file: 2025-08-13 12:07:20.000
+2025-09-12 08:34:26.501   Installing the file.
+2025-09-12 08:34:26.501   Successfully installed the file.
+2025-09-12 08:34:26.502   -- File entry --
+2025-09-12 08:34:26.502   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_GLOBAL_WEB_CONFIG.include
+2025-09-12 08:34:26.502   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.502   Installing the file.
+2025-09-12 08:34:26.503   Successfully installed the file.
+2025-09-12 08:34:26.503   -- File entry --
+2025-09-12 08:34:26.503   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_HAS_IO.include
+2025-09-12 08:34:26.503   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.503   Installing the file.
+2025-09-12 08:34:26.504   Successfully installed the file.
+2025-09-12 08:34:26.504   -- File entry --
+2025-09-12 08:34:26.504   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_IS_AUDIOPTT.include
+2025-09-12 08:34:26.504   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.504   Installing the file.
+2025-09-12 08:34:26.505   Successfully installed the file.
+2025-09-12 08:34:26.505   -- File entry --
+2025-09-12 08:34:26.505   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_IS_DIGIO.include
+2025-09-12 08:34:26.505   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.505   Installing the file.
+2025-09-12 08:34:26.506   Successfully installed the file.
+2025-09-12 08:34:26.506   -- File entry --
+2025-09-12 08:34:26.506   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_IS_MOTIONDETECTIONZONE.include
+2025-09-12 08:34:26.507   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.507   Installing the file.
+2025-09-12 08:34:26.507   Successfully installed the file.
+2025-09-12 08:34:26.507   -- File entry --
+2025-09-12 08:34:26.507   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_METAINFORMATION.include
+2025-09-12 08:34:26.507   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.507   Installing the file.
+2025-09-12 08:34:26.509   Successfully installed the file.
+2025-09-12 08:34:26.509   -- File entry --
+2025-09-12 08:34:26.509   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_MODBUS_IO_DEVICE_ANALOG_INPUTS.include
+2025-09-12 08:34:26.509   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.509   Installing the file.
+2025-09-12 08:34:26.510   Successfully installed the file.
+2025-09-12 08:34:26.510   -- File entry --
+2025-09-12 08:34:26.510   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_MODBUS_IO_DEVICE_ANALOG_OUTPUTS.include
+2025-09-12 08:34:26.510   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.510   Installing the file.
+2025-09-12 08:34:26.510   Successfully installed the file.
+2025-09-12 08:34:26.511   -- File entry --
+2025-09-12 08:34:26.511   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_MODBUS_IO_DEVICE_BASE.include
+2025-09-12 08:34:26.511   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.511   Installing the file.
+2025-09-12 08:34:26.512   Successfully installed the file.
+2025-09-12 08:34:26.512   -- File entry --
+2025-09-12 08:34:26.512   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_MODBUS_IO_DEVICE_DIGITAL_INPUTS.include
+2025-09-12 08:34:26.513   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.513   Installing the file.
+2025-09-12 08:34:26.513   Successfully installed the file.
+2025-09-12 08:34:26.513   -- File entry --
+2025-09-12 08:34:26.514   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_MODBUS_IO_DEVICE_DIGITAL_OUTPUTS.include
+2025-09-12 08:34:26.514   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.514   Installing the file.
+2025-09-12 08:34:26.515   Successfully installed the file.
+2025-09-12 08:34:26.515   -- File entry --
+2025-09-12 08:34:26.515   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_MOTIONDETECTION.include
+2025-09-12 08:34:26.515   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.515   Installing the file.
+2025-09-12 08:34:26.516   Successfully installed the file.
+2025-09-12 08:34:26.516   -- File entry --
+2025-09-12 08:34:26.516   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_MTND_GLOBAL_GROUPS.include
+2025-09-12 08:34:26.516   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.516   Installing the file.
+2025-09-12 08:34:26.517   Successfully installed the file.
+2025-09-12 08:34:26.517   -- File entry --
+2025-09-12 08:34:26.517   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_MTND_MOTIONZONE_BASICS.include
+2025-09-12 08:34:26.517   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.517   Installing the file.
+2025-09-12 08:34:26.518   Successfully installed the file.
+2025-09-12 08:34:26.518   -- File entry --
+2025-09-12 08:34:26.518   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_MTND_MOTIONZONE_SIMPLE.include
+2025-09-12 08:34:26.518   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.518   Installing the file.
+2025-09-12 08:34:26.519   Successfully installed the file.
+2025-09-12 08:34:26.519   -- File entry --
+2025-09-12 08:34:26.519   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_MTND_SMARTDETECT_CLASSES.include
+2025-09-12 08:34:26.519   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.519   Installing the file.
+2025-09-12 08:34:26.520   Successfully installed the file.
+2025-09-12 08:34:26.520   -- File entry --
+2025-09-12 08:34:26.520   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_MTND_SMARTDETECT_PROPS.include
+2025-09-12 08:34:26.520   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.520   Installing the file.
+2025-09-12 08:34:26.521   Successfully installed the file.
+2025-09-12 08:34:26.521   -- File entry --
+2025-09-12 08:34:26.521   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_PERMITTOKEN_BASICS.include
+2025-09-12 08:34:26.521   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.521   Installing the file.
+2025-09-12 08:34:26.522   Successfully installed the file.
+2025-09-12 08:34:26.522   -- File entry --
+2025-09-12 08:34:26.522   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_PLAYBACK_PROXY_ISDEVICE.include
+2025-09-12 08:34:26.522   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.522   Installing the file.
+2025-09-12 08:34:26.523   Successfully installed the file.
+2025-09-12 08:34:26.523   -- File entry --
+2025-09-12 08:34:26.523   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_PRIVACYZONES.include
+2025-09-12 08:34:26.523   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.523   Installing the file.
+2025-09-12 08:34:26.524   Successfully installed the file.
+2025-09-12 08:34:26.524   -- File entry --
+2025-09-12 08:34:26.524   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_PRVC_GLOBAL_GROUPS.include
+2025-09-12 08:34:26.524   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.524   Installing the file.
+2025-09-12 08:34:26.525   Successfully installed the file.
+2025-09-12 08:34:26.525   -- File entry --
+2025-09-12 08:34:26.525   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_PRVC_IS_FEATUREPRIVACYZONE.include
+2025-09-12 08:34:26.525   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.525   Installing the file.
+2025-09-12 08:34:26.526   Successfully installed the file.
+2025-09-12 08:34:26.526   -- File entry --
+2025-09-12 08:34:26.527   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_PRVC_IS_OVERLAY.include
+2025-09-12 08:34:26.527   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.527   Installing the file.
+2025-09-12 08:34:26.528   Successfully installed the file.
+2025-09-12 08:34:26.528   -- File entry --
+2025-09-12 08:34:26.528   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_PRVC_IS_STRONGPRIVACYZONE.include
+2025-09-12 08:34:26.528   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.528   Installing the file.
+2025-09-12 08:34:26.528   Successfully installed the file.
+2025-09-12 08:34:26.529   -- File entry --
+2025-09-12 08:34:26.529   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_PRVC_PRIVACYZONE_BASICS.include
+2025-09-12 08:34:26.529   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.529   Installing the file.
+2025-09-12 08:34:26.530   Successfully installed the file.
+2025-09-12 08:34:26.530   -- File entry --
+2025-09-12 08:34:26.531   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_PRVC_SMARTDETECT_CLASSES.include
+2025-09-12 08:34:26.531   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.531   Installing the file.
+2025-09-12 08:34:26.531   Successfully installed the file.
+2025-09-12 08:34:26.531   -- File entry --
+2025-09-12 08:34:26.532   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_PRVC_SMARTDETECT_PROPS.include
+2025-09-12 08:34:26.532   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.532   Installing the file.
+2025-09-12 08:34:26.532   Successfully installed the file.
+2025-09-12 08:34:26.532   -- File entry --
+2025-09-12 08:34:26.533   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_PRVC_STRONGPRIVACYZONE_PERMITS.include
+2025-09-12 08:34:26.533   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.533   Installing the file.
+2025-09-12 08:34:26.533   Successfully installed the file.
+2025-09-12 08:34:26.533   -- File entry --
+2025-09-12 08:34:26.534   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_PTZ_INTERNAL.include
+2025-09-12 08:34:26.534   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.534   Installing the file.
+2025-09-12 08:34:26.534   Successfully installed the file.
+2025-09-12 08:34:26.534   -- File entry --
+2025-09-12 08:34:26.535   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_PTZ_ISDEVICE.include
+2025-09-12 08:34:26.535   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.535   Installing the file.
+2025-09-12 08:34:26.535   Successfully installed the file.
+2025-09-12 08:34:26.535   -- File entry --
+2025-09-12 08:34:26.536   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_PTZ_PRESETS_DEVICE.include
+2025-09-12 08:34:26.536   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.536   Installing the file.
+2025-09-12 08:34:26.536   Successfully installed the file.
+2025-09-12 08:34:26.536   -- File entry --
+2025-09-12 08:34:26.537   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_PTZ_PROPERTIES.include
+2025-09-12 08:34:26.537   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.537   Installing the file.
+2025-09-12 08:34:26.537   Successfully installed the file.
+2025-09-12 08:34:26.537   -- File entry --
+2025-09-12 08:34:26.538   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_RECORDING.include
+2025-09-12 08:34:26.538   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.538   Installing the file.
+2025-09-12 08:34:26.538   Successfully installed the file.
+2025-09-12 08:34:26.538   -- File entry --
+2025-09-12 08:34:26.538   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_SORHEA_SOLARIS_COLUMNS.include
+2025-09-12 08:34:26.538   Time stamp of our file: 2025-07-11 13:18:10.000
+2025-09-12 08:34:26.538   Installing the file.
+2025-09-12 08:34:26.539   Successfully installed the file.
+2025-09-12 08:34:26.539   -- File entry --
+2025-09-12 08:34:26.539   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_SORHEA_SOLARIS_COLUMN_ENTRY_BASE.include
+2025-09-12 08:34:26.539   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.539   Installing the file.
+2025-09-12 08:34:26.540   Successfully installed the file.
+2025-09-12 08:34:26.540   -- File entry --
+2025-09-12 08:34:26.540   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_SORHEA_SOLARIS_INTRUSION.include
+2025-09-12 08:34:26.540   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.540   Installing the file.
+2025-09-12 08:34:26.541   Successfully installed the file.
+2025-09-12 08:34:26.541   -- File entry --
+2025-09-12 08:34:26.541   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_SORHEA_SOLARIS_MANIPULATION.include
+2025-09-12 08:34:26.541   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.541   Installing the file.
+2025-09-12 08:34:26.541   Successfully installed the file.
+2025-09-12 08:34:26.541   -- File entry --
+2025-09-12 08:34:26.543   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_SORHEA_SOLARIS_TECFAULT.include
+2025-09-12 08:34:26.543   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.543   Installing the file.
+2025-09-12 08:34:26.544   Successfully installed the file.
+2025-09-12 08:34:26.544   -- File entry --
+2025-09-12 08:34:26.544   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_STREAM_ON_DEMAND.include
+2025-09-12 08:34:26.544   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.544   Installing the file.
+2025-09-12 08:34:26.545   Successfully installed the file.
+2025-09-12 08:34:26.545   -- File entry --
+2025-09-12 08:34:26.545   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INC_VIMACC_HID_BASE.include
+2025-09-12 08:34:26.545   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.545   Installing the file.
+2025-09-12 08:34:26.546   Successfully installed the file.
+2025-09-12 08:34:26.546   -- File entry --
+2025-09-12 08:34:26.546   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\INDIGOVISION_IV_VIDEO_DEVICE.template
+2025-09-12 08:34:26.546   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.546   Installing the file.
+2025-09-12 08:34:26.546   Successfully installed the file.
+2025-09-12 08:34:26.546   -- File entry --
+2025-09-12 08:34:26.547   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\MOBOTIX_AUDIO_DEVICE.template
+2025-09-12 08:34:26.547   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.547   Installing the file.
+2025-09-12 08:34:26.547   Successfully installed the file.
+2025-09-12 08:34:26.547   -- File entry --
+2025-09-12 08:34:26.548   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\MOBOTIX_VIDEO_DEVICE.template
+2025-09-12 08:34:26.548   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.548   Installing the file.
+2025-09-12 08:34:26.548   Successfully installed the file.
+2025-09-12 08:34:26.548   -- File entry --
+2025-09-12 08:34:26.549   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\MODBUS_IO_DEVICE.template
+2025-09-12 08:34:26.549   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.549   Installing the file.
+2025-09-12 08:34:26.549   Successfully installed the file.
+2025-09-12 08:34:26.549   -- File entry --
+2025-09-12 08:34:26.549   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\MODBUS_IO_DEVICE_ADAM6015.template
+2025-09-12 08:34:26.549   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.549   Installing the file.
+2025-09-12 08:34:26.551   Successfully installed the file.
+2025-09-12 08:34:26.551   -- File entry --
+2025-09-12 08:34:26.551   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\MODBUS_IO_DEVICE_ADAM6017.template
+2025-09-12 08:34:26.551   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.551   Installing the file.
+2025-09-12 08:34:26.552   Successfully installed the file.
+2025-09-12 08:34:26.552   -- File entry --
+2025-09-12 08:34:26.552   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\MODBUS_IO_DEVICE_ADAM6018.template
+2025-09-12 08:34:26.552   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.552   Installing the file.
+2025-09-12 08:34:26.553   Successfully installed the file.
+2025-09-12 08:34:26.553   -- File entry --
+2025-09-12 08:34:26.553   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\MODBUS_IO_DEVICE_ADAM6018plus.template
+2025-09-12 08:34:26.553   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.553   Installing the file.
+2025-09-12 08:34:26.554   Successfully installed the file.
+2025-09-12 08:34:26.554   -- File entry --
+2025-09-12 08:34:26.554   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\MODBUS_IO_DEVICE_ADAM6024.template
+2025-09-12 08:34:26.554   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.554   Installing the file.
+2025-09-12 08:34:26.555   Successfully installed the file.
+2025-09-12 08:34:26.555   -- File entry --
+2025-09-12 08:34:26.555   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\MODBUS_IO_DEVICE_ADAM6050.template
+2025-09-12 08:34:26.555   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.555   Installing the file.
+2025-09-12 08:34:26.556   Successfully installed the file.
+2025-09-12 08:34:26.556   -- File entry --
+2025-09-12 08:34:26.557   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\MODBUS_IO_DEVICE_ADAM6051.template
+2025-09-12 08:34:26.557   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.557   Installing the file.
+2025-09-12 08:34:26.557   Successfully installed the file.
+2025-09-12 08:34:26.557   -- File entry --
+2025-09-12 08:34:26.558   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\MODBUS_IO_DEVICE_ADAM6052.template
+2025-09-12 08:34:26.558   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.558   Installing the file.
+2025-09-12 08:34:26.558   Successfully installed the file.
+2025-09-12 08:34:26.558   -- File entry --
+2025-09-12 08:34:26.559   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\MODBUS_IO_DEVICE_ADAM6060_ADAM6066.template
+2025-09-12 08:34:26.559   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.559   Installing the file.
+2025-09-12 08:34:26.559   Successfully installed the file.
+2025-09-12 08:34:26.559   -- File entry --
+2025-09-12 08:34:26.560   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\MODBUS_IO_DEVICE_PATLITE_LA6_SIGNAL_TOWER.template
+2025-09-12 08:34:26.560   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.560   Installing the file.
+2025-09-12 08:34:26.560   Successfully installed the file.
+2025-09-12 08:34:26.560   -- File entry --
+2025-09-12 08:34:26.560   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\MODBUS_IO_DEVICE_SORHEA_MAXIBUS_UNIV_GFENCE3000.template
+2025-09-12 08:34:26.560   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.560   Installing the file.
+2025-09-12 08:34:26.561   Successfully installed the file.
+2025-09-12 08:34:26.562   -- File entry --
+2025-09-12 08:34:26.562   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\MODBUS_IO_DEVICE_SORHEA_MAXIBUS_UNIV_SOLARIS.template
+2025-09-12 08:34:26.562   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.562   Installing the file.
+2025-09-12 08:34:26.562   Successfully installed the file.
+2025-09-12 08:34:26.563   -- File entry --
+2025-09-12 08:34:26.563   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\MODBUS_IO_DEVICE_WT_WEBIO40-57838.template
+2025-09-12 08:34:26.563   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.563   Installing the file.
+2025-09-12 08:34:26.564   Successfully installed the file.
+2025-09-12 08:34:26.564   -- File entry --
+2025-09-12 08:34:26.564   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\MOXA_IO_DEVICE.template
+2025-09-12 08:34:26.564   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.564   Installing the file.
+2025-09-12 08:34:26.565   Successfully installed the file.
+2025-09-12 08:34:26.565   -- File entry --
+2025-09-12 08:34:26.565   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\MOXA_IO_E1K_DEVICE.template
+2025-09-12 08:34:26.565   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.565   Installing the file.
+2025-09-12 08:34:26.566   Successfully installed the file.
+2025-09-12 08:34:26.566   -- File entry --
+2025-09-12 08:34:26.566   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\MOXA_VIDEO_DEVICE.template
+2025-09-12 08:34:26.566   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.566   Installing the file.
+2025-09-12 08:34:26.567   Successfully installed the file.
+2025-09-12 08:34:26.567   -- File entry --
+2025-09-12 08:34:26.567   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\MTND_MOTIONZONE.template
+2025-09-12 08:34:26.567   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.567   Installing the file.
+2025-09-12 08:34:26.568   Successfully installed the file.
+2025-09-12 08:34:26.568   -- File entry --
+2025-09-12 08:34:26.568   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\MTND_MOTIONZONE_MODEL_CUSTOM1.template
+2025-09-12 08:34:26.568   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.568   Installing the file.
+2025-09-12 08:34:26.569   Successfully installed the file.
+2025-09-12 08:34:26.569   -- File entry --
+2025-09-12 08:34:26.569   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\MTND_MOTIONZONE_MODEL_CUSTOM2.template
+2025-09-12 08:34:26.569   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.569   Installing the file.
+2025-09-12 08:34:26.569   Successfully installed the file.
+2025-09-12 08:34:26.569   -- File entry --
+2025-09-12 08:34:26.570   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\MTND_MOTIONZONE_MODEL_CUSTOM3.template
+2025-09-12 08:34:26.570   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.570   Installing the file.
+2025-09-12 08:34:26.571   Successfully installed the file.
+2025-09-12 08:34:26.571   -- File entry --
+2025-09-12 08:34:26.571   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\MTND_MOTIONZONE_OBJECT.template
+2025-09-12 08:34:26.571   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.571   Installing the file.
+2025-09-12 08:34:26.572   Successfully installed the file.
+2025-09-12 08:34:26.572   -- File entry --
+2025-09-12 08:34:26.572   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\ONVIF_VIDEO_DEVICE.template
+2025-09-12 08:34:26.572   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.572   Installing the file.
+2025-09-12 08:34:26.573   Successfully installed the file.
+2025-09-12 08:34:26.573   -- File entry --
+2025-09-12 08:34:26.574   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\OP_MODE.template
+2025-09-12 08:34:26.574   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.574   Installing the file.
+2025-09-12 08:34:26.575   Successfully installed the file.
+2025-09-12 08:34:26.575   -- File entry --
+2025-09-12 08:34:26.575   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\PERMITTOKEN_IODEVICE.template
+2025-09-12 08:34:26.575   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.575   Installing the file.
+2025-09-12 08:34:26.576   Successfully installed the file.
+2025-09-12 08:34:26.576   -- File entry --
+2025-09-12 08:34:26.576   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\PRVC_OVERLAY.template
+2025-09-12 08:34:26.576   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.576   Installing the file.
+2025-09-12 08:34:26.577   Successfully installed the file.
+2025-09-12 08:34:26.577   -- File entry --
+2025-09-12 08:34:26.577   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\PRVC_PRIVACYZONE.template
+2025-09-12 08:34:26.577   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.577   Installing the file.
+2025-09-12 08:34:26.577   Successfully installed the file.
+2025-09-12 08:34:26.577   -- File entry --
+2025-09-12 08:34:26.578   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\PRVC_PRIVACYZONE_FACE.template
+2025-09-12 08:34:26.578   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.578   Installing the file.
+2025-09-12 08:34:26.578   Successfully installed the file.
+2025-09-12 08:34:26.578   -- File entry --
+2025-09-12 08:34:26.579   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\PRVC_PRIVACYZONE_MODEL_CUSTOM1.template
+2025-09-12 08:34:26.579   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.579   Installing the file.
+2025-09-12 08:34:26.579   Successfully installed the file.
+2025-09-12 08:34:26.579   -- File entry --
+2025-09-12 08:34:26.580   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\PRVC_PRIVACYZONE_MODEL_CUSTOM2.template
+2025-09-12 08:34:26.580   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.580   Installing the file.
+2025-09-12 08:34:26.581   Successfully installed the file.
+2025-09-12 08:34:26.581   -- File entry --
+2025-09-12 08:34:26.581   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\PRVC_PRIVACYZONE_MODEL_CUSTOM3.template
+2025-09-12 08:34:26.581   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.581   Installing the file.
+2025-09-12 08:34:26.582   Successfully installed the file.
+2025-09-12 08:34:26.582   -- File entry --
+2025-09-12 08:34:26.582   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\PRVC_PRIVACYZONE_OBJECT.template
+2025-09-12 08:34:26.582   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.582   Installing the file.
+2025-09-12 08:34:26.583   Successfully installed the file.
+2025-09-12 08:34:26.583   -- File entry --
+2025-09-12 08:34:26.583   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\PRVC_PRIVACYZONE_PERSON.template
+2025-09-12 08:34:26.583   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.583   Installing the file.
+2025-09-12 08:34:26.584   Successfully installed the file.
+2025-09-12 08:34:26.584   -- File entry --
+2025-09-12 08:34:26.584   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\PRVC_STRONGPRIVACYZONE.template
+2025-09-12 08:34:26.584   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.584   Installing the file.
+2025-09-12 08:34:26.585   Successfully installed the file.
+2025-09-12 08:34:26.585   -- File entry --
+2025-09-12 08:34:26.585   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\PRVC_STRONGPRIVACYZONE_FACE.template
+2025-09-12 08:34:26.585   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.585   Installing the file.
+2025-09-12 08:34:26.586   Successfully installed the file.
+2025-09-12 08:34:26.586   -- File entry --
+2025-09-12 08:34:26.586   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\PRVC_STRONGPRIVACYZONE_OBJECT.template
+2025-09-12 08:34:26.586   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.586   Installing the file.
+2025-09-12 08:34:26.587   Successfully installed the file.
+2025-09-12 08:34:26.587   -- File entry --
+2025-09-12 08:34:26.587   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\PRVC_STRONGPRIVACYZONE_PERSON.template
+2025-09-12 08:34:26.587   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.587   Installing the file.
+2025-09-12 08:34:26.588   Successfully installed the file.
+2025-09-12 08:34:26.588   -- File entry --
+2025-09-12 08:34:26.588   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\RCPP_VIDEO_DEVICE.template
+2025-09-12 08:34:26.588   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.588   Installing the file.
+2025-09-12 08:34:26.589   Successfully installed the file.
+2025-09-12 08:34:26.589   -- File entry --
+2025-09-12 08:34:26.589   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SERIAL_RCPP_CLIENT.template
+2025-09-12 08:34:26.589   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.589   Installing the file.
+2025-09-12 08:34:26.590   Successfully installed the file.
+2025-09-12 08:34:26.590   -- File entry --
+2025-09-12 08:34:26.590   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SERIAL_TCP_CLIENT.template
+2025-09-12 08:34:26.590   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.590   Installing the file.
+2025-09-12 08:34:26.591   Successfully installed the file.
+2025-09-12 08:34:26.591   -- File entry --
+2025-09-12 08:34:26.591   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SERIAL_TCP_CLIENT_WUT.template
+2025-09-12 08:34:26.591   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.591   Installing the file.
+2025-09-12 08:34:26.591   Successfully installed the file.
+2025-09-12 08:34:26.592   -- File entry --
+2025-09-12 08:34:26.593   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SIEMENS_SISTORE_CX_DEVICE.template
+2025-09-12 08:34:26.593   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.593   Installing the file.
+2025-09-12 08:34:26.593   Successfully installed the file.
+2025-09-12 08:34:26.593   -- File entry --
+2025-09-12 08:34:26.594   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SONY_VIDEO_DEVICE.template
+2025-09-12 08:34:26.594   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.594   Installing the file.
+2025-09-12 08:34:26.594   Successfully installed the file.
+2025-09-12 08:34:26.594   -- File entry --
+2025-09-12 08:34:26.595   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_01.template
+2025-09-12 08:34:26.595   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.595   Installing the file.
+2025-09-12 08:34:26.596   Successfully installed the file.
+2025-09-12 08:34:26.596   -- File entry --
+2025-09-12 08:34:26.596   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_02.template
+2025-09-12 08:34:26.596   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.596   Installing the file.
+2025-09-12 08:34:26.597   Successfully installed the file.
+2025-09-12 08:34:26.597   -- File entry --
+2025-09-12 08:34:26.597   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_03.template
+2025-09-12 08:34:26.597   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.597   Installing the file.
+2025-09-12 08:34:26.598   Successfully installed the file.
+2025-09-12 08:34:26.598   -- File entry --
+2025-09-12 08:34:26.598   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_04.template
+2025-09-12 08:34:26.598   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.598   Installing the file.
+2025-09-12 08:34:26.599   Successfully installed the file.
+2025-09-12 08:34:26.599   -- File entry --
+2025-09-12 08:34:26.600   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_05.template
+2025-09-12 08:34:26.600   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.600   Installing the file.
+2025-09-12 08:34:26.600   Successfully installed the file.
+2025-09-12 08:34:26.600   -- File entry --
+2025-09-12 08:34:26.600   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_06.template
+2025-09-12 08:34:26.600   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.600   Installing the file.
+2025-09-12 08:34:26.601   Successfully installed the file.
+2025-09-12 08:34:26.601   -- File entry --
+2025-09-12 08:34:26.601   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_07.template
+2025-09-12 08:34:26.601   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.601   Installing the file.
+2025-09-12 08:34:26.602   Successfully installed the file.
+2025-09-12 08:34:26.602   -- File entry --
+2025-09-12 08:34:26.602   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_08.template
+2025-09-12 08:34:26.602   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.602   Installing the file.
+2025-09-12 08:34:26.603   Successfully installed the file.
+2025-09-12 08:34:26.603   -- File entry --
+2025-09-12 08:34:26.603   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_09.template
+2025-09-12 08:34:26.604   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.604   Installing the file.
+2025-09-12 08:34:26.604   Successfully installed the file.
+2025-09-12 08:34:26.604   -- File entry --
+2025-09-12 08:34:26.605   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_10.template
+2025-09-12 08:34:26.605   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.605   Installing the file.
+2025-09-12 08:34:26.605   Successfully installed the file.
+2025-09-12 08:34:26.605   -- File entry --
+2025-09-12 08:34:26.606   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_11.template
+2025-09-12 08:34:26.606   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.606   Installing the file.
+2025-09-12 08:34:26.607   Successfully installed the file.
+2025-09-12 08:34:26.607   -- File entry --
+2025-09-12 08:34:26.607   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_12.template
+2025-09-12 08:34:26.608   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.608   Installing the file.
+2025-09-12 08:34:26.609   Successfully installed the file.
+2025-09-12 08:34:26.609   -- File entry --
+2025-09-12 08:34:26.609   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_13.template
+2025-09-12 08:34:26.609   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.609   Installing the file.
+2025-09-12 08:34:26.610   Successfully installed the file.
+2025-09-12 08:34:26.610   -- File entry --
+2025-09-12 08:34:26.610   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_14.template
+2025-09-12 08:34:26.610   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.610   Installing the file.
+2025-09-12 08:34:26.612   Successfully installed the file.
+2025-09-12 08:34:26.612   -- File entry --
+2025-09-12 08:34:26.612   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_15.template
+2025-09-12 08:34:26.612   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.612   Installing the file.
+2025-09-12 08:34:26.613   Successfully installed the file.
+2025-09-12 08:34:26.613   -- File entry --
+2025-09-12 08:34:26.613   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_16.template
+2025-09-12 08:34:26.613   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.613   Installing the file.
+2025-09-12 08:34:26.614   Successfully installed the file.
+2025-09-12 08:34:26.614   -- File entry --
+2025-09-12 08:34:26.614   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_17.template
+2025-09-12 08:34:26.614   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.614   Installing the file.
+2025-09-12 08:34:26.615   Successfully installed the file.
+2025-09-12 08:34:26.615   -- File entry --
+2025-09-12 08:34:26.615   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_18.template
+2025-09-12 08:34:26.615   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.615   Installing the file.
+2025-09-12 08:34:26.616   Successfully installed the file.
+2025-09-12 08:34:26.616   -- File entry --
+2025-09-12 08:34:26.616   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_19.template
+2025-09-12 08:34:26.616   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.616   Installing the file.
+2025-09-12 08:34:26.617   Successfully installed the file.
+2025-09-12 08:34:26.617   -- File entry --
+2025-09-12 08:34:26.617   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_20.template
+2025-09-12 08:34:26.617   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.617   Installing the file.
+2025-09-12 08:34:26.618   Successfully installed the file.
+2025-09-12 08:34:26.618   -- File entry --
+2025-09-12 08:34:26.618   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_21.template
+2025-09-12 08:34:26.618   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.618   Installing the file.
+2025-09-12 08:34:26.619   Successfully installed the file.
+2025-09-12 08:34:26.619   -- File entry --
+2025-09-12 08:34:26.619   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_22.template
+2025-09-12 08:34:26.619   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.619   Installing the file.
+2025-09-12 08:34:26.620   Successfully installed the file.
+2025-09-12 08:34:26.620   -- File entry --
+2025-09-12 08:34:26.620   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_23.template
+2025-09-12 08:34:26.620   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.620   Installing the file.
+2025-09-12 08:34:26.622   Successfully installed the file.
+2025-09-12 08:34:26.622   -- File entry --
+2025-09-12 08:34:26.623   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_24.template
+2025-09-12 08:34:26.623   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.623   Installing the file.
+2025-09-12 08:34:26.623   Successfully installed the file.
+2025-09-12 08:34:26.623   -- File entry --
+2025-09-12 08:34:26.624   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_25.template
+2025-09-12 08:34:26.624   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.624   Installing the file.
+2025-09-12 08:34:26.624   Successfully installed the file.
+2025-09-12 08:34:26.624   -- File entry --
+2025-09-12 08:34:26.624   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_26.template
+2025-09-12 08:34:26.625   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.625   Installing the file.
+2025-09-12 08:34:26.625   Successfully installed the file.
+2025-09-12 08:34:26.625   -- File entry --
+2025-09-12 08:34:26.626   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_27.template
+2025-09-12 08:34:26.626   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.626   Installing the file.
+2025-09-12 08:34:26.626   Successfully installed the file.
+2025-09-12 08:34:26.626   -- File entry --
+2025-09-12 08:34:26.627   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_28.template
+2025-09-12 08:34:26.627   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.627   Installing the file.
+2025-09-12 08:34:26.628   Successfully installed the file.
+2025-09-12 08:34:26.628   -- File entry --
+2025-09-12 08:34:26.628   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_29.template
+2025-09-12 08:34:26.628   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.628   Installing the file.
+2025-09-12 08:34:26.629   Successfully installed the file.
+2025-09-12 08:34:26.629   -- File entry --
+2025-09-12 08:34:26.630   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_30.template
+2025-09-12 08:34:26.630   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.630   Installing the file.
+2025-09-12 08:34:26.630   Successfully installed the file.
+2025-09-12 08:34:26.630   -- File entry --
+2025-09-12 08:34:26.630   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_31.template
+2025-09-12 08:34:26.630   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.630   Installing the file.
+2025-09-12 08:34:26.632   Successfully installed the file.
+2025-09-12 08:34:26.632   -- File entry --
+2025-09-12 08:34:26.632   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_32.template
+2025-09-12 08:34:26.632   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.632   Installing the file.
+2025-09-12 08:34:26.633   Successfully installed the file.
+2025-09-12 08:34:26.633   -- File entry --
+2025-09-12 08:34:26.633   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_33.template
+2025-09-12 08:34:26.634   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.634   Installing the file.
+2025-09-12 08:34:26.634   Successfully installed the file.
+2025-09-12 08:34:26.634   -- File entry --
+2025-09-12 08:34:26.635   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_34.template
+2025-09-12 08:34:26.635   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.635   Installing the file.
+2025-09-12 08:34:26.635   Successfully installed the file.
+2025-09-12 08:34:26.635   -- File entry --
+2025-09-12 08:34:26.635   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_35.template
+2025-09-12 08:34:26.635   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.635   Installing the file.
+2025-09-12 08:34:26.636   Successfully installed the file.
+2025-09-12 08:34:26.636   -- File entry --
+2025-09-12 08:34:26.638   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_36.template
+2025-09-12 08:34:26.638   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.638   Installing the file.
+2025-09-12 08:34:26.639   Successfully installed the file.
+2025-09-12 08:34:26.639   -- File entry --
+2025-09-12 08:34:26.639   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_37.template
+2025-09-12 08:34:26.639   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.639   Installing the file.
+2025-09-12 08:34:26.640   Successfully installed the file.
+2025-09-12 08:34:26.640   -- File entry --
+2025-09-12 08:34:26.640   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_38.template
+2025-09-12 08:34:26.640   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.640   Installing the file.
+2025-09-12 08:34:26.641   Successfully installed the file.
+2025-09-12 08:34:26.641   -- File entry --
+2025-09-12 08:34:26.641   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_39.template
+2025-09-12 08:34:26.641   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.641   Installing the file.
+2025-09-12 08:34:26.642   Successfully installed the file.
+2025-09-12 08:34:26.642   -- File entry --
+2025-09-12 08:34:26.642   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_40.template
+2025-09-12 08:34:26.642   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.642   Installing the file.
+2025-09-12 08:34:26.643   Successfully installed the file.
+2025-09-12 08:34:26.643   -- File entry --
+2025-09-12 08:34:26.643   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_41.template
+2025-09-12 08:34:26.643   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.643   Installing the file.
+2025-09-12 08:34:26.644   Successfully installed the file.
+2025-09-12 08:34:26.644   -- File entry --
+2025-09-12 08:34:26.645   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_42.template
+2025-09-12 08:34:26.645   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.645   Installing the file.
+2025-09-12 08:34:26.645   Successfully installed the file.
+2025-09-12 08:34:26.645   -- File entry --
+2025-09-12 08:34:26.646   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_43.template
+2025-09-12 08:34:26.646   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.646   Installing the file.
+2025-09-12 08:34:26.646   Successfully installed the file.
+2025-09-12 08:34:26.647   -- File entry --
+2025-09-12 08:34:26.647   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_44.template
+2025-09-12 08:34:26.647   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.647   Installing the file.
+2025-09-12 08:34:26.647   Successfully installed the file.
+2025-09-12 08:34:26.648   -- File entry --
+2025-09-12 08:34:26.648   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_45.template
+2025-09-12 08:34:26.648   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.648   Installing the file.
+2025-09-12 08:34:26.649   Successfully installed the file.
+2025-09-12 08:34:26.649   -- File entry --
+2025-09-12 08:34:26.649   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_46.template
+2025-09-12 08:34:26.649   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.649   Installing the file.
+2025-09-12 08:34:26.650   Successfully installed the file.
+2025-09-12 08:34:26.650   -- File entry --
+2025-09-12 08:34:26.650   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_47.template
+2025-09-12 08:34:26.650   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.650   Installing the file.
+2025-09-12 08:34:26.651   Successfully installed the file.
+2025-09-12 08:34:26.651   -- File entry --
+2025-09-12 08:34:26.651   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_48.template
+2025-09-12 08:34:26.651   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.651   Installing the file.
+2025-09-12 08:34:26.652   Successfully installed the file.
+2025-09-12 08:34:26.652   -- File entry --
+2025-09-12 08:34:26.652   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_49.template
+2025-09-12 08:34:26.652   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.652   Installing the file.
+2025-09-12 08:34:26.654   Successfully installed the file.
+2025-09-12 08:34:26.654   -- File entry --
+2025-09-12 08:34:26.654   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_50.template
+2025-09-12 08:34:26.655   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.655   Installing the file.
+2025-09-12 08:34:26.655   Successfully installed the file.
+2025-09-12 08:34:26.655   -- File entry --
+2025-09-12 08:34:26.655   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_51.template
+2025-09-12 08:34:26.655   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.655   Installing the file.
+2025-09-12 08:34:26.656   Successfully installed the file.
+2025-09-12 08:34:26.656   -- File entry --
+2025-09-12 08:34:26.656   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_52.template
+2025-09-12 08:34:26.656   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.656   Installing the file.
+2025-09-12 08:34:26.657   Successfully installed the file.
+2025-09-12 08:34:26.657   -- File entry --
+2025-09-12 08:34:26.657   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_53.template
+2025-09-12 08:34:26.657   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.657   Installing the file.
+2025-09-12 08:34:26.658   Successfully installed the file.
+2025-09-12 08:34:26.658   -- File entry --
+2025-09-12 08:34:26.658   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_54.template
+2025-09-12 08:34:26.659   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.659   Installing the file.
+2025-09-12 08:34:26.660   Successfully installed the file.
+2025-09-12 08:34:26.660   -- File entry --
+2025-09-12 08:34:26.660   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_55.template
+2025-09-12 08:34:26.660   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.660   Installing the file.
+2025-09-12 08:34:26.661   Successfully installed the file.
+2025-09-12 08:34:26.661   -- File entry --
+2025-09-12 08:34:26.661   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_56.template
+2025-09-12 08:34:26.661   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.661   Installing the file.
+2025-09-12 08:34:26.661   Successfully installed the file.
+2025-09-12 08:34:26.661   -- File entry --
+2025-09-12 08:34:26.662   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_57.template
+2025-09-12 08:34:26.662   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.662   Installing the file.
+2025-09-12 08:34:26.663   Successfully installed the file.
+2025-09-12 08:34:26.663   -- File entry --
+2025-09-12 08:34:26.663   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_58.template
+2025-09-12 08:34:26.663   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.663   Installing the file.
+2025-09-12 08:34:26.664   Successfully installed the file.
+2025-09-12 08:34:26.664   -- File entry --
+2025-09-12 08:34:26.665   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_59.template
+2025-09-12 08:34:26.665   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.665   Installing the file.
+2025-09-12 08:34:26.665   Successfully installed the file.
+2025-09-12 08:34:26.665   -- File entry --
+2025-09-12 08:34:26.666   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_60.template
+2025-09-12 08:34:26.666   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.666   Installing the file.
+2025-09-12 08:34:26.666   Successfully installed the file.
+2025-09-12 08:34:26.666   -- File entry --
+2025-09-12 08:34:26.666   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_61.template
+2025-09-12 08:34:26.668   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.668   Installing the file.
+2025-09-12 08:34:26.668   Successfully installed the file.
+2025-09-12 08:34:26.668   -- File entry --
+2025-09-12 08:34:26.669   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_62.template
+2025-09-12 08:34:26.669   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.669   Installing the file.
+2025-09-12 08:34:26.669   Successfully installed the file.
+2025-09-12 08:34:26.670   -- File entry --
+2025-09-12 08:34:26.670   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_63.template
+2025-09-12 08:34:26.670   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.670   Installing the file.
+2025-09-12 08:34:26.670   Successfully installed the file.
+2025-09-12 08:34:26.670   -- File entry --
+2025-09-12 08:34:26.671   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_COLUMN_ENTRY_64.template
+2025-09-12 08:34:26.671   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.671   Installing the file.
+2025-09-12 08:34:26.671   Successfully installed the file.
+2025-09-12 08:34:26.671   -- File entry --
+2025-09-12 08:34:26.672   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SORHEA_SOLARIS_TARGET_ENTRY_CAMERA.template
+2025-09-12 08:34:26.672   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.672   Installing the file.
+2025-09-12 08:34:26.673   Successfully installed the file.
+2025-09-12 08:34:26.673   -- File entry --
+2025-09-12 08:34:26.673   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SPSFT_DEVICE.template
+2025-09-12 08:34:26.673   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.673   Installing the file.
+2025-09-12 08:34:26.674   Successfully installed the file.
+2025-09-12 08:34:26.674   -- File entry --
+2025-09-12 08:34:26.674   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\SQL_GENERIC.template
+2025-09-12 08:34:26.674   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.674   Installing the file.
+2025-09-12 08:34:26.675   Successfully installed the file.
+2025-09-12 08:34:26.675   -- File entry --
+2025-09-12 08:34:26.675   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\VAPIX_MJPEG_DEVICE.template
+2025-09-12 08:34:26.675   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.675   Installing the file.
+2025-09-12 08:34:26.676   Successfully installed the file.
+2025-09-12 08:34:26.676   -- File entry --
+2025-09-12 08:34:26.676   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\VAPIX_RTSP_DEVICE.template
+2025-09-12 08:34:26.676   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.676   Installing the file.
+2025-09-12 08:34:26.677   Successfully installed the file.
+2025-09-12 08:34:26.677   -- File entry --
+2025-09-12 08:34:26.678   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\VIMACC_ASSEMBLIES_MANAGER.template
+2025-09-12 08:34:26.678   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.678   Installing the file.
+2025-09-12 08:34:26.678   Successfully installed the file.
+2025-09-12 08:34:26.678   -- File entry --
+2025-09-12 08:34:26.679   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\VIMACC_CTRL_INTERFACE.template
+2025-09-12 08:34:26.679   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.679   Installing the file.
+2025-09-12 08:34:26.679   Successfully installed the file.
+2025-09-12 08:34:26.679   -- File entry --
+2025-09-12 08:34:26.680   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\VIMACC_DEMO.template
+2025-09-12 08:34:26.680   Time stamp of our file: 2025-08-13 12:07:20.000
+2025-09-12 08:34:26.680   Installing the file.
+2025-09-12 08:34:26.680   Successfully installed the file.
+2025-09-12 08:34:26.681   -- File entry --
+2025-09-12 08:34:26.681   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\VIMACC_EMAIL_SENDER.template
+2025-09-12 08:34:26.681   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.681   Installing the file.
+2025-09-12 08:34:26.681   Successfully installed the file.
+2025-09-12 08:34:26.682   -- File entry --
+2025-09-12 08:34:26.682   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\VIMACC_EVENT_MANAGER.template
+2025-09-12 08:34:26.682   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.682   Installing the file.
+2025-09-12 08:34:26.682   Successfully installed the file.
+2025-09-12 08:34:26.683   -- File entry --
+2025-09-12 08:34:26.683   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\VIMACC_EXPORT_REPORT_SERVICE.template
+2025-09-12 08:34:26.683   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.683   Installing the file.
+2025-09-12 08:34:26.683   Successfully installed the file.
+2025-09-12 08:34:26.683   -- File entry --
+2025-09-12 08:34:26.683   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\VIMACC_EXPORT_SERVICE.template
+2025-09-12 08:34:26.684   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.684   Installing the file.
+2025-09-12 08:34:26.684   Successfully installed the file.
+2025-09-12 08:34:26.684   -- File entry --
+2025-09-12 08:34:26.684   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\VIMACC_FTP_ALARMRECV.template
+2025-09-12 08:34:26.685   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.685   Installing the file.
+2025-09-12 08:34:26.686   Successfully installed the file.
+2025-09-12 08:34:26.686   -- File entry --
+2025-09-12 08:34:26.686   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\VIMACC_FTP_UPLOADER.template
+2025-09-12 08:34:26.686   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.686   Installing the file.
+2025-09-12 08:34:26.687   Successfully installed the file.
+2025-09-12 08:34:26.687   -- File entry --
+2025-09-12 08:34:26.687   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\VIMACC_HID.template
+2025-09-12 08:34:26.687   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.687   Installing the file.
+2025-09-12 08:34:26.688   Successfully installed the file.
+2025-09-12 08:34:26.688   -- File entry --
+2025-09-12 08:34:26.688   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\VIMACC_HID_AXIS_T8312_KEYPAD.template
+2025-09-12 08:34:26.688   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.688   Installing the file.
+2025-09-12 08:34:26.689   Successfully installed the file.
+2025-09-12 08:34:26.689   -- File entry --
+2025-09-12 08:34:26.689   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\VIMACC_HID_AXIS_T8313_JOGDIAL.template
+2025-09-12 08:34:26.689   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.689   Installing the file.
+2025-09-12 08:34:26.690   Successfully installed the file.
+2025-09-12 08:34:26.690   -- File entry --
+2025-09-12 08:34:26.690   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\VIMACC_HID_AXIS_TU9002_JOYSTICK.template
+2025-09-12 08:34:26.690   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.690   Installing the file.
+2025-09-12 08:34:26.691   Successfully installed the file.
+2025-09-12 08:34:26.691   -- File entry --
+2025-09-12 08:34:26.692   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\VIMACC_HID_AXIS_TU9003_KEYPAD.template
+2025-09-12 08:34:26.692   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.692   Installing the file.
+2025-09-12 08:34:26.692   Successfully installed the file.
+2025-09-12 08:34:26.692   -- File entry --
+2025-09-12 08:34:26.692   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\VIMACC_HTTP_SERVER.template
+2025-09-12 08:34:26.692   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.692   Installing the file.
+2025-09-12 08:34:26.693   Successfully installed the file.
+2025-09-12 08:34:26.693   -- File entry --
+2025-09-12 08:34:26.693   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\VIMACC_INTERFACE_PROXY.template
+2025-09-12 08:34:26.693   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.693   Installing the file.
+2025-09-12 08:34:26.694   Successfully installed the file.
+2025-09-12 08:34:26.694   -- File entry --
+2025-09-12 08:34:26.694   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\VIMACC_PLAYBACK_PROXY.template
+2025-09-12 08:34:26.694   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.694   Installing the file.
+2025-09-12 08:34:26.695   Successfully installed the file.
+2025-09-12 08:34:26.695   -- File entry --
+2025-09-12 08:34:26.695   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\VIMACC_RECORDED_STREAM.template
+2025-09-12 08:34:26.695   Time stamp of our file: 2025-08-13 12:07:20.000
+2025-09-12 08:34:26.695   Installing the file.
+2025-09-12 08:34:26.696   Successfully installed the file.
+2025-09-12 08:34:26.696   -- File entry --
+2025-09-12 08:34:26.696   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\VIMACC_REPORT_SERVER.template
+2025-09-12 08:34:26.696   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.696   Installing the file.
+2025-09-12 08:34:26.697   Successfully installed the file.
+2025-09-12 08:34:26.697   -- File entry --
+2025-09-12 08:34:26.697   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\VIMACC_RTSP_SERVER.template
+2025-09-12 08:34:26.697   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.697   Installing the file.
+2025-09-12 08:34:26.697   Successfully installed the file.
+2025-09-12 08:34:26.697   -- File entry --
+2025-09-12 08:34:26.699   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\VIMACC_SCHEDULER.template
+2025-09-12 08:34:26.699   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.699   Installing the file.
+2025-09-12 08:34:26.699   Successfully installed the file.
+2025-09-12 08:34:26.699   -- File entry --
+2025-09-12 08:34:26.700   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\VIMACC_SCHEDULER_PATROL.template
+2025-09-12 08:34:26.700   Time stamp of our file: 2025-07-11 13:18:10.000
+2025-09-12 08:34:26.700   Installing the file.
+2025-09-12 08:34:26.700   Successfully installed the file.
+2025-09-12 08:34:26.701   -- File entry --
+2025-09-12 08:34:26.701   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\VIMACC_SCHEDULER_PATROL_ACTION_GOTOPRESET.template
+2025-09-12 08:34:26.701   Time stamp of our file: 2025-07-11 13:18:10.000
+2025-09-12 08:34:26.701   Installing the file.
+2025-09-12 08:34:26.702   Successfully installed the file.
+2025-09-12 08:34:26.702   -- File entry --
+2025-09-12 08:34:26.702   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\VIMACC_SCHEDULER_PULSE.template
+2025-09-12 08:34:26.702   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.702   Installing the file.
+2025-09-12 08:34:26.703   Successfully installed the file.
+2025-09-12 08:34:26.703   -- File entry --
+2025-09-12 08:34:26.704   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\VIMACC_SCREEN2RTSP_VIDEO_DEVICE.template
+2025-09-12 08:34:26.704   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.704   Installing the file.
+2025-09-12 08:34:26.704   Successfully installed the file.
+2025-09-12 08:34:26.704   -- File entry --
+2025-09-12 08:34:26.705   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\VIMACC_SMS_GATEWAY.template
+2025-09-12 08:34:26.705   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.705   Installing the file.
+2025-09-12 08:34:26.706   Successfully installed the file.
+2025-09-12 08:34:26.706   -- File entry --
+2025-09-12 08:34:26.706   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\VIMACC_SNMP_AGENT.template
+2025-09-12 08:34:26.706   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.706   Installing the file.
+2025-09-12 08:34:26.707   Successfully installed the file.
+2025-09-12 08:34:26.707   -- File entry --
+2025-09-12 08:34:26.707   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\VIMACC_STREAMING_SERVER.template
+2025-09-12 08:34:26.707   Time stamp of our file: 2025-05-05 13:05:50.000
+2025-09-12 08:34:26.707   Installing the file.
+2025-09-12 08:34:26.708   Successfully installed the file.
+2025-09-12 08:34:26.708   -- File entry --
+2025-09-12 08:34:26.708   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\VIMACC_SYSTEM_MONITORING.template
+2025-09-12 08:34:26.708   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.708   Installing the file.
+2025-09-12 08:34:26.709   Successfully installed the file.
+2025-09-12 08:34:26.709   -- File entry --
+2025-09-12 08:34:26.709   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\VIMACC_TEST.template
+2025-09-12 08:34:26.709   Time stamp of our file: 2025-08-13 12:07:20.000
+2025-09-12 08:34:26.709   Installing the file.
+2025-09-12 08:34:26.710   Successfully installed the file.
+2025-09-12 08:34:26.710   -- File entry --
+2025-09-12 08:34:26.710   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\VIMACC_USB_TEST.template
+2025-09-12 08:34:26.711   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.711   Installing the file.
+2025-09-12 08:34:26.711   Successfully installed the file.
+2025-09-12 08:34:26.711   -- File entry --
+2025-09-12 08:34:26.711   Dest filename: C:\vimacc\data\configTemplates\de_DE\devTemplates\VIMACC_WORKSTATION_DEVICE.template
+2025-09-12 08:34:26.712   Time stamp of our file: 2025-05-05 13:05:52.000
+2025-09-12 08:34:26.712   Installing the file.
+2025-09-12 08:34:26.712   Successfully installed the file.
+2025-09-12 08:34:26.712   -- File entry --
+2025-09-12 08:34:26.712   Dest filename: C:\vimacc\bin\AccVimaccAssembliesManager.exe
+2025-09-12 08:34:26.713   Time stamp of our file: 2025-08-13 12:27:52.000
+2025-09-12 08:34:26.713   Installing the file.
+2025-09-12 08:34:26.721   Successfully installed the file.
+2025-09-12 08:34:26.721   -- File entry --
+2025-09-12 08:34:26.721   Dest filename: C:\vimacc\data\i18n\AccVimaccAssembliesManager_de.qm
+2025-09-12 08:34:26.721   Time stamp of our file: 2025-08-13 12:21:38.000
+2025-09-12 08:34:26.721   Installing the file.
+2025-09-12 08:34:26.722   Successfully installed the file.
+2025-09-12 08:34:26.722   -- File entry --
+2025-09-12 08:34:26.722   Dest filename: C:\vimacc\data\i18n\AccVimaccAssembliesManager_en.qm
+2025-09-12 08:34:26.722   Time stamp of our file: 2025-08-13 12:21:38.000
+2025-09-12 08:34:26.722   Installing the file.
+2025-09-12 08:34:26.723   Successfully installed the file.
+2025-09-12 08:34:26.723   -- File entry --
+2025-09-12 08:34:26.723   Dest filename: C:\vimacc\bin\AccVimaccCommander.exe
+2025-09-12 08:34:26.723   Time stamp of our file: 2025-08-13 12:27:54.000
+2025-09-12 08:34:26.723   Installing the file.
+2025-09-12 08:34:26.734   Successfully installed the file.
+2025-09-12 08:34:26.734   -- File entry --
+2025-09-12 08:34:26.734   Dest filename: C:\vimacc\bin\AccVimaccConfig.exe
+2025-09-12 08:34:26.734   Time stamp of our file: 2025-08-13 12:27:54.000
+2025-09-12 08:34:26.734   Installing the file.
+2025-09-12 08:34:26.739   Successfully installed the file.
+2025-09-12 08:34:26.739   -- File entry --
+2025-09-12 08:34:26.739   Dest filename: C:\vimacc\data\plugins\sqldrivers\qsqlite.dll
+2025-09-12 08:34:26.739   Time stamp of our file: 2024-05-25 08:47:32.000
+2025-09-12 08:34:26.739   Dest file exists.
+2025-09-12 08:34:26.739   Time stamp of existing file: 2024-05-25 08:47:32.000
+2025-09-12 08:34:26.739   Installing the file.
+2025-09-12 08:34:26.768   Successfully installed the file.
+2025-09-12 08:34:26.769   -- File entry --
+2025-09-12 08:34:26.769   Dest filename: C:\vimacc\data\featuresDatabase\setup\features.2.2.15.5.vccdbf
+2025-09-12 08:34:26.769   Time stamp of our file: 2025-08-13 12:32:44.000
+2025-09-12 08:34:26.769   Installing the file.
+2025-09-12 08:34:26.769   Creating directory: C:\vimacc\data\featuresDatabase\setup
+2025-09-12 08:34:26.770   Successfully installed the file.
+2025-09-12 08:34:26.770   -- File entry --
+2025-09-12 08:34:26.771   Dest filename: C:\vimacc\bin\AccVimaccAdminCenter.exe
+2025-09-12 08:34:26.771   Time stamp of our file: 2025-08-13 12:27:52.000
+2025-09-12 08:34:26.771   Installing the file.
+2025-09-12 08:34:26.820   Successfully installed the file.
+2025-09-12 08:34:26.820   -- File entry --
+2025-09-12 08:34:26.820   Dest filename: C:\vimacc\data\i18n\AccVimaccAdminCenter_de.qm
+2025-09-12 08:34:26.820   Time stamp of our file: 2025-08-13 12:23:00.000
+2025-09-12 08:34:26.820   Installing the file.
+2025-09-12 08:34:26.822   Successfully installed the file.
+2025-09-12 08:34:26.822   -- File entry --
+2025-09-12 08:34:26.822   Dest filename: C:\vimacc\data\i18n\AccVimaccAdminCenter_en.qm
+2025-09-12 08:34:26.822   Time stamp of our file: 2025-08-13 12:22:58.000
+2025-09-12 08:34:26.822   Installing the file.
+2025-09-12 08:34:26.823   Successfully installed the file.
+2025-09-12 08:34:26.823   -- File entry --
+2025-09-12 08:34:26.823   Dest filename: C:\vimacc\config\AccVimaccAdminCenter_workstation.conf
+2025-09-12 08:34:26.823   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:26.823   Installing the file.
+2025-09-12 08:34:26.824   Successfully installed the file.
+2025-09-12 08:34:26.824   -- File entry --
+2025-09-12 08:34:26.825   Dest filename: C:\vimacc\bin\AccVimaccSecurityWizard.exe
+2025-09-12 08:34:26.825   Time stamp of our file: 2025-08-13 12:28:06.000
+2025-09-12 08:34:26.825   Installing the file.
+2025-09-12 08:34:26.832   Successfully installed the file.
+2025-09-12 08:34:26.832   -- File entry --
+2025-09-12 08:34:26.832   Dest filename: C:\vimacc\data\i18n\AccVimaccSecurityWizard_de.qm
+2025-09-12 08:34:26.833   Time stamp of our file: 2025-08-13 12:21:52.000
+2025-09-12 08:34:26.833   Installing the file.
+2025-09-12 08:34:26.833   Successfully installed the file.
+2025-09-12 08:34:26.833   -- File entry --
+2025-09-12 08:34:26.834   Dest filename: C:\vimacc\data\i18n\AccVimaccSecurityWizard_en.qm
+2025-09-12 08:34:26.834   Time stamp of our file: 2025-08-13 12:21:52.000
+2025-09-12 08:34:26.834   Installing the file.
+2025-09-12 08:34:26.834   Successfully installed the file.
+2025-09-12 08:34:26.834   -- File entry --
+2025-09-12 08:34:26.835   Dest filename: C:\vimacc\config\AccVimaccSecurityWizard_workstation.conf
+2025-09-12 08:34:26.835   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:26.835   Installing the file.
+2025-09-12 08:34:26.835   Successfully installed the file.
+2025-09-12 08:34:26.835   -- File entry --
+2025-09-12 08:34:26.835   Dest filename: C:\vimacc\bin\AccVimaccConfigurationCenter.exe
+2025-09-12 08:34:26.835   Time stamp of our file: 2025-08-13 12:27:54.000
+2025-09-12 08:34:26.835   Installing the file.
+2025-09-12 08:34:26.852   Successfully installed the file.
+2025-09-12 08:34:26.853   -- File entry --
+2025-09-12 08:34:26.853   Dest filename: C:\vimacc\data\i18n\AccVimaccConfigurationCenter_de.qm
+2025-09-12 08:34:26.853   Time stamp of our file: 2025-08-13 12:23:00.000
+2025-09-12 08:34:26.853   Installing the file.
+2025-09-12 08:34:26.854   Successfully installed the file.
+2025-09-12 08:34:26.854   -- File entry --
+2025-09-12 08:34:26.854   Dest filename: C:\vimacc\data\i18n\AccVimaccConfigurationCenter_en.qm
+2025-09-12 08:34:26.854   Time stamp of our file: 2025-08-13 12:22:58.000
+2025-09-12 08:34:26.854   Installing the file.
+2025-09-12 08:34:26.854   Successfully installed the file.
+2025-09-12 08:34:26.855   -- File entry --
+2025-09-12 08:34:26.855   Dest filename: C:\vimacc\config\AccVimaccConfigurationCenter_workstation.conf
+2025-09-12 08:34:26.855   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:26.855   Installing the file.
+2025-09-12 08:34:26.856   Successfully installed the file.
+2025-09-12 08:34:26.856   -- File entry --
+2025-09-12 08:34:26.857   Dest filename: C:\vimacc\bin\AccVimaccUserManagement.exe
+2025-09-12 08:34:26.857   Time stamp of our file: 2025-08-13 12:28:10.000
+2025-09-12 08:34:26.857   Installing the file.
+2025-09-12 08:34:26.879   Successfully installed the file.
+2025-09-12 08:34:26.879   -- File entry --
+2025-09-12 08:34:26.879   Dest filename: C:\vimacc\data\i18n\RuntimeFeatures_de_DE.mta
+2025-09-12 08:34:26.879   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:26.879   Installing the file.
+2025-09-12 08:34:26.880   Successfully installed the file.
+2025-09-12 08:34:26.880   -- File entry --
+2025-09-12 08:34:26.880   Dest filename: C:\vimacc\config\AccVimaccUserManagement_workstation.conf
+2025-09-12 08:34:26.880   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:26.880   Installing the file.
+2025-09-12 08:34:26.881   Successfully installed the file.
+2025-09-12 08:34:26.881   -- File entry --
+2025-09-12 08:34:26.881   Dest filename: C:\vimacc\data\i18n\AccVimaccUserManagement_de.qm
+2025-09-12 08:34:26.881   Time stamp of our file: 2025-08-13 12:22:58.000
+2025-09-12 08:34:26.881   Installing the file.
+2025-09-12 08:34:26.882   Successfully installed the file.
+2025-09-12 08:34:26.882   -- File entry --
+2025-09-12 08:34:26.883   Dest filename: C:\vimacc\data\i18n\AccVimaccUserManagement_en.qm
+2025-09-12 08:34:26.883   Time stamp of our file: 2025-08-13 12:22:58.000
+2025-09-12 08:34:26.883   Installing the file.
+2025-09-12 08:34:26.883   Successfully installed the file.
+2025-09-12 08:34:26.883   -- File entry --
+2025-09-12 08:34:26.884   Dest filename: C:\vimacc\bin\AccVimaccControlCommand.exe
+2025-09-12 08:34:26.884   Time stamp of our file: 2025-08-13 12:27:54.000
+2025-09-12 08:34:26.884   Installing the file.
+2025-09-12 08:34:26.889   Successfully installed the file.
+2025-09-12 08:34:26.889   -- File entry --
+2025-09-12 08:34:26.889   Dest filename: C:\vimacc\bin\AccVimaccControlInterface.exe
+2025-09-12 08:34:26.889   Time stamp of our file: 2025-08-13 12:27:56.000
+2025-09-12 08:34:26.889   Installing the file.
+2025-09-12 08:34:26.897   Successfully installed the file.
+2025-09-12 08:34:26.897   -- File entry --
+2025-09-12 08:34:26.897   Dest filename: C:\vimacc\config\AccVimaccControlInterface_workstation.conf
+2025-09-12 08:34:26.897   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:26.897   Installing the file.
+2025-09-12 08:34:26.898   Successfully installed the file.
+2025-09-12 08:34:26.898   -- File entry --
+2025-09-12 08:34:26.898   Dest filename: C:\vimacc\bin\AccVimaccDigIOInterface.exe
+2025-09-12 08:34:26.898   Time stamp of our file: 2025-08-13 12:27:56.000
+2025-09-12 08:34:26.898   Installing the file.
+2025-09-12 08:34:26.903   Successfully installed the file.
+2025-09-12 08:34:26.903   -- File entry --
+2025-09-12 08:34:26.903   Dest filename: C:\vimacc\bin\MXIO.dll
+2025-09-12 08:34:26.903   Time stamp of our file: 2025-08-13 12:28:16.000
+2025-09-12 08:34:26.903   Installing the file.
+2025-09-12 08:34:26.915   Successfully installed the file.
+2025-09-12 08:34:26.915   -- File entry --
+2025-09-12 08:34:26.915   Dest filename: C:\vimacc\bin\AccVimaccDongle.exe
+2025-09-12 08:34:26.916   Time stamp of our file: 2025-08-13 12:27:56.000
+2025-09-12 08:34:26.916   Installing the file.
+2025-09-12 08:34:26.918   Successfully installed the file.
+2025-09-12 08:34:26.918   -- File entry --
+2025-09-12 08:34:26.918   Dest filename: C:\vimacc\bin\AccDonglePasswordManager.exe
+2025-09-12 08:34:26.918   Time stamp of our file: 2025-08-13 12:27:52.000
+2025-09-12 08:34:26.918   Installing the file.
+2025-09-12 08:34:26.921   Successfully installed the file.
+2025-09-12 08:34:26.922   -- File entry --
+2025-09-12 08:34:26.922   Dest filename: C:\vimacc\data\i18n\AccDonglePasswordManager_de.qm
+2025-09-12 08:34:26.922   Time stamp of our file: 2025-08-13 12:23:04.000
+2025-09-12 08:34:26.922   Installing the file.
+2025-09-12 08:34:26.924   Successfully installed the file.
+2025-09-12 08:34:26.924   -- File entry --
+2025-09-12 08:34:26.924   Dest filename: C:\vimacc\data\i18n\AccDonglePasswordManager_en.qm
+2025-09-12 08:34:26.924   Time stamp of our file: 2025-08-13 12:23:06.000
+2025-09-12 08:34:26.924   Installing the file.
+2025-09-12 08:34:26.925   Successfully installed the file.
+2025-09-12 08:34:26.925   -- File entry --
+2025-09-12 08:34:26.925   Dest filename: C:\vimacc\bin\AccVimaccDumpDb.exe
+2025-09-12 08:34:26.925   Time stamp of our file: 2025-08-13 12:27:58.000
+2025-09-12 08:34:26.925   Installing the file.
+2025-09-12 08:34:26.937   Successfully installed the file.
+2025-09-12 08:34:26.937   -- File entry --
+2025-09-12 08:34:26.937   Dest filename: C:\vimacc\config\VimaccDumpDb_dump.bat
+2025-09-12 08:34:26.937   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:26.937   Installing the file.
+2025-09-12 08:34:26.938   Successfully installed the file.
+2025-09-12 08:34:26.938   -- File entry --
+2025-09-12 08:34:26.938   Dest filename: C:\vimacc\config\VimaccDumpDb_import.bat
+2025-09-12 08:34:26.938   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:26.938   Installing the file.
+2025-09-12 08:34:26.938   Successfully installed the file.
+2025-09-12 08:34:26.938   -- File entry --
+2025-09-12 08:34:26.939   Dest filename: C:\vimacc\config\vimacc_db_workstation_windows.sql
+2025-09-12 08:34:26.939   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:26.939   Installing the file.
+2025-09-12 08:34:26.939   Successfully installed the file.
+2025-09-12 08:34:26.940   -- File entry --
+2025-09-12 08:34:26.940   Dest filename: C:\vimacc\config\vimacc_workstation_windows.vic
+2025-09-12 08:34:26.940   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:26.940   Installing the file.
+2025-09-12 08:34:26.941   Successfully installed the file.
+2025-09-12 08:34:26.941   -- File entry --
+2025-09-12 08:34:26.942   Dest filename: C:\vimacc\bin\AccVimaccEventManager.exe
+2025-09-12 08:34:26.942   Time stamp of our file: 2025-08-13 12:27:58.000
+2025-09-12 08:34:26.942   Installing the file.
+2025-09-12 08:34:26.952   Successfully installed the file.
+2025-09-12 08:34:26.952   -- File entry --
+2025-09-12 08:34:26.953   Dest filename: C:\vimacc\data\i18n\AccVimaccEventManager_de.qm
+2025-09-12 08:34:26.953   Time stamp of our file: 2025-08-13 12:21:36.000
+2025-09-12 08:34:26.953   Installing the file.
+2025-09-12 08:34:26.953   Successfully installed the file.
+2025-09-12 08:34:26.954   -- File entry --
+2025-09-12 08:34:26.954   Dest filename: C:\vimacc\data\i18n\AccVimaccEventManager_en.qm
+2025-09-12 08:34:26.954   Time stamp of our file: 2025-08-13 12:21:36.000
+2025-09-12 08:34:26.954   Installing the file.
+2025-09-12 08:34:26.954   Successfully installed the file.
+2025-09-12 08:34:26.955   -- File entry --
+2025-09-12 08:34:26.955   Dest filename: C:\vimacc\bin\AccVimaccEventMonitor.exe
+2025-09-12 08:34:26.955   Time stamp of our file: 2025-08-13 12:27:58.000
+2025-09-12 08:34:26.955   Installing the file.
+2025-09-12 08:34:26.959   Successfully installed the file.
+2025-09-12 08:34:26.959   -- File entry --
+2025-09-12 08:34:26.960   Dest filename: C:\vimacc\data\i18n\AccVimaccEventMonitor_de.qm
+2025-09-12 08:34:26.960   Time stamp of our file: 2025-08-13 12:22:58.000
+2025-09-12 08:34:26.960   Installing the file.
+2025-09-12 08:34:26.960   Successfully installed the file.
+2025-09-12 08:34:26.960   -- File entry --
+2025-09-12 08:34:26.961   Dest filename: C:\vimacc\data\i18n\AccVimaccEventMonitor_en.qm
+2025-09-12 08:34:26.961   Time stamp of our file: 2025-08-13 12:22:58.000
+2025-09-12 08:34:26.961   Installing the file.
+2025-09-12 08:34:26.961   Successfully installed the file.
+2025-09-12 08:34:26.961   -- File entry --
+2025-09-12 08:34:26.962   Dest filename: C:\vimacc\bin\AccVimaccEmailSender.exe
+2025-09-12 08:34:26.962   Time stamp of our file: 2025-08-13 12:27:58.000
+2025-09-12 08:34:26.962   Installing the file.
+2025-09-12 08:34:26.965   Successfully installed the file.
+2025-09-12 08:34:26.965   -- File entry --
+2025-09-12 08:34:26.966   Dest filename: C:\vimacc\data\i18n\AccVimaccEmailSender_de.qm
+2025-09-12 08:34:26.966   Time stamp of our file: 2025-08-13 12:21:38.000
+2025-09-12 08:34:26.966   Installing the file.
+2025-09-12 08:34:26.966   Successfully installed the file.
+2025-09-12 08:34:26.966   -- File entry --
+2025-09-12 08:34:26.967   Dest filename: C:\vimacc\data\i18n\AccVimaccEmailSender_en.qm
+2025-09-12 08:34:26.967   Time stamp of our file: 2025-08-13 12:21:38.000
+2025-09-12 08:34:26.967   Installing the file.
+2025-09-12 08:34:26.967   Successfully installed the file.
+2025-09-12 08:34:26.967   -- File entry --
+2025-09-12 08:34:26.968   Dest filename: C:\vimacc\bin\AccVimaccSmsGateway.exe
+2025-09-12 08:34:26.968   Time stamp of our file: 2025-08-13 12:28:08.000
+2025-09-12 08:34:26.968   Installing the file.
+2025-09-12 08:34:26.971   Successfully installed the file.
+2025-09-12 08:34:26.971   -- File entry --
+2025-09-12 08:34:26.971   Dest filename: C:\vimacc\data\i18n\AccVimaccSmsGateway_de.qm
+2025-09-12 08:34:26.971   Time stamp of our file: 2025-08-13 12:21:38.000
+2025-09-12 08:34:26.971   Installing the file.
+2025-09-12 08:34:26.972   Successfully installed the file.
+2025-09-12 08:34:26.972   -- File entry --
+2025-09-12 08:34:26.972   Dest filename: C:\vimacc\data\i18n\AccVimaccSmsGateway_en.qm
+2025-09-12 08:34:26.972   Time stamp of our file: 2025-08-13 12:21:38.000
+2025-09-12 08:34:26.972   Installing the file.
+2025-09-12 08:34:26.973   Successfully installed the file.
+2025-09-12 08:34:26.973   -- File entry --
+2025-09-12 08:34:26.973   Dest filename: C:\vimacc\bin\AccVimaccExport.exe
+2025-09-12 08:34:26.973   Time stamp of our file: 2025-08-13 12:27:58.000
+2025-09-12 08:34:26.973   Installing the file.
+2025-09-12 08:34:26.977   Successfully installed the file.
+2025-09-12 08:34:26.977   -- File entry --
+2025-09-12 08:34:26.977   Dest filename: C:\vimacc\bin\ffmpeg.exe
+2025-09-12 08:34:26.978   Time stamp of our file: 2025-05-05 13:06:12.000
+2025-09-12 08:34:26.978   Installing the file.
+2025-09-12 08:34:26.993   Successfully installed the file.
+2025-09-12 08:34:26.993   -- File entry --
+2025-09-12 08:34:26.993   Dest filename: C:\vimacc\config\AccVimaccExport_workstation.conf
+2025-09-12 08:34:26.994   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:26.994   Installing the file.
+2025-09-12 08:34:26.994   Successfully installed the file.
+2025-09-12 08:34:26.994   -- File entry --
+2025-09-12 08:34:26.995   Dest filename: C:\vimacc\data\i18n\AccVimaccExport_fr.qm
+2025-09-12 08:34:26.995   Time stamp of our file: 2025-08-13 12:22:58.000
+2025-09-12 08:34:26.995   Installing the file.
+2025-09-12 08:34:26.995   Successfully installed the file.
+2025-09-12 08:34:26.995   -- File entry --
+2025-09-12 08:34:26.996   Dest filename: C:\vimacc\data\i18n\AccVimaccExport_de.qm
+2025-09-12 08:34:26.996   Time stamp of our file: 2025-08-13 12:22:58.000
+2025-09-12 08:34:26.996   Installing the file.
+2025-09-12 08:34:26.996   Successfully installed the file.
+2025-09-12 08:34:26.996   -- File entry --
+2025-09-12 08:34:26.997   Dest filename: C:\vimacc\data\i18n\AccVimaccExport_en.qm
+2025-09-12 08:34:26.997   Time stamp of our file: 2025-08-13 12:22:58.000
+2025-09-12 08:34:26.997   Installing the file.
+2025-09-12 08:34:26.997   Successfully installed the file.
+2025-09-12 08:34:26.997   -- File entry --
+2025-09-12 08:34:26.998   Dest filename: C:\vimacc\data\forExport\StartVideoPlayer.exe
+2025-09-12 08:34:26.998   Time stamp of our file: 2025-05-05 13:06:36.000
+2025-09-12 08:34:26.998   Installing the file.
+2025-09-12 08:34:26.998   Creating directory: C:\vimacc\data\forExport
+2025-09-12 08:34:27.001   Successfully installed the file.
+2025-09-12 08:34:27.001   -- File entry --
+2025-09-12 08:34:27.001   Dest filename: C:\vimacc\data\forExport\Readme.txt
+2025-09-12 08:34:27.001   Time stamp of our file: 2025-05-05 13:09:06.000
+2025-09-12 08:34:27.001   Installing the file.
+2025-09-12 08:34:27.001   Successfully installed the file.
+2025-09-12 08:34:27.001   -- File entry --
+2025-09-12 08:34:27.002   Dest filename: C:\vimacc\data\forExport\player64bit\AccVimaccCore.dll
+2025-09-12 08:34:27.002   Time stamp of our file: 2025-08-13 12:27:56.000
+2025-09-12 08:34:27.002   Installing the file.
+2025-09-12 08:34:27.002   Creating directory: C:\vimacc\data\forExport\player64bit
+2025-09-12 08:34:27.079   Successfully installed the file.
+2025-09-12 08:34:27.079   -- File entry --
+2025-09-12 08:34:27.080   Dest filename: C:\vimacc\data\forExport\player64bit\AccVimaccUtil.dll
+2025-09-12 08:34:27.080   Time stamp of our file: 2025-08-13 12:28:10.000
+2025-09-12 08:34:27.080   Installing the file.
+2025-09-12 08:34:27.110   Successfully installed the file.
+2025-09-12 08:34:27.111   -- File entry --
+2025-09-12 08:34:27.111   Dest filename: C:\vimacc\data\forExport\player64bit\AccVimaccCrypto.dll
+2025-09-12 08:34:27.111   Time stamp of our file: 2025-08-13 12:27:56.000
+2025-09-12 08:34:27.111   Installing the file.
+2025-09-12 08:34:27.135   Successfully installed the file.
+2025-09-12 08:34:27.135   -- File entry --
+2025-09-12 08:34:27.135   Dest filename: C:\vimacc\data\forExport\player64bit\AccVimaccMixer.dll
+2025-09-12 08:34:27.135   Time stamp of our file: 2025-08-13 12:28:02.000
+2025-09-12 08:34:27.135   Installing the file.
+2025-09-12 08:34:27.157   Successfully installed the file.
+2025-09-12 08:34:27.157   -- File entry --
+2025-09-12 08:34:27.157   Dest filename: C:\vimacc\data\forExport\player64bit\AccVimaccStreaming.dll
+2025-09-12 08:34:27.157   Time stamp of our file: 2025-08-13 12:28:08.000
+2025-09-12 08:34:27.157   Installing the file.
+2025-09-12 08:34:27.180   Successfully installed the file.
+2025-09-12 08:34:27.180   -- File entry --
+2025-09-12 08:34:27.181   Dest filename: C:\vimacc\data\forExport\player64bit\AccVimaccVideoPresentation.dll
+2025-09-12 08:34:27.181   Time stamp of our file: 2025-08-13 12:28:10.000
+2025-09-12 08:34:27.181   Installing the file.
+2025-09-12 08:34:27.236   Successfully installed the file.
+2025-09-12 08:34:27.237   -- File entry --
+2025-09-12 08:34:27.237   Dest filename: C:\vimacc\data\forExport\player64bit\AccVimaccIndex.dll
+2025-09-12 08:34:27.237   Time stamp of our file: 2025-08-13 12:28:00.000
+2025-09-12 08:34:27.237   Installing the file.
+2025-09-12 08:34:27.259   Successfully installed the file.
+2025-09-12 08:34:27.259   -- File entry --
+2025-09-12 08:34:27.260   Dest filename: C:\vimacc\data\forExport\player64bit\AccVimaccPlayback.exe
+2025-09-12 08:34:27.260   Time stamp of our file: 2025-08-13 12:28:04.000
+2025-09-12 08:34:27.260   Installing the file.
+2025-09-12 08:34:27.269   Successfully installed the file.
+2025-09-12 08:34:27.269   -- File entry --
+2025-09-12 08:34:27.269   Dest filename: C:\vimacc\data\forExport\player64bit\AccVimaccMapToolbox.dll
+2025-09-12 08:34:27.269   Time stamp of our file: 2025-08-13 12:28:02.000
+2025-09-12 08:34:27.269   Installing the file.
+2025-09-12 08:34:27.292   Successfully installed the file.
+2025-09-12 08:34:27.293   -- File entry --
+2025-09-12 08:34:27.293   Dest filename: C:\vimacc\data\forExport\player64bit\AccVimaccPlayerToolbox.dll
+2025-09-12 08:34:27.293   Time stamp of our file: 2025-08-13 12:28:04.000
+2025-09-12 08:34:27.293   Installing the file.
+2025-09-12 08:34:27.368   Successfully installed the file.
+2025-09-12 08:34:27.368   -- File entry --
+2025-09-12 08:34:27.369   Dest filename: C:\vimacc\data\forExport\player64bit\AccVimaccBurnTools.dll
+2025-09-12 08:34:27.369   Time stamp of our file: 2025-08-13 12:27:54.000
+2025-09-12 08:34:27.369   Installing the file.
+2025-09-12 08:34:27.388   Successfully installed the file.
+2025-09-12 08:34:27.389   -- File entry --
+2025-09-12 08:34:27.389   Dest filename: C:\vimacc\data\forExport\player64bit\AccVimaccConfigurationCommon.dll
+2025-09-12 08:34:27.390   Time stamp of our file: 2025-08-13 12:27:54.000
+2025-09-12 08:34:27.390   Installing the file.
+2025-09-12 08:34:27.417   Successfully installed the file.
+2025-09-12 08:34:27.417   -- File entry --
+2025-09-12 08:34:27.418   Dest filename: C:\vimacc\data\forExport\player64bit\AccVimaccVideoAnalytics.dll
+2025-09-12 08:34:27.418   Time stamp of our file: 2025-08-13 12:28:10.000
+2025-09-12 08:34:27.418   Installing the file.
+2025-09-12 08:34:27.441   Successfully installed the file.
+2025-09-12 08:34:27.442   -- File entry --
+2025-09-12 08:34:27.442   Dest filename: C:\vimacc\data\forExport\player64bit\Qt5Core.dll
+2025-09-12 08:34:27.442   Time stamp of our file: 2024-05-25 08:03:46.000
+2025-09-12 08:34:27.442   Installing the file.
+2025-09-12 08:34:27.513   Successfully installed the file.
+2025-09-12 08:34:27.513   -- File entry --
+2025-09-12 08:34:27.514   Dest filename: C:\vimacc\data\forExport\player64bit\Qt5PrintSupport.dll
+2025-09-12 08:34:27.514   Time stamp of our file: 2024-05-25 08:41:32.000
+2025-09-12 08:34:27.514   Installing the file.
+2025-09-12 08:34:27.537   Successfully installed the file.
+2025-09-12 08:34:27.538   -- File entry --
+2025-09-12 08:34:27.538   Dest filename: C:\vimacc\data\forExport\player64bit\Qt5Gui.dll
+2025-09-12 08:34:27.538   Time stamp of our file: 2024-05-25 08:23:16.000
+2025-09-12 08:34:27.538   Installing the file.
+2025-09-12 08:34:27.690   Successfully installed the file.
+2025-09-12 08:34:27.690   -- File entry --
+2025-09-12 08:34:27.691   Dest filename: C:\vimacc\data\forExport\player64bit\Qt5Widgets.dll
+2025-09-12 08:34:27.691   Time stamp of our file: 2024-05-25 08:39:26.000
+2025-09-12 08:34:27.691   Installing the file.
+2025-09-12 08:34:27.761   Successfully installed the file.
+2025-09-12 08:34:27.761   -- File entry --
+2025-09-12 08:34:27.762   Dest filename: C:\vimacc\data\forExport\player64bit\Qt5Network.dll
+2025-09-12 08:34:27.762   Time stamp of our file: 2024-05-25 08:19:24.000
+2025-09-12 08:34:27.762   Installing the file.
+2025-09-12 08:34:27.796   Successfully installed the file.
+2025-09-12 08:34:27.796   -- File entry --
+2025-09-12 08:34:27.796   Dest filename: C:\vimacc\data\forExport\player64bit\Qt5Script.dll
+2025-09-12 08:34:27.796   Time stamp of our file: 2024-05-25 13:46:34.000
+2025-09-12 08:34:27.796   Installing the file.
+2025-09-12 08:34:27.820   Successfully installed the file.
+2025-09-12 08:34:27.820   -- File entry --
+2025-09-12 08:34:27.820   Dest filename: C:\vimacc\data\forExport\player64bit\Qt5Sql.dll
+2025-09-12 08:34:27.821   Time stamp of our file: 2024-05-25 08:07:56.000
+2025-09-12 08:34:27.821   Installing the file.
+2025-09-12 08:34:27.841   Successfully installed the file.
+2025-09-12 08:34:27.841   -- File entry --
+2025-09-12 08:34:27.841   Dest filename: C:\vimacc\data\forExport\player64bit\Qt5Svg.dll
+2025-09-12 08:34:27.841   Time stamp of our file: 2024-05-25 09:00:02.000
+2025-09-12 08:34:27.842   Installing the file.
+2025-09-12 08:34:27.862   Successfully installed the file.
+2025-09-12 08:34:27.862   -- File entry --
+2025-09-12 08:34:27.863   Dest filename: C:\vimacc\data\forExport\player64bit\Qt5Xml.dll
+2025-09-12 08:34:27.864   Time stamp of our file: 2024-05-25 08:05:00.000
+2025-09-12 08:34:27.864   Installing the file.
+2025-09-12 08:34:27.883   Successfully installed the file.
+2025-09-12 08:34:27.883   -- File entry --
+2025-09-12 08:34:27.884   Dest filename: C:\vimacc\data\forExport\player64bit\Qt5Concurrent.dll
+2025-09-12 08:34:27.884   Time stamp of our file: 2024-05-25 08:06:56.000
+2025-09-12 08:34:27.884   Installing the file.
+2025-09-12 08:34:27.900   Successfully installed the file.
+2025-09-12 08:34:27.900   -- File entry --
+2025-09-12 08:34:27.900   Dest filename: C:\vimacc\data\forExport\player64bit\Qt5Location.dll
+2025-09-12 08:34:27.901   Time stamp of our file: 2024-05-25 13:26:40.000
+2025-09-12 08:34:27.901   Installing the file.
+2025-09-12 08:34:27.932   Successfully installed the file.
+2025-09-12 08:34:27.932   -- File entry --
+2025-09-12 08:34:27.933   Dest filename: C:\vimacc\data\forExport\player64bit\Qt5Positioning.dll
+2025-09-12 08:34:27.933   Time stamp of our file: 2024-05-25 12:35:54.000
+2025-09-12 08:34:27.933   Installing the file.
+2025-09-12 08:34:27.953   Successfully installed the file.
+2025-09-12 08:34:27.953   -- File entry --
+2025-09-12 08:34:27.954   Dest filename: C:\vimacc\data\forExport\player64bit\Qt5PositioningQuick.dll
+2025-09-12 08:34:27.954   Time stamp of our file: 2024-05-25 12:42:06.000
+2025-09-12 08:34:27.954   Installing the file.
+2025-09-12 08:34:27.970   Successfully installed the file.
+2025-09-12 08:34:27.971   -- File entry --
+2025-09-12 08:34:27.971   Dest filename: C:\vimacc\data\forExport\player64bit\Qt5PrintSupport.dll
+2025-09-12 08:34:27.971   Time stamp of our file: 2024-05-25 08:41:32.000
+2025-09-12 08:34:27.971   Dest file exists.
+2025-09-12 08:34:27.971   Time stamp of existing file: 2024-05-25 08:41:32.000
+2025-09-12 08:34:27.971   Installing the file.
+2025-09-12 08:34:27.972   Successfully installed the file.
+2025-09-12 08:34:27.972   -- File entry --
+2025-09-12 08:34:27.973   Dest filename: C:\vimacc\data\forExport\player64bit\Qt5Qml.dll
+2025-09-12 08:34:27.973   Time stamp of our file: 2024-05-25 09:18:08.000
+2025-09-12 08:34:27.973   Installing the file.
+2025-09-12 08:34:28.018   Successfully installed the file.
+2025-09-12 08:34:28.018   -- File entry --
+2025-09-12 08:34:28.019   Dest filename: C:\vimacc\data\forExport\player64bit\Qt5QmlModels.dll
+2025-09-12 08:34:28.019   Time stamp of our file: 2024-05-25 09:19:20.000
+2025-09-12 08:34:28.019   Installing the file.
+2025-09-12 08:34:28.039   Successfully installed the file.
+2025-09-12 08:34:28.039   -- File entry --
+2025-09-12 08:34:28.040   Dest filename: C:\vimacc\data\forExport\player64bit\Qt5QmlWorkerScript.dll
+2025-09-12 08:34:28.040   Time stamp of our file: 2024-05-25 09:19:52.000
+2025-09-12 08:34:28.040   Installing the file.
+2025-09-12 08:34:28.056   Successfully installed the file.
+2025-09-12 08:34:28.057   -- File entry --
+2025-09-12 08:34:28.057   Dest filename: C:\vimacc\data\forExport\player64bit\Qt5Quick.dll
+2025-09-12 08:34:28.057   Time stamp of our file: 2024-05-25 09:38:32.000
+2025-09-12 08:34:28.057   Installing the file.
+2025-09-12 08:34:28.119   Successfully installed the file.
+2025-09-12 08:34:28.119   -- File entry --
+2025-09-12 08:34:28.119   Dest filename: C:\vimacc\data\forExport\player64bit\Qt5QuickControls2.dll
+2025-09-12 08:34:28.120   Time stamp of our file: 2024-05-25 11:49:36.000
+2025-09-12 08:34:28.120   Installing the file.
+2025-09-12 08:34:28.139   Successfully installed the file.
+2025-09-12 08:34:28.139   -- File entry --
+2025-09-12 08:34:28.139   Dest filename: C:\vimacc\data\forExport\player64bit\Qt5QuickTemplates2.dll
+2025-09-12 08:34:28.140   Time stamp of our file: 2024-05-25 11:34:20.000
+2025-09-12 08:34:28.140   Installing the file.
+2025-09-12 08:34:28.168   Successfully installed the file.
+2025-09-12 08:34:28.168   -- File entry --
+2025-09-12 08:34:28.168   Dest filename: C:\vimacc\data\forExport\player64bit\Qt5SerialPort.dll
+2025-09-12 08:34:28.168   Time stamp of our file: 2024-05-25 08:59:04.000
+2025-09-12 08:34:28.169   Installing the file.
+2025-09-12 08:34:28.186   Successfully installed the file.
+2025-09-12 08:34:28.186   -- File entry --
+2025-09-12 08:34:28.186   Dest filename: C:\vimacc\data\forExport\player64bit\Qt5XmlPatterns.dll
+2025-09-12 08:34:28.187   Time stamp of our file: 2024-05-25 11:00:16.000
+2025-09-12 08:34:28.187   Installing the file.
+2025-09-12 08:34:28.207   Successfully installed the file.
+2025-09-12 08:34:28.207   -- File entry --
+2025-09-12 08:34:28.208   Dest filename: C:\vimacc\data\forExport\player64bit\platforms\qwindows.dll
+2025-09-12 08:34:28.208   Time stamp of our file: 2024-05-25 08:55:56.000
+2025-09-12 08:34:28.208   Installing the file.
+2025-09-12 08:34:28.208   Creating directory: C:\vimacc\data\forExport\player64bit\platforms
+2025-09-12 08:34:28.235   Successfully installed the file.
+2025-09-12 08:34:28.235   -- File entry --
+2025-09-12 08:34:28.235   Dest filename: C:\vimacc\data\forExport\player64bit\styles\qwindowsvistastyle.dll
+2025-09-12 08:34:28.235   Time stamp of our file: 2024-05-25 08:50:44.000
+2025-09-12 08:34:28.235   Installing the file.
+2025-09-12 08:34:28.235   Creating directory: C:\vimacc\data\forExport\player64bit\styles
+2025-09-12 08:34:28.252   Successfully installed the file.
+2025-09-12 08:34:28.253   -- File entry --
+2025-09-12 08:34:28.253   Dest filename: C:\vimacc\data\forExport\player64bit\libEGL.dll
+2025-09-12 08:34:28.253   Time stamp of our file: 2024-05-25 08:01:48.000
+2025-09-12 08:34:28.253   Installing the file.
+2025-09-12 08:34:28.268   Successfully installed the file.
+2025-09-12 08:34:28.268   -- File entry --
+2025-09-12 08:34:28.268   Dest filename: C:\vimacc\data\forExport\player64bit\libGLESv2.dll
+2025-09-12 08:34:28.268   Time stamp of our file: 2024-05-25 08:01:00.000
+2025-09-12 08:34:28.268   Installing the file.
+2025-09-12 08:34:28.292   Successfully installed the file.
+2025-09-12 08:34:28.292   -- File entry --
+2025-09-12 08:34:28.293   Dest filename: C:\vimacc\data\forExport\player64bit\plugins\imageformats\qgif.dll
+2025-09-12 08:34:28.293   Time stamp of our file: 2024-05-25 08:46:06.000
+2025-09-12 08:34:28.293   Installing the file.
+2025-09-12 08:34:28.293   Creating directory: C:\vimacc\data\forExport\player64bit\plugins
+2025-09-12 08:34:28.293   Creating directory: C:\vimacc\data\forExport\player64bit\plugins\imageformats
+2025-09-12 08:34:28.311   Successfully installed the file.
+2025-09-12 08:34:28.311   -- File entry --
+2025-09-12 08:34:28.311   Dest filename: C:\vimacc\data\forExport\player64bit\plugins\imageformats\qico.dll
+2025-09-12 08:34:28.311   Time stamp of our file: 2024-05-25 08:43:54.000
+2025-09-12 08:34:28.311   Installing the file.
+2025-09-12 08:34:28.327   Successfully installed the file.
+2025-09-12 08:34:28.327   -- File entry --
+2025-09-12 08:34:28.327   Dest filename: C:\vimacc\data\forExport\player64bit\plugins\imageformats\qjpeg.dll
+2025-09-12 08:34:28.328   Time stamp of our file: 2024-05-25 08:45:06.000
+2025-09-12 08:34:28.328   Installing the file.
+2025-09-12 08:34:28.354   Successfully installed the file.
+2025-09-12 08:34:28.354   -- File entry --
+2025-09-12 08:34:28.354   Dest filename: C:\vimacc\data\forExport\player64bit\plugins\imageformats\qsvg.dll
+2025-09-12 08:34:28.354   Time stamp of our file: 2024-05-25 09:01:10.000
+2025-09-12 08:34:28.354   Installing the file.
+2025-09-12 08:34:28.370   Successfully installed the file.
+2025-09-12 08:34:28.370   -- File entry --
+2025-09-12 08:34:28.371   Dest filename: C:\vimacc\data\forExport\player64bit\plugins\imageformats\qtiff.dll
+2025-09-12 08:34:28.371   Time stamp of our file: 2024-05-25 08:59:30.000
+2025-09-12 08:34:28.371   Installing the file.
+2025-09-12 08:34:28.386   Successfully installed the file.
+2025-09-12 08:34:28.386   -- File entry --
+2025-09-12 08:34:28.387   Dest filename: C:\vimacc\data\forExport\player64bit\plugins\iconengines\qsvgicon.dll
+2025-09-12 08:34:28.387   Time stamp of our file: 2024-05-25 09:01:22.000
+2025-09-12 08:34:28.387   Installing the file.
+2025-09-12 08:34:28.387   Creating directory: C:\vimacc\data\forExport\player64bit\plugins\iconengines
+2025-09-12 08:34:28.405   Successfully installed the file.
+2025-09-12 08:34:28.405   -- File entry --
+2025-09-12 08:34:28.405   Dest filename: C:\vimacc\data\forExport\player64bit\jpeg8.dll
+2025-09-12 08:34:28.405   Time stamp of our file: 2025-08-13 12:28:16.000
+2025-09-12 08:34:28.405   Installing the file.
+2025-09-12 08:34:28.423   Successfully installed the file.
+2025-09-12 08:34:28.424   -- File entry --
+2025-09-12 08:34:28.424   Dest filename: C:\vimacc\data\forExport\player64bit\turbojpeg.dll
+2025-09-12 08:34:28.424   Time stamp of our file: 2025-08-13 12:28:28.000
+2025-09-12 08:34:28.424   Installing the file.
+2025-09-12 08:34:28.454   Successfully installed the file.
+2025-09-12 08:34:28.454   -- File entry --
+2025-09-12 08:34:28.455   Dest filename: C:\vimacc\data\forExport\player64bit\avcodec_AccVimacc-58.dll
+2025-09-12 08:34:28.455   Time stamp of our file: 2025-08-13 12:28:12.000
+2025-09-12 08:34:28.455   Installing the file.
+2025-09-12 08:34:28.504   Successfully installed the file.
+2025-09-12 08:34:28.504   -- File entry --
+2025-09-12 08:34:28.505   Dest filename: C:\vimacc\data\forExport\player64bit\avdevice_AccVimacc-58.dll
+2025-09-12 08:34:28.505   Time stamp of our file: 2025-08-13 12:28:12.000
+2025-09-12 08:34:28.505   Installing the file.
+2025-09-12 08:34:28.535   Successfully installed the file.
+2025-09-12 08:34:28.535   -- File entry --
+2025-09-12 08:34:28.536   Dest filename: C:\vimacc\data\forExport\player64bit\avfilter_AccVimacc-7.dll
+2025-09-12 08:34:28.536   Time stamp of our file: 2025-08-13 12:28:12.000
+2025-09-12 08:34:28.536   Installing the file.
+2025-09-12 08:34:28.569   Successfully installed the file.
+2025-09-12 08:34:28.570   -- File entry --
+2025-09-12 08:34:28.570   Dest filename: C:\vimacc\data\forExport\player64bit\avformat_AccVimacc-58.dll
+2025-09-12 08:34:28.570   Time stamp of our file: 2025-08-13 12:28:12.000
+2025-09-12 08:34:28.570   Installing the file.
+2025-09-12 08:34:28.604   Successfully installed the file.
+2025-09-12 08:34:28.604   -- File entry --
+2025-09-12 08:34:28.605   Dest filename: C:\vimacc\data\forExport\player64bit\avutil_AccVimacc-56.dll
+2025-09-12 08:34:28.605   Time stamp of our file: 2025-08-13 12:28:12.000
+2025-09-12 08:34:28.605   Installing the file.
+2025-09-12 08:34:28.637   Successfully installed the file.
+2025-09-12 08:34:28.637   -- File entry --
+2025-09-12 08:34:28.638   Dest filename: C:\vimacc\data\forExport\player64bit\swresample_AccVimacc-3.dll
+2025-09-12 08:34:28.638   Time stamp of our file: 2025-08-13 12:28:26.000
+2025-09-12 08:34:28.638   Installing the file.
+2025-09-12 08:34:28.665   Successfully installed the file.
+2025-09-12 08:34:28.665   -- File entry --
+2025-09-12 08:34:28.665   Dest filename: C:\vimacc\data\forExport\player64bit\swscale_AccVimacc-5.dll
+2025-09-12 08:34:28.666   Time stamp of our file: 2025-08-13 12:28:26.000
+2025-09-12 08:34:28.666   Installing the file.
+2025-09-12 08:34:28.694   Successfully installed the file.
+2025-09-12 08:34:28.694   -- File entry --
+2025-09-12 08:34:28.694   Dest filename: C:\vimacc\data\forExport\player64bit\libcrypto-3-x64.dll
+2025-09-12 08:34:28.696   Time stamp of our file: 2025-08-13 12:28:16.000
+2025-09-12 08:34:28.696   Installing the file.
+2025-09-12 08:34:28.739   Successfully installed the file.
+2025-09-12 08:34:28.739   -- File entry --
+2025-09-12 08:34:28.740   Dest filename: C:\vimacc\data\forExport\player64bit\liblz4.dll
+2025-09-12 08:34:28.740   Time stamp of our file: 2025-08-13 12:28:16.000
+2025-09-12 08:34:28.740   Installing the file.
+2025-09-12 08:34:28.758   Successfully installed the file.
+2025-09-12 08:34:28.758   -- File entry --
+2025-09-12 08:34:28.758   Dest filename: C:\vimacc\data\forExport\player64bit\opencv_core470.dll
+2025-09-12 08:34:28.758   Time stamp of our file: 2025-08-13 12:28:18.000
+2025-09-12 08:34:28.758   Installing the file.
+2025-09-12 08:34:28.810   Successfully installed the file.
+2025-09-12 08:34:28.810   -- File entry --
+2025-09-12 08:34:28.810   Dest filename: C:\vimacc\data\forExport\player64bit\opencv_imgproc470.dll
+2025-09-12 08:34:28.810   Time stamp of our file: 2025-08-13 12:28:20.000
+2025-09-12 08:34:28.810   Installing the file.
+2025-09-12 08:34:28.878   Successfully installed the file.
+2025-09-12 08:34:28.878   -- File entry --
+2025-09-12 08:34:28.879   Dest filename: C:\vimacc\data\forExport\player64bit\opencv_highgui470.dll
+2025-09-12 08:34:28.879   Time stamp of our file: 2025-08-13 12:28:20.000
+2025-09-12 08:34:28.879   Installing the file.
+2025-09-12 08:34:28.903   Successfully installed the file.
+2025-09-12 08:34:28.903   -- File entry --
+2025-09-12 08:34:28.903   Dest filename: C:\vimacc\data\forExport\player64bit\opencv_imgcodecs470.dll
+2025-09-12 08:34:28.903   Time stamp of our file: 2025-08-13 12:28:20.000
+2025-09-12 08:34:28.903   Installing the file.
+2025-09-12 08:34:28.926   Successfully installed the file.
+2025-09-12 08:34:28.927   -- File entry --
+2025-09-12 08:34:28.927   Dest filename: C:\vimacc\data\forExport\player64bit\opencv_videoio470.dll
+2025-09-12 08:34:28.927   Time stamp of our file: 2025-08-13 12:28:22.000
+2025-09-12 08:34:28.927   Installing the file.
+2025-09-12 08:34:28.947   Successfully installed the file.
+2025-09-12 08:34:28.947   -- File entry --
+2025-09-12 08:34:28.949   Dest filename: C:\vimacc\data\forExport\player64bit\libssl-3-x64.dll
+2025-09-12 08:34:28.949   Time stamp of our file: 2025-05-05 13:06:56.000
+2025-09-12 08:34:28.949   Installing the file.
+2025-09-12 08:34:28.960   Successfully installed the file.
+2025-09-12 08:34:28.961   -- File entry --
+2025-09-12 08:34:28.961   Dest filename: C:\vimacc\data\forExport\player64bit\opengl32sw.dll
+2025-09-12 08:34:28.961   Time stamp of our file: 2025-05-05 13:06:28.000
+2025-09-12 08:34:28.961   Installing the file.
+2025-09-12 08:34:29.185   Successfully installed the file.
+2025-09-12 08:34:29.185   -- File entry --
+2025-09-12 08:34:29.186   Dest filename: C:\vimacc\data\forExport\player64bit\concrt140.dll
+2025-09-12 08:34:29.186   Time stamp of our file: 2024-05-29 00:34:12.000
+2025-09-12 08:34:29.186   Installing the file.
+2025-09-12 08:34:29.201   Successfully installed the file.
+2025-09-12 08:34:29.201   -- File entry --
+2025-09-12 08:34:29.201   Dest filename: C:\vimacc\data\forExport\player64bit\msvcp140.dll
+2025-09-12 08:34:29.202   Time stamp of our file: 2024-05-29 00:34:12.000
+2025-09-12 08:34:29.202   Installing the file.
+2025-09-12 08:34:29.209   Successfully installed the file.
+2025-09-12 08:34:29.209   -- File entry --
+2025-09-12 08:34:29.209   Dest filename: C:\vimacc\data\forExport\player64bit\msvcp140_1.dll
+2025-09-12 08:34:29.210   Time stamp of our file: 2024-05-29 00:34:12.000
+2025-09-12 08:34:29.210   Installing the file.
+2025-09-12 08:34:29.211   Successfully installed the file.
+2025-09-12 08:34:29.211   -- File entry --
+2025-09-12 08:34:29.211   Dest filename: C:\vimacc\data\forExport\player64bit\msvcp140_2.dll
+2025-09-12 08:34:29.212   Time stamp of our file: 2024-05-29 00:34:12.000
+2025-09-12 08:34:29.212   Installing the file.
+2025-09-12 08:34:29.215   Successfully installed the file.
+2025-09-12 08:34:29.216   -- File entry --
+2025-09-12 08:34:29.216   Dest filename: C:\vimacc\data\forExport\player64bit\msvcp140_atomic_wait.dll
+2025-09-12 08:34:29.216   Time stamp of our file: 2024-05-29 00:34:12.000
+2025-09-12 08:34:29.216   Installing the file.
+2025-09-12 08:34:29.217   Successfully installed the file.
+2025-09-12 08:34:29.217   -- File entry --
+2025-09-12 08:34:29.218   Dest filename: C:\vimacc\data\forExport\player64bit\msvcp140_codecvt_ids.dll
+2025-09-12 08:34:29.218   Time stamp of our file: 2024-05-29 00:34:12.000
+2025-09-12 08:34:29.218   Installing the file.
+2025-09-12 08:34:29.219   Successfully installed the file.
+2025-09-12 08:34:29.219   -- File entry --
+2025-09-12 08:34:29.219   Dest filename: C:\vimacc\data\forExport\player64bit\vccorlib140.dll
+2025-09-12 08:34:29.219   Time stamp of our file: 2024-05-29 00:34:12.000
+2025-09-12 08:34:29.219   Installing the file.
+2025-09-12 08:34:29.224   Successfully installed the file.
+2025-09-12 08:34:29.224   -- File entry --
+2025-09-12 08:34:29.224   Dest filename: C:\vimacc\data\forExport\player64bit\vcruntime140.dll
+2025-09-12 08:34:29.224   Time stamp of our file: 2024-05-29 00:34:12.000
+2025-09-12 08:34:29.224   Installing the file.
+2025-09-12 08:34:29.227   Successfully installed the file.
+2025-09-12 08:34:29.227   -- File entry --
+2025-09-12 08:34:29.227   Dest filename: C:\vimacc\data\forExport\player64bit\vcruntime140_1.dll
+2025-09-12 08:34:29.227   Time stamp of our file: 2024-05-29 00:34:12.000
+2025-09-12 08:34:29.227   Installing the file.
+2025-09-12 08:34:29.228   Successfully installed the file.
+2025-09-12 08:34:29.228   -- File entry --
+2025-09-12 08:34:29.229   Dest filename: C:\vimacc\data\forExport\player64bit\vcruntime140_threads.dll
+2025-09-12 08:34:29.229   Time stamp of our file: 2024-05-29 00:34:12.000
+2025-09-12 08:34:29.229   Installing the file.
+2025-09-12 08:34:29.230   Successfully installed the file.
+2025-09-12 08:34:29.230   -- File entry --
+2025-09-12 08:34:29.230   Dest filename: C:\vimacc\bin\AccVimaccHIDController.exe
+2025-09-12 08:34:29.230   Time stamp of our file: 2025-08-13 12:28:00.000
+2025-09-12 08:34:29.230   Installing the file.
+2025-09-12 08:34:29.236   Successfully installed the file.
+2025-09-12 08:34:29.236   -- File entry --
+2025-09-12 08:34:29.237   Dest filename: C:\vimacc\bin\AccVimaccInterface.exe
+2025-09-12 08:34:29.237   Time stamp of our file: 2025-08-13 12:28:02.000
+2025-09-12 08:34:29.237   Installing the file.
+2025-09-12 08:34:29.289   Successfully installed the file.
+2025-09-12 08:34:29.289   -- File entry --
+2025-09-12 08:34:29.289   Dest filename: C:\vimacc\bin\AccVimaccMotionDetector.exe
+2025-09-12 08:34:29.289   Time stamp of our file: 2025-08-13 12:28:02.000
+2025-09-12 08:34:29.290   Installing the file.
+2025-09-12 08:34:29.292   Successfully installed the file.
+2025-09-12 08:34:29.293   -- File entry --
+2025-09-12 08:34:29.293   Dest filename: C:\vimacc\bin\AccVimaccLicensePlateDetector.exe
+2025-09-12 08:34:29.293   Time stamp of our file: 2025-08-13 12:28:02.000
+2025-09-12 08:34:29.293   Installing the file.
+2025-09-12 08:34:29.295   Successfully installed the file.
+2025-09-12 08:34:29.295   -- File entry --
+2025-09-12 08:34:29.296   Dest filename: C:\vimacc\bin\intrada.dll
+2025-09-12 08:34:29.296   Time stamp of our file: 2025-05-05 13:05:58.000
+2025-09-12 08:34:29.296   Installing the file.
+2025-09-12 08:34:29.411   Successfully installed the file.
+2025-09-12 08:34:29.411   -- File entry --
+2025-09-12 08:34:29.412   Dest filename: C:\vimacc\bin\intrada_cm_X_EU.dll
+2025-09-12 08:34:29.412   Time stamp of our file: 2025-05-05 13:05:58.000
+2025-09-12 08:34:29.412   Installing the file.
+2025-09-12 08:34:29.415   Successfully installed the file.
+2025-09-12 08:34:29.415   -- File entry --
+2025-09-12 08:34:29.416   Dest filename: C:\vimacc\bin\intrada_cm_D1.dll
+2025-09-12 08:34:29.416   Time stamp of our file: 2025-05-05 13:05:58.000
+2025-09-12 08:34:29.416   Installing the file.
+2025-09-12 08:34:29.428   Successfully installed the file.
+2025-09-12 08:34:29.428   -- File entry --
+2025-09-12 08:34:29.429   Dest filename: C:\vimacc\bin\intrada_cm_D2.dll
+2025-09-12 08:34:29.429   Time stamp of our file: 2025-05-05 13:05:58.000
+2025-09-12 08:34:29.429   Installing the file.
+2025-09-12 08:34:29.435   Successfully installed the file.
+2025-09-12 08:34:29.435   -- File entry --
+2025-09-12 08:34:29.435   Dest filename: C:\vimacc\bin\intrada.lic
+2025-09-12 08:34:29.435   Time stamp of our file: 2025-05-05 13:05:56.000
+2025-09-12 08:34:29.435   Installing the file.
+2025-09-12 08:34:29.436   Successfully installed the file.
+2025-09-12 08:34:29.436   -- File entry --
+2025-09-12 08:34:29.436   Dest filename: C:\vimacc\bin\AccVimaccFtpClient.dll
+2025-09-12 08:34:29.436   Time stamp of our file: 2025-08-13 12:27:58.000
+2025-09-12 08:34:29.436   Installing the file.
+2025-09-12 08:34:29.438   Successfully installed the file.
+2025-09-12 08:34:29.438   -- File entry --
+2025-09-12 08:34:29.439   Dest filename: C:\vimacc\bin\AccVimaccFtpAlarmReceiver.exe
+2025-09-12 08:34:29.439   Time stamp of our file: 2025-08-13 12:27:58.000
+2025-09-12 08:34:29.439   Installing the file.
+2025-09-12 08:34:29.442   Successfully installed the file.
+2025-09-12 08:34:29.442   -- File entry --
+2025-09-12 08:34:29.442   Dest filename: C:\vimacc\data\i18n\AccVimaccFtpAlarmReceiver_de.qm
+2025-09-12 08:34:29.442   Time stamp of our file: 2025-08-13 12:22:58.000
+2025-09-12 08:34:29.442   Installing the file.
+2025-09-12 08:34:29.443   Successfully installed the file.
+2025-09-12 08:34:29.443   -- File entry --
+2025-09-12 08:34:29.443   Dest filename: C:\vimacc\data\i18n\AccVimaccFtpAlarmReceiver_en.qm
+2025-09-12 08:34:29.443   Time stamp of our file: 2025-08-13 12:22:58.000
+2025-09-12 08:34:29.444   Installing the file.
+2025-09-12 08:34:29.444   Successfully installed the file.
+2025-09-12 08:34:29.444   -- File entry --
+2025-09-12 08:34:29.444   Dest filename: C:\vimacc\data\i18n\AccVimaccFtpClient_de.qm
+2025-09-12 08:34:29.445   Time stamp of our file: 2025-08-13 12:20:26.000
+2025-09-12 08:34:29.445   Installing the file.
+2025-09-12 08:34:29.445   Successfully installed the file.
+2025-09-12 08:34:29.445   -- File entry --
+2025-09-12 08:34:29.445   Dest filename: C:\vimacc\data\i18n\AccVimaccFtpClient_en.qm
+2025-09-12 08:34:29.445   Time stamp of our file: 2025-08-13 12:20:26.000
+2025-09-12 08:34:29.445   Installing the file.
+2025-09-12 08:34:29.446   Successfully installed the file.
+2025-09-12 08:34:29.446   -- File entry --
+2025-09-12 08:34:29.446   Dest filename: C:\vimacc\bin\AccVimaccFtpClient.dll
+2025-09-12 08:34:29.446   Time stamp of our file: 2025-08-13 12:27:58.000
+2025-09-12 08:34:29.446   Dest file exists.
+2025-09-12 08:34:29.446   Time stamp of existing file: 2025-08-13 12:27:58.000
+2025-09-12 08:34:29.446   Installing the file.
+2025-09-12 08:34:29.467   Successfully installed the file.
+2025-09-12 08:34:29.467   -- File entry --
+2025-09-12 08:34:29.467   Dest filename: C:\vimacc\bin\AccVimaccFtpUploader.exe
+2025-09-12 08:34:29.467   Time stamp of our file: 2025-08-13 12:28:00.000
+2025-09-12 08:34:29.467   Installing the file.
+2025-09-12 08:34:29.472   Successfully installed the file.
+2025-09-12 08:34:29.472   -- File entry --
+2025-09-12 08:34:29.472   Dest filename: C:\vimacc\data\i18n\AccVimaccFtpUploader_de.qm
+2025-09-12 08:34:29.472   Time stamp of our file: 2025-08-13 12:22:58.000
+2025-09-12 08:34:29.472   Installing the file.
+2025-09-12 08:34:29.482   Successfully installed the file.
+2025-09-12 08:34:29.482   -- File entry --
+2025-09-12 08:34:29.483   Dest filename: C:\vimacc\data\i18n\AccVimaccFtpUploader_en.qm
+2025-09-12 08:34:29.483   Time stamp of our file: 2025-08-13 12:22:58.000
+2025-09-12 08:34:29.483   Installing the file.
+2025-09-12 08:34:29.483   Successfully installed the file.
+2025-09-12 08:34:29.483   -- File entry --
+2025-09-12 08:34:29.484   Dest filename: C:\vimacc\data\i18n\AccVimaccFtpClient_de.qm
+2025-09-12 08:34:29.484   Time stamp of our file: 2025-08-13 12:20:26.000
+2025-09-12 08:34:29.484   Dest file exists.
+2025-09-12 08:34:29.484   Time stamp of existing file: 2025-08-13 12:20:26.000
+2025-09-12 08:34:29.484   Installing the file.
+2025-09-12 08:34:29.485   Successfully installed the file.
+2025-09-12 08:34:29.485   -- File entry --
+2025-09-12 08:34:29.485   Dest filename: C:\vimacc\data\i18n\AccVimaccFtpClient_en.qm
+2025-09-12 08:34:29.485   Time stamp of our file: 2025-08-13 12:20:26.000
+2025-09-12 08:34:29.485   Dest file exists.
+2025-09-12 08:34:29.485   Time stamp of existing file: 2025-08-13 12:20:26.000
+2025-09-12 08:34:29.485   Installing the file.
+2025-09-12 08:34:29.486   Successfully installed the file.
+2025-09-12 08:34:29.486   -- File entry --
+2025-09-12 08:34:29.487   Dest filename: C:\vimacc\bin\AccVimaccIpAlarmReceiver.exe
+2025-09-12 08:34:29.487   Time stamp of our file: 2025-08-13 12:28:02.000
+2025-09-12 08:34:29.487   Installing the file.
+2025-09-12 08:34:29.491   Successfully installed the file.
+2025-09-12 08:34:29.491   -- File entry --
+2025-09-12 08:34:29.491   Dest filename: C:\vimacc\bin\AccVimaccOpcClient.exe
+2025-09-12 08:34:29.491   Time stamp of our file: 2025-08-13 12:28:04.000
+2025-09-12 08:34:29.491   Installing the file.
+2025-09-12 08:34:29.497   Successfully installed the file.
+2025-09-12 08:34:29.497   -- File entry --
+2025-09-12 08:34:29.497   Dest filename: C:\vimacc\config\AccVimaccOpcClient_workstation.conf
+2025-09-12 08:34:29.497   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:29.497   Installing the file.
+2025-09-12 08:34:29.499   Successfully installed the file.
+2025-09-12 08:34:29.499   -- File entry --
+2025-09-12 08:34:29.500   Dest filename: C:\WINDOWS\system32\opcproxy.dll
+2025-09-12 08:34:29.500   Time stamp of our file: 2025-05-05 13:06:26.000
+2025-09-12 08:34:29.500   Installing the file.
+2025-09-12 08:34:29.502   Successfully installed the file.
+2025-09-12 08:34:29.502   Will register the file (a DLL/OCX) later.
+2025-09-12 08:34:29.502   -- File entry --
+2025-09-12 08:34:29.502   Dest filename: C:\vimacc\bin\Qt5OpcUa.dll
+2025-09-12 08:34:29.503   Time stamp of our file: 2025-05-05 13:06:44.000
+2025-09-12 08:34:29.503   Installing the file.
+2025-09-12 08:34:29.511   Successfully installed the file.
+2025-09-12 08:34:29.511   -- File entry --
+2025-09-12 08:34:29.511   Dest filename: C:\vimacc\bin\plugins\opcua\open62541_backend.dll
+2025-09-12 08:34:29.511   Time stamp of our file: 2025-05-05 13:06:44.000
+2025-09-12 08:34:29.511   Installing the file.
+2025-09-12 08:34:29.524   Successfully installed the file.
+2025-09-12 08:34:29.524   -- File entry --
+2025-09-12 08:34:29.524   Dest filename: C:\vimacc\data\pki\own\createOpcUAHostCert.ps1
+2025-09-12 08:34:29.524   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:29.524   Installing the file.
+2025-09-12 08:34:29.525   Successfully installed the file.
+2025-09-12 08:34:29.525   -- File entry --
+2025-09-12 08:34:29.526   Dest filename: C:\vimacc\data\pki\own\opcua_sslext.cnf
+2025-09-12 08:34:29.526   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:29.526   Installing the file.
+2025-09-12 08:34:29.526   Successfully installed the file.
+2025-09-12 08:34:29.526   -- File entry --
+2025-09-12 08:34:29.527   Dest filename: C:\vimacc\data\pki\trusted\certs\ca.der
+2025-09-12 08:34:29.527   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:29.527   Installing the file.
+2025-09-12 08:34:29.527   Successfully installed the file.
+2025-09-12 08:34:29.527   -- File entry --
+2025-09-12 08:34:29.528   Dest filename: C:\vimacc\data\pki\trusted\crl\ca.crl.pem
+2025-09-12 08:34:29.528   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:29.528   Installing the file.
+2025-09-12 08:34:29.528   Successfully installed the file.
+2025-09-12 08:34:29.528   -- File entry --
+2025-09-12 08:34:29.528   Dest filename: C:\vimacc\bin\AccVimaccReportClient.exe
+2025-09-12 08:34:29.528   Time stamp of our file: 2025-08-13 12:28:04.000
+2025-09-12 08:34:29.528   Installing the file.
+2025-09-12 08:34:29.532   Successfully installed the file.
+2025-09-12 08:34:29.532   -- File entry --
+2025-09-12 08:34:29.532   Dest filename: C:\vimacc\bin\AccVimaccReportServer.exe
+2025-09-12 08:34:29.532   Time stamp of our file: 2025-08-13 12:28:06.000
+2025-09-12 08:34:29.532   Installing the file.
+2025-09-12 08:34:29.536   Successfully installed the file.
+2025-09-12 08:34:29.536   -- File entry --
+2025-09-12 08:34:29.536   Dest filename: C:\vimacc\bin\AccVimaccRoot.exe
+2025-09-12 08:34:29.536   Time stamp of our file: 2025-08-13 12:28:06.000
+2025-09-12 08:34:29.536   Installing the file.
+2025-09-12 08:34:29.547   Successfully installed the file.
+2025-09-12 08:34:29.547   -- File entry --
+2025-09-12 08:34:29.547   Dest filename: C:\vimacc\bin\AccVimaccRTSPServer.exe
+2025-09-12 08:34:29.547   Time stamp of our file: 2025-08-13 12:28:06.000
+2025-09-12 08:34:29.547   Installing the file.
+2025-09-12 08:34:29.552   Successfully installed the file.
+2025-09-12 08:34:29.552   -- File entry --
+2025-09-12 08:34:29.552   Dest filename: C:\vimacc\bin\AccVimaccScheduler.exe
+2025-09-12 08:34:29.553   Time stamp of our file: 2025-08-13 12:28:06.000
+2025-09-12 08:34:29.553   Installing the file.
+2025-09-12 08:34:29.555   Successfully installed the file.
+2025-09-12 08:34:29.555   -- File entry --
+2025-09-12 08:34:29.555   Dest filename: C:\vimacc\bin\AccVimaccServer.exe
+2025-09-12 08:34:29.556   Time stamp of our file: 2025-08-13 12:28:06.000
+2025-09-12 08:34:29.556   Installing the file.
+2025-09-12 08:34:29.563   Successfully installed the file.
+2025-09-12 08:34:29.563   -- File entry --
+2025-09-12 08:34:29.563   Dest filename: C:\vimacc\config\AccVimaccServer_workstation.conf
+2025-09-12 08:34:29.563   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:29.563   Installing the file.
+2025-09-12 08:34:29.564   Successfully installed the file.
+2025-09-12 08:34:29.564   -- File entry --
+2025-09-12 08:34:29.565   Dest filename: C:\vimacc\bin\AccVimaccSign.exe
+2025-09-12 08:34:29.565   Time stamp of our file: 2025-08-13 12:28:08.000
+2025-09-12 08:34:29.565   Installing the file.
+2025-09-12 08:34:29.580   Successfully installed the file.
+2025-09-12 08:34:29.580   -- File entry --
+2025-09-12 08:34:29.580   Dest filename: C:\vimacc\bin\AccVimaccSnmpAgent.exe
+2025-09-12 08:34:29.580   Time stamp of our file: 2025-08-13 12:28:08.000
+2025-09-12 08:34:29.580   Installing the file.
+2025-09-12 08:34:29.585   Successfully installed the file.
+2025-09-12 08:34:29.585   -- File entry --
+2025-09-12 08:34:29.585   Dest filename: C:\vimacc\bin\snmp_pp.dll
+2025-09-12 08:34:29.586   Time stamp of our file: 2025-05-05 13:06:26.000
+2025-09-12 08:34:29.586   Installing the file.
+2025-09-12 08:34:29.592   Successfully installed the file.
+2025-09-12 08:34:29.593   -- File entry --
+2025-09-12 08:34:29.593   Dest filename: C:\vimacc\config\AccVimaccSnmpAgent_workstation.conf
+2025-09-12 08:34:29.594   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:29.594   Installing the file.
+2025-09-12 08:34:29.595   Successfully installed the file.
+2025-09-12 08:34:29.595   -- File entry --
+2025-09-12 08:34:29.595   Dest filename: C:\vimacc\data\i18n\AccVimaccSnmpAgent_de.qm
+2025-09-12 08:34:29.595   Time stamp of our file: 2025-08-13 12:23:04.000
+2025-09-12 08:34:29.595   Installing the file.
+2025-09-12 08:34:29.596   Successfully installed the file.
+2025-09-12 08:34:29.596   -- File entry --
+2025-09-12 08:34:29.596   Dest filename: C:\vimacc\data\i18n\AccVimaccSnmpAgent_en.qm
+2025-09-12 08:34:29.596   Time stamp of our file: 2025-08-13 12:23:02.000
+2025-09-12 08:34:29.596   Installing the file.
+2025-09-12 08:34:29.597   Successfully installed the file.
+2025-09-12 08:34:29.597   -- File entry --
+2025-09-12 08:34:29.597   Dest filename: C:\vimacc\bin\AccVimaccSiteMapEditor.exe
+2025-09-12 08:34:29.597   Time stamp of our file: 2025-08-13 12:28:08.000
+2025-09-12 08:34:29.597   Installing the file.
+2025-09-12 08:34:29.609   Successfully installed the file.
+2025-09-12 08:34:29.609   -- File entry --
+2025-09-12 08:34:29.610   Dest filename: C:\vimacc\data\i18n\AccVimaccSiteMapEditor_de.qm
+2025-09-12 08:34:29.610   Time stamp of our file: 2025-08-13 12:22:58.000
+2025-09-12 08:34:29.610   Installing the file.
+2025-09-12 08:34:29.610   Successfully installed the file.
+2025-09-12 08:34:29.610   -- File entry --
+2025-09-12 08:34:29.610   Dest filename: C:\vimacc\data\i18n\AccVimaccSiteMapEditor_en.qm
+2025-09-12 08:34:29.610   Time stamp of our file: 2025-08-13 12:22:58.000
+2025-09-12 08:34:29.610   Installing the file.
+2025-09-12 08:34:29.612   Successfully installed the file.
+2025-09-12 08:34:29.612   -- File entry --
+2025-09-12 08:34:29.612   Dest filename: C:\vimacc\bin\AccVimaccSystemMonitor.exe
+2025-09-12 08:34:29.612   Time stamp of our file: 2025-08-13 12:28:10.000
+2025-09-12 08:34:29.612   Installing the file.
+2025-09-12 08:34:29.616   Successfully installed the file.
+2025-09-12 08:34:29.616   -- File entry --
+2025-09-12 08:34:29.618   Dest filename: C:\vimacc\config\AccVimaccSystemMonitor_workstation.conf
+2025-09-12 08:34:29.618   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:29.618   Installing the file.
+2025-09-12 08:34:29.618   Successfully installed the file.
+2025-09-12 08:34:29.618   -- File entry --
+2025-09-12 08:34:29.618   Dest filename: C:\vimacc\data\i18n\AccVimaccSystemMonitor_de.qm
+2025-09-12 08:34:29.618   Time stamp of our file: 2025-08-13 12:20:42.000
+2025-09-12 08:34:29.618   Installing the file.
+2025-09-12 08:34:29.619   Successfully installed the file.
+2025-09-12 08:34:29.619   -- File entry --
+2025-09-12 08:34:29.619   Dest filename: C:\vimacc\data\i18n\AccVimaccSystemMonitor_en.qm
+2025-09-12 08:34:29.619   Time stamp of our file: 2025-08-13 12:20:42.000
+2025-09-12 08:34:29.619   Installing the file.
+2025-09-12 08:34:29.620   Successfully installed the file.
+2025-09-12 08:34:29.620   -- File entry --
+2025-09-12 08:34:29.620   Dest filename: C:\vimacc\bin\AccVimaccSystray.exe
+2025-09-12 08:34:29.620   Time stamp of our file: 2025-08-13 12:28:10.000
+2025-09-12 08:34:29.620   Installing the file.
+2025-09-12 08:34:29.628   Successfully installed the file.
+2025-09-12 08:34:29.628   -- File entry --
+2025-09-12 08:34:29.629   Dest filename: C:\vimacc\data\i18n\AccVimaccSystray_de.qm
+2025-09-12 08:34:29.629   Time stamp of our file: 2025-08-13 12:20:44.000
+2025-09-12 08:34:29.629   Installing the file.
+2025-09-12 08:34:29.629   Successfully installed the file.
+2025-09-12 08:34:29.629   -- File entry --
+2025-09-12 08:34:29.630   Dest filename: C:\vimacc\data\i18n\AccVimaccSystray_en.qm
+2025-09-12 08:34:29.630   Time stamp of our file: 2025-08-13 12:20:42.000
+2025-09-12 08:34:29.630   Installing the file.
+2025-09-12 08:34:29.630   Successfully installed the file.
+2025-09-12 08:34:29.630   -- File entry --
+2025-09-12 08:34:29.631   Dest filename: C:\vimacc\bin\AccVimaccUpdate.exe
+2025-09-12 08:34:29.631   Time stamp of our file: 2025-08-13 12:28:10.000
+2025-09-12 08:34:29.631   Installing the file.
+2025-09-12 08:34:29.636   Successfully installed the file.
+2025-09-12 08:34:29.636   -- File entry --
+2025-09-12 08:34:29.636   Dest filename: C:\vimacc\data\i18n\AccVimaccUpdate_de.qm
+2025-09-12 08:34:29.637   Time stamp of our file: 2025-08-13 12:23:00.000
+2025-09-12 08:34:29.637   Installing the file.
+2025-09-12 08:34:29.637   Successfully installed the file.
+2025-09-12 08:34:29.637   -- File entry --
+2025-09-12 08:34:29.638   Dest filename: C:\vimacc\data\i18n\AccVimaccUpdate_en.qm
+2025-09-12 08:34:29.638   Time stamp of our file: 2025-08-13 12:23:00.000
+2025-09-12 08:34:29.638   Installing the file.
+2025-09-12 08:34:29.638   Successfully installed the file.
+2025-09-12 08:34:29.638   -- File entry --
+2025-09-12 08:34:29.639   Dest filename: C:\vimacc\bin\AccVimaccIcxInterface.exe
+2025-09-12 08:34:29.639   Time stamp of our file: 2025-08-13 12:28:00.000
+2025-09-12 08:34:29.639   Installing the file.
+2025-09-12 08:34:29.644   Successfully installed the file.
+2025-09-12 08:34:29.644   -- File entry --
+2025-09-12 08:34:29.645   Dest filename: C:\vimacc\bin\AccVimaccSPS-FT_Interface.exe
+2025-09-12 08:34:29.645   Time stamp of our file: 2025-08-13 12:28:08.000
+2025-09-12 08:34:29.645   Installing the file.
+2025-09-12 08:34:29.647   Successfully installed the file.
+2025-09-12 08:34:29.647   -- File entry --
+2025-09-12 08:34:29.647   Dest filename: C:\vimacc\bin\AccVimaccWorkstation.exe
+2025-09-12 08:34:29.648   Time stamp of our file: 2025-08-13 12:28:12.000
+2025-09-12 08:34:29.648   Installing the file.
+2025-09-12 08:34:29.699   Successfully installed the file.
+2025-09-12 08:34:29.699   -- File entry --
+2025-09-12 08:34:29.700   Dest filename: C:\vimacc\data\Workstation\stylesheet.qss.workstation
+2025-09-12 08:34:29.700   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.700   Installing the file.
+2025-09-12 08:34:29.701   Successfully installed the file.
+2025-09-12 08:34:29.701   -- File entry --
+2025-09-12 08:34:29.701   Dest filename: C:\vimacc\data\Workstation\Videowallconfiguration.xml.workstation
+2025-09-12 08:34:29.701   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.701   Installing the file.
+2025-09-12 08:34:29.702   Successfully installed the file.
+2025-09-12 08:34:29.703   -- File entry --
+2025-09-12 08:34:29.703   Dest filename: C:\vimacc\data\Workstation\12p1Grid.gld
+2025-09-12 08:34:29.703   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.703   Installing the file.
+2025-09-12 08:34:29.704   Successfully installed the file.
+2025-09-12 08:34:29.704   -- File entry --
+2025-09-12 08:34:29.704   Dest filename: C:\vimacc\data\Workstation\1p11Grid.gld
+2025-09-12 08:34:29.704   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.704   Installing the file.
+2025-09-12 08:34:29.705   Successfully installed the file.
+2025-09-12 08:34:29.705   -- File entry --
+2025-09-12 08:34:29.705   Dest filename: C:\vimacc\data\Workstation\1p1x2Grid.gld
+2025-09-12 08:34:29.705   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.705   Installing the file.
+2025-09-12 08:34:29.706   Successfully installed the file.
+2025-09-12 08:34:29.706   -- File entry --
+2025-09-12 08:34:29.706   Dest filename: C:\vimacc\data\Workstation\1p1x4Grid.gld
+2025-09-12 08:34:29.706   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.706   Installing the file.
+2025-09-12 08:34:29.707   Successfully installed the file.
+2025-09-12 08:34:29.707   -- File entry --
+2025-09-12 08:34:29.707   Dest filename: C:\vimacc\data\Workstation\1p2Grid.gld
+2025-09-12 08:34:29.707   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.707   Installing the file.
+2025-09-12 08:34:29.707   Successfully installed the file.
+2025-09-12 08:34:29.708   -- File entry --
+2025-09-12 08:34:29.708   Dest filename: C:\vimacc\data\Workstation\1p5Grid.gld
+2025-09-12 08:34:29.708   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.708   Installing the file.
+2025-09-12 08:34:29.708   Successfully installed the file.
+2025-09-12 08:34:29.709   -- File entry --
+2025-09-12 08:34:29.709   Dest filename: C:\vimacc\data\Workstation\1p6Grid.gld
+2025-09-12 08:34:29.709   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.709   Installing the file.
+2025-09-12 08:34:29.709   Successfully installed the file.
+2025-09-12 08:34:29.709   -- File entry --
+2025-09-12 08:34:29.710   Dest filename: C:\vimacc\data\Workstation\1x3Grid.gld
+2025-09-12 08:34:29.710   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.710   Installing the file.
+2025-09-12 08:34:29.710   Successfully installed the file.
+2025-09-12 08:34:29.710   -- File entry --
+2025-09-12 08:34:29.711   Dest filename: C:\vimacc\data\Workstation\26p1Grid.gld
+2025-09-12 08:34:29.711   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.711   Installing the file.
+2025-09-12 08:34:29.711   Successfully installed the file.
+2025-09-12 08:34:29.711   -- File entry --
+2025-09-12 08:34:29.711   Dest filename: C:\vimacc\data\Workstation\2p1Grid.gld
+2025-09-12 08:34:29.711   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.711   Installing the file.
+2025-09-12 08:34:29.713   Successfully installed the file.
+2025-09-12 08:34:29.713   -- File entry --
+2025-09-12 08:34:29.713   Dest filename: C:\vimacc\data\Workstation\2x1Grid.gld
+2025-09-12 08:34:29.713   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.713   Installing the file.
+2025-09-12 08:34:29.714   Successfully installed the file.
+2025-09-12 08:34:29.714   -- File entry --
+2025-09-12 08:34:29.714   Dest filename: C:\vimacc\data\Workstation\2x3p4Grid.gld
+2025-09-12 08:34:29.714   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.714   Installing the file.
+2025-09-12 08:34:29.714   Successfully installed the file.
+2025-09-12 08:34:29.714   -- File entry --
+2025-09-12 08:34:29.715   Dest filename: C:\vimacc\data\Workstation\2x4Grid.gld
+2025-09-12 08:34:29.715   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.715   Installing the file.
+2025-09-12 08:34:29.715   Successfully installed the file.
+2025-09-12 08:34:29.715   -- File entry --
+2025-09-12 08:34:29.716   Dest filename: C:\vimacc\data\Workstation\2x4p2Grid.gld
+2025-09-12 08:34:29.716   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.716   Installing the file.
+2025-09-12 08:34:29.716   Successfully installed the file.
+2025-09-12 08:34:29.716   -- File entry --
+2025-09-12 08:34:29.717   Dest filename: C:\vimacc\data\Workstation\2x4p5Grid.gld
+2025-09-12 08:34:29.717   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.717   Installing the file.
+2025-09-12 08:34:29.717   Successfully installed the file.
+2025-09-12 08:34:29.717   -- File entry --
+2025-09-12 08:34:29.718   Dest filename: C:\vimacc\data\Workstation\3p1x2Grid.gld
+2025-09-12 08:34:29.718   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.718   Installing the file.
+2025-09-12 08:34:29.718   Successfully installed the file.
+2025-09-12 08:34:29.718   -- File entry --
+2025-09-12 08:34:29.719   Dest filename: C:\vimacc\data\Workstation\3p2Grid.gld
+2025-09-12 08:34:29.719   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.719   Installing the file.
+2025-09-12 08:34:29.719   Successfully installed the file.
+2025-09-12 08:34:29.719   -- File entry --
+2025-09-12 08:34:29.720   Dest filename: C:\vimacc\data\Workstation\3x3Grid.gld
+2025-09-12 08:34:29.720   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.720   Installing the file.
+2025-09-12 08:34:29.720   Successfully installed the file.
+2025-09-12 08:34:29.720   -- File entry --
+2025-09-12 08:34:29.720   Dest filename: C:\vimacc\data\Workstation\4x4Grid.gld
+2025-09-12 08:34:29.721   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.721   Installing the file.
+2025-09-12 08:34:29.721   Successfully installed the file.
+2025-09-12 08:34:29.721   -- File entry --
+2025-09-12 08:34:29.721   Dest filename: C:\vimacc\data\Workstation\4x8Grid.gld
+2025-09-12 08:34:29.721   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.721   Installing the file.
+2025-09-12 08:34:29.722   Successfully installed the file.
+2025-09-12 08:34:29.722   -- File entry --
+2025-09-12 08:34:29.722   Dest filename: C:\vimacc\data\Workstation\5p1Grid.gld
+2025-09-12 08:34:29.722   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.722   Installing the file.
+2025-09-12 08:34:29.723   Successfully installed the file.
+2025-09-12 08:34:29.723   -- File entry --
+2025-09-12 08:34:29.723   Dest filename: C:\vimacc\data\Workstation\5p2x4Grid.gld
+2025-09-12 08:34:29.723   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.723   Installing the file.
+2025-09-12 08:34:29.724   Successfully installed the file.
+2025-09-12 08:34:29.724   -- File entry --
+2025-09-12 08:34:29.724   Dest filename: C:\vimacc\data\Workstation\5x6Grid.gld
+2025-09-12 08:34:29.724   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.724   Installing the file.
+2025-09-12 08:34:29.724   Successfully installed the file.
+2025-09-12 08:34:29.724   -- File entry --
+2025-09-12 08:34:29.726   Dest filename: C:\vimacc\data\i18n\AccVimaccWorkstation_de.qm
+2025-09-12 08:34:29.726   Time stamp of our file: 2025-08-13 12:24:30.000
+2025-09-12 08:34:29.726   Installing the file.
+2025-09-12 08:34:29.726   Successfully installed the file.
+2025-09-12 08:34:29.727   -- File entry --
+2025-09-12 08:34:29.727   Dest filename: C:\vimacc\data\i18n\AccVimaccWorkstation_en.qm
+2025-09-12 08:34:29.727   Time stamp of our file: 2025-08-13 12:24:30.000
+2025-09-12 08:34:29.727   Installing the file.
+2025-09-12 08:34:29.727   Successfully installed the file.
+2025-09-12 08:34:29.727   -- File entry --
+2025-09-12 08:34:29.728   Dest filename: C:\vimacc\config\AccVimaccWorkstation_workstation.conf
+2025-09-12 08:34:29.728   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:29.728   Installing the file.
+2025-09-12 08:34:29.728   Successfully installed the file.
+2025-09-12 08:34:29.728   -- File entry --
+2025-09-12 08:34:29.729   Dest filename: C:\vimacc\config\AccVimaccWorkstationDsp1_workstation.conf
+2025-09-12 08:34:29.729   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:29.729   Installing the file.
+2025-09-12 08:34:29.729   Successfully installed the file.
+2025-09-12 08:34:29.730   -- File entry --
+2025-09-12 08:34:29.731   Dest filename: C:\vimacc\config\AccVimaccWorkstationDsp2_workstation.conf
+2025-09-12 08:34:29.731   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:29.731   Installing the file.
+2025-09-12 08:34:29.731   Successfully installed the file.
+2025-09-12 08:34:29.731   -- File entry --
+2025-09-12 08:34:29.732   Dest filename: C:\vimacc\config\AccVimaccWorkstationDsp3_workstation.conf
+2025-09-12 08:34:29.732   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:29.732   Installing the file.
+2025-09-12 08:34:29.732   Successfully installed the file.
+2025-09-12 08:34:29.732   -- File entry --
+2025-09-12 08:34:29.732   Dest filename: C:\vimacc\config\AccVimaccWorkstationDsp4_workstation.conf
+2025-09-12 08:34:29.733   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:29.733   Installing the file.
+2025-09-12 08:34:29.733   Successfully installed the file.
+2025-09-12 08:34:29.733   -- File entry --
+2025-09-12 08:34:29.733   Dest filename: C:\vimacc\config\AccVimaccWorkstation_2M_workstation.conf
+2025-09-12 08:34:29.734   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:29.734   Installing the file.
+2025-09-12 08:34:29.734   Successfully installed the file.
+2025-09-12 08:34:29.734   -- File entry --
+2025-09-12 08:34:29.734   Dest filename: C:\vimacc\config\AccVimaccWorkstationDsp1_2M_workstation.conf
+2025-09-12 08:34:29.734   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:29.734   Installing the file.
+2025-09-12 08:34:29.734   Successfully installed the file.
+2025-09-12 08:34:29.736   -- File entry --
+2025-09-12 08:34:29.736   Dest filename: C:\vimacc\config\AccVimaccWorkstationDsp2_2M_workstation.conf
+2025-09-12 08:34:29.736   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:29.736   Installing the file.
+2025-09-12 08:34:29.736   Successfully installed the file.
+2025-09-12 08:34:29.737   -- File entry --
+2025-09-12 08:34:29.737   Dest filename: C:\vimacc\config\AccVimaccWorkstationDsp3_2M_workstation.conf
+2025-09-12 08:34:29.737   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:29.737   Installing the file.
+2025-09-12 08:34:29.737   Successfully installed the file.
+2025-09-12 08:34:29.737   -- File entry --
+2025-09-12 08:34:29.738   Dest filename: C:\vimacc\config\AccVimaccWorkstationDsp4_2M_workstation.conf
+2025-09-12 08:34:29.738   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:29.738   Installing the file.
+2025-09-12 08:34:29.739   Successfully installed the file.
+2025-09-12 08:34:29.739   -- File entry --
+2025-09-12 08:34:29.739   Dest filename: C:\vimacc\config\AccVimaccWorkstation_5M_workstation.conf
+2025-09-12 08:34:29.739   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:29.739   Installing the file.
+2025-09-12 08:34:29.740   Successfully installed the file.
+2025-09-12 08:34:29.740   -- File entry --
+2025-09-12 08:34:29.740   Dest filename: C:\vimacc\config\AccVimaccWorkstationDsp1_5M_workstation.conf
+2025-09-12 08:34:29.740   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:29.740   Installing the file.
+2025-09-12 08:34:29.741   Successfully installed the file.
+2025-09-12 08:34:29.741   -- File entry --
+2025-09-12 08:34:29.741   Dest filename: C:\vimacc\config\AccVimaccWorkstationDsp2_5M_workstation.conf
+2025-09-12 08:34:29.741   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:29.741   Installing the file.
+2025-09-12 08:34:29.742   Successfully installed the file.
+2025-09-12 08:34:29.742   -- File entry --
+2025-09-12 08:34:29.742   Dest filename: C:\vimacc\config\AccVimaccWorkstationDsp3_5M_workstation.conf
+2025-09-12 08:34:29.742   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:29.742   Installing the file.
+2025-09-12 08:34:29.742   Successfully installed the file.
+2025-09-12 08:34:29.742   -- File entry --
+2025-09-12 08:34:29.742   Dest filename: C:\vimacc\config\AccVimaccWorkstationDsp4_5M_workstation.conf
+2025-09-12 08:34:29.743   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:29.743   Installing the file.
+2025-09-12 08:34:29.743   Successfully installed the file.
+2025-09-12 08:34:29.743   -- File entry --
+2025-09-12 08:34:29.743   Dest filename: C:\vimacc\bin\AccVimaccDisplay.exe
+2025-09-12 08:34:29.743   Time stamp of our file: 2025-08-13 12:27:56.000
+2025-09-12 08:34:29.743   Installing the file.
+2025-09-12 08:34:29.764   Successfully installed the file.
+2025-09-12 08:34:29.764   -- File entry --
+2025-09-12 08:34:29.764   Dest filename: C:\vimacc\data\Workstation\12p1Grid.gld
+2025-09-12 08:34:29.764   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.764   Dest file exists.
+2025-09-12 08:34:29.765   Time stamp of existing file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.765   Installing the file.
+2025-09-12 08:34:29.766   Successfully installed the file.
+2025-09-12 08:34:29.766   -- File entry --
+2025-09-12 08:34:29.766   Dest filename: C:\vimacc\data\Workstation\1p11Grid.gld
+2025-09-12 08:34:29.766   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.766   Dest file exists.
+2025-09-12 08:34:29.766   Time stamp of existing file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.766   Installing the file.
+2025-09-12 08:34:29.768   Successfully installed the file.
+2025-09-12 08:34:29.768   -- File entry --
+2025-09-12 08:34:29.769   Dest filename: C:\vimacc\data\Workstation\1p1x2Grid.gld
+2025-09-12 08:34:29.769   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.769   Dest file exists.
+2025-09-12 08:34:29.769   Time stamp of existing file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.769   Installing the file.
+2025-09-12 08:34:29.770   Successfully installed the file.
+2025-09-12 08:34:29.770   -- File entry --
+2025-09-12 08:34:29.770   Dest filename: C:\vimacc\data\Workstation\1p1x4Grid.gld
+2025-09-12 08:34:29.770   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.770   Dest file exists.
+2025-09-12 08:34:29.770   Time stamp of existing file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.771   Installing the file.
+2025-09-12 08:34:29.771   Successfully installed the file.
+2025-09-12 08:34:29.772   -- File entry --
+2025-09-12 08:34:29.772   Dest filename: C:\vimacc\data\Workstation\1p2Grid.gld
+2025-09-12 08:34:29.772   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.772   Dest file exists.
+2025-09-12 08:34:29.772   Time stamp of existing file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.772   Installing the file.
+2025-09-12 08:34:29.773   Successfully installed the file.
+2025-09-12 08:34:29.773   -- File entry --
+2025-09-12 08:34:29.773   Dest filename: C:\vimacc\data\Workstation\1p5Grid.gld
+2025-09-12 08:34:29.773   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.773   Dest file exists.
+2025-09-12 08:34:29.773   Time stamp of existing file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.773   Installing the file.
+2025-09-12 08:34:29.774   Successfully installed the file.
+2025-09-12 08:34:29.774   -- File entry --
+2025-09-12 08:34:29.775   Dest filename: C:\vimacc\data\Workstation\1p6Grid.gld
+2025-09-12 08:34:29.775   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.775   Dest file exists.
+2025-09-12 08:34:29.775   Time stamp of existing file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.775   Installing the file.
+2025-09-12 08:34:29.783   Successfully installed the file.
+2025-09-12 08:34:29.783   -- File entry --
+2025-09-12 08:34:29.783   Dest filename: C:\vimacc\data\Workstation\1x3Grid.gld
+2025-09-12 08:34:29.783   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.783   Dest file exists.
+2025-09-12 08:34:29.783   Time stamp of existing file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.783   Installing the file.
+2025-09-12 08:34:29.784   Successfully installed the file.
+2025-09-12 08:34:29.784   -- File entry --
+2025-09-12 08:34:29.785   Dest filename: C:\vimacc\data\Workstation\26p1Grid.gld
+2025-09-12 08:34:29.785   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.785   Dest file exists.
+2025-09-12 08:34:29.785   Time stamp of existing file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.785   Installing the file.
+2025-09-12 08:34:29.786   Successfully installed the file.
+2025-09-12 08:34:29.786   -- File entry --
+2025-09-12 08:34:29.786   Dest filename: C:\vimacc\data\Workstation\2p1Grid.gld
+2025-09-12 08:34:29.786   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.786   Dest file exists.
+2025-09-12 08:34:29.786   Time stamp of existing file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.786   Installing the file.
+2025-09-12 08:34:29.791   Successfully installed the file.
+2025-09-12 08:34:29.791   -- File entry --
+2025-09-12 08:34:29.791   Dest filename: C:\vimacc\data\Workstation\2x1Grid.gld
+2025-09-12 08:34:29.791   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.791   Dest file exists.
+2025-09-12 08:34:29.791   Time stamp of existing file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.791   Installing the file.
+2025-09-12 08:34:29.795   Successfully installed the file.
+2025-09-12 08:34:29.795   -- File entry --
+2025-09-12 08:34:29.796   Dest filename: C:\vimacc\data\Workstation\2x3p4Grid.gld
+2025-09-12 08:34:29.796   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.796   Dest file exists.
+2025-09-12 08:34:29.796   Time stamp of existing file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.796   Installing the file.
+2025-09-12 08:34:29.796   Successfully installed the file.
+2025-09-12 08:34:29.796   -- File entry --
+2025-09-12 08:34:29.797   Dest filename: C:\vimacc\data\Workstation\2x4Grid.gld
+2025-09-12 08:34:29.797   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.797   Dest file exists.
+2025-09-12 08:34:29.797   Time stamp of existing file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.797   Installing the file.
+2025-09-12 08:34:29.798   Successfully installed the file.
+2025-09-12 08:34:29.798   -- File entry --
+2025-09-12 08:34:29.798   Dest filename: C:\vimacc\data\Workstation\2x4p2Grid.gld
+2025-09-12 08:34:29.798   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.798   Dest file exists.
+2025-09-12 08:34:29.798   Time stamp of existing file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.798   Installing the file.
+2025-09-12 08:34:29.799   Successfully installed the file.
+2025-09-12 08:34:29.800   -- File entry --
+2025-09-12 08:34:29.800   Dest filename: C:\vimacc\data\Workstation\2x4p5Grid.gld
+2025-09-12 08:34:29.800   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.800   Dest file exists.
+2025-09-12 08:34:29.800   Time stamp of existing file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.800   Installing the file.
+2025-09-12 08:34:29.801   Successfully installed the file.
+2025-09-12 08:34:29.801   -- File entry --
+2025-09-12 08:34:29.801   Dest filename: C:\vimacc\data\Workstation\3p1x2Grid.gld
+2025-09-12 08:34:29.801   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.801   Dest file exists.
+2025-09-12 08:34:29.801   Time stamp of existing file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.801   Installing the file.
+2025-09-12 08:34:29.802   Successfully installed the file.
+2025-09-12 08:34:29.802   -- File entry --
+2025-09-12 08:34:29.803   Dest filename: C:\vimacc\data\Workstation\3p2Grid.gld
+2025-09-12 08:34:29.803   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.803   Dest file exists.
+2025-09-12 08:34:29.803   Time stamp of existing file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.803   Installing the file.
+2025-09-12 08:34:29.808   Successfully installed the file.
+2025-09-12 08:34:29.808   -- File entry --
+2025-09-12 08:34:29.808   Dest filename: C:\vimacc\data\Workstation\3x3Grid.gld
+2025-09-12 08:34:29.808   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.808   Dest file exists.
+2025-09-12 08:34:29.808   Time stamp of existing file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.808   Installing the file.
+2025-09-12 08:34:29.809   Successfully installed the file.
+2025-09-12 08:34:29.809   -- File entry --
+2025-09-12 08:34:29.810   Dest filename: C:\vimacc\data\Workstation\4x4Grid.gld
+2025-09-12 08:34:29.810   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.810   Dest file exists.
+2025-09-12 08:34:29.810   Time stamp of existing file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.810   Installing the file.
+2025-09-12 08:34:29.811   Successfully installed the file.
+2025-09-12 08:34:29.811   -- File entry --
+2025-09-12 08:34:29.811   Dest filename: C:\vimacc\data\Workstation\4x8Grid.gld
+2025-09-12 08:34:29.811   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.811   Dest file exists.
+2025-09-12 08:34:29.811   Time stamp of existing file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.811   Installing the file.
+2025-09-12 08:34:29.812   Successfully installed the file.
+2025-09-12 08:34:29.812   -- File entry --
+2025-09-12 08:34:29.813   Dest filename: C:\vimacc\data\Workstation\5p1Grid.gld
+2025-09-12 08:34:29.813   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.813   Dest file exists.
+2025-09-12 08:34:29.813   Time stamp of existing file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.813   Installing the file.
+2025-09-12 08:34:29.814   Successfully installed the file.
+2025-09-12 08:34:29.814   -- File entry --
+2025-09-12 08:34:29.814   Dest filename: C:\vimacc\data\Workstation\5p2x4Grid.gld
+2025-09-12 08:34:29.814   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.814   Dest file exists.
+2025-09-12 08:34:29.814   Time stamp of existing file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.814   Installing the file.
+2025-09-12 08:34:29.815   Successfully installed the file.
+2025-09-12 08:34:29.816   -- File entry --
+2025-09-12 08:34:29.816   Dest filename: C:\vimacc\data\Workstation\5x6Grid.gld
+2025-09-12 08:34:29.816   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.816   Dest file exists.
+2025-09-12 08:34:29.816   Time stamp of existing file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.816   Installing the file.
+2025-09-12 08:34:29.816   Successfully installed the file.
+2025-09-12 08:34:29.818   -- File entry --
+2025-09-12 08:34:29.818   Dest filename: C:\vimacc\data\i18n\AccVimaccWorkstation_de.qm
+2025-09-12 08:34:29.818   Time stamp of our file: 2025-08-13 12:24:30.000
+2025-09-12 08:34:29.818   Dest file exists.
+2025-09-12 08:34:29.818   Time stamp of existing file: 2025-08-13 12:24:30.000
+2025-09-12 08:34:29.818   Installing the file.
+2025-09-12 08:34:29.822   Successfully installed the file.
+2025-09-12 08:34:29.822   -- File entry --
+2025-09-12 08:34:29.822   Dest filename: C:\vimacc\data\i18n\AccVimaccWorkstation_en.qm
+2025-09-12 08:34:29.822   Time stamp of our file: 2025-08-13 12:24:30.000
+2025-09-12 08:34:29.822   Dest file exists.
+2025-09-12 08:34:29.822   Time stamp of existing file: 2025-08-13 12:24:30.000
+2025-09-12 08:34:29.822   Installing the file.
+2025-09-12 08:34:29.827   Successfully installed the file.
+2025-09-12 08:34:29.827   -- File entry --
+2025-09-12 08:34:29.827   Dest filename: C:\vimacc\config\AccVimaccDisplay_workstation.conf
+2025-09-12 08:34:29.827   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:29.827   Installing the file.
+2025-09-12 08:34:29.828   Successfully installed the file.
+2025-09-12 08:34:29.828   -- File entry --
+2025-09-12 08:34:29.828   Dest filename: C:\vimacc\config\AccVimaccDisplay2_workstation.conf
+2025-09-12 08:34:29.828   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:29.828   Installing the file.
+2025-09-12 08:34:29.829   Successfully installed the file.
+2025-09-12 08:34:29.829   -- File entry --
+2025-09-12 08:34:29.829   Dest filename: C:\vimacc\config\AccVimaccDisplay3_workstation.conf
+2025-09-12 08:34:29.829   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:29.829   Installing the file.
+2025-09-12 08:34:29.830   Successfully installed the file.
+2025-09-12 08:34:29.830   -- File entry --
+2025-09-12 08:34:29.830   Dest filename: C:\vimacc\config\AccVimaccDisplay4_workstation.conf
+2025-09-12 08:34:29.830   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:29.830   Installing the file.
+2025-09-12 08:34:29.831   Successfully installed the file.
+2025-09-12 08:34:29.831   -- File entry --
+2025-09-12 08:34:29.831   Dest filename: C:\vimacc\bin\AccVimaccDisplayInterface.exe
+2025-09-12 08:34:29.831   Time stamp of our file: 2025-08-13 12:27:56.000
+2025-09-12 08:34:29.831   Installing the file.
+2025-09-12 08:34:29.837   Successfully installed the file.
+2025-09-12 08:34:29.837   -- File entry --
+2025-09-12 08:34:29.838   Dest filename: C:\vimacc\data\Workstation\12p1Grid.gld
+2025-09-12 08:34:29.838   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.838   Dest file exists.
+2025-09-12 08:34:29.838   Time stamp of existing file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.838   Installing the file.
+2025-09-12 08:34:29.839   Successfully installed the file.
+2025-09-12 08:34:29.839   -- File entry --
+2025-09-12 08:34:29.839   Dest filename: C:\vimacc\data\Workstation\1p11Grid.gld
+2025-09-12 08:34:29.840   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.840   Dest file exists.
+2025-09-12 08:34:29.840   Time stamp of existing file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.840   Installing the file.
+2025-09-12 08:34:29.841   Successfully installed the file.
+2025-09-12 08:34:29.841   -- File entry --
+2025-09-12 08:34:29.841   Dest filename: C:\vimacc\data\Workstation\1p1x2Grid.gld
+2025-09-12 08:34:29.841   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.841   Dest file exists.
+2025-09-12 08:34:29.841   Time stamp of existing file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.841   Installing the file.
+2025-09-12 08:34:29.842   Successfully installed the file.
+2025-09-12 08:34:29.842   -- File entry --
+2025-09-12 08:34:29.843   Dest filename: C:\vimacc\data\Workstation\1p1x4Grid.gld
+2025-09-12 08:34:29.843   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.843   Dest file exists.
+2025-09-12 08:34:29.843   Time stamp of existing file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.843   Installing the file.
+2025-09-12 08:34:29.844   Successfully installed the file.
+2025-09-12 08:34:29.844   -- File entry --
+2025-09-12 08:34:29.844   Dest filename: C:\vimacc\data\Workstation\1p2Grid.gld
+2025-09-12 08:34:29.844   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.844   Dest file exists.
+2025-09-12 08:34:29.844   Time stamp of existing file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.844   Installing the file.
+2025-09-12 08:34:29.845   Successfully installed the file.
+2025-09-12 08:34:29.845   -- File entry --
+2025-09-12 08:34:29.846   Dest filename: C:\vimacc\data\Workstation\1p5Grid.gld
+2025-09-12 08:34:29.846   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.846   Dest file exists.
+2025-09-12 08:34:29.846   Time stamp of existing file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.846   Installing the file.
+2025-09-12 08:34:29.847   Successfully installed the file.
+2025-09-12 08:34:29.847   -- File entry --
+2025-09-12 08:34:29.847   Dest filename: C:\vimacc\data\Workstation\1p6Grid.gld
+2025-09-12 08:34:29.847   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.847   Dest file exists.
+2025-09-12 08:34:29.847   Time stamp of existing file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.847   Installing the file.
+2025-09-12 08:34:29.849   Successfully installed the file.
+2025-09-12 08:34:29.849   -- File entry --
+2025-09-12 08:34:29.849   Dest filename: C:\vimacc\data\Workstation\1x3Grid.gld
+2025-09-12 08:34:29.849   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.849   Dest file exists.
+2025-09-12 08:34:29.849   Time stamp of existing file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.849   Installing the file.
+2025-09-12 08:34:29.850   Successfully installed the file.
+2025-09-12 08:34:29.850   -- File entry --
+2025-09-12 08:34:29.851   Dest filename: C:\vimacc\data\Workstation\26p1Grid.gld
+2025-09-12 08:34:29.851   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.851   Dest file exists.
+2025-09-12 08:34:29.851   Time stamp of existing file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.851   Installing the file.
+2025-09-12 08:34:29.851   Successfully installed the file.
+2025-09-12 08:34:29.851   -- File entry --
+2025-09-12 08:34:29.852   Dest filename: C:\vimacc\data\Workstation\2p1Grid.gld
+2025-09-12 08:34:29.852   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.852   Dest file exists.
+2025-09-12 08:34:29.852   Time stamp of existing file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.852   Installing the file.
+2025-09-12 08:34:29.853   Successfully installed the file.
+2025-09-12 08:34:29.853   -- File entry --
+2025-09-12 08:34:29.853   Dest filename: C:\vimacc\data\Workstation\2x1Grid.gld
+2025-09-12 08:34:29.853   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.853   Dest file exists.
+2025-09-12 08:34:29.853   Time stamp of existing file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.853   Installing the file.
+2025-09-12 08:34:29.855   Successfully installed the file.
+2025-09-12 08:34:29.855   -- File entry --
+2025-09-12 08:34:29.856   Dest filename: C:\vimacc\data\Workstation\2x3p4Grid.gld
+2025-09-12 08:34:29.856   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.856   Dest file exists.
+2025-09-12 08:34:29.856   Time stamp of existing file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.856   Installing the file.
+2025-09-12 08:34:29.857   Successfully installed the file.
+2025-09-12 08:34:29.857   -- File entry --
+2025-09-12 08:34:29.857   Dest filename: C:\vimacc\data\Workstation\2x4Grid.gld
+2025-09-12 08:34:29.857   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.857   Dest file exists.
+2025-09-12 08:34:29.858   Time stamp of existing file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.858   Installing the file.
+2025-09-12 08:34:29.858   Successfully installed the file.
+2025-09-12 08:34:29.859   -- File entry --
+2025-09-12 08:34:29.859   Dest filename: C:\vimacc\data\Workstation\2x4p2Grid.gld
+2025-09-12 08:34:29.859   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.859   Dest file exists.
+2025-09-12 08:34:29.859   Time stamp of existing file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.859   Installing the file.
+2025-09-12 08:34:29.860   Successfully installed the file.
+2025-09-12 08:34:29.860   -- File entry --
+2025-09-12 08:34:29.860   Dest filename: C:\vimacc\data\Workstation\2x4p5Grid.gld
+2025-09-12 08:34:29.860   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.860   Dest file exists.
+2025-09-12 08:34:29.860   Time stamp of existing file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.860   Installing the file.
+2025-09-12 08:34:29.861   Successfully installed the file.
+2025-09-12 08:34:29.861   -- File entry --
+2025-09-12 08:34:29.862   Dest filename: C:\vimacc\data\Workstation\3p1x2Grid.gld
+2025-09-12 08:34:29.862   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.862   Dest file exists.
+2025-09-12 08:34:29.862   Time stamp of existing file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.862   Installing the file.
+2025-09-12 08:34:29.863   Successfully installed the file.
+2025-09-12 08:34:29.863   -- File entry --
+2025-09-12 08:34:29.863   Dest filename: C:\vimacc\data\Workstation\3p2Grid.gld
+2025-09-12 08:34:29.863   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.863   Dest file exists.
+2025-09-12 08:34:29.863   Time stamp of existing file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.863   Installing the file.
+2025-09-12 08:34:29.864   Successfully installed the file.
+2025-09-12 08:34:29.865   -- File entry --
+2025-09-12 08:34:29.865   Dest filename: C:\vimacc\data\Workstation\3x3Grid.gld
+2025-09-12 08:34:29.865   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.865   Dest file exists.
+2025-09-12 08:34:29.865   Time stamp of existing file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.865   Installing the file.
+2025-09-12 08:34:29.866   Successfully installed the file.
+2025-09-12 08:34:29.867   -- File entry --
+2025-09-12 08:34:29.867   Dest filename: C:\vimacc\data\Workstation\4x4Grid.gld
+2025-09-12 08:34:29.867   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.867   Dest file exists.
+2025-09-12 08:34:29.867   Time stamp of existing file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.867   Installing the file.
+2025-09-12 08:34:29.868   Successfully installed the file.
+2025-09-12 08:34:29.868   -- File entry --
+2025-09-12 08:34:29.869   Dest filename: C:\vimacc\data\Workstation\4x8Grid.gld
+2025-09-12 08:34:29.869   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.869   Dest file exists.
+2025-09-12 08:34:29.869   Time stamp of existing file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.869   Installing the file.
+2025-09-12 08:34:29.869   Successfully installed the file.
+2025-09-12 08:34:29.869   -- File entry --
+2025-09-12 08:34:29.870   Dest filename: C:\vimacc\data\Workstation\5p1Grid.gld
+2025-09-12 08:34:29.870   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.870   Dest file exists.
+2025-09-12 08:34:29.870   Time stamp of existing file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.870   Installing the file.
+2025-09-12 08:34:29.871   Successfully installed the file.
+2025-09-12 08:34:29.871   -- File entry --
+2025-09-12 08:34:29.871   Dest filename: C:\vimacc\data\Workstation\5p2x4Grid.gld
+2025-09-12 08:34:29.871   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.871   Dest file exists.
+2025-09-12 08:34:29.871   Time stamp of existing file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.871   Installing the file.
+2025-09-12 08:34:29.872   Successfully installed the file.
+2025-09-12 08:34:29.873   -- File entry --
+2025-09-12 08:34:29.873   Dest filename: C:\vimacc\data\Workstation\5x6Grid.gld
+2025-09-12 08:34:29.873   Time stamp of our file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.873   Dest file exists.
+2025-09-12 08:34:29.873   Time stamp of existing file: 2025-05-05 13:10:02.000
+2025-09-12 08:34:29.873   Installing the file.
+2025-09-12 08:34:29.874   Successfully installed the file.
+2025-09-12 08:34:29.874   -- File entry --
+2025-09-12 08:34:29.875   Dest filename: C:\vimacc\data\vimacc\record\SDSRC\autobahn_1_2\2011\09\21\07\autobahn_1_2_25.video
+2025-09-12 08:34:29.875   Time stamp of our file: 2025-05-05 13:10:28.000
+2025-09-12 08:34:29.875   Installing the file.
+2025-09-12 08:34:29.875   Creating directory: C:\vimacc\data\vimacc
+2025-09-12 08:34:29.875   Creating directory: C:\vimacc\data\vimacc\record
+2025-09-12 08:34:29.875   Creating directory: C:\vimacc\data\vimacc\record\SDSRC
+2025-09-12 08:34:29.875   Creating directory: C:\vimacc\data\vimacc\record\SDSRC\autobahn_1_2
+2025-09-12 08:34:29.875   Creating directory: C:\vimacc\data\vimacc\record\SDSRC\autobahn_1_2\2011
+2025-09-12 08:34:29.875   Creating directory: C:\vimacc\data\vimacc\record\SDSRC\autobahn_1_2\2011\09
+2025-09-12 08:34:29.875   Creating directory: C:\vimacc\data\vimacc\record\SDSRC\autobahn_1_2\2011\09\21
+2025-09-12 08:34:29.875   Creating directory: C:\vimacc\data\vimacc\record\SDSRC\autobahn_1_2\2011\09\21\07
+2025-09-12 08:34:29.906   Successfully installed the file.
+2025-09-12 08:34:29.906   -- File entry --
+2025-09-12 08:34:29.906   Dest filename: C:\vimacc\data\vimacc\record\SDSRC\autobahn_1_2\2011\09\21\07\autobahn_1_2_30.video
+2025-09-12 08:34:29.906   Time stamp of our file: 2025-05-05 13:10:28.000
+2025-09-12 08:34:29.906   Installing the file.
+2025-09-12 08:34:30.049   Successfully installed the file.
+2025-09-12 08:34:30.050   -- File entry --
+2025-09-12 08:34:30.050   Dest filename: C:\vimacc\data\vimacc\record\SDSRC\autobahn_1_2\2011\09\21\07\autobahn_1_2_35.video
+2025-09-12 08:34:30.050   Time stamp of our file: 2025-05-05 13:10:28.000
+2025-09-12 08:34:30.050   Installing the file.
+2025-09-12 08:34:30.169   Successfully installed the file.
+2025-09-12 08:34:30.169   -- File entry --
+2025-09-12 08:34:30.170   Dest filename: C:\vimacc\data\vimacc\record\SDSRC\autobahn_1_2\autobahn_1_2_video.idx\20110921.idx
+2025-09-12 08:34:30.170   Time stamp of our file: 2025-05-05 13:10:28.000
+2025-09-12 08:34:30.170   Installing the file.
+2025-09-12 08:34:30.170   Creating directory: C:\vimacc\data\vimacc\record\SDSRC\autobahn_1_2\autobahn_1_2_video.idx
+2025-09-12 08:34:30.171   Successfully installed the file.
+2025-09-12 08:34:30.171   -- File entry --
+2025-09-12 08:34:30.172   Dest filename: C:\vimacc\data\vimacc\record\SDSRC\autobahn_2_2\2011\09\21\07\autobahn_2_2_30.video
+2025-09-12 08:34:30.172   Time stamp of our file: 2025-05-05 13:10:30.000
+2025-09-12 08:34:30.172   Installing the file.
+2025-09-12 08:34:30.173   Creating directory: C:\vimacc\data\vimacc\record\SDSRC\autobahn_2_2
+2025-09-12 08:34:30.173   Creating directory: C:\vimacc\data\vimacc\record\SDSRC\autobahn_2_2\2011
+2025-09-12 08:34:30.173   Creating directory: C:\vimacc\data\vimacc\record\SDSRC\autobahn_2_2\2011\09
+2025-09-12 08:34:30.173   Creating directory: C:\vimacc\data\vimacc\record\SDSRC\autobahn_2_2\2011\09\21
+2025-09-12 08:34:30.173   Creating directory: C:\vimacc\data\vimacc\record\SDSRC\autobahn_2_2\2011\09\21\07
+2025-09-12 08:34:30.212   Successfully installed the file.
+2025-09-12 08:34:30.212   -- File entry --
+2025-09-12 08:34:30.213   Dest filename: C:\vimacc\data\vimacc\record\SDSRC\autobahn_2_2\2011\09\21\07\autobahn_2_2_35.video
+2025-09-12 08:34:30.213   Time stamp of our file: 2025-05-05 13:10:30.000
+2025-09-12 08:34:30.213   Installing the file.
+2025-09-12 08:34:30.380   Successfully installed the file.
+2025-09-12 08:34:30.380   -- File entry --
+2025-09-12 08:34:30.380   Dest filename: C:\vimacc\data\vimacc\record\SDSRC\autobahn_2_2\2011\09\21\07\autobahn_2_2_40.video
+2025-09-12 08:34:30.380   Time stamp of our file: 2025-05-05 13:10:30.000
+2025-09-12 08:34:30.380   Installing the file.
+2025-09-12 08:34:30.415   Successfully installed the file.
+2025-09-12 08:34:30.415   -- File entry --
+2025-09-12 08:34:30.415   Dest filename: C:\vimacc\data\vimacc\record\SDSRC\autobahn_2_2\autobahn_2_2_video.idx\20110921.idx
+2025-09-12 08:34:30.415   Time stamp of our file: 2025-05-05 13:10:28.000
+2025-09-12 08:34:30.416   Installing the file.
+2025-09-12 08:34:30.416   Creating directory: C:\vimacc\data\vimacc\record\SDSRC\autobahn_2_2\autobahn_2_2_video.idx
+2025-09-12 08:34:30.416   Successfully installed the file.
+2025-09-12 08:34:30.416   -- File entry --
+2025-09-12 08:34:30.418   Dest filename: C:\vimacc\data\vimacc\record\SDSRC\manekineko_high\2024\03\14\09\manekineko_high_40.video
+2025-09-12 08:34:30.418   Time stamp of our file: 2025-05-05 13:11:04.000
+2025-09-12 08:34:30.418   Installing the file.
+2025-09-12 08:34:30.418   Creating directory: C:\vimacc\data\vimacc\record\SDSRC\manekineko_high
+2025-09-12 08:34:30.418   Creating directory: C:\vimacc\data\vimacc\record\SDSRC\manekineko_high\2024
+2025-09-12 08:34:30.418   Creating directory: C:\vimacc\data\vimacc\record\SDSRC\manekineko_high\2024\03
+2025-09-12 08:34:30.418   Creating directory: C:\vimacc\data\vimacc\record\SDSRC\manekineko_high\2024\03\14
+2025-09-12 08:34:30.418   Creating directory: C:\vimacc\data\vimacc\record\SDSRC\manekineko_high\2024\03\14\09
+2025-09-12 08:34:30.540   Successfully installed the file.
+2025-09-12 08:34:30.540   -- File entry --
+2025-09-12 08:34:30.541   Dest filename: C:\vimacc\data\vimacc\record\SDSRC\manekineko_high\manekineko_high_video.idx\20240314.idx
+2025-09-12 08:34:30.541   Time stamp of our file: 2025-05-05 13:11:04.000
+2025-09-12 08:34:30.541   Installing the file.
+2025-09-12 08:34:30.541   Creating directory: C:\vimacc\data\vimacc\record\SDSRC\manekineko_high\manekineko_high_video.idx
+2025-09-12 08:34:30.542   Successfully installed the file.
+2025-09-12 08:34:30.542   -- File entry --
+2025-09-12 08:34:30.542   Dest filename: C:\vimacc\data\vimacc\record\SDSRC\manekineko_middle\2024\03\14\09\manekineko_middle_40.video
+2025-09-12 08:34:30.542   Time stamp of our file: 2025-05-05 13:10:26.000
+2025-09-12 08:34:30.542   Installing the file.
+2025-09-12 08:34:30.542   Creating directory: C:\vimacc\data\vimacc\record\SDSRC\manekineko_middle
+2025-09-12 08:34:30.543   Creating directory: C:\vimacc\data\vimacc\record\SDSRC\manekineko_middle\2024
+2025-09-12 08:34:30.543   Creating directory: C:\vimacc\data\vimacc\record\SDSRC\manekineko_middle\2024\03
+2025-09-12 08:34:30.543   Creating directory: C:\vimacc\data\vimacc\record\SDSRC\manekineko_middle\2024\03\14
+2025-09-12 08:34:30.543   Creating directory: C:\vimacc\data\vimacc\record\SDSRC\manekineko_middle\2024\03\14\09
+2025-09-12 08:34:30.586   Successfully installed the file.
+2025-09-12 08:34:30.586   -- File entry --
+2025-09-12 08:34:30.586   Dest filename: C:\vimacc\data\vimacc\record\SDSRC\manekineko_middle\manekineko_middle_video.idx\20240314.idx
+2025-09-12 08:34:30.586   Time stamp of our file: 2025-05-05 13:10:26.000
+2025-09-12 08:34:30.586   Installing the file.
+2025-09-12 08:34:30.586   Creating directory: C:\vimacc\data\vimacc\record\SDSRC\manekineko_middle\manekineko_middle_video.idx
+2025-09-12 08:34:30.587   Successfully installed the file.
+2025-09-12 08:34:30.587   -- File entry --
+2025-09-12 08:34:30.588   Dest filename: C:\vimacc\data\vimacc\record\SDSRC\manekineko_low\2024\03\14\09\manekineko_low_40.video
+2025-09-12 08:34:30.588   Time stamp of our file: 2025-05-05 13:10:28.000
+2025-09-12 08:34:30.588   Installing the file.
+2025-09-12 08:34:30.588   Creating directory: C:\vimacc\data\vimacc\record\SDSRC\manekineko_low
+2025-09-12 08:34:30.588   Creating directory: C:\vimacc\data\vimacc\record\SDSRC\manekineko_low\2024
+2025-09-12 08:34:30.588   Creating directory: C:\vimacc\data\vimacc\record\SDSRC\manekineko_low\2024\03
+2025-09-12 08:34:30.588   Creating directory: C:\vimacc\data\vimacc\record\SDSRC\manekineko_low\2024\03\14
+2025-09-12 08:34:30.588   Creating directory: C:\vimacc\data\vimacc\record\SDSRC\manekineko_low\2024\03\14\09
+2025-09-12 08:34:30.625   Successfully installed the file.
+2025-09-12 08:34:30.626   -- File entry --
+2025-09-12 08:34:30.626   Dest filename: C:\vimacc\data\vimacc\record\SDSRC\manekineko_low\manekineko_low_video.idx\20240314.idx
+2025-09-12 08:34:30.626   Time stamp of our file: 2025-05-05 13:10:28.000
+2025-09-12 08:34:30.626   Installing the file.
+2025-09-12 08:34:30.626   Creating directory: C:\vimacc\data\vimacc\record\SDSRC\manekineko_low\manekineko_low_video.idx
+2025-09-12 08:34:30.627   Successfully installed the file.
+2025-09-12 08:34:30.627   -- File entry --
+2025-09-12 08:34:30.628   Dest filename: C:\vimacc\data\maps\H_Garbsen.map
+2025-09-12 08:34:30.628   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.628   Installing the file.
+2025-09-12 08:34:30.628   Successfully installed the file.
+2025-09-12 08:34:30.628   -- File entry --
+2025-09-12 08:34:30.629   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\Cam_DARK.svg
+2025-09-12 08:34:30.629   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.629   Installing the file.
+2025-09-12 08:34:30.629   Successfully installed the file.
+2025-09-12 08:34:30.629   -- File entry --
+2025-09-12 08:34:30.629   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\Cam_DARK_HL.svg
+2025-09-12 08:34:30.629   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.629   Installing the file.
+2025-09-12 08:34:30.630   Successfully installed the file.
+2025-09-12 08:34:30.630   -- File entry --
+2025-09-12 08:34:30.630   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\Cam_ERROR.svg
+2025-09-12 08:34:30.630   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.630   Installing the file.
+2025-09-12 08:34:30.631   Successfully installed the file.
+2025-09-12 08:34:30.631   -- File entry --
+2025-09-12 08:34:30.631   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\Cam_ERROR_HL.svg
+2025-09-12 08:34:30.632   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.632   Installing the file.
+2025-09-12 08:34:30.632   Successfully installed the file.
+2025-09-12 08:34:30.632   -- File entry --
+2025-09-12 08:34:30.632   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\Cam_OK.svg
+2025-09-12 08:34:30.633   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.633   Installing the file.
+2025-09-12 08:34:30.633   Successfully installed the file.
+2025-09-12 08:34:30.633   -- File entry --
+2025-09-12 08:34:30.633   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\Cam_OK_HL.svg
+2025-09-12 08:34:30.634   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.634   Installing the file.
+2025-09-12 08:34:30.635   Successfully installed the file.
+2025-09-12 08:34:30.635   -- File entry --
+2025-09-12 08:34:30.635   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\Cam_TEMP.svg
+2025-09-12 08:34:30.635   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.635   Installing the file.
+2025-09-12 08:34:30.635   Successfully installed the file.
+2025-09-12 08:34:30.635   -- File entry --
+2025-09-12 08:34:30.636   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\Cam_TEMP_HL.svg
+2025-09-12 08:34:30.636   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.636   Installing the file.
+2025-09-12 08:34:30.636   Successfully installed the file.
+2025-09-12 08:34:30.637   -- File entry --
+2025-09-12 08:34:30.637   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\cctv.svg
+2025-09-12 08:34:30.637   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.637   Installing the file.
+2025-09-12 08:34:30.637   Successfully installed the file.
+2025-09-12 08:34:30.637   -- File entry --
+2025-09-12 08:34:30.639   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\empty.svg
+2025-09-12 08:34:30.639   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.639   Installing the file.
+2025-09-12 08:34:30.639   Successfully installed the file.
+2025-09-12 08:34:30.639   -- File entry --
+2025-09-12 08:34:30.640   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\event.svg
+2025-09-12 08:34:30.640   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.640   Installing the file.
+2025-09-12 08:34:30.640   Successfully installed the file.
+2025-09-12 08:34:30.640   -- File entry --
+2025-09-12 08:34:30.641   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\Fixed_Camera.svg
+2025-09-12 08:34:30.641   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.641   Installing the file.
+2025-09-12 08:34:30.641   Successfully installed the file.
+2025-09-12 08:34:30.641   -- File entry --
+2025-09-12 08:34:30.642   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\Fixed_Camera_ERROR.svg
+2025-09-12 08:34:30.642   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.642   Installing the file.
+2025-09-12 08:34:30.642   Successfully installed the file.
+2025-09-12 08:34:30.643   -- File entry --
+2025-09-12 08:34:30.643   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\Fixed_Camera_OK.svg
+2025-09-12 08:34:30.643   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.643   Installing the file.
+2025-09-12 08:34:30.644   Successfully installed the file.
+2025-09-12 08:34:30.644   -- File entry --
+2025-09-12 08:34:30.644   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\globe.svg
+2025-09-12 08:34:30.644   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.644   Installing the file.
+2025-09-12 08:34:30.645   Successfully installed the file.
+2025-09-12 08:34:30.645   -- File entry --
+2025-09-12 08:34:30.646   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\Kamera_Festobjektiv.svg
+2025-09-12 08:34:30.646   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.646   Installing the file.
+2025-09-12 08:34:30.646   Successfully installed the file.
+2025-09-12 08:34:30.647   -- File entry --
+2025-09-12 08:34:30.647   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\Kamera_SchwenkNeige_Motorzoom.svg
+2025-09-12 08:34:30.647   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.647   Installing the file.
+2025-09-12 08:34:30.648   Successfully installed the file.
+2025-09-12 08:34:30.648   -- File entry --
+2025-09-12 08:34:30.648   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\Kamera_Varioobjektiv.svg
+2025-09-12 08:34:30.648   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.648   Installing the file.
+2025-09-12 08:34:30.648   Successfully installed the file.
+2025-09-12 08:34:30.649   -- File entry --
+2025-09-12 08:34:30.649   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\Kuppelkamera_AutoDome.svg
+2025-09-12 08:34:30.649   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.649   Installing the file.
+2025-09-12 08:34:30.649   Successfully installed the file.
+2025-09-12 08:34:30.650   -- File entry --
+2025-09-12 08:34:30.650   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\Kuppelkamera_FixDome.svg
+2025-09-12 08:34:30.650   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.650   Installing the file.
+2025-09-12 08:34:30.651   Successfully installed the file.
+2025-09-12 08:34:30.651   -- File entry --
+2025-09-12 08:34:30.651   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\PTZ_Camera.svg
+2025-09-12 08:34:30.651   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.651   Installing the file.
+2025-09-12 08:34:30.652   Successfully installed the file.
+2025-09-12 08:34:30.652   -- File entry --
+2025-09-12 08:34:30.652   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\PTZ_Camera_ERROR.svg
+2025-09-12 08:34:30.652   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.652   Installing the file.
+2025-09-12 08:34:30.653   Successfully installed the file.
+2025-09-12 08:34:30.653   -- File entry --
+2025-09-12 08:34:30.653   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\PTZ_Camera_OK.svg
+2025-09-12 08:34:30.653   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.653   Installing the file.
+2025-09-12 08:34:30.654   Successfully installed the file.
+2025-09-12 08:34:30.654   -- File entry --
+2025-09-12 08:34:30.654   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\scenario.svg
+2025-09-12 08:34:30.654   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.654   Installing the file.
+2025-09-12 08:34:30.655   Successfully installed the file.
+2025-09-12 08:34:30.655   -- File entry --
+2025-09-12 08:34:30.655   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\scenario_HL.svg
+2025-09-12 08:34:30.655   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.655   Installing the file.
+2025-09-12 08:34:30.656   Successfully installed the file.
+2025-09-12 08:34:30.656   -- File entry --
+2025-09-12 08:34:30.656   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\sequence.svg
+2025-09-12 08:34:30.656   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.656   Installing the file.
+2025-09-12 08:34:30.657   Successfully installed the file.
+2025-09-12 08:34:30.657   -- File entry --
+2025-09-12 08:34:30.657   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\sequence_HL.svg
+2025-09-12 08:34:30.657   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.657   Installing the file.
+2025-09-12 08:34:30.658   Successfully installed the file.
+2025-09-12 08:34:30.658   -- File entry --
+2025-09-12 08:34:30.658   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\MAP_A2.png
+2025-09-12 08:34:30.658   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.658   Dest file exists.
+2025-09-12 08:34:30.658   Time stamp of existing file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.658   Installing the file.
+2025-09-12 08:34:30.670   Successfully installed the file.
+2025-09-12 08:34:30.670   -- File entry --
+2025-09-12 08:34:30.671   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\MAP_A2_HL.png
+2025-09-12 08:34:30.671   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.671   Dest file exists.
+2025-09-12 08:34:30.671   Time stamp of existing file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.671   Installing the file.
+2025-09-12 08:34:30.683   Successfully installed the file.
+2025-09-12 08:34:30.683   -- File entry --
+2025-09-12 08:34:30.683   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\MAP_CONTI.png
+2025-09-12 08:34:30.684   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.684   Dest file exists.
+2025-09-12 08:34:30.684   Time stamp of existing file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.684   Installing the file.
+2025-09-12 08:34:30.688   Successfully installed the file.
+2025-09-12 08:34:30.688   -- File entry --
+2025-09-12 08:34:30.689   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\MAP_CONTI_HL.png
+2025-09-12 08:34:30.689   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.689   Dest file exists.
+2025-09-12 08:34:30.689   Time stamp of existing file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.689   Installing the file.
+2025-09-12 08:34:30.693   Successfully installed the file.
+2025-09-12 08:34:30.693   -- File entry --
+2025-09-12 08:34:30.693   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\MAP_SBAHN.png
+2025-09-12 08:34:30.693   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.693   Dest file exists.
+2025-09-12 08:34:30.694   Time stamp of existing file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.694   Installing the file.
+2025-09-12 08:34:30.696   Successfully installed the file.
+2025-09-12 08:34:30.697   -- File entry --
+2025-09-12 08:34:30.697   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\MAP_SBAHN_HL.png
+2025-09-12 08:34:30.697   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.697   Dest file exists.
+2025-09-12 08:34:30.697   Time stamp of existing file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.697   Installing the file.
+2025-09-12 08:34:30.701   Successfully installed the file.
+2025-09-12 08:34:30.701   -- File entry --
+2025-09-12 08:34:30.701   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\MAP_SHELL.png
+2025-09-12 08:34:30.701   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.701   Dest file exists.
+2025-09-12 08:34:30.701   Time stamp of existing file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.701   Installing the file.
+2025-09-12 08:34:30.704   Successfully installed the file.
+2025-09-12 08:34:30.704   -- File entry --
+2025-09-12 08:34:30.704   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\MAP_SHELL_HL.png
+2025-09-12 08:34:30.704   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.704   Dest file exists.
+2025-09-12 08:34:30.705   Time stamp of existing file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.705   Installing the file.
+2025-09-12 08:34:30.707   Successfully installed the file.
+2025-09-12 08:34:30.707   -- File entry --
+2025-09-12 08:34:30.707   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\MAP_SICAN.png
+2025-09-12 08:34:30.707   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.707   Dest file exists.
+2025-09-12 08:34:30.707   Time stamp of existing file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.707   Installing the file.
+2025-09-12 08:34:30.710   Successfully installed the file.
+2025-09-12 08:34:30.710   -- File entry --
+2025-09-12 08:34:30.710   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\MAP_SICAN_B0.png
+2025-09-12 08:34:30.710   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.710   Dest file exists.
+2025-09-12 08:34:30.710   Time stamp of existing file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.710   Installing the file.
+2025-09-12 08:34:30.711   Successfully installed the file.
+2025-09-12 08:34:30.711   -- File entry --
+2025-09-12 08:34:30.711   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\MAP_SICAN_B0_HL.png
+2025-09-12 08:34:30.711   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.711   Dest file exists.
+2025-09-12 08:34:30.711   Time stamp of existing file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.711   Installing the file.
+2025-09-12 08:34:30.712   Successfully installed the file.
+2025-09-12 08:34:30.712   -- File entry --
+2025-09-12 08:34:30.712   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\MAP_SICAN_HL.png
+2025-09-12 08:34:30.712   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.712   Dest file exists.
+2025-09-12 08:34:30.712   Time stamp of existing file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.712   Installing the file.
+2025-09-12 08:34:30.714   Successfully installed the file.
+2025-09-12 08:34:30.714   -- File entry --
+2025-09-12 08:34:30.715   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\SICAN_DOWN.png
+2025-09-12 08:34:30.715   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.715   Dest file exists.
+2025-09-12 08:34:30.715   Time stamp of existing file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.715   Installing the file.
+2025-09-12 08:34:30.715   Successfully installed the file.
+2025-09-12 08:34:30.715   -- File entry --
+2025-09-12 08:34:30.716   Dest filename: C:\vimacc\data\maps\H_Garbsen\icons\SICAN_UP.png
+2025-09-12 08:34:30.716   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.716   Dest file exists.
+2025-09-12 08:34:30.716   Time stamp of existing file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.716   Installing the file.
+2025-09-12 08:34:30.717   Successfully installed the file.
+2025-09-12 08:34:30.717   -- File entry --
+2025-09-12 08:34:30.718   Dest filename: C:\vimacc\data\maps\H_Garbsen\maps\H_Garbsen.png
+2025-09-12 08:34:30.718   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.718   Dest file exists.
+2025-09-12 08:34:30.718   Time stamp of existing file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.718   Installing the file.
+2025-09-12 08:34:30.726   Successfully installed the file.
+2025-09-12 08:34:30.727   -- File entry --
+2025-09-12 08:34:30.727   Dest filename: C:\vimacc\data\maps\H_Garbsen\maps\MAP_A2.png
+2025-09-12 08:34:30.727   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.727   Dest file exists.
+2025-09-12 08:34:30.727   Time stamp of existing file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.727   Installing the file.
+2025-09-12 08:34:30.735   Successfully installed the file.
+2025-09-12 08:34:30.735   -- File entry --
+2025-09-12 08:34:30.735   Dest filename: C:\vimacc\data\maps\H_Garbsen\maps\MAP_CONTI.png
+2025-09-12 08:34:30.735   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.735   Dest file exists.
+2025-09-12 08:34:30.735   Time stamp of existing file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.735   Installing the file.
+2025-09-12 08:34:30.748   Successfully installed the file.
+2025-09-12 08:34:30.748   -- File entry --
+2025-09-12 08:34:30.748   Dest filename: C:\vimacc\data\maps\H_Garbsen\maps\MAP_SBAHN.png
+2025-09-12 08:34:30.749   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.749   Dest file exists.
+2025-09-12 08:34:30.749   Time stamp of existing file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.749   Installing the file.
+2025-09-12 08:34:30.757   Successfully installed the file.
+2025-09-12 08:34:30.757   -- File entry --
+2025-09-12 08:34:30.757   Dest filename: C:\vimacc\data\maps\H_Garbsen\maps\MAP_SHELL.png
+2025-09-12 08:34:30.757   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.757   Dest file exists.
+2025-09-12 08:34:30.757   Time stamp of existing file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.757   Installing the file.
+2025-09-12 08:34:30.768   Successfully installed the file.
+2025-09-12 08:34:30.768   -- File entry --
+2025-09-12 08:34:30.768   Dest filename: C:\vimacc\data\maps\H_Garbsen\maps\MAP_SICAN.png
+2025-09-12 08:34:30.768   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.768   Dest file exists.
+2025-09-12 08:34:30.768   Time stamp of existing file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.768   Installing the file.
+2025-09-12 08:34:30.771   Successfully installed the file.
+2025-09-12 08:34:30.772   -- File entry --
+2025-09-12 08:34:30.772   Dest filename: C:\vimacc\data\maps\H_Garbsen\maps\MAP_SICAN_B0.png
+2025-09-12 08:34:30.772   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.772   Dest file exists.
+2025-09-12 08:34:30.772   Time stamp of existing file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.772   Installing the file.
+2025-09-12 08:34:30.773   Successfully installed the file.
+2025-09-12 08:34:30.773   -- File entry --
+2025-09-12 08:34:30.774   Dest filename: C:\vimacc\data\maps\H_Garbsen\maps\MAP_SICAN_B1.png
+2025-09-12 08:34:30.774   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.774   Dest file exists.
+2025-09-12 08:34:30.774   Time stamp of existing file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.774   Installing the file.
+2025-09-12 08:34:30.774   Successfully installed the file.
+2025-09-12 08:34:30.774   -- File entry --
+2025-09-12 08:34:30.775   Dest filename: C:\vimacc\data\maps\H_Garbsen\maps\MAP_SICAN_B2.png
+2025-09-12 08:34:30.775   Time stamp of our file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.775   Dest file exists.
+2025-09-12 08:34:30.775   Time stamp of existing file: 2025-05-05 13:10:00.000
+2025-09-12 08:34:30.775   Installing the file.
+2025-09-12 08:34:30.776   Successfully installed the file.
+2025-09-12 08:34:30.776   -- Icon entry --
+2025-09-12 08:34:30.776   Dest filename: C:\Users\Public\Desktop\vimacc Admin Center.lnk
+2025-09-12 08:34:30.777   Creating the icon.
+2025-09-12 08:34:30.823   Successfully created the icon.
+2025-09-12 08:34:30.827   -- Icon entry --
+2025-09-12 08:34:30.827   Dest filename: C:\Users\Public\Desktop\vimacc User Management.lnk
+2025-09-12 08:34:30.827   Creating the icon.
+2025-09-12 08:34:30.853   Successfully created the icon.
+2025-09-12 08:34:31.549   -- Icon entry --
+2025-09-12 08:34:31.549   Dest filename: C:\Users\Public\Desktop\vimacc Workstation.lnk
+2025-09-12 08:34:31.550   Creating the icon.
+2025-09-12 08:34:31.591   Successfully created the icon.
+2025-09-12 08:34:32.334   -- Icon entry --
+2025-09-12 08:34:32.334   Dest filename: C:\Users\Public\Desktop\vimacc Start 1WS+4DSP.lnk
+2025-09-12 08:34:32.334   Creating the icon.
+2025-09-12 08:34:32.337   Successfully created the icon.
+2025-09-12 08:34:32.340   -- Icon entry --
+2025-09-12 08:34:32.340   Dest filename: C:\ProgramData\Microsoft\Windows\Start Menu\Programs\vimacc Professional\vimacc StartApplications.lnk
+2025-09-12 08:34:32.341   Creating directory: C:\ProgramData\Microsoft\Windows\Start Menu\Programs\vimacc Professional
+2025-09-12 08:34:32.344   Creating the icon.
+2025-09-12 08:34:32.346   Successfully created the icon.
+2025-09-12 08:34:33.864   -- Icon entry --
+2025-09-12 08:34:33.864   Dest filename: C:\ProgramData\Microsoft\Windows\Start Menu\Programs\vimacc Professional\vimacc StopApplications.lnk
+2025-09-12 08:34:33.865   Creating the icon.
+2025-09-12 08:34:33.866   Successfully created the icon.
+2025-09-12 08:34:33.877   -- Icon entry --
+2025-09-12 08:34:33.877   Dest filename: C:\ProgramData\Microsoft\Windows\Start Menu\Programs\vimacc Professional\vimacc Security Wizard.lnk
+2025-09-12 08:34:33.878   Creating the icon.
+2025-09-12 08:34:33.909   Successfully created the icon.
+2025-09-12 08:34:33.912   -- Icon entry --
+2025-09-12 08:34:33.912   Dest filename: C:\ProgramData\Microsoft\Windows\Start Menu\Programs\vimacc Professional\vimacc Admin Center.lnk
+2025-09-12 08:34:33.913   Creating the icon.
+2025-09-12 08:34:33.914   Successfully created the icon.
+2025-09-12 08:34:33.918   -- Icon entry --
+2025-09-12 08:34:33.918   Dest filename: C:\ProgramData\Microsoft\Windows\Start Menu\Programs\vimacc Professional\vimacc User Management.lnk
+2025-09-12 08:34:33.918   Creating the icon.
+2025-09-12 08:34:33.920   Successfully created the icon.
+2025-09-12 08:34:33.924   -- Icon entry --
+2025-09-12 08:34:33.924   Dest filename: C:\ProgramData\Microsoft\Windows\Start Menu\Programs\vimacc Professional\vimacc Workstation.lnk
+2025-09-12 08:34:33.925   Creating the icon.
+2025-09-12 08:34:33.926   Successfully created the icon.
+2025-09-12 08:34:33.929   -- Icon entry --
+2025-09-12 08:34:33.929   Dest filename: C:\ProgramData\Microsoft\Windows\Start Menu\Programs\vimacc Professional\vimacc StartServices.lnk
+2025-09-12 08:34:33.930   Creating the icon.
+2025-09-12 08:34:33.931   Successfully created the icon.
+2025-09-12 08:34:33.934   -- Icon entry --
+2025-09-12 08:34:33.934   Dest filename: C:\ProgramData\Microsoft\Windows\Start Menu\Programs\vimacc Professional\vimacc StopServices.lnk
+2025-09-12 08:34:33.934   Creating the icon.
+2025-09-12 08:34:33.936   Successfully created the icon.
+2025-09-12 08:34:33.940   -- Icon entry --
+2025-09-12 08:34:33.940   Dest filename: C:\ProgramData\Microsoft\Windows\Start Menu\Programs\vimacc Professional\vimacc Start 1WS+4DSP.lnk
+2025-09-12 08:34:33.941   Creating the icon.
+2025-09-12 08:34:33.942   Successfully created the icon.
+2025-09-12 08:34:33.946   -- Icon entry --
+2025-09-12 08:34:33.946   Dest filename: C:\ProgramData\Microsoft\Windows\Start Menu\Programs\vimacc Professional\vimacc Start 1WS+4DSP 2 Monitore.lnk
+2025-09-12 08:34:33.946   Creating the icon.
+2025-09-12 08:34:33.947   Successfully created the icon.
+2025-09-12 08:34:33.952   -- Icon entry --
+2025-09-12 08:34:33.952   Dest filename: C:\ProgramData\Microsoft\Windows\Start Menu\Programs\vimacc Professional\vimacc Start 1WS+4DSP 5 Monitore.lnk
+2025-09-12 08:34:33.952   Creating the icon.
+2025-09-12 08:34:33.954   Successfully created the icon.
+2025-09-12 08:34:33.958   -- Icon entry --
+2025-09-12 08:34:33.958   Dest filename: C:\ProgramData\Microsoft\Windows\Start Menu\Programs\vimacc Professional\Uninstall vimacc.lnk
+2025-09-12 08:34:33.958   Creating the icon.
+2025-09-12 08:34:34.093   Successfully created the icon.
+2025-09-12 08:34:34.155   Registering 64-bit DLL/OCX: C:\WINDOWS\system32\opcproxy.dll
+2025-09-12 08:34:34.158   Spawning 64-bit RegSvr32: "C:\WINDOWS\system32\regsvr32.exe" /s "C:\WINDOWS\system32\opcproxy.dll"
+2025-09-12 08:34:34.192   Registration successful.
+2025-09-12 08:34:34.197   Installation process succeeded.
+2025-09-12 08:34:47.560   startStop_services: found service below app dir.: name: "AccVimaccAssembliesManager", image path: C:\vimacc\bin\AccVimaccAssembliesManager.exe
+2025-09-12 08:34:47.560   startStop_services: found service below app dir.: name: "AccVimaccConfig", image path: C:\vimacc\bin\AccVimaccConfig.exe
+2025-09-12 08:34:47.560   startStop_services: found service below app dir.: name: "AccVimaccControlInterface", image path: C:\vimacc\bin\AccVimaccControlInterface.exe
+2025-09-12 08:34:47.561   startStop_services: found service below app dir.: name: "AccVimaccDigIOInterface", image path: C:\vimacc\bin\AccVimaccDigIOInterface.exe
+2025-09-12 08:34:47.561   startStop_services: found service below app dir.: name: "AccVimaccDisplayInterface", image path: C:\vimacc\bin\AccVimaccDisplayInterface.exe
+2025-09-12 08:34:47.561   startStop_services: found service below app dir.: name: "AccVimaccDongle", image path: C:\vimacc\bin\AccVimaccDongle.exe
+2025-09-12 08:34:47.561   startStop_services: found service below app dir.: name: "AccVimaccEmailSender", image path: C:\vimacc\bin\AccVimaccEmailSender.exe
+2025-09-12 08:34:47.561   startStop_services: found service below app dir.: name: "AccVimaccEventManager", image path: C:\vimacc\bin\AccVimaccEventManager.exe
+2025-09-12 08:34:47.561   startStop_services: found service below app dir.: name: "AccVimaccExport", image path: C:\vimacc\bin\AccVimaccExport.exe
+2025-09-12 08:34:47.561   startStop_services: found service below app dir.: name: "AccVimaccFtpAlarmReceiver", image path: C:\vimacc\bin\AccVimaccFtpAlarmReceiver.exe
+2025-09-12 08:34:47.561   startStop_services: found service below app dir.: name: "AccVimaccFtpUploader", image path: C:\vimacc\bin\AccVimaccFtpUploader.exe
+2025-09-12 08:34:47.561   startStop_services: found service below app dir.: name: "AccVimaccHIDController", image path: C:\vimacc\bin\AccVimaccHIDController.exe
+2025-09-12 08:34:47.561   startStop_services: found service below app dir.: name: "AccVimaccIcxInterface", image path: C:\vimacc\bin\AccVimaccIcxInterface.exe
+2025-09-12 08:34:47.561   startStop_services: found service below app dir.: name: "AccVimaccInterface", image path: C:\vimacc\bin\AccVimaccInterface.exe 
+2025-09-12 08:34:47.561   startStop_services: found service below app dir.: name: "AccVimaccIpAlarmReceiver", image path: C:\vimacc\bin\AccVimaccIpAlarmReceiver.exe
+2025-09-12 08:34:47.561   startStop_services: found service below app dir.: name: "AccVimaccLicensePlateDetector", image path: C:\vimacc\bin\AccVimaccLicensePlateDetector.exe
+2025-09-12 08:34:47.561   startStop_services: found service below app dir.: name: "AccVimaccMotionDetector", image path: C:\vimacc\bin\AccVimaccMotionDetector.exe
+2025-09-12 08:34:47.561   startStop_services: found service below app dir.: name: "AccVimaccReportClient", image path: C:\vimacc\bin\AccVimaccReportClient.exe
+2025-09-12 08:34:47.561   startStop_services: found service below app dir.: name: "AccVimaccReportServer", image path: C:\vimacc\bin\AccVimaccReportServer.exe
+2025-09-12 08:34:47.561   startStop_services: found service below app dir.: name: "AccVimaccRoot", image path: C:\vimacc\bin\AccVimaccRoot.exe
+2025-09-12 08:34:47.561   startStop_services: found service below app dir.: name: "AccVimaccRTSPServer", image path: C:\vimacc\bin\AccVimaccRTSPServer.exe
+2025-09-12 08:34:47.561   startStop_services: found service below app dir.: name: "AccVimaccScheduler", image path: C:\vimacc\bin\AccVimaccScheduler.exe
+2025-09-12 08:34:47.561   startStop_services: found service below app dir.: name: "AccVimaccServer", image path: C:\vimacc\bin\AccVimaccServer.exe 
+2025-09-12 08:34:47.561   startStop_services: found service below app dir.: name: "AccVimaccSmsGateway", image path: C:\vimacc\bin\AccVimaccSmsGateway.exe
+2025-09-12 08:34:47.561   startStop_services: found service below app dir.: name: "AccVimaccSnmpAgent", image path: C:\vimacc\bin\AccVimaccSnmpAgent.exe
+2025-09-12 08:34:47.561   startStop_services: found service below app dir.: name: "AccVimaccSPS-FT_Interface", image path: C:\vimacc\bin\AccVimaccSPS-FT_Interface.exe
+2025-09-12 08:34:47.561   startStop_services: found service below app dir.: name: "AccVimaccSystemMonitor", image path: C:\vimacc\bin\AccVimaccSystemMonitor.exe
+2025-09-12 08:34:47.582   StartServiceWait: starting service AccVimaccAssembliesManager ...
+2025-09-12 08:34:47.754   StartServiceWait: DONE starting service AccVimaccAssembliesManager.
+2025-09-12 08:34:47.842   StartServiceWait: starting service AccVimaccConfig ...
+2025-09-12 08:34:47.900   StartServiceWait: DONE starting service AccVimaccConfig.
+2025-09-12 08:34:47.980   StartServiceWait: starting service AccVimaccControlInterface ...
+2025-09-12 08:34:48.088   StartServiceWait: DONE starting service AccVimaccControlInterface.
+2025-09-12 08:34:48.168   StartServiceWait: starting service AccVimaccDigIOInterface ...
+2025-09-12 08:34:48.256   StartServiceWait: DONE starting service AccVimaccDigIOInterface.
+2025-09-12 08:34:48.341   StartServiceWait: starting service AccVimaccDisplayInterface ...
+2025-09-12 08:34:48.434   StartServiceWait: DONE starting service AccVimaccDisplayInterface.
+2025-09-12 08:34:48.512   StartServiceWait: starting service AccVimaccDongle ...
+2025-09-12 08:34:48.562   StartServiceWait: DONE starting service AccVimaccDongle.
+2025-09-12 08:34:48.635   StartServiceWait: starting service AccVimaccEmailSender ...
+2025-09-12 08:34:48.748   StartServiceWait: DONE starting service AccVimaccEmailSender.
+2025-09-12 08:34:48.821   StartServiceWait: starting service AccVimaccEventManager ...
+2025-09-12 08:34:48.869   StartServiceWait: DONE starting service AccVimaccEventManager.
+2025-09-12 08:34:48.944   StartServiceWait: starting service AccVimaccExport ...
+2025-09-12 08:34:49.025   StartServiceWait: DONE starting service AccVimaccExport.
+2025-09-12 08:34:49.098   StartServiceWait: starting service AccVimaccFtpAlarmReceiver ...
+2025-09-12 08:34:49.168   StartServiceWait: DONE starting service AccVimaccFtpAlarmReceiver.
+2025-09-12 08:34:49.254   StartServiceWait: starting service AccVimaccFtpUploader ...
+2025-09-12 08:34:49.310   StartServiceWait: DONE starting service AccVimaccFtpUploader.
+2025-09-12 08:34:49.395   StartServiceWait: starting service AccVimaccHIDController ...
+2025-09-12 08:34:49.444   StartServiceWait: DONE starting service AccVimaccHIDController.
+2025-09-12 08:34:49.519   StartServiceWait: starting service AccVimaccIcxInterface ...
+2025-09-12 08:34:49.587   StartServiceWait: DONE starting service AccVimaccIcxInterface.
+2025-09-12 08:34:49.831   StartServiceWait: starting service AccVimaccIpAlarmReceiver ...
+2025-09-12 08:34:49.880   StartServiceWait: DONE starting service AccVimaccIpAlarmReceiver.
+2025-09-12 08:34:49.955   StartServiceWait: starting service AccVimaccLicensePlateDetector ...
+2025-09-12 08:34:50.111   StartServiceWait: DONE starting service AccVimaccLicensePlateDetector.
+2025-09-12 08:34:50.188   StartServiceWait: starting service AccVimaccMotionDetector ...
+2025-09-12 08:34:50.348   StartServiceWait: DONE starting service AccVimaccMotionDetector.
+2025-09-12 08:34:50.438   StartServiceWait: starting service AccVimaccReportClient ...
+2025-09-12 08:34:50.498   StartServiceWait: DONE starting service AccVimaccReportClient.
+2025-09-12 08:34:50.577   StartServiceWait: starting service AccVimaccReportServer ...
+2025-09-12 08:34:50.623   StartServiceWait: DONE starting service AccVimaccReportServer.
+2025-09-12 08:34:50.702   StartServiceWait: starting service AccVimaccRoot ...
+2025-09-12 08:34:50.860   StartServiceWait: DONE starting service AccVimaccRoot.
+2025-09-12 08:34:50.936   StartServiceWait: starting service AccVimaccRTSPServer ...
+2025-09-12 08:34:50.989   StartServiceWait: DONE starting service AccVimaccRTSPServer.
+2025-09-12 08:34:51.062   StartServiceWait: starting service AccVimaccScheduler ...
+2025-09-12 08:34:51.108   StartServiceWait: DONE starting service AccVimaccScheduler.
+2025-09-12 08:34:51.313   StartServiceWait: starting service AccVimaccSmsGateway ...
+2025-09-12 08:34:51.363   StartServiceWait: DONE starting service AccVimaccSmsGateway.
+2025-09-12 08:34:51.437   StartServiceWait: starting service AccVimaccSnmpAgent ...
+2025-09-12 08:34:51.595   StartServiceWait: DONE starting service AccVimaccSnmpAgent.
+2025-09-12 08:34:51.670   StartServiceWait: starting service AccVimaccSPS-FT_Interface ...
+2025-09-12 08:34:51.726   StartServiceWait: DONE starting service AccVimaccSPS-FT_Interface.
+2025-09-12 08:34:51.808   StartServiceWait: starting service AccVimaccSystemMonitor ...
+2025-09-12 08:34:51.879   StartServiceWait: DONE starting service AccVimaccSystemMonitor.
+2025-09-12 08:34:52.038   Need to restart Windows? No
+2025-09-12 08:34:52.044   Deinitializing Setup.
+2025-09-12 08:34:52.048   Stopping 64-bit helper process. (PID: 34504)
+2025-09-12 08:34:52.052   Helper process exited.
+2025-09-12 08:34:52.060   Log closed.


### PR DESCRIPTION
New release 2.2.15.5 of vimacc Professional.
Correction of Application-ID, cause wrong ID was used for 2.2.15.4.

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/292490)