### PR TITLE
New package: FileTally.FileTally version 0.2.0-preview-r7

### DIFF
--- a/manifests/f/FileTally/FileTally/0.2.0-preview-r7/FileTally.FileTally.installer.yaml
+++ b/manifests/f/FileTally/FileTally/0.2.0-preview-r7/FileTally.FileTally.installer.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: FileTally.FileTally
+PackageVersion: 0.2.0-preview-r7
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: burn
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: /quiet
+  SilentWithProgress: /passive
+UpgradeBehavior: install
+ReleaseDate: 2026-04-14
+Installers:
+- Architecture: x64
+  InstallerUrl: https://filetally.com/downloads/v0.2.0-preview-r7/FileTallySetup.exe
+  InstallerSha256: 8EFCC28BD700F8349FD9647CFFF26F8B04468E0ED63C091DD364D49AEF0F57F5
+  ProductCode: '{20753FC0-73A6-426F-A18B-B64758B8B0D3}'
+  AppsAndFeaturesEntries:
+  - DisplayName: FileTally
+    Publisher: FileTally
+    DisplayVersion: 0.2.0-preview-r7
+    ProductCode: '{20753FC0-73A6-426F-A18B-B64758B8B0D3}'
+    UpgradeCode: '{8B8B70D6-06F1-4A49-A2A2-5F6F5D1E9F15}'
+    InstallerType: burn
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/FileTally/FileTally/0.2.0-preview-r7/FileTally.FileTally.locale.en-US.yaml
+++ b/manifests/f/FileTally/FileTally/0.2.0-preview-r7/FileTally.FileTally.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: FileTally.FileTally
+PackageVersion: 0.2.0-preview-r7
+PackageLocale: en-US
+Publisher: FileTally
+PublisherUrl: https://filetally.com/
+PublisherSupportUrl: https://filetally.com/support.html
+PrivacyUrl: https://filetally.com/privacy.html
+Author: Andrew Badger
+PackageName: FileTally
+PackageUrl: https://filetally.com/
+License: Proprietary
+LicenseUrl: https://filetally.com/eula.html
+Copyright: Copyright (c) Andrew Badger
+ShortDescription: Windows desktop utility for counting pages across mixed document folders.
+Description: |-
+  FileTally is a local Windows desktop utility for counting pages across mixed document folders.
+  It scans document-heavy folders on the PC, highlights unreadable items, and exports results for review or reporting.
+Tags:
+- documents
+- local-processing
+- page-counting
+- pdf
+- tiff
+ReleaseNotes: |-
+  Corrected signed preview release of FileTally for Windows.
+  This package replaces the earlier preview submission with a bundle whose embedded metadata matches the shipped installer.
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/FileTally/FileTally/0.2.0-preview-r7/FileTally.FileTally.yaml
+++ b/manifests/f/FileTally/FileTally/0.2.0-preview-r7/FileTally.FileTally.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: FileTally.FileTally
+PackageVersion: 0.2.0-preview-r7
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Package Submission
- Added FileTally.FileTally version `0.2.0-preview-r7`
- Uses a new signed, immutable public installer URL at `https://filetally.com/downloads/v0.2.0-preview-r7/FileTallySetup.exe`
- Manifest values were derived from the exact shipped Burn bundle metadata for this installer

## Notes
- This supersedes the earlier `0.2.0-preview` submission because that immutable installer binary had mismatched embedded bundle metadata.
- Validated locally with `winget validate`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/360484)