### PR TITLE
Hastily implemented feedback from GitHub(/Reddit?): Mozilla.MaintenanceService 149.0.2rc1

### DIFF
--- a/manifests/m/Mozilla/MaintenanceService/149.0.2rc1/Mozilla.MaintenanceService.installer.yaml
+++ b/manifests/m/Mozilla/MaintenanceService/149.0.2rc1/Mozilla.MaintenanceService.installer.yaml
@@ -8,11 +8,9 @@ NestedInstallerType: nullsoft
 NestedInstallerFiles:
 - RelativeFilePath: firefox\maintenanceservice_installer.exe
 Installers:
-- Architecture: x86
-  InstallerUrl: https://archive.mozilla.org/pub/firefox/candidates/149.0.2-candidates/build1/win32/en-US/firefox-149.0.2.zip
-  InstallerSha256: d25b7ceb295fb5c2b9d48e1c3b52d7243a3f16542636c42da8148e05741d6734
 - Architecture: neutral
   InstallerUrl: https://archive.mozilla.org/pub/firefox/candidates/149.0.2-candidates/build1/win32/en-US/firefox-149.0.2.zip
   InstallerSha256: d25b7ceb295fb5c2b9d48e1c3b52d7243a3f16542636c42da8148e05741d6734
+RequireExplicitUpgrade: true
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/m/Mozilla/MaintenanceService/149.0.2rc1/Mozilla.MaintenanceService.locale.en-US.yaml
+++ b/manifests/m/Mozilla/MaintenanceService/149.0.2rc1/Mozilla.MaintenanceService.locale.en-US.yaml
@@ -4,20 +4,24 @@ PackageIdentifier: Mozilla.MaintenanceService
 PackageVersion: 149.0.2rc1
 PackageLocale: en-US
 Publisher: Mozilla
-PackageName: Mozilla Maintenance Service (Standalone)
+PackageName: Mozilla Maintenance Service (Standalone; not intended for updates)
 PackageUrl: https://archive.mozilla.org/pub/firefox/candidates/
 License: MPL-2.0
-ShortDescription: Standalone installer for Mozilla Maintenance Service, a tool used by Mozilla to more easily update Firefox and Thunderbird installations.
+ShortDescription: Standalone installer for Mozilla Maintenance Service, a tool used by Mozilla to more easily update Firefox and Thunderbird installations. Intended for re-installs / fresh installs of Maintenance Service, and generally not for Maintenance Service updates.
 Description: |-
   Standalone installer for Mozilla Maintenance Service, a tool used by Mozilla to more easily update Firefox and Thunderbird installations.
 
-  The installer comes from Mozilla's well-hid but publicly available "Release Candidates" builds of Firefox, which are likely between Stable and Beta in their channel system, and which have portable Firefox builds available.
+  The installer comes from Mozilla's well-hid but publicly available "Release Candidates" builds of Firefox Stable, as official Firefox portable packages published by Mozilla exist for those.
+
+  The package is mostly intended for anyone wanting re-installs after having previously uninstalled Maintenance Service. If you already have Maintenance Service installed, you probably don't need to update it.
 Tags:
+- maintenanceservice_installer
 - mozilla-maintenance-service
 - mozillamaintenanceservice
 - mozilla-firefox
 - mozillafirefox
 - mozilla-thunderbird
 - mozillathunderbird
+- mms
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?  If so, fill in the Issue number below.
   <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

Manifests
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---
Notes from me:
* Implementing various feedback from #357996 and https://new.reddit.com/r/firefox/comments/1sm28m4/how_do_i_update_mozilla_maintenance_services_mms/ . `RequireExplicitUpgrade` is now set to true; documentation is poor on what exactly that does, but it's maybe a 1-in-3 chance it won't make the package show up in `winget update`. I lacked time to test that.
* As it seems to cause sizable confusion about a new update being available when Mozilla themselves are *very* tight-lipped on Maintenance Service's changelogs and known commits, various clarifications are added that the package is at least *currently* intended for updating existing Maintenance Service installations; and seems unlikely to become intended unless Mozilla starts being (Ironically for them) secretive and with no widely known source code for MMS.
* I lacked the necessary energy this afternoon to change the version number from `149.0.2rc1` to simply `1`, which would have solved at least most of the situation but which would have required me to delete and re-submit the package, and I'd need to build up some goodwill and to display good intentions before that could be done.
* `x86` is removed from the manifest and leaves only the `neutral` arch remaining, to prevent confusion for x64/ARM64 Firefox users.