### PR TITLE
Wharflab.Tally version 0.32.0

### DIFF
--- a/manifests/w/Wharflab/Tally/0.32.0/Wharflab.Tally.installer.yaml
+++ b/manifests/w/Wharflab/Tally/0.32.0/Wharflab.Tally.installer.yaml
@@ -1,0 +1,26 @@
+# Created by tally release automation
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: Wharflab.Tally
+PackageVersion: 0.32.0
+Commands:
+- tally
+FileExtensions:
+- dockerfile
+- containerfile
+ReleaseDate: '2026-04-06'
+Installers:
+- Architecture: x64
+  InstallerType: portable
+  InstallerUrl: https://github.com/wharflab/tally/releases/download/v0.32.0/tally_0.32.0_Windows_x86_64.exe
+  InstallerSha256: 04E247F9E91EFB8D9D98A6753E6DB75791BD6145489D2E7FB18E9C2B07046F84
+  Commands:
+  - tally
+- Architecture: arm64
+  InstallerType: portable
+  InstallerUrl: https://github.com/wharflab/tally/releases/download/v0.32.0/tally_0.32.0_Windows_arm64.exe
+  InstallerSha256: 902ACE6A3DD5DE9B9180B11878F8F9A8BC0298755B3046A11A4B6205320A0E82
+  Commands:
+  - tally
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/w/Wharflab/Tally/0.32.0/Wharflab.Tally.locale.en-US.yaml
+++ b/manifests/w/Wharflab/Tally/0.32.0/Wharflab.Tally.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# Created by tally release automation
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: Wharflab.Tally
+PackageVersion: 0.32.0
+PackageLocale: en-US
+Publisher: Wharflab
+PublisherUrl: https://github.com/wharflab
+PublisherSupportUrl: https://github.com/wharflab/tally/issues
+PackageName: Tally
+PackageUrl: https://github.com/wharflab/tally
+ShortDescription: Dockerfile linter and formatter with first-class PowerShell and
+  Windows container support.
+Moniker: tally
+License: GPL-3.0-only
+LicenseUrl: https://github.com/wharflab/tally/blob/main/LICENSE
+ReleaseNotesUrl: https://github.com/wharflab/tally/releases/tag/v0.32.0
+Documentations:
+- DocumentLabel: Docs
+  DocumentUrl: https://wharflab.github.io/tally/
+Tags:
+- docker
+- dockerfile
+- containerfile
+- linter
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/w/Wharflab/Tally/0.32.0/Wharflab.Tally.yaml
+++ b/manifests/w/Wharflab/Tally/0.32.0/Wharflab.Tally.yaml
@@ -1,0 +1,8 @@
+# Created by tally release automation
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: Wharflab.Tally
+PackageVersion: 0.32.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Publishing version v0.32.0 of [tally](https://github.com/wharflab/tally) to WinGet.

Tally is a Dockerfile linter and formatter written in Go, promoting modern container syntax and helping avoid common pitfalls.

[Changelog](https://github.com/wharflab/tally/releases/tag/v0.32.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/355840)