### PR TITLE
Update ripgrep GNU moniker to rg

### DIFF
--- a/manifests/b/BurntSushi/ripgrep/GNU/15.1.0/BurntSushi.ripgrep.GNU.locale.en-US.yaml
+++ b/manifests/b/BurntSushi/ripgrep/GNU/15.1.0/BurntSushi.ripgrep.GNU.locale.en-US.yaml
@@ -23,7 +23,7 @@ Description: |-
   support on Windows, macOS and Linux, with binary downloads available for every
   release. ripgrep is similar to other popular search tools like The Silver
   Searcher, ack and grep.
-Moniker: ripgrep
+Moniker: rg
 Tags:
 - cli
 - command-line

--- a/manifests/b/BurntSushi/ripgrep/MSVC/15.1.0/BurntSushi.ripgrep.MSVC.locale.en-US.yaml
+++ b/manifests/b/BurntSushi/ripgrep/MSVC/15.1.0/BurntSushi.ripgrep.MSVC.locale.en-US.yaml
@@ -23,6 +23,7 @@ Description: |-
   support on Windows, macOS and Linux, with binary downloads available for every
   release. ripgrep is similar to other popular search tools like The Silver
   Searcher, ack and grep.
+Moniker: rg
 Tags:
 - cli
 - command-line

--- a/manifests/b/BurntSushi/ripgrep/MSVC/15.1.0/BurntSushi.ripgrep.MSVC.locale.en-US.yaml
+++ b/manifests/b/BurntSushi/ripgrep/MSVC/15.1.0/BurntSushi.ripgrep.MSVC.locale.en-US.yaml
@@ -23,7 +23,6 @@ Description: |-
   support on Windows, macOS and Linux, with binary downloads available for every
   release. ripgrep is similar to other popular search tools like The Silver
   Searcher, ack and grep.
-Moniker: rg
 Tags:
 - cli
 - command-line


### PR DESCRIPTION
`winget install rg` currently resolves to ChemTable's Reg Organizer instead of ripgrep, because neither ripgrep package claims `rg` as its moniker.

This PR changes the `Moniker` field from `ripgrep` to `rg` (the binary name) for `BurntSushi.ripgrep.GNU`. The corresponding change for `BurntSushi.ripgrep.MSVC` is in #348127. `winget install ripgrep` continues to work via PackageName and Tags matching.

Reg Organizer is unaffected by this change — it never declared `rg` as its moniker and was only matching via fuzzy search on "Reg". Users who want it can still install it with `winget install "Reg Organizer"` or `winget install ChemTableSoftware.RegOrganizer`.

Fixes #347904
