### PR TITLE
M-Igashi.headroom 1.7.0: add Gyan.FFmpeg dependency

### DIFF
--- a/manifests/m/M-Igashi/headroom/1.7.0/M-Igashi.headroom.installer.yaml
+++ b/manifests/m/M-Igashi/headroom/1.7.0/M-Igashi.headroom.installer.yaml
@@ -8,6 +8,9 @@ InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
   - RelativeFilePath: headroom.exe
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Gyan.FFmpeg
 ReleaseDate: 2026-03-01
 Installers:
   - Architecture: x64

--- a/manifests/m/M-Igashi/headroom/1.7.0/M-Igashi.headroom.installer.yaml
+++ b/manifests/m/M-Igashi/headroom/1.7.0/M-Igashi.headroom.installer.yaml
@@ -3,7 +3,6 @@
 
 PackageIdentifier: M-Igashi.headroom
 PackageVersion: 1.7.0
-InstallerLocale: en-US
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:


### PR DESCRIPTION
### Add PackageDependency on Gyan.FFmpeg to M-Igashi.headroom 1.7.0

headroom requires ffmpeg for audio analysis and lossless format processing. This change adds `Gyan.FFmpeg` as a `PackageDependency` so that winget automatically installs ffmpeg when installing headroom.

This dependency is already declared in the [Homebrew formula](https://github.com/M-Igashi/homebrew-tap/blob/main/Formula/headroom.rb) (`depends_on "ffmpeg"`) and [Scoop manifest](https://github.com/M-Igashi/scoop-bucket/blob/main/bucket/headroom.json) (`"depends": "ffmpeg"`).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/344206)