### PR TITLE
Add MNardit.Beetroot version 1.6.5

### DIFF
--- a/manifests/m/MNardit/Beetroot/1.6.5/MNardit.Beetroot.installer.yaml
+++ b/manifests/m/MNardit/Beetroot/1.6.5/MNardit.Beetroot.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: MNardit.Beetroot
+PackageVersion: 1.6.5
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/mnardit/beetroot-releases/releases/download/v1.6.5/Beetroot_1.6.5_x64-setup.exe
+    InstallerSha256: 68C0F90607B973030E135D4FEAA568C3746EA5EC4EB04E0212E5EDE930E04C33
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/MNardit/Beetroot/1.6.5/MNardit.Beetroot.locale.en-US.yaml
+++ b/manifests/m/MNardit/Beetroot/1.6.5/MNardit.Beetroot.locale.en-US.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: MNardit.Beetroot
+PackageVersion: 1.6.5
+PackageLocale: en-US
+Publisher: MNardit
+PublisherUrl: https://github.com/mnardit
+Author: MNardit
+PackageName: Beetroot
+PackageUrl: https://github.com/mnardit/beetroot-releases
+License: Proprietary
+LicenseUrl: https://github.com/mnardit/beetroot-releases/blob/main/LICENSE
+ShortDescription: Lightweight clipboard manager for Windows with AI-powered text transforms
+Description: |-
+  Beetroot is a modern clipboard manager for Windows that runs in the system tray.
+  Features:
+  - Unlimited clipboard history (text and images)
+  - Global hotkey (Ctrl+`) to instantly access history
+  - Fuzzy and regex search
+  - AI-powered text transforms via OpenAI (10 built-in + custom prompts)
+  - OCR text extraction from images (native Windows engine)
+  - Notes on clipboard items
+  - Pin window on top or follow cursor mode
+  - Multi-select batch operations
+  - 9 themes + custom accent color
+  - 26 languages
+  - Automatic database backup and recovery
+  - Customizable UI and code fonts
+  - Auto-update with option to disable for fully offline operation
+  - Plain text paste hotkey
+  - Non-QWERTY keyboard layout support (AZERTY, QWERTZ, AltGr) with instant layout detection
+ReleaseNotesUrl: https://github.com/mnardit/beetroot-releases/releases/tag/v1.6.5
+Tags:
+  - clipboard
+  - clipboard-manager
+  - productivity
+  - tauri
+  - windows
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/MNardit/Beetroot/1.6.5/MNardit.Beetroot.yaml
+++ b/manifests/m/MNardit/Beetroot/1.6.5/MNardit.Beetroot.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: MNardit.Beetroot
+PackageVersion: 1.6.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New version: MNardit.Beetroot 1.6.5

- Background AI job queue (non-blocking transforms)
- AI Vision Transforms (analyze images with cloud/local AI)
- Native Windows notifications
- All AI providers moved to native Rust
- 10 bug fixes

**Installer:** NSIS (nullsoft), x64 only
**URL:** https://github.com/mnardit/beetroot-releases/releases/download/v1.6.5/Beetroot_1.6.5_x64-setup.exe
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/355336)