### PR TITLE
New package: Fanis.ClaudeCodeSwitcher version 0.3.0

### DIFF
--- a/manifests/f/Fanis/ClaudeCodeSwitcher/0.3.0/Fanis.ClaudeCodeSwitcher.installer.yaml
+++ b/manifests/f/Fanis/ClaudeCodeSwitcher/0.3.0/Fanis.ClaudeCodeSwitcher.installer.yaml
@@ -1,0 +1,14 @@
+# Created using wingetcreate
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: Fanis.ClaudeCodeSwitcher
+PackageVersion: 0.3.0
+InstallerType: portable
+Commands:
+  - claude-code-switcher
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/fanis/claude-code-switcher/releases/download/0.3.0/claude-code-switcher.exe
+    InstallerSha256: B168294D2A1C684712F311CBFA61DF7599C2457279D4BC3B6667D681B1A5827C
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/f/Fanis/ClaudeCodeSwitcher/0.3.0/Fanis.ClaudeCodeSwitcher.locale.en-US.yaml
+++ b/manifests/f/Fanis/ClaudeCodeSwitcher/0.3.0/Fanis.ClaudeCodeSwitcher.locale.en-US.yaml
@@ -1,0 +1,20 @@
+# Created using wingetcreate
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: Fanis.ClaudeCodeSwitcher
+PackageVersion: 0.3.0
+PackageLocale: en-US
+Publisher: Fanis Hatzidakis
+PackageName: Claude Code Switcher
+PackageUrl: https://github.com/fanis/claude-code-switcher
+License: PolyForm Internal Use License 1.0.0
+LicenseUrl: https://github.com/fanis/claude-code-switcher/blob/master/LICENCE.md
+ShortDescription: Fast native Windows utility for switching between Claude Code projects.
+Description: A fast, native Windows utility for switching between Claude Code projects. Shows all your Claude Code projects in a popup dialog sorted by most recently used, with fuzzy search filtering.
+Tags:
+  - claude
+  - claude-code
+  - developer-tools
+  - windows-terminal
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/f/Fanis/ClaudeCodeSwitcher/0.3.0/Fanis.ClaudeCodeSwitcher.yaml
+++ b/manifests/f/Fanis/ClaudeCodeSwitcher/0.3.0/Fanis.ClaudeCodeSwitcher.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: Fanis.ClaudeCodeSwitcher
+PackageVersion: 0.3.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
### New package submission

- Package identifier: Fanis.ClaudeCodeSwitcher
- Package version: 0.3.0
- Installer URL: https://github.com/fanis/claude-code-switcher/releases/download/0.3.0/claude-code-switcher.exe
- Installer type: portable

### Description

A fast, native Windows utility for switching between Claude Code projects. Shows all your Claude Code projects in a popup dialog sorted by most recently used, with fuzzy search filtering.

### Checklist

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one manifest
- [x] Manifest is a multi-file manifest
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/348690)