### PR TITLE
Add Hermithic.aiask version 2.0.1

### DIFF
--- a/manifests/h/Hermithic/aiask/1.0.0/Hermithic.aiask.installer.yaml
+++ b/manifests/h/Hermithic/aiask/1.0.0/Hermithic.aiask.installer.yaml
@@ -5,13 +5,13 @@ NestedInstallerType: portable
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/Hermithic/aiask/releases/download/v1.0.0/aiask-1.0.0-windows-amd64.zip
-    InstallerSha256: FB99F94458C362720CA4154FFEAF93A26C7227652A185CC9E01AE63321DEF78A
+    InstallerSha256: E23B2664A466CF8BAC2D60EE4EC611ABA61C04EF94E202CCB56D21ADFE1CBE07
     NestedInstallerFiles:
       - RelativeFilePath: aiask-windows-amd64.exe
         PortableCommandAlias: aiask
   - Architecture: arm64
     InstallerUrl: https://github.com/Hermithic/aiask/releases/download/v1.0.0/aiask-1.0.0-windows-arm64.zip
-    InstallerSha256: 022F4FC4486F0102ACA5BD0C8CE48114810E98F7721F04194F7CBF2A4136F04E
+    InstallerSha256: F94C2C1CEC47ABEAA2BE01ED8FA3B5E7331DF07C26C0489891B58E0AF3EE0E80
     NestedInstallerFiles:
       - RelativeFilePath: aiask-windows-arm64.exe
         PortableCommandAlias: aiask

--- a/manifests/h/Hermithic/aiask/1.0.0/Hermithic.aiask.installer.yaml
+++ b/manifests/h/Hermithic/aiask/1.0.0/Hermithic.aiask.installer.yaml
@@ -5,13 +5,13 @@ NestedInstallerType: portable
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/Hermithic/aiask/releases/download/v1.0.0/aiask-1.0.0-windows-amd64.zip
-    InstallerSha256: PLACEHOLDER_SHA256_WILL_BE_UPDATED_AFTER_RELEASE
+    InstallerSha256: FB99F94458C362720CA4154FFEAF93A26C7227652A185CC9E01AE63321DEF78A
     NestedInstallerFiles:
       - RelativeFilePath: aiask-windows-amd64.exe
         PortableCommandAlias: aiask
   - Architecture: arm64
     InstallerUrl: https://github.com/Hermithic/aiask/releases/download/v1.0.0/aiask-1.0.0-windows-arm64.zip
-    InstallerSha256: PLACEHOLDER_SHA256_WILL_BE_UPDATED_AFTER_RELEASE
+    InstallerSha256: 022F4FC4486F0102ACA5BD0C8CE48114810E98F7721F04194F7CBF2A4136F04E
     NestedInstallerFiles:
       - RelativeFilePath: aiask-windows-arm64.exe
         PortableCommandAlias: aiask

--- a/manifests/h/Hermithic/aiask/1.0.0/Hermithic.aiask.installer.yaml
+++ b/manifests/h/Hermithic/aiask/1.0.0/Hermithic.aiask.installer.yaml
@@ -1,0 +1,20 @@
+PackageIdentifier: Hermithic.aiask
+PackageVersion: 1.0.0
+InstallerType: zip
+NestedInstallerType: portable
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Hermithic/aiask/releases/download/v1.0.0/aiask-1.0.0-windows-amd64.zip
+    InstallerSha256: PLACEHOLDER_SHA256_WILL_BE_UPDATED_AFTER_RELEASE
+    NestedInstallerFiles:
+      - RelativeFilePath: aiask-windows-amd64.exe
+        PortableCommandAlias: aiask
+  - Architecture: arm64
+    InstallerUrl: https://github.com/Hermithic/aiask/releases/download/v1.0.0/aiask-1.0.0-windows-arm64.zip
+    InstallerSha256: PLACEHOLDER_SHA256_WILL_BE_UPDATED_AFTER_RELEASE
+    NestedInstallerFiles:
+      - RelativeFilePath: aiask-windows-arm64.exe
+        PortableCommandAlias: aiask
+ManifestType: installer
+ManifestVersion: 1.6.0
+

--- a/manifests/h/Hermithic/aiask/1.0.0/Hermithic.aiask.locale.en-US.yaml
+++ b/manifests/h/Hermithic/aiask/1.0.0/Hermithic.aiask.locale.en-US.yaml
@@ -1,0 +1,34 @@
+PackageIdentifier: Hermithic.aiask
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: Hermithic
+PublisherUrl: https://github.com/Hermithic
+PublisherSupportUrl: https://github.com/Hermithic/aiask/issues
+Author: Hermithic
+PackageName: AIask
+PackageUrl: https://github.com/Hermithic/aiask
+License: MIT
+LicenseUrl: https://github.com/Hermithic/aiask/blob/main/LICENSE
+ShortDescription: AI-powered command line assistant
+Description: |-
+  AIask is an AI-powered command line assistant that converts natural language 
+  into shell commands for PowerShell, CMD, Bash, and Zsh.
+  
+  Features:
+  - Natural language to command conversion
+  - Multiple LLM provider support (Grok, OpenAI, Anthropic, Gemini, Ollama)
+  - Auto-detect current shell
+  - Execute, copy, edit, or re-prompt commands
+Moniker: aiask
+Tags:
+  - cli
+  - ai
+  - shell
+  - command-line
+  - assistant
+  - productivity
+  - llm
+ReleaseNotesUrl: https://github.com/Hermithic/aiask/releases/tag/v1.0.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0
+

--- a/manifests/h/Hermithic/aiask/1.0.0/Hermithic.aiask.locale.en-US.yaml
+++ b/manifests/h/Hermithic/aiask/1.0.0/Hermithic.aiask.locale.en-US.yaml
@@ -8,7 +8,7 @@ Author: Hermithic
 PackageName: AIask
 PackageUrl: https://github.com/Hermithic/aiask
 License: MIT
-LicenseUrl: https://github.com/Hermithic/aiask/blob/main/LICENSE
+LicenseUrl: https://github.com/Hermithic/aiask/blob/master/LICENSE
 ShortDescription: AI-powered command line assistant
 Description: |-
   AIask is an AI-powered command line assistant that converts natural language 

--- a/manifests/h/Hermithic/aiask/1.0.0/Hermithic.aiask.yaml
+++ b/manifests/h/Hermithic/aiask/1.0.0/Hermithic.aiask.yaml
@@ -1,0 +1,6 @@
+PackageIdentifier: Hermithic.aiask
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0
+

--- a/manifests/h/Hermithic/aiask/2.0.0/Hermithic.aiask.installer.yaml
+++ b/manifests/h/Hermithic/aiask/2.0.0/Hermithic.aiask.installer.yaml
@@ -1,0 +1,20 @@
+PackageIdentifier: Hermithic.aiask
+PackageVersion: 2.0.0
+InstallerType: zip
+NestedInstallerType: portable
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Hermithic/aiask/releases/download/v2.0.0/aiask-2.0.0-windows-amd64.zip
+    InstallerSha256: F6A6339F3E9365FB57A675CD5F5B3BAE68099AA72B248FE3BE42223587A48058
+    NestedInstallerFiles:
+      - RelativeFilePath: aiask-windows-amd64.exe
+        PortableCommandAlias: aiask
+  - Architecture: arm64
+    InstallerUrl: https://github.com/Hermithic/aiask/releases/download/v2.0.0/aiask-2.0.0-windows-arm64.zip
+    InstallerSha256: AFC39D7C775B143007C0DE2F2F2364BA245BA4FE8E5689ACB958F659DA3020BF
+    NestedInstallerFiles:
+      - RelativeFilePath: aiask-windows-arm64.exe
+        PortableCommandAlias: aiask
+ManifestType: installer
+ManifestVersion: 1.6.0
+

--- a/manifests/h/Hermithic/aiask/2.0.0/Hermithic.aiask.locale.en-US.yaml
+++ b/manifests/h/Hermithic/aiask/2.0.0/Hermithic.aiask.locale.en-US.yaml
@@ -1,0 +1,83 @@
+PackageIdentifier: Hermithic.aiask
+PackageVersion: 2.0.0
+PackageLocale: en-US
+Publisher: Hermithic
+PublisherUrl: https://github.com/Hermithic
+PublisherSupportUrl: https://github.com/Hermithic/aiask/issues
+Author: Hermithic
+PackageName: AIask
+PackageUrl: https://github.com/Hermithic/aiask
+License: MIT
+LicenseUrl: https://github.com/Hermithic/aiask/blob/main/LICENSE
+ShortDescription: AI-powered command line assistant
+Description: |-
+  AIask is an AI-powered command line assistant that converts natural language 
+  into shell commands for PowerShell, CMD, Bash, and Zsh.
+  
+  Core Features:
+  - Natural language to command conversion
+  - Multiple LLM provider support (Grok, OpenAI, Anthropic, Gemini, Ollama)
+  - Auto-detect current shell and OS
+  - Execute, copy, edit, or re-prompt commands
+  
+  New in v2.0:
+  - Command history with search (aiask history)
+  - Save and reuse prompt templates (aiask save, aiask run)
+  - Explain mode - understand what commands do (aiask explain)
+  - Interactive REPL mode (aiask interactive)
+  - Dangerous command warnings with confirmation
+  - Undo suggestions after execution
+  - Stdin support for piping (--stdin flag)
+  - JSON output for scripting (--json flag)
+  - Verbose/debug mode (-v flag)
+  - Shell completions (Bash, Zsh, Fish, PowerShell)
+  - Environment variable configuration
+  - Configurable timeout
+  - Git context awareness
+Moniker: aiask
+Tags:
+  - cli
+  - ai
+  - shell
+  - command-line
+  - assistant
+  - productivity
+  - llm
+  - terminal
+  - powershell
+  - grok
+  - openai
+  - claude
+  - gemini
+  - ollama
+ReleaseNotes: |-
+  v2.0.0 - Major Feature Release
+  
+  New Commands:
+  - aiask explain - Understand what any command does
+  - aiask history - View and search command history
+  - aiask templates - Manage saved prompt templates
+  - aiask save - Save a new template
+  - aiask run - Run a saved template
+  - aiask interactive - Start REPL mode
+  - aiask completion - Generate shell completions
+  
+  New Flags:
+  - --json - Output as JSON for scripting
+  - --stdin - Read context from stdin
+  - --stream - Stream responses
+  - -v/--verbose - Debug output
+  
+  Safety Features:
+  - Dangerous command detection and warnings
+  - Undo suggestions after execution
+  - Error recovery assistance
+  
+  Configuration:
+  - Environment variable support
+  - Configurable timeout
+  - Custom system prompts
+ReleaseNotesUrl: https://github.com/Hermithic/aiask/releases/tag/v2.0.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0
+

--- a/manifests/h/Hermithic/aiask/2.0.0/Hermithic.aiask.yaml
+++ b/manifests/h/Hermithic/aiask/2.0.0/Hermithic.aiask.yaml
@@ -1,0 +1,6 @@
+PackageIdentifier: Hermithic.aiask
+PackageVersion: 2.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0
+

--- a/manifests/h/Hermithic/aiask/2.0.1/Hermithic.aiask.installer.yaml
+++ b/manifests/h/Hermithic/aiask/2.0.1/Hermithic.aiask.installer.yaml
@@ -1,0 +1,20 @@
+PackageIdentifier: Hermithic.aiask
+PackageVersion: 2.0.1
+InstallerType: zip
+NestedInstallerType: portable
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Hermithic/aiask/releases/download/v2.0.1/aiask-2.0.1-windows-amd64.zip
+    InstallerSha256: DC4FDBB819D77DF9DE5D4B26BA2C8134AE4C09183ED3475F76EFA234DF0D8C53
+    NestedInstallerFiles:
+      - RelativeFilePath: aiask-windows-amd64.exe
+        PortableCommandAlias: aiask
+  - Architecture: arm64
+    InstallerUrl: https://github.com/Hermithic/aiask/releases/download/v2.0.1/aiask-2.0.1-windows-arm64.zip
+    InstallerSha256: 661A181EDB10B5E2E6611E002F003E1DAE625D024748A6177F229A3D3B780893
+    NestedInstallerFiles:
+      - RelativeFilePath: aiask-windows-arm64.exe
+        PortableCommandAlias: aiask
+ManifestType: installer
+ManifestVersion: 1.6.0
+

--- a/manifests/h/Hermithic/aiask/2.0.1/Hermithic.aiask.locale.en-US.yaml
+++ b/manifests/h/Hermithic/aiask/2.0.1/Hermithic.aiask.locale.en-US.yaml
@@ -1,0 +1,63 @@
+PackageIdentifier: Hermithic.aiask
+PackageVersion: 2.0.1
+PackageLocale: en-US
+Publisher: Hermithic
+PublisherUrl: https://github.com/Hermithic
+PublisherSupportUrl: https://github.com/Hermithic/aiask/issues
+Author: Hermithic
+PackageName: AIask
+PackageUrl: https://github.com/Hermithic/aiask
+License: MIT
+LicenseUrl: https://github.com/Hermithic/aiask/blob/main/LICENSE
+ShortDescription: AI-powered command line assistant
+Description: |-
+  AIask is an AI-powered command line assistant that converts natural language 
+  into shell commands for PowerShell, CMD, Bash, and Zsh.
+  
+  Core Features:
+  - Natural language to command conversion
+  - Multiple LLM provider support (Grok, OpenAI, Anthropic, Gemini, Ollama)
+  - Auto-detect current shell and OS
+  - Execute, copy, edit, or re-prompt commands
+  
+  New in v2.0:
+  - Command history with search (aiask history)
+  - Save and reuse prompt templates (aiask save, aiask run)
+  - Explain mode - understand what commands do (aiask explain)
+  - Interactive REPL mode (aiask interactive)
+  - Dangerous command warnings with confirmation
+  - Undo suggestions after execution
+  - Stdin support for piping (--stdin flag)
+  - JSON output for scripting (--json flag)
+  - Verbose/debug mode (-v flag)
+  - Shell completions (Bash, Zsh, Fish, PowerShell)
+  - Environment variable configuration
+  - Configurable timeout
+  - Git context awareness
+Moniker: aiask
+Tags:
+  - cli
+  - ai
+  - shell
+  - command-line
+  - assistant
+  - productivity
+  - llm
+  - terminal
+  - powershell
+  - grok
+  - openai
+  - claude
+  - gemini
+  - ollama
+ReleaseNotes: |-
+  v2.0.1 - Release Artifact Fix
+  
+  Fixed:
+  - Fixed release artifacts and distribution package configurations
+  - Updated Homebrew formula with correct checksums
+  - Fixed winget manifest structure for package submission
+ReleaseNotesUrl: https://github.com/Hermithic/aiask/releases/tag/v2.0.1
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0
+

--- a/manifests/h/Hermithic/aiask/2.0.1/Hermithic.aiask.yaml
+++ b/manifests/h/Hermithic/aiask/2.0.1/Hermithic.aiask.yaml
@@ -1,0 +1,6 @@
+PackageIdentifier: Hermithic.aiask
+PackageVersion: 2.0.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0
+


### PR DESCRIPTION
## Description

Adding version 2.0.1 of Hermithic.aiask - AI-powered command line assistant.

### Changes
- Fixed release artifacts and distribution package configurations
- Updated Homebrew formula with correct checksums
- Fixed winget manifest structure for package submission

### Manifest
- Package: Hermithic.aiask
- Version: 2.0.1
- Installer Type: zip (portable)
- Architectures: x64, arm64

### Links
- [GitHub Release](https://github.com/Hermithic/aiask/releases/tag/v2.0.1)
- [Repository](https://github.com/Hermithic/aiask)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/317078)