### PR TITLE
New package: Hitalin.NoteDeck version 0.2.3

### DIFF
--- a/manifests/h/Hitalin/NoteDeck/0.2.3/Hitalin.NoteDeck.installer.yaml
+++ b/manifests/h/Hitalin/NoteDeck/0.2.3/Hitalin.NoteDeck.installer.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: Hitalin.NoteDeck
+PackageVersion: 0.2.3
+InstallerType: nullsoft
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/hitalin/notedeck/releases/download/v0.2.3/NoteDeck-0.2.3-windows-x64-setup.exe
+    InstallerSha256: 675b45cb588dae0490e21f8d325edd87997b5c589d98f88080485bdc6debb1d5
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/h/Hitalin/NoteDeck/0.2.3/Hitalin.NoteDeck.locale.en-US.yaml
+++ b/manifests/h/Hitalin/NoteDeck/0.2.3/Hitalin.NoteDeck.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.9.0.schema.json
+PackageIdentifier: Hitalin.NoteDeck
+PackageVersion: 0.2.3
+PackageLocale: en-US
+Publisher: hitalin
+PublisherUrl: https://github.com/hitalin
+PackageName: NoteDeck
+PackageUrl: https://github.com/hitalin/notedeck
+License: AGPL-3.0
+LicenseUrl: https://github.com/hitalin/notedeck/blob/main/LICENSE
+ShortDescription: A multi-platform deck client for Misskey and its forks
+Description: |-
+  NoteDeck is a deck client for Misskey and its forks.
+  It provides efficient multi-server timeline viewing with features like local full-text search,
+  AI integration, and localhost API that are only possible with a native desktop application.
+Tags:
+  - misskey
+  - fediverse
+  - deck
+  - social-media
+ManifestType: locale
+ManifestVersion: 1.9.0

--- a/manifests/h/Hitalin/NoteDeck/0.2.3/Hitalin.NoteDeck.locale.ja-JP.yaml
+++ b/manifests/h/Hitalin/NoteDeck/0.2.3/Hitalin.NoteDeck.locale.ja-JP.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: Hitalin.NoteDeck
+PackageVersion: 0.2.3
+PackageLocale: ja-JP
+Publisher: hitalin
+PublisherUrl: https://github.com/hitalin
+PackageName: NoteDeck
+PackageUrl: https://github.com/hitalin/notedeck
+License: AGPL-3.0
+LicenseUrl: https://github.com/hitalin/notedeck/blob/main/LICENSE
+ShortDescription: Misskey とそのフォークに対応したマルチプラットフォーム対応デッキクライアント
+Description: |-
+  NoteDeck は Misskey とそのフォークに対応したデッキクライアントです。
+  複数サーバーのタイムラインを効率よく閲覧でき、ローカル全文検索、AI 統合、localhost API など
+  デスクトップネイティブならではの機能を備えています。
+Tags:
+  - misskey
+  - fediverse
+  - deck
+  - social-media
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/h/Hitalin/NoteDeck/0.2.3/Hitalin.NoteDeck.yaml
+++ b/manifests/h/Hitalin/NoteDeck/0.2.3/Hitalin.NoteDeck.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: Hitalin.NoteDeck
+PackageVersion: 0.2.3
+DefaultLocale: ja-JP
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## New package submission

- **Package identifier**: Hitalin.NoteDeck
- **Version**: 0.2.3
- **Installer type**: NSIS (nullsoft)
- **URL**: https://github.com/hitalin/notedeck/releases/download/v0.2.3/NoteDeck-0.2.3-windows-x64-setup.exe

A multi-platform deck client for Misskey and its forks.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/348619)