### PR TITLE
Add nos version 1.1.4

### DIFF
--- a/manifests/p/PlebOne/nos/1.1.3/PlebOne.nos.installer.yaml
+++ b/manifests/p/PlebOne/nos/1.1.3/PlebOne.nos.installer.yaml
@@ -1,0 +1,24 @@
+# Created using winget-create 1.6.0.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.8.0.schema.json
+
+PackageIdentifier: PlebOne.nos
+PackageVersion: 1.1.3
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: exe
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/PlebOne/nos/releases/download/v1.1.3/nos-1.1.3-windows-amd64.exe
+  InstallerSha256: 8517b5008f84dc4e00bcd03d1e9b611c5513cce38ce03c151226f55a9e6a17f0
+  InstallerSwitches:
+    Silent: ""
+    SilentWithProgress: ""
+- Architecture: arm64
+  InstallerUrl: https://github.com/PlebOne/nos/releases/download/v1.1.3/nos-1.1.3-windows-arm64.exe
+  InstallerSha256: 128a9154bee9c9929797a0e2e594b9d1532f467eb4a4ec481e3a529b68b0a063
+  InstallerSwitches:
+    Silent: ""
+    SilentWithProgress: ""
+ManifestType: installer
+ManifestVersion: 1.8.0

--- a/manifests/p/PlebOne/nos/1.1.3/PlebOne.nos.installer.yaml
+++ b/manifests/p/PlebOne/nos/1.1.3/PlebOne.nos.installer.yaml
@@ -1,5 +1,5 @@
 # Created using winget-create 1.6.0.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.8.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
 
 PackageIdentifier: PlebOne.nos
 PackageVersion: 1.1.3
@@ -21,4 +21,4 @@ Installers:
     Silent: ""
     SilentWithProgress: ""
 ManifestType: installer
-ManifestVersion: 1.8.0
+ManifestVersion: 1.10.0

--- a/manifests/p/PlebOne/nos/1.1.3/PlebOne.nos.installer.yaml
+++ b/manifests/p/PlebOne/nos/1.1.3/PlebOne.nos.installer.yaml
@@ -6,19 +6,13 @@ PackageVersion: 1.1.3
 Platform:
 - Windows.Desktop
 MinimumOSVersion: 10.0.0.0
-InstallerType: exe
+InstallerType: portable
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/PlebOne/nos/releases/download/v1.1.3/nos-1.1.3-windows-amd64.exe
   InstallerSha256: 8517b5008f84dc4e00bcd03d1e9b611c5513cce38ce03c151226f55a9e6a17f0
-  InstallerSwitches:
-    Silent: ""
-    SilentWithProgress: ""
 - Architecture: arm64
   InstallerUrl: https://github.com/PlebOne/nos/releases/download/v1.1.3/nos-1.1.3-windows-arm64.exe
   InstallerSha256: 128a9154bee9c9929797a0e2e594b9d1532f467eb4a4ec481e3a529b68b0a063
-  InstallerSwitches:
-    Silent: ""
-    SilentWithProgress: ""
 ManifestType: installer
 ManifestVersion: 1.10.0

--- a/manifests/p/PlebOne/nos/1.1.3/PlebOne.nos.installer.yaml
+++ b/manifests/p/PlebOne/nos/1.1.3/PlebOne.nos.installer.yaml
@@ -10,9 +10,9 @@ InstallerType: portable
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/PlebOne/nos/releases/download/v1.1.3/nos-1.1.3-windows-amd64.exe
-  InstallerSha256: 8517b5008f84dc4e00bcd03d1e9b611c5513cce38ce03c151226f55a9e6a17f0
+  InstallerSha256: 7d49eac8ef6538bd4ceff0b8efa9aece392a9e444756ff2ff66afd9ad4b67a63
 - Architecture: arm64
   InstallerUrl: https://github.com/PlebOne/nos/releases/download/v1.1.3/nos-1.1.3-windows-arm64.exe
-  InstallerSha256: 128a9154bee9c9929797a0e2e594b9d1532f467eb4a4ec481e3a529b68b0a063
+  InstallerSha256: ce2c79d1dafe4c95712fb2d626dc36b51c7f4fcf8b8863f40f4e12ac93f5837f
 ManifestType: installer
 ManifestVersion: 1.10.0

--- a/manifests/p/PlebOne/nos/1.1.3/PlebOne.nos.installer.yaml
+++ b/manifests/p/PlebOne/nos/1.1.3/PlebOne.nos.installer.yaml
@@ -7,6 +7,8 @@ Platform:
 - Windows.Desktop
 MinimumOSVersion: 10.0.0.0
 InstallerType: portable
+Commands:
+- nos
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/PlebOne/nos/releases/download/v1.1.3/nos-1.1.3-windows-amd64.exe

--- a/manifests/p/PlebOne/nos/1.1.3/PlebOne.nos.locale.en-US.yaml
+++ b/manifests/p/PlebOne/nos/1.1.3/PlebOne.nos.locale.en-US.yaml
@@ -1,0 +1,37 @@
+# Created using winget-create 1.6.0.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.8.0.schema.json
+
+PackageIdentifier: PlebOne.nos
+PackageVersion: 1.1.1
+PackageLocale: en-US
+Publisher: PlebOne
+PublisherUrl: https://github.com/PlebOne
+PublisherSupportUrl: https://github.com/PlebOne/nos/issues
+Author: PlebOne
+PackageName: nos
+PackageUrl: https://github.com/PlebOne/nos
+License: MIT
+LicenseUrl: https://raw.githubusercontent.com/PlebOne/nos/main/LICENSE
+Copyright: Copyright (c) 2024 PlebOne
+ShortDescription: A beautiful command-line client for posting to Nostr
+Description: |-
+  nos is a command-line client for Nostr, a decentralized social network protocol.
+  It provides a beautiful and easy-to-use interface for posting messages, viewing feeds,
+  and interacting with the Nostr network directly from your terminal.
+  
+  Features:
+  - Post messages to Nostr relays
+  - Beautiful command-line interface
+  - Cross-platform support (Windows, macOS, Linux)
+  - Fast and lightweight
+Tags:
+- nostr
+- social-network
+- cli
+- command-line
+- decentralized
+ReleaseNotes: |-
+  Release v1.1.1 includes automated winget support and improved release pipeline.
+ReleaseNotesUrl: https://github.com/PlebOne/nos/releases/tag/v1.1.1
+ManifestType: defaultLocale
+ManifestVersion: 1.8.0

--- a/manifests/p/PlebOne/nos/1.1.3/PlebOne.nos.locale.en-US.yaml
+++ b/manifests/p/PlebOne/nos/1.1.3/PlebOne.nos.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created using winget-create 1.6.0.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.8.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
 
 PackageIdentifier: PlebOne.nos
 PackageVersion: 1.1.1
@@ -34,4 +34,4 @@ ReleaseNotes: |-
   Release v1.1.1 includes automated winget support and improved release pipeline.
 ReleaseNotesUrl: https://github.com/PlebOne/nos/releases/tag/v1.1.1
 ManifestType: defaultLocale
-ManifestVersion: 1.8.0
+ManifestVersion: 1.10.0

--- a/manifests/p/PlebOne/nos/1.1.3/PlebOne.nos.locale.en-US.yaml
+++ b/manifests/p/PlebOne/nos/1.1.3/PlebOne.nos.locale.en-US.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
 
 PackageIdentifier: PlebOne.nos
-PackageVersion: 1.1.1
+PackageVersion: 1.1.3
 PackageLocale: en-US
 Publisher: PlebOne
 PublisherUrl: https://github.com/PlebOne
@@ -31,7 +31,7 @@ Tags:
 - command-line
 - decentralized
 ReleaseNotes: |-
-  Release v1.1.1 includes automated winget support and improved release pipeline.
-ReleaseNotesUrl: https://github.com/PlebOne/nos/releases/tag/v1.1.1
+  Release v1.1.3 includes automated winget support and improved release pipeline.
+ReleaseNotesUrl: https://github.com/PlebOne/nos/releases/tag/v1.1.3
 ManifestType: defaultLocale
 ManifestVersion: 1.10.0

--- a/manifests/p/PlebOne/nos/1.1.3/PlebOne.nos.yaml
+++ b/manifests/p/PlebOne/nos/1.1.3/PlebOne.nos.yaml
@@ -1,0 +1,8 @@
+# Created using winget-create 1.6.0.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.8.0.schema.json
+
+PackageIdentifier: PlebOne.nos
+PackageVersion: 1.1.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.8.0

--- a/manifests/p/PlebOne/nos/1.1.3/PlebOne.nos.yaml
+++ b/manifests/p/PlebOne/nos/1.1.3/PlebOne.nos.yaml
@@ -1,8 +1,8 @@
 # Created using winget-create 1.6.0.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.8.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
 
 PackageIdentifier: PlebOne.nos
 PackageVersion: 1.1.3
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.8.0
+ManifestVersion: 1.10.0

--- a/manifests/p/PlebOne/nos/1.1.4/PlebOne.nos.installer.yaml
+++ b/manifests/p/PlebOne/nos/1.1.4/PlebOne.nos.installer.yaml
@@ -1,0 +1,20 @@
+# Created using winget-create 1.6.0.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: PlebOne.nos
+PackageVersion: 1.1.4
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: portable
+Commands:
+- nos
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/PlebOne/nos/releases/download/v1.1.4/nos-1.1.4-windows-amd64.exe
+  InstallerSha256: 86b5b20a92dab7d735b9f106c3996f3e77cfb514671b0b829243038bbf1fa5af
+- Architecture: arm64
+  InstallerUrl: https://github.com/PlebOne/nos/releases/download/v1.1.4/nos-1.1.4-windows-arm64.exe
+  InstallerSha256: 6105201af0c634c87e2b834fd1655579af1c47bfd46c561dcc86aae0ca2cda0e
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/p/PlebOne/nos/1.1.4/PlebOne.nos.locale.en-US.yaml
+++ b/manifests/p/PlebOne/nos/1.1.4/PlebOne.nos.locale.en-US.yaml
@@ -1,0 +1,37 @@
+# Created using winget-create 1.6.0.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: PlebOne.nos
+PackageVersion: 1.1.4
+PackageLocale: en-US
+Publisher: PlebOne
+PublisherUrl: https://github.com/PlebOne
+PublisherSupportUrl: https://github.com/PlebOne/nos/issues
+Author: PlebOne
+PackageName: nos
+PackageUrl: https://github.com/PlebOne/nos
+License: MIT
+LicenseUrl: https://raw.githubusercontent.com/PlebOne/nos/main/LICENSE
+Copyright: Copyright (c) 2024 PlebOne
+ShortDescription: A beautiful command-line client for posting to Nostr
+Description: |-
+  nos is a command-line client for Nostr, a decentralized social network protocol.
+  It provides a beautiful and easy-to-use interface for posting messages, viewing feeds,
+  and interacting with the Nostr network directly from your terminal.
+  
+  Features:
+  - Post messages to Nostr relays
+  - Beautiful command-line interface
+  - Cross-platform support (Windows, macOS, Linux)
+  - Fast and lightweight
+Tags:
+- nostr
+- social-network
+- cli
+- command-line
+- decentralized
+ReleaseNotes: |-
+  Release v1.1.4 includes automated winget support and improved release pipeline.
+ReleaseNotesUrl: https://github.com/PlebOne/nos/releases/tag/v1.1.4
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/p/PlebOne/nos/1.1.4/PlebOne.nos.yaml
+++ b/manifests/p/PlebOne/nos/1.1.4/PlebOne.nos.yaml
@@ -1,0 +1,8 @@
+# Created using winget-create 1.6.0.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: PlebOne.nos
+PackageVersion: 1.1.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Summary

This PR adds nos version 1.1.4 which fixes the command alias issue from v1.1.3.

### Changes
- **Fixed command alias**: Users can now type \
os\ instead of the full filename \
os-1.1.4-windows-amd64.exe\
- **Added Commands section**: Includes \Commands: - nos\ in installer manifest
- **Updated checksums**: All checksums updated for v1.1.4 binaries
- **Maintains portable installer**: Continues using portable installer type for standalone executables

### Related
- Fixes command line usability issue reported for v1.1.3
- Release: https://github.com/PlebOne/nos/releases/tag/v1.1.4

### Validation
✅ \winget validate\ passes successfully
✅ All required manifest files present (installer, locale, version)
✅ Checksums verified against GitHub release assets
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/292714)