### PR TITLE
[Update ONLYOFFICE.DesktopEditors] Remove .msi installers

### DIFF
--- a/manifests/o/ONLYOFFICE/DesktopEditors/9.0.4/ONLYOFFICE.DesktopEditors.installer.yaml
+++ b/manifests/o/ONLYOFFICE/DesktopEditors/9.0.4/ONLYOFFICE.DesktopEditors.installer.yaml
@@ -47,17 +47,6 @@ FileExtensions:
 - xps
 Installers:
 - Architecture: x86
-  InstallerType: msi
-  InstallerUrl: https://github.com/ONLYOFFICE/DesktopEditors/releases/download/v9.0.4/DesktopEditors_x86.msi
-  InstallerSha256: 8B72E45E6C6DECC01C0121FF73A7A2574C44FAD09D983E51184A00BA513C41FE
-  ProductCode: '{3BDDEBC9-0719-4AE3-D358-6D8AC8C6D2C7}'
-  AppsAndFeaturesEntries:
-  - DisplayName: ONLYOFFICE
-    Publisher: Ascensio System SIA
-    DisplayVersion: 9.0.4.50
-    ProductCode: '{3BDDEBC9-0719-4AE3-D358-6D8AC8C6D2C7}'
-    UpgradeCode: '{47EEF706-B0E4-4C43-944B-E5F914B92B79}'
-- Architecture: x86
   InstallerType: inno
   InstallerUrl: https://github.com/ONLYOFFICE/DesktopEditors/releases/download/v9.0.4/DesktopEditors_x86.exe
   InstallerSha256: 77AF5A04ADA0A017940099A0C370275F62635572F2996A967702D12625DF06CC
@@ -69,17 +58,6 @@ Installers:
   ElevationRequirement: elevatesSelf
   InstallationMetadata:
     DefaultInstallLocation: '%ProgramFiles%\ONLYOFFICE\DesktopEditors'
-- Architecture: x64
-  InstallerType: msi
-  InstallerUrl: https://github.com/ONLYOFFICE/DesktopEditors/releases/download/v9.0.4/DesktopEditors_x64.msi
-  InstallerSha256: 476F26711FDC4D9C3D243DF36087E547DBE54C7F1DDFBBD2288760DC92958E3B
-  ProductCode: '{77B4A9C1-A903-1830-18E7-FF97AE2AC0E6}'
-  AppsAndFeaturesEntries:
-  - DisplayName: ONLYOFFICE
-    Publisher: Ascensio System SIA
-    DisplayVersion: 9.0.4.50
-    ProductCode: '{77B4A9C1-A903-1830-18E7-FF97AE2AC0E6}'
-    UpgradeCode: '{47EEF706-B0E4-4C43-944B-E5F914B92B79}'
 - Architecture: x64
   InstallerType: inno
   InstallerUrl: https://github.com/ONLYOFFICE/DesktopEditors/releases/download/v9.0.4/DesktopEditors_x64.exe
@@ -95,4 +73,5 @@ Installers:
 ManifestType: installer
 ManifestVersion: 1.10.0
 ReleaseDate: 2025-08-06
+
 


### PR DESCRIPTION
… .exe for upgrade compatibility

This PR removes support for .msi installers as they do not support seamless version upgrades. When a new version is released, the .msi-based installation gets uninstalled automatically and replaced with the .exe version, which supports in-place upgrades.

.msi packages cause upgrade issues — they require manual uninstall before installing a new version. The .exe installer provides a better user experience with built-in upgrade support.

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/301171)