### PR TITLE
Add ARM64 installers for Posit.Positron version 2026.02.1

### DIFF
--- a/manifests/p/Posit/Positron/2026.02.1/Posit.Positron.installer.yaml
+++ b/manifests/p/Posit/Positron/2026.02.1/Posit.Positron.installer.yaml
@@ -159,5 +159,15 @@ Installers:
   InstallerUrl: https://cdn.posit.co/positron/releases/win/x86_64/Positron-2026.02.1-5-Setup-x64.exe
   InstallerSha256: 444DB0F1ECD00565E742487508111283E061065D59AA44B7852122E2E7671DF8
   ProductCode: '{08FC0438-DEF4-4349-85AE-FA80317766E9}_is1'
+- Architecture: arm64
+  Scope: user
+  InstallerUrl: https://cdn.posit.co/positron/releases/win/arm64/Positron-2026.02.1-5-UserSetup-arm64.exe
+  InstallerSha256: C98DFC21421983F27C7A013907C622157FE5813B2FF7F951A012211FB2C96178
+  ProductCode: '{585852C3-3385-447E-8711-67F60DE17946}_is1'
+- Architecture: arm64
+  Scope: machine
+  InstallerUrl: https://cdn.posit.co/positron/releases/win/arm64/Positron-2026.02.1-5-Setup-arm64.exe
+  InstallerSha256: 6FCE02DD24D02E73E8723F0955C56F76B05CDEFA32F055C25645C87593B91973
+  ProductCode: '{17BBF21B-410B-40F4-ACC4-2E9515616AC6}_is1'
 ManifestType: installer
 ManifestVersion: 1.12.0


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the CLA?
- [x] Is there a linked Issue?
  - Fixes https://github.com/microsoft/winget-pkgs/issues/342254

Manifests
- [x] Have you checked that there aren't other open PRs for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
  - Cannot test ARM64 locally (no ARM64 hardware). The issue reporter (@jaredlander) has ARM64 hardware and can verify.
- [x] Does your manifest conform to the 1.12 schema?

---

Add ARM64 (Windows on ARM) installer entries for Positron 2026.02.1.
Currently the manifest only includes x64 installers, which fail to install on ARM64 devices.
See posit-dev/positron#12053.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/342256)