### PR TITLE
New version: kts982.WinTUI version 0.1.0

### DIFF
--- a/manifests/k/kts982/WinTUI/0.1.0/kts982.WinTUI.installer.yaml
+++ b/manifests/k/kts982/WinTUI/0.1.0/kts982.WinTUI.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: kts982.WinTUI
+PackageVersion: 0.1.0
+MinimumOSVersion: 10.0.17763.0
+InstallerType: portable
+Commands:
+  - wintui
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/kts982/wintui/releases/download/v0.1.0/wintui_0.1.0_windows_amd64.exe
+    InstallerSha256: 1C77B7069BF3F4C56186D71E90018C8988642990DE2138CE7D4EA20EDC98568F
+  - Architecture: arm64
+    InstallerUrl: https://github.com/kts982/wintui/releases/download/v0.1.0/wintui_0.1.0_windows_arm64.exe
+    InstallerSha256: D1407944A853BBF53D147F0D518BD769E0C76169A3D96D49FCD89438E5C0B7A6
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/k/kts982/WinTUI/0.1.0/kts982.WinTUI.locale.en-US.yaml
+++ b/manifests/k/kts982/WinTUI/0.1.0/kts982.WinTUI.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: kts982.WinTUI
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: kts982
+PublisherUrl: https://github.com/kts982
+PublisherSupportUrl: https://github.com/kts982/wintui/issues
+Author: Kostas T.
+PackageName: WinTUI
+PackageUrl: https://github.com/kts982/wintui
+License: MIT
+LicenseUrl: https://github.com/kts982/wintui/blob/main/LICENSE
+ShortDescription: Terminal UI for winget on Windows.
+Description: >-
+  WinTUI is a terminal user interface for Windows Package Manager. It lets you
+  browse installed packages, search package sources, install and upgrade
+  packages, export and restore package selections, and run a few workstation
+  utility tasks without leaving the terminal.
+Moniker: wintui
+Tags:
+  - winget
+  - windows
+  - tui
+  - terminal
+  - package-manager
+ReleaseNotesUrl: https://github.com/kts982/wintui/releases/tag/v0.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/k/kts982/WinTUI/0.1.0/kts982.WinTUI.yaml
+++ b/manifests/k/kts982/WinTUI/0.1.0/kts982.WinTUI.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: kts982.WinTUI
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Package
- Package Identifier: `kts982.WinTUI`
- Package Version: `0.1.0`
- Package Type: `portable`

## Release
- GitHub Release: https://github.com/kts982/wintui/releases/tag/v0.1.0
- x64 asset: https://github.com/kts982/wintui/releases/download/v0.1.0/wintui_0.1.0_windows_amd64.exe
- arm64 asset: https://github.com/kts982/wintui/releases/download/v0.1.0/wintui_0.1.0_windows_arm64.exe

## Validation
- `winget validate manifests\k\kts982\WinTUI\0.1.0`

## Notes
- Command alias: `wintui`
- Minimum OS version: `10.0.17763.0`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/352681)