### PR TITLE
New package: Microsoft.MediaCreationTool.Windows10 version 22H2

### DIFF
--- a/manifests/m/Microsoft/MediaCreationTool/Windows10/22H2/Microsoft.MediaCreationTool.Windows10.installer.yaml
+++ b/manifests/m/Microsoft/MediaCreationTool/Windows10/22H2/Microsoft.MediaCreationTool.Windows10.installer.yaml
@@ -1,0 +1,19 @@
+# Created using winget CLI
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: Microsoft.MediaCreationTool.Windows10
+PackageVersion: 22H2
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: portable
+Commands:
+  - MediaCreationTool10
+Installers:
+  - Architecture: x86
+    InstallerUrl: https://download.microsoft.com/download/9/e/a/9eac306f-d134-4609-9c58-35d1638c2363/MediaCreationTool_22H2.exe
+    InstallerSha256: 690C8A63769D444FAD47B7DDECEE7F24C9333AA735D0BD46587D0DF5CF15CDE5
+    AppsAndFeaturesEntries:
+      - DisplayName: Windows 10 Media Creation Tool
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/m/Microsoft/MediaCreationTool/Windows10/22H2/Microsoft.MediaCreationTool.Windows10.locale.en-US.yaml
+++ b/manifests/m/Microsoft/MediaCreationTool/Windows10/22H2/Microsoft.MediaCreationTool.Windows10.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# Created using winget CLI
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: Microsoft.MediaCreationTool.Windows10
+PackageVersion: 22H2
+PackageLocale: en-US
+Publisher: Microsoft Corporation
+PublisherUrl: https://www.microsoft.com
+PublisherSupportUrl: https://support.microsoft.com
+PrivacyUrl: https://privacy.microsoft.com
+Author: Microsoft Corporation
+PackageName: Windows 10 Media Creation Tool
+PackageUrl: https://www.microsoft.com/software-download/windows10
+License: Proprietary
+Copyright: Copyright (c) Microsoft Corporation. All rights reserved.
+CopyrightUrl: https://www.microsoft.com/en-us/legal/intellectualproperty/copyright
+ShortDescription: Create Windows 10 installation media (USB flash drive, DVD, or ISO file).
+Description: |-
+  The Windows 10 Media Creation Tool allows you to download Windows 10 and create
+  installation media using a USB flash drive or DVD. You can also use it to upgrade
+  your current PC to Windows 10 or create an ISO file for later use.
+Moniker: win10mct
+Tags:
+  - installer
+  - media-creation
+  - windows
+  - windows-10
+  - usb
+  - iso
+ReleaseNotes: Windows 10 version 22H2
+ReleaseNotesUrl: https://learn.microsoft.com/en-us/windows/release-health/status-windows-10-22h2
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/m/Microsoft/MediaCreationTool/Windows10/22H2/Microsoft.MediaCreationTool.Windows10.locale.tr-TR.yaml
+++ b/manifests/m/Microsoft/MediaCreationTool/Windows10/22H2/Microsoft.MediaCreationTool.Windows10.locale.tr-TR.yaml
@@ -1,0 +1,32 @@
+# Created using winget CLI
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.9.0.schema.json
+
+PackageIdentifier: Microsoft.MediaCreationTool.Windows10
+PackageVersion: 22H2
+PackageLocale: tr-TR
+Publisher: Microsoft Corporation
+PublisherUrl: https://www.microsoft.com/tr-tr
+PublisherSupportUrl: https://support.microsoft.com/tr-tr
+PrivacyUrl: https://privacy.microsoft.com/tr-tr
+Author: Microsoft Corporation
+PackageName: Windows 10 Medya Oluşturma Aracı
+PackageUrl: https://www.microsoft.com/tr-tr/software-download/windows10
+License: Tescilli
+Copyright: Telif Hakkı (c) Microsoft Corporation. Tüm hakları saklıdır.
+ShortDescription: Windows 10 yükleme medyası oluşturun (USB flash sürücü, DVD veya ISO dosyası).
+Description: |-
+  Windows 10 Medya Oluşturma Aracı, Windows 10'u indirmenize ve bir USB flash sürücü
+  veya DVD kullanarak yükleme medyası oluşturmanıza olanak tanır. Ayrıca mevcut
+  bilgisayarınızı Windows 10'a yükseltmek veya daha sonra kullanmak üzere bir ISO
+  dosyası oluşturmak için de kullanabilirsiniz.
+Tags:
+  - yükleyici
+  - medya-oluşturma
+  - windows
+  - windows-10
+  - usb
+  - iso
+ReleaseNotes: Windows 10 sürüm 22H2
+ReleaseNotesUrl: https://learn.microsoft.com/tr-tr/windows/release-health/status-windows-10-22h2
+ManifestType: locale
+ManifestVersion: 1.9.0

--- a/manifests/m/Microsoft/MediaCreationTool/Windows10/22H2/Microsoft.MediaCreationTool.Windows10.yaml
+++ b/manifests/m/Microsoft/MediaCreationTool/Windows10/22H2/Microsoft.MediaCreationTool.Windows10.yaml
@@ -1,0 +1,8 @@
+# Created using winget CLI
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: Microsoft.MediaCreationTool.Windows10
+PackageVersion: 22H2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
### New Package

- Package: Microsoft.MediaCreationTool.Windows10
- Version: 22H2
- Installer Type: portable
- Architecture: x86
- Command alias: `MediaCreationTool10`
- Locale: en-US, tr-TR

### Description

Windows 10 Media Creation Tool — allows users to download Windows 10 and create installation media (USB/DVD/ISO). This is separate from the existing `Microsoft.MediaCreationTool` which is for Windows 11.

### Validation

- [x] `winget validate` passed
- [x] `winget install --manifest` tested successfully
- [x] `winget uninstall` tested successfully
- [x] SHA256 hash verified
- [x] Executable runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/353070)