### PR TITLE
Add arm64 installer for Databricks.DatabricksCLI version 0.296.0

### DIFF
--- a/manifests/d/Databricks/DatabricksCLI/0.296.0/Databricks.DatabricksCLI.installer.yaml
+++ b/manifests/d/Databricks/DatabricksCLI/0.296.0/Databricks.DatabricksCLI.installer.yaml
@@ -13,5 +13,8 @@ Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/databricks/cli/releases/download/v0.296.0/databricks_cli_0.296.0_windows_amd64.zip
   InstallerSha256: 50FF2D61DC375B08B899FCF8E79FB4A5EA78C76ED53C58CDD7064BE9EAFC4164
+- Architecture: arm64
+  InstallerUrl: https://github.com/databricks/cli/releases/download/v0.296.0/databricks_cli_0.296.0_windows_arm64.zip
+  InstallerSha256: 8BAFCB68B044163AA4E5158E732FDC7A3DD21F6DA1ABF1FC2FC865CFAA7AEB1D
 ManifestType: installer
 ManifestVersion: 1.9.0


### PR DESCRIPTION
Add ARM64 (Windows on ARM) installer entry for Databricks CLI 0.296.0.

The arm64 binary has been published in every GitHub release but was missing from the WinGet manifest.

See https://github.com/databricks/cli/releases/tag/v0.296.0.