### PR TITLE
Add TimeTracker version 0.4.1

### DIFF
--- a/manifests/t/tmtrckr/TimeTracker/0.4.1/tmtrckr.TimeTracker.installer.yaml
+++ b/manifests/t/tmtrckr/TimeTracker/0.4.1/tmtrckr.TimeTracker.installer.yaml
@@ -1,4 +1,4 @@
-# Created with GitHub Actions
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
 PackageIdentifier: tmtrckr.TimeTracker
 PackageVersion: 0.4.1
 Installers:

--- a/manifests/t/tmtrckr/TimeTracker/0.4.1/tmtrckr.TimeTracker.installer.yaml
+++ b/manifests/t/tmtrckr/TimeTracker/0.4.1/tmtrckr.TimeTracker.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
 PackageIdentifier: tmtrckr.TimeTracker
 PackageVersion: 0.4.1
 Installers:

--- a/manifests/t/tmtrckr/TimeTracker/0.4.1/tmtrckr.TimeTracker.installer.yaml
+++ b/manifests/t/tmtrckr/TimeTracker/0.4.1/tmtrckr.TimeTracker.installer.yaml
@@ -1,0 +1,15 @@
+# Created with GitHub Actions
+PackageIdentifier: tmtrckr.TimeTracker
+PackageVersion: 0.4.1
+Installers:
+  - InstallerType: msi
+    Architecture: x64
+    InstallerUrl: https://github.com/tmtrckr/time-tracker-app/releases/download/v0.4.1/TimeTracker_0.4.1_x64_en-US.msi
+    InstallerSha256: 7bb5f0f31e025473e0304243e487d71f82c80a402ecc84f07476b327927d0d1f
+    InstallModes:
+      - silent
+      - silentWithProgress
+    Scope: machine
+ManifestType: installer
+ManifestVersion: 1.10.0
+

--- a/manifests/t/tmtrckr/TimeTracker/0.4.1/tmtrckr.TimeTracker.locale.en-US.yaml
+++ b/manifests/t/tmtrckr/TimeTracker/0.4.1/tmtrckr.TimeTracker.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# Created with GitHub Actions
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
 PackageIdentifier: tmtrckr.TimeTracker
 PackageVersion: 0.4.1
 PackageLocale: en-US

--- a/manifests/t/tmtrckr/TimeTracker/0.4.1/tmtrckr.TimeTracker.locale.en-US.yaml
+++ b/manifests/t/tmtrckr/TimeTracker/0.4.1/tmtrckr.TimeTracker.locale.en-US.yaml
@@ -9,7 +9,7 @@ Author: tmtrckr
 PackageName: TimeTracker
 PackageUrl: https://github.com/tmtrckr/time-tracker-app
 License: MIT
-LicenseUrl: https://github.com/tmtrckr/time-tracker-app/blob/main/LICENSE
+LicenseUrl: https://github.com/tmtrckr/time-tracker-app/blob/v0.4.1/LICENSE
 Copyright: Copyright (c) 2026 tmtrckr
 CopyrightUrl: https://github.com/tmtrckr/time-tracker-app
 ShortDescription: Time Tracking Application

--- a/manifests/t/tmtrckr/TimeTracker/0.4.1/tmtrckr.TimeTracker.locale.en-US.yaml
+++ b/manifests/t/tmtrckr/TimeTracker/0.4.1/tmtrckr.TimeTracker.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# Created with GitHub Actions
+PackageIdentifier: tmtrckr.TimeTracker
+PackageVersion: 0.4.1
+PackageLocale: en-US
+Publisher: tmtrckr
+PublisherUrl: https://github.com/tmtrckr/time-tracker-app
+PublisherSupportUrl: https://github.com/tmtrckr/time-tracker-app/issues
+Author: tmtrckr
+PackageName: TimeTracker
+PackageUrl: https://github.com/tmtrckr/time-tracker-app
+License: MIT
+LicenseUrl: https://github.com/tmtrckr/time-tracker-app/blob/main/LICENSE
+Copyright: Copyright (c) 2026 tmtrckr
+CopyrightUrl: https://github.com/tmtrckr/time-tracker-app
+ShortDescription: Time Tracking Application
+Description: Desktop application for automatic time tracking that shows where your working time goes, with smart handling of idle time.
+Tags:
+  - time-tracking
+  - productivity
+  - time-management
+Moniker: timetracker
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0
+

--- a/manifests/t/tmtrckr/TimeTracker/0.4.1/tmtrckr.TimeTracker.yaml
+++ b/manifests/t/tmtrckr/TimeTracker/0.4.1/tmtrckr.TimeTracker.yaml
@@ -1,4 +1,4 @@
-# Created with GitHub Actions
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
 PackageIdentifier: tmtrckr.TimeTracker
 PackageVersion: 0.4.1
 DefaultLocale: en-US

--- a/manifests/t/tmtrckr/TimeTracker/0.4.1/tmtrckr.TimeTracker.yaml
+++ b/manifests/t/tmtrckr/TimeTracker/0.4.1/tmtrckr.TimeTracker.yaml
@@ -1,0 +1,7 @@
+# Created with GitHub Actions
+PackageIdentifier: tmtrckr.TimeTracker
+PackageVersion: 0.4.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0
+


### PR DESCRIPTION
## Description
This PR adds TimeTracker version 0.4.1 to the WinGet repository.

## Changes
- Added manifests for TimeTracker 0.4.1
- Installer: MSI package
- Architecture: x64

## Checklist
- [x] Manifest files are correctly formatted
- [x] Installer URL is valid and accessible
- [x] SHA256 checksum is correct
- [x] Silent install switches are configured

## Related
Release: https://github.com/tmtrckr/time-tracker-app/releases/tag/v0.4.1

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/339608)