### PR TITLE
New version: Peters.Horizon version 0.2.5

### DIFF
--- a/manifests/p/Peters/Horizon/0.2.5/Peters.Horizon.installer.yaml
+++ b/manifests/p/Peters/Horizon/0.2.5/Peters.Horizon.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: Peters.Horizon
+PackageVersion: 0.2.5
+InstallerType: portable
+Commands:
+- horizon
+ReleaseDate: 2026-04-11
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/peters/horizon/releases/download/v0.2.5/horizon-windows-x64.exe
+  InstallerSha256: AE89CD7C8CAD32F67C628E8EC7D69D2132707BE6932FCF83E53EB91E59D8A4CD
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/p/Peters/Horizon/0.2.5/Peters.Horizon.locale.en-US.yaml
+++ b/manifests/p/Peters/Horizon/0.2.5/Peters.Horizon.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: Peters.Horizon
+PackageVersion: 0.2.5
+PackageLocale: en-US
+Publisher: Peter Rekdal Khan-Sunde
+PublisherUrl: https://github.com/peters
+PublisherSupportUrl: https://github.com/peters/horizon/issues
+PackageName: Horizon
+PackageUrl: https://github.com/peters/horizon
+License: MIT
+LicenseUrl: https://github.com/peters/horizon/blob/v0.2.5/LICENSE
+ShortDescription: GPU-accelerated terminal board on an infinite canvas.
+Description: |-
+  Horizon is a GPU-accelerated terminal board for managing multiple terminal sessions as freely positioned, resizable panels on an infinite canvas.
+  It combines workspaces, panel presets, remote hosts, session persistence, and agent-friendly terminal workflows in one desktop app.
+Tags:
+- terminal
+- workspace
+- developer-tools
+ReleaseNotesUrl: https://github.com/peters/horizon/releases/tag/v0.2.5
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/p/Peters/Horizon/0.2.5/Peters.Horizon.yaml
+++ b/manifests/p/Peters/Horizon/0.2.5/Peters.Horizon.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: Peters.Horizon
+PackageVersion: 0.2.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
New stable Horizon release submission for WinGet.

- Package identifier: `Peters.Horizon`
- Version: `0.2.5`
- Installer URL: https://github.com/peters/horizon/releases/download/v0.2.5/horizon-windows-x64.exe
- Installer SHA256: `ae89cd7c8cad32f67c628e8ec7d69d2132707be6932fcf83e53eb91e59d8a4cd`

Generated by the Horizon stable release workflow.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/358433)