### PR TITLE
Move MicheleLocati.GettextIconv 0.26+1.17 to mlocati.GetText 0.26+1.17

### DIFF
--- a/manifests/m/mlocati/GetText/0.26+1.17/mlocati.GetText.installer.yaml
+++ b/manifests/m/mlocati/GetText/0.26+1.17/mlocati.GetText.installer.yaml
@@ -1,0 +1,15 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: mlocati.GetText
+PackageVersion: 0.26+1.17
+InstallerType: inno
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/mlocati/gettext-iconv-windows/releases/download/v0.26-v1.17/gettext0.26-iconv1.17-shared-64.exe
+  InstallerSha256: C6BB3EB85ED660E2366EDEBD83EED03074FC277F7C91527C511E52D9235711A7
+- Architecture: x86
+  InstallerUrl: https://github.com/mlocati/gettext-iconv-windows/releases/download/v0.26-v1.17/gettext0.26-iconv1.17-shared-32.exe
+  InstallerSha256: D5E9EB02322BCF1CFB3166AAB88A82C12424D0766D221A622B5F10D2CF75B6CF
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/m/mlocati/GetText/0.26+1.17/mlocati.GetText.locale.en-US.yaml
+++ b/manifests/m/mlocati/GetText/0.26+1.17/mlocati.GetText.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: mlocati.GetText
+PackageVersion: 0.26+1.17
+PackageLocale: en-US
+Publisher: Michele Locati
+PackageName: gettext and iconv binaries for Windows (Shared)
+PackageUrl: https://github.com/mlocati/gettext-iconv-windows
+License: MIT
+ShortDescription: Pre-compiled Windows binaries of the GNU-created textfile command line tools iconv and gettext.
+Tags:
+- requirescmd
+- texthandling
+- textconverter
+- encodingconverting
+- gnu
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/m/mlocati/GetText/0.26+1.17/mlocati.GetText.yaml
+++ b/manifests/m/mlocati/GetText/0.26+1.17/mlocati.GetText.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: mlocati.GetText
+PackageVersion: 0.26+1.17
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Someone submitted [my gettext installers](https://github.com/mlocati/gettext-iconv-windows) as `MicheleLocati.GettextIconv`, but we already had `mlocati.GetText`.

How about the renaming `MicheleLocati.GettextIconv` to `mlocati.GetText`?

PS: I'm planning to improve the release process to automatically send a PR to winget-pkgs, so no one else feels the need to do it.



Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?  No

Manifests
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] This PR only modifies one (1) manifest
- [X] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [X] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/338178)