### PR TITLE
New package: zippoxer.recall version 0.2.0

### DIFF
--- a/manifests/z/zippoxer/recall/0.2.0/zippoxer.recall.installer.yaml
+++ b/manifests/z/zippoxer/recall/0.2.0/zippoxer.recall.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: zippoxer.recall
+PackageVersion: 0.2.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: recall.exe
+    PortableCommandAlias: recall
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/zippoxer/recall/releases/download/v0.2.0/recall-windows-x86_64.zip
+    InstallerSha256: B288B018C799CB331FE51985C21435D717F0BCECEEF0052EAB35F29076E5316A
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/z/zippoxer/recall/0.2.0/zippoxer.recall.locale.en-US.yaml
+++ b/manifests/z/zippoxer/recall/0.2.0/zippoxer.recall.locale.en-US.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: zippoxer.recall
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: zippoxer
+PackageName: recall
+PackageUrl: https://github.com/zippoxer/recall
+License: MIT
+LicenseUrl: https://github.com/zippoxer/recall/blob/main/LICENSE
+ShortDescription: Search and resume Claude Code and Codex CLI conversations
+Description: A TUI for searching and resuming past conversations from Claude Code, Codex CLI, and Factory (Droid). Features full-text search, match highlighting, and seamless resume directly into the CLI.
+Tags:
+  - cli
+  - claude
+  - codex
+  - ai
+  - search
+  - tui
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/z/zippoxer/recall/0.2.0/zippoxer.recall.yaml
+++ b/manifests/z/zippoxer/recall/0.2.0/zippoxer.recall.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: zippoxer.recall
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New Package Submission

**Package Name:** recall
**Publisher:** zippoxer
**Version:** 0.2.0
**Package Identifier:** zippoxer.recall

### Description

A TUI for searching and resuming past conversations from Claude Code, Codex CLI, and Factory (Droid). Features full-text search, match highlighting, and seamless resume directly into the CLI.

### Installation

After approval:
```
winget install zippoxer.recall
```

### Links

- **Homepage:** https://github.com/zippoxer/recall
- **License:** MIT
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/319104)