### PR TITLE
New version: WilddogJP.OpenBPX version 0.1.8

### DIFF
--- a/manifests/w/WilddogJP/OpenBPX/0.1.8/WilddogJP.OpenBPX.installer.yaml
+++ b/manifests/w/WilddogJP/OpenBPX/0.1.8/WilddogJP.OpenBPX.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+
+PackageIdentifier: WilddogJP.OpenBPX
+PackageVersion: 0.1.8
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: bpx.exe
+  PortableCommandAlias: bpx
+ReleaseDate: 2026-03-08
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/wilddogjp/openbpx/releases/download/v0.1.8/bpx_0.1.8_windows_amd64.zip
+  InstallerSha256: 2b20bb3d7e0a9e976d5f5f7976f03503b2ed580b1ce3cfb4af6afcf7dccdd724
+- Architecture: arm64
+  InstallerUrl: https://github.com/wilddogjp/openbpx/releases/download/v0.1.8/bpx_0.1.8_windows_arm64.zip
+  InstallerSha256: 8ae621f798912c997d9cdbc30b57c8a72f594d7c45f6ab17a62dac33bb621767
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/w/WilddogJP/OpenBPX/0.1.8/WilddogJP.OpenBPX.locale.en-US.yaml
+++ b/manifests/w/WilddogJP/OpenBPX/0.1.8/WilddogJP.OpenBPX.locale.en-US.yaml
@@ -1,0 +1,21 @@
+PackageIdentifier: WilddogJP.OpenBPX
+PackageVersion: 0.1.8
+PackageLocale: en-US
+Publisher: Wild Dog, Inc.
+PublisherUrl: https://wilddog.jp/
+PublisherSupportUrl: https://github.com/wilddogjp/openbpx/issues
+Author: Wild Dog, Inc.
+PackageName: OpenBPX
+PackageUrl: https://github.com/wilddogjp/openbpx
+License: Apache-2.0
+LicenseUrl: https://github.com/wilddogjp/openbpx/blob/main/LICENSE
+ShortDescription: Blueprint toolkit for Unreal Engine package assets.
+Description: OpenBPX is a CLI toolkit for reading and safely editing Unreal Engine .uasset and .umap files with binary preservation safeguards.
+Moniker: openbpx
+Tags:
+- unreal
+- unreal-engine
+- cli
+- gamedev
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/w/WilddogJP/OpenBPX/0.1.8/WilddogJP.OpenBPX.yaml
+++ b/manifests/w/WilddogJP/OpenBPX/0.1.8/WilddogJP.OpenBPX.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: WilddogJP.OpenBPX
+PackageVersion: 0.1.8
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0


### PR DESCRIPTION
## Description
- Add OpenBPX 0.1.8 manifests
- Installer source: GitHub release assets from wilddogjp/openbpx
- Keep the existing `InstallerType: zip` + `NestedInstallerType: portable` manifest pattern used for OpenBPX 0.1.7

## Validation
- Checksums copied from release `checksums.txt`
- URLs verified against release `v0.1.8` assets
- Updates existing package `WilddogJP.OpenBPX` from 0.1.7 to 0.1.8
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/346361)