### PR TITLE
Fix ProductCode escape in brunoleocam.ZPL2PDF 2.0.1

### DIFF
--- a/manifests/b/brunoleocam/ZPL2PDF/2.0.1/brunoleocam.ZPL2PDF.installer.yaml
+++ b/manifests/b/brunoleocam/ZPL2PDF/2.0.1/brunoleocam.ZPL2PDF.installer.yaml
@@ -27,6 +27,6 @@ Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/brunoleocam/ZPL2PDF/releases/download/v2.0.1/ZPL2PDF-Setup-2.0.1.exe
   InstallerSha256: 931AEE60DB1399AF37DA13A77A0EBE5C16307E5AD159B18C256A6364FF0D91DD
-  ProductCode: '{A7F8C3D2-9E1B-4F6A-8D2C-5E9A3B7C1F4D}_is1'
+  ProductCode: '{{A7F8C3D2-9E1B-4F6A-8D2C-5E9A3B7C1F4D}_is1'
 ManifestType: installer
 ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary

Fixed the ProductCode escape in the installer manifest for brunoleocam.ZPL2PDF 2.0.1.

## Changes

- Changed ProductCode from \'{A7F8C3D2-9E1B-4F6A-8D2C-5E9A3B7C1F4D}_is1'\ to \'{{A7F8C3D2-9E1B-4F6A-8D2C-5E9A3B7C1F4D}_is1'\

## Why

The opening brace \{\ needs to be escaped as \{{\ in YAML to properly represent the Windows registry ProductCode. Without this fix, \winget upgrade\ cannot detect the installed version correctly.

## Validation

- [x] \winget validate\ passes
- [x] Tested locally - \winget upgrade\ now works correctly
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/324144)