### PR TITLE
MetanoicArmor.I2PChat version 1.3.1 / MetanoicArmor.I2PChat.TUI version 1.3.1

### DIFF
--- a/manifests/m/MetanoicArmor/I2PChat/1.3.1/MetanoicArmor.I2PChat.installer.yaml
+++ b/manifests/m/MetanoicArmor/I2PChat/1.3.1/MetanoicArmor.I2PChat.installer.yaml
@@ -1,0 +1,24 @@
+PackageIdentifier: MetanoicArmor.I2PChat
+PackageVersion: 1.3.1
+InstallerLocale: en-US
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallModes:
+  - interactive
+  - silent
+# GUI winget: *-winget-* zip has no embedded i2pd (SHA from packaging/refresh-checksums.sh 1.3.1).
+Installers:
+  - Architecture: x64
+    InstallerType: zip
+    InstallerUrl: https://github.com/MetanoicArmor/I2PChat/releases/download/v1.3.1/I2PChat-windows-x64-winget-v1.3.1.zip
+    InstallerSha256: 2f34c50f393dad6e13f156dbed5f20ad5dbc61a5f0deb1fea7692634d8e85b41
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: I2PChat/I2PChat.exe
+        PortableCommandAlias: i2pchat
+      - RelativeFilePath: I2PChat/I2PChat-tui.exe
+        PortableCommandAlias: i2pchat-tui
+    ReleaseDate: 2026-04-12
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/MetanoicArmor/I2PChat/1.3.1/MetanoicArmor.I2PChat.locale.en-US.yaml
+++ b/manifests/m/MetanoicArmor/I2PChat/1.3.1/MetanoicArmor.I2PChat.locale.en-US.yaml
@@ -1,0 +1,29 @@
+PackageIdentifier: MetanoicArmor.I2PChat
+PackageVersion: 1.3.1
+PackageLocale: en-US
+Publisher: MetanoicArmor
+PublisherUrl: https://github.com/MetanoicArmor
+PackageName: I2PChat
+PackageUrl: https://github.com/MetanoicArmor/I2PChat
+License: AGPL-3.0
+LicenseUrl: https://github.com/MetanoicArmor/I2PChat/blob/main/LICENSE
+Copyright: Copyright (c) MetanoicArmor and contributors
+ShortDescription: Experimental peer-to-peer chat client for the I2P anonymity network
+Description: |-
+  I2PChat is a cross-platform GUI (PyQt6) chat client for the I2P network, with optional
+  console TUI. Binaries are portable (zip); GUI is I2PChat.exe; TUI is I2PChat-tui.exe in the I2PChat folder.
+  This winget package uses the *-winget-* release zip, which omits the embedded i2pd router binary so
+  Microsoft’s installer validation can succeed; use a system i2pd (SAM) or install the full Windows zip from
+  GitHub Releases if you want the bundled router. The full zip includes i2pd (PurpleI2P/i2pd), which some AV
+  vendors label generic “riskware” even though it is legitimate open-source software.
+Moniker: i2pchat
+Tags:
+  - i2p
+  - chat
+  - p2p
+  - privacy
+ReleaseNotesUrl: https://github.com/MetanoicArmor/I2PChat/releases/tag/v1.3.1
+ReleaseNotes: |-
+  v1.3.1: Intel macOS bundled i2pd path (darwin-x64), BlindBox runtime hardening, Nix/Qt polish, refreshed icons, GUI fixes. Winget ships the *-winget-* zip without embedded i2pd. Full Windows zip with bundled router: I2PChat-windows-x64-v*.zip on GitHub Releases. i2pd: https://github.com/PurpleI2P/i2pd
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/MetanoicArmor/I2PChat/1.3.1/MetanoicArmor.I2PChat.yaml
+++ b/manifests/m/MetanoicArmor/I2PChat/1.3.1/MetanoicArmor.I2PChat.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: MetanoicArmor.I2PChat
+PackageVersion: 1.3.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0

--- a/manifests/m/MetanoicArmor/I2PChat/TUI/1.3.1/MetanoicArmor.I2PChat.TUI.installer.yaml
+++ b/manifests/m/MetanoicArmor/I2PChat/TUI/1.3.1/MetanoicArmor.I2PChat.TUI.installer.yaml
@@ -1,0 +1,22 @@
+PackageIdentifier: MetanoicArmor.I2PChat.TUI
+PackageVersion: 1.3.1
+InstallerLocale: en-US
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallModes:
+  - interactive
+  - silent
+# TUI winget: *-winget-* zip omits embedded i2pd (SHA from packaging/refresh-checksums.sh 1.3.1).
+Installers:
+  - Architecture: x64
+    InstallerType: zip
+    InstallerUrl: https://github.com/MetanoicArmor/I2PChat/releases/download/v1.3.1/I2PChat-windows-tui-x64-winget-v1.3.1.zip
+    InstallerSha256: 9fa69e5537a2fcf5cec30ff1360729bc436222b147454dd8b3082f518b6fd8ed
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: I2PChat/I2PChat-tui.exe
+        PortableCommandAlias: i2pchat-tui
+    ReleaseDate: 2026-04-12
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/MetanoicArmor/I2PChat/TUI/1.3.1/MetanoicArmor.I2PChat.TUI.locale.en-US.yaml
+++ b/manifests/m/MetanoicArmor/I2PChat/TUI/1.3.1/MetanoicArmor.I2PChat.TUI.locale.en-US.yaml
@@ -1,0 +1,27 @@
+PackageIdentifier: MetanoicArmor.I2PChat.TUI
+PackageVersion: 1.3.1
+PackageLocale: en-US
+Publisher: MetanoicArmor
+PublisherUrl: https://github.com/MetanoicArmor
+PackageName: I2PChat TUI
+PackageUrl: https://github.com/MetanoicArmor/I2PChat
+License: AGPL-3.0
+LicenseUrl: https://github.com/MetanoicArmor/I2PChat/blob/main/LICENSE
+Copyright: Copyright (c) MetanoicArmor and contributors
+ShortDescription: Terminal UI (Textual) for I2PChat over I2P SAM
+Description: |-
+  I2PChat TUI is the Textual console client for I2PChat (no PyQt GUI). This winget package uses the
+  *-winget-* release zip without embedded i2pd; use a system i2pd with SAM or the full TUI zip from GitHub Releases
+  for a bundled router.
+Moniker: i2pchat-tui
+Tags:
+  - i2p
+  - chat
+  - p2p
+  - privacy
+  - terminal
+ReleaseNotesUrl: https://github.com/MetanoicArmor/I2PChat/releases/tag/v1.3.1
+ReleaseNotes: |-
+  v1.3.1: aligns with I2PChat 1.3.1 (Intel macOS i2pd bundling, BlindBox/Nix/icons). Winget *-winget-* zip without embedded i2pd. Full TUI zip with bundled router: I2PChat-windows-tui-x64-v*.zip on GitHub Releases. i2pd: https://github.com/PurpleI2P/i2pd
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/MetanoicArmor/I2PChat/TUI/1.3.1/MetanoicArmor.I2PChat.TUI.yaml
+++ b/manifests/m/MetanoicArmor/I2PChat/TUI/1.3.1/MetanoicArmor.I2PChat.TUI.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: MetanoicArmor.I2PChat.TUI
+PackageVersion: 1.3.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## MetanoicArmor.I2PChat 1.3.1
- [x] InstallerUrl uses `*-winget-*` zip (no embedded i2pd; Installers Scan / ESRP)
- SHA256 verified against https://github.com/MetanoicArmor/I2PChat/releases/tag/v1.3.1

## MetanoicArmor.I2PChat.TUI 1.3.1
- Same *-winget-* policy for TUI portable zip

Upstream release notes: https://github.com/MetanoicArmor/I2PChat/releases/tag/v1.3.1

### Checklist
- [x] Signed CLA
- [x] Manifests validated locally (winget validate) if available

Made with [Cursor](https://cursor.com)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/358628)