### PR TITLE
Splitting up the "neutral" EXE installer: Microsoft.DirectX version 9.29.1974.0

### DIFF
--- a/manifests/m/Microsoft/DirectX/9.29.1974.0/Microsoft.DirectX.installer.yaml
+++ b/manifests/m/Microsoft/DirectX/9.29.1974.0/Microsoft.DirectX.installer.yaml
@@ -23,7 +23,34 @@ Installers:
   - Windows.Universal
   MinimumOSVersion: 10.0.18200.0
   PackageFamilyName: Microsoft.DirectXRuntime_8wekyb3d8bbwe
-- Architecture: neutral
+- Architecture: x64
+  InstallerType: exe
+  InstallerSwitches:
+    Silent: /Q
+    SilentWithProgress: /Q
+  InstallerUrl: https://download.microsoft.com/download/1/7/1/1718ccc4-6315-4d8e-9543-8e28a4e18c4c/dxwebsetup.exe
+  InstallerSha256: 2CF71D098C608C56E07F4655855A886C3102553F648DF88458DF616B26FD612F
+  InstallerSuccessCodes:
+  - 2852126720
+- Architecture: x86
+  InstallerType: exe
+  InstallerSwitches:
+    Silent: /Q
+    SilentWithProgress: /Q
+  InstallerUrl: https://download.microsoft.com/download/1/7/1/1718ccc4-6315-4d8e-9543-8e28a4e18c4c/dxwebsetup.exe
+  InstallerSha256: 2CF71D098C608C56E07F4655855A886C3102553F648DF88458DF616B26FD612F
+  InstallerSuccessCodes:
+  - 2852126720
+- Architecture: arm64
+  InstallerType: exe
+  InstallerSwitches:
+    Silent: /Q
+    SilentWithProgress: /Q
+  InstallerUrl: https://download.microsoft.com/download/1/7/1/1718ccc4-6315-4d8e-9543-8e28a4e18c4c/dxwebsetup.exe
+  InstallerSha256: 2CF71D098C608C56E07F4655855A886C3102553F648DF88458DF616B26FD612F
+  InstallerSuccessCodes:
+  - 2852126720
+- Architecture: arm
   InstallerType: exe
   InstallerSwitches:
     Silent: /Q

--- a/manifests/m/Microsoft/DirectX/9.29.1974.0/Microsoft.DirectX.installer.yaml
+++ b/manifests/m/Microsoft/DirectX/9.29.1974.0/Microsoft.DirectX.installer.yaml
@@ -41,16 +41,7 @@ Installers:
   InstallerSha256: 2CF71D098C608C56E07F4655855A886C3102553F648DF88458DF616B26FD612F
   InstallerSuccessCodes:
   - 2852126720
-- Architecture: arm64
-  InstallerType: exe
-  InstallerSwitches:
-    Silent: /Q
-    SilentWithProgress: /Q
-  InstallerUrl: https://download.microsoft.com/download/1/7/1/1718ccc4-6315-4d8e-9543-8e28a4e18c4c/dxwebsetup.exe
-  InstallerSha256: 2CF71D098C608C56E07F4655855A886C3102553F648DF88458DF616B26FD612F
-  InstallerSuccessCodes:
-  - 2852126720
-- Architecture: arm
+- Architecture: neutral
   InstallerType: exe
   InstallerSwitches:
     Silent: /Q


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?  If so, fill in the Issue number below.
   <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---
Notes from me:
* Trying to mitigate yet another of the newest glitches the pipelines have contracted, as seen in https://github.com/microsoft/winget-pkgs/pull/339478#issuecomment-3924951397.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/340766)