### PR TITLE
Add arndawg.tmux-windows version 3.6a-win32.7

### DIFF
--- a/manifests/a/arndawg/tmux-windows/3.6a-win32.7/arndawg.tmux-windows.installer.yaml
+++ b/manifests/a/arndawg/tmux-windows/3.6a-win32.7/arndawg.tmux-windows.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: arndawg.tmux-windows
+PackageVersion: 3.6a-win32.7
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: tmux.exe
+  PortableCommandAlias: tmux
+ReleaseDate: 2026-03-01
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/arndawg/tmux-windows/releases/download/v3.6a-win32.7/tmux-windows-v3.6a-win32.7.zip
+  InstallerSha256: 8AC011C4D124084B6C159FE7A8D16557BB1E04A944E80C158C4352C2C0906460
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/a/arndawg/tmux-windows/3.6a-win32.7/arndawg.tmux-windows.locale.en-US.yaml
+++ b/manifests/a/arndawg/tmux-windows/3.6a-win32.7/arndawg.tmux-windows.locale.en-US.yaml
@@ -1,0 +1,45 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: arndawg.tmux-windows
+PackageVersion: 3.6a-win32.7
+PackageLocale: en-US
+Publisher: arndawg
+PublisherUrl: https://github.com/arndawg
+PublisherSupportUrl: https://github.com/arndawg/tmux-windows/issues
+Author: arndawg
+PackageName: tmux-windows
+PackageUrl: https://github.com/arndawg/tmux-windows
+License: ISC
+LicenseUrl: https://github.com/arndawg/tmux-windows/blob/master/COPYING
+ShortDescription: Terminal multiplexer for Windows, ported from tmux using ConPTY
+Description: |-
+  A native Windows port of tmux, the terminal multiplexer. Split your terminal
+  into multiple panes, create persistent sessions that survive disconnects, and
+  detach/reattach workflows — all natively on Windows 10+.
+
+  Built with ConPTY for full pseudo-terminal support and Windows Named Pipes for
+  secure, kernel-enforced IPC. Works in Windows Terminal, VS Code terminal, and
+  any VT-capable console host. Builds with MSVC, no Cygwin or WSL required.
+ReleaseNotes: |-
+  SSH Session Survival
+
+  The tmux server now survives SSH disconnects. Previously, closing an SSH
+  connection would terminate the tmux server and all attached sessions,
+  because Windows OpenSSH uses job objects to kill all child processes when
+  a session ends.
+
+  Changes:
+  - Server launch uses CREATE_BREAKAWAY_FROM_JOB to detach from the SSH
+    job object, the Windows equivalent of Unix setsid()
+  - Falls back to previous behavior if the job does not allow breakaway
+  - Sessions started over SSH can be reattached from the local console
+    or a new SSH connection
+Tags:
+- cli
+- terminal
+- multiplexer
+- tmux
+- conpty
+ReleaseNotesUrl: https://github.com/arndawg/tmux-windows/releases/tag/v3.6a-win32.7
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/a/arndawg/tmux-windows/3.6a-win32.7/arndawg.tmux-windows.yaml
+++ b/manifests/a/arndawg/tmux-windows/3.6a-win32.7/arndawg.tmux-windows.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: arndawg.tmux-windows
+PackageVersion: 3.6a-win32.7
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
### New version: arndawg.tmux-windows 3.6a-win32.7

- tmux server now survives SSH disconnects via job object breakaway
- Sessions started over SSH persist and can be reattached from local console or new SSH
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/344149)