### PR TITLE
Remove New-(Package|Manifest) label on PR re-run & mod trigger

### DIFF
--- a/.github/policies/labelManagement.issueUpdated.yml
+++ b/.github/policies/labelManagement.issueUpdated.yml
@@ -478,6 +478,10 @@ configuration:
           - removeLabel:
               label: Needs-SmartScreen-Investigation
           - removeLabel:
+              label: New-Manifest
+          - removeLabel:
+              label: New-Package
+          - removeLabel:
               label: Policy-Test-1.1.A
           - removeLabel:
               label: Policy-Test-1.1.B

--- a/.github/policies/moderatorTriggers.yml
+++ b/.github/policies/moderatorTriggers.yml
@@ -589,6 +589,10 @@ configuration:
                   - removeLabel:
                       label: Network-Blocker
                   - removeLabel:
+                      label: New-Manifest
+                  - removeLabel:
+                      label: New-Package
+                  - removeLabel:
                       label: Package-Request
                   - removeLabel:
                       label: Package-Update


### PR DESCRIPTION
Another attempt for PR:
- #305514

Found out that the bot is applying the labels incorrectly in https://github.com/microsoft/winget-pkgs/issues/305506, but subsequent runs apply the correct label. The old label should be cleared out in case of re-run. These labels were already being removed in case of PR synchronize (in the case that PR changes from New-Package to New-Version or vice-versa in subsequent commits)

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/313762)