### PR TITLE
Update InstallerSHA and ProductCode for 7.6.0.101 given updated assets

### DIFF
--- a/manifests/m/Microsoft/PowerShell/Preview/7.6.0.101/Microsoft.PowerShell.Preview.installer.yaml
+++ b/manifests/m/Microsoft/PowerShell/Preview/7.6.0.101/Microsoft.PowerShell.Preview.installer.yaml
@@ -17,29 +17,29 @@ ReleaseDate: 2026-02-19
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.6.0-rc.1/PowerShell-7.6.0-rc.1-win-x64.msi
-  InstallerSha256: DE1A677E7483E74101CB5CAF4BDB28056A690732F899B83C7F3A0D76AE724A95
-  ProductCode: '{9A3FBA45-A15F-450E-89BC-57DE1DF12DDE}'
+  InstallerSha256: B45CF971EE1350E7FF7E3DA632F305463F33D283ED858A32EC3F3C3DAE5129F4
+  ProductCode: '{85BDCF78-9FF8-4483-A1EC-2DAC9E8A27E6}'
   AppsAndFeaturesEntries:
   - DisplayName: PowerShell 7-preview-x64
     Publisher: Microsoft Corporation
 - Architecture: x86
   InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.6.0-rc.1/PowerShell-7.6.0-rc.1-win-x86.msi
-  InstallerSha256: 76037C0A3CC599C015683A42111A81D3FB228E485B25116DE6D30B7803CC5ED7
-  ProductCode: '{018C133F-6571-4143-9AFF-790968F86E0F}'
+  InstallerSha256: 21252FEA082DBD7B7D945143D3B0FA06D5EB0E4AC04EE5DFED822E04A73D8A49
+  ProductCode: '{608B5683-D041-4217-9EDB-B301016E16A0}'
   AppsAndFeaturesEntries:
   - DisplayName: PowerShell 7-preview-x86
     Publisher: Microsoft Corporation
 - Architecture: arm
   InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.6.0-rc.1/PowerShell-7.6.0-rc.1-win-arm64.msi
-  InstallerSha256: 9E6C3F5DB3E91163180C4C56DE6B66D82D30F46EC99B34695429620E9E967A65
-  ProductCode: '{D4C5A6B7-13C9-40A0-A404-76010651C9A4}'
+  InstallerSha256: F0E52335F170150489C418DB13506314648185B90D86957E97013E26F9304CE3
+  ProductCode: '{CD8F5396-2D3C-47EF-98E6-876CFA941F28}'
   AppsAndFeaturesEntries:
   - DisplayName: PowerShell 7-preview-arm64
     Publisher: Microsoft Corporation
 - Architecture: arm64
   InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.6.0-rc.1/PowerShell-7.6.0-rc.1-win-arm64.msi
-  InstallerSha256: 9E6C3F5DB3E91163180C4C56DE6B66D82D30F46EC99B34695429620E9E967A65
-  ProductCode: '{D4C5A6B7-13C9-40A0-A404-76010651C9A4}'
+  InstallerSha256: F0E52335F170150489C418DB13506314648185B90D86957E97013E26F9304CE3
+  ProductCode: '{CD8F5396-2D3C-47EF-98E6-876CFA941F28}'
   AppsAndFeaturesEntries:
   - DisplayName: PowerShell 7-preview-arm64
     Publisher: Microsoft Corporation


### PR DESCRIPTION
PowerShell team updated assets since the winget manifest for 7.6.0-rc1 (7.6.0.101) was published. So update the existing winget manifest to refer to the InstallerSHA and Product codes for the new assets.

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Is there a linked Issue?  If so, fill in the Issue number below.
   <!-- Example: Resolves #328283 -->
  - Resolves #342341


Manifests
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/342542)