### PR TITLE
New package: FernandoTonon.QtMeshEditor version 2.18.1

### DIFF
--- a/manifests/f/FernandoTonon/QtMeshEditor/2.18.1/FernandoTonon.QtMeshEditor.installer.yaml
+++ b/manifests/f/FernandoTonon/QtMeshEditor/2.18.1/FernandoTonon.QtMeshEditor.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: FernandoTonon.QtMeshEditor
+PackageVersion: 2.18.1
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: bin\QtMeshEditor.exe
+    PortableCommandAlias: qtmesheditor
+  - RelativeFilePath: bin\qtmesh.exe
+    PortableCommandAlias: qtmesh
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/fernandotonon/QtMeshEditor/releases/download/2.18.1/QtMeshEditor-2.18.1-bin-Windows.zip
+    InstallerSha256: 8A468D0496A539A4A2A4F0E78DF225C85326C047C8A1E81A9C03AE4CA4D07CE3
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/FernandoTonon/QtMeshEditor/2.18.1/FernandoTonon.QtMeshEditor.locale.en-US.yaml
+++ b/manifests/f/FernandoTonon/QtMeshEditor/2.18.1/FernandoTonon.QtMeshEditor.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: FernandoTonon.QtMeshEditor
+PackageVersion: 2.18.1
+PackageLocale: en-US
+Publisher: Fernando Tonon
+PublisherUrl: https://github.com/fernandotonon
+PublisherSupportUrl: https://github.com/fernandotonon/QtMeshEditor/issues
+PackageName: QtMeshEditor
+PackageUrl: https://github.com/fernandotonon/QtMeshEditor
+License: MIT
+LicenseUrl: https://github.com/fernandotonon/QtMeshEditor/blob/master/License
+ShortDescription: Free 3D asset tool for indie game developers
+Description: |-
+  QtMeshEditor is a free 3D asset tool for indie game developers.
+  Merge animations from multiple files, convert between 40+ formats,
+  edit materials with AI, and inspect skeletons and bone weights.
+  Supports GUI, CLI (qtmesh), and REST API via MCP server.
+Tags:
+  - 3d
+  - mesh-editor
+  - animation
+  - fbx
+  - gltf
+  - ogre3d
+  - game-development
+  - material-editor
+Moniker: qtmesheditor
+ReleaseNotesUrl: https://github.com/fernandotonon/QtMeshEditor/releases/tag/2.18.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/FernandoTonon/QtMeshEditor/2.18.1/FernandoTonon.QtMeshEditor.yaml
+++ b/manifests/f/FernandoTonon/QtMeshEditor/2.18.1/FernandoTonon.QtMeshEditor.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: FernandoTonon.QtMeshEditor
+PackageVersion: 2.18.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Windows Package Manager Manifest

- **Package**: FernandoTonon.QtMeshEditor
- **Version**: 2.18.1
- **Installer**: Portable ZIP (x64)

### Release Notes
- Support animation-only FBX imports (e.g. Unreal Engine retargets)
- Fix Windows APPCRASH on machines without OpenGL (affects WinGet validation environment)
- Auto-detect FBX Z-up (Unreal Engine) vs Y-up (Mixamo) coordinate systems
- Offer immediate animation merge when an animation-only file is imported with a mesh selected

https://github.com/fernandotonon/QtMeshEditor/releases/tag/2.18.1
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/354568)