### PR TITLE
New package: arndawg.zellij-windows version 0.43.1-win32.1

### DIFF
--- a/manifests/a/arndawg/zellij-windows/0.43.1-win32.1/arndawg.zellij-windows.installer.yaml
+++ b/manifests/a/arndawg/zellij-windows/0.43.1-win32.1/arndawg.zellij-windows.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: arndawg.zellij-windows
+PackageVersion: 0.43.1-win32.1
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: zellij.exe
+  PortableCommandAlias: zellij
+ReleaseDate: 2026-02-25
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/arndawg/zellij-windows/releases/download/v0.43.1-win32.1/zellij-windows-v0.43.1-win32.1.zip
+  InstallerSha256: 8D7CBE95D857AB08161EF2D53368CCEE61FE3F6D73BFC66CF31993949AECB834
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/a/arndawg/zellij-windows/0.43.1-win32.1/arndawg.zellij-windows.locale.en-US.yaml
+++ b/manifests/a/arndawg/zellij-windows/0.43.1-win32.1/arndawg.zellij-windows.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: arndawg.zellij-windows
+PackageVersion: 0.43.1-win32.1
+PackageLocale: en-US
+Publisher: arndawg
+PublisherUrl: https://github.com/arndawg
+PublisherSupportUrl: https://github.com/arndawg/zellij-windows/issues
+Author: arndawg
+PackageName: zellij-windows
+PackageUrl: https://github.com/arndawg/zellij-windows
+License: MIT
+LicenseUrl: https://github.com/arndawg/zellij-windows/blob/main/LICENSE.md
+ShortDescription: Terminal workspace for Windows, ported from zellij using ConPTY
+Description: |-
+  A native Windows port of zellij, the terminal workspace. Uses ConPTY for
+  pseudo-terminal support with panes, tabs, sessions, and a built-in web client.
+  Features ACL-secured IPC, reliable Ctrl+C delivery, and WASM plugin support.
+  Requires Windows 10 version 1809+ and Windows Terminal or a VT-capable console.
+Tags:
+- cli
+- terminal
+- multiplexer
+- zellij
+- conpty
+- panes
+- tabs
+ReleaseNotesUrl: https://github.com/arndawg/zellij-windows/releases/tag/v0.43.1-win32.1
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/a/arndawg/zellij-windows/0.43.1-win32.1/arndawg.zellij-windows.yaml
+++ b/manifests/a/arndawg/zellij-windows/0.43.1-win32.1/arndawg.zellij-windows.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: arndawg.zellij-windows
+PackageVersion: 0.43.1-win32.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
### New package submission

- **PackageIdentifier:** arndawg.zellij-windows
- **PackageVersion:** 0.43.1-win32.1
- **InstallerType:** zip (portable)
- **Architecture:** x64

Native Windows port of [zellij](https://zellij.dev) terminal workspace using ConPTY. Features panes, tabs, sessions, WASM plugins, and a built-in web client.

**Release:** https://github.com/arndawg/zellij-windows/releases/tag/v0.43.1-win32.1
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/342861)