### PR TITLE
New package: Hex.PSMirrorServer version 2025.12.37

### DIFF
--- a/manifests/h/Hex/PSMirrorServer/2025.12.37/Hex.PSMirrorServer.installer.yaml
+++ b/manifests/h/Hex/PSMirrorServer/2025.12.37/Hex.PSMirrorServer.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: Hex.PSMirrorServer
+PackageVersion: 2025.12.37
+InstallerType: portable
+Commands:
+  - PSMirrorServer
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/hex/ps-mirror-server/releases/download/v2025.12.37/PSMirrorServer-windows-x64.exe
+    InstallerSha256: DAAA1420AF2DE979E933C808949DC7EA05D655B2545F03CE7104DA9ECA86073B
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/h/Hex/PSMirrorServer/2025.12.37/Hex.PSMirrorServer.locale.en-US.yaml
+++ b/manifests/h/Hex/PSMirrorServer/2025.12.37/Hex.PSMirrorServer.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: Hex.PSMirrorServer
+PackageVersion: 2025.12.37
+PackageLocale: en-US
+Publisher: hex
+PublisherUrl: https://github.com/hex
+PackageName: PS Mirror Server
+PackageUrl: https://github.com/hex/ps-mirror-server
+License: MIT
+LicenseUrl: https://github.com/hex/ps-mirror-server/blob/main/LICENSE
+ShortDescription: WebSocket relay server for PS Mirror - bridges Photoshop plugin to iOS clients
+Description: |-
+  PS Mirror Server is a WebSocket relay that bridges Adobe Photoshop to iOS devices for real-time artboard preview.
+  It receives preview images from the PS Mirror Photoshop plugin and broadcasts them to connected iOS clients.
+  The server advertises via Bonjour/mDNS for automatic discovery on local networks.
+Tags:
+  - photoshop
+  - design
+  - preview
+  - websocket
+  - relay
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/h/Hex/PSMirrorServer/2025.12.37/Hex.PSMirrorServer.yaml
+++ b/manifests/h/Hex/PSMirrorServer/2025.12.37/Hex.PSMirrorServer.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: Hex.PSMirrorServer
+PackageVersion: 2025.12.37
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package submission

- **Package**: Hex.PSMirrorServer
- **Version**: 2025.12.37
- **License**: MIT
- **Description**: WebSocket relay server for Mirror for Photoshop - bridges Photoshop plugin to iOS clients

### What does this package do?

Mirror Server for Photoshop is a WebSocket relay that bridges Adobe Photoshop to iOS devices for real-time artboard preview. It receives preview images from the PS Mirror Photoshop plugin and broadcasts them to connected iOS clients. The server advertises via Bonjour/mDNS for automatic discovery on local networks.

### Checklist

- [x] Manifest validates against schema
- [x] SHA256 hash verified
- [x] Package is portable (standalone exe)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/321700)