### PR TITLE
New package: Tatsh.WinPrefs 0.4.0

### DIFF
--- a/manifests/t/Tatsh/WinPrefs/0.4.0/Tatsh.WinPrefs.installer.yaml
+++ b/manifests/t/Tatsh/WinPrefs/0.4.0/Tatsh.WinPrefs.installer.yaml
@@ -1,0 +1,23 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: Tatsh.WinPrefs
+PackageVersion: 0.4.0
+InstallerType: zip
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: winprefs-0.4.0-win64/bin/winprefs.exe
+    PortableCommandAlias: winprefs
+  - RelativeFilePath: winprefs-0.4.0-win64/bin/winprefsw.exe
+    PortableCommandAlias: winprefsw
+UpgradeBehavior: install
+ReleaseDate: 2025-09-16
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Tatsh/winprefs/releases/download/v0.4.0/winprefs-0.4.0-win64.zip
+  InstallerSha256: 6a3fce7b8b9c3cbe962f6fe4d9de0185bb39bb70a3d85ba2618765448729724e
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/t/Tatsh/WinPrefs/0.4.0/Tatsh.WinPrefs.locale.en-US.yaml
+++ b/manifests/t/Tatsh/WinPrefs/0.4.0/Tatsh.WinPrefs.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: Tatsh.WinPrefs
+PackageVersion: 0.4.0
+PackageLocale: en-US
+Publisher: Tatsh
+PublisherUrl: https://github.com/Tatsh
+PublisherSupportUrl: https://github.com/Tatsh/winprefs/issues
+Author: Tatsh
+PackageName: WinPrefs
+PackageUrl: https://github.com/Tatsh/winprefs
+License: MIT License
+LicenseUrl: https://github.com/Tatsh/winprefs/blob/master/LICENSE.txt
+Copyright: Copyright 2025 WinPrefs authors
+ShortDescription: Tool to export registry paths to script and code formats (native component only).
+Description: Developer tool to dump a registry path to equivalent reg commands, C#, C, or PowerShell code. It can filter based on depth and based on configurable wildcard strings. This is the native component only and does not include the PowerShell module.
+Moniker: winprefs
+Tags:
+- backup
+- batch
+- c
+- csharp
+- powershell
+- registry
+- win32
+- windows
+ReleaseNotesUrl: https://github.com/Tatsh/winprefs/blob/master/CHANGELOG.md
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/t/Tatsh/WinPrefs/0.4.0/Tatsh.WinPrefs.yaml
+++ b/manifests/t/Tatsh/WinPrefs/0.4.0/Tatsh.WinPrefs.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: Tatsh.WinPrefs
+PackageVersion: 0.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

[winprefs](https://github.com/Tatsh/winprefs) is my utility to mass dump the registry to various formats usable in other code. Effectively it is a code snippet generator.

Interface:

```
Usage: winprefs.exe [OPTION...] [REG_PATH]

If a path to a value name is specified, the output directory argument is ignored and the line is printed to standard output.

Options:
  -F, --format=FORMAT Format to output. Options: c, cs, c#, ps, ps1, powershell, reg. Default: reg.
  -K, --deploy-key    Deploy key for committing.
  -c, --commit        Commit changes.
  -d, --debug         Enable debug logging.
  -f, --output-file   Output filename.
  -m, --max-depth=INT Set maximum depth.
  -o, --output-dir    Output directory.
  -h, --help          Display this help and exit.
```

Because this is a native app it is extremely fast. It does have a [PowerShell module](https://www.powershellgallery.com/packages/WinPrefs) but this only includes the native component.

`winprefs.exe` is the normal CLI version. `winprefsw.exe` accepts the same arguments but does not print to standard output, useful for automated tasks.

It can use Git to save changes, and even push when given a key.

Example output:

Default output to standard output with maximum depth 3:

```
$ winprefs -f - -m3
reg add "HKCU\AppEvents\Schemes" /ve /t REG_SZ /d ".Default" /f
reg add "HKCU\AppEvents\Schemes" /v "packagebase" /t REG_SZ /d "C:\WINDOWS\media" /f
reg add "HKCU\Console\%%%%Startup" /v "DelegationConsole" /t REG_SZ /d "{2EACA947-7F5F-4CFA-BA87-8F7FBEEFBE69}" /f
reg add "HKCU\Console\%%%%Startup" /v "DelegationTerminal" /t REG_SZ /d "{E12CFF52-A866-4C77-9A90-F570A7AA2C6B}" /f
...
```

C# output, custom path (even binary values are printed properly):

```
$ winprefs -f - -F cs -m3 'HKCU\System\GameConfigStore'
Registry.SetValue("HKEY_CURRENT_USER\\System\\GameConfigStore\\Children\\069e9773-6b7f-4613-b22a-447602fe702c", "Type", 1, RegistryValueKind.DWord);
Registry.SetValue("HKEY_CURRENT_USER\\System\\GameConfigStore\\Children\\069e9773-6b7f-4613-b22a-447602fe702c", "Revision", 2513, RegistryValueKind.DWord);
Registry.SetValue("HKEY_CURRENT_USER\\System\\GameConfigStore\\Children\\069e9773-6b7f-4613-b22a-447602fe702c", "Flags", 51, RegistryValueKind.DWord);
Registry.SetValue("HKEY_CURRENT_USER\\System\\GameConfigStore\\Children\\069e9773-6b7f-4613-b22a-447602fe702c", "Parent", { 0x01, 0x00, 0x00, 0x00, 0xd0, 0x8c, 0x9d, 0xdf, 0x01, 0x15, 0xd1, 0x11, 0x8c, 0x7a, 0x00, 0xc0, 0x4f, 0xc2, 0x97, 0xeb, 0x01, 0x00, 0x00, 0x00, 0xd6, 0x5c, 0xb9, 0x8a, 0x93, 0x3c, 0xb1, 0x44, 0x95, 0xea, 0x9c, 0x2d, 0xe8, 0xd8, 0x20, 0x9a, 0x04, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x66, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x20, 0x00, 0x00, 0x00, 0xae, 0xd4, 0xe3, 0xe7, 0x1a, 0x4d, 0xd5, 0xbc, 0x95, 0xe8, 0xe2, 0xff, 0xa2, 0xf9, 0x03, 0x01, 0x4a, 0xf4, 0x67, 0xdf, 0x34, 0xfb, 0x83, 0x2c, 0x86, 0xc8, 0x65, 0x7a, 0xac, 0x1e, 0x9a, 0xbe, 0x00, 0x00, 0x00, 0x00, 0x0e, 0x80, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x20, 0x00, 0x00, 0x00, 0x36, 0x47, 0xca, 0x5d, 0xeb, 0x14, 0x8b, 0x05, 0xec, 0x8d, 0x10, 0xc6, 0x27, 0xcd, 0xe4, 0x49, 0x0c, 0xb7, 0xbf, 0x44, 0x7a, 0x97, 0x08, 0xa9, 0xff, 0x24, 0x77, 0x62, 0x4e, 0xfa, 0x61, 0xfe, 0x20, 0x00, 0x00, 0x00, 0x03, 0xb0, 0xef, 0x6e, 0x6b, 0xfa, 0x2e, 0x9f, 0xb8, 0x89, 0x71, 0xe9, 0x22, 0x5e, 0x47, 0x6a, 0x35, 0x12, 0x9e, 0xd8, 0x86, 0x2d, 0xde, 0x59, 0x86, 0x71, 0xbe, 0x40, 0xfe, 0x7b, 0x4b, 0xeb, 0x40, 0x00, 0x00, 0x00, 0x2e, 0xa5, 0x4e, 0x9c, 0x67, 0x18, 0x00, 0x9e, 0x5b, 0xd4, 0x49, 0xbd, 0xe6, 0x97, 0x9b, 0x4a, 0xa5, 0x98, 0x6a, 0x4a, 0xf7, 0x99, 0x63, 0xe3, 0x95, 0x56, 0x29, 0xc7, 0xa1, 0xd9, 0xd4, 0xac, 0x30, 0x52, 0x32, 0xff, 0xdb, 0x5b, 0xee, 0x12, 0xd2, 0x98, 0xe9, 0xb7, 0xa6, 0xb7, 0x83, 0xaa, 0xb7, 0x3f, 0xa9, 0xc1, 0x55, 0x0d, 0x08, 0x53, 0xe2, 0x56, 0x13, 0x08, 0x4f, 0x41, 0xd2, 0x33 }, RegistryValueKind.Binary);
...
```

PowerShell output:

```
$ winprefs -f - -F powershell
if (!(Test-Path 'HKCU:\AppEvents\Schemes')) { New-Item -Path 'HKCU:\AppEvents\Schemes' -Force | Out-Null } New-ItemProperty -LiteralPath 'HKCU:\AppEvents\Schemes' -Name '(Default)' -PropertyType String -Force -Value '.Default'
if (!(Test-Path 'HKCU:\AppEvents\Schemes')) { New-Item -Path 'HKCU:\AppEvents\Schemes' -Force | Out-Null } New-ItemProperty -LiteralPath 'HKCU:\AppEvents\Schemes' -Name 'packagebase' -PropertyType String -Force -Value 'C:\WINDOWS\media'
...
```

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/293987)