### PR TITLE
New version: MetanoicArmor.I2PChat.TUI version 1.3.1

### DIFF
--- a/manifests/m/MetanoicArmor/I2PChat/TUI/1.3.1/MetanoicArmor.I2PChat.TUI.installer.yaml
+++ b/manifests/m/MetanoicArmor/I2PChat/TUI/1.3.1/MetanoicArmor.I2PChat.TUI.installer.yaml
@@ -1,0 +1,22 @@
+PackageIdentifier: MetanoicArmor.I2PChat.TUI
+PackageVersion: 1.3.1
+InstallerLocale: en-US
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallModes:
+  - interactive
+  - silent
+# TUI winget: *-winget-* zip omits embedded i2pd (SHA from packaging/refresh-checksums.sh 1.3.1).
+Installers:
+  - Architecture: x64
+    InstallerType: zip
+    InstallerUrl: https://github.com/MetanoicArmor/I2PChat/releases/download/v1.3.1/I2PChat-windows-tui-x64-winget-v1.3.1.zip
+    InstallerSha256: 9fa69e5537a2fcf5cec30ff1360729bc436222b147454dd8b3082f518b6fd8ed
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: I2PChat/I2PChat-tui.exe
+        PortableCommandAlias: i2pchat-tui
+    ReleaseDate: 2026-04-12
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/MetanoicArmor/I2PChat/TUI/1.3.1/MetanoicArmor.I2PChat.TUI.locale.en-US.yaml
+++ b/manifests/m/MetanoicArmor/I2PChat/TUI/1.3.1/MetanoicArmor.I2PChat.TUI.locale.en-US.yaml
@@ -1,0 +1,27 @@
+PackageIdentifier: MetanoicArmor.I2PChat.TUI
+PackageVersion: 1.3.1
+PackageLocale: en-US
+Publisher: MetanoicArmor
+PublisherUrl: https://github.com/MetanoicArmor
+PackageName: I2PChat TUI
+PackageUrl: https://github.com/MetanoicArmor/I2PChat
+License: AGPL-3.0
+LicenseUrl: https://github.com/MetanoicArmor/I2PChat/blob/main/LICENSE
+Copyright: Copyright (c) MetanoicArmor and contributors
+ShortDescription: Terminal UI (Textual) for I2PChat over I2P SAM
+Description: |-
+  I2PChat TUI is the Textual console client for I2PChat (no PyQt GUI). This winget package uses the
+  *-winget-* release zip without embedded i2pd; use a system i2pd with SAM or the full TUI zip from GitHub Releases
+  for a bundled router.
+Moniker: i2pchat-tui
+Tags:
+  - i2p
+  - chat
+  - p2p
+  - privacy
+  - terminal
+ReleaseNotesUrl: https://github.com/MetanoicArmor/I2PChat/releases/tag/v1.3.1
+ReleaseNotes: |-
+  v1.3.1: aligns with I2PChat 1.3.1 (Intel macOS i2pd bundling, BlindBox/Nix/icons). Winget *-winget-* zip without embedded i2pd. Full TUI zip with bundled router: I2PChat-windows-tui-x64-v*.zip on GitHub Releases. i2pd: https://github.com/PurpleI2P/i2pd
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/MetanoicArmor/I2PChat/TUI/1.3.1/MetanoicArmor.I2PChat.TUI.yaml
+++ b/manifests/m/MetanoicArmor/I2PChat/TUI/1.3.1/MetanoicArmor.I2PChat.TUI.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: MetanoicArmor.I2PChat.TUI
+PackageVersion: 1.3.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary
Adds **MetanoicArmor.I2PChat.TUI** 1.3.1 (TUI portable zip without embedded i2pd).

Manifests: `I2PChat-windows-tui-x64-winget-v1.3.1.zip`.

**Note:** GUI package (`MetanoicArmor.I2PChat`) is submitted in a **separate PR** per winget-pkgs policy (one application per PR). See linked PR for the GUI submission.


Made with [Cursor](https://cursor.com)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/359187)