### PR TITLE
Fix jdx.mise 2026.2.9 manifest to include shim executable

### DIFF
--- a/manifests/j/jdx/mise/2026.2.9/jdx.mise.installer.yaml
+++ b/manifests/j/jdx/mise/2026.2.9/jdx.mise.installer.yaml
@@ -7,6 +7,7 @@ InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
 - RelativeFilePath: mise/bin/mise.exe
+- RelativeFilePath: mise/bin/mise-shim.exe
 UpgradeBehavior: install
 Dependencies:
   PackageDependencies:
@@ -21,3 +22,4 @@ Installers:
   InstallerSha256: 332D2C4023C0F70717E92F3BD357479FC703519A98D4DB8969554E7564C8A6A0
 ManifestType: installer
 ManifestVersion: 1.12.0
+


### PR DESCRIPTION
Add 'mise-shim.exe' as a nested installer file, it is available and required since 2026.2.7, see https://github.com/jdx/mise/pull/8045

Same PR for 2026.2.8: https://github.com/microsoft/winget-pkgs/pull/338303

Checklist for Pull Requests
- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?  If so, fill in the Issue number below.
   <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/338495)