### PR TITLE
Swift: adjust package dependencies

### DIFF
--- a/manifests/s/Swift/Toolchain/6.3.0/Swift.Toolchain.installer.yaml
+++ b/manifests/s/Swift/Toolchain/6.3.0/Swift.Toolchain.installer.yaml
@@ -16,9 +16,6 @@ FileExtensions:
 Dependencies:
   PackageDependencies:
   - PackageIdentifier: Git.Git
-  - PackageIdentifier: Microsoft.VCRedist.2015+.x64
-    MinimumVersion: 14.28.29913.0
-  - PackageIdentifier: Python.Python.3.10
 ReleaseDate: 2025-09-15
 Installers:
 - Architecture: x64
@@ -29,6 +26,11 @@ Installers:
     ProductCode: '{F1ECBACC-1BEE-400C-9EE2-668FB3BB3391}'
     UpgradeCode: '{FE697529-162A-4D62-904E-F5BC964C370F}'
     InstallerType: burn
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+      MinimumVersion: 14.28.29913.0
+    - PackageIdentifier: Python.Python.3.10
 - Architecture: arm64
   InstallerUrl: https://download.swift.org/swift-6.3-release/windows10-arm64/swift-6.3-RELEASE/swift-6.3-RELEASE-windows10-arm64.exe
   InstallerSha256: ECA190022838D48984D04F8FDEDEF613E6252F694DF2079E7EB6C4137B8BBDAC
@@ -37,5 +39,9 @@ Installers:
     ProductCode: '{336A1EB0-71AD-4B17-85D7-5F914729DF22}'
     UpgradeCode: '{FE697529-162A-4D62-904E-F5BC964C370F}'
     InstallerType: burn
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.arm64
+      MinimumVersion: 14.28.29913.0
 ManifestType: installer
 ManifestVersion: 1.10.0


### PR DESCRIPTION
Make package dependencies architecture specific and shared. Git is shared, but ensure that we depend on the ARM64 runtime redistributable on ARM64 and the X64 on X64. Push the python dependency down into a package dependency that is filtered on architecture as this dependency is also architecture dependent.

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?  If so, fill in the Issue number below.
   <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

Manifests
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/354903)