### PR TITLE
Added the ARM64 installer + Added various tags: Mozilla.Firefox.MSIX version 142.0.1

### DIFF
--- a/manifests/m/Mozilla/Firefox/MSIX/142.0.1/Mozilla.Firefox.MSIX.installer.yaml
+++ b/manifests/m/Mozilla/Firefox/MSIX/142.0.1/Mozilla.Firefox.MSIX.installer.yaml
@@ -32,5 +32,8 @@ Installers:
   InstallerUrl: https://download-installer.cdn.mozilla.net/pub/firefox/releases/142.0.1/win64/multi/Firefox%20Setup%20142.0.1.msix
   InstallerSha256: E87D3B67B6ED324044083FB5C4F634A0D4555678147D69A953EBC7ED674DED1B
   SignatureSha256: 28EBCFAE9A6E35D493E4D9909988A78E76F308BCF283C9C4E2F5D18EEA1E6F29
+- Architecture: arm64
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/firefox/releases/142.0.1/win64-aarch64/multi/Firefox%20Setup%20142.0.1.msix
+  InstallerSha256: E2A11FDD6A6AA2E25244AB380AB3826EFB3CDFBAC36F7FB55FFBDED983F09C52
 ManifestType: installer
 ManifestVersion: 1.10.0

--- a/manifests/m/Mozilla/Firefox/MSIX/142.0.1/Mozilla.Firefox.MSIX.installer.yaml
+++ b/manifests/m/Mozilla/Firefox/MSIX/142.0.1/Mozilla.Firefox.MSIX.installer.yaml
@@ -35,5 +35,6 @@ Installers:
 - Architecture: arm64
   InstallerUrl: https://download-installer.cdn.mozilla.net/pub/firefox/releases/142.0.1/win64-aarch64/multi/Firefox%20Setup%20142.0.1.msix
   InstallerSha256: E2A11FDD6A6AA2E25244AB380AB3826EFB3CDFBAC36F7FB55FFBDED983F09C52
+  SignatureSha256: 597C432D0315BAFD58B52491BD4034C91DACEEA93930D4E64E8E1F0B0AFCDBC6
 ManifestType: installer
 ManifestVersion: 1.10.0

--- a/manifests/m/Mozilla/Firefox/MSIX/142.0.1/Mozilla.Firefox.MSIX.locale.en-GB.yaml
+++ b/manifests/m/Mozilla/Firefox/MSIX/142.0.1/Mozilla.Firefox.MSIX.locale.en-GB.yaml
@@ -15,7 +15,10 @@ Tags:
 - spidermonkey
 - web
 - web-browser
-- webpage
+- webpages
+- pdfreader
+- 9nzvdkpmr9rd
+- websites
 ReleaseNotesUrl: https://www.mozilla.org/firefox/142.0.1/releasenotes/
 ManifestType: locale
 ManifestVersion: 1.10.0

--- a/manifests/m/Mozilla/Firefox/MSIX/142.0.1/Mozilla.Firefox.MSIX.locale.en-US.yaml
+++ b/manifests/m/Mozilla/Firefox/MSIX/142.0.1/Mozilla.Firefox.MSIX.locale.en-US.yaml
@@ -26,7 +26,10 @@ Tags:
 - spidermonkey
 - web
 - web-browser
-- webpage
+- webpages
+- pdfreader
+- 9nzvdkpmr9rd
+- websites
 ReleaseNotes: |-
   Fixed
   - Dragging multiple non-adjacent tabs in horizontal tab strip mode now correctly moves them together as a group. (Bug 1982933)

--- a/manifests/m/Mozilla/Firefox/MSIX/142.0.1/Mozilla.Firefox.MSIX.locale.nb-NO.yaml
+++ b/manifests/m/Mozilla/Firefox/MSIX/142.0.1/Mozilla.Firefox.MSIX.locale.nb-NO.yaml
@@ -12,6 +12,12 @@ ShortDescription: Mozilla Firefox er gratis programvare med åpen kildekode, byg
 Description: Firefox Browser, også kjent som Mozilla Firefox eller bare Firefox, er en gratis nettleser med åpen kildekode utviklet av Mozilla Foundation og dets datterselskap, Mozilla Corporation. Firefox bruker Gecko-layoutmotoren til å gjengi nettsider, som implementerer gjeldende og forventede webstandarder. I 2017 begynte Firefox å innlemme ny teknologi under kodenavnet Quantum for å fremme parallellitet og et mer intuitivt brukergrensesnitt. Firefox er offisielt tilgjengelig for Windows 7 eller nyere, macOS og Linux. Dens uoffisielle porter er tilgjengelige for forskjellige Unix og Unix-lignende operativsystemer, inkludert FreeBSD, OpenBSD, NetBSD, illumos og Solaris Unix.
 Tags:
 - nettleser
+- internett
+- nettsider
+- nettsteder
+- pdfleser
+- 9nzvdkpmr9rd
+- nettlesing
 ReleaseNotesUrl: https://www.mozilla.org/firefox/142.0.1/releasenotes/
 ManifestType: locale
 ManifestVersion: 1.10.0


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---
Notes from me:
* I found the installer by analysing the package's x64 installer(s), and compared it with the folders at https://archive.mozilla.org/pub/firefox/releases/142.0.1/ . Thus I merged the 2 URLs and it worked on the first try.
* `9nzvdkpmr9rd` is the Microsoft Store ID of Firefox MSIX, so that the Winget package shows up (alongside the `msstore` source result) when users search `winget search 9nzvdkpmr9rd`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/292553)