### PR TITLE
Bring back WingetPathUpdater, v1.3, with better download program

### DIFF
--- a/manifests/j/jazzdelightsme/WingetPathUpdater/1.3/jazzdelightsme.WingetPathUpdater.installer.yaml
+++ b/manifests/j/jazzdelightsme/WingetPathUpdater/1.3/jazzdelightsme.WingetPathUpdater.installer.yaml
@@ -1,0 +1,23 @@
+# Created with YamlCreate.ps1 v2.3.4 $debug=AUSU.CRLF.5-1-19041-4170.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: jazzdelightsme.WingetPathUpdater
+PackageVersion: "1.3"
+InstallerType: exe
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: Silent https://raw.githubusercontent.com/jazzdelightsme/WingetPathUpdater/v1.2/WingetPathUpdaterInstall.ps1 6ee42c4b00a1f1fd54b24bd1be5b441c555ae31f32434f9d988908944402cbea
+  SilentWithProgress: SilentWithProgress https://raw.githubusercontent.com/jazzdelightsme/WingetPathUpdater/v1.2/WingetPathUpdaterInstall.ps1 6ee42c4b00a1f1fd54b24bd1be5b441c555ae31f32434f9d988908944402cbea
+  Interactive: Interactive https://raw.githubusercontent.com/jazzdelightsme/WingetPathUpdater/v1.2/WingetPathUpdaterInstall.ps1 6ee42c4b00a1f1fd54b24bd1be5b441c555ae31f32434f9d988908944402cbea
+  Log: -LogPath <LOGPATH>
+ElevationRequirement: elevationRequired
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/jazzdelightsme/PowershellStub/releases/download/v2.0.0/PowershellStub.exe
+  InstallerSha256: FC093668F648FBA3F13234837F4DAE93C46CEA9EDE4F4E045EF35A8FC3AA7A06
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/j/jazzdelightsme/WingetPathUpdater/1.3/jazzdelightsme.WingetPathUpdater.locale.en-US.yaml
+++ b/manifests/j/jazzdelightsme/WingetPathUpdater/1.3/jazzdelightsme.WingetPathUpdater.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# Created with YamlCreate.ps1 v2.3.4 $debug=AUSU.CRLF.5-1-19041-4170.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: jazzdelightsme.WingetPathUpdater
+PackageVersion: "1.3"
+PackageLocale: en-US
+Publisher: jazzdelightsme
+PublisherUrl: https://github.com/jazzdelightsme
+# PublisherSupportUrl:
+# PrivacyUrl:
+Author: jazzdelightsme
+PackageName: WingetPathUpdater
+PackageUrl: https://github.com/jazzdelightsme/WingetPathUpdater
+License: MIT License
+# LicenseUrl:
+# Copyright:
+# CopyrightUrl:
+ShortDescription: 'Addresses winget-cli #549 by providing shell wrapper scripts to update your PATH.'
+# Description:
+Moniker: wingetpathupdater
+Tags:
+- environment
+- path
+- winget
+# ReleaseNotes:
+# ReleaseNotesUrl:
+# PurchaseUrl:
+# InstallationNotes:
+# Documentations:
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/j/jazzdelightsme/WingetPathUpdater/1.3/jazzdelightsme.WingetPathUpdater.yaml
+++ b/manifests/j/jazzdelightsme/WingetPathUpdater/1.3/jazzdelightsme.WingetPathUpdater.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.3.4 $debug=AUSU.CRLF.5-1-19041-4170.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: jazzdelightsme.WingetPathUpdater
+PackageVersion: "1.3"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
The WingetPathUpdater package was removed in this change: https://github.com/microsoft/winget-pkgs/pull/329262

After conferring with the authorities, this PR brings back the package, with a better stub download program, which requires the script hash be a part of the winget package, and validates it.

More info here about the stub EXE: https://github.com/jazzdelightsme/PowershellStub

But the TL;DR is that instead of just passing along whatever arguments you give straight to `powershell.exe`, it now requires you to pass the winget install mode, the target script URL, and the target script hash. It then calls `powershell.exe` with a set wrapper script which downloads the target script, validates the hash, validates a signature if it exists, and only then runs the target script.

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/340129)