### PR TITLE
New version: NordicSemiconductor.JLink version 8.10a x64

### DIFF
--- a/manifests/n/NordicSemiconductor/JLink/8.10a/NordicSemiconductor.JLink.installer.yaml
+++ b/manifests/n/NordicSemiconductor/JLink/8.10a/NordicSemiconductor.JLink.installer.yaml
@@ -12,4 +12,4 @@ Installers:
   InstallerUrl: https://files.nordicsemi.com/artifactory/swtools/external/jlink/JLink_Windows_V810a_x86_64.exe
   InstallerSha256: df6731efd4f56a8b70e5779ebfcb016f27da91f8ea8f856b3d7775fcbb4a05c8
 ManifestType: installer
-ManifestVersion: 1.9.0
+ManifestVersion: 1.10.0

--- a/manifests/n/NordicSemiconductor/JLink/8.10a/NordicSemiconductor.JLink.installer.yaml
+++ b/manifests/n/NordicSemiconductor/JLink/8.10a/NordicSemiconductor.JLink.installer.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
 PackageIdentifier: NordicSemiconductor.JLink
 PackageVersion: 8.10a
 InstallerType: nullsoft

--- a/manifests/n/NordicSemiconductor/JLink/8.10a/NordicSemiconductor.JLink.installer.yaml
+++ b/manifests/n/NordicSemiconductor/JLink/8.10a/NordicSemiconductor.JLink.installer.yaml
@@ -1,0 +1,13 @@
+PackageIdentifier: NordicSemiconductor.JLink
+PackageVersion: 8.10a
+InstallerType: nullsoft
+InstallModes:
+- silent
+InstallerSwitches:
+  Silent: -Silent=1 -InstAllUsers=1 -InstUSBDriver=1 -CreateStartMenuEntry=0 -CreateDesktopShortCut=0 -UpdateExisting=0 -StartDLLUpdater=0
+Installers:
+- Architecture: x64
+  InstallerUrl: https://files.nordicsemi.com/artifactory/swtools/external/jlink/JLink_Windows_V810a_x86_64.exe
+  InstallerSha256: df6731efd4f56a8b70e5779ebfcb016f27da91f8ea8f856b3d7775fcbb4a05c8
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/n/NordicSemiconductor/JLink/8.10a/NordicSemiconductor.JLink.installer.yaml
+++ b/manifests/n/NordicSemiconductor/JLink/8.10a/NordicSemiconductor.JLink.installer.yaml
@@ -5,6 +5,7 @@ PackageVersion: 8.10a
 InstallerType: nullsoft
 InstallModes:
 - silent
+ElevationRequirement: elevationRequired
 InstallerSwitches:
   Silent: -Silent=1 -InstAllUsers=1 -InstUSBDriver=1 -CreateStartMenuEntry=0 -CreateDesktopShortCut=0 -UpdateExisting=0 -StartDLLUpdater=0
 Installers:

--- a/manifests/n/NordicSemiconductor/JLink/8.10a/NordicSemiconductor.JLink.locale.en-US.yaml
+++ b/manifests/n/NordicSemiconductor/JLink/8.10a/NordicSemiconductor.JLink.locale.en-US.yaml
@@ -9,4 +9,4 @@ License: SEGGER Microcontroller GmbH proprietary
 Copyright: SEGGER Microcontroller GmbH
 ShortDescription: J-Link software and documentation pack setup
 ManifestType: defaultLocale
-ManifestVersion: 1.9.0
+ManifestVersion: 1.10.0

--- a/manifests/n/NordicSemiconductor/JLink/8.10a/NordicSemiconductor.JLink.locale.en-US.yaml
+++ b/manifests/n/NordicSemiconductor/JLink/8.10a/NordicSemiconductor.JLink.locale.en-US.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
 PackageIdentifier: NordicSemiconductor.JLink
 PackageVersion: 8.10a
 PackageLocale: en-US

--- a/manifests/n/NordicSemiconductor/JLink/8.10a/NordicSemiconductor.JLink.locale.en-US.yaml
+++ b/manifests/n/NordicSemiconductor/JLink/8.10a/NordicSemiconductor.JLink.locale.en-US.yaml
@@ -1,0 +1,10 @@
+PackageIdentifier: NordicSemiconductor.JLink
+PackageVersion: 8.10a
+PackageLocale: en-US
+Publisher: Nordic Semiconductor ASA
+PackageName: J-Link
+License: SEGGER Microcontroller GmbH proprietary
+Copyright: SEGGER Microcontroller GmbH
+ShortDescription: J-Link software and documentation pack setup
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/n/NordicSemiconductor/JLink/8.10a/NordicSemiconductor.JLink.yaml
+++ b/manifests/n/NordicSemiconductor/JLink/8.10a/NordicSemiconductor.JLink.yaml
@@ -4,4 +4,4 @@ PackageIdentifier: NordicSemiconductor.JLink
 PackageVersion: 8.10a
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.9.0
+ManifestVersion: 1.10.0

--- a/manifests/n/NordicSemiconductor/JLink/8.10a/NordicSemiconductor.JLink.yaml
+++ b/manifests/n/NordicSemiconductor/JLink/8.10a/NordicSemiconductor.JLink.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: NordicSemiconductor.JLink
+PackageVersion: 8.10a
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0

--- a/manifests/n/NordicSemiconductor/JLink/8.10a/NordicSemiconductor.JLink.yaml
+++ b/manifests/n/NordicSemiconductor/JLink/8.10a/NordicSemiconductor.JLink.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
 PackageIdentifier: NordicSemiconductor.JLink
 PackageVersion: 8.10a
 DefaultLocale: en-US


### PR DESCRIPTION
Automated submission of manifest files of version 8.10a x64 of Segger JLink software on behalf of Nordic Semiconductor
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/326940)