### PR TITLE
New package: aahepburn.RAGAssistantForZotero version 0.4.5

### DIFF
--- a/manifests/a/aahepburn/RAGAssistantForZotero/0.4.5/aahepburn.RAGAssistantForZotero.installer.yaml
+++ b/manifests/a/aahepburn/RAGAssistantForZotero/0.4.5/aahepburn.RAGAssistantForZotero.installer.yaml
@@ -1,0 +1,17 @@
+PackageIdentifier: aahepburn.RAGAssistantForZotero
+PackageVersion: 0.4.5
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/aahepburn/RAG-Assistant-for-Zotero/releases/download/v0.4.5/RAG.Assistant-0.4.5-win-x64.exe
+    InstallerSha256: c3126252510ef8222f3588afc901735ef4af9cc59502255a559edd78a3d4004b
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/a/aahepburn/RAGAssistantForZotero/0.4.5/aahepburn.RAGAssistantForZotero.installer.yaml
+++ b/manifests/a/aahepburn/RAGAssistantForZotero/0.4.5/aahepburn.RAGAssistantForZotero.installer.yaml
@@ -12,6 +12,6 @@ UpgradeBehavior: install
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/aahepburn/RAG-Assistant-for-Zotero/releases/download/v0.4.5/RAG.Assistant-0.4.5-win-x64.exe
-    InstallerSha256: c3126252510ef8222f3588afc901735ef4af9cc59502255a559edd78a3d4004b
+    InstallerSha256: 3e0ee4a1c257a502175bb8dd1c8fbe1a493a2c8fc7cc79b9519e4d24d778abdc
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/a/aahepburn/RAGAssistantForZotero/0.4.5/aahepburn.RAGAssistantForZotero.locale.en-US.yaml
+++ b/manifests/a/aahepburn/RAGAssistantForZotero/0.4.5/aahepburn.RAGAssistantForZotero.locale.en-US.yaml
@@ -1,0 +1,27 @@
+PackageIdentifier: aahepburn.RAGAssistantForZotero
+PackageVersion: 0.4.5
+PackageLocale: en-US
+Publisher: Alexander Hepburn
+PublisherUrl: https://github.com/aahepburn
+PublisherSupportUrl: https://github.com/aahepburn/RAG-Assistant-for-Zotero/issues
+PackageName: RAG Assistant for Zotero
+PackageUrl: https://github.com/aahepburn/RAG-Assistant-for-Zotero
+License: Apache-2.0
+LicenseUrl: https://github.com/aahepburn/RAG-Assistant-for-Zotero/blob/master/LICENSE
+ShortDescription: AI-powered research assistant for your Zotero library
+Description: |-
+  RAG Assistant for Zotero is an AI-powered research assistant that lets you
+  chat with your Zotero library using natural language. It uses retrieval-
+  augmented generation (RAG) to provide cited answers from your research
+  papers and documents, and works with local models (Ollama) or cloud APIs
+  (OpenAI, Anthropic, Google, Mistral, and others).
+Tags:
+  - zotero
+  - ai
+  - research
+  - rag
+  - llm
+  - assistant
+  - productivity
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/a/aahepburn/RAGAssistantForZotero/0.4.5/aahepburn.RAGAssistantForZotero.yaml
+++ b/manifests/a/aahepburn/RAGAssistantForZotero/0.4.5/aahepburn.RAGAssistantForZotero.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: aahepburn.RAGAssistantForZotero
+PackageVersion: 0.4.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## New package submission

**Package:** aahepburn.RAGAssistantForZotero  
**Version:** 0.4.5  
**Publisher:** Alexander Hepburn  

An open‑source desktop RAG application that enables semantic search across your Zotero library. Easily discover conceptually related papers and ideas within your PDF collection using local or cloud‑based LLMs. The app provides source attribution, metadata filtering, and seamless integration with Zotero to support deeper, more efficient research.

- License: Apache-2.0
- Homepage: https://github.com/aahepburn/RAG-Assistant-for-Zotero
- Installer: NSIS, user scope, x64
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/350915)