### PR TITLE
New package: Infiniact.IATerm version 0.1.55

### DIFF
--- a/manifests/i/Infiniact/IATerm/0.1.55/Infiniact.IATerm.installer.yaml
+++ b/manifests/i/Infiniact/IATerm/0.1.55/Infiniact.IATerm.installer.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+# Created using winget manifest templates
+
+PackageIdentifier: Infiniact.IATerm
+PackageVersion: "0.1.55"
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+InstallerLocale: en-US
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+  InstallLocation: /D=<INSTALLPATH>
+UpgradeBehavior: install
+ReleaseDate: "2026-03-04"
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/infiniact/homebrew-iaterm/releases/download/v0.1.55/IATerm_0.1.55_x64-setup.exe
+    InstallerSha256: 1C2890353928DD845D12D9259C6B1C69C15521E1A061D2234329B2AAB63E011B
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/i/Infiniact/IATerm/0.1.55/Infiniact.IATerm.locale.en-US.yaml
+++ b/manifests/i/Infiniact/IATerm/0.1.55/Infiniact.IATerm.locale.en-US.yaml
@@ -1,0 +1,53 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+# Created using winget manifest templates
+
+PackageIdentifier: Infiniact.IATerm
+PackageVersion: "0.1.55"
+PackageLocale: en-US
+Publisher: INFINIACT CO., LIMITED
+PublisherUrl: https://www.infiniact.com
+PublisherSupportUrl: https://github.com/infiniact/Homebrew-iaterm/issues
+PrivacyUrl: https://www.infiniact.com/en/privacy
+Author: INFINIACT CO., LIMITED
+PackageName: IATerm
+PackageUrl: https://www.infiniact.com/iaterm
+License: Proprietary
+LicenseUrl: https://www.infiniact.com/en/terms
+Copyright: Copyright (c) INFINIACT CO., LIMITED. All rights reserved.
+Moniker: iaterm
+ShortDescription: Next-gen AI-powered remote terminal with multi-workspace, SSH connections and intelligent command execution
+Description: |-
+  IATerm is a next-generation cross-platform desktop terminal application built for developers and system administrators.
+
+  AI Integration
+  - Powerful built-in AI engine
+  - Natural language to command translation
+  - Context-aware command execution
+
+  Professional Terminal
+  - Local shell, SSH, and serial connections
+  - Real-time bidirectional streaming with fast response
+
+  Efficient Workspaces
+  - Parallel multi-workspace management
+  - Flexible panel layout system
+  - Automatic session save and restore
+
+  Personalization
+  - Dark/light theme switching
+  - Custom fonts and color schemes
+
+  Security
+  - Encrypted database storage
+  - Secure credential management
+  - Privacy compliance
+ReleaseNotesUrl: https://github.com/infiniact/Homebrew-iaterm/releases/tag/v0.1.55
+Tags:
+  - terminal
+  - ssh
+  - serial
+  - ai
+  - developer-tools
+  - command-line
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/i/Infiniact/IATerm/0.1.55/Infiniact.IATerm.locale.zh-CN.yaml
+++ b/manifests/i/Infiniact/IATerm/0.1.55/Infiniact.IATerm.locale.zh-CN.yaml
@@ -1,0 +1,52 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.10.0.schema.json
+# Created using winget manifest templates
+
+PackageIdentifier: Infiniact.IATerm
+PackageVersion: "0.1.55"
+PackageLocale: zh-CN
+Publisher: INFINIACT CO., LIMITED
+PublisherUrl: https://www.infiniact.com
+PublisherSupportUrl: https://github.com/infiniact/Homebrew-iaterm/issues
+PrivacyUrl: https://www.infiniact.com/zh/privacy
+Author: INFINIACT CO., LIMITED
+PackageName: IATerm
+PackageUrl: https://www.infiniact.com/iaterm
+License: Proprietary
+LicenseUrl: https://www.infiniact.com/zh/terms
+Copyright: Copyright (c) INFINIACT CO., LIMITED. All rights reserved.
+ShortDescription: 集成AI能力的下一代远程终端应用，支持多工作空间、SSH连接和智能命令执行
+Description: |-
+  IATerm 是新一代跨平台桌面终端应用，为开发者和系统管理员打造。
+
+  AI智能集成
+  - 集成强大的AI引擎
+  - 自然语言命令转换
+  - 上下文感知的命令执行
+
+  专业终端功能
+  - 本地Shell、SSH、串口多种连接方式
+  - 实时双向流通信，响应迅速
+
+  高效工作空间
+  - 多工作空间并行管理
+  - 灵活的面板布局系统
+  - 工作状态自动保存与恢复
+
+  个性化体验
+  - 深色/浅色主题自由切换
+  - 自定义字体与配色方案
+
+  安全可靠
+  - 数据库加密存储
+  - 安全的凭证管理
+  - 符合隐私合规要求
+ReleaseNotesUrl: https://github.com/infiniact/Homebrew-iaterm/releases/tag/v0.1.55
+Tags:
+  - 终端
+  - ssh
+  - 串口
+  - ai
+  - 开发工具
+  - 命令行
+ManifestType: locale
+ManifestVersion: 1.10.0

--- a/manifests/i/Infiniact/IATerm/0.1.55/Infiniact.IATerm.yaml
+++ b/manifests/i/Infiniact/IATerm/0.1.55/Infiniact.IATerm.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+# Created using winget manifest templates
+# https://aka.ms/winget-manifest
+
+PackageIdentifier: Infiniact.IATerm
+PackageVersion: "0.1.55"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
### New Submission

- Package: Infiniact.IATerm
- Version: 0.1.55
- Installer URL: https://github.com/infiniact/homebrew-iaterm/releases/download/v0.1.55/IATerm_0.1.55_x64-setup.exe
- Installer Type: nullsoft (NSIS)

---

Replaces #341621 with corrected PackageIdentifier format (`Publisher.Package`).

Automated submission from [IATerm](https://www.infiniact.com/iaterm) release workflow.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/345089)