### PR TITLE
New package: adamtheturtle.literalizer-cli version 2026.03.23.6

### DIFF
--- a/manifests/a/adamtheturtle/literalizer-cli/2026.03.23.6/adamtheturtle.literalizer-cli.installer.yaml
+++ b/manifests/a/adamtheturtle/literalizer-cli/2026.03.23.6/adamtheturtle.literalizer-cli.installer.yaml
@@ -1,0 +1,14 @@
+# Created with Komac v2.15.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: adamtheturtle.literalizer-cli
+PackageVersion: 2026.03.23.6
+InstallerType: portable
+Commands:
+  - literalize
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/adamtheturtle/literalizer-cli/releases/download/2026.03.23.6/literalize-windows.exe
+    InstallerSha256: 40B80EED735E788B02F5369C32CD9B178F04B05F9CD0062B59646E9834439D99
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/a/adamtheturtle/literalizer-cli/2026.03.23.6/adamtheturtle.literalizer-cli.locale.en-US.yaml
+++ b/manifests/a/adamtheturtle/literalizer-cli/2026.03.23.6/adamtheturtle.literalizer-cli.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# Created with Komac v2.15.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: adamtheturtle.literalizer-cli
+PackageVersion: 2026.03.23.6
+PackageLocale: en-US
+Publisher: Adam Dangoor
+PublisherUrl: https://github.com/adamtheturtle
+PublisherSupportUrl: https://github.com/adamtheturtle/literalizer-cli/issues
+Author: Adam Dangoor
+PackageName: literalizer-cli
+PackageUrl: https://github.com/adamtheturtle/literalizer-cli
+License: MIT
+LicenseUrl: https://github.com/adamtheturtle/literalizer-cli/blob/main/LICENSE
+ShortDescription: Convert data structures to native language literal syntax
+Description: CLI for literalizer - convert data structures to native language literal syntax. Supports Python, Rust, and Go output formats.
+Tags:
+  - cli
+  - go
+  - json
+  - python
+  - rust
+ReleaseNotesUrl: https://github.com/adamtheturtle/literalizer-cli/releases/tag/2026.03.23.6
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/a/adamtheturtle/literalizer-cli/2026.03.23.6/adamtheturtle.literalizer-cli.yaml
+++ b/manifests/a/adamtheturtle/literalizer-cli/2026.03.23.6/adamtheturtle.literalizer-cli.yaml
@@ -1,0 +1,8 @@
+# Created with Komac v2.15.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: adamtheturtle.literalizer-cli
+PackageVersion: 2026.03.23.6
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
### New Package Submission

- Package Identifier: adamtheturtle.literalizer-cli
- Package Version: 2026.03.23.6
- Package Name: literalizer-cli
- Publisher: Adam Dangoor
- License: MIT

### Description
CLI for literalizer - convert data structures to native language literal syntax. Supports Python, Rust, and Go output formats.

### URLs
- Package URL: https://github.com/adamtheturtle/literalizer-cli
- Release Notes: https://github.com/adamtheturtle/literalizer-cli/releases/tag/2026.03.23.6