### PR TITLE
Add version: OraDBDumpViewer.OraDBDumpViewer version 3.3.1 (deprecation notice)

### DIFF
--- a/manifests/o/OraDBDumpViewer/OraDBDumpViewer/3.3.1/OraDBDumpViewer.OraDBDumpViewer.installer.yaml
+++ b/manifests/o/OraDBDumpViewer/OraDBDumpViewer/3.3.1/OraDBDumpViewer.OraDBDumpViewer.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: OraDBDumpViewer.OraDBDumpViewer
+PackageVersion: 3.3.1
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: inno
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Open-DUMP-Viewer/Open-DUMP-Viewer/releases/download/v3.3.0/OraDBDumpViewer_v3.3.0_installer_x64.exe
+  InstallerSha256: ED625E5E9416C66D70A05EE85628C4A17D213CDFD114F418BD5991D3A2921BFE
+- Architecture: arm64
+  InstallerUrl: https://github.com/Open-DUMP-Viewer/Open-DUMP-Viewer/releases/download/v3.3.0/OraDBDumpViewer_v3.3.0_installer_arm64.exe
+  InstallerSha256: 78D622D0858F62FC946DA042B1F577F1B13BEC6D57B73BF71B367FB378E61DE1
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/o/OraDBDumpViewer/OraDBDumpViewer/3.3.1/OraDBDumpViewer.OraDBDumpViewer.locale.ja-JP.yaml
+++ b/manifests/o/OraDBDumpViewer/OraDBDumpViewer/3.3.1/OraDBDumpViewer.OraDBDumpViewer.locale.ja-JP.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: OraDBDumpViewer.OraDBDumpViewer
+PackageVersion: 3.3.1
+PackageLocale: ja-JP
+Publisher: YANAI Taketo
+PublisherUrl: https://www.odv.dev/
+PackageName: "[非推奨] OraDB DUMP Viewer - OpenDumpViewer.OpenDumpViewer へリネーム"
+PackageUrl: https://www.odv.dev/
+License: Proprietary
+LicenseUrl: https://github.com/Open-DUMP-Viewer/Open-DUMP-Viewer/blob/main/EULA.md
+ShortDescription: "[非推奨] このパッケージは OpenDumpViewer.OpenDumpViewer にリネームされました。新IDをご利用ください。"
+Description: |-
+  ⚠️ このパッケージ `OraDBDumpViewer.OraDBDumpViewer` は非推奨です。
+
+  商標遵守のため、ツール名は v4.0.0 で「OraDB DUMP Viewer」から「Open DUMP Viewer for Oracle database」にリネームされました。Winget パッケージ ID も以下に変更されています:
+
+    winget install OpenDumpViewer.OpenDumpViewer
+
+  ## 移行手順
+
+  1. 旧版をアンインストール: winget uninstall OraDBDumpViewer.OraDBDumpViewer
+  2. 新版をインストール: winget install OpenDumpViewer.OpenDumpViewer
+
+  既存ライセンスキー (ODV-XXXX-XXXX-XXXX 形式) はそのまま有効です。新版の初回起動時にライセンスキーの再入力が必要です。
+
+  詳細: https://github.com/Open-DUMP-Viewer/Open-DUMP-Viewer/blob/main/CHANGELOG.md
+ReleaseNotes: |-
+  [非推奨バージョン] このバージョンは以前のバージョンと同じインストーラーを使用しますが、パッケージ ID のリネーム (OraDBDumpViewer.OraDBDumpViewer → OpenDumpViewer.OpenDumpViewer) をユーザーに通知する目的のみに存在します。
+ReleaseNotesUrl: https://github.com/Open-DUMP-Viewer/Open-DUMP-Viewer/blob/main/CHANGELOG.md
+Tags:
+- oracle
+- dump
+- viewer
+- database
+- deprecated
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/o/OraDBDumpViewer/OraDBDumpViewer/3.3.1/OraDBDumpViewer.OraDBDumpViewer.yaml
+++ b/manifests/o/OraDBDumpViewer/OraDBDumpViewer/3.3.1/OraDBDumpViewer.OraDBDumpViewer.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: OraDBDumpViewer.OraDBDumpViewer
+PackageVersion: 3.3.1
+DefaultLocale: ja-JP
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Deprecation Notice Version

This PR adds **version 3.3.1** of `OraDBDumpViewer.OraDBDumpViewer` as a **deprecation-only version**.

### Why?

The tool has been renamed from "OraDB DUMP Viewer" to "**Open DUMP Viewer for Oracle database**" (v4.0.0) in compliance with Oracle Corporation's trademark policy. The Winget package ID has been migrated to `OpenDumpViewer.OpenDumpViewer` (to be submitted in a separate PR).

This 3.3.1 release:
- **Reuses the v3.3.0 installer binaries** (no new artifact uploaded — same InstallerSha256 as 3.3.0)
- Updates `PackageName`, `ShortDescription`, `Description`, and `ReleaseNotes` to inform users about the rename and guide them to the new package ID
- Ensures users running `winget upgrade` on the old ID see the migration notice

### Migration Path for Users

1. `winget uninstall OraDBDumpViewer.OraDBDumpViewer`
2. `winget install OpenDumpViewer.OpenDumpViewer`

Existing license keys remain valid (`ODV-XXXX-XXXX-XXXX` format unchanged); users will re-authenticate on first launch of v4.0.0.

### Checklist
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-cli/blob/master/schemas/JSON/manifests/v1.6.0/)?

### Related
Full rename details: https://github.com/Open-DUMP-Viewer/Open-DUMP-Viewer/blob/main/CHANGELOG.md
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/361461)