### PR TITLE
New package: jawhitti.INTERCAL64 version 2.0.0

### DIFF
--- a/manifests/j/jawhitti/INTERCAL64/2.0.0/jawhitti.INTERCAL64.installer.yaml
+++ b/manifests/j/jawhitti/INTERCAL64/2.0.0/jawhitti.INTERCAL64.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: jawhitti.INTERCAL64
+PackageVersion: 2.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: bin\churn.exe
+    PortableCommandAlias: churn
+  - RelativeFilePath: bin\intercal64-dap.exe
+    PortableCommandAlias: intercal64-dap
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/jawhitti/INTERCAL64/releases/download/v2.0.0/intercal64-v2.0.0-win-x64.zip
+    InstallerSha256: 74ADCD5A2EA2A2A807D5F2DD642C3EF46F64B0F09AA9D88F62CBA3ACBD4F7ECC
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/j/jawhitti/INTERCAL64/2.0.0/jawhitti.INTERCAL64.locale.en-US.yaml
+++ b/manifests/j/jawhitti/INTERCAL64/2.0.0/jawhitti.INTERCAL64.locale.en-US.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: jawhitti.INTERCAL64
+PackageVersion: 2.0.0
+PackageLocale: en-US
+Publisher: jawhitti
+PublisherUrl: https://github.com/jawhitti
+PackageName: INTERCAL-64
+PackageUrl: https://github.com/jawhitti/INTERCAL64
+License: MIT
+ShortDescription: "INTERCAL-64: a 64-bit INTERCAL compiler and runtime"
+Description: |-
+  The biggest update to INTERCAL in over 25 years. 64-bit arithmetic, a complete
+  system library in pure INTERCAL, a real debugger in VS Code, and a compiler named
+  churn. Old dog. New ticks.
+Tags:
+  - intercal
+  - compiler
+  - esoteric
+  - programming-language
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/j/jawhitti/INTERCAL64/2.0.0/jawhitti.INTERCAL64.yaml
+++ b/manifests/j/jawhitti/INTERCAL64/2.0.0/jawhitti.INTERCAL64.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: jawhitti.INTERCAL64
+PackageVersion: 2.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package submission

- **Package:** jawhitti.INTERCAL64
- **Version:** 2.0.0
- **Installer:** https://github.com/jawhitti/INTERCAL64/releases/download/v2.0.0/intercal64-v2.0.0-win-x64.zip
- **SHA256:** 74ADCD5A2EA2A2A807D5F2DD642C3EF46F64B0F09AA9D88F62CBA3ACBD4F7ECC
- **Type:** zip/portable

INTERCAL-64 is a 64-bit INTERCAL compiler and runtime for .NET 9. Includes the `churn` compiler and `intercal64-dap` VS Code debug adapter.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/352372)