### PR TITLE
Add raskell-io.hx version 0.4.1

### DIFF
--- a/manifests/r/raskell-io/hx/0.4.1/raskell-io.hx.installer.yaml
+++ b/manifests/r/raskell-io/hx/0.4.1/raskell-io.hx.installer.yaml
@@ -1,0 +1,13 @@
+PackageIdentifier: raskell-io.hx
+PackageVersion: 0.4.1
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: hx.exe
+    PortableCommandAlias: hx
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/raskell-io/hx/releases/download/v0.4.1/hx-v0.4.1-x86_64-pc-windows-msvc.zip
+    InstallerSha256: 785718CFA6E465D40A2B1572C52AE8626C0FC80154050BA65002F662158C2265
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/r/raskell-io/hx/0.4.1/raskell-io.hx.locale.en-US.yaml
+++ b/manifests/r/raskell-io/hx/0.4.1/raskell-io.hx.locale.en-US.yaml
@@ -1,0 +1,10 @@
+PackageIdentifier: raskell-io.hx
+PackageVersion: 0.4.1
+PackageLocale: en-US
+Publisher: raskell-io
+PackageName: hx
+License: MIT
+ShortDescription: Fast, opinionated Haskell toolchain CLI
+PackageUrl: https://github.com/raskell-io/hx
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/r/raskell-io/hx/0.4.1/raskell-io.hx.yaml
+++ b/manifests/r/raskell-io/hx/0.4.1/raskell-io.hx.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: raskell-io.hx
+PackageVersion: 0.4.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: raskell-io.hx

hx is a CLI for Haskell that wraps ghc/cabal/ghcup into something less painful.

- Homepage: https://github.com/raskell-io/hx
- License: MIT
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/333584)