### PR TITLE
New package: FediMust.EyesAndEars 2.6.9

### DIFF
--- a/manifests/f/FediMust/EyesAndEars/2.6.9/FediMust.EyesAndEars.installer.yaml
+++ b/manifests/f/FediMust/EyesAndEars/2.6.9/FediMust.EyesAndEars.installer.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: FediMust.EyesAndEars
+PackageVersion: "2.6.9"
+InstallerType: portable
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Fedi-Must/EyesAndEars/releases/download/v2.6.9/EyesAndEars-2.6.9-x64.exe
+  InstallerSha256: 8E7B240BBF289B71F89CE6721DB3DA40E010EA2502CE0DAC13C4749419E1F0A6
+  Commands:
+  - eyesandears
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/f/FediMust/EyesAndEars/2.6.9/FediMust.EyesAndEars.locale.en-US.yaml
+++ b/manifests/f/FediMust/EyesAndEars/2.6.9/FediMust.EyesAndEars.locale.en-US.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: FediMust.EyesAndEars
+PackageVersion: "2.6.9"
+PackageLocale: en-US
+Publisher: Fedi-Must
+PublisherUrl: https://github.com/Fedi-Must
+PublisherSupportUrl: https://github.com/Fedi-Must/EyesAndEars/issues
+Author: Fedi-Must
+PackageName: EyesAndEars
+PackageUrl: https://github.com/Fedi-Must/EyesAndEars
+License: MIT
+ShortDescription: Screenshot-to-answer assistant with hotkey typing workflow.
+Description: Self-contained Windows app that captures screenshots, queries Gemini, and can type generated responses on demand with an always-on indicator.
+Moniker: eyesandears
+Tags:
+- ai
+- automation
+- python
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/f/FediMust/EyesAndEars/2.6.9/FediMust.EyesAndEars.yaml
+++ b/manifests/f/FediMust/EyesAndEars/2.6.9/FediMust.EyesAndEars.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: FediMust.EyesAndEars
+PackageVersion: "2.6.9"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Summary
- Adds `FediMust.EyesAndEars` version `2.6.9`
- Installer type: portable
- Installer source: GitHub release asset

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/353983)