### PR TITLE
Migrated Package: StacksLabs.Clarinet version 3.14.0

### DIFF
--- a/manifests/s/StacksLabs/Clarinet/3.14.0/StacksLabs.Clarinet.installer.yaml
+++ b/manifests/s/StacksLabs/Clarinet/3.14.0/StacksLabs.Clarinet.installer.yaml
@@ -1,0 +1,24 @@
+# Created with komac v2.15.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: StacksLabs.Clarinet
+PackageVersion: 3.14.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: clarinet.exe
+  PortableCommandAlias: clarinet
+InstallModes:
+- silent
+UpgradeBehavior: install
+Commands:
+- clarinet
+FileExtensions:
+- clar
+ReleaseDate: 2026-02-12
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/stx-labs/clarinet/releases/download/v3.14.0/clarinet-windows-x64.zip
+  InstallerSha256: 5F2617661ACD67E446F1AA2DF727A9C25CCA8881E02ECC2A186B59F3AC969E1D
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/StacksLabs/Clarinet/3.14.0/StacksLabs.Clarinet.locale.en-US.yaml
+++ b/manifests/s/StacksLabs/Clarinet/3.14.0/StacksLabs.Clarinet.locale.en-US.yaml
@@ -1,0 +1,55 @@
+# Created with komac v2.15.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: StacksLabs.Clarinet
+PackageVersion: 3.14.0
+PackageLocale: en-US
+Publisher: Stacks Labs
+PublisherUrl: https://github.com/stx-labs
+PublisherSupportUrl: https://github.com/stx-labs/clarinet/issues
+Author: Stacks Labs
+PackageName: Clarinet
+PackageUrl: https://github.com/stx-labs/clarinet
+License: GPL-3.0
+LicenseUrl: https://github.com/stx-labs/clarinet/blob/HEAD/LICENSE
+Copyright: Copyright (c) Stacks Labs
+ShortDescription: Write, test and deploy high-quality smart contracts to the Stacks blockchain.
+Description: Clarinet is a Clarity runtime packaged as a command line tool, designed to facilitate smart contract understanding, development, testing and deployment. Clarinet consists of a Clarity REPL and a testing framework. Allowing to rapidly develop and test Clarity smart contracts, with the ability to deploy the contract to a local devnet or to testnet and mainnet.
+Moniker: clarinet
+Tags:
+- blockchain
+- clarinet
+- clarity
+- smart-contracts
+ReleaseNotes: |-
+  ✨ Features
+  - Add unnecessary_public lint (#2190) (4db9207)
+  - Add error_const lint (#2186) (3af1642)
+  - Improve deployment plan transaction structure (#2175) (81cb8ff)
+  - Add hex string support to toBeBuff matcher (#2176) (63b0041)
+  🐎 Performance Improvements
+  - Improve Linux performance by using jemalloc instead of default allocator (#2149) (fb198d8)
+  ➰ Refactors
+  - Remove a few clone() in orchestrator.rs (#2193) (7eaa919)
+  - Remove forced epoch dead code (#2183) (cf5f55b)
+  - Remove epoch parameter since its no longer necessary (#2180) (76fc026)
+  🪲 Bug Fixes
+  - Formatter: commented-out function params (#2191) (86f1188)
+  - deploy_contract respects cost tracking (#2158) (8e40fe4)
+  - Preserve user settings, key ordering, and comments when editing Clarinet.toml (#2167) (c1df374)
+  - encode_error failure in certain environments (#2192) (552642c)
+  🧹 Chores
+  - Upgrade stacks docker images (#2171) (210d88f)
+  - Remove generated completions files (#2153) (382f9eb)
+  📖 Documentation Changes
+  - Updated links from hiro docs to stacks docs (#2160) (3d62752)
+  Contributors
+  @xoloki-stacks
+  @brady-stacks
+  @hstove-stacks
+  @eric-stacks
+  @hugo-stacks
+  @jbencin-stacks
+ReleaseNotesUrl: https://github.com/stx-labs/clarinet/releases/tag/v3.14.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/StacksLabs/Clarinet/3.14.0/StacksLabs.Clarinet.yaml
+++ b/manifests/s/StacksLabs/Clarinet/3.14.0/StacksLabs.Clarinet.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.15.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: StacksLabs.Clarinet
+PackageVersion: 3.14.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Manifests created with Komac, but pushed manually.

## Migration needed

Clarinet already exists on Winget under `HiroSystems.Clarinet`: https://github.com/microsoft/winget-pkgs/tree/master/manifests/h/HiroSystems/Clarinet

Last year, Clarinet was migrated from HiroSystems to StacksLabs, as can attest the repository migration:
https://github.com/hirosystems/clarinet redirects to https://github.com/stx-labs/clarinet

I took me some time to handle all packages migrations, this is the last one.

We would like this new package / version to be installed with
```bash
winget install clarinet
```

And the old `HiroSystems.Clarinet` should be marked as deprecated.

Let me know what's possible to do.

Thanks a lot for your help in advance
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/340920)