### PR TITLE
Update: PJO2.tftpd64 version 4.74

### DIFF
--- a/manifests/p/PJO2/tftpd64/4.74/PJO2.tftpd64.installer.yaml
+++ b/manifests/p/PJO2/tftpd64/4.74/PJO2.tftpd64.installer.yaml
@@ -6,7 +6,8 @@ PackageVersion: "4.74"
 InstallerType: nullsoft
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/PJO2/tftpd64/releases/download/v4.71/Tftpd64_Installer_v4.71.exe
-  InstallerSha256: AA0B06B5F3C7EA771E78C172F4223C29F01377EE134E6233DDA5C46E1112305C
+  InstallerUrl: https://github.com/PJO2/tftpd64/releases/download/v4.74/--Recommended--Tftpd64_Installer_v4.74.exe
+  InstallerSha256: a79c58d6a0546b5c7a7fcb2c8444d24fbd20c9c62225d93251a2102fc14d597d
 ManifestType: installer
 ManifestVersion: 1.10.0
+

--- a/manifests/p/PJO2/tftpd64/4.74/PJO2.tftpd64.installer.yaml
+++ b/manifests/p/PJO2/tftpd64/4.74/PJO2.tftpd64.installer.yaml
@@ -7,7 +7,6 @@ InstallerType: nullsoft
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/PJO2/tftpd64/releases/download/v4.74/--Recommended--Tftpd64_Installer_v4.74.exe
-  InstallerSha256: a79c58d6a0546b5c7a7fcb2c8444d24fbd20c9c62225d93251a2102fc14d597d
+  InstallerSha256: A79C58D6A0546B5C7A7FCB2C8444D24FBD20C9C62225D93251A2102FC14D597D
 ManifestType: installer
 ManifestVersion: 1.10.0
-


### PR DESCRIPTION
Fix incorrect `InstallerUrl` in manifest (pointed to old installer version).

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Is there a linked Issue?  If so, fill in the Issue number below.
  - Resolves #337743

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/337811)