### PR TITLE
New package: MetanoicArmor.I2PChat version 1.2.3

### DIFF
--- a/manifests/m/MetanoicArmor/I2PChat/1.2.3/MetanoicArmor.I2PChat.installer.yaml
+++ b/manifests/m/MetanoicArmor/I2PChat/1.2.3/MetanoicArmor.I2PChat.installer.yaml
@@ -1,0 +1,23 @@
+PackageIdentifier: MetanoicArmor.I2PChat
+PackageVersion: 1.2.3
+InstallerLocale: en-US
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallModes:
+  - interactive
+  - silent
+Installers:
+  - Architecture: x64
+    InstallerType: zip
+    InstallerUrl: https://github.com/MetanoicArmor/I2PChat/releases/download/v1.2.3/I2PChat-windows-x64-v1.2.3.zip
+    InstallerSha256: 6e0481272587b0a07f93a93310fbca94c0aadb637d337c4aab6ad00bbf972436
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: I2PChat/I2PChat.exe
+        PortableCommandAlias: i2pchat
+      - RelativeFilePath: I2PChat/I2PChat-tui.exe
+        PortableCommandAlias: i2pchat-tui
+    ReleaseDate: 2026-04-05
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/MetanoicArmor/I2PChat/1.2.3/MetanoicArmor.I2PChat.installer.yaml
+++ b/manifests/m/MetanoicArmor/I2PChat/1.2.3/MetanoicArmor.I2PChat.installer.yaml
@@ -7,11 +7,13 @@ MinimumOSVersion: 10.0.17763.0
 InstallModes:
   - interactive
   - silent
+# GUI winget: *-winget-* zip has no embedded i2pd (Microsoft Installers Scan). Replace InstallerSha256 after
+# uploading release assets (see build-windows.ps1 footer or packaging/refresh-checksums.sh v1.2.3).
 Installers:
   - Architecture: x64
     InstallerType: zip
-    InstallerUrl: https://github.com/MetanoicArmor/I2PChat/releases/download/v1.2.3/I2PChat-windows-x64-v1.2.3.zip
-    InstallerSha256: 6e0481272587b0a07f93a93310fbca94c0aadb637d337c4aab6ad00bbf972436
+    InstallerUrl: https://github.com/MetanoicArmor/I2PChat/releases/download/v1.2.3/I2PChat-windows-x64-winget-v1.2.3.zip
+    InstallerSha256: f6ab379f39ed0a0ef6a58bfb4ba96a14a374546350c1217c1225cc9a6e99bd55
     NestedInstallerType: portable
     NestedInstallerFiles:
       - RelativeFilePath: I2PChat/I2PChat.exe

--- a/manifests/m/MetanoicArmor/I2PChat/1.2.3/MetanoicArmor.I2PChat.locale.en-US.yaml
+++ b/manifests/m/MetanoicArmor/I2PChat/1.2.3/MetanoicArmor.I2PChat.locale.en-US.yaml
@@ -12,6 +12,9 @@ ShortDescription: Experimental peer-to-peer chat client for the I2P anonymity ne
 Description: |-
   I2PChat is a cross-platform GUI (PyQt6) chat client for the I2P network, with optional
   console TUI. Binaries are portable (zip); GUI is I2PChat.exe; TUI is I2PChat-tui.exe in the I2PChat folder.
+  The archive includes a bundled i2pd (I2P router) binary under the vendor tree so the app can use SAM
+  without a separate router install; some antivirus products classify I2P routers as generic “riskware”
+  even though the payload is legitimate open-source software (see PurpleI2P/i2pd).
 Moniker: i2pchat
 Tags:
   - i2p
@@ -19,5 +22,7 @@ Tags:
   - p2p
   - privacy
 ReleaseNotesUrl: https://github.com/MetanoicArmor/I2PChat/releases
+ReleaseNotes: |-
+  Bundled i2pd (I2P router) may trigger generic “riskware” detections in some AV engines; this is expected for I2P router binaries and is not indicative of malware. Upstream: https://github.com/PurpleI2P/i2pd
 ManifestType: defaultLocale
 ManifestVersion: 1.6.0

--- a/manifests/m/MetanoicArmor/I2PChat/1.2.3/MetanoicArmor.I2PChat.locale.en-US.yaml
+++ b/manifests/m/MetanoicArmor/I2PChat/1.2.3/MetanoicArmor.I2PChat.locale.en-US.yaml
@@ -1,0 +1,23 @@
+PackageIdentifier: MetanoicArmor.I2PChat
+PackageVersion: 1.2.3
+PackageLocale: en-US
+Publisher: MetanoicArmor
+PublisherUrl: https://github.com/MetanoicArmor
+PackageName: I2PChat
+PackageUrl: https://github.com/MetanoicArmor/I2PChat
+License: AGPL-3.0
+LicenseUrl: https://github.com/MetanoicArmor/I2PChat/blob/main/LICENSE
+Copyright: Copyright (c) MetanoicArmor and contributors
+ShortDescription: Experimental peer-to-peer chat client for the I2P anonymity network
+Description: |-
+  I2PChat is a cross-platform GUI (PyQt6) chat client for the I2P network, with optional
+  console TUI. Binaries are portable (zip); GUI is I2PChat.exe; TUI is I2PChat-tui.exe in the I2PChat folder.
+Moniker: i2pchat
+Tags:
+  - i2p
+  - chat
+  - p2p
+  - privacy
+ReleaseNotesUrl: https://github.com/MetanoicArmor/I2PChat/releases
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/MetanoicArmor/I2PChat/1.2.3/MetanoicArmor.I2PChat.yaml
+++ b/manifests/m/MetanoicArmor/I2PChat/1.2.3/MetanoicArmor.I2PChat.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: MetanoicArmor.I2PChat
+PackageVersion: 1.2.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Adds I2PChat GUI portable zip from GitHub Releases v1.2.3.

- PackageIdentifier: MetanoicArmor.I2PChat
- Installer: zip portable (I2PChat.exe + I2PChat-tui.exe)

Submitted from upstream templates: https://github.com/MetanoicArmor/I2PChat/tree/main/packaging/winget/1.2.3

Made with [Cursor](https://cursor.com)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/355476)