### PR TITLE
New package: stescobedo92.JWMV version 1.0.0

### DIFF
--- a/manifests/s/stescobedo92/JWMV/1.0.0/stescobedo92.JWMV.installer.yaml
+++ b/manifests/s/stescobedo92/JWMV/1.0.0/stescobedo92.JWMV.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: stescobedo92.JWMV
+PackageVersion: 1.0.0
+MinimumOSVersion: 10.0.17763.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: jwmv.exe
+    PortableCommandAlias: jwmv
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/stescobedo92/jwmv/releases/download/v1.0.0/jwmv-win-x64.zip
+    InstallerSha256: F60BF92BDDC198F42B8EA9EB6B8ADEA3F059426839FE0630E8C02B998AF23AA7
+  - Architecture: arm64
+    InstallerUrl: https://github.com/stescobedo92/jwmv/releases/download/v1.0.0/jwmv-win-arm64.zip
+    InstallerSha256: 5FBE001EA347B00DA80B8182875EACF379F20D287EFCC6D999E920224605F944
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/stescobedo92/JWMV/1.0.0/stescobedo92.JWMV.locale.en-US.yaml
+++ b/manifests/s/stescobedo92/JWMV/1.0.0/stescobedo92.JWMV.locale.en-US.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: stescobedo92.JWMV
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: Sergio Triana Escobedo
+PublisherUrl: https://github.com/stescobedo92
+Author: Sergio Triana Escobedo
+PackageName: JWMV
+PackageUrl: https://github.com/stescobedo92/jwmv
+License: MIT
+LicenseUrl: https://github.com/stescobedo92/jwmv/blob/main/LICENSE
+ShortDescription: A fast, lightweight CLI to install, manage, and switch between multiple Java (JDK) versions on Windows.
+Tags:
+  - java
+  - jdk
+  - version-manager
+  - cli
+  - developer-tools
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/stescobedo92/JWMV/1.0.0/stescobedo92.JWMV.version.yaml
+++ b/manifests/s/stescobedo92/JWMV/1.0.0/stescobedo92.JWMV.version.yaml
@@ -1,6 +1,0 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
-PackageIdentifier: stescobedo92.JWMV
-PackageVersion: 1.0.0
-DefaultLocale: en-US
-ManifestType: version
-ManifestVersion: 1.6.0

--- a/manifests/s/stescobedo92/JWMV/1.0.0/stescobedo92.JWMV.version.yaml
+++ b/manifests/s/stescobedo92/JWMV/1.0.0/stescobedo92.JWMV.version.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: stescobedo92.JWMV
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0

--- a/manifests/s/stescobedo92/JWMV/1.0.0/stescobedo92.JWMV.yaml
+++ b/manifests/s/stescobedo92/JWMV/1.0.0/stescobedo92.JWMV.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: stescobedo92.JWMV
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package submission

- **PackageIdentifier:** stescobedo92.JWMV
- **PackageVersion:** 1.0.0
- **PackageUrl:** https://github.com/stescobedo92/jwmv
- **License:** MIT
- **Description:** A fast, lightweight CLI to install, manage, and switch between multiple Java (JDK) versions on Windows.

### Checklist

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls?q=is%3Apr+stescobedo92.JWMV) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Does your manifest conform to the 1.12 schema?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/356370)