### PR TITLE
New package: Koyubi.SKK version 0.1.0

### DIFF
--- a/manifests/k/Koyubi/SKK/0.1.0/Koyubi.SKK.installer.yaml
+++ b/manifests/k/Koyubi/SKK/0.1.0/Koyubi.SKK.installer.yaml
@@ -11,7 +11,7 @@ ElevationRequirement: elevationRequired
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/m-takeuchi/koyubi/releases/download/v0.1.0/koyubi-0.1.0-setup.exe
-    InstallerSha256: 3cc15e672232128d3f14558ae3e93f889a2f91557f78767488285407575ec447
+    InstallerSha256: 5dbeeb9f935696cbc5d26c7838c28ad9feb6d0c13db1e26b936a34b84bcc48d2
     InstallerSwitches:
       Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
       SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART

--- a/manifests/k/Koyubi/SKK/0.1.0/Koyubi.SKK.installer.yaml
+++ b/manifests/k/Koyubi/SKK/0.1.0/Koyubi.SKK.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: Koyubi.SKK
+PackageVersion: 0.1.0
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: machine
+ElevationRequirement: elevationRequired
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/m-takeuchi/koyubi/releases/download/v0.1.0/koyubi-0.1.0-setup.exe
+    InstallerSha256: 3cc15e672232128d3f14558ae3e93f889a2f91557f78767488285407575ec447
+    InstallerSwitches:
+      Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+      SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/k/Koyubi/SKK/0.1.0/Koyubi.SKK.locale.en-US.yaml
+++ b/manifests/k/Koyubi/SKK/0.1.0/Koyubi.SKK.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: Koyubi.SKK
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Koyubi Project
+PackageName: Koyubi SKK
+PackageUrl: https://github.com/m-takeuchi/koyubi
+License: MIT
+LicenseUrl: https://github.com/m-takeuchi/koyubi/blob/main/LICENSE
+ShortDescription: SKK Japanese input method for Windows (English keyboard layout)
+Description: >-
+  Koyubi is an SKK-based Japanese input method system for Windows,
+  designed for English keyboard layout users (especially HHKB).
+  Implemented as a TSF (Text Services Framework) IME in Rust.
+Tags:
+  - ime
+  - japanese
+  - input-method
+  - skk
+  - tsf
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/k/Koyubi/SKK/0.1.0/Koyubi.SKK.yaml
+++ b/manifests/k/Koyubi/SKK/0.1.0/Koyubi.SKK.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: Koyubi.SKK
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package submission

- Package: Koyubi.SKK
- Version: 0.1.0
- URL: https://github.com/m-takeuchi/koyubi

SKK Japanese input method for Windows, designed for English keyboard layout users (HHKB etc.). Implemented as a TSF (Text Services Framework) IME in Rust.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/341666)