### PR TITLE
New version: nelsonduarte.PDFApps version 1.9.0

### DIFF
--- a/manifests/n/nelsonduarte/PDFApps/1.9.0/nelsonduarte.PDFApps.installer.yaml
+++ b/manifests/n/nelsonduarte/PDFApps/1.9.0/nelsonduarte.PDFApps.installer.yaml
@@ -1,0 +1,13 @@
+PackageIdentifier: nelsonduarte.PDFApps
+PackageVersion: 1.9.0
+InstallerType: portable
+Scope: user
+Commands:
+  - pdfapps
+ReleaseDate: 2026-04-07
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/nelsonduarte/PDFApps/releases/download/v1.9.0/PDFApps.exe
+    InstallerSha256: C0933BA16FB85FCAC43F3FBA59DFFFE295E6EC9A5D3DC7A94CA26FE4D0E9EF96
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/n/nelsonduarte/PDFApps/1.9.0/nelsonduarte.PDFApps.locale.en-US.yaml
+++ b/manifests/n/nelsonduarte/PDFApps/1.9.0/nelsonduarte.PDFApps.locale.en-US.yaml
@@ -1,0 +1,46 @@
+PackageIdentifier: nelsonduarte.PDFApps
+PackageVersion: 1.9.0
+PackageLocale: en-US
+Publisher: Nelson Duarte
+PublisherUrl: https://github.com/nelsonduarte
+PublisherSupportUrl: https://github.com/nelsonduarte/PDFApps/issues
+Author: Nelson Duarte
+PackageName: PDFApps
+PackageUrl: https://nelsonduarte.github.io/PDFApps/
+License: MIT
+LicenseUrl: https://github.com/nelsonduarte/PDFApps/blob/main/LICENSE
+Copyright: Copyright (c) Nelson Duarte
+ShortDescription: Fast, offline, subscription-free PDF editor
+Description: |-
+  PDFApps is an all-in-one PDF editor with 13 built-in tools: split, merge, rotate,
+  extract, reorder, compress, encrypt, watermark, OCR, convert (PNG/JPG/DOCX/TXT),
+  visual editor (redact, text, images, signatures, highlights, notes), import
+  (TXT/images/Markdown), and metadata viewer.
+
+  Features include continuous-scroll viewer, presentation mode (F5), fullscreen
+  (F11), tabbed viewing, dark/light themes, drag and drop, multi-select PDF open,
+  and 8-language interface (EN, PT, ES, FR, DE, ZH, IT, NL).
+
+  100% offline. No subscriptions, no cloud uploads, no account required.
+Moniker: pdfapps
+Tags:
+  - pdf
+  - pdf-editor
+  - pdf-viewer
+  - pdf-tools
+  - offline
+  - open-source
+  - ocr
+  - split
+  - merge
+  - compress
+  - encrypt
+  - watermark
+ReleaseNotes: |-
+  - Bookmarks/TOC clickable side panel
+  - Night reading mode (invert PDF colors)
+  - Release notes shown in update dialog
+  - TOC and night mode buttons in workspace bar
+ReleaseNotesUrl: https://github.com/nelsonduarte/PDFApps/releases/tag/v1.9.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/n/nelsonduarte/PDFApps/1.9.0/nelsonduarte.PDFApps.yaml
+++ b/manifests/n/nelsonduarte/PDFApps/1.9.0/nelsonduarte.PDFApps.yaml
@@ -1,0 +1,7 @@
+# Created with winget create
+# https://github.com/microsoft/winget-pkgs
+PackageIdentifier: nelsonduarte.PDFApps
+PackageVersion: 1.9.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Update

Bumps `nelsonduarte.PDFApps` to **v1.9.0**.

### What's new

- Bookmarks/TOC clickable side panel
- Night reading mode (invert PDF colors)
- Release notes shown in update dialog
- TOC and night mode buttons in workspace bar

## Validation

- [x] SHA256 verified against the v1.9.0 release asset
- [x] Manifests follow winget schema 1.6.0

## Links

- Release: https://github.com/nelsonduarte/PDFApps/releases/tag/v1.9.0
- Source: https://github.com/nelsonduarte/PDFApps
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/356313)