### PR TITLE
[PHP] Add `PHP.PHP-NTS.8.3` (Non-thread safe builds of PHP 8.3)

### DIFF
--- a/manifests/p/PHP/PHP-NTS/8/3/8.3.25/PHP.PHP-NTS.8.3.installer.yaml
+++ b/manifests/p/PHP/PHP-NTS/8/3/8.3.25/PHP.PHP-NTS.8.3.installer.yaml
@@ -1,0 +1,32 @@
+# Created with PHPWatch/winget-pkgs - https://github.com/PHPWatch/php-winget-manifest
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: PHP.PHP-NTS.8.3
+PackageVersion: 8.3.25
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: php.exe
+    PortableCommandAlias: php
+Commands:
+  - php
+  - php83
+UpgradeBehavior: install
+ReleaseDate: 2025-08-26
+ArchiveBinariesDependOnPath: true
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://downloads.php.net/~windows/releases/php-8.3.25-nts-Win32-vs16-x64.zip
+    InstallerSha256: 66023a578b9a299827fb6d1993d6afe07a7b12623192d59ab935656a96e9a5ce
+    Dependencies:
+      PackageDependencies:
+        - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+  - Architecture: x86
+    InstallerUrl: https://downloads.php.net/~windows/releases/php-8.3.25-nts-Win32-vs16-x86.zip
+    InstallerSha256: 8e2d6d12fb764ba8b5ced6686e6f1e41f68bec1dba8374802f2f554e52ca3fea
+    Dependencies:
+      PackageDependencies:
+        - PackageIdentifier: Microsoft.VCRedist.2015+.x86
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/p/PHP/PHP-NTS/8/3/8.3.25/PHP.PHP-NTS.8.3.locale.en-US.yaml
+++ b/manifests/p/PHP/PHP-NTS/8/3/8.3.25/PHP.PHP-NTS.8.3.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# Created with PHPWatch/winget-pkgs - https://github.com/PHPWatch/php-winget-manifest
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: PHP.PHP-NTS.8.3
+Description: "PHP (recursive acronym for PHP: Hypertext Preprocessor) is a widely-used open source general-purpose scripting language that is especially suited for web development and can be embedded into HTML."
+ShortDescription: PHP 8.3 - Non-thread safe
+PackageVersion: 8.3.25
+ReleaseNotesUrl: https://www.php.net/ChangeLog-8.php#8.3.25
+PackageLocale: en-US
+Publisher: PHP Group
+PublisherUrl: https://php.net
+PublisherSupportUrl: https://www.php.net/docs.php
+Author: PHP Group
+PackageName: PHP 8.3 - Non-thread safe
+PackageUrl: https://php.net
+License: PHP License v3.01
+LicenseUrl: https://www.php.net/license/3_01.txt
+Copyright: (c) PHP Group
+CopyrightUrl: https://www.php.net/credits.php
+Moniker: php8.3
+Tags:
+  - php
+  - php83
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/p/PHP/PHP-NTS/8/3/8.3.25/PHP.PHP-NTS.8.3.yaml
+++ b/manifests/p/PHP/PHP-NTS/8/3/8.3.25/PHP.PHP-NTS.8.3.yaml
@@ -1,0 +1,8 @@
+# Created with PHPWatch/winget-pkgs - https://github.com/PHPWatch/php-winget-manifest
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: PHP.PHP-NTS.8.3
+PackageVersion: 8.3.25
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Adds support for PHP Non-thread safe builds, which are commonly used in CLI, and applications that do not need thread-safety.

---

This is a follow-up to the PR that added to `PHP.PHP.8.3`[^1].

Currently, the `PHP.PHP.8.3` package provides thread-safe builds of PHP, which are mostly suitable for Apache, and other applications that require a thread-safe build of PHP. Thread-safe builds can be used in CLI applications as well, but the proposed `PHP.PHP-NTS.8.3` and non-thread safe builds in general perform faster, and has less resource impact.

---

There is another PR (#292727) that proposes to add NTS builds as well.

This PR proposes to use the `PHP.PHP-NTS.` namespace, while the linked PR proposes `PHP.PHP.NTS` namespace.

I believe, the `PHP.PHP-NTS` namespace I propose here is more suitable, and in-line how PHP packages are named as well.

For example, notice the `-nts` suffix to the version name in NTS builds:

```
 TS: https://windows.php.net/downloads/releases/php-8.3.25-Win32-vs16-x64.zip`
NTS: https://windows.php.net/downloads/releases/php-8.3.25-nts-Win32-vs16-x64.zip`
```

Further, I (@Ayesh) was the author of the initial `PHP.PHP.8.3` package manifest, and have an automated setup[^2] to add new versions.

[^1]: https://github.com/microsoft/winget-pkgs/pull/196728
[^2]: https://github.com/PHPWatch/php-winget-manifest/actions

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Is there a linked Issue? Yes: #291357

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/292997)