### PR TITLE
New version: JanOdegard.TinyClips version 0.0.7

### DIFF
--- a/manifests/j/JanOdegard/TinyClips/0.0.7/JanOdegard.TinyClips.installer.yaml
+++ b/manifests/j/JanOdegard/TinyClips/0.0.7/JanOdegard.TinyClips.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: JanOdegard.TinyClips
+PackageVersion: 0.0.7
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: TinyClips.exe
+  PortableCommandAlias: tinyclips
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/janode/tiny-clips-win/releases/download/v0.0.7/TinyClips-x64.zip
+  InstallerSha256: C5F858EE4DFABF19EAC6D0034082B0153FF28E6142311CFA6D471D9E197F31F0
+- Architecture: arm64
+  InstallerUrl: https://github.com/janode/tiny-clips-win/releases/download/v0.0.7/TinyClips-arm64.zip
+  InstallerSha256: 8C67F3F39A95C44862BB527BF20C48A037946C395CD83C4086A7C13CE1D94AC3
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/j/JanOdegard/TinyClips/0.0.7/JanOdegard.TinyClips.locale.en-US.yaml
+++ b/manifests/j/JanOdegard/TinyClips/0.0.7/JanOdegard.TinyClips.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: JanOdegard.TinyClips
+PackageVersion: 0.0.7
+PackageLocale: en-US
+Publisher: Jan Ødegård
+PublisherUrl: https://github.com/janode
+PublisherSupportUrl: https://github.com/janode/tiny-clips-win/issues
+PackageName: TinyClips
+PackageUrl: https://tinyclips.dev
+License: Proprietary
+LicenseUrl: https://github.com/janode/tiny-clips-win
+ShortDescription: Lightweight screen capture app for Windows 11 — screenshots, video, and GIF from the system tray.
+Description: |-
+  TinyClips is a Windows 11 system-tray app for screen capture. Take screenshots,
+  record video (H.264 MP4), or capture animated GIFs — all from global hotkeys or
+  the tray menu. Features include region/screen/window capture modes, configurable
+  countdown, floating always-on-top panels, and customizable file naming.
+Tags:
+- capture
+- gif
+- recording
+- screen-capture
+- screenshot
+- video
+ReleaseNotesUrl: https://github.com/janode/tiny-clips-win/releases/tag/v0.0.7
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/j/JanOdegard/TinyClips/0.0.7/JanOdegard.TinyClips.yaml
+++ b/manifests/j/JanOdegard/TinyClips/0.0.7/JanOdegard.TinyClips.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: JanOdegard.TinyClips
+PackageVersion: 0.0.7
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New version submission

- Package ID: JanOdegard.TinyClips
- Version: 0.0.7
- URL: https://tinyclips.dev
- Architectures: x64, arm64

TinyClips is a lightweight Windows 11 system-tray app for screen capture — screenshots, video (H.264 MP4), and animated GIFs.

Changes since 0.0.5:

- Fixed Settings window crash on systems without GPU composition support (VMs without OpenGL 2.0+) — Mica/Acrylic backdrop setup now wrapped in try/catch with graceful fallback to solid background
- Hardened ShowSettings() with error handling so window construction failures never crash the app