### PR TITLE
Fix installer URLs in LINQPad manifest

### DIFF
--- a/manifests/l/LINQPad/LINQPad/7/7.8.10/LINQPad.LINQPad.7.installer.yaml
+++ b/manifests/l/LINQPad/LINQPad/7/7.8.10/LINQPad.LINQPad.7.installer.yaml
@@ -1,6 +1,3 @@
-# Automatically updated by the winget bot at 2024/Feb/03
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
-
 PackageIdentifier: LINQPad.LINQPad.7
 PackageVersion: 7.8.10
 MinimumOSVersion: 10.0.0.0
@@ -19,4 +16,5 @@ Installers:
   InstallerUrl: https://cdn.linqpad.net/public/LINQPad7Setup.exe
   InstallerSha256: 2EEB973B082F8C8005FA7FEB86A5C10C2276FA6922DDC203D56540D9E4BB821D
 ManifestType: installer
-ManifestVersion: 1.4.0
+ManifestVersion: 1.10.0
+

--- a/manifests/l/LINQPad/LINQPad/7/7.8.10/LINQPad.LINQPad.7.installer.yaml
+++ b/manifests/l/LINQPad/LINQPad/7/7.8.10/LINQPad.LINQPad.7.installer.yaml
@@ -13,10 +13,10 @@ Dependencies:
   - PackageIdentifier: Microsoft.DotNet.Runtime.6
 Installers:
 - Architecture: x64
-  InstallerUrl: https://linqpad.azureedge.net/public/LINQPad7Setup.exe
+  InstallerUrl: https://cdn.linqpad.net/public/LINQPad7Setup.exe
   InstallerSha256: 2EEB973B082F8C8005FA7FEB86A5C10C2276FA6922DDC203D56540D9E4BB821D
 - Architecture: x86
-  InstallerUrl: https://linqpad.azureedge.net/public/LINQPad7Setup.exe
+  InstallerUrl: https://cdn.linqpad.net/public/LINQPad7Setup.exe
   InstallerSha256: 2EEB973B082F8C8005FA7FEB86A5C10C2276FA6922DDC203D56540D9E4BB821D
 ManifestType: installer
 ManifestVersion: 1.4.0

--- a/manifests/l/LINQPad/LINQPad/7/7.8.10/LINQPad.LINQPad.7.locale.en-US.yaml
+++ b/manifests/l/LINQPad/LINQPad/7/7.8.10/LINQPad.LINQPad.7.locale.en-US.yaml
@@ -1,6 +1,3 @@
-# Automatically updated by the winget bot at 2024/Feb/03
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.4.0.schema.json
-
 PackageIdentifier: LINQPad.LINQPad.7
 PackageVersion: 7.8.10
 PackageLocale: en-US
@@ -24,4 +21,5 @@ Tags:
 - linq
 - sql
 ManifestType: defaultLocale
-ManifestVersion: 1.4.0
+ManifestVersion: 1.10.0
+

--- a/manifests/l/LINQPad/LINQPad/7/7.8.10/LINQPad.LINQPad.7.yaml
+++ b/manifests/l/LINQPad/LINQPad/7/7.8.10/LINQPad.LINQPad.7.yaml
@@ -1,8 +1,6 @@
-# Automatically updated by the winget bot at 2024/Feb/03
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.4.0.schema.json
-
 PackageIdentifier: LINQPad.LINQPad.7
 PackageVersion: 7.8.10
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.4.0
+ManifestVersion: 1.10.0
+


### PR DESCRIPTION
Updated download URI to canonical CDN prior to the shutdown of azureedge.net.

Checklist for Pull Requests
- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?  If so, fill in the Issue number below.
   <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

Manifests
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/339052)