### PR TITLE
Add Nassim0x.NSearcher version 1.0.2

### DIFF
--- a/manifests/n/Nassim0x/NSearcher/1.0.2/Nassim0x.NSearcher.installer.yaml
+++ b/manifests/n/Nassim0x/NSearcher/1.0.2/Nassim0x.NSearcher.installer.yaml
@@ -1,4 +1,5 @@
 # Created with https://aka.ms/winget-create
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: 'Nassim0x.NSearcher'
 PackageVersion: '1.0.2'

--- a/manifests/n/Nassim0x/NSearcher/1.0.2/Nassim0x.NSearcher.installer.yaml
+++ b/manifests/n/Nassim0x/NSearcher/1.0.2/Nassim0x.NSearcher.installer.yaml
@@ -1,0 +1,27 @@
+# Created with https://aka.ms/winget-create
+
+PackageIdentifier: 'Nassim0x.NSearcher'
+PackageVersion: '1.0.2'
+InstallerType: 'exe'
+Scope: 'user'
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: 'install'
+Commands:
+- NSearcher
+Installers:
+- Architecture: x64
+  InstallerLocale: 'en-US'
+  InstallerUrl: 'https://github.com/Nassim0x/nsearcher/releases/download/v1.0.2/NSearcher-Setup-v1.0.2-win-x64.exe'
+  InstallerSha256: '6F27CCB2EFA5A2856420A91EBD50D8B632F185897C0A10817759CA62DF225F43'
+  InstallerSwitches:
+    Silent: '/quiet'
+    SilentWithProgress: '/quiet'
+    InstallLocation: '/dir <INSTALLPATH>'
+  AppsAndFeaturesEntries:
+  - DisplayName: 'NSearcher'
+    Publisher: 'Nassim0x'
+ManifestType: installer
+ManifestVersion: '1.10.0'

--- a/manifests/n/Nassim0x/NSearcher/1.0.2/Nassim0x.NSearcher.installer.yaml
+++ b/manifests/n/Nassim0x/NSearcher/1.0.2/Nassim0x.NSearcher.installer.yaml
@@ -24,4 +24,4 @@ Installers:
   - DisplayName: 'NSearcher'
     Publisher: 'Nassim0x'
 ManifestType: installer
-ManifestVersion: '1.10.0'
+ManifestVersion: '1.12.0'

--- a/manifests/n/Nassim0x/NSearcher/1.0.2/Nassim0x.NSearcher.locale.en-US.yaml
+++ b/manifests/n/Nassim0x/NSearcher/1.0.2/Nassim0x.NSearcher.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# Created with https://aka.ms/winget-create
+
+PackageIdentifier: 'Nassim0x.NSearcher'
+PackageVersion: '1.0.2'
+PackageLocale: 'en-US'
+Publisher: 'Nassim0x'
+PublisherUrl: 'https://github.com/Nassim0x'
+PublisherSupportUrl: 'https://github.com/Nassim0x/nsearcher/issues'
+Author: 'Nassim'
+PackageName: 'NSearcher'
+PackageUrl: 'https://github.com/Nassim0x/nsearcher'
+License: 'MIT'
+LicenseUrl: 'https://github.com/Nassim0x/nsearcher/blob/main/LICENSE'
+ShortDescription: 'Fast recursive search for Windows, built to be serious about throughput.'
+Description: 'NSearcher is a high-performance CLI search tool for large directory trees and day-to-day codebase work. It focuses on fast literal search, practical regex support, predictable Windows installation, and transparent benchmarking against ripgrep, grep, and ugrep.'
+Moniker: 'nsearcher'
+Tags:
+- 'search'
+- 'grep'
+- 'regex'
+- 'cli'
+- 'windows'
+- 'developer-tools'
+ReleaseNotes: |-
+  Adds a standalone Windows setup executable.
+  Publishes a portable ZIP package with checksums and release notes.
+  Keeps the native Windows launcher plus .NET search engine packaging flow.
+ReleaseNotesUrl: 'https://github.com/Nassim0x/nsearcher/releases/tag/v1.0.2'
+ManifestType: defaultLocale
+ManifestVersion: '1.10.0'

--- a/manifests/n/Nassim0x/NSearcher/1.0.2/Nassim0x.NSearcher.locale.en-US.yaml
+++ b/manifests/n/Nassim0x/NSearcher/1.0.2/Nassim0x.NSearcher.locale.en-US.yaml
@@ -1,4 +1,5 @@
 # Created with https://aka.ms/winget-create
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: 'Nassim0x.NSearcher'
 PackageVersion: '1.0.2'

--- a/manifests/n/Nassim0x/NSearcher/1.0.2/Nassim0x.NSearcher.locale.en-US.yaml
+++ b/manifests/n/Nassim0x/NSearcher/1.0.2/Nassim0x.NSearcher.locale.en-US.yaml
@@ -27,4 +27,4 @@ ReleaseNotes: |-
   Keeps the native Windows launcher plus .NET search engine packaging flow.
 ReleaseNotesUrl: 'https://github.com/Nassim0x/nsearcher/releases/tag/v1.0.2'
 ManifestType: defaultLocale
-ManifestVersion: '1.10.0'
+ManifestVersion: '1.12.0'

--- a/manifests/n/Nassim0x/NSearcher/1.0.2/Nassim0x.NSearcher.yaml
+++ b/manifests/n/Nassim0x/NSearcher/1.0.2/Nassim0x.NSearcher.yaml
@@ -1,0 +1,7 @@
+# Created with https://aka.ms/winget-create
+
+PackageIdentifier: 'Nassim0x.NSearcher'
+PackageVersion: '1.0.2'
+DefaultLocale: 'en-US'
+ManifestType: version
+ManifestVersion: '1.10.0'

--- a/manifests/n/Nassim0x/NSearcher/1.0.2/Nassim0x.NSearcher.yaml
+++ b/manifests/n/Nassim0x/NSearcher/1.0.2/Nassim0x.NSearcher.yaml
@@ -4,4 +4,4 @@ PackageIdentifier: 'Nassim0x.NSearcher'
 PackageVersion: '1.0.2'
 DefaultLocale: 'en-US'
 ManifestType: version
-ManifestVersion: '1.10.0'
+ManifestVersion: '1.12.0'

--- a/manifests/n/Nassim0x/NSearcher/1.0.2/Nassim0x.NSearcher.yaml
+++ b/manifests/n/Nassim0x/NSearcher/1.0.2/Nassim0x.NSearcher.yaml
@@ -1,4 +1,5 @@
 # Created with https://aka.ms/winget-create
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: 'Nassim0x.NSearcher'
 PackageVersion: '1.0.2'


### PR DESCRIPTION
## Summary
- add winget manifests for Nassim0x.NSearcher version 1.0.2
- use the Windows setup .exe installer published in the GitHub release
- include checksum-backed manifests generated from the released asset
## Release
- https://github.com/Nassim0x/nsearcher/releases/tag/v1.0.2
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/355206)