### PR TITLE
Add NalleBerg.IPGui version 4.1.9

### DIFF
--- a/manifests/n/NalleBerg/IPGui/4.1.9/NalleBerg.IPGui.installer.yaml
+++ b/manifests/n/NalleBerg/IPGui/4.1.9/NalleBerg.IPGui.installer.yaml
@@ -1,0 +1,12 @@
+# Created using wingetcreate v2.0.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: NalleBerg.IPGui
+PackageVersion: 4.1.9
+Installers:
+  - Architecture: x64
+    InstallerType: msi
+    InstallerUrl: https://prog.nalle.no/user/data/apps/IPGui-4.1.9-Setup.msi
+    InstallerSha256: AB1F959E5A5A6B290B4C4B4CD131121D09EDC5BB36E5B1A2B8453AA0C491572B
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/n/NalleBerg/IPGui/4.1.9/NalleBerg.IPGui.locale.en-US.yaml
+++ b/manifests/n/NalleBerg/IPGui/4.1.9/NalleBerg.IPGui.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# Created using wingetcreate v2.0.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: NalleBerg.IPGui
+PackageVersion: 4.1.9
+PackageLocale: en-US
+Publisher: Nalle Berg
+PublisherUrl: https://prog.nalle.no
+PackageName: IPGui
+License: GPL-2.0-only
+LicenseUrl: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ShortDescription: A graphical interface to ipconfig with network diagnostics and tools.
+Description: |
+  IPGui is a graphical interface to the command line's ipconfig with not just a few extras.
+  It has become the Swiss Army Knife for network diagnosis and tasks.
+  Even if it is much the same for any ordinary users, a wealth of functions are hidden in
+  the Actions -> NetTools menu.
+  It is a very useful network tool and something every IT Consultant who works with networks
+  at all would like to have on their USB drive.
+Tags:
+  - network
+  - ipconfig
+  - diagnostics
+  - nettools
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/n/NalleBerg/IPGui/4.1.9/NalleBerg.IPGui.yaml
+++ b/manifests/n/NalleBerg/IPGui/4.1.9/NalleBerg.IPGui.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate v2.0.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: NalleBerg.IPGui
+PackageVersion: 4.1.9
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## New Package: NalleBerg.IPGui version 4.1.9

IPGui is a graphical interface to the command line's ipconfig with extra network diagnostics and tools.

- **Installer type:** MSI (x64)
- **License:** GPL-2.0-only
- **Publisher URL:** https://prog.nalle.no
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/352471)