### PR TITLE
New package: Microsoft.Aspire.CLI.Preview version 3.2.0-preview.1.26110.8

### DIFF
--- a/manifests/m/Microsoft/Aspire/CLI/Preview/13.2.0-preview.1.26110.8/Microsoft.Aspire.CLI.Preview.installer.yaml
+++ b/manifests/m/Microsoft/Aspire/CLI/Preview/13.2.0-preview.1.26110.8/Microsoft.Aspire.CLI.Preview.installer.yaml
@@ -1,0 +1,22 @@
+# Created with komac v2.15.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.Aspire.CLI.Preview
+PackageVersion: 13.2.0-preview.1.26110.8
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: aspire.exe
+InstallModes:
+- silent
+UpgradeBehavior: uninstallPrevious
+ReleaseDate: 2026-02-11
+Installers:
+- Architecture: x64
+  InstallerUrl: https://ci.dot.net/public/aspire/13.2.0-preview.1.26110.8/aspire-cli-win-x64-13.2.0-preview.1.26110.8.zip
+  InstallerSha256: 3A020D8AB51B97656B506720FD17884F955ECB8D042871E25AF91AF824C15774
+- Architecture: arm64
+  InstallerUrl: https://ci.dot.net/public/aspire/13.2.0-preview.1.26110.8/aspire-cli-win-arm64-13.2.0-preview.1.26110.8.zip
+  InstallerSha256: 94ECC5A6FFF8D4E356B5216BC88D12124571D8FC0545DD21A4610035523E9E06
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/Microsoft/Aspire/CLI/Preview/13.2.0-preview.1.26110.8/Microsoft.Aspire.CLI.Preview.locale.en-US.yaml
+++ b/manifests/m/Microsoft/Aspire/CLI/Preview/13.2.0-preview.1.26110.8/Microsoft.Aspire.CLI.Preview.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# Created with komac v2.15.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.Aspire.CLI.Preview
+PackageVersion: 13.2.0-preview.1.26110.8
+PackageLocale: en-US
+Publisher: Microsoft Corporation
+PublisherUrl: https://www.microsoft.com/en-us/
+PublisherSupportUrl: https://aspire.dev/support/
+PackageName: Aspire CLI
+PackageUrl: https://aspire.dev/
+License: MIT
+LicenseUrl: https://github.com/dotnet/aspire/blob/main/LICENSE.TXT
+Copyright: (c) Microsoft 2026
+CopyrightUrl: https://aspire.dev/#:~:text=%C2%A9%20Microsoft%202026
+ShortDescription: Your stack, streamlined.
+Description: >
+  Orchestrate front ends, APIs, containers, and databases effortlesslyno rewrites, no limits. Extend
+  Aspire to power any project.
+Tags:
+- cloud
+- dotnet
+- hacktoberfest
+- python
+- typescript
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/Microsoft/Aspire/CLI/Preview/13.2.0-preview.1.26110.8/Microsoft.Aspire.CLI.Preview.locale.zh-CN.yaml
+++ b/manifests/m/Microsoft/Aspire/CLI/Preview/13.2.0-preview.1.26110.8/Microsoft.Aspire.CLI.Preview.locale.zh-CN.yaml
@@ -1,0 +1,11 @@
+# Created with komac v2.15.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.Aspire.CLI.Preview
+PackageVersion: 13.2.0-preview.1.26110.8
+PackageLocale: zh-CN
+PublisherUrl: https://www.microsoft.com/zh-cn/
+ShortDescription: 精简你的技术栈。
+Description: 轻松编排前端、API、容器和数据库—无需重写，无限可能。扩展 Aspire 为任何项目赋能。
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/m/Microsoft/Aspire/CLI/Preview/13.2.0-preview.1.26110.8/Microsoft.Aspire.CLI.Preview.yaml
+++ b/manifests/m/Microsoft/Aspire/CLI/Preview/13.2.0-preview.1.26110.8/Microsoft.Aspire.CLI.Preview.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.15.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.Aspire.CLI.Preview
+PackageVersion: 13.2.0-preview.1.26110.8
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Checklist for Pull Requests

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Is there a linked Issue? If so, fill in the Issue number below.
  - Resolves #338465

## Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

## Manual validation

> [!WARNING]
> 
> In Simplified Chinese OS with code page 936 (GBK), the first launch of `aspire.exe` will get a HUGE section of mess and then follow the help content.
> 
> The second and later launch with exactly same command, those mess disappear.

<img width="1540" height="685" alt="Image" src="https://github.com/user-attachments/assets/9971d154-e405-419a-9462-021a2fe7b988" />
<img width="1920" height="1108" alt="Image" src="https://github.com/user-attachments/assets/8b83374c-7362-4d14-82dd-bacf8552556c" />
<img width="1920" height="1332" alt="Image" src="https://github.com/user-attachments/assets/4807f716-9c71-44f0-b539-9d2839875172" />
<img width="998" height="69" alt="Image" src="https://github.com/user-attachments/assets/86483d2b-289b-4919-a0fc-967327335add" />

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/338531)