### PR TITLE
Move Min.Min 1.26.0 to MinBrowser.Min 1.26.0 

### DIFF
--- a/manifests/m/MinBrowser/Min/1.26.0/MinBrowser.Min.installer.yaml
+++ b/manifests/m/MinBrowser/Min/1.26.0/MinBrowser.Min.installer.yaml
@@ -1,0 +1,19 @@
+# Created with YamlCreate.ps1 v2.4.3 $debug=AUSU.CRLF.7-4-6.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: MinBrowser.Min
+PackageVersion: 1.26.0
+InstallerLocale: en-US
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- silent
+UpgradeBehavior: install
+ReleaseDate: 2022-09-26
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/minbrowser/min/releases/download/v1.26.0/min-1.26.0-setup.exe
+  InstallerSha256: BAF3BD9442E99C2157735F5521EE2311084145ADDB1BB7F3806D01E519B107C3
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/m/MinBrowser/Min/1.26.0/MinBrowser.Min.locale.en-US.yaml
+++ b/manifests/m/MinBrowser/Min/1.26.0/MinBrowser.Min.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# Created with YamlCreate.ps1 v2.4.3 $debug=AUSU.CRLF.7-4-6.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: MinBrowser.Min
+PackageVersion: 1.26.0
+PackageLocale: en-US
+Publisher: PalmerAL
+# PublisherUrl:
+PublisherSupportUrl: https://github.com/minbrowser/min/issues
+# PrivacyUrl:
+Author: PalmerAL
+PackageName: Min
+PackageUrl: https://minbrowser.org
+License: Apache License 2.0
+LicenseUrl: https://raw.githubusercontent.com/minbrowser/min/master/LICENSE.txt
+# Copyright:
+CopyrightUrl: https://raw.githubusercontent.com/minbrowser/min/master/LICENSE.txt
+ShortDescription: A fast, minimal browser that protects your privacy.
+# Description:
+Moniker: minbrowser
+Tags:
+- browser
+- fast
+- privacy
+# ReleaseNotes:
+ReleaseNotesUrl: https://github.com/minbrowser/min/releases/tag/v1.26.0
+# PurchaseUrl:
+# InstallationNotes:
+# Documentations:
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/m/MinBrowser/Min/1.26.0/MinBrowser.Min.yaml
+++ b/manifests/m/MinBrowser/Min/1.26.0/MinBrowser.Min.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.4.3 $debug=AUSU.CRLF.7-4-6.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: MinBrowser.Min
+PackageVersion: 1.26.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
This PRs is part of an effort to move the package to the package identifier `MinBrowser.Min`. 

related #358550
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/358789)