### PR TITLE
New package: GiftedAgent.Watashi version 0.2.0

### DIFF
--- a/manifests/g/GiftedAgent/Watashi/0.2.0/GiftedAgent.Watashi.installer.yaml
+++ b/manifests/g/GiftedAgent/Watashi/0.2.0/GiftedAgent.Watashi.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: GiftedAgent.Watashi
+PackageVersion: 0.2.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: watashi.exe
+    PortableCommandAlias: watashi
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/gftdcojp/watashi/releases/download/v0.2.0/watashi-0.2.0-windows-x64.zip
+    InstallerSha256: 0BB65A105005D58B8EC5B7E12C05B4D4AA430632573BFFF4C93F4E6BFE33A0AE
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/g/GiftedAgent/Watashi/0.2.0/GiftedAgent.Watashi.locale.en-US.yaml
+++ b/manifests/g/GiftedAgent/Watashi/0.2.0/GiftedAgent.Watashi.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: GiftedAgent.Watashi
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: GIFTED AGENT LLC
+PublisherUrl: https://gftd.co.jp
+PublisherSupportUrl: https://github.com/gftdcojp/watashi/issues
+PackageName: Watashi
+PackageUrl: https://github.com/gftdcojp/watashi
+License: MIT
+LicenseUrl: https://github.com/gftdcojp/watashi/blob/main/LICENSE
+ShortDescription: Cross-platform mouse/keyboard sharing with encrypted UDP and mDNS auto-discovery.
+Description: |-
+  Watashi (渡し) seamlessly shares mouse and keyboard across macOS and Windows machines.
+  Move your cursor to the screen edge and it appears on the other computer.
+  Uses ChaCha20-Poly1305 encrypted UDP transport with X25519 key exchange,
+  mDNS zero-configuration peer discovery, and a KAMI Engine wgpu GUI.
+Tags:
+  - input-sharing
+  - keyboard
+  - kvm
+  - mouse
+  - cross-platform
+  - encrypted
+  - mdns
+  - rust
+ReleaseNotesUrl: https://github.com/gftdcojp/watashi/releases/tag/v0.2.0
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/g/GiftedAgent/Watashi/0.2.0/GiftedAgent.Watashi.yaml
+++ b/manifests/g/GiftedAgent/Watashi/0.2.0/GiftedAgent.Watashi.yaml
@@ -1,0 +1,7 @@
+# Created using winget CLI
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: GiftedAgent.Watashi
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
### New Package Submission

**Package Identifier:** GiftedAgent.Watashi
**Package Version:** 0.2.0
**Package URL:** https://github.com/gftdcojp/watashi
**Publisher:** GIFTED AGENT LLC
**License:** MIT

### Description
Watashi (渡し) — Cross-platform mouse/keyboard sharing with encrypted UDP (ChaCha20-Poly1305 + X25519) and mDNS zero-configuration peer discovery. Built in Rust.

### Installation
```
winget install GiftedAgent.Watashi
```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/356573)