### PR TITLE
New version: NordicSemiconductor.JLink version 8.10b x64

### DIFF
--- a/manifests/n/NordicSemiconductor/JLink/8.10b/NordicSemiconductor.JLink.installer.yaml
+++ b/manifests/n/NordicSemiconductor/JLink/8.10b/NordicSemiconductor.JLink.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: NordicSemiconductor.JLink
+PackageVersion: 8.10b
+InstallerType: nullsoft
+InstallModes:
+- silent
+ElevationRequirement: elevationRequired
+InstallerSwitches:
+  Silent: -Silent=1 -InstAllUsers=1 -InstUSBDriver=1 -CreateStartMenuEntry=0 -CreateDesktopShortCut=0 -UpdateExisting=0 -StartDLLUpdater=0
+Installers:
+- Architecture: x64
+  InstallerUrl: https://files.nordicsemi.com/artifactory/swtools/external/jlink/JLink_Windows_V810b_x86_64.exe
+  InstallerSha256: 051e992a91e052ade3ba0e1251aae79f4d07c9e2d115050d544dce4be9593f51
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/n/NordicSemiconductor/JLink/8.10b/NordicSemiconductor.JLink.locale.en-US.yaml
+++ b/manifests/n/NordicSemiconductor/JLink/8.10b/NordicSemiconductor.JLink.locale.en-US.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: NordicSemiconductor.JLink
+PackageVersion: 8.10b
+PackageLocale: en-US
+Publisher: Nordic Semiconductor ASA
+PackageName: J-Link
+License: SEGGER Microcontroller GmbH proprietary
+Copyright: SEGGER Microcontroller GmbH
+ShortDescription: J-Link software and documentation pack setup
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/n/NordicSemiconductor/JLink/8.10b/NordicSemiconductor.JLink.yaml
+++ b/manifests/n/NordicSemiconductor/JLink/8.10b/NordicSemiconductor.JLink.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: NordicSemiconductor.JLink
+PackageVersion: 8.10b
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Automated submission of manifest files of version 8.10b x64 of Segger JLink software on behalf of Nordic Semiconductor
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/327460)