### PR TITLE
Register esrp-winget-prod[bot] as owner for Microsoft.ESRPWingetTest

### DIFF
--- a/manifests/m/Microsoft/ESRPWingetTest/.package
+++ b/manifests/m/Microsoft/ESRPWingetTest/.package
@@ -1,0 +1,11 @@
+{
+    "schemaVersion": "0.1",
+    "owners":
+    [
+        {
+            "type": "Bot",
+            "login": "esrp-winget-prod[bot]",
+            "id": 273969822
+        }
+    ]
+}


### PR DESCRIPTION
Adds .package file to register esrp-winget-ppe[bot] (ID: 252570494) as owner of the Microsoft.ESRPWingetTest manifest directory.

This package will verify the verified developer configuration flow and be deleted once completed.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/360805)