### PR TITLE
New package: AdLock.AdLock version 2.1.7.1

### DIFF
--- a/manifests/a/AdLock/AdLock/2.1.7.1/AdLock.AdLock.installer.yaml
+++ b/manifests/a/AdLock/AdLock/2.1.7.1/AdLock.AdLock.installer.yaml
@@ -1,0 +1,12 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: AdLock.AdLock
+PackageVersion: 2.1.7.1
+InstallerType: inno
+Installers:
+- Architecture: x86
+  InstallerUrl: https://downloads.adlock.com/windows/Adlock_Installer.exe
+  InstallerSha256: B44056622F4EA1E08C3F8259F18A803B2D3610F908FF296137EC45B6C5059E65
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/a/AdLock/AdLock/2.1.7.1/AdLock.AdLock.locale.en-US.yaml
+++ b/manifests/a/AdLock/AdLock/2.1.7.1/AdLock.AdLock.locale.en-US.yaml
@@ -1,0 +1,20 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: AdLock.AdLock
+PackageVersion: 2.1.7.1
+PackageLocale: en-US
+Publisher: Hankuper s.r.o.
+PackageName: AdLock
+PackageUrl: https://adlock.com/adlock-for-windows/
+License: Proprietary (Trialware)
+ShortDescription: Removes ads from all browsers, games, and other apps providing top-notch privacy security all along.
+Tags:
+- adblocking
+- adblocker
+- antimalware
+- privacy
+- adguardsyntax
+PurchaseUrl: https://adlock.com/purchase/
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/a/AdLock/AdLock/2.1.7.1/AdLock.AdLock.locale.en-US.yaml
+++ b/manifests/a/AdLock/AdLock/2.1.7.1/AdLock.AdLock.locale.en-US.yaml
@@ -10,6 +10,7 @@ PackageUrl: https://adlock.com/adlock-for-windows/
 License: Proprietary (Trialware)
 ShortDescription: Removes ads from all browsers, games, and other apps providing top-notch privacy security all along.
 Tags:
+- adblock
 - adblocking
 - adblocker
 - antimalware

--- a/manifests/a/AdLock/AdLock/2.1.7.1/AdLock.AdLock.yaml
+++ b/manifests/a/AdLock/AdLock/2.1.7.1/AdLock.AdLock.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: AdLock.AdLock
+PackageVersion: 2.1.7.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---
Notes from me:
* AdLock underperforms in comparison to its 2 main competitors AdGuard for Windows and Zen Privacy, in particular that its settings menu for some reason runs on an Internet Explorer 11 backend and that it doesn't credit listmakers. But the competition among desktop adblockers is small enough that I'm submitting it anyway.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/299192)