### PR TITLE
New version: AppWork.JDownloader version 2.1

### DIFF
--- a/manifests/a/AppWork/JDownloader/2.1/AppWork.JDownloader.installer.yaml
+++ b/manifests/a/AppWork/JDownloader/2.1/AppWork.JDownloader.installer.yaml
@@ -1,0 +1,18 @@
+# Created with Sundry.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: AppWork.JDownloader
+PackageVersion: "2.1"
+InstallerType: exe
+InstallerSwitches:
+  Silent: -q
+  SilentWithProgress: -q
+ElevationRequirement: elevationRequired
+InstallerSuccessCodes:
+  - 22
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/byGOG/jdownloader2-mirror/releases/download/v2025.06.17/JDownloader2Setup_windows_x64_java21.exe
+    InstallerSha256: 504B6AF59EA6C42582AFDCF48F3CB8165CD92DAACECAC9FB01FFF67054617E45
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/a/AppWork/JDownloader/2.1/AppWork.JDownloader.locale.en-US.yaml
+++ b/manifests/a/AppWork/JDownloader/2.1/AppWork.JDownloader.locale.en-US.yaml
@@ -1,0 +1,20 @@
+# Created with Sundry.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: AppWork.JDownloader
+PackageVersion: "2.1"
+PackageLocale: en-US
+Publisher: AppWork GmbH
+PublisherUrl: https://jdownloader.org
+PublisherSupportUrl: https://support.jdownloader.org
+Author: AppWork GmbH
+PackageName: JDownloader 2
+PackageUrl: https://jdownloader.org
+License: Copyright © 2009-2020 AppWork GmbH
+ShortDescription: Download Manager for File Hosters
+Description: JDownloader is a free, open-source download management tool with a huge community of developers that makes downloading as easy and fast as it should be. Users can start, stop or pause downloads, set bandwith limitations, auto-extract archives and much more.
+Tags:
+  - download-manager
+  - file-hoster
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/a/AppWork/JDownloader/2.1/AppWork.JDownloader.locale.tr-TR.yaml
+++ b/manifests/a/AppWork/JDownloader/2.1/AppWork.JDownloader.locale.tr-TR.yaml
@@ -1,0 +1,20 @@
+# Created with Sundry.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.10.0.schema.json
+
+PackageIdentifier: AppWork.JDownloader
+PackageVersion: "2.1"
+PackageLocale: tr-TR
+Publisher: AppWork GmbH
+PublisherUrl: https://jdownloader.org
+PublisherSupportUrl: https://support.jdownloader.org
+Author: AppWork GmbH
+PackageName: JDownloader 2
+PackageUrl: https://jdownloader.org
+License: Telif Hakkı © 2009-2020 AppWork GmbH
+ShortDescription: Dosya Paylaşım Siteleri için İndirme Yöneticisi
+Description: JDownloader, indirme işlemlerini olabildiğince kolay ve hızlı hale getiren, büyük bir geliştirici topluluğuna sahip ücretsiz ve açık kaynaklı bir indirme yönetim aracıdır. Kullanıcılar indirmeleri başlatabilir, durdurabilir veya duraklatabilir, bant genişliği sınırlamaları ayarlayabilir, arşivleri otomatik olarak çıkarabilir ve çok daha fazlasını yapabilir.
+Tags:
+  - indirme-yöneticisi
+  - dosya-barındırıcı
+ManifestType: locale
+ManifestVersion: 1.10.0

--- a/manifests/a/AppWork/JDownloader/2.1/AppWork.JDownloader.yaml
+++ b/manifests/a/AppWork/JDownloader/2.1/AppWork.JDownloader.yaml
@@ -1,0 +1,8 @@
+# Created with Sundry.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: AppWork.JDownloader
+PackageVersion: "2.1"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Summary
- Updates JDownloader package from 2.0 to 2.1
- Uses GitHub Release mirror as static installer URL (official `installer.jdownloader.org` no longer serves files)
- Adds Turkish (tr-TR) locale
- Adds `InstallerSuccessCodes: [22]` for install4j installer compatibility

## Test plan
- [x] `winget validate` passed
- [x] Hash verified (SHA256: `504B6AF5...`)
- [x] Tested silent install on clean Windows 11 machine — installed successfully to `C:\Program Files\JDownloader`
- [x] Tested on second machine — confirmed working

🤖 Generated with [Claude Code](https://claude.com/claude-code)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/353570)