### PR TITLE
New package: SteampunkLabs.AWSLoggy version 3.9.0

### DIFF
--- a/manifests/s/SteampunkLabs/AWSLoggy/3.9.0/SteampunkLabs.AWSLoggy.installer.yaml
+++ b/manifests/s/SteampunkLabs/AWSLoggy/3.9.0/SteampunkLabs.AWSLoggy.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: SteampunkLabs.AWSLoggy
+PackageVersion: 3.9.0
+InstallerType: msi
+Scope: machine
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/aegixx/aws-loggy/releases/download/v3.9.0/Loggy-3.9.0-windows-x86_64.msi
+  InstallerSha256: 16B34B3B51B00FDA52AC3C640F0E5D20BC2C31AECE0949CF6E0088AFFBCD5346
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/SteampunkLabs/AWSLoggy/3.9.0/SteampunkLabs.AWSLoggy.locale.en-US.yaml
+++ b/manifests/s/SteampunkLabs/AWSLoggy/3.9.0/SteampunkLabs.AWSLoggy.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: SteampunkLabs.AWSLoggy
+PackageVersion: 3.9.0
+PackageLocale: en-US
+Publisher: Steampunk Labs
+PublisherUrl: https://github.com/aegixx
+PackageName: AWS Loggy
+PackageUrl: https://github.com/aegixx/aws-loggy
+License: MIT
+LicenseUrl: https://github.com/aegixx/aws-loggy/blob/main/LICENSE
+ShortDescription: A fast, native desktop app for browsing and tailing AWS CloudWatch logs
+Description: Loggy is a desktop application for viewing AWS CloudWatch logs. Features include live tail streaming, fuzzy search log group selection, log level filtering, find-in-log, keyboard-driven navigation, and Lambda invocation grouping.
+Tags:
+- aws
+- cloudwatch
+- logs
+- monitoring
+- devtools
+- lambda
+ReleaseNotesUrl: https://github.com/aegixx/aws-loggy/releases/tag/v3.9.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/SteampunkLabs/AWSLoggy/3.9.0/SteampunkLabs.AWSLoggy.yaml
+++ b/manifests/s/SteampunkLabs/AWSLoggy/3.9.0/SteampunkLabs.AWSLoggy.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: SteampunkLabs.AWSLoggy
+PackageVersion: 3.9.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New Package Submission

- **Package identifier**: SteampunkLabs.AWSLoggy
- **Package version**: 3.9.0
- **Installer type**: MSI (x64)
- **License**: MIT

**Description**: Loggy is a fast, native desktop app for browsing and tailing AWS CloudWatch logs. Built with Tauri (Rust + React/TypeScript).

**Homepage**: https://github.com/aegixx/aws-loggy
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/343294)