### PR TITLE
Add arndawg.tmux-windows version 3.6a-win32.6

### DIFF
--- a/manifests/a/arndawg/tmux-windows/3.6a-win32.6/arndawg.tmux-windows.installer.yaml
+++ b/manifests/a/arndawg/tmux-windows/3.6a-win32.6/arndawg.tmux-windows.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: arndawg.tmux-windows
+PackageVersion: 3.6a-win32.6
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: tmux.exe
+  PortableCommandAlias: tmux
+ReleaseDate: 2026-02-25
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/arndawg/tmux-windows/releases/download/v3.6a-win32.6/tmux-windows-v3.6a-win32.6.zip
+  InstallerSha256: 9E81E20BAE1458A8D577E426CA774DEAAC98582F9B723894E9EF9C6A02A0BF9A
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/a/arndawg/tmux-windows/3.6a-win32.6/arndawg.tmux-windows.locale.en-US.yaml
+++ b/manifests/a/arndawg/tmux-windows/3.6a-win32.6/arndawg.tmux-windows.locale.en-US.yaml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: arndawg.tmux-windows
+PackageVersion: 3.6a-win32.6
+PackageLocale: en-US
+Publisher: arndawg
+PublisherUrl: https://github.com/arndawg
+PublisherSupportUrl: https://github.com/arndawg/tmux-windows/issues
+Author: arndawg
+PackageName: tmux-windows
+PackageUrl: https://github.com/arndawg/tmux-windows
+License: ISC
+LicenseUrl: https://github.com/arndawg/tmux-windows/blob/master/COPYING
+ShortDescription: Terminal multiplexer for Windows, ported from tmux using ConPTY
+Description: |-
+  A native Windows port of tmux, the terminal multiplexer. Split your terminal
+  into multiple panes, create persistent sessions that survive disconnects, and
+  detach/reattach workflows — all natively on Windows 10+.
+
+  Built with ConPTY for full pseudo-terminal support and Windows Named Pipes for
+  secure, kernel-enforced IPC. Works in Windows Terminal, VS Code terminal, and
+  any VT-capable console host. Builds with MSVC, no Cygwin or WSL required.
+ReleaseNotes: |-
+  Single-File Static Distribution
+
+  tmux-windows is now a single statically-linked executable with no DLL
+  dependencies. Previously the release included event_core.dll (libevent);
+  this is now compiled directly into tmux.exe.
+
+  Changes:
+  - Switched vcpkg triplet from x64-windows to x64-windows-static so
+    libevent is linked into tmux.exe at build time
+  - Release ZIP contains only tmux.exe — no DLLs, no README.txt
+  - Simpler deployment: just drop tmux.exe into your PATH
+Tags:
+- cli
+- terminal
+- multiplexer
+- tmux
+- conpty
+ReleaseNotesUrl: https://github.com/arndawg/tmux-windows/releases/tag/v3.6a-win32.6
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/a/arndawg/tmux-windows/3.6a-win32.6/arndawg.tmux-windows.yaml
+++ b/manifests/a/arndawg/tmux-windows/3.6a-win32.6/arndawg.tmux-windows.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: arndawg.tmux-windows
+PackageVersion: 3.6a-win32.6
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
### New version: arndawg.tmux-windows 3.6a-win32.6

- Switched to static linking — single `tmux.exe` with no DLL dependencies
- Release ZIP contains only `tmux.exe` (no `event_core.dll`, no `README.txt`)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/342755)