### PR TITLE
Add Microsoft Fluent Fonts package

### DIFF
--- a/fonts/m/Microsoft/FluentFonts/1.0.0.0/Microsoft.FluentFonts.installer.yaml
+++ b/fonts/m/Microsoft/FluentFonts/1.0.0.0/Microsoft.FluentFonts.installer.yaml
@@ -1,0 +1,22 @@
+# Created using wingetcreate 1.10.0.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.FluentFonts
+PackageVersion: 1.0.0.0
+Installers:
+- Architecture: neutral
+  InstallerType: zip
+  InstallerUrl: https://download.microsoft.com/download/1/6/9/1698b73e-f6c5-44ad-b2cf-88d21d610897/Microsoft Fluent Fonts for non-Windows OS.zip
+  InstallerSha256: 74E400E6A74F272608DDB16B98296F7D0B93F8423D2F0A64A850B3E1DD140DD7
+  NestedInstallerType: font
+  NestedInstallerFiles:
+  - RelativeFilePath: Fluent_Calibri-Bold.ttf
+  - RelativeFilePath: Fluent_Calibri-BoldItalic.ttf
+  - RelativeFilePath: Fluent_Calibri-Italic.ttf
+  - RelativeFilePath: Fluent_Calibri.ttf
+  - RelativeFilePath: Fluent_SitkaSmall-Bold.ttf
+  - RelativeFilePath: Fluent_SitkaSmall-BoldItalic.ttf
+  - RelativeFilePath: Fluent_SitkaSmall-Italic.ttf
+  - RelativeFilePath: Fluent_SitkaSmall.ttf
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/m/Microsoft/FluentFonts/1.0.0.0/Microsoft.FluentFonts.locale.en-US.yaml
+++ b/fonts/m/Microsoft/FluentFonts/1.0.0.0/Microsoft.FluentFonts.locale.en-US.yaml
@@ -1,0 +1,12 @@
+# Created using wingetcreate 1.10.0.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.FluentFonts
+PackageVersion: 1.0.0.0
+PackageLocale: en-US
+Publisher: Microsoft Corporation
+PackageName: Microsoft Fluent Calibri and Sitka
+License: MIT License
+ShortDescription: Variants of Microsoft Calibri and Sitka fonts intended to help with visual crowding.
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/m/Microsoft/FluentFonts/1.0.0.0/Microsoft.FluentFonts.yaml
+++ b/fonts/m/Microsoft/FluentFonts/1.0.0.0/Microsoft.FluentFonts.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.10.0.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.FluentFonts
+PackageVersion: 1.0.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
This manifest conforms to the 1.12 schema and passes validation with latest winget-cli build.

This will not be picked up by the source yet because it is not in the manifests directory, but those with experimental fonts turned on can point to this manifest as a valid one to test the feature and use as an example for making other font packages and testing font winget support.

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/300617)