### PR TITLE
New version: trustbe.mousestride version 0.0.10

### DIFF
--- a/manifests/t/trustbe/mousestride/0.0.10/trustbe.mousestride.installer.yaml
+++ b/manifests/t/trustbe/mousestride/0.0.10/trustbe.mousestride.installer.yaml
@@ -1,0 +1,15 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: trustbe.mousestride
+PackageVersion: 0.0.10
+InstallerLocale: en-US
+InstallerType: wix
+ProductCode: '{2338D4A9-ED57-4C9F-B712-46B3FC1160F3}'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/trustbe/MouseStride/releases/download/v0.0.10/mousestride-0.0.10-x86_64.msi
+  InstallerSha256: 31D95BE4DE2951E7C53B9EF64BDA4649BB10D884E50BC3789FF5BAA5C4256656
+ManifestType: installer
+ManifestVersion: 1.10.0
+ReleaseDate: 2026-04-10

--- a/manifests/t/trustbe/mousestride/0.0.10/trustbe.mousestride.locale.en-US.yaml
+++ b/manifests/t/trustbe/mousestride/0.0.10/trustbe.mousestride.locale.en-US.yaml
@@ -1,0 +1,16 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: trustbe.mousestride
+PackageVersion: 0.0.10
+PackageLocale: en-US
+Publisher: trustbe
+PublisherUrl: https://github.com/trustbe
+PublisherSupportUrl: https://github.com/trustbe/MouseStride/issues
+PackageName: mousestride
+PackageUrl: https://github.com/trustbe/MouseStride
+License: MIT
+ShortDescription: A lightweight system tray app that tracks how far your mouse cursor travels
+ReleaseNotesUrl: https://github.com/trustbe/MouseStride/releases/tag/v0.0.10
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/t/trustbe/mousestride/0.0.10/trustbe.mousestride.yaml
+++ b/manifests/t/trustbe/mousestride/0.0.10/trustbe.mousestride.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: trustbe.mousestride
+PackageVersion: 0.0.10
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## New version: trustbe.mousestride version 0.0.10

New release of MouseStride — a lightweight system tray app that tracks how far your mouse cursor travels.

### Changes in 0.0.10
- Signed and notarized macOS build (not relevant for Windows, included for context)
- Windows MSI rebuilt with updated Rust toolchain

### Checks
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-create#wingetcreate-usage) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Release: https://github.com/trustbe/MouseStride/releases/tag/v0.0.10
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/357488)