### PR TITLE
[PHP] Add new version `PHP.PHP.NTS.8.5` - `8.5.2`

### DIFF
--- a/manifests/p/PHP/PHP/NTS/8/5/8.5.2/PHP.PHP.NTS.8.5.installer.yaml
+++ b/manifests/p/PHP/PHP/NTS/8/5/8.5.2/PHP.PHP.NTS.8.5.installer.yaml
@@ -1,0 +1,32 @@
+# Created with PHPWatch/winget-pkgs - https://github.com/PHPWatch/php-winget-manifest
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: PHP.PHP.NTS.8.5
+PackageVersion: 8.5.2
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: php.exe
+    PortableCommandAlias: php
+Commands:
+  - php
+  - php85
+UpgradeBehavior: install
+ReleaseDate: 2026-01-13
+ArchiveBinariesDependOnPath: true
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://downloads.php.net/~windows/releases/php-8.5.2-nts-Win32-vs17-x64.zip
+    InstallerSha256: acb844830aee008a7dde4092f6aab62b09541b3f16260806beff4e4dcc7d9617
+    Dependencies:
+      PackageDependencies:
+        - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+  - Architecture: x86
+    InstallerUrl: https://downloads.php.net/~windows/releases/php-8.5.2-nts-Win32-vs17-x86.zip
+    InstallerSha256: 6d52684520ef79421f678c8d70792bfe746df31e0b76224ac39d3107f5f89daa
+    Dependencies:
+      PackageDependencies:
+        - PackageIdentifier: Microsoft.VCRedist.2015+.x86
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/p/PHP/PHP/NTS/8/5/8.5.2/PHP.PHP.NTS.8.5.locale.en-US.yaml
+++ b/manifests/p/PHP/PHP/NTS/8/5/8.5.2/PHP.PHP.NTS.8.5.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# Created with PHPWatch/winget-pkgs - https://github.com/PHPWatch/php-winget-manifest
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: PHP.PHP.NTS.8.5
+Description: "PHP (recursive acronym for PHP: Hypertext Preprocessor) is a widely-used open source general-purpose scripting language that is especially suited for web development and can be embedded into HTML."
+ShortDescription: PHP 8.5 - Non-thread safe
+PackageVersion: 8.5.2
+ReleaseNotesUrl: https://www.php.net/ChangeLog-8.php#8.5.2
+PackageLocale: en-US
+Publisher: PHP Group
+PublisherUrl: https://php.net
+PublisherSupportUrl: https://www.php.net/docs.php
+Author: PHP Group
+PackageName: PHP 8.5 - Non-thread safe
+PackageUrl: https://php.net
+License: PHP License v3.01
+LicenseUrl: https://www.php.net/license/3_01.txt
+Copyright: (c) PHP Group
+CopyrightUrl: https://www.php.net/credits.php
+Moniker: php8.5
+Tags:
+  - php
+  - php85
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/p/PHP/PHP/NTS/8/5/8.5.2/PHP.PHP.NTS.8.5.yaml
+++ b/manifests/p/PHP/PHP/NTS/8/5/8.5.2/PHP.PHP.NTS.8.5.yaml
@@ -1,0 +1,8 @@
+# Created with PHPWatch/winget-pkgs - https://github.com/PHPWatch/php-winget-manifest
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: PHP.PHP.NTS.8.5
+PackageVersion: 8.5.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Updates `PHP.PHP.NTS.8.5` to PHP `8.5.2`

---

**PHP 8.5.2**
x86 zip Download: https://downloads.php.net/~windows/releases/php-8.5.2-nts-Win32-vs17-x86.zip
x86 zip checksum: `6d52684520ef79421f678c8d70792bfe746df31e0b76224ac39d3107f5f89daa`
x64 zip Download: https://downloads.php.net/~windows/releases/php-8.5.2-nts-Win32-vs17-x64.zip
x64 zip Checksum: `acb844830aee008a7dde4092f6aab62b09541b3f16260806beff4e4dcc7d9617`

Info: [PHP 8.5](https://windows.php.net/download#php-8.5) - [PHP 8.5.2](https://php.watch/versions/8.5/releases/8.5.2#download-windows) - [php/php-src 8.5.2](https://github.com/php/php-src/releases/tag/php-8.5.2)

---

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

---

###### Manifest built [automatically](https://github.com/PHPWatch/php-winget-manifest/actions/runs/21050766130) and [attested](https://github.com/PHPWatch/php-winget-manifest/attestations/16742549) by [PHPWatch/php-winget-manifest](https://github.com/PHPWatch/php-winget-manifest/).


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/330890)