### PR TITLE
Add Kiankinakomochi.unifocl version 1.0.0

### DIFF
--- a/manifests/k/Kiankinakomochi/unifocl/1.0.0/Kiankinakomochi.unifocl.installer.yaml
+++ b/manifests/k/Kiankinakomochi/unifocl/1.0.0/Kiankinakomochi.unifocl.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: Kiankinakomochi.unifocl
+PackageVersion: 1.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: unifocl-1.0.0-win-x64/unifocl.exe
+    PortableCommandAlias: unifocl
+InstallModes:
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Kiankinakomochi/unifocl/releases/download/v1.0.0/unifocl-1.0.0-win-x64.zip
+    InstallerSha256: 57082c2e9554b4f3a8afeb458be58e25baf76e607fca3a48bd148dd4e2952c44
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/k/Kiankinakomochi/unifocl/1.0.0/Kiankinakomochi.unifocl.locale.en-US.yaml
+++ b/manifests/k/Kiankinakomochi/unifocl/1.0.0/Kiankinakomochi.unifocl.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: Kiankinakomochi.unifocl
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: Kiankinakomochi
+PublisherUrl: https://github.com/Kiankinakomochi
+PublisherSupportUrl: https://github.com/Kiankinakomochi/unifocl/issues
+Author: Kinichi Anju Makino
+PackageName: unifocl
+PackageUrl: https://github.com/Kiankinakomochi/unifocl
+License: Apache-2.0
+LicenseUrl: https://github.com/Kiankinakomochi/unifocl/blob/main/LICENSE
+ShortDescription: Terminal-first Unity development companion.
+Description: unifocl is a terminal-first Unity development companion for project lifecycle, hierarchy, inspector, package, and build workflows through CLI and agentic execution paths.
+Moniker: unifocl
+ReleaseNotesUrl: https://github.com/Kiankinakomochi/unifocl/releases/tag/v1.0.0
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/k/Kiankinakomochi/unifocl/1.0.0/Kiankinakomochi.unifocl.yaml
+++ b/manifests/k/Kiankinakomochi/unifocl/1.0.0/Kiankinakomochi.unifocl.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: Kiankinakomochi.unifocl
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Summary
- Add new package manifest for Kiankinakomochi.unifocl version 1.0.0
- Installer type: zip with nested portable executable
- Source release assets: https://github.com/Kiankinakomochi/unifocl/releases/tag/v1.0.0

## Verification
- SHA256 (Windows x64 zip): 57082c2e9554b4f3a8afeb458be58e25baf76e607fca3a48bd148dd4e2952c44
- Nested portable path: unifocl-1.0.0-win-x64/unifocl.exe
- Command alias: unifocl

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/350729)