### PR TITLE
Enable ArchiveBinariesDependOnPath in installer YAML

### DIFF
--- a/manifests/g/Gyan/FFmpeg/Shared/8.1/Gyan.FFmpeg.Shared.installer.yaml
+++ b/manifests/g/Gyan/FFmpeg/Shared/8.1/Gyan.FFmpeg.Shared.installer.yaml
@@ -13,6 +13,7 @@ NestedInstallerFiles:
 - RelativeFilePath: ffmpeg-8.1-full_build-shared\bin\ffprobe.exe
   PortableCommandAlias: ffprobe
 ReleaseDate: 2026-03-17
+ArchiveBinariesDependOnPath: true
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/GyanD/codexffmpeg/releases/download/8.1/ffmpeg-8.1-full_build-shared.zip


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?  If so, fill in the Issue number below.
   <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/351982)