### PR TITLE
New package: BOpenIO.Scribe version 0.0.54

### DIFF
--- a/manifests/b/BOpenIO/Scribe/0.0.54/BOpenIO.Scribe.installer.yaml
+++ b/manifests/b/BOpenIO/Scribe/0.0.54/BOpenIO.Scribe.installer.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: BOpenIO.Scribe
+PackageVersion: "0.0.54"
+Installers:
+  - Architecture: x64
+    InstallerType: zip
+    InstallerUrl: https://jkygjvqfie32bnvq.public.blob.vercel-storage.com/releases/Scribe-0.0.54-Setup-win-x64.zip
+    InstallerSha256: 1F9D6804F3EBE5228CC81787EB80FD013D31419D6D87F85DCA19F63C67285847
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/b/BOpenIO/Scribe/0.0.54/BOpenIO.Scribe.locale.en-US.yaml
+++ b/manifests/b/BOpenIO/Scribe/0.0.54/BOpenIO.Scribe.locale.en-US.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: BOpenIO.Scribe
+PackageVersion: "0.0.54"
+PackageLocale: en-US
+Publisher: B-Open-IO
+PublisherUrl: https://bopen.io
+PackageName: Scribe
+PackageUrl: https://scribe.cool
+License: MIT
+ShortDescription: Timeline-based work evidence aggregator
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/b/BOpenIO/Scribe/0.0.54/BOpenIO.Scribe.yaml
+++ b/manifests/b/BOpenIO/Scribe/0.0.54/BOpenIO.Scribe.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: BOpenIO.Scribe
+PackageVersion: "0.0.54"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package submission

- Package: BOpenIO.Scribe
- Version: 0.0.54
- URL: https://scribe.cool
- License: MIT

Scribe is a timeline-based work evidence aggregator desktop app.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/335465)