### PR TITLE
New package: TeamSlop.Slopcode version 0.0.5

### DIFF
--- a/manifests/t/TeamSlop/Slopcode/0.0.5/TeamSlop.Slopcode.installer.yaml
+++ b/manifests/t/TeamSlop/Slopcode/0.0.5/TeamSlop.Slopcode.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: TeamSlop.Slopcode
+PackageVersion: 0.0.5
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: slopcode.exe
+  PortableCommandAlias: slopcode
+Commands:
+- slopcode
+ReleaseDate: 2026-03-01
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/teamslop/slopcode/releases/download/v0.0.5/slopcode-windows-x64-baseline.zip
+  InstallerSha256: E85CC49DADE79C56CCA5995191EE9E0919930FF7331A0A16741EF109E737DD6B
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/t/TeamSlop/Slopcode/0.0.5/TeamSlop.Slopcode.locale.en-US.yaml
+++ b/manifests/t/TeamSlop/Slopcode/0.0.5/TeamSlop.Slopcode.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: TeamSlop.Slopcode
+PackageVersion: 0.0.5
+PackageLocale: en-US
+Publisher: TeamSlop
+PublisherUrl: https://github.com/teamslop
+PublisherSupportUrl: https://github.com/teamslop/slopcode/issues
+PackageName: SlopCode
+PackageUrl: https://slopcode.dev/
+License: MIT
+LicenseUrl: https://github.com/teamslop/slopcode/blob/v0.0.5/LICENSE
+ShortDescription: The AI coding agent built for the terminal.
+Description: |-
+  SlopCode is an AI coding agent for the terminal.
+  It provides a native TUI, parallel agent workflows, and support for many model providers.
+Moniker: slopcode
+Tags:
+- ai
+- cli
+- coding
+- terminal
+ReleaseNotesUrl: https://github.com/teamslop/slopcode/releases/tag/v0.0.5
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/TeamSlop/Slopcode/0.0.5/TeamSlop.Slopcode.yaml
+++ b/manifests/t/TeamSlop/Slopcode/0.0.5/TeamSlop.Slopcode.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: TeamSlop.Slopcode
+PackageVersion: 0.0.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Checklist
- [x] I have performed a self-review of my own code
- [x] I have tested this package to ensure it meets all requirements

## Package details
- PackageIdentifier: `TeamSlop.Slopcode`
- PackageVersion: `0.0.5`
- InstallerType: `zip` (portable)
- InstallerUrl: https://github.com/teamslop/slopcode/releases/download/v0.0.5/slopcode-windows-x64-baseline.zip
- SHA256: `E85CC49DADE79C56CCA5995191EE9E0919930FF7331A0A16741EF109E737DD6B`
- Release: https://github.com/teamslop/slopcode/releases/tag/v0.0.5

## Notes
This is the initial WinGet submission for SlopCode under a new package identifier.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/344275)