### PR TITLE
New version: michaelnoergaard.USBGroove version 1.62

### DIFF
--- a/manifests/m/michaelnoergaard/USBGroove/1.62/michaelnoergaard.USBGroove.installer.yaml
+++ b/manifests/m/michaelnoergaard/USBGroove/1.62/michaelnoergaard.USBGroove.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: michaelnoergaard.USBGroove
+PackageVersion: "1.62"
+MinimumOSVersion: 10.0.17763.0
+Commands:
+- USBGroove
+Installers:
+- Architecture: x64
+  InstallerType: portable
+  InstallerUrl: https://github.com/michaelnoergaard/USB-Groove/releases/download/v1.62/USBGroove.exe
+  InstallerSha256: C09EF06D80465C693E5003234A6DE878AC4FAC1DC71F8586EFB56325FA82E656
+- Architecture: x64
+  InstallerType: inno
+  InstallerUrl: https://github.com/michaelnoergaard/USB-Groove/releases/download/v1.62/USBGroove_Setup_v1.62.exe
+  InstallerSha256: 04AE8798C4B34F60CFC7D3622E0220AC5E8E85F61028918F0A7F783F1F5377AB
+  InstallerSwitches:
+    Silent: /VERYSILENT /SUPPRESSMSGBOXES
+    SilentWithProgress: /SILENT /SUPPRESSMSGBOXES
+ManifestType: installer
+ManifestVersion: 1.10.0
+ReleaseDate: 2026-03-16

--- a/manifests/m/michaelnoergaard/USBGroove/1.62/michaelnoergaard.USBGroove.installer.yaml
+++ b/manifests/m/michaelnoergaard/USBGroove/1.62/michaelnoergaard.USBGroove.installer.yaml
@@ -3,11 +3,11 @@
 PackageIdentifier: michaelnoergaard.USBGroove
 PackageVersion: "1.62"
 MinimumOSVersion: 10.0.17763.0
+InstallerType: portable
 Commands:
 - USBGroove
 Installers:
 - Architecture: x64
-  InstallerType: portable
   InstallerUrl: https://github.com/michaelnoergaard/USB-Groove/releases/download/v1.62/USBGroove.exe
   InstallerSha256: C09EF06D80465C693E5003234A6DE878AC4FAC1DC71F8586EFB56325FA82E656
 - Architecture: x64

--- a/manifests/m/michaelnoergaard/USBGroove/1.62/michaelnoergaard.USBGroove.locale.en-US.yaml
+++ b/manifests/m/michaelnoergaard/USBGroove/1.62/michaelnoergaard.USBGroove.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: michaelnoergaard.USBGroove
+PackageVersion: "1.62"
+PackageLocale: en-US
+Publisher: michaelnoergaard
+PublisherUrl: https://github.com/michaelnoergaard
+PublisherSupportUrl: https://github.com/michaelnoergaard/USB-Groove/issues
+PackageName: USBGroove
+PackageUrl: https://github.com/michaelnoergaard/USB-Groove
+License: MIT
+LicenseUrl: https://github.com/michaelnoergaard/USB-Groove/blob/main/LICENSE
+ShortDescription: Cross-platform system tray app that auto-plays MP3s from USB drives
+Tags:
+- audio-player
+- cpp
+- cross-platform
+- mp3-player
+- system-tray
+- usb
+- windows
+ReleaseNotesUrl: https://github.com/michaelnoergaard/USB-Groove/releases/tag/v1.62
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/m/michaelnoergaard/USBGroove/1.62/michaelnoergaard.USBGroove.yaml
+++ b/manifests/m/michaelnoergaard/USBGroove/1.62/michaelnoergaard.USBGroove.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: michaelnoergaard.USBGroove
+PackageVersion: "1.62"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
### New version: michaelnoergaard.USBGroove version 1.62

#### Changes
- Added Inno Setup installer alongside existing portable exe
- Fixed macOS eject USB using DiskArbitration API
- Updated README for all three platforms

#### Installers
| Type | Architecture | File |
|------|-------------|------|
| Portable | x64 | `USBGroove.exe` |
| Inno Setup | x64 | `USBGroove_Setup_v1.62.exe` |

The Inno installer provides Start Menu shortcuts, Add/Remove Programs registration, and silent install support (`/VERYSILENT /SUPPRESSMSGBOXES`).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/349006)