### PR TITLE
Fix InstallerSha256 values in Bruno installer

### DIFF
--- a/manifests/b/Bruno/Bruno/3.0.2/Bruno.Bruno.installer.yaml
+++ b/manifests/b/Bruno/Bruno/3.0.2/Bruno.Bruno.installer.yaml
@@ -14,14 +14,14 @@ Installers:
   NestedInstallerFiles:
   - RelativeFilePath: Bruno.exe
   InstallerUrl: https://github.com/usebruno/bruno/releases/download/v3.0.2/bruno_3.0.2_x64_win.zip
-  InstallerSha256: EA1F59C004A8EA3AD14783AD97C27330126FBC2FB40AC7F3C6F2295DFCEF82B2
+  InstallerSha256: bb1e3c609cb6855fb40b9dc1b8ee5446677ad6e9b02bcdcc15de09370dd544e7
   ArchiveBinariesDependOnPath: true
 - InstallerLocale: en-US
   Architecture: x64
   InstallerType: nullsoft
   Scope: user
   InstallerUrl: https://github.com/usebruno/bruno/releases/download/v3.0.2/bruno_3.0.2_x64_win.exe
-  InstallerSha256: 28181E7C763D01643732DD4DE2387F9D36FD79E3F3906B43A2B554C4770A5E0C
+  InstallerSha256: 9520156b5d187b8ba896ec9b4a5153cc912be26f18efce898518a852899af246
   UpgradeBehavior: install
   ProductCode: 35fe443c-39df-5cca-9e6d-73ca33a1ce77
   AppsAndFeaturesEntries:
@@ -29,3 +29,4 @@ Installers:
     ProductCode: 35fe443c-39df-5cca-9e6d-73ca33a1ce77
 ManifestType: installer
 ManifestVersion: 1.10.0
+


### PR DESCRIPTION
Updated InstallerSha256 values for zip and exe installers.

Checklist for Pull Requests
- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?  If so, fill in the Issue number below.
   <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

Manifests
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/328629)