### PR TITLE
Fix output of CheckDisplayVersions.ps1

### DIFF
--- a/Tools/CheckDisplayVersions.ps1
+++ b/Tools/CheckDisplayVersions.ps1
@@ -117,7 +117,6 @@ Write-Verbose "Found $($versionsWithOverlap.count) DisplayVersions with multiple
 
 if ($versionsWithOverlap.Count -gt 0) {
     $versionsWithOverlap | Format-Table -Wrap
-    exit 1
 }
 
 class UnmetDependencyException : Exception {

--- a/Tools/CheckDisplayVersions.ps1
+++ b/Tools/CheckDisplayVersions.ps1
@@ -113,11 +113,10 @@ $versionsWithOverlap = $allPackages | ForEach-Object {
     }
 }
 $versionsWithOverlap = $versionsWithOverlap.Where({ $_ })
-Write-Verbose "Found $($versionsWithOverlap.count) monikers with multiple packages"
-
+Write-Verbose "Found $($versionsWithOverlap.count) DisplayVersions with multiple packages"
 
 if ($versionsWithOverlap.Count -gt 0) {
-    Write-Output $versionsWithOverlap
+    Write-Output $versionsWithOverlap | Format-Table -Wrap
     exit 1
 }
 

--- a/Tools/CheckDisplayVersions.ps1
+++ b/Tools/CheckDisplayVersions.ps1
@@ -116,7 +116,7 @@ $versionsWithOverlap = $versionsWithOverlap.Where({ $_ })
 Write-Verbose "Found $($versionsWithOverlap.count) DisplayVersions with multiple packages"
 
 if ($versionsWithOverlap.Count -gt 0) {
-    Write-Output $versionsWithOverlap | Format-Table -Wrap
+    $versionsWithOverlap | Format-Table -Wrap
     exit 1
 }
 


### PR DESCRIPTION
I was just try to use some of the scripts in the Tools folder, I found out that `CheckDisplayVersions.ps1` weirdly didn't output anything:
<img width="400" alt="Screenshot 2026-01-05 082606" src="https://github.com/user-attachments/assets/b9c9e624-cf16-4fcb-b782-dc0d22a74942" />

Despite there is a value in that variable visible only on `Write-Host`:
<img width="400" alt="Screenshot 2026-01-05 084706" src="https://github.com/user-attachments/assets/22aa8059-6516-46ee-9107-3156b25bd26d" />

So, I add `Format-Table` to output as table like it supposed to be:
<img width="400" alt="Screenshot 2026-01-05 091506" src="https://github.com/user-attachments/assets/beaca286-d902-42b3-b6d4-e8b3f626ed1d" />

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/327815)