### PR TITLE
Add git-fire.git-fire version 0.1.1-alpha

### DIFF
--- a/manifests/g/git-fire/git-fire/0.1.1-alpha/git-fire.git-fire.installer.yaml
+++ b/manifests/g/git-fire/git-fire/0.1.1-alpha/git-fire.git-fire.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: git-fire.git-fire
+PackageVersion: 0.1.1-alpha
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: git-fire.exe
+  PortableCommandAlias: git-fire
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/git-fire/git-fire/releases/download/v0.1.1-alpha/git-fire_0.1.1-alpha_windows_386.zip
+  InstallerSha256: 14A99A1AE6305C62C851F5DBCBFBCB7EDEB66C6BAF04F8AAF433F3177BE72A93
+- Architecture: x64
+  InstallerUrl: https://github.com/git-fire/git-fire/releases/download/v0.1.1-alpha/git-fire_0.1.1-alpha_windows_amd64.zip
+  InstallerSha256: 117ECA228268B12DF5401B6178CC74119EB1EA90CE9C4E9DAA6987A757C0B616
+- Architecture: arm64
+  InstallerUrl: https://github.com/git-fire/git-fire/releases/download/v0.1.1-alpha/git-fire_0.1.1-alpha_windows_arm64.zip
+  InstallerSha256: 6EC2660B2AE70C0309D3C162B61CE500416EA71D8E74EDE4AD072EA775333C8D
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/g/git-fire/git-fire/0.1.1-alpha/git-fire.git-fire.locale.en-US.yaml
+++ b/manifests/g/git-fire/git-fire/0.1.1-alpha/git-fire.git-fire.locale.en-US.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: git-fire.git-fire
+PackageVersion: 0.1.1-alpha
+PackageLocale: en-US
+Publisher: git-fire
+PublisherUrl: https://github.com/git-fire
+PublisherSupportUrl: https://github.com/git-fire/git-fire/issues
+PackageName: git-fire
+PackageUrl: https://github.com/git-fire/git-fire
+License: MIT
+LicenseUrl: https://github.com/git-fire/git-fire/blob/v0.1.1-alpha/LICENSE
+ShortDescription: Multi-repo checkpoint CLI for Git.
+Description: git-fire is one command to checkpoint many repositories with safer commit and push backup flows.
+Tags:
+- git
+- backup
+- cli
+ReleaseNotesUrl: https://github.com/git-fire/git-fire/releases/tag/v0.1.1-alpha
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/g/git-fire/git-fire/0.1.1-alpha/git-fire.git-fire.yaml
+++ b/manifests/g/git-fire/git-fire/0.1.1-alpha/git-fire.git-fire.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: git-fire.git-fire
+PackageVersion: 0.1.1-alpha
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Summary
- Add initial `git-fire.git-fire` WinGet manifest for version `0.1.1-alpha`.
- Include multi-file manifests (version, default locale, installer) using portable ZIP packaging.
- Add x86, x64, and arm64 Windows release assets with SHA256 values from the `v0.1.1-alpha` release checksums.

## Test plan
- [x] Verify manifest files are present under `manifests/g/git-fire/git-fire/0.1.1-alpha/`.
- [x] Parse all three YAML files for syntax correctness.
- [x] Run `winget validate --manifest manifests/g/git-fire/git-fire/0.1.1-alpha` on Windows.
- [x] Run `winget install --manifest manifests/g/git-fire/git-fire/0.1.1-alpha` on Windows.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/355775)