### PR TITLE
Add DirCompare-Pro.DirectoryComparePro version 1.06.0

### DIFF
--- a/manifests/d/DirCompare-Pro/DirectoryComparePro/1.06.0/DirCompare-Pro.DirectoryComparePro.installer.yaml
+++ b/manifests/d/DirCompare-Pro/DirectoryComparePro/1.06.0/DirCompare-Pro.DirectoryComparePro.installer.yaml
@@ -11,6 +11,6 @@ NestedInstallerFiles:
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/DirCompare-Pro/DirectoryComparePro/releases/download/v1.06/DirectoryComparePro-v1.06-Windows.zip
-    InstallerSha256: C84FC4A43C76101EB734EB56C52394369779C7E2B94B542452C26FE54F143F16
+    InstallerSha256: 3882EBD73845B621C616C6ADCF2F20F99A128F310BC26DAA3DC0A92A5BDBDD15
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/d/DirCompare-Pro/DirectoryComparePro/1.06.0/DirCompare-Pro.DirectoryComparePro.installer.yaml
+++ b/manifests/d/DirCompare-Pro/DirectoryComparePro/1.06.0/DirCompare-Pro.DirectoryComparePro.installer.yaml
@@ -11,6 +11,6 @@ NestedInstallerFiles:
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/DirCompare-Pro/DirectoryComparePro/releases/download/v1.06/DirectoryComparePro-v1.06-Windows.zip
-    InstallerSha256: 3882EBD73845B621C616C6ADCF2F20F99A128F310BC26DAA3DC0A92A5BDBDD15
+    InstallerSha256: 21A71598B016535CCB54FE40C812E1590B1CBEEBD72897BD5EDAA8A814A43114
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/d/DirCompare-Pro/DirectoryComparePro/1.06.0/DirCompare-Pro.DirectoryComparePro.installer.yaml
+++ b/manifests/d/DirCompare-Pro/DirectoryComparePro/1.06.0/DirCompare-Pro.DirectoryComparePro.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: DirCompare-Pro.DirectoryComparePro
+PackageVersion: 1.06.0
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: DirectoryComparePro.exe
+    PortableCommandAlias: dircomparepro
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/DirCompare-Pro/DirectoryComparePro/releases/download/v1.06/DirectoryComparePro-v1.06-Windows.zip
+    InstallerSha256: C84FC4A43C76101EB734EB56C52394369779C7E2B94B542452C26FE54F143F16
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/d/DirCompare-Pro/DirectoryComparePro/1.06.0/DirCompare-Pro.DirectoryComparePro.locale.en-US.yaml
+++ b/manifests/d/DirCompare-Pro/DirectoryComparePro/1.06.0/DirCompare-Pro.DirectoryComparePro.locale.en-US.yaml
@@ -1,0 +1,64 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: DirCompare-Pro.DirectoryComparePro
+PackageVersion: 1.06.0
+PackageLocale: en-US
+Publisher: DirCompare Pro
+PublisherUrl: https://directorycompare-pro.com
+PublisherSupportUrl: https://github.com/DirCompare-Pro/DirectoryComparePro/issues
+PrivacyUrl: https://directorycompare-pro.com/privacy
+PackageName: DirectoryCompare Pro
+PackageUrl: https://directorycompare-pro.com
+License: Proprietary
+LicenseUrl: https://github.com/DirCompare-Pro/DirectoryComparePro/blob/master/LICENSE
+Copyright: Copyright (c) 2025 DirCompare Pro
+ShortDescription: Compare folders, Git repos, archives, FTP servers, and web URLs - side by side or up to 16 sources at once.
+Description: |-
+  DirectoryCompare Pro is a desktop file and folder comparison tool for Windows and Linux.
+
+  Everything a developer needs day-to-day is free. You only pay when you're running it at scale.
+
+  Free tier covers: 2-way compare, diff, 3-way merge, archives, CSV, Excel, hex, sync,
+  sessions, bookmarks, smart folder alignment, and exports.
+
+  Standard ($39) adds: N-way comparison (up to 16 sources), Git, GitHub, plugin viewers,
+  dark mode, and branding removal.
+
+  Premium ($79) adds: Patch generator, CLI (dircompare), FTP/SFTP, web URL comparison,
+  similarity search, and priority support.
+
+  Lifetime ($199): One-time purchase, all Premium features, no subscription.
+
+  Distributed as a single portable .exe - no installer, no dependencies, no DLLs required.
+  A 30-day full-featured trial starts automatically on first launch. No sign-up required.
+Moniker: dircomparepro
+Tags:
+  - compare
+  - diff
+  - merge
+  - folder
+  - directory
+  - file
+  - git
+  - github
+  - ftp
+  - archive
+  - zip
+  - patch
+  - sync
+  - developer
+  - productivity
+ReleaseNotes: |-
+  v1.06 (2026-04-06)
+  - Fix: eliminated git2.dll runtime dependency - exe is now fully static with zero DLL requirements
+  - Git mergetool integration: invoke as "dircomparepro -m BASE LOCAL REMOTE MERGED"
+  - Home screen shown at startup for quick access to recent sessions and common actions
+  - Colorblind-friendly theme added (blue/orange palette, cycles with Light/Dark toggle)
+  - Trial extended to 30 days, zero-friction (no sign-up required)
+  - License status shown in title bar: [FREE], [TRIAL - N days], [TRIAL EXPIRED]
+  - Notification banner with contextual upgrade and trial CTAs
+  - Web comparison now correctly gated to Premium tier
+  - All file diffs in Browse mode use N-way viewer (legacy 2-way path removed)
+ReleaseNotesUrl: https://github.com/DirCompare-Pro/DirectoryComparePro/releases/tag/v1.06
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/d/DirCompare-Pro/DirectoryComparePro/1.06.0/DirCompare-Pro.DirectoryComparePro.yaml
+++ b/manifests/d/DirCompare-Pro/DirectoryComparePro/1.06.0/DirCompare-Pro.DirectoryComparePro.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: DirCompare-Pro.DirectoryComparePro
+PackageVersion: 1.06.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Add DirCompare-Pro.DirectoryComparePro 1.06.0

**Package:** DirCompare-Pro.DirectoryComparePro
**Version:** 1.06.0
**URL:** https://github.com/DirCompare-Pro/DirectoryComparePro/releases/tag/v1.06

### Changes in this release
- Git mergetool integration
- Home screen for quick access to recent sessions
- Colorblind-friendly theme
- 30-day free trial, no sign-up required
- License status shown in title bar
- Various bug fixes and stability improvements