### PR TITLE
New package: avemeva.agent-telegram version 0.1.12

### DIFF
--- a/manifests/a/avemeva/agent-telegram/0.1.12/avemeva.agent-telegram.installer.yaml
+++ b/manifests/a/avemeva/agent-telegram/0.1.12/avemeva.agent-telegram.installer.yaml
@@ -1,0 +1,16 @@
+# Created using winget-pkgs manual submission
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: avemeva.agent-telegram
+PackageVersion: 0.1.12
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: bin\agent-telegram.exe
+    PortableCommandAlias: agent-telegram
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/avemeva/kurier/releases/download/v0.1.12/agent-telegram-win32-x64.zip
+    InstallerSha256: 995A0454D254CCF50388C1746BCEE8ED5C0E19734BDB6C56AAA5AD686AD3F713
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/a/avemeva/agent-telegram/0.1.12/avemeva.agent-telegram.locale.en-US.yaml
+++ b/manifests/a/avemeva/agent-telegram/0.1.12/avemeva.agent-telegram.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# Created using winget-pkgs manual submission
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: avemeva.agent-telegram
+PackageVersion: 0.1.12
+PackageLocale: en-US
+Publisher: avemeva
+PublisherUrl: https://github.com/avemeva
+PackageName: agent-telegram
+PackageUrl: https://github.com/avemeva/kurier
+License: MIT
+LicenseUrl: https://github.com/avemeva/kurier/blob/main/LICENSE
+ShortDescription: AI-powered Telegram CLI
+Tags:
+  - telegram
+  - cli
+  - ai
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/a/avemeva/agent-telegram/0.1.12/avemeva.agent-telegram.yaml
+++ b/manifests/a/avemeva/agent-telegram/0.1.12/avemeva.agent-telegram.yaml
@@ -1,0 +1,8 @@
+# Created using winget-pkgs manual submission
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: avemeva.agent-telegram
+PackageVersion: 0.1.12
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
### New package submission

- **Package identifier:** avemeva.agent-telegram
- **Version:** 0.1.12
- **Installer URL:** https://github.com/avemeva/kurier/releases/download/v0.1.12/agent-telegram-win32-x64.zip
- **Architecture:** x64
- **Installer type:** zip (portable)

AI-powered Telegram CLI for agents.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/346119)