### PR TITLE
New package: arndawg.tmux-windows version 3.5a-win32

### DIFF
--- a/manifests/a/arndawg/tmux-windows/3.5a-win32/arndawg.tmux-windows.installer.yaml
+++ b/manifests/a/arndawg/tmux-windows/3.5a-win32/arndawg.tmux-windows.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
 
 PackageIdentifier: arndawg.tmux-windows
 PackageVersion: 3.5a-win32
@@ -13,4 +13,4 @@ Installers:
   InstallerUrl: https://github.com/arndawg/tmux-windows/releases/download/v3.5a-win32/tmux-windows-v3.5a-win32.zip
   InstallerSha256: B24B06C42BDD42AF89833F71DB1B9F93C8115E7E7396F56066426FD5B8DD7C0E
 ManifestType: installer
-ManifestVersion: 1.5.0
+ManifestVersion: 1.10.0

--- a/manifests/a/arndawg/tmux-windows/3.5a-win32/arndawg.tmux-windows.installer.yaml
+++ b/manifests/a/arndawg/tmux-windows/3.5a-win32/arndawg.tmux-windows.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+
+PackageIdentifier: arndawg.tmux-windows
+PackageVersion: 3.5a-win32
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: tmux.exe
+  PortableCommandAlias: tmux
+ReleaseDate: 2026-02-21
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/arndawg/tmux-windows/releases/download/v3.5a-win32/tmux-windows-v3.5a-win32.zip
+  InstallerSha256: B24B06C42BDD42AF89833F71DB1B9F93C8115E7E7396F56066426FD5B8DD7C0E
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/a/arndawg/tmux-windows/3.5a-win32/arndawg.tmux-windows.locale.en-US.yaml
+++ b/manifests/a/arndawg/tmux-windows/3.5a-win32/arndawg.tmux-windows.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
 
 PackageIdentifier: arndawg.tmux-windows
 PackageVersion: 3.5a-win32
@@ -16,7 +16,7 @@ Description: |-
   A native Windows port of tmux, the terminal multiplexer. Uses ConPTY for
   pseudo-terminal support, TCP loopback for IPC, and builds with MSVC.
   Enables split-pane terminal sessions, session persistence, and detach/attach
-  workflows on Windows 10+. Supports Claude Code agent team split-pane mode.
+  workflows on Windows 10+.
 Tags:
 - cli
 - terminal
@@ -25,4 +25,4 @@ Tags:
 - conpty
 ReleaseNotesUrl: https://github.com/arndawg/tmux-windows/releases/tag/v3.5a-win32
 ManifestType: defaultLocale
-ManifestVersion: 1.5.0
+ManifestVersion: 1.10.0

--- a/manifests/a/arndawg/tmux-windows/3.5a-win32/arndawg.tmux-windows.locale.en-US.yaml
+++ b/manifests/a/arndawg/tmux-windows/3.5a-win32/arndawg.tmux-windows.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+
+PackageIdentifier: arndawg.tmux-windows
+PackageVersion: 3.5a-win32
+PackageLocale: en-US
+Publisher: arndawg
+PublisherUrl: https://github.com/arndawg
+PublisherSupportUrl: https://github.com/arndawg/tmux-windows/issues
+Author: arndawg
+PackageName: tmux-windows
+PackageUrl: https://github.com/arndawg/tmux-windows
+License: ISC
+LicenseUrl: https://github.com/arndawg/tmux-windows/blob/master/COPYING
+ShortDescription: Terminal multiplexer for Windows, ported from tmux using ConPTY
+Description: |-
+  A native Windows port of tmux, the terminal multiplexer. Uses ConPTY for
+  pseudo-terminal support, TCP loopback for IPC, and builds with MSVC.
+  Enables split-pane terminal sessions, session persistence, and detach/attach
+  workflows on Windows 10+. Supports Claude Code agent team split-pane mode.
+Tags:
+- cli
+- terminal
+- multiplexer
+- tmux
+- conpty
+ReleaseNotesUrl: https://github.com/arndawg/tmux-windows/releases/tag/v3.5a-win32
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/a/arndawg/tmux-windows/3.5a-win32/arndawg.tmux-windows.yaml
+++ b/manifests/a/arndawg/tmux-windows/3.5a-win32/arndawg.tmux-windows.yaml
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
 
 PackageIdentifier: arndawg.tmux-windows
 PackageVersion: 3.5a-win32
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.5.0
+ManifestVersion: 1.10.0

--- a/manifests/a/arndawg/tmux-windows/3.5a-win32/arndawg.tmux-windows.yaml
+++ b/manifests/a/arndawg/tmux-windows/3.5a-win32/arndawg.tmux-windows.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+
+PackageIdentifier: arndawg.tmux-windows
+PackageVersion: 3.5a-win32
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0


### PR DESCRIPTION
### New Package Submission

- Package: arndawg.tmux-windows
- Version: 3.5a-win32

### Description

A native Windows port of [tmux](https://github.com/tmux/tmux), the terminal multiplexer. Uses ConPTY for pseudo-terminal support, TCP loopback for IPC, and builds with MSVC. Enables split-pane terminal sessions, session persistence, and detach/attach workflows on Windows 10+.

### Installer Type

`zip` with `portable` nested installer — creates a `tmux` command alias (same pattern as `junegunn.fzf` and `BurntSushi.ripgrep.MSVC`).

### Links

- Repository: https://github.com/arndawg/tmux-windows
- Release: https://github.com/arndawg/tmux-windows/releases/tag/v3.5a-win32
- License: ISC (same as upstream tmux)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/341456)