### PR TITLE
Add FerumLanguage.ferrumc 0.3.0

### DIFF
--- a/manifests/f/FerumLanguage/ferrumc/0.3.0/FerumLanguage.ferrumc.installer.yaml
+++ b/manifests/f/FerumLanguage/ferrumc/0.3.0/FerumLanguage.ferrumc.installer.yaml
@@ -1,0 +1,18 @@
+PackageIdentifier: FerumLanguage.ferrumc
+PackageVersion: 0.3.0
+MinimumOSVersion: "10.0.0.0"
+InstallerType: zip
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Ferrum-Language/Ferrum/releases/download/v0.3.0/ferrumc-v0.3.0-windows-x86_64.zip
+    InstallerSha256: 4b332aee1b5d2eb954a25706d1eec1203b23cd4de4776493be833cb39e22518d
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: ferrumc.exe
+        PortableCommandAlias: ferrumc
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/f/FerumLanguage/ferrumc/0.3.0/FerumLanguage.ferrumc.installer.yaml
+++ b/manifests/f/FerumLanguage/ferrumc/0.3.0/FerumLanguage.ferrumc.installer.yaml
@@ -2,10 +2,6 @@ PackageIdentifier: FerumLanguage.ferrumc
 PackageVersion: 0.3.0
 MinimumOSVersion: "10.0.0.0"
 InstallerType: zip
-InstallModes:
-  - interactive
-  - silent
-  - silentWithProgress
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/Ferrum-Language/Ferrum/releases/download/v0.3.0/ferrumc-v0.3.0-windows-x86_64.zip

--- a/manifests/f/FerumLanguage/ferrumc/0.3.0/FerumLanguage.ferrumc.installer.yaml
+++ b/manifests/f/FerumLanguage/ferrumc/0.3.0/FerumLanguage.ferrumc.installer.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 PackageIdentifier: FerumLanguage.ferrumc
 PackageVersion: 0.3.0
 MinimumOSVersion: "10.0.0.0"

--- a/manifests/f/FerumLanguage/ferrumc/0.3.0/FerumLanguage.ferrumc.locale.en-US.yaml
+++ b/manifests/f/FerumLanguage/ferrumc/0.3.0/FerumLanguage.ferrumc.locale.en-US.yaml
@@ -3,11 +3,12 @@ PackageVersion: 0.3.0
 PackageLocale: en-US
 Publisher: Ferrum-Language
 PublisherUrl: https://github.com/Ferrum-Language
+PublisherSupportUrl: https://github.com/Ferrum-Language/Ferrum/issues
 PackageName: ferrumc
 PackageUrl: https://ferrum-language.github.io/Ferrum/
-License: GPL-3.0
+License: GPL-3.0-only
 LicenseUrl: https://github.com/Ferrum-Language/Ferrum/blob/main/LICENSE
-ShortDescription: Ferrum-language compiler — systems programming with compile-time memory safety
+ShortDescription: Ferrum-language compiler with compile-time memory safety
 Description: |
   Ferrum-language is a systems programming language with C syntax and
   compile-time memory safety via a borrow checker and ownership model.
@@ -18,6 +19,6 @@ Tags:
   - llvm
   - memory-safety
   - systems-programming
-ReleaseNotes: https://github.com/Ferrum-Language/Ferrum/releases/tag/v0.3.0
+ReleaseNotesUrl: https://github.com/Ferrum-Language/Ferrum/releases/tag/v0.3.0
 ManifestType: defaultLocale
 ManifestVersion: 1.9.0

--- a/manifests/f/FerumLanguage/ferrumc/0.3.0/FerumLanguage.ferrumc.locale.en-US.yaml
+++ b/manifests/f/FerumLanguage/ferrumc/0.3.0/FerumLanguage.ferrumc.locale.en-US.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 PackageIdentifier: FerumLanguage.ferrumc
 PackageVersion: 0.3.0
 PackageLocale: en-US

--- a/manifests/f/FerumLanguage/ferrumc/0.3.0/FerumLanguage.ferrumc.locale.en-US.yaml
+++ b/manifests/f/FerumLanguage/ferrumc/0.3.0/FerumLanguage.ferrumc.locale.en-US.yaml
@@ -1,0 +1,23 @@
+PackageIdentifier: FerumLanguage.ferrumc
+PackageVersion: 0.3.0
+PackageLocale: en-US
+Publisher: Ferrum-Language
+PublisherUrl: https://github.com/Ferrum-Language
+PackageName: ferrumc
+PackageUrl: https://ferrum-language.github.io/Ferrum/
+License: MIT
+LicenseUrl: https://github.com/Ferrum-Language/Ferrum/blob/main/LICENSE
+ShortDescription: Ferrum-language compiler — systems programming with compile-time memory safety
+Description: |
+  Ferrum-language is a systems programming language with C syntax and
+  compile-time memory safety via a borrow checker and ownership model.
+  Compiled to native code through LLVM 18. No garbage collector, no runtime.
+Tags:
+  - compiler
+  - language
+  - llvm
+  - memory-safety
+  - systems-programming
+ReleaseNotes: https://github.com/Ferrum-Language/Ferrum/releases/tag/v0.3.0
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/f/FerumLanguage/ferrumc/0.3.0/FerumLanguage.ferrumc.locale.en-US.yaml
+++ b/manifests/f/FerumLanguage/ferrumc/0.3.0/FerumLanguage.ferrumc.locale.en-US.yaml
@@ -5,7 +5,7 @@ Publisher: Ferrum-Language
 PublisherUrl: https://github.com/Ferrum-Language
 PackageName: ferrumc
 PackageUrl: https://ferrum-language.github.io/Ferrum/
-License: MIT
+License: GPL-3.0
 LicenseUrl: https://github.com/Ferrum-Language/Ferrum/blob/main/LICENSE
 ShortDescription: Ferrum-language compiler — systems programming with compile-time memory safety
 Description: |

--- a/manifests/f/FerumLanguage/ferrumc/0.3.0/FerumLanguage.ferrumc.yaml
+++ b/manifests/f/FerumLanguage/ferrumc/0.3.0/FerumLanguage.ferrumc.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: FerumLanguage.ferrumc
+PackageVersion: 0.3.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0

--- a/manifests/f/FerumLanguage/ferrumc/0.3.0/FerumLanguage.ferrumc.yaml
+++ b/manifests/f/FerumLanguage/ferrumc/0.3.0/FerumLanguage.ferrumc.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
 PackageIdentifier: FerumLanguage.ferrumc
 PackageVersion: 0.3.0
 DefaultLocale: en-US

--- a/manifests/f/FerumLanguage/ferrumc/0.3.0/FerumLanguage.ferrumc.yaml
+++ b/manifests/f/FerumLanguage/ferrumc/0.3.0/FerumLanguage.ferrumc.yaml
@@ -1,28 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<component type="console-application">
-  <id>org.ferrum_lang.ferrumc</id>
-  <name>ferrumc</name>
-  <summary>Ferrum-language compiler with compile-time memory safety</summary>
-  <metadata_license>CC0-1.0</metadata_license>
-  <project_license>GPL-3.0-only</project_license>
-  <description>
-    <p>
-      Ferrum-language is a systems programming language with C syntax and
-      compile-time memory safety via a borrow checker and ownership model.
-      Compiled to native code through LLVM 18.
-    </p>
-    <ul>
-      <li>Ownership and move semantics</li>
-      <li>Immutable and mutable borrows enforced at compile time</li>
-      <li>Opt-in unsafe blocks for raw pointer arithmetic and FFI</li>
-      <li>C interoperability via #include</li>
-      <li>Zero runtime overhead — no garbage collector, no reference counting</li>
-    </ul>
-  </description>
-  <url type="homepage">https://ferrum-language.github.io/Ferrum/</url>
-  <url type="bugtracker">https://github.com/Ferrum-Language/Ferrum/issues</url>
-  <releases>
-    <release version="0.3.0" date="2026-03-23"/>
-  </releases>
-  <content_rating type="oars-1.1"/>
-</component>
+PackageIdentifier: FerumLanguage.ferrumc
+PackageVersion: 0.3.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0

--- a/manifests/f/FerumLanguage/ferrumc/0.3.0/FerumLanguage.ferrumc.yaml
+++ b/manifests/f/FerumLanguage/ferrumc/0.3.0/FerumLanguage.ferrumc.yaml
@@ -1,5 +1,28 @@
-PackageIdentifier: FerumLanguage.ferrumc
-PackageVersion: 0.3.0
-DefaultLocale: en-US
-ManifestType: version
-ManifestVersion: 1.9.0
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="console-application">
+  <id>org.ferrum_lang.ferrumc</id>
+  <name>ferrumc</name>
+  <summary>Ferrum-language compiler with compile-time memory safety</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-only</project_license>
+  <description>
+    <p>
+      Ferrum-language is a systems programming language with C syntax and
+      compile-time memory safety via a borrow checker and ownership model.
+      Compiled to native code through LLVM 18.
+    </p>
+    <ul>
+      <li>Ownership and move semantics</li>
+      <li>Immutable and mutable borrows enforced at compile time</li>
+      <li>Opt-in unsafe blocks for raw pointer arithmetic and FFI</li>
+      <li>C interoperability via #include</li>
+      <li>Zero runtime overhead — no garbage collector, no reference counting</li>
+    </ul>
+  </description>
+  <url type="homepage">https://ferrum-language.github.io/Ferrum/</url>
+  <url type="bugtracker">https://github.com/Ferrum-Language/Ferrum/issues</url>
+  <releases>
+    <release version="0.3.0" date="2026-03-23"/>
+  </releases>
+  <content_rating type="oars-1.1"/>
+</component>


### PR DESCRIPTION
## Description
New package submission for Ferrum-language compiler v0.3.0.

Ferrum-language is a systems programming language with C syntax and compile-time memory safety via a borrow checker and ownership system — compiled to native code through LLVM 18.

- **Homepage:** https://ferrum-language.github.io/Ferrum/
- **License:** MIT
- **GitHub:** https://github.com/Ferrum-Language/Ferrum
- **Release:** https://github.com/Ferrum-Language/Ferrum/releases/tag/v0.3.0

## Validation
- [x] SHA256 verified against release asset
- [x] Installer type: portable zip
- [x] `ferrumc.exe` extracted and accessible via PATH alias `ferrumc`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/351339)