### PR TITLE
Tags maintenance + Added the ARM64 version: BtbN.FFmpeg.LGPL.Shared.7.1 version 7.1.2-20250930

### DIFF
--- a/manifests/b/BtbN/FFmpeg/LGPL/Shared/7/1/7.1.2-20250930/BtbN.FFmpeg.LGPL.Shared.7.1.installer.yaml
+++ b/manifests/b/BtbN/FFmpeg/LGPL/Shared/7/1/7.1.2-20250930/BtbN.FFmpeg.LGPL.Shared.7.1.installer.yaml
@@ -5,13 +5,6 @@ PackageIdentifier: BtbN.FFmpeg.LGPL.Shared.7.1
 PackageVersion: 7.1.2-20250930
 InstallerType: zip
 NestedInstallerType: portable
-NestedInstallerFiles:
-- RelativeFilePath: ffmpeg-n7.1.2-5-g8f77695e65-win64-lgpl-shared-7.1\bin\ffmpeg.exe
-  PortableCommandAlias: ffmpeg
-- RelativeFilePath: ffmpeg-n7.1.2-5-g8f77695e65-win64-lgpl-shared-7.1\bin\ffplay.exe
-  PortableCommandAlias: ffplay
-- RelativeFilePath: ffmpeg-n7.1.2-5-g8f77695e65-win64-lgpl-shared-7.1\bin\ffprobe.exe
-  PortableCommandAlias: ffprobe
 Commands:
 - ffmpeg
 - ffplay
@@ -22,8 +15,22 @@ Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2025-09-30-13-19/ffmpeg-n7.1.2-5-g8f77695e65-win64-lgpl-shared-7.1.zip
   InstallerSha256: 6CEF4917CBDAE50136F24D5ED1F55424A67FF610BFA3107EE1821ADAF67F7A1C
+  NestedInstallerFiles:
+  - RelativeFilePath: ffmpeg-n7.1.2-5-g8f77695e65-win64-lgpl-shared-7.1\bin\ffmpeg.exe
+    PortableCommandAlias: ffmpeg
+  - RelativeFilePath: ffmpeg-n7.1.2-5-g8f77695e65-win64-lgpl-shared-7.1\bin\ffplay.exe
+    PortableCommandAlias: ffplay
+  - RelativeFilePath: ffmpeg-n7.1.2-5-g8f77695e65-win64-lgpl-shared-7.1\bin\ffprobe.exe
+    PortableCommandAlias: ffprobe
 - Architecture: arm64
   InstallerUrl: https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2025-09-30-13-19/ffmpeg-n7.1.2-5-g8f77695e65-winarm64-lgpl-shared-7.1.zip
   InstallerSha256: 5A90289F20812E3A7DF0B0D1EB5D4597855ACCF8BD074AD391C2290910FB2646
+  NestedInstallerFiles:
+  - RelativeFilePath: ffmpeg-n7.1.2-5-g8f77695e65-winarm64-lgpl-shared-7.1\bin\ffmpeg.exe
+    PortableCommandAlias: ffmpeg
+  - RelativeFilePath: ffmpeg-n7.1.2-5-g8f77695e65-winarm64-lgpl-shared-7.1\bin\ffplay.exe
+    PortableCommandAlias: ffplay
+  - RelativeFilePath: ffmpeg-n7.1.2-5-g8f77695e65-winarm64-lgpl-shared-7.1\bin\ffprobe.exe
+    PortableCommandAlias: ffprobe
 ManifestType: installer
 ManifestVersion: 1.10.0

--- a/manifests/b/BtbN/FFmpeg/LGPL/Shared/7/1/7.1.2-20250930/BtbN.FFmpeg.LGPL.Shared.7.1.installer.yaml
+++ b/manifests/b/BtbN/FFmpeg/LGPL/Shared/7/1/7.1.2-20250930/BtbN.FFmpeg.LGPL.Shared.7.1.installer.yaml
@@ -22,5 +22,8 @@ Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2025-09-30-13-19/ffmpeg-n7.1.2-5-g8f77695e65-win64-lgpl-shared-7.1.zip
   InstallerSha256: 6CEF4917CBDAE50136F24D5ED1F55424A67FF610BFA3107EE1821ADAF67F7A1C
+- Architecture: arm64
+  InstallerUrl: https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2025-09-30-13-19/ffmpeg-n7.1.2-5-g8f77695e65-winarm64-lgpl-shared-7.1.zip
+  InstallerSha256: 5A90289F20812E3A7DF0B0D1EB5D4597855ACCF8BD074AD391C2290910FB2646
 ManifestType: installer
 ManifestVersion: 1.10.0

--- a/manifests/b/BtbN/FFmpeg/LGPL/Shared/7/1/7.1.2-20250930/BtbN.FFmpeg.LGPL.Shared.7.1.locale.en-US.yaml
+++ b/manifests/b/BtbN/FFmpeg/LGPL/Shared/7/1/7.1.2-20250930/BtbN.FFmpeg.LGPL.Shared.7.1.locale.en-US.yaml
@@ -11,7 +11,7 @@ PackageName: FFmpeg (LGPL shared variant, 7.1 release branch)
 PackageUrl: https://github.com/BtbN/FFmpeg-Builds
 License: LGPL-2.1
 LicenseUrl: https://www.ffmpeg.org/legal.html
-Copyright: Copyright (c) 2000-2025 the FFmpeg developers
+Copyright: Copyright © 2000-2025 the FFmpeg developers
 ShortDescription: A complete, cross-platform solution to record, convert and stream audio and video.
 Description: |-
   FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge.
@@ -24,17 +24,20 @@ Tags:
 - demux
 - encode
 - filter
-- media
 - multimedia
 - mux
 - record
-- stream
 - streaming
 - transcode
 - video
+- ffmpegforaudacity
+- avformat-61.dll
+- avformat.dll
 ReleaseNotesUrl: https://github.com/BtbN/FFmpeg-Builds/releases/tag/autobuild-2025-09-30-13-19
 Documentations:
 - DocumentLabel: Documentation
   DocumentUrl: https://ffmpeg.org/documentation.html
+- DocumentLabel: Documentation
+  DocumentUrl: https://github.com/audacity/audacity-support/blob/main/basics/installing-ffmpeg.md
 ManifestType: defaultLocale
 ManifestVersion: 1.10.0


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Is there a linked Issue? #301976

Manifests
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---
Notes from me:
* https://github.com/audacity/audacity-support/blob/main/basics/installing-ffmpeg.md certainly confirms that it can use non-Buanzo versions of FFmpeg, which was of special interest to me since Buanzo's version was outdated (Uses `avformat-59.dll`). I was able to get the BtbN version to work, but only the 7.1 version and not 8.0 (The latter uses `avformat-62.dll`, while Audacity's highest supported is `avformat-61.dll`).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/301977)