### PR TITLE
New package: Qiyuey.BingWallpaperNow version 1.4.3

### DIFF
--- a/manifests/q/Qiyuey/BingWallpaperNow/1.4.3/Qiyuey.BingWallpaperNow.installer.yaml
+++ b/manifests/q/Qiyuey/BingWallpaperNow/1.4.3/Qiyuey.BingWallpaperNow.installer.yaml
@@ -1,0 +1,34 @@
+# Created using hand-crafted manifest
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: Qiyuey.BingWallpaperNow
+PackageVersion: 1.4.3
+InstallerLocale: zh-CN
+InstallerType: burn
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerType: msi
+    InstallerUrl: https://github.com/qiyuey/bing-wallpaper-now/releases/download/1.4.3/Bing.Wallpaper.Now_1.4.3_x64_zh-CN.msi
+    InstallerSha256: 6C58DF2D4BF153056F425AED769962CB9741850D6C84412C3B9A8DA6E67DBE74
+    ProductCode: '{B9233E29-E13F-4B09-802E-2E3C07F1B6E3}'
+  - Architecture: x64
+    InstallerType: exe
+    InstallerUrl: https://github.com/qiyuey/bing-wallpaper-now/releases/download/1.4.3/Bing.Wallpaper.Now_1.4.3_x64-setup.exe
+    InstallerSha256: 53197566032C590BE6519C3DCA02646420264A81D8B208F4905D835447945827
+    InstallerSwitches:
+      Silent: /S
+      SilentWithProgress: /S
+  - Architecture: arm64
+    InstallerType: msi
+    InstallerUrl: https://github.com/qiyuey/bing-wallpaper-now/releases/download/1.4.3/Bing.Wallpaper.Now_1.4.3_arm64_zh-CN.msi
+    InstallerSha256: 16A936BB3E9D5E45A8A1D8E81E08DB8D3E134D10F69FFC35EAD4255099D2309E
+  - Architecture: arm64
+    InstallerType: exe
+    InstallerUrl: https://github.com/qiyuey/bing-wallpaper-now/releases/download/1.4.3/Bing.Wallpaper.Now_1.4.3_arm64-setup.exe
+    InstallerSha256: 74A7C2464A8D56CA03993F90050F3D042E4BA4C9F68ACEDAD3F118CF2351CF10
+    InstallerSwitches:
+      Silent: /S
+      SilentWithProgress: /S
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/q/Qiyuey/BingWallpaperNow/1.4.3/Qiyuey.BingWallpaperNow.locale.en-US.yaml
+++ b/manifests/q/Qiyuey/BingWallpaperNow/1.4.3/Qiyuey.BingWallpaperNow.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# Created using hand-crafted manifest
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: Qiyuey.BingWallpaperNow
+PackageVersion: 1.4.3
+PackageLocale: en-US
+Publisher: qiyuey
+PublisherUrl: https://github.com/qiyuey
+PublisherSupportUrl: https://github.com/qiyuey/bing-wallpaper-now/issues
+PackageName: Bing Wallpaper Now
+PackageUrl: https://github.com/qiyuey/bing-wallpaper-now
+License: Anti-996 License
+LicenseUrl: https://github.com/qiyuey/bing-wallpaper-now/blob/main/LICENSE
+ShortDescription: A cross-platform desktop app to automatically fetch and set Bing daily wallpapers
+Description: |-
+  Bing Wallpaper Now is a lightweight cross-platform desktop application built with Tauri 2.0 (Rust + React).
+  It automatically fetches and sets Bing's daily wallpapers in UHD resolution.
+  Features include portrait display support, multi-monitor wallpaper setting, macOS deep integration
+  (Space auto-restore, fullscreen handling), in-app auto-update, and dark/light theme support.
+Tags:
+  - wallpaper
+  - bing
+  - desktop
+  - tauri
+  - background
+ReleaseNotesUrl: https://github.com/qiyuey/bing-wallpaper-now/releases/tag/1.4.3
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/q/Qiyuey/BingWallpaperNow/1.4.3/Qiyuey.BingWallpaperNow.locale.zh-CN.yaml
+++ b/manifests/q/Qiyuey/BingWallpaperNow/1.4.3/Qiyuey.BingWallpaperNow.locale.zh-CN.yaml
@@ -1,0 +1,28 @@
+# Created using hand-crafted manifest
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
+
+PackageIdentifier: Qiyuey.BingWallpaperNow
+PackageVersion: 1.4.3
+PackageLocale: zh-CN
+Publisher: qiyuey
+PublisherUrl: https://github.com/qiyuey
+PublisherSupportUrl: https://github.com/qiyuey/bing-wallpaper-now/issues
+PackageName: Bing Wallpaper Now
+PackageUrl: https://github.com/qiyuey/bing-wallpaper-now
+License: Anti-996 License
+LicenseUrl: https://github.com/qiyuey/bing-wallpaper-now/blob/main/LICENSE
+ShortDescription: 自动获取并设置 Bing 每日精美壁纸的跨平台桌面应用
+Description: |-
+  Bing Wallpaper Now 是一款基于 Tauri 2.0（Rust + React）构建的轻量跨平台桌面应用。
+  自动获取 Bing 每日壁纸并设置为桌面背景，支持 UHD 超高清分辨率。
+  特性包括竖屏显示器自动识别、多显示器壁纸设置、macOS 深度集成
+  （Space 自动恢复、全屏应用处理）、应用内自动更新、深色/浅色主题等。
+Tags:
+  - wallpaper
+  - bing
+  - desktop
+  - tauri
+  - background
+ReleaseNotesUrl: https://github.com/qiyuey/bing-wallpaper-now/releases/tag/1.4.3
+ManifestType: locale
+ManifestVersion: 1.6.0

--- a/manifests/q/Qiyuey/BingWallpaperNow/1.4.3/Qiyuey.BingWallpaperNow.yaml
+++ b/manifests/q/Qiyuey/BingWallpaperNow/1.4.3/Qiyuey.BingWallpaperNow.yaml
@@ -1,0 +1,8 @@
+# Created using hand-crafted manifest
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: Qiyuey.BingWallpaperNow
+PackageVersion: 1.4.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package submission

- Package: Qiyuey.BingWallpaperNow
- Version: 1.4.0

### Description

Bing Wallpaper Now is a lightweight cross-platform desktop application built with Tauri 2.0 (Rust + React). It automatically fetches and sets Bing's daily wallpapers in UHD resolution.

### Installers

| Architecture | Type | URL |
|---|---|---|
| x64 | MSI | [Download](https://github.com/qiyuey/bing-wallpaper-now/releases/download/1.4.0/Bing.Wallpaper.Now_1.4.0_x64_zh-CN.msi) |
| x64 | EXE | [Download](https://github.com/qiyuey/bing-wallpaper-now/releases/download/1.4.0/Bing.Wallpaper.Now_1.4.0_x64-setup.exe) |
| arm64 | MSI | [Download](https://github.com/qiyuey/bing-wallpaper-now/releases/download/1.4.0/Bing.Wallpaper.Now_1.4.0_arm64_zh-CN.msi) |
| arm64 | EXE | [Download](https://github.com/qiyuey/bing-wallpaper-now/releases/download/1.4.0/Bing.Wallpaper.Now_1.4.0_arm64-setup.exe) |

### Checklist

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/creation?
- [x] This PR only modifies files in the **manifests** folder
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?


Made with [Cursor](https://cursor.com)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/343820)