### PR TITLE
Add NalleBerg.WinProgramSuite version 2026.03.26.07

### DIFF
--- a/manifests/n/NalleBerg/WinProgramSuite/2026.03.26.07/NalleBerg.WinProgramSuite.installer.yaml
+++ b/manifests/n/NalleBerg/WinProgramSuite/2026.03.26.07/NalleBerg.WinProgramSuite.installer.yaml
@@ -1,0 +1,12 @@
+# Created using wingetcreate v2.0.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: NalleBerg.WinProgramSuite
+PackageVersion: 2026.03.26.07
+Installers:
+  - Architecture: x64
+    InstallerType: msi
+    InstallerUrl: https://prog.nalle.no/user/data/apps/WinProgramSuiteSetup2006.03.26.07.msi
+    InstallerSha256: B240E9CDD23DCB84ACD39C440285FD5D5A2521FE16C2CA5145CA212FB283E8F0
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/n/NalleBerg/WinProgramSuite/2026.03.26.07/NalleBerg.WinProgramSuite.installer.yaml
+++ b/manifests/n/NalleBerg/WinProgramSuite/2026.03.26.07/NalleBerg.WinProgramSuite.installer.yaml
@@ -7,6 +7,6 @@ Installers:
   - Architecture: x64
     InstallerType: msi
     InstallerUrl: https://prog.nalle.no/user/data/apps/WinProgramSuiteSetup2006.03.26.07.msi
-    InstallerSha256: B240E9CDD23DCB84ACD39C440285FD5D5A2521FE16C2CA5145CA212FB283E8F0
+    InstallerSha256: FA45431D4ECBCDF6BEC342025C0485DC902047D0B9987FCB6B5CDD08EBBE8A71
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/n/NalleBerg/WinProgramSuite/2026.03.26.07/NalleBerg.WinProgramSuite.locale.en-US.yaml
+++ b/manifests/n/NalleBerg/WinProgramSuite/2026.03.26.07/NalleBerg.WinProgramSuite.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# Created using wingetcreate v2.0.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: NalleBerg.WinProgramSuite
+PackageVersion: 2026.03.26.07
+PackageLocale: en-US
+Publisher: Nalle Berg
+PublisherUrl: https://prog.nalle.no
+PackageName: WinProgramSuite
+License: GPL-2.0-only
+LicenseUrl: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ShortDescription: A complete Windows package management suite with a winget GUI and background programme updater.
+Description: |
+  WinProgramSuite is a complete Windows package management system consisting of two tools:
+
+  WinProgramManager is a programme to help you install programmes winget offers. There are
+  more than 10,000 of them, so this app makes it easier to find the one you want. The
+  programmes are categorised and there is a search function that is quite good, as you can
+  also search in the results of the previous search, and regex search is supported. It also
+  comes with an automatic update of the database — an app that updates the database once a
+  week by default, but in Settings you can decide yourself when and how often you want it to
+  update in the background.
+
+  WinUpdate is the winning updater. This programme relies on winget, which is included in
+  Windows 10 and Windows 11. It supports more than 10,000 software packages and you will be
+  notified when programmes are available if you run it in the background, where it uses only
+  0.3MB of memory. If you wish, you can simply run it manually, or have it scan at Windows
+  startup and notify you only when it finds an update for your programmes.
+Tags:
+  - winget
+  - package-manager
+  - updater
+  - windows
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/n/NalleBerg/WinProgramSuite/2026.03.26.07/NalleBerg.WinProgramSuite.yaml
+++ b/manifests/n/NalleBerg/WinProgramSuite/2026.03.26.07/NalleBerg.WinProgramSuite.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate v2.0.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: NalleBerg.WinProgramSuite
+PackageVersion: 2026.03.26.07
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## New Package: NalleBerg.WinProgramSuite version 2026.03.26.07

WinProgramSuite is a complete Windows package management system consisting of WinProgramManager (a GUI for browsing and installing winget packages) and WinUpdate (a background programme updater supporting more than 10,000 packages).

- **Installer type:** MSI (x64)
- **License:** GPL-2.0-only
- **Publisher URL:** https://prog.nalle.no
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/352472)