### PR TITLE
New package: micahkepe.jsongrep version 0.8.0

### DIFF
--- a/manifests/m/micahkepe/jsongrep/0.8.0/micahkepe.jsongrep.installer.yaml
+++ b/manifests/m/micahkepe/jsongrep/0.8.0/micahkepe.jsongrep.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: micahkepe.jsongrep
+PackageVersion: 0.8.0
+InstallerType: zip
+NestedInstallerType: portable
+ReleaseDate: 2026-03-28
+Installers:
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: jsongrep-0.8.0-x86_64-pc-windows-msvc\jg.exe
+    PortableCommandAlias: jg
+  InstallerUrl: https://github.com/micahkepe/jsongrep/releases/download/v0.8.0/jsongrep-0.8.0-x86_64-pc-windows-msvc.zip
+  InstallerSha256: B00F748D572E97644EF88CDD664931A501DE6496C32C7568A2FF87DA9028AE53
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/m/micahkepe/jsongrep/0.8.0/micahkepe.jsongrep.locale.en-US.yaml
+++ b/manifests/m/micahkepe/jsongrep/0.8.0/micahkepe.jsongrep.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: micahkepe.jsongrep
+PackageVersion: 0.8.0
+PackageLocale: en-US
+Publisher: micahkepe
+PublisherUrl: https://github.com/micahkepe
+PublisherSupportUrl: https://github.com/micahkepe/jsongrep/issues
+Author: Micah Kepe
+PackageName: jsongrep
+PackageUrl: https://github.com/micahkepe/jsongrep
+License: MIT
+LicenseUrl: https://github.com/micahkepe/jsongrep/blob/main/LICENSE
+ShortDescription: JSONPath-inspired query language for JSON, YAML, TOML, and other serialization formats
+Description: |-
+  jsongrep is a command-line tool providing a JSONPath-inspired query language
+  for searching and filtering JSON, YAML, TOML, CBOR, and MessagePack data.
+  It supports wildcards, recursive descent, array slicing, filter expressions,
+  and regex matching.
+Moniker: jg
+Tags:
+- cli
+- command-line
+- command-line-tool
+- json
+- jsonpath
+- grep
+- search
+- yaml
+- toml
+- rust
+ReleaseNotesUrl: https://github.com/micahkepe/jsongrep/releases/tag/v0.8.0
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/m/micahkepe/jsongrep/0.8.0/micahkepe.jsongrep.yaml
+++ b/manifests/m/micahkepe/jsongrep/0.8.0/micahkepe.jsongrep.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: micahkepe.jsongrep
+PackageVersion: 0.8.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
### New package: micahkepe.jsongrep version 0.8.0

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [conventions](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

> Note: Local validation and install testing were not performed as this was authored on macOS. Relying on CI validation.