### PR TITLE
Update: rpaasch.AulaSync version 2.2.2

### DIFF
--- a/manifests/r/rpaasch/AulaSync/2.2.2/rpaasch.AulaSync.installer.yaml
+++ b/manifests/r/rpaasch/AulaSync/2.2.2/rpaasch.AulaSync.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: rpaasch.AulaSync
+PackageVersion: 2.2.2
+InstallerType: portable
+Commands:
+  - AulaSync
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/rpaasch/AulaSync/releases/download/v2.2.2/AulaSync.exe
+    InstallerSha256: 1ffaffa0735e44a8972df1ca59bddabebf627abfb53b3dacb758f9e670518775
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/r/rpaasch/AulaSync/2.2.2/rpaasch.AulaSync.locale.da-DK.yaml
+++ b/manifests/r/rpaasch/AulaSync/2.2.2/rpaasch.AulaSync.locale.da-DK.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: rpaasch.AulaSync
+PackageVersion: 2.2.2
+PackageLocale: da-DK
+Publisher: rpaasch
+PublisherUrl: https://github.com/rpaasch
+PackageName: AulaSync
+PackageUrl: https://github.com/rpaasch/AulaSync
+License: MIT
+ShortDescription: Synkroniserer beskeder og skemaer fra Aula til Microsoft Outlook
+Description: |-
+  AulaSync henter beskeder fra Aula (dansk skoleplatform) og viser dem i Microsoft Outlook.
+  Understøtter alle kommuners login via WebView2 (UniLogin, Azure AD, MitID m.fl.).
+  Sætter korrekte tidsstempler og afsendere via direkte MAPI.
+  Skemaer synkroniseres som ICS-kalendere via lokal webserver.
+  Ikke affilieret med eller godkendt af Aula/KMD.
+Tags:
+  - aula
+  - outlook
+  - skole
+  - sync
+  - education
+  - kalender
+  - ics
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/r/rpaasch/AulaSync/2.2.2/rpaasch.AulaSync.yaml
+++ b/manifests/r/rpaasch/AulaSync/2.2.2/rpaasch.AulaSync.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: rpaasch.AulaSync
+PackageVersion: 2.2.2
+DefaultLocale: da-DK
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## rpaasch.AulaSync v2.2.2

Updated from v2.1.1 to v2.2.2.

### Changes
- ICS calendar subscriptions via local web server
- Silent mode (--silent) for enterprise deployment
- Automatic update check
- Security fixes (path traversal, HTML encoding)
- RFC 5545 compliant ICS generation
- Rolling calendar sync
- MIT license added
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/354397)