### PR TITLE
New package: M-Igashi.mp3rgain version 1.1.0

### DIFF
--- a/manifests/m/M-Igashi/mp3rgain/1.1.0/M-Igashi.mp3rgain.installer.yaml
+++ b/manifests/m/M-Igashi/mp3rgain/1.1.0/M-Igashi.mp3rgain.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgain
+PackageVersion: 1.1.0
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: mp3rgain.exe
+    PortableCommandAlias: mp3rgain
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/M-Igashi/mp3rgain/releases/download/v1.1.0/mp3rgain-v1.1.0-windows-x86_64.zip
+    InstallerSha256: 50018229ACEF9EA9FD388B46EDEEF94D3F9D7889F2A021167DC241810C235D1E
+  - Architecture: arm64
+    InstallerUrl: https://github.com/M-Igashi/mp3rgain/releases/download/v1.1.0/mp3rgain-v1.1.0-windows-arm64.zip
+    InstallerSha256: D56C1A27BDF4CF376014F33EC4ED7082282FACF1D0C52706DBD3A8527CB3AB00
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/M-Igashi/mp3rgain/1.1.0/M-Igashi.mp3rgain.installer.yaml
+++ b/manifests/m/M-Igashi/mp3rgain/1.1.0/M-Igashi.mp3rgain.installer.yaml
@@ -1,21 +1,25 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: M-Igashi.mp3rgain
 PackageVersion: 1.1.0
-Platform:
-  - Windows.Desktop
-MinimumOSVersion: 10.0.0.0
+InstallerLocale: en-US
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
-  - RelativeFilePath: mp3rgain.exe
-    PortableCommandAlias: mp3rgain
+- RelativeFilePath: mp3rgain.exe
+ReleaseDate: 2025-01-09
 Installers:
-  - Architecture: x64
-    InstallerUrl: https://github.com/M-Igashi/mp3rgain/releases/download/v1.1.0/mp3rgain-v1.1.0-windows-x86_64.zip
-    InstallerSha256: 50018229ACEF9EA9FD388B46EDEEF94D3F9D7889F2A021167DC241810C235D1E
-  - Architecture: arm64
-    InstallerUrl: https://github.com/M-Igashi/mp3rgain/releases/download/v1.1.0/mp3rgain-v1.1.0-windows-arm64.zip
-    InstallerSha256: D56C1A27BDF4CF376014F33EC4ED7082282FACF1D0C52706DBD3A8527CB3AB00
+- Architecture: x64
+  InstallerUrl: https://github.com/M-Igashi/mp3rgain/releases/download/v1.1.0/mp3rgain-v1.1.0-windows-x86_64.zip
+  InstallerSha256: 50018229ACEF9EA9FD388B46EDEEF94D3F9D7889F2A021167DC241810C235D1E
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+- Architecture: arm64
+  InstallerUrl: https://github.com/M-Igashi/mp3rgain/releases/download/v1.1.0/mp3rgain-v1.1.0-windows-arm64.zip
+  InstallerSha256: D56C1A27BDF4CF376014F33EC4ED7082282FACF1D0C52706DBD3A8527CB3AB00
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.arm64
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/mp3rgain/1.1.0/M-Igashi.mp3rgain.locale.en-US.yaml
+++ b/manifests/m/M-Igashi/mp3rgain/1.1.0/M-Igashi.mp3rgain.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: M-Igashi.mp3rgain
 PackageVersion: 1.1.0
@@ -17,15 +17,15 @@ Description: |-
   Features include ReplayGain analysis, AAC/M4A support, and full mp3gain command-line compatibility.
 Moniker: mp3rgain
 Tags:
-  - audio
-  - cli
-  - gain
-  - lossless
-  - mp3
-  - music
-  - replaygain
-  - rust
-  - volume
+- audio
+- cli
+- gain
+- lossless
+- mp3
+- music
+- replaygain
+- rust
+- volume
 ReleaseNotesUrl: https://github.com/M-Igashi/mp3rgain/releases/tag/v1.1.0
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/mp3rgain/1.1.0/M-Igashi.mp3rgain.locale.en-US.yaml
+++ b/manifests/m/M-Igashi/mp3rgain/1.1.0/M-Igashi.mp3rgain.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgain
+PackageVersion: 1.1.0
+PackageLocale: en-US
+Publisher: Masanari Higashi
+PublisherUrl: https://github.com/M-Igashi
+Author: Masanari Higashi
+PackageName: mp3rgain
+PackageUrl: https://github.com/M-Igashi/mp3rgain
+License: MIT
+LicenseUrl: https://github.com/M-Igashi/mp3rgain/blob/master/LICENSE
+ShortDescription: Lossless MP3 volume adjustment - a modern mp3gain replacement written in Rust
+Description: |-
+  mp3rgain adjusts MP3 volume without re-encoding by modifying the global_gain field in each frame's side information.
+  This preserves audio quality while achieving permanent volume changes.
+  Features include ReplayGain analysis, AAC/M4A support, and full mp3gain command-line compatibility.
+Moniker: mp3rgain
+Tags:
+  - audio
+  - cli
+  - gain
+  - lossless
+  - mp3
+  - music
+  - replaygain
+  - rust
+  - volume
+ReleaseNotesUrl: https://github.com/M-Igashi/mp3rgain/releases/tag/v1.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/M-Igashi/mp3rgain/1.1.0/M-Igashi.mp3rgain.yaml
+++ b/manifests/m/M-Igashi/mp3rgain/1.1.0/M-Igashi.mp3rgain.yaml
@@ -1,0 +1,8 @@
+# Created using winget CLI
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgain
+PackageVersion: 1.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0

--- a/manifests/m/M-Igashi/mp3rgain/1.1.0/M-Igashi.mp3rgain.yaml
+++ b/manifests/m/M-Igashi/mp3rgain/1.1.0/M-Igashi.mp3rgain.yaml
@@ -1,8 +1,7 @@
-# Created using winget CLI
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: M-Igashi.mp3rgain
 PackageVersion: 1.1.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

This PR adds mp3rgain to the Windows Package Manager community repository.

**mp3rgain** is a modern replacement for the classic mp3gain tool, written in Rust. It provides lossless MP3 volume adjustment by modifying the `global_gain` field in each frame's side information.

### Features
- Lossless volume adjustment (no re-encoding)
- ReplayGain analysis (track and album gain)
- AAC/M4A support (ReplayGain tags)
- Full mp3gain command-line compatibility
- Zero runtime dependencies (single static binary)
- Cross-platform: Windows (x86_64 and ARM64), macOS, Linux

### Links
- Homepage: https://github.com/M-Igashi/mp3rgain
- License: MIT
- Releases: https://github.com/M-Igashi/mp3rgain/releases

### Validation
- [x] Manifest validates successfully
- [x] Binary is a portable command-line tool
- [x] SHA256 checksums verified

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/329667)