### PR TITLE
Add DirComparePro.DirectoryComparePro version 1.05.0

### DIFF
--- a/manifests/d/DirCompare-Pro/DirectoryComparePro/1.04/DirCompare-Pro.DirectoryComparePro.installer.yaml
+++ b/manifests/d/DirCompare-Pro/DirectoryComparePro/1.04/DirCompare-Pro.DirectoryComparePro.installer.yaml
@@ -1,0 +1,14 @@
+PackageIdentifier: DirCompare-Pro.DirectoryComparePro
+PackageVersion: "1.04"
+MinimumOSVersion: 10.0.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: DirectoryComparePro.exe
+    PortableCommandAlias: dcp
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/DirCompare-Pro/DirectoryComparePro/releases/download/v1.04/DirectoryComparePro-v1.04-Windows.zip
+    InstallerSha256: FE3CF1730BDD6DEE27FE42F4380CCC47A907D22056ED27919226C462799B0505
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/d/DirCompare-Pro/DirectoryComparePro/1.04/DirCompare-Pro.DirectoryComparePro.locale.en-US.yaml
+++ b/manifests/d/DirCompare-Pro/DirectoryComparePro/1.04/DirCompare-Pro.DirectoryComparePro.locale.en-US.yaml
@@ -1,0 +1,29 @@
+PackageIdentifier: DirCompare-Pro.DirectoryComparePro
+PackageVersion: "1.04"
+PackageLocale: en-US
+Publisher: DirCompare-Pro
+PublisherUrl: https://dircompare-pro.github.io/
+PublisherSupportUrl: https://github.com/DirCompare-Pro/DirectoryComparePro/issues
+PackageName: DirectoryCompare Pro
+PackageUrl: https://dircompare-pro.github.io/
+License: Proprietary
+LicenseUrl: https://dircompare-pro.github.io/download.html
+ShortDescription: N-way directory and file comparison tool with diff viewer, 3-way merge, and Git integration.
+Description: |-
+  DirectoryCompare Pro is a fast, multi-source directory comparison tool for Windows.
+  Compare 2 to 8 directories simultaneously, view side-by-side diffs, perform 3-way merges,
+  browse archives (zip/tar), compare CSV files, and sync folders — all in one app.
+  Includes Git branch comparison, similarity search, and a built-in file browser.
+  Free tier available; Standard and Premium tiers unlock advanced features.
+Moniker: dcp
+Tags:
+  - diff
+  - compare
+  - directory
+  - merge
+  - file-comparison
+  - git
+  - sync
+ReleaseNotesUrl: https://github.com/DirCompare-Pro/DirectoryComparePro/releases/tag/v1.04
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/d/DirCompare-Pro/DirectoryComparePro/1.04/DirCompare-Pro.DirectoryComparePro.yaml
+++ b/manifests/d/DirCompare-Pro/DirectoryComparePro/1.04/DirCompare-Pro.DirectoryComparePro.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: DirCompare-Pro.DirectoryComparePro
+  PackageVersion: "1.04"
+  DefaultLocale: en-US
+  ManifestType: version
+  ManifestVersion: 1.6.0

--- a/manifests/d/DirCompare-Pro/DirectoryComparePro/1.04/DirCompare-Pro.DirectoryComparePro.yaml
+++ b/manifests/d/DirCompare-Pro/DirectoryComparePro/1.04/DirCompare-Pro.DirectoryComparePro.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: DirCompare-Pro.DirectoryComparePro
-  PackageVersion: "1.04"
-  DefaultLocale: en-US
-  ManifestType: version
-  ManifestVersion: 1.6.0
+PackageVersion: "1.04"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0

--- a/manifests/d/DirComparePro/DirectoryComparePro/1.05.0/DirComparePro.DirectoryComparePro.installer.yaml
+++ b/manifests/d/DirComparePro/DirectoryComparePro/1.05.0/DirComparePro.DirectoryComparePro.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: DirComparePro.DirectoryComparePro
+PackageVersion: 1.05.0
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: DirectoryComparePro.exe
+    PortableCommandAlias: dircomparepro
+InstallModes:
+  - interactive
+  - silent
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/DirCompare-Pro/DirectoryComparePro/releases/download/v1.05/DirectoryComparePro-v1.05-Windows.zip
+    InstallerSha256: D4E67E84F32E7CB6ECD0640F5CF853802C0869DF564BAD409D028FC5AE230589
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/d/DirComparePro/DirectoryComparePro/1.05.0/DirComparePro.DirectoryComparePro.locale.en-US.yaml
+++ b/manifests/d/DirComparePro/DirectoryComparePro/1.05.0/DirComparePro.DirectoryComparePro.locale.en-US.yaml
@@ -1,0 +1,57 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: DirComparePro.DirectoryComparePro
+PackageVersion: 1.05.0
+PackageLocale: en-US
+Publisher: DirCompare Pro
+PublisherUrl: https://directorycompare-pro.com
+PublisherSupportUrl: https://directorycompare-pro.com/support
+PrivacyUrl: https://directorycompare-pro.com/privacy
+PackageName: DirectoryCompare Pro
+PackageUrl: https://directorycompare-pro.com
+License: Proprietary
+LicenseUrl: https://directorycompare-pro.com/license
+Copyright: Copyright (c) 2025 DirCompare Pro
+ShortDescription: Compare folders, Git repos, archives, FTP servers, and web URLs — side by side or up to 16 sources at once.
+Description: |-
+  DirectoryCompare Pro is a desktop file and folder comparison tool for Windows and Linux.
+
+  Everything a developer needs day-to-day is free. You only pay when you're running it at scale.
+
+  Free tier covers: 2-way compare, diff, 3-way merge, archives, CSV, Excel, hex, sync,
+  sessions, bookmarks, smart folder alignment, and exports.
+
+  Standard ($39) adds: N-way comparison (up to 16 sources), Git, GitHub, plugin viewers,
+  dark mode, and branding removal.
+
+  Premium ($79) adds: Patch generator, CLI (dircompare), FTP/SFTP, web URL comparison,
+  similarity search, and priority support.
+
+  Lifetime ($199): One-time purchase, all Premium features, no subscription.
+
+  Distributed as a single portable .exe — no installer, no dependencies, no DLLs required.
+  A 30-day full-featured trial starts automatically on first launch. No sign-up required.
+Moniker: dircomparepro
+Tags:
+  - compare
+  - diff
+  - merge
+  - folder
+  - directory
+  - file
+  - git
+  - github
+  - ftp
+  - archive
+  - zip
+  - patch
+  - sync
+  - developer
+  - productivity
+ReleaseNotes: |-
+  v1.05 (2026-04-02)
+  - N-way diff viewer: synchronized scrolling now locks all panels simultaneously,
+    eliminating lag and jumpiness when dragging the scrollbar thumb
+ReleaseNotesUrl: https://github.com/DirCompare-Pro/DirectoryComparePro/releases/tag/v1.05
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/d/DirComparePro/DirectoryComparePro/1.05.0/DirComparePro.DirectoryComparePro.yaml
+++ b/manifests/d/DirComparePro/DirectoryComparePro/1.05.0/DirComparePro.DirectoryComparePro.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: DirComparePro.DirectoryComparePro
+PackageVersion: 1.05.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## New Package: DirectoryCompare Pro 1.05.0

This PR adds version 1.05.0 of DirectoryCompare Pro.

**Manifest type:** Portable ZIP
**Publisher:** DirCompare Pro
**Package:** DirectoryCompare Pro â€” N-way directory comparison tool

### Release notes
### Fixed
- N-way diff viewer: synchronized scrolling now drives all panels simultaneously via direct RICHEDIT messages, eliminating the lag and jumpiness when dragging the scrollbar thumb

---

---
This submission was generated by the DCP publish script.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/354519)