### PR TITLE
Add copilot instructions for manifest-changed PRs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 ## Repository Overview
 
-This is the **Windows Package Manager (WinGet)** community repository containing **~415,000 manifest files** for software packages installable via `winget`. The repository is a **manifest-only** repository - no application code, just YAML metadata files describing how to install Windows applications.
+This is the **Windows Package Manager (WinGet)** community repository containing **~415,000+ manifest files** for software packages installable via `winget`. The repository is a **manifest-only** repository - no application code, just YAML metadata files describing how to install Windows applications.
 
 **Key Facts:**
 - **Primary Language:** YAML manifest files, PowerShell scripts for tooling

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,113 @@
+# Windows Package Manager Community Repository - Copilot Instructions
+
+## Repository Overview
+
+This is the **Windows Package Manager (WinGet)** community repository containing **~415,000 manifest files** for software packages installable via `winget`. The repository is a **manifest-only** repository - no application code, just YAML metadata files describing how to install Windows applications.
+
+**Key Facts:**
+- **Primary Language:** YAML manifest files, PowerShell scripts for tooling
+- **Target Runtime:** Windows 10/11, Windows Package Manager client
+- **Size:** Large repository with alphabetically organized manifests
+- **Schema:** Uses multi-file YAML manifests (version 1.10.0 recommended, 1.9.0 also supported)
+- **Supported Installers:** MSIX, MSI, APPX, EXE only (scripts are not supported)
+
+## Critical: How This Repository Works
+
+**This is NOT a traditional code repository.** You typically work with **manifest files only**, not application source code. Each PR should modify **exactly one package** (one manifest set).
+
+### Manifest Structure (Multi-File Format Required)
+
+Manifests are located in: `manifests/<first-letter>/<Publisher>/<Package>/<Version>/`
+
+For example: `manifests/m/Microsoft/WindowsTerminal/1.0.1401.0/`
+
+**Required files per version:**
+1. `<PackageIdentifier>.yaml` - Version file (references other files)
+2. `<PackageIdentifier>.installer.yaml` - Installer details, URLs, SHA256
+3. `<PackageIdentifier>.locale.en-US.yaml` - Default locale metadata
+
+**File Naming:** Must match `PackageIdentifier` exactly (case-sensitive).
+
+## Instruction Priority
+
+The instructions in the **Performance Rules**, **Allowed Local Searches**, and **Explicit Required Behavior** sections are **mandatory**.  
+They override all other information in this file.
+
+Copilot must always follow these rules when performing PR reviews, even if other documentation in this file describes general repository behavior.
+
+## Performance Rules (Very Important)
+
+This repository contains a very large directory: `manifests/`.  
+Copilot must **never recursively scan or search the entire `manifests/` folder** during PR reviews.
+
+Large-scale searches cause severe performance issues and timeouts.
+
+## Allowed Local Searches (Package-Scoped Only)
+
+When Copilot needs to compare or validate manifest conventions (for example, `ReleaseDate`, `InstallerSha256`, or schema field placement):
+
+### Copilot is allowed to:
+- Search **ONLY within the package folder of the manifest being modified**.
+- This package folder follows the structure: `manifests/<first-letter>/<Publisher>/<Package>/<Version>/`
+
+### Copilot MUST NOT:
+- Search sibling publishers
+- Search unrelated packages
+- Search the entire `manifests/` directory
+- Perform global searches to find examples
+- Use `search_dir` on `manifests/` or any directory wider than the package root
+
+## Allowed Searches Outside the Manifests Directory
+
+Copilot is allowed to search in **documentation folders** to understand schema rules, authoring guidelines, and repository conventions. These include, but are not limited to:
+
+- `doc/`
+- `schemas/`
+- `README.md`
+- `CONTRIBUTING.md`
+- `PULL_REQUEST_TEMPLATE.md`
+- Any other non-manifest documentation files
+
+These locations are safe to search because they contain guidance, not large numbers of manifest files.
+
+However, **Copilot must still avoid recursive searches of the `manifests/` directory**, except for the package-scoped searches described earlier.
+
+---
+
+## Explicit Required Behavior
+
+When reviewing a PR:
+
+- Focus on **only the changed manifest files** and their immediate package folder.
+- If searching for "similar manifests" or examples:
+- Restrict the search scope to the **same package root**, e.g.:
+
+  For:
+  ```
+  manifests/m/Microsoft/WSL/2.6.2/
+  ```
+  Only search within:
+  ```
+  manifests/m/Microsoft/WSL/
+  manifests/m/Microsoft/
+  ```
+
+- DO NOT search:
+  ```
+  manifests/m/*
+  manifests/*
+  ```
+  or the entire repo for matching fields
+
+- If broader repo context seems needed:
+  - **Skip the global search**
+  - Continue the review using only local context
+
+---
+
+## Summary
+
+- Only analyze **diffs** and **local package manifests**.
+- Never run expensive global scans.
+- Never crawl the entire `manifests/` directory.
+- Keep all search operations **package-scoped** for reliability.

--- a/.github/instructions/manifests.instructions.md
+++ b/.github/instructions/manifests.instructions.md
@@ -104,7 +104,7 @@ When reviewing a PR:
   or the entire repo for matching fields
 
 - If broader repo context seems needed:
-  - **Skip the global search**
+  - **Skip the global search** and exactly say: "Global search prevented by repository instructions."
   - Continue the review using only local context
 
 ---

--- a/.github/instructions/manifests.instructions.md
+++ b/.github/instructions/manifests.instructions.md
@@ -1,3 +1,7 @@
+---
+applyTo: "manifests/**/*"
+---
+
 # Windows Package Manager Community Repository - Copilot Instructions
 
 ## Repository Overview


### PR DESCRIPTION
I've been testing the Copilot PR review feature for a while and I noticed some issues. Sometimes, the review process will get stuck and timed out (see #320829; #320832; #320830; and much more).

Upon looking at the [pipeline runs that handles this PR review](https://github.com/microsoft/winget-pkgs/actions/workflows/copilot-pull-request-reviewer/copilot-pull-request-reviewer?page=3), they seem to be stuck in similar pattern, it's trying to scan the whole "manifests" folder, which makes sense since it's a really large folder in this repo.

So this `copilot-instructions.md` file I've just created is made to prevent this kind of situation, it contains a general context what this repo is and the explicit restriction to scan the "manifests" folder, hopefully that solves the problem.

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/320873)