### PR TITLE
New package: RichardFairthorne.pairqr version 0.1.11

### DIFF
--- a/manifests/r/RichardFairthorne/pairqr/0.1.11/RichardFairthorne.pairqr.installer.yaml
+++ b/manifests/r/RichardFairthorne/pairqr/0.1.11/RichardFairthorne.pairqr.installer.yaml
@@ -1,0 +1,16 @@
+PackageIdentifier: RichardFairthorne.pairqr
+PackageVersion: 0.1.11
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: pairqr.exe
+  PortableCommandAlias: pairqr
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/richard-fairthorne/pairqr/releases/download/v0.1.11/pairqr-windows-x64.zip
+  InstallerSha256: 4BACCB6BEE824C158BD945C08DCF044A5001FEAC969B69F007EC7568D9B1E57D
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/r/RichardFairthorne/pairqr/0.1.11/RichardFairthorne.pairqr.locale.en-US.yaml
+++ b/manifests/r/RichardFairthorne/pairqr/0.1.11/RichardFairthorne.pairqr.locale.en-US.yaml
@@ -1,0 +1,18 @@
+PackageIdentifier: RichardFairthorne.pairqr
+PackageVersion: 0.1.11
+PackageLocale: en-US
+Publisher: Richard Fairthorne
+PackageName: pairqr
+PackageUrl: https://github.com/richard-fairthorne/pairqr
+License: GPL-3.0
+LicenseUrl: https://github.com/richard-fairthorne/pairqr/blob/main/LICENSE
+ShortDescription: Pair Android devices for wireless ADB debugging by scanning a QR code
+Description: A command-line tool to pair Android devices for wireless ADB debugging by scanning a QR code, just like Android Studio.
+Tags:
+- adb
+- android
+- debugging
+- qrcode
+- wireless
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/r/RichardFairthorne/pairqr/0.1.11/RichardFairthorne.pairqr.yaml
+++ b/manifests/r/RichardFairthorne/pairqr/0.1.11/RichardFairthorne.pairqr.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: RichardFairthorne.pairqr
+PackageVersion: 0.1.11
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New Package Submission

**Package Name:** pairqr
**Version:** 0.1.11
**Publisher:** Richard Fairthorne

### Description
A command-line tool to pair Android devices for wireless ADB debugging by scanning a QR code, just like Android Studio.

### Homepage
https://github.com/richard-fairthorne/pairqr

### License
GPL-3.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/326962)