### PR TITLE
Add missing PortableCommandAlias for dundee.gdu 5.32.0

### DIFF
--- a/manifests/d/dundee/gdu/5.32.0/dundee.gdu.installer.yaml
+++ b/manifests/d/dundee/gdu/5.32.0/dundee.gdu.installer.yaml
@@ -7,6 +7,7 @@ InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
 - RelativeFilePath: gdu_windows_amd64.exe
+  PortableCommandAlias: gdu
 ReleaseDate: 2025-11-22
 Installers:
 - Architecture: x64


### PR DESCRIPTION
Re-adds PortableCommandAlias present in previous manifests.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/316371)