### PR TITLE
Update jawhitti.INTERCAL64 to version 2.0.1

### DIFF
--- a/manifests/j/jawhitti/INTERCAL64/2.0.1/jawhitti.INTERCAL64.installer.yaml
+++ b/manifests/j/jawhitti/INTERCAL64/2.0.1/jawhitti.INTERCAL64.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: jawhitti.INTERCAL64
+PackageVersion: 2.0.1
+InstallerType: inno
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/jawhitti/INTERCAL64/releases/download/v2.0.1/intercal64-2.0.1-win-x64-setup.exe
+    InstallerSha256: 4384C77B1222EF50B43D2A09DC4E23787C10E6DE12C9C39D1643105CD2FDEFFF
+    InstallerSwitches:
+      Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+      SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/j/jawhitti/INTERCAL64/2.0.1/jawhitti.INTERCAL64.locale.en-US.yaml
+++ b/manifests/j/jawhitti/INTERCAL64/2.0.1/jawhitti.INTERCAL64.locale.en-US.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: jawhitti.INTERCAL64
+PackageVersion: 2.0.1
+PackageLocale: en-US
+Publisher: jawhitti
+PublisherUrl: https://github.com/jawhitti
+PackageName: INTERCAL-64
+PackageUrl: https://github.com/jawhitti/INTERCAL64
+License: MIT
+ShortDescription: "INTERCAL-64: a 64-bit INTERCAL compiler and runtime"
+Description: |-
+  The biggest update to INTERCAL in over 25 years. 64-bit arithmetic, a complete
+  system library in pure INTERCAL, a real debugger in VS Code, and a compiler named
+  churn. Old dog. New ticks.
+Tags:
+  - intercal
+  - compiler
+  - esoteric
+  - programming-language
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/j/jawhitti/INTERCAL64/2.0.1/jawhitti.INTERCAL64.yaml
+++ b/manifests/j/jawhitti/INTERCAL64/2.0.1/jawhitti.INTERCAL64.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: jawhitti.INTERCAL64
+PackageVersion: 2.0.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Package update

- **Package:** jawhitti.INTERCAL64
- **Version:** 2.0.1
- **Installer:** https://github.com/jawhitti/INTERCAL64/releases/download/v2.0.1/intercal64-2.0.1-win-x64-setup.exe
- **SHA256:** 4384C77B1222EF50B43D2A09DC4E23787C10E6DE12C9C39D1643105CD2FDEFFF
- **Type:** Inno Setup exe (was zip/portable in 2.0.0)

Changes from 2.0.0:
- Switched from portable zip to Inno Setup installer
- Installer adds churn to PATH, copies runtime DLLs, installs VS Code extension
- Framework-dependent (requires .NET 9) — much smaller install
- Fixed compiler dependency resolution
- Fixed DAP debugger compilation
- Build artifact cleanup
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/353121)