### PR TITLE
Add arndawg.tmux-windows version 3.6a-win32.5

### DIFF
--- a/manifests/a/arndawg/tmux-windows/3.6a-win32.5/arndawg.tmux-windows.installer.yaml
+++ b/manifests/a/arndawg/tmux-windows/3.6a-win32.5/arndawg.tmux-windows.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: arndawg.tmux-windows
+PackageVersion: 3.6a-win32.5
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: tmux.exe
+  PortableCommandAlias: tmux
+ReleaseDate: 2026-02-24
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/arndawg/tmux-windows/releases/download/v3.6a-win32.5/tmux-windows-v3.6a-win32.5.zip
+  InstallerSha256: BFBE2105205E57F17FA23C50A1D83E3B3D960E7EFB9E11D355E364BCF915CA0E
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/a/arndawg/tmux-windows/3.6a-win32.5/arndawg.tmux-windows.locale.en-US.yaml
+++ b/manifests/a/arndawg/tmux-windows/3.6a-win32.5/arndawg.tmux-windows.locale.en-US.yaml
@@ -1,0 +1,52 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: arndawg.tmux-windows
+PackageVersion: 3.6a-win32.5
+PackageLocale: en-US
+Publisher: arndawg
+PublisherUrl: https://github.com/arndawg
+PublisherSupportUrl: https://github.com/arndawg/tmux-windows/issues
+Author: arndawg
+PackageName: tmux-windows
+PackageUrl: https://github.com/arndawg/tmux-windows
+License: ISC
+LicenseUrl: https://github.com/arndawg/tmux-windows/blob/master/COPYING
+ShortDescription: Terminal multiplexer for Windows, ported from tmux using ConPTY
+Description: |-
+  A native Windows port of tmux, the terminal multiplexer. Split your terminal
+  into multiple panes, create persistent sessions that survive disconnects, and
+  detach/reattach workflows — all natively on Windows 10+.
+
+  Built with ConPTY for full pseudo-terminal support and Windows Named Pipes for
+  secure, kernel-enforced IPC. Works in Windows Terminal, VS Code terminal, and
+  any VT-capable console host. Builds with MSVC, no Cygwin or WSL required.
+ReleaseNotes: |-
+  Terminal Rendering Fixes
+
+  Fixes two visual rendering issues on Windows: the status bar rendering in
+  black-and-white instead of the default green, and the status bar misaligning
+  after reattach when the pane contained long lines that wrapped past the
+  terminal width.
+
+  Status Bar Color Fix:
+  - Implement tparm() conditional and comparison operators in win32-compat.c
+  - The setab/setaf terminfo format strings use conditionals to select between
+    8-color, 16-color, and 256-color escape sequences
+  - Without these operators, color output was garbled and the status bar
+    rendered black-and-white instead of the default green
+
+  Wrapped-Line Redraw Fix:
+  - Disable the wrapped-line cursor optimization on Windows in tty-draw.c
+  - ConPTY xenl (delayed wrap) behavior differs from Unix terminals, causing
+    cursor position desync after writing to the last column
+  - Forces explicit CUP positioning for every line, guaranteeing correct
+    status bar alignment after reattach with wrapped content
+Tags:
+- cli
+- terminal
+- multiplexer
+- tmux
+- conpty
+ReleaseNotesUrl: https://github.com/arndawg/tmux-windows/releases/tag/v3.6a-win32.5
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/a/arndawg/tmux-windows/3.6a-win32.5/arndawg.tmux-windows.yaml
+++ b/manifests/a/arndawg/tmux-windows/3.6a-win32.5/arndawg.tmux-windows.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: arndawg.tmux-windows
+PackageVersion: 3.6a-win32.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
### New version: arndawg.tmux-windows 3.6a-win32.5

Terminal rendering fixes: status bar color support (tparm conditionals) and wrapped-line redraw fix for correct reattach display.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/342470)