### PR TITLE
New package: sirrlock.Sirrd 1.0.40 and sirrlock.Sirr 1.0.40

### DIFF
--- a/manifests/s/sirrlock/Sirr/1.0.40/sirrlock.Sirr.installer.yaml
+++ b/manifests/s/sirrlock/Sirr/1.0.40/sirrlock.Sirr.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: sirrlock.Sirr
+PackageVersion: 1.0.40
+MinimumOSVersion: 10.0.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: sirr.exe
+    PortableCommandAlias: sirr
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/sirrlock/sirr/releases/download/v1.0.40/sirr-windows-x64.zip
+    InstallerSha256: 8D150109FF1ABD7333CFC90E3BF80B0C9545DF20AA4B61A9224A25D4A4344554
+  - Architecture: arm64
+    InstallerUrl: https://github.com/sirrlock/sirr/releases/download/v1.0.40/sirr-windows-arm64.zip
+    InstallerSha256: 68DBE4D78BC5B91BAFF1FC816E8EF9324A56E21197B2DABD44DB189FACE84A61
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/sirrlock/Sirr/1.0.40/sirrlock.Sirr.locale.en-US.yaml
+++ b/manifests/s/sirrlock/Sirr/1.0.40/sirrlock.Sirr.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: sirrlock.Sirr
+PackageVersion: 1.0.40
+PackageLocale: en-US
+Publisher: Sirrlock
+PublisherUrl: https://sirrlock.com
+PublisherSupportUrl: https://github.com/sirrlock/sirr/issues
+PackageName: Sirr
+PackageUrl: https://sirrlock.com
+License: MIT
+LicenseUrl: https://github.com/sirrlock/sirr/blob/main/crates/sirr/LICENSE
+ShortDescription: Ephemeral secret vault CLI — burn-after-read secrets for developers
+Description: |-
+  Sirr is a CLI client for the Sirr ephemeral secret vault. Push secrets that
+  automatically expire after a set number of reads or a TTL. Works with any
+  Sirr server instance.
+Moniker: sirr
+Tags:
+  - secrets
+  - security
+  - ephemeral
+  - burn-after-read
+  - vault
+  - cli
+ReleaseNotesUrl: https://github.com/sirrlock/sirr/releases/tag/v1.0.40
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/sirrlock/Sirr/1.0.40/sirrlock.Sirr.yaml
+++ b/manifests/s/sirrlock/Sirr/1.0.40/sirrlock.Sirr.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: sirrlock.Sirr
+PackageVersion: 1.0.40
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0

--- a/manifests/s/sirrlock/Sirrd/1.0.40/sirrlock.Sirrd.installer.yaml
+++ b/manifests/s/sirrlock/Sirrd/1.0.40/sirrlock.Sirrd.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: sirrlock.Sirrd
+PackageVersion: 1.0.40
+MinimumOSVersion: 10.0.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: sirrd.exe
+    PortableCommandAlias: sirrd
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/sirrlock/sirr/releases/download/v1.0.40/sirrd-windows-x64.zip
+    InstallerSha256: B9539724847569D701936AFB2B589C1CE5BA1DEFF5B3CDFF189C22420D9270A2
+  - Architecture: arm64
+    InstallerUrl: https://github.com/sirrlock/sirr/releases/download/v1.0.40/sirrd-windows-arm64.zip
+    InstallerSha256: 7BD91E342886C34970276E691BAE47BFF685BE5140B3549BC7011ACCBF418747
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/sirrlock/Sirrd/1.0.40/sirrlock.Sirrd.locale.en-US.yaml
+++ b/manifests/s/sirrlock/Sirrd/1.0.40/sirrlock.Sirrd.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: sirrlock.Sirrd
+PackageVersion: 1.0.40
+PackageLocale: en-US
+Publisher: Sirrlock
+PublisherUrl: https://sirrlock.com
+PublisherSupportUrl: https://github.com/sirrlock/sirr/issues
+PackageName: Sirrd
+PackageUrl: https://sirrlock.com
+License: BUSL-1.1
+LicenseUrl: https://github.com/sirrlock/sirr/blob/main/LICENSE
+ShortDescription: Ephemeral secret vault server — burn-after-read secrets for developers
+Description: |-
+  Sirrd is a self-hosted ephemeral secret vault. Store secrets that automatically
+  expire after a set number of reads or a TTL. Encrypted at rest with
+  ChaCha20-Poly1305. Free for up to 100 secrets per instance.
+Moniker: sirrd
+Tags:
+  - secrets
+  - security
+  - ephemeral
+  - burn-after-read
+  - vault
+  - cli
+ReleaseNotesUrl: https://github.com/sirrlock/sirr/releases/tag/v1.0.40
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/sirrlock/Sirrd/1.0.40/sirrlock.Sirrd.yaml
+++ b/manifests/s/sirrlock/Sirrd/1.0.40/sirrlock.Sirrd.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: sirrlock.Sirrd
+PackageVersion: 1.0.40
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## New packages

### sirrlock.Sirrd 1.0.40
Ephemeral secret vault server — burn-after-read secrets for developers. Self-hosted, encrypted at rest with ChaCha20-Poly1305.

### sirrlock.Sirr 1.0.40
CLI client for the Sirr ephemeral secret vault.

- **Publisher**: Sirrlock
- **Website**: https://sirrlock.com
- **Repository**: https://github.com/sirrlock/sirr
- **Architectures**: x64, arm64
- **Installer type**: zip (portable)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/354152)