### PR TITLE
New package: M-Igashi.mp3rgain version 1.3.1

### DIFF
--- a/manifests/m/M-Igashi/mp3rgain/1.3.1/M-Igashi.mp3rgain.installer.yaml
+++ b/manifests/m/M-Igashi/mp3rgain/1.3.1/M-Igashi.mp3rgain.installer.yaml
@@ -7,6 +7,7 @@ InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
   - RelativeFilePath: mp3rgain.exe
+    PortableCommandAlias: mp3rgain
 ReleaseDate: 2026-01-16
 Installers:
   - Architecture: x64

--- a/manifests/m/M-Igashi/mp3rgain/1.3.1/M-Igashi.mp3rgain.installer.yaml
+++ b/manifests/m/M-Igashi/mp3rgain/1.3.1/M-Igashi.mp3rgain.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgain
+PackageVersion: 1.3.1
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: mp3rgain.exe
+ReleaseDate: 2026-01-16
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/M-Igashi/mp3rgain/releases/download/v1.3.1/mp3rgain-v1.3.1-windows-x86_64.zip
+    InstallerSha256: 6FED71A6A680AFF87032148EA487772973A8259AC9B0DDAD738D3337AC94F8B2
+  - Architecture: arm64
+    InstallerUrl: https://github.com/M-Igashi/mp3rgain/releases/download/v1.3.1/mp3rgain-v1.3.1-windows-arm64.zip
+    InstallerSha256: 142A78EAD930B35F5522C7D16A2A8E2EE4165A4718A93ED96F7AF02F93A0F9FC
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/mp3rgain/1.3.1/M-Igashi.mp3rgain.locale.en-US.yaml
+++ b/manifests/m/M-Igashi/mp3rgain/1.3.1/M-Igashi.mp3rgain.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgain
+PackageVersion: 1.3.1
+PackageLocale: en-US
+Publisher: Jesse Pinkman
+PublisherUrl: https://github.com/M-Igashi
+Author: Jesse Pinkman
+PackageName: mp3rgain
+PackageUrl: https://github.com/M-Igashi/mp3rgain
+License: MIT
+LicenseUrl: https://github.com/M-Igashi/mp3rgain/blob/master/LICENSE
+ShortDescription: Lossless MP3 volume adjustment - a modern mp3gain replacement written in Rust
+Description: |-
+  mp3rgain adjusts MP3 volume without re-encoding by modifying the global_gain field in each frame's side information.
+  This preserves audio quality while achieving permanent volume changes.
+  Features include ReplayGain analysis, AAC/M4A support, and full mp3gain command-line compatibility.
+Moniker: mp3rgain
+Tags:
+  - audio
+  - cli
+  - gain
+  - lossless
+  - mp3
+  - music
+  - replaygain
+  - rust
+  - volume
+ReleaseNotesUrl: https://github.com/M-Igashi/mp3rgain/releases/tag/v1.3.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/mp3rgain/1.3.1/M-Igashi.mp3rgain.yaml
+++ b/manifests/m/M-Igashi/mp3rgain/1.3.1/M-Igashi.mp3rgain.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgain
+PackageVersion: 1.3.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Package Information

- Package: M-Igashi.mp3rgain
- Version: 1.3.1

### Changes

This is a new submission for mp3rgain v1.3.1.

Previous PR #329716 (v1.1.1) was closed due to antivirus false positive detection (Trojan:Win32/Sprisky.U!cl). This new version includes the following build changes to address the issue:

- Changed LTO from `true` (fat LTO) to `"thin"` for less aggressive optimization
- Changed strip from `true` (full strip) to `"debuginfo"` to preserve symbol table

These changes should reduce the likelihood of heuristic-based false positives while maintaining binary functionality.

### Checklist
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one manifest
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [manifest specification](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/331004)