### PR TITLE
Add machinewrapped.SmartCopy version 2.0.8

### DIFF
--- a/manifests/m/machinewrapped/SmartCopy/2.0.8/machinewrapped.SmartCopy.installer.yaml
+++ b/manifests/m/machinewrapped/SmartCopy/2.0.8/machinewrapped.SmartCopy.installer.yaml
@@ -1,0 +1,14 @@
+PackageIdentifier: machinewrapped.SmartCopy
+PackageVersion: 2.0.8
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: SmartCopy.exe
+  PortableCommandAlias: SmartCopy
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/machinewrapped/SmartCopy2026/releases/download/v2.0.8/SmartCopy-2.0.8-win-x64.zip
+  InstallerSha256: 924F11FBFE5C87621F92A8BCAC18377C2E3BD9CB20EBF85976543B23AB74D57F
+ManifestType: installer
+ManifestVersion: 1.6.0
+

--- a/manifests/m/machinewrapped/SmartCopy/2.0.8/machinewrapped.SmartCopy.installer.yaml
+++ b/manifests/m/machinewrapped/SmartCopy/2.0.8/machinewrapped.SmartCopy.installer.yaml
@@ -1,3 +1,6 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
 PackageIdentifier: machinewrapped.SmartCopy
 PackageVersion: 2.0.8
 InstallerType: zip
@@ -10,5 +13,5 @@ Installers:
   InstallerUrl: https://github.com/machinewrapped/SmartCopy2026/releases/download/v2.0.8/SmartCopy-2.0.8-win-x64.zip
   InstallerSha256: 924F11FBFE5C87621F92A8BCAC18377C2E3BD9CB20EBF85976543B23AB74D57F
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0
 

--- a/manifests/m/machinewrapped/SmartCopy/2.0.8/machinewrapped.SmartCopy.locale.en-US.yaml
+++ b/manifests/m/machinewrapped/SmartCopy/2.0.8/machinewrapped.SmartCopy.locale.en-US.yaml
@@ -1,3 +1,6 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
 PackageIdentifier: machinewrapped.SmartCopy
 PackageVersion: 2.0.8
 PackageLocale: en-US
@@ -8,11 +11,11 @@ PackageName: SmartCopy
 PackageUrl: https://github.com/machinewrapped/SmartCopy2026
 License: MIT
 LicenseUrl: https://github.com/machinewrapped/SmartCopy2026/blob/main/LICENSE
-ShortDescription: Intelligently copy large directories via composable filters and transform pipelines
+ShortDescription: Selectively copy large directories via composable filters and transform pipelines
 Tags:
 - file-manager
 - copy
 - utility
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0
 

--- a/manifests/m/machinewrapped/SmartCopy/2.0.8/machinewrapped.SmartCopy.locale.en-US.yaml
+++ b/manifests/m/machinewrapped/SmartCopy/2.0.8/machinewrapped.SmartCopy.locale.en-US.yaml
@@ -1,0 +1,18 @@
+PackageIdentifier: machinewrapped.SmartCopy
+PackageVersion: 2.0.8
+PackageLocale: en-US
+Publisher: machinewrapped
+PublisherUrl: https://github.com/machinewrapped
+PublisherSupportUrl: https://github.com/machinewrapped/SmartCopy2026/issues
+PackageName: SmartCopy
+PackageUrl: https://github.com/machinewrapped/SmartCopy2026
+License: MIT
+LicenseUrl: https://github.com/machinewrapped/SmartCopy2026/blob/main/LICENSE
+ShortDescription: Intelligently copy large directories via composable filters and transform pipelines
+Tags:
+- file-manager
+- copy
+- utility
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0
+

--- a/manifests/m/machinewrapped/SmartCopy/2.0.8/machinewrapped.SmartCopy.yaml
+++ b/manifests/m/machinewrapped/SmartCopy/2.0.8/machinewrapped.SmartCopy.yaml
@@ -1,0 +1,6 @@
+PackageIdentifier: machinewrapped.SmartCopy
+PackageVersion: 2.0.8
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0
+

--- a/manifests/m/machinewrapped/SmartCopy/2.0.8/machinewrapped.SmartCopy.yaml
+++ b/manifests/m/machinewrapped/SmartCopy/2.0.8/machinewrapped.SmartCopy.yaml
@@ -1,6 +1,9 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
 PackageIdentifier: machinewrapped.SmartCopy
 PackageVersion: 2.0.8
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0
 


### PR DESCRIPTION
## Package info

- **Package:** machinewrapped.SmartCopy
- **Version:** 2.0.8
- **Publisher:** machinewrapped
- **Homepage:** https://github.com/machinewrapped/SmartCopy2026

## Description

SmartCopy is a cross-platform file manager (Windows/Linux/macOS) that intelligently copies large directories via composable filters and transform pipelines.

## Installer

- Type: ZIP (portable executable)
- Architecture: x64
- SHA256 verified

## Checklist

- [x] Have you checked that there are no other open PRs for the same package/version?
- [x] Have you read and agreed to the [Contribution License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Were the manifests created using `winget-create` or the latest available version of [YamlCreate.ps1](https://github.com/microsoft/winget-pkgs/blob/master/Tools/YamlCreate.ps1)?
- [x] Have you verified the installer URLs are still accessible?
- [x] Have you checked the SHA256 hash?