### PR TITLE
New version: xmn.BetterTrumpet version 3.0.4

### DIFF
--- a/manifests/x/xmn/BetterTrumpet/3.0.4/xmn.BetterTrumpet.installer.yaml
+++ b/manifests/x/xmn/BetterTrumpet/3.0.4/xmn.BetterTrumpet.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: xmn.BetterTrumpet
+PackageVersion: 3.0.4
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17134.0
+InstallerType: inno
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/xammen/BetterTrumpet/releases/download/v3.0.4/BetterTrumpet-3.0.4-setup.exe
+  InstallerSha256: 6BB113C3F6FC744EA936E49F2AF81039D82B84FD527B36EE667A67124D8B18C5
+  InstallerSwitches:
+    Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+    SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+ManifestType: installer
+ManifestVersion: 1.10.0
+ReleaseDate: 2026-03-17

--- a/manifests/x/xmn/BetterTrumpet/3.0.4/xmn.BetterTrumpet.locale.en-US.yaml
+++ b/manifests/x/xmn/BetterTrumpet/3.0.4/xmn.BetterTrumpet.locale.en-US.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: xmn.BetterTrumpet
+PackageVersion: 3.0.4
+PackageLocale: en-US
+Publisher: xmn
+PublisherUrl: https://github.com/xammen
+PublisherSupportUrl: https://github.com/xammen/BetterTrumpet/issues
+PackageName: BetterTrumpet
+PackageUrl: https://github.com/xammen/BetterTrumpet
+License: MIT
+LicenseUrl: https://github.com/xammen/BetterTrumpet/blob/master/LICENSE
+ShortDescription: A refined fork of EarTrumpet with enhanced volume control, themes, and auto-updates
+Description: |-
+  BetterTrumpet is a refined fork of EarTrumpet, the beloved Windows volume mixer.
+  Features include per-app volume control, a media popup with album art, 28+ built-in themes,
+  volume profiles, undo/redo, CLI with 19 commands, crash reporting via Sentry,
+  auto-updates with silent install, and a premium onboarding experience.
+Tags:
+- audio
+- volume
+- mixer
+- sound
+- music
+- bettertrumpet
+- eartrumpet
+- windows
+ReleaseNotes: |-
+  - Dynamic changelog — fetches release notes from GitHub instead of hardcoded content
+  - Auto-update — downloads and installs updates silently via Inno Setup
+  - Update check every 6 hours instead of only at startup
+  - Onboarding improvements — step dots, checkmark on device selection, tray pin page with GIF
+  - Preset selection now properly disables Dynamic Album Art theme
+  - Fixed onboarding hidden behind changelog on first launch
+  - Fixed silent install not relaunching BetterTrumpet
+  - Fixed Sentry noise from package identity exception in portable/installer mode
+ReleaseNotesUrl: https://github.com/xammen/BetterTrumpet/releases/tag/v3.0.4
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/x/xmn/BetterTrumpet/3.0.4/xmn.BetterTrumpet.yaml
+++ b/manifests/x/xmn/BetterTrumpet/3.0.4/xmn.BetterTrumpet.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: xmn.BetterTrumpet
+PackageVersion: 3.0.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
### New version: [xmn.BetterTrumpet v3.0.4](https://github.com/xammen/BetterTrumpet/releases/tag/v3.0.4)

**Changed installer type from `portable` to `inno`** — BetterTrumpet now ships as an Inno Setup installer (.exe) instead of a standalone portable executable.

- Installer type: `inno`
- Scope: `user`
- Architecture: `x86`
- Silent switches configured
- SHA256 verified
- `winget validate` passed locally
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/349200)