### PR TITLE
Add OpenKara version 0.2.0

### DIFF
--- a/manifests/t/thedavidweng/OpenKara/0.2.0/thedavidweng.OpenKara.installer.yaml
+++ b/manifests/t/thedavidweng/OpenKara/0.2.0/thedavidweng.OpenKara.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: "thedavidweng.OpenKara"
+PackageVersion: "0.2.0"
+InstallerLocale: en-US
+Platform:
+  - Windows.Desktop
+Installers:
+  - Architecture: x64
+    InstallerType: nullsoft
+    InstallerUrl: "https://github.com/thedavidweng/OpenKara/releases/download/v0.2.0/OpenKara_0.2.0_x64-setup.exe"
+    InstallerSha256: "00db5dd2329ee1c8625f6dc60264931d2075c9ac2fe31dfc8b844959831dcb8d"
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/t/thedavidweng/OpenKara/0.2.0/thedavidweng.OpenKara.installer.yaml
+++ b/manifests/t/thedavidweng/OpenKara/0.2.0/thedavidweng.OpenKara.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: "thedavidweng.OpenKara"
 PackageVersion: "0.2.0"
@@ -11,4 +11,4 @@ Installers:
     InstallerUrl: "https://github.com/thedavidweng/OpenKara/releases/download/v0.2.0/OpenKara_0.2.0_x64-setup.exe"
     InstallerSha256: "00db5dd2329ee1c8625f6dc60264931d2075c9ac2fe31dfc8b844959831dcb8d"
 ManifestType: installer
-ManifestVersion: 1.10.0
+ManifestVersion: 1.12.0

--- a/manifests/t/thedavidweng/OpenKara/0.2.0/thedavidweng.OpenKara.locale.en-US.yaml
+++ b/manifests/t/thedavidweng/OpenKara/0.2.0/thedavidweng.OpenKara.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: "thedavidweng.OpenKara"
 PackageVersion: "0.2.0"
@@ -21,4 +21,4 @@ Tags:
   - ai
   - tauri
 ManifestType: defaultLocale
-ManifestVersion: 1.10.0
+ManifestVersion: 1.12.0

--- a/manifests/t/thedavidweng/OpenKara/0.2.0/thedavidweng.OpenKara.locale.en-US.yaml
+++ b/manifests/t/thedavidweng/OpenKara/0.2.0/thedavidweng.OpenKara.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: "thedavidweng.OpenKara"
+PackageVersion: "0.2.0"
+PackageLocale: en-US
+Publisher: "thedavidweng"
+PublisherUrl: "https://github.com/thedavidweng"
+PublisherSupportUrl: "https://github.com/thedavidweng/OpenKara/issues"
+Author: "thedavidweng"
+PackageName: OpenKara
+PackageUrl: "https://github.com/thedavidweng/OpenKara"
+License: MIT
+LicenseUrl: https://github.com/thedavidweng/OpenKara/blob/main/LICENSE
+ShortDescription: Turn your music library into a karaoke stage.
+Description: OpenKara is an open-source desktop karaoke app that turns songs you already own into karaoke tracks with on-device vocal separation, synced lyrics, and a portable local library.
+Moniker: openkara
+Tags:
+  - karaoke
+  - music
+  - lyrics
+  - ai
+  - tauri
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/t/thedavidweng/OpenKara/0.2.0/thedavidweng.OpenKara.yaml
+++ b/manifests/t/thedavidweng/OpenKara/0.2.0/thedavidweng.OpenKara.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: "thedavidweng.OpenKara"
+PackageVersion: "0.2.0"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0

--- a/manifests/t/thedavidweng/OpenKara/0.2.0/thedavidweng.OpenKara.yaml
+++ b/manifests/t/thedavidweng/OpenKara/0.2.0/thedavidweng.OpenKara.yaml
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: "thedavidweng.OpenKara"
 PackageVersion: "0.2.0"
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.10.0
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description
Add WinGet manifests for OpenKara 0.2.0.

## Validation
- Generated from the published OpenKara v0.2.0 release assets
- Manifest path: `manifests/t/thedavidweng/OpenKara/0.2.0`
- Windows installer URL and SHA256 are taken from the public GitHub Release