### PR TITLE
New package: 4Worlds.Inkwell version 1.1.0

### DIFF
--- a/manifests/4/4Worlds/Inkwell/1.1.0/4Worlds.Inkwell.installer.yaml
+++ b/manifests/4/4Worlds/Inkwell/1.1.0/4Worlds.Inkwell.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: 4Worlds.Inkwell
+PackageVersion: 1.1.0
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: portable
+Commands:
+  - inkwell
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/4worlds4w-svg/inkwell/releases/download/v1.1/inkwell.exe
+    InstallerSha256: AAD5E90504A2B096DDC4F27C09AA481919DE70BBD8E9F964B8F768090FE9DE93
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/4/4Worlds/Inkwell/1.1.0/4Worlds.Inkwell.locale.en-US.yaml
+++ b/manifests/4/4Worlds/Inkwell/1.1.0/4Worlds.Inkwell.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: 4Worlds.Inkwell
+PackageVersion: 1.1.0
+PackageLocale: en-US
+Publisher: 4Worlds
+PublisherUrl: https://github.com/4worlds4w-svg
+PublisherSupportUrl: https://github.com/4worlds4w-svg/inkwell/issues
+PackageName: Inkwell
+PackageUrl: https://github.com/4worlds4w-svg/inkwell
+License: Proprietary
+LicenseUrl: https://github.com/4worlds4w-svg/inkwell/blob/main/LICENSE
+Copyright: Copyright (c) 2026 4Worlds
+ShortDescription: A portable Markdown editor with focus mode, themes, and PDF/HTML exports.
+Description: |-
+  Inkwell is a single-file Markdown editor built for focused writing. No cloud, no accounts, no telemetry.
+  Features include find & replace, typewriter mode, version history with diff viewer, 4 themes, 3 font families,
+  focus mode, file tabs, templates, search, and license-gated PDF/HTML export.
+  Part of the 4Worlds anti-SaaS portable app suite.
+Tags:
+  - markdown
+  - editor
+  - writing
+  - portable
+  - notes
+  - productivity
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/4/4Worlds/Inkwell/1.1.0/4Worlds.Inkwell.locale.en-US.yaml
+++ b/manifests/4/4Worlds/Inkwell/1.1.0/4Worlds.Inkwell.locale.en-US.yaml
@@ -9,7 +9,7 @@ PublisherSupportUrl: https://github.com/4worlds4w-svg/inkwell/issues
 PackageName: Inkwell
 PackageUrl: https://github.com/4worlds4w-svg/inkwell
 License: Proprietary
-LicenseUrl: https://github.com/4worlds4w-svg/inkwell/blob/main/LICENSE
+LicenseUrl: https://github.com/4worlds4w-svg/inkwell/blob/main/LICENSE.md
 Copyright: Copyright (c) 2026 4Worlds
 ShortDescription: A portable Markdown editor with focus mode, themes, and PDF/HTML exports.
 Description: |-

--- a/manifests/4/4Worlds/Inkwell/1.1.0/4Worlds.Inkwell.yaml
+++ b/manifests/4/4Worlds/Inkwell/1.1.0/4Worlds.Inkwell.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: 4Worlds.Inkwell
+PackageVersion: 1.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
### New package submission

**Package:** 4Worlds.Inkwell
**Version:** 1.1.0
**InstallerType:** portable (standalone .exe, no zip wrapper)

Inkwell is a portable Markdown editor, no installer, no cloud, no telemetry. Single exe download.

Previous submission (#348537) failed Dynamic Scan with zip+nested portable. This submission uses direct portable InstallerType with the bare .exe.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/348630)