### PR TITLE
Add HDZTony.FlowUI version 14.1.0

### DIFF
--- a/manifests/h/HDZTony/FlowUI/14.1.0/HDZTony.FlowUI.installer.yaml
+++ b/manifests/h/HDZTony/FlowUI/14.1.0/HDZTony.FlowUI.installer.yaml
@@ -1,0 +1,19 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: HDZTony.FlowUI
+PackageVersion: 14.1.0
+Installers:
+  - Architecture: x64
+    InstallerType: zip
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: 多平台运营工具.exe
+        PortableCommandAlias: flowui
+    InstallerUrl: https://gitee.com/qq_connect-A6102553/e-commerce-operation-tools/releases/download/v14.1.0/FlowUI-14.1.0-win-x64.zip
+    InstallerSha256: 29FA3DA1AD4736E22A0F5E3B9ED733AFE06501D4D4177CACEE49CE48BD02FA83
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Microsoft.EdgeWebView2Runtime
+Commands:
+  - flowui
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/h/HDZTony/FlowUI/14.1.0/HDZTony.FlowUI.locale.zh-CN.yaml
+++ b/manifests/h/HDZTony/FlowUI/14.1.0/HDZTony.FlowUI.locale.zh-CN.yaml
@@ -1,0 +1,21 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: HDZTony.FlowUI
+PackageVersion: 14.1.0
+PackageLocale: zh-CN
+Publisher: HDZTony
+PackageName: 多平台运营工具
+ShortDescription: 多平台运营工具 — 桌面节点工作流编辑器
+Description: |
+  多平台运营工具（曾用名 FlowUI）是基于 pywebview 与 Vue 3 + BaklavaJS 的桌面节点工作流编辑器。
+Moniker: flowui
+License: Proprietary
+LicenseUrl: https://gitee.com/qq_connect-A6102553/e-commerce-operation-tools/raw/master/LICENSE.txt
+Copyright: Copyright (c) HDZTony
+ReleaseNotes: Release 14.1.0.
+ReleaseNotesUrl: https://gitee.com/qq_connect-A6102553/e-commerce-operation-tools/releases/tag/v14.1.0
+Tags:
+  - workflow
+  - node-editor
+  - vue
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/h/HDZTony/FlowUI/14.1.0/HDZTony.FlowUI.yaml
+++ b/manifests/h/HDZTony/FlowUI/14.1.0/HDZTony.FlowUI.yaml
@@ -1,0 +1,6 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: HDZTony.FlowUI
+PackageVersion: 14.1.0
+DefaultLocale: zh-CN
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Summary
- Add 多平台运营工具 (HDZTony.FlowUI) 14.1.0 manifests.
- Installer: portable zip from Gitee Release v14.1.0.
- SHA256 verified against published asset.

## Validation
- \winget validate --manifest\ passed locally.

Made with [Cursor](https://cursor.com)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/355906)