### PR TITLE
New package: babyworm.VideoViewer version 0.5.4

### DIFF
--- a/manifests/b/babyworm/VideoViewer/0.5.4/babyworm.VideoViewer.installer.yaml
+++ b/manifests/b/babyworm/VideoViewer/0.5.4/babyworm.VideoViewer.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: babyworm.VideoViewer
+PackageVersion: 0.5.4
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: video-viewer.exe
+    PortableCommandAlias: video-viewer
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/babyworm/video-viewer/releases/download/v0.5.4/video-viewer-v0.5.4-windows-x86_64.zip
+    InstallerSha256: 48E1A73C375D1350071BC0A133D44DA88A98C2D8142CAB3F4B84D2FF57689E4C
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/b/babyworm/VideoViewer/0.5.4/babyworm.VideoViewer.locale.en-US.yaml
+++ b/manifests/b/babyworm/VideoViewer/0.5.4/babyworm.VideoViewer.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: babyworm.VideoViewer
+PackageVersion: 0.5.4
+PackageLocale: en-US
+Publisher: babyworm
+PublisherUrl: https://github.com/babyworm
+PublisherSupportUrl: https://github.com/babyworm/video-viewer/issues
+PackageName: Video Viewer
+PackageUrl: https://github.com/babyworm/video-viewer
+License: MIT
+LicenseUrl: https://github.com/babyworm/video-viewer/blob/main/LICENSE
+ShortDescription: YUV/Raw video viewer with ISP sideband overlay support
+Description: A native YUV/Raw video viewer supporting 75+ pixel formats with professional analysis tools including histogram, waveform, vectorscope, PSNR/SSIM metrics, and ISP sideband CTU heatmap overlay.
+Tags:
+  - video
+  - yuv
+  - raw
+  - viewer
+  - isp
+  - codec
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/b/babyworm/VideoViewer/0.5.4/babyworm.VideoViewer.yaml
+++ b/manifests/b/babyworm/VideoViewer/0.5.4/babyworm.VideoViewer.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: babyworm.VideoViewer
+PackageVersion: 0.5.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package submission

- Package identifier: babyworm.VideoViewer
- Package version: 0.5.4
- Installer type: zip (portable)

### Description

YUV/Raw video viewer supporting 75+ pixel formats with professional analysis tools (histogram, waveform, vectorscope, PSNR/SSIM) and ISP sideband CTU heatmap overlay. Built with Rust/egui for native performance.

### Checklist
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one manifest
- [x] Have you validated your manifest locally with `winget validate`?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/354360)