### PR TITLE
New package: DTHCST.Fregonator version 6.0.0

### DIFF
--- a/manifests/d/DTHCST/Fregonator/6.0.0/DTHCST.Fregonator.installer.yaml
+++ b/manifests/d/DTHCST/Fregonator/6.0.0/DTHCST.Fregonator.installer.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: DTHCST.Fregonator
+PackageVersion: 6.0.0
+InstallerType: inno
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/dthcst/fregonator/releases/download/v6.0/Fregonator-6.0-Setup.exe
+  InstallerSha256: 52B7D21CC57A0083A6D9526F165C9D276D30870D3787E7E7DACE24E0ACE5A51A
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/d/DTHCST/Fregonator/6.0.0/DTHCST.Fregonator.locale.en-US.yaml
+++ b/manifests/d/DTHCST/Fregonator/6.0.0/DTHCST.Fregonator.locale.en-US.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: DTHCST.Fregonator
+PackageVersion: 6.0.0
+PackageLocale: en-US
+Publisher: DTHCST - Costa da Morte
+PublisherUrl: https://dthcst.com
+PublisherSupportUrl: https://github.com/dthcst/fregonator/issues
+Author: Martin Caamano
+PackageName: Fregonator
+PackageUrl: https://fregonator.com
+License: MIT
+LicenseUrl: https://github.com/dthcst/fregonator/blob/main/LICENSE
+ShortDescription: Optimize Windows in 20 seconds with parallel cleanup tasks
+Description: |-
+  Fregonator cleans your Windows PC in 20 seconds with 13 parallel PowerShell tasks.
+  No ads, no Pro version, no telemetry, no registry modifications, no browser data deletion.
+  Features include temp file cleanup, recycling bin emptying, DNS flush, SSD TRIM,
+  bloatware removal, DISM/SFC system repair, automatic restore point creation,
+  and a real-time progress monitor. 100% open source, 100% free forever.
+  250K+ views on Reddit. The CCleaner alternative that respects your PC.
+Moniker: fregonator
+Tags:
+- cache
+- ccleaner-alternative
+- clean
+- cleanup
+- disk-space
+- free
+- junk
+- optimize
+- open-source
+- parallel
+- pc-cleaner
+- powershell
+- system
+- temp
+- windows
+ReleaseNotesUrl: https://github.com/dthcst/fregonator/releases/tag/v6.0
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/d/DTHCST/Fregonator/6.0.0/DTHCST.Fregonator.yaml
+++ b/manifests/d/DTHCST/Fregonator/6.0.0/DTHCST.Fregonator.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: DTHCST.Fregonator
+PackageVersion: 6.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
### New Package Submission

- Package Identifier: DTHCST.Fregonator
- Package Version: 6.0.0
- Package URL: https://fregonator.com
- Publisher: DTHCST - Costa da Morte
- License: MIT
- Source: https://github.com/dthcst/fregonator

### Description

Fregonator is a free, open-source Windows PC optimizer that runs 13 parallel cleanup tasks in 20 seconds. Unlike CCleaner, it does not modify the Windows registry, does not delete browser data, includes zero telemetry, and has no ads or Pro version. Features include temp file cleanup, recycling bin emptying, DNS flush, SSD TRIM, bloatware removal, DISM/SFC system repair, automatic restore points, and a real-time progress monitor.

- 250K+ views on Reddit r/pcmasterrace
- ~2,000 downloads
- Listed on AlternativeTo
- PowerShell-based, 100% visible source code

### Validation

`winget validate` passed successfully.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/346296)