### PR TITLE
Add Kingpindev.VICESonar version 3.4.2

### DIFF
--- a/manifests/k/Kingpindev/VICESonar/3.4.2/Kingpindev.VICESonar.installer.yaml
+++ b/manifests/k/Kingpindev/VICESonar/3.4.2/Kingpindev.VICESonar.installer.yaml
@@ -1,0 +1,16 @@
+PackageIdentifier: Kingpindev.VICESonar
+PackageVersion: 3.4.2
+InstallerLocale: en-US
+InstallerType: inno
+InstallModes:
+  - interactive
+  - silent
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: SteelSeries.GG
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/kingpin1dev/VICE-Sonar/releases/download/v3.4.2/ViceSonar_Setup_v3.4.2.exe
+    InstallerSha256: 1F6133AAC17C10030CF5DF5F57DD54975AA90235227728A73613EFF09779A371
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/k/Kingpindev/VICESonar/3.4.2/Kingpindev.VICESonar.locale.en-US.yaml
+++ b/manifests/k/Kingpindev/VICESonar/3.4.2/Kingpindev.VICESonar.locale.en-US.yaml
@@ -1,0 +1,20 @@
+PackageIdentifier: Kingpindev.VICESonar
+PackageVersion: 3.4.2
+PackageLocale: en-US
+Publisher: Kingpindev
+PublisherUrl: https://github.com/kingpin1dev
+PublisherSupportUrl: https://github.com/kingpin1dev/VICE-Sonar/issues
+PackageName: VICE Sonar
+PackageUrl: https://github.com/kingpin1dev/VICE-Sonar
+License: Proprietary
+LicenseUrl: https://github.com/kingpin1dev/VICE-Sonar/blob/main/LICENSE
+ShortDescription: Lightweight desktop widget for SteelSeries GG Sonar audio controls
+Description: VICE Sonar is a lightweight Windows desktop widget that puts your SteelSeries GG Sonar audio controls right at your fingertips. Requires SteelSeries GG to be installed.
+Tags:
+  - audio
+  - steelseries
+  - sonar
+  - widget
+  - gaming
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/k/Kingpindev/VICESonar/3.4.2/Kingpindev.VICESonar.locale.en-US.yaml
+++ b/manifests/k/Kingpindev/VICESonar/3.4.2/Kingpindev.VICESonar.locale.en-US.yaml
@@ -7,7 +7,6 @@ PublisherSupportUrl: https://github.com/kingpin1dev/VICE-Sonar/issues
 PackageName: VICE Sonar
 PackageUrl: https://github.com/kingpin1dev/VICE-Sonar
 License: Proprietary
-LicenseUrl: https://github.com/kingpin1dev/VICE-Sonar/blob/main/LICENSE
 ShortDescription: Lightweight desktop widget for SteelSeries GG Sonar audio controls
 Description: VICE Sonar is a lightweight Windows desktop widget that puts your SteelSeries GG Sonar audio controls right at your fingertips. Requires SteelSeries GG to be installed.
 Tags:

--- a/manifests/k/Kingpindev/VICESonar/3.4.2/Kingpindev.VICESonar.yaml
+++ b/manifests/k/Kingpindev/VICESonar/3.4.2/Kingpindev.VICESonar.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Kingpindev.VICESonar
+PackageVersion: 3.4.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Add Kingpindev.VICESonar 3.4.2

**Package:** Kingpindev.VICESonar
**Version:** 3.4.2
**Publisher:** Kingpindev

### Package Description
VICE Sonar is a lightweight Windows desktop widget that puts your SteelSeries GG Sonar audio controls right at your fingertips.

### Changes from 3.4.1
- Added SteelSeries.GG as PackageDependency (resolves validation failure from PR #353344)
- Updated to latest version

### Validation Checklist
- [x] Installer URL is accessible and returns the correct file
- [x] SHA256 hash verified against the installer
- [x] Manifest files validated with winget-manifest schema 1.6.0
- [x] SteelSeries.GG listed as PackageDependency
- [x] No source code included — binary installer only
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/355628)