### PR TITLE
Add script for generating a new Windows 11 VM for validation

### DIFF
--- a/.github/workflows/scriptAnalyzer.yaml
+++ b/.github/workflows/scriptAnalyzer.yaml
@@ -6,9 +6,11 @@ on:
       - master
     paths:
       - "**/*.ps1"
+      - "**/*.psm1"
   push:
     paths:
       - "**/*.ps1"
+      - "**/*.psm1"
 
 permissions:
   contents: read # Needed to check out the code
@@ -26,7 +28,8 @@ jobs:
       - name: Run PSScriptAnalyzer
         run: |
           # Run PSScriptAnalyzer on all PowerShell scripts
-          $results = Get-ChildItem -Recurse -Filter *.ps1 | Invoke-ScriptAnalyzer
+          $results = @(Get-ChildItem -Recurse -Filter *.ps1 | Invoke-ScriptAnalyzer)
+          $results += @(Get-ChildItem -Recurse -Filter *.psm1 | Invoke-ScriptAnalyzer)
           if ($results) {
             Write-Output $results | Format-List -GroupBy ScriptName
           }

--- a/Tools/Build-MinWinVHD.ps1
+++ b/Tools/Build-MinWinVHD.ps1
@@ -1,0 +1,193 @@
+﻿# ================================
+# Minimal Windows 11 VHDX Builder
+# ================================
+# Run as Administrator
+
+#Requires -Version 5.1
+#Requires -RunAsAdministrator
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'This script is not intended to have any outputs piped')]
+
+param
+(
+    [Parameter(
+        Mandatory = $true,
+        HelpMessage = 'Drive letter where Windows 11 ISO is mounted (e.g., D:)'
+    )] [string] $IsoDrive = 'D:',
+    [Parameter(
+        Mandatory = $true,
+        HelpMessage = 'Index of the Windows 11 edition to install from the image (use /Get-ImageInfo to check)'
+    )] [ValidateRange(1, 10)] [int] $ImageIndex = 1,
+    [Parameter(
+        Mandatory = $true,
+        HelpMessage = 'Path to create the VHDX file (e.g., C:\MinWin11.vhdx)'
+    )] [string] $VhdPath = 'C:\MinWin11.vhdx',
+    [Parameter(
+        Mandatory = $false,
+        HelpMessage = 'Size of the VHDX in GB'
+    )] [ValidateRange(20, [int]::MaxValue)] [int] $VhdSizeGB = 25,
+    [Parameter(
+        Mandatory = $false,
+        HelpMessage = 'Name of the Hyper-V VM to create (optional)'
+    )] [string] $VmName = 'MinWin11'
+)
+
+Write-Host '=== Step 0: Prepare paths and image info ===' -ForegroundColor Cyan
+
+# Determine install.wim or install.esd path
+$InstallWim = Join-Path $IsoDrive 'sources\install.wim'
+if (-not (Test-Path $InstallWim)) {
+    $InstallWim = Join-Path $IsoDrive 'sources\install.esd'
+}
+
+# Verify image file exists
+if (-not (Test-Path $InstallWim)) {
+    throw "Cannot find install.wim or install.esd on $IsoDrive. Mount a Windows 11 ISO and update `\$IsoDrive`."
+}
+
+Write-Host "Using image file: $InstallWim" -ForegroundColor Yellow
+
+Write-Host '=== Step 1: Create and initialize VHDX ===' -ForegroundColor Cyan
+
+# Create VHDX
+New-VHD -Path $VhdPath -SizeBytes ("${VhdSizeGB}GB") -Dynamic | Out-Null
+
+# Mount and initialize
+$disk = Mount-VHD -Path $VhdPath -Passthru
+Initialize-Disk -Number $disk.Number -PartitionStyle GPT | Out-Null
+
+# Create EFI + OS partitions
+$efiPartition = New-Partition -DiskNumber $disk.Number -Size 100MB -GptType '{C12A7328-F81F-11D2-BA4B-00A0C93EC93B}' -AssignDriveLetter
+$osPartition = New-Partition -DiskNumber $disk.Number -UseMaximumSize -AssignDriveLetter
+
+# Format partitions
+Format-Volume -Partition $efiPartition -FileSystem FAT32 -NewFileSystemLabel 'System' -Confirm:$false | Out-Null
+Format-Volume -Partition $osPartition -FileSystem NTFS -NewFileSystemLabel 'Windows' -Confirm:$false | Out-Null
+
+$EfiDrive = ($efiPartition | Get-Volume).DriveLetter + ':'
+$OsDrive = ($osPartition | Get-Volume).DriveLetter + ':'
+
+Write-Host "EFI drive: $EfiDrive  OS drive: $OsDrive" -ForegroundColor Yellow
+
+
+Write-Host '=== Step 2: Apply Windows image to OS partition ===' -ForegroundColor Cyan
+
+# If using ESD, DISM can still apply directly
+dism /Apply-Image /ImageFile:$InstallWim /Index:$ImageIndex /ApplyDir:$OsDrive | Out-Null
+
+
+Write-Host '=== Step 3: Basic boot configuration ===' -ForegroundColor Cyan
+
+# Create boot files on EFI partition
+bcdboot "$OsDrive\Windows" /s $EfiDrive /f UEFI | Out-Null
+
+
+Write-Host '=== Step 4: Mount offline image for servicing ===' -ForegroundColor Cyan
+
+# Mount the OS volume as an offline image for DISM servicing
+$MountDir = 'D:\Mount_MinWin11'
+if (-not (Test-Path $MountDir)) {
+    New-Item -ItemType Directory -Path $MountDir | Out-Null
+}
+
+# Use DISM to mount the offline image
+dism /Mount-Image /ImageFile:$InstallWim /Index:$ImageIndex /MountDir:$MountDir /ReadOnly | Out-Null
+
+# NOTE:
+# We will service the *applied* OS at $OsDrive, not the ISO image.
+# For feature removal, we target the offline OS with /Image:$OsDrive not /Image:$MountDir.
+
+Write-Host '=== Step 5: Remove optional features (offline) ===' -ForegroundColor Cyan
+
+# You can see available features with:
+# dism /Image:$OsDrive /Get-Features
+
+# Aggressive feature removal list (adjust to taste)
+$featuresToDisable = @(
+    'FaxServicesClientPackage',
+    'Printing-Foundation-Features',
+    'Printing-PrintToPDFServices-Features',
+    'Printing-XPSServices-Features',
+    'MSRDC-Infrastructure',
+    'Microsoft-Windows-Subsystem-Linux',
+    'MediaPlayback' ,
+    'WindowsMediaPlayer',
+    'WorkFolders-Client',
+    'SMB1Protocol',
+    'WCF-Services45',
+    'WCF-TCP-PortSharing45',
+    'IIS-WebServerRole',
+    'IIS-WebServer',
+    'IIS-DefaultDocument',
+    'IIS-DirectoryBrowsing',
+    'IIS-HttpErrors',
+    'IIS-StaticContent',
+    'IIS-HttpRedirect',
+    'IIS-ApplicationDevelopment',
+    'IIS-ISAPIExtensions',
+    'IIS-ISAPIFilter',
+    # "IIS-NetFxExtensibility45",
+    'IIS-ASPNET45',
+    'IIS-HealthAndDiagnostics',
+    'IIS-HttpLogging',
+    'IIS-LoggingLibraries',
+    'IIS-RequestMonitor',
+    'IIS-HttpTracing',
+    'IIS-Security',
+    'IIS-RequestFiltering',
+    'IIS-IPSecurity',
+    'IIS-Performance',
+    'IIS-HttpCompressionStatic',
+    'IIS-WebServerManagementTools',
+    'IIS-IIS6ManagementCompatibility',
+    'IIS-Metabase',
+    'IIS-HostableWebCore'
+)
+
+foreach ($feature in $featuresToDisable) {
+    Write-Host "Disabling feature: $feature" -ForegroundColor DarkYellow
+    dism /Image:$OsDrive /Disable-Feature /FeatureName:$feature /Remove | Out-Null
+}
+
+Write-Host '=== Step 6: Remove provisioned apps (offline) ===' -ForegroundColor Cyan
+
+# Remove all provisioned appx packages except Store and framework (adjust as needed)
+$ProvisionedApps = dism /Image:$OsDrive /Get-ProvisionedAppxPackages | Select-String 'PackageName'
+foreach ($line in $ProvisionedApps) {
+    $pkg = $line.ToString().Split(':')[1].Trim()
+    if ($pkg -notlike '*Store*' -and $pkg -notlike '*NET*' -and $pkg -notlike '*AppInstaller*') {
+        Write-Host "Removing provisioned app: $pkg" -ForegroundColor DarkYellow
+        dism /Image:$OsDrive /Remove-ProvisionedAppxPackage /PackageName:$pkg | Out-Null
+    }
+}
+
+Write-Host '=== Step 7: WinSxS cleanup and image optimization ===' -ForegroundColor Cyan
+
+# Component store cleanup to reduce size
+dism /Image:$OsDrive /Cleanup-Image /StartComponentCleanup /ResetBase | Out-Null
+
+Write-Host '=== Step 8: Unmount temporary mount and clean up ===' -ForegroundColor Cyan
+
+# Unmount DISM image
+dism /Unmount-Image /MountDir:$MountDir /Discard | Out-Null
+# Remove mount directory
+Remove-Item $MountDir -Recurse -Force | Out-Null
+
+# Dismount VHD (you can leave it mounted if you want to inspect it)
+Dismount-VHD -Path $VhdPath
+
+Write-Host '=== Step 9: (Optional) Create a Hyper-V VM using this VHDX ===' -ForegroundColor Cyan
+
+# Create a Hyper-V VM if Hyper-V module is available
+if (Get-Command New-VM -ErrorAction SilentlyContinue) {
+    if (-not (Get-VM -Name $VmName -ErrorAction SilentlyContinue)) {
+        New-VM -Name $VmName -MemoryStartupBytes 2GB -Generation 2 -VHDPath $VhdPath | Out-Null
+        Set-VMFirmware -VMName $VmName -FirstBootDevice (Get-VMFirmware -VMName $VmName).BootOrder[0]
+        Write-Host "Created Hyper-V VM '$VmName' using $VhdPath" -ForegroundColor Green
+    } else {
+        Write-Host "Hyper-V VM '$VmName' already exists. Attach $VhdPath manually if needed." -ForegroundColor Yellow
+    }
+} else {
+    Write-Host "Hyper-V module not available. Create a VM manually and attach $VhdPath." -ForegroundColor Yellow
+}
+
+Write-Host "=== DONE. Minimal Windows 11 VHDX created at $VhdPath ===" -ForegroundColor Green

--- a/doc/tools/Build-MinWinVHD.md
+++ b/doc/tools/Build-MinWinVHD.md
@@ -1,0 +1,86 @@
+**Build-MinWin11.ps1**
+
+Minimal Windows 11 VHDX builder script.
+
+- **Script:** [Tools/Build-MinWin11.ps1](Tools/Build-MinWin11.ps1)
+
+**Summary:**
+- Creates a dynamically sized VHDX, initializes GPT partitions (EFI + OS), applies a Windows 11 image from a mounted ISO, configures basic UEFI boot, optionally services the offline image (removes features / provisioned apps), and optionally creates a Hyper-V VM using the VHDX.
+
+**Prerequisites:**
+- **Run as Administrator:** The script must be executed from an elevated PowerShell session.
+- **PowerShell version:** Requires PowerShell 5.1 (Windows PowerShell) due to use of built-in cmdlets and DISM commands.
+- **Windows 11 ISO downloaded and mounted:** Mount the Windows 11 ISO (right-click -> Mount, or use `Mount-DiskImage`) and note the assigned drive letter (e.g., `D:`). Download from the official Microsoft page: https://www.microsoft.com/software-download/windows11
+- **DISM and bcdboot:** The script uses the built-in `dism` and `bcdboot` utilities.
+- **Hyper-V (optional):** If the Hyper-V module is available and you want a VM created automatically, enable Hyper-V beforehand and run from an Admin session.
+
+**Important note:** The script includes an "aggressive" list of features and provisioned app removals. Review the script before running if you need specific Windows features or provisioned packages preserved.
+
+**Parameters:**
+- **`-IsoDrive`**: (string) Drive letter where the Windows 11 ISO is mounted. Example: `D:`. (Required)
+- **`-ImageIndex`**: (int) Index of the Windows 11 image within the `install.wim` or `install.esd`. Use DISM to check the available indexes. (Required)
+- **`-VhdPath`**: (string) Full path to create the VHDX file. Example: `C:\MinWin11.vhdx`. (Required)
+- **`-VhdSizeGB`**: (int) Size of the VHDX in GB (dynamic disk). Default: `25`.
+- **`-VmName`**: (string) Name of the Hyper-V VM to create (optional). Default: `MinWin11`.
+
+**How to determine image index:**
+- Use DISM to list images in the WIM/ESD on the mounted ISO. Replace `D:` with your ISO drive letter:
+
+```powershell
+# For WIM
+dism /Get-WimInfo /WimFile:D:\sources\install.wim
+
+# For ESD (DISM supports reading ESD similarly)
+dism /Get-ImageInfo /ImageFile:D:\sources\install.esd
+```
+
+Look for the `Index :` value you want to apply (for example, 1 for the first edition).
+
+**Basic usage examples:**
+
+Open an elevated PowerShell prompt and run (example values shown):
+
+```powershell
+# From the Tools folder
+cd <path-to-repo>\Tools
+
+# Basic: create a 25GB dynamic VHDX from the image at D:, using index 1
+.\Build-MinWin11.ps1 -IsoDrive D: -ImageIndex 1 -VhdPath C:\MinWin11.vhdx
+
+# With custom size and VM name
+.\Build-MinWin11.ps1 -IsoDrive D: -ImageIndex 2 -VhdPath C:\MinWin11.vhdx -VhdSizeGB 40 -VmName "MyMinWin11"
+```
+
+**What the script does (high level):**
+- Locates `install.wim` or `install.esd` on the mounted ISO at `\sources`.
+- Creates a dynamic VHDX at the path provided (`-VhdPath`) and mounts it.
+- Initializes the disk as GPT and creates a 100MB EFI partition and the remaining OS partition.
+- Formats the partitions (EFI = FAT32, OS = NTFS).
+- Applies the Windows image to the OS partition using `dism /Apply-Image`.
+- Creates UEFI boot files with `bcdboot`.
+- Optionally mounts an offline copy of the image for servicing and removes a predefined list of optional features and provisioned appx packages (see script for the removal list).
+- Runs component-store cleanup (`/StartComponentCleanup /ResetBase`) to reduce size.
+- Dismounts VHD and optionally creates a Hyper-V VM named `-VmName` if the Hyper-V cmdlets are present.
+
+**Output:**
+- A VHDX file at the path specified by `-VhdPath` (e.g., `C:\MinWin11.vhdx`).
+- If Hyper-V is available and `-VmName` does not exist, a new Gen 2 VM is created and attached to the VHDX.
+
+**Warnings & tips:**
+- The script will throw an error if it cannot locate `install.wim` or `install.esd` in the ISO `sources` folder.
+- Review and edit the features/provisioned-app removal lists in the script before running in production environments — the defaults are aggressive and intended for minimal builds.
+- If you prefer to inspect the VHD before dismounting, modify the script or run the VHD mounting steps manually.
+- Ensure sufficient free space on the volume where `-VhdPath` is located.
+
+**Troubleshooting:**
+- If the ISO is not mounted as a drive letter, use `Mount-DiskImage -ImagePath "C:\path\to\Win11.iso"` and then run `Get-Volume` or check Explorer to find the assigned drive letter.
+- If `dism /Apply-Image` fails, verify the `-ImageIndex` value, and confirm whether the image file is `install.wim` or `install.esd`.
+- If Hyper-V VM creation fails, verify the `Hyper-V` Windows feature is enabled and that you are running elevated PowerShell.
+
+**Related files:**
+- Script source: [Tools/Build-MinWin11.ps1](Tools/Build-MinWin11.ps1)
+- Example sandbox/test reference: [doc/tools/SandboxTest.md](doc/tools/SandboxTest.md)
+
+---
+
+If you'd like, I can update the script's top-of-file comment block with a condensed usage summary or add example commands to the repository README.

--- a/doc/tools/Build-MinWinVHD.md
+++ b/doc/tools/Build-MinWinVHD.md
@@ -1,30 +1,37 @@
-**Build-MinWin11.ps1**
+# Using Build-MinWin11.ps1
 
-Minimal Windows 11 VHDX builder script.
+The [Build-MinWinVHD.ps1](Tools/Build-MinWinVHD.ps1) script creates a new `V`irtual `H`ard `D`isk (VHD) using a mounted Windows ISO for use with a virtual machine. This image will have as few dependencies and apps enabled as possible, to provide the best approximation of the images uses by the validation pipelines. Although this is not the same image, it should be close enough to use for testing manifests for those who are unable to use Windows Sandbox and [SandboxTest.ps1](doc/tools/SandboxTest.ps1).
 
-- **Script:** [Tools/Build-MinWin11.ps1](Tools/Build-MinWin11.ps1)
+## Summary
 
-**Summary:**
-- Creates a dynamically sized VHDX, initializes GPT partitions (EFI + OS), applies a Windows 11 image from a mounted ISO, configures basic UEFI boot, optionally services the offline image (removes features / provisioned apps), and optionally creates a Hyper-V VM using the VHDX.
+This script creates a dynamically sized VHDX, initializes GPT partitions (EFI + OS), applies a Windows image from a mounted ISO, configures basic UEFI boot, services the offline image (removes features / provisioned apps), and optionally creates a Hyper-V VM using the VHDX.
 
-**Prerequisites:**
+## Prerequisites
+
 - **Run as Administrator:** The script must be executed from an elevated PowerShell session.
-- **PowerShell version:** Requires PowerShell 5.1 (Windows PowerShell) due to use of built-in cmdlets and DISM commands.
-- **Windows 11 ISO downloaded and mounted:** Mount the Windows 11 ISO (right-click -> Mount, or use `Mount-DiskImage`) and note the assigned drive letter (e.g., `D:`). Download from the official Microsoft page: https://www.microsoft.com/software-download/windows11
-- **DISM and bcdboot:** The script uses the built-in `dism` and `bcdboot` utilities.
-- **Hyper-V (optional):** If the Hyper-V module is available and you want a VM created automatically, enable Hyper-V beforehand and run from an Admin session.
+- **PowerShell version:** Requires PowerShell 5.1 or newer due to use of built-in cmdlets and DISM commands.
+- **Windows ISO downloaded and mounted:** Mount the Windows 11 ISO (right-click -> Mount, or use `Mount-DiskImage`) and note the assigned drive letter (e.g., `D:`). ISO images can be downloaded from the official Microsoft page: https://www.microsoft.com/software-download/windows11
+- **DISM and bcdboot:** The script uses the built-in `dism` and `bcdboot` utilities. Ensure these commands are present on your path.
+- **Hyper-V (optional):** If the Hyper-V module is available and you want a VM created automatically, ensure Hyper-V is enabled and that you can manually create a new VM.
 
-**Important note:** The script includes an "aggressive" list of features and provisioned app removals. Review the script before running if you need specific Windows features or provisioned packages preserved.
+> [!IMPORTANT]
+> The script includes an "aggressive" list of features and provisioned app removals. Review the script before running if you need specific Windows features or provisioned packages preserved.
 
-**Parameters:**
-- **`-IsoDrive`**: (string) Drive letter where the Windows 11 ISO is mounted. Example: `D:`. (Required)
-- **`-ImageIndex`**: (int) Index of the Windows 11 image within the `install.wim` or `install.esd`. Use DISM to check the available indexes. (Required)
-- **`-VhdPath`**: (string) Full path to create the VHDX file. Example: `C:\MinWin11.vhdx`. (Required)
-- **`-VhdSizeGB`**: (int) Size of the VHDX in GB (dynamic disk). Default: `25`.
-- **`-VmName`**: (string) Name of the Hyper-V VM to create (optional). Default: `MinWin11`.
+## Parameters
 
-**How to determine image index:**
-- Use DISM to list images in the WIM/ESD on the mounted ISO. Replace `D:` with your ISO drive letter:
+## Parameters
+
+| Argument | Description | Required | Default |
+|------------------------------|-----------------------------------------------------------------------------|:--------:|:-------:|
+| **-IsoDrive** | Drive letter where the Windows ISO is mounted (string). Example: D:. | true | — |
+| **-ImageIndex** | Index of the Windows image within `install.wim` or `install.esd` (int). Use DISM to list available indexes (for example `dism /Get-WimInfo /WimFile:D:\sources\install.wim`). | true | — |
+| **-VhdPath** | Full path to create the VHDX file (string). Example: `C:\MinWin11.vhdx`. | true | — |
+| **-VhdSizeGB** | Size of the VHDX in GB (int). | false | 25 |
+| **-VmName** | Name of the Hyper-V VM to create (string). | false | MinWin11 |
+
+## How to determine image index
+
+Use DISM to list images in the WIM/ESD on the mounted ISO. Replace `D:` with your ISO drive letter:
 
 ```powershell
 # For WIM
@@ -36,7 +43,7 @@ dism /Get-ImageInfo /ImageFile:D:\sources\install.esd
 
 Look for the `Index :` value you want to apply (for example, 1 for the first edition).
 
-**Basic usage examples:**
+## Basic usage examples
 
 Open an elevated PowerShell prompt and run (example values shown):
 
@@ -51,36 +58,32 @@ cd <path-to-repo>\Tools
 .\Build-MinWin11.ps1 -IsoDrive D: -ImageIndex 2 -VhdPath C:\MinWin11.vhdx -VhdSizeGB 40 -VmName "MyMinWin11"
 ```
 
-**What the script does (high level):**
+## What the script does (high level)
+
 - Locates `install.wim` or `install.esd` on the mounted ISO at `\sources`.
 - Creates a dynamic VHDX at the path provided (`-VhdPath`) and mounts it.
 - Initializes the disk as GPT and creates a 100MB EFI partition and the remaining OS partition.
 - Formats the partitions (EFI = FAT32, OS = NTFS).
 - Applies the Windows image to the OS partition using `dism /Apply-Image`.
 - Creates UEFI boot files with `bcdboot`.
-- Optionally mounts an offline copy of the image for servicing and removes a predefined list of optional features and provisioned appx packages (see script for the removal list).
+- Mounts an offline copy of the image for servicing and removes a predefined list of optional features and provisioned appx packages (see script for the removal list).
 - Runs component-store cleanup (`/StartComponentCleanup /ResetBase`) to reduce size.
 - Dismounts VHD and optionally creates a Hyper-V VM named `-VmName` if the Hyper-V cmdlets are present.
 
-**Output:**
+## Output
+
 - A VHDX file at the path specified by `-VhdPath` (e.g., `C:\MinWin11.vhdx`).
 - If Hyper-V is available and `-VmName` does not exist, a new Gen 2 VM is created and attached to the VHDX.
 
-**Warnings & tips:**
+## Warnings & tips
+
 - The script will throw an error if it cannot locate `install.wim` or `install.esd` in the ISO `sources` folder.
 - Review and edit the features/provisioned-app removal lists in the script before running in production environments — the defaults are aggressive and intended for minimal builds.
 - If you prefer to inspect the VHD before dismounting, modify the script or run the VHD mounting steps manually.
 - Ensure sufficient free space on the volume where `-VhdPath` is located.
 
-**Troubleshooting:**
+## Troubleshooting
+
 - If the ISO is not mounted as a drive letter, use `Mount-DiskImage -ImagePath "C:\path\to\Win11.iso"` and then run `Get-Volume` or check Explorer to find the assigned drive letter.
 - If `dism /Apply-Image` fails, verify the `-ImageIndex` value, and confirm whether the image file is `install.wim` or `install.esd`.
 - If Hyper-V VM creation fails, verify the `Hyper-V` Windows feature is enabled and that you are running elevated PowerShell.
-
-**Related files:**
-- Script source: [Tools/Build-MinWin11.ps1](Tools/Build-MinWin11.ps1)
-- Example sandbox/test reference: [doc/tools/SandboxTest.md](doc/tools/SandboxTest.md)
-
----
-
-If you'd like, I can update the script's top-of-file comment block with a condensed usage summary or add example commands to the repository README.

--- a/doc/tools/Build-MinWinVHD.md
+++ b/doc/tools/Build-MinWinVHD.md
@@ -19,8 +19,6 @@ This script creates a dynamically sized VHDX, initializes GPT partitions (EFI + 
 
 ## Parameters
 
-## Parameters
-
 | Argument | Description | Required | Default |
 |------------------------------|-----------------------------------------------------------------------------|:--------:|:-------:|
 | **-IsoDrive** | Drive letter where the Windows ISO is mounted (string). Example: D:. | true | — |
@@ -87,3 +85,12 @@ cd <path-to-repo>\Tools
 - If the ISO is not mounted as a drive letter, use `Mount-DiskImage -ImagePath "C:\path\to\Win11.iso"` and then run `Get-Volume` or check Explorer to find the assigned drive letter.
 - If `dism /Apply-Image` fails, verify the `-ImageIndex` value, and confirm whether the image file is `install.wim` or `install.esd`.
 - If Hyper-V VM creation fails, verify the `Hyper-V` Windows feature is enabled and that you are running elevated PowerShell.
+
+## Using with other VM Providers
+
+- The produced VHDX (`C:\MinWin11.vhdx`) can be used with other hypervisors, but many providers require a different disk format; convert the VHDX to the format your provider expects before attaching.
+- QEMU/KVM: convert to `qcow2` with `qemu-img convert -O qcow2`.
+- VMware: convert to `vmdk` with `qemu-img convert -O vmdk` (or use VMware tools if available).
+- VirtualBox: use `VBoxManage clonemedium disk --format VDI` or convert with `qemu-img` to `vdi`/`vmdk` as needed.
+- Before converting, ensure the VHDX is dismounted and not in use. After conversion, attach the converted disk to a VM configured for UEFI/GPT (Gen2/EFI) and the appropriate disk controller.
+- Expect to install or enable guest additions/tools for the target hypervisor and verify drivers (network, storage) inside the guest; hardware differences may require small post-boot fixes.


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Not all editions of Windows support using Windows Sandbox. Notably, it is only available for `Pro` and `Enterprise` editions, and not available on `Home`. Anyone who wishes to validate their manifests using Windows 11 Home must either test on their host machine, a different machine, or a VM.  

This script generates a virtual hard disk (`.vhdx`) file that is compatible with Hyper-V as a minimal image, similar to what the validation pipelines use. It isn't exactly the same, but the resulting image should have as few pre-installed packages as possible. Hyper-V, similar to Windows Sandbox, is only available for `Pro` and `Enterprise` editions of Windows. However, tools for converting the `.vhdx` format to the formats required by other hypervisors are readily available and well documented, making this image largely available for anyone who wishes to use a VM as a validation environment.

@denelon @stephengillie @mdanish-kh
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/326455)