### PR TITLE
New version: M-Igashi.mp3rgain version 1.4.0

### DIFF
--- a/manifests/m/M-Igashi/mp3rgain/1.4.0/M-Igashi.mp3rgain.installer.yaml
+++ b/manifests/m/M-Igashi/mp3rgain/1.4.0/M-Igashi.mp3rgain.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgain
+PackageVersion: 1.4.0
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: mp3rgain.exe
+ReleaseDate: 2026-01-16
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/M-Igashi/mp3rgain/releases/download/v1.4.0/mp3rgain-v1.4.0-windows-x86_64.zip
+    InstallerSha256: 790BD0B58509FF63F6E3D82A1988F43B6D105D8B98234EF45174595C781FD91B
+  - Architecture: arm64
+    InstallerUrl: https://github.com/M-Igashi/mp3rgain/releases/download/v1.4.0/mp3rgain-v1.4.0-windows-arm64.zip
+    InstallerSha256: 6CC9D8BC9D3F86E7653B195005372E2395FF00B16340310199B7F47F2E6D2889
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/mp3rgain/1.4.0/M-Igashi.mp3rgain.locale.en-US.yaml
+++ b/manifests/m/M-Igashi/mp3rgain/1.4.0/M-Igashi.mp3rgain.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgain
+PackageVersion: 1.4.0
+PackageLocale: en-US
+Publisher: Jesse Pinkman
+PublisherUrl: https://github.com/M-Igashi
+Author: Jesse Pinkman
+PackageName: mp3rgain
+PackageUrl: https://github.com/M-Igashi/mp3rgain
+License: MIT
+LicenseUrl: https://github.com/M-Igashi/mp3rgain/blob/master/LICENSE
+ShortDescription: Lossless MP3 volume adjustment - a modern mp3gain replacement written in Rust
+Description: |-
+  mp3rgain adjusts MP3 volume without re-encoding by modifying the global_gain field in each frame's side information.
+  This preserves audio quality while achieving permanent volume changes.
+  Features include ReplayGain analysis, AAC/M4A support, and full mp3gain command-line compatibility.
+Moniker: mp3rgain
+Tags:
+  - audio
+  - cli
+  - gain
+  - lossless
+  - mp3
+  - music
+  - replaygain
+  - rust
+  - volume
+ReleaseNotesUrl: https://github.com/M-Igashi/mp3rgain/releases/tag/v1.4.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/mp3rgain/1.4.0/M-Igashi.mp3rgain.locale.en-US.yaml
+++ b/manifests/m/M-Igashi/mp3rgain/1.4.0/M-Igashi.mp3rgain.locale.en-US.yaml
@@ -3,9 +3,10 @@
 PackageIdentifier: M-Igashi.mp3rgain
 PackageVersion: 1.4.0
 PackageLocale: en-US
-Publisher: Jesse Pinkman
+Publisher: M-Igashi
 PublisherUrl: https://github.com/M-Igashi
-Author: Jesse Pinkman
+PublisherSupportUrl: https://github.com/M-Igashi/mp3rgain/issues
+Author: M-Igashi
 PackageName: mp3rgain
 PackageUrl: https://github.com/M-Igashi/mp3rgain
 License: MIT
@@ -19,10 +20,13 @@ Moniker: mp3rgain
 Tags:
   - audio
   - cli
+  - flac
   - gain
   - lossless
   - mp3
   - music
+  - normalize
+  - ogg
   - replaygain
   - rust
   - volume

--- a/manifests/m/M-Igashi/mp3rgain/1.4.0/M-Igashi.mp3rgain.yaml
+++ b/manifests/m/M-Igashi/mp3rgain/1.4.0/M-Igashi.mp3rgain.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgain
+PackageVersion: 1.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

New version of mp3rgain: 1.4.0

## Changes in v1.4.0

- Fix: Handle last frame before APE/ID3 tags
- Fix: M4A info display improvements
- Fix: Improve max amplitude detection and global_gain range

## Links

- Release: https://github.com/M-Igashi/mp3rgain/releases/tag/v1.4.0
- Repository: https://github.com/M-Igashi/mp3rgain
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/331741)