### PR TITLE
New package: rpaasch.AulaSync version 2.0.0

### DIFF
--- a/manifests/r/rpaasch/AulaSync/2.0.0/rpaasch.AulaSync.installer.yaml
+++ b/manifests/r/rpaasch/AulaSync/2.0.0/rpaasch.AulaSync.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: rpaasch.AulaSync
+PackageVersion: 2.0.0
+InstallerType: portable
+Commands:
+  - AulaSync
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/rpaasch/AulaSync/releases/download/v2.0.0/AulaSync.exe
+    InstallerSha256: 586b32ae9a924d0196141f291d5546503412b9a79cf5a8d9fe771a689ea34be4
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/r/rpaasch/AulaSync/2.0.0/rpaasch.AulaSync.locale.da-DK.yaml
+++ b/manifests/r/rpaasch/AulaSync/2.0.0/rpaasch.AulaSync.locale.da-DK.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: rpaasch.AulaSync
+PackageVersion: 2.0.0
+PackageLocale: da-DK
+Publisher: rpaasch
+PublisherUrl: https://github.com/rpaasch
+PackageName: AulaSync
+PackageUrl: https://github.com/rpaasch/AulaSync
+License: MIT
+ShortDescription: Synkroniserer beskeder fra Aula til Microsoft Outlook
+Description: |-
+  AulaSync henter beskeder fra Aula (dansk skoleplatform) og viser dem i Microsoft Outlook.
+  Understøtter alle kommuners login via WebView2 (UniLogin, Azure AD, MitID m.fl.).
+  Sætter korrekte tidsstempler og afsendere via direkte MAPI.
+Tags:
+  - aula
+  - outlook
+  - skole
+  - sync
+  - education
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/r/rpaasch/AulaSync/2.0.0/rpaasch.AulaSync.yaml
+++ b/manifests/r/rpaasch/AulaSync/2.0.0/rpaasch.AulaSync.yaml
@@ -1,0 +1,8 @@
+# Created using winget CLI
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: rpaasch.AulaSync
+PackageVersion: 2.0.0
+DefaultLocale: da-DK
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package submission

- Package: rpaasch.AulaSync
- Version: 2.0.0
- URL: https://github.com/rpaasch/AulaSync

### Description

AulaSync syncs messages from Aula (Danish school platform) to Microsoft Outlook. Supports all municipalities' identity providers via WebView2.

### Checklist

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one manifest
- [x] Manifest validation: passed locally
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/353253)