### PR TITLE
Fix version: Hugin.Hugin version 2025.0.0

### DIFF
--- a/manifests/h/Hugin/Hugin/2025.0.0/Hugin.Hugin.installer.yaml
+++ b/manifests/h/Hugin/Hugin/2025.0.0/Hugin.Hugin.installer.yaml
@@ -10,7 +10,6 @@ ProductCode: '{DE267FF1-6F03-4BE5-98AB-AF1539216887}'
 AppsAndFeaturesEntries:
 - DisplayName: Hugin
   Publisher: Hugin developer team
-  DisplayVersion: 20.25.0
   ProductCode: '{DE267FF1-6F03-4BE5-98AB-AF1539216887}'
   UpgradeCode: '{1B85EFEB-F843-49C6-80D3-A539B035D319}'
 InstallationMetadata:
@@ -22,3 +21,4 @@ Installers:
 ManifestType: installer
 ManifestVersion: 1.10.0
 ReleaseDate: 2025-11-15
+


### PR DESCRIPTION
AppsAndFeaturesEntries DisplayVersion is reused in 2025.0.1. See #341956

Checklist for Pull Requests
- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?  If so, fill in the Issue number below.
   <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

Manifests
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/342911)