### PR TITLE
Fix install scope from WPS Office installer

### DIFF
--- a/manifests/k/Kingsoft/WPSOffice/CN/12.1.0.25225/Kingsoft.WPSOffice.CN.installer.yaml
+++ b/manifests/k/Kingsoft/WPSOffice/CN/12.1.0.25225/Kingsoft.WPSOffice.CN.installer.yaml
@@ -4,7 +4,6 @@
 PackageIdentifier: Kingsoft.WPSOffice.CN
 PackageVersion: 12.1.0.25225
 InstallerType: nullsoft
-Scope: user
 InstallerSwitches:
   Custom: -agreelicense
 InstallerSuccessCodes:


### PR DESCRIPTION
Fix install scope from the WPS Office installer configuration.

Checklist for Pull Requests
- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?  If so, fill in the Issue number below.
   <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

Manifests
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/355929)