### PR TITLE
Fix SQLite.SQLite 3.51.2 installer SHA256

### DIFF
--- a/manifests/s/SQLite/SQLite/3.51.2/SQLite.SQLite.installer.yaml
+++ b/manifests/s/SQLite/SQLite/3.51.2/SQLite.SQLite.installer.yaml
@@ -18,9 +18,10 @@ ReleaseDate: 2026-01-09
 Installers:
 - Architecture: x64
   InstallerUrl: https://www.sqlite.org/2026/sqlite-tools-win-x64-3510200.zip
-  InstallerSha256: 4F37B51322F1E15F85E451DAAECAA5EB28296BFA6523FDDA1B4042638E89E410
+  InstallerSha256: 042805D77076E2B806C86B1AC4082D65C2F2D4BDEF5CE8995EED7845878FD69F
 - Architecture: arm64
   InstallerUrl: https://www.sqlite.org/2026/sqlite-tools-win-arm64-3510200.zip
   InstallerSha256: F1399231B07D43121F0C1F625F5824606934CB95752B9B84F8E53D870A816F29
 ManifestType: installer
 ManifestVersion: 1.12.0
+


### PR DESCRIPTION
Updated installer SHA256 for x64 architecture.

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?  If so, fill in the Issue number below.
   <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

#329080 added the new version 3.51.2 of SQLite.SQLite, but the sha256 hash of the x64 installer in the manifest seems wrong.

By the way, this also ever happened for 3.51.1 (#318001 -> #321647 & #322585). The fix's author @bucweat mentioned:

> You cannot use the hashes from https://sqlite.org/download.html as they are SHA3-256.

@UnownPlain Could you please fix this bug in your bot? Thanks~

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/329808)