### PR TITLE
WatchGuard.MobileVPNWithSSLClient: Add /autokill to fix upgrade while…

### DIFF
--- a/manifests/w/WatchGuard/MobileVPNWithSSLClient/2026.1/WatchGuard.MobileVPNWithSSLClient.installer.yaml
+++ b/manifests/w/WatchGuard/MobileVPNWithSSLClient/2026.1/WatchGuard.MobileVPNWithSSLClient.installer.yaml
@@ -1,6 +1,5 @@
 # Created with YamlCreate.ps1 Dumplings Mod
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
-
 PackageIdentifier: WatchGuard.MobileVPNWithSSLClient
 PackageVersion: "2026.1"
 InstallerType: inno
@@ -11,6 +10,9 @@ ProductCode: Mobile VPN with SSL client_is1
 ElevationRequirement: elevatesSelf
 InstallationMetadata:
   DefaultInstallLocation: '%ProgramFiles%\WatchGuard\WatchGuard Mobile VPN with SSL'
+InstallerSwitches:
+  Silent: /verysilent /autokill
+  SilentWithProgress: /silent /autokill
 Installers:
 - Architecture: x86
   InstallerUrl: https://cdn.watchguard.com/SoftwareCenter/Files/MUVPN_SSL/2026_1/WG-MVPN-SSL_2026_1.exe


### PR DESCRIPTION
WatchGuard.MobileVPNWithSSLClient: Add /autokill switch

Added InstallerSwitches with /autokill parameter to prevent installation failures when the VPN client is running.

Reference: https://techsearch.watchguard.com/KB?type=Article&SFDCID=kA10H000000g3E9SAI
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/341755)