### PR TITLE
New package: zhitong.SoloMD version 0.1.8

### DIFF
--- a/manifests/z/zhitong/SoloMD/0.1.8/zhitong.SoloMD.installer.yaml
+++ b/manifests/z/zhitong/SoloMD/0.1.8/zhitong.SoloMD.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: zhitong.SoloMD
+PackageVersion: 0.1.8
+MinimumOSVersion: 10.0.17763.0
+InstallerType: wix
+UpgradeBehavior: install
+FileExtensions:
+- md
+- markdown
+- mdown
+- mkd
+- txt
+ReleaseDate: 2026-04-13
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/zhitongblog/solomd/releases/download/v0.1.8/SoloMD_0.1.8_x64_en-US.msi
+  InstallerSha256: BE380EFFBFB6AB32FFB81F5F5D06D4B9D9F0C2C959CC62F5D31FBB62AF1A2467
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/z/zhitong/SoloMD/0.1.8/zhitong.SoloMD.locale.en-US.yaml
+++ b/manifests/z/zhitong/SoloMD/0.1.8/zhitong.SoloMD.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: zhitong.SoloMD
+PackageVersion: 0.1.8
+PackageLocale: en-US
+Publisher: zhitong
+PublisherUrl: https://github.com/zhitongblog
+PublisherSupportUrl: https://github.com/zhitongblog/solomd/issues
+PackageName: SoloMD
+PackageUrl: https://solomd.app
+License: MIT
+LicenseUrl: https://github.com/zhitongblog/solomd/blob/main/LICENSE
+Copyright: Copyright (c) 2026 xiangdong li
+ShortDescription: A lightweight Markdown and plain text editor
+Description: |-
+  SoloMD is a free, open-source, cross-platform Markdown + plain text editor
+  built with Tauri 2 + Vue 3 + CodeMirror 6. Under 15 MB installed.
+  Features: Live Preview, Vim mode, 8 themes (Nord, Solarized, Monokai,
+  GitHub, Dracula, etc.), KaTeX math, Mermaid diagrams, Clean AI Artifacts,
+  one-click Copy (HTML/Markdown/Plain/Image), Export to PDF/DOCX/HTML/PNG,
+  CJK encoding auto-detect (GBK/Big5), focus mode, typewriter mode.
+Moniker: solomd
+Tags:
+- editor
+- markdown
+- text-editor
+- tauri
+- vim
+ReleaseNotesUrl: https://github.com/zhitongblog/solomd/releases/tag/v0.1.8
+Documentations:
+- DocumentLabel: Website
+  DocumentUrl: https://solomd.app
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/z/zhitong/SoloMD/0.1.8/zhitong.SoloMD.locale.zh-CN.yaml
+++ b/manifests/z/zhitong/SoloMD/0.1.8/zhitong.SoloMD.locale.zh-CN.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.9.0.schema.json
+
+PackageIdentifier: zhitong.SoloMD
+PackageVersion: 0.1.8
+PackageLocale: zh-CN
+Publisher: zhitong
+PackageName: SoloMD
+License: MIT
+ShortDescription: 一款轻量跨平台的 Markdown 与纯文本编辑器
+Description: |-
+  SoloMD 是一款免费开源的 Markdown + 纯文本编辑器，基于 Tauri 2 + Vue 3 +
+  CodeMirror 6 构建，安装包仅 15 MB。支持实时预览、Vim 模式、8 种主题
+  (Nord、Solarized、Monokai、GitHub、Dracula 等)、KaTeX 数学公式、
+  Mermaid 图表、一键清除 AI 格式、一键复制 (HTML/Markdown/纯文本/图片)、
+  导出 PDF/DOCX/HTML/PNG、GBK/Big5 编码自动识别、专注模式、打字机模式。
+Tags:
+- markdown
+- 编辑器
+- 文本编辑器
+ManifestType: locale
+ManifestVersion: 1.9.0

--- a/manifests/z/zhitong/SoloMD/0.1.8/zhitong.SoloMD.yaml
+++ b/manifests/z/zhitong/SoloMD/0.1.8/zhitong.SoloMD.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: zhitong.SoloMD
+PackageVersion: 0.1.8
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
### New Package Submission

- Package Identifier: zhitong.SoloMD
- Package Version: 0.1.8
- Installer Type: wix (MSI)
- Architecture: x64

### Description

SoloMD is a lightweight, open-source Markdown + plain text editor built with Tauri 2. ~15 MB installed, MIT licensed.

**Key features:** Live Preview, Vim mode, 8 editor themes, KaTeX math, Mermaid diagrams, Clean AI Artifacts, export to PDF/DOCX/HTML/PNG, CJK encoding support.

**Homepage:** https://solomd.app
**GitHub:** https://github.com/zhitongblog/solomd
**License:** MIT

### Checklist

- [x] Manifest validation passed
- [x] SHA256 hash verified
- [x] MSI installer tested on Windows
- [x] Includes en-US and zh-CN locale manifests
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/359527)