### PR TITLE
New version: CXWorld.CapFrameX.Beta version 1.7.7.15

### DIFF
--- a/manifests/c/CXWorld/CapFrameX/Beta/1.7.7.15/CXWorld.CapFrameX.Beta.installer.yaml
+++ b/manifests/c/CXWorld/CapFrameX/Beta/1.7.7.15/CXWorld.CapFrameX.Beta.installer.yaml
@@ -1,0 +1,33 @@
+# Created with komac v2.14.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: CXWorld.CapFrameX.Beta
+PackageVersion: 1.7.7.15
+UpgradeBehavior: install
+ReleaseDate: 2025-08-07
+Installers:
+- Architecture: x64
+  InstallerType: zip
+  InstallerUrl: https://github.com/CXWorld/CapFrameX/releases/download/v1.7.7beta/beta_1.7.7_installer.zip
+  InstallerSha256: 69A0F875F967ECD24EFD335D4D83BE6C6B8156B40CC0D2C46D46934A89E4D967
+  NestedInstallerType: burn
+  NestedInstallerFiles:
+  - RelativeFilePath: CapFrameXBootstrapper.exe
+  AppsAndFeaturesEntries:
+  - DisplayName: CapFrameX Capture and Analysis Tool
+    Publisher: DevTechProfile
+    ProductCode: '{4b647ea4-79d5-48b4-b7f2-1ab9014a898e}'
+    UpgradeCode: '{D124F3FF-D15F-4B43-BD0D-CD631DD931DA}'
+    InstallerType: burn
+- Architecture: neutral
+  InstallerType: zip
+  InstallerUrl: https://github.com/CXWorld/CapFrameX/releases/download/v1.7.7beta/beta_1.7.7_portable.zip
+  InstallerSha256: B9D33724910B46880D7C6DAEAD7BB968BA0FBBAC8A7A1B71A3ACBA8F2E6F298A
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: CapFrameX.exe
+    PortableCommandAlias: CapFrameX.exe
+  ArchiveBinariesDependOnPath: true
+ManifestType: installer
+ManifestVersion: 1.10.0
+

--- a/manifests/c/CXWorld/CapFrameX/Beta/1.7.7.15/CXWorld.CapFrameX.Beta.installer.yaml
+++ b/manifests/c/CXWorld/CapFrameX/Beta/1.7.7.15/CXWorld.CapFrameX.Beta.installer.yaml
@@ -4,7 +4,7 @@
 PackageIdentifier: CXWorld.CapFrameX.Beta
 PackageVersion: 1.7.7.15
 UpgradeBehavior: install
-ReleaseDate: 2025-08-07
+ReleaseDate: 2026-01-01
 Installers:
 - Architecture: x64
   InstallerType: zip

--- a/manifests/c/CXWorld/CapFrameX/Beta/1.7.7.15/CXWorld.CapFrameX.Beta.locale.en-US.yaml
+++ b/manifests/c/CXWorld/CapFrameX/Beta/1.7.7.15/CXWorld.CapFrameX.Beta.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# Created with komac v2.14.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: CXWorld.CapFrameX.Beta
+PackageVersion: 1.7.7.15
+PackageLocale: en-US
+Publisher: CXWorld
+PublisherUrl: https://www.capframex.com/
+PublisherSupportUrl: https://www.capframex.com/support
+Author: CapFrameX Team
+PackageName: CapFrameX Beta
+PackageUrl: https://github.com/CXWorld/CapFrameX
+License: MIT
+LicenseUrl: https://github.com/CXWorld/CapFrameX/blob/HEAD/LICENSE
+ShortDescription: Frametime capture and analysis tool
+Description: Frametimes capture and analysis tool based on Intel's PresentMon. Overlay provided by Rivatuner Statistics Server.
+Moniker: capframex-beta
+Tags:
+- analysis-tool
+- benchmark
+- benchmarking
+- fps
+- frametime
+- rivatuner
+ReleaseNotesUrl: https://github.com/CXWorld/CapFrameX/releases/tag/v1.7.7beta
+InstallationNotes: If you are using a network drive as your capture directory and having problems connecting to it on autostart, you might want to download this additional zip file (https://cxblobs.blob.core.windows.net/releases/Autostart%20using%20network%20drives.zip) too and read the info inside it.
+Documentations:
+- DocumentLabel: README for CapFrameX
+  DocumentUrl: https://github.com/CXWorld/CapFrameX/blob/master/README.md
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/c/CXWorld/CapFrameX/Beta/1.7.7.15/CXWorld.CapFrameX.Beta.yaml
+++ b/manifests/c/CXWorld/CapFrameX/Beta/1.7.7.15/CXWorld.CapFrameX.Beta.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.14.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: CXWorld.CapFrameX.Beta
+PackageVersion: 1.7.7.15
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
This combines the portable and burn installer suggested in https://github.com/microsoft/winget-pkgs/pull/326515#pullrequestreview-3614475987
Replaces https://github.com/microsoft/winget-pkgs/tree/master/manifests/c/CXWorld/CapFrameX/Beta/1.7.7
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/327533)