### PR TITLE
Microsoft.Teams: Remove user scope enforcement as MSIX packages can be provisioned for all users by use of the machine scope

### DIFF
--- a/manifests/m/Microsoft/Teams/25332.1210.4188.1171/Microsoft.Teams.installer.yaml
+++ b/manifests/m/Microsoft/Teams/25332.1210.4188.1171/Microsoft.Teams.installer.yaml
@@ -7,7 +7,6 @@ Platform:
 - Windows.Desktop
 MinimumOSVersion: 10.0.17763.0
 InstallerType: msix
-Scope: user
 UpgradeBehavior: install
 PackageFamilyName: MSTeams_8wekyb3d8bbwe
 Installers:


### PR DESCRIPTION
Fixes #328507.

cc @SpecterShell, as you made the last version updates for Microsoft.Teams and I have no idea where the Dumplings automation pulls its scope from (apparently the installer manifest for the previous version?)

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/328508)