### PR TITLE
New package: MetanoicArmor.I2PChat.TUI version 1.2.5

### DIFF
--- a/manifests/m/MetanoicArmor/I2PChat/TUI/1.2.5/MetanoicArmor.I2PChat.TUI.installer.yaml
+++ b/manifests/m/MetanoicArmor/I2PChat/TUI/1.2.5/MetanoicArmor.I2PChat.TUI.installer.yaml
@@ -1,0 +1,22 @@
+PackageIdentifier: MetanoicArmor.I2PChat.TUI
+PackageVersion: 1.2.5
+InstallerLocale: en-US
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallModes:
+  - interactive
+  - silent
+# TUI winget: *-winget-* zip omits embedded i2pd. Replace InstallerSha256 after assets are on the release.
+Installers:
+  - Architecture: x64
+    InstallerType: zip
+    InstallerUrl: https://github.com/MetanoicArmor/I2PChat/releases/download/v1.2.5/I2PChat-windows-tui-x64-winget-v1.2.5.zip
+    InstallerSha256: 5a95a02ca40522c78541db80fba5454d893aedbca403614db9bae80a1f6d2944
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: I2PChat/I2PChat-tui.exe
+        PortableCommandAlias: i2pchat-tui
+    ReleaseDate: 2026-04-08
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/MetanoicArmor/I2PChat/TUI/1.2.5/MetanoicArmor.I2PChat.TUI.locale.en-US.yaml
+++ b/manifests/m/MetanoicArmor/I2PChat/TUI/1.2.5/MetanoicArmor.I2PChat.TUI.locale.en-US.yaml
@@ -1,0 +1,29 @@
+PackageIdentifier: MetanoicArmor.I2PChat.TUI
+PackageVersion: 1.2.5
+PackageLocale: en-US
+Publisher: MetanoicArmor
+PublisherUrl: https://github.com/MetanoicArmor
+PackageName: I2PChat (TUI)
+PackageUrl: https://github.com/MetanoicArmor/I2PChat
+License: AGPL-3.0
+LicenseUrl: https://github.com/MetanoicArmor/I2PChat/blob/main/LICENSE
+Copyright: Copyright (c) MetanoicArmor and contributors
+ShortDescription: I2PChat Textual terminal UI (console client for I2P)
+Description: |-
+  Console-only build of I2PChat (Textual TUI). Does not include the PyQt GUI binary.
+  After install, run i2pchat-tui from a terminal. Optional profile name as the first argument.
+  This winget package uses the *-winget-* release zip without embedded i2pd (Microsoft installer validation).
+  Use system i2pd (SAM) or the full TUI zip from GitHub Releases for the bundled router.
+Moniker: i2pchat-tui
+Tags:
+  - i2p
+  - chat
+  - p2p
+  - privacy
+  - terminal
+  - tui
+ReleaseNotesUrl: https://github.com/MetanoicArmor/I2PChat/releases/tag/v1.2.5
+ReleaseNotes: |-
+  v1.2.5: GUI build fixes (upstream); TUI winget zip unchanged layout. Full TUI zip with bundled router: I2PChat-windows-tui-x64-v*.zip on GitHub Releases. i2pd: https://github.com/PurpleI2P/i2pd
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/MetanoicArmor/I2PChat/TUI/1.2.5/MetanoicArmor.I2PChat.TUI.yaml
+++ b/manifests/m/MetanoicArmor/I2PChat/TUI/1.2.5/MetanoicArmor.I2PChat.TUI.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: MetanoicArmor.I2PChat.TUI
+PackageVersion: 1.2.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Manifests
Portable TUI zip (no embedded i2pd): \I2PChat-windows-tui-x64-winget-v1.2.5.zip\ from [I2PChat v1.2.5](https://github.com/MetanoicArmor/I2PChat/releases/tag/v1.2.5).

Source: [packaging/winget-tui/.../TUI/1.2.5](https://github.com/MetanoicArmor/I2PChat/tree/main/packaging/winget-tui/manifests/m/MetanoicArmor/I2PChat/TUI/1.2.5)

### Checklist
- [x] SHA256 matches GitHub release asset digest
- [x] \*-winget-*\ zip (Installers Scan / no bundled i2pd)

Supersedes closed PR for 1.2.4 (not merged).

Made with [Cursor](https://cursor.com)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/356553)