### PR TITLE
Add Echowire.Echowire version 1.17.0

### DIFF
--- a/manifests/e/Echowire/Echowire/1.17.0/Echowire.Echowire.installer.yaml
+++ b/manifests/e/Echowire/Echowire/1.17.0/Echowire.Echowire.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Echowire.Echowire
+PackageVersion: 1.17.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+UpgradeBehavior: install
+ReleaseDate: 2026-03-03
+Installers:
+- Architecture: x64
+  InstallerUrl: https://echowire.org/dl/desktop/stable/win32/x64/Echowire-1.17.0-x64.exe
+  InstallerSha256: 2FB11940D2AE603EB279663B969923AAAFA5FF19BF5CB26705754119CB5B6E68
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/e/Echowire/Echowire/1.17.0/Echowire.Echowire.installer.yaml
+++ b/manifests/e/Echowire/Echowire/1.17.0/Echowire.Echowire.installer.yaml
@@ -9,8 +9,8 @@ InstallModes:
 - silent
 - silentWithProgress
 InstallerSwitches:
-  Silent: /S
-  SilentWithProgress: /S
+  Silent: /S /currentuser
+  SilentWithProgress: /S /currentuser
 UpgradeBehavior: install
 ReleaseDate: 2026-03-03
 Installers:

--- a/manifests/e/Echowire/Echowire/1.17.0/Echowire.Echowire.locale.en-US.yaml
+++ b/manifests/e/Echowire/Echowire/1.17.0/Echowire.Echowire.locale.en-US.yaml
@@ -10,7 +10,7 @@ Author: Proudlock Technology
 PackageName: Echowire
 PackageUrl: https://echowire.org
 License: AGPL-3.0-or-later
-LicenseUrl: https://github.com/cproudlock/echowire/blob/echowire/LICENSE
+LicenseUrl: https://github.com/cproudlock/fluxer/blob/echowire/LICENSE
 Copyright: Copyright (c) 2026 Echowire
 ShortDescription: Self-hosted, federated chat platform with voice, video, threads, and scheduled events.
 Description: |-

--- a/manifests/e/Echowire/Echowire/1.17.0/Echowire.Echowire.locale.en-US.yaml
+++ b/manifests/e/Echowire/Echowire/1.17.0/Echowire.Echowire.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Echowire.Echowire
+PackageVersion: 1.17.0
+PackageLocale: en-US
+Publisher: Echowire
+PublisherUrl: https://echowire.org
+PublisherSupportUrl: https://echowire.org
+Author: Proudlock Technology
+PackageName: Echowire
+PackageUrl: https://echowire.org
+License: AGPL-3.0-or-later
+LicenseUrl: https://github.com/cproudlock/echowire/blob/echowire/LICENSE
+Copyright: Copyright (c) 2026 Echowire
+ShortDescription: Self-hosted, federated chat platform with voice, video, threads, and scheduled events.
+Description: |-
+  Echowire is a self-hosted, open-source chat platform offering Discord-style guilds,
+  channels, threads, scheduled events, voice and video calls with WebRTC, custom
+  soundboards, passkey authentication, and direct messages. Built for communities
+  that want full control of their data without compromising on features. Supports
+  federation between instances. AGPL-3.0 licensed.
+Moniker: echowire
+Tags:
+- chat
+- voice
+- video
+- messaging
+- voip
+- communities
+- self-hosted
+- federated
+- open-source
+- discord-alternative
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/e/Echowire/Echowire/1.17.0/Echowire.Echowire.yaml
+++ b/manifests/e/Echowire/Echowire/1.17.0/Echowire.Echowire.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Echowire.Echowire
+PackageVersion: 1.17.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## What

Adds the initial winget manifest for **Echowire** (`Echowire.Echowire`), a self-hosted, federated chat platform with voice, video, threads, and scheduled events. Open source under AGPL-3.0.

## Manifest details

- **PackageIdentifier:** `Echowire.Echowire`
- **PackageVersion:** `1.17.0`
- **InstallerType:** `nullsoft` (electron-builder NSIS, `oneClick: false`, `perMachine: false`)
- **Architecture:** x64
- **Scope:** user
- **Silent install:** `/S`
- **InstallerUrl:** `https://echowire.org/dl/desktop/stable/win32/x64/Echowire-1.17.0-x64.exe`
- **InstallerSha256:** `2FB11940D2AE603EB279663B969923AAAFA5FF19BF5CB26705754119CB5B6E68`
- **License:** `AGPL-3.0-or-later`

## Verification done

- [x] SHA256 verified by downloading the installer from the public URL
- [x] Manifest schema 1.12.0 (matches current winget tooling)
- [x] `Publisher` field matches `CompanyName` embedded in the .exe VERSIONINFO (`Echowire`)
- [x] Confirmed `Echowire.Echowire` package identifier is not already in use
- [x] Hosted on a stable HTTPS URL (Cloudflare R2 via echowire.org reverse proxy, won't move)

## Notes

- The installer is currently unsigned. Code signing is in progress (SSL.com order pending) and will be added in a future version submission.
- This is an initial submission; future versions will be submitted via `wingetcreate update`.

Project: https://echowire.org
Source: https://github.com/cproudlock/echowire
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/356898)