### PR TITLE
Add luolangaga.ASG.Director version 3.1.3

### DIFF
--- a/manifests/l/luolangaga/ASG/Director/3.1.3/luolangaga.ASG.Director.installer.yaml
+++ b/manifests/l/luolangaga/ASG/Director/3.1.3/luolangaga.ASG.Director.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: luolangaga.ASG.Director
+PackageVersion: 3.1.3
+InstallerLocale: zh-CN
+InstallerType: nullsoft
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-03-14
+AppsAndFeaturesEntries:
+  - DisplayName: Idvevent导播端
+    Publisher: ASG
+Installers:
+  - Architecture: x64
+    Scope: user
+    InstallerUrl: https://gitee.com/luolangaga/asg-director/releases/download/11/Idvevent%E5%AF%BC%E6%92%AD%E7%AB%AF%20Setup%203.1.3.exe
+    InstallerSha256: 3AD9AA2EA58B95FD1A16CC52A23DAC58BAC7261F9F09588D2AE20446569C0B82
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/l/luolangaga/ASG/Director/3.1.3/luolangaga.ASG.Director.locale.zh-CN.yaml
+++ b/manifests/l/luolangaga/ASG/Director/3.1.3/luolangaga.ASG.Director.locale.zh-CN.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: luolangaga.ASG.Director
+PackageVersion: 3.1.3
+PackageLocale: zh-CN
+Publisher: 哈基毅
+PublisherUrl: https://idvevent.cn
+PublisherSupportUrl: https://github.com/luolangaga/ASG.Director/issues
+Author: 哈基毅
+PackageName: Idvevent导播端
+PackageUrl: https://github.com/luolangaga/ASG.Director
+License: MIT
+LicenseUrl: https://github.com/luolangaga/ASG.Director/blob/main/license.txt
+ShortDescription: 面向《第五人格》赛事直播的本地导播工具，适用于 OBS 直播、录播和复盘场景。
+Description: |-
+  Idvevent导播端（ASG.Director）是一个面向《第五人格》赛事直播的本地导播工具。
+
+  它提供本地 BP 流程控制、前台展示窗口、比分板、赛后数据展示、地图展示、角色展示、布局保存与导入导出、自定义页面映射以及插件系统，适合配合 OBS 使用。
+Moniker: asg-director
+Tags:
+  - 第五人格
+  - director
+  - electron
+  - identity-v
+  - obs
+  - 赛事
+  - 导播
+ReleaseNotes: 支持3D实时渲染。
+ReleaseNotesUrl: https://github.com/luolangaga/ASG.Director/releases/tag/auto-build-38
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/l/luolangaga/ASG/Director/3.1.3/luolangaga.ASG.Director.yaml
+++ b/manifests/l/luolangaga/ASG/Director/3.1.3/luolangaga.ASG.Director.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: luolangaga.ASG.Director
+PackageVersion: 3.1.3
+DefaultLocale: zh-CN
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Summary
- Add winget manifest for `luolangaga.ASG.Director` version `3.1.3`.
- Installer URL points to the fixed 3.1.3 release asset.
- Author set to `哈基毅`.

## Validation
- `winget validate --manifest manifests/l/luolangaga/ASG/Director/3.1.3`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/348634)