### PR TITLE
New package: Cod-e-Codes.Marchat version 0.11.0-beta.5

### DIFF
--- a/manifests/c/Cod-e-Codes/Marchat/0.11.0-beta.5/Cod-e-Codes.Marchat.installer.yaml
+++ b/manifests/c/Cod-e-Codes/Marchat/0.11.0-beta.5/Cod-e-Codes.Marchat.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Cod-e-Codes.Marchat
+PackageVersion: 0.11.0-beta.5
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: zip
+NestedInstallerType: portable
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Cod-e-Codes/marchat/releases/download/v0.11.0-beta.5/marchat-v0.11.0-beta.5-windows-amd64.zip
+    InstallerSha256: F38696037C3927C3F7C80E778F73A0AF094A22F3B1FB93082495F8857948BFB4
+    NestedInstallerFiles:
+      - RelativeFilePath: marchat-client-windows-amd64.exe
+        PortableCommandAlias: marchat-client
+      - RelativeFilePath: marchat-server-windows-amd64.exe
+        PortableCommandAlias: marchat-server
+    ReleaseDate: 2026-04-10
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/c/Cod-e-Codes/Marchat/0.11.0-beta.5/Cod-e-Codes.Marchat.locale.en-US.yaml
+++ b/manifests/c/Cod-e-Codes/Marchat/0.11.0-beta.5/Cod-e-Codes.Marchat.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Cod-e-Codes.Marchat
+PackageVersion: 0.11.0-beta.5
+PackageLocale: en-US
+Publisher: Cod-e-Codes
+PublisherUrl: https://github.com/Cod-e-Codes
+PackageName: marchat
+PackageUrl: https://github.com/Cod-e-Codes/marchat
+License: MIT
+LicenseUrl: https://github.com/Cod-e-Codes/marchat/blob/main/LICENSE
+ShortDescription: Lightweight terminal chat with WebSockets and optional E2E encryption
+Description: |
+  marchat is a self-hosted terminal chat with real-time messaging over WebSockets, optional E2E encryption, and a plugin ecosystem. This package installs the official release build of marchat-client and marchat-server.
+Moniker: marchat
+Tags:
+  - chat
+  - websocket
+  - terminal
+  - tui
+  - cli
+ReleaseNotesUrl: https://github.com/Cod-e-Codes/marchat/releases/tag/v0.11.0-beta.5
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/c/Cod-e-Codes/Marchat/0.11.0-beta.5/Cod-e-Codes.Marchat.yaml
+++ b/manifests/c/Cod-e-Codes/Marchat/0.11.0-beta.5/Cod-e-Codes.Marchat.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Cod-e-Codes.Marchat
+PackageVersion: 0.11.0-beta.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Adds marchat (marchat-client + marchat-server) portable zip from official GitHub releases.

Upstream: https://github.com/Cod-e-Codes/marchat

Validated locally with winget validate.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/358094)