### PR TITLE
New package: PrinceJain.Launchpad version 1.0.0

### DIFF
--- a/manifests/p/PrinceJain/Launchpad/1.0.0/PrinceJain.Launchpad.installer.yaml
+++ b/manifests/p/PrinceJain/Launchpad/1.0.0/PrinceJain.Launchpad.installer.yaml
@@ -1,0 +1,18 @@
+# Created using winget create
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: PrinceJain.Launchpad
+PackageVersion: 1.0.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/product-noob/launchpage-app/releases/download/v1.0.0/Launchpad.Setup.1.0.0.exe
+    InstallerSha256: 02CE8C8076491CB7D0365A85F1DBE27FF754ED9149551B2849BDFD86B3D2AAFC
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/p/PrinceJain/Launchpad/1.0.0/PrinceJain.Launchpad.locale.en-US.yaml
+++ b/manifests/p/PrinceJain/Launchpad/1.0.0/PrinceJain.Launchpad.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# Created using winget create
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: PrinceJain.Launchpad
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: Prince Jain
+PublisherUrl: https://github.com/product-noob
+PackageName: Launchpad
+PackageUrl: https://github.com/product-noob/launchpage-app
+License: MIT
+LicenseUrl: https://github.com/product-noob/launchpage-app/blob/main/LICENSE
+ShortDescription: A tray app for launching, managing, and monitoring local development servers.
+Description: |-
+  Launchpad is an Electron tray app for launching, managing, and monitoring local development apps (Vite, Streamlit, FastAPI, Astro, Next.js, and more) from a single system tray icon. Features dark/light themes, live log viewer, process metrics, drag-and-drop reordering, and grouped multi-service apps.
+Tags:
+  - developer-tools
+  - electron
+  - dev-server
+  - process-manager
+  - tray-app
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/p/PrinceJain/Launchpad/1.0.0/PrinceJain.Launchpad.yaml
+++ b/manifests/p/PrinceJain/Launchpad/1.0.0/PrinceJain.Launchpad.yaml
@@ -1,0 +1,8 @@
+# Created using winget create
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: PrinceJain.Launchpad
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
### New Package Submission

- Package Identifier: PrinceJain.Launchpad
- Package Version: 1.0.0
- Installer Type: NSIS (nullsoft)
- Installer Architecture: x64
- Installer URL: https://github.com/product-noob/launchpage-app/releases/download/v1.0.0/Launchpad.Setup.1.0.0.exe

### Description

Launchpad is an Electron tray app for launching, managing, and monitoring local development servers (Vite, Streamlit, FastAPI, Astro, Next.js, and more) from a single system tray icon.

### Checklist

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/creation?
- [x] This PR only modifies files in the **manifests** folder
- [x] Manifest has valid **InstallerSha256**
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/345120)