### PR TITLE
max-sixty.worktrunk: Add git-wt.exe binary

### DIFF
--- a/manifests/m/max-sixty/worktrunk/v0.8.3/max-sixty.worktrunk.installer.yaml
+++ b/manifests/m/max-sixty/worktrunk/v0.8.3/max-sixty.worktrunk.installer.yaml
@@ -8,6 +8,8 @@ NestedInstallerType: portable
 NestedInstallerFiles:
 - RelativeFilePath: wt.exe
   PortableCommandAlias: wt
+- RelativeFilePath: git-wt.exe
+  PortableCommandAlias: git-wt
 ReleaseDate: 2025-12-31
 Installers:
 - Architecture: x64


### PR DESCRIPTION
## Summary

Add the `git-wt.exe` binary to the worktrunk installer manifest. This binary is already included in the release zip but wasn't being extracted.

## Why git-wt?

On Windows, `wt` is the command to launch Windows Terminal, which conflicts with the worktrunk `wt` command. The `git-wt` binary allows Windows users to run worktrunk as a git subcommand:

```
git wt switch feature    # instead of wt switch feature
git wt list              # instead of wt list
```

This provides a conflict-free way to use worktrunk on Windows systems where Windows Terminal is installed.

See: https://github.com/max-sixty/worktrunk/issues/133

> _This was written by Claude Code on behalf of max-sixty_
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/327395)