### PR TITLE
New version: Peters.Horizon version 0.2.4

### DIFF
--- a/manifests/p/Peters/Horizon/0.2.4/Peters.Horizon.installer.yaml
+++ b/manifests/p/Peters/Horizon/0.2.4/Peters.Horizon.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: Peters.Horizon
+PackageVersion: 0.2.4
+InstallerType: portable
+Commands:
+- horizon
+ReleaseDate: 2026-03-30
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/peters/horizon/releases/download/v0.2.4/horizon-windows-x64.exe
+  InstallerSha256: AC82B29F3ADAECE877D4055EAF689D72BE45073F7A35281D0D5BEE2E7F997494
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/p/Peters/Horizon/0.2.4/Peters.Horizon.locale.en-US.yaml
+++ b/manifests/p/Peters/Horizon/0.2.4/Peters.Horizon.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: Peters.Horizon
+PackageVersion: 0.2.4
+PackageLocale: en-US
+Publisher: Peter Rekdal Khan-Sunde
+PublisherUrl: https://github.com/peters
+PublisherSupportUrl: https://github.com/peters/horizon/issues
+PackageName: Horizon
+PackageUrl: https://github.com/peters/horizon
+License: MIT
+LicenseUrl: https://github.com/peters/horizon/blob/v0.2.4/LICENSE
+ShortDescription: GPU-accelerated terminal board on an infinite canvas.
+Description: |-
+  Horizon is a GPU-accelerated terminal board for managing multiple terminal sessions as freely positioned, resizable panels on an infinite canvas.
+  It combines workspaces, panel presets, remote hosts, session persistence, and agent-friendly terminal workflows in one desktop app.
+Tags:
+- terminal
+- workspace
+- developer-tools
+ReleaseNotesUrl: https://github.com/peters/horizon/releases/tag/v0.2.4
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/p/Peters/Horizon/0.2.4/Peters.Horizon.yaml
+++ b/manifests/p/Peters/Horizon/0.2.4/Peters.Horizon.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: Peters.Horizon
+PackageVersion: 0.2.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
New stable Horizon release submission for WinGet.

- Package identifier: `Peters.Horizon`
- Version: `0.2.4`
- Installer URL: https://github.com/peters/horizon/releases/download/v0.2.4/horizon-windows-x64.exe
- Installer SHA256: `ac82b29f3adaece877d4055eaf689d72be45073f7a35281d0d5bee2e7f997494`

Generated by the Horizon stable release workflow.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/353815)