### PR TITLE
Update RemixTeam.RemixIDE to 1.1.6 - Repository Migration

### DIFF
--- a/manifests/r/RemixTeam/RemixIDE/1.1.6/RemixTeam.RemixIDE.installer.yaml
+++ b/manifests/r/RemixTeam/RemixIDE/1.1.6/RemixTeam.RemixIDE.installer.yaml
@@ -2,6 +2,12 @@
 PackageIdentifier: RemixTeam.RemixIDE
 PackageVersion: 1.1.6
 InstallerType: nullsoft
+InstallerLocale: en-US
+UpgradeBehavior: install
+InstallModes:
+  - silent
+  - silentWithProgress
+ReleaseDate: 2025-10-30
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/remix-project-org/remix-desktop/releases/download/v1.1.6/Remix-Desktop-Setup-1.1.6.exe

--- a/manifests/r/RemixTeam/RemixIDE/1.1.6/RemixTeam.RemixIDE.installer.yaml
+++ b/manifests/r/RemixTeam/RemixIDE/1.1.6/RemixTeam.RemixIDE.installer.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: RemixTeam.RemixIDE
+PackageVersion: 1.1.6
+InstallerType: nullsoft
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/remix-project-org/remix-desktop/releases/download/v1.1.6/Remix-Desktop-Setup-1.1.6.exe
+    InstallerSha256: 98ccdf583373a01f2ae8067080f3306378a15350be75c2b9a4ed88658d326ad0
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/r/RemixTeam/RemixIDE/1.1.6/RemixTeam.RemixIDE.installer.yaml
+++ b/manifests/r/RemixTeam/RemixIDE/1.1.6/RemixTeam.RemixIDE.installer.yaml
@@ -3,14 +3,24 @@ PackageIdentifier: RemixTeam.RemixIDE
 PackageVersion: 1.1.6
 InstallerType: nullsoft
 InstallerLocale: en-US
+Scope: user
 UpgradeBehavior: install
 InstallModes:
   - silent
   - silentWithProgress
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+  Custom: /currentuser
 ReleaseDate: 2025-10-30
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/remix-project-org/remix-desktop/releases/download/v1.1.6/Remix-Desktop-Setup-1.1.6.exe
     InstallerSha256: 98ccdf583373a01f2ae8067080f3306378a15350be75c2b9a4ed88658d326ad0
+    ProductCode: d62e8524-eb11-5f72-b726-7906fed339c7
+    AppsAndFeaturesEntries:
+      - DisplayName: Remix-Desktop 1.1.6
+        Publisher: Remix Project
+        DisplayVersion: 1.1.6
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/r/RemixTeam/RemixIDE/1.1.6/RemixTeam.RemixIDE.installer.yaml
+++ b/manifests/r/RemixTeam/RemixIDE/1.1.6/RemixTeam.RemixIDE.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 PackageIdentifier: RemixTeam.RemixIDE
 PackageVersion: 1.1.6
 InstallerType: nullsoft
@@ -6,21 +6,23 @@ InstallerLocale: en-US
 Scope: user
 UpgradeBehavior: install
 InstallModes:
+  - interactive
   - silent
   - silentWithProgress
 InstallerSwitches:
   Silent: /S
   SilentWithProgress: /S
   Custom: /currentuser
+ProductCode: d62e8524-eb11-5f72-b726-7906fed339c7
 ReleaseDate: 2025-10-30
+AppsAndFeaturesEntries:
+  - DisplayName: Remix-Desktop 1.1.6
+    Publisher: Remix Project
+    DisplayVersion: 1.1.6
+    ProductCode: d62e8524-eb11-5f72-b726-7906fed339c7
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/remix-project-org/remix-desktop/releases/download/v1.1.6/Remix-Desktop-Setup-1.1.6.exe
     InstallerSha256: 98ccdf583373a01f2ae8067080f3306378a15350be75c2b9a4ed88658d326ad0
-    ProductCode: d62e8524-eb11-5f72-b726-7906fed339c7
-    AppsAndFeaturesEntries:
-      - DisplayName: Remix-Desktop 1.1.6
-        Publisher: Remix Project
-        DisplayVersion: 1.1.6
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/r/RemixTeam/RemixIDE/1.1.6/RemixTeam.RemixIDE.locale.en-US.yaml
+++ b/manifests/r/RemixTeam/RemixIDE/1.1.6/RemixTeam.RemixIDE.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 PackageIdentifier: RemixTeam.RemixIDE
 PackageVersion: 1.1.6
 PackageLocale: en-US
@@ -8,10 +8,10 @@ PublisherSupportUrl: https://github.com/remix-project-org/remix-desktop/issues
 Author: Remix Team
 PackageName: Remix Desktop
 PackageUrl: https://github.com/remix-project-org/remix-desktop/
-License: MIT
+License: MIT License
 Copyright: Copyright (c) 2024 Remix Project
 ShortDescription: Remix Desktop is an Electron version of Remix IDE.
 Description: Remix Desktop is a desktop application of Remix IDE, providing a better integration with the local filesystem.
 ReleaseNotesUrl: https://github.com/remix-project-org/remix-desktop/releases/tag/v1.1.6
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/r/RemixTeam/RemixIDE/1.1.6/RemixTeam.RemixIDE.locale.en-US.yaml
+++ b/manifests/r/RemixTeam/RemixIDE/1.1.6/RemixTeam.RemixIDE.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: RemixTeam.RemixIDE
+PackageVersion: 1.1.6
+PackageLocale: en-US
+Publisher: Remix Project
+PublisherUrl: https://github.com/remix-project-org/remix-desktop/
+PublisherSupportUrl: https://github.com/remix-project-org/remix-desktop/issues
+Author: Remix Team
+PackageName: Remix Desktop
+PackageUrl: https://github.com/remix-project-org/remix-desktop/
+License: MIT
+Copyright: Copyright (c) 2024 Remix Project
+ShortDescription: Remix Desktop is an Electron version of Remix IDE.
+Description: Remix Desktop is a desktop application of Remix IDE, providing a better integration with the local filesystem.
+ReleaseNotesUrl: https://github.com/remix-project-org/remix-desktop/releases/tag/v1.1.6
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/r/RemixTeam/RemixIDE/1.1.6/RemixTeam.RemixIDE.yaml
+++ b/manifests/r/RemixTeam/RemixIDE/1.1.6/RemixTeam.RemixIDE.yaml
@@ -1,6 +1,6 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
 PackageIdentifier: RemixTeam.RemixIDE
 PackageVersion: 1.1.6
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/r/RemixTeam/RemixIDE/1.1.6/RemixTeam.RemixIDE.yaml
+++ b/manifests/r/RemixTeam/RemixIDE/1.1.6/RemixTeam.RemixIDE.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: RemixTeam.RemixIDE
+PackageVersion: 1.1.6
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
This PR updates the Remix IDE manifest to version 1.1.6 and migrates the source to the new official repository organization.

**Key Changes:**

1. **Repository Migration**: Moved InstallerUrl, PublisherUrl, and metadata from the deprecated ethereum/remix-desktop to the new official remix-project-org/remix-desktop repository.
2. **Version Reset**: Please note that the developers reset their versioning track during this migration. Version 1.1.6 is the current, active stable release (2025/2026), which succeeds the legacy 1.3.6 (2022) release from the old organization.
3. **Architecture**: Updated to the current official x64 Nullsoft installer with the verified SHA256 hash.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/340764)