### PR TITLE
Found a makeshift fix for the pipeline, to prevent it from mass-spamming "Needs-Author-Feedback" labels.

### DIFF
--- a/.github/policies/labelAdded.validationInstallationError.yml
+++ b/.github/policies/labelAdded.validationInstallationError.yml
@@ -12,9 +12,9 @@ configuration:
           When the label "Validation-Installation-Error" is added to a pull request
           * Add a reply notifying the issue author
           * Assign to the author
-          * Label with Needs-Author-Feedback
+          # * Label with Needs-Author-Feedback
           * Remove Azure-Pipeline-Passed label
-          * Remove Needs-Attention label
+          # * Remove Needs-Attention label
         if:
           - payloadType: Pull_Request
           - labelAdded:
@@ -28,15 +28,16 @@ configuration:
                 The package manager bot determined there was an issue with installing the application correctly. Please check the application installs correctly. Once repaired, please push an update to your pull request.
 
 
+                If you are certain it installs correctly, it may be caused by validation pipeline congestion. If so, doing a null-edit to the pull request, or to close and re-open the existing pull request, will usually re-run the pipeline.
+
+
                 Template: msftbot/validationError/installation/general
           - assignTo:
               author: True
           - addLabel:
-              label: Needs-Author-Feedback
+              label: Needs-Attention
           - removeLabel:
               label: Azure-Pipeline-Passed
-          - removeLabel:
-              label: Needs-Attention
         # The policy service should trigger even when the label was added by the policy service
         triggerOnOwnActions: true
 onFailure:


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Is there a linked Issue?  If so, fill in the Issue number below.
   <!-- Example: Resolves #328283 -->
  - Based on #323120, though does not fix it outright.

Manifests
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---
Notes from me:
* Summary of what the PR does:
* * No longer assigns the "Needs-Author-Feedback" label.
* * Assigns the "Needs-Attention" label instead.
* * Adds a secondary explanation for what the cause of the `Validation-Installation-Error` could be.
* I see no current drawbacks with merging the PR, and in fact it's possibly the most important hotfix the repo has had in years.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/355564)