### PR TITLE
clifton.clifton Fix file name inside installer

### DIFF
--- a/manifests/c/clifton/clifton/0.3.0/clifton.clifton.installer.yaml
+++ b/manifests/c/clifton/clifton/0.3.0/clifton.clifton.installer.yaml
@@ -6,7 +6,7 @@ PackageVersion: 0.3.0
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
-- RelativeFilePath: clifton-windows-x86_64.exe
+- RelativeFilePath: clifton.exe
 ReleaseDate: 2025-10-17
 Installers:
 - Architecture: x64
@@ -14,4 +14,5 @@ Installers:
   InstallerSha256: 073BBDADEE4FD31FD93E996442C704FA8134F729E39A7BEEA95EE8268D8D644B
 ManifestType: installer
 ManifestVersion: 1.10.0
+
 

--- a/manifests/c/clifton/clifton/0.3.0/clifton.clifton.installer.yaml
+++ b/manifests/c/clifton/clifton/0.3.0/clifton.clifton.installer.yaml
@@ -11,6 +11,7 @@ ReleaseDate: 2025-10-17
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/isambard-sc/clifton/releases/download/0.3.0/clifton-windows-x86_64.zip
-  InstallerSha256: D03C2A50C54E5348ADB34DD22F42F8578EB0A57A98BBE7A178D008A6AB1C99E9
+  InstallerSha256: 073BBDADEE4FD31FD93E996442C704FA8134F729E39A7BEEA95EE8268D8D644B
 ManifestType: installer
 ManifestVersion: 1.10.0
+


### PR DESCRIPTION
The installer had a misnamed file in it. The file inside the zip has now been renamed to `clifton.exe`.

This is exactly the same application code, and only a change to the installer has been made.

The file is currently going through the Microsoft Security Intelligence submission process.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/305828)