### PR TITLE
New package: FileTally.FileTally version 0.2.0-preview-r9

### DIFF
--- a/manifests/f/FileTally/FileTally/0.2.0-preview-r9/FileTally.FileTally.installer.yaml
+++ b/manifests/f/FileTally/FileTally/0.2.0-preview-r9/FileTally.FileTally.installer.yaml
@@ -1,0 +1,21 @@
+# Created by Codex
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: FileTally.FileTally
+PackageVersion: 0.2.0-preview-r9
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: burn
+Scope: user
+UpgradeBehavior: install
+ProductCode: '{E9B96C60-8509-42D8-B4D9-F51B30A43DB9}'
+AppsAndFeaturesEntries:
+- ProductCode: '{E9B96C60-8509-42D8-B4D9-F51B30A43DB9}'
+  UpgradeCode: '{8B8B70D6-06F1-4A49-A2A2-5F6F5D1E9F15}'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://filetally.com/downloads/v0.2.0-preview-r9/FileTallySetup.exe
+  InstallerSha256: CF6FFDC9E17034E2F38C46F150E1BA8498BA82D1729FD99E7B09FFA39FFF8CC7
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/FileTally/FileTally/0.2.0-preview-r9/FileTally.FileTally.locale.en-US.yaml
+++ b/manifests/f/FileTally/FileTally/0.2.0-preview-r9/FileTally.FileTally.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# Created by Codex
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: FileTally.FileTally
+PackageVersion: 0.2.0-preview-r9
+PackageLocale: en-US
+Publisher: FileTally
+PublisherUrl: https://filetally.com/
+PublisherSupportUrl: https://filetally.com/support.html
+PrivacyUrl: https://filetally.com/privacy.html
+PackageName: FileTally
+PackageUrl: https://filetally.com/
+License: Proprietary
+LicenseUrl: https://filetally.com/eula.html
+ShortDescription: Fast page counting across mixed document folders on Windows.
+Description: FileTally is a Windows desktop utility that counts total pages across PDFs, TIFFs, Word, Excel, PowerPoint, images, emails, and mixed document folders, then exports results to CSV or XLSX. It runs locally on the machine with no cloud upload required.
+Moniker: filetally
+Tags:
+- documents
+- office
+- page-count
+- pdf
+- tiff
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/FileTally/FileTally/0.2.0-preview-r9/FileTally.FileTally.yaml
+++ b/manifests/f/FileTally/FileTally/0.2.0-preview-r9/FileTally.FileTally.yaml
@@ -1,0 +1,8 @@
+# Created by Codex
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: FileTally.FileTally
+PackageVersion: 0.2.0-preview-r9
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
#### Package Submission
Added `FileTally.FileTally` version `0.2.0-preview-r9`

- Uses a new signed, immutable public installer URL at `https://filetally.com/downloads/v0.2.0-preview-r9/FileTallySetup.exe`
- Manifest values were derived from the exact shipped Burn bundle metadata for this installer
- This supersedes the earlier closed preview submissions after the older immutable installer was confirmed to have mismatched embedded bundle metadata
- Validated locally with `winget validate`
- Verified the exact signed `0.2.0-preview-r9` installer on the real upgrade path from `0.2.0-preview-r8`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/360515)