### PR TITLE
Fix RetroArch Steam false ARP match by adding DisplayName and Publisher

### DIFF
--- a/manifests/l/Libretro/RetroArch/1.22.2/Libretro.RetroArch.installer.yaml
+++ b/manifests/l/Libretro/RetroArch/1.22.2/Libretro.RetroArch.installer.yaml
@@ -9,7 +9,9 @@ Scope: machine
 UpgradeBehavior: install
 ProductCode: RetroArch
 AppsAndFeaturesEntries:
-- ProductCode: RetroArch
+- DisplayName: RetroArch
+  Publisher: Libretro
+  ProductCode: RetroArch
 Installers:
 - Architecture: x86
   InstallerUrl: https://buildbot.libretro.com/stable/1.22.2/windows/x86/RetroArch-Win32-setup.exe


### PR DESCRIPTION
## Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Is there a linked Issue? If so, fill in the Issue number below.
  - Resolves https://github.com/microsoft/winget-pkgs/issues/357447

### Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

## Summary
- Added `DisplayName: RetroArch` and `Publisher: Libretro` to `AppsAndFeaturesEntries` in the installer manifest
- This tightens ARP matching so Steam-installed RetroArch (which registers without version info and under a different publisher/product code) is no longer falsely correlated to `Libretro.RetroArch`
- Prevents `winget upgrade --include-unknown` from installing duplicate copies alongside the Steam version

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/360973)