### PR TITLE
Stop GitHub making references spam for linked issue

### DIFF
--- a/.github/policies/labelManagement.issueOpened.yml
+++ b/.github/policies/labelManagement.issueOpened.yml
@@ -45,7 +45,10 @@ configuration:
                 [![Validation Pipeline Badge](https://img.shields.io/endpoint?url=https://winget-validation-pme-f8gqfjhzacawbecy.z01.azurefd.net/api/GetServiceComponentStatusBadge?component=ValidationPipeline "Validation Pipeline Badge")](https://dev.azure.com/shine-oss/winget-pkgs/_build?definitionId=14)&nbsp;[![Publish Pipeline Badge](https://img.shields.io/endpoint?url=https://winget-validation-pme-f8gqfjhzacawbecy.z01.azurefd.net/api/GetServiceComponentStatusBadge?component=PublishPipeline "Publish Pipeline Badge")](https://dev.azure.com/shine-oss/winget-pkgs/_build?definitionId=12)
 
 
-                - #325114
+                > [!IMPORTANT]
+
+
+                > [P.S.A. Validation throughput (#325114)](https://www.github.com/microsoft/winget-pkgs/issues/325114)
           # If the user is a first-time contributor, add the Needs-CLA Label
           - if:
               - activitySenderHasAssociation:


### PR DESCRIPTION
When adding a link to a GitHub issue if you add `www` in the URL after `https://`, GitHub won't add a reference. The downside is that it won't render as pretty, but that's why I wrapped it in an `[!IMPORTANT]` block as

> [!IMPORTANT]
> [P.S.A. Validation throughput (#325114)](https://www.github.com/microsoft/winget-pkgs/issues/325114)

Related to: #325948

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/325993)