### PR TITLE
Add OleBhartvigsen.FanFolder version 1.0.0

### DIFF
--- a/manifests/o/OleBhartvigsen/FanFolder/1.0.0/OleBhartvigsen.FanFolder.installer.yaml
+++ b/manifests/o/OleBhartvigsen/FanFolder/1.0.0/OleBhartvigsen.FanFolder.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: OleBhartvigsen.FanFolder
+PackageVersion: 1.0.0
+InstallerLocale: en-US
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: msi
+InstallModes:
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/olebhartvigsen/win-dir-fan/releases/download/v1.0.0/FanFolderSetup.msi
+    InstallerSha256: 5CF9D9803554B10B09A3819986839708CC3681A8AC1024ABB9E41D9AB5FD5881
+    ProductCode: '{2418DDE7-3E97-424D-966C-273769C03042}'
+    InstallerSwitches:
+      Silent: /quiet /norestart
+      SilentWithProgress: /passive /norestart
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/o/OleBhartvigsen/FanFolder/1.0.0/OleBhartvigsen.FanFolder.locale.en-US.yaml
+++ b/manifests/o/OleBhartvigsen/FanFolder/1.0.0/OleBhartvigsen.FanFolder.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: OleBhartvigsen.FanFolder
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: Ole Bhartvigsen
+PublisherUrl: https://github.com/olebhartvigsen
+PublisherSupportUrl: https://github.com/olebhartvigsen/win-dir-fan/issues
+PackageName: FanFolder
+PackageUrl: https://github.com/olebhartvigsen/win-dir-fan
+License: MIT
+LicenseUrl: https://github.com/olebhartvigsen/win-dir-fan/blob/master/LICENSE
+ShortDescription: macOS-style animated fan folder for the Windows taskbar
+Description: >-
+  FanFolder replicates the macOS Dock "Fan" folder experience on the Windows
+  taskbar. Clicking the taskbar icon reveals an animated, arc-shaped popup
+  showing the most recently modified items in a configured folder. Items can
+  be opened, right-clicked (full shell context menu), or dragged to other
+  applications. Supports 16 languages and is fully configurable via the
+  Windows registry.
+Tags:
+  - taskbar
+  - productivity
+  - launcher
+  - dock
+  - macos
+  - fan
+  - folder
+  - utility
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/o/OleBhartvigsen/FanFolder/1.0.0/OleBhartvigsen.FanFolder.yaml
+++ b/manifests/o/OleBhartvigsen/FanFolder/1.0.0/OleBhartvigsen.FanFolder.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: OleBhartvigsen.FanFolder
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## FanFolder v1.0.0

macOS-style animated fan folder for the Windows taskbar.

- Installs per-user to %LOCALAPPDATA%\FanFolder
- Start Menu and Desktop shortcuts
- Auto-starts on login via HKCU Run key
- 16 language localisations
- No admin rights required

**Package:** OleBhartvigsen.FanFolder  
**Version:** 1.0.0  
**Installer:** MSI (WiX v4, perUser scope)  
**Release:** https://github.com/olebhartvigsen/win-dir-fan/releases/tag/v1.0.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/358886)