### PR TITLE
Add gandli.ctf-tui version 0.1.2

### DIFF
--- a/manifests/g/gandli/ctf-tui/0.1.2/gandli.ctf-tui.installer.yaml
+++ b/manifests/g/gandli/ctf-tui/0.1.2/gandli.ctf-tui.installer.yaml
@@ -1,0 +1,16 @@
+PackageIdentifier: gandli.ctf-tui
+PackageVersion: 0.1.2
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: ctf-tui.exe
+    PortableCommandAlias: ctf-tui
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/gandli/ctf-tui-launcher/releases/download/v0.1.2/ctf-tui-windows-x86_64.zip
+    InstallerSha256: 02CA639A6F6067B07F44AAE47144AE78664C7516579D037DC02FAA4D9B194F5B
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Docker.DockerDesktop
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/g/gandli/ctf-tui/0.1.2/gandli.ctf-tui.locale.en-US.yaml
+++ b/manifests/g/gandli/ctf-tui/0.1.2/gandli.ctf-tui.locale.en-US.yaml
@@ -1,0 +1,15 @@
+PackageIdentifier: gandli.ctf-tui
+PackageVersion: 0.1.2
+PackageLocale: en-US
+Publisher: gandli
+PublisherUrl: https://github.com/gandli
+PackageName: ctf-tui
+PackageUrl: https://github.com/gandli/ctf-tui-launcher
+License: MIT
+ShortDescription: CTF TUI launcher for challenge environment workflows.
+Tags:
+  - ctf
+  - tui
+  - docker
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/g/gandli/ctf-tui/0.1.2/gandli.ctf-tui.yaml
+++ b/manifests/g/gandli/ctf-tui/0.1.2/gandli.ctf-tui.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: gandli.ctf-tui
+PackageVersion: 0.1.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Summary\nAdd winget manifests for **gandli.ctf-tui** version **0.1.2**.\n\n## Installer\n- URL: https://github.com/gandli/ctf-tui-launcher/releases/download/v0.1.2/ctf-tui-windows-x86_64.zip\n- SHA256: 02CA639A6F6067B07F44AAE47144AE78664C7516579D037DC02FAA4D9B194F5B\n- Command alias: ctf-tui\n\n## Notes\nThis CLI is a CTF environment launcher. Docker Desktop is declared as dependency.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/344370)