### PR TITLE
Remove misspelled publisher folder: w1hjk

### DIFF
--- a/manifests/w/w1hjk/fldigi/.validation
+++ b/manifests/w/w1hjk/fldigi/.validation
@@ -1,1 +1,0 @@
-{"ValidationVersion":"1.0.0","Waivers":[{"WaiverId":"12d423c8-0604-40f0-bbfe-814df1859bb5","TestPlan":"Validation-Domain","PackagePath":"manifests/w/w1hjk/fldigi/4.2.09","CommitId":"51b03da580f395193a12cb81297dbdfc58ba8464"}],"InstallationVerification":{"Executables":[]}}


### PR DESCRIPTION
The publisher `w1hjk` is a misspelled entry in the repo I’ve been working on fixing (correct publisher being `w1hkj`).  I have removed everything from it through #326198 and #326190.

This implements the final step of deleting the publisher folder itself.

Closes #326123

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/326522)