### PR TITLE
New package: M-Igashi.headroom version 1.4.2

### DIFF
--- a/manifests/m/M-Igashi/headroom/1.4.2/M-Igashi.headroom.installer.yaml
+++ b/manifests/m/M-Igashi/headroom/1.4.2/M-Igashi.headroom.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: M-Igashi.headroom
+PackageVersion: 1.4.2
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: headroom.exe
+  PortableCommandAlias: headroom
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/M-Igashi/headroom/releases/download/v1.4.2/headroom-v1.4.2-windows-x86_64.zip
+  InstallerSha256: 193BC36A21C235ADAA10AEDADA5DF5F834E5BCBE8466DAC013CC1ABAEA63DDFA
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/M-Igashi/headroom/1.4.2/M-Igashi.headroom.locale.en-US.yaml
+++ b/manifests/m/M-Igashi/headroom/1.4.2/M-Igashi.headroom.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: M-Igashi.headroom
+PackageVersion: 1.4.2
+PackageLocale: en-US
+Publisher: M-Igashi
+PublisherUrl: https://github.com/M-Igashi
+PublisherSupportUrl: https://github.com/M-Igashi/headroom/issues
+Author: M-Igashi
+PackageName: headroom
+PackageUrl: https://github.com/M-Igashi/headroom
+License: MIT
+LicenseUrl: https://github.com/M-Igashi/headroom/blob/main/LICENSE
+ShortDescription: Audio loudness analyzer and gain adjustment tool for mastering workflows
+Description: headroom is a CLI tool for audio loudness analysis and gain adjustment. It analyzes audio files using FFmpeg and provides LUFS measurements. For MP3 files, it can apply lossless gain adjustments using mp3rgain.
+Moniker: headroom
+Tags:
+- audio
+- cli
+- ffmpeg
+- loudness
+- lufs
+- mastering
+- mp3
+- replaygain
+- rust
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/M-Igashi/headroom/1.4.2/M-Igashi.headroom.yaml
+++ b/manifests/m/M-Igashi/headroom/1.4.2/M-Igashi.headroom.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: M-Igashi.headroom
+PackageVersion: 1.4.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Description

New package for headroom version 1.4.2.

headroom is a CLI tool for audio loudness analysis and gain adjustment for mastering workflows.

## Changes

- New package: M-Igashi.headroom version 1.4.2
- Build profile updated to use thin LTO and preserve debuginfo (addresses Windows Defender false positive from v1.4.0/v1.4.1)

## Notes

Previous PRs (#330773 for v1.4.0 and #331808 for v1.4.1) failed due to Windows Defender false positive detection (Trojan:Script/Wacatac.H!ml).

This release includes the same build profile changes that successfully resolved the issue for M-Igashi.mp3rgain (#331125):
- LTO: `true` → `"thin"`
- Strip: `true` → `"debuginfo"`

## Links

- Release: https://github.com/M-Igashi/headroom/releases/tag/v1.4.2
- Repository: https://github.com/M-Igashi/headroom
- Build workflow: https://github.com/M-Igashi/headroom/blob/main/.github/workflows/release.yml
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/333227)