### PR TITLE
Add hexajohnny.Rusty version 0.1.1

### DIFF
--- a/manifests/h/hexajohnny/Rusty/0.1.1/hexajohnny.Rusty.installer.yaml
+++ b/manifests/h/hexajohnny/Rusty/0.1.1/hexajohnny.Rusty.installer.yaml
@@ -1,0 +1,18 @@
+﻿# Created with wingetcreate
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: hexajohnny.Rusty
+PackageVersion: 0.1.1
+InstallerType: wix
+Scope: machine
+UpgradeBehavior: install
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/hexajohnny/rusty/releases/download/v0.1.1/Rusty-0.1.1.msi
+  InstallerSha256: 4AE026B1E1E1FC307DBACED2D1246B1FA5C06F66E8F839D76458A4DCB47AD4BA
+  ProductCode: '{B3F870C8-5DBB-4079-A048-7D5731191200}'
+  AppsAndFeaturesEntries:
+  - ProductCode: '{B3F870C8-5DBB-4079-A048-7D5731191200}'
+    UpgradeCode: '{A77A6E2E-8A7F-4C9F-9D44E1A44F1A}'
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/h/hexajohnny/Rusty/0.1.1/hexajohnny.Rusty.locale.en-US.yaml
+++ b/manifests/h/hexajohnny/Rusty/0.1.1/hexajohnny.Rusty.locale.en-US.yaml
@@ -1,0 +1,27 @@
+﻿# Created with wingetcreate
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: hexajohnny.Rusty
+PackageVersion: 0.1.1
+PackageLocale: en-US
+Publisher: hexajohnny
+PublisherUrl: https://github.com/hexajohnny
+PublisherSupportUrl: https://github.com/hexajohnny/rusty/issues
+Author: hexajohnny
+PackageName: Rusty
+PackageUrl: https://github.com/hexajohnny/rusty
+License: MIT OR Apache-2.0
+LicenseUrl: https://github.com/hexajohnny/rusty/blob/main/LICENSE-MIT
+Copyright: Copyright (c) hexajohnny
+ShortDescription: Windows desktop SSH client with tabbed terminals and integrated SFTP.
+Description: Rusty is a Windows desktop SSH client built in Rust with color-coded organization, split-pane tabbed terminals, an integrated SFTP browser, and a global transfer manager.
+Moniker: rusty
+Tags:
+- ssh
+- sftp
+- terminal
+- remote
+- rust
+ReleaseNotesUrl: https://github.com/hexajohnny/rusty/releases/tag/v0.1.1
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/h/hexajohnny/Rusty/0.1.1/hexajohnny.Rusty.yaml
+++ b/manifests/h/hexajohnny/Rusty/0.1.1/hexajohnny.Rusty.yaml
@@ -1,0 +1,8 @@
+﻿# Created with wingetcreate
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: hexajohnny.Rusty
+PackageVersion: 0.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## Summary
- Add new package manifest for hexajohnny.Rusty version  .1.1`n- Installer: MSI (wix), x86, machine scope
- Moniker: usty`n
## Installer
- URL: https://github.com/hexajohnny/rusty/releases/download/v0.1.1/Rusty-0.1.1.msi
- SHA256: 4AE026B1E1E1FC307DBACED2D1246B1FA5C06F66E8F839D76458A4DCB47AD4BA

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/341598)