### PR TITLE
New package: Datahunter 6.0.3 (Manual Fix)

### DIFF
--- a/manifests/d/Datahunter/Datahunter/6.0.3/Datahunter.Datahunter.installer.yaml
+++ b/manifests/d/Datahunter/Datahunter/6.0.3/Datahunter.Datahunter.installer.yaml
@@ -1,0 +1,18 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: Datahunter.Datahunter
+PackageVersion: 6.0.3
+InstallerLocale: en-US
+InstallerType: msi
+Scope: machine
+ProductCode: '{FC504B20-D4F6-4936-A216-3E1531B41411}'
+AppsAndFeaturesEntries:
+- UpgradeCode: 3C067876-A7E0-418A-8F55-A7555396BDA0
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/matkaise/datahunter-releases/releases/download/v6.0.3/Datahunter-6.0.3-win64.msi
+  InstallerSha256: 426F363044595FAE98E918AB438E93BFF2230077D63CAEBA44030671FA859691
+ManifestType: installer
+ManifestVersion: 1.10.0
+ReleaseDate: 2025-12-28

--- a/manifests/d/Datahunter/Datahunter/6.0.3/Datahunter.Datahunter.locale.en-US.yaml
+++ b/manifests/d/Datahunter/Datahunter/6.0.3/Datahunter.Datahunter.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: Datahunter.Datahunter
+PackageVersion: 6.0.3
+PackageLocale: en-US
+Publisher: Datahunter.ch
+PublisherUrl: https://github.com/matkaise
+PublisherSupportUrl: https://github.com/matkaise/datahunter-releases/issues
+PackageName: Datahunter
+PackageUrl: https://github.com/matkaise/datahunter-releases
+License: Proprietary
+ShortDescription: Datahunter Windows App
+ReleaseNotesUrl: https://github.com/matkaise/datahunter-releases/releases/tag/v6.0.3
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/matkaise/datahunter-releases/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/d/Datahunter/Datahunter/6.0.3/Datahunter.Datahunter.yaml
+++ b/manifests/d/Datahunter/Datahunter/6.0.3/Datahunter.Datahunter.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: Datahunter.Datahunter
+PackageVersion: 6.0.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
**Validation Update:**
This is a manual submission because wingetcreate failed to sync the fork.
The previous PR (#326551) was blocked by an ESET false positive.
I contacted ESET support, and they confirmed it was a false positive and fixed it.

**Current VirusTotal Status:**
ESET-NOD32 is now showing "Undetected" (Clean).
VirusTotal: https://www.virustotal.com/gui/file/426f363044595fae98e918ab438e93bff2230077d63caeba44030671fa859691/detection

(Note: Please ignore the AliCloud detection, it is a known false positive for PyInstaller binaries and not part of the primary ESRP blocking list.)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/330841)