### PR TITLE
Add JTL.Wawi version 1.11.2

### DIFF
--- a/manifests/j/JTL/Wawi/1.11.1/JTL.Wawi.installer.yaml
+++ b/manifests/j/JTL/Wawi/1.11.1/JTL.Wawi.installer.yaml
@@ -1,0 +1,13 @@
+# Created using wingetcreate 1.9.14.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: JTL.Wawi
+PackageVersion: 1.11.1
+InstallerType: inno
+Scope: machine
+Installers:
+- Architecture: x86
+  InstallerUrl: https://downloads.jtl-software.de/setup-jtl-wawi_1.11.1_1017-2113_47c2d81a914.exe
+  InstallerSha256: DD7191FD3941C284A73542A25FB291B6EF4F6FC05445FF7C07272419FD6D8FF3
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/j/JTL/Wawi/1.11.1/JTL.Wawi.locale.de-DE.yaml
+++ b/manifests/j/JTL/Wawi/1.11.1/JTL.Wawi.locale.de-DE.yaml
@@ -1,0 +1,12 @@
+# Created using wingetcreate 1.9.14.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: JTL.Wawi
+PackageVersion: 1.11.1
+PackageLocale: de-DE
+Publisher: JTL-Software-GmbH
+PackageName: JTL-Wawi
+License: Proprietary
+ShortDescription: Das kostenlose Warenwirtschaftssystem vereinfacht Ihre Geschäftsprozesse spürbar. Transparenter Warenfluss, bessere Übersicht, volle Kontrolle.
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/j/JTL/Wawi/1.11.1/JTL.Wawi.locale.en-US.yaml
+++ b/manifests/j/JTL/Wawi/1.11.1/JTL.Wawi.locale.en-US.yaml
@@ -1,0 +1,12 @@
+# Created using wingetcreate 1.9.14.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.9.0.schema.json
+
+PackageIdentifier: JTL.Wawi
+PackageVersion: 1.11.1
+PackageLocale: en-US
+Publisher: JTL-Software-GmbH
+PackageName: JTL-Wawi
+License: Proprietary
+ShortDescription: The free inventory management system noticeably simplifies your business processes. Transparent flow of goods, better overview, full control.
+ManifestType: locale
+ManifestVersion: 1.9.0

--- a/manifests/j/JTL/Wawi/1.11.1/JTL.Wawi.yaml
+++ b/manifests/j/JTL/Wawi/1.11.1/JTL.Wawi.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.9.14.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: JTL.Wawi
+PackageVersion: 1.11.1
+DefaultLocale: de-DE
+ManifestType: version
+ManifestVersion: 1.9.0

--- a/manifests/j/JTL/Wawi/1.11.2/JTL.Wawi.installer.yaml
+++ b/manifests/j/JTL/Wawi/1.11.2/JTL.Wawi.installer.yaml
@@ -1,0 +1,13 @@
+# Created using wingetcreate 1.9.14.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: JTL.Wawi
+PackageVersion: 1.11.2
+InstallerType: inno
+Scope: machine
+Installers:
+- Architecture: x86
+  InstallerUrl: https://downloads.jtl-software.de/setup-jtl-wawi_1.11.2_1029-1110_e35d3397680.exe
+  InstallerSha256: 755A30DDA5758CA262E3CBE802E301FB0492D164E1F689DBA8CAB3B34CBD2B77
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/j/JTL/Wawi/1.11.2/JTL.Wawi.locale.de-DE.yaml
+++ b/manifests/j/JTL/Wawi/1.11.2/JTL.Wawi.locale.de-DE.yaml
@@ -1,0 +1,12 @@
+# Created using wingetcreate 1.9.14.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: JTL.Wawi
+PackageVersion: 1.11.2
+PackageLocale: de-DE
+Publisher: JTL-Software-GmbH
+PackageName: JTL-Wawi
+License: Proprietary
+ShortDescription: Das kostenlose Warenwirtschaftssystem vereinfacht Ihre Geschäftsprozesse spürbar. Transparenter Warenfluss, bessere Übersicht, volle Kontrolle.
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/j/JTL/Wawi/1.11.2/JTL.Wawi.locale.en-US.yaml
+++ b/manifests/j/JTL/Wawi/1.11.2/JTL.Wawi.locale.en-US.yaml
@@ -1,0 +1,12 @@
+# Created using wingetcreate 1.9.14.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.9.0.schema.json
+
+PackageIdentifier: JTL.Wawi
+PackageVersion: 1.11.2
+PackageLocale: en-US
+Publisher: JTL-Software-GmbH
+PackageName: JTL-Wawi
+License: Proprietary
+ShortDescription: The free inventory management system noticeably simplifies your business processes. Transparent flow of goods, better overview, full control.
+ManifestType: locale
+ManifestVersion: 1.9.0

--- a/manifests/j/JTL/Wawi/1.11.2/JTL.Wawi.yaml
+++ b/manifests/j/JTL/Wawi/1.11.2/JTL.Wawi.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.9.14.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: JTL.Wawi
+PackageVersion: 1.11.2
+DefaultLocale: de-DE
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## Summary
- Added manifest files for JTL.Wawi version 1.11.2
- Updated installer URL to the new version: https://downloads.jtl-software.de/setup-jtl-wawi_1.11.2_1029-1110_e35d3397680.exe
- Verified SHA256 hash of the installer: 755A30DDA5758CA262E3CBE802E301FB0492D164E1F689DBA8CAB3B34CBD2B77

## Test plan
- [x] Verified manifest files are properly formatted
- [x] Ensured all required fields are present
- [x] Downloaded and verified SHA256 hash matches
- [x] Installer URL is accessible
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/309462)