### PR TITLE
New version: axpnet.AeroFTP version 3.0.7

### DIFF
--- a/manifests/a/axpnet/AeroFTP/3.0.7/axpnet.AeroFTP.installer.yaml
+++ b/manifests/a/axpnet/AeroFTP/3.0.7/axpnet.AeroFTP.installer.yaml
@@ -1,0 +1,38 @@
+# Created with WinGet Releaser using komac v2.15.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: axpnet.AeroFTP
+PackageVersion: 3.0.7
+InstallerLocale: en-US
+ReleaseDate: 2026-03-21
+Installers:
+- Architecture: x64
+  InstallerType: nullsoft
+  Scope: user
+  InstallerUrl: https://github.com/axpnet/aeroftp/releases/download/v3.0.7/AeroFTP_3.0.6_x64-setup.exe
+  InstallerSha256: A2F32FB06471883E9E599AD513F979858AF78581F7154FD31C52A47C63173C35
+  InstallerSwitches:
+    Silent: /S
+    SilentWithProgress: /S
+  ProductCode: AeroFTP
+  AppsAndFeaturesEntries:
+  - Publisher: aeroftp
+    DisplayVersion: 3.0.6
+    ProductCode: AeroFTP
+  InstallationMetadata:
+    DefaultInstallLocation: '%LocalAppData%\AeroFTP'
+- Architecture: x64
+  InstallerType: wix
+  Scope: machine
+  InstallerUrl: https://github.com/axpnet/aeroftp/releases/download/v3.0.7/AeroFTP_3.0.6_x64_en-US.msi
+  InstallerSha256: E3130C0AE7EAF38D94CBAE5E37DF5BBAB618B6F03A55F10ADB2A80877A1180DF
+  ProductCode: '{9A41768D-FD7B-48A3-8DDB-F976CB2B866D}'
+  AppsAndFeaturesEntries:
+  - Publisher: aeroftp
+    DisplayVersion: 3.0.6
+    ProductCode: '{9A41768D-FD7B-48A3-8DDB-F976CB2B866D}'
+    UpgradeCode: '{3A660390-AA69-5CCD-A202-013C64158D37}'
+  InstallationMetadata:
+    DefaultInstallLocation: '%ProgramFiles%/AeroFTP'
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/axpnet/AeroFTP/3.0.7/axpnet.AeroFTP.locale.en-US.yaml
+++ b/manifests/a/axpnet/AeroFTP/3.0.7/axpnet.AeroFTP.locale.en-US.yaml
@@ -1,0 +1,61 @@
+# Created with WinGet Releaser using komac v2.15.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: axpnet.AeroFTP
+PackageVersion: 3.0.7
+PackageLocale: en-US
+Publisher: axpnet
+PublisherUrl: https://github.com/axpnet
+PublisherSupportUrl: https://github.com/axpnet/aeroftp/issues
+Author: axpnet
+PackageName: AeroFTP
+PackageUrl: https://github.com/axpnet/aeroftp
+License: GPL-3.0
+LicenseUrl: https://github.com/axpnet/aeroftp/blob/HEAD/LICENSE
+ShortDescription: A modern, multi-protocol file manager and FTP client with integrated AI, cloud sync, and military-grade encryption.
+Description: |-
+  AeroFTP is an open-source, multi-protocol file manager built with Tauri 2 (Rust + React 18 + TypeScript).
+  It supports 16 protocols (FTP, FTPS, SFTP, WebDAV, S3, Google Drive, Dropbox, OneDrive, MEGA, Box, pCloud, Azure Blob, 4shared, Filen, Zoho WorkDrive, and Cryptomator vaults),
+  features an AI assistant with 45 tools and 15 LLM providers, military-grade encrypted vaults (AES-256-GCM-SIV + Argon2id),
+  bidirectional real-time sync, a built-in code editor, SSH terminal, and media player with visualizers.
+  Available in 47 languages with 4 themes.
+Moniker: aeroftp
+Tags:
+- cloud-storage
+- encryption
+- file-manager
+- file-transfer
+- ftp
+- ftp-client
+- multi-protocol
+- rust
+- s3
+- sftp
+- sync
+- tauri
+- webdav
+ReleaseNotes: |-
+  [3.0.7] - 2026-03-21
+  Filen Encrypted Notes, Provider Toolbar & UX Polish
+  End-to-end encrypted notes for Filen with per-note AES-256-GCM keys, provider-specific toolbar buttons replacing context menu clutter, and connection UX improvements.
+  Added
+  - Filen Encrypted Notes (Beta): Full CRUD for Filen's E2E encrypted notes — create, read, edit, trash, archive, restore, delete. Per-note AES-256-GCM key derived via PBKDF2, encrypted with master key. Auto-save (2s debounce) + manual save button. Version history viewer with restore. Tag management (create, rename, delete, assign/remove). Filter by All/Favorites/Pinned/Archived/Trash. 20 Tauri commands, filen/notes.rs module (660 lines)
+  - Filen Notes toolbar button: Emerald FileText icon in remote address bar when connected to Filen — same pattern as GitHub Actions/Releases/Pages buttons
+  - Provider trash toolbar button: Single conditional Trash2 button in remote address bar for 10 providers (Zoho, Jottacloud, MEGA, Google Drive, Box, Dropbox, FileLu, Koofr, OpenDrive, Yandex). Replaces per-provider "View Trash" entries in context menu
+  - Connect loading spinner: Persistent Loader2 spinner on saved server connect button with disabled state preventing double-click. Awaits full connection lifecycle via async onConnect
+  - GitHub file dates: Parallel per-file last-commit date fetching via Commits API (10 concurrent, capped at 60 entries) — GitHub file listings now show modification dates
+  Fixed
+  - GitHub sync navigation: resolve_path("/") was treating root as current directory — synchronized navigation broke on upward traversal when remote panel received cd("/")
+  - Filen module structure: Refactored filen.rs (1607 lines) into filen/mod.rs + filen/notes.rs directory module for maintainability
+  - Context menu cleanup: Removed ~50 lines of "View Trash" entries from right-click menu across 10 providers — now accessible via toolbar button
+  Changed
+  - Saved Servers button styling: Health Check (emerald) and Export/Import (amber) buttons match AeroCloud/AeroFile compact badge style — p-1.5 padding, 16px icons, colored backgrounds
+  - Save feedback in note editor: Three-state indicator — amber "Unsaved", blue spinner "Saving...", green check "Saved"
+  - 18 i18n keys: Filen Notes UI strings translated in all 47 languages
+  Downloads:
+  - Windows: .msi installer or .exe
+  - macOS: .dmg disk image
+  - Linux: .deb, .rpm, .snap, or .AppImage
+ReleaseNotesUrl: https://github.com/axpnet/aeroftp/releases/tag/v3.0.7
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/axpnet/AeroFTP/3.0.7/axpnet.AeroFTP.yaml
+++ b/manifests/a/axpnet/AeroFTP/3.0.7/axpnet.AeroFTP.yaml
@@ -1,0 +1,8 @@
+# Created with WinGet Releaser using komac v2.15.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: axpnet.AeroFTP
+PackageVersion: 3.0.7
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Closing in favor of #350745 (v3.0.8) which supersedes this version. The v3.0.7 validation failed with STATUS_DLL_NOT_FOUND.