### PR TITLE
New package: alarmz.Recoll version 1.43.13

### DIFF
--- a/manifests/a/alarmz/Recoll/1.43.13/alarmz.Recoll.installer.yaml
+++ b/manifests/a/alarmz/Recoll/1.43.13/alarmz.Recoll.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: alarmz.Recoll
+PackageVersion: 1.43.13
+Platform:
+- Windows.Desktop
+InstallerType: inno
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-04-06
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/alarmz/recoll/releases/download/1.43.13-1/recoll-1.43.13-1-win64-setup.exe
+  InstallerSha256: 164F705D4FC3692895C6CD116BD580F2B76E22AC0739B793C9EDE61C1298B375
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/alarmz/Recoll/1.43.13/alarmz.Recoll.locale.en-US.yaml
+++ b/manifests/a/alarmz/Recoll/1.43.13/alarmz.Recoll.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: alarmz.Recoll
+PackageVersion: 1.43.13
+PackageLocale: en-US
+Publisher: alarmz
+PublisherUrl: https://github.com/alarmz
+PublisherSupportUrl: https://github.com/alarmz/recoll/issues
+Author: alarmz
+PackageName: Recoll
+PackageUrl: https://github.com/alarmz/recoll
+License: GPL-2.0-or-later
+LicenseUrl: https://github.com/alarmz/recoll/blob/HEAD/COPYING
+ShortDescription: Free desktop full-text search tool for Windows
+Description: Recoll is an open source desktop full-text search tool. It indexes and searches documents including PDF, Word, email, and hundreds of other formats. This is a community-maintained Windows build with Qt6 GUI.
+Moniker: recoll
+Tags:
+- desktop-search
+- file-search
+- full-text-search
+- indexer
+- recoll
+- search
+ReleaseNotesUrl: https://github.com/alarmz/recoll/releases/tag/1.43.13-1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/alarmz/Recoll/1.43.13/alarmz.Recoll.yaml
+++ b/manifests/a/alarmz/Recoll/1.43.13/alarmz.Recoll.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: alarmz.Recoll
+PackageVersion: 1.43.13
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Summary
- Adds new package `alarmz.Recoll` version `1.43.13`
- Community-maintained Windows build of Recoll (desktop full-text search tool) with Qt6 GUI
- Inno Setup installer, x64

## Validation
- [x] Manifest files follow schema 1.12.0
- [x] InstallerSha256 verified: `164F705D4FC3692895C6CD116BD580F2B76E22AC0739B793C9EDE61C1298B375`
- [x] InstallerUrl is a stable GitHub release asset
- [x] License: GPL-2.0-or-later
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/355845)