### PR TITLE
Transfer package ownership from iwhalecloud to tea4go

### DIFF
--- a/manifests/t/tea4go/QShell/5.4.0/tea4go.QShell.installer.yaml
+++ b/manifests/t/tea4go/QShell/5.4.0/tea4go.QShell.installer.yaml
@@ -6,7 +6,7 @@ Installers:
     InstallerType: exe
     InstallerUrl: https://github.com/tea4go/qshell/releases/download/v5.4.0/QShell.exe
     InstallerSha256: 1060070a2835c517d02012f743e7a5445145865b521397dec00551ebf0bc251b
-    InstallerSwitches:  # ← 使用正确的字段名
+    InstallerSwitches:  # ← 使用正确的字段name
       Silent: "/S"     # ← 静默安装参数
       SilentWithProgress: "/S"  # ← 静默进度参数
 ManifestType: installer

--- a/manifests/t/tea4go/QShell/5.4.0/tea4go.QShell.installer.yaml
+++ b/manifests/t/tea4go/QShell/5.4.0/tea4go.QShell.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: tea4go.QShell
+PackageVersion: 5.4.0
+Installers:
+  - Architecture: x64
+    InstallerType: exe
+    InstallerUrl: https://github.com/tea4go/qshell/releases/download/v5.4.0/QShell.exe
+    InstallerSha256: 1060070a2835c517d02012f743e7a5445145865b521397dec00551ebf0bc251b
+    InstallerSwitches:  # ← 使用正确的字段名
+      Silent: "/S"     # ← 静默安装参数
+      SilentWithProgress: "/S"  # ← 静默进度参数
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/t/tea4go/QShell/5.4.0/tea4go.QShell.locale.en-US.yaml
+++ b/manifests/t/tea4go/QShell/5.4.0/tea4go.QShell.locale.en-US.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: tea4go.QShell
+PackageVersion: 5.4.0
+PackageLocale: en-US
+Publisher: tea4go
+PackageName: QShell
+License: Apache 2.0
+LicenseUrl: https://github.com/tea4go/qshell/blob/main/LICENSE
+PackageUrl: https://github.com/tea4go/qshell/releases/download/v5.4.0/QShell.exe
+ShortDescription: QShell is a cross-platform modern terminal tool that integrates multiple remote connection methods.
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/t/tea4go/QShell/5.4.0/tea4go.QShell.locale.en-US.yaml
+++ b/manifests/t/tea4go/QShell/5.4.0/tea4go.QShell.locale.en-US.yaml
@@ -7,6 +7,6 @@ PackageName: QShell
 License: Apache 2.0
 LicenseUrl: https://github.com/tea4go/qshell/blob/main/LICENSE
 PackageUrl: https://github.com/tea4go/qshell/releases/download/v5.4.0/QShell.exe
-ShortDescription: QShell is a cross-platform modern terminal tool that integrates multiple remote connection methods.
+ShortDescription: QShell is a cross-platform terminal tool that integrates multiple remote connection methods.
 ManifestType: defaultLocale
 ManifestVersion: 1.10.0

--- a/manifests/t/tea4go/QShell/5.4.0/tea4go.QShell.yaml
+++ b/manifests/t/tea4go/QShell/5.4.0/tea4go.QShell.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: tea4go.QShell
+PackageVersion: 5.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0

--- a/manifests/t/tea4go/QShell/5.4.0/tea4go.QShell.yaml
+++ b/manifests/t/tea4go/QShell/5.4.0/tea4go.QShell.yaml
@@ -3,4 +3,4 @@ PackageIdentifier: tea4go.QShell
 PackageVersion: 5.4.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.10.0
+ManifestVersion: 1.10.0 # ← change from 1.4.0 to 1.10.0


### PR DESCRIPTION
## Description

This PR transfers the package ownership from my account 'Mredward123' to another account 'tea4go':

- [x] Deprecate old package: `iwhalecloud.QShell`
- [x] Add new package: `tea4.QShell`

## Changes

1. **Deprecated old package**: Added `Tags: [deprecated]` to `iwhalecloud.QShell` manifest with migration instructions
2. **Added new package**: Created new manifest for `tea4go.QShell` with updated publisher information

## Related PR
- Old package PR: #[309654]

## Validation

- [x] Both manifests pass `winget validate`
- [x] Installer works correctly with new manifest
- [x] Old package correctly shows as deprecated

## Reason for Change

Transferring package ownership from my GitHub account (`Mredward123`) to another account(`tea4go`)  for better maintenance and brand alignment.'tea4go' this account is the one I use frequently.

## Proof of Ownership

I control both the old publisher (`iwhalecloud`) and new publisher (`tea4go`) identities, and have commit history on the original package.

## User Migration

Existing users of `iwhalecloud.QShell` will see deprecation notices and are encouraged to migrate to `tea4go.QShell` for future updates.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/309661)