### PR TITLE
Add SecondLoop.SecondLoop version 1.20.0

### DIFF
--- a/manifests/s/SecondLoop/SecondLoop/1.20.0/SecondLoop.SecondLoop.installer.yaml
+++ b/manifests/s/SecondLoop/SecondLoop/1.20.0/SecondLoop.SecondLoop.installer.yaml
@@ -1,0 +1,18 @@
+PackageIdentifier: SecondLoop.SecondLoop
+PackageVersion: 1.20.0
+InstallerType: exe
+UpgradeBehavior: install
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: --silent
+  SilentWithProgress: --silent
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/dale0525/SecondLoop/releases/download/v1.20.0/com.secondloop.secondloop-win-Setup.exe
+    InstallerSha256: 9C11EA864F0E9D6C2FE4A4536C767EBDE0DF1F36DAE2557330605D117771DF28
+    InstallerLocale: en-US
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/s/SecondLoop/SecondLoop/1.20.0/SecondLoop.SecondLoop.installer.yaml
+++ b/manifests/s/SecondLoop/SecondLoop/1.20.0/SecondLoop.SecondLoop.installer.yaml
@@ -11,6 +11,9 @@ InstallModes:
 InstallerSwitches:
   Silent: --silent
   SilentWithProgress: --silent
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/dale0525/SecondLoop/releases/download/v1.20.0/com.secondloop.secondloop-win-Setup.exe

--- a/manifests/s/SecondLoop/SecondLoop/1.20.0/SecondLoop.SecondLoop.installer.yaml
+++ b/manifests/s/SecondLoop/SecondLoop/1.20.0/SecondLoop.SecondLoop.installer.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
 PackageIdentifier: SecondLoop.SecondLoop
 PackageVersion: 1.20.0
 InstallerType: exe

--- a/manifests/s/SecondLoop/SecondLoop/1.20.0/SecondLoop.SecondLoop.installer.yaml
+++ b/manifests/s/SecondLoop/SecondLoop/1.20.0/SecondLoop.SecondLoop.installer.yaml
@@ -4,6 +4,7 @@ PackageIdentifier: SecondLoop.SecondLoop
 PackageVersion: 1.20.0
 InstallerType: exe
 UpgradeBehavior: install
+Scope: user
 InstallModes:
   - interactive
   - silent

--- a/manifests/s/SecondLoop/SecondLoop/1.20.0/SecondLoop.SecondLoop.installer.yaml
+++ b/manifests/s/SecondLoop/SecondLoop/1.20.0/SecondLoop.SecondLoop.installer.yaml
@@ -4,7 +4,6 @@ PackageIdentifier: SecondLoop.SecondLoop
 PackageVersion: 1.20.0
 InstallerType: exe
 UpgradeBehavior: install
-Scope: user
 InstallModes:
   - interactive
   - silent

--- a/manifests/s/SecondLoop/SecondLoop/1.20.0/SecondLoop.SecondLoop.locale.en-US.yaml
+++ b/manifests/s/SecondLoop/SecondLoop/1.20.0/SecondLoop.SecondLoop.locale.en-US.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
 PackageIdentifier: SecondLoop.SecondLoop
 PackageVersion: 1.20.0
 PackageLocale: en-US

--- a/manifests/s/SecondLoop/SecondLoop/1.20.0/SecondLoop.SecondLoop.locale.en-US.yaml
+++ b/manifests/s/SecondLoop/SecondLoop/1.20.0/SecondLoop.SecondLoop.locale.en-US.yaml
@@ -1,0 +1,21 @@
+PackageIdentifier: SecondLoop.SecondLoop
+PackageVersion: 1.20.0
+PackageLocale: en-US
+Publisher: SecondLoop
+PublisherUrl: https://secondloop.app
+PublisherSupportUrl: https://github.com/dale0525/SecondLoop/issues
+Author: SecondLoop
+PackageName: SecondLoop
+PackageUrl: https://secondloop.app
+License: Apache-2.0
+LicenseUrl: https://github.com/dale0525/SecondLoop/blob/main/LICENSE
+ShortDescription: Local-first personal AI assistant with long-term memory.
+Description: SecondLoop helps you capture, remember, and act with a local-first workflow.
+Moniker: secondloop
+Tags:
+  - ai
+  - notes
+  - productivity
+ReleaseNotesUrl: https://github.com/dale0525/SecondLoop/releases/tag/v1.20.0
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/s/SecondLoop/SecondLoop/1.20.0/SecondLoop.SecondLoop.yaml
+++ b/manifests/s/SecondLoop/SecondLoop/1.20.0/SecondLoop.SecondLoop.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
 PackageIdentifier: SecondLoop.SecondLoop
 PackageVersion: 1.20.0
 DefaultLocale: en-US

--- a/manifests/s/SecondLoop/SecondLoop/1.20.0/SecondLoop.SecondLoop.yaml
+++ b/manifests/s/SecondLoop/SecondLoop/1.20.0/SecondLoop.SecondLoop.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: SecondLoop.SecondLoop
+PackageVersion: 1.20.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Summary

- Add WinGet manifests for SecondLoop.SecondLoop 1.20.0
- Source release: https://github.com/dale0525/SecondLoop/releases/tag/v1.20.0

## Validation

- Installer URL and SHA256 were generated from GitHub release assets
- Manifest files were produced by scripts/generate_winget_manifests.py
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/345114)