### PR TITLE
Add Convectiva.AgentWatcher version 1.0.1

### DIFF
--- a/manifests/c/Convectiva/AgentWatcher/1.0.1/Convectiva.AgentWatcher.installer.yaml
+++ b/manifests/c/Convectiva/AgentWatcher/1.0.1/Convectiva.AgentWatcher.installer.yaml
@@ -1,0 +1,21 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: Convectiva.AgentWatcher
+PackageVersion: 1.0.1
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/ederpardeiro/AgentWatcher/releases/download/v1.0.1/AgentWatcher_Setup.exe
+  InstallerSha256: 1135FA424CE4924F58F1CFC1705C60BD99050283284C09A410A03A3FFD14FB40
+  ProductCode: AgentWatcher_is1
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/c/Convectiva/AgentWatcher/1.0.1/Convectiva.AgentWatcher.installer.yaml
+++ b/manifests/c/Convectiva/AgentWatcher/1.0.1/Convectiva.AgentWatcher.installer.yaml
@@ -3,10 +3,12 @@
 
 PackageIdentifier: Convectiva.AgentWatcher
 PackageVersion: 1.0.1
+InstallerLocale: pt-BR
 Platform:
 - Windows.Desktop
-MinimumOSVersion: 10.0.0.0
+MinimumOSVersion: 10.0.10240.0
 InstallerType: inno
+Scope: machine
 InstallModes:
 - interactive
 - silent

--- a/manifests/c/Convectiva/AgentWatcher/1.0.1/Convectiva.AgentWatcher.locale.en-US.yaml
+++ b/manifests/c/Convectiva/AgentWatcher/1.0.1/Convectiva.AgentWatcher.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: Convectiva.AgentWatcher
+PackageVersion: 1.0.1
+PackageLocale: en-US
+Publisher: Convectiva
+PublisherUrl: https://www.convectiva.com/
+PublisherSupportUrl: https://www.convectiva.com/yeastar/agentwatcher/
+PackageName: AgentWatcher
+PackageUrl: https://www.convectiva.com/yeastar/agentwatcher/
+License: Proprietary
+LicenseUrl: https://www.convectiva.com/yeastar/agentwatcher/
+Copyright: Copyright (c) 2026 Convectiva
+ShortDescription: AgentWatcher automatically manages the presence status of Yeastar iPBX extensions based on Windows session lock state.
+Description: AgentWatcher is a Windows application that automatically manages the presence status (Available/Away) of Yeastar iPBX extensions based on system activity and Windows session lock state. When the user locks the workstation or it becomes inactive, AgentWatcher sets the extension status to Away. When the user returns and unlocks the workstation, it sets the status back to Available.
+Tags:
+- yeastar
+- pbx
+- presence
+- voip
+- telephony
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/c/Convectiva/AgentWatcher/1.0.1/Convectiva.AgentWatcher.locale.en-US.yaml
+++ b/manifests/c/Convectiva/AgentWatcher/1.0.1/Convectiva.AgentWatcher.locale.en-US.yaml
@@ -5,20 +5,21 @@ PackageIdentifier: Convectiva.AgentWatcher
 PackageVersion: 1.0.1
 PackageLocale: en-US
 Publisher: Convectiva
-PublisherUrl: https://www.convectiva.com/
+PublisherUrl: https://www.convectiva.com
 PublisherSupportUrl: https://www.convectiva.com/yeastar/agentwatcher/
+Author: Convectiva
 PackageName: AgentWatcher
 PackageUrl: https://www.convectiva.com/yeastar/agentwatcher/
 License: Proprietary
-LicenseUrl: https://www.convectiva.com/yeastar/agentwatcher/
-Copyright: Copyright (c) 2026 Convectiva
-ShortDescription: AgentWatcher automatically manages the presence status of Yeastar iPBX extensions based on Windows session lock state.
-Description: AgentWatcher is a Windows application that automatically manages the presence status (Available/Away) of Yeastar iPBX extensions based on system activity and Windows session lock state. When the user locks the workstation or it becomes inactive, AgentWatcher sets the extension status to Away. When the user returns and unlocks the workstation, it sets the status back to Available.
+ShortDescription: Automatic presence status manager for Yeastar iPBX systems
+Description: AgentWatcher is a Windows application that automatically manages your presence status (Available/Away) based on system activity and lock state. It integrates with Yeastar iPBX systems via REST API to update your extension status in real-time.
 Tags:
 - yeastar
-- pbx
+- ipbx
 - presence
-- voip
-- telephony
+- status
+- automation
+- pbx
+ReleaseNotesUrl: https://github.com/ederpardeiro/AgentWatcher/releases/tag/v1.0.1
 ManifestType: defaultLocale
 ManifestVersion: 1.6.0

--- a/manifests/c/Convectiva/AgentWatcher/1.0.1/Convectiva.AgentWatcher.locale.pt-BR.yaml
+++ b/manifests/c/Convectiva/AgentWatcher/1.0.1/Convectiva.AgentWatcher.locale.pt-BR.yaml
@@ -1,0 +1,22 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
+
+PackageIdentifier: Convectiva.AgentWatcher
+PackageVersion: 1.0.1
+PackageLocale: pt-BR
+Publisher: Convectiva
+PublisherUrl: https://www.convectiva.com/
+PublisherSupportUrl: https://www.convectiva.com/yeastar/agentwatcher/
+PackageName: AgentWatcher
+PackageUrl: https://www.convectiva.com/yeastar/agentwatcher/
+License: Proprietário
+ShortDescription: O AgentWatcher gerencia automaticamente o status de presença de ramais Yeastar iPBX com base no estado de bloqueio da sessão do Windows.
+Description: O AgentWatcher é um aplicativo Windows que gerencia automaticamente o status de presença (Disponível/Ausente) de ramais Yeastar iPBX com base na atividade do sistema e no estado de bloqueio da sessão do Windows. Quando o usuário bloqueia a estação de trabalho ou ela fica inativa, o AgentWatcher define o status do ramal como Ausente. Quando o usuário retorna e desbloqueia a estação de trabalho, o status é definido de volta para Disponível.
+Tags:
+- yeastar
+- pbx
+- presença
+- voip
+- telefonia
+ManifestType: locale
+ManifestVersion: 1.6.0

--- a/manifests/c/Convectiva/AgentWatcher/1.0.1/Convectiva.AgentWatcher.yaml
+++ b/manifests/c/Convectiva/AgentWatcher/1.0.1/Convectiva.AgentWatcher.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: Convectiva.AgentWatcher
+PackageVersion: 1.0.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## AgentWatcher by Convectiva

### Description
AgentWatcher is a Windows application that automatically manages the presence status (Available/Away) of Yeastar iPBX extensions based on system activity and Windows session lock state.

### Package Details
- **Publisher:** Convectiva
- **Package ID:** Convectiva.AgentWatcher
- **Version:** 1.0.1
- **Installer Type:** Inno Setup
- **Architecture:** x64
- **License:** Proprietary
- **Support URL:** https://www.convectiva.com/yeastar/agentwatcher/

### Validation
- [x] Installer URL is publicly accessible
- [x] SHA256 hash verified
- [x] Manifest validated against schema
- [x] Application installs and uninstalls correctly
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/345094)