### PR TITLE
New package: apotenza92.FacebookMessengerDesktop version 0.3.1

### DIFF
--- a/manifests/a/apotenza92/FacebookMessengerDesktop/0.3.1/apotenza92.FacebookMessengerDesktop.installer.yaml
+++ b/manifests/a/apotenza92/FacebookMessengerDesktop/0.3.1/apotenza92.FacebookMessengerDesktop.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: apotenza92.FacebookMessengerDesktop
+PackageVersion: 0.3.1
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/apotenza92/facebook-messenger-desktop/releases/download/v0.3.1/Messenger-windows-setup.exe
+    InstallerSha256: 0B13366DD21C46FD1B5EE550009ABF5741C8015A4E891DD927656471C1EBBB50
+ManifestType: installer
+ManifestVersion: 1.6.0
+

--- a/manifests/a/apotenza92/FacebookMessengerDesktop/0.3.1/apotenza92.FacebookMessengerDesktop.locale.en-US.yaml
+++ b/manifests/a/apotenza92/FacebookMessengerDesktop/0.3.1/apotenza92.FacebookMessengerDesktop.locale.en-US.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: apotenza92.FacebookMessengerDesktop
+PackageVersion: 0.3.1
+PackageLocale: en-US
+Publisher: Alex Potenza
+PackageName: Facebook Messenger Desktop
+License: MIT
+ShortDescription: A self-contained desktop app for Facebook Messenger
+Description: A self-contained desktop application for Facebook Messenger, built with Electron. Wraps messenger.com with native platform notifications and badge counts.
+PackageUrl: https://github.com/apotenza92/facebook-messenger-desktop
+LicenseUrl: https://github.com/apotenza92/facebook-messenger-desktop/blob/main/LICENSE
+ReleaseNotesUrl: https://github.com/apotenza92/facebook-messenger-desktop/releases/tag/v0.3.1
+Tags:
+  - chat
+  - electron
+  - facebook
+  - messenger
+  - social
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0
+

--- a/manifests/a/apotenza92/FacebookMessengerDesktop/0.3.1/apotenza92.FacebookMessengerDesktop.yaml
+++ b/manifests/a/apotenza92/FacebookMessengerDesktop/0.3.1/apotenza92.FacebookMessengerDesktop.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: apotenza92.FacebookMessengerDesktop
+PackageVersion: 0.3.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0
+


### PR DESCRIPTION
### New Package Submission

**Package Identifier:** apotenza92.FacebookMessengerDesktop
**Package Version:** 0.3.1

#### Description
A self-contained desktop application for Facebook Messenger, built with Electron. Wraps messenger.com with native platform notifications and badge counts.

#### Checklist
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one manifest
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest)?

#### Links
- Homepage: https://github.com/apotenza92/facebook-messenger-desktop
- Installer: https://github.com/apotenza92/facebook-messenger-desktop/releases/download/v0.3.1/Messenger-windows-setup.exe
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/327225)