### PR TITLE
Add QShell version 5.5.7

### DIFF
--- a/manifests/t/tea4go/QShell/5.4.0/tea4go.QShell.installer.yaml
+++ b/manifests/t/tea4go/QShell/5.4.0/tea4go.QShell.installer.yaml
@@ -6,7 +6,7 @@ Installers:
     InstallerType: exe
     InstallerUrl: https://github.com/tea4go/qshell/releases/download/v5.4.0/QShell.exe
     InstallerSha256: 1060070a2835c517d02012f743e7a5445145865b521397dec00551ebf0bc251b
-    InstallerSwitches:  # ← 使用正确的字段名
+    InstallerSwitches:  # ← 使用正确的字段name
       Silent: "/S"     # ← 静默安装参数
       SilentWithProgress: "/S"  # ← 静默进度参数
 ManifestType: installer

--- a/manifests/t/tea4go/QShell/5.4.0/tea4go.QShell.installer.yaml
+++ b/manifests/t/tea4go/QShell/5.4.0/tea4go.QShell.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: tea4go.QShell
+PackageVersion: 5.4.0
+Installers:
+  - Architecture: x64
+    InstallerType: exe
+    InstallerUrl: https://github.com/tea4go/qshell/releases/download/v5.4.0/QShell.exe
+    InstallerSha256: 1060070a2835c517d02012f743e7a5445145865b521397dec00551ebf0bc251b
+    InstallerSwitches:  # ← 使用正确的字段名
+      Silent: "/S"     # ← 静默安装参数
+      SilentWithProgress: "/S"  # ← 静默进度参数
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/t/tea4go/QShell/5.4.0/tea4go.QShell.locale.en-US.yaml
+++ b/manifests/t/tea4go/QShell/5.4.0/tea4go.QShell.locale.en-US.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: tea4go.QShell
+PackageVersion: 5.4.0
+PackageLocale: en-US
+Publisher: tea4go
+PackageName: QShell
+License: Apache 2.0
+LicenseUrl: https://github.com/tea4go/qshell/blob/main/LICENSE
+PackageUrl: https://github.com/tea4go/qshell/releases/download/v5.4.0/QShell.exe
+ShortDescription: QShell is a cross-platform modern terminal tool that integrates multiple remote connection methods.
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/t/tea4go/QShell/5.4.0/tea4go.QShell.locale.en-US.yaml
+++ b/manifests/t/tea4go/QShell/5.4.0/tea4go.QShell.locale.en-US.yaml
@@ -7,6 +7,6 @@ PackageName: QShell
 License: Apache 2.0
 LicenseUrl: https://github.com/tea4go/qshell/blob/main/LICENSE
 PackageUrl: https://github.com/tea4go/qshell/releases/download/v5.4.0/QShell.exe
-ShortDescription: QShell is a cross-platform modern terminal tool that integrates multiple remote connection methods.
+ShortDescription: QShell is a cross-platform terminal tool that integrates multiple remote connection methods.
 ManifestType: defaultLocale
 ManifestVersion: 1.10.0

--- a/manifests/t/tea4go/QShell/5.4.0/tea4go.QShell.yaml
+++ b/manifests/t/tea4go/QShell/5.4.0/tea4go.QShell.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: tea4go.QShell
+PackageVersion: 5.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0

--- a/manifests/t/tea4go/QShell/5.4.0/tea4go.QShell.yaml
+++ b/manifests/t/tea4go/QShell/5.4.0/tea4go.QShell.yaml
@@ -3,4 +3,4 @@ PackageIdentifier: tea4go.QShell
 PackageVersion: 5.4.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.10.0
+ManifestVersion: 1.10.0 # ← change from 1.4.0 to 1.10.0

--- a/manifests/t/tea4go/QShell/5.5.7/tea4go.QShell.installer.yaml
+++ b/manifests/t/tea4go/QShell/5.5.7/tea4go.QShell.installer.yaml
@@ -1,0 +1,15 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: tea4go.QShell
+PackageVersion: 5.5.7
+InstallerType: exe
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/tea4go/qshell/releases/download/v5.5.7/QShell.exe
+  InstallerSha256: 8544AE3048C7EFCA8519C0C1E55E00F82DB53EEC107B15E7352BE8F21AF72826
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/t/tea4go/QShell/5.5.7/tea4go.QShell.locale.en-US.yaml
+++ b/manifests/t/tea4go/QShell/5.5.7/tea4go.QShell.locale.en-US.yaml
@@ -1,0 +1,14 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: tea4go.QShell
+PackageVersion: 5.5.7
+PackageLocale: en-US
+Publisher: tea4go
+PackageName: QShell
+PackageUrl: https://github.com/tea4go/qshell
+License: Apache 2.0
+LicenseUrl: https://github.com/tea4go/qshell/blob/main/LICENSE
+ShortDescription: QShell is a cross-platform terminal tool that integrates multiple remote connection methods.
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/t/tea4go/QShell/5.5.7/tea4go.QShell.yaml
+++ b/manifests/t/tea4go/QShell/5.5.7/tea4go.QShell.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: tea4go.QShell
+PackageVersion: 5.5.7
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Description
- Add new version 5.5.7 for QShell package
- This is a version update and Some new functions have been added in the new version package.

## Package Details
**Package Identifier:** `tea4go.QShell`  
**New Version:** 5.5.7  
**Previous Version:** 5.4.0  
**Installer Type:** exe  
**Installer SHA256:** [8544AE3048C7EFCA8519C0C1E55E00F82DB53EEC107B15E7352BE8F21AF72826]

## Changes Made
- Added new manifest directory: `manifests/t/tea4go/QShell/5.5.7/`
- Updated version number to 5.5.7
- Updated installer URL to point to v5.5.7 release
- Updated SHA256 hash for new installer

## Validation
- [x] Manifest validation passes: `winget validate manifests/t/tea4go/QShell/5.5.7/`
- [x] Installer URL is accessible and correct
- [x] SHA256 hash matches the new installer
- [x] Silent installation parameters verified

## Testing
The installer has been tested locally and functions correctly with the provided silent parameters.

## Notes
- Existing version 5.4.0 remains available for users who need it
- Users with 5.4.0 will see this as an available upgrade when running `winget upgrade`

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/311724)