### PR TITLE
New package: FlorianBruniaux.ccboard v0.21.0

### DIFF
--- a/manifests/f/FlorianBruniaux/ccboard/0.21.0/FlorianBruniaux.ccboard.installer.yaml
+++ b/manifests/f/FlorianBruniaux/ccboard/0.21.0/FlorianBruniaux.ccboard.installer.yaml
@@ -13,4 +13,4 @@ Installers:
   - RelativeFilePath: ccboard.exe
     PortableCommandAlias: ccboard
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/f/FlorianBruniaux/ccboard/0.21.0/FlorianBruniaux.ccboard.locale.en-US.yaml
+++ b/manifests/f/FlorianBruniaux/ccboard/0.21.0/FlorianBruniaux.ccboard.locale.en-US.yaml
@@ -7,7 +7,7 @@ PublisherSupportUrl: https://github.com/FlorianBruniaux/ccboard/issues
 PackageName: ccboard
 PackageUrl: https://github.com/FlorianBruniaux/ccboard
 License: MIT OR Apache-2.0
-LicenseUrl: https://github.com/FlorianBruniaux/ccboard/blob/main/LICENSE-MIT
+LicenseUrl: https://github.com/FlorianBruniaux/ccboard/blob/v0.21.0/LICENSE-MIT
 Copyright: Copyright (c) 2025-2026 Florian Bruniaux
 ShortDescription: Unified TUI/Web dashboard for Claude Code session monitoring, cost tracking & config management
 Description: |-
@@ -25,4 +25,4 @@ Tags:
 - rust
 ReleaseNotesUrl: https://github.com/FlorianBruniaux/ccboard/releases/tag/v0.21.0
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/f/FlorianBruniaux/ccboard/0.21.0/FlorianBruniaux.ccboard.yaml
+++ b/manifests/f/FlorianBruniaux/ccboard/0.21.0/FlorianBruniaux.ccboard.yaml
@@ -2,4 +2,4 @@ PackageIdentifier: FlorianBruniaux.ccboard
 PackageVersion: 0.21.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## New Package Submission

**Package Identifier**: FlorianBruniaux.ccboard
**Version**: 0.21.0
**Publisher**: Florian Bruniaux

### Description
ccboard is a free, open-source Rust TUI and web dashboard for Claude Code session monitoring, cost tracking and config management. Single 5.8MB binary, 13 interactive tabs, 89x faster startup via SQLite cache.

### Validation
- [x] I have verified the manifest using `winget validate`
- [x] The package installs and runs correctly on Windows
- [x] SHA256 checksums verified against release assets
- [x] Package URL is accessible: https://github.com/FlorianBruniaux/ccboard/releases/tag/v0.21.0

### Changes vs #353771
- Fixed `ManifestVersion`: `1.6.0` → `1.12.0` in all 3 manifests
- Fixed `LicenseUrl`: now points to version-specific tag `v0.21.0` instead of `blob/main`

### Manifest Location
`manifests/f/FlorianBruniaux/ccboard/0.21.0/`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/354446)