### PR TITLE
Add rg moniker to BurntSushi.ripgrep.MSVC

### DIFF
--- a/manifests/b/BurntSushi/ripgrep/MSVC/15.1.0/BurntSushi.ripgrep.MSVC.locale.en-US.yaml
+++ b/manifests/b/BurntSushi/ripgrep/MSVC/15.1.0/BurntSushi.ripgrep.MSVC.locale.en-US.yaml
@@ -23,6 +23,7 @@ Description: |-
   support on Windows, macOS and Linux, with binary downloads available for every
   release. ripgrep is similar to other popular search tools like The Silver
   Searcher, ack and grep.
+Moniker: rg
 Tags:
 - cli
 - command-line


### PR DESCRIPTION
`winget install rg` currently resolves to ChemTable's Reg Organizer instead of ripgrep, because neither ripgrep package claims `rg` as its moniker.

This PR adds `Moniker: rg` to `BurntSushi.ripgrep.MSVC`. The corresponding change for `BurntSushi.ripgrep.GNU` is in #347905.

Fixes #347904

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/348127)