### PR TITLE
Add markusleben.ha-nova version 0.3.1

### DIFF
--- a/manifests/m/markusleben/ha-nova/0.3.1/markusleben.ha-nova.installer.yaml
+++ b/manifests/m/markusleben/ha-nova/0.3.1/markusleben.ha-nova.installer.yaml
@@ -1,0 +1,17 @@
+# Created by HA NOVA release automation
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: markusleben.ha-nova
+PackageVersion: 0.3.1
+InstallerType: zip
+NestedInstallerType: portable
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/markusleben/ha-nova/releases/download/v0.3.1/ha-nova-installer-bundle-windows-amd64.zip
+    InstallerSha256: 4A8084FB77DB42118F93A1EA99C9A9883EE434B403CA14E4265DABFDEE420BDF
+    NestedInstallerFiles:
+      - RelativeFilePath: ha-nova/ha-nova.exe
+        PortableCommandAlias: ha-nova
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/m/markusleben/ha-nova/0.3.1/markusleben.ha-nova.locale.en-US.yaml
+++ b/manifests/m/markusleben/ha-nova/0.3.1/markusleben.ha-nova.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# Created by HA NOVA release automation
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: markusleben.ha-nova
+PackageVersion: 0.3.1
+PackageLocale: en-US
+Publisher: Markus Leben
+PublisherUrl: https://github.com/markusleben/ha-nova
+PublisherSupportUrl: https://github.com/markusleben/ha-nova/issues
+Author: Markus Leben
+PackageName: HA NOVA
+PackageUrl: https://github.com/markusleben/ha-nova
+License: MIT
+LicenseUrl: https://github.com/markusleben/ha-nova/blob/main/LICENSE
+ShortDescription: AI-powered Home Assistant management through LLM coding agents
+Moniker: ha-nova
+Tags:
+  - home-assistant
+  - automation
+  - smart-home
+  - ai
+ReleaseNotesUrl: https://github.com/markusleben/ha-nova/releases/tag/v0.3.1
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/m/markusleben/ha-nova/0.3.1/markusleben.ha-nova.yaml
+++ b/manifests/m/markusleben/ha-nova/0.3.1/markusleben.ha-nova.yaml
@@ -1,0 +1,8 @@
+# Created by HA NOVA release automation
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: markusleben.ha-nova
+PackageVersion: 0.3.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## Summary

- Add markusleben.ha-nova version 0.3.1
- Source release tag: v0.3.1
- Source installer URL: https://github.com/markusleben/ha-nova/releases/download/v0.3.1/ha-nova-installer-bundle-windows-amd64.zip

## Validation

- [ ] `winget validate --manifest "<staged-manifest-dir-on-your-validation-host>"` completed on Windows without warnings
- [x] Installer SHA256 matches both the generated release manifest and the staged Windows bundle bytes
- [ ] Initial published-source install/check-update/uninstall smoke will run after merge/publication
- [ ] Upgrade continuity smoke will run from an older published version once that lane exists

## Notes

- Portable install sourced from the tagged HA NOVA Windows bundle
- Public docs will stay on `install.ps1` until the published-source smoke passes

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/352236)