### PR TITLE
New package: JanOdegard.TinyClips version 0.0.2

### DIFF
--- a/manifests/j/JanOdegard/TinyClips/0.0.2/JanOdegard.TinyClips.installer.yaml
+++ b/manifests/j/JanOdegard/TinyClips/0.0.2/JanOdegard.TinyClips.installer.yaml
@@ -1,0 +1,19 @@
+# Created using winget CLI
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0
+
+PackageIdentifier: JanOdegard.TinyClips
+PackageVersion: 0.0.2
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: TinyClips.exe
+  PortableCommandAlias: tinyclips
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/janode/tiny-clips-win/releases/download/v0.0.2/TinyClips-x64.zip
+  InstallerSha256: A61E7C87DA30CF0AD03F5605648D4905868BDFDD25C3ADD8206E12F1BB041A9A
+- Architecture: arm64
+  InstallerUrl: https://github.com/janode/tiny-clips-win/releases/download/v0.0.2/TinyClips-arm64.zip
+  InstallerSha256: 4AFF4E30363302F0409D4299FCA2C4027252FAFE4E563502FF03F8E3DE95D71C
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/j/JanOdegard/TinyClips/0.0.2/JanOdegard.TinyClips.locale.en-US.yaml
+++ b/manifests/j/JanOdegard/TinyClips/0.0.2/JanOdegard.TinyClips.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# Created using winget CLI
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0
+
+PackageIdentifier: JanOdegard.TinyClips
+PackageVersion: 0.0.2
+PackageLocale: en-US
+Publisher: Jan Ødegård
+PublisherUrl: https://github.com/janode
+PublisherSupportUrl: https://github.com/janode/tiny-clips-win/issues
+PackageName: TinyClips
+PackageUrl: https://tinyclips.dev
+License: Proprietary
+LicenseUrl: https://github.com/janode/tiny-clips-win
+ShortDescription: Lightweight screen capture app for Windows 11 — screenshots, video, and GIF from the system tray.
+Description: |-
+  TinyClips is a Windows 11 system-tray app for screen capture. Take screenshots, record video (H.264 MP4), or capture animated GIFs — all from global hotkeys or the tray menu. Features include region/screen/window capture modes, configurable countdown, floating always-on-top panels, and customizable file naming.
+Tags:
+- capture
+- gif
+- recording
+- screen-capture
+- screenshot
+- video
+ReleaseNotesUrl: https://github.com/janode/tiny-clips-win/releases/tag/v0.0.2
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/j/JanOdegard/TinyClips/0.0.2/JanOdegard.TinyClips.yaml
+++ b/manifests/j/JanOdegard/TinyClips/0.0.2/JanOdegard.TinyClips.yaml
@@ -1,0 +1,8 @@
+# Created using winget CLI
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0
+
+PackageIdentifier: JanOdegard.TinyClips
+PackageVersion: 0.0.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New package submission\n\n- Package ID: JanOdegard.TinyClips\n- Version: 0.0.2\n- URL: https://tinyclips.dev\n- Architectures: x64, arm64\n\nTinyClips is a lightweight Windows 11 system-tray app for screen capture — screenshots, video (H.264 MP4), and animated GIFs.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/353314)