### PR TITLE
Add SecurityRonin.blazehash 0.2.0

### DIFF
--- a/manifests/s/SecurityRonin/blazehash/0.2.0/SecurityRonin.blazehash.installer.yaml
+++ b/manifests/s/SecurityRonin/blazehash/0.2.0/SecurityRonin.blazehash.installer.yaml
@@ -1,0 +1,17 @@
+# Created with YamlCreate.ps1 v2.4.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: SecurityRonin.blazehash
+PackageVersion: 0.2.0
+InstallerLocale: en-US
+InstallerType: wix
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/SecurityRonin/blazehash/releases/download/v0.2.0/blazehash-0.2.0-x86_64-pc-windows-msvc.msi
+    InstallerSha256: E509728EF1B16440A1EC309953668CC99691CB91A53CDDA589BCA01BF9869B37
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/SecurityRonin/blazehash/0.2.0/SecurityRonin.blazehash.locale.en-US.yaml
+++ b/manifests/s/SecurityRonin/blazehash/0.2.0/SecurityRonin.blazehash.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# Created with YamlCreate.ps1 v2.4.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: SecurityRonin.blazehash
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: SecurityRonin
+PublisherUrl: https://github.com/SecurityRonin
+PublisherSupportUrl: https://github.com/SecurityRonin/blazehash/issues
+PackageName: blazehash
+PackageUrl: https://github.com/SecurityRonin/blazehash
+License: MIT
+LicenseUrl: https://github.com/SecurityRonin/blazehash/blob/main/LICENSE
+Copyright: Copyright (c) SecurityRonin
+ShortDescription: Forensic file hasher — hashdeep for the modern era, BLAKE3 by default
+Description: |-
+  blazehash is a fast, forensic-grade file hashing tool and MCP server.
+  It supports BLAKE3, SHA-256, SHA-512, SHA-3, MD5, WHIRLPOOL, SSDEEP, and TLSH.
+  Compatible with hashdeep manifest format for audit workflows.
+  Includes an MCP server subcommand for AI-native forensic pipelines.
+Moniker: blazehash
+Tags:
+  - cli
+  - forensics
+  - hash
+  - blake3
+  - sha256
+  - hashdeep
+  - dfir
+  - mcp
+ReleaseNotesUrl: https://github.com/SecurityRonin/blazehash/releases/tag/v0.2.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/SecurityRonin/blazehash/0.2.0/SecurityRonin.blazehash.yaml
+++ b/manifests/s/SecurityRonin/blazehash/0.2.0/SecurityRonin.blazehash.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.4.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: SecurityRonin.blazehash
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Description

Add new package: **blazehash** 0.2.0 by SecurityRonin.

blazehash is a fast, forensic-grade file hashing tool and MCP server. It supports BLAKE3, SHA-256, SHA-512, SHA-3, MD5, WHIRLPOOL, SSDEEP, and TLSH, and is compatible with the hashdeep manifest format for audit workflows.

## Validation

- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Is the installer working without any issues?

## Manifest

- **Publisher:** SecurityRonin
- **Package:** blazehash
- **Version:** 0.2.0
- **Installer type:** WiX MSI (x64)
- **License:** MIT
- **Source:** https://github.com/SecurityRonin/blazehash
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/355736)