### PR TITLE
New version: M-Igashi.headroom version 1.6.0

### DIFF
--- a/manifests/m/M-Igashi/headroom/1.6.0/M-Igashi.headroom.installer.yaml
+++ b/manifests/m/M-Igashi/headroom/1.6.0/M-Igashi.headroom.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.headroom
+PackageVersion: 1.6.0
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: headroom.exe
+ReleaseDate: 2026-02-10
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/M-Igashi/headroom/releases/download/v1.6.0/headroom-v1.6.0-windows-x86_64.zip
+    InstallerSha256: 53D328803ECEAE9CBA4B34558F8D8C735EF643785FAA80A503E4FF576465E755
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/headroom/1.6.0/M-Igashi.headroom.locale.en-US.yaml
+++ b/manifests/m/M-Igashi/headroom/1.6.0/M-Igashi.headroom.locale.en-US.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.headroom
+PackageVersion: 1.6.0
+PackageLocale: en-US
+Publisher: M-Igashi
+PublisherUrl: https://github.com/M-Igashi
+PublisherSupportUrl: https://github.com/M-Igashi/headroom/issues
+Author: M-Igashi
+PackageName: headroom
+PackageUrl: https://github.com/M-Igashi/headroom
+License: MIT
+LicenseUrl: https://github.com/M-Igashi/headroom/blob/main/LICENSE
+ShortDescription: Audio loudness analyzer and gain adjustment tool for mastering and DJ workflows
+Description: |-
+  headroom analyzes audio files for loudness (LUFS) and headroom, then applies lossless gain adjustment.
+  It supports MP3, AAC/M4A, FLAC, AIFF, and WAV files.
+  Features include batch processing, ReplayGain analysis, and integration with mp3rgain for lossless MP3 adjustment.
+Moniker: headroom
+Tags:
+  - audio
+  - cli
+  - dj
+  - ffmpeg
+  - gain
+  - loudness
+  - lufs
+  - mastering
+  - mp3
+  - music
+  - normalize
+  - replaygain
+  - rust
+  - volume
+ReleaseNotesUrl: https://github.com/M-Igashi/headroom/releases/tag/v1.6.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/headroom/1.6.0/M-Igashi.headroom.yaml
+++ b/manifests/m/M-Igashi/headroom/1.6.0/M-Igashi.headroom.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.headroom
+PackageVersion: 1.6.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

New version for headroom 1.6.0.

headroom is a CLI tool for audio loudness analysis and gain adjustment for mastering and DJ workflows.

## Changes

- New version: M-Igashi.headroom version 1.6.0
- Updated built-in mp3rgain library to 1.6.0 (MP4/M4A hardened file handling, atomic writes, ALAC/DRM detection)
- Internal code simplification for better maintainability

## Links

- Release: https://github.com/M-Igashi/headroom/releases/tag/v1.6.0
- Repository: https://github.com/M-Igashi/headroom
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/338098)