### PR TITLE
Add msi entries for new PowerShell version 7.6.0.0

### DIFF
--- a/manifests/m/Microsoft/PowerShell/7.6.0.0/Microsoft.PowerShell.installer.yaml
+++ b/manifests/m/Microsoft/PowerShell/7.6.0.0/Microsoft.PowerShell.installer.yaml
@@ -1,0 +1,35 @@
+# Created with YamlCreate.ps1 v2.7.1 $debug=NVS1.CRLF.7-5-5.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.PowerShell
+PackageVersion: 7.6.0.0
+MinimumOSVersion: 10.0.17763.0
+InstallerType: wix
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Commands:
+- pwsh
+ReleaseDate: 2026-03-12
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.6.0/PowerShell-7.6.0-win-x64.msi
+  InstallerSha256: CE60D76319739B52B281C744144CD8E942AED9CDA02483CE9BD732E140F75982
+  ProductCode: '{18AF003E-70BD-4CD0-874C-D53E4D0B9708}'
+- Architecture: x86
+  InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.6.0/PowerShell-7.6.0-win-x86.msi
+  InstallerSha256: FFA746FC7F9E939117D416C82454E028A3AD8FC8C0B406F1762C1EB287DC5FC2
+  ProductCode: '{E2B82C18-C154-4D5B-9C67-FBEC4FDDB994}'
+- Architecture: arm
+  InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.6.0/PowerShell-7.6.0-win-arm64.msi
+  InstallerSha256: 565AFDEF6E4E20B26117D0D467C2647D96EA49F1F7D3FC542D29D18B742F1A9B
+  ProductCode: '{4B719655-6808-400E-AABC-64CA1CE773F2}'
+- Architecture: arm64
+  InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.6.0/PowerShell-7.6.0-win-arm64.msi
+  InstallerSha256: 565AFDEF6E4E20B26117D0D467C2647D96EA49F1F7D3FC542D29D18B742F1A9B
+  ProductCode: '{4B719655-6808-400E-AABC-64CA1CE773F2}'
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/Microsoft/PowerShell/7.6.0.0/Microsoft.PowerShell.installer.yaml
+++ b/manifests/m/Microsoft/PowerShell/7.6.0.0/Microsoft.PowerShell.installer.yaml
@@ -19,10 +19,6 @@ Installers:
   InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.6.0/PowerShell-7.6.0-win-x64.msi
   InstallerSha256: CE60D76319739B52B281C744144CD8E942AED9CDA02483CE9BD732E140F75982
   ProductCode: '{18AF003E-70BD-4CD0-874C-D53E4D0B9708}'
-- Architecture: x86
-  InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.6.0/PowerShell-7.6.0-win-x86.msi
-  InstallerSha256: FFA746FC7F9E939117D416C82454E028A3AD8FC8C0B406F1762C1EB287DC5FC2
-  ProductCode: '{E2B82C18-C154-4D5B-9C67-FBEC4FDDB994}'
 - Architecture: arm
   InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.6.0/PowerShell-7.6.0-win-arm64.msi
   InstallerSha256: 565AFDEF6E4E20B26117D0D467C2647D96EA49F1F7D3FC542D29D18B742F1A9B

--- a/manifests/m/Microsoft/PowerShell/7.6.0.0/Microsoft.PowerShell.locale.en-US.yaml
+++ b/manifests/m/Microsoft/PowerShell/7.6.0.0/Microsoft.PowerShell.locale.en-US.yaml
@@ -1,0 +1,40 @@
+# Created with YamlCreate.ps1 v2.7.1 $debug=NVS1.CRLF.7-5-5.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.PowerShell
+PackageVersion: 7.6.0.0
+PackageLocale: en-US
+Publisher: Microsoft Corporation
+PublisherUrl: https://github.com/PowerShell/PowerShell/
+PublisherSupportUrl: https://github.com/PowerShell/PowerShell/issues
+# PrivacyUrl:
+Author: Microsoft Corporation
+PackageName: PowerShell
+PackageUrl: https://microsoft.com/PowerShell
+License: MIT
+LicenseUrl: https://github.com/PowerShell/PowerShell/blob/master/LICENSE.txt
+Copyright: Copyright (c) Microsoft Corporation
+CopyrightUrl: https://github.com/PowerShell/PowerShell/blob/master/LICENSE.txt
+ShortDescription: PowerShell is a cross-platform task automation solution made up of a command-line shell, a scripting language, and a configuration management framework. PowerShell runs on Windows, Linux, and macOS.
+Description: |-
+  PowerShell is a cross-platform (Windows, Linux, and macOS) automation and configuration tool/framework that works well with your existing tools and is optimized for dealing with structured data (e.g. JSON, CSV, XML, etc.), REST APIs, and object models.
+  It includes a command-line shell, an associated scripting language and a framework for processing cmdlets.
+Moniker: pwsh
+Tags:
+- command-line
+- cross-platform
+- open-source
+- powershell
+- pwsh
+- shell
+# ReleaseNotes:
+ReleaseNotesUrl: https://github.com/PowerShell/PowerShell/releases/tag/v7.6.0
+# PurchaseUrl:
+# InstallationNotes:
+Documentations:
+- DocumentLabel: Product Documentation
+  DocumentUrl: https://learn.microsoft.com/powershell
+- DocumentLabel: FAQ
+  DocumentUrl: https://github.com/PowerShell/PowerShell/blob/master/docs/FAQ.md
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/Microsoft/PowerShell/7.6.0.0/Microsoft.PowerShell.yaml
+++ b/manifests/m/Microsoft/PowerShell/7.6.0.0/Microsoft.PowerShell.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.7.1 $debug=NVS1.CRLF.7-5-5.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.PowerShell
+PackageVersion: 7.6.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?  If so, fill in the Issue number below.
   <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

Note: x86 MSI entry is not included in the WinGet manifest for PowerShell 7.6.x stable versions, since .NET 10 no longer supports x86.
---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/349858)