### PR TITLE
New Package: AcaciaAve.HUD version 1.0.76.0

### DIFF
--- a/manifests/a/AcaciaAve/HUD/1.0.76.0/AcaciaAve.HUD.installer.yaml
+++ b/manifests/a/AcaciaAve/HUD/1.0.76.0/AcaciaAve.HUD.installer.yaml
@@ -12,6 +12,9 @@ InstallModes:
 InstallerSwitches:
   Silent: /quiet
   SilentWithProgress: /passive
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
 UpgradeBehavior: install
 Installers:
   - Architecture: x64

--- a/manifests/a/AcaciaAve/HUD/1.0.76.0/AcaciaAve.HUD.installer.yaml
+++ b/manifests/a/AcaciaAve/HUD/1.0.76.0/AcaciaAve.HUD.installer.yaml
@@ -1,0 +1,21 @@
+# Created using wingetcreate 1.9.4.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: AcaciaAve.HUD
+PackageVersion: 1.0.76.0
+InstallerLocale: en-US
+InstallerType: msi
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+InstallerSwitches:
+  Silent: /quiet
+  SilentWithProgress: /passive
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/acaciaavellc/Heads-Up-Display/releases/download/v1.0.076.0/AcaciaAve-HUD-Personal-x64.msi
+    InstallerSha256: 35bd894fea5691222ffe16d9f857ca32c738eebcbef119a7d2a6152bf2b194fd
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/a/AcaciaAve/HUD/1.0.76.0/AcaciaAve.HUD.installer.yaml
+++ b/manifests/a/AcaciaAve/HUD/1.0.76.0/AcaciaAve.HUD.installer.yaml
@@ -5,7 +5,6 @@ PackageIdentifier: AcaciaAve.HUD
 PackageVersion: 1.0.76.0
 InstallerLocale: en-US
 InstallerType: msi
-Scope: user
 InstallModes:
   - interactive
   - silent

--- a/manifests/a/AcaciaAve/HUD/1.0.76.0/AcaciaAve.HUD.locale.en-US.yaml
+++ b/manifests/a/AcaciaAve/HUD/1.0.76.0/AcaciaAve.HUD.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# Created using wingetcreate 1.9.4.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: AcaciaAve.HUD
+PackageVersion: 1.0.76.0
+PackageLocale: en-US
+Publisher: Acacia Avenue LLC
+PublisherUrl: https://www.acaciaave.com
+PublisherSupportUrl: https://github.com/acaciaavellc/Heads-Up-Display/issues
+PrivacyUrl: https://www.acaciaave.com/privacy-policy.html
+PackageName: Heads-Up Display
+PackageUrl: https://www.acaciaave.com/hud-personal.html
+License: Proprietary
+LicenseUrl: https://www.acaciaave.com/hud-personal.html
+Copyright: Copyright (c) 2026 Acacia Avenue LLC
+ShortDescription: Persistent classification banner for Windows desktops
+Description: |-
+  Heads-Up Display (HUD) is a lightweight, always-on classification banner for Windows.
+  It provides a persistent visual indicator of the current system classification state,
+  designed for use in government, defense, and enterprise environments where users must
+  maintain constant awareness of the sensitivity level of the data they are handling.
+  HUD Personal is free for personal and evaluation use.
+Tags:
+  - classification
+  - banner
+  - security
+  - government
+  - defense
+  - netbanner
+ReleaseNotesUrl: https://github.com/acaciaavellc/Heads-Up-Display/releases/tag/v1.0.076.0
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/a/AcaciaAve/HUD/1.0.76.0/AcaciaAve.HUD.yaml
+++ b/manifests/a/AcaciaAve/HUD/1.0.76.0/AcaciaAve.HUD.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.9.4.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: AcaciaAve.HUD
+PackageVersion: 1.0.76.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## Windows Package Manager Package Submission

### Package
- **Package identifier:** AcaciaAve.HUD
- **Package version:** 1.0.76.0
- **Publisher:** Acacia Avenue LLC

### Description
Heads-Up Display (HUD) is a lightweight, always-on classification banner for Windows. It provides a persistent visual indicator of the current system classification state, designed for use in government, defense, and enterprise environments.

HUD Personal is free for personal and evaluation use.

### Validation
- Installer is EV code-signed (IdenTrust)
- MSI is per-user scope (no elevation required)
- SHA256 verified against GitHub release asset
- Tested on Windows 11 25H2

### Urls
- Home page: https://www.acaciaave.com/hud-personal.html
- Release: https://github.com/acaciaavellc/Heads-Up-Display/releases/tag/v1.0.076.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/349771)