### PR TITLE
Trying out something real quick to fix a "winget update" bug: Microsoft.VisualStudio.BuildTools version 18.4.3

### DIFF
--- a/manifests/m/Microsoft/VisualStudio/BuildTools/18.4.3/Microsoft.VisualStudio.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/BuildTools/18.4.3/Microsoft.VisualStudio.BuildTools.installer.yaml
@@ -89,5 +89,7 @@ Installers:
   Scope: machine
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/c03aa7dd-8afd-49cc-9274-19c9a1b26aee/064858587f647fb494e80146fe18eac1a082f95ef1c8485bb1915dfe444d4068/vs_BuildTools.exe
   InstallerSha256: 064858587f647fb494e80146fe18eac1a082f95ef1c8485bb1915dfe444d4068
+AppsAndFeaturesEntries:
+- DisplayVersion: 18.4.3
 ManifestType: installer
 ManifestVersion: 1.9.0


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?  If so, fill in the Issue number below.
   <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---
Notes from me:
* The bug is that after having updated an existing BuildTools installation (For instance 18.4.0), then updating it to 18.4.3 will still have it show up as 18.4.0 in `winget update`.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/356592)