### PR TITLE
New version: JanOdegard.TinyClips version 0.0.5

### DIFF
--- a/manifests/j/JanOdegard/TinyClips/0.0.5/JanOdegard.TinyClips.installer.yaml
+++ b/manifests/j/JanOdegard/TinyClips/0.0.5/JanOdegard.TinyClips.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: JanOdegard.TinyClips
+PackageVersion: 0.0.5
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: TinyClips.exe
+  PortableCommandAlias: tinyclips
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/janode/tiny-clips-win/releases/download/v0.0.5/TinyClips-x64.zip
+  InstallerSha256: 2B56D46D951D038913B3B89381C1641F2E19A99104F2710FB72A994933C8960B
+- Architecture: arm64
+  InstallerUrl: https://github.com/janode/tiny-clips-win/releases/download/v0.0.5/TinyClips-arm64.zip
+  InstallerSha256: 2499EC2400E7F3579626D597D20DA983DC54CED7B8D2FAC540A3F44A3FDA0A92
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/j/JanOdegard/TinyClips/0.0.5/JanOdegard.TinyClips.locale.en-US.yaml
+++ b/manifests/j/JanOdegard/TinyClips/0.0.5/JanOdegard.TinyClips.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: JanOdegard.TinyClips
+PackageVersion: 0.0.5
+PackageLocale: en-US
+Publisher: Jan Ødegård
+PublisherUrl: https://github.com/janode
+PublisherSupportUrl: https://github.com/janode/tiny-clips-win/issues
+PackageName: TinyClips
+PackageUrl: https://tinyclips.dev
+License: Proprietary
+LicenseUrl: https://github.com/janode/tiny-clips-win
+ShortDescription: Lightweight screen capture app for Windows 11 — screenshots, video, and GIF from the system tray.
+Description: |-
+  TinyClips is a Windows 11 system-tray app for screen capture. Take screenshots,
+  record video (H.264 MP4), or capture animated GIFs — all from global hotkeys or
+  the tray menu. Features include region/screen/window capture modes, configurable
+  countdown, floating always-on-top panels, and customizable file naming.
+Tags:
+- capture
+- gif
+- recording
+- screen-capture
+- screenshot
+- video
+ReleaseNotesUrl: https://github.com/janode/tiny-clips-win/releases/tag/v0.0.5
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/j/JanOdegard/TinyClips/0.0.5/JanOdegard.TinyClips.yaml
+++ b/manifests/j/JanOdegard/TinyClips/0.0.5/JanOdegard.TinyClips.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: JanOdegard.TinyClips
+PackageVersion: 0.0.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New version submission

- Package ID: JanOdegard.TinyClips
- Version: 0.0.5
- URL: https://tinyclips.dev
- Architectures: x64, arm64

TinyClips is a lightweight Windows 11 system-tray app for screen capture — screenshots, video (H.264 MP4), and animated GIFs.

**Changes since 0.0.2:**
- Fixed Settings window crash on systems without GPU composition support (VMs without OpenGL 2.0+) — Mica/Acrylic backdrops now guarded with `IsSupported()` checks
- Video/GIF trimmer windows
- Screenshot editor (crop, annotate, blur)
- WASAPI loopback system audio recording
- Customizable keyboard shortcuts