### PR TITLE
Add Kingpindev.VICESonar version 3.4.1

### DIFF
--- a/manifests/k/Kingpindev/VICESonar/3.4.1/Kingpindev.VICESonar.installer.yaml
+++ b/manifests/k/Kingpindev/VICESonar/3.4.1/Kingpindev.VICESonar.installer.yaml
@@ -1,0 +1,13 @@
+PackageIdentifier: Kingpindev.VICESonar
+PackageVersion: 3.4.1
+InstallerLocale: en-US
+InstallerType: inno
+InstallModes:
+  - interactive
+  - silent
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/kingpin1dev/VICE-Sonar/releases/download/v3.4.1/ViceSonar_Setup_v3.4.1.exe
+    InstallerSha256: 025AE4EB932752520A7B5754F17E53CA4A9806C3BDE9D6508DDD40A79E18C596
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/k/Kingpindev/VICESonar/3.4.1/Kingpindev.VICESonar.locale.en-US.yaml
+++ b/manifests/k/Kingpindev/VICESonar/3.4.1/Kingpindev.VICESonar.locale.en-US.yaml
@@ -1,0 +1,25 @@
+PackageIdentifier: Kingpindev.VICESonar
+PackageVersion: 3.4.1
+PackageLocale: en-US
+Publisher: Kingpindev
+PackageName: VICE Sonar
+PackageUrl: https://github.com/kingpin1dev/VICE-Sonar
+License: Proprietary
+LicenseUrl: https://github.com/kingpin1dev/VICE-Sonar
+ShortDescription: A sleek always-on-top desktop widget for SteelSeries GG Sonar
+Description: |-
+  VICE Sonar is a free Windows desktop widget that gives you instant access to
+  SteelSeries Sonar — volume sliders, ChatMix, EQ presets, and GameSense RGB —
+  all in a compact, always-on-top overlay. No need to open SteelSeries GG.
+Tags:
+  - steelseries
+  - sonar
+  - audio
+  - widget
+  - gaming
+  - chatmix
+  - eq
+  - rgb
+ReleaseNotesUrl: https://github.com/kingpin1dev/VICE-Sonar/releases/tag/v3.4.1
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/k/Kingpindev/VICESonar/3.4.1/Kingpindev.VICESonar.yaml
+++ b/manifests/k/Kingpindev/VICESonar/3.4.1/Kingpindev.VICESonar.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Kingpindev.VICESonar
+PackageVersion: 3.4.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Add Kingpindev.VICESonar 3.4.1

**Package:** Kingpindev.VICESonar  
**Version:** 3.4.1  
**Publisher:** Kingpindev  

### Package Description
VICE Sonar is a free Windows desktop widget that gives you instant access to SteelSeries Sonar — volume sliders, ChatMix, EQ presets, and GameSense RGB — all in a compact, always-on-top overlay.

### Manifest Information
- **Installer Type:** Inno Setup (inno)
- **Architecture:** x64
- **Install Modes:** interactive, silent
- **Installer URL:** https://github.com/kingpin1dev/VICE-Sonar/releases/download/v3.4.1/ViceSonar_Setup_v3.4.1.exe
- **SHA256:** 025AE4EB932752520A7B5754F17E53CA4A9806C3BDE9D6508DDD40A79E18C596

### Validation Checklist
- [x] Installer URL is accessible and returns the correct file
- [x] SHA256 hash verified against the installer
- [x] Manifest files validated with winget-manifest schema 1.6.0
- [x] Package installs and uninstalls cleanly
- [x] No source code included — binary installer only
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/353344)