### PR TITLE
New package: FlorianBruniaux.ccboard v0.21.0

### DIFF
--- a/manifests/f/FlorianBruniaux/ccboard/0.21.0/FlorianBruniaux.ccboard.installer.yaml
+++ b/manifests/f/FlorianBruniaux/ccboard/0.21.0/FlorianBruniaux.ccboard.installer.yaml
@@ -1,0 +1,16 @@
+PackageIdentifier: FlorianBruniaux.ccboard
+PackageVersion: 0.21.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: zip
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/FlorianBruniaux/ccboard/releases/download/v0.21.0/ccboard-windows-x86_64.exe.zip
+  InstallerSha256: 8a90fe9b167c4c901b424a11f556c5fb816262d73b3b2b49d4c628ba21eda920
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: ccboard.exe
+    PortableCommandAlias: ccboard
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/f/FlorianBruniaux/ccboard/0.21.0/FlorianBruniaux.ccboard.locale.en-US.yaml
+++ b/manifests/f/FlorianBruniaux/ccboard/0.21.0/FlorianBruniaux.ccboard.locale.en-US.yaml
@@ -1,0 +1,28 @@
+PackageIdentifier: FlorianBruniaux.ccboard
+PackageVersion: 0.21.0
+PackageLocale: en-US
+Publisher: Florian Bruniaux
+PublisherUrl: https://github.com/FlorianBruniaux
+PublisherSupportUrl: https://github.com/FlorianBruniaux/ccboard/issues
+PackageName: ccboard
+PackageUrl: https://github.com/FlorianBruniaux/ccboard
+License: MIT OR Apache-2.0
+LicenseUrl: https://github.com/FlorianBruniaux/ccboard/blob/main/LICENSE-MIT
+Copyright: Copyright (c) 2025-2026 Florian Bruniaux
+ShortDescription: Unified TUI/Web dashboard for Claude Code session monitoring, cost tracking & config management
+Description: |-
+  ccboard is a free, open-source Rust TUI and web dashboard for Claude Code.
+  It provides 13 interactive tabs covering sessions, analytics, costs, hooks,
+  agents, MCP servers, config management, a Brain knowledge base, and more.
+  Single 5.8MB binary with 89x faster startup via SQLite cache.
+Moniker: ccboard
+Tags:
+- claude
+- dashboard
+- tui
+- monitoring
+- cli
+- rust
+ReleaseNotesUrl: https://github.com/FlorianBruniaux/ccboard/releases/tag/v0.21.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/f/FlorianBruniaux/ccboard/0.21.0/FlorianBruniaux.ccboard.yaml
+++ b/manifests/f/FlorianBruniaux/ccboard/0.21.0/FlorianBruniaux.ccboard.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: FlorianBruniaux.ccboard
+PackageVersion: 0.21.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## New Package Submission

**Package Identifier**: FlorianBruniaux.ccboard
**Version**: 0.21.0
**Publisher**: Florian Bruniaux

### Description
ccboard is a free, open-source Rust TUI and web dashboard for Claude Code session monitoring, cost tracking and config management. Single 5.8MB binary, 13 interactive tabs, 89x faster startup via SQLite cache.

### Validation
- [x] I have verified the manifest using `winget validate`
- [x] The package installs and runs correctly on Windows
- [x] SHA256 checksums verified against release assets
- [x] Package URL is accessible: https://github.com/FlorianBruniaux/ccboard/releases/tag/v0.21.0

### Manifest Location
`manifests/f/FlorianBruniaux/ccboard/0.21.0/`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/353771)