### PR TITLE
EugeneZrazhevsky.WeblocOpener version 2.0.2

### DIFF
--- a/manifests/e/EugeneZrazhevsky/WeblocOpener/2.0.2/EugeneZrazhevsky.WeblocOpener.installer.yaml
+++ b/manifests/e/EugeneZrazhevsky/WeblocOpener/2.0.2/EugeneZrazhevsky.WeblocOpener.installer.yaml
@@ -1,0 +1,12 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: EugeneZrazhevsky.WeblocOpener
+PackageVersion: 2.0.2
+InstallerType: inno
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/benchdoos/WeblocOpener/releases/download/v2.0.2.0/WeblocOpenerSetup.exe
+  InstallerSha256: FEF503B9F03584CCC4CDBD92BAE67943B2A00CA07C4229AEFB019637F7A5A007
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/e/EugeneZrazhevsky/WeblocOpener/2.0.2/EugeneZrazhevsky.WeblocOpener.installer.yaml
+++ b/manifests/e/EugeneZrazhevsky/WeblocOpener/2.0.2/EugeneZrazhevsky.WeblocOpener.installer.yaml
@@ -4,6 +4,10 @@
 PackageIdentifier: EugeneZrazhevsky.WeblocOpener
 PackageVersion: 2.0.2
 InstallerType: inno
+ElevationRequirement: elevatesSelf
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: EclipseAdoptium.Temurin.17.JRE
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/benchdoos/WeblocOpener/releases/download/v2.0.2.0/WeblocOpenerSetup.exe

--- a/manifests/e/EugeneZrazhevsky/WeblocOpener/2.0.2/EugeneZrazhevsky.WeblocOpener.locale.en-US.yaml
+++ b/manifests/e/EugeneZrazhevsky/WeblocOpener/2.0.2/EugeneZrazhevsky.WeblocOpener.locale.en-US.yaml
@@ -10,7 +10,7 @@ PublisherSupportUrl: https://github.com/benchdoos/WeblocOpener/issues
 Author: Eugene Zrazhevsky
 PackageName: WeblocOpener
 PackageUrl: https://github.com/benchdoos/WeblocOpener
-License: MIT
+License: Apache-2.0
 LicenseUrl: https://github.com/benchdoos/WeblocOpener/blob/master/LICENSE
 Copyright: Copyright © 2016-2023 Eugene Zrazhevsky
 ShortDescription: Open, create, and edit Apple .webloc files on Windows.

--- a/manifests/e/EugeneZrazhevsky/WeblocOpener/2.0.2/EugeneZrazhevsky.WeblocOpener.locale.en-US.yaml
+++ b/manifests/e/EugeneZrazhevsky/WeblocOpener/2.0.2/EugeneZrazhevsky.WeblocOpener.locale.en-US.yaml
@@ -23,7 +23,16 @@ Tags:
 - converter
 - apple
 - html
-ReleaseNotes: Minor improvements and bug fixes.
+ReleaseNotes: |-
+  What’s new
+  Improvements
+  - Improved the stability of the application and some of its components
+  - Reduced the size of the application and its components
+  - Added a setting to not convert .webarchive and open the original site if it's available
+  Fixed
+  - The installer has been fixed, now it supports newer versions of Java
+  - Fixed context menu for DuckDuckGo and Brave
+  - Fixed file opening with specific symbols
 ReleaseNotesUrl: https://github.com/benchdoos/WeblocOpener/releases/tag/v2.0.2.0
 InstallationNotes: Thank you for installing WeblocOpener!
 ManifestType: defaultLocale

--- a/manifests/e/EugeneZrazhevsky/WeblocOpener/2.0.2/EugeneZrazhevsky.WeblocOpener.locale.en-US.yaml
+++ b/manifests/e/EugeneZrazhevsky/WeblocOpener/2.0.2/EugeneZrazhevsky.WeblocOpener.locale.en-US.yaml
@@ -17,7 +17,12 @@ ShortDescription: Open, create, and edit Apple .webloc files on Windows.
 Description: WeblocOpener is a simple way to open, create and edit Apple .webloc files on Windows. It can convert between .webloc, .url and .desktop shortcuts, and .webarchive to .html.
 Moniker: weblocopener
 Tags:
-- webloc,url,shortcut,converter,apple,html
+- webloc
+- url
+- shortcut
+- converter
+- apple
+- html
 ReleaseNotes: Minor improvements and bug fixes.
 ReleaseNotesUrl: https://github.com/benchdoos/WeblocOpener/releases/tag/v2.0.2.0
 InstallationNotes: Thank you for installing WeblocOpener!

--- a/manifests/e/EugeneZrazhevsky/WeblocOpener/2.0.2/EugeneZrazhevsky.WeblocOpener.locale.en-US.yaml
+++ b/manifests/e/EugeneZrazhevsky/WeblocOpener/2.0.2/EugeneZrazhevsky.WeblocOpener.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: EugeneZrazhevsky.WeblocOpener
+PackageVersion: 2.0.2
+PackageLocale: en-US
+Publisher: benchdoos
+PublisherUrl: https://github.com/benchdoos
+PublisherSupportUrl: https://github.com/benchdoos/WeblocOpener/issues
+Author: Eugene Zrazhevsky
+PackageName: WeblocOpener
+PackageUrl: https://github.com/benchdoos/WeblocOpener
+License: MIT
+LicenseUrl: https://github.com/benchdoos/WeblocOpener/blob/master/LICENSE
+Copyright: Copyright © 2016-2023 Eugene Zrazhevsky
+ShortDescription: Open, create, and edit Apple .webloc files on Windows.
+Description: WeblocOpener is a simple way to open, create and edit Apple .webloc files on Windows. It can convert between .webloc, .url and .desktop shortcuts, and .webarchive to .html.
+Moniker: weblocopener
+Tags:
+- webloc,url,shortcut,converter,apple,html
+ReleaseNotes: Minor improvements and bug fixes.
+ReleaseNotesUrl: https://github.com/benchdoos/WeblocOpener/releases/tag/v2.0.2.0
+InstallationNotes: Thank you for installing WeblocOpener!
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/e/EugeneZrazhevsky/WeblocOpener/2.0.2/EugeneZrazhevsky.WeblocOpener.yaml
+++ b/manifests/e/EugeneZrazhevsky/WeblocOpener/2.0.2/EugeneZrazhevsky.WeblocOpener.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: EugeneZrazhevsky.WeblocOpener
+PackageVersion: 2.0.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
### Package Submission: EugeneZrazhevsky.WeblocOpener version 2.0.2

This pull request adds a new manifest for **EugeneZrazhevsky.WeblocOpener** as requested in issue #306937.

---

### 📦 Package Details
- **Publisher:** benchdoos  
- **Author:** Eugene Zrazhevsky  
- **Package Name:** WeblocOpener  
- **Version:** 2.0.2  
- **Installer Type:** Inno Setup (EXE)  
- **License:** Apache-2.0
- **Installer URL:** [Download WeblocOpenerSetup.exe](https://github.com/benchdoos/WeblocOpener/releases/download/v2.0.2.0/WeblocOpenerSetup.exe)  
- **SHA256:** `FEF503B9F03584CCC4CDBD92BAE67943B2A00CA07C4229AEFB019637F7A5A007`

---

### 🧪 Validation and Testing
- Manifest successfully validated with:
  ```bash
  winget validate --manifest .\manifests\e\EugeneZrazhevsky\WeblocOpener\2.0.2\
  ```
- Installation tested locally:
  ```bash
  winget install --manifest .\manifests\e\EugeneZrazhevsky\WeblocOpener\2.0.2\
  ```
- All validation pipelines have passed ✅  
- Tags and metadata updated per reviewer feedback.  

---

### 🗒️ Notes
- Silent flags not provided since the installer runs interactively.  
- Verified installer hash matches official GitHub release.  
- Schema version: **1.10.0**

---

### 🔗 Related Issue
Fixes #306937
