### PR TITLE
Move Min.Min 1.29.0 to MinBrowser.Min 1.29.0 

### DIFF
--- a/manifests/m/MinBrowser/Min/1.29.0/MinBrowser.Min.installer.yaml
+++ b/manifests/m/MinBrowser/Min/1.29.0/MinBrowser.Min.installer.yaml
@@ -1,0 +1,18 @@
+# Created with YamlCreate.ps1 v2.4.3 $debug=AUSU.CRLF.7-4-6.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: MinBrowser.Min
+PackageVersion: 1.29.0
+InstallerLocale: en-US
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- silent
+UpgradeBehavior: install
+ReleaseDate: 2023-09-13
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/minbrowser/min/releases/download/v1.29.0/min-1.29.0-setup.exe
+  InstallerSha256: 85BCBB841F94BF40EF0B37B8CCF9AA96EC21E4D2EAF262894A41A1EF2DCFFF1D
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/m/MinBrowser/Min/1.29.0/MinBrowser.Min.locale.en-US.yaml
+++ b/manifests/m/MinBrowser/Min/1.29.0/MinBrowser.Min.locale.en-US.yaml
@@ -1,0 +1,45 @@
+# Created with YamlCreate.ps1 v2.4.3 $debug=AUSU.CRLF.7-4-6.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: MinBrowser.Min
+PackageVersion: 1.29.0
+PackageLocale: en-US
+Publisher: PalmerAL
+PublisherUrl: https://minbrowser.org
+PublisherSupportUrl: https://github.com/minbrowser/min/issues
+# PrivacyUrl:
+Author: PalmerAL
+PackageName: Min
+PackageUrl: https://minbrowser.org
+License: Apache License 2.0
+LicenseUrl: https://raw.githubusercontent.com/minbrowser/min/master/LICENSE.txt
+# Copyright:
+CopyrightUrl: https://raw.githubusercontent.com/minbrowser/min/master/LICENSE.txt
+ShortDescription: A fast, minimal browser that protects your privacy.
+# Description:
+Moniker: minbrowser
+Tags:
+- browser
+- fast
+- privacy
+ReleaseNotes: |-
+  - Added a setting to show the task list whenever a new window is opened.
+  - The PDF viewer now has a sepia theme, and in dark mode, there's a new option to invert the colors of the PDF.
+  - Added a "new window" entry to the macOS dock menu.
+  - Tab dragging on macOS no longer requires holding the command key.
+  - Trackpad gestures to navigate between pages in history now work more accurately.
+  - Full-text search now highlights matched terms in the searchbar.
+  - Bookmark tag suggestions are now more accurate.
+  - Fix: "Save Link As" didn't work with PDF files (@Sestowner)
+  - Fix: Some keyboard shortcuts didn't work on AZERTY keyboard layouts.
+  - Fix: reduced the amount of white flickering that appears while navigating in dark mode.
+  - Added Catalan language (@markusand)
+  - Added Danish language (@FlameyFox)
+  - Numerous other translation updates - thank you to all of our translators!
+  - Upgraded Chromium (This addresses a recently-announced security vulnerability).
+ReleaseNotesUrl: https://github.com/minbrowser/min/releases/tag/v1.29.0
+# PurchaseUrl:
+# InstallationNotes:
+# Documentations:
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/m/MinBrowser/Min/1.29.0/MinBrowser.Min.yaml
+++ b/manifests/m/MinBrowser/Min/1.29.0/MinBrowser.Min.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.4.3 $debug=AUSU.CRLF.7-4-6.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: MinBrowser.Min
+PackageVersion: 1.29.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
This PRs is part of an effort to move the package to the package identifier `MinBrowser.Min`. 

related #358550
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/358793)