### PR TITLE
Update AlperHan.CrossMacro version 0.9.7 installer hash

### DIFF
--- a/manifests/a/AlperHan/CrossMacro/0.9.7/AlperHan.CrossMacro.installer.yaml
+++ b/manifests/a/AlperHan/CrossMacro/0.9.7/AlperHan.CrossMacro.installer.yaml
@@ -10,6 +10,6 @@ ReleaseDate: 2026-02-21
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/alper-han/CrossMacro/releases/download/v0.9.7/CrossMacro-0.9.7-win-x64.exe
-  InstallerSha256: 9A03B475ED5F5B6585B80D1D8E2A3A3BF42918A7D85EDFE79EED77B9CC212030
+  InstallerSha256: 3D8413E8CA7307CE0B3B95E3ED4503F96175322AF190D9E102997D627E5C403E
 ManifestType: installer
 ManifestVersion: 1.12.0


### PR DESCRIPTION
### Summary
- Updates `InstallerSha256` for `AlperHan.CrossMacro` `0.9.7` to match the current release asset at:
  `https://github.com/alper-han/CrossMacro/releases/download/v0.9.7/CrossMacro-0.9.7-win-x64.exe`

### Why
- Users currently hit `Installer hash does not match` when installing via:
  `winget install --id AlperHan.CrossMacro`

### Verification
- Recomputed SHA256 for the current installer URL:
  `3D8413E8CA7307CE0B3B95E3ED4503F96175322AF190D9E102997D627E5C403E`

### Related
- https://github.com/alper-han/CrossMacro/issues/26
- https://github.com/microsoft/winget-pkgs/pull/341433

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/343796)