### PR TITLE
New version: kts982.WinTUI version 1.0.0

### DIFF
--- a/manifests/k/kts982/WinTUI/1.0.0/kts982.WinTUI.installer.yaml
+++ b/manifests/k/kts982/WinTUI/1.0.0/kts982.WinTUI.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: kts982.WinTUI
+PackageVersion: 1.0.0
+MinimumOSVersion: 10.0.17763.0
+InstallerType: portable
+Commands:
+  - wintui
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/kts982/wintui/releases/download/v1.0.0/wintui_1.0.0_windows_amd64.exe
+    InstallerSha256: 1E9FFC104B3CA3D193972067764DE6D02F00FBFAA7AA76EC9ACC74D3867E3479
+  - Architecture: arm64
+    InstallerUrl: https://github.com/kts982/wintui/releases/download/v1.0.0/wintui_1.0.0_windows_arm64.exe
+    InstallerSha256: DB701EE800359BED1603BEFCF7D5B361A81CB78C1DC3B538A4ADE45119E49785
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/k/kts982/WinTUI/1.0.0/kts982.WinTUI.locale.en-US.yaml
+++ b/manifests/k/kts982/WinTUI/1.0.0/kts982.WinTUI.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: kts982.WinTUI
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: kts982
+PublisherUrl: https://github.com/kts982
+PublisherSupportUrl: https://github.com/kts982/wintui/issues
+Author: Kostas T.
+PackageName: WinTUI
+PackageUrl: https://github.com/kts982/wintui
+License: MIT
+LicenseUrl: https://github.com/kts982/wintui/blob/main/LICENSE
+ShortDescription: Terminal UI for winget on Windows.
+Description: >-
+  WinTUI is a terminal user interface for Windows Package Manager. It lets you
+  browse installed packages, search package sources, install and upgrade
+  packages, export and restore package selections, and run a few workstation
+  utility tasks without leaving the terminal. Includes a headless CLI mode for
+  scripting and a built-in elevated helper for seamless batch operations with
+  a single UAC prompt.
+Moniker: wintui
+Tags:
+  - winget
+  - windows
+  - tui
+  - terminal
+  - package-manager
+  - cli
+ReleaseNotesUrl: https://github.com/kts982/wintui/releases/tag/v1.0.0
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/k/kts982/WinTUI/1.0.0/kts982.WinTUI.yaml
+++ b/manifests/k/kts982/WinTUI/1.0.0/kts982.WinTUI.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: kts982.WinTUI
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
### New version: kts982.WinTUI version 1.0.0

Updates the existing kts982.WinTUI package from 0.1.0 to 1.0.0.

**What's new in v1.0.0:**
- Charm v2 migration (Bubble Tea, Bubbles, Lip Gloss)
- Headless CLI mode (`--check`, `--list`, `--json`)
- Built-in elevated helper with named pipe IPC (single UAC prompt for batch operations)
- Upfront elevation in silent mode to avoid installer UAC popups
- Version selection for install and upgrade
- Responsive table widths
- Live log viewport during execution
- Compact header mode for small terminals
- Numerous UX fixes and polish

Release: https://github.com/kts982/wintui/releases/tag/v1.0.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/353876)