### PR TITLE
New package: MetanoicArmor.I2PChat.TUI version 1.2.6

### DIFF
--- a/manifests/m/MetanoicArmor/I2PChat/TUI/1.2.6/MetanoicArmor.I2PChat.TUI.installer.yaml
+++ b/manifests/m/MetanoicArmor/I2PChat/TUI/1.2.6/MetanoicArmor.I2PChat.TUI.installer.yaml
@@ -1,0 +1,22 @@
+PackageIdentifier: MetanoicArmor.I2PChat.TUI
+PackageVersion: 1.2.6
+InstallerLocale: en-US
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallModes:
+  - interactive
+  - silent
+# TUI winget: *-winget-* zip omits embedded i2pd. Replace InstallerSha256 after assets are on the release.
+Installers:
+  - Architecture: x64
+    InstallerType: zip
+    InstallerUrl: https://github.com/MetanoicArmor/I2PChat/releases/download/v1.2.6/I2PChat-windows-tui-x64-winget-v1.2.6.zip
+    InstallerSha256: 34556cfc1c407ebe4c44873cb3e704c68291bde51a4cdf5a6291edcdc79cb722
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: I2PChat/I2PChat-tui.exe
+        PortableCommandAlias: i2pchat-tui
+    ReleaseDate: 2026-04-09
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/MetanoicArmor/I2PChat/TUI/1.2.6/MetanoicArmor.I2PChat.TUI.locale.en-US.yaml
+++ b/manifests/m/MetanoicArmor/I2PChat/TUI/1.2.6/MetanoicArmor.I2PChat.TUI.locale.en-US.yaml
@@ -1,0 +1,29 @@
+PackageIdentifier: MetanoicArmor.I2PChat.TUI
+PackageVersion: 1.2.6
+PackageLocale: en-US
+Publisher: MetanoicArmor
+PublisherUrl: https://github.com/MetanoicArmor
+PackageName: I2PChat (TUI)
+PackageUrl: https://github.com/MetanoicArmor/I2PChat
+License: AGPL-3.0
+LicenseUrl: https://github.com/MetanoicArmor/I2PChat/blob/main/LICENSE
+Copyright: Copyright (c) MetanoicArmor and contributors
+ShortDescription: I2PChat Textual terminal UI (console client for I2P)
+Description: |-
+  Console-only build of I2PChat (Textual TUI). Does not include the PyQt GUI binary.
+  After install, run i2pchat-tui from a terminal. Optional profile name as the first argument.
+  This winget package uses the *-winget-* release zip without embedded i2pd (Microsoft installer validation).
+  Use system i2pd (SAM) or the full TUI zip from GitHub Releases for the bundled router.
+Moniker: i2pchat-tui
+Tags:
+  - i2p
+  - chat
+  - p2p
+  - privacy
+  - terminal
+  - tui
+ReleaseNotesUrl: https://github.com/MetanoicArmor/I2PChat/releases/tag/v1.2.6
+ReleaseNotes: |-
+  v1.2.6: aligns with I2PChat 1.2.6 (core/session fixes). Winget *-winget-* zip without embedded i2pd. Full TUI zip with bundled router: I2PChat-windows-tui-x64-v*.zip on GitHub Releases. i2pd: https://github.com/PurpleI2P/i2pd
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/MetanoicArmor/I2PChat/TUI/1.2.6/MetanoicArmor.I2PChat.TUI.yaml
+++ b/manifests/m/MetanoicArmor/I2PChat/TUI/1.2.6/MetanoicArmor.I2PChat.TUI.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: MetanoicArmor.I2PChat.TUI
+PackageVersion: 1.2.6
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary
Adds **MetanoicArmor.I2PChat.TUI** **1.2.6** (Windows x64 portable TUI zip from GitHub Release **v1.2.6**).

- Installer URL: `I2PChat-windows-tui-x64-winget-v1.2.6.zip` (no embedded i2pd).

Supersedes closed PR #356553 (1.2.5).

### Reference
- https://github.com/MetanoicArmor/I2PChat/releases/tag/v1.2.6

Made with [Cursor](https://cursor.com)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/357028)