### PR TITLE
Add Discrakt v3.4.0 manifest

### DIFF
--- a/manifests/a/afonsojramos/discrakt/3.4.0/afonsojramos.discrakt.installer.yaml
+++ b/manifests/a/afonsojramos/discrakt/3.4.0/afonsojramos.discrakt.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: afonsojramos.discrakt
+PackageVersion: 3.4.0
+MinimumOSVersion: 10.0.0.0
+InstallerType: msi
+Scope: user
+InstallModes:
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/afonsojramos/discrakt/releases/download/v3.4.0/Discrakt_3.4.0_win64.msi
+    InstallerSha256: 4ABAFD3ABA70F7492CB40CBF941BC02F945361806C62BE8951D082E93F500FCC
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/a/afonsojramos/discrakt/3.4.0/afonsojramos.discrakt.locale.en-US.yaml
+++ b/manifests/a/afonsojramos/discrakt/3.4.0/afonsojramos.discrakt.locale.en-US.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: afonsojramos.discrakt
+PackageVersion: 3.4.0
+PackageLocale: en-US
+Publisher: afonsojramos
+PublisherUrl: https://github.com/afonsojramos
+PackageName: Discrakt
+PackageUrl: https://github.com/afonsojramos/discrakt
+License: MIT
+LicenseUrl: https://github.com/afonsojramos/discrakt/blob/main/LICENSE
+ShortDescription: Trakt to Discord Rich Presence
+Description: Discrakt bridges your Trakt.tv watching status to Discord Rich Presence. It runs silently in your system tray and automatically updates your Discord status when watching movies or TV shows tracked by Trakt.tv.
+Tags:
+  - discord
+  - trakt
+  - rich-presence
+  - plex
+  - media
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/a/afonsojramos/discrakt/3.4.0/afonsojramos.discrakt.yaml
+++ b/manifests/a/afonsojramos/discrakt/3.4.0/afonsojramos.discrakt.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: afonsojramos.discrakt
+PackageVersion: 3.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Adds Windows Package Manager manifest for Discrakt, a Trakt.tv to Discord Rich Presence bridge.
Package Details

     Identifier: afonsojramos.discrakt
     Version: 3.4.0
     Installer: MSI (x64, user scope)
     License: MIT

Files Added

     manifests/a/afonsojramos/discrakt/3.4.0/afonsojramos.discrakt.yaml
     manifests/a/afonsojramos/discrakt/3.4.0/afonsojramos.discrakt.installer.yaml
     manifests/a/afonsojramos/discrakt/3.4.0/afonsojramos.discrakt.locale.en-US.yaml

    
---
    
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue? No

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/328977)