### PR TITLE
Wharflab.Tally version 0.30.0

### DIFF
--- a/manifests/w/Wharflab/Tally/0.30.0/Wharflab.Tally.installer.yaml
+++ b/manifests/w/Wharflab/Tally/0.30.0/Wharflab.Tally.installer.yaml
@@ -1,0 +1,26 @@
+# Created by tally release automation
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: Wharflab.Tally
+PackageVersion: 0.30.0
+Commands:
+- tally
+FileExtensions:
+- dockerfile
+- containerfile
+ReleaseDate: '2026-03-26'
+Installers:
+- Architecture: x64
+  InstallerType: portable
+  InstallerUrl: https://github.com/wharflab/tally/releases/download/v0.30.0/tally_0.30.0_Windows_x86_64.exe
+  InstallerSha256: B592E83987B61A7D6C7B6B1FB81D36981EBA7D13DB5A0C38B03AEAB7555C628C
+  Commands:
+  - tally
+- Architecture: arm64
+  InstallerType: portable
+  InstallerUrl: https://github.com/wharflab/tally/releases/download/v0.30.0/tally_0.30.0_Windows_arm64.exe
+  InstallerSha256: '09F50D1CADBDB8D76446B4A5AFE14818671698C19397FB220B7241A8D250918A'
+  Commands:
+  - tally
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/w/Wharflab/Tally/0.30.0/Wharflab.Tally.locale.en-US.yaml
+++ b/manifests/w/Wharflab/Tally/0.30.0/Wharflab.Tally.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# Created by tally release automation
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: Wharflab.Tally
+PackageVersion: 0.30.0
+PackageLocale: en-US
+Publisher: Wharflab
+PublisherUrl: https://github.com/wharflab
+PublisherSupportUrl: https://github.com/wharflab/tally/issues
+PackageName: Tally
+PackageUrl: https://github.com/wharflab/tally
+ShortDescription: Dockerfile linter and formatter with first-class PowerShell and
+  Windows container support.
+Moniker: tally
+License: GPL-3.0-only
+LicenseUrl: https://github.com/wharflab/tally/blob/main/LICENSE
+ReleaseNotesUrl: https://github.com/wharflab/tally/releases/tag/v0.30.0
+Documentations:
+- DocumentLabel: Docs
+  DocumentUrl: https://wharflab.github.io/tally/
+Tags:
+- docker
+- dockerfile
+- containerfile
+- linter
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/w/Wharflab/Tally/0.30.0/Wharflab.Tally.yaml
+++ b/manifests/w/Wharflab/Tally/0.30.0/Wharflab.Tally.yaml
@@ -1,0 +1,8 @@
+# Created by tally release automation
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: Wharflab.Tally
+PackageVersion: 0.30.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Publishing version v0.30.0 of [tally](https://github.com/wharflab/tally) to WinGet.

Tally is a Dockerfile linter and formatter written in Go, promoting modern container syntax and helping avoid common pitfalls.

[Changelog](https://github.com/wharflab/tally/releases/tag/v0.30.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/352804)