### PR TITLE
New package: M-Igashi.mp3rgain version 1.1.1

### DIFF
--- a/manifests/m/M-Igashi/mp3rgain/1.1.1/M-Igashi.mp3rgain.installer.yaml
+++ b/manifests/m/M-Igashi/mp3rgain/1.1.1/M-Igashi.mp3rgain.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgain
+PackageVersion: 1.1.1
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: mp3rgain.exe
+ReleaseDate: 2026-01-13
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/M-Igashi/mp3rgain/releases/download/v1.1.1/mp3rgain-v1.1.1-windows-x86_64.zip
+    InstallerSha256: DF71A2B3E8CD35C1FE02302015C04109F8AE62FD723B4C2AA97FAA00EC25A789
+  - Architecture: arm64
+    InstallerUrl: https://github.com/M-Igashi/mp3rgain/releases/download/v1.1.1/mp3rgain-v1.1.1-windows-arm64.zip
+    InstallerSha256: E605418E58095944541599DE09841869C41181AB79A4A3B4EDCF349B66D8624E
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/mp3rgain/1.1.1/M-Igashi.mp3rgain.locale.en-US.yaml
+++ b/manifests/m/M-Igashi/mp3rgain/1.1.1/M-Igashi.mp3rgain.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgain
+PackageVersion: 1.1.1
+PackageLocale: en-US
+Publisher: Masanari Higashi
+PublisherUrl: https://github.com/M-Igashi
+Author: Masanari Higashi
+PackageName: mp3rgain
+PackageUrl: https://github.com/M-Igashi/mp3rgain
+License: MIT
+LicenseUrl: https://github.com/M-Igashi/mp3rgain/blob/master/LICENSE
+ShortDescription: Lossless MP3 volume adjustment - a modern mp3gain replacement written in Rust
+Description: |-
+  mp3rgain adjusts MP3 volume without re-encoding by modifying the global_gain field in each frame's side information.
+  This preserves audio quality while achieving permanent volume changes.
+  Features include ReplayGain analysis, AAC/M4A support, and full mp3gain command-line compatibility.
+Moniker: mp3rgain
+Tags:
+  - audio
+  - cli
+  - gain
+  - lossless
+  - mp3
+  - music
+  - replaygain
+  - rust
+  - volume
+ReleaseNotesUrl: https://github.com/M-Igashi/mp3rgain/releases/tag/v1.1.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/mp3rgain/1.1.1/M-Igashi.mp3rgain.yaml
+++ b/manifests/m/M-Igashi/mp3rgain/1.1.1/M-Igashi.mp3rgain.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgain
+PackageVersion: 1.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

mp3rgain is a modern MP3 gain adjustment tool written in Rust. It provides lossless volume adjustment by modifying the global_gain field in MP3 frames.

### Changes in v1.1.1
- Windows binaries now use static CRT linking (no VCRedist dependency required)

### Features
- Lossless MP3 volume adjustment (no re-encoding)
- ReplayGain analysis support
- AAC/M4A support
- Full mp3gain command-line compatibility
- Cross-platform (Windows x64/ARM64, macOS, Linux)

### Microsoft Store Submission
- [x] I have tested installing this package
- [x] This package does not contain malware
- [x] This package follows the [winget-pkgs contribution guidelines](https://github.com/microsoft/winget-pkgs/blob/master/CONTRIBUTING.md)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/329716)