### PR TITLE
Add sasler.TroubleScout version 1.2.6

### DIFF
--- a/manifests/s/sasler/TroubleScout/1.2.6/sasler.TroubleScout.installer.yaml
+++ b/manifests/s/sasler/TroubleScout/1.2.6/sasler.TroubleScout.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: sasler.TroubleScout
+PackageVersion: 1.2.6
+Installers:
+- Architecture: x64
+  InstallerType: zip
+  InstallerUrl: https://github.com/sasler/TroubleScout/releases/download/v1.2.6/TroubleScout-v1.2.6-win-x64.zip
+  InstallerSha256: FD9700123B4B7ADAA87A7D281CE1F9222346BD591BBCD0FD9B6800AD65A92F00
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: TroubleScout.exe
+    PortableCommandAlias: troublescout
+  Commands:
+  - troublescout
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: OpenJS.NodeJS.LTS
+  UpgradeBehavior: install
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/s/sasler/TroubleScout/1.2.6/sasler.TroubleScout.installer.yaml
+++ b/manifests/s/sasler/TroubleScout/1.2.6/sasler.TroubleScout.installer.yaml
@@ -13,9 +13,6 @@ Installers:
     PortableCommandAlias: troublescout
   Commands:
   - troublescout
-  Dependencies:
-    PackageDependencies:
-    - PackageIdentifier: OpenJS.NodeJS.LTS
   UpgradeBehavior: install
 ManifestType: installer
 ManifestVersion: 1.10.0

--- a/manifests/s/sasler/TroubleScout/1.2.6/sasler.TroubleScout.locale.en-US.yaml
+++ b/manifests/s/sasler/TroubleScout/1.2.6/sasler.TroubleScout.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: sasler.TroubleScout
+PackageVersion: 1.2.6
+PackageLocale: en-US
+Publisher: sasler
+PublisherUrl: https://github.com/sasler
+PublisherSupportUrl: https://github.com/sasler/TroubleScout/issues
+PackageName: TroubleScout
+PackageUrl: https://github.com/sasler/TroubleScout
+License: MIT
+LicenseUrl: https://github.com/sasler/TroubleScout/blob/v1.2.6/README.md#license
+ShortDescription: AI-powered Windows Server troubleshooting assistant.
+Description: TroubleScout is a .NET CLI tool using the GitHub Copilot SDK to diagnose Windows Server issues using safe, read-only PowerShell commands.
+ReleaseNotesUrl: https://github.com/sasler/TroubleScout/releases/tag/v1.2.6
+Tags:
+- windows
+- windows-server
+- troubleshooting
+- powershell
+- copilot
+- cli
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/s/sasler/TroubleScout/1.2.6/sasler.TroubleScout.yaml
+++ b/manifests/s/sasler/TroubleScout/1.2.6/sasler.TroubleScout.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: sasler.TroubleScout
+PackageVersion: 1.2.6
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the Contributor License Agreement? (done previously)
- [ ] Is there a linked Issue? If so, fill in the Issue number below.
  - Resolves #

Manifests
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the 1.10 schema?

Path tested:
- manifests\s\sasler\TroubleScout\1.2.6

Validation notes:
- Local Defender CLI scan of the v1.2.6 ZIP and extracted TroubleScout.exe found no threats (exit code 0 for both).
- Prior PR #337119 failed manual security checks in approval VMs for v1.2.4; this PR updates to latest v1.2.6.
- Installer dependency declared: OpenJS.NodeJS.LTS
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/338980)