### PR TITLE
Fix invalid manifest key and add valid Documentations entries

### DIFF
--- a/manifests/g/Garmin/Express/7.28.0/Garmin.Express.locale.en-US.yaml
+++ b/manifests/g/Garmin/Express/7.28.0/Garmin.Express.locale.en-US.yaml
@@ -32,6 +32,10 @@ Tags:
   - gps
   - maps
   - sync
-DocumentationUrl: https://support.garmin.com/en-US/?productID=180766&tab=topics
+Documentations:
+- DocumentLabel: Get Help
+  DocumentUrl: https://support.garmin.com/en-US/?productID=168768&tab=topics
+- DocumentLabel: Video Tutorials
+  DocumentUrl: https://support.garmin.com/en-US/?productID=168768&tab=videos
 ManifestType: defaultLocale
 ManifestVersion: 1.10.0


### PR DESCRIPTION
This PR fixes an invalid documentation field in the Garmin Express 7.28.0 manifest.

- Removed the unsupported standalone `DocumentationUrl` key
- Replaced it with a valid `Documentations` block
- Used existing Garmin Express support links that are not version-specific and remain valid
- Removed the broken 404 documentation link

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?

Manifests
- [x] This PR only modifies one (1) manifest

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/351069)