### PR TITLE
New package: dlbroadfoot.bb version 2.84.0

### DIFF
--- a/manifests/d/dlbroadfoot/bb/2.84.0/dlbroadfoot.bb.installer.yaml
+++ b/manifests/d/dlbroadfoot/bb/2.84.0/dlbroadfoot.bb.installer.yaml
@@ -1,0 +1,27 @@
+# Created using wingetcreate
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: dlbroadfoot.bb
+PackageVersion: 2.84.0
+InstallerType: msi
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+Scope: machine
+Commands:
+  - bb
+UpgradeBehavior: install
+ReleaseDate: 2025-12-12
+Installers:
+  - Architecture: x86
+    InstallerUrl: https://github.com/dlbroadfoot/bitbucket-cli/releases/download/v2.84.0/bb_2.84.0_windows_386.msi
+    InstallerSha256: 6F067C621BD2BC8163D7C222614F2C680B9234CA46B7F5D3802E87561891058F
+  - Architecture: x64
+    InstallerUrl: https://github.com/dlbroadfoot/bitbucket-cli/releases/download/v2.84.0/bb_2.84.0_windows_amd64.msi
+    InstallerSha256: 4CC7CFCA005588BAD067770024D46082FE72C4898357041CD43DBF52E87A1706
+  - Architecture: arm64
+    InstallerUrl: https://github.com/dlbroadfoot/bitbucket-cli/releases/download/v2.84.0/bb_2.84.0_windows_arm64.msi
+    InstallerSha256: F19499167D326AE3C41998537AB2562AD339B2422A2B3630A93AC6614CAB4745
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/d/dlbroadfoot/bb/2.84.0/dlbroadfoot.bb.locale.en-US.yaml
+++ b/manifests/d/dlbroadfoot/bb/2.84.0/dlbroadfoot.bb.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# Created using wingetcreate
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: dlbroadfoot.bb
+PackageVersion: 2.84.0
+PackageLocale: en-US
+Publisher: dlbroadfoot
+PublisherUrl: https://github.com/dlbroadfoot
+PublisherSupportUrl: https://github.com/dlbroadfoot/bitbucket-cli/issues
+PackageName: Bitbucket CLI
+PackageUrl: https://github.com/dlbroadfoot/bitbucket-cli
+License: MIT
+LicenseUrl: https://github.com/dlbroadfoot/bitbucket-cli/blob/main/LICENSE
+ShortDescription: Work seamlessly with Bitbucket from the command line
+Description: |-
+  Bitbucket CLI (bb) brings Bitbucket to your terminal.
+  Manage pull requests, repositories, and pipelines without leaving your development environment.
+Tags:
+  - bitbucket
+  - cli
+  - command-line
+  - developer-tools
+  - git
+  - open-source
+ReleaseNotesUrl: https://github.com/dlbroadfoot/bitbucket-cli/releases/tag/v2.84.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/d/dlbroadfoot/bb/2.84.0/dlbroadfoot.bb.yaml
+++ b/manifests/d/dlbroadfoot/bb/2.84.0/dlbroadfoot.bb.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: dlbroadfoot.bb
+PackageVersion: 2.84.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Package Information

- PackageIdentifier: dlbroadfoot.bb
- PackageVersion: 2.84.0
- Publisher: dlbroadfoot

### Description

Bitbucket CLI (bb) - Work seamlessly with Bitbucket from the command line. Manage pull requests, repositories, and pipelines without leaving your development environment.

### Checklist

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one manifest
- [x] Have you validated your manifest with `winget validate`?
- [x] Have you tested your manifest with `winget install`?

### Links

- [GitHub Repository](https://github.com/dlbroadfoot/bitbucket-cli)
- [Release](https://github.com/dlbroadfoot/bitbucket-cli/releases/tag/v2.84.0)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/322719)