### PR TITLE
New package: FernandoTonon.QtMeshEditor version 2.18.0

### DIFF
--- a/manifests/f/FernandoTonon/QtMeshEditor/2.18.0/FernandoTonon.QtMeshEditor.installer.yaml
+++ b/manifests/f/FernandoTonon/QtMeshEditor/2.18.0/FernandoTonon.QtMeshEditor.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: FernandoTonon.QtMeshEditor
+PackageVersion: 2.18.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: bin\QtMeshEditor.exe
+    PortableCommandAlias: qtmesheditor
+  - RelativeFilePath: bin\qtmesh.exe
+    PortableCommandAlias: qtmesh
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/fernandotonon/QtMeshEditor/releases/download/2.18.0/QtMeshEditor-2.18.0-bin-Windows.zip
+    InstallerSha256: 25C5519EFAB228D2F71177CE091249E922ABBC11471332CA04BE8B1E7C80CDD0
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/FernandoTonon/QtMeshEditor/2.18.0/FernandoTonon.QtMeshEditor.locale.en-US.yaml
+++ b/manifests/f/FernandoTonon/QtMeshEditor/2.18.0/FernandoTonon.QtMeshEditor.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: FernandoTonon.QtMeshEditor
+PackageVersion: 2.18.0
+PackageLocale: en-US
+Publisher: Fernando Tonon
+PublisherUrl: https://github.com/fernandotonon
+PublisherSupportUrl: https://github.com/fernandotonon/QtMeshEditor/issues
+PackageName: QtMeshEditor
+PackageUrl: https://github.com/fernandotonon/QtMeshEditor
+License: MIT
+LicenseUrl: https://github.com/fernandotonon/QtMeshEditor/blob/master/License
+ShortDescription: Free 3D asset tool for indie game developers
+Description: |-
+  QtMeshEditor is a free 3D asset tool for indie game developers.
+  Merge animations from multiple files, convert between 40+ formats,
+  edit materials with AI, and inspect skeletons and bone weights.
+  Supports GUI, CLI (qtmesh), and REST API via MCP server.
+Tags:
+  - 3d
+  - mesh-editor
+  - animation
+  - fbx
+  - gltf
+  - ogre3d
+  - game-development
+  - material-editor
+Moniker: qtmesheditor
+ReleaseNotesUrl: https://github.com/fernandotonon/QtMeshEditor/releases/tag/2.18.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/FernandoTonon/QtMeshEditor/2.18.0/FernandoTonon.QtMeshEditor.yaml
+++ b/manifests/f/FernandoTonon/QtMeshEditor/2.18.0/FernandoTonon.QtMeshEditor.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: FernandoTonon.QtMeshEditor
+PackageVersion: 2.18.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## New Package: FernandoTonon.QtMeshEditor 2.18.0

**Package identifier:** FernandoTonon.QtMeshEditor  
**Version:** 2.18.0  
**Release:** https://github.com/fernandotonon/QtMeshEditor/releases/tag/2.18.0

### Package description

QtMeshEditor is a free 3D asset tool for indie game developers. Features include:
- Merge animations from multiple files
- Convert between 40+ 3D formats (FBX, glTF, OBJ, DAE, …)
- Material editor with AI texture generation
- Skeleton and bone weight visualization
- GUI, CLI (`qtmesh`), and REST/MCP server modes

### Installer

- **Type:** ZIP (portable)
- **Architecture:** x64
- **Nested executables:** `bin\QtMeshEditor.exe` (alias: `qtmesheditor`), `bin\qtmesh.exe` (alias: `qtmesh`)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/354181)