### PR TITLE
New version: MNardit.Beetroot version 1.0.6

### DIFF
--- a/manifests/m/MNardit/Beetroot/1.0.6/MNardit.Beetroot.installer.yaml
+++ b/manifests/m/MNardit/Beetroot/1.0.6/MNardit.Beetroot.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: MNardit.Beetroot
+PackageVersion: 1.0.6
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/mnardit/beetroot-releases/releases/download/v1.0.6/Beetroot_1.0.6_x64-setup.exe
+    InstallerSha256: 18A9D3C542BEAF9F8AB6EA6E0407DBE2FDA2E2BA7A591B2369E5F7B1A3A6EA44
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/MNardit/Beetroot/1.0.6/MNardit.Beetroot.locale.en-US.yaml
+++ b/manifests/m/MNardit/Beetroot/1.0.6/MNardit.Beetroot.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: MNardit.Beetroot
+PackageVersion: 1.0.6
+PackageLocale: en-US
+Publisher: MNardit
+PublisherUrl: https://github.com/mnardit
+Author: MNardit
+PackageName: Beetroot
+PackageUrl: https://github.com/mnardit/beetroot-releases
+License: Proprietary
+LicenseUrl: https://github.com/mnardit/beetroot-releases/blob/main/LICENSE
+ShortDescription: Lightweight clipboard manager for Windows with AI-powered text transforms
+Description: |-
+  Beetroot is a modern clipboard manager for Windows that runs in the system tray.
+  Features:
+  - Unlimited clipboard history (text and images)
+  - Global hotkey (Ctrl+`) to instantly access history
+  - Fuzzy and regex search
+  - AI-powered text transforms via OpenAI
+  - OCR text extraction from images
+  - Notes on clipboard items
+  - Multi-select batch operations
+  - 8 themes + custom accent color
+  - 10 languages (English, Russian, German, Spanish, Chinese, Japanese, French, Portuguese, Korean, Turkish)
+  - Auto-update with option to disable for fully offline operation
+Tags:
+  - clipboard
+  - clipboard-manager
+  - productivity
+  - tauri
+  - windows
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/MNardit/Beetroot/1.0.6/MNardit.Beetroot.yaml
+++ b/manifests/m/MNardit/Beetroot/1.0.6/MNardit.Beetroot.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: MNardit.Beetroot
+PackageVersion: 1.0.6
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Version update

- Package identifier: MNardit.Beetroot
- Package version: 1.0.6
- Installer URL: https://github.com/mnardit/beetroot-releases/releases/download/v1.0.6/Beetroot_1.0.6_x64-setup.exe

### Changes from 1.0.4

- Hotkey rewrite: AltGr and non-QWERTY layout support (AZERTY, QWERTZ, JIS)
- Native file dialog (modal, no longer hidden behind window)
- Auto-update toggle (can be disabled for fully offline operation)
- Data path Move/Switch options
- 4 new languages: French, Portuguese, Korean, Turkish (10 total)
- Multiple bug fixes
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/344228)