### PR TITLE
New Version: Educator.Engine v1.0.8.20

### DIFF
--- a/manifests/e/Educator/Engine/1.0.8.20/Educator.Engine.installer.yaml
+++ b/manifests/e/Educator/Engine/1.0.8.20/Educator.Engine.installer.yaml
@@ -1,0 +1,17 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: Educator.Engine
+PackageVersion: 1.0.8.20
+InstallerLocale: ja-JP
+InstallerType: msi
+ProductCode: '{0E5DA9AF-D50F-4D62-9194-3B455450E5A9}'
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.10
+Installers:
+- Architecture: x64
+  InstallerUrl: https://jlsms-downloads.s3.ap-northeast-1.amazonaws.com/Educator.Engine.Production-1.0.8.20-x64.msi
+  InstallerSha256: 26A0A6AC0026F9AB7A85A002AF075D83512D58D59F491756F17F9F0727EACC3E
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/e/Educator/Engine/1.0.8.20/Educator.Engine.installer.yaml
+++ b/manifests/e/Educator/Engine/1.0.8.20/Educator.Engine.installer.yaml
@@ -6,6 +6,10 @@ PackageVersion: 1.0.8.20
 InstallerLocale: ja-JP
 InstallerType: msi
 ProductCode: '{0E5DA9AF-D50F-4D62-9194-3B455450E5A9}'
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.10
+    MinimumVersion: 10.0.3
 Installers:
 - Architecture: x64
   InstallerUrl: https://jlsms-downloads.s3.ap-northeast-1.amazonaws.com/Educator.Engine.Production-1.0.8.20-x64.msi

--- a/manifests/e/Educator/Engine/1.0.8.20/Educator.Engine.installer.yaml
+++ b/manifests/e/Educator/Engine/1.0.8.20/Educator.Engine.installer.yaml
@@ -6,10 +6,6 @@ PackageVersion: 1.0.8.20
 InstallerLocale: ja-JP
 InstallerType: msi
 ProductCode: '{0E5DA9AF-D50F-4D62-9194-3B455450E5A9}'
-Dependencies:
-  PackageDependencies:
-  - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.10
-    MinimumVersion: 10.0.3
 Installers:
 - Architecture: x64
   InstallerUrl: https://jlsms-downloads.s3.ap-northeast-1.amazonaws.com/Educator.Engine.Production-1.0.8.20-x64.msi

--- a/manifests/e/Educator/Engine/1.0.8.20/Educator.Engine.installer.yaml
+++ b/manifests/e/Educator/Engine/1.0.8.20/Educator.Engine.installer.yaml
@@ -6,9 +6,6 @@ PackageVersion: 1.0.8.20
 InstallerLocale: ja-JP
 InstallerType: msi
 ProductCode: '{0E5DA9AF-D50F-4D62-9194-3B455450E5A9}'
-Dependencies:
-  PackageDependencies:
-  - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.10
 Installers:
 - Architecture: x64
   InstallerUrl: https://jlsms-downloads.s3.ap-northeast-1.amazonaws.com/Educator.Engine.Production-1.0.8.20-x64.msi

--- a/manifests/e/Educator/Engine/1.0.8.20/Educator.Engine.locale.ja-JP.yaml
+++ b/manifests/e/Educator/Engine/1.0.8.20/Educator.Engine.locale.ja-JP.yaml
@@ -1,0 +1,21 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: Educator.Engine
+PackageVersion: 1.0.8.20
+PackageLocale: ja-JP
+Publisher: ODINSOFT
+PublisherUrl: https://educatorengine.com
+PublisherSupportUrl:
+PrivacyUrl: https://www.educatorengine.com/html/sub06/sub0601.asp
+Author: ODINSOFT
+PackageName: Educator Engine
+PackageUrl: https://www.educatorengine.com/html/sub01/sub0101.asp
+License: Proprietary
+LicenseUrl:
+Copyright: OdinSoft CO., LTD
+CopyrightUrl: https://www.odinsoft.co.kr
+ShortDescription: This application is a management software for Japanese language schools in Japan.
+Description: This application is a management software for Japanese language schools in Japan. It supports student management, exam and attendance tracking, and the creation and management of various official reporting documents.
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/e/Educator/Engine/1.0.8.20/Educator.Engine.yaml
+++ b/manifests/e/Educator/Engine/1.0.8.20/Educator.Engine.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: Educator.Engine
+PackageVersion: 1.0.8.20
+DefaultLocale: ja-JP
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Summary
- Add Educator.Engine version 1.0.8.20 manifest
- InstallerUrl: https://jlsms-downloads.s3.ap-northeast-1.amazonaws.com/Educator.Engine.Production-1.0.8.20-x64.msi
- Architecture: x64
- InstallerType: msi
- Dependencies: Microsoft.DotNet.DesktopRuntime.10
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/339215)