### PR TITLE
Fix ARP mapping for Zaarrg.StremioCommunity to avoid overriding Stremio.Stremio

### DIFF
--- a/manifests/z/Zaarrg/StremioCommunity/5.0.20/Zaarrg.StremioCommunity.installer.yaml
+++ b/manifests/z/Zaarrg/StremioCommunity/5.0.20/Zaarrg.StremioCommunity.installer.yaml
@@ -15,10 +15,6 @@ FileExtensions:
 - torrent
 ProductCode: Stremio
 ReleaseDate: 2025-10-08
-AppsAndFeaturesEntries:
-- DisplayName: Stremio
-  Publisher: Smart Code Ltd
-  ProductCode: Stremio
 InstallationMetadata:
   DefaultInstallLocation: '%LocalAppData%\Programs\LNV\Stremio-5'
 Installers:
@@ -27,3 +23,4 @@ Installers:
   InstallerSha256: 8EA913D802602B3ACA1D6333E142A9A11CF070015F2D4FF7F5A4F1D543448879
 ManifestType: installer
 ManifestVersion: 1.10.0
+


### PR DESCRIPTION
The current installer manifest for `Zaarrg.StremioCommunity` defines `AppsAndFeaturesEntries` with the same metadata as the official Stremio client winget id `Stremio.Stremio` (DisplayName: Stremio, Publisher: Smart Code Ltd, ProductCode: Stremio).

This causes `winget upgrade --all --include-unknown` to treat `Zaarrg.StremioCommunity` as an upgrade for `Stremio.Stremio`, which can unexpectedly replace the official client with the community fork.

As a temporary fix until the installer’s ARP metadata is adjusted, this PR removes AppsAndFeaturesEntries from the manifest so that Zaarrg.StremioCommunity is not matched to the official install.

See also related issue comment https://github.com/Zaarrg/stremio-community-v5/pull/175#issuecomment-3624223415
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/320876)