### PR TITLE
New version: kts982.WinTUI version 2.0.1

### DIFF
--- a/manifests/k/kts982/WinTUI/2.0.1/kts982.WinTUI.installer.yaml
+++ b/manifests/k/kts982/WinTUI/2.0.1/kts982.WinTUI.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: kts982.WinTUI
+PackageVersion: 2.0.1
+MinimumOSVersion: 10.0.17763.0
+InstallerType: portable
+Commands:
+  - wintui
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/kts982/wintui/releases/download/v2.0.1/wintui_2.0.1_windows_amd64.exe
+    InstallerSha256: 535F0F2C74741280DD9F0FEBD318329BE8B76548B7741C72303A42FFFAFB9721
+  - Architecture: arm64
+    InstallerUrl: https://github.com/kts982/wintui/releases/download/v2.0.1/wintui_2.0.1_windows_arm64.exe
+    InstallerSha256: A53DD3386D3C2EC3737491E83745650C1808A8474B923EB2ACFFA7AD037F79FA
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/k/kts982/WinTUI/2.0.1/kts982.WinTUI.locale.en-US.yaml
+++ b/manifests/k/kts982/WinTUI/2.0.1/kts982.WinTUI.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: kts982.WinTUI
+PackageVersion: 2.0.1
+PackageLocale: en-US
+Publisher: kts982
+PublisherUrl: https://github.com/kts982
+PublisherSupportUrl: https://github.com/kts982/wintui/issues
+Author: Kostas T.
+PackageName: WinTUI
+PackageUrl: https://github.com/kts982/wintui
+License: MIT
+LicenseUrl: https://github.com/kts982/wintui/blob/main/LICENSE
+ShortDescription: Terminal UI for winget on Windows.
+Description: >-
+  WinTUI is a terminal user interface for Windows Package Manager featuring a
+  split-panel workspace for browsing, searching, installing, upgrading, and
+  managing packages. Includes disk-persistent cache for instant startup,
+  background refresh, integrated search with install queue, batch operations
+  with a single UAC prompt, system health checks, temp cleanup, and a headless
+  CLI mode for scripting.
+Moniker: wintui
+Tags:
+  - winget
+  - windows
+  - tui
+  - terminal
+  - package-manager
+  - cli
+ReleaseNotesUrl: https://github.com/kts982/wintui/releases/tag/v2.0.1
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/k/kts982/WinTUI/2.0.1/kts982.WinTUI.yaml
+++ b/manifests/k/kts982/WinTUI/2.0.1/kts982.WinTUI.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: kts982.WinTUI
+PackageVersion: 2.0.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
### kts982.WinTUI v2.0.1

- Disk-persistent cache for instant startup with background refresh
- Update count badge in tab bar
- Cache status indicator
- Fix `q` quitting during active modal/execution
- Replace deprecated `wmic` with PowerShell/CIM for health uptime check

Release: https://github.com/kts982/wintui/releases/tag/v2.0.1
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/355733)