### PR TITLE
Add JTL.Wawi version 1.11.4

### DIFF
--- a/manifests/j/JTL/Wawi/1.11.4/JTL.Wawi.installer.yaml
+++ b/manifests/j/JTL/Wawi/1.11.4/JTL.Wawi.installer.yaml
@@ -1,0 +1,13 @@
+# Created using wingetcreate 1.9.14.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: JTL.Wawi
+PackageVersion: 1.11.4
+InstallerType: inno
+Scope: machine
+Installers:
+- Architecture: x86
+  InstallerUrl: https://downloads.jtl-software.de/setup-jtl-wawi_1.11.4_1113-0907_57f0e1d82b7.exe
+  InstallerSha256: 6195470E59573427710115FB7B86E6DFB29AAC364A0402D101CDA979C4BA666A
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/j/JTL/Wawi/1.11.4/JTL.Wawi.locale.de-DE.yaml
+++ b/manifests/j/JTL/Wawi/1.11.4/JTL.Wawi.locale.de-DE.yaml
@@ -1,0 +1,12 @@
+# Created using wingetcreate 1.9.14.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: JTL.Wawi
+PackageVersion: 1.11.4
+PackageLocale: de-DE
+Publisher: JTL-Software-GmbH
+PackageName: JTL-Wawi
+License: Proprietary
+ShortDescription: Das kostenlose Warenwirtschaftssystem vereinfacht Ihre Geschäftsprozesse spürbar. Transparenter Warenfluss, bessere Übersicht, volle Kontrolle.
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/j/JTL/Wawi/1.11.4/JTL.Wawi.locale.en-US.yaml
+++ b/manifests/j/JTL/Wawi/1.11.4/JTL.Wawi.locale.en-US.yaml
@@ -1,0 +1,12 @@
+# Created using wingetcreate 1.9.14.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.9.0.schema.json
+
+PackageIdentifier: JTL.Wawi
+PackageVersion: 1.11.4
+PackageLocale: en-US
+Publisher: JTL-Software-GmbH
+PackageName: JTL-Wawi
+License: Proprietary
+ShortDescription: The free inventory management system noticeably simplifies your business processes. Transparent flow of goods, better overview, full control.
+ManifestType: locale
+ManifestVersion: 1.9.0

--- a/manifests/j/JTL/Wawi/1.11.4/JTL.Wawi.yaml
+++ b/manifests/j/JTL/Wawi/1.11.4/JTL.Wawi.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.9.14.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: JTL.Wawi
+PackageVersion: 1.11.4
+DefaultLocale: de-DE
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## Summary
- Added manifest files for JTL.Wawi version 1.11.4
- Updated installer URL to the new version: https://downloads.jtl-software.de/setup-jtl-wawi_1.11.4_1113-0907_57f0e1d82b7.exe
- Verified SHA256 hash of the installer: 6195470E59573427710115FB7B86E6DFB29AAC364A0402D101CDA979C4BA666A

## Test plan
- [x] Verified manifest files are properly formatted
- [x] Ensured all required fields are present
- [x] Downloaded and verified SHA256 hash matches
- [x] Installer URL is accessible


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/314557)