### PR TITLE
New package: ShivaPlays.SmartStartRecording version 2025.2.17

### DIFF
--- a/manifests/s/ShivaPlays/SmartStartRecording/2025.2.17/ShivaPlays.SmartStartRecording.installer.yaml
+++ b/manifests/s/ShivaPlays/SmartStartRecording/2025.2.17/ShivaPlays.SmartStartRecording.installer.yaml
@@ -1,0 +1,24 @@
+# Created with komac v2.14.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: ShivaPlays.SmartStartRecording
+PackageVersion: 2025.2.17
+InstallerLocale: en-US
+InstallerType: inno
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{9ACE9D32-0849-44B4-ACE6-A789BDE37294}_is1'
+ReleaseDate: 2025-02-17
+AppsAndFeaturesEntries:
+- DisplayVersion: '1.0'
+  ProductCode: '{9ACE9D32-0849-44B4-ACE6-A789BDE37294}_is1'
+ElevationRequirement: elevatesSelf
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/ShivaPlays/smartstart_recording/releases/download/plugin/smartstart_recording_win64_setup.exe
+  InstallerSha256: CFA2B849FCCA508421D346180858CAF24B36DE86384A3F489409EDCD827220B5
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/s/ShivaPlays/SmartStartRecording/2025.2.17/ShivaPlays.SmartStartRecording.locale.en-US.yaml
+++ b/manifests/s/ShivaPlays/SmartStartRecording/2025.2.17/ShivaPlays.SmartStartRecording.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# Created with komac v2.14.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: ShivaPlays.SmartStartRecording
+PackageVersion: 2025.2.17
+PackageLocale: en-US
+Publisher: ShivaPlays
+PublisherUrl: https://github.com/ShivaPlays
+PublisherSupportUrl: https://github.com/ShivaPlays/smartstart_recording/issues
+Author: ShivaPlays
+PackageName: SmartStart Recording
+PackageUrl: https://github.com/ShivaPlays/smartstart_recording
+License: GPL-2.0
+LicenseUrl: https://github.com/ShivaPlays/smartstart_recording/blob/master/LICENSE
+ShortDescription: Automatic Scene-Based Recording for OBS
+Description: This plugin for OBS Studio allows you to start recordings
+  automatically for each scene after a predefined time. It intelligently
+  considers events, ensuring recordings begin at the right moment without manual
+  intervention. Perfect for workflows that require precise scene-based recording
+  automation.
+ReleaseNotes: |-
+  Automatic Scene-Based Recording for OBS
+  This plugin for OBS Studio allows you to start recordings automatically for each scene after a predefined time. It intelligently considers events, ensuring recordings begin at the right moment without manual intervention. Perfect for workflows that require precise scene-based recording automation.
+ReleaseNotesUrl: https://github.com/ShivaPlays/smartstart_recording/releases/tag/plugin
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/s/ShivaPlays/SmartStartRecording/2025.2.17/ShivaPlays.SmartStartRecording.yaml
+++ b/manifests/s/ShivaPlays/SmartStartRecording/2025.2.17/ShivaPlays.SmartStartRecording.yaml
@@ -1,0 +1,10 @@
+# Created with komac v2.14.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: ShivaPlays.SmartStartRecording
+# Original author tagged the package as "files", which IS NOT versioned.
+# Here uses the assets upload date of this tag.
+PackageVersion: 2025.2.17
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Checklist for Pull Requests

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Resolve #320139

## Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

## Manual validation

> [!IMPORTANT]
> 
> Since there're multiple versions of OBS Studio (stable `OBSProject.OBSStudio` and pre-release `OBSProject.OBSStudio.Pre-release`), and `winget.exe` DOES NOT support an "OR" logic of dependency identifiers. So users HAVE TO install OBS Studio on their own.

<img width="1666" height="633" alt="Image" src="https://github.com/user-attachments/assets/a0772d3c-5300-4987-bcd1-e6e391af1dd1" />
<img width="1720" height="1125" alt="Image" src="https://github.com/user-attachments/assets/5af0889a-9a3e-402c-8bd3-ed458c488486" />
<img width="1720" height="648" alt="Image" src="https://github.com/user-attachments/assets/b9b31bb8-82ac-4fbb-b526-590185d74df5" />
<img width="1147" height="720" alt="Image" src="https://github.com/user-attachments/assets/0dc6442c-106e-418e-b775-562602be9e97" />

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/320388)