### PR TITLE
New package: TONresistor.TONBrowser version 1.5.3

### DIFF
--- a/manifests/t/TONresistor/TONBrowser/1.5.3/TONresistor.TONBrowser.installer.yaml
+++ b/manifests/t/TONresistor/TONBrowser/1.5.3/TONresistor.TONBrowser.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: TONresistor.TONBrowser
+PackageVersion: 1.5.3
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/TONresistor/Tonnet-Browser/releases/download/v1.5.3/TON.Browser.Setup.1.5.3.exe
+    InstallerSha256: 7daf857194fba15b00298fef7db2c7a6a9177db8eb365b9ea34c02c306fee4df
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/t/TONresistor/TONBrowser/1.5.3/TONresistor.TONBrowser.locale.en-US.yaml
+++ b/manifests/t/TONresistor/TONBrowser/1.5.3/TONresistor.TONBrowser.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: TONresistor.TONBrowser
+PackageVersion: 1.5.3
+PackageLocale: en-US
+Publisher: TON Browser Team
+PublisherUrl: https://github.com/TONresistor
+PackageName: TON Browser
+PackageUrl: https://github.com/TONresistor/Tonnet-Browser
+License: MIT
+LicenseUrl: https://github.com/TONresistor/Tonnet-Browser/blob/main/LICENSE
+ShortDescription: Native browser for the TON network
+Tags:
+  - browser
+  - ton
+  - blockchain
+  - web3
+  - privacy
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/TONresistor/TONBrowser/1.5.3/TONresistor.TONBrowser.yaml
+++ b/manifests/t/TONresistor/TONBrowser/1.5.3/TONresistor.TONBrowser.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: TONresistor.TONBrowser
+PackageVersion: 1.5.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New Submission

- Package: TONresistor.TONBrowser
- Version: 1.5.3
- URL: https://github.com/TONresistor/Tonnet-Browser

### Description

TON Browser is a native desktop browser for the TON network, built with Electron. Open source, MIT licensed.

### Checklist

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/creation?
- [x] This PR only modifies files in the `manifests` folder
- [x] The manifest was validated using `winget validate`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/352395)