### PR TITLE
Add missing CLI utilities to libvips.libvips 8.18.0

### DIFF
--- a/manifests/l/libvips/libvips/8.18.0/libvips.libvips.installer.yaml
+++ b/manifests/l/libvips/libvips/8.18.0/libvips.libvips.installer.yaml
@@ -8,6 +8,10 @@ NestedInstallerType: portable
 NestedInstallerFiles:
 - RelativeFilePath: vips-dev-8.18/bin/vips.exe
   PortableCommandAlias: vips
+- RelativeFilePath: vips-dev-8.18/bin/vipsheader.exe
+  PortableCommandAlias: vipsheader
+- RelativeFilePath: vips-dev-8.18/bin/vipsthumbnail.exe
+  PortableCommandAlias: vipsthumbnail
 InstallModes:
 - interactive
 - silent


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

- `vipsheader` prints image header fields.
- `vipsthumbnail` efficiently creates image thumbnails.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/333228)