### PR TITLE
New package: pay-skill.pay version 0.2.2

### DIFF
--- a/manifests/p/pay-skill/pay/0.2.2/pay-skill.pay.installer.yaml
+++ b/manifests/p/pay-skill/pay/0.2.2/pay-skill.pay.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: pay-skill.pay
+PackageVersion: 0.2.2
+InstallerType: portable
+Commands:
+  - pay
+ReleaseDate: 2026-04-10
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/pay-skill/pay-cli/releases/download/v0.2.2/pay-windows-amd64.exe
+    InstallerSha256: 2B9BE9CDCC192C1C687A56115B2202DCF34A180DDEFC354F0EBE38032A1A8142
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/p/pay-skill/pay/0.2.2/pay-skill.pay.locale.en-US.yaml
+++ b/manifests/p/pay-skill/pay/0.2.2/pay-skill.pay.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: pay-skill.pay
+PackageVersion: 0.2.2
+PackageLocale: en-US
+Publisher: pay-skill
+PublisherUrl: https://pay-skill.com
+PublisherSupportUrl: https://github.com/pay-skill/pay-cli/issues
+PackageName: pay
+PackageUrl: https://pay-skill.com
+License: MIT
+LicenseUrl: https://github.com/pay-skill/pay-cli/blob/main/LICENSE
+ShortDescription: Payment CLI for AI agents - USDC on Base
+Description: Command-line tool for AI agent payments using USDC on Base. Supports direct payments, metered tabs, and x402 protocol integration.
+Moniker: pay
+Tags:
+  - ai
+  - blockchain
+  - cli
+  - crypto
+  - payment
+  - usdc
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/p/pay-skill/pay/0.2.2/pay-skill.pay.yaml
+++ b/manifests/p/pay-skill/pay/0.2.2/pay-skill.pay.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: pay-skill.pay
+PackageVersion: 0.2.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package submission

- Package: pay-skill.pay
- Version: 0.2.2
- Installer type: portable (single exe)
- Architecture: x64
- URL: https://github.com/pay-skill/pay-cli/releases/download/v0.2.2/pay-windows-amd64.exe
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/357380)