### PR TITLE
New package: FileTally.FileTally version 0.2.0-preview

### DIFF
--- a/manifests/f/FileTally/FileTally/0.2.0-preview/FileTally.FileTally.installer.yaml
+++ b/manifests/f/FileTally/FileTally/0.2.0-preview/FileTally.FileTally.installer.yaml
@@ -4,6 +4,7 @@ PackageIdentifier: FileTally.FileTally
 PackageVersion: 0.2.0-preview
 Platform:
 - Windows.Desktop
+MinimumOSVersion: 10.0.0.0
 InstallerType: burn
 Scope: user
 InstallModes:

--- a/manifests/f/FileTally/FileTally/0.2.0-preview/FileTally.FileTally.installer.yaml
+++ b/manifests/f/FileTally/FileTally/0.2.0-preview/FileTally.FileTally.installer.yaml
@@ -17,7 +17,7 @@ UpgradeBehavior: install
 ReleaseDate: 2026-04-09
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/abobilly/filetally/releases/download/v0.2.0-preview/FileTallySetup.exe
+  InstallerUrl: https://filetally.com/downloads/v0.2.0-preview/FileTallySetup.exe
   InstallerSha256: 2AF34AB308AFEDB9C488666D6722342EE3BB6E798F7220768A341F693322811C
   ProductCode: '{2987B31A-8D76-41A0-812C-518547747378}'
   AppsAndFeaturesEntries:

--- a/manifests/f/FileTally/FileTally/0.2.0-preview/FileTally.FileTally.installer.yaml
+++ b/manifests/f/FileTally/FileTally/0.2.0-preview/FileTally.FileTally.installer.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: FileTally.FileTally
+PackageVersion: 0.2.0-preview
+Platform:
+- Windows.Desktop
+InstallerType: burn
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: /quiet
+  SilentWithProgress: /passive
+UpgradeBehavior: install
+ReleaseDate: 2026-04-09
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/abobilly/filetally/releases/download/v0.2.0-preview/FileTallySetup.exe
+  InstallerSha256: 2AF34AB308AFEDB9C488666D6722342EE3BB6E798F7220768A341F693322811C
+  ProductCode: '{2987B31A-8D76-41A0-812C-518547747378}'
+  AppsAndFeaturesEntries:
+  - DisplayName: FileTally
+    Publisher: FileTally
+    DisplayVersion: 0.2.0-preview-r6
+    ProductCode: '{2987B31A-8D76-41A0-812C-518547747378}'
+    UpgradeCode: '{8B8B70D6-06F1-4A49-A2A2-5F6F5D1E9F15}'
+    InstallerType: burn
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/FileTally/FileTally/0.2.0-preview/FileTally.FileTally.locale.en-US.yaml
+++ b/manifests/f/FileTally/FileTally/0.2.0-preview/FileTally.FileTally.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: FileTally.FileTally
+PackageVersion: 0.2.0-preview
+PackageLocale: en-US
+Publisher: FileTally
+PublisherUrl: https://filetally.com/
+PublisherSupportUrl: https://filetally.com/support.html
+PrivacyUrl: https://filetally.com/privacy.html
+Author: Andrew Badger
+PackageName: FileTally
+PackageUrl: https://filetally.com/
+License: Proprietary
+LicenseUrl: https://filetally.com/eula.html
+Copyright: Copyright (c) Andrew Badger
+ShortDescription: Windows desktop utility for counting pages across mixed document folders.
+Description: |-
+  FileTally is a local Windows desktop utility for counting pages across mixed document folders.
+  It scans document-heavy folders on the PC, highlights unreadable items, and exports results for review or reporting.
+Tags:
+- documents
+- local-processing
+- page-counting
+- pdf
+- tiff
+ReleaseNotes: |-
+  Signed preview release of FileTally for Windows.
+  This release ships the Windows desktop app in a WiX Burn installer signed via Azure Trusted Signing.
+ReleaseNotesUrl: https://github.com/abobilly/filetally/releases/tag/v0.2.0-preview
+Documentations:
+- DocumentLabel: Repository
+  DocumentUrl: https://github.com/abobilly/filetally
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/FileTally/FileTally/0.2.0-preview/FileTally.FileTally.locale.en-US.yaml
+++ b/manifests/f/FileTally/FileTally/0.2.0-preview/FileTally.FileTally.locale.en-US.yaml
@@ -26,9 +26,5 @@ Tags:
 ReleaseNotes: |-
   Signed preview release of FileTally for Windows.
   This release ships the Windows desktop app in a WiX Burn installer signed via Azure Trusted Signing.
-ReleaseNotesUrl: https://github.com/abobilly/filetally/releases/tag/v0.2.0-preview
-Documentations:
-- DocumentLabel: Repository
-  DocumentUrl: https://github.com/abobilly/filetally
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0

--- a/manifests/f/FileTally/FileTally/0.2.0-preview/FileTally.FileTally.yaml
+++ b/manifests/f/FileTally/FileTally/0.2.0-preview/FileTally.FileTally.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: FileTally.FileTally
+PackageVersion: 0.2.0-preview
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
FileTally is a signed Windows desktop utility for counting pages across mixed document folders. The installer is a WiX Burn bundle signed via Azure Trusted Signing. InstallerType is burn with /quiet for silent install.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/360458)