### PR TITLE
Remove Blocked-InstallerType label on PR synchronize, re-run & mod trigger

### DIFF
--- a/.github/policies/labelManagement.issueUpdated.yml
+++ b/.github/policies/labelManagement.issueUpdated.yml
@@ -240,6 +240,8 @@ configuration:
           - removeLabel:
               label: Binary-Validation-Error
           - removeLabel:
+              label: Blocked-InstallerType
+          - removeLabel:
               label: Blocking-Issue
           - removeLabel:
               label: Changes-Requested

--- a/.github/policies/labelManagement.issueUpdated.yml
+++ b/.github/policies/labelManagement.issueUpdated.yml
@@ -426,6 +426,8 @@ configuration:
           - removeLabel:
               label: Binary-Validation-Error
           - removeLabel:
+              label: Blocked-InstallerType
+          - removeLabel:
               label: Blocking-Issue
           - removeLabel:
               label: EULA-Install

--- a/.github/policies/moderatorTriggers.yml
+++ b/.github/policies/moderatorTriggers.yml
@@ -523,6 +523,8 @@ configuration:
                   - removeLabel:
                       label: Area-Validation-Pipeline
                   - removeLabel:
+                      label: Blocked-InstallerType
+                  - removeLabel:
                       label: Blocking-Issue
                   - removeLabel:
                       label: Changes-Requested


### PR DESCRIPTION
If the installer type is still incorrect after new changes / PR re-run then I'm assuming the automation will attach the label back again.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/294638)