### PR TITLE
Verified Developer Policy for ADO Validation Pipeline

### DIFF
--- a/.github/policies/verifiedDeveloper.yml
+++ b/.github/policies/verifiedDeveloper.yml
@@ -53,5 +53,22 @@ configuration:
 
                 Template: msftbot/verifiedDeveloper/approved
         triggerOnOwnActions: true
+      - description: >-
+          Fallback: When Publisher-Verified is set by wingetbot but
+          Validation-Completed is missing, add it to trigger the merge chain.
+        if:
+          - payloadType: Pull_Request
+          - labelAdded:
+              label: Publisher-Verified
+          - isActivitySender:
+              user: wingetbot
+          - not:
+              hasLabel:
+                label: Validation-Completed
+          - isOpen
+        then:
+          - addLabel:
+              label: Validation-Completed
+        triggerOnOwnActions: true
 onFailure:
 onSuccess:


### PR DESCRIPTION
When Publisher-Verified is set by wingetbot Validation-Completed is missing for Azure DevOps Validation Pipeline. Once the fix is deployed this rule will be deleted.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/361190)