### PR TITLE
New package: polrivero.GitHubDesktopPlus version 3.5.6.5

### DIFF
--- a/manifests/p/polrivero/GitHubDesktopPlus/3.5.6.5/polrivero.GitHubDesktopPlus.installer.yaml
+++ b/manifests/p/polrivero/GitHubDesktopPlus/3.5.6.5/polrivero.GitHubDesktopPlus.installer.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: polrivero.GitHubDesktopPlus
+PackageVersion: 3.5.6.5
+UpgradeBehavior: install
+Protocols:
+- github-windows
+- x-github-client
+- x-github-desktop-auth
+ReleaseDate: 2026-02-28
+Installers:
+- Architecture: x64
+  InstallerType: exe
+  Scope: user
+  InstallerUrl: https://github.com/pol-rivero/github-desktop-plus/releases/download/v3.5.6.5/GitHubDesktopPlus-v3.5.6.5-windows-x64.exe
+  InstallerSha256: D59C1670082B6DFC252DE9EE8850B54D73427F6F329392064FA13CA11CCD4541
+  InstallModes:
+  - interactive
+  - silent
+  InstallerSwitches:
+    Silent: --silent
+    SilentWithProgress: --silent
+- Architecture: arm64
+  InstallerType: exe
+  Scope: user
+  InstallerUrl: https://github.com/pol-rivero/github-desktop-plus/releases/download/v3.5.6.5/GitHubDesktopPlus-v3.5.6.5-windows-arm64.exe
+  InstallerSha256: 3FE84D7EE4D3C4429D74972EE3594AC78D3E70380AECE1EB3A8AA7147BB5A071
+  InstallModes:
+  - interactive
+  - silent
+  InstallerSwitches:
+    Silent: --silent
+    SilentWithProgress: --silent
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/p/polrivero/GitHubDesktopPlus/3.5.6.5/polrivero.GitHubDesktopPlus.locale.en-US.yaml
+++ b/manifests/p/polrivero/GitHubDesktopPlus/3.5.6.5/polrivero.GitHubDesktopPlus.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: polrivero.GitHubDesktopPlus
+PackageVersion: 3.5.6.5
+PackageLocale: en-US
+Publisher: pol-rivero
+PublisherUrl: https://github.com/pol-rivero
+PublisherSupportUrl: https://github.com/pol-rivero/github-desktop-plus/issues
+Author: pol-rivero
+PackageName: GitHub Desktop Plus
+PackageUrl: https://github.com/pol-rivero/github-desktop-plus
+License: MIT
+LicenseUrl: https://github.com/pol-rivero/github-desktop-plus/blob/HEAD/LICENSE
+Copyright: Copyright (c) GitHub, Inc.
+ShortDescription: A GitHub Desktop fork with advanced functionality and Bitbucket, GitLab integration.
+Description: An up-to-date fork of GitHub Desktop with additional features including multiple account support, Bitbucket and GitLab integration, commit search, multiple stashes per branch, and more.
+Moniker: github-desktop-plus
+Tags:
+- git
+- github
+- bitbucket
+- gitlab
+- desktop-app
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/p/polrivero/GitHubDesktopPlus/3.5.6.5/polrivero.GitHubDesktopPlus.yaml
+++ b/manifests/p/polrivero/GitHubDesktopPlus/3.5.6.5/polrivero.GitHubDesktopPlus.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: polrivero.GitHubDesktopPlus
+PackageVersion: 3.5.6.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Summary

- Add new package manifest for **GitHub Desktop Plus** (`polrivero.GitHubDesktopPlus`) version `3.5.6.5`
- GitHub Desktop Plus is an up-to-date fork of GitHub Desktop with additional features including multiple account support, Bitbucket/GitLab integration, commit search, and more
- Includes x64 and arm64 EXE installers for Windows

## Package Info

- **Package ID**: `polrivero.GitHubDesktopPlus`
- **Version**: `3.5.6.5`
- **License**: MIT
- **Homepage**: https://github.com/pol-rivero/github-desktop-plus
- **Architectures**: x64, arm64

🤖 Generated with [Claude Code](https://claude.com/claude-code)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/346183)