### PR TITLE
New package: loonghao.msvc-kit version 0.2.2

### DIFF
--- a/manifests/l/loonghao/msvc-kit/0.2.2/loonghao.msvc-kit.installer.yaml
+++ b/manifests/l/loonghao/msvc-kit/0.2.2/loonghao.msvc-kit.installer.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: loonghao.msvc-kit
+PackageVersion: 0.2.2
+InstallerType: portable
+Commands:
+- msvc-kit
+UpgradeBehavior: uninstallPrevious
+ReleaseDate: 2026-01-05
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/loonghao/msvc-kit/releases/download/v0.2.2/msvc-kit-0.2.2-x86_64-windows.exe
+  InstallerSha256: 1445A1B7262F695DAFA9A8ABCC04BDE185B8C4EE3E02DE09243CF22EF41CD61B
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+- Architecture: x86
+  InstallerUrl: https://github.com/loonghao/msvc-kit/releases/download/v0.2.2/msvc-kit-0.2.2-i686-windows.exe
+  InstallerSha256: 25B8E7D78A3227645C2A393BB2BC73B26B08C7BFDB2D321708F4C66560CF0492
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x86
+- Architecture: arm64
+  InstallerUrl: https://github.com/loonghao/msvc-kit/releases/download/v0.2.2/msvc-kit-0.2.2-aarch64-windows.exe
+  InstallerSha256: 95F6BC3988AB9139507A8A4F0A4D601C0F84F2A7D6441197433D28341D683716
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.arm64
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/l/loonghao/msvc-kit/0.2.2/loonghao.msvc-kit.locale.en-US.yaml
+++ b/manifests/l/loonghao/msvc-kit/0.2.2/loonghao.msvc-kit.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: loonghao.msvc-kit
+PackageVersion: 0.2.2
+PackageLocale: en-US
+Publisher: loonghao
+PublisherUrl: https://github.com/loonghao
+PublisherSupportUrl: https://github.com/loonghao/msvc-kit/issues
+PackageName: msvc-kit
+PackageUrl: https://github.com/loonghao/msvc-kit
+License: MIT
+LicenseUrl: https://github.com/loonghao/msvc-kit/blob/main/LICENSE
+ShortDescription: A portable MSVC Build Tools installer and manager for Rust development
+Description: msvc-kit is a portable MSVC Build Tools installer and manager for Rust/Windows development. Download and manage MSVC compiler and Windows SDK without full Visual Studio installation.
+Tags:
+- cli
+- msvc
+- rust
+- windows-sdk
+- build-tools
+- compiler
+- development
+ReleaseNotesUrl: https://github.com/loonghao/msvc-kit/releases/tag/v0.2.2
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/l/loonghao/msvc-kit/0.2.2/loonghao.msvc-kit.yaml
+++ b/manifests/l/loonghao/msvc-kit/0.2.2/loonghao.msvc-kit.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: loonghao.msvc-kit
+PackageVersion: 0.2.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
### New Package Submission

- Package Identifier: loonghao.msvc-kit
- Package Version: 0.2.2
- Package URL: https://github.com/loonghao/msvc-kit
- Release: https://github.com/loonghao/msvc-kit/releases/tag/v0.2.2

### Description

msvc-kit is a portable MSVC Build Tools installer and manager for Rust/Windows development. Download and manage MSVC compiler and Windows SDK without installing full Visual Studio.

### Notes

- Updated to v0.2.2 which includes the fix for running without arguments (winget validation executes the binary directly).
- Added per-architecture VC++ runtime dependencies (x64/x86/arm64).

### Checklist

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one manifest
- [x] Have you validated your manifest locally with `winget validate`?
- [x] Have you tested your manifest locally with `winget install`?
