### PR TITLE
New package: M-Igashi.mp3rgain version 1.3.2

### DIFF
--- a/manifests/m/M-Igashi/mp3rgain/1.3.2/M-Igashi.mp3rgain.installer.yaml
+++ b/manifests/m/M-Igashi/mp3rgain/1.3.2/M-Igashi.mp3rgain.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgain
+PackageVersion: 1.3.2
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: mp3rgain.exe
+  PortableCommandAlias: mp3rgain
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/M-Igashi/mp3rgain/releases/download/v1.3.2/mp3rgain-v1.3.2-windows-x86_64.zip
+  InstallerSha256: B30D50A5C80ACD59104CD19590F6F72041BBFC62CCC29CD124599C446BCBCC7B
+- Architecture: arm64
+  InstallerUrl: https://github.com/M-Igashi/mp3rgain/releases/download/v1.3.2/mp3rgain-v1.3.2-windows-arm64.zip
+  InstallerSha256: D12F87AFE8D6ABF1297C98800772F9EB29D9FFEC08F35D7F3B36AA814E2E24B1
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/M-Igashi/mp3rgain/1.3.2/M-Igashi.mp3rgain.locale.en-US.yaml
+++ b/manifests/m/M-Igashi/mp3rgain/1.3.2/M-Igashi.mp3rgain.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgain
+PackageVersion: 1.3.2
+PackageLocale: en-US
+Publisher: M-Igashi
+PublisherUrl: https://github.com/M-Igashi
+PublisherSupportUrl: https://github.com/M-Igashi/mp3rgain/issues
+Author: M-Igashi
+PackageName: mp3rgain
+PackageUrl: https://github.com/M-Igashi/mp3rgain
+License: MIT
+LicenseUrl: https://github.com/M-Igashi/mp3rgain/blob/master/LICENSE
+ShortDescription: A fast, cross-platform CLI tool for applying ReplayGain to MP3, AAC, FLAC, and Ogg Vorbis files
+Description: mp3rgain is a command-line tool that analyzes and applies ReplayGain to audio files. It supports MP3, AAC (M4A), FLAC, and Ogg Vorbis formats. The tool can perform both track-level and album-level ReplayGain analysis, helping to normalize the perceived loudness of audio files.
+Moniker: mp3rgain
+Tags:
+- audio
+- cli
+- flac
+- mp3
+- music
+- normalize
+- ogg
+- replaygain
+- rust
+- volume
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/M-Igashi/mp3rgain/1.3.2/M-Igashi.mp3rgain.yaml
+++ b/manifests/m/M-Igashi/mp3rgain/1.3.2/M-Igashi.mp3rgain.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgain
+PackageVersion: 1.3.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Description

This PR adds a new package for mp3rgain version 1.3.2.

mp3rgain is a fast, cross-platform CLI tool for applying ReplayGain to MP3, AAC, FLAC, and Ogg Vorbis files. It is written in Rust.

## Changes

- New package: M-Igashi.mp3rgain version 1.3.2

## Checklist

- [x] I have tested the installation of this package
- [x] This manifest follows the guidelines
- [x] Installer URLs are valid and accessible
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/331125)