### PR TITLE
New package: Hyperpolymath.Bunsenite version 1.0.2

### DIFF
--- a/manifests/h/Hyperpolymath/Bunsenite/1.0.2/Hyperpolymath.Bunsenite.installer.yaml
+++ b/manifests/h/Hyperpolymath/Bunsenite/1.0.2/Hyperpolymath.Bunsenite.installer.yaml
@@ -6,6 +6,9 @@ NestedInstallerType: portable
 NestedInstallerFiles:
   - RelativeFilePath: bunsenite.exe
     PortableCommandAlias: bunsenite
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/hyperpolymath/bunsenite/releases/download/v1.0.2/bunsenite-v1.0.2-x86_64-pc-windows-msvc.zip

--- a/manifests/h/Hyperpolymath/Bunsenite/1.0.2/Hyperpolymath.Bunsenite.installer.yaml
+++ b/manifests/h/Hyperpolymath/Bunsenite/1.0.2/Hyperpolymath.Bunsenite.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Hyperpolymath.Bunsenite
+PackageVersion: 1.0.2
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: bunsenite.exe
+    PortableCommandAlias: bunsenite
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/hyperpolymath/bunsenite/releases/download/v1.0.2/bunsenite-v1.0.2-x86_64-pc-windows-msvc.zip
+    InstallerSha256: 54C62B1EB864500ABE993978122AB53E1B80FF5E8240CAA60F71A60FF1E90009
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/h/Hyperpolymath/Bunsenite/1.0.2/Hyperpolymath.Bunsenite.installer.yaml
+++ b/manifests/h/Hyperpolymath/Bunsenite/1.0.2/Hyperpolymath.Bunsenite.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
 PackageIdentifier: Hyperpolymath.Bunsenite
 PackageVersion: 1.0.2
 InstallerType: zip
@@ -14,4 +14,4 @@ Installers:
     InstallerUrl: https://github.com/hyperpolymath/bunsenite/releases/download/v1.0.2/bunsenite-v1.0.2-x86_64-pc-windows-msvc.zip
     InstallerSha256: 54C62B1EB864500ABE993978122AB53E1B80FF5E8240CAA60F71A60FF1E90009
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.10.0

--- a/manifests/h/Hyperpolymath/Bunsenite/1.0.2/Hyperpolymath.Bunsenite.locale.en-US.yaml
+++ b/manifests/h/Hyperpolymath/Bunsenite/1.0.2/Hyperpolymath.Bunsenite.locale.en-US.yaml
@@ -8,7 +8,7 @@ PublisherSupportUrl: https://github.com/hyperpolymath/bunsenite/issues
 PackageName: Bunsenite
 PackageUrl: https://github.com/hyperpolymath/bunsenite
 License: AGPL-3.0-or-later
-LicenseUrl: https://github.com/hyperpolymath/bunsenite/blob/main/LICENSE
+LicenseUrl: https://github.com/hyperpolymath/bunsenite/blob/main/LICENSE.txt
 ShortDescription: Nickel configuration file parser with multi-language FFI bindings
 Description: |-
   Bunsenite is a Nickel configuration file parser with multi-language FFI bindings.

--- a/manifests/h/Hyperpolymath/Bunsenite/1.0.2/Hyperpolymath.Bunsenite.locale.en-US.yaml
+++ b/manifests/h/Hyperpolymath/Bunsenite/1.0.2/Hyperpolymath.Bunsenite.locale.en-US.yaml
@@ -7,7 +7,7 @@ PublisherUrl: https://github.com/hyperpolymath
 PublisherSupportUrl: https://github.com/hyperpolymath/bunsenite/issues
 PackageName: Bunsenite
 PackageUrl: https://github.com/hyperpolymath/bunsenite
-License: AGPL-3.0-or-later
+License: MIT OR AGPL-3.0-or-later
 LicenseUrl: https://github.com/hyperpolymath/bunsenite/blob/main/LICENSE.txt
 ShortDescription: Nickel configuration file parser with multi-language FFI bindings
 Description: |-

--- a/manifests/h/Hyperpolymath/Bunsenite/1.0.2/Hyperpolymath.Bunsenite.locale.en-US.yaml
+++ b/manifests/h/Hyperpolymath/Bunsenite/1.0.2/Hyperpolymath.Bunsenite.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Hyperpolymath.Bunsenite
+PackageVersion: 1.0.2
+PackageLocale: en-US
+Publisher: Hyperpolymath
+PublisherUrl: https://github.com/hyperpolymath
+PublisherSupportUrl: https://github.com/hyperpolymath/bunsenite/issues
+PackageName: Bunsenite
+PackageUrl: https://github.com/hyperpolymath/bunsenite
+License: AGPL-3.0-or-later
+LicenseUrl: https://github.com/hyperpolymath/bunsenite/blob/main/LICENSE
+ShortDescription: Nickel configuration file parser with multi-language FFI bindings
+Description: |-
+  Bunsenite is a Nickel configuration file parser with multi-language FFI bindings.
+  It provides a Rust core library with a stable C ABI layer that enables bindings
+  for Deno, ReScript, and WebAssembly. Parse and evaluate Nickel configuration files
+  from any language with type-safe, memory-safe bindings.
+Tags:
+  - cli
+  - configuration
+  - ffi
+  - nickel
+  - parser
+  - rust
+ReleaseNotesUrl: https://github.com/hyperpolymath/bunsenite/releases/tag/v1.0.2
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/h/Hyperpolymath/Bunsenite/1.0.2/Hyperpolymath.Bunsenite.locale.en-US.yaml
+++ b/manifests/h/Hyperpolymath/Bunsenite/1.0.2/Hyperpolymath.Bunsenite.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
 PackageIdentifier: Hyperpolymath.Bunsenite
 PackageVersion: 1.0.2
 PackageLocale: en-US
@@ -24,4 +24,4 @@ Tags:
   - rust
 ReleaseNotesUrl: https://github.com/hyperpolymath/bunsenite/releases/tag/v1.0.2
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.10.0

--- a/manifests/h/Hyperpolymath/Bunsenite/1.0.2/Hyperpolymath.Bunsenite.yaml
+++ b/manifests/h/Hyperpolymath/Bunsenite/1.0.2/Hyperpolymath.Bunsenite.yaml
@@ -1,6 +1,6 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
 PackageIdentifier: Hyperpolymath.Bunsenite
 PackageVersion: 1.0.2
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.10.0

--- a/manifests/h/Hyperpolymath/Bunsenite/1.0.2/Hyperpolymath.Bunsenite.yaml
+++ b/manifests/h/Hyperpolymath/Bunsenite/1.0.2/Hyperpolymath.Bunsenite.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Hyperpolymath.Bunsenite
+PackageVersion: 1.0.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Package Information

- Package: Hyperpolymath.Bunsenite
- Version: 1.0.2
- Publisher: hyperpolymath

## Description

Bunsenite is a Nickel configuration file parser with multi-language FFI bindings. It provides a Rust core library with a stable C ABI layer that enables bindings for Deno, ReScript, and WebAssembly.

## Links

- Homepage: https://github.com/hyperpolymath/bunsenite
- Release: https://github.com/hyperpolymath/bunsenite/releases/tag/v1.0.2

## Checklist

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest follow the [Manifest Spec](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/326697)