### PR TITLE
Add TimeTracker version 0.2.3

### DIFF
--- a/manifests/t/TimeTracker/0.2.3/defaultLocale.yaml
+++ b/manifests/t/TimeTracker/0.2.3/defaultLocale.yaml
@@ -1,0 +1,23 @@
+# Created with GitHub Actions
+PackageIdentifier: TimeTracker.TimeTracker
+Version: 0.2.3
+PackageLocale: en-US
+Publisher: TimeTracker
+PublisherUrl: https://github.com/bthos/time-tracker-app
+PublisherSupportUrl: https://github.com/bthos/time-tracker-app/issues
+Author: TimeTracker
+PackageName: TimeTracker
+PackageUrl: https://github.com/bthos/time-tracker-app
+License: MIT
+LicenseUrl: https://github.com/bthos/time-tracker-app/blob/main/LICENSE
+Copyright: Copyright (c) 2026 bthos
+CopyrightUrl: https://github.com/bthos/time-tracker-app
+ShortDescription: Time Tracking Application
+Description: Desktop application for automatic time tracking that shows where your working time goes, with smart handling of idle time.
+Tags:
+  - time-tracking
+  - productivity
+  - pomodoro
+  - time-management
+Moniker: timetracker
+

--- a/manifests/t/TimeTracker/0.2.3/installer.yaml
+++ b/manifests/t/TimeTracker/0.2.3/installer.yaml
@@ -1,0 +1,15 @@
+# Created with GitHub Actions
+PackageIdentifier: TimeTracker.TimeTracker
+Version: 0.2.3
+InstallerType: msi
+Architecture: x64
+InstallerUrl: https://github.com/bthos/time-tracker-app/releases/download/v0.2.3/TimeTracker_0.2.2_x64_en-US.msi
+InstallerSha256: e4ea5900c3fea8c9cc26abda5e9230521af7e133425d4c15105d521c9f478d12
+InstallerSwitches:
+  Silent: "/quiet"
+  SilentWithProgress: "/quiet /norestart"
+InstallModes:
+  - silent
+  - silentWithProgress
+Scope: machine
+

--- a/manifests/t/TimeTracker/0.2.3/version.yaml
+++ b/manifests/t/TimeTracker/0.2.3/version.yaml
@@ -1,0 +1,7 @@
+# Created with GitHub Actions
+PackageIdentifier: TimeTracker.TimeTracker
+Version: 0.2.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.4.0
+


### PR DESCRIPTION
## Description
This PR adds TimeTracker version 0.2.3 to the WinGet repository.

## Changes
- Added manifests for TimeTracker 0.2.3
- Installer: MSI package
- Architecture: x64

## Checklist
- [x] Manifest files are correctly formatted
- [x] Installer URL is valid and accessible
- [x] SHA256 checksum is correct
- [x] Silent install switches are configured

## Related
Release: https://github.com/bthos/time-tracker-app/releases/tag/v0.2.3
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/334703)