### PR TITLE
New package: FediMust.EyesAndEars 2.6.8

### DIFF
--- a/manifests/f/FediMust/EyesAndEars/2.6.8/FediMust.EyesAndEars.installer.yaml
+++ b/manifests/f/FediMust/EyesAndEars/2.6.8/FediMust.EyesAndEars.installer.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: FediMust.EyesAndEars
+PackageVersion: "2.6.8"
+InstallerType: portable
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Fedi-Must/EyesAndEars/releases/download/v2.6.8/EyesAndEars-2.6.8-x64.exe
+  InstallerSha256: 12BF27A5447430C759F247A52D661687339AAD20D3316A56AD002679888021A3
+  Commands:
+  - eyesandears
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/f/FediMust/EyesAndEars/2.6.8/FediMust.EyesAndEars.locale.en-US.yaml
+++ b/manifests/f/FediMust/EyesAndEars/2.6.8/FediMust.EyesAndEars.locale.en-US.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: FediMust.EyesAndEars
+PackageVersion: "2.6.8"
+PackageLocale: en-US
+Publisher: Fedi-Must
+PublisherUrl: https://github.com/Fedi-Must
+PublisherSupportUrl: https://github.com/Fedi-Must/EyesAndEars/issues
+Author: Fedi-Must
+PackageName: EyesAndEars
+PackageUrl: https://github.com/Fedi-Must/EyesAndEars
+License: MIT
+ShortDescription: Screenshot-to-answer assistant with hotkey typing workflow.
+Description: Self-contained Windows app that captures screenshots, queries Gemini, and can type generated responses on demand with an always-on indicator.
+Moniker: eyesandears
+Tags:
+- ai
+- automation
+- python
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/f/FediMust/EyesAndEars/2.6.8/FediMust.EyesAndEars.yaml
+++ b/manifests/f/FediMust/EyesAndEars/2.6.8/FediMust.EyesAndEars.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: FediMust.EyesAndEars
+PackageVersion: "2.6.8"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Summary
- Adds `FediMust.EyesAndEars` version `2.6.8`
- Installer type: portable
- Installer source: GitHub release asset

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/352399)