### PR TITLE
New package: GordonBeeming.CopilotHere version 2026.02.19

### DIFF
--- a/manifests/g/GordonBeeming/CopilotHere/2026.02.19/GordonBeeming.CopilotHere.installer.yaml
+++ b/manifests/g/GordonBeeming/CopilotHere/2026.02.19/GordonBeeming.CopilotHere.installer.yaml
@@ -1,0 +1,24 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: GordonBeeming.CopilotHere
+PackageVersion: 2026.02.19
+Installers:
+- Architecture: x64
+  InstallerType: zip
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: copilot_here.exe
+    PortableCommandAlias: copilot_here
+  InstallerUrl: https://github.com/GordonBeeming/copilot_here/releases/download/cli-v2026.02.19-bea3d9f/copilot_here-win-x64.zip
+  InstallerSha256: DA5D5AB65F19904976B4917E5C39934FE17F8A3D4709B87EF15C5B4BDB248DDC
+- Architecture: arm64
+  InstallerType: zip
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: copilot_here.exe
+    PortableCommandAlias: copilot_here
+  InstallerUrl: https://github.com/GordonBeeming/copilot_here/releases/download/cli-v2026.02.19-bea3d9f/copilot_here-win-arm64.zip
+  InstallerSha256: 18247C78A0B89CF6DFBF88F36E79D8B9241536AD10DF8746853DC71930BBC4CD
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/g/GordonBeeming/CopilotHere/2026.02.19/GordonBeeming.CopilotHere.installer.yaml
+++ b/manifests/g/GordonBeeming/CopilotHere/2026.02.19/GordonBeeming.CopilotHere.installer.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.10.3.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
 
 PackageIdentifier: GordonBeeming.CopilotHere
 PackageVersion: 2026.02.19
@@ -21,4 +21,4 @@ Installers:
   InstallerUrl: https://github.com/GordonBeeming/copilot_here/releases/download/cli-v2026.02.19-bea3d9f/copilot_here-win-arm64.zip
   InstallerSha256: 18247C78A0B89CF6DFBF88F36E79D8B9241536AD10DF8746853DC71930BBC4CD
 ManifestType: installer
-ManifestVersion: 1.12.0
+ManifestVersion: 1.10.0

--- a/manifests/g/GordonBeeming/CopilotHere/2026.02.19/GordonBeeming.CopilotHere.locale.en-US.yaml
+++ b/manifests/g/GordonBeeming/CopilotHere/2026.02.19/GordonBeeming.CopilotHere.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.10.3.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
 
 PackageIdentifier: GordonBeeming.CopilotHere
 PackageVersion: 2026.02.19
@@ -23,4 +23,4 @@ Tags:
 - github
 - github-copilot
 ManifestType: defaultLocale
-ManifestVersion: 1.12.0
+ManifestVersion: 1.10.0

--- a/manifests/g/GordonBeeming/CopilotHere/2026.02.19/GordonBeeming.CopilotHere.locale.en-US.yaml
+++ b/manifests/g/GordonBeeming/CopilotHere/2026.02.19/GordonBeeming.CopilotHere.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: GordonBeeming.CopilotHere
+PackageVersion: 2026.02.19
+PackageLocale: en-US
+Publisher: Gordon Beeming
+PublisherUrl: https://github.com/GordonBeeming
+PublisherSupportUrl: https://github.com/GordonBeeming/copilot_here/issues
+PackageName: copilot_here
+PackageUrl: https://github.com/GordonBeeming/copilot_here
+License: FSL-1.1-MIT
+LicenseUrl: https://github.com/GordonBeeming/copilot_here/blob/main/LICENSE
+ShortDescription: Run GitHub Copilot CLI in a sandboxed Docker container
+Description: |-
+  copilot_here lets you run GitHub Copilot CLI commands inside a sandboxed Docker container,
+  keeping your host machine clean and secure. It provides shell function wrappers for Bash,
+  Zsh, and PowerShell that seamlessly proxy Copilot CLI commands through a containerized environment.
+Tags:
+- cli
+- copilot
+- docker
+- github
+- github-copilot
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/g/GordonBeeming/CopilotHere/2026.02.19/GordonBeeming.CopilotHere.yaml
+++ b/manifests/g/GordonBeeming/CopilotHere/2026.02.19/GordonBeeming.CopilotHere.yaml
@@ -1,8 +1,8 @@
 # Created using wingetcreate 1.10.3.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
 
 PackageIdentifier: GordonBeeming.CopilotHere
 PackageVersion: 2026.02.19
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.12.0
+ManifestVersion: 1.10.0

--- a/manifests/g/GordonBeeming/CopilotHere/2026.02.19/GordonBeeming.CopilotHere.yaml
+++ b/manifests/g/GordonBeeming/CopilotHere/2026.02.19/GordonBeeming.CopilotHere.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: GordonBeeming.CopilotHere
+PackageVersion: 2026.02.19
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New package submission

- Package identifier: GordonBeeming.CopilotHere
- Package version: 2026.02.19
- Package URL: https://github.com/GordonBeeming/copilot_here
- Installer type: zip (portable)
- Architectures: x64, arm64

### Description

copilot_here lets you run GitHub Copilot CLI commands inside a sandboxed Docker container, keeping your host machine clean and secure.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/345531)