### PR TITLE
Move Min.Min 1.34.1 to MinBrowser.Min 1.34.1 

### DIFF
--- a/manifests/m/MinBrowser/Min/1.34.1/MinBrowser.Min.installer.yaml
+++ b/manifests/m/MinBrowser/Min/1.34.1/MinBrowser.Min.installer.yaml
@@ -1,0 +1,18 @@
+# Created with WinGet Updater using komac v2.10.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: MinBrowser.Min
+PackageVersion: 1.34.1
+InstallerLocale: en-US
+InstallerType: exe
+Scope: user
+InstallModes:
+- silent
+UpgradeBehavior: install
+ReleaseDate: 2025-02-23
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/minbrowser/min/releases/download/v1.34.1/min-1.34.1-ia32-setup.exe
+  InstallerSha256: ABA0F8AD4DF9CBBA591F5C803344D36BFFD75FD7EC42B4D577436E287BA1C110
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/m/MinBrowser/Min/1.34.1/MinBrowser.Min.locale.en-US.yaml
+++ b/manifests/m/MinBrowser/Min/1.34.1/MinBrowser.Min.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# Created with WinGet Updater using komac v2.10.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: MinBrowser.Min
+PackageVersion: 1.34.1
+PackageLocale: en-US
+Publisher: PalmerAL
+PublisherUrl: https://minbrowser.org/
+PublisherSupportUrl: https://github.com/minbrowser/min/issues
+Author: PalmerAL
+PackageName: Min
+PackageUrl: https://minbrowser.org/
+License: Apache-2.0
+LicenseUrl: https://github.com/minbrowser/min/blob/HEAD/LICENSE.txt
+CopyrightUrl: https://raw.githubusercontent.com/minbrowser/min/master/LICENSE.txt
+ShortDescription: A fast, minimal browser that protects your privacy.
+Moniker: minbrowser
+Tags:
+- browser
+- fast
+- privacy
+ReleaseNotes: |-
+  - Fixed: Maximized windows would be incorrectly sized on Windows
+  - Fixed: Unable to enable the camera and microphone in Google Meet
+  - Upgraded Electron
+ReleaseNotesUrl: https://github.com/minbrowser/min/releases/tag/v1.34.1
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/m/MinBrowser/Min/1.34.1/MinBrowser.Min.yaml
+++ b/manifests/m/MinBrowser/Min/1.34.1/MinBrowser.Min.yaml
@@ -1,0 +1,8 @@
+# Created with WinGet Updater using komac v2.10.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: MinBrowser.Min
+PackageVersion: 1.34.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
This PRs is part of an effort to move the package to the package identifier `MinBrowser.Min`. 

related #358550
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/358796)