### PR TITLE
Update willibrandon.dotsider to 0.4.1

### DIFF
--- a/manifests/w/willibrandon/dotsider/0.4.1/willibrandon.dotsider.installer.yaml
+++ b/manifests/w/willibrandon/dotsider/0.4.1/willibrandon.dotsider.installer.yaml
@@ -1,0 +1,27 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: willibrandon.dotsider
+PackageVersion: 0.4.1
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.18362.0
+InstallerType: msi
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/willibrandon/dotsider/releases/download/v0.4.1/dotsider-win-x64.msi
+  InstallerSha256: F1737895BAB161AF8401764D774A7903BE63655DD264730DB036F59D46EFA564
+  ProductCode: '{FE7E6137-4A8E-4646-9CDB-F690126AC720}'
+- Architecture: arm64
+  InstallerUrl: https://github.com/willibrandon/dotsider/releases/download/v0.4.1/dotsider-win-arm64.msi
+  InstallerSha256: 0DD119BC22F410B6F37D0BC115E9983F4F3DFFE3552C03768743347EB90126A1
+  ProductCode: '{C2C9608B-08B4-410F-9D2C-94A02401D492}'
+ManifestType: installer
+ManifestVersion: 1.10.0
+ReleaseDate: 2026-03-12

--- a/manifests/w/willibrandon/dotsider/0.4.1/willibrandon.dotsider.locale.en-US.yaml
+++ b/manifests/w/willibrandon/dotsider/0.4.1/willibrandon.dotsider.locale.en-US.yaml
@@ -1,0 +1,36 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: willibrandon.dotsider
+PackageVersion: 0.4.1
+PackageLocale: en-US
+Publisher: willibrandon
+PublisherUrl: https://github.com/willibrandon
+PublisherSupportUrl: https://github.com/willibrandon/dotsider/issues
+PackageName: dotsider
+PackageUrl: https://github.com/willibrandon/dotsider
+License: MIT
+LicenseUrl: https://github.com/willibrandon/dotsider/blob/main/LICENSE
+ShortDescription: A TUI for analyzing .NET assemblies
+Description: |-
+  dotsider is a terminal UI for analyzing .NET assemblies — structure, metadata,
+  IL disassembly, strings, hex dump, dependency graphs, size maps, and live
+  runtime tracing via EventPipe. It also supports assembly diffing and NuGet
+  package browsing.
+Tags:
+- dotnet
+- assembly
+- tui
+- il
+- metadata
+- pe
+- disassembler
+- cli
+- terminal
+- devtools
+ReleaseNotesUrl: https://github.com/willibrandon/dotsider/releases/tag/v0.4.1
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/willibrandon/dotsider/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/w/willibrandon/dotsider/0.4.1/willibrandon.dotsider.yaml
+++ b/manifests/w/willibrandon/dotsider/0.4.1/willibrandon.dotsider.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: willibrandon.dotsider
+PackageVersion: 0.4.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Description

Update dotsider to version 0.4.1

## Release notes

https://github.com/willibrandon/dotsider/releases/tag/v0.4.1
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/348132)