### PR TITLE
Update: Fix versioning issues

### DIFF
--- a/manifests/g/GitHub/Copilot/modernization/agent/0.0.226/GitHub.Copilot.modernization.agent.installer.yaml
+++ b/manifests/g/GitHub/Copilot/modernization/agent/0.0.226/GitHub.Copilot.modernization.agent.installer.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
 
 PackageIdentifier: GitHub.Copilot.modernization.agent
-PackageVersion: v0.0.266
+PackageVersion: v0.0.226
 InstallerLocale: en-US
 InstallerType: wix
 Commands:

--- a/manifests/g/GitHub/Copilot/modernization/agent/0.0.226/GitHub.Copilot.modernization.agent.installer.yaml
+++ b/manifests/g/GitHub/Copilot/modernization/agent/0.0.226/GitHub.Copilot.modernization.agent.installer.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
 
 PackageIdentifier: GitHub.Copilot.modernization.agent
-PackageVersion: v0.0.226
+PackageVersion: 0.0.226
 InstallerLocale: en-US
 InstallerType: wix
 Commands:

--- a/manifests/g/GitHub/Copilot/modernization/agent/0.0.226/GitHub.Copilot.modernization.agent.locale.en-US.yaml
+++ b/manifests/g/GitHub/Copilot/modernization/agent/0.0.226/GitHub.Copilot.modernization.agent.locale.en-US.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
 
 PackageIdentifier: GitHub.Copilot.modernization.agent
-PackageVersion: v0.0.226
+PackageVersion: 0.0.226
 PackageLocale: en-US
 Publisher: GitHub, Inc.
 PublisherUrl: https://github.com/home/

--- a/manifests/g/GitHub/Copilot/modernization/agent/0.0.226/GitHub.Copilot.modernization.agent.locale.en-US.yaml
+++ b/manifests/g/GitHub/Copilot/modernization/agent/0.0.226/GitHub.Copilot.modernization.agent.locale.en-US.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
 
 PackageIdentifier: GitHub.Copilot.modernization.agent
-PackageVersion: v0.0.266
+PackageVersion: v0.0.226
 PackageLocale: en-US
 Publisher: GitHub, Inc.
 PublisherUrl: https://github.com/home/

--- a/manifests/g/GitHub/Copilot/modernization/agent/0.0.226/GitHub.Copilot.modernization.agent.yaml
+++ b/manifests/g/GitHub/Copilot/modernization/agent/0.0.226/GitHub.Copilot.modernization.agent.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
 
 PackageIdentifier: GitHub.Copilot.modernization.agent
-PackageVersion: v0.0.266
+PackageVersion: v0.0.226
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.10.0

--- a/manifests/g/GitHub/Copilot/modernization/agent/0.0.226/GitHub.Copilot.modernization.agent.yaml
+++ b/manifests/g/GitHub/Copilot/modernization/agent/0.0.226/GitHub.Copilot.modernization.agent.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
 
 PackageIdentifier: GitHub.Copilot.modernization.agent
-PackageVersion: v0.0.226
+PackageVersion: 0.0.226
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.10.0


### PR DESCRIPTION
This pull request updates the GitHub Copilot Modernization Agent manifests by rolling back the package version from `v0.0.266` to `v0.0.226` and renaming the manifest files to reflect the new version. No other changes were made.

* Package version rollback:
  * Updated `PackageVersion` from `v0.0.266` to `v0.0.226` in `GitHub.Copilot.modernization.agent.yaml`, `GitHub.Copilot.modernization.agent.installer.yaml`, and `GitHub.Copilot.modernization.agent.locale.en-US.yaml`. [[1]](diffhunk://#diff-1d60c3241e745230ff022607165d638ffe55f67dcbe8b0a9176907ccfd14ec31L5-R5) [[2]](diffhunk://#diff-6ad1e401043baca76ea864dd8c191b887aa456b0a2c8e4cfbc5bc7ae347b315fL5-R5) [[3]](diffhunk://#diff-f8c6dcb584016e00f5d20c8bc8a59415c8c7f8187b922f41a7c70962497600ddL5-R5)

* Manifest file renaming:
  * Renamed manifest files and their directories from `v0.0.266` to `0.0.226` to match the new package version. [[1]](diffhunk://#diff-1d60c3241e745230ff022607165d638ffe55f67dcbe8b0a9176907ccfd14ec31L5-R5) [[2]](diffhunk://#diff-6ad1e401043baca76ea864dd8c191b887aa456b0a2c8e4cfbc5bc7ae347b315fL5-R5) [[3]](diffhunk://#diff-f8c6dcb584016e00f5d20c8bc8a59415c8c7f8187b922f41a7c70962497600ddL5-R5)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/349592)