### PR TITLE
New package: Buypass.Javafri version 1.4.1.16

### DIFF
--- a/manifests/b/Buypass/Javafri/1.4.1.16/Buypass.Javafri.installer.yaml
+++ b/manifests/b/Buypass/Javafri/1.4.1.16/Buypass.Javafri.installer.yaml
@@ -1,0 +1,22 @@
+# Created with komac v2.15.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Buypass.Javafri
+PackageVersion: 1.4.1.16
+InstallerType: burn
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+AppsAndFeaturesEntries:
+- ProductCode: '{64f4f023-45cd-4e30-82bd-3f8606654751}'
+  UpgradeCode: '{F6F7022D-E68A-4728-BD1A-D6452E3A33D7}'
+  InstallerType: burn
+Installers:
+- Architecture: x86
+  InstallerUrl: https://www.buypass.com/help/buypass-id/smartcard/javafri/_/attachment/download/d3359e04-34e3-487d-a04c-4dfd2a5a105e:a710386d5c89fab06f050fd18d1f2b453ed5ce15/Buypass.Javafri.Setup_1_4_1.exe
+  InstallerSha256: B60E73AB083D8268E8F7A7D09CC62EBBD017D1F2A935CC17084FF3C19C8C3EA0
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/b/Buypass/Javafri/1.4.1.16/Buypass.Javafri.installer.yaml
+++ b/manifests/b/Buypass/Javafri/1.4.1.16/Buypass.Javafri.installer.yaml
@@ -3,20 +3,31 @@
 
 PackageIdentifier: Buypass.Javafri
 PackageVersion: 1.4.1.16
-InstallerType: burn
 Scope: machine
 InstallModes:
 - interactive
 - silent
 - silentWithProgress
 UpgradeBehavior: install
-AppsAndFeaturesEntries:
-- ProductCode: '{64f4f023-45cd-4e30-82bd-3f8606654751}'
-  UpgradeCode: '{F6F7022D-E68A-4728-BD1A-D6452E3A33D7}'
-  InstallerType: burn
 Installers:
 - Architecture: x86
+  InstallerType: burn
+  AppsAndFeaturesEntries:
+  - ProductCode: '{64f4f023-45cd-4e30-82bd-3f8606654751}'
+    UpgradeCode: '{F6F7022D-E68A-4728-BD1A-D6452E3A33D7}'
   InstallerUrl: https://www.buypass.com/help/buypass-id/smartcard/javafri/_/attachment/download/d3359e04-34e3-487d-a04c-4dfd2a5a105e:a710386d5c89fab06f050fd18d1f2b453ed5ce15/Buypass.Javafri.Setup_1_4_1.exe
   InstallerSha256: B60E73AB083D8268E8F7A7D09CC62EBBD017D1F2A935CC17084FF3C19C8C3EA0
+- InstallerLocale: en-US
+  Architecture: x86
+  InstallerType: wix
+  InstallerUrl: https://www.buypass.com/help/buypass-id/smartcard/javafri/_/attachment/download/180271ed-b207-4b4c-ba2b-e5276761760a:ca1961d47ac9de15265e67da2ae149282e3eb94e/Buypass.SCProxy.Setup_1_4_1.msi
+  InstallerSha256: 35EAF01EECFED1A25A628B7F47C83162E9C059E5DC6822B26B987FC2FB17556A
+  AppsAndFeaturesEntries:
+  - DisplayName: Buypass Javafree
+    Publisher: Buypass
+    ProductCode: '{F1C74CB2-8DF7-4C0E-BBCF-3A4116C0575A}'
+    UpgradeCode: '{503C6FBD-F0D6-4277-BD6C-44D33F56689B}'
+  InstallationMetadata:
+    DefaultInstallLocation: '%ProgramFiles(x86)%\Buypass\Javafree\NSSTools'
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/b/Buypass/Javafri/1.4.1.16/Buypass.Javafri.locale.en-US.yaml
+++ b/manifests/b/Buypass/Javafri/1.4.1.16/Buypass.Javafri.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# Created with komac v2.15.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Buypass.Javafri
+PackageVersion: 1.4.1.16
+PackageLocale: en-US
+Publisher: Buypass AS
+PublisherUrl: https://www.buypass.com/the-company
+PublisherSupportUrl: https://www.buypass.com/help
+PackageName: Javafri løsning
+PackageUrl: https://www.buypass.com/help/buypass-id/smartcard/javafri
+License: Proprietary
+Copyright: Copyright (c) Buypass AS. All rights reserved.
+ShortDescription: >
+  Buypass Javafri is a software solution that enables secure communication between your web browser
+  and Buypass Smart Card.
+Description: The solution is used by a number of our customer sites as well as in our authentication services.
+Tags:
+- buypass-javafree
+- norway
+- scproxy
+- smartcardreaders
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/b/Buypass/Javafri/1.4.1.16/Buypass.Javafri.yaml
+++ b/manifests/b/Buypass/Javafri/1.4.1.16/Buypass.Javafri.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.15.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Buypass.Javafri
+PackageVersion: 1.4.1.16
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Checklist for Pull Requests

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Is there a linked Issue? If so, fill in the Issue number below.
  - Resolves #350044

## Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

## Manual validation

> [!NOTE]
> 
> This package successfully installed in my _Windows Sandbox_ instance. But there's no desktop icon or startup menu icon created.
> 
> The package installed to `C:\Program Files (x86)\Buypass\Javafree`, but it can't launch as expected (no explicit UI pops up). Also there's no tray icon of the package. No errors (such as DLL not found) are shown.

<img width="1344" height="582" alt="Image" src="https://github.com/user-attachments/assets/3779f413-a442-4428-b638-387645062f99" />
<img width="1720" height="887" alt="Image" src="https://github.com/user-attachments/assets/0739fc30-e143-4357-9169-051dc24d18b2" />
<img width="1032" height="585" alt="Image" src="https://github.com/user-attachments/assets/61aeb16b-0945-4f54-9a3d-0cacca5388e5" />
<img width="1202" height="609" alt="Image" src="https://github.com/user-attachments/assets/d15251e5-e070-45f0-832b-4ed159bb9c56" />

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/350616)