### PR TITLE
New version: arndawg.tmux-windows version 3.6a-win32.3

### DIFF
--- a/manifests/a/arndawg/tmux-windows/3.6a-win32.3/arndawg.tmux-windows.installer.yaml
+++ b/manifests/a/arndawg/tmux-windows/3.6a-win32.3/arndawg.tmux-windows.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: arndawg.tmux-windows
+PackageVersion: 3.6a-win32.3
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: tmux.exe
+  PortableCommandAlias: tmux
+ReleaseDate: 2026-02-24
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/arndawg/tmux-windows/releases/download/v3.6a-win32.3/tmux-windows-v3.6a-win32.3.zip
+  InstallerSha256: 7EBF298DCA1D41FF15430350BE5242D0234B1044D8A2BDADEF15066280306135
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/a/arndawg/tmux-windows/3.6a-win32.3/arndawg.tmux-windows.locale.en-US.yaml
+++ b/manifests/a/arndawg/tmux-windows/3.6a-win32.3/arndawg.tmux-windows.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: arndawg.tmux-windows
+PackageVersion: 3.6a-win32.3
+PackageLocale: en-US
+Publisher: arndawg
+PublisherUrl: https://github.com/arndawg
+PublisherSupportUrl: https://github.com/arndawg/tmux-windows/issues
+Author: arndawg
+PackageName: tmux-windows
+PackageUrl: https://github.com/arndawg/tmux-windows
+License: ISC
+LicenseUrl: https://github.com/arndawg/tmux-windows/blob/master/COPYING
+ShortDescription: Terminal multiplexer for Windows, ported from tmux using ConPTY
+Description: |-
+  A native Windows port of tmux, the terminal multiplexer. Split your terminal
+  into multiple panes, create persistent sessions that survive disconnects, and
+  detach/reattach workflows — all natively on Windows 10+.
+
+  Built with ConPTY for full pseudo-terminal support and Windows Named Pipes for
+  secure, kernel-enforced IPC. Works in Windows Terminal, VS Code terminal, and
+  any VT-capable console host. Builds with MSVC, no Cygwin or WSL required.
+Tags:
+- cli
+- terminal
+- multiplexer
+- tmux
+- conpty
+ReleaseNotesUrl: https://github.com/arndawg/tmux-windows/releases/tag/v3.6a-win32.3
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/a/arndawg/tmux-windows/3.6a-win32.3/arndawg.tmux-windows.yaml
+++ b/manifests/a/arndawg/tmux-windows/3.6a-win32.3/arndawg.tmux-windows.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: arndawg.tmux-windows
+PackageVersion: 3.6a-win32.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
### New version: arndawg.tmux-windows version 3.6a-win32.3

**Release URL:** https://github.com/arndawg/tmux-windows/releases/tag/v3.6a-win32.3

#### Changes since 3.6a-win32.2

- **Regression test expansion (2 → 8 tests, ~220+ assertions)** — format strings, config parsing, key handling, has-session, layout verification, pane operations
- **Fix: MSYS2 path handling** — `file.c` and `cmd-source-file.c` now recognize MSYS2-escaped drive letter paths (`C\:/foo`) as absolute, fixing `source-file` failures
- **Updated package description** — reflects named pipe IPC (replaced TCP loopback mention from previous versions)

#### Description update

Previous description mentioned "TCP loopback for IPC" which is no longer accurate after v3.6a-win32.2 switched to Windows Named Pipes. Updated to reflect the current architecture.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/341919)