### PR TITLE
Update willibrandon.dotsider-mcp to 0.6.1

### DIFF
--- a/manifests/w/willibrandon/dotsider-mcp/0.6.1/willibrandon.dotsider-mcp.installer.yaml
+++ b/manifests/w/willibrandon/dotsider-mcp/0.6.1/willibrandon.dotsider-mcp.installer.yaml
@@ -1,0 +1,27 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: willibrandon.dotsider-mcp
+PackageVersion: 0.6.1
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.18362.0
+InstallerType: msi
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/willibrandon/dotsider/releases/download/v0.6.1/dotsider-mcp-win-x64.msi
+  InstallerSha256: 9B777B4B757FF184589FE294E381B06EDF7F9D1E57887678DDF6C326EB8CD2B4
+  ProductCode: '{C16A29B5-5669-4E9A-B9FC-0FFC613EE5E6}'
+- Architecture: arm64
+  InstallerUrl: https://github.com/willibrandon/dotsider/releases/download/v0.6.1/dotsider-mcp-win-arm64.msi
+  InstallerSha256: 16A839CE2B2691416094783B4072A408756BC8CE3A286C65436A7FE72AF7FA77
+  ProductCode: '{57FB30C0-977F-4247-A445-3CCFC29255C5}'
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-03-24

--- a/manifests/w/willibrandon/dotsider-mcp/0.6.1/willibrandon.dotsider-mcp.locale.en-US.yaml
+++ b/manifests/w/willibrandon/dotsider-mcp/0.6.1/willibrandon.dotsider-mcp.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: willibrandon.dotsider-mcp
+PackageVersion: 0.6.1
+PackageLocale: en-US
+Publisher: willibrandon
+PublisherUrl: https://github.com/willibrandon
+PublisherSupportUrl: https://github.com/willibrandon/dotsider/issues
+PackageName: dotsider-mcp
+PackageUrl: https://github.com/willibrandon/dotsider
+License: MIT
+LicenseUrl: https://github.com/willibrandon/dotsider/blob/main/LICENSE
+ShortDescription: MCP server for AI-assisted .NET assembly analysis
+Description: |-
+  dotsider-mcp is a standalone Model Context Protocol server that exposes
+  dotsider's .NET assembly analysis engine to AI coding assistants like
+  Claude Code, VS Code Copilot, and others. It provides 28 tools for
+  assembly analysis, IL disassembly, metadata inspection, dependency graphs,
+  size analysis, string extraction, diffing, and runtime tracing.
+Tags:
+- dotnet
+- assembly
+- mcp
+- ai
+- analysis
+- il
+- metadata
+- devtools
+ReleaseNotesUrl: https://github.com/willibrandon/dotsider/releases/tag/v0.6.1
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/willibrandon/dotsider/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/w/willibrandon/dotsider-mcp/0.6.1/willibrandon.dotsider-mcp.yaml
+++ b/manifests/w/willibrandon/dotsider-mcp/0.6.1/willibrandon.dotsider-mcp.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: willibrandon.dotsider-mcp
+PackageVersion: 0.6.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Update dotsider-mcp to version 0.6.1

## Release notes

https://github.com/willibrandon/dotsider/releases/tag/v0.6.1
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/351372)