### PR TITLE
Add Microsoft.Windows.BusesTracing manifest file

### DIFF
--- a/manifests/m/Microsoft/WindowsBusesTracing/4.0.0/Microsoft.Windows.BusesTracing.yml
+++ b/manifests/m/Microsoft/WindowsBusesTracing/4.0.0/Microsoft.Windows.BusesTracing.yml
@@ -1,0 +1,27 @@
+PackageIdentifier: microsoft.windows.busestracing
+PackageVersion: 2.0.0
+PackageName: msbustracing
+PackageLocale: en-US
+Publisher: matwilli
+PublisherUrl: https://github.com/matwilli/busiotools
+License: MIT
+LicenseUrl: https://github.com/matwilli/busiotools/blob/main/LICENSE
+ShortDescription: Buses tracing scripts for debugging
+Description: A set of PowerShell and batch scripts for buses tracing.
+Moniker: busestracing scripts
+ManifestType: singleton
+ManifestVersion: 1.6.0
+Tags:
+  - usb
+  - tracing
+  - scripts
+ReleaseNotes: https://github.com/matwilli/busiotools/releases/tag/v2.0.0
+Installers:
+  - Architecture: x64
+    InstallerType: zip
+    InstallerUrl: https://github.com/matwilli/busiotools/releases/download/v4.0.0/busestracing.zip
+    InstallerSha256: a50bed1a000c1abf85da72c37f1aee59f61e7b9e79ad5b6fe1b4a05b1c4423f2
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: BusesTraceWrapper.exe
+        PortableCommandAlias: startmsbusestrace


### PR DESCRIPTION
Added a manifest file for the Microsoft Windows Buses Tracing package, including details on the package version, publisher, description, and installation information.

Checklist for Pull Requests
- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/312838)