### PR TITLE
New version: Teradata.Loom version 1.0.2

### DIFF
--- a/manifests/t/Teradata/Loom/1.0.2/Teradata.Loom.installer.yaml
+++ b/manifests/t/Teradata/Loom/1.0.2/Teradata.Loom.installer.yaml
@@ -1,0 +1,23 @@
+# Created using wingetcreate
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: Teradata.Loom
+PackageVersion: 1.0.2
+InstallerType: zip
+InstallModes:
+- silent
+UpgradeBehavior: install
+ReleaseDate: 2026-01-14
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/teradata-labs/loom/releases/download/v1.0.2/loom-windows-x64.zip
+  InstallerSha256: 33D2D3C5F83D0EB04B1318225B4E1C891405D554BC86D4168E4B5DD53E30FBC3
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: loom-package/loom-windows-amd64.exe
+    PortableCommandAlias: loom
+  - RelativeFilePath: loom-package/looms-windows-amd64.exe
+    PortableCommandAlias: looms
+ManifestType: installer
+ManifestVersion: 1.6.0
+

--- a/manifests/t/Teradata/Loom/1.0.2/Teradata.Loom.locale.en-US.yaml
+++ b/manifests/t/Teradata/Loom/1.0.2/Teradata.Loom.locale.en-US.yaml
@@ -1,0 +1,43 @@
+# Created using wingetcreate
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: Teradata.Loom
+PackageVersion: 1.0.2
+PackageLocale: en-US
+Publisher: Teradata
+PublisherUrl: https://github.com/teradata-labs
+PublisherSupportUrl: https://github.com/teradata-labs/loom/issues
+PackageName: Loom
+PackageUrl: https://github.com/teradata-labs/loom
+License: Apache-2.0
+LicenseUrl: https://github.com/teradata-labs/loom/blob/main/LICENSE
+ShortDescription: LLM agent framework with natural language agent creation
+Description: |-
+  Loom is a Go framework for building autonomous LLM agent threads with natural language agent creation,
+  pattern-guided learning, and multi-agent orchestration. It includes:
+
+  - Natural language agent creation via the weaver meta-agent
+  - Multi-agent orchestration with 6 workflow patterns
+  - 90+ reusable patterns across 16 domains
+  - 8 LLM provider integrations (Anthropic, Bedrock, OpenAI, etc.)
+  - Multi-modal support (vision, document parsing)
+  - Built-in judge evaluation system with DSPy integration
+  - Self-improving agents with pattern proposal capabilities
+  - Real-time streaming and complete observability
+Moniker: loom
+Tags:
+- ai
+- llm
+- agents
+- anthropic
+- claude
+- openai
+- automation
+- golang
+- framework
+- multi-agent
+- orchestration
+ReleaseNotes: See https://github.com/teradata-labs/loom/releases/tag/v1.0.2
+ReleaseNotesUrl: https://github.com/teradata-labs/loom/releases/tag/v1.0.2
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/t/Teradata/Loom/1.0.2/Teradata.Loom.yaml
+++ b/manifests/t/Teradata/Loom/1.0.2/Teradata.Loom.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: Teradata.Loom
+PackageVersion: 1.0.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Updates Teradata.Loom to version 1.0.2

## Changes
- Update to v1.0.2
- Update SHA256 hashes for both installers

## Verification
- Release: https://github.com/teradata-labs/loom/releases/tag/v1.0.2
- Binaries verified and hashes calculated from official release

Automated PR from GitHub Actions.

@microsoft-github-policy-service agree
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/330894)