### PR TITLE
Add TimeTracker version 0.2.6

### DIFF
--- a/manifests/t/bthos/TimeTracker/0.2.6/bthos.TimeTracker.installer.yaml
+++ b/manifests/t/bthos/TimeTracker/0.2.6/bthos.TimeTracker.installer.yaml
@@ -1,0 +1,19 @@
+# Created with GitHub Actions
+PackageIdentifier: bthos.TimeTracker
+PackageVersion: 0.2.6
+ManifestType: installer
+ManifestVersion: 1.4.0
+Installers:
+  - InstallerIdentifier: bthos.TimeTracker
+    InstallerType: msi
+    Architecture: x64
+    InstallerUrl: https://github.com/bthos/time-tracker-app/releases/download/v0.2.6/TimeTracker_0.2.6_x64_en-US.msi
+    InstallerSha256: f2395385cabeb5ed0c8661e4d9ce1d258fd7aac6bf3f1920adad9354156e1dc2
+    InstallerSwitches:
+      Silent: "/quiet"
+      SilentWithProgress: "/quiet /norestart"
+    InstallModes:
+      - silent
+      - silentWithProgress
+    Scope: machine
+

--- a/manifests/t/bthos/TimeTracker/0.2.6/bthos.TimeTracker.locale.en-US.yaml
+++ b/manifests/t/bthos/TimeTracker/0.2.6/bthos.TimeTracker.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# Created with GitHub Actions
+PackageIdentifier: bthos.TimeTracker
+PackageVersion: 0.2.6
+ManifestType: defaultLocale
+ManifestVersion: 1.4.0
+PackageLocale: en-US
+Publisher: bthos
+PublisherUrl: https://github.com/bthos/time-tracker-app
+PublisherSupportUrl: https://github.com/bthos/time-tracker-app/issues
+Author: bthos
+PackageName: TimeTracker
+PackageUrl: https://github.com/bthos/time-tracker-app
+License: MIT
+LicenseUrl: https://github.com/bthos/time-tracker-app/blob/main/LICENSE
+Copyright: Copyright (c) 2026 bthos
+CopyrightUrl: https://github.com/bthos/time-tracker-app
+ShortDescription: Time Tracking Application
+Description: Desktop application for automatic time tracking that shows where your working time goes, with smart handling of idle time.
+Tags:
+  - time-tracking
+  - productivity
+  - pomodoro
+  - time-management
+Moniker: timetracker
+

--- a/manifests/t/bthos/TimeTracker/0.2.6/bthos.TimeTracker.yaml
+++ b/manifests/t/bthos/TimeTracker/0.2.6/bthos.TimeTracker.yaml
@@ -1,0 +1,7 @@
+# Created with GitHub Actions
+PackageIdentifier: bthos.TimeTracker
+PackageVersion: 0.2.6
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.4.0
+


### PR DESCRIPTION
## Description
This PR adds TimeTracker version 0.2.6 to the WinGet repository.

## Changes
- Added manifests for TimeTracker 0.2.6
- Installer: MSI package
- Architecture: x64

## Checklist
- [x] Manifest files are correctly formatted
- [x] Installer URL is valid and accessible
- [x] SHA256 checksum is correct
- [x] Silent install switches are configured

## Related
Release: https://github.com/bthos/time-tracker-app/releases/tag/v0.2.6
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/334834)