### PR TITLE
Restore JDownloader package version 2.0

### DIFF
--- a/manifests/a/AppWork/JDownloader/2.0/AppWork.JDownloader.installer.yaml
+++ b/manifests/a/AppWork/JDownloader/2.0/AppWork.JDownloader.installer.yaml
@@ -1,0 +1,24 @@
+# Created with Sundry.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: AppWork.JDownloader
+PackageVersion: "2.0"
+InstallerType: exe
+Scope: user
+InstallerSwitches:
+  Silent: -q
+  SilentWithProgress: -q
+InstallerSuccessCodes:
+  - 22
+Installers:
+  - Architecture: x86
+    InstallerUrl: https://installer.jdownloader.org/winget/2026-03-31/JDownloader2Setup_windows-x86_v1_8_0_472.exe
+    InstallerSha256: 653b6e189aaf8250038e673c54f23135414cb7365f4d49e73b091003c9c92225
+  - Architecture: x64
+    InstallerUrl: https://installer.jdownloader.org/winget/2026-03-31/JDownloader2Setup_windows-amd64_v1_8_0_482.exe
+    InstallerSha256: f4346f7dcedd3e885f271fbb3182e9e7cef3bbd02c6b034f7d1b959856d100e7
+  - Architecture: arm64
+    InstallerUrl: https://installer.jdownloader.org/winget/2026-03-31/JDownloader2Setup_windows-aarch64_v21_0_10.exe
+    InstallerSha256: 497b4490b2a7673bfbfd4fe084ef09dbea909b6cee985deddac2dccb6ea73e3d
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/a/AppWork/JDownloader/2.0/AppWork.JDownloader.locale.en-US.yaml
+++ b/manifests/a/AppWork/JDownloader/2.0/AppWork.JDownloader.locale.en-US.yaml
@@ -1,0 +1,20 @@
+# Created with Sundry.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: AppWork.JDownloader
+PackageVersion: "2.0"
+PackageLocale: en-US
+Publisher: AppWork GmbH
+PublisherUrl: https://jdownloader.org
+PublisherSupportUrl: https://support.jdownloader.org
+Author: AppWork GmbH
+PackageName: JDownloader 2
+PackageUrl: https://jdownloader.org
+License: Copyright © 2009-2026 AppWork GmbH
+ShortDescription: Download Manager for File Hosters
+Description: JDownloader is a free, open-source download management tool with a huge community of developers that makes downloading as easy and fast as it should be. Users can start, stop or pause downloads, set bandwith limitations, auto-extract archives and much more.
+Tags:
+  - download-manager
+  - file-hoster
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/a/AppWork/JDownloader/2.0/AppWork.JDownloader.locale.tr-TR.yaml
+++ b/manifests/a/AppWork/JDownloader/2.0/AppWork.JDownloader.locale.tr-TR.yaml
@@ -1,0 +1,20 @@
+# Created with Sundry.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.10.0.schema.json
+
+PackageIdentifier: AppWork.JDownloader
+PackageVersion: "2.0"
+PackageLocale: tr-TR
+Publisher: AppWork GmbH
+PublisherUrl: https://jdownloader.org
+PublisherSupportUrl: https://support.jdownloader.org
+Author: AppWork GmbH
+PackageName: JDownloader 2
+PackageUrl: https://jdownloader.org
+License: Telif Hakkı © 2009-2026 AppWork GmbH
+ShortDescription: Dosya Paylaşım Siteleri için İndirme Yöneticisi
+Description: JDownloader, indirme işlemlerini olabildiğince kolay ve hızlı hale getiren, büyük bir geliştirici topluluğuna sahip ücretsiz ve açık kaynaklı bir indirme yönetim aracıdır. Kullanıcılar indirmeleri başlatabilir, durdurabilir veya duraklatabilir, bant genişliği sınırlamaları ayarlayabilir, arşivleri otomatik olarak çıkarabilir ve çok daha fazlasını yapabilir.
+Tags:
+  - indirme-yöneticisi
+  - dosya-barındırıcı
+ManifestType: locale
+ManifestVersion: 1.10.0

--- a/manifests/a/AppWork/JDownloader/2.0/AppWork.JDownloader.yaml
+++ b/manifests/a/AppWork/JDownloader/2.0/AppWork.JDownloader.yaml
@@ -1,0 +1,8 @@
+# Created with Sundry.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: AppWork.JDownloader
+PackageVersion: "2.0"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Restore correct package version 2.0 , see discussion here https://github.com/microsoft/winget-pkgs/issues/354250
After successful merge of 2.0, I will delete invalid version 2.1 via another pull request.

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?  If so, fill in the Issue number below.
   <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

Manifests
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/354762)