### PR TITLE
New package: vmvarela.sql-pipe version 0.3.0

### DIFF
--- a/manifests/v/vmvarela/sql-pipe/0.3.0/vmvarela.sql-pipe.installer.yaml
+++ b/manifests/v/vmvarela/sql-pipe/0.3.0/vmvarela.sql-pipe.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: vmvarela.sql-pipe
+PackageVersion: 0.3.0
+InstallerType: portable
+Commands:
+  - sql-pipe
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/vmvarela/sql-pipe/releases/download/v0.3.0/sql-pipe-x86_64-windows.exe
+    InstallerSha256: daa74a5bf383c8f52cbe32be3a30dfeac518104e11ee951c505191f19bd49cd0
+  - Architecture: x86
+    InstallerUrl: https://github.com/vmvarela/sql-pipe/releases/download/v0.3.0/sql-pipe-x86-windows.exe
+    InstallerSha256: 17f0e7a722e44d0c26af4e193085497dbc0763323934dd8d4ed827f525056112
+  - Architecture: arm64
+    InstallerUrl: https://github.com/vmvarela/sql-pipe/releases/download/v0.3.0/sql-pipe-aarch64-windows.exe
+    InstallerSha256: f12e6ec29bf9ee24d32c0c33600b1995c67fc7edcb8ffcd1e84b61ee155a7cb3
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/v/vmvarela/sql-pipe/0.3.0/vmvarela.sql-pipe.locale.en-US.yaml
+++ b/manifests/v/vmvarela/sql-pipe/0.3.0/vmvarela.sql-pipe.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: vmvarela.sql-pipe
+PackageVersion: 0.3.0
+PackageLocale: en-US
+Publisher: vmvarela
+PublisherUrl: https://github.com/vmvarela
+PackageName: sql-pipe
+PackageUrl: https://github.com/vmvarela/sql-pipe
+License: MIT
+LicenseUrl: https://github.com/vmvarela/sql-pipe/blob/master/LICENSE
+ShortDescription: Read CSV from stdin, query with SQL, write CSV to stdout
+Description: >-
+  sql-pipe reads CSV from stdin, loads it into an in-memory SQLite database,
+  runs a SQL query, and prints the results as CSV. No server, no schema files,
+  no setup. If you know SQL and work with CSV in the terminal, this is the tool
+  you have been reaching for.
+Tags:
+  - csv
+  - sql
+  - sqlite
+  - cli
+  - pipe
+  - data
+ReleaseNotesUrl: https://github.com/vmvarela/sql-pipe/releases/tag/v0.3.0
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/v/vmvarela/sql-pipe/0.3.0/vmvarela.sql-pipe.yaml
+++ b/manifests/v/vmvarela/sql-pipe/0.3.0/vmvarela.sql-pipe.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: vmvarela.sql-pipe
+PackageVersion: 0.3.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## New package submission

- **Package:** vmvarela.sql-pipe
- **Version:** 0.3.0
- **Type:** portable

### Description

sql-pipe reads CSV from stdin, loads it into an in-memory SQLite database, runs a SQL query, and prints the results as CSV. No server, no schema files, no setup.

### Validation

- [x] Installer URLs are valid and publicly accessible
- [x] SHA256 hashes verified against [release sha256sums.txt](https://github.com/vmvarela/sql-pipe/releases/download/v0.3.0/sha256sums.txt)
- [x] Manifests validated against winget schema 1.9.0
- [x] Package supports x64, x86, and arm64 architectures
- [x] InstallerType: portable (single executable, no install required)

### URLs

- x64: https://github.com/vmvarela/sql-pipe/releases/download/v0.3.0/sql-pipe-x86_64-windows.exe
- x86: https://github.com/vmvarela/sql-pipe/releases/download/v0.3.0/sql-pipe-x86-windows.exe
- arm64: https://github.com/vmvarela/sql-pipe/releases/download/v0.3.0/sql-pipe-aarch64-windows.exe
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/348726)