### PR TITLE
Modify: Ventoy.Ventoy for binary file detection by reordering architecture-specific executable paths

### DIFF
--- a/manifests/v/Ventoy/Ventoy/1.1.08/Ventoy.Ventoy.installer.yaml
+++ b/manifests/v/Ventoy/Ventoy/1.1.08/Ventoy.Ventoy.installer.yaml
@@ -10,42 +10,42 @@ ArchiveBinariesDependOnPath: true
 Installers:
 - Architecture: x86
   NestedInstallerFiles:
-  - RelativeFilePath: ventoy-1.1.08\Ventoy2Disk.exe
-    PortableCommandAlias: Ventoy2Disk
-  - RelativeFilePath: ventoy-1.1.08\VentoyPlugson.exe
-    PortableCommandAlias: VentoyPlugson
-  - RelativeFilePath: ventoy-1.1.08\VentoyVlnk.exe
+  - RelativeFilePath: 'ventoy-1.1.08\VentoyVlnk.exe'
     PortableCommandAlias: VentoyVlnk
+  - RelativeFilePath: 'ventoy-1.1.08\VentoyPlugson.exe'
+    PortableCommandAlias: VentoyPlugson
+  - RelativeFilePath: 'ventoy-1.1.08\Ventoy2Disk.exe'
+    PortableCommandAlias: Ventoy2Disk
   InstallerUrl: https://github.com/ventoy/Ventoy/releases/download/v1.1.08/ventoy-1.1.08-windows.zip
   InstallerSha256: 2EEB7553E62A940449A42B59EDE3B4D3550023B2FF864A297DEE818086E3564B
 - Architecture: x64
   NestedInstallerFiles:
-  - RelativeFilePath: ventoy-1.1.08\altexe\Ventoy2Disk_X64.exe
-    PortableCommandAlias: Ventoy2Disk
-  - RelativeFilePath: ventoy-1.1.08\altexe\VentoyPlugson_X64.exe
-    PortableCommandAlias: VentoyPlugson
-  - RelativeFilePath: ventoy-1.1.08\VentoyVlnk.exe
+  - RelativeFilePath: 'ventoy-1.1.08\VentoyVlnk.exe'
     PortableCommandAlias: VentoyVlnk
+  - RelativeFilePath: 'ventoy-1.1.08\altexe\VentoyPlugson_X64.exe'
+    PortableCommandAlias: VentoyPlugson
+  - RelativeFilePath: 'ventoy-1.1.08\altexe\Ventoy2Disk_X64.exe'
+    PortableCommandAlias: Ventoy2Disk.exe
   InstallerUrl: https://github.com/ventoy/Ventoy/releases/download/v1.1.08/ventoy-1.1.08-windows.zip
   InstallerSha256: 2EEB7553E62A940449A42B59EDE3B4D3550023B2FF864A297DEE818086E3564B
 - Architecture: arm
   NestedInstallerFiles:
-  - RelativeFilePath: ventoy-1.1.08\altexe\Ventoy2Disk_ARM.exe
-    PortableCommandAlias: Ventoy2Disk
-  - RelativeFilePath: ventoy-1.1.08\VentoyPlugson.exe
-    PortableCommandAlias: VentoyPlugson
-  - RelativeFilePath: ventoy-1.1.08\VentoyVlnk.exe
+  - RelativeFilePath: 'ventoy-1.1.08\VentoyVlnk.exe'
     PortableCommandAlias: VentoyVlnk
+  - RelativeFilePath: 'ventoy-1.1.08\VentoyPlugson.exe'
+    PortableCommandAlias: VentoyPlugson
+  - RelativeFilePath: 'ventoy-1.1.08\altexe\Ventoy2Disk_ARM.exe'
+    PortableCommandAlias: Ventoy2Disk
   InstallerUrl: https://github.com/ventoy/Ventoy/releases/download/v1.1.08/ventoy-1.1.08-windows.zip
   InstallerSha256: 2EEB7553E62A940449A42B59EDE3B4D3550023B2FF864A297DEE818086E3564B
 - Architecture: arm64
   NestedInstallerFiles:
-  - RelativeFilePath: ventoy-1.1.08\altexe\Ventoy2Disk_ARM64.exe
-    PortableCommandAlias: Ventoy2Disk
-  - RelativeFilePath: ventoy-1.1.08\VentoyPlugson.exe
-    PortableCommandAlias: VentoyPlugson
-  - RelativeFilePath: ventoy-1.1.08\VentoyVlnk.exe
+  - RelativeFilePath: 'ventoy-1.1.08\VentoyVlnk.exe'
     PortableCommandAlias: VentoyVlnk
+  - RelativeFilePath: 'ventoy-1.1.08\VentoyPlugson.exe'
+    PortableCommandAlias: VentoyPlugson
+  - RelativeFilePath: 'ventoy-1.1.08\altexe\Ventoy2Disk_ARM64.exe'
+    PortableCommandAlias: Ventoy2Disk
   InstallerUrl: https://github.com/ventoy/Ventoy/releases/download/v1.1.08/ventoy-1.1.08-windows.zip
   InstallerSha256: 2EEB7553E62A940449A42B59EDE3B4D3550023B2FF864A297DEE818086E3564B
 ManifestType: installer


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory name containing the manifest `Ventoy.Ventoy.installer.yaml`.

---

## Package Information

- Package Name: `Ventoy.Ventoy`
- Package Version: `1.1.08`

## Description

This PR fixes the executable paths for `Ventoy` to use architecture-specific binaries from the `altexe` folder where appropriate.

### Problem

The current manifest configuration causes the following issues:
- On `x64` systems, the PATH incorrectly includes the `<installation-target>/altexe` subdirectory instead of `<installation-target>`
- Users cannot find the `Ventoy2Disk` executable after installation
- Architecture-specific optimized binaries in the `altexe` folder are not being used

### Solution

- Use appropriate executables from the `altexe` folder for each architecture:
  - x64: `Ventoy2Disk_X64.exe`, `VentoyPlugson_X64.exe`
  - arm64: `Ventoy2Disk_ARM64.exe`
  - arm: `Ventoy2Disk_ARM.exe`
  - x86: Use root directory executables (32-bit versions)
- Wrap `RelativeFilePath` values with single quotes for consistency
- Maintain the same `PortableCommandAlias` for consistent user experience across architectures

### Testing

- [x] Tested on `x64` system
- [x] `Ventoy2Disk` command is accessible from `PATH`
- [x] Correct architecture-specific executable is used
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/323227)