### PR TITLE
New package: FileTally.FileTally version 0.2.0-preview-r10

### DIFF
--- a/manifests/f/FileTally/FileTally/0.2.0-preview-r10/FileTally.FileTally.installer.yaml
+++ b/manifests/f/FileTally/FileTally/0.2.0-preview-r10/FileTally.FileTally.installer.yaml
@@ -1,0 +1,21 @@
+# Created by Codex
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: FileTally.FileTally
+PackageVersion: 0.2.0-preview-r10
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: burn
+Scope: user
+UpgradeBehavior: install
+ProductCode: '{704A65E3-14AF-4BB7-9B1D-2E5F7851978D}'
+AppsAndFeaturesEntries:
+- ProductCode: '{704A65E3-14AF-4BB7-9B1D-2E5F7851978D}'
+  UpgradeCode: '{2C9103CB-9F1F-41D4-9E55-C48D57D6E4C2}'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://filetally.com/downloads/v0.2.0-preview-r10/FileTallySetup.exe
+  InstallerSha256: E3232F3F4153BFBBE9DA96261AC6EB8BBA827768F9E72251F8E3329E9F02DEB9
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/FileTally/FileTally/0.2.0-preview-r10/FileTally.FileTally.locale.en-US.yaml
+++ b/manifests/f/FileTally/FileTally/0.2.0-preview-r10/FileTally.FileTally.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# Created by Codex
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: FileTally.FileTally
+PackageVersion: 0.2.0-preview-r10
+PackageLocale: en-US
+Publisher: FileTally
+PublisherUrl: https://filetally.com/
+PublisherSupportUrl: https://filetally.com/support.html
+PrivacyUrl: https://filetally.com/privacy.html
+PackageName: FileTally
+PackageUrl: https://filetally.com/
+License: Proprietary
+LicenseUrl: https://filetally.com/eula.html
+ShortDescription: Fast page counting across mixed document folders on Windows.
+Description: FileTally is a Windows desktop utility that counts total pages across PDFs, TIFFs, Word, Excel, PowerPoint, images, emails, and mixed document folders, then exports results to CSV or XLSX. It runs locally on the machine with no cloud upload required.
+Moniker: filetally
+Tags:
+- documents
+- office
+- page-count
+- pdf
+- tiff
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/FileTally/FileTally/0.2.0-preview-r10/FileTally.FileTally.yaml
+++ b/manifests/f/FileTally/FileTally/0.2.0-preview-r10/FileTally.FileTally.yaml
@@ -1,0 +1,8 @@
+# Created by Codex
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: FileTally.FileTally
+PackageVersion: 0.2.0-preview-r10
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Package Submission
Added FileTally.FileTally version 0.2.0-preview-r10
Uses a new signed, immutable public installer URL at https://filetally.com/downloads/v0.2.0-preview-r10/FileTallySetup.exe
Manifest values were derived from the exact shipped Burn bundle metadata for this installer.

Notes
This supersedes the earlier 0.2.0-preview-r9 submission because that older script-based bundle failed Microsoft validation with ShellExecute access-violation errors.
Validated locally with winget validate.
Microsoft Reviewers: Open in CodeFlow
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/360606)