### PR TITLE
[Package Update]: Add traditional installer for Rufus 4.11

### DIFF
--- a/manifests/r/Rufus/Rufus/4.11/Rufus.Rufus.installer.yaml
+++ b/manifests/r/Rufus/Rufus/4.11/Rufus.Rufus.installer.yaml
@@ -3,19 +3,41 @@
 
 PackageIdentifier: Rufus.Rufus
 PackageVersion: '4.11'
-InstallerType: portable
-Commands:
-- rufus
 ReleaseDate: 2025-10-02
+Commands:
+  - rufus
+
+# Portable Installers (existing)
 Installers:
-- Architecture: x86
-  InstallerUrl: https://github.com/pbatard/rufus/releases/download/v4.11/rufus-4.11_x86.exe
-  InstallerSha256: DA70B5A684B643798EB20B720BF362E01AB6987EC47BD99A12F6E2D950A446BF
-- Architecture: x64
-  InstallerUrl: https://github.com/pbatard/rufus/releases/download/v4.11/rufus-4.11.exe
-  InstallerSha256: ABBF04D50A44A9612C027FC8072F6DA67F5BCDA2B826F1F852C9C24D7A1FCDFF
-- Architecture: arm64
-  InstallerUrl: https://github.com/pbatard/rufus/releases/download/v4.11/rufus-4.11_arm64.exe
-  InstallerSha256: D826E054400C2801FF36BAA2A46684EE5E133B5267E4B6A97B02BAB337152018
+  - Architecture: x86
+    InstallerType: portable
+    InstallerUrl: https://github.com/pbatard/rufus/releases/download/v4.11/rufus-4.11_x86.exe
+    InstallerSha256: DA70B5A684B643798EB20B720BF362E01AB6987EC47BD99A12F6E2D950A446BF
+
+  - Architecture: x64
+    InstallerType: portable
+    InstallerUrl: https://github.com/pbatard/rufus/releases/download/v4.11/rufus-4.11.exe
+    InstallerSha256: ABBF04D50A44A9612C027FC8072F6DA67F5BCDA2B826F1F852C9C24D7A1FCDFF
+
+  - Architecture: arm64
+    InstallerType: portable
+    InstallerUrl: https://github.com/pbatard/rufus/releases/download/v4.11/rufus-4.11_arm64.exe
+    InstallerSha256: D826E054400C2801FF36BAA2A46684EE5E133B5267E4B6A97B02BAB337152018
+
+# Traditional Installer (newly added)
+  - Architecture: x64
+    InstallerType: exe
+    InstallerUrl: https://github.com/pbatard/rufus/releases/download/v4.11/rufus-4.11p.exe
+    InstallerSha256: 3D9C1C5A232BEA13B2D1E02D9F80CBE8B64F34AD68876E83C8F82C2267F58A23
+    Scope: machine
+    InstallModes:
+      - interactive
+      - silent
+      - silentWithProgress
+    UpgradeBehavior: install
+    InstallerSwitches:
+      Silent: "/S"
+      SilentWithProgress: "/S"
+
 ManifestType: installer
 ManifestVersion: 1.10.0

--- a/manifests/r/Rufus/Rufus/4.11/Rufus.Rufus.installer.yaml
+++ b/manifests/r/Rufus/Rufus/4.11/Rufus.Rufus.installer.yaml
@@ -28,7 +28,7 @@ Installers:
   - Architecture: x64
     InstallerType: exe
     InstallerUrl: https://github.com/pbatard/rufus/releases/download/v4.11/rufus-4.11p.exe
-    InstallerSha256: 3D9C1C5A232BEA13B2D1E02D9F80CBE8B64F34AD68876E83C8F82C2267F58A23
+    InstallerSha256: ABBF04D50A44A9612C027FC8072F6DA67F5BCDA2B826F1F852C9C24D7A1FCDFF
     Scope: machine
     InstallModes:
       - interactive


### PR DESCRIPTION
### Summary
This pull request adds a **traditional EXE installer** for Rufus 4.11 alongside the existing portable installers.

This addition allows system-wide deployment (e.g., via Intune EPM) instead of installing under user-local paths.

### Changes
- Added **x64 EXE installer** for Rufus 4.11 (`InstallerType: exe`)
- Set **Scope: machine** for enterprise environments
- Added standard silent switches (`/S`)
- Verified **SHA256 hash** from the official Rufus GitHub release
- Retained existing **portable installers** (x86, x64, arm64)

### Validation
- [x] Manifest validated against schema **1.10.0**
- [x] Folder and naming conventions confirmed
- [x] Successfully tested locally with `winget validate`
- [x] Manifest installs correctly with `winget install --manifest`

### Related Issue
Closes #309766

---

### Checklist for Pull Requests
- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [x] There is a linked Issue (#309766).
- [x] I have checked that there are no duplicate PRs for this change.
- [x] This PR modifies only one manifest.
- [x] I have validated my manifest locally with `winget validate --manifest`.
- [x] I have tested installation with `winget install --manifest`.
- [x] The manifest conforms to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/310578)