### PR TITLE
More accurate estimate of its version number + Implemented web feedback: Mozilla.MaintenanceService version 94.0

### DIFF
--- a/manifests/m/Mozilla/MaintenanceService/94.0/Mozilla.MaintenanceService.installer.yaml
+++ b/manifests/m/Mozilla/MaintenanceService/94.0/Mozilla.MaintenanceService.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Mozilla.MaintenanceService
+PackageVersion: "94.0" # The earliest Firefox version known to contain the 2021-07-24 Maintenance Service timestamp version.
+ReleaseDate: 2021-11-02
+InstallerType: zip
+NestedInstallerType: nullsoft
+NestedInstallerFiles:
+- RelativeFilePath: firefox\maintenanceservice_installer.exe
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://archive.mozilla.org/pub/firefox/candidates/149.0.2-candidates/build1/win32/en-US/firefox-149.0.2.zip
+  InstallerSha256: d25b7ceb295fb5c2b9d48e1c3b52d7243a3f16542636c42da8148e05741d6734
+RequireExplicitUpgrade: true
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/Mozilla/MaintenanceService/94.0/Mozilla.MaintenanceService.locale.en-US.yaml
+++ b/manifests/m/Mozilla/MaintenanceService/94.0/Mozilla.MaintenanceService.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Mozilla.MaintenanceService
+PackageVersion: "94.0" # The earliest Firefox version known to contain the 2021-07-24 Maintenance Service timestamp version.
+PackageLocale: en-US
+Publisher: Mozilla
+PackageName: Mozilla Maintenance Service (Standalone)
+PackageUrl: https://archive.mozilla.org/pub/firefox/candidates/
+License: Unclear, presumably MPL-2.0
+ShortDescription: Standalone installer for Mozilla Maintenance Service, a tool used by Mozilla to more easily update Firefox and Thunderbird installations.
+Description: |-
+  Standalone installer for Mozilla Maintenance Service, a tool used by Mozilla to more easily update Firefox and Thunderbird installations.
+
+  The installer comes from Mozilla's well-hid but publicly available "Release Candidates" builds of Firefox Stable, as official Firefox portable packages published by Mozilla exist for those.
+
+  The package is mostly intended for anyone wanting re-installs after having previously uninstalled Maintenance Service, or who use very old Firefox versions. Further oddities are listed in Release Notes below.
+ReleaseNotes: |-
+  Due to the total lack of Mozilla changelogs for Maintenance Service, and in fact that it's unclear if it's open source or not since the location of its source code is unknown, figuring out its version number relies on qualified guesses. There are however at least 2 versions known to exist (1 from 2016 and 1 from 2021), of which this version is the newest of them.
+  • Scanning the installer with MiTeC.ExeExplorer shows its timestamp as being 2021-07-24. This would have made Firefox 91.0 the first Firefox version released after the timestamp.
+  • The first Firefox (non-Beta) Portable "Candidates" build known to include the 2021-07-24 installer version was 94.0, released on 2021-11-01.
+  • The .exe-s all have version numbers of the Firefox versions they are included in, and seemingly all have a file version of 1.0.0.0. This leaves the timestamp as the only somewhat reliable indicator.
+  • For security reasons, the Winget package's installer comes from one bundled with Firefox Portable 149.0.2, even if using the one bundled with Firefox Portable 94.0 would almost certainly be identical.
+Tags:
+- maintenanceservice_installer
+- mozilla-maintenance-service
+- mozillamaintenanceservice
+- mozilla-firefox
+- mozillafirefox
+- mozilla-thunderbird
+- mozillathunderbird
+- mms
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/Mozilla/MaintenanceService/94.0/Mozilla.MaintenanceService.yaml
+++ b/manifests/m/Mozilla/MaintenanceService/94.0/Mozilla.MaintenanceService.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Mozilla.MaintenanceService
+PackageVersion: "94.0"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?  If so, fill in the Issue number below.
   <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

Manifests
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---
Notes from me:
* Pretty much everyone on the planet (Me included, just to have said that) have been completely confused as to how Mozilla Maintenance Service is versioned, as Mozilla's documentation of it is non-existent. Thanks to another Winget package, `MiTeC.ExeExplorer`, I could tell that at least 2 versions of Maintenance Service exist: One from 2016, and one from 2021. As such, I couldn't number it as `1` after all, and instead numbered it for the Firefox version it was first bundled with that I could tell.
* The various changes first attempted in #361084 are carried over into this PR, with the (current?) exception of the "Not intended for upgrades" specifyings, as people seeing `Mozilla.MaintenanceService` when running `winget update` will be drastically reduced.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/361091)