### PR TITLE
Add version: pdfzus.PDFZusammenfuegen 0.1.1

### DIFF
--- a/manifests/p/pdfzus/PDFZusammenfuegen/0.1.1/pdfzus.PDFZusammenfuegen.installer.yaml
+++ b/manifests/p/pdfzus/PDFZusammenfuegen/0.1.1/pdfzus.PDFZusammenfuegen.installer.yaml
@@ -1,0 +1,16 @@
+PackageIdentifier: pdfzus.PDFZusammenfuegen
+PackageVersion: 0.1.1
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-03-08
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/wsgtcyx/PDF-zusammenfuegen-winget/releases/download/v0.1.1/PDF-Zusammenfuegen-Setup-0.1.1.exe
+    InstallerSha256: 20B3C8C2C14707587B321447BD4BB1549873C1D4ABF694CF3577D64E78150ECD
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/p/pdfzus/PDFZusammenfuegen/0.1.1/pdfzus.PDFZusammenfuegen.installer.yaml
+++ b/manifests/p/pdfzus/PDFZusammenfuegen/0.1.1/pdfzus.PDFZusammenfuegen.installer.yaml
@@ -1,3 +1,6 @@
+# Created by pdfzus winget manifest generator
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
 PackageIdentifier: pdfzus.PDFZusammenfuegen
 PackageVersion: 0.1.1
 InstallerType: nullsoft
@@ -7,7 +10,7 @@ InstallModes:
   - silent
   - silentWithProgress
 UpgradeBehavior: install
-ReleaseDate: 2026-03-08
+ReleaseDate: 2026-03-13
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/wsgtcyx/PDF-zusammenfuegen-winget/releases/download/v0.1.1/PDF-Zusammenfuegen-Setup-0.1.1.exe

--- a/manifests/p/pdfzus/PDFZusammenfuegen/0.1.1/pdfzus.PDFZusammenfuegen.locale.de-DE.yaml
+++ b/manifests/p/pdfzus/PDFZusammenfuegen/0.1.1/pdfzus.PDFZusammenfuegen.locale.de-DE.yaml
@@ -1,3 +1,6 @@
+# Created by pdfzus winget manifest generator
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
 PackageIdentifier: pdfzus.PDFZusammenfuegen
 PackageVersion: 0.1.1
 PackageLocale: de-DE

--- a/manifests/p/pdfzus/PDFZusammenfuegen/0.1.1/pdfzus.PDFZusammenfuegen.locale.de-DE.yaml
+++ b/manifests/p/pdfzus/PDFZusammenfuegen/0.1.1/pdfzus.PDFZusammenfuegen.locale.de-DE.yaml
@@ -1,0 +1,26 @@
+PackageIdentifier: pdfzus.PDFZusammenfuegen
+PackageVersion: 0.1.1
+PackageLocale: de-DE
+Publisher: pdfzus
+PublisherUrl: https://pdfzus.de/
+PublisherSupportUrl: https://pdfzus.de/
+PrivacyUrl: https://pdfzus.de/privacy-policy
+Author: pdfzus
+PackageName: PDF Zusammenfügen
+PackageUrl: https://pdfzus.de/
+License: MIT
+ShortDescription: Lokales Tool zum PDF Zusammenfügen ohne Upload, ohne Konto und ohne Wasserzeichen.
+Description: PDF Zusammenfügen fuer Windows verbindet mehrere PDF-Dateien direkt auf dem Geraet. Die App ist auf Datenschutz, DSGVO-orientierte Workflows und einen schnellen lokalen Export ausgelegt.
+Moniker: pdfzus
+Tags:
+  - pdf
+  - pdf-zusammenfuegen
+  - pdf-verbinden
+  - merge
+  - lokal
+  - dsgvo
+  - ohne-upload
+ReleaseNotes: Erste Desktop-Version fuer lokales PDF Zusammenfuegen unter Windows.
+ReleaseNotesUrl: https://github.com/wsgtcyx/PDF-zusammenfuegen-winget/releases/tag/v0.1.1
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/p/pdfzus/PDFZusammenfuegen/0.1.1/pdfzus.PDFZusammenfuegen.yaml
+++ b/manifests/p/pdfzus/PDFZusammenfuegen/0.1.1/pdfzus.PDFZusammenfuegen.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: pdfzus.PDFZusammenfuegen
+PackageVersion: 0.1.1
+DefaultLocale: de-DE
+ManifestType: version
+ManifestVersion: 1.10.0

--- a/manifests/p/pdfzus/PDFZusammenfuegen/0.1.1/pdfzus.PDFZusammenfuegen.yaml
+++ b/manifests/p/pdfzus/PDFZusammenfuegen/0.1.1/pdfzus.PDFZusammenfuegen.yaml
@@ -1,3 +1,6 @@
+# Created by pdfzus winget manifest generator
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
 PackageIdentifier: pdfzus.PDFZusammenfuegen
 PackageVersion: 0.1.1
 DefaultLocale: de-DE


### PR DESCRIPTION
## Zusammenfassung

- Fuegt `pdfzus.PDFZusammenfuegen` in Version `0.1.1` hinzu
- Installer-Quelle verweist auf den GitHub Release von `wsgtcyx/PDF-zusammenfuegen-winget`
- Metadaten und Beschreibung sind auf `de-DE` fuer das Keyword `PDF Zusammenfuegen` ausgerichtet

## Verifikation

- SHA256 mit Release-Asset abgeglichen
- NSIS-Installer wurde im Release-Workflow gebaut
- Silent-Install-Smoke-Test im Windows-Workflow erfolgreich

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/346345)