### PR TITLE
New package: git-rain.git-rain version 0.9.1

### DIFF
--- a/manifests/g/git-rain/git-rain/0.9.1/git-rain.git-rain.installer.yaml
+++ b/manifests/g/git-rain/git-rain/0.9.1/git-rain.git-rain.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: git-rain.git-rain
+PackageVersion: 0.9.1
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: git-rain.exe
+  PortableCommandAlias: git-rain
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/git-fire/git-rain/releases/download/v0.9.1/git-rain_0.9.1_windows_386.zip
+  InstallerSha256: E51E164B5EA27D0AD88BA948CDE23DDADDEF50C8ABCF492238A39D1570ECD643
+- Architecture: x64
+  InstallerUrl: https://github.com/git-fire/git-rain/releases/download/v0.9.1/git-rain_0.9.1_windows_amd64.zip
+  InstallerSha256: 1A529D0AA4E3F3CAEAF73724471F05791DFB65934B3B25E5986E665C81483153
+- Architecture: arm64
+  InstallerUrl: https://github.com/git-fire/git-rain/releases/download/v0.9.1/git-rain_0.9.1_windows_arm64.zip
+  InstallerSha256: A1338C2B35813418355EE67CA808DE1E93F6FE79D00CA0098BC84DC073737A5B
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/g/git-rain/git-rain/0.9.1/git-rain.git-rain.locale.en-US.yaml
+++ b/manifests/g/git-rain/git-rain/0.9.1/git-rain.git-rain.locale.en-US.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: git-rain.git-rain
+PackageVersion: 0.9.1
+PackageLocale: en-US
+Publisher: git-fire
+PublisherUrl: https://github.com/git-fire
+PublisherSupportUrl: https://github.com/git-fire/git-rain/issues
+PackageName: git-rain
+PackageUrl: https://github.com/git-fire/git-rain
+License: MIT
+LicenseUrl: https://github.com/git-fire/git-rain/blob/v0.9.1/LICENSE
+ShortDescription: Multi-repo sync CLI for Git.
+Description: git-rain discovers local git repositories and syncs them from their remotes in one command — the reverse of git-fire.
+Tags:
+- git
+- sync
+- cli
+ReleaseNotesUrl: https://github.com/git-fire/git-rain/releases/tag/v0.9.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/g/git-rain/git-rain/0.9.1/git-rain.git-rain.yaml
+++ b/manifests/g/git-rain/git-rain/0.9.1/git-rain.git-rain.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: git-rain.git-rain
+PackageVersion: 0.9.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Summary

Adds **git-rain** `0.9.1` to WinGet as a portable package (zip + nested installer), matching the pattern used for [git-fire](https://github.com/microsoft/winget-pkgs/pull/355775).

- **Package identifier:** `git-rain.git-rain`
- **Installers:** Windows x86, x64, arm64 zips from [git-fire/git-rain v0.9.1](https://github.com/git-fire/git-rain/releases/tag/v0.9.1)
- **Nested portable:** `git-rain.exe` with command alias `git-rain`

Checksums were taken from the release asset digests on GitHub and verified locally against downloaded zips.

## Validation

- [x] `winget validate --manifest manifests/g/git-rain/git-rain/0.9.1/` (not run in this environment — please run on Windows before merge if required)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/361006)