### PR TITLE
[PHP] Add `PHP.PHP-NTS.8.4` (Non-thread safe builds of PHP 8.4)

### DIFF
--- a/manifests/p/PHP/PHP-NTS/8/4/8.4.12/PHP.PHP-NTS.8.4.installer.yaml
+++ b/manifests/p/PHP/PHP-NTS/8/4/8.4.12/PHP.PHP-NTS.8.4.installer.yaml
@@ -1,0 +1,32 @@
+# Created with PHPWatch/winget-pkgs - https://github.com/PHPWatch/php-winget-manifest
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: PHP.PHP-NTS.8.4
+PackageVersion: 8.4.12
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: php.exe
+    PortableCommandAlias: php
+Commands:
+  - php
+  - php84
+UpgradeBehavior: install
+ReleaseDate: 2025-08-26
+ArchiveBinariesDependOnPath: true
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://downloads.php.net/~windows/releases/php-8.4.12-nts-Win32-vs17-x64.zip
+    InstallerSha256: 585a8ea45d31238a36fed4bddddd182723557e2a85a2914e8bc27dad0629d670
+    Dependencies:
+      PackageDependencies:
+        - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+  - Architecture: x86
+    InstallerUrl: https://downloads.php.net/~windows/releases/php-8.4.12-nts-Win32-vs17-x86.zip
+    InstallerSha256: a8919fcf5c0a106de8cd7d245684e6653282f17709f55c82f59904c1fc088a5b
+    Dependencies:
+      PackageDependencies:
+        - PackageIdentifier: Microsoft.VCRedist.2015+.x86
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/p/PHP/PHP-NTS/8/4/8.4.12/PHP.PHP-NTS.8.4.locale.en-US.yaml
+++ b/manifests/p/PHP/PHP-NTS/8/4/8.4.12/PHP.PHP-NTS.8.4.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# Created with PHPWatch/winget-pkgs - https://github.com/PHPWatch/php-winget-manifest
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: PHP.PHP-NTS.8.4
+Description: "PHP (recursive acronym for PHP: Hypertext Preprocessor) is a widely-used open source general-purpose scripting language that is especially suited for web development and can be embedded into HTML."
+ShortDescription: PHP 8.4 - Non-thread safe
+PackageVersion: 8.4.12
+ReleaseNotesUrl: https://www.php.net/ChangeLog-8.php#8.4.12
+PackageLocale: en-US
+Publisher: PHP Group
+PublisherUrl: https://php.net
+PublisherSupportUrl: https://www.php.net/docs.php
+Author: PHP Group
+PackageName: PHP 8.4 - Non-thread safe
+PackageUrl: https://php.net
+License: PHP License v3.01
+LicenseUrl: https://www.php.net/license/3_01.txt
+Copyright: (c) PHP Group
+CopyrightUrl: https://www.php.net/credits.php
+Moniker: php8.4
+Tags:
+  - php
+  - php84
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/p/PHP/PHP-NTS/8/4/8.4.12/PHP.PHP-NTS.8.4.yaml
+++ b/manifests/p/PHP/PHP-NTS/8/4/8.4.12/PHP.PHP-NTS.8.4.yaml
@@ -1,0 +1,8 @@
+# Created with PHPWatch/winget-pkgs - https://github.com/PHPWatch/php-winget-manifest
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: PHP.PHP-NTS.8.4
+PackageVersion: 8.4.12
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Adds support for PHP Non-thread safe builds, which are commonly used in CLI, and applications that do not need thread-safety.

---

This is a follow-up to the PR that added to `PHP.PHP.8.4`[^1].

Currently, the `PHP.PHP.8.4` package provides thread-safe builds of PHP, which are mostly suitable for Apache, and other applications that require a thread-safe build of PHP. Thread-safe builds can be used in CLI applications as well, but the proposed `PHP.PHP-NTS.8.4` and non-thread safe builds in general perform faster, and has less resource impact.

---

There is another PR (#292723) that proposes to add NTS builds as well.

This PR proposes to use the `PHP.PHP-NTS.` namespace, while the linked PR proposes `PHP.PHP.NTS` namespace.

I believe, the `PHP.PHP-NTS` namespace I propose here is more suitable, and in-line how PHP packages are named as well.

For example, notice the `-nts` suffix to the version name in NTS builds:

```
 TS: https://windows.php.net/downloads/releases/php-8.4.12-Win32-vs16-x64.zip`
NTS: https://windows.php.net/downloads/releases/php-8.4.12-nts-Win32-vs16-x64.zip`
```

Further, I (@Ayesh) was the author of the initial `PHP.PHP.8.4` package manifest, and have an automated setup[^2] to add new versions.

[^1]: https://github.com/microsoft/winget-pkgs/pull/196185
[^2]: https://github.com/PHPWatch/php-winget-manifest/actions

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Is there a linked Issue? Yes - #291357

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/292998)