### PR TITLE
New package: JacobHuemmer.dops version 0.9.0

### DIFF
--- a/manifests/j/JacobHuemmer/dops/0.9.0/JacobHuemmer.dops.installer.yaml
+++ b/manifests/j/JacobHuemmer/dops/0.9.0/JacobHuemmer.dops.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: JacobHuemmer.dops
+PackageVersion: 0.9.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: dops.exe
+ReleaseDate: 2026-03-28
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/jacobhuemmer/dops-cli/releases/download/v0.9.0/dops-cli_0.9.0_windows_amd64.zip
+  InstallerSha256: 911B275A158425FA4D2A187A79DF07FC69F6613BCA55DB0235B02657311BC7D8
+- Architecture: arm64
+  InstallerUrl: https://github.com/jacobhuemmer/dops-cli/releases/download/v0.9.0/dops-cli_0.9.0_windows_arm64.zip
+  InstallerSha256: FD6D0F611D5A1A11AB9C6B8DCA6B8231FDFAA34409C687438BB06A8E5BB67784
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/j/JacobHuemmer/dops/0.9.0/JacobHuemmer.dops.locale.en-US.yaml
+++ b/manifests/j/JacobHuemmer/dops/0.9.0/JacobHuemmer.dops.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: JacobHuemmer.dops
+PackageVersion: 0.9.0
+PackageLocale: en-US
+Publisher: Jacob Huemmer
+PublisherUrl: https://github.com/jacobhuemmer
+PublisherSupportUrl: https://github.com/jacobhuemmer/dops-cli/issues
+Author: Jacob Huemmer
+PackageName: dops
+PackageUrl: https://github.com/jacobhuemmer/dops-cli
+License: MIT
+LicenseUrl: https://github.com/jacobhuemmer/dops-cli/blob/HEAD/LICENSE
+ShortDescription: Developer Operations TUI - browse, parameterize, and execute runbooks from the terminal
+Moniker: dops
+Tags:
+- cli
+- devops
+- operations
+- runbooks
+- terminal
+- tui
+ReleaseNotesUrl: https://github.com/jacobhuemmer/dops-cli/releases/tag/v0.9.0
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/j/JacobHuemmer/dops/0.9.0/JacobHuemmer.dops.yaml
+++ b/manifests/j/JacobHuemmer/dops/0.9.0/JacobHuemmer.dops.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: JacobHuemmer.dops
+PackageVersion: 0.9.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
### New package submission

- **PackageIdentifier:** JacobHuemmer.dops
- **PackageVersion:** 0.9.0
- **PackageUrl:** https://github.com/jacobhuemmer/dops-cli
- **License:** MIT

### Description

dops is a Developer Operations TUI that provides a browsable catalog of automation scripts that operators can select, parameterize, and execute directly from the terminal. Built for DevOps and platform engineering workflows.

### Checklist

- [x] URLs are publicly accessible
- [x] SHA-256 hashes match release assets
- [x] Manifest validates against schema
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/353185)