### PR TITLE
Add ONFStudios.OreNoFusen version 1.1.1

### DIFF
--- a/manifests/o/ONFStudios/OreNoFusen/1.1.1/ONFStudios.OreNoFusen.installer.yaml
+++ b/manifests/o/ONFStudios/OreNoFusen/1.1.1/ONFStudios.OreNoFusen.installer.yaml
@@ -1,0 +1,12 @@
+# Created using winget-create v2.x
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: ONFStudios.OreNoFusen
+PackageVersion: 1.1.1
+InstallerType: nullsoft
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/ore-no-fusen/ore-no-fusen/releases/download/v1.1.1/ore-no-fusen_1.1.1_x64-setup.exe
+    InstallerSha256: FEB72B08BDA0EF2D267795AF60087F483599DACA49A7C6C879CEF120E947EC20
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/o/ONFStudios/OreNoFusen/1.1.1/ONFStudios.OreNoFusen.locale.en-US.yaml
+++ b/manifests/o/ONFStudios/OreNoFusen/1.1.1/ONFStudios.OreNoFusen.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# Created using winget-create v2.x
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: ONFStudios.OreNoFusen
+PackageVersion: 1.1.1
+PackageLocale: en-US
+Publisher: ONF Studios
+PublisherUrl: https://github.com/ore-no-fusen
+PublisherSupportUrl: https://github.com/ore-no-fusen/ore-no-fusen/issues
+PackageName: 俺の付箋
+PackageUrl: https://github.com/ore-no-fusen/ore-no-fusen
+License: MIT
+LicenseUrl: https://github.com/ore-no-fusen/ore-no-fusen/blob/main/LICENSE
+Copyright: Copyright (c) ONF Studios
+ShortDescription: A fast sticky note app that stays on your desktop
+Description: |-
+  俺の付箋 (Ore no Fusen) is a desktop sticky note app built with Tauri + Next.js.
+  Key features:
+  - Instant editing — cursor is ready on first click
+  - WYSIWYG rich text (bold, headings, lists, checkboxes)
+  - Auto-save with floating windows that stay on top
+  - Multi-window: each note is an independent window
+Moniker: ore-no-fusen
+Tags:
+  - notes
+  - sticky-notes
+  - productivity
+  - desktop
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/o/ONFStudios/OreNoFusen/1.1.1/ONFStudios.OreNoFusen.yaml
+++ b/manifests/o/ONFStudios/OreNoFusen/1.1.1/ONFStudios.OreNoFusen.yaml
@@ -1,0 +1,8 @@
+# Created using winget-create v2.x
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: ONFStudios.OreNoFusen
+PackageVersion: 1.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Description
Add new package manifest for 俺の付箋 (Ore no Fusen) v1.1.1.

## Package Details
- **Package Identifier**: ONFStudios.OreNoFusen
- **Version**: 1.1.1
- **Publisher**: ONF Studios
- **License**: MIT
- **InstallerType**: nullsoft (NSIS)
- **Architecture**: x64

## Validation
- Manifest validated with `winget validate --manifest`

## Links
- Homepage: https://github.com/ore-no-fusen/ore-no-fusen
- Release: https://github.com/ore-no-fusen/ore-no-fusen/releases/tag/v1.1.1
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/348884)