### PR TITLE
New version: Winix suite v0.2.0 (12 tools)

### DIFF
--- a/manifests/w/Winix/Files/0.2.0/Winix.Files.installer.yaml
+++ b/manifests/w/Winix/Files/0.2.0/Winix.Files.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Winix.Files
+PackageVersion: 0.2.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: files.exe
+    PortableCommandAlias: files
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Yortw/winix/releases/download/v0.2.0/files-win-x64.zip
+    InstallerSha256: 90647AB41DB8E19D09FFD43FC25289166391E4CA4E12F0B87711F2DF9F4463D8
+    UpgradeBehavior: uninstallPrevious
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/w/Winix/Files/0.2.0/Winix.Files.locale.en-US.yaml
+++ b/manifests/w/Winix/Files/0.2.0/Winix.Files.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Winix.Files
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: Troy Willmot
+PublisherUrl: https://github.com/Yortw
+PublisherSupportUrl: https://github.com/Yortw/winix/issues
+PackageName: Winix Files
+PackageUrl: https://github.com/Yortw/winix
+License: MIT
+LicenseUrl: https://github.com/Yortw/winix/blob/main/LICENSE
+ShortDescription: Find files by name, size, date, type, and content. A cross-platform find replacement.
+Tags:
+  - cli
+  - developer-tools
+ReleaseNotesUrl: https://github.com/Yortw/winix/releases/tag/v0.2.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/w/Winix/Files/0.2.0/Winix.Files.yaml
+++ b/manifests/w/Winix/Files/0.2.0/Winix.Files.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Winix.Files
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/manifests/w/Winix/Less/0.2.0/Winix.Less.installer.yaml
+++ b/manifests/w/Winix/Less/0.2.0/Winix.Less.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Winix.Less
+PackageVersion: 0.2.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: less.exe
+    PortableCommandAlias: less
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Yortw/winix/releases/download/v0.2.0/less-win-x64.zip
+    InstallerSha256: B4B820840405952FCBCDEB555E1472B05923A0564D088E566124E154106F103F
+    UpgradeBehavior: uninstallPrevious
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/w/Winix/Less/0.2.0/Winix.Less.locale.en-US.yaml
+++ b/manifests/w/Winix/Less/0.2.0/Winix.Less.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Winix.Less
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: Troy Willmot
+PublisherUrl: https://github.com/Yortw
+PublisherSupportUrl: https://github.com/Yortw/winix/issues
+PackageName: Winix Less
+PackageUrl: https://github.com/Yortw/winix
+License: MIT
+LicenseUrl: https://github.com/Yortw/winix/blob/main/LICENSE
+ShortDescription: Native terminal pager with ANSI colour, search, follow mode, and modern defaults.
+Tags:
+  - cli
+  - developer-tools
+ReleaseNotesUrl: https://github.com/Yortw/winix/releases/tag/v0.2.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/w/Winix/Less/0.2.0/Winix.Less.yaml
+++ b/manifests/w/Winix/Less/0.2.0/Winix.Less.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Winix.Less
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/manifests/w/Winix/Man/0.2.0/Winix.Man.installer.yaml
+++ b/manifests/w/Winix/Man/0.2.0/Winix.Man.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Winix.Man
+PackageVersion: 0.2.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: man.exe
+    PortableCommandAlias: man
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Yortw/winix/releases/download/v0.2.0/man-win-x64.zip
+    InstallerSha256: 2C453FFD287B3EF55F86E7C5170983A93B65E21CCD0BF3B10D159F113505781C
+    UpgradeBehavior: uninstallPrevious
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/w/Winix/Man/0.2.0/Winix.Man.locale.en-US.yaml
+++ b/manifests/w/Winix/Man/0.2.0/Winix.Man.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Winix.Man
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: Troy Willmot
+PublisherUrl: https://github.com/Yortw
+PublisherSupportUrl: https://github.com/Yortw/winix/issues
+PackageName: Winix Man
+PackageUrl: https://github.com/Yortw/winix
+License: MIT
+LicenseUrl: https://github.com/Yortw/winix/blob/main/LICENSE
+ShortDescription: Cross-platform man page viewer with colour, hyperlinks, and pager support.
+Tags:
+  - cli
+  - developer-tools
+ReleaseNotesUrl: https://github.com/Yortw/winix/releases/tag/v0.2.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/w/Winix/Man/0.2.0/Winix.Man.yaml
+++ b/manifests/w/Winix/Man/0.2.0/Winix.Man.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Winix.Man
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/manifests/w/Winix/NetCat/0.2.0/Winix.NetCat.installer.yaml
+++ b/manifests/w/Winix/NetCat/0.2.0/Winix.NetCat.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Winix.NetCat
+PackageVersion: 0.2.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: nc.exe
+    PortableCommandAlias: nc
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Yortw/winix/releases/download/v0.2.0/nc-win-x64.zip
+    InstallerSha256: 3D6B141861493215293E5160B297229C2F611BB098C6458C53206C40B7BF2478
+    UpgradeBehavior: uninstallPrevious
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/w/Winix/NetCat/0.2.0/Winix.NetCat.locale.en-US.yaml
+++ b/manifests/w/Winix/NetCat/0.2.0/Winix.NetCat.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Winix.NetCat
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: Troy Willmot
+PublisherUrl: https://github.com/Yortw
+PublisherSupportUrl: https://github.com/Yortw/winix/issues
+PackageName: Winix NetCat
+PackageUrl: https://github.com/Yortw/winix
+License: MIT
+LicenseUrl: https://github.com/Yortw/winix/blob/main/LICENSE
+ShortDescription: Cross-platform netcat — TCP/UDP send/receive, port checks, TLS clients.
+Tags:
+  - cli
+  - developer-tools
+ReleaseNotesUrl: https://github.com/Yortw/winix/releases/tag/v0.2.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/w/Winix/NetCat/0.2.0/Winix.NetCat.yaml
+++ b/manifests/w/Winix/NetCat/0.2.0/Winix.NetCat.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Winix.NetCat
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/manifests/w/Winix/Peep/0.2.0/Winix.Peep.installer.yaml
+++ b/manifests/w/Winix/Peep/0.2.0/Winix.Peep.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Winix.Peep
+PackageVersion: 0.2.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: peep.exe
+    PortableCommandAlias: peep
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Yortw/winix/releases/download/v0.2.0/peep-win-x64.zip
+    InstallerSha256: 9FEB7937E6AF9CC7836BE8D1958B5F4B31AF032EC6A96FBA7BD2BCB2127596B8
+    UpgradeBehavior: uninstallPrevious
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/w/Winix/Peep/0.2.0/Winix.Peep.locale.en-US.yaml
+++ b/manifests/w/Winix/Peep/0.2.0/Winix.Peep.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Winix.Peep
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: Troy Willmot
+PublisherUrl: https://github.com/Yortw
+PublisherSupportUrl: https://github.com/Yortw/winix/issues
+PackageName: Winix Peep
+PackageUrl: https://github.com/Yortw/winix
+License: MIT
+LicenseUrl: https://github.com/Yortw/winix/blob/main/LICENSE
+ShortDescription: Run a command repeatedly and display output on a refreshing screen.
+Tags:
+  - cli
+  - developer-tools
+ReleaseNotesUrl: https://github.com/Yortw/winix/releases/tag/v0.2.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/w/Winix/Peep/0.2.0/Winix.Peep.yaml
+++ b/manifests/w/Winix/Peep/0.2.0/Winix.Peep.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Winix.Peep
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/manifests/w/Winix/Schedule/0.2.0/Winix.Schedule.installer.yaml
+++ b/manifests/w/Winix/Schedule/0.2.0/Winix.Schedule.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Winix.Schedule
+PackageVersion: 0.2.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: schedule.exe
+    PortableCommandAlias: schedule
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Yortw/winix/releases/download/v0.2.0/schedule-win-x64.zip
+    InstallerSha256: A8C7929EF37C4DCB20B33A13ACDDBEFA485D298B7B20CE4A197797A816DAE314
+    UpgradeBehavior: uninstallPrevious
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/w/Winix/Schedule/0.2.0/Winix.Schedule.locale.en-US.yaml
+++ b/manifests/w/Winix/Schedule/0.2.0/Winix.Schedule.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Winix.Schedule
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: Troy Willmot
+PublisherUrl: https://github.com/Yortw
+PublisherSupportUrl: https://github.com/Yortw/winix/issues
+PackageName: Winix Schedule
+PackageUrl: https://github.com/Yortw/winix
+License: MIT
+LicenseUrl: https://github.com/Yortw/winix/blob/main/LICENSE
+ShortDescription: Cross-platform task scheduler with cron expressions.
+Tags:
+  - cli
+  - developer-tools
+ReleaseNotesUrl: https://github.com/Yortw/winix/releases/tag/v0.2.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/w/Winix/Schedule/0.2.0/Winix.Schedule.yaml
+++ b/manifests/w/Winix/Schedule/0.2.0/Winix.Schedule.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Winix.Schedule
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/manifests/w/Winix/Squeeze/0.2.0/Winix.Squeeze.installer.yaml
+++ b/manifests/w/Winix/Squeeze/0.2.0/Winix.Squeeze.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Winix.Squeeze
+PackageVersion: 0.2.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: squeeze.exe
+    PortableCommandAlias: squeeze
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Yortw/winix/releases/download/v0.2.0/squeeze-win-x64.zip
+    InstallerSha256: 7C69874ECE4B5DF24A5919D65D44DCC432E4ABE5FBF7DAB7840EBBBCC631405B
+    UpgradeBehavior: uninstallPrevious
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/w/Winix/Squeeze/0.2.0/Winix.Squeeze.locale.en-US.yaml
+++ b/manifests/w/Winix/Squeeze/0.2.0/Winix.Squeeze.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Winix.Squeeze
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: Troy Willmot
+PublisherUrl: https://github.com/Yortw
+PublisherSupportUrl: https://github.com/Yortw/winix/issues
+PackageName: Winix Squeeze
+PackageUrl: https://github.com/Yortw/winix
+License: MIT
+LicenseUrl: https://github.com/Yortw/winix/blob/main/LICENSE
+ShortDescription: Compress and decompress files using gzip, brotli, or zstd.
+Tags:
+  - cli
+  - developer-tools
+ReleaseNotesUrl: https://github.com/Yortw/winix/releases/tag/v0.2.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/w/Winix/Squeeze/0.2.0/Winix.Squeeze.yaml
+++ b/manifests/w/Winix/Squeeze/0.2.0/Winix.Squeeze.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Winix.Squeeze
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/manifests/w/Winix/TimeIt/0.2.0/Winix.TimeIt.installer.yaml
+++ b/manifests/w/Winix/TimeIt/0.2.0/Winix.TimeIt.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Winix.TimeIt
+PackageVersion: 0.2.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: timeit.exe
+    PortableCommandAlias: timeit
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Yortw/winix/releases/download/v0.2.0/timeit-win-x64.zip
+    InstallerSha256: F87B7B867D2AFE2A063754DF09F10DF5812E79481DE371D6FD6C9926F2E3AE4D
+    UpgradeBehavior: uninstallPrevious
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/w/Winix/TimeIt/0.2.0/Winix.TimeIt.locale.en-US.yaml
+++ b/manifests/w/Winix/TimeIt/0.2.0/Winix.TimeIt.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Winix.TimeIt
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: Troy Willmot
+PublisherUrl: https://github.com/Yortw
+PublisherSupportUrl: https://github.com/Yortw/winix/issues
+PackageName: Winix TimeIt
+PackageUrl: https://github.com/Yortw/winix
+License: MIT
+LicenseUrl: https://github.com/Yortw/winix/blob/main/LICENSE
+ShortDescription: Time a command — wall clock, CPU time, peak memory, exit code.
+Tags:
+  - cli
+  - developer-tools
+ReleaseNotesUrl: https://github.com/Yortw/winix/releases/tag/v0.2.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/w/Winix/TimeIt/0.2.0/Winix.TimeIt.yaml
+++ b/manifests/w/Winix/TimeIt/0.2.0/Winix.TimeIt.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Winix.TimeIt
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/manifests/w/Winix/TreeX/0.2.0/Winix.TreeX.installer.yaml
+++ b/manifests/w/Winix/TreeX/0.2.0/Winix.TreeX.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Winix.TreeX
+PackageVersion: 0.2.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: treex.exe
+    PortableCommandAlias: treex
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Yortw/winix/releases/download/v0.2.0/treex-win-x64.zip
+    InstallerSha256: C2E057D1D2AF4F860758F0ABC63EB86003BFC852D06A162DFA0392300A076CB9
+    UpgradeBehavior: uninstallPrevious
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/w/Winix/TreeX/0.2.0/Winix.TreeX.locale.en-US.yaml
+++ b/manifests/w/Winix/TreeX/0.2.0/Winix.TreeX.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Winix.TreeX
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: Troy Willmot
+PublisherUrl: https://github.com/Yortw
+PublisherSupportUrl: https://github.com/Yortw/winix/issues
+PackageName: Winix TreeX
+PackageUrl: https://github.com/Yortw/winix
+License: MIT
+LicenseUrl: https://github.com/Yortw/winix/blob/main/LICENSE
+ShortDescription: Enhanced directory tree with colour, filtering, size rollups, gitignore, and clickable hyperlinks.
+Tags:
+  - cli
+  - developer-tools
+ReleaseNotesUrl: https://github.com/Yortw/winix/releases/tag/v0.2.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/w/Winix/TreeX/0.2.0/Winix.TreeX.yaml
+++ b/manifests/w/Winix/TreeX/0.2.0/Winix.TreeX.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Winix.TreeX
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/manifests/w/Winix/Wargs/0.2.0/Winix.Wargs.installer.yaml
+++ b/manifests/w/Winix/Wargs/0.2.0/Winix.Wargs.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Winix.Wargs
+PackageVersion: 0.2.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: wargs.exe
+    PortableCommandAlias: wargs
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Yortw/winix/releases/download/v0.2.0/wargs-win-x64.zip
+    InstallerSha256: 0BB52B27CD35F64C6B35EFFBAA3FA1E6E981A8904E1AE19327D4608345158D8A
+    UpgradeBehavior: uninstallPrevious
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/w/Winix/Wargs/0.2.0/Winix.Wargs.locale.en-US.yaml
+++ b/manifests/w/Winix/Wargs/0.2.0/Winix.Wargs.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Winix.Wargs
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: Troy Willmot
+PublisherUrl: https://github.com/Yortw
+PublisherSupportUrl: https://github.com/Yortw/winix/issues
+PackageName: Winix Wargs
+PackageUrl: https://github.com/Yortw/winix
+License: MIT
+LicenseUrl: https://github.com/Yortw/winix/blob/main/LICENSE
+ShortDescription: Cross-platform xargs replacement with sane defaults.
+Tags:
+  - cli
+  - developer-tools
+ReleaseNotesUrl: https://github.com/Yortw/winix/releases/tag/v0.2.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/w/Winix/Wargs/0.2.0/Winix.Wargs.yaml
+++ b/manifests/w/Winix/Wargs/0.2.0/Winix.Wargs.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Winix.Wargs
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/manifests/w/Winix/WhoHolds/0.2.0/Winix.WhoHolds.installer.yaml
+++ b/manifests/w/Winix/WhoHolds/0.2.0/Winix.WhoHolds.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Winix.WhoHolds
+PackageVersion: 0.2.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: whoholds.exe
+    PortableCommandAlias: whoholds
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Yortw/winix/releases/download/v0.2.0/whoholds-win-x64.zip
+    InstallerSha256: 0D3C7A7BB7DDD5410EED257205067154B96AE664E8F4149D012CC92594998CC5
+    UpgradeBehavior: uninstallPrevious
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/w/Winix/WhoHolds/0.2.0/Winix.WhoHolds.locale.en-US.yaml
+++ b/manifests/w/Winix/WhoHolds/0.2.0/Winix.WhoHolds.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Winix.WhoHolds
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: Troy Willmot
+PublisherUrl: https://github.com/Yortw
+PublisherSupportUrl: https://github.com/Yortw/winix/issues
+PackageName: Winix WhoHolds
+PackageUrl: https://github.com/Yortw/winix
+License: MIT
+LicenseUrl: https://github.com/Yortw/winix/blob/main/LICENSE
+ShortDescription: Find which processes are holding a file lock or binding a network port.
+Tags:
+  - cli
+  - developer-tools
+ReleaseNotesUrl: https://github.com/Yortw/winix/releases/tag/v0.2.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/w/Winix/WhoHolds/0.2.0/Winix.WhoHolds.yaml
+++ b/manifests/w/Winix/WhoHolds/0.2.0/Winix.WhoHolds.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Winix.WhoHolds
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/manifests/w/Winix/Winix/0.2.0/Winix.Winix.installer.yaml
+++ b/manifests/w/Winix/Winix/0.2.0/Winix.Winix.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Winix.Winix
+PackageVersion: 0.2.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: winix.exe
+    PortableCommandAlias: winix
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Yortw/winix/releases/download/v0.2.0/winix-win-x64.zip
+    InstallerSha256: 5F6D9F1CB71334950379AA4D60287F1DFA1C5149336AC5A204456912DC350C5E
+    UpgradeBehavior: uninstallPrevious
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/w/Winix/Winix/0.2.0/Winix.Winix.locale.en-US.yaml
+++ b/manifests/w/Winix/Winix/0.2.0/Winix.Winix.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Winix.Winix
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: Troy Willmot
+PublisherUrl: https://github.com/Yortw
+PublisherSupportUrl: https://github.com/Yortw/winix/issues
+PackageName: Winix Winix
+PackageUrl: https://github.com/Yortw/winix
+License: MIT
+LicenseUrl: https://github.com/Yortw/winix/blob/main/LICENSE
+ShortDescription: Cross-platform installer for the Winix CLI tool suite.
+Tags:
+  - cli
+  - developer-tools
+ReleaseNotesUrl: https://github.com/Yortw/winix/releases/tag/v0.2.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/w/Winix/Winix/0.2.0/Winix.Winix.yaml
+++ b/manifests/w/Winix/Winix/0.2.0/Winix.Winix.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Winix.Winix
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### 12 packages — new versions for Winix CLI tool suite v0.2.0

**Updated packages (v0.1.0 → v0.2.0):**
- Winix.TimeIt
- Winix.Squeeze
- Winix.Peep
- Winix.Wargs
- Winix.Files
- Winix.TreeX

**New packages (first submission):**
- Winix.Man
- Winix.Less
- Winix.WhoHolds
- Winix.Schedule
- Winix.NetCat
- Winix.Winix

All manifests validated locally with `winget validate`. Binaries are Authenticode-signed (Certum Code Signing 2021 CA, "Open Source Developer Troy Willmot").

Release: https://github.com/Yortw/winix/releases/tag/v0.2.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/361359)