### PR TITLE
Update: SecondLoop.SecondLoop version 1.29.0

### DIFF
--- a/manifests/s/SecondLoop/SecondLoop/1.29.0/SecondLoop.SecondLoop.installer.yaml
+++ b/manifests/s/SecondLoop/SecondLoop/1.29.0/SecondLoop.SecondLoop.installer.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: SecondLoop.SecondLoop
+PackageVersion: 1.29.0
+InstallerType: msi
+UpgradeBehavior: install
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+InstallModes:
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Custom: SECONDLOOP_LAUNCH_AFTER_INSTALL=0
+ProductCode: '{891AD104-2F7F-4112-BC58-308D4E6B57B4}'
+AppsAndFeaturesEntries:
+  - DisplayName: SecondLoop
+    Publisher: SecondLoop
+    ProductCode: '{891AD104-2F7F-4112-BC58-308D4E6B57B4}'
+    UpgradeCode: '{8B5A0942-79D3-4B5A-A4E5-3FB906DA63A1}'
+    InstallerType: msi
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/dale0525/SecondLoop/releases/download/v1.29.0/SecondLoop-win.msi
+    InstallerSha256: 80D82010FB5903BDA1CE1FF5F883963FC6D3A45C9A8F6CF28A146E7ED1CFC53A
+    InstallerLocale: en-US
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/s/SecondLoop/SecondLoop/1.29.0/SecondLoop.SecondLoop.locale.en-US.yaml
+++ b/manifests/s/SecondLoop/SecondLoop/1.29.0/SecondLoop.SecondLoop.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: SecondLoop.SecondLoop
+PackageVersion: 1.29.0
+PackageLocale: en-US
+Publisher: SecondLoop
+PublisherUrl: https://secondloop.app
+PublisherSupportUrl: https://github.com/dale0525/SecondLoop/issues
+Author: SecondLoop
+PackageName: SecondLoop
+PackageUrl: https://secondloop.app
+License: Apache-2.0
+LicenseUrl: https://github.com/dale0525/SecondLoop/blob/main/LICENSE
+ShortDescription: Local-first personal AI assistant with long-term memory.
+Description: SecondLoop helps you capture, remember, and act with a local-first workflow.
+Moniker: secondloop
+Tags:
+  - ai
+  - notes
+  - productivity
+ReleaseNotesUrl: https://github.com/dale0525/SecondLoop/releases/tag/v1.29.0
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/s/SecondLoop/SecondLoop/1.29.0/SecondLoop.SecondLoop.yaml
+++ b/manifests/s/SecondLoop/SecondLoop/1.29.0/SecondLoop.SecondLoop.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: SecondLoop.SecondLoop
+PackageVersion: 1.29.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Summary

- Update WinGet manifests for SecondLoop.SecondLoop 1.29.0
- Source release: https://github.com/dale0525/SecondLoop/releases/tag/v1.29.0

## Validation

- Installer URL and SHA256 were generated from GitHub release assets
- Manifest files were produced by scripts/generate_winget_manifests.py
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/358695)