### PR TITLE
New package: openwong2kim.wmux version 2.5.0

### DIFF
--- a/manifests/o/openwong2kim/wmux/2.5.0/openwong2kim.wmux.installer.yaml
+++ b/manifests/o/openwong2kim/wmux/2.5.0/openwong2kim.wmux.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: openwong2kim.wmux
+PackageVersion: 2.5.0
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.0
+InstallerType: exe
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/openwong2kim/wmux/releases/download/v2.5.0/wmux-2.5.0.Setup.exe
+    InstallerSha256: 407E957240AFC068B11C8F5CBE92ACCA56EB4BB4BA5BB6534DE94A3A95B303C6
+    Scope: user
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/o/openwong2kim/wmux/2.5.0/openwong2kim.wmux.locale.en-US.yaml
+++ b/manifests/o/openwong2kim/wmux/2.5.0/openwong2kim.wmux.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: openwong2kim.wmux
+PackageVersion: 2.5.0
+PackageLocale: en-US
+Publisher: openwong2kim
+PublisherUrl: https://github.com/openwong2kim
+PackageName: wmux
+PackageUrl: https://github.com/openwong2kim/wmux
+License: MIT
+LicenseUrl: https://github.com/openwong2kim/wmux/blob/main/LICENSE
+ShortDescription: Windows terminal multiplexer with MCP server for AI agents
+Description: |-
+  wmux is a Windows terminal multiplexer built for AI coding agents.
+  Run Claude Code, Codex, and Gemini CLI side by side with split terminals,
+  browser automation, and MCP integration. Features include session persistence,
+  dangerous command detection, real-time token cost tracking, and cross-workspace
+  terminal control via MCP tools.
+Tags:
+  - terminal
+  - multiplexer
+  - ai-agent
+  - mcp
+  - windows
+  - electron
+  - developer-tools
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/o/openwong2kim/wmux/2.5.0/openwong2kim.wmux.yaml
+++ b/manifests/o/openwong2kim/wmux/2.5.0/openwong2kim.wmux.yaml
@@ -1,0 +1,8 @@
+# Created using winget CLI
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: openwong2kim.wmux
+PackageVersion: 2.5.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New Package Submission

- **Package Identifier:** openwong2kim.wmux
- **Package Version:** 2.5.0
- **Package URL:** https://github.com/openwong2kim/wmux
- **License:** MIT
- **Installer URL:** https://github.com/openwong2kim/wmux/releases/download/v2.5.0/wmux-2.5.0.Setup.exe

### Description

wmux is a Windows terminal multiplexer built for AI coding agents. Run Claude Code, Codex, and Gemini CLI side by side with split terminals, browser automation, and MCP integration.

### Checklist

- [x] I have tested the manifest with `winget validate`
- [x] The installer URL is publicly accessible
- [x] SHA256 hash is verified
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/358609)