### PR TITLE
New package: AndyBochmann.DevKill version 1.1.0

### DIFF
--- a/manifests/a/AndyBochmann/DevKill/1.1.0/AndyBochmann.DevKill.installer.yaml
+++ b/manifests/a/AndyBochmann/DevKill/1.1.0/AndyBochmann.DevKill.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: AndyBochmann.DevKill
+PackageVersion: 1.1.0
+InstallerType: portable
+Commands:
+  - devkill
+ElevationRequirement: elevatesSelf
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/andybochmann/DevKill/releases/download/v1.1.0/devkill.exe
+    InstallerSha256: 904BD85B7F821B6890AF3A6E3F6EC78994FDCB0C5738E602610412CEAD352AF5
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/a/AndyBochmann/DevKill/1.1.0/AndyBochmann.DevKill.locale.en-US.yaml
+++ b/manifests/a/AndyBochmann/DevKill/1.1.0/AndyBochmann.DevKill.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: AndyBochmann.DevKill
+PackageVersion: 1.1.0
+PackageLocale: en-US
+Publisher: Andy Bochmann
+PublisherUrl: https://github.com/andybochmann
+PackageName: DevKill
+PackageUrl: https://github.com/andybochmann/DevKill
+License: MIT
+LicenseUrl: https://github.com/andybochmann/DevKill/blob/master/LICENSE
+ShortDescription: Find and kill orphaned dev server processes hogging your ports.
+Description: |-
+  DevKill is a Windows utility that discovers processes listening on ports via native Windows APIs and lets you kill them. It auto-discovers zombie dev servers (Node, .NET, Python, PHP, Vite, and others), shows them in a modern dark Fluent UI, and lets you kill them individually or in bulk. Includes CLI mode (devkill 3000), system tray integration, and auto-refresh.
+Tags:
+  - developer-tools
+  - port-manager
+  - process-killer
+  - network
+  - windows
+  - wpf
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/a/AndyBochmann/DevKill/1.1.0/AndyBochmann.DevKill.yaml
+++ b/manifests/a/AndyBochmann/DevKill/1.1.0/AndyBochmann.DevKill.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: AndyBochmann.DevKill
+PackageVersion: 1.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package submission

- Package identifier: `AndyBochmann.DevKill`
- Package version: `1.1.0`
- Package URL: https://github.com/andybochmann/DevKill
- Installer type: portable (standalone exe)
- License: MIT

### Description

DevKill is a Windows utility that finds and kills orphaned dev server processes hogging your ports. It auto-discovers zombie dev servers (Node, .NET, Python, PHP, Vite, and others) via native Windows APIs, displays them in a Fluent UI, and lets you kill them individually or in bulk. Includes CLI mode (`devkill 3000`) and system tray integration.

### Checklist

- [x] Manifest validation passed (`winget validate`)
- [x] Manifest follows schema 1.6.0
- [x] InstallerSha256 verified from GitHub release digest
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/340292)