### PR TITLE
Hoping to prevent infinite "Validation-Unapproved-URL" labels for OptiPNG.

### DIFF
--- a/manifests/o/OptiPNG/OptiPNG/.validation
+++ b/manifests/o/OptiPNG/OptiPNG/.validation
@@ -1,0 +1,1 @@
+{"ValidationVersion":"1.0.0","Waivers":[{"WaiverId":"48345b83-8a05-4e73-4873-4c89024576fd","TestPlan":"Validation-Unapproved-URL","PackagePath":"manifests/o/OptiPNG/OptiPNG/7.9.1","CommitId":"78954a90437834b67349485687e4390347eadc4e"}


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Is there a linked Issue? #295112 #298707

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---
Notes from me:
* I wasn't sure how the IDs were calculated, so I did some keyboard mashing to generate some random hexadec numbers.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/298710)