### PR TITLE
New package: Mozilla.ProfileManager version 1.0

### DIFF
--- a/manifests/m/Mozilla/ProfileManager/1.0/Mozilla.ProfileManager.installer.yaml
+++ b/manifests/m/Mozilla/ProfileManager/1.0/Mozilla.ProfileManager.installer.yaml
@@ -14,5 +14,8 @@ Installers:
 - Architecture: x86
   InstallerUrl: https://archive.mozilla.org/pub/utilities/profilemanager/1.0/profilemanager.win32.zip
   InstallerSha256: 3365234A59C8A2127E3708082E49120A1ED34F353945898EDE26DDB4FCDE38ED
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Mozilla.Firefox
 ManifestType: installer
 ManifestVersion: 1.10.0

--- a/manifests/m/Mozilla/ProfileManager/1.0/Mozilla.ProfileManager.installer.yaml
+++ b/manifests/m/Mozilla/ProfileManager/1.0/Mozilla.ProfileManager.installer.yaml
@@ -1,0 +1,18 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: Mozilla.ProfileManager
+PackageVersion: "1.0"
+ReleaseDate: 2011-11-04
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: profilemanager\profilemanager.exe
+  PortableCommandAlias: profilemanager
+ArchiveBinariesDependOnPath: true
+Installers:
+- Architecture: x86
+  InstallerUrl: https://archive.mozilla.org/pub/utilities/profilemanager/1.0/profilemanager.win32.zip
+  InstallerSha256: 3365234A59C8A2127E3708082E49120A1ED34F353945898EDE26DDB4FCDE38ED
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/m/Mozilla/ProfileManager/1.0/Mozilla.ProfileManager.installer.yaml
+++ b/manifests/m/Mozilla/ProfileManager/1.0/Mozilla.ProfileManager.installer.yaml
@@ -7,7 +7,7 @@ ReleaseDate: 2011-11-04
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
-- RelativeFilePath: profilemanager\profilemanager.exe
+- RelativeFilePath: profilemanager/profilemanager.exe
   PortableCommandAlias: profilemanager
 ArchiveBinariesDependOnPath: true
 Installers:

--- a/manifests/m/Mozilla/ProfileManager/1.0/Mozilla.ProfileManager.locale.en-US.yaml
+++ b/manifests/m/Mozilla/ProfileManager/1.0/Mozilla.ProfileManager.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: Mozilla.ProfileManager
+PackageVersion: "1.0"
+PackageLocale: en-US
+Publisher: Mozilla
+PackageName: Profile Manager
+PackageUrl: https://archive.mozilla.org/pub/utilities/profilemanager/
+License: MPL
+ShortDescription: Tool to manage multiple Firefox browser profiles and multiple Firefox installations.
+Tags:
+- firefox
+- userprofiles
+- user-profiles
+- browserprofiles
+- browser-profiles
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/m/Mozilla/ProfileManager/1.0/Mozilla.ProfileManager.yaml
+++ b/manifests/m/Mozilla/ProfileManager/1.0/Mozilla.ProfileManager.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: Mozilla.ProfileManager
+PackageVersion: "1.0"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---
Notes from me:
* Despite the program last being updated 14 years ago, it still detected my existing user profiles from Firefox Developer Edition 146 automatically, and was able to launch it (and with the intended profile) as well if the path to `firefox.exe` had been added in Profile Manager's settings.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/317709)