### PR TITLE
Add SecondLoop.SecondLoop version 1.20.4

### DIFF
--- a/manifests/s/SecondLoop/SecondLoop/1.20.4/SecondLoop.SecondLoop.installer.yaml
+++ b/manifests/s/SecondLoop/SecondLoop/1.20.4/SecondLoop.SecondLoop.installer.yaml
@@ -3,7 +3,6 @@
 PackageIdentifier: SecondLoop.SecondLoop
 PackageVersion: 1.20.4
 InstallerType: msi
-Scope: user
 UpgradeBehavior: install
 InstallerSwitches:
   Custom: SECONDLOOP_LAUNCH_AFTER_INSTALL=0

--- a/manifests/s/SecondLoop/SecondLoop/1.20.4/SecondLoop.SecondLoop.installer.yaml
+++ b/manifests/s/SecondLoop/SecondLoop/1.20.4/SecondLoop.SecondLoop.installer.yaml
@@ -5,6 +5,8 @@ PackageVersion: 1.20.4
 InstallerType: msi
 Scope: user
 UpgradeBehavior: install
+InstallerSwitches:
+  Custom: SECONDLOOP_LAUNCH_AFTER_INSTALL=0
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/dale0525/SecondLoop/releases/download/v1.20.4/SecondLoop-win.msi

--- a/manifests/s/SecondLoop/SecondLoop/1.20.4/SecondLoop.SecondLoop.installer.yaml
+++ b/manifests/s/SecondLoop/SecondLoop/1.20.4/SecondLoop.SecondLoop.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: SecondLoop.SecondLoop
+PackageVersion: 1.20.4
+InstallerType: msi
+Scope: user
+UpgradeBehavior: install
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/dale0525/SecondLoop/releases/download/v1.20.4/SecondLoop-win.msi
+    InstallerSha256: 3B64EE2AE4EF50E452499F7DADD964E93EDD02A0DA7AB5303065E36B92C8D319
+    InstallerLocale: en-US
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/s/SecondLoop/SecondLoop/1.20.4/SecondLoop.SecondLoop.installer.yaml
+++ b/manifests/s/SecondLoop/SecondLoop/1.20.4/SecondLoop.SecondLoop.installer.yaml
@@ -5,9 +5,6 @@ PackageVersion: 1.20.4
 InstallerType: msi
 Scope: user
 UpgradeBehavior: install
-Dependencies:
-  PackageDependencies:
-    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/dale0525/SecondLoop/releases/download/v1.20.4/SecondLoop-win.msi

--- a/manifests/s/SecondLoop/SecondLoop/1.20.4/SecondLoop.SecondLoop.installer.yaml
+++ b/manifests/s/SecondLoop/SecondLoop/1.20.4/SecondLoop.SecondLoop.installer.yaml
@@ -4,6 +4,9 @@ PackageIdentifier: SecondLoop.SecondLoop
 PackageVersion: 1.20.4
 InstallerType: msi
 UpgradeBehavior: install
+InstallModes:
+  - silent
+  - silentWithProgress
 InstallerSwitches:
   Custom: SECONDLOOP_LAUNCH_AFTER_INSTALL=0
 Installers:

--- a/manifests/s/SecondLoop/SecondLoop/1.20.4/SecondLoop.SecondLoop.locale.en-US.yaml
+++ b/manifests/s/SecondLoop/SecondLoop/1.20.4/SecondLoop.SecondLoop.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: SecondLoop.SecondLoop
+PackageVersion: 1.20.4
+PackageLocale: en-US
+Publisher: SecondLoop
+PublisherUrl: https://secondloop.app
+PublisherSupportUrl: https://github.com/dale0525/SecondLoop/issues
+Author: SecondLoop
+PackageName: SecondLoop
+PackageUrl: https://secondloop.app
+License: Apache-2.0
+LicenseUrl: https://github.com/dale0525/SecondLoop/blob/main/LICENSE
+ShortDescription: Local-first personal AI assistant with long-term memory.
+Description: SecondLoop helps you capture, remember, and act with a local-first workflow.
+Moniker: secondloop
+Tags:
+  - ai
+  - notes
+  - productivity
+ReleaseNotesUrl: https://github.com/dale0525/SecondLoop/releases/tag/v1.20.4
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/s/SecondLoop/SecondLoop/1.20.4/SecondLoop.SecondLoop.yaml
+++ b/manifests/s/SecondLoop/SecondLoop/1.20.4/SecondLoop.SecondLoop.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: SecondLoop.SecondLoop
+PackageVersion: 1.20.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Summary

- Add WinGet manifests for SecondLoop.SecondLoop 1.20.4
- Source release: https://github.com/dale0525/SecondLoop/releases/tag/v1.20.4

## Validation

- Installer URL and SHA256 were generated from GitHub release assets
- Manifest files were produced by scripts/generate_winget_manifests.py
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/345444)