### PR TITLE
New version: VB-Audio.Voicemeeter.Banana version 2.1.2.2

### DIFF
--- a/manifests/v/VB-Audio/Voicemeeter/Banana/2.1.2.2/VB-Audio.Voicemeeter.Banana.installer.yaml
+++ b/manifests/v/VB-Audio/Voicemeeter/Banana/2.1.2.2/VB-Audio.Voicemeeter.Banana.installer.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: VB-Audio.Voicemeeter.Banana
+PackageVersion: 2.1.2.2
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 5.1.2600.2180
+InstallerType: zip
+NestedInstallerType: exe
+NestedInstallerFiles:
+- RelativeFilePath: voicemeeterprosetup.exe
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: -install
+  SilentWithProgress: -install
+  Upgrade: -upgrade
+InstallerSuccessCodes:
+- 1 # This is expected
+UpgradeBehavior: install
+Protocols:
+- vban
+ReleaseDate: 2025-12-11
+Installers:
+- Architecture: x64
+  InstallerUrl: https://download.vb-audio.com/Download_CABLE/VoicemeeterSetup_v2122.zip
+  InstallerSha256: FDA1C82522B4A8C87A89C5C50A56E7E25E3519B9E1F1A8E63475B8590FF09EE5
+- Architecture: x86
+  InstallerUrl: https://download.vb-audio.com/Download_CABLE/VoicemeeterSetup_v2122.zip
+  InstallerSha256: FDA1C82522B4A8C87A89C5C50A56E7E25E3519B9E1F1A8E63475B8590FF09EE5
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/v/VB-Audio/Voicemeeter/Banana/2.1.2.2/VB-Audio.Voicemeeter.Banana.locale.en-US.yaml
+++ b/manifests/v/VB-Audio/Voicemeeter/Banana/2.1.2.2/VB-Audio.Voicemeeter.Banana.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: VB-Audio.Voicemeeter.Banana
+PackageVersion: 2.1.2.2
+PackageLocale: en-US
+Publisher: VB-Audio Software
+PublisherUrl: https://vb-audio.com/index.htm
+PublisherSupportUrl: https://vb-audio.com/Services/support.htm
+PrivacyUrl: https://vb-audio.com/Services/PrivacyPolicy.htm
+Author: VB-Audio Software
+PackageName: Voicemeeter Banana
+PackageUrl: https://vb-audio.com/Voicemeeter/banana.htm
+License: Donationware
+LicenseUrl: https://www.vb-audio.com/Services/licensing.htm
+Copyright: Copyright V.Burel ©1998-2018. All rights reserved.
+CopyrightUrl: https://www.vb-audio.com/Services/licensing.htm
+ShortDescription: Advanced Virtual Audio Mixer with 5 inputs, 5 outputs, and 2 virtual audio devices for professional audio mixing on Windows.
+Description: Voicemeeter Banana is an Advanced Audio Mixer Application endowed with Virtual Audio Device used as Virtual I/O to mix and manage any audio sources from or to any audio devices or applications (3x Physical I/O and 2x Virtual I/O).
+Moniker: voicemeeter-banana
+Tags:
+- asio
+- audio
+- mixer
+- voicemeeter
+- wasapi
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/v/VB-Audio/Voicemeeter/Banana/2.1.2.2/VB-Audio.Voicemeeter.Banana.yaml
+++ b/manifests/v/VB-Audio/Voicemeeter/Banana/2.1.2.2/VB-Audio.Voicemeeter.Banana.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: VB-Audio.Voicemeeter.Banana
+PackageVersion: 2.1.2.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Re-add `VB-Audio.Voicemeeter.Banana` which was removed in #327752 under the assumption that `VB-Audio.Voicemeeter` installs both editions. This is incorrect. `VB-Audio.Voicemeeter` only installs Voicemeeter Standard (`v1.x`), not Banana (`v2.x`). They are separate installers with different download URLs.

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Is there a linked Issue?  If so, fill in the Issue number below.
    - Related to #327752

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/346516)