### PR TITLE
New package: adamtheturtle.doccmd version 2026.01.23.4

### DIFF
--- a/manifests/a/adamtheturtle/doccmd/2026.01.23.4/adamtheturtle.doccmd.installer.yaml
+++ b/manifests/a/adamtheturtle/doccmd/2026.01.23.4/adamtheturtle.doccmd.installer.yaml
@@ -1,0 +1,15 @@
+# Created with Komac v2.15.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: adamtheturtle.doccmd
+PackageVersion: 2026.01.23.4
+InstallerType: portable
+Commands:
+  - doccmd
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/adamtheturtle/doccmd/releases/download/2026.01.23.4/doccmd-windows.exe
+    InstallerSha256: D72B19D70D72CA846770FE44EFCD031B5574D0CB2C7849665A49E33C5C90ED1C
+ManifestType: installer
+ManifestVersion: 1.9.0
+

--- a/manifests/a/adamtheturtle/doccmd/2026.01.23.4/adamtheturtle.doccmd.locale.en-US.yaml
+++ b/manifests/a/adamtheturtle/doccmd/2026.01.23.4/adamtheturtle.doccmd.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# Created with Komac v2.15.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: adamtheturtle.doccmd
+PackageVersion: 2026.01.23.4
+PackageLocale: en-US
+Publisher: Adam Dangoor
+PublisherUrl: https://github.com/adamtheturtle
+PublisherSupportUrl: https://github.com/adamtheturtle/doccmd/issues
+Author: Adam Dangoor
+PackageName: doccmd
+PackageUrl: https://github.com/adamtheturtle/doccmd
+License: MIT
+LicenseUrl: https://github.com/adamtheturtle/doccmd/blob/main/LICENSE
+ShortDescription: Run tools against code blocks in documentation
+Description: Run tools against code blocks in documentation. This allows you to run linters, formatters, and other tools against code examples in your documentation files.
+Tags:
+  - cli
+  - documentation
+  - linting
+  - markdown
+  - python
+  - rst
+ReleaseNotesUrl: https://github.com/adamtheturtle/doccmd/releases/tag/2026.01.23.4
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0
+

--- a/manifests/a/adamtheturtle/doccmd/2026.01.23.4/adamtheturtle.doccmd.yaml
+++ b/manifests/a/adamtheturtle/doccmd/2026.01.23.4/adamtheturtle.doccmd.yaml
@@ -1,0 +1,9 @@
+# Created with Komac v2.15.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: adamtheturtle.doccmd
+PackageVersion: 2026.01.23.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0
+


### PR DESCRIPTION
### New Package Submission

- Package Identifier: adamtheturtle.doccmd
- Package Version: 2026.01.23.4
- Package Name: doccmd
- Publisher: Adam Dangoor
- License: MIT

### Description
Run tools against code blocks in documentation. This allows you to run linters, formatters, and other tools against code examples in your documentation files.

### URLs
- Package URL: https://github.com/adamtheturtle/doccmd
- Release Notes: https://github.com/adamtheturtle/doccmd/releases/tag/2026.01.23.4
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/333409)