### PR TITLE
Move Min.Min 1.19.0 to MinBrowser.Min 1.19.0 

### DIFF
--- a/manifests/m/MinBrowser/Min/1.19.0/MinBrowser.Min.installer.yaml
+++ b/manifests/m/MinBrowser/Min/1.19.0/MinBrowser.Min.installer.yaml
@@ -1,0 +1,13 @@
+# Created with YamlCreate.ps1 v2.4.3 $debug=AUSU.CRLF.7-4-6.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: MinBrowser.Min
+PackageVersion: 1.19.0
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/minbrowser/min/releases/download/v1.19.0/min-1.19.0-setup.exe
+  InstallerSha256: DD38198A631449768DB1F726D872D5DD5A647EB4D1F20766996AECCCAB040E01
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/m/MinBrowser/Min/1.19.0/MinBrowser.Min.locale.en-US.yaml
+++ b/manifests/m/MinBrowser/Min/1.19.0/MinBrowser.Min.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# Created with YamlCreate.ps1 v2.4.3 $debug=AUSU.CRLF.7-4-6.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: MinBrowser.Min
+PackageVersion: 1.19.0
+PackageLocale: en-US
+Publisher: Min
+# PublisherUrl:
+# PublisherSupportUrl:
+# PrivacyUrl:
+# Author:
+PackageName: Min Browser
+PackageUrl: https://minbrowser.org/
+License: Apache-2.0 License
+LicenseUrl: https://raw.githubusercontent.com/minbrowser/min/v1.19.0/LICENSE.txt
+# Copyright:
+# CopyrightUrl:
+ShortDescription: A fast, minimal browser that protects your privacy.
+# Description:
+# Moniker: minbrowser
+# Tags:
+# ReleaseNotes:
+# ReleaseNotesUrl:
+# PurchaseUrl:
+# InstallationNotes:
+# Documentations:
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/m/MinBrowser/Min/1.19.0/MinBrowser.Min.yaml
+++ b/manifests/m/MinBrowser/Min/1.19.0/MinBrowser.Min.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.4.3 $debug=AUSU.CRLF.7-4-6.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: MinBrowser.Min
+PackageVersion: 1.19.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
This PRs is part of an effort to move the package to the package identifier `MinBrowser.Min`. 

related #358550
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/358768)