### PR TITLE
Add leandrofariasldf.die-cli version 0.1.4

### DIFF
--- a/manifests/l/leandrofariasldf/die-cli/0.1.4/leandrofariasldf.die-cli.installer.yaml
+++ b/manifests/l/leandrofariasldf/die-cli/0.1.4/leandrofariasldf.die-cli.installer.yaml
@@ -1,0 +1,17 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: leandrofariasldf.die-cli
+PackageVersion: 0.1.4
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: die-cli.exe
+  PortableCommandAlias: die-cli
+ArchiveBinariesDependOnPath: true
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/leandrofariasldf/die-cli/releases/download/0.1.4/die-cli-0.1.4-win-x64.zip
+  InstallerSha256: FA6A77A8782B1879B95968711C5E8C404865FF0A6057900605649D773B709D49
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/l/leandrofariasldf/die-cli/0.1.4/leandrofariasldf.die-cli.locale.en-US.yaml
+++ b/manifests/l/leandrofariasldf/die-cli/0.1.4/leandrofariasldf.die-cli.locale.en-US.yaml
@@ -1,0 +1,12 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: leandrofariasldf.die-cli
+PackageVersion: 0.1.4
+PackageLocale: en-US
+Publisher: Leandro Farias
+PackageName: die-cli
+License: MIT License
+ShortDescription: A fast, htop-inspired ASCII TUI for brutally killing Windows processes (no prompts, no mercy).
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/l/leandrofariasldf/die-cli/0.1.4/leandrofariasldf.die-cli.yaml
+++ b/manifests/l/leandrofariasldf/die-cli/0.1.4/leandrofariasldf.die-cli.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: leandrofariasldf.die-cli
+PackageVersion: 0.1.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
This PR adds **die-cli 0.1.4** (portable zip).

Release: https://github.com/leandrofariasldf/die-cli/releases/tag/v0.1.4  
Installer: https://github.com/leandrofariasldf/die-cli/releases/download/0.1.4/die-cli-0.1.4-win-x64.zip  
SHA256: FA6A77A8782B1879B95968711C5E8C404865FF0A6057900605649D773B709D49

Notes:
- Addresses prior review feedback about fast refresh/flicker and selection behavior (pin/stable selection during refresh).
- Adds CLI flags: --version/-v and --help/-h (TUI still launches with no args).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/330874)