### PR TITLE
New package: curiousdev.az-loadenv-cli version 1.0.2

### DIFF
--- a/manifests/c/curiousdev/az-loadenv-cli/1.0.2/curiousdev.az-loadenv-cli.installer.yaml
+++ b/manifests/c/curiousdev/az-loadenv-cli/1.0.2/curiousdev.az-loadenv-cli.installer.yaml
@@ -1,0 +1,16 @@
+# Created using wingetcreate
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: curiousdev.az-loadenv-cli
+PackageVersion: 1.0.2
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: az-loadenv.exe
+    PortableCommandAlias: az-loadenv
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/curiousdev/az-loadenv/releases/download/v1.0.2/az-loadenv-windows-amd64.zip
+    InstallerSha256: D7539B8C2F81FA4FBE95E9D7A0F616409105B754B6F5BFF5104AC7D73EDE0919
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/c/curiousdev/az-loadenv-cli/1.0.2/curiousdev.az-loadenv-cli.locale.en-US.yaml
+++ b/manifests/c/curiousdev/az-loadenv-cli/1.0.2/curiousdev.az-loadenv-cli.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# Created using wingetcreate
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: curiousdev.az-loadenv-cli
+PackageVersion: 1.0.2
+PackageLocale: en-US
+Publisher: curiousdev
+PackageName: az-loadenv-cli
+PackageUrl: https://github.com/curiousdev/az-loadenv
+License: MIT
+LicenseUrl: https://github.com/curiousdev/az-loadenv/blob/main/LICENSE
+ShortDescription: Export Azure Web App settings to a .env file with automatic Key Vault secret resolution
+Description: |-
+  az-loadenv fetches application settings from an Azure App Service web app and writes them to a .env file.
+  Any settings that reference Azure Key Vault secrets are automatically resolved to their actual values.
+  Key Vault references are resolved concurrently and the output file is written atomically.
+Tags:
+  - azure
+  - cli
+  - dotenv
+  - env
+  - keyvault
+  - secrets
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/c/curiousdev/az-loadenv-cli/1.0.2/curiousdev.az-loadenv-cli.yaml
+++ b/manifests/c/curiousdev/az-loadenv-cli/1.0.2/curiousdev.az-loadenv-cli.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: curiousdev.az-loadenv-cli
+PackageVersion: 1.0.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package submission

- **PackageIdentifier:** curiousdev.az-loadenv-cli
- **PackageVersion:** 1.0.2
- **PackageUrl:** https://github.com/curiousdev/az-loadenv
- **License:** MIT

### Description

az-loadenv exports Azure Web App settings to a .env file with automatic Key Vault secret resolution. Key Vault references are resolved concurrently and the output file is written atomically.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/340023)