### PR TITLE
Update willibrandon.dotsider to 0.8.0

### DIFF
--- a/manifests/w/willibrandon/dotsider/0.8.0/willibrandon.dotsider.installer.yaml
+++ b/manifests/w/willibrandon/dotsider/0.8.0/willibrandon.dotsider.installer.yaml
@@ -1,0 +1,27 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: willibrandon.dotsider
+PackageVersion: 0.8.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.18362.0
+InstallerType: msi
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/willibrandon/dotsider/releases/download/v0.8.0/dotsider-win-x64.msi
+  InstallerSha256: A16329316600657A0B92A8067AC4EF5CA55714875E632EDD4D2FDFF9C3541D70
+  ProductCode: '{5D221323-97E3-4A64-934D-D21576BB85C3}'
+- Architecture: arm64
+  InstallerUrl: https://github.com/willibrandon/dotsider/releases/download/v0.8.0/dotsider-win-arm64.msi
+  InstallerSha256: 97D1AA9F33FA8408650713EE2424045A3B7B37DBD690EB5F92EA99C3587530B0
+  ProductCode: '{08A1278D-9FBC-486E-B7C6-D28997E41F0B}'
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-04-04

--- a/manifests/w/willibrandon/dotsider/0.8.0/willibrandon.dotsider.locale.en-US.yaml
+++ b/manifests/w/willibrandon/dotsider/0.8.0/willibrandon.dotsider.locale.en-US.yaml
@@ -1,0 +1,36 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: willibrandon.dotsider
+PackageVersion: 0.8.0
+PackageLocale: en-US
+Publisher: willibrandon
+PublisherUrl: https://github.com/willibrandon
+PublisherSupportUrl: https://github.com/willibrandon/dotsider/issues
+PackageName: dotsider
+PackageUrl: https://github.com/willibrandon/dotsider
+License: MIT
+LicenseUrl: https://github.com/willibrandon/dotsider/blob/main/LICENSE
+ShortDescription: A TUI for analyzing .NET assemblies
+Description: |-
+  dotsider is a terminal UI for analyzing .NET assemblies — structure, metadata,
+  IL disassembly, strings, hex dump, dependency graphs, size maps, and live
+  runtime tracing via EventPipe. It also supports assembly diffing and NuGet
+  package browsing.
+Tags:
+- dotnet
+- assembly
+- tui
+- il
+- metadata
+- pe
+- disassembler
+- cli
+- terminal
+- devtools
+ReleaseNotesUrl: https://github.com/willibrandon/dotsider/releases/tag/v0.8.0
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/willibrandon/dotsider/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/w/willibrandon/dotsider/0.8.0/willibrandon.dotsider.yaml
+++ b/manifests/w/willibrandon/dotsider/0.8.0/willibrandon.dotsider.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: willibrandon.dotsider
+PackageVersion: 0.8.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Update dotsider to version 0.8.0

## Release notes

https://github.com/willibrandon/dotsider/releases/tag/v0.8.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/355420)