### PR TITLE
New version: Hex.MirrorForPhotoshopServer version 2025.12.56

### DIFF
--- a/manifests/h/Hex/MirrorForPhotoshopServer/2025.12.56/Hex.MirrorForPhotoshopServer.installer.yaml
+++ b/manifests/h/Hex/MirrorForPhotoshopServer/2025.12.56/Hex.MirrorForPhotoshopServer.installer.yaml
@@ -1,0 +1,9 @@
+PackageIdentifier: Hex.MirrorForPhotoshopServer
+PackageVersion: 2025.12.56
+InstallerType: inno
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/hex/mirror-for-photoshop-server/releases/download/v2025.12.56/mirror-for-photoshop-server-installer-win-x64.exe
+    InstallerSha256: a035acf3ac49004ca4e99ab683fd7fcd4405eef3f127d25df5e76dda71c98435
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/h/Hex/MirrorForPhotoshopServer/2025.12.56/Hex.MirrorForPhotoshopServer.locale.en-US.yaml
+++ b/manifests/h/Hex/MirrorForPhotoshopServer/2025.12.56/Hex.MirrorForPhotoshopServer.locale.en-US.yaml
@@ -1,0 +1,22 @@
+PackageIdentifier: Hex.MirrorForPhotoshopServer
+PackageVersion: 2025.12.56
+PackageLocale: en-US
+Publisher: hex
+PublisherUrl: https://github.com/hex
+Author: hex
+PackageName: Mirror for Photoshop Server
+PackageUrl: https://mirrorps.hexul.com/
+License: MIT
+LicenseUrl: https://github.com/hex/mirror-for-photoshop-server/blob/main/LICENSE
+ShortDescription: WebSocket relay server bridging Adobe Photoshop to iOS devices
+ReleaseNotesUrl: https://github.com/hex/mirror-for-photoshop-server/releases/tag/v2025.12.56
+Description: Mirror for Photoshop Server is a WebSocket relay that connects Adobe Photoshop to iOS devices for real-time preview. It enables the Photoshop plugin to transmit preview images to connected iOS clients via Bonjour/mDNS discovery.
+Tags:
+  - photoshop
+  - preview
+  - design
+  - ios
+  - websocket
+  - relay
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/h/Hex/MirrorForPhotoshopServer/2025.12.56/Hex.MirrorForPhotoshopServer.yaml
+++ b/manifests/h/Hex/MirrorForPhotoshopServer/2025.12.56/Hex.MirrorForPhotoshopServer.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Hex.MirrorForPhotoshopServer
+PackageVersion: 2025.12.56
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Package submission

- Package: Hex.MirrorForPhotoshopServer
- Version: 2025.12.56
- Installer type: ZIP with nested portable executable

WebSocket relay server for Mirror for Photoshop - bridges Adobe Photoshop to iOS devices for real-time preview.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/324486)