### PR TITLE
Re-order installers for Notepad++

### DIFF
--- a/manifests/n/Notepad++/Notepad++/8.8.5/Notepad++.Notepad++.installer.yaml
+++ b/manifests/n/Notepad++/Notepad++/8.8.5/Notepad++.Notepad++.installer.yaml
@@ -6,44 +6,6 @@ PackageVersion: 8.8.5
 InstallerLocale: en-US
 ReleaseDate: 2025-08-13
 Installers:
-- Architecture: x86
-  InstallerType: zip
-  NestedInstallerType: portable
-  NestedInstallerFiles:
-  - RelativeFilePath: notepad++.exe
-    PortableCommandAlias: notepad++
-  InstallerUrl: https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.8.5/npp.8.8.5.portable.zip
-  InstallerSha256: A08A9E4D6A3610F11F1961C4C07BD0AD85B04A47AA46D96B684AC5D2A63237F5
-  ArchiveBinariesDependOnPath: true
-- Architecture: x86
-  InstallerType: nullsoft
-  Scope: machine
-  InstallerUrl: https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.8.5/npp.8.8.5.Installer.exe
-  InstallerSha256: 05ABC57952974D08FEAFA399D6FDB37945A3FD0A10F37833DD837A5788E421D5
-  InstallModes:
-  - interactive
-  - silent
-  ExpectedReturnCodes:
-  - InstallerReturnCode: 5
-    ReturnResponse: packageInUse
-  UpgradeBehavior: install
-  ProductCode: Notepad++
-  AppsAndFeaturesEntries:
-  - DisplayName: Notepad++ (32-bit x86)
-    Publisher: Notepad++ Team
-    ProductCode: Notepad++
-  ElevationRequirement: elevatesSelf
-  InstallationMetadata:
-    DefaultInstallLocation: '%ProgramFiles(x86)%\Notepad++'
-- Architecture: x64
-  InstallerType: zip
-  NestedInstallerType: portable
-  NestedInstallerFiles:
-  - RelativeFilePath: notepad++.exe
-    PortableCommandAlias: notepad++
-  InstallerUrl: https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.8.5/npp.8.8.5.portable.x64.zip
-  InstallerSha256: 372BD3A9B15566AF7793DF86212A5C213739BD57E1B09AB007A1E00CE4DE555B
-  ArchiveBinariesDependOnPath: true
 - Architecture: x64
   InstallerType: nullsoft
   Scope: machine
@@ -64,15 +26,26 @@ Installers:
   ElevationRequirement: elevatesSelf
   InstallationMetadata:
     DefaultInstallLocation: '%ProgramFiles(x86)%\Notepad++'
-- Architecture: arm64
-  InstallerType: zip
-  NestedInstallerType: portable
-  NestedInstallerFiles:
-  - RelativeFilePath: notepad++.exe
-    PortableCommandAlias: notepad++
-  InstallerUrl: https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.8.5/npp.8.8.5.portable.arm64.zip
-  InstallerSha256: 0D08F428AC33235F6F8B694B9C9967023F222A22542E2A5C9FFC2A595F3F9A4A
-  ArchiveBinariesDependOnPath: true
+- Architecture: x86
+  InstallerType: nullsoft
+  Scope: machine
+  InstallerUrl: https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.8.5/npp.8.8.5.Installer.exe
+  InstallerSha256: 05ABC57952974D08FEAFA399D6FDB37945A3FD0A10F37833DD837A5788E421D5
+  InstallModes:
+  - interactive
+  - silent
+  ExpectedReturnCodes:
+  - InstallerReturnCode: 5
+    ReturnResponse: packageInUse
+  UpgradeBehavior: install
+  ProductCode: Notepad++
+  AppsAndFeaturesEntries:
+  - DisplayName: Notepad++ (32-bit x86)
+    Publisher: Notepad++ Team
+    ProductCode: Notepad++
+  ElevationRequirement: elevatesSelf
+  InstallationMetadata:
+    DefaultInstallLocation: '%ProgramFiles(x86)%\Notepad++'
 - Architecture: arm64
   InstallerType: nullsoft
   Scope: machine
@@ -93,5 +66,33 @@ Installers:
   ElevationRequirement: elevatesSelf
   InstallationMetadata:
     DefaultInstallLocation: '%ProgramFiles(x86)%\Notepad++'
+- Architecture: x86
+  InstallerType: zip
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: notepad++.exe
+    PortableCommandAlias: notepad++
+  InstallerUrl: https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.8.5/npp.8.8.5.portable.zip
+  InstallerSha256: A08A9E4D6A3610F11F1961C4C07BD0AD85B04A47AA46D96B684AC5D2A63237F5
+  ArchiveBinariesDependOnPath: true
+- Architecture: x64
+  InstallerType: zip
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: notepad++.exe
+    PortableCommandAlias: notepad++
+  InstallerUrl: https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.8.5/npp.8.8.5.portable.x64.zip
+  InstallerSha256: 372BD3A9B15566AF7793DF86212A5C213739BD57E1B09AB007A1E00CE4DE555B
+  ArchiveBinariesDependOnPath: true
+- Architecture: arm64
+  InstallerType: zip
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: notepad++.exe
+    PortableCommandAlias: notepad++
+  InstallerUrl: https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.8.5/npp.8.8.5.portable.arm64.zip
+  InstallerSha256: 0D08F428AC33235F6F8B694B9C9967023F222A22542E2A5C9FFC2A595F3F9A4A
+  ArchiveBinariesDependOnPath: true
 ManifestType: installer
 ManifestVersion: 1.10.0
+


### PR DESCRIPTION
This is so that WinGet picks the nullsoft installer in first-time installs. See comment https://github.com/microsoft/winget-pkgs/issues/296850#issuecomment-3329028044

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/296853)