### PR TITLE
[PHP] Add new version `PHP.PHP.NTS.8.1` - `8.1.34`

### DIFF
--- a/manifests/p/PHP/PHP/NTS/8/1/8.1.34/PHP.PHP.NTS.8.1.installer.yaml
+++ b/manifests/p/PHP/PHP/NTS/8/1/8.1.34/PHP.PHP.NTS.8.1.installer.yaml
@@ -1,0 +1,32 @@
+# Created with PHPWatch/winget-pkgs - https://github.com/PHPWatch/php-winget-manifest
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: PHP.PHP.NTS.8.1
+PackageVersion: 8.1.34
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: php.exe
+    PortableCommandAlias: php
+Commands:
+  - php
+  - php81
+UpgradeBehavior: install
+ReleaseDate: 2025-12-16
+ArchiveBinariesDependOnPath: true
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://downloads.php.net/~windows/releases/php-8.1.34-nts-Win32-vs16-x64.zip
+    InstallerSha256: 9cfe246cb144076c16f5913a3ef88a474c3dd7e60f0f0c8bb95faf68674016cc
+    Dependencies:
+      PackageDependencies:
+        - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+  - Architecture: x86
+    InstallerUrl: https://downloads.php.net/~windows/releases/php-8.1.34-nts-Win32-vs16-x86.zip
+    InstallerSha256: 925f3b6b098cfc4b324056b8b8b8b870ad11cd22c15c2c29a03067a5eb14dc4c
+    Dependencies:
+      PackageDependencies:
+        - PackageIdentifier: Microsoft.VCRedist.2015+.x86
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/p/PHP/PHP/NTS/8/1/8.1.34/PHP.PHP.NTS.8.1.locale.en-US.yaml
+++ b/manifests/p/PHP/PHP/NTS/8/1/8.1.34/PHP.PHP.NTS.8.1.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# Created with PHPWatch/winget-pkgs - https://github.com/PHPWatch/php-winget-manifest
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: PHP.PHP.NTS.8.1
+Description: "PHP (recursive acronym for PHP: Hypertext Preprocessor) is a widely-used open source general-purpose scripting language that is especially suited for web development and can be embedded into HTML."
+ShortDescription: PHP 8.1 - Non-thread safe
+PackageVersion: 8.1.34
+ReleaseNotesUrl: https://www.php.net/ChangeLog-8.php#8.1.34
+PackageLocale: en-US
+Publisher: PHP Group
+PublisherUrl: https://php.net
+PublisherSupportUrl: https://www.php.net/docs.php
+Author: PHP Group
+PackageName: PHP 8.1 - Non-thread safe
+PackageUrl: https://php.net
+License: PHP License v3.01
+LicenseUrl: https://www.php.net/license/3_01.txt
+Copyright: (c) PHP Group
+CopyrightUrl: https://www.php.net/credits.php
+Moniker: php8.1
+Tags:
+  - php
+  - php81
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/p/PHP/PHP/NTS/8/1/8.1.34/PHP.PHP.NTS.8.1.yaml
+++ b/manifests/p/PHP/PHP/NTS/8/1/8.1.34/PHP.PHP.NTS.8.1.yaml
@@ -1,0 +1,8 @@
+# Created with PHPWatch/winget-pkgs - https://github.com/PHPWatch/php-winget-manifest
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: PHP.PHP.NTS.8.1
+PackageVersion: 8.1.34
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Updates `PHP.PHP.NTS.8.1` to PHP `8.1.34`

---

**PHP 8.1.34**
x86 zip Download: https://downloads.php.net/~windows/releases/php-8.1.34-nts-Win32-vs16-x86.zip
x86 zip checksum: `925f3b6b098cfc4b324056b8b8b8b870ad11cd22c15c2c29a03067a5eb14dc4c`
x64 zip Download: https://downloads.php.net/~windows/releases/php-8.1.34-nts-Win32-vs16-x64.zip
x64 zip Checksum: `9cfe246cb144076c16f5913a3ef88a474c3dd7e60f0f0c8bb95faf68674016cc`

Info: [PHP 8.1](https://windows.php.net/download#php-8.1) - [PHP 8.1.34](https://php.watch/versions/8.1/releases/8.1.34#download-windows) - [php/php-src 8.1.34](https://github.com/php/php-src/releases/tag/php-8.1.34)

---

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

---

###### Manifest built [automatically](https://github.com/PHPWatch/php-winget-manifest/actions/runs/20280393769) and [attested](https://github.com/PHPWatch/php-winget-manifest/attestations/15233731) by [PHPWatch/php-winget-manifest](https://github.com/PHPWatch/php-winget-manifest/).


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/323766)