### PR TITLE
Add arm64 installer support for SQLite version 3.50.4

### DIFF
--- a/manifests/s/SQLite/SQLite/3.50.4/SQLite.SQLite.installer.yaml
+++ b/manifests/s/SQLite/SQLite/3.50.4/SQLite.SQLite.installer.yaml
@@ -19,5 +19,8 @@ Installers:
 - Architecture: x64
   InstallerUrl: https://www.sqlite.org/2025/sqlite-tools-win-x64-3500400.zip
   InstallerSha256: 8CE18347EA86A1CE65F33B533D2F144D8D1237140529FBF818574CA11FA13AD5
+- Architecture: arm64
+  InstallerUrl: https://www.sqlite.org/2025/sqlite-tools-win-arm64-3500400.zip
+  InstallerSha256: 3343FCD41124B2C1A73E9C210612153DECE741193F5B1B1CDBFD0866496F91D0
 ManifestType: installer
 ManifestVersion: 1.10.0


### PR DESCRIPTION
This change adds an `arm64` architecture installer for the `SQLite.SQLite` package for version `3.50.4`.

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

Fixes #295464
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/295466)