### PR TITLE
New package: Mozilla.Firefox.EMEfree version 145.0.2

### DIFF
--- a/manifests/m/Mozilla/Firefox/EMEfree/145.0.2/Mozilla.Firefox.EMEfree.installer.yaml
+++ b/manifests/m/Mozilla/Firefox/EMEfree/145.0.2/Mozilla.Firefox.EMEfree.installer.yaml
@@ -1,0 +1,38 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: Mozilla.Firefox.EMEfree
+PackageVersion: 145.0.2
+InstallerType: nullsoft
+Scope: machine
+InstallerSwitches:
+  Silent: /S /PreventRebootRequired=true
+  SilentWithProgress: /S /PreventRebootRequired=true
+  InstallLocation: /InstallDirectoryPath="<INSTALLPATH>"
+UpgradeBehavior: install
+Protocols:
+- http
+- https
+- mailto
+FileExtensions:
+- avif
+- htm
+- html
+- pdf
+- shtml
+- svg
+- webp
+- xht
+- xhtml
+ReleaseDate: 2025-11-25
+Installers:
+- Architecture: x86
+  InstallerUrl: https://ftp.mozilla.org/pub/firefox/releases/145.0.2/win32-EME-free/en-US/Firefox%20Setup%20145.0.2.exe
+  InstallerSha256: 93db130f5bca1d6a079c0f8bce9c54511769b0fc45f1db1365f5826d786c3284
+  ProductCode: Mozilla Firefox 145.0.2 EME-free (x86 en-US)
+- Architecture: x64
+  InstallerUrl: https://ftp.mozilla.org/pub/firefox/releases/145.0.2/win64-EME-free/en-US/Firefox%20Setup%20145.0.2.exe
+  InstallerSha256: 01bab0f066a38972295a3088f041b18128fe51b7bc013cd71802f3e06372750d
+  ProductCode: Mozilla Firefox 145.0.2 EME-free (x64 en-US)
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/m/Mozilla/Firefox/EMEfree/145.0.2/Mozilla.Firefox.EMEfree.locale.en-US.yaml
+++ b/manifests/m/Mozilla/Firefox/EMEfree/145.0.2/Mozilla.Firefox.EMEfree.locale.en-US.yaml
@@ -1,0 +1,42 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: Mozilla.Firefox.EMEfree
+PackageVersion: 145.0.2
+PackageLocale: en-US
+Publisher: Mozilla
+PublisherUrl: https://www.mozilla.org/
+PublisherSupportUrl: https://support.mozilla.org/
+PrivacyUrl: https://www.mozilla.org/privacy/firefox/
+Author: Mozilla Foundation
+PackageName: Mozilla Firefox (EME-free, en-US)
+PackageUrl: https://www.mozilla.org/firefox/
+License: MPL-2.0
+LicenseUrl: https://www.mozilla.org/MPL/2.0
+Copyright: © Firefox and Mozilla Developers; available under the MPL 2 license.
+CopyrightUrl: https://www.mozilla.org/foundation/trademarks/policy
+ShortDescription: Mozilla Firefox is free and open source software, built by a community of thousands from all over the world. (EME-free = Does not implement Encrypted Media Extensions.)
+Description: Firefox Browser, also known as Mozilla Firefox or simply Firefox, is a free and open-source web browser developed by the Mozilla Foundation and its subsidiary, the Mozilla Corporation. Firefox uses the Gecko layout engine to render web pages, which implements current and anticipated web standards. In 2017, Firefox began incorporating new technology under the code name Quantum to promote parallelism and a more intuitive user interface. Firefox is officially available for Windows 7 or newer, macOS, and Linux. Its unofficial ports are available for various Unix and Unix-like operating systems including FreeBSD, OpenBSD, NetBSD, illumos, and Solaris Unix.
+Moniker: firefox
+Tags:
+- browser
+- gecko
+- internet
+- quantum
+- spidermonkey
+- web
+- web-browser
+- webpage
+- eme-free
+- no-widewine
+- no-eme
+- no-encrypted-media-extensions
+ReleaseNotes: |-
+  Fixed
+  - Fixed an issue that prevented typing in Baidu’s search box when using Chinese IMEs on Windows.(Bug 2000479)
+  - Reference link to 145.0.1 release notes.
+  Unresolved
+  - On Windows, clicking tabs may not work at the very top of the screen when Firefox is maximized on a second monitor. We’re working to fix this in a future release.
+ReleaseNotesUrl: https://www.mozilla.org/firefox/145.0.2/releasenotes/
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/m/Mozilla/Firefox/EMEfree/145.0.2/Mozilla.Firefox.EMEfree.yaml
+++ b/manifests/m/Mozilla/Firefox/EMEfree/145.0.2/Mozilla.Firefox.EMEfree.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: Mozilla.Firefox.EMEfree
+PackageVersion: 145.0.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---
Notes from me:
* For some reason, Mozilla apparently has a parallel-released version of Firefox's stable and beta channels that explicitly does not use https://en.wikipedia.org/wiki/Encrypted_Media_Extensions (which essentially means Widevine), and which I found while browsing Mozilla's file archive.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/317974)