### PR TITLE
New Package: Add PabloDraw version 3.3.14 installer and locale manifests

### DIFF
--- a/manifests/c/cwensley/PabloDraw/3.3.14/cwensley.PabloDraw.installer.yaml
+++ b/manifests/c/cwensley/PabloDraw/3.3.14/cwensley.PabloDraw.installer.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: cwensley.PabloDraw
+PackageVersion: 3.3.14
+InstallerType: msi
+ReleaseDate: 2025-03-29
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/cwensley/pablodraw/releases/download/3.3.14-beta/PabloDraw-win-x64.msi
+  InstallerSha256: EAB582380EA9F28F18385C4B352A33DEF3924CA7BFA7AAA696D055A00FC32ED9
+  ProductCode: '{FA47E997-BA8E-4727-9166-EA54934FAC86}'
+  AppsAndFeaturesEntries:
+  - DisplayName: PabloDraw
+    Publisher: Picoe Software Solutions
+    ProductCode: '{FA47E997-BA8E-4727-9166-EA54934FAC86}'
+    UpgradeCode: '{DC30A6A5-E756-4440-B8CD-CC823D9DE7A3}'
+- Architecture: arm64
+  InstallerUrl: https://github.com/cwensley/pablodraw/releases/download/3.3.14-beta/PabloDraw-win-arm64.msi
+  InstallerSha256: A7C4F81859FEA5D06B0887201EE9756357B29CDAC66B521A35BC32F1FF85B1F8
+  ProductCode: '{289683D8-D5C9-4EC6-96AA-9E0F43494D16}'
+  AppsAndFeaturesEntries:
+  - DisplayName: PabloDraw
+    Publisher: Picoe Software Solutions
+    ProductCode: '{289683D8-D5C9-4EC6-96AA-9E0F43494D16}'
+    UpgradeCode: '{DC30A6A5-E756-4440-B8CD-CC823D9DE7A3}'
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/c/cwensley/PabloDraw/3.3.14/cwensley.PabloDraw.locale.en-US.yaml
+++ b/manifests/c/cwensley/PabloDraw/3.3.14/cwensley.PabloDraw.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: cwensley.PabloDraw
+PackageVersion: 3.3.14
+PackageLocale: en-US
+Publisher: Picoe Software Solutions
+PublisherSupportUrl: https://github.com/cwensley/pablodraw/issues
+Author: Curtis Wensley
+PackageName: PabloDraw
+PackageUrl: https://github.com/cwensley/pablodraw
+License: MIT
+LicenseUrl: https://github.com/cwensley/pablodraw/blob/3.3.14-beta/LICENSE
+ShortDescription: An ANSI/ASCII text and RIPscrip vector graphic art editor/viewer with multi-user capabilities.
+Moniker: pablodraw
+Tags:
+- ansi
+- ascii
+- rip
+- ripscrip
+- bbs
+- art
+- editor
+- textmode
+- xbin
+ReleaseNotesUrl: https://github.com/cwensley/pablodraw/releases/tag/3.3.14-beta
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/c/cwensley/PabloDraw/3.3.14/cwensley.PabloDraw.yaml
+++ b/manifests/c/cwensley/PabloDraw/3.3.14/cwensley.PabloDraw.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: cwensley.PabloDraw
+PackageVersion: 3.3.14
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Checklist for Pull Requests
- [x] Have you signed the Contributor License Agreement (CLA)?
- [ ] Is there a linked Issue?

## Manifests
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
```pwsh
winget install --manifest "manifests\c\cwensley\PabloDraw\3.3.14"
Found PabloDraw [cwensley.PabloDraw] Version 3.3.14
This application is licensed to you by its owner.
Microsoft is not responsible for, nor does it grant any licenses to, third-party packages.
Downloading https://github.com/cwensley/pablodraw/releases/download/3.3.14-beta/PabloDraw-win-x64.msi
                                  61.1 MB / 61.1 MB
Successfully verified installer hash
Starting package install...
Successfully installed
```
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the 1.10 schema?

Path validated:
- `manifests\c\cwensley\PabloDraw\3.3.14`

---
Adds a new WinGet package for PabloDraw.

PackageIdentifier: cwensley.PabloDraw
PackageVersion: 3.3.14 (matches MSI ProductVersion)
Installer type: MSI
Architectures: x64, arm64
Installer source: GitHub Releases (3.3.14-beta tag; version inside MSI is 3.3.14)
Includes ProductCode/UpgradeCode for reliable upgrade correlation
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/325115)