### PR TITLE
Add ElrikCty.HeatSaveManager version 1.0.11

### DIFF
--- a/manifests/e/ElrikCty/HeatSaveManager/1.0.11/ElrikCty.HeatSaveManager.installer.yaml
+++ b/manifests/e/ElrikCty/HeatSaveManager/1.0.11/ElrikCty.HeatSaveManager.installer.yaml
@@ -11,6 +11,6 @@ Installers:
     AppsAndFeaturesEntries:
       - DisplayName: Heat Save Manager
         Publisher: Eduardo Baltra
-        DisplayVersion: 1.0.11
+        DisplayVersion: 1.0.0
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/e/ElrikCty/HeatSaveManager/1.0.11/ElrikCty.HeatSaveManager.installer.yaml
+++ b/manifests/e/ElrikCty/HeatSaveManager/1.0.11/ElrikCty.HeatSaveManager.installer.yaml
@@ -1,0 +1,16 @@
+# Created with scripts/generate-winget-manifests.ps1
+PackageIdentifier: ElrikCty.HeatSaveManager
+PackageVersion: 1.0.11
+InstallerType: nullsoft
+Scope: machine
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/ElrikCty/heat-save-manager/releases/download/v1.0.11/HeatSaveManager-v1.0.11-windows-x64-installer.exe
+    InstallerSha256: FC99D9B66B5E0A16E5B151493A62018711BB75440F76DF91551210EAB5C760EA
+    InstallerLocale: en-US
+    AppsAndFeaturesEntries:
+      - DisplayName: Heat Save Manager
+        Publisher: Eduardo Baltra
+        DisplayVersion: 1.0.11
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/e/ElrikCty/HeatSaveManager/1.0.11/ElrikCty.HeatSaveManager.locale.en-US.yaml
+++ b/manifests/e/ElrikCty/HeatSaveManager/1.0.11/ElrikCty.HeatSaveManager.locale.en-US.yaml
@@ -1,0 +1,11 @@
+# Created with scripts/generate-winget-manifests.ps1
+PackageIdentifier: ElrikCty.HeatSaveManager
+PackageVersion: 1.0.11
+PackageLocale: en-US
+Publisher: Eduardo Baltra
+PackageName: Heat Save Manager
+License: MIT
+ShortDescription: Desktop app to manage Need for Speed Heat save profiles on Windows.
+ReleaseNotesUrl: https://github.com/ElrikCty/heat-save-manager/releases/tag/v1.0.11
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/e/ElrikCty/HeatSaveManager/1.0.11/ElrikCty.HeatSaveManager.yaml
+++ b/manifests/e/ElrikCty/HeatSaveManager/1.0.11/ElrikCty.HeatSaveManager.yaml
@@ -1,0 +1,6 @@
+# Created with scripts/generate-winget-manifests.ps1
+PackageIdentifier: ElrikCty.HeatSaveManager
+PackageVersion: 1.0.11
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary
- Add `ElrikCty.HeatSaveManager` version `1.0.11` manifests.
- Installer source: `https://github.com/ElrikCty/heat-save-manager/releases/download/v1.0.11/HeatSaveManager-v1.0.11-windows-x64-installer.exe`
- Manifest targets the standard NSIS installer rather than the standalone portable executable.

## Files
- `manifests/e/ElrikCty/HeatSaveManager/1.0.11/ElrikCty.HeatSaveManager.yaml`
- `manifests/e/ElrikCty/HeatSaveManager/1.0.11/ElrikCty.HeatSaveManager.installer.yaml`
- `manifests/e/ElrikCty/HeatSaveManager/1.0.11/ElrikCty.HeatSaveManager.locale.en-US.yaml`

## Validation
- `winget validate --manifest manifests/e/ElrikCty/HeatSaveManager/1.0.11`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/347839)