### PR TITLE
New version: Garmin.Express version 7.28.0

### DIFF
--- a/manifests/g/Garmin/Express/7.28.0/Garmin.Express.installer.yaml
+++ b/manifests/g/Garmin/Express/7.28.0/Garmin.Express.installer.yaml
@@ -1,0 +1,20 @@
+# Created using winget-create
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: Garmin.Express
+PackageVersion: 7.28.0
+InstallerLocale: en-US
+InstallerType: burn
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2025-01-28
+Installers:
+  - Architecture: x86
+    InstallerUrl: https://download.garmin.com/omt/express/GarminExpress.exe
+    InstallerSha256: B9B82E864C32CC8F3934EF4BEBF6E5939B884C0EF98AF5FC7FF3314E7B5BA781
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/g/Garmin/Express/7.28.0/Garmin.Express.locale.en-US.yaml
+++ b/manifests/g/Garmin/Express/7.28.0/Garmin.Express.locale.en-US.yaml
@@ -1,0 +1,37 @@
+# Created using winget-create
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: Garmin.Express
+PackageVersion: 7.28.0
+PackageLocale: en-US
+Publisher: Garmin Ltd. or its subsidiaries
+PublisherUrl: https://www.garmin.com
+PublisherSupportUrl: https://support.garmin.com
+PrivacyUrl: https://www.garmin.com/en-US/privacy/connect
+PackageName: Garmin Express
+PackageUrl: https://www.garmin.com/en-US/software/express
+License: Proprietary
+LicenseUrl: https://www.garmin.com/en-US/legal/terms-of-use
+Copyright: Copyright (c) Garmin Ltd. or its subsidiaries
+ShortDescription: Update maps and software, sync with Garmin Connect and register your device.
+Description: |-
+  Garmin Express is a desktop application for managing your Garmin devices.
+  Use Garmin Express to update maps and software, sync with Garmin Connect and register your device.
+  - Keep your street maps updated to find new places and get accurate directions to your destinations
+  - Upload your activities and wellness data to your Garmin Connect account
+  - Install free software updates as they become available
+  - Download content from the Connect IQ Store app including watch faces and apps
+  - Download and install marine charts
+  - Download CourseView golf course updates for your compatible Garmin device
+  - Activate and redeem map vouchers and product keys
+Moniker: garmin-express
+Tags:
+  - garmin
+  - garmin-connect
+  - garmin-express
+  - gps
+  - maps
+  - sync
+DocumentationUrl: https://support.garmin.com/en-US/?productID=180766&tab=topics
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/g/Garmin/Express/7.28.0/Garmin.Express.yaml
+++ b/manifests/g/Garmin/Express/7.28.0/Garmin.Express.yaml
@@ -1,0 +1,8 @@
+# Created using winget-create
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: Garmin.Express
+PackageVersion: 7.28.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
### Description

Update Garmin Express from 7.27.1.0 to 7.28.0

### Validation

- [x] Manifest validated with `winget validate`
- [x] Tested locally with `winget install --manifest`

### Details

- **InstallerUrl:** https://download.garmin.com/omt/express/GarminExpress.exe
- **InstallerSha256:** B9B82E864C32CC8F3934EF4BEBF6E5939B884C0EF98AF5FC7FF3314E7B5BA781
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/335933)