### PR TITLE
New version: arndawg.tmux-windows version 3.6a-win32.4

### DIFF
--- a/manifests/a/arndawg/tmux-windows/3.6a-win32.4/arndawg.tmux-windows.installer.yaml
+++ b/manifests/a/arndawg/tmux-windows/3.6a-win32.4/arndawg.tmux-windows.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: arndawg.tmux-windows
+PackageVersion: 3.6a-win32.4
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: tmux.exe
+  PortableCommandAlias: tmux
+ReleaseDate: 2026-02-24
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/arndawg/tmux-windows/releases/download/v3.6a-win32.4/tmux-windows-v3.6a-win32.4.zip
+  InstallerSha256: C70A7EE6016449E353C5221BE5426C70A207E878A51EAF19EA9A20E4B88E693A
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/a/arndawg/tmux-windows/3.6a-win32.4/arndawg.tmux-windows.locale.en-US.yaml
+++ b/manifests/a/arndawg/tmux-windows/3.6a-win32.4/arndawg.tmux-windows.locale.en-US.yaml
@@ -1,0 +1,54 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: arndawg.tmux-windows
+PackageVersion: 3.6a-win32.4
+PackageLocale: en-US
+Publisher: arndawg
+PublisherUrl: https://github.com/arndawg
+PublisherSupportUrl: https://github.com/arndawg/tmux-windows/issues
+Author: arndawg
+PackageName: tmux-windows
+PackageUrl: https://github.com/arndawg/tmux-windows
+License: ISC
+LicenseUrl: https://github.com/arndawg/tmux-windows/blob/master/COPYING
+ShortDescription: Terminal multiplexer for Windows, ported from tmux using ConPTY
+Description: |-
+  A native Windows port of tmux, the terminal multiplexer. Split your terminal
+  into multiple panes, create persistent sessions that survive disconnects, and
+  detach/reattach workflows — all natively on Windows 10+.
+
+  Built with ConPTY for full pseudo-terminal support and Windows Named Pipes for
+  secure, kernel-enforced IPC. Works in Windows Terminal, VS Code terminal, and
+  any VT-capable console host. Builds with MSVC, no Cygwin or WSL required.
+ReleaseNotes: |-
+  TTY Race Condition Fix & Security Hardening
+
+  Fixes the startup reliability issue where tmux new would intermittently fail
+  with "open terminal failed: not a terminal" or display a blank screen. Also
+  hardens the named pipe IPC against command injection and enables truecolor
+  by default.
+
+  Startup Race Condition Fix:
+  - Client: move TTY channel connection before identify messages, giving the
+    server maximum time to accept it
+  - Server: defer command processing with a blocking cmdq callback when the
+    TTY channel has not arrived yet; 2-second safety timeout
+  - Late init: preserve terminal dimensions across tty_init() memset, then
+    force recalculate_sizes() and full redraw
+
+  Security Hardening:
+  - Sanitize IPC label names to prevent arbitrary named pipe paths via
+    crafted -L arguments
+  - Cap pending TTY connection queue at 16 entries with 30-second expiry
+
+  Truecolor Support:
+  - 24-bit color now enabled by default on Windows
+Tags:
+- cli
+- terminal
+- multiplexer
+- tmux
+- conpty
+ReleaseNotesUrl: https://github.com/arndawg/tmux-windows/releases/tag/v3.6a-win32.4
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/a/arndawg/tmux-windows/3.6a-win32.4/arndawg.tmux-windows.yaml
+++ b/manifests/a/arndawg/tmux-windows/3.6a-win32.4/arndawg.tmux-windows.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: arndawg.tmux-windows
+PackageVersion: 3.6a-win32.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
### New version: arndawg.tmux-windows version 3.6a-win32.4

**Release URL:** https://github.com/arndawg/tmux-windows/releases/tag/v3.6a-win32.4

#### Changes since 3.6a-win32.3

- **Startup race condition fix** — the TTY channel's second named-pipe round-trip often delayed `accept()` past `MSG_IDENTIFY_DONE`, causing "open terminal failed" or blank screens. Fixed with early TTY connection, deferred cmdq processing, and proper terminal dimension preservation across late init
- **Security hardening** — sanitize IPC label names against command injection via crafted `-L` arguments; cap pending TTY queue at 16 entries with 30-second expiry
- **Truecolor by default** — 24-bit color now enabled out of the box on Windows

#### Manifest changes

Version bump only (3.6a-win32.3 → 3.6a-win32.4), new installer URL/SHA256, added `ReleaseNotes` field.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/341990)