### PR TITLE
Add AegisPDF.AegisPDF version 0.1.0

### DIFF
--- a/manifests/a/AegisPDF/AegisPDF/0.1.0/AegisPDF.AegisPDF.installer.yaml
+++ b/manifests/a/AegisPDF/AegisPDF/0.1.0/AegisPDF.AegisPDF.installer.yaml
@@ -1,0 +1,14 @@
+PackageIdentifier: AegisPDF.AegisPDF
+PackageVersion: 0.1.0
+InstallerLocale: en-US
+Installers:
+  - Architecture: x64
+    InstallerType: nullsoft
+    Scope: user
+    InstallerUrl: https://github.com/TheRadDani/aegispdf/releases/download/v0.1.3/AegisPDF_0.1.0_x64-setup.exe
+    InstallerSha256: AD6CF47CF78468DE10548AA10FD10CDCED33245B486CD8D0F85AE1532BBFE619
+    InstallerSwitches:
+      Silent: /S
+      SilentWithProgress: /S
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/AegisPDF/AegisPDF/0.1.0/AegisPDF.AegisPDF.locale.en-US.yaml
+++ b/manifests/a/AegisPDF/AegisPDF/0.1.0/AegisPDF.AegisPDF.locale.en-US.yaml
@@ -1,0 +1,26 @@
+PackageIdentifier: AegisPDF.AegisPDF
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: AegisPDF Contributors
+PublisherUrl: https://github.com/TheRadDani/aegispdf
+PublisherSupportUrl: https://github.com/TheRadDani/aegispdf/issues
+Author: AegisPDF Contributors
+PackageName: AegisPDF
+PackageUrl: https://github.com/TheRadDani/aegispdf
+License: MIT
+LicenseUrl: https://github.com/TheRadDani/aegispdf/blob/main/LICENSE
+Copyright: Copyright © 2024 AegisPDF Contributors
+ShortDescription: Privacy-focused offline PDF workspace
+Description: AegisPDF is a free, open-source, cross-platform PDF workspace. Open, render, reorder, merge, split, compress, OCR and annotate PDFs with a fast Rust/Tauri backend, fully offline with no cloud dependency.
+Moniker: aegispdf
+Tags:
+  - pdf
+  - tauri
+  - rust
+  - react
+  - ocr
+  - annotations
+  - offline
+ReleaseNotesUrl: https://github.com/TheRadDani/aegispdf/releases/tag/v0.1.3
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/AegisPDF/AegisPDF/0.1.0/AegisPDF.AegisPDF.yaml
+++ b/manifests/a/AegisPDF/AegisPDF/0.1.0/AegisPDF.AegisPDF.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: AegisPDF.AegisPDF
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Summary
Add initial WinGet manifest for AegisPDF.AegisPDF version 0.1.0.

## Package
- PackageIdentifier: AegisPDF.AegisPDF
- PackageVersion: 0.1.0
- InstallerType: nullsoft
- Architecture: x64

## Installer
- URL: https://github.com/TheRadDani/aegispdf/releases/download/v0.1.3/AegisPDF_0.1.0_x64-setup.exe
- SHA256: AD6CF47CF78468DE10548AA10FD10CDCED33245B486CD8D0F85AE1532BBFE619
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/352330)