### PR TITLE
Move Min.Min 1.35.4 to MinBrowser.Min 1.35.4 

### DIFF
--- a/manifests/m/MinBrowser/Min/1.35.4/MinBrowser.Min.installer.yaml
+++ b/manifests/m/MinBrowser/Min/1.35.4/MinBrowser.Min.installer.yaml
@@ -1,0 +1,18 @@
+# Created with komac v2.15.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: MinBrowser.Min
+PackageVersion: 1.35.4
+InstallerLocale: en-US
+InstallerType: exe
+Scope: user
+InstallModes:
+- silent
+UpgradeBehavior: install
+ReleaseDate: 2026-03-01
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/minbrowser/min/releases/download/v1.35.4/min-1.35.4-ia32-setup.exe
+  InstallerSha256: 3452F64369F906909C82557A4AA6EA7EF08301DD267CB29E5CD22D9275ACC9E0
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/MinBrowser/Min/1.35.4/MinBrowser.Min.locale.en-US.yaml
+++ b/manifests/m/MinBrowser/Min/1.35.4/MinBrowser.Min.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# Created with komac v2.15.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: MinBrowser.Min
+PackageVersion: 1.35.4
+PackageLocale: en-US
+Publisher: PalmerAL
+PublisherUrl: https://minbrowser.org/
+PublisherSupportUrl: https://github.com/minbrowser/min/issues
+Author: PalmerAL
+PackageName: Min
+PackageUrl: https://minbrowser.org/
+License: Apache-2.0
+LicenseUrl: https://github.com/minbrowser/min/blob/HEAD/LICENSE.txt
+CopyrightUrl: https://raw.githubusercontent.com/minbrowser/min/master/LICENSE.txt
+ShortDescription: A fast, minimal browser that protects your privacy.
+Moniker: minbrowser
+Tags:
+- browser
+- fast
+- privacy
+ReleaseNotes: '- Upgraded Chromium.'
+ReleaseNotesUrl: https://github.com/minbrowser/min/releases/tag/v1.35.4
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/MinBrowser/Min/1.35.4/MinBrowser.Min.yaml
+++ b/manifests/m/MinBrowser/Min/1.35.4/MinBrowser.Min.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.15.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: MinBrowser.Min
+PackageVersion: 1.35.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
This PRs is part of an effort to move the package to the package identifier `MinBrowser.Min`. 

related #358550
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/358802)