### PR TITLE
Remove Validation-Forbidden-URL-Error label when a PR is re-run

### DIFF
--- a/.github/policies/labelManagement.issueUpdated.yml
+++ b/.github/policies/labelManagement.issueUpdated.yml
@@ -526,6 +526,8 @@ configuration:
           - removeLabel:
               label: Validation-Executable-Error
           - removeLabel:
+              label: Validation-Forbidden-URL-Error
+          - removeLabel:
               label: Validation-Hash-Verification-Failed
           - removeLabel:
               label: Validation-Installation-Error


### PR DESCRIPTION
Sometimes, simply rerunning the Validation Pipeline can resolve the error:
- https://github.com/microsoft/winget-pkgs/pull/313030

If the error occurs again, I assume the automation will attach the label back.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/313219)