### PR TITLE
Desperate hotfix(es?) to prevent app config deletions: AdGuard.AdGuardHome version 0.107.72

### DIFF
--- a/manifests/a/AdGuard/AdGuardHome/0.107.72/AdGuard.AdGuardHome.installer.yaml
+++ b/manifests/a/AdGuard/AdGuardHome/0.107.72/AdGuard.AdGuardHome.installer.yaml
@@ -19,7 +19,6 @@ Installers:
 - Architecture: arm64
   InstallerUrl: https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.72/AdGuardHome_windows_arm64.zip
   InstallerSha256: 1485F6167BCA09BE70E987BA427FE606D2C40AA465909D080E77656153AFD60E
-InstallationMetadata:
-- DefaultInstallLocation: 'C:\AdGuardHome'
+UpgradeBehavior: install
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/a/AdGuard/AdGuardHome/0.107.72/AdGuard.AdGuardHome.installer.yaml
+++ b/manifests/a/AdGuard/AdGuardHome/0.107.72/AdGuard.AdGuardHome.installer.yaml
@@ -19,5 +19,7 @@ Installers:
 - Architecture: arm64
   InstallerUrl: https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.72/AdGuardHome_windows_arm64.zip
   InstallerSha256: 1485F6167BCA09BE70E987BA427FE606D2C40AA465909D080E77656153AFD60E
+InstallationMetadata:
+- DefaultInstallLocation: 'C:\AdGuardHome'
 ManifestType: installer
 ManifestVersion: 1.12.0


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?  If so, fill in the Issue number below.
   <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---
Notes from me:
* I noticed after running `winget update AdGuard.AdGuardHome` this morning that it was installing it to a different folder… and deleted the existing one. That's **not** a good thing to have happening when running a network server tool. So it has to get fixed *really* fast in *some or another* way.
* Partially related: https://yomotherboard.com/question/how-to-keep-custom-install-locations-when-upgrading-packages-with-winget/
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/341071)