### PR TITLE
Wharflab.Tally version 0.33.0

### DIFF
--- a/manifests/w/Wharflab/Tally/0.33.0/Wharflab.Tally.installer.yaml
+++ b/manifests/w/Wharflab/Tally/0.33.0/Wharflab.Tally.installer.yaml
@@ -1,0 +1,26 @@
+# Created by tally release automation
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: Wharflab.Tally
+PackageVersion: 0.33.0
+Commands:
+- tally
+FileExtensions:
+- dockerfile
+- containerfile
+ReleaseDate: '2026-04-15'
+Installers:
+- Architecture: x64
+  InstallerType: portable
+  InstallerUrl: https://github.com/wharflab/tally/releases/download/v0.33.0/tally_0.33.0_Windows_x86_64.exe
+  InstallerSha256: E73EB608D6415745A68965AFF50809278D20C61146C6E8C1C2C9FA6240A25A59
+  Commands:
+  - tally
+- Architecture: arm64
+  InstallerType: portable
+  InstallerUrl: https://github.com/wharflab/tally/releases/download/v0.33.0/tally_0.33.0_Windows_arm64.exe
+  InstallerSha256: B974F5CAE5807ECA5A6C67A4C98AE3D124352057CF55AFD48E1657FB03068B63
+  Commands:
+  - tally
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/w/Wharflab/Tally/0.33.0/Wharflab.Tally.locale.en-US.yaml
+++ b/manifests/w/Wharflab/Tally/0.33.0/Wharflab.Tally.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# Created by tally release automation
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: Wharflab.Tally
+PackageVersion: 0.33.0
+PackageLocale: en-US
+Publisher: Wharflab
+PublisherUrl: https://github.com/wharflab
+PublisherSupportUrl: https://github.com/wharflab/tally/issues
+PackageName: Tally
+PackageUrl: https://github.com/wharflab/tally
+ShortDescription: Dockerfile linter and formatter with first-class PowerShell and
+  Windows container support.
+Moniker: tally
+License: GPL-3.0-only
+LicenseUrl: https://github.com/wharflab/tally/blob/main/LICENSE
+ReleaseNotesUrl: https://github.com/wharflab/tally/releases/tag/v0.33.0
+Documentations:
+- DocumentLabel: Docs
+  DocumentUrl: https://wharflab.github.io/tally/
+Tags:
+- docker
+- dockerfile
+- containerfile
+- linter
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/w/Wharflab/Tally/0.33.0/Wharflab.Tally.yaml
+++ b/manifests/w/Wharflab/Tally/0.33.0/Wharflab.Tally.yaml
@@ -1,0 +1,8 @@
+# Created by tally release automation
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: Wharflab.Tally
+PackageVersion: 0.33.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Publishing version v0.33.0 of [tally](https://github.com/wharflab/tally) to WinGet.

Tally is a Dockerfile linter and formatter written in Go, promoting modern container syntax and helping avoid common pitfalls.

[Changelog](https://github.com/wharflab/tally/releases/tag/v0.33.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/361237)