### PR TITLE
Verified Developer Policy

### DIFF
--- a/.github/policies/labelAdded.validationCompleted.yml
+++ b/.github/policies/labelAdded.validationCompleted.yml
@@ -21,6 +21,9 @@ configuration:
           - not:
               hasLabel:
                 label: Validation-Metadata
+          - not:
+              hasLabel:
+                label: Publisher-Verified
           - isOpen
         then:
           - addReply:

--- a/.github/policies/verifiedDeveloper.yml
+++ b/.github/policies/verifiedDeveloper.yml
@@ -1,0 +1,57 @@
+id: verifiedDeveloper
+name: GitOps.PullRequestIssueManagement
+description: Handles auto-approval for verified developer submissions
+owner:
+resource: repository
+disabled: false
+where:
+configuration:
+  resourceManagementConfiguration:
+    eventResponderTasks:
+      - description: >-
+          Approve and comment when a verified developer's PR completes validation.
+          Triggers when Validation-Completed is added and Publisher-Verified is present.
+        if:
+          - payloadType: Pull_Request
+          - labelAdded:
+              label: Validation-Completed
+          - hasLabel:
+              label: Publisher-Verified
+          - isOpen
+        then:
+          - approvePullRequest:
+              comment: ""
+          - addReply:
+              reply: >-
+                This pull request was submitted by a **verified developer** and all validation checks have passed.
+
+
+                The author is a trusted publisher registered with the Windows Package Manager service. No additional moderator review is required — this PR will be merged automatically.
+
+
+                Template: msftbot/verifiedDeveloper/approved
+        triggerOnOwnActions: true
+      - description: >-
+          Handle case where Publisher-Verified is added after Validation-Completed.
+        if:
+          - payloadType: Pull_Request
+          - labelAdded:
+              label: Publisher-Verified
+          - hasLabel:
+              label: Validation-Completed
+          - isOpen
+        then:
+          - approvePullRequest:
+              comment: ""
+          - addReply:
+              reply: >-
+                This pull request was submitted by a **verified developer** and all validation checks have passed.
+
+
+                The author is a trusted publisher registered with the Windows Package Manager service. No additional moderator review is required — this PR will be merged automatically.
+
+
+                Template: msftbot/verifiedDeveloper/approved
+        triggerOnOwnActions: true
+onFailure:
+onSuccess:


### PR DESCRIPTION
﻿Add policy rules for the Verified Developer auto-approval flow:

 - verifiedDeveloper.yml — Auto-approves PRs when both Validation-Completed and Publisher-Verified labels are present. Handles both label orderings.
 - labelAdded.validationCompleted.yml — Automatically merge verified developer PRs.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/357585)