### PR TITLE
New version: Hex.MirrorForPhotoshopServer version 2025.12.40

### DIFF
--- a/manifests/h/Hex/MirrorForPhotoshopServer/2025.12.40/Hex.MirrorForPhotoshopServer.installer.yaml
+++ b/manifests/h/Hex/MirrorForPhotoshopServer/2025.12.40/Hex.MirrorForPhotoshopServer.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Hex.MirrorForPhotoshopServer
+PackageVersion: 2025.12.40
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: mirror-for-photoshop-server-win-x64.exe
+    PortableCommandAlias: mirror-for-photoshop-server
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/hex/mirror-for-photoshop-server/releases/download/v2025.12.40/mirror-for-photoshop-server-win-x64.zip
+    InstallerSha256: EC5E6D4EAA340C29E9F3F63E615130FA315907D4F12A39EB996EBC2191D3DE37
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/h/Hex/MirrorForPhotoshopServer/2025.12.40/Hex.MirrorForPhotoshopServer.locale.en-US.yaml
+++ b/manifests/h/Hex/MirrorForPhotoshopServer/2025.12.40/Hex.MirrorForPhotoshopServer.locale.en-US.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Hex.MirrorForPhotoshopServer
+PackageVersion: 2025.12.40
+PackageLocale: en-US
+Publisher: hex
+PublisherUrl: https://github.com/hex
+PackageName: Mirror for Photoshop Server
+PackageUrl: https://github.com/hex/mirror-for-photoshop-server
+License: MIT
+LicenseUrl: https://github.com/hex/mirror-for-photoshop-server/blob/main/LICENSE
+ShortDescription: WebSocket relay server bridging Adobe Photoshop to iOS devices
+Description: Mirror for Photoshop Server is a WebSocket relay that connects Adobe Photoshop to iOS devices for real-time preview. It enables the Photoshop plugin to transmit preview images to connected iOS clients via Bonjour/mDNS discovery.
+Tags:
+  - photoshop
+  - preview
+  - design
+  - ios
+  - websocket
+  - relay
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/h/Hex/MirrorForPhotoshopServer/2025.12.40/Hex.MirrorForPhotoshopServer.yaml
+++ b/manifests/h/Hex/MirrorForPhotoshopServer/2025.12.40/Hex.MirrorForPhotoshopServer.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Hex.MirrorForPhotoshopServer
+PackageVersion: 2025.12.40
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package submission

- **Package:** Hex.MirrorForPhotoshopServer
- **Version:** 2025.12.40
- **Installer type:** ZIP with nested portable executable

### Description
Mirror for Photoshop Server is a WebSocket relay that connects Adobe Photoshop to iOS devices for real-time preview. It enables the Photoshop plugin to transmit preview images to connected iOS clients via Bonjour/mDNS discovery.

### Validation
- Manifest validated with `winget validate`
- Local installation tested successfully
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/322127)