### PR TITLE
Add MarcoHefti.YTVodManager version 0.1.3

### DIFF
--- a/manifests/m/MarcoHefti/YTVodManager/0.1.3/MarcoHefti.YTVodManager.installer.yaml
+++ b/manifests/m/MarcoHefti/YTVodManager/0.1.3/MarcoHefti.YTVodManager.installer.yaml
@@ -11,7 +11,7 @@ NestedInstallerFiles:
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/marcohefti/yt-vod-manager/releases/download/v0.1.3/yt-vod-manager_v0.1.3_windows_amd64.zip
-  InstallerSha256: 530AE62C75CC1B1B7341E43F53D5D671DFA93915FB3972180E5C91471CFAAB3C
+  InstallerSha256: DD5F59A2858D9D3856F125A6EBD3336ED5027EE98654F4FA575666A2CD25451F
 ReleaseDate: 2026-02-18
 ManifestType: installer
 ManifestVersion: 1.10.0

--- a/manifests/m/MarcoHefti/YTVodManager/0.1.3/MarcoHefti.YTVodManager.installer.yaml
+++ b/manifests/m/MarcoHefti/YTVodManager/0.1.3/MarcoHefti.YTVodManager.installer.yaml
@@ -1,0 +1,17 @@
+# Created by packaging/winget/generate-manifests.sh
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: MarcoHefti.YTVodManager
+PackageVersion: 0.1.3
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: 'yt-vod-manager_v0.1.3_windows_amd64\yt-vod-manager.exe'
+  PortableCommandAlias: yt-vod-manager
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/marcohefti/yt-vod-manager/releases/download/v0.1.3/yt-vod-manager_v0.1.3_windows_amd64.zip
+  InstallerSha256: 530AE62C75CC1B1B7341E43F53D5D671DFA93915FB3972180E5C91471CFAAB3C
+ReleaseDate: 2026-02-18
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/m/MarcoHefti/YTVodManager/0.1.3/MarcoHefti.YTVodManager.locale.en-US.yaml
+++ b/manifests/m/MarcoHefti/YTVodManager/0.1.3/MarcoHefti.YTVodManager.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# Created by packaging/winget/generate-manifests.sh
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: MarcoHefti.YTVodManager
+PackageVersion: 0.1.3
+PackageLocale: en-US
+Publisher: Marco Hefti
+PublisherUrl: https://github.com/marcohefti
+PublisherSupportUrl: https://github.com/marcohefti/yt-vod-manager/issues
+PackageName: yt-vod-manager
+PackageUrl: https://github.com/marcohefti/yt-vod-manager
+License: MIT
+LicenseUrl: https://github.com/marcohefti/yt-vod-manager/blob/v0.1.3/LICENSE
+ShortDescription: CLI app to download YouTube channels and playlists and keep them up to date locally.
+Moniker: yt-vod-manager
+Tags:
+- youtube
+- yt-dlp
+- vod
+- cli
+ReleaseNotesUrl: https://github.com/marcohefti/yt-vod-manager/releases/tag/v0.1.3
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/m/MarcoHefti/YTVodManager/0.1.3/MarcoHefti.YTVodManager.yaml
+++ b/manifests/m/MarcoHefti/YTVodManager/0.1.3/MarcoHefti.YTVodManager.yaml
@@ -1,0 +1,8 @@
+# Created by packaging/winget/generate-manifests.sh
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: MarcoHefti.YTVodManager
+PackageVersion: 0.1.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Summary
- Add initial WinGet manifests for `MarcoHefti.YTVodManager`
- Version: `0.1.3`
- Installer type: `zip` (portable nested installer)

## Source
- Release tag: `v0.1.3`
- Installer URL: `https://github.com/marcohefti/yt-vod-manager/releases/download/v0.1.3/yt-vod-manager_v0.1.3_windows_amd64.zip`
