### PR TITLE
New package: randlee.claude-history version 0.3.0

### DIFF
--- a/manifests/r/randlee/claude-history/0.3.0/randlee.claude-history.installer.yaml
+++ b/manifests/r/randlee/claude-history/0.3.0/randlee.claude-history.installer.yaml
@@ -1,0 +1,20 @@
+# Created using winget-create
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: randlee.claude-history
+PackageVersion: 0.3.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: zip
+ReleaseDate: 2026-02-07
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/randlee/claude-history/releases/download/v0.3.0/claude-history_0.3.0_windows_amd64.zip
+  InstallerSha256: 32a88dd394c3ee027790ba6ba6110a7233145ab366780c8e764bb1fbca55040c
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: claude-history.exe
+    PortableCommandAlias: claude-history
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/r/randlee/claude-history/0.3.0/randlee.claude-history.locale.en-US.yaml
+++ b/manifests/r/randlee/claude-history/0.3.0/randlee.claude-history.locale.en-US.yaml
@@ -1,0 +1,38 @@
+# Created using winget-create
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: randlee.claude-history
+PackageVersion: 0.3.0
+PackageLocale: en-US
+Publisher: randlee
+PublisherUrl: https://github.com/randlee
+PublisherSupportUrl: https://github.com/randlee/claude-history/issues
+Author: randlee
+PackageName: claude-history
+PackageUrl: https://github.com/randlee/claude-history
+License: MIT
+LicenseUrl: https://github.com/randlee/claude-history/blob/main/LICENSE
+ShortDescription: CLI tool for programmatic access to Claude Code's agent history storage
+Description: |-
+  claude-history is a Go CLI tool that provides programmatic access to Claude Code's agent history storage.
+  It maps between filesystem paths and Claude's internal storage format, enabling querying, filtering,
+  and export of conversation history including subagent sessions and tool calls.
+Moniker: claude-history
+Tags:
+- cli
+- claude
+- history
+- agent
+- conversation
+- export
+ReleaseNotes: |-
+  Phase 15: Query HTML format with subagent support
+  - Enhanced query command with HTML output format
+  - Subagent conversation rendering in HTML
+  - Improved message role labels and formatting
+  - Fixed empty message bubble issues
+  - Clickable file paths in conversation view
+  - Comprehensive test coverage for HTML rendering
+ReleaseNotesUrl: https://github.com/randlee/claude-history/releases/tag/v0.3.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/r/randlee/claude-history/0.3.0/randlee.claude-history.yaml
+++ b/manifests/r/randlee/claude-history/0.3.0/randlee.claude-history.yaml
@@ -1,0 +1,8 @@
+# Created using winget-create
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: randlee.claude-history
+PackageVersion: 0.3.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
This PR adds the initial manifest for claude-history v0.3.0.

## Package Information
- **Package Identifier**: randlee.claude-history
- **Version**: 0.3.0
- **Publisher**: randlee
- **License**: MIT
- **Repository**: https://github.com/randlee/claude-history

## Description
CLI tool for programmatic access to Claude Code's agent history storage. It maps between filesystem paths and Claude's internal storage format, enabling querying, filtering, and export of conversation history including subagent sessions and tool calls.

## Validation
- [x] Manifest files follow winget schema 1.6.0
- [x] SHA256 checksum verified from GitHub release
- [x] License verified (MIT)
- [x] All URLs are valid and accessible
- [x] Release binaries available at https://github.com/randlee/claude-history/releases/tag/v0.3.0

## Additional Notes
This is the initial submission for this package. Future releases will be automatically updated via winget-releaser.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/337541)