### PR TITLE
Add arm64 architecture installer support for sharkdp.bat 0.26.0

### DIFF
--- a/manifests/s/sharkdp/bat/0.26.0/sharkdp.bat.installer.yaml
+++ b/manifests/s/sharkdp/bat/0.26.0/sharkdp.bat.installer.yaml
@@ -23,5 +23,13 @@ Installers:
   Dependencies:
     PackageDependencies:
     - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+- Architecture: arm64
+  NestedInstallerFiles:
+  - RelativeFilePath: bat-v0.26.0-aarch64-pc-windows-msvc/bat.exe
+  InstallerUrl: https://github.com/sharkdp/bat/releases/download/v0.26.0/bat-v0.26.0-aarch64-pc-windows-msvc.zip
+  InstallerSha256: 8FEB1582B5A141B2C6D63D1F1ABFC496C97FF2255EB9B797D5444393D233232C
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.arm64
 ManifestType: installer
 ManifestVersion: 1.10.0


### PR DESCRIPTION
This change adds an `arm64` architecture installer for the `sharkdp.bat` package for version `0.26.0`.

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

Fixes #306491
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/306504)