### PR TITLE
Update SystemInformer InstallerUrl to point to the correct release.

### DIFF
--- a/manifests/w/WinsiderSS/SystemInformer/3.2.25011.2103/WinsiderSS.SystemInformer.installer.yaml
+++ b/manifests/w/WinsiderSS/SystemInformer/3.2.25011.2103/WinsiderSS.SystemInformer.installer.yaml
@@ -18,8 +18,9 @@ ProductCode: SystemInformer
 ElevationRequirement: elevatesSelf
 Installers:
 - Architecture: neutral
-  InstallerUrl: https://github.com/winsiderss/si-builds/releases/download/3.2.25011/systeminformer-3.2.25011-release-setup.exe
+  InstallerUrl: https://github.com/winsiderss/systeminformer/releases/download/v3.2.25011.2103/systeminformer-3.2.25011-release-setup.exe
   InstallerSha256: 7612D5E44A5A392AB9F0D1B5B8A79BDA3CDBE19848E8EE9EC23909AAF3DAAD45
 ManifestType: installer
 ManifestVersion: 1.9.0
 ReleaseDate: 2025-01-11
+

--- a/manifests/w/WinsiderSS/SystemInformer/3.2.25011.2103/WinsiderSS.SystemInformer.locale.en-US.yaml
+++ b/manifests/w/WinsiderSS/SystemInformer/3.2.25011.2103/WinsiderSS.SystemInformer.locale.en-US.yaml
@@ -32,6 +32,7 @@ Tags:
 - monitor-performance
 - performance-monitoring
 - system-monitor
-ReleaseNotesUrl: https://github.com/winsiderss/si-builds/releases/tag/3.2.25011
+ReleaseNotesUrl: https://github.com/winsiderss/systeminformer/releases/tag/v3.2.25011.2103
 ManifestType: defaultLocale
 ManifestVersion: 1.9.0
+


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

This PR fixes the `ReleaseNotesUrl` and `InstallerUrl` for the winget manifest used to install the stable release of System Informer:

1) The current ReleaseNotesUrl points to a blank page. This PR updates the ReleaseNotesUrl link the actual release notes.
2) The current InstallerUrl points to an unofficial alpha repository: https://github.com/winsiderss/si-builds
3) This PR updates the InstallerUrl to the official repo: https://github.com/winsiderss/systeminformer - The readme of the repository contains the same information. 

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/327837)