### PR TITLE
Fix: GordonBeeming.CopilotHere 2026.03.08.438 installer schema compliance

### DIFF
--- a/manifests/g/GordonBeeming/CopilotHere/2026.03.08.438/GordonBeeming.CopilotHere.installer.yaml
+++ b/manifests/g/GordonBeeming/CopilotHere/2026.03.08.438/GordonBeeming.CopilotHere.installer.yaml
@@ -3,18 +3,24 @@
 
 PackageIdentifier: GordonBeeming.CopilotHere
 PackageVersion: 2026.03.08.438
-InstallerType: zip
-NestedInstallerType: portable
-NestedInstallerFiles:
-- RelativeFilePath: copilot_here.exe
-  PortableCommandAlias: copilot_here
 Installers:
 - Architecture: x64
+  InstallerType: zip
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: copilot_here.exe
+    PortableCommandAlias: copilot_here
   InstallerUrl: https://github.com/GordonBeeming/copilot_here/releases/download/cli-v2026.03.08.438-85f0c7c/copilot_here-win-x64.zip
   InstallerSha256: D21D7F64E8E53B13FD61874C5FC147F806F634819A08F3200B42899B9EEF06F2
+  ReleaseDate: 2026-03-08
 - Architecture: arm64
+  InstallerType: zip
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: copilot_here.exe
+    PortableCommandAlias: copilot_here
   InstallerUrl: https://github.com/GordonBeeming/copilot_here/releases/download/cli-v2026.03.08.438-85f0c7c/copilot_here-win-arm64.zip
   InstallerSha256: C4F19CEFE28117D35DCD8363C1D42AADC5B3EFDFF9D9BEAA9355F2E6AD7778E1
+  ReleaseDate: 2026-03-08
 ManifestType: installer
 ManifestVersion: 1.10.0
-ReleaseDate: 2026-03-08


### PR DESCRIPTION
Move InstallerType, NestedInstallerType, NestedInstallerFiles, and ReleaseDate from manifest root to per-installer entries to comply with v1.10 schema best practices. This ensures future wingetcreate updates inherit the correct structure.

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/346982)