### PR TITLE
New package: Jeason.NovelEditor version 0.1.11

### DIFF
--- a/manifests/j/Jeason/NovelEditor/0.1.11/Jeason.NovelEditor.installer.yaml
+++ b/manifests/j/Jeason/NovelEditor/0.1.11/Jeason.NovelEditor.installer.yaml
@@ -1,0 +1,22 @@
+# Created using wingetcreate 1.5.0.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+
+PackageIdentifier: Jeason.NovelEditor
+PackageVersion: 0.1.11
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: wix
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/jeasoncc/novel-editor/releases/download/desktop-v0.1.11/novel-editor_0.1.11_x64_zh-CN.msi
+  InstallerSha256: 40BF5E5228AA183198DFD34F9BA48AE8A2B325EDF1EC230E4D32124257C42EDD
+  ProductCode: '{BE47635A-D137-4EDE-9215-381509E69DB9}'
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/j/Jeason/NovelEditor/0.1.11/Jeason.NovelEditor.locale.zh-CN.yaml
+++ b/manifests/j/Jeason/NovelEditor/0.1.11/Jeason.NovelEditor.locale.zh-CN.yaml
@@ -1,0 +1,37 @@
+# Created using wingetcreate 1.5.0.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+
+PackageIdentifier: Jeason.NovelEditor
+PackageVersion: 0.1.11
+PackageLocale: zh-CN
+Publisher: Lotus
+PublisherUrl: https://github.com/jeasoncc
+PublisherSupportUrl: https://github.com/jeasoncc/novel-editor/issues
+Author: Jeason
+PackageName: Novel Editor
+PackageUrl: https://github.com/jeasoncc/novel-editor
+License: MIT
+LicenseUrl: https://github.com/jeasoncc/novel-editor/blob/main/LICENSE
+Copyright: Copyright (c) 2024 Jeason
+ShortDescription: 一个现代化的小说编辑器
+Description: |-
+  Novel Editor 是一个功能强大的小说编辑器，提供丰富的编辑功能和直观的用户界面。
+  
+  主要特性：
+  - 富文本编辑器，支持 Markdown
+  - 章节管理和大纲视图
+  - 角色管理
+  - 场景管理
+  - 自动保存
+  - 跨平台支持
+Moniker: novel-editor
+Tags:
+- editor
+- novel
+- writing
+- markdown
+- 小说
+- 编辑器
+- 写作
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/j/Jeason/NovelEditor/0.1.11/Jeason.NovelEditor.yaml
+++ b/manifests/j/Jeason/NovelEditor/0.1.11/Jeason.NovelEditor.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.5.0.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+
+PackageIdentifier: Jeason.NovelEditor
+PackageVersion: 0.1.11
+DefaultLocale: zh-CN
+ManifestType: version
+ManifestVersion: 1.5.0


### PR DESCRIPTION
Novel Editor - 一个现代化的小说编辑器

**Package Information:**
- Package: Jeason.NovelEditor
- Version: 0.1.11
- Publisher: Lotus
- License: MIT

**Description:**
Novel Editor 是一个功能强大的小说编辑器，提供丰富的编辑功能和直观的用户界面。

**Features:**
- 富文本编辑器，支持 Markdown
- 章节管理和大纲视图
- 角色管理
- 场景管理
- 自动保存
- 跨平台支持

**Links:**
- Homepage: https://github.com/jeasoncc/novel-editor
- Release: https://github.com/jeasoncc/novel-editor/releases/tag/desktop-v0.1.11

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/320823)