### PR TITLE
Update willibrandon.dotsider to 0.4.2

### DIFF
--- a/manifests/w/willibrandon/dotsider/0.4.2/willibrandon.dotsider.installer.yaml
+++ b/manifests/w/willibrandon/dotsider/0.4.2/willibrandon.dotsider.installer.yaml
@@ -1,0 +1,27 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: willibrandon.dotsider
+PackageVersion: 0.4.2
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.18362.0
+InstallerType: msi
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/willibrandon/dotsider/releases/download/v0.4.2/dotsider-win-x64.msi
+  InstallerSha256: 4898C2593ED90238A020E553E6A7C9A29A9516F27F416893356439BA9C7C0296
+  ProductCode: '{2F72A673-20B3-4226-9BF0-135C6C2E7EC1}'
+- Architecture: arm64
+  InstallerUrl: https://github.com/willibrandon/dotsider/releases/download/v0.4.2/dotsider-win-arm64.msi
+  InstallerSha256: 022745CB591B158F21BBD6C6FDF37351B00B95F8A6DC3699CD782B07695F93E9
+  ProductCode: '{637FD267-2B4F-4328-9A53-CDACB456FD73}'
+ManifestType: installer
+ManifestVersion: 1.10.0
+ReleaseDate: 2026-03-15

--- a/manifests/w/willibrandon/dotsider/0.4.2/willibrandon.dotsider.locale.en-US.yaml
+++ b/manifests/w/willibrandon/dotsider/0.4.2/willibrandon.dotsider.locale.en-US.yaml
@@ -1,0 +1,36 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: willibrandon.dotsider
+PackageVersion: 0.4.2
+PackageLocale: en-US
+Publisher: willibrandon
+PublisherUrl: https://github.com/willibrandon
+PublisherSupportUrl: https://github.com/willibrandon/dotsider/issues
+PackageName: dotsider
+PackageUrl: https://github.com/willibrandon/dotsider
+License: MIT
+LicenseUrl: https://github.com/willibrandon/dotsider/blob/main/LICENSE
+ShortDescription: A TUI for analyzing .NET assemblies
+Description: |-
+  dotsider is a terminal UI for analyzing .NET assemblies — structure, metadata,
+  IL disassembly, strings, hex dump, dependency graphs, size maps, and live
+  runtime tracing via EventPipe. It also supports assembly diffing and NuGet
+  package browsing.
+Tags:
+- dotnet
+- assembly
+- tui
+- il
+- metadata
+- pe
+- disassembler
+- cli
+- terminal
+- devtools
+ReleaseNotesUrl: https://github.com/willibrandon/dotsider/releases/tag/v0.4.2
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/willibrandon/dotsider/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/w/willibrandon/dotsider/0.4.2/willibrandon.dotsider.yaml
+++ b/manifests/w/willibrandon/dotsider/0.4.2/willibrandon.dotsider.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: willibrandon.dotsider
+PackageVersion: 0.4.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Description

Update dotsider to version 0.4.2

## Release notes

https://github.com/willibrandon/dotsider/releases/tag/v0.4.2
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/348740)