### PR TITLE
Fix InstallerSha256 in Neovim installer manifest

### DIFF
--- a/manifests/n/Neovim/Neovim/Nightly/0.12.0/Neovim.Neovim.Nightly.installer.yaml
+++ b/manifests/n/Neovim/Neovim/Nightly/0.12.0/Neovim.Neovim.Nightly.installer.yaml
@@ -17,6 +17,7 @@ InstallationMetadata:
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/neovim/neovim/releases/download/nightly/nvim-win64.msi
-  InstallerSha256: C99D34AFFC6B4F4F813E1821403CF80458A482C3DAFC20040923ED3D8F0398FD
+  InstallerSha256: fbae96fb4fd4f6d80c41b44c8b202e6504afce66c45851c5845048fd381a0f42
 ManifestType: installer
 ManifestVersion: 1.10.0
+


### PR DESCRIPTION
Updated the InstallerSha256 for the Neovim Nightly installer.

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?  If so, fill in the Issue number below.
   <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/330951)