### PR TITLE
Add Ailuntx.Winmon version 0.7.0

### DIFF
--- a/manifests/a/Ailuntx/Winmon/0.7.0/Ailuntx.Winmon.installer.yaml
+++ b/manifests/a/Ailuntx/Winmon/0.7.0/Ailuntx.Winmon.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Ailuntx.Winmon
+PackageVersion: 0.7.0
+MinimumOSVersion: 10.0.17763.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: winmon.exe
+  PortableCommandAlias: winmon
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/ailuntx/winmon/releases/download/v0.7.0/winmon-windows-x64.zip
+  InstallerSha256: 5261FC3028C0CFCACD1BA8468F1CE57052234BBE416813F7E88769F2B8FD4B9B
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/Ailuntx/Winmon/0.7.0/Ailuntx.Winmon.locale.en-US.yaml
+++ b/manifests/a/Ailuntx/Winmon/0.7.0/Ailuntx.Winmon.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Ailuntx.Winmon
+PackageVersion: 0.7.0
+PackageLocale: en-US
+Publisher: ailuntx
+PublisherUrl: https://github.com/ailuntx
+PublisherSupportUrl: https://github.com/ailuntx/winmon/issues
+Author: ailuntx
+PackageName: winmon
+PackageUrl: https://github.com/ailuntx/winmon
+License: MIT
+LicenseUrl: https://github.com/ailuntx/winmon/blob/main/LICENSE
+ShortDescription: Windows terminal hardware monitor for Intel CPU and NVIDIA GPU
+Description: Terminal hardware monitor for Windows focused on Intel CPU and NVIDIA discrete GPU. Starts a TUI by default and also supports pipe, debug, and serve modes.
+Moniker: winmon
+Tags:
+- monitor
+- terminal
+- cli
+- intel
+- nvidia
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/Ailuntx/Winmon/0.7.0/Ailuntx.Winmon.yaml
+++ b/manifests/a/Ailuntx/Winmon/0.7.0/Ailuntx.Winmon.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Ailuntx.Winmon
+PackageVersion: 0.7.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Summary
- add a new package `Ailuntx.Winmon`
- publish version `0.7.0`
- point the installer to the current public GitHub release asset

## Release
- https://github.com/ailuntx/winmon/releases/tag/v0.7.0
- installer: https://github.com/ailuntx/winmon/releases/download/v0.7.0/winmon-windows-x64.zip
- sha256: `5261FC3028C0CFCACD1BA8468F1CE57052234BBE416813F7E88769F2B8FD4B9B`

## Notes
This submission intentionally uses the requested package identifier `Ailuntx.Winmon`.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/356261)