### PR TITLE
Added "ArchiveBinariesDependOnPath": AdGuard.AdGuardHome version 0.107.72

### DIFF
--- a/manifests/a/AdGuard/AdGuardHome/0.107.72/AdGuard.AdGuardHome.installer.yaml
+++ b/manifests/a/AdGuard/AdGuardHome/0.107.72/AdGuard.AdGuardHome.installer.yaml
@@ -8,6 +8,7 @@ InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
 - RelativeFilePath: AdGuardHome/AdGuardHome.exe
+ArchiveBinariesDependOnPath: true
 ReleaseDate: 2026-02-19
 Installers:
 - Architecture: x86


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?  If so, fill in the Issue number below.
   <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---
Notes from me:
* Though I'm somewhat pessimistic for whether it'll successfully handle #341077, it's at least worth a try.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/343840)