### PR TITLE
Fix InstallerUrl for Amazon.AWSCLI-2.32.29

### DIFF
--- a/manifests/a/Amazon/AWSCLI/2.32.29/Amazon.AWSCLI.installer.yaml
+++ b/manifests/a/Amazon/AWSCLI/2.32.29/Amazon.AWSCLI.installer.yaml
@@ -25,7 +25,8 @@ InstallationMetadata:
   DefaultInstallLocation: '%ProgramFiles%\Amazon\AWSCLIV2'
 Installers:
 - Architecture: x64
-  InstallerUrl: https://awscli.amazonaws.com/AWSCLIV2.msi
+  InstallerUrl: https://awscli.amazonaws.com/AWSCLIV2-2.32.29.msi
   InstallerSha256: 6A8D85711124ADA4813470061A6A468A16BA9C4B4236DEB292188E3C76F10C0B
 ManifestType: installer
 ManifestVersion: 1.10.0
+


### PR DESCRIPTION
The non-versioned InstallerUrl will not work here, see [this comment](https://github.com/microsoft/winget-pkgs/pull/328156/changes#r2666580976).  Previous winget versions have the AWSCLI version included in the URL, this one does not.

I don't know how to make the bot not do this when the next version is populated in winget.

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/328387)