### PR TITLE
New version: M-Igashi.headroom version 1.7.0

### DIFF
--- a/manifests/m/M-Igashi/headroom/1.7.0/M-Igashi.headroom.installer.yaml
+++ b/manifests/m/M-Igashi/headroom/1.7.0/M-Igashi.headroom.installer.yaml
@@ -1,0 +1,17 @@
+# Created using wingetcreate 1.6.5.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.headroom
+PackageVersion: 1.7.0
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: headroom.exe
+ReleaseDate: 2026-03-01
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/M-Igashi/headroom/releases/download/v1.7.0/headroom-v1.7.0-windows-x86_64.zip
+    InstallerSha256: BE74BE8267A33E5DB2044AEA7D4868F72326E8632168DE70B8FD9E50C58F417D
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/headroom/1.7.0/M-Igashi.headroom.locale.en-US.yaml
+++ b/manifests/m/M-Igashi/headroom/1.7.0/M-Igashi.headroom.locale.en-US.yaml
@@ -1,0 +1,39 @@
+# Created using wingetcreate 1.6.5.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.headroom
+PackageVersion: 1.7.0
+PackageLocale: en-US
+Publisher: M-Igashi
+PublisherUrl: https://github.com/M-Igashi
+PublisherSupportUrl: https://github.com/M-Igashi/headroom/issues
+Author: M-Igashi
+PackageName: headroom
+PackageUrl: https://github.com/M-Igashi/headroom
+License: MIT
+LicenseUrl: https://github.com/M-Igashi/headroom/blob/main/LICENSE
+ShortDescription: Audio loudness analyzer and gain adjustment tool for mastering and DJ workflows
+Description: |-
+  headroom analyzes audio files for loudness (LUFS) and headroom, then applies lossless gain adjustment.
+  It supports MP3, AAC/M4A, FLAC, AIFF, and WAV files.
+  Features include batch processing, ReplayGain analysis, lossless MP3 gain via mp3rgain, and lossless AAC/M4A gain adjustment.
+Moniker: headroom
+Tags:
+  - aac
+  - audio
+  - cli
+  - dj
+  - ffmpeg
+  - gain
+  - loudness
+  - lufs
+  - mastering
+  - mp3
+  - music
+  - normalize
+  - replaygain
+  - rust
+  - volume
+ReleaseNotesUrl: https://github.com/M-Igashi/headroom/releases/tag/v1.7.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/headroom/1.7.0/M-Igashi.headroom.yaml
+++ b/manifests/m/M-Igashi/headroom/1.7.0/M-Igashi.headroom.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.6.5.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.headroom
+PackageVersion: 1.7.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New version: [M-Igashi.headroom version 1.7.0](https://github.com/M-Igashi/headroom/releases/tag/v1.7.0)

Release Notes:
- Add lossless AAC/M4A gain adjustment via mp3rgain v2.0
- Three-tier processing for both MP3 and AAC: native lossless → ffmpeg re-encode → skip
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/344183)