### PR TITLE
New package: Nexus.OmniGet version 1.0.0

### DIFF
--- a/manifests/n/Nexus/OmniGet/1.0.0/Nexus.OmniGet.installer.yaml
+++ b/manifests/n/Nexus/OmniGet/1.0.0/Nexus.OmniGet.installer.yaml
@@ -4,14 +4,14 @@ InstallerLocale: en-US
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
-  - RelativeFilePath: omniget.cmd
+  - RelativeFilePath: omniget.exe
     PortableCommandAlias: omniget
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/Pranav-Nexus/omniget/releases/download/v1.0.0/omniget.zip
-    InstallerSha256: BF1011F6EBFB475D8C3F851EFBC5922D5979E782BA0823FE2E65B271DDE9B6D8
+    InstallerSha256: 8661AF96D5CF72865B4D844B84744398BA9397568774F83DA26E3D4997E6B02C
   - Architecture: x86
     InstallerUrl: https://github.com/Pranav-Nexus/omniget/releases/download/v1.0.0/omniget.zip
-    InstallerSha256: BF1011F6EBFB475D8C3F851EFBC5922D5979E782BA0823FE2E65B271DDE9B6D8
+    InstallerSha256: 8661AF96D5CF72865B4D844B84744398BA9397568774F83DA26E3D4997E6B02C
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/n/Nexus/OmniGet/1.0.0/Nexus.OmniGet.installer.yaml
+++ b/manifests/n/Nexus/OmniGet/1.0.0/Nexus.OmniGet.installer.yaml
@@ -4,14 +4,14 @@ InstallerLocale: en-US
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
-  - RelativeFilePath: omniget.exe
+  - RelativeFilePath: omniget.cmd
     PortableCommandAlias: omniget
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/Pranav-Nexus/omniget/releases/download/v1.0.0/omniget.zip
-    InstallerSha256: 1A7ABD338332369B80AE54F8A198EFF85A03CD571C12FAC257D8ED9C52AC3968
+    InstallerSha256: BF1011F6EBFB475D8C3F851EFBC5922D5979E782BA0823FE2E65B271DDE9B6D8
   - Architecture: x86
     InstallerUrl: https://github.com/Pranav-Nexus/omniget/releases/download/v1.0.0/omniget.zip
-    InstallerSha256: 1A7ABD338332369B80AE54F8A198EFF85A03CD571C12FAC257D8ED9C52AC3968
+    InstallerSha256: BF1011F6EBFB475D8C3F851EFBC5922D5979E782BA0823FE2E65B271DDE9B6D8
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/n/Nexus/OmniGet/1.0.0/Nexus.OmniGet.installer.yaml
+++ b/manifests/n/Nexus/OmniGet/1.0.0/Nexus.OmniGet.installer.yaml
@@ -1,17 +1,16 @@
 PackageIdentifier: Nexus.OmniGet
 PackageVersion: 1.0.0
 InstallerLocale: en-US
-InstallerType: zip
-NestedInstallerType: portable
-NestedInstallerFiles:
-  - RelativeFilePath: omniget.exe
-    PortableCommandAlias: omniget
+InstallerType: exe
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
 Installers:
   - Architecture: x64
-    InstallerUrl: https://github.com/Pranav-Nexus/omniget/releases/download/v1.0.0/omniget.zip
-    InstallerSha256: 829972B35ED1D62D683FAC70A263AAA553765D03388EFD9B74D10CA688494C73
+    InstallerUrl: https://github.com/Pranav-Nexus/omniget/releases/download/v1.0.0/OmniGetSetup.exe
+    InstallerSha256: 36FEEC03B6394604E07128133E9E402E9334147746F37F7062818E7C707011DA
   - Architecture: x86
-    InstallerUrl: https://github.com/Pranav-Nexus/omniget/releases/download/v1.0.0/omniget.zip
-    InstallerSha256: 829972B35ED1D62D683FAC70A263AAA553765D03388EFD9B74D10CA688494C73
+    InstallerUrl: https://github.com/Pranav-Nexus/omniget/releases/download/v1.0.0/OmniGetSetup.exe
+    InstallerSha256: 36FEEC03B6394604E07128133E9E402E9334147746F37F7062818E7C707011DA
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/n/Nexus/OmniGet/1.0.0/Nexus.OmniGet.installer.yaml
+++ b/manifests/n/Nexus/OmniGet/1.0.0/Nexus.OmniGet.installer.yaml
@@ -9,9 +9,9 @@ NestedInstallerFiles:
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/Pranav-Nexus/omniget/releases/download/v1.0.0/omniget.zip
-    InstallerSha256: 8661AF96D5CF72865B4D844B84744398BA9397568774F83DA26E3D4997E6B02C
+    InstallerSha256: 0D2256D25592DDBA00DF00AAAE9165E834622F94F2A9B9DA812FD48A816150FE
   - Architecture: x86
     InstallerUrl: https://github.com/Pranav-Nexus/omniget/releases/download/v1.0.0/omniget.zip
-    InstallerSha256: 8661AF96D5CF72865B4D844B84744398BA9397568774F83DA26E3D4997E6B02C
+    InstallerSha256: 0D2256D25592DDBA00DF00AAAE9165E834622F94F2A9B9DA812FD48A816150FE
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/n/Nexus/OmniGet/1.0.0/Nexus.OmniGet.installer.yaml
+++ b/manifests/n/Nexus/OmniGet/1.0.0/Nexus.OmniGet.installer.yaml
@@ -9,9 +9,9 @@ NestedInstallerFiles:
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/Pranav-Nexus/omniget/releases/download/v1.0.0/omniget.zip
-    InstallerSha256: 0D2256D25592DDBA00DF00AAAE9165E834622F94F2A9B9DA812FD48A816150FE
+    InstallerSha256: 829972B35ED1D62D683FAC70A263AAA553765D03388EFD9B74D10CA688494C73
   - Architecture: x86
     InstallerUrl: https://github.com/Pranav-Nexus/omniget/releases/download/v1.0.0/omniget.zip
-    InstallerSha256: 0D2256D25592DDBA00DF00AAAE9165E834622F94F2A9B9DA812FD48A816150FE
+    InstallerSha256: 829972B35ED1D62D683FAC70A263AAA553765D03388EFD9B74D10CA688494C73
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/n/Nexus/OmniGet/1.0.0/Nexus.OmniGet.installer.yaml
+++ b/manifests/n/Nexus/OmniGet/1.0.0/Nexus.OmniGet.installer.yaml
@@ -1,0 +1,20 @@
+PackageIdentifier: Nexus.OmniGet
+PackageVersion: 1.0.0
+InstallerType: zip
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Pranav-Nexus/omniget/releases/download/v1.0.0/omniget.zip
+    InstallerSha256: 1A7ABD338332369B80AE54F8A198EFF85A03CD571C12FFAC257D8ED9C52AC3968
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: omniget.exe
+        PortableCommandAlias: omniget
+  - Architecture: x86
+    InstallerUrl: https://github.com/Pranav-Nexus/omniget/releases/download/v1.0.0/omniget.zip
+    InstallerSha256: 1A7ABD338332369B80AE54F8A198EFF85A03CD571C12FFAC257D8ED9C52AC3968
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: omniget.exe
+        PortableCommandAlias: omniget
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/n/Nexus/OmniGet/1.0.0/Nexus.OmniGet.installer.yaml
+++ b/manifests/n/Nexus/OmniGet/1.0.0/Nexus.OmniGet.installer.yaml
@@ -1,20 +1,17 @@
 PackageIdentifier: Nexus.OmniGet
 PackageVersion: 1.0.0
+InstallerLocale: en-US
 InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: omniget.exe
+    PortableCommandAlias: omniget
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/Pranav-Nexus/omniget/releases/download/v1.0.0/omniget.zip
-    InstallerSha256: 1A7ABD338332369B80AE54F8A198EFF85A03CD571C12FFAC257D8ED9C52AC3968
-    NestedInstallerType: portable
-    NestedInstallerFiles:
-      - RelativeFilePath: omniget.exe
-        PortableCommandAlias: omniget
+    InstallerSha256: 1A7ABD338332369B80AE54F8A198EFF85A03CD571C12FAC257D8ED9C52AC3968
   - Architecture: x86
     InstallerUrl: https://github.com/Pranav-Nexus/omniget/releases/download/v1.0.0/omniget.zip
-    InstallerSha256: 1A7ABD338332369B80AE54F8A198EFF85A03CD571C12FFAC257D8ED9C52AC3968
-    NestedInstallerType: portable
-    NestedInstallerFiles:
-      - RelativeFilePath: omniget.exe
-        PortableCommandAlias: omniget
+    InstallerSha256: 1A7ABD338332369B80AE54F8A198EFF85A03CD571C12FAC257D8ED9C52AC3968
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/n/Nexus/OmniGet/1.0.0/Nexus.OmniGet.locale.en-US.yaml
+++ b/manifests/n/Nexus/OmniGet/1.0.0/Nexus.OmniGet.locale.en-US.yaml
@@ -1,0 +1,19 @@
+PackageIdentifier: Nexus.OmniGet
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: Nexus
+PublisherUrl: https://github.com/Pranav-Nexus
+PackageName: OmniGet
+PackageUrl: https://github.com/Pranav-Nexus/omniget
+License: MIT
+LicenseUrl: https://github.com/Pranav-Nexus/omniget/blob/main/LICENSE
+ShortDescription: A universal wrapper for Windows package managers (WinGet, Chocolatey, Scoop).
+Description: OmniGet is a unified command-line wrapper that lets you manage packages across WinGet, Chocolatey, and Scoop with a single consistent interface. It automatically detects which package managers are installed and routes commands accordingly.
+Tags:
+  - winget
+  - scoop
+  - package-manager
+  - powershell
+  - wrapper
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/n/Nexus/OmniGet/1.0.0/Nexus.OmniGet.locale.en-US.yaml
+++ b/manifests/n/Nexus/OmniGet/1.0.0/Nexus.OmniGet.locale.en-US.yaml
@@ -1,19 +1,20 @@
 PackageIdentifier: Nexus.OmniGet
 PackageVersion: 1.0.0
 PackageLocale: en-US
-Publisher: Nexus
+Publisher: Pranav-Nexus
 PublisherUrl: https://github.com/Pranav-Nexus
+PublisherSupportUrl: https://github.com/Pranav-Nexus/omniget/issues
 PackageName: OmniGet
 PackageUrl: https://github.com/Pranav-Nexus/omniget
 License: MIT
 LicenseUrl: https://github.com/Pranav-Nexus/omniget/blob/main/LICENSE
-ShortDescription: A universal wrapper for Windows package managers (WinGet, Chocolatey, Scoop).
-Description: OmniGet is a unified command-line wrapper that lets you manage packages across WinGet, Chocolatey, and Scoop with a single consistent interface. It automatically detects which package managers are installed and routes commands accordingly.
+ShortDescription: A unified command-line wrapper for Windows package managers WinGet and Scoop.
+Description: OmniGet is a unified command-line wrapper that lets you install, update, search, and manage packages across WinGet and Scoop with a single consistent interface. It automatically detects which package managers are installed and routes commands accordingly, so you don't have to remember different syntax for each tool.
 Tags:
-  - winget
-  - scoop
   - package-manager
   - powershell
+  - scoop
+  - winget
   - wrapper
 ManifestType: defaultLocale
 ManifestVersion: 1.6.0

--- a/manifests/n/Nexus/OmniGet/1.0.0/Nexus.OmniGet.yaml
+++ b/manifests/n/Nexus/OmniGet/1.0.0/Nexus.OmniGet.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Nexus.OmniGet
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Windows Package Manager Package Submission

### Package details
- **Package identifier**: Nexus.OmniGet
- **Package version**: 1.0.0
- **Publisher**: Nexus / Pranav-Nexus
- **Description**: OmniGet is a unified command-line wrapper for Windows package managers (WinGet and Scoop). It routes commands to whichever package managers are installed.

### Manifest details
- Installer type: zip (portable)
- Architecture: x64, x86
- Nested installer: omniget.exe (compiled from PowerShell via ps2exe)
- Command alias: omniget

### Checklist
- [x] The package is open source (MIT license)
- [x] The installer URL is stable and from the official GitHub Releases
- [x] SHA256 hash matches the release asset
- [x] Manifests are valid YAML following the 1.6.0 schema
- [x] The tool is useful and has a real purpose
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/355466)