### PR TITLE
New package: DoiT.dci version 1.0.0

### DIFF
--- a/manifests/d/DoiT/dci/1.0.0/DoiT.dci.installer.yaml
+++ b/manifests/d/DoiT/dci/1.0.0/DoiT.dci.installer.yaml
@@ -1,0 +1,13 @@
+PackageIdentifier: DoiT.dci
+PackageVersion: 1.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: dci.exe
+    PortableCommandAlias: dci
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/doitintl/dci-cli/releases/download/v1.0.0/dci_1.0.0_windows_amd64.zip
+    InstallerSha256: eef60540905b2b1c154c1f5210a831f61feb4f14ae3978737989df5de1057b53
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/d/DoiT/dci/1.0.0/DoiT.dci.locale.en-US.yaml
+++ b/manifests/d/DoiT/dci/1.0.0/DoiT.dci.locale.en-US.yaml
@@ -1,0 +1,18 @@
+PackageIdentifier: DoiT.dci
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: DoiT
+PublisherUrl: https://www.doit.com
+PublisherSupportUrl: https://github.com/doitintl/dci-cli/issues
+PackageName: dci
+ShortDescription: DoiT Cloud Intelligence CLI
+Moniker: dci
+Tags:
+  - cli
+  - doit
+  - finops
+License: See repository
+LicenseUrl: https://github.com/doitintl/dci-cli
+ReleaseNotesUrl: https://github.com/doitintl/dci-cli/releases/tag/v1.0.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/d/DoiT/dci/1.0.0/DoiT.dci.locale.en-US.yaml
+++ b/manifests/d/DoiT/dci/1.0.0/DoiT.dci.locale.en-US.yaml
@@ -2,7 +2,7 @@ PackageIdentifier: DoiT.dci
 PackageVersion: 1.0.0
 PackageLocale: en-US
 Publisher: DoiT
-PublisherUrl: https://www.doit.com
+PublisherUrl: https://github.com/doitintl
 PublisherSupportUrl: https://github.com/doitintl/dci-cli/issues
 PackageName: dci
 ShortDescription: DoiT Cloud Intelligence CLI
@@ -11,8 +11,8 @@ Tags:
   - cli
   - doit
   - finops
-License: See repository
-LicenseUrl: https://github.com/doitintl/dci-cli
+License: MIT
+LicenseUrl: https://github.com/doitintl/dci-cli/blob/main/LICENSE
 ReleaseNotesUrl: https://github.com/doitintl/dci-cli/releases/tag/v1.0.0
 ManifestType: defaultLocale
 ManifestVersion: 1.6.0

--- a/manifests/d/DoiT/dci/1.0.0/DoiT.dci.yaml
+++ b/manifests/d/DoiT/dci/1.0.0/DoiT.dci.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: DoiT.dci
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## New package submission

- **PackageIdentifier:** DoiT.dci
- **PackageVersion:** 1.0.0
- **InstallerUrl:** https://github.com/doitintl/dci-cli/releases/download/v1.0.0/dci_1.0.0_windows_amd64.zip
- **Publisher:** DoiT

### Description

`dci` is the command-line interface for the [DoiT Cloud Intelligence](https://www.doit.com/) API. Manage budgets, reports, alerts, and run analytics queries directly from your terminal.

- Source: https://github.com/doitintl/dci-cli
- Releases: https://github.com/doitintl/dci-cli/releases
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/347697)