### PR TITLE
Added DisplayName：Microsoft.VisualStudio.2022.BuildTools version 17.14.23

### DIFF
--- a/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.14.23/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/2022/BuildTools/17.14.23/Microsoft.VisualStudio.2022.BuildTools.installer.yaml
@@ -89,5 +89,7 @@ Installers:
   Scope: machine
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/a80deb24-6a28-4d30-b99f-13b6e89c9727/5439781a4deb7951895e041d3d0a5b409034ad56070e5fc5576dda2e0e364faa/vs_BuildTools.exe
   InstallerSha256: 5439781a4deb7951895e041d3d0a5b409034ad56070e5fc5576dda2e0e364faa
+AppsAndFeaturesEntries:
+- DisplayName: Visual Studio Build Tools 2022
 ManifestType: installer
 ManifestVersion: 1.9.0


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?  If so, fill in the Issue number below.
   <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

Manifests
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---
Notes from me:
* For reasons unknown to me, the program consistently writes `Visual Studio Build Tools 2022 (2)` as its program name in my registry, despite it being the only installation of Visual Studio Build Tools 2022 on my PC that I know of. So I've added a DisplayName to hopefully prevent the ` (2)` part.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/330058)