### PR TITLE
Update AppWork.JDownloader.installer.yaml, official builds/urls

### DIFF
--- a/manifests/a/AppWork/JDownloader/2.1/AppWork.JDownloader.installer.yaml
+++ b/manifests/a/AppWork/JDownloader/2.1/AppWork.JDownloader.installer.yaml
@@ -2,17 +2,21 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
 
 PackageIdentifier: AppWork.JDownloader
-PackageVersion: "2.1"
+PackageVersion: "2.0"
 InstallerType: exe
+Scope: user
 InstallerSwitches:
   Silent: -q
   SilentWithProgress: -q
-ElevationRequirement: elevationRequired
 InstallerSuccessCodes:
   - 22
+  - 0
 Installers:
+  - Architecture: x86
+    InstallerUrl: https://installer.jdownloader.org/winget/2026-03-31/JDownloader2Setup_windows-x86_v1_8_0_472.exe
+    InstallerSha256: 653b6e189aaf8250038e673c54f23135414cb7365f4d49e73b091003c9c92225
   - Architecture: x64
-    InstallerUrl: https://github.com/byGOG/jdownloader2-mirror/releases/download/v2025.06.17/JDownloader2Setup_windows_x64_java21.exe
-    InstallerSha256: 504B6AF59EA6C42582AFDCF48F3CB8165CD92DAACECAC9FB01FFF67054617E45
+    InstallerUrl: https://installer.jdownloader.org/winget/2026-03-31/JDownloader2Setup_windows-amd64_v1_8_0_482.exe
+    InstallerSha256: f4346f7dcedd3e885f271fbb3182e9e7cef3bbd02c6b034f7d1b959856d100e7
 ManifestType: installer
 ManifestVersion: 1.10.0

--- a/manifests/a/AppWork/JDownloader/2.1/AppWork.JDownloader.installer.yaml
+++ b/manifests/a/AppWork/JDownloader/2.1/AppWork.JDownloader.installer.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
 
 PackageIdentifier: AppWork.JDownloader
-PackageVersion: "2.0"
+PackageVersion: "2.1"
 InstallerType: exe
 Scope: user
 InstallerSwitches:

--- a/manifests/a/AppWork/JDownloader/2.1/AppWork.JDownloader.installer.yaml
+++ b/manifests/a/AppWork/JDownloader/2.1/AppWork.JDownloader.installer.yaml
@@ -10,7 +10,6 @@ InstallerSwitches:
   SilentWithProgress: -q
 InstallerSuccessCodes:
   - 22
-  - 0
 Installers:
   - Architecture: x86
     InstallerUrl: https://installer.jdownloader.org/winget/2026-03-31/JDownloader2Setup_windows-x86_v1_8_0_472.exe


### PR DESCRIPTION
-set package version back to 2.0 to avoid confusion because users do think that package version is about application version -special exit code 22 for headless/silent
-application runs in user scope
-updated installers to latest builds
-updated urls, official dedicated urls for winget
-neither installer, nor application does require administrator-level permissions

I did remove arm64 build/url because previous pull request failed in validation and no hints about why, so will push arm64 build at later time.

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?  If so, fill in the Issue number below.
   <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

Manifests
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/354372)