### PR TITLE
New version: Nervosys.Nvtop version 3.3.1

### DIFF
--- a/manifests/n/Nervosys/Nvtop/3.3.1/Nervosys.Nvtop.installer.yaml
+++ b/manifests/n/Nervosys/Nvtop/3.3.1/Nervosys.Nvtop.installer.yaml
@@ -1,0 +1,13 @@
+PackageIdentifier: Nervosys.Nvtop
+PackageVersion: 3.3.1
+InstallerType: msi
+Scope: machine
+UpgradeBehavior: install
+Commands:
+- nvtop
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/nervosys/nvtop/releases/download/v3.3.1/nvtop-3.3.1-x64.msi
+  InstallerSha256: A48D2B0316E42D858B0BE1B4FFB1391CCBEB04DD571B6FD325656597DD6D2166
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/n/Nervosys/Nvtop/3.3.1/Nervosys.Nvtop.locale.en-US.yaml
+++ b/manifests/n/Nervosys/Nvtop/3.3.1/Nervosys.Nvtop.locale.en-US.yaml
@@ -1,0 +1,29 @@
+PackageIdentifier: Nervosys.Nvtop
+PackageVersion: 3.3.1
+PackageLocale: en-US
+Publisher: Nervosys
+PublisherUrl: https://github.com/nervosys
+PublisherSupportUrl: https://github.com/nervosys/nvtop/issues
+PackageName: NVTOP
+PackageUrl: https://github.com/nervosys/nvtop
+License: GPL-3.0
+LicenseUrl: https://github.com/nervosys/nvtop/blob/windows/COPYING
+Copyright: Copyright (C) 2025 Nervosys
+ShortDescription: GPU monitoring tool for Windows - htop-like task monitor for NVIDIA, AMD, and Intel GPUs
+Description: NVTOP (Neat Videocard TOP) is a GPU monitoring tool for Windows that provides real-time information about GPU usage. Features multi-vendor GPU support (NVIDIA, AMD, Intel), per-process monitoring, color-coded utilization bars, and native Windows performance.
+Moniker: nvtop
+Tags:
+- amd
+- gpu
+- gpu-monitoring
+- intel
+- monitoring
+- nvidia
+- performance
+- system-monitor
+ReleaseNotes: |-
+  - Fixed N/A devices being displayed in the UI and JSON snapshot output
+  - Devices without valid device names are now filtered out
+ReleaseNotesUrl: https://github.com/nervosys/nvtop/releases/tag/v3.3.1
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/n/Nervosys/Nvtop/3.3.1/Nervosys.Nvtop.yaml
+++ b/manifests/n/Nervosys/Nvtop/3.3.1/Nervosys.Nvtop.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Nervosys.Nvtop
+PackageVersion: 3.3.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Description

Update Nervosys.Nvtop to version 3.3.1

### Changes in this version
- Fixed N/A devices being displayed in the UI and JSON snapshot output
- Devices without valid device names are now filtered out

### Manifest validation
Manifest validated successfully using `winget validate --manifest`

### Installation test
Tested on Windows 11 x64
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/330357)