### PR TITLE
New package: PranavPeshwe.PromptRefiner version 1.1.0

### DIFF
--- a/manifests/p/PranavPeshwe/PromptRefiner/1.1.0/PranavPeshwe.PromptRefiner.installer.yaml
+++ b/manifests/p/PranavPeshwe/PromptRefiner/1.1.0/PranavPeshwe.PromptRefiner.installer.yaml
@@ -1,0 +1,16 @@
+# Created using winget CLI
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: PranavPeshwe.PromptRefiner
+PackageVersion: 1.1.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: PromptRefiner.exe
+    PortableCommandAlias: prompt-refiner
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/PranavPeshwe/prompt-refiner/releases/download/v1.1.0/PromptRefiner-win-x64.zip
+    InstallerSha256: 6486C1E7A0090CA9E6D1EDC02672F26BE014A729C14EB9C79F861F7C0D5F48F5
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/p/PranavPeshwe/PromptRefiner/1.1.0/PranavPeshwe.PromptRefiner.locale.en-US.yaml
+++ b/manifests/p/PranavPeshwe/PromptRefiner/1.1.0/PranavPeshwe.PromptRefiner.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# Created using winget CLI
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: PranavPeshwe.PromptRefiner
+PackageVersion: 1.1.0
+PackageLocale: en-US
+Publisher: Pranav Peshwe
+PublisherUrl: https://github.com/PranavPeshwe
+PackageName: Prompt Refiner
+PackageUrl: https://github.com/PranavPeshwe/prompt-refiner
+License: MIT
+LicenseUrl: https://github.com/PranavPeshwe/prompt-refiner/blob/master/LICENSE
+ShortDescription: A Windows desktop app that refines rough prompts into comprehensive, precise prompts using the GitHub Copilot SDK.
+Description: |-
+  Prompt Refiner is a lightweight Windows desktop application (.NET 8, WinForms) that takes a basic user prompt as input, sends it to a large language model via the GitHub Copilot SDK, and returns a polished, comprehensive version. Supports both a full GUI and a headless CLI for scripting and pipelines. Features real-time streaming, dynamic model selection, debug mode, and copy-able error dialogs.
+Tags:
+  - prompt-engineering
+  - copilot
+  - llm
+  - cli
+  - winforms
+  - ai
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/p/PranavPeshwe/PromptRefiner/1.1.0/PranavPeshwe.PromptRefiner.yaml
+++ b/manifests/p/PranavPeshwe/PromptRefiner/1.1.0/PranavPeshwe.PromptRefiner.yaml
@@ -1,8 +1,9 @@
 # Created using winget CLI
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: \=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: PranavPeshwe.PromptRefiner
 PackageVersion: 1.1.0
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.6.0
+

--- a/manifests/p/PranavPeshwe/PromptRefiner/1.1.0/PranavPeshwe.PromptRefiner.yaml
+++ b/manifests/p/PranavPeshwe/PromptRefiner/1.1.0/PranavPeshwe.PromptRefiner.yaml
@@ -1,0 +1,8 @@
+# Created using winget CLI
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: PranavPeshwe.PromptRefiner
+PackageVersion: 1.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Package: PranavPeshwe.PromptRefiner v1.1.0

**Description:** A lightweight Windows desktop app (.NET 8, WinForms) that refines rough prompts into comprehensive, precise prompts using the GitHub Copilot SDK. Supports both GUI and CLI modes.

**Homepage:** https://github.com/PranavPeshwe/prompt-refiner
**License:** MIT
**Installer:** Self-contained portable zip (win-x64, ~115 MB)

### Manifest validation
- [x] Package identifier follows publisher.appname convention
- [x] SHA256 hash verified against release artifact
- [x] Installer URL is publicly accessible (GitHub Release)
- [x] Multi-file manifest (version + installer + defaultLocale)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/344075)