### PR TITLE
Fix GlassWire.GlassWire 3.8.1033 installer URL returning 403

### DIFF
--- a/manifests/g/GlassWire/GlassWire/3.8.1033/GlassWire.GlassWire.installer.yaml
+++ b/manifests/g/GlassWire/GlassWire/3.8.1033/GlassWire.GlassWire.installer.yaml
@@ -15,7 +15,7 @@ InstallationMetadata:
   DefaultInstallLocation: '%ProgramFiles(x86)%\GlassWire'
 Installers:
 - Architecture: x86
-  InstallerUrl: https://s3.us-east-1.amazonaws.com/s3.glasswire.com/download/cdd8444f47c3e9bd2b3e094adf92a9eb/GlassWireSetup.exe
-  InstallerSha256: F3700BAA2BB95D8A718C53CAB25CD4D665A6D95D40C178ABF66F4D587C51371B
+  InstallerUrl: https://s3.us-east-1.amazonaws.com/s3.glasswire.com/download/GlassWireSetup.exe
+  InstallerSha256: A1BECAAB08F4EE236E7602A705C4AF1824E73077ED38F85FE6CAED1BC28C1F77
 ManifestType: installer
 ManifestVersion: 1.12.0


### PR DESCRIPTION
## Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Is there a linked Issue? If so, fill in the Issue number below.
  - Resolves #351341
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

---

## Summary

The existing installer URL for GlassWire 3.8.1033 (`https://s3.us-east-1.amazonaws.com/s3.glasswire.com/download/cdd8444f47c3e9bd2b3e094adf92a9eb/GlassWireSetup.exe`) returns HTTP 403 Forbidden, making installation/update impossible via winget.

Updated the URL to the working S3 path (`/download/GlassWireSetup.exe`) and updated the SHA256 hash accordingly.

**Verification:**
- Confirmed the new URL returns HTTP 200
- SHA256 hash matches the downloaded installer: `A1BECAAB08F4EE236E7602A705C4AF1824E73077ED38F85FE6CAED1BC28C1F77`

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/360969)