### PR TITLE
New version: getfloma.Floma version 0.3.16

### DIFF
--- a/manifests/g/getfloma/Floma/0.3.16/getfloma.Floma.installer.yaml
+++ b/manifests/g/getfloma/Floma/0.3.16/getfloma.Floma.installer.yaml
@@ -1,0 +1,14 @@
+# Created using wingetcreate 1.6.5.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: getfloma.Floma
+PackageVersion: 0.3.16
+InstallerType: portable
+Commands:
+  - floma
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://pub-3da12ce477ba4b969191f6514d7505ff.r2.dev/0.3.16/floma-windows-x86_64.exe
+    InstallerSha256: 628650d42e03f17b168485b93910b4c7546595d250cab6cc33efc803da27ad89
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/g/getfloma/Floma/0.3.16/getfloma.Floma.locale.en-US.yaml
+++ b/manifests/g/getfloma/Floma/0.3.16/getfloma.Floma.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# Created using wingetcreate 1.6.5.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: getfloma.Floma
+PackageVersion: 0.3.16
+PackageLocale: en-US
+Publisher: Aditya Thakkar
+PublisherUrl: https://getfloma.com
+PublisherSupportUrl: https://github.com/AdityaT248/releo/issues
+PackageName: Floma
+PackageUrl: https://getfloma.com
+License: Proprietary
+Copyright: Copyright (c) 2025 Aditya Thakkar
+ShortDescription: AI-Powered Workflow Automation Tool
+Description: Floma is a CLI automation tool that uses AI to create and manage workflows with built-in email integration. Automate file management, data processing, email reports, and more with natural language commands.
+Moniker: floma
+Tags:
+  - automation
+  - cli
+  - workflow
+  - ai
+  - productivity
+  - email
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/g/getfloma/Floma/0.3.16/getfloma.Floma.locale.en-US.yaml
+++ b/manifests/g/getfloma/Floma/0.3.16/getfloma.Floma.locale.en-US.yaml
@@ -6,7 +6,6 @@ PackageVersion: 0.3.16
 PackageLocale: en-US
 Publisher: Aditya Thakkar
 PublisherUrl: https://getfloma.com
-PublisherSupportUrl: https://github.com/AdityaT248/releo/issues
 PackageName: Floma
 PackageUrl: https://getfloma.com
 License: Proprietary

--- a/manifests/g/getfloma/Floma/0.3.16/getfloma.Floma.yaml
+++ b/manifests/g/getfloma/Floma/0.3.16/getfloma.Floma.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.6.5.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: getfloma.Floma
+PackageVersion: 0.3.16
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
This PR adds Floma v0.3.16 to the Windows Package Manager repository.

**Package Information:**
- Package: getfloma.Floma
- Version: 0.3.16
- Publisher: Aditya Thakkar

**Changes:**
- Updated to version 0.3.16
- Fixed PostHog telemetry host to US region
- Added opt-out telemetry (enabled by default)
- Command usage tracking for all commands

**Package URL:** https://getfloma.com
**Installer URL:** https://pub-3da12ce477ba4b969191f6514d7505ff.r2.dev/0.3.16/floma-windows-x86_64.exe
**SHA256:** 628650d42e03f17b168485b93910b4c7546595d250cab6cc33efc803da27ad89
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/309211)