### PR TITLE
Adds manifest for Kemforge 1.3.2 to winget

### DIFF
--- a/manifests/c/ConnectingApps/Kemforge/1.3.2/ConnectingApps.Kemforge.installer.yaml
+++ b/manifests/c/ConnectingApps/Kemforge/1.3.2/ConnectingApps.Kemforge.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: ConnectingApps.Kemforge
+PackageVersion: 1.3.2
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: kemforge.exe
+    PortableCommandAlias: kemforge
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/ConnectingApps/kemforge/releases/download/v1.3.2/kemforge.zip
+    InstallerSha256: FBF0E82058E8F2814E1269C0EA2B953C8678F5592CAD6AA8EC8C49E4419A23F4
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/ConnectingApps/Kemforge/1.3.2/ConnectingApps.Kemforge.locale.en-US.yaml
+++ b/manifests/c/ConnectingApps/Kemforge/1.3.2/ConnectingApps.Kemforge.locale.en-US.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: ConnectingApps.Kemforge
+PackageVersion: 1.3.2
+PackageLocale: en-US
+Publisher: Connecting Apps
+PackageName: Kemforge
+ShortDescription: A modern, curl-compatible CLI tool for making web requests with Post-Quantum Cryptography (PQC) support.
+License: GPL-3.0-only
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/ConnectingApps/Kemforge/1.3.2/ConnectingApps.Kemforge.yaml
+++ b/manifests/c/ConnectingApps/Kemforge/1.3.2/ConnectingApps.Kemforge.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: ConnectingApps.Kemforge
+PackageVersion: 1.3.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Introduces installer, version, and locale manifests for Kemforge CLI tool version 1.3.2, enabling distribution via Windows Package Manager. Facilitates discovery and installation with metadata, licensing, and portable deployment details.

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Is there a linked Issue?  No

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

@microsoft-github-policy-service agree

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/351466)