### PR TITLE
New package: co2lab.Polvo version 0.1.0

### DIFF
--- a/manifests/c/co2lab/Polvo/0.1.0/co2lab.Polvo.installer.yaml
+++ b/manifests/c/co2lab/Polvo/0.1.0/co2lab.Polvo.installer.yaml
@@ -9,7 +9,7 @@ InstallModes:
   - silentWithProgress
 Installers:
   - Architecture: x64
-    InstallerUrl: https://github.com/co2-lab/polvo/releases/download/v0.1.0/Polvo_0.1.0_x64_en-US.msi
+    InstallerUrl: https://github.com/co2-lab/polvo/releases/download/v0.1.0/polvo_0.1.0_x64_en-US.msi
     InstallerSha256: 5DD8D7E33C6A6903B77454A2808C6CE55F8CC9ED8253CF7FE630EE21F4A577EE
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/c/co2lab/Polvo/0.1.0/co2lab.Polvo.installer.yaml
+++ b/manifests/c/co2lab/Polvo/0.1.0/co2lab.Polvo.installer.yaml
@@ -1,0 +1,15 @@
+PackageIdentifier: co2lab.Polvo
+PackageVersion: 0.1.0
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: msi
+InstallModes:
+  - silent
+  - silentWithProgress
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/co2-lab/polvo/releases/download/v0.1.0/Polvo_0.1.0_x64_en-US.msi
+    InstallerSha256: 5DD8D7E33C6A6903B77454A2808C6CE55F8CC9ED8253CF7FE630EE21F4A577EE
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/co2lab/Polvo/0.1.0/co2lab.Polvo.installer.yaml
+++ b/manifests/c/co2lab/Polvo/0.1.0/co2lab.Polvo.installer.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 PackageIdentifier: co2lab.Polvo
 PackageVersion: 0.1.0
 Platform:

--- a/manifests/c/co2lab/Polvo/0.1.0/co2lab.Polvo.locale.en-US.yaml
+++ b/manifests/c/co2lab/Polvo/0.1.0/co2lab.Polvo.locale.en-US.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 PackageIdentifier: co2lab.Polvo
 PackageVersion: 0.1.0
 PackageLocale: en-US

--- a/manifests/c/co2lab/Polvo/0.1.0/co2lab.Polvo.locale.en-US.yaml
+++ b/manifests/c/co2lab/Polvo/0.1.0/co2lab.Polvo.locale.en-US.yaml
@@ -1,0 +1,23 @@
+PackageIdentifier: co2lab.Polvo
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: co2lab
+PublisherUrl: https://github.com/co2-lab
+PublisherSupportUrl: https://github.com/co2-lab/polvo/issues
+PackageName: Polvo
+PackageUrl: https://github.com/co2-lab/polvo
+License: Elastic License 2.0
+LicenseUrl: https://github.com/co2-lab/polvo/blob/main/LICENSE
+ShortDescription: AI agent orchestrator for spec-first projects
+Description: Polvo watches your repository for file changes and triggers specialized AI agents to generate, verify, and fix project artifacts via Pull Requests. Includes a built-in web IDE with code editor, integrated terminal, and agent dashboard.
+Moniker: polvo
+Tags:
+  - ai
+  - agent
+  - developer-tools
+  - ide
+  - code-editor
+  - spec-first
+ReleaseNotesUrl: https://github.com/co2-lab/polvo/releases/tag/v0.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/co2lab/Polvo/0.1.0/co2lab.Polvo.yaml
+++ b/manifests/c/co2lab/Polvo/0.1.0/co2lab.Polvo.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 PackageIdentifier: co2lab.Polvo
 PackageVersion: 0.1.0
 DefaultLocale: en-US

--- a/manifests/c/co2lab/Polvo/0.1.0/co2lab.Polvo.yaml
+++ b/manifests/c/co2lab/Polvo/0.1.0/co2lab.Polvo.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: co2lab.Polvo
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## New package submission

**Package:** co2lab.Polvo  
**Version:** 0.1.0

> Replaces #357312 — fixed `PackageIdentifier` from `co2-lab.Polvo` to `co2lab.Polvo` (removed hyphen from publisher name to comply with manifest spec).

## Checklist
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] This PR only modifies one (1) manifest
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/361550)