### PR TITLE
Update GitHub.Copilot to declare dependency on PowerShell

### DIFF
--- a/manifests/g/GitHub/Copilot/Prerelease/v0.0.400-0/GitHub.Copilot.Prerelease.installer.yaml
+++ b/manifests/g/GitHub/Copilot/Prerelease/v0.0.400-0/GitHub.Copilot.Prerelease.installer.yaml
@@ -7,6 +7,10 @@ InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
 - RelativeFilePath: copilot.exe
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Microsoft.PowerShell
+      MinimumVersion: "7.0.0"
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/github/copilot-cli/releases/download/v0.0.400-0/copilot-win32-x64.zip

--- a/manifests/g/GitHub/Copilot/v0.0.400/GitHub.Copilot.installer.yaml
+++ b/manifests/g/GitHub/Copilot/v0.0.400/GitHub.Copilot.installer.yaml
@@ -9,6 +9,10 @@ NestedInstallerFiles:
 - RelativeFilePath: copilot.exe
 Commands:
 - copilot
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Microsoft.PowerShell
+      MinimumVersion: "7.0.0"
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/github/copilot-cli/releases/download/v0.0.400/copilot-win32-x64.zip

--- a/manifests/g/GitHub/Copilot/v0.0.400/GitHub.Copilot.installer.yaml
+++ b/manifests/g/GitHub/Copilot/v0.0.400/GitHub.Copilot.installer.yaml
@@ -9,10 +9,6 @@ NestedInstallerFiles:
 - RelativeFilePath: copilot.exe
 Commands:
 - copilot
-Dependencies:
-  PackageDependencies:
-    - PackageIdentifier: Microsoft.PowerShell
-      MinimumVersion: "7.0.0"
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/github/copilot-cli/releases/download/v0.0.400/copilot-win32-x64.zip
@@ -23,3 +19,4 @@ Installers:
 ManifestType: installer
 ManifestVersion: 1.10.0
 ReleaseDate: 2026-01-30
+

--- a/manifests/g/GitHub/Copilot/v0.0.400/GitHub.Copilot.installer.yaml
+++ b/manifests/g/GitHub/Copilot/v0.0.400/GitHub.Copilot.installer.yaml
@@ -19,4 +19,3 @@ Installers:
 ManifestType: installer
 ManifestVersion: 1.10.0
 ReleaseDate: 2026-01-30
-


### PR DESCRIPTION
We already require PowerShell 6+ at runtime, so this change to the manifest should make installation easier.

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?  If so, fill in the Issue number below.
   <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/335848)