### PR TITLE
Update: Fix #326930 incorrect installer hash in Dystroy.broot v1.54.0 manifest

### DIFF
--- a/manifests/d/Dystroy/broot/1.54.0/Dystroy.broot.installer.yaml
+++ b/manifests/d/Dystroy/broot/1.54.0/Dystroy.broot.installer.yaml
@@ -11,7 +11,7 @@ ReleaseDate: 2025-12-03
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/Canop/broot/releases/download/v1.54.0/broot_1.54.0.zip
-  InstallerSha256: 48678b4bfcddcdcf0292b317a49a2524942565e22cccf586c1b90a4c17d4c779
-ManifestType: installer
+  InstallerSha256: 48678B4BFCDDCDCF0292B317A49A2524942565E22CCCF586C1B90A4C17D4C779
+  ManifestType: installer
 ManifestVersion: 1.10.0
 

--- a/manifests/d/Dystroy/broot/1.54.0/Dystroy.broot.installer.yaml
+++ b/manifests/d/Dystroy/broot/1.54.0/Dystroy.broot.installer.yaml
@@ -12,5 +12,5 @@ Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/Canop/broot/releases/download/v1.54.0/broot_1.54.0.zip
   InstallerSha256: 48678B4BFCDDCDCF0292B317A49A2524942565E22CCCF586C1B90A4C17D4C779
-  ManifestType: installer
+ManifestType: installer
 ManifestVersion: 1.10.0

--- a/manifests/d/Dystroy/broot/1.54.0/Dystroy.broot.installer.yaml
+++ b/manifests/d/Dystroy/broot/1.54.0/Dystroy.broot.installer.yaml
@@ -14,4 +14,3 @@ Installers:
   InstallerSha256: 48678B4BFCDDCDCF0292B317A49A2524942565E22CCCF586C1B90A4C17D4C779
   ManifestType: installer
 ManifestVersion: 1.10.0
-

--- a/manifests/d/Dystroy/broot/1.54.0/Dystroy.broot.installer.yaml
+++ b/manifests/d/Dystroy/broot/1.54.0/Dystroy.broot.installer.yaml
@@ -11,6 +11,7 @@ ReleaseDate: 2025-12-03
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/Canop/broot/releases/download/v1.54.0/broot_1.54.0.zip
-  InstallerSha256: 059C52F5A17E3A7EDC5B6CDD81F1F007E9198DC20CE26B827C7D1F6595284728
+  InstallerSha256: 48678b4bfcddcdcf0292b317a49a2524942565e22cccf586c1b90a4c17d4c779
 ManifestType: installer
 ManifestVersion: 1.10.0
+


### PR DESCRIPTION
Updated the `InstallerSha256` for the Dystroy.broot package to resolve issue #326930

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Is there a linked Issue? #326930

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/326934)