### PR TITLE
Update HamzaAbdulWahab.Bonjou 1.1.0 installer hash

### DIFF
--- a/manifests/h/HamzaAbdulWahab/Bonjou/1.1.0/HamzaAbdulWahab.Bonjou.installer.yaml
+++ b/manifests/h/HamzaAbdulWahab/Bonjou/1.1.0/HamzaAbdulWahab.Bonjou.installer.yaml
@@ -8,7 +8,7 @@ Commands:
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/hamzaabdulwahab/bonjou-cli/releases/download/v1.1.0/bonjou.exe
-  InstallerSha256: c3c6dd5fabf8f03128a92289547a3e8e4b74c46254497052f26349d0106210b6
+  InstallerSha256: 696086d121736a8de9e3d75130f83b095ab5fd8a4c9f20c0fda49a33545edb10
   PortableCommandAlias: bonjou
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/h/HamzaAbdulWahab/Bonjou/1.1.0/HamzaAbdulWahab.Bonjou.yaml
+++ b/manifests/h/HamzaAbdulWahab/Bonjou/1.1.0/HamzaAbdulWahab.Bonjou.yaml
@@ -1,31 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
 PackageIdentifier: HamzaAbdulWahab.Bonjou
 PackageVersion: 1.1.0
 DefaultLocale: en-US
-ManifestType: singleton
-ManifestVersion: 1.6.0
-
-PackageName: Bonjou
-Publisher: Hamza Abdul Wahab
-License: MIT
-LicenseUrl: https://github.com/hamzaabdulwahab/bonjou-cli/blob/main/LICENSE
-ShortDescription: Terminal-based LAN chat and file transfer for local networks
-Description: |-
-  Bonjou is a terminal app for chatting and sending files over a local network
-  (LAN/Wi-Fi). No internet required. Peers are auto-discovered on the same
-  subnet via UDP broadcast. All transfers are end-to-end encrypted.
-PackageUrl: https://github.com/hamzaabdulwahab/bonjou-cli
-Tags:
-- chat
-- cli
-- file-transfer
-- lan
-- terminal
-
-Installers:
-- Architecture: x64
-  InstallerType: portable
-  InstallerUrl: https://github.com/hamzaabdulwahab/bonjou-cli/releases/download/v1.1.0/bonjou.exe
-  InstallerSha256: 696086d121736a8de9e3d75130f83b095ab5fd8a4c9f20c0fda49a33545edb10
-  Commands:
-  - bonjou
-  PortableCommandAlias: bonjou
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/manifests/h/HamzaAbdulWahab/Bonjou/1.1.0/HamzaAbdulWahab.Bonjou.yaml
+++ b/manifests/h/HamzaAbdulWahab/Bonjou/1.1.0/HamzaAbdulWahab.Bonjou.yaml
@@ -1,7 +1,31 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
-
 PackageIdentifier: HamzaAbdulWahab.Bonjou
 PackageVersion: 1.1.0
 DefaultLocale: en-US
-ManifestType: version
-ManifestVersion: 1.12.0
+ManifestType: singleton
+ManifestVersion: 1.6.0
+
+PackageName: Bonjou
+Publisher: Hamza Abdul Wahab
+License: MIT
+LicenseUrl: https://github.com/hamzaabdulwahab/bonjou-cli/blob/main/LICENSE
+ShortDescription: Terminal-based LAN chat and file transfer for local networks
+Description: |-
+  Bonjou is a terminal app for chatting and sending files over a local network
+  (LAN/Wi-Fi). No internet required. Peers are auto-discovered on the same
+  subnet via UDP broadcast. All transfers are end-to-end encrypted.
+PackageUrl: https://github.com/hamzaabdulwahab/bonjou-cli
+Tags:
+- chat
+- cli
+- file-transfer
+- lan
+- terminal
+
+Installers:
+- Architecture: x64
+  InstallerType: portable
+  InstallerUrl: https://github.com/hamzaabdulwahab/bonjou-cli/releases/download/v1.1.0/bonjou.exe
+  InstallerSha256: 696086d121736a8de9e3d75130f83b095ab5fd8a4c9f20c0fda49a33545edb10
+  Commands:
+  - bonjou
+  PortableCommandAlias: bonjou


### PR DESCRIPTION
Refreshes the Bonjou 1.1.0 manifest SHA256 after in-place release rewrite of v1.1.0 assets.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/355563)