### PR TITLE
New package: BlackwellSystems.blackdot version 4.0.0-rc6

### DIFF
--- a/manifests/b/BlackwellSystems/blackdot/4.0.0-rc6/BlackwellSystems.blackdot.installer.yaml
+++ b/manifests/b/BlackwellSystems/blackdot/4.0.0-rc6/BlackwellSystems.blackdot.installer.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: BlackwellSystems.blackdot
+PackageVersion: 4.0.0-rc6
+InstallerLocale: en-US
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: zip
+NestedInstallerType: portable
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/blackwell-systems/blackdot/releases/download/v4.0.0-rc6/blackdot_4.0.0-rc6_Windows_x86_64.zip
+    InstallerSha256: 43b45395b04dd40871c8bfa891db40b6ea8a7aabb3fd5f2b7567b9cd50a08047
+    NestedInstallerFiles:
+      - RelativeFilePath: blackdot.exe
+        PortableCommandAlias: blackdot
+  - Architecture: arm64
+    InstallerUrl: https://github.com/blackwell-systems/blackdot/releases/download/v4.0.0-rc6/blackdot_4.0.0-rc6_Windows_arm64.zip
+    InstallerSha256: 92510b3dae3416670b82ed1fe20f749288b07387f136e0cb3457a01f0b58ca1f
+    NestedInstallerFiles:
+      - RelativeFilePath: blackdot.exe
+        PortableCommandAlias: blackdot
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/b/BlackwellSystems/blackdot/4.0.0-rc6/BlackwellSystems.blackdot.locale.en-US.yaml
+++ b/manifests/b/BlackwellSystems/blackdot/4.0.0-rc6/BlackwellSystems.blackdot.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: BlackwellSystems.blackdot
+PackageVersion: 4.0.0-rc6
+PackageLocale: en-US
+Publisher: Blackwell Systems
+PublisherUrl: https://github.com/blackwell-systems
+PublisherSupportUrl: https://github.com/blackwell-systems/blackdot/issues
+PackageName: blackdot
+PackageUrl: https://github.com/blackwell-systems/blackdot
+License: Apache-2.0
+LicenseUrl: https://github.com/blackwell-systems/blackdot/blob/main/LICENSE
+ShortDescription: Developer dotfiles and environment management CLI
+Description: |-
+  blackdot is a modular developer environment management CLI with multi-vault
+  secrets, extensible hooks, feature flags, shell integration, and health checks.
+  Supports macOS, Linux, Windows, and devcontainers.
+Moniker: blackdot
+Tags:
+  - dotfiles
+  - developer-tools
+  - cli
+  - devtools
+  - automation
+  - secrets
+  - vault
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/b/BlackwellSystems/blackdot/4.0.0-rc6/BlackwellSystems.blackdot.yaml
+++ b/manifests/b/BlackwellSystems/blackdot/4.0.0-rc6/BlackwellSystems.blackdot.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: BlackwellSystems.blackdot
+PackageVersion: 4.0.0-rc6
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

New package submission for blackdot — developer dotfiles and environment management CLI.

- **Publisher:** Blackwell Systems
- **Package:** BlackwellSystems.blackdot
- **Version:** 4.0.0-rc6
- **Release:** https://github.com/blackwell-systems/blackdot/releases/tag/v4.0.0-rc6

## Manifest

Verified:
- [x] SHA256 checksums match release assets
- [x] Both x64 and arm64 architectures included
- [x] Portable installer type with `blackdot` command alias
- [x] License: Apache-2.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/361063)