### PR TITLE
Add PCMan 9.5.0-beta3 manifest

### DIFF
--- a/manifests/p/PCMan.yaml
+++ b/manifests/p/PCMan.yaml
@@ -1,0 +1,15 @@
+Id: PCMan.PCMan
+Version: 9.5.0-beta3
+Name: PCMan
+Publisher: PCMan-BBS
+Description: PCMan Windows 客戶端
+License: GPL-3.0-or-later
+LicenseNotes: |
+  大部分程式碼使用 GPL 授權，
+  Lite 目錄下的 Rijndael.cpp / Rijndael.h 為專有程式碼，不包含在 GPL 內。
+InstallerType: Exe
+Scope: user
+Installers:
+  - Architecture: x64
+    Url: https://github.com/pcman-bbs/pcman-windows/releases/download/v9.5.0-beta3/PCMan.exe
+    Sha256: 79BABAC187348A23DC1EF30A04618F0D006665CA677392D1FF2A8E373E24260D


### PR DESCRIPTION
新增 PCMan 9.5.0-beta3 的 Windows 客戶端 manifest。
包含 x64 exe 安裝器與 SHA256 驗證。

Checklist for Pull Requests
- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/306961)