### PR TITLE
Update ESET.Security 18.1.13.0 installer hash

### DIFF
--- a/manifests/e/ESET/Security/18.1.13.0/ESET.Security.installer.yaml
+++ b/manifests/e/ESET/Security/18.1.13.0/ESET.Security.installer.yaml
@@ -18,6 +18,6 @@ ProductCode: '{0F3CB7F7-E580-4E9D-BC90-58BF9A860742}'
 Installers:
 - Architecture: x86
   InstallerUrl: https://download.eset.com/com/eset/tools/installers/live_eis/latest/eset_internet_security_live_installer.exe
-  InstallerSha256: B7D3A04CFDF3950454CF612442EA4D2441D7FC9EBA0BEB0C7A89ADF7D3AC150B
+  InstallerSha256: 3D5DC868933DA8D6140914922B7E1377E439B15C0F0BE625DD81A58A53BC3CF6
 ManifestType: installer
 ManifestVersion: 1.10.0


### PR DESCRIPTION
## Summary
- Updated `InstallerSha256` for ESET.Security 18.1.13.0
- The live installer URL (`https://download.eset.com/com/eset/tools/installers/live_eis/latest/eset_internet_security_live_installer.exe`) returns an updated binary, causing `winget install ESET.Security` to fail with "Installer hash does not match"
- New hash: `3D5DC868933DA8D6140914922B7E1377E439B15C0F0BE625DD81A58A53BC3CF6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/350938)