### PR TITLE
﻿Add triggerOnOwnActions to automergeTriggers for Validation-Completed

### DIFF
--- a/.github/policies/automergeTriggers.yml
+++ b/.github/policies/automergeTriggers.yml
@@ -19,5 +19,6 @@ configuration:
         then:
           - enableAutoMerge:
               mergeMethod: Squash
+        triggerOnOwnActions: true
 onFailure:
 onSuccess:


### PR DESCRIPTION
﻿`automergeTriggers.yml` doesn't fire when `Validation-Completed` is added by the policy bot itself. This is because the policy service ignores its own actions by default, and this file never had `triggerOnOwnActions: true`.

**Background**: This has been a recurring issue. In commit `fb56c37` (Mar 2024), a labelAdded condition was added alongside the existing hasLabel as a workaround for auto-merge not being enabled reliably. The hasLabel branch acts as an safety net, it catches the label on subsequent PR events after it's already been set. But when `Validation-Completed` is added by the policy bot and no further PR event follows, neither fires.

**Fix**: Add `triggerOnOwnActions: true` so the rule fires regardless of which actor sets the label.

Flows this fixes:
 - Super-moderator manual validation: [Policy] Manually-Validated adds `Validation-Completed` via the policy bot
 - Waiver PRs: `wingetbotTriggers.yml` adds `Validation-Completed` via the policy bot

The action is idempotent, no loop or side-effect risk. It will also require approval of the PR to merge.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/361219)