### PR TITLE
Fixing Mobirise version

### DIFF
--- a/manifests/m/Mobirise/Mobirise/6.1.4.164/Mobirise.Mobirise.installer.yaml
+++ b/manifests/m/Mobirise/Mobirise/6.1.4.164/Mobirise.Mobirise.installer.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
 
 PackageIdentifier: Mobirise.Mobirise
-PackageVersion: 6.1.4.164
+PackageVersion: 6.1.4
 InstallerType: nullsoft
 Scope: machine
 InstallerSwitches:

--- a/manifests/m/Mobirise/Mobirise/6.1.4.164/Mobirise.Mobirise.locale.en-US.yaml
+++ b/manifests/m/Mobirise/Mobirise/6.1.4.164/Mobirise.Mobirise.locale.en-US.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
 
 PackageIdentifier: Mobirise.Mobirise
-PackageVersion: 6.1.4.164
+PackageVersion: 6.1.4
 PackageLocale: en-US
 Publisher: Mobirise.com
 PublisherUrl: https://mobirise.com/

--- a/manifests/m/Mobirise/Mobirise/6.1.4.164/Mobirise.Mobirise.locale.zh-CN.yaml
+++ b/manifests/m/Mobirise/Mobirise/6.1.4.164/Mobirise.Mobirise.locale.zh-CN.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.10.0.schema.json
 
 PackageIdentifier: Mobirise.Mobirise
-PackageVersion: 6.1.4.164
+PackageVersion: 6.1.4
 PackageLocale: zh-CN
 License: 专有软件
 ShortDescription: 无代码网站创建器

--- a/manifests/m/Mobirise/Mobirise/6.1.4.164/Mobirise.Mobirise.yaml
+++ b/manifests/m/Mobirise/Mobirise/6.1.4.164/Mobirise.Mobirise.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
 
 PackageIdentifier: Mobirise.Mobirise
-PackageVersion: 6.1.4.164
+PackageVersion: 6.1.4
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.10.0


### PR DESCRIPTION
After installation of the newest version of Mobirise, the installatioon gets only reported as 6.1.4 and therefore the next time the same version gets installed again.

This PR removes the .164 at the end which causes the issue.

C:\Windows\System32>winget update
Name                   Id                          Version      Available    Source
-----------------------------------------------------------------------------------
Mobirise 6.1.4         Mobirise.Mobirise           6.1.4        6.1.4.164    winget
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/305440)