### PR TITLE
New package: M-Igashi.headroom version 1.4.3

### DIFF
--- a/manifests/m/M-Igashi/headroom/1.4.3/M-Igashi.headroom.installer.yaml
+++ b/manifests/m/M-Igashi/headroom/1.4.3/M-Igashi.headroom.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: M-Igashi.headroom
+PackageVersion: 1.4.3
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: headroom.exe
+  PortableCommandAlias: headroom
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/M-Igashi/headroom/releases/download/v1.4.3/headroom-v1.4.3-windows-x86_64.zip
+  InstallerSha256: 08219B29C4A38A688EC9453028CDDB905155B12294D49B1A44B0B79536F6B67D
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/M-Igashi/headroom/1.4.3/M-Igashi.headroom.locale.en-US.yaml
+++ b/manifests/m/M-Igashi/headroom/1.4.3/M-Igashi.headroom.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: M-Igashi.headroom
+PackageVersion: 1.4.3
+PackageLocale: en-US
+Publisher: M-Igashi
+PublisherUrl: https://github.com/M-Igashi
+PublisherSupportUrl: https://github.com/M-Igashi/headroom/issues
+Author: M-Igashi
+PackageName: headroom
+PackageUrl: https://github.com/M-Igashi/headroom
+License: MIT
+LicenseUrl: https://github.com/M-Igashi/headroom/blob/main/LICENSE
+ShortDescription: Audio loudness analyzer and gain adjustment tool for mastering workflows
+Description: headroom is a CLI tool for audio loudness analysis and gain adjustment. It analyzes audio files using FFmpeg and provides LUFS measurements. For MP3 files, it can apply lossless gain adjustments using mp3rgain.
+Moniker: headroom
+Tags:
+- audio
+- cli
+- ffmpeg
+- loudness
+- lufs
+- mastering
+- mp3
+- replaygain
+- rust
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/M-Igashi/headroom/1.4.3/M-Igashi.headroom.yaml
+++ b/manifests/m/M-Igashi/headroom/1.4.3/M-Igashi.headroom.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: M-Igashi.headroom
+PackageVersion: 1.4.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Description

New package for headroom version 1.4.3.

headroom is a CLI tool for audio loudness analysis and gain adjustment for mastering workflows.

## Changes

- New package: M-Igashi.headroom version 1.4.3
- This release fixes incorrect version display in banner (was showing v1.4.1 instead of actual version)

## Notes

Previous PR #333227 (v1.4.2) was closed because the application banner displayed incorrect version number.
This release (v1.4.3) corrects the version display.

## Links

- Release: https://github.com/M-Igashi/headroom/releases/tag/v1.4.3
- Repository: https://github.com/M-Igashi/headroom
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/335130)