### PR TITLE
New package: Tatsh.winpbcopy 0.0.4

### DIFF
--- a/manifests/t/Tatsh/winpbcopy/0.0.4/Tatsh.winpbcopy.installer.yaml
+++ b/manifests/t/Tatsh/winpbcopy/0.0.4/Tatsh.winpbcopy.installer.yaml
@@ -1,0 +1,23 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: Tatsh.winpbcopy
+PackageVersion: 0.0.4
+InstallerType: zip
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: winpbcopy-0.0.4-win64/bin/pbcopy.exe
+    PortableCommandAlias: pbcopy
+  - RelativeFilePath: winpbcopy-0.0.4-win64/bin/pbpaste.exe
+    PortableCommandAlias: pbpaste
+UpgradeBehavior: install
+ReleaseDate: 2025-07-12
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Tatsh/winpbcopy/releases/download/v0.0.4/winpbcopy-0.0.4-win64.zip
+  InstallerSha256: 6981384cb283b3f2632fd69e71d3984ff4019bef06016121f70ab4003220fad6
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/t/Tatsh/winpbcopy/0.0.4/Tatsh.winpbcopy.locale.en-US.yaml
+++ b/manifests/t/Tatsh/winpbcopy/0.0.4/Tatsh.winpbcopy.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: Tatsh.winpbcopy
+PackageVersion: 0.0.4
+PackageLocale: en-US
+Publisher: Tatsh
+PublisherUrl: https://github.com/Tatsh
+PublisherSupportUrl: https://github.com/Tatsh/winpbcopy/issues
+Author: Tatsh
+PackageName: winpbcopy
+PackageUrl: https://github.com/Tatsh/winpbcopy
+License: MIT License
+LicenseUrl: https://github.com/Tatsh/winpbcopy/blob/master/LICENSE.txt
+Copyright: Copyright 2025 winpbcopy authors
+ShortDescription: macOS-style copy and paste commands for Windows.
+Description: This package provides pbcopy/pbpaste to read and write the default CF_TEXT clipboard. pbpaste prints the clipboard content to standard output.
+Moniker: pbcopy
+Tags:
+- clipboard
+- utility
+ReleaseNotesUrl: https://github.com/Tatsh/winpbcopy/blob/master/CHANGELOG.md
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/t/Tatsh/winpbcopy/0.0.4/Tatsh.winpbcopy.yaml
+++ b/manifests/t/Tatsh/winpbcopy/0.0.4/Tatsh.winpbcopy.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: Tatsh.winpbcopy
+PackageVersion: 0.0.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---
`pbcopy` is virtually the same as `clip`, but there is no equivalent paste command officially. This
package provides pbpaste to read the default `CF_TEXT` clipboard and print it to stdout. Unlike `clip`,
`pbcopy` waits for input even if no arguments are passed, same as on macOS.

Why? I am used to typing `pbcopy` + `pbpaste` on Linux (where I have an alias) and macOS.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/293992)