### PR TITLE
New package: FelipeMorandini.jwt-term version 1.1.1

### DIFF
--- a/manifests/f/FelipeMorandini/jwt-term/1.1.1/FelipeMorandini.jwt-term.installer.yaml
+++ b/manifests/f/FelipeMorandini/jwt-term/1.1.1/FelipeMorandini.jwt-term.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: FelipeMorandini.jwt-term
+PackageVersion: 1.1.1
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: jwt-term.exe
+    PortableCommandAlias: jwt-term
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/felipemorandini/jwt-term/releases/download/v1.1.1/jwt-term-x86_64-pc-windows-msvc.zip
+    InstallerSha256: AD823CC573F9B7A5B0FD7C963C2B58B16D5AB3ED5717FCC4C773191311FDF0B6
+  - Architecture: arm64
+    InstallerUrl: https://github.com/felipemorandini/jwt-term/releases/download/v1.1.1/jwt-term-aarch64-pc-windows-msvc.zip
+    InstallerSha256: 9143EE593D2A1F49867124CEA49F1F13999F474A6292B872EACDD4A90091EB35
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/f/FelipeMorandini/jwt-term/1.1.1/FelipeMorandini.jwt-term.locale.en-US.yaml
+++ b/manifests/f/FelipeMorandini/jwt-term/1.1.1/FelipeMorandini.jwt-term.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: FelipeMorandini.jwt-term
+PackageVersion: 1.1.1
+PackageLocale: en-US
+Publisher: Felipe Pires Morandini
+PublisherUrl: https://github.com/felipemorandini
+PackageName: jwt-term
+PackageUrl: https://github.com/felipemorandini/jwt-term
+License: MIT
+LicenseUrl: https://github.com/felipemorandini/jwt-term/blob/main/LICENSE
+ShortDescription: A blazing-fast, secure, and offline-first CLI for inspecting, validating, and manipulating JWTs
+Description: |-
+  jwt-term is a CLI tool built in Rust for inspecting, validating, and manipulating JSON Web Tokens (JWTs)
+  and OAuth tokens. It keeps sensitive tokens out of third-party web portals by bringing token debugging
+  directly to the terminal. Supports HMAC, RSA, ECDSA, EdDSA signatures, remote JWKS validation, and
+  time-travel debugging.
+Tags:
+  - jwt
+  - oauth
+  - cli
+  - security
+  - token
+  - rust
+Moniker: jwt-term
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/f/FelipeMorandini/jwt-term/1.1.1/FelipeMorandini.jwt-term.yaml
+++ b/manifests/f/FelipeMorandini/jwt-term/1.1.1/FelipeMorandini.jwt-term.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: FelipeMorandini.jwt-term
+PackageVersion: 1.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package submission

- **Package identifier:** FelipeMorandini.jwt-term
- **Package version:** 1.1.1
- **Package URL:** https://github.com/felipemorandini/jwt-term

A blazing-fast, secure, and offline-first CLI for inspecting, validating, and manipulating JWTs.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/349834)