### PR TITLE
Deprecate iwhalecloud.QShell package

### DIFF
--- a/manifests/t/tea4go/QShell/5.4.0/tea4go.QShell.installer.yaml
+++ b/manifests/t/tea4go/QShell/5.4.0/tea4go.QShell.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: tea4go.QShell
+PackageVersion: 5.4.0
+Installers:
+  - Architecture: x64
+    InstallerType: exe
+    InstallerUrl: https://github.com/tea4go/qshell/releases/download/v5.4.0/QShell.exe
+    InstallerSha256: 1060070a2835c517d02012f743e7a5445145865b521397dec00551ebf0bc251b
+    InstallerSwitches:  # ← 使用正确的字段名
+      Silent: "/S"     # ← 静默安装参数
+      SilentWithProgress: "/S"  # ← 静默进度参数
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/t/tea4go/QShell/5.4.0/tea4go.QShell.locale.en-US.yaml
+++ b/manifests/t/tea4go/QShell/5.4.0/tea4go.QShell.locale.en-US.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: tea4go.QShell
+PackageVersion: 5.4.0
+PackageLocale: en-US
+Publisher: tea4go
+PackageName: QShell
+License: Apache 2.0
+LicenseUrl: https://github.com/tea4go/qshell/blob/main/LICENSE
+PackageUrl: https://github.com/tea4go/qshell/releases/download/v5.4.0/QShell.exe
+ShortDescription: QShell is a cross-platform modern terminal tool that integrates multiple remote connection methods.
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/t/tea4go/QShell/5.4.0/tea4go.QShell.yaml
+++ b/manifests/t/tea4go/QShell/5.4.0/tea4go.QShell.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: tea4go.QShell
+PackageVersion: 5.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Description
Deprecate iwhalecloud.QShell package

## Changes
- Added `Tags: [deprecated]` to iwhalecloud.QShell manifest
- Added migration instructions in ReleaseNotes

## Reason
tea4go this account is the one I use frequently.
This package has been replaced by tea4go.QShell as part of ownership transfer from Mredward123 to tea4go account.
I control both the old publisher (`iwhalecloud`) and new publisher (`tea4go`) identities.
## Related PR
- New package PR: #[1]

## Validation
- [x] Manifest passes `winget validate`
- [x] Deprecation tags correctly applied
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/309503)