### PR TITLE
New package: JJs23.Racemo version 0.1.7

### DIFF
--- a/manifests/j/JJs23/Racemo/0.1.7/JJs23.Racemo.installer.yaml
+++ b/manifests/j/JJs23/Racemo/0.1.7/JJs23.Racemo.installer.yaml
@@ -5,7 +5,7 @@ PackageVersion: 0.1.7
 Platform:
   - Windows.Desktop
 MinimumOSVersion: 10.0.17763.0
-InstallerType: nsis
+InstallerType: nullsoft
 Scope: user
 InstallModes:
   - interactive

--- a/manifests/j/JJs23/Racemo/0.1.7/JJs23.Racemo.installer.yaml
+++ b/manifests/j/JJs23/Racemo/0.1.7/JJs23.Racemo.installer.yaml
@@ -1,7 +1,10 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
 
 PackageIdentifier: JJs23.Racemo
 PackageVersion: 0.1.7
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
 InstallerType: nsis
 Scope: user
 InstallModes:
@@ -14,4 +17,4 @@ Installers:
     InstallerUrl: https://github.com/JJs23/racemo-releases/releases/download/v0.1.7/Racemo_0.1.7_x64-setup.exe
     InstallerSha256: 952C8D5CB496C9C94127EE93433E1DFB4584FA5EDEABD1B4BA21E56F9AC4CFF4
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.10.0

--- a/manifests/j/JJs23/Racemo/0.1.7/JJs23.Racemo.installer.yaml
+++ b/manifests/j/JJs23/Racemo/0.1.7/JJs23.Racemo.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: JJs23.Racemo
+PackageVersion: 0.1.7
+InstallerType: nsis
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/JJs23/racemo-releases/releases/download/v0.1.7/Racemo_0.1.7_x64-setup.exe
+    InstallerSha256: 952C8D5CB496C9C94127EE93433E1DFB4584FA5EDEABD1B4BA21E56F9AC4CFF4
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/j/JJs23/Racemo/0.1.7/JJs23.Racemo.locale.en-US.yaml
+++ b/manifests/j/JJs23/Racemo/0.1.7/JJs23.Racemo.locale.en-US.yaml
@@ -1,12 +1,14 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
 
 PackageIdentifier: JJs23.Racemo
 PackageVersion: 0.1.7
 PackageLocale: en-US
 Publisher: JJs23
+PublisherUrl: https://github.com/JJs23/racemo-releases
 PackageName: Racemo
 PackageUrl: https://github.com/JJs23/racemo-releases
 License: MIT
+LicenseUrl: https://github.com/JJs23/racemo-releases/blob/main/LICENSE
 ShortDescription: GUI Terminal Multiplexer built with Tauri
 Tags:
   - terminal
@@ -14,4 +16,4 @@ Tags:
   - developer-tools
   - tauri
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.10.0

--- a/manifests/j/JJs23/Racemo/0.1.7/JJs23.Racemo.locale.en-US.yaml
+++ b/manifests/j/JJs23/Racemo/0.1.7/JJs23.Racemo.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: JJs23.Racemo
+PackageVersion: 0.1.7
+PackageLocale: en-US
+Publisher: JJs23
+PackageName: Racemo
+PackageUrl: https://github.com/JJs23/racemo-releases
+License: MIT
+ShortDescription: GUI Terminal Multiplexer built with Tauri
+Tags:
+  - terminal
+  - multiplexer
+  - developer-tools
+  - tauri
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/j/JJs23/Racemo/0.1.7/JJs23.Racemo.locale.en-US.yaml
+++ b/manifests/j/JJs23/Racemo/0.1.7/JJs23.Racemo.locale.en-US.yaml
@@ -7,7 +7,7 @@ Publisher: JJs23
 PublisherUrl: https://github.com/JJs23/racemo-releases
 PackageName: Racemo
 PackageUrl: https://github.com/JJs23/racemo-releases
-License: MIT
+License: Apache-2.0
 LicenseUrl: https://github.com/JJs23/racemo-releases/blob/main/LICENSE
 ShortDescription: GUI Terminal Multiplexer built with Tauri
 Tags:

--- a/manifests/j/JJs23/Racemo/0.1.7/JJs23.Racemo.yaml
+++ b/manifests/j/JJs23/Racemo/0.1.7/JJs23.Racemo.yaml
@@ -1,8 +1,7 @@
-# Created using winget CLI
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
 
 PackageIdentifier: JJs23.Racemo
 PackageVersion: 0.1.7
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.10.0

--- a/manifests/j/JJs23/Racemo/0.1.7/JJs23.Racemo.yaml
+++ b/manifests/j/JJs23/Racemo/0.1.7/JJs23.Racemo.yaml
@@ -1,0 +1,8 @@
+# Created using winget CLI
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: JJs23.Racemo
+PackageVersion: 0.1.7
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New Package Submission

- Package: JJs23.Racemo
- Version: 0.1.7

### Description

Racemo is a GUI Terminal Multiplexer built with Tauri (Rust + React). It provides split panes, session management, and remote terminal sharing via WebRTC.

### URLs

- Installer: https://github.com/JJs23/racemo-releases/releases/download/v0.1.7/Racemo_0.1.7_x64-setup.exe
- Repository: https://github.com/JJs23/racemo-releases
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/343054)