### PR TITLE
Remove DisplayVersion from S3Drive 1.15.5+2

### DIFF
--- a/manifests/s/S3Drive/S3Drive/1.15.5+2/S3Drive.S3Drive.installer.yaml
+++ b/manifests/s/S3Drive/S3Drive/1.15.5+2/S3Drive.S3Drive.installer.yaml
@@ -17,8 +17,7 @@ Dependencies:
 ProductCode: '{C7936438-3CBC-4585-B934-70C6A51AA21B}}_is1'
 ReleaseDate: 2025-11-02
 AppsAndFeaturesEntries:
-- DisplayVersion: 1.15.5
-  ProductCode: '{C7936438-3CBC-4585-B934-70C6A51AA21B}}_is1'
+- ProductCode: '{C7936438-3CBC-4585-B934-70C6A51AA21B}}_is1'
 ElevationRequirement: elevatesSelf
 InstallationMetadata:
   DefaultInstallLocation: '%ProgramFiles%\S3Drive'
@@ -30,3 +29,4 @@ Installers:
     Custom: /ALLUSERS
 ManifestType: installer
 ManifestVersion: 1.10.0
+


### PR DESCRIPTION
Remove conflicting `DisplayVersion` from lower version manifest.  The other version is:
https://github.com/microsoft/winget-pkgs/tree/master/manifests/s/S3Drive/S3Drive/1.15.5%2B3
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/330875)