### PR TITLE
New package: Hyperpolymath.Bunsenite version 1.0.2

### DIFF
--- a/manifests/h/Hyperpolymath/Bunsenite/1.0.2/Hyperpolymath.Bunsenite.yaml
+++ b/manifests/h/Hyperpolymath/Bunsenite/1.0.2/Hyperpolymath.Bunsenite.yaml
@@ -1,0 +1,46 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.singleton.1.6.0.schema.json
+
+PackageIdentifier: Hyperpolymath.Bunsenite
+PackageVersion: 1.0.2
+PackageLocale: en-US
+Publisher: hyperpolymath
+PublisherUrl: https://github.com/hyperpolymath
+PublisherSupportUrl: https://github.com/hyperpolymath/bunsenite/issues
+PackageName: Bunsenite
+PackageUrl: https://github.com/hyperpolymath/bunsenite
+License: MIT OR Palimpsest-0.8
+LicenseUrl: https://github.com/hyperpolymath/bunsenite/blob/main/LICENSE.txt
+ShortDescription: Nickel configuration file parser with multi-language FFI bindings
+Description: |
+  Bunsenite is a Nickel configuration file parser with multi-language FFI bindings.
+  It provides a Rust core library with a stable C ABI layer (via Zig) that enables
+  bindings for Deno (JavaScript/TypeScript), Rescript, and WebAssembly.
+
+  Features:
+  - Type Safety: Compile-time guarantees via Rust's type system
+  - Memory Safety: Rust ownership model, zero unsafe blocks
+  - Offline-First: Works completely air-gapped
+  - Multi-Language: FFI bindings for Deno, Rescript, and WASM
+Tags:
+  - nickel
+  - config
+  - parser
+  - ffi
+  - rust
+  - cli
+  - configuration
+Moniker: bunsenite
+Commands:
+  - bunsenite
+ReleaseNotesUrl: https://github.com/hyperpolymath/bunsenite/releases/tag/v1.0.2
+Installers:
+  - Architecture: x64
+    InstallerType: zip
+    InstallerUrl: https://github.com/hyperpolymath/bunsenite/releases/download/v1.0.2/bunsenite-v1.0.2-x86_64-pc-windows-msvc.zip
+    InstallerSha256: 54c62b1eb864500abe993978122ab53e1b80ff5e8240caa60f71a60ff1e90009
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: bunsenite.exe
+        PortableCommandAlias: bunsenite
+ManifestType: singleton
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Package Information

- Package: Hyperpolymath.Bunsenite
- Version: 1.0.2
- Publisher: hyperpolymath

## Description

Bunsenite is a Nickel configuration file parser with multi-language FFI bindings. It provides a Rust core library with a stable C ABI layer that enables bindings for Deno, Rescript, and WebAssembly.

## Links

- Homepage: https://github.com/hyperpolymath/bunsenite
- Release: https://github.com/hyperpolymath/bunsenite/releases/tag/v1.0.2

## Checklist

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one manifest
- [x] Have you validated your manifest locally with `winget validate`?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/323892)