### PR TITLE
New package: Hex.MirrorForPhotoshopServer version 2025.12.38

### DIFF
--- a/manifests/h/Hex/MirrorForPhotoshopServer/2025.12.38/Hex.MirrorForPhotoshopServer.installer.yaml
+++ b/manifests/h/Hex/MirrorForPhotoshopServer/2025.12.38/Hex.MirrorForPhotoshopServer.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: Hex.MirrorForPhotoshopServer
+PackageVersion: 2025.12.38
+InstallerType: portable
+Commands:
+  - mirror-for-photoshop-server
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/hex/mirror-for-photoshop-server/releases/download/v2025.12.38/mirror-for-photoshop-server-win-x64.exe
+    InstallerSha256: 54B11714F934FAD6BB2AAE007E10EF8DE22957AFFA6DE3418F80E9C327BDC766
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/h/Hex/MirrorForPhotoshopServer/2025.12.38/Hex.MirrorForPhotoshopServer.locale.en-US.yaml
+++ b/manifests/h/Hex/MirrorForPhotoshopServer/2025.12.38/Hex.MirrorForPhotoshopServer.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: Hex.MirrorForPhotoshopServer
+PackageVersion: 2025.12.38
+PackageLocale: en-US
+Publisher: hex
+PublisherUrl: https://psmirror.hexul.com
+PackageName: Mirror for Photoshop Server
+PackageUrl: https://github.com/hex/mirror-for-photoshop-server
+License: MIT
+LicenseUrl: https://github.com/hex/mirror-for-photoshop-server/blob/main/LICENSE
+ShortDescription: WebSocket relay server for Mirror for Photoshop - Photoshop to iOS preview
+Description: |-
+  Mirror for Photoshop Server is a WebSocket relay that bridges Adobe Photoshop to iOS devices.
+  It receives preview images from the Photoshop UXP plugin and broadcasts them to connected iOS clients.
+  The server advertises via Bonjour/mDNS for automatic discovery on local networks.
+Tags:
+  - photoshop
+  - preview
+  - design
+  - ios
+  - websocket
+  - relay
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/h/Hex/MirrorForPhotoshopServer/2025.12.38/Hex.MirrorForPhotoshopServer.yaml
+++ b/manifests/h/Hex/MirrorForPhotoshopServer/2025.12.38/Hex.MirrorForPhotoshopServer.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: Hex.MirrorForPhotoshopServer
+PackageVersion: 2025.12.38
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package submission

**Package name:** Mirror for Photoshop Server
**Package identifier:** Hex.MirrorForPhotoshopServer
**Package version:** 2025.12.38

### Description

WebSocket relay server for Mirror for Photoshop - bridges Adobe Photoshop to iOS devices for real-time preview. The server receives preview images from the Photoshop UXP plugin and broadcasts them to connected iOS clients via Bonjour/mDNS for automatic discovery.

### Links

- Homepage: https://psmirror.hexul.com
- Repository: https://github.com/hex/mirror-for-photoshop-server
- Release: https://github.com/hex/mirror-for-photoshop-server/releases/tag/v2025.12.38

### Checklist

- [x] I have verified the manifest meets the [manifest schema requirements](https://docs.microsoft.com/windows/package-manager/package/manifest)
- [x] The package installs successfully using `winget install --manifest <path>`
- [x] This is a portable application (standalone exe)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/321789)