### PR TITLE
New version: DuckDB.cli version 1.4.4

### DIFF
--- a/manifests/d/DuckDB/cli/1.4.4/DuckDB.cli.installer.yaml
+++ b/manifests/d/DuckDB/cli/1.4.4/DuckDB.cli.installer.yaml
@@ -1,0 +1,29 @@
+# Created with komac v2.15.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: DuckDB.cli
+PackageVersion: 1.4.4
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: duckdb.exe
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+ReleaseDate: 2026-01-26
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/duckdb/duckdb/releases/download/v1.4.4/duckdb_cli-windows-amd64.zip
+  InstallerSha256: CD24E5736AC69A33DC1411209F161DED5595FFC578E3CF016474346C64A87F5E
+- Architecture: arm64
+  InstallerUrl: https://github.com/duckdb/duckdb/releases/download/v1.4.4/duckdb_cli-windows-arm64.zip
+  InstallerSha256: ED4B333A0BFD783137F47421F49E35F5998461C47C2A1283E5FF17A5FCF5E511
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/d/DuckDB/cli/1.4.4/DuckDB.cli.installer.yaml
+++ b/manifests/d/DuckDB/cli/1.4.4/DuckDB.cli.installer.yaml
@@ -24,5 +24,8 @@ Installers:
 - Architecture: arm64
   InstallerUrl: https://github.com/duckdb/duckdb/releases/download/v1.4.4/duckdb_cli-windows-arm64.zip
   InstallerSha256: ED4B333A0BFD783137F47421F49E35F5998461C47C2A1283E5FF17A5FCF5E511
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.arm64
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/d/DuckDB/cli/1.4.4/DuckDB.cli.installer.yaml
+++ b/manifests/d/DuckDB/cli/1.4.4/DuckDB.cli.installer.yaml
@@ -14,16 +14,19 @@ InstallModes:
 - silent
 - silentWithProgress
 UpgradeBehavior: install
-Dependencies:
-  PackageDependencies:
-  - PackageIdentifier: Microsoft.VCRedist.2015+.x64
 ReleaseDate: 2026-01-26
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/duckdb/duckdb/releases/download/v1.4.4/duckdb_cli-windows-amd64.zip
   InstallerSha256: CD24E5736AC69A33DC1411209F161DED5595FFC578E3CF016474346C64A87F5E
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
 - Architecture: arm64
   InstallerUrl: https://github.com/duckdb/duckdb/releases/download/v1.4.4/duckdb_cli-windows-arm64.zip
   InstallerSha256: ED4B333A0BFD783137F47421F49E35F5998461C47C2A1283E5FF17A5FCF5E511
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.arm64
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/d/DuckDB/cli/1.4.4/DuckDB.cli.installer.yaml
+++ b/manifests/d/DuckDB/cli/1.4.4/DuckDB.cli.installer.yaml
@@ -8,7 +8,6 @@ InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
 - RelativeFilePath: duckdb.exe
-Scope: user
 InstallModes:
 - interactive
 - silent

--- a/manifests/d/DuckDB/cli/1.4.4/DuckDB.cli.installer.yaml
+++ b/manifests/d/DuckDB/cli/1.4.4/DuckDB.cli.installer.yaml
@@ -21,11 +21,5 @@ Installers:
   Dependencies:
     PackageDependencies:
     - PackageIdentifier: Microsoft.VCRedist.2015+.x64
-- Architecture: arm64
-  InstallerUrl: https://github.com/duckdb/duckdb/releases/download/v1.4.4/duckdb_cli-windows-arm64.zip
-  InstallerSha256: ED4B333A0BFD783137F47421F49E35F5998461C47C2A1283E5FF17A5FCF5E511
-  Dependencies:
-    PackageDependencies:
-    - PackageIdentifier: Microsoft.VCRedist.2015+.arm64
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/d/DuckDB/cli/1.4.4/DuckDB.cli.installer.yaml
+++ b/manifests/d/DuckDB/cli/1.4.4/DuckDB.cli.installer.yaml
@@ -24,8 +24,5 @@ Installers:
 - Architecture: arm64
   InstallerUrl: https://github.com/duckdb/duckdb/releases/download/v1.4.4/duckdb_cli-windows-arm64.zip
   InstallerSha256: ED4B333A0BFD783137F47421F49E35F5998461C47C2A1283E5FF17A5FCF5E511
-  Dependencies:
-    PackageDependencies:
-    - PackageIdentifier: Microsoft.VCRedist.2015+.arm64
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/d/DuckDB/cli/1.4.4/DuckDB.cli.locale.en-US.yaml
+++ b/manifests/d/DuckDB/cli/1.4.4/DuckDB.cli.locale.en-US.yaml
@@ -1,0 +1,119 @@
+# Created with komac v2.15.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: DuckDB.cli
+PackageVersion: 1.4.4
+PackageLocale: en-US
+Publisher: DuckDB
+PublisherUrl: https://www.duckdb.org/
+PublisherSupportUrl: https://github.com/duckdb/duckdb/issues
+Author: Stichting DuckDB Foundation
+PackageName: DuckDB CLI
+PackageUrl: https://github.com/duckdb/duckdb
+License: MIT
+LicenseUrl: https://github.com/duckdb/duckdb/blob/HEAD/LICENSE
+Copyright: Copyright (c) Stichting DuckDB Foundation
+CopyrightUrl: https://github.com/duckdb/duckdb/blob/master/LICENSE
+ShortDescription: DuckDB is an in-process SQL OLAP Database Management System
+Description: |-
+  DuckDB is a high-performance analytical database system.
+  It is designed to be fast, reliable and easy to use.
+  DuckDB provides a rich SQL dialect, with support far beyond basic SQL.
+Moniker: duckdb-cli
+Tags:
+- analytics
+- database
+- embedded-database
+- olap
+- sql
+ReleaseNotes: |-
+  This is a bug fix release for various issues discovered after we released 1.4.3. Please excuse the erroneous release earlier.
+  What's Changed
+  - Cast Fix: Correctly handle negative exponent with a number with a decimal in VARCHAR -> INTEGER cast by @Mytherin in #20098
+  - [Storage] Fix NULL filter check for constant segments by @Tishj in #20103
+  - fixing staged upload for install.duckdb.org - hopefully by @hannes in #20104
+  - Remove undefined loop by @artjomPlaunov in #20105
+  - [Test] Adjust concurrent attach-detach test to expect write-write conflict by @taniabogatsch in #20108
+  - Fix ALIAS function in filter pushdown to preserve column aliases(#20008) by @henry8128 in #20106
+  - Headers missing from http logs by @samansmink in #20030
+  - Bumping httpfs to include duckdb/duckdb-httpfs#174 by @carlopi in #20145
+  - Issue #20136: Secondary IGNORE NULLS by @hawkfish in #20153
+  - Fix minio nightly tests by @c-herrewijn in #20132
+  - Fix use-after-free in mode aggregate Combine function by @victor-ab in #20146
+  - Only pushdown varchar if the arrow type is not a string view by @evertlammerts in #20165
+  - Quote filters in adbc_get_objects by @evertlammerts in #20172
+  - Issue #20156: Streaming Window Unions by @hawkfish in #20191
+  - MergeInto: correctly clean-up buffer and handle non trivial GetData by @carlopi in #20163
+  - Fix extentension-ci-tools to latest release version in the v1.4-andium branch by @carlopi in #20227
+  - [Chore] Clean up CI nightly run to prevent time outs by @taniabogatsch in #20150
+  - Bump Julia to v1.4.3 by @maiadegraaf in #20248
+  - Internal #6881: 2025c Time Zones by @hawkfish in #20258
+  - Split statements by semicolon by @Dtenwolde in #20174
+  - [chore] Remove numeric_cast.hpp import and other tidy stuff by @taniabogatsch in #20278
+  - [chore] Reduce latency of VARCHAR index creation test by @taniabogatsch in #20277
+  - Reuse correct table-level metadata during checkpoints by @ywelsch in #20267
+  - Fix view resolution not being stable if the referenced table lives in a different schema by @Tishj in #20260
+  - ConstantOrNullFunction input validity mask overwrite bugfix by @artjomPlaunov in #20283
+  - dbgen: use TaskExecutor framework by @Mytherin in #20284
+  - fix(adbc): return error when setting an empty sql query by @gishor in #20071
+  - Bump iceberg, and add wasm platforms! by @carlopi in #20205
+  - _extension_distribution: Pin to v1.4-andium branch of extension-ci-tools by @carlopi in #20294
+  - Optimize prepared statement parameter lookups by @EtgarDev in #20252
+  - Update VectorType in ComputePartitionIndices by @lnkuiper in #20343
+  - Add some defensive programming in RadixPartitionedHashTable::Combine and RadixPartitionedHashTable::Finalize by @lnkuiper in #20342
+  - Increase reserved size for paths in SetPathsInternal by @Flogex in #20340
+  - Use UTF-16 console output in Windows shell (1.4) by @staticlibs in #20339
+  - Force repartitioning in RadixPartitionedHashTable::Combine by @lnkuiper in #20357
+  - Fixup comparison to wrong iterator on abdc's driver by @carlopi in #20360
+  - [chore] dsdgen generation signed integer overflow fix by @taniabogatsch in #20279
+  - Give preference do variables set in config by @pdet in #20396
+  - Add QueryContext also to Write(void *buffer, idx_t nr_bytes), so that BytesWritten are updated also there by @carlopi in #20393
+  - Fix Issue #20233: fix function chain in qualify by @ArNine in #20302
+  - Backport client data cleanup by @taniabogatsch in #20403
+  - Add v1.4.4 to Storage Version by @maiadegraaf in #20404
+  - Parquet Reader: Ignore invalid UTF8 in string stats, instead of throwing an error by @Mytherin in #20405
+  - Don't add a semicolon to final query when splitting statements by @Dtenwolde in #20401
+  - Fixup BRANCHES_TO_BE_CACHED, vars are not available on PRs, so env it is by @carlopi in #20411
+  - [Fix] Defensive infinite loop guard and UTF-8 check in C API by @taniabogatsch in #20348
+  - Add ducklake, httpfs and iceberg tests so they are run in CI by @carlopi in #20319
+  - [Stats] date_trunc stat propagation fix by @Tishj in #20421
+  - Refactor allowed path sanitize by @hannes in #20346
+  - Issue #20413: ASOF SEMI/ANTI Bindings by @hawkfish in #20433
+  - Fix #20410: fix for RIGHT SEMI/ANTI - cannot fully label chain as found if there are non-equality predicates present in the join condition by @Mytherin in #20435
+  - [Fix] Misaligned size in ART prefix count by @taniabogatsch in #20455
+  - Wrap ccache in own action by @carlopi in #20466
+  - [Chore] Add ORDER BY to AS OF test by @taniabogatsch in #20465
+  - Fix segfault in hive partitioning with NULL values by @Schwarf in #20468
+  - Nightly test encryption fixes by @ccfelius in #20461
+  - [C API] Fix error data creation by @taniabogatsch in #20451
+  - Skip concurrent_encrypted_attach due to race in autoloading httpfs by @carlopi in #20471
+  - CI fixup: Comparisons needs to be done via strings (since input via workflow_call is a string) by @carlopi in #20464
+  - Add unity_catalog to extensions built by duckdb/duckdb by @carlopi in #20445
+  - Invert the setup of ccache and cleanup_runner by @carlopi in #20429
+  - bump spatial for andium by @Maxxen in #20479
+  - Reclaim disk space on MacOS runners by @lnkuiper in #20493
+  - Adding secure clear functions by @ccfelius in #20285
+  - rewrite unaligned scan by @artjomPlaunov in #20474
+  - Issue #20470: TIMESTAMPTZ to DATE by @hawkfish in #20498
+  - Reset cached dictionaries in TRY expression by @Maxxen in #20452
+  - [Copy] Fix #20324 partition_by option binding by @Tishj in #20509
+  - Bump multiple extensions by @maiadegraaf in #20504
+  - update azure ref for v1.4-andium by @benfleis in #20506
+  - [Fix] Directly retrieve the logical column index during MERGE INTO binding by @taniabogatsch in #20503
+  - Sanitize pragmas by @samansmink in #20514
+  - Bump httpfs, ducklake and postgres by @carlopi in #20518
+  - Revert vortex bump for v1.4.4 by @taniabogatsch in #20527
+  - Bump VSS by @taniabogatsch in #20542
+  - Bump Excel by @maiadegraaf in #20540
+  - Fix Issue #20233: Fix function chain in having and merge to v1.4 by @ArNine in #20532
+  - bump iceberg by @Tmonster in #20549
+  - Bump Iceberg v1.4 by @Tmonster in #20604
+  - Fix KeyValueSecretReader init by @NiclasHaderer in #20620
+  - Fail fast extensions by @carlopi in #20605
+  New Contributors
+  - @victor-ab made their first contribution in #20146
+  - @gishor made their first contribution in #20071
+  Full Changelog: v1.4.3...v1.4.4
+ReleaseNotesUrl: https://github.com/duckdb/duckdb/releases/tag/v1.4.4
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/d/DuckDB/cli/1.4.4/DuckDB.cli.yaml
+++ b/manifests/d/DuckDB/cli/1.4.4/DuckDB.cli.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.15.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: DuckDB.cli
+PackageVersion: 1.4.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
This PR is a follow up to #334074.

It tries to fix the validation problem:

> No suitable installer found for manifest Microsoft.VCRedist.2015+.x64 with version 14.50.35719.0

It splits the `Microsoft.VCRedist` dependency for `x64` and `arm64` architectures.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/335288)