### PR TITLE
Add benchdoos.WeblocOpener version 2.0.2 (#306937)

### DIFF
--- a/manifests/b/benchdoos/WeblocOpener/2.0.2/benchdoos.WeblocOpener.yaml
+++ b/manifests/b/benchdoos/WeblocOpener/2.0.2/benchdoos.WeblocOpener.yaml
@@ -1,0 +1,15 @@
+PackageIdentifier: benchdoos.WeblocOpener
+PackageVersion: 2.0.2
+PackageLocale: en-US
+Publisher: benchdoos
+PackageName: WeblocOpener
+License: MIT
+ShortDescription: Open, create, and edit Apple .webloc files on Windows.
+Description: WeblocOpener is a simple way to open, create and edit Apple .webloc files on Windows. It can convert between .webloc, .url and .desktop shortcuts, and .webarchive to .html.
+InstallerType: exe
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/benchdoos/WeblocOpener/releases/download/v2.0.2.0/WeblocOpenerSetup.exe
+    InstallerSha256: FEF503B9F03584CCC4CDBD92BAE67943B2A00CA07C4229AEFB019637F7A5A007
+ManifestType: singleton
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Package Request
Fixes #306937

### Summary
Added manifest for **WeblocOpener 2.0.2** as requested in issue #306937.

- **Publisher:** benchdoos  
- **Package Name:** WeblocOpener  
- **Version:** 2.0.2  
- **Installer Type:** exe  
- **Installer URL:** https://github.com/benchdoos/WeblocOpener/releases/download/v2.0.2.0/WeblocOpenerSetup.exe  
- **Installer SHA256:** FEF503B9F03584CCC4CDBD92BAE67943B2A00CA07C4229AEFB019637F7A5A007  

### Notes
- Validated successfully using `winget validate`.  
- Silent install flags not specified because the installer runs interactively.  
- Hash verified locally and matches upstream release.  

### Verification
The manifest installs successfully via:
winget install --manifest .\manifests\b\benchdoos\WeblocOpener\2.0.2\
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/306962)