### PR TITLE
Fix GrafanaLabs.k6 manifest

### DIFF
--- a/manifests/g/GrafanaLabs/k6/1.2.3/GrafanaLabs.k6.installer.yaml
+++ b/manifests/g/GrafanaLabs/k6/1.2.3/GrafanaLabs.k6.installer.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
 PackageIdentifier: GrafanaLabs.k6
 PackageVersion: 1.2.3
-ElevationRequirement: elevationRequired
+ElevationRequirement: elevatesSelf
 InstallerLocale: en-US
 InstallerType: wix
 InstallModes:


### PR DESCRIPTION
Fix non-silent install by using correct `ElevationRequired` value.

<img width="838" height="200" alt="image" src="https://github.com/user-attachments/assets/56d576dc-5f85-4ed6-a0f1-e9a3e77fd6fd" />

Otherwise install is only successful if `--silent` is specified.

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/295437)