### PR TITLE
New package: 0-don.clippy version 1.5.8

### DIFF
--- a/manifests/0/0-don/clippy/1.5.8/0-don.clippy.installer.yaml
+++ b/manifests/0/0-don/clippy/1.5.8/0-don.clippy.installer.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
 PackageIdentifier: 0-don.clippy
 PackageVersion: 1.5.8
 InstallerType: nullsoft

--- a/manifests/0/0-don/clippy/1.5.8/0-don.clippy.installer.yaml
+++ b/manifests/0/0-don/clippy/1.5.8/0-don.clippy.installer.yaml
@@ -1,0 +1,10 @@
+PackageIdentifier: 0-don.clippy
+PackageVersion: 1.5.8
+InstallerType: nullsoft
+UpgradeBehavior: uninstallPrevious
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/0-don/clippy/releases/download/v1.5.8/clippy_1.5.8_x64-setup.exe
+    InstallerSha256: D9608232E28D5B894EF915BB8378BDE85D6D9D5D27A41E33A083BB73D1CDD410
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/0/0-don/clippy/1.5.8/0-don.clippy.locale.en-US.yaml
+++ b/manifests/0/0-don/clippy/1.5.8/0-don.clippy.locale.en-US.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
 PackageIdentifier: 0-don.clippy
 PackageVersion: 1.5.8
 PackageLocale: en-US

--- a/manifests/0/0-don/clippy/1.5.8/0-don.clippy.locale.en-US.yaml
+++ b/manifests/0/0-don/clippy/1.5.8/0-don.clippy.locale.en-US.yaml
@@ -1,0 +1,18 @@
+PackageIdentifier: 0-don.clippy
+PackageVersion: 1.5.8
+PackageLocale: en-US
+Publisher: 0-don
+PublisherUrl: https://github.com/0-don
+PackageName: Clippy
+PackageUrl: https://github.com/0-don/clippy
+License: MIT
+LicenseUrl: https://github.com/0-don/clippy/blob/main/LICENSE
+ShortDescription: Clipboard Manager built with Rust & Typescript
+Description: Privacy focused clipboard manager with sync and encryption. Supports text, images, files, HTML, and RTF content with cloud sync via Google Drive.
+Tags:
+  - clipboard
+  - clipboard-manager
+  - productivity
+  - utility
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/0/0-don/clippy/1.5.8/0-don.clippy.yaml
+++ b/manifests/0/0-don/clippy/1.5.8/0-don.clippy.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
 PackageIdentifier: 0-don.clippy
 PackageVersion: 1.5.8
 DefaultLocale: en-US

--- a/manifests/0/0-don/clippy/1.5.8/0-don.clippy.yaml
+++ b/manifests/0/0-don/clippy/1.5.8/0-don.clippy.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: 0-don.clippy
+PackageVersion: 1.5.8
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
### New Package Submission

- **Package Identifier:** 0-don.clippy
- **Package Version:** 1.5.8
- **Package URL:** https://github.com/0-don/clippy
- **License:** MIT

Privacy focused clipboard manager with sync and encryption, built with Rust and Typescript.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/353083)