### PR TITLE
Add Natthasath.hostctl version 1.0.0

### DIFF
--- a/manifests/n/Natthasath/hostctl/1.0.0/Natthasath.hostctl.installer.yaml
+++ b/manifests/n/Natthasath/hostctl/1.0.0/Natthasath.hostctl.installer.yaml
@@ -1,0 +1,12 @@
+# Natthasath.hostctl.installer.yaml
+PackageIdentifier: Natthasath.hostctl
+PackageVersion: 1.0.0
+InstallerType: portable
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/natthasath/hostctl/releases/download/v1.0.0/hostctl.exe
+    InstallerSha256: 97B383F9AE0D95BF8D4D9A05802C71EA736CFF8EEBA3A31D80075E15F7693015
+    Commands:
+      - hostctl
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/n/Natthasath/hostctl/1.0.0/Natthasath.hostctl.locale.en-US.yaml
+++ b/manifests/n/Natthasath/hostctl/1.0.0/Natthasath.hostctl.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# Natthasath.hostctl.locale.en-US.yaml
+PackageIdentifier: Natthasath.hostctl
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: Natthasath
+PublisherUrl: https://github.com/natthasath
+PackageName: hostctl
+ShortDescription: Windows hosts manager with tags.
+Description: >
+  hostctl is a small CLI tool for managing the Windows hosts file with tagged entries:
+  list, add, edit, remove hosts, manage tags, and create backups. Supports sorting by IP,
+  hostname, and tags.
+Tags:
+  - hosts
+  - cli
+  - networking
+  - dns
+  - admin
+License: GPL-2.0-or-later
+LicenseUrl: https://www.gnu.org/licenses/gpl-2.0.html
+PackageUrl: https://github.com/natthasath/hostctl
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/n/Natthasath/hostctl/1.0.0/Natthasath.hostctl.yaml
+++ b/manifests/n/Natthasath/hostctl/1.0.0/Natthasath.hostctl.yaml
@@ -1,0 +1,6 @@
+# Natthasath.hostctl.yaml
+PackageIdentifier: Natthasath.hostctl
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
New package: Natthasath.hostctl 1.0.0

- Portable executable hostctl.exe
- Hosts manager CLI for Windows with tagging support
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/309439)