### PR TITLE
Fix typo: sourcegit-scm.SourceGit version 2026.05

### DIFF
--- a/manifests/s/sourcegit-scm/SourceGit/2026.05/sourcegit-scm.SourceGit.locale.en-US.yaml
+++ b/manifests/s/sourcegit-scm/SourceGit/2026.05/sourcegit-scm.SourceGit.locale.en-US.yaml
@@ -33,6 +33,6 @@ ReleaseNotes: |-
   - Fix the issue that highlighting selected revision lines in Blame window did not work.
   - Unify the behavior of Reveal in File Explorer when the selected is a folder across all platforms
   - Several other UI/UX changes.
-ReleaseNotesUrl: https://github.com/sourcegit-scm/sourcegit/releases/tag/v2026.04
+ReleaseNotesUrl: https://github.com/sourcegit-scm/sourcegit/releases/tag/v2026.05
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?  If so, fill in the Issue number below.
   <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

This fixes a typo in the release notes URL pointing to 2026.04 instead of the correct 2026.05.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/349080)