### PR TITLE
SQLite.SQLite.installer.yaml 03.51.01 incorrect hash 

### DIFF
--- a/manifests/s/SQLite/SQLite/3.51.1/SQLite.SQLite.installer.yaml
+++ b/manifests/s/SQLite/SQLite/3.51.1/SQLite.SQLite.installer.yaml
@@ -18,9 +18,10 @@ ReleaseDate: 2025-11-28
 Installers:
 - Architecture: x64
   InstallerUrl: https://www.sqlite.org/2025/sqlite-tools-win-x64-3510100.zip
-  InstallerSha256: 7131A88CE4BC7CAEE1B0D585D42837BCDA456C874FAD28DBF19B10B464520168
+  InstallerSha256: 508858AA62C7A5B750BAE4457BF85B422F9EAECF9F37107C2F97CD4FA4D36FCC
 - Architecture: arm64
   InstallerUrl: https://www.sqlite.org/2025/sqlite-tools-win-arm64-3510100.zip
   InstallerSha256: 0AB583903756EED87796E073D771A04EFB6728FE2F3FD02C067A6501473AED0A
 ManifestType: installer
 ManifestVersion: 1.10.0
+


### PR DESCRIPTION
hash for the x64 file is incorrect. This pull request fixes it. 

```
winget install sqlite.sqlite
Found SQLite [SQLite.SQLite] Version 3.51.1
This application is licensed to you by its owner.
Microsoft is not responsible for, nor does it grant any licenses to, third-party packages.
Downloading https://www.sqlite.org/2025/sqlite-tools-win-x64-3510100.zip
  ██████████████████████████████  6.14 MB / 6.14 MB
Installer hash does not match.
```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/322585)