### PR TITLE
rushabhpasad.MDEditor version 1.1.0

### DIFF
--- a/manifests/r/rushabhpasad/MDEditor/1.1.0/rushabhpasad.MDEditor.installer.yaml
+++ b/manifests/r/rushabhpasad/MDEditor/1.1.0/rushabhpasad.MDEditor.installer.yaml
@@ -1,0 +1,16 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: rushabhpasad.MDEditor
+PackageVersion: 1.1.0
+InstallerLocale: en-US
+InstallerType: msi
+Scope: user
+InstallModes:
+- interactive
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/rushabhpasad/md-editor/releases/download/v1.1.0/MD.Editor_1.1.0_x64_en-US.msi
+  InstallerSha256: cf3f590b5b6616c4a63bbaebf4fd16a6c5f82d8fa7215d3a965ff1132febf2f1
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/r/rushabhpasad/MDEditor/1.1.0/rushabhpasad.MDEditor.locale.en-US.yaml
+++ b/manifests/r/rushabhpasad/MDEditor/1.1.0/rushabhpasad.MDEditor.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: rushabhpasad.MDEditor
+PackageVersion: 1.1.0
+PackageLocale: en-US
+Publisher: rushabhpasad
+PublisherUrl: https://github.com/rushabhpasad
+PackageName: MD Editor
+PackageUrl: https://github.com/rushabhpasad/md-editor
+License: MIT
+LicenseUrl: https://github.com/rushabhpasad/md-editor/blob/main/LICENSE
+ShortDescription: Lightweight cross-platform desktop Markdown editor with live split-pane preview
+Tags:
+- markdown
+- editor
+- markdown-editor
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/r/rushabhpasad/MDEditor/1.1.0/rushabhpasad.MDEditor.yaml
+++ b/manifests/r/rushabhpasad/MDEditor/1.1.0/rushabhpasad.MDEditor.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: rushabhpasad.MDEditor
+PackageVersion: 1.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## rushabhpasad.MDEditor version 1.1.0

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Is there a linked Issue?  If so, fill in the Issue number below.
  - Resolves #[Issue Number]

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

---

New package submission for **MD Editor v1.1.0** — a lightweight cross-platform desktop Markdown editor with live split-pane preview (Tauri v2 + React).

**Release notes:** https://github.com/rushabhpasad/md-editor/releases/tag/v1.1.0

**Changes in v1.1.0:**
- Dashboard welcome screen on cold start / when no tabs are open
- Custom Find/Replace bar in the editor (Cmd+F) with match count
- Find bar in the Preview pane
- Export dialog: Print Preview (PDF) and Print Raw Markdown options added
- Font & line height settings now apply correctly to editor and preview
- Undo no longer blanks the editor after opening a file
- Save command fixed (stale-closure bug — now always saves in-place for existing files)
- Close window dialog now has a proper Cancel option
- Cmd+O opens files in a new tab instead of replacing the current one
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/350900)