### PR TITLE
New version: MNardit.Beetroot version 1.0.7

### DIFF
--- a/manifests/m/MNardit/Beetroot/1.0.7/MNardit.Beetroot.installer.yaml
+++ b/manifests/m/MNardit/Beetroot/1.0.7/MNardit.Beetroot.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: MNardit.Beetroot
+PackageVersion: 1.0.7
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/mnardit/beetroot-releases/releases/download/v1.0.7/Beetroot_1.0.7_x64-setup.exe
+    InstallerSha256: AB630FBAA65C0E120C919DD6AF1115A333BDB060214A5C83BF841049E513B7F6
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/MNardit/Beetroot/1.0.7/MNardit.Beetroot.locale.en-US.yaml
+++ b/manifests/m/MNardit/Beetroot/1.0.7/MNardit.Beetroot.locale.en-US.yaml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: MNardit.Beetroot
+PackageVersion: 1.0.7
+PackageLocale: en-US
+Publisher: MNardit
+PublisherUrl: https://github.com/mnardit
+Author: MNardit
+PackageName: Beetroot
+PackageUrl: https://github.com/mnardit/beetroot-releases
+License: Proprietary
+LicenseUrl: https://github.com/mnardit/beetroot-releases/blob/main/LICENSE
+ShortDescription: Lightweight clipboard manager for Windows with AI-powered text transforms
+Description: |-
+  Beetroot is a modern clipboard manager for Windows that runs in the system tray.
+  Features:
+  - Unlimited clipboard history (text and images)
+  - Global hotkey (Ctrl+`) to instantly access history
+  - Fuzzy and regex search
+  - AI-powered text transforms via OpenAI
+  - OCR text extraction from images
+  - Notes on clipboard items
+  - Multi-select batch operations
+  - 8 themes + custom accent color
+  - 10 languages (English, Russian, German, Spanish, Chinese, Japanese, French, Portuguese, Korean, Turkish)
+  - Auto-update with option to disable for fully offline operation
+  - Plain text paste hotkey
+  - Non-QWERTY keyboard layout support (AZERTY, QWERTZ, AltGr)
+ReleaseNotesUrl: https://github.com/mnardit/beetroot-releases/releases/tag/v1.0.7
+Tags:
+  - clipboard
+  - clipboard-manager
+  - productivity
+  - tauri
+  - windows
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/MNardit/Beetroot/1.0.7/MNardit.Beetroot.yaml
+++ b/manifests/m/MNardit/Beetroot/1.0.7/MNardit.Beetroot.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: MNardit.Beetroot
+PackageVersion: 1.0.7
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New version: MNardit.Beetroot version 1.0.7

- Package: MNardit.Beetroot
- Version: 1.0.7
- Installer: NSIS (x64)
- URL: https://github.com/mnardit/beetroot-releases/releases/download/v1.0.7/Beetroot_1.0.7_x64-setup.exe
- SHA256: AB630FBAA65C0E120C919DD6AF1115A333BDB060214A5C83BF841049E513B7F6
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/344354)