### PR TITLE
New package: FernandoTonon.QtMeshEditor version 2.16.1

### DIFF
--- a/manifests/f/FernandoTonon/QtMeshEditor/2.16.1/FernandoTonon.QtMeshEditor.installer.yaml
+++ b/manifests/f/FernandoTonon/QtMeshEditor/2.16.1/FernandoTonon.QtMeshEditor.installer.yaml
@@ -4,9 +4,9 @@ PackageVersion: 2.16.1
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
-  - RelativeFilePath: QtMeshEditor.exe
+  - RelativeFilePath: bin\QtMeshEditor.exe
     PortableCommandAlias: qtmesheditor
-  - RelativeFilePath: qtmesh.exe
+  - RelativeFilePath: bin\qtmesh.exe
     PortableCommandAlias: qtmesh
 Installers:
   - Architecture: x64

--- a/manifests/f/FernandoTonon/QtMeshEditor/2.16.1/FernandoTonon.QtMeshEditor.installer.yaml
+++ b/manifests/f/FernandoTonon/QtMeshEditor/2.16.1/FernandoTonon.QtMeshEditor.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: FernandoTonon.QtMeshEditor
+PackageVersion: 2.16.1
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: QtMeshEditor.exe
+    PortableCommandAlias: qtmesheditor
+  - RelativeFilePath: qtmesh.exe
+    PortableCommandAlias: qtmesh
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/fernandotonon/QtMeshEditor/releases/download/2.16.1/QtMeshEditor-2.16.1-bin-Windows.zip
+    InstallerSha256: C0EAA88B4F2568415190D94F19F5F6EFD8170DDE4BC46D5FEE265CF93B3A129B
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/FernandoTonon/QtMeshEditor/2.16.1/FernandoTonon.QtMeshEditor.locale.en-US.yaml
+++ b/manifests/f/FernandoTonon/QtMeshEditor/2.16.1/FernandoTonon.QtMeshEditor.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: FernandoTonon.QtMeshEditor
+PackageVersion: 2.16.1
+PackageLocale: en-US
+Publisher: Fernando Tonon
+PublisherUrl: https://github.com/fernandotonon
+PublisherSupportUrl: https://github.com/fernandotonon/QtMeshEditor/issues
+PackageName: QtMeshEditor
+PackageUrl: https://github.com/fernandotonon/QtMeshEditor
+License: MIT
+LicenseUrl: https://github.com/fernandotonon/QtMeshEditor/blob/master/License
+ShortDescription: Free 3D asset tool for indie game developers
+Description: |-
+  QtMeshEditor is a free 3D asset tool for indie game developers.
+  Merge animations from multiple files, convert between 40+ formats,
+  edit materials with AI, and inspect skeletons and bone weights.
+  Supports GUI, CLI (qtmesh), and REST API via MCP server.
+Tags:
+  - 3d
+  - mesh-editor
+  - animation
+  - fbx
+  - gltf
+  - ogre3d
+  - game-development
+  - material-editor
+Moniker: qtmesheditor
+ReleaseNotesUrl: https://github.com/fernandotonon/QtMeshEditor/releases/tag/2.16.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/FernandoTonon/QtMeshEditor/2.16.1/FernandoTonon.QtMeshEditor.yaml
+++ b/manifests/f/FernandoTonon/QtMeshEditor/2.16.1/FernandoTonon.QtMeshEditor.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: FernandoTonon.QtMeshEditor
+PackageVersion: 2.16.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New package submission

- **Package ID**: FernandoTonon.QtMeshEditor
- **Version**: 2.16.1
- **Installer type**: zip (portable)
- **Architecture**: x64
- **Manifest schema**: 1.12.0

### About

QtMeshEditor is a free, open-source 3D asset tool for indie game developers. Merge animations from multiple files, convert between 40+ formats, edit materials with AI, and more.

- GitHub: https://github.com/fernandotonon/QtMeshEditor
- License: MIT

### Portable commands

- `qtmesheditor` — GUI editor
- `qtmesh` — CLI pipeline tool
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/351752)