### PR TITLE
New version: nelsonduarte.PDFApps version 1.8.3

### DIFF
--- a/manifests/n/nelsonduarte/PDFApps/1.8.3/nelsonduarte.PDFApps.installer.yaml
+++ b/manifests/n/nelsonduarte/PDFApps/1.8.3/nelsonduarte.PDFApps.installer.yaml
@@ -1,0 +1,13 @@
+PackageIdentifier: nelsonduarte.PDFApps
+PackageVersion: 1.8.3
+InstallerType: portable
+Scope: user
+Commands:
+  - pdfapps
+ReleaseDate: 2026-04-05
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/nelsonduarte/PDFApps/releases/download/v1.8.3/PDFApps.exe
+    InstallerSha256: FF2E97AEF39FB44D785256BB85C0F42331BE8B99A103B985BACC1271EA3D6390
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/n/nelsonduarte/PDFApps/1.8.3/nelsonduarte.PDFApps.locale.en-US.yaml
+++ b/manifests/n/nelsonduarte/PDFApps/1.8.3/nelsonduarte.PDFApps.locale.en-US.yaml
@@ -1,0 +1,49 @@
+PackageIdentifier: nelsonduarte.PDFApps
+PackageVersion: 1.8.3
+PackageLocale: en-US
+Publisher: Nelson Duarte
+PublisherUrl: https://github.com/nelsonduarte
+PublisherSupportUrl: https://github.com/nelsonduarte/PDFApps/issues
+Author: Nelson Duarte
+PackageName: PDFApps
+PackageUrl: https://nelsonduarte.github.io/PDFApps/
+License: MIT
+LicenseUrl: https://github.com/nelsonduarte/PDFApps/blob/main/LICENSE
+Copyright: Copyright (c) Nelson Duarte
+ShortDescription: Fast, offline, subscription-free PDF editor
+Description: |-
+  PDFApps is an all-in-one PDF editor with 13 built-in tools: split, merge, rotate,
+  extract, reorder, compress, encrypt, watermark, OCR, convert (PNG/JPG/DOCX/TXT),
+  visual editor (redact, text, images, signatures, highlights, notes), import
+  (TXT/images/Markdown), and metadata viewer.
+
+  Features include continuous-scroll viewer, presentation mode (F5), fullscreen
+  (F11), tabbed viewing, dark/light themes, drag and drop, multi-select PDF open,
+  and 8-language interface (EN, PT, ES, FR, DE, ZH, IT, NL).
+
+  100% offline. No subscriptions, no cloud uploads, no account required.
+Moniker: pdfapps
+Tags:
+  - pdf
+  - pdf-editor
+  - pdf-viewer
+  - pdf-tools
+  - offline
+  - open-source
+  - ocr
+  - split
+  - merge
+  - compress
+  - encrypt
+  - watermark
+ReleaseNotes: |-
+  - Global keyboard shortcuts (Ctrl+O/S/P/W)
+  - Multi-select PDFs in file dialog and drag and drop
+  - Canvas background adapts to light/dark theme
+  - Theme-aware dialogs in light mode
+  - Digital signature tool (draw, type, or import)
+  - Continuous scroll editor
+  - Presentation mode (F5) and fullscreen (F11)
+ReleaseNotesUrl: https://github.com/nelsonduarte/PDFApps/releases/tag/v1.8.3
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/n/nelsonduarte/PDFApps/1.8.3/nelsonduarte.PDFApps.yaml
+++ b/manifests/n/nelsonduarte/PDFApps/1.8.3/nelsonduarte.PDFApps.yaml
@@ -1,0 +1,7 @@
+# Created with winget create
+# https://github.com/microsoft/winget-pkgs
+PackageIdentifier: nelsonduarte.PDFApps
+PackageVersion: 1.8.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Submission

This PR adds **PDFApps**, a fast, offline, subscription-free PDF editor.

- **Package Identifier**: `nelsonduarte.PDFApps`
- **Version**: 1.8.3
- **Type**: portable (single-file PyInstaller executable)
- **Architecture**: x64
- **License**: MIT

## App description

PDFApps is an all-in-one PDF editor with 13 built-in tools: split, merge, rotate, extract, reorder, compress, encrypt, watermark, OCR, convert, visual editor, import, and metadata viewer.

Features include continuous-scroll viewer, presentation mode (F5), fullscreen (F11), tabbed viewing, dark/light themes, and 8-language interface.

## Links

- **Homepage**: https://nelsonduarte.github.io/PDFApps/
- **Source**: https://github.com/nelsonduarte/PDFApps
- **Release**: https://github.com/nelsonduarte/PDFApps/releases/tag/v1.8.3

## Validation

- [x] Manifests follow winget schema 1.6.0
- [x] SHA256 verified against the release asset
- [x] Tested locally on Windows 11
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/355709)