### PR TITLE
RedEyeNetworks.HopMatrix version 1.4.5

### DIFF
--- a/manifests/r/RedEyeNetworks/HopMatrix/1.4.5/RedEyeNetworks.HopMatrix.installer.yaml
+++ b/manifests/r/RedEyeNetworks/HopMatrix/1.4.5/RedEyeNetworks.HopMatrix.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: RedEyeNetworks.HopMatrix
+PackageVersion: 1.4.5
+InstallerType: inno
+Scope: machine
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  Custom: /NORESTART
+UpgradeBehavior: install
+Commands:
+- HopMatrix
+Installers:
+- Architecture: x64
+  InstallerUrl: https://download.redeyenetworks.com/releases/1.4.5/HopMatrix-win-x64-setup.exe
+  InstallerSha256: 8D799AB425C57B00C2FB40F05BD66498064CD01EFE5B4FAF035F88192875CFD9
+- Architecture: arm64
+  InstallerUrl: https://download.redeyenetworks.com/releases/1.4.5/HopMatrix-win-arm64-setup.exe
+  InstallerSha256: 3DD5D48E2646A7EC34126DDC15CC8F396584663969E28B7970433F76817A0D56
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/r/RedEyeNetworks/HopMatrix/1.4.5/RedEyeNetworks.HopMatrix.locale.en-US.yaml
+++ b/manifests/r/RedEyeNetworks/HopMatrix/1.4.5/RedEyeNetworks.HopMatrix.locale.en-US.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: RedEyeNetworks.HopMatrix
+PackageVersion: 1.4.5
+PackageLocale: en-US
+Publisher: RedEye Network Solutions LLC
+PublisherUrl: https://redeyenetworks.com
+PublisherSupportUrl: https://redeyenetworks.com/support
+Author: RedEye Network Solutions LLC
+PackageName: HopMatrix
+PackageUrl: https://redeyenetworks.com
+License: Proprietary
+Copyright: Copyright 2025-2026 RedEye Network Solutions LLC. All rights reserved.
+ShortDescription: Visual multi-path traceroute, network monitoring, and analysis platform
+Description: |-
+  HopMatrix is a portable, single-executable, cross-platform network analysis platform
+  with eight operational modes: Trace, Monitor, iPerf, OUI/MAC Lookup, SNMP, Multicast,
+  L2 Inspector, and Quick Tools. Features continuous multi-path traceroute with real-time
+  topology visualization, 256-endpoint fleet monitoring, iperf3-compatible bandwidth
+  testing, SNMP v1/v2c/v3 discovery, and multicast/CDP/LLDP analysis.
+Moniker: hopmatrix
+Tags:
+- traceroute
+- network
+- monitoring
+- bandwidth
+- iperf
+- snmp
+- multicast
+- network-analysis
+- pathping
+- topology
+- cdp
+- lldp
+- nmap
+- oui
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/RedEyeNetworks/HopMatrix/1.4.5/RedEyeNetworks.HopMatrix.yaml
+++ b/manifests/r/RedEyeNetworks/HopMatrix/1.4.5/RedEyeNetworks.HopMatrix.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: RedEyeNetworks.HopMatrix
+PackageVersion: 1.4.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Summary

New version submission for RedEyeNetworks.HopMatrix 1.4.5.

- Inno Setup installer for x64 and ARM64
- Binaries hosted on public R2 CDN (download.redeyenetworks.com)
- Resubmission of #360931 with corrected URLs (fixed PackageUrl, removed non-existent ReleaseNotesUrl)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/360976)