### PR TITLE
Add SecondLoop.SecondLoop version 1.19.0

### DIFF
--- a/manifests/s/SecondLoop\/SecondLoop/1.19.0/SecondLoop.SecondLoop.installer.yaml
+++ b/manifests/s/SecondLoop\/SecondLoop/1.19.0/SecondLoop.SecondLoop.installer.yaml
@@ -1,0 +1,18 @@
+PackageIdentifier: SecondLoop.SecondLoop
+PackageVersion: 1.19.0
+InstallerType: exe
+UpgradeBehavior: install
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: --silent
+  SilentWithProgress: --silent
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/dale0525/SecondLoop/releases/download/v1.19.0/com.secondloop.secondloop-win-Setup.exe
+    InstallerSha256: D75AB35905E4F7691C8363070F111FFF309F116A2DA12FBCA8A7890AEEC47040
+    InstallerLocale: en-US
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/s/SecondLoop\/SecondLoop/1.19.0/SecondLoop.SecondLoop.locale.en-US.yaml
+++ b/manifests/s/SecondLoop\/SecondLoop/1.19.0/SecondLoop.SecondLoop.locale.en-US.yaml
@@ -1,0 +1,21 @@
+PackageIdentifier: SecondLoop.SecondLoop
+PackageVersion: 1.19.0
+PackageLocale: en-US
+Publisher: SecondLoop
+PublisherUrl: https://secondloop.app
+PublisherSupportUrl: https://github.com/dale0525/SecondLoop/issues
+Author: SecondLoop
+PackageName: SecondLoop
+PackageUrl: https://secondloop.app
+License: Apache-2.0
+LicenseUrl: https://github.com/dale0525/SecondLoop/blob/main/LICENSE
+ShortDescription: Local-first personal AI assistant with long-term memory.
+Description: SecondLoop helps you capture, remember, and act with a local-first workflow.
+Moniker: secondloop
+Tags:
+  - ai
+  - notes
+  - productivity
+ReleaseNotesUrl: https://github.com/dale0525/SecondLoop/releases/tag/v1.19.0
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/s/SecondLoop\/SecondLoop/1.19.0/SecondLoop.SecondLoop.yaml
+++ b/manifests/s/SecondLoop\/SecondLoop/1.19.0/SecondLoop.SecondLoop.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: SecondLoop.SecondLoop
+PackageVersion: 1.19.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Summary

- Add WinGet manifests for SecondLoop.SecondLoop 1.19.0
- Source release: https://github.com/dale0525/SecondLoop/releases/tag/v1.19.0

## Validation

- Installer URL and SHA256 were generated from GitHub release assets
- Manifest files were produced by scripts/generate_winget_manifests.py
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/344341)