### PR TITLE
New version: M-Igashi.mp3rgain version 2.0.0

### DIFF
--- a/manifests/m/M-Igashi/mp3rgain/2.0.0/M-Igashi.mp3rgain.installer.yaml
+++ b/manifests/m/M-Igashi/mp3rgain/2.0.0/M-Igashi.mp3rgain.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgain
+PackageVersion: 2.0.0
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: mp3rgain.exe
+ReleaseDate: 2026-02-28
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/M-Igashi/mp3rgain/releases/download/v2.0.0/mp3rgain-v2.0.0-windows-x86_64.zip
+    InstallerSha256: F67C39280A0C07FBB8F3ABD4E449C4B9D344A952AD2E130DE46F2B7BECBEDDDA
+  - Architecture: arm64
+    InstallerUrl: https://github.com/M-Igashi/mp3rgain/releases/download/v2.0.0/mp3rgain-v2.0.0-windows-arm64.zip
+    InstallerSha256: 4AF3D043904266332F78D6FDF53F4A326F24AE5D77F3985534A413781FB5B7C3
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/mp3rgain/2.0.0/M-Igashi.mp3rgain.locale.en-US.yaml
+++ b/manifests/m/M-Igashi/mp3rgain/2.0.0/M-Igashi.mp3rgain.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgain
+PackageVersion: 2.0.0
+PackageLocale: en-US
+Publisher: M-Igashi
+PublisherUrl: https://github.com/M-Igashi
+PublisherSupportUrl: https://github.com/M-Igashi/mp3rgain/issues
+Author: M-Igashi
+PackageName: mp3rgain
+PackageUrl: https://github.com/M-Igashi/mp3rgain
+License: MIT
+LicenseUrl: https://github.com/M-Igashi/mp3rgain/blob/master/LICENSE
+ShortDescription: Lossless MP3 volume adjustment - a modern mp3gain replacement written in Rust
+Description: |-
+  mp3rgain adjusts MP3 volume without re-encoding by modifying the global_gain field in each frame's side information.
+  This preserves audio quality while achieving permanent volume changes.
+  Features include ReplayGain analysis, AAC/M4A support, and full mp3gain command-line compatibility.
+Moniker: mp3rgain
+Tags:
+  - audio
+  - cli
+  - flac
+  - gain
+  - lossless
+  - mp3
+  - music
+  - normalize
+  - ogg
+  - replaygain
+  - rust
+  - volume
+ReleaseNotesUrl: https://github.com/M-Igashi/mp3rgain/releases/tag/v2.0.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/mp3rgain/2.0.0/M-Igashi.mp3rgain.yaml
+++ b/manifests/m/M-Igashi/mp3rgain/2.0.0/M-Igashi.mp3rgain.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgain
+PackageVersion: 2.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

New version of mp3rgain: 2.0.0

This is a major release with significant new features and breaking API changes.

## Changes in v2.0.0

### New Features
- **Full AAC/M4A lossless gain adjustment**: True lossless volume adjustment for AAC files by modifying global_gain in the AAC bitstream
- **ID3v2 ReplayGain tag storage** (`-s i`): Full support for writing/reading ReplayGain data in ID3v2 TXXX frames
- **HE-AAC/SBR and multi-channel support**: Proper handling of SBR extension data and 5.1ch layouts
- **AAC undo support**: Undo data stored in iTunes freeform tags

### Improvements
- macOS resource fork files (._*) automatically skipped in recursive mode
- Improved mp3gain output compatibility (ReplayGain results in default output, album summary lines)
- Warning when using channel gain on Joint Stereo files

### Library API (Breaking Changes)
- Custom error types replacing anyhow::Result
- GainOptions builder pattern replacing multiple apply_gain_* functions
- Type-safe MpegVersion and ChannelMode enums
- Modular source structure

## Links

- Release: https://github.com/M-Igashi/mp3rgain/releases/tag/v2.0.0
- Repository: https://github.com/M-Igashi/mp3rgain
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/344114)