### PR TITLE
New package: MetanoicArmor.I2PChat version 1.2.5

### DIFF
--- a/manifests/m/MetanoicArmor/I2PChat/1.2.5/MetanoicArmor.I2PChat.installer.yaml
+++ b/manifests/m/MetanoicArmor/I2PChat/1.2.5/MetanoicArmor.I2PChat.installer.yaml
@@ -1,0 +1,25 @@
+PackageIdentifier: MetanoicArmor.I2PChat
+PackageVersion: 1.2.5
+InstallerLocale: en-US
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallModes:
+  - interactive
+  - silent
+# GUI winget: *-winget-* zip has no embedded i2pd (Microsoft Installers Scan). Replace InstallerSha256 after
+# uploading release assets (see build-windows.ps1 footer or packaging/refresh-checksums.sh 1.2.5).
+Installers:
+  - Architecture: x64
+    InstallerType: zip
+    InstallerUrl: https://github.com/MetanoicArmor/I2PChat/releases/download/v1.2.5/I2PChat-windows-x64-winget-v1.2.5.zip
+    InstallerSha256: e765ff9a85ba89b06cc2ca642c8d52d0ab8e22079693bf19dee3f89671a400eb
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: I2PChat/I2PChat.exe
+        PortableCommandAlias: i2pchat
+      - RelativeFilePath: I2PChat/I2PChat-tui.exe
+        PortableCommandAlias: i2pchat-tui
+    ReleaseDate: 2026-04-08
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/MetanoicArmor/I2PChat/1.2.5/MetanoicArmor.I2PChat.locale.en-US.yaml
+++ b/manifests/m/MetanoicArmor/I2PChat/1.2.5/MetanoicArmor.I2PChat.locale.en-US.yaml
@@ -1,0 +1,29 @@
+PackageIdentifier: MetanoicArmor.I2PChat
+PackageVersion: 1.2.5
+PackageLocale: en-US
+Publisher: MetanoicArmor
+PublisherUrl: https://github.com/MetanoicArmor
+PackageName: I2PChat
+PackageUrl: https://github.com/MetanoicArmor/I2PChat
+License: AGPL-3.0
+LicenseUrl: https://github.com/MetanoicArmor/I2PChat/blob/main/LICENSE
+Copyright: Copyright (c) MetanoicArmor and contributors
+ShortDescription: Experimental peer-to-peer chat client for the I2P anonymity network
+Description: |-
+  I2PChat is a cross-platform GUI (PyQt6) chat client for the I2P network, with optional
+  console TUI. Binaries are portable (zip); GUI is I2PChat.exe; TUI is I2PChat-tui.exe in the I2PChat folder.
+  This winget package uses the *-winget-* release zip, which omits the embedded i2pd router binary so
+  Microsoft’s installer validation can succeed; use a system i2pd (SAM) or install the full Windows zip from
+  GitHub Releases if you want the bundled router. The full zip includes i2pd (PurpleI2P/i2pd), which some AV
+  vendors label generic “riskware” even though it is legitimate open-source software.
+Moniker: i2pchat
+Tags:
+  - i2p
+  - chat
+  - p2p
+  - privacy
+ReleaseNotesUrl: https://github.com/MetanoicArmor/I2PChat/releases/tag/v1.2.5
+ReleaseNotes: |-
+  v1.2.5: GUI no longer crashes when the I2P session fails to start (e.g. SAM unreachable); status/connect/send controls stay safe with core=None. Winget ships the *-winget-* zip without embedded i2pd. For the bundled router, use I2PChat-windows-x64-v*.zip on GitHub Releases. i2pd: https://github.com/PurpleI2P/i2pd
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/MetanoicArmor/I2PChat/1.2.5/MetanoicArmor.I2PChat.yaml
+++ b/manifests/m/MetanoicArmor/I2PChat/1.2.5/MetanoicArmor.I2PChat.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: MetanoicArmor.I2PChat
+PackageVersion: 1.2.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Manifests
Portable zip (no embedded i2pd): \I2PChat-windows-x64-winget-v1.2.5.zip\ from [I2PChat v1.2.5](https://github.com/MetanoicArmor/I2PChat/releases/tag/v1.2.5).

Source manifests: [packaging/winget/1.2.5](https://github.com/MetanoicArmor/I2PChat/tree/main/packaging/winget/1.2.5)

### Checklist
- [x] SHA256 matches GitHub release asset digest
- [x] \*-winget-*\ zip (Microsoft Installers Scan / no bundled i2pd)

Closes superseded PR for 1.2.4 (not merged).

Made with [Cursor](https://cursor.com)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/356552)