### PR TITLE
Add Ink1ing.AntiAPI version 2.9.0

### DIFF
--- a/manifests/i/Ink1ing/AntiAPI/2.9.0/Ink1ing.AntiAPI.installer.yaml
+++ b/manifests/i/Ink1ing/AntiAPI/2.9.0/Ink1ing.AntiAPI.installer.yaml
@@ -12,4 +12,4 @@ Installers:
   InstallerUrl: https://github.com/ink1ing/anti-api/releases/download/v2.9.0/anti-api-winget-x64.zip
   InstallerSha256: 8EEDC01D4F379D0A2A6F16C44341229DCDD87B3D142562622900A9F46FE1B5C2
 ManifestType: installer
-ManifestVersion: 1.9.0
+ManifestVersion: 1.12.0

--- a/manifests/i/Ink1ing/AntiAPI/2.9.0/Ink1ing.AntiAPI.installer.yaml
+++ b/manifests/i/Ink1ing/AntiAPI/2.9.0/Ink1ing.AntiAPI.installer.yaml
@@ -1,0 +1,15 @@
+PackageIdentifier: Ink1ing.AntiAPI
+PackageVersion: 2.9.0
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: anti-api/anti-api.exe
+  PortableCommandAlias: anti-api
+ReleaseDate: 2026-03-25
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/ink1ing/anti-api/releases/download/v2.9.0/anti-api-winget-x64.zip
+  InstallerSha256: 8EEDC01D4F379D0A2A6F16C44341229DCDD87B3D142562622900A9F46FE1B5C2
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/i/Ink1ing/AntiAPI/2.9.0/Ink1ing.AntiAPI.locale.en-US.yaml
+++ b/manifests/i/Ink1ing/AntiAPI/2.9.0/Ink1ing.AntiAPI.locale.en-US.yaml
@@ -22,4 +22,4 @@ Tags:
 - copilot
 - zed
 ManifestType: defaultLocale
-ManifestVersion: 1.9.0
+ManifestVersion: 1.12.0

--- a/manifests/i/Ink1ing/AntiAPI/2.9.0/Ink1ing.AntiAPI.locale.en-US.yaml
+++ b/manifests/i/Ink1ing/AntiAPI/2.9.0/Ink1ing.AntiAPI.locale.en-US.yaml
@@ -1,0 +1,25 @@
+PackageIdentifier: Ink1ing.AntiAPI
+PackageVersion: 2.9.0
+PackageLocale: en-US
+Publisher: ink1ing
+PublisherUrl: https://github.com/ink1ing
+PublisherSupportUrl: https://github.com/ink1ing/anti-api/issues
+Author: ink1ing
+PackageName: Anti-API
+PackageUrl: https://github.com/ink1ing/anti-api
+License: MIT
+LicenseUrl: https://github.com/ink1ing/anti-api/blob/main/LICENSE
+ShortDescription: Local OpenAI/Anthropic-compatible proxy for Antigravity, Codex, GitHub Copilot, and Zed.
+Description: Anti-API exposes Antigravity, Codex, GitHub Copilot, and Zed hosted models through local OpenAI-compatible and Anthropic-compatible endpoints with routing, quota monitoring, and account switching.
+Moniker: anti-api
+Tags:
+- ai
+- llm
+- proxy
+- openai
+- anthropic
+- codex
+- copilot
+- zed
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/i/Ink1ing/AntiAPI/2.9.0/Ink1ing.AntiAPI.yaml
+++ b/manifests/i/Ink1ing/AntiAPI/2.9.0/Ink1ing.AntiAPI.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Ink1ing.AntiAPI
+PackageVersion: 2.9.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0

--- a/manifests/i/Ink1ing/AntiAPI/2.9.0/Ink1ing.AntiAPI.yaml
+++ b/manifests/i/Ink1ing/AntiAPI/2.9.0/Ink1ing.AntiAPI.yaml
@@ -2,4 +2,4 @@ PackageIdentifier: Ink1ing.AntiAPI
 PackageVersion: 2.9.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.9.0
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Summary\n- add Ink1ing.AntiAPI version 2.9.0\n- ship Windows portable package for Anti-API\n- expose the portable command alias `anti-api` for direct terminal startup\n\n## Validation\n- release asset uploaded to https://github.com/ink1ing/anti-api/releases/tag/v2.9.0\n- installer SHA256 matches the uploaded zip\n- manifest generated from the released asset
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/352079)