### PR TITLE
New package: SakiStudio.SakiVI version 1.0.0

### DIFF
--- a/manifests/s/SakiStudio/SakiVI/1.0.0/SakiStudio.SakiVI.installer.yaml
+++ b/manifests/s/SakiStudio/SakiVI/1.0.0/SakiStudio.SakiVI.installer.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: SakiStudio.SakiVI
+PackageVersion: 1.0.0
+InstallerType: portable
+Commands:
+  - vi
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Saki-tw/Vi-SakiWin64/releases/download/v1.0.0/vi.exe
+    InstallerSha256: 6c5782d8d5ff6f43411450d4fdde7d4b086cf4b52f8ba6ef91be00408bc0bc8d
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/SakiStudio/SakiVI/1.0.0/SakiStudio.SakiVI.installer.yaml
+++ b/manifests/s/SakiStudio/SakiVI/1.0.0/SakiStudio.SakiVI.installer.yaml
@@ -7,6 +7,6 @@ Commands:
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/Saki-tw/Vi-SakiWin64/releases/download/v1.0.0/vi.exe
-    InstallerSha256: 6c5782d8d5ff6f43411450d4fdde7d4b086cf4b52f8ba6ef91be00408bc0bc8d
+    InstallerSha256: f8235794d90eb100ced49bf6532a678c0dae5f5b53e132659817c920d88adf3b
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/s/SakiStudio/SakiVI/1.0.0/SakiStudio.SakiVI.locale.en-US.yaml
+++ b/manifests/s/SakiStudio/SakiVI/1.0.0/SakiStudio.SakiVI.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: SakiStudio.SakiVI
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: Saki Studio
+PublisherUrl: https://saki-studio.com.tw
+PublisherSupportUrl: https://github.com/Saki-tw/Vi-SakiWin64/issues
+Author: Saki (咲ちゃん)
+PackageName: Vi
+PackageUrl: https://github.com/Saki-tw/Vi-SakiWin64
+License: GPL-2.0-only
+LicenseUrl: https://github.com/Saki-tw/Vi-SakiWin64/blob/main/LICENSE
+Copyright: Copyright (C) 2026 Saki Studio
+ShortDescription: "Vi — the original Vi, not Vim. Trilingual native Win64 build."
+Description: |-
+  Vi — the original Vi. The one Bill Joy wrote, alive again on Windows.
+  Built from BusyBox-w32 with MSYS2 UCRT64 toolchain as a native Win64 binary.
+  Trilingual interface (Traditional Chinese / Japanese / English),
+  direct Unicode output via WriteConsoleW, single portable executable.
+  Install it, type vi. That's it.
+Tags:
+  - vi
+  - editor
+  - text-editor
+  - busybox
+  - trilingual
+  - portable
+  - cli
+  - unicode
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/SakiStudio/SakiVI/1.0.0/SakiStudio.SakiVI.locale.en-US.yaml
+++ b/manifests/s/SakiStudio/SakiVI/1.0.0/SakiStudio.SakiVI.locale.en-US.yaml
@@ -3,7 +3,7 @@ PackageIdentifier: SakiStudio.SakiVI
 PackageVersion: 1.0.0
 PackageLocale: en-US
 Publisher: Saki Studio
-PublisherUrl: https://saki-studio.com.tw
+PublisherUrl: http://saki-studio.com.tw
 PublisherSupportUrl: https://github.com/Saki-tw/Vi-SakiWin64/issues
 Author: Saki (咲ちゃん)
 PackageName: Vi

--- a/manifests/s/SakiStudio/SakiVI/1.0.0/SakiStudio.SakiVI.locale.en-US.yaml
+++ b/manifests/s/SakiStudio/SakiVI/1.0.0/SakiStudio.SakiVI.locale.en-US.yaml
@@ -3,7 +3,7 @@ PackageIdentifier: SakiStudio.SakiVI
 PackageVersion: 1.0.0
 PackageLocale: en-US
 Publisher: Saki Studio
-PublisherUrl: http://saki-studio.com.tw
+PublisherUrl: https://saki-studio.com.tw
 PublisherSupportUrl: https://github.com/Saki-tw/Vi-SakiWin64/issues
 Author: Saki (咲ちゃん)
 PackageName: Vi

--- a/manifests/s/SakiStudio/SakiVI/1.0.0/SakiStudio.SakiVI.locale.zh-Hant.yaml
+++ b/manifests/s/SakiStudio/SakiVI/1.0.0/SakiStudio.SakiVI.locale.zh-Hant.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
+PackageIdentifier: SakiStudio.SakiVI
+PackageVersion: 1.0.0
+PackageLocale: zh-Hant
+Publisher: Saki Studio
+PublisherUrl: https://saki-studio.com.tw
+PublisherSupportUrl: https://github.com/Saki-tw/Vi-SakiWin64/issues
+Author: 咲ちゃん（Saki）
+PackageName: Vi
+PackageUrl: https://github.com/Saki-tw/Vi-SakiWin64
+License: GPL-2.0-only
+LicenseUrl: https://github.com/Saki-tw/Vi-SakiWin64/blob/main/LICENSE
+Copyright: Copyright (C) 2026 咲ちゃん（Saki）/ Saki Studio
+ShortDescription: Vi — 就是那個 Vi，不是什麼 Vim。三語 Windows 原生版。
+Description: |-
+  Vi — 就是那個 Vi。Bill Joy 寫的那個，在 Windows 上活過來了。
+  基於 BusyBox-w32，以 MSYS2 UCRT64 工具鏈編譯為原生 Win64 執行檔。
+  三語介面（繁體中文 / 日本語 / English），WriteConsoleW Unicode 直接輸出，
+  單檔可攜式，裝完打 vi 就是 vi。
+Tags:
+  - vi
+  - editor
+  - text-editor
+  - busybox
+  - trilingual
+  - portable
+  - cli
+  - unicode
+ManifestType: locale
+ManifestVersion: 1.6.0

--- a/manifests/s/SakiStudio/SakiVI/1.0.0/SakiStudio.SakiVI.locale.zh-Hant.yaml
+++ b/manifests/s/SakiStudio/SakiVI/1.0.0/SakiStudio.SakiVI.locale.zh-Hant.yaml
@@ -3,7 +3,7 @@ PackageIdentifier: SakiStudio.SakiVI
 PackageVersion: 1.0.0
 PackageLocale: zh-Hant
 Publisher: Saki Studio
-PublisherUrl: http://saki-studio.com.tw
+PublisherUrl: https://saki-studio.com.tw
 PublisherSupportUrl: https://github.com/Saki-tw/Vi-SakiWin64/issues
 Author: 咲ちゃん（Saki）
 PackageName: Vi

--- a/manifests/s/SakiStudio/SakiVI/1.0.0/SakiStudio.SakiVI.locale.zh-Hant.yaml
+++ b/manifests/s/SakiStudio/SakiVI/1.0.0/SakiStudio.SakiVI.locale.zh-Hant.yaml
@@ -3,7 +3,7 @@ PackageIdentifier: SakiStudio.SakiVI
 PackageVersion: 1.0.0
 PackageLocale: zh-Hant
 Publisher: Saki Studio
-PublisherUrl: https://saki-studio.com.tw
+PublisherUrl: http://saki-studio.com.tw
 PublisherSupportUrl: https://github.com/Saki-tw/Vi-SakiWin64/issues
 Author: 咲ちゃん（Saki）
 PackageName: Vi

--- a/manifests/s/SakiStudio/SakiVI/1.0.0/SakiStudio.SakiVI.yaml
+++ b/manifests/s/SakiStudio/SakiVI/1.0.0/SakiStudio.SakiVI.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: SakiStudio.SakiVI
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package submission

- **PackageIdentifier**: SakiStudio.SakiVI
- **PackageVersion**: 1.0.0
- **PackageName**: Vi
- **Publisher**: Saki Studio
- **License**: GPL-2.0-only
- **InstallerType**: portable
- **Homepage**: https://saki-studio.com.tw/vi/

Vi — the original Vi, not Vim. Single portable Win64 binary (178KB), UCRT64 native, trilingual interface.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/339486)