### PR TITLE
New package: loonghao.vx version 0.5.15

### DIFF
--- a/manifests/l/loonghao/vx/0.5.15/loonghao.vx.installer.yaml
+++ b/manifests/l/loonghao/vx/0.5.15/loonghao.vx.installer.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: loonghao.vx
+PackageVersion: 0.5.15
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: vx.exe
+  PortableCommandAlias: vx
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: uninstallPrevious
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+ReleaseDate: 2025-12-24
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/loonghao/vx/releases/download/vx-v0.5.15/vx-x86_64-pc-windows-msvc.zip
+  InstallerSha256: C3CC458DF8D0F3E172B1A5D1BB62655DEC60B9661D66185ADCAC90E724C669DD
+- Architecture: arm64
+  InstallerUrl: https://github.com/loonghao/vx/releases/download/vx-v0.5.15/vx-aarch64-pc-windows-msvc.zip
+  InstallerSha256: 9A411811FB2C9A9F02832CA78443012634DAB1F855A4A76D7365BC9DFF3CB988
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/l/loonghao/vx/0.5.15/loonghao.vx.locale.en-US.yaml
+++ b/manifests/l/loonghao/vx/0.5.15/loonghao.vx.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: loonghao.vx
+PackageVersion: 0.5.15
+PackageLocale: en-US
+Publisher: loonghao
+PublisherUrl: https://github.com/loonghao
+PublisherSupportUrl: https://github.com/loonghao/vx/issues
+PackageName: vx
+PackageUrl: https://github.com/loonghao/vx
+License: MIT
+LicenseUrl: https://github.com/loonghao/vx/blob/main/LICENSE
+ShortDescription: Universal Development Tool Manager
+Description: vx is a universal development tool manager that automatically installs and manages development tools like Node.js, Python, Go, Rust, etc. Zero learning curve - just use familiar commands and vx handles the rest.
+Tags:
+- cli
+- development
+- tool-manager
+- nodejs
+- python
+- go
+- rust
+- version-manager
+ReleaseNotesUrl: https://github.com/loonghao/vx/releases/tag/vx-v0.5.15
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/l/loonghao/vx/0.5.15/loonghao.vx.yaml
+++ b/manifests/l/loonghao/vx/0.5.15/loonghao.vx.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: loonghao.vx
+PackageVersion: 0.5.15
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
### New Package Submission

- Package Identifier: loonghao.vx
- Package Version: 0.5.15
- Package URL: https://github.com/loonghao/vx

### Description

vx is a universal development tool manager that automatically installs and manages development tools like Node.js, Python, Go, Rust, etc. Zero learning curve - just use familiar commands and vx handles the rest.

### Checklist

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one manifest
- [x] Have you validated your manifest locally with `winget validate`?
- [x] Have you tested your manifest locally with `winget install`?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/326009)