### PR TITLE
Update ten-framework.tman to 0.11.63

### DIFF
--- a/manifests/t/ten-framework/tman/0.11.63/ten-framework.tman.installer.yaml
+++ b/manifests/t/ten-framework/tman/0.11.63/ten-framework.tman.installer.yaml
@@ -1,0 +1,13 @@
+PackageIdentifier: ten-framework.tman
+PackageVersion: 0.11.63
+InstallerType: zip
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/TEN-framework/ten-framework/releases/download/0.11.63/tman-win-release-x64.zip
+    InstallerSha256: 38779f064d7037bdf09bb83aa97c474cadda01d0afaca25a60975d8255e21135
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: ten_manager\bin\tman.exe
+        PortableCommandAlias: tman
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/t/ten-framework/tman/0.11.63/ten-framework.tman.locale.en-US.yaml
+++ b/manifests/t/ten-framework/tman/0.11.63/ten-framework.tman.locale.en-US.yaml
@@ -1,0 +1,31 @@
+PackageIdentifier: ten-framework.tman
+PackageVersion: 0.11.63
+PackageLocale: en-US
+Publisher: TEN Framework Team
+PublisherUrl: https://github.com/TEN-framework
+PublisherSupportUrl: https://github.com/TEN-framework/ten-framework/issues
+PackageName: tman
+PackageUrl: https://github.com/TEN-framework/ten-framework
+License: Apache 2.0 with certain conditions
+LicenseUrl: https://github.com/TEN-framework/ten-framework/blob/main/LICENSE
+ShortDescription: TEN Framework Package Manager
+Description: |-
+  tman is the official package manager for the TEN Framework.
+  It helps developers manage extensions, protocols, and other TEN framework components.
+  Key Features:
+  - Install and manage TEN packages with ease
+  - Automatic dependency resolution
+  - Package version control and updates
+  - Support for multiple package types (extensions, protocols, etc.)
+  - Seamless integration with TEN Framework projects
+  The TEN Framework is a powerful framework for building real-time communication applications,
+  and tman makes it easy to extend and customize your applications with community packages.
+Tags:
+  - package-manager
+  - ten-framework
+  - extension-manager
+  - developer-tools
+  - cli
+  - ten
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/t/ten-framework/tman/0.11.63/ten-framework.tman.locale.ja-JP.yaml
+++ b/manifests/t/ten-framework/tman/0.11.63/ten-framework.tman.locale.ja-JP.yaml
@@ -1,0 +1,31 @@
+PackageIdentifier: ten-framework.tman
+PackageVersion: 0.11.63
+PackageLocale: ja-JP
+Publisher: TEN Framework チーム
+PublisherUrl: https://github.com/TEN-framework
+PublisherSupportUrl: https://github.com/TEN-framework/ten-framework/issues
+PackageName: tman
+PackageUrl: https://github.com/TEN-framework/ten-framework
+License: Apache 2.0 with certain conditions
+LicenseUrl: https://github.com/TEN-framework/ten-framework/blob/main/LICENSE
+ShortDescription: TEN Framework パッケージマネージャー
+Description: |-
+  tmanはTEN Frameworkの公式パッケージマネージャーです。
+  開発者が拡張機能、プロトコル、その他のTENフレームワークコンポーネントを管理するのに役立ちます。
+  主な機能：
+  - TENパッケージの簡単なインストールと管理
+  - 自動依存関係解決
+  - パッケージのバージョン管理と更新
+  - 複数のパッケージタイプのサポート（拡張機能、プロトコルなど）
+  - TEN Frameworkプロジェクトとのシームレスな統合
+  TEN Frameworkはリアルタイム通信アプリケーションを構築するための強力なフレームワークであり、
+  tmanを使用すると、コミュニティパッケージでアプリケーションを簡単に拡張およびカスタマイズできます。
+Tags:
+  - package-manager
+  - ten-framework
+  - extension-manager
+  - developer-tools
+  - cli
+  - ten
+ManifestType: locale
+ManifestVersion: 1.6.0

--- a/manifests/t/ten-framework/tman/0.11.63/ten-framework.tman.locale.ko-KR.yaml
+++ b/manifests/t/ten-framework/tman/0.11.63/ten-framework.tman.locale.ko-KR.yaml
@@ -1,0 +1,31 @@
+PackageIdentifier: ten-framework.tman
+PackageVersion: 0.11.63
+PackageLocale: ko-KR
+Publisher: TEN Framework 팀
+PublisherUrl: https://github.com/TEN-framework
+PublisherSupportUrl: https://github.com/TEN-framework/ten-framework/issues
+PackageName: tman
+PackageUrl: https://github.com/TEN-framework/ten-framework
+License: Apache 2.0 with certain conditions
+LicenseUrl: https://github.com/TEN-framework/ten-framework/blob/main/LICENSE
+ShortDescription: TEN Framework 패키지 관리자
+Description: |-
+  tman은 TEN Framework의 공식 패키지 관리자입니다.
+  개발자가 확장 기능, 프로토콜 및 기타 TEN 프레임워크 구성 요소를 관리하는 데 도움이 됩니다.
+  주요 기능:
+  - TEN 패키지를 쉽게 설치하고 관리
+  - 자동 종속성 해결
+  - 패키지 버전 제어 및 업데이트
+  - 다양한 패키지 유형 지원 (확장 기능, 프로토콜 등)
+  - TEN Framework 프로젝트와의 원활한 통합
+  TEN Framework는 실시간 통신 애플리케이션 구축을 위한 강력한 프레임워크이며,
+  tman을 사용하면 커뮤니티 패키지로 애플리케이션을 쉽게 확장하고 사용자 지정할 수 있습니다.
+Tags:
+  - package-manager
+  - ten-framework
+  - extension-manager
+  - developer-tools
+  - cli
+  - ten
+ManifestType: locale
+ManifestVersion: 1.6.0

--- a/manifests/t/ten-framework/tman/0.11.63/ten-framework.tman.locale.zh-CN.yaml
+++ b/manifests/t/ten-framework/tman/0.11.63/ten-framework.tman.locale.zh-CN.yaml
@@ -1,0 +1,31 @@
+PackageIdentifier: ten-framework.tman
+PackageVersion: 0.11.63
+PackageLocale: zh-CN
+Publisher: TEN Framework 团队
+PublisherUrl: https://github.com/TEN-framework
+PublisherSupportUrl: https://github.com/TEN-framework/ten-framework/issues
+PackageName: tman
+PackageUrl: https://github.com/TEN-framework/ten-framework
+License: Apache 2.0 with certain conditions
+LicenseUrl: https://github.com/TEN-framework/ten-framework/blob/main/LICENSE
+ShortDescription: TEN Framework 包管理器
+Description: |-
+  tman 是 TEN Framework 的官方包管理器。
+  它帮助开发者管理扩展、协议和其他 TEN 框架组件。
+  主要特性：
+  - 轻松安装和管理 TEN 包
+  - 自动依赖解析
+  - 包版本控制和更新
+  - 支持多种包类型（扩展、协议等）
+  - 与 TEN Framework 项目无缝集成
+  TEN Framework 是一个强大的实时通信应用框架，
+  tman 让您可以轻松扩展和定制应用程序。
+Tags:
+  - package-manager
+  - ten-framework
+  - extension-manager
+  - developer-tools
+  - cli
+  - ten
+ManifestType: locale
+ManifestVersion: 1.6.0

--- a/manifests/t/ten-framework/tman/0.11.63/ten-framework.tman.locale.zh-TW.yaml
+++ b/manifests/t/ten-framework/tman/0.11.63/ten-framework.tman.locale.zh-TW.yaml
@@ -1,0 +1,31 @@
+PackageIdentifier: ten-framework.tman
+PackageVersion: 0.11.63
+PackageLocale: zh-TW
+Publisher: TEN Framework 團隊
+PublisherUrl: https://github.com/TEN-framework
+PublisherSupportUrl: https://github.com/TEN-framework/ten-framework/issues
+PackageName: tman
+PackageUrl: https://github.com/TEN-framework/ten-framework
+License: Apache 2.0 with certain conditions
+LicenseUrl: https://github.com/TEN-framework/ten-framework/blob/main/LICENSE
+ShortDescription: TEN Framework 套件管理器
+Description: |-
+  tman 是 TEN Framework 的官方套件管理器。
+  它幫助開發者管理擴充套件、通訊協定和其他 TEN 框架元件。
+  主要特性：
+  - 輕鬆安裝和管理 TEN 套件
+  - 自動相依性解析
+  - 套件版本控制和更新
+  - 支援多種套件類型（擴充套件、通訊協定等）
+  - 與 TEN Framework 專案無縫整合
+  TEN Framework 是一個強大的即時通訊應用程式框架，
+  tman 讓您可以輕鬆擴充和客製化應用程式。
+Tags:
+  - package-manager
+  - ten-framework
+  - extension-manager
+  - developer-tools
+  - cli
+  - ten
+ManifestType: locale
+ManifestVersion: 1.6.0

--- a/manifests/t/ten-framework/tman/0.11.63/ten-framework.tman.yaml
+++ b/manifests/t/ten-framework/tman/0.11.63/ten-framework.tman.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: ten-framework.tman
+PackageVersion: 0.11.63
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Update ten-framework.tman to version 0.11.63

This PR updates the tman package to version 0.11.63.

### Package Information
- **Package**: ten-framework.tman
- **Version**: 0.11.63
- **Release URL**: https://github.com/TEN-framework/ten-framework/releases/tag/0.11.63

### What is tman?
tman is the official package manager for the TEN Framework. It helps developers manage extensions, protocols, and other TEN framework components.

### Changes
- Updated package version to 0.11.63
- Updated installer URL and SHA256 checksum

### Verification
- SHA256 checksum verified: 38779f064d7037bdf09bb83aa97c474cadda01d0afaca25a60975d8255e21135
- Release asset available at: https://github.com/TEN-framework/ten-framework/releases/download/0.11.63/tman-win-release-x64.zip

---
*This PR was generated using [submit-to-winget.ps1](https://github.com/TEN-framework/ten-framework/blob/main/tools/winget/submit-to-winget.ps1)*
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/354874)