### PR TITLE
Hotfix for wrong publisher: XueyunRuiChuang.JsDesign version 1.0.7

### DIFF
--- a/manifests/x/XueyunRuiChuang/JsDesign/1.0.7/XueyunRuiChuang.JsDesign.locale.en-US.yaml
+++ b/manifests/x/XueyunRuiChuang/JsDesign/1.0.7/XueyunRuiChuang.JsDesign.locale.en-US.yaml
@@ -4,7 +4,7 @@
 PackageIdentifier: XueyunRuiChuang.JsDesign
 PackageVersion: 1.0.7
 PackageLocale: en-US
-Publisher: Diego Fernandes
+Publisher: Js.Design Incm
 PublisherUrl: https://js.design/
 PublisherSupportUrl: https://js.design/help
 # PrivacyUrl:


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---
Notes from me:
* That some guy called Diego Fernandes was the publisher of a PRC web company's software seemed unlikely to me at best, and a quick web searching didn't turn out any obvious candidates for guys with that name who worked for Xueyun. So I replaced `Publisher:` with the one listed on the far-bottom-left of Js.Design's homepage.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/305449)