### PR TITLE
Add version: kts982.WinTUI version 2.1.0

### DIFF
--- a/manifests/k/kts982/WinTUI/2.1.0/kts982.WinTUI.installer.yaml
+++ b/manifests/k/kts982/WinTUI/2.1.0/kts982.WinTUI.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: kts982.WinTUI
+PackageVersion: 2.1.0
+MinimumOSVersion: 10.0.17763.0
+InstallerType: portable
+Commands:
+  - wintui
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/kts982/wintui/releases/download/v2.1.0/wintui_2.1.0_windows_amd64.exe
+    InstallerSha256: 8830A7305721BB5A526092DC0D8AEBB0DE2B12E73E88AF5754448723AB77B847
+  - Architecture: arm64
+    InstallerUrl: https://github.com/kts982/wintui/releases/download/v2.1.0/wintui_2.1.0_windows_arm64.exe
+    InstallerSha256: 838CCFC75B6951E9A3C75B57561E43A67F28CC59975327021B4D4B9D0B2DFC9C
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/k/kts982/WinTUI/2.1.0/kts982.WinTUI.locale.en-US.yaml
+++ b/manifests/k/kts982/WinTUI/2.1.0/kts982.WinTUI.locale.en-US.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: kts982.WinTUI
+PackageVersion: 2.1.0
+PackageLocale: en-US
+Publisher: kts982
+PublisherUrl: https://github.com/kts982
+PublisherSupportUrl: https://github.com/kts982/wintui/issues
+Author: Kostas T.
+PackageName: WinTUI
+PackageUrl: https://github.com/kts982/wintui
+License: MIT
+LicenseUrl: https://github.com/kts982/wintui/blob/main/LICENSE
+ShortDescription: Terminal UI for winget on Windows.
+Description: >-
+  WinTUI is a terminal user interface for Windows Package Manager featuring a
+  split-panel workspace for browsing, searching, installing, upgrading, and
+  managing packages. Includes disk-persistent cache for instant startup,
+  background refresh, integrated search with install queue, batch operations
+  with a single UAC prompt, system health checks, temp cleanup, and a headless
+  CLI mode for scripting.
+Moniker: wintui
+Tags:
+  - winget
+  - windows
+  - tui
+  - terminal
+  - package-manager
+  - cli
+ReleaseNotes: |-
+  - Added a unified apply flow (`g`) so staged installs, upgrades, and uninstalls can run in one mixed batch.
+  - Normalized Packages screen actions: `Space` stages items, while `i`, `u`, and `x` remain direct accelerators.
+  - Added self-upgrade handoff for the installed WinGet build of WinTUI so the running portable executable can be replaced cleanly.
+  - Improved package details with target-aware "What's New" headings, release-notes links (`n`), and a small-terminal scroll fix.
+ReleaseNotesUrl: https://github.com/kts982/wintui/releases/tag/v2.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/k/kts982/WinTUI/2.1.0/kts982.WinTUI.yaml
+++ b/manifests/k/kts982/WinTUI/2.1.0/kts982.WinTUI.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: kts982.WinTUI
+PackageVersion: 2.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Validation
- [x] winget validate manifests/k/kts982/WinTUI/2.1.0

## Source
- Release: https://github.com/kts982/wintui/releases/tag/v2.1.0
- amd64 installer: https://github.com/kts982/wintui/releases/download/v2.1.0/wintui_2.1.0_windows_amd64.exe
- arm64 installer: https://github.com/kts982/wintui/releases/download/v2.1.0/wintui_2.1.0_windows_arm64.exe
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/357171)