### PR TITLE
Add Convectiva.AgentWatcher version 1.0.0

### DIFF
--- a/manifests/c/Convectiva/AgentWatcher/1.0.0/Convectiva.AgentWatcher.installer.yaml
+++ b/manifests/c/Convectiva/AgentWatcher/1.0.0/Convectiva.AgentWatcher.installer.yaml
@@ -1,0 +1,20 @@
+PackageIdentifier: Convectiva.AgentWatcher
+PackageVersion: 1.0.0
+InstallerLocale: pt-BR
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.10240.0
+InstallerType: inno
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/ederpardeiro/AgentWatcher/releases/download/v1.0.0/AgentWatcher_Setup.exe
+    InstallerSha256: E74F0C72EB807387D181BF8360A162AA70764DE271A9D909D033ED6E662E238A
+    ProductCode: AgentWatcher_is1
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/c/Convectiva/AgentWatcher/1.0.0/Convectiva.AgentWatcher.locale.en-US.yaml
+++ b/manifests/c/Convectiva/AgentWatcher/1.0.0/Convectiva.AgentWatcher.locale.en-US.yaml
@@ -1,0 +1,22 @@
+PackageIdentifier: Convectiva.AgentWatcher
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: Convectiva
+PublisherUrl: https://www.convectiva.com
+PublisherSupportUrl: https://www.convectiva.com/yeastar/agentwatcher/
+Author: Convectiva
+PackageName: AgentWatcher
+PackageUrl: https://www.convectiva.com/yeastar/agentwatcher/
+License: Proprietary
+ShortDescription: Automatic presence status manager for Yeastar iPBX systems
+Description: AgentWatcher is a Windows application that automatically manages your presence status (Available/Away) based on system activity and lock state. It integrates with Yeastar iPBX systems via REST API to update your extension status in real-time.
+Tags:
+  - yeastar
+  - ipbx
+  - presence
+  - status
+  - automation
+  - pbx
+ReleaseNotesUrl: https://github.com/ederpardeiro/AgentWatcher/releases/tag/v1.0.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/c/Convectiva/AgentWatcher/1.0.0/Convectiva.AgentWatcher.locale.pt-BR.yaml
+++ b/manifests/c/Convectiva/AgentWatcher/1.0.0/Convectiva.AgentWatcher.locale.pt-BR.yaml
@@ -1,0 +1,22 @@
+PackageIdentifier: Convectiva.AgentWatcher
+PackageVersion: 1.0.0
+PackageLocale: pt-BR
+Publisher: Convectiva
+PublisherUrl: https://www.convectiva.com
+PublisherSupportUrl: https://www.convectiva.com/yeastar/agentwatcher/
+Author: Convectiva
+PackageName: AgentWatcher
+PackageUrl: https://www.convectiva.com/yeastar/agentwatcher/
+License: Proprietário
+ShortDescription: Gerenciador automático de status de presença para sistemas Yeastar iPBX
+Description: AgentWatcher é uma aplicação Windows que gerencia automaticamente seu status de presença (Disponível/Ausente) com base na atividade do sistema e estado de bloqueio. Integra-se com sistemas Yeastar iPBX via API REST para atualizar o status do ramal em tempo real.
+Tags:
+  - yeastar
+  - ipbx
+  - presença
+  - status
+  - automação
+  - pbx
+ReleaseNotesUrl: https://github.com/ederpardeiro/AgentWatcher/releases/tag/v1.0.0
+ManifestType: locale
+ManifestVersion: 1.6.0

--- a/manifests/c/Convectiva/AgentWatcher/1.0.0/Convectiva.AgentWatcher.yaml
+++ b/manifests/c/Convectiva/AgentWatcher/1.0.0/Convectiva.AgentWatcher.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Convectiva.AgentWatcher
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0

--- a/manifests/c/ConvectivaTecnologia/RMCConvectiva/1.7/ConvectivaTecnologia.RMCConvectiva.installer.yaml
+++ b/manifests/c/ConvectivaTecnologia/RMCConvectiva/1.7/ConvectivaTecnologia.RMCConvectiva.installer.yaml
@@ -1,0 +1,12 @@
+# Created using wingetcreate 1.6.5.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: ConvectivaTecnologia.RMCConvectiva
+PackageVersion: "1.7"
+InstallerType: inno
+Installers:
+- Architecture: x64
+  InstallerUrl: https://www.convectiva.com/rmc_client/RMCSetup.exe
+  InstallerSha256: 12782D1048DDB14B10F30B3BF3D9B539AD1AB50B12BBB3624C2516B294FEA462
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/c/ConvectivaTecnologia/RMCConvectiva/1.7/ConvectivaTecnologia.RMCConvectiva.installer.yaml
+++ b/manifests/c/ConvectivaTecnologia/RMCConvectiva/1.7/ConvectivaTecnologia.RMCConvectiva.installer.yaml
@@ -7,6 +7,6 @@ InstallerType: inno
 Installers:
 - Architecture: x64
   InstallerUrl: https://www.convectiva.com/rmc_client/RMCSetup.exe
-  InstallerSha256: EC25DED148393D0E1930C497685A052C6296FD3FE380F8D743FD0F50A22EBE92
+  InstallerSha256: C1612EE696A42FE6D3209583295DAE6F0563E257E3C9C223D701964AE9386DAF
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/c/ConvectivaTecnologia/RMCConvectiva/1.7/ConvectivaTecnologia.RMCConvectiva.installer.yaml
+++ b/manifests/c/ConvectivaTecnologia/RMCConvectiva/1.7/ConvectivaTecnologia.RMCConvectiva.installer.yaml
@@ -2,11 +2,11 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: ConvectivaTecnologia.RMCConvectiva
-PackageVersion: "1.7"
+PackageVersion: "1.8"
 InstallerType: inno
 Installers:
 - Architecture: x64
   InstallerUrl: https://www.convectiva.com/rmc_client/RMCSetup.exe
-  InstallerSha256: 12782D1048DDB14B10F30B3BF3D9B539AD1AB50B12BBB3624C2516B294FEA462
+  InstallerSha256: EC25DED148393D0E1930C497685A052C6296FD3FE380F8D743FD0F50A22EBE92
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/c/ConvectivaTecnologia/RMCConvectiva/1.7/ConvectivaTecnologia.RMCConvectiva.installer.yaml
+++ b/manifests/c/ConvectivaTecnologia/RMCConvectiva/1.7/ConvectivaTecnologia.RMCConvectiva.installer.yaml
@@ -7,6 +7,6 @@ InstallerType: inno
 Installers:
 - Architecture: x64
   InstallerUrl: https://www.convectiva.com/rmc_client/RMCSetup.exe
-  InstallerSha256: C1612EE696A42FE6D3209583295DAE6F0563E257E3C9C223D701964AE9386DAF
+  InstallerSha256: 1EEDBAE480BED77A2D1F01B466BD023F06DA97452A0877427E5FF1949F8F1A4E
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/c/ConvectivaTecnologia/RMCConvectiva/1.7/ConvectivaTecnologia.RMCConvectiva.locale.pt-BR.yaml
+++ b/manifests/c/ConvectivaTecnologia/RMCConvectiva/1.7/ConvectivaTecnologia.RMCConvectiva.locale.pt-BR.yaml
@@ -1,0 +1,18 @@
+# Created using wingetcreate 1.6.5.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: ConvectivaTecnologia.RMCConvectiva
+PackageVersion: "1.7"
+PackageLocale: pt-BR
+Publisher: Convectiva Tecnologia
+PublisherUrl: https://www.convectiva.com
+PublisherSupportUrl: https://www.convectiva.com#contato
+Author: Eder Pardeiro
+PackageName: RMC Client
+PackageUrl: https://www.convectiva.com
+License: Licença
+Copyright: Convectiva Tecnologia
+ShortDescription: RMC Client Setup
+Description: Instalador do Agente do RMC
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/c/ConvectivaTecnologia/RMCConvectiva/1.7/ConvectivaTecnologia.RMCConvectiva.locale.pt-BR.yaml
+++ b/manifests/c/ConvectivaTecnologia/RMCConvectiva/1.7/ConvectivaTecnologia.RMCConvectiva.locale.pt-BR.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: ConvectivaTecnologia.RMCConvectiva
-PackageVersion: "1.7"
+PackageVersion: "1.8"
 PackageLocale: pt-BR
 Publisher: Convectiva Tecnologia
 PublisherUrl: https://www.convectiva.com

--- a/manifests/c/ConvectivaTecnologia/RMCConvectiva/1.7/ConvectivaTecnologia.RMCConvectiva.yaml
+++ b/manifests/c/ConvectivaTecnologia/RMCConvectiva/1.7/ConvectivaTecnologia.RMCConvectiva.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.6.5.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: ConvectivaTecnologia.RMCConvectiva
+PackageVersion: "1.7"
+DefaultLocale: pt-BR
+ManifestType: version
+ManifestVersion: 1.6.0

--- a/manifests/c/ConvectivaTecnologia/RMCConvectiva/1.7/ConvectivaTecnologia.RMCConvectiva.yaml
+++ b/manifests/c/ConvectivaTecnologia/RMCConvectiva/1.7/ConvectivaTecnologia.RMCConvectiva.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: ConvectivaTecnologia.RMCConvectiva
-PackageVersion: "1.7"
+PackageVersion: "1.8"
 DefaultLocale: pt-BR
 ManifestType: version
 ManifestVersion: 1.6.0


### PR DESCRIPTION
## AgentWatcher by Convectiva

### Description
AgentWatcher is a Windows application that automatically manages the presence status (Available/Away) of Yeastar iPBX extensions based on system activity and Windows session lock state.

### Package Details
- **Publisher:** Convectiva
- **Package ID:** Convectiva.AgentWatcher
- **Version:** 1.0.0
- **Installer Type:** Inno Setup
- **Architecture:** x64
- **License:** Proprietary
- **Support URL:** https://www.convectiva.com/yeastar/agentwatcher/

### Validation
- [x] Installer URL is publicly accessible
- [x] SHA256 hash verified
- [x] Manifest validated against schema
- [x] Application installs and uninstalls correctly
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/344686)