### PR TITLE
Tags maintenance + Added the ARM64 version: BtbN.FFmpeg.GPL.Shared.7.1 version 7.1.2-20250930

### DIFF
--- a/manifests/b/BtbN/FFmpeg/GPL/Shared/7/1/7.1.2-20250930/BtbN.FFmpeg.GPL.Shared.7.1.installer.yaml
+++ b/manifests/b/BtbN/FFmpeg/GPL/Shared/7/1/7.1.2-20250930/BtbN.FFmpeg.GPL.Shared.7.1.installer.yaml
@@ -5,13 +5,6 @@ PackageIdentifier: BtbN.FFmpeg.GPL.Shared.7.1
 PackageVersion: 7.1.2-20250930
 InstallerType: zip
 NestedInstallerType: portable
-NestedInstallerFiles:
-- RelativeFilePath: ffmpeg-n7.1.2-5-g8f77695e65-win64-gpl-shared-7.1\bin\ffmpeg.exe
-  PortableCommandAlias: ffmpeg
-- RelativeFilePath: ffmpeg-n7.1.2-5-g8f77695e65-win64-gpl-shared-7.1\bin\ffplay.exe
-  PortableCommandAlias: ffplay
-- RelativeFilePath: ffmpeg-n7.1.2-5-g8f77695e65-win64-gpl-shared-7.1\bin\ffprobe.exe
-  PortableCommandAlias: ffprobe
 Commands:
 - ffmpeg
 - ffplay
@@ -22,5 +15,22 @@ Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2025-09-30-13-19/ffmpeg-n7.1.2-5-g8f77695e65-win64-gpl-shared-7.1.zip
   InstallerSha256: 453B9047C5C3CB5ADA06C3127A9D038855663AD936FE3EB3B5572790734E6A63
+  NestedInstallerFiles:
+  - RelativeFilePath: ffmpeg-n7.1.2-5-g8f77695e65-win64-gpl-shared-7.1\bin\ffmpeg.exe
+    PortableCommandAlias: ffmpeg
+  - RelativeFilePath: ffmpeg-n7.1.2-5-g8f77695e65-win64-gpl-shared-7.1\bin\ffplay.exe
+    PortableCommandAlias: ffplay
+  - RelativeFilePath: ffmpeg-n7.1.2-5-g8f77695e65-win64-gpl-shared-7.1\bin\ffprobe.exe
+    PortableCommandAlias: ffprobe
+- Architecture: arm64
+  InstallerUrl: https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2025-09-30-13-19/ffmpeg-n7.1.2-5-g8f77695e65-winarm64-gpl-shared-7.1.zip
+  InstallerSha256: 84C3D54B799C52B7BFED94CB467F6C419E50B6F399152F3D87E57492FABBB280
+  NestedInstallerFiles:
+  - RelativeFilePath: ffmpeg-n7.1.2-5-g8f77695e65-winarm64-gpl-shared-7.1\bin\ffmpeg.exe
+    PortableCommandAlias: ffmpeg
+  - RelativeFilePath: ffmpeg-n7.1.2-5-g8f77695e65-winarm64-gpl-shared-7.1\bin\ffplay.exe
+    PortableCommandAlias: ffplay
+  - RelativeFilePath: ffmpeg-n7.1.2-5-g8f77695e65-winarm64-gpl-shared-7.1\bin\ffprobe.exe
+    PortableCommandAlias: ffprobe
 ManifestType: installer
 ManifestVersion: 1.10.0

--- a/manifests/b/BtbN/FFmpeg/GPL/Shared/7/1/7.1.2-20250930/BtbN.FFmpeg.GPL.Shared.7.1.locale.en-US.yaml
+++ b/manifests/b/BtbN/FFmpeg/GPL/Shared/7/1/7.1.2-20250930/BtbN.FFmpeg.GPL.Shared.7.1.locale.en-US.yaml
@@ -11,7 +11,7 @@ PackageName: FFmpeg (GPL shared variant, 7.1 release branch)
 PackageUrl: https://github.com/BtbN/FFmpeg-Builds
 License: GPL-3.0
 LicenseUrl: https://www.ffmpeg.org/legal.html
-Copyright: Copyright (c) 2000-2025 the FFmpeg developers
+Copyright: Copyright © 2000-2025 the FFmpeg developers
 ShortDescription: A complete, cross-platform solution to record, convert and stream audio and video.
 Description: |-
   FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge.
@@ -24,17 +24,20 @@ Tags:
 - demux
 - encode
 - filter
-- media
 - multimedia
 - mux
 - record
-- stream
 - streaming
 - transcode
 - video
+- ffmpegforaudacity
+- avformat-61.dll
+- avformat.dll
 ReleaseNotesUrl: https://github.com/BtbN/FFmpeg-Builds/releases/tag/autobuild-2025-09-30-13-19
 Documentations:
 - DocumentLabel: Documentation
   DocumentUrl: https://ffmpeg.org/documentation.html
+- DocumentLabel: Documentation
+  DocumentUrl: https://github.com/audacity/audacity-support/blob/main/basics/installing-ffmpeg.md
 ManifestType: defaultLocale
 ManifestVersion: 1.10.0


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---
Notes from me:
* https://github.com/audacity/audacity-support/blob/main/basics/installing-ffmpeg.md certainly confirms that it can use non-Buanzo versions of FFmpeg, which was of special interest to me since Buanzo's version was outdated (Uses `avformat-59.dll`). I was able to get the BtbN version to work, but only the 7.1 version and not 8.0 (The latter uses `avformat-62.dll`, while Audacity's highest supported is `avformat-61.dll`).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/301976)