### PR TITLE
New package: randlee.agent-team-mail version 1.0.0

### DIFF
--- a/manifests/r/randlee/agent-team-mail/1.0.0/randlee.agent-team-mail.installer.yaml
+++ b/manifests/r/randlee/agent-team-mail/1.0.0/randlee.agent-team-mail.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: randlee.agent-team-mail
+PackageVersion: 1.0.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: atm.exe
+  PortableCommandAlias: atm
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/randlee/atm-core/releases/download/v1.0.0/atm_1.0.0_x86_64-pc-windows-msvc.zip
+  InstallerSha256: 758FAA6E68A5B34AE9332D80802F2FB07D194EC3CCC284E071E8C0445A442F89
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/r/randlee/agent-team-mail/1.0.0/randlee.agent-team-mail.locale.en-US.yaml
+++ b/manifests/r/randlee/agent-team-mail/1.0.0/randlee.agent-team-mail.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: randlee.agent-team-mail
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: Randy Lee
+PublisherUrl: https://github.com/randlee
+PublisherSupportUrl: https://github.com/randlee/atm-core/issues
+Author: Randy Lee
+PackageName: agent-team-mail
+PackageUrl: https://github.com/randlee/atm-core
+License: MIT OR Apache-2.0
+LicenseUrl: https://github.com/randlee/atm-core/blob/main/LICENSE
+ShortDescription: Daemon-free CLI for local agent team mail workflows
+Description: |-
+  agent-team-mail (atm) is a daemon-free CLI for mail-like messaging with
+  Claude agent teams. It provides send, read, ack, clear, doctor, log, teams,
+  and members workflows over a file-based API with atomic I/O and conflict
+  detection.
+Moniker: atm
+Tags:
+- cli
+- agent
+- mail
+- teams
+- developer-tools
+- rust
+ReleaseNotesUrl: https://github.com/randlee/atm-core/releases/tag/v1.0.0
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/r/randlee/agent-team-mail/1.0.0/randlee.agent-team-mail.yaml
+++ b/manifests/r/randlee/agent-team-mail/1.0.0/randlee.agent-team-mail.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: randlee.agent-team-mail
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
### New Package Submission

- Package identifier: `randlee.agent-team-mail`
- Package version: `1.0.0`
- Package URL: https://github.com/randlee/atm-core
- Installer type: zip (portable)
- Architecture: x64
- Binary: `atm.exe`

### Description

agent-team-mail (atm) is a daemon-free Rust CLI for mail-like messaging with Claude agent teams. It provides send, read, ack, clear, doctor, log, teams, and members workflows over a file-based API with atomic I/O and conflict detection.

### Checklist

- [x] Three-file manifest (version, installer, defaultLocale)
- [x] ManifestVersion 1.9.0
- [x] SHA256 hash verified against release checksums.txt
- [x] InstallerUrl points to GitHub Release asset
- [x] NestedInstallerType: portable with PortableCommandAlias: atm
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/356979)