### PR TITLE
New package: MetanoicArmor.I2PChat version 1.2.6

### DIFF
--- a/manifests/m/MetanoicArmor/I2PChat/1.2.6/MetanoicArmor.I2PChat.installer.yaml
+++ b/manifests/m/MetanoicArmor/I2PChat/1.2.6/MetanoicArmor.I2PChat.installer.yaml
@@ -1,0 +1,25 @@
+PackageIdentifier: MetanoicArmor.I2PChat
+PackageVersion: 1.2.6
+InstallerLocale: en-US
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallModes:
+  - interactive
+  - silent
+# GUI winget: *-winget-* zip has no embedded i2pd (Microsoft Installers Scan). Replace InstallerSha256 after
+# uploading release assets (see build-windows.ps1 footer or packaging/refresh-checksums.sh 1.2.6).
+Installers:
+  - Architecture: x64
+    InstallerType: zip
+    InstallerUrl: https://github.com/MetanoicArmor/I2PChat/releases/download/v1.2.6/I2PChat-windows-x64-winget-v1.2.6.zip
+    InstallerSha256: ab8265e3752c1321802744f825641e951503e1169bc21b9868739c538e10c183
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: I2PChat/I2PChat.exe
+        PortableCommandAlias: i2pchat
+      - RelativeFilePath: I2PChat/I2PChat-tui.exe
+        PortableCommandAlias: i2pchat-tui
+    ReleaseDate: 2026-04-09
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/MetanoicArmor/I2PChat/1.2.6/MetanoicArmor.I2PChat.locale.en-US.yaml
+++ b/manifests/m/MetanoicArmor/I2PChat/1.2.6/MetanoicArmor.I2PChat.locale.en-US.yaml
@@ -1,0 +1,29 @@
+PackageIdentifier: MetanoicArmor.I2PChat
+PackageVersion: 1.2.6
+PackageLocale: en-US
+Publisher: MetanoicArmor
+PublisherUrl: https://github.com/MetanoicArmor
+PackageName: I2PChat
+PackageUrl: https://github.com/MetanoicArmor/I2PChat
+License: AGPL-3.0
+LicenseUrl: https://github.com/MetanoicArmor/I2PChat/blob/main/LICENSE
+Copyright: Copyright (c) MetanoicArmor and contributors
+ShortDescription: Experimental peer-to-peer chat client for the I2P anonymity network
+Description: |-
+  I2PChat is a cross-platform GUI (PyQt6) chat client for the I2P network, with optional
+  console TUI. Binaries are portable (zip); GUI is I2PChat.exe; TUI is I2PChat-tui.exe in the I2PChat folder.
+  This winget package uses the *-winget-* release zip, which omits the embedded i2pd router binary so
+  Microsoft’s installer validation can succeed; use a system i2pd (SAM) or install the full Windows zip from
+  GitHub Releases if you want the bundled router. The full zip includes i2pd (PurpleI2P/i2pd), which some AV
+  vendors label generic “riskware” even though it is legitimate open-source software.
+Moniker: i2pchat
+Tags:
+  - i2p
+  - chat
+  - p2p
+  - privacy
+ReleaseNotesUrl: https://github.com/MetanoicArmor/I2PChat/releases/tag/v1.2.6
+ReleaseNotes: |-
+  v1.2.6: SessionManager per-peer transport lifecycle; Send control updates after secure handshake; BlindBox/offline and packaging fixes. Winget ships the *-winget-* zip without embedded i2pd. For the bundled router, use I2PChat-windows-x64-v*.zip on GitHub Releases. i2pd: https://github.com/PurpleI2P/i2pd
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/MetanoicArmor/I2PChat/1.2.6/MetanoicArmor.I2PChat.yaml
+++ b/manifests/m/MetanoicArmor/I2PChat/1.2.6/MetanoicArmor.I2PChat.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: MetanoicArmor.I2PChat
+PackageVersion: 1.2.6
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary
Adds **MetanoicArmor.I2PChat** **1.2.6** (Windows x64 portable zip from GitHub Release **v1.2.6**).

- Installer URL: `I2PChat-windows-x64-winget-v1.2.6.zip` (no embedded i2pd — Installers Scan).
- SHA256 verified against release asset digest.

Supersedes closed PR #356552 (1.2.5).

### Reference
- https://github.com/MetanoicArmor/I2PChat/releases/tag/v1.2.6

Made with [Cursor](https://cursor.com)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/357027)