### PR TITLE
Update arndawg.tmux-windows to version 3.6a-win32

### DIFF
--- a/manifests/a/arndawg/tmux-windows/3.6a-win32/arndawg.tmux-windows.installer.yaml
+++ b/manifests/a/arndawg/tmux-windows/3.6a-win32/arndawg.tmux-windows.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: arndawg.tmux-windows
+PackageVersion: 3.6a-win32
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: tmux.exe
+  PortableCommandAlias: tmux
+ReleaseDate: 2026-02-23
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/arndawg/tmux-windows/releases/download/v3.6a-win32/tmux-windows-v3.6a-win32.zip
+  InstallerSha256: E83D0A9BD164AB6D34E202CA2807E2CD9917390442408B01B0EE6A6546FBA2FC
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/a/arndawg/tmux-windows/3.6a-win32/arndawg.tmux-windows.locale.en-US.yaml
+++ b/manifests/a/arndawg/tmux-windows/3.6a-win32/arndawg.tmux-windows.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: arndawg.tmux-windows
+PackageVersion: 3.6a-win32
+PackageLocale: en-US
+Publisher: arndawg
+PublisherUrl: https://github.com/arndawg
+PublisherSupportUrl: https://github.com/arndawg/tmux-windows/issues
+Author: arndawg
+PackageName: tmux-windows
+PackageUrl: https://github.com/arndawg/tmux-windows
+License: ISC
+LicenseUrl: https://github.com/arndawg/tmux-windows/blob/master/COPYING
+ShortDescription: Terminal multiplexer for Windows, ported from tmux using ConPTY
+Description: |-
+  A native Windows port of tmux, the terminal multiplexer. Uses ConPTY for
+  pseudo-terminal support, TCP loopback for IPC, and builds with MSVC.
+  Enables split-pane terminal sessions, session persistence, and detach/attach
+  workflows on Windows 10+.
+Tags:
+- cli
+- terminal
+- multiplexer
+- tmux
+- conpty
+ReleaseNotesUrl: https://github.com/arndawg/tmux-windows/releases/tag/v3.6a-win32
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/a/arndawg/tmux-windows/3.6a-win32/arndawg.tmux-windows.yaml
+++ b/manifests/a/arndawg/tmux-windows/3.6a-win32/arndawg.tmux-windows.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: arndawg.tmux-windows
+PackageVersion: 3.6a-win32
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
### Version Update

- Package: arndawg.tmux-windows
- Version: 3.5a-win32 → 3.6a-win32

### Changes in this release

#### Security Fixes
- Fix auth race condition — token created before server listens, connections rejected when token missing
- Auth/port files restricted to current user via Windows DACL
- Constant-time auth token comparison to prevent timing side-channel attacks

#### Version Correction
- Updated from 3.5a-win32 to 3.6a-win32 to match the actual upstream tmux codebase lineage (fork point is 138 commits past upstream 3.6a tag)

### Links
- Release: https://github.com/arndawg/tmux-windows/releases/tag/v3.6a-win32
- Full changelog: https://github.com/arndawg/tmux-windows/compare/v3.5a-win32...v3.6a-win32
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/341769)