### PR TITLE
Fix Ailuntz.Winmon 0.7.0 release URLs

### DIFF
--- a/manifests/a/Ailuntz/Winmon/0.7.0/Ailuntz.Winmon.installer.yaml
+++ b/manifests/a/Ailuntz/Winmon/0.7.0/Ailuntz.Winmon.installer.yaml
@@ -10,7 +10,7 @@ NestedInstallerFiles:
   PortableCommandAlias: winmon
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/ailuntz/winmon/releases/download/v0.7.0/winmon-windows-x64.zip
-  InstallerSha256: E397B97727A13B343A9C92B0FD3990B696979FF1EB9E3E78C61B405E9BF8D78E
+  InstallerUrl: https://github.com/ailuntx/winmon/releases/download/v0.7.0/winmon-windows-x64.zip
+  InstallerSha256: 5261FC3028C0CFCACD1BA8468F1CE57052234BBE416813F7E88769F2B8FD4B9B
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/a/Ailuntz/Winmon/0.7.0/Ailuntz.Winmon.locale.en-US.yaml
+++ b/manifests/a/Ailuntz/Winmon/0.7.0/Ailuntz.Winmon.locale.en-US.yaml
@@ -3,21 +3,22 @@
 PackageIdentifier: Ailuntz.Winmon
 PackageVersion: 0.7.0
 PackageLocale: en-US
-Publisher: ailuntz
-PublisherUrl: https://github.com/ailuntz
-PublisherSupportUrl: https://github.com/ailuntz/winmon/issues
-Author: ailuntz
+Publisher: ailuntx
+PublisherUrl: https://github.com/ailuntx
+PublisherSupportUrl: https://github.com/ailuntx/winmon/issues
+Author: ailuntx
 PackageName: winmon
-PackageUrl: https://github.com/ailuntz/winmon
+PackageUrl: https://github.com/ailuntx/winmon
 License: MIT
-LicenseUrl: https://github.com/ailuntz/winmon/blob/main/LICENSE
-ShortDescription: Windows terminal hardware monitor
-Description: Terminal hardware monitor for Windows. Starts a TUI by default and also supports pipe and debug modes.
+LicenseUrl: https://github.com/ailuntx/winmon/blob/main/LICENSE
+ShortDescription: Windows terminal hardware monitor for Intel CPU and NVIDIA GPU
+Description: Terminal hardware monitor for Windows focused on Intel CPU and NVIDIA discrete GPU. Starts a TUI by default and also supports pipe, debug, and serve modes.
 Moniker: winmon
 Tags:
 - monitor
 - terminal
 - cli
-- hardware
+- intel
+- nvidia
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0


### PR DESCRIPTION
## Summary
- fix the broken 0.7.0 installer URL for `Ailuntz.Winmon`
- update the SHA256 to match the current `winmon-windows-x64.zip`
- refresh publisher/support/package URLs to the active `ailuntx/winmon` repository

## Why
The original `Ailuntz.Winmon` 0.7.0 manifest points to `https://github.com/ailuntz/winmon/...`, but that repository is no longer the active source. The current public release for v0.7.0 is hosted at `https://github.com/ailuntx/winmon/releases/tag/v0.7.0`.

This PR keeps the existing `PackageIdentifier` unchanged to avoid creating a duplicate package and only repairs the existing 0.7.0 metadata.

## Verification
- release page: https://github.com/ailuntx/winmon/releases/tag/v0.7.0
- installer URL: https://github.com/ailuntx/winmon/releases/download/v0.7.0/winmon-windows-x64.zip
- installer sha256: `5261FC3028C0CFCACD1BA8468F1CE57052234BBE416813F7E88769F2B8FD4B9B`

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/356260)