### PR TITLE
Add Omibranch.Gitty version 2.2.1

### DIFF
--- a/manifests/o/Omibranch/Gitty/2.2.1/Omibranch.Gitty.installer.yaml
+++ b/manifests/o/Omibranch/Gitty/2.2.1/Omibranch.Gitty.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Omibranch.Gitty
+PackageVersion: 2.2.1
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: portable
+InstallModes:
+  - interactive
+  - silent
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Omibranch/gitty/releases/download/v2.2.1/gitty.exe
+    InstallerSha256: 993591FDC58A2A7921CBF8FBF7E6A5A23D268243194151011A6D7F5159E1B29A
+    InstallerType: portable
+    ProductCode: Omibranch.Gitty
+Commands:
+  - gitty
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/o/Omibranch/Gitty/2.2.1/Omibranch.Gitty.locale.en-US.yaml
+++ b/manifests/o/Omibranch/Gitty/2.2.1/Omibranch.Gitty.locale.en-US.yaml
@@ -1,0 +1,21 @@
+PackageIdentifier: Omibranch.Gitty
+PackageVersion: 2.2.1
+PackageLocale: en-US
+Publisher: Omibranch
+PackageName: gitty
+License: MIT
+LicenseUrl: https://github.com/Omibranch/gitty/blob/master/LICENSE
+ShortDescription: Minimal Git & GitHub CLI wrapper — one binary, human-friendly commands
+Description: |-
+  gitty wraps Git and GitHub CLI into short, human-readable commands.
+  'gitty up' replaces the entire add → commit → push cycle.
+  Supports Linux, macOS and Windows. Handles branch management,
+  selective commits, conflict resolution, history tools, .gitignore
+  templates, aliases, proxy support, and command chaining with 'and'.
+Tags:
+  - git
+  - github
+  - cli
+  - developer-tools
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/o/Omibranch/Gitty/2.2.1/Omibranch.Gitty.yaml
+++ b/manifests/o/Omibranch/Gitty/2.2.1/Omibranch.Gitty.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Omibranch.Gitty
+PackageVersion: 2.2.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Add Omibranch.Gitty 2.2.1

This PR adds version 2.2.1 of [gitty](https://github.com/Omibranch/gitty) — a minimal Git & GitHub CLI wrapper.

### Changes in this version
- `gitty fix`: now shows conflict content (mine/theirs) before the choice menu
- Fix: conflict "Abort" properly runs `git rebase --abort` instead of silently returning
- Internal cleanup: removed duplicate function

### Manifest info
- PackageIdentifier: Omibranch.Gitty
- PackageVersion: 2.2.1
- InstallerType: portable
- Architecture: x64
- InstallerUrl: https://github.com/Omibranch/gitty/releases/download/v2.2.1/gitty.exe
- InstallerSha256: 993591FDC58A2A7921CBF8FBF7E6A5A23D268243194151011A6D7F5159E1B29A
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/361629)