### PR TITLE
Add version: OpenDumpViewer.OpenDumpViewer version 3.3.0 (migrated from OraDBDumpViewer)

### DIFF
--- a/manifests/o/OpenDumpViewer/OpenDumpViewer/3.3.0/OpenDumpViewer.OpenDumpViewer.installer.yaml
+++ b/manifests/o/OpenDumpViewer/OpenDumpViewer/3.3.0/OpenDumpViewer.OpenDumpViewer.installer.yaml
@@ -1,0 +1,23 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: OpenDumpViewer.OpenDumpViewer
+PackageVersion: 3.3.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: inno
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/OraDB-DUMP-Viewer/OraDB-DUMP-Viewer/releases/download/v3.3.0/OraDBDumpViewer_v3.3.0_installer_x64.exe
+  InstallerSha256: ED625E5E9416C66D70A05EE85628C4A17D213CDFD114F418BD5991D3A2921BFE
+- Architecture: arm64
+  InstallerUrl: https://github.com/OraDB-DUMP-Viewer/OraDB-DUMP-Viewer/releases/download/v3.3.0/OraDBDumpViewer_v3.3.0_installer_arm64.exe
+  InstallerSha256: 78D622D0858F62FC946DA042B1F577F1B13BEC6D57B73BF71B367FB378E61DE1
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/o/OpenDumpViewer/OpenDumpViewer/3.3.0/OpenDumpViewer.OpenDumpViewer.locale.ja-JP.yaml
+++ b/manifests/o/OpenDumpViewer/OpenDumpViewer/3.3.0/OpenDumpViewer.OpenDumpViewer.locale.ja-JP.yaml
@@ -1,0 +1,19 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: OpenDumpViewer.OpenDumpViewer
+PackageVersion: 3.3.0
+PackageLocale: ja-JP
+Publisher: YANAI Taketo
+PublisherUrl: https://www.odv.dev/
+PackageName: Open DUMP Viewer for Oracle database
+PackageUrl: https://www.odv.dev/
+License: Proprietary
+ShortDescription: Oracle EXP/EXPDP DUMPファイルビューア（旧名 OraDB DUMP Viewer）
+Tags:
+- oracle
+- dump
+- viewer
+- database
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/o/OpenDumpViewer/OpenDumpViewer/3.3.0/OpenDumpViewer.OpenDumpViewer.yaml
+++ b/manifests/o/OpenDumpViewer/OpenDumpViewer/3.3.0/OpenDumpViewer.OpenDumpViewer.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: OpenDumpViewer.OpenDumpViewer
+PackageVersion: 3.3.0
+DefaultLocale: ja-JP
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Migration PR

This PR adds **version 3.3.0** of `OpenDumpViewer.OpenDumpViewer`, migrated from the old package ID `OraDBDumpViewer.OraDBDumpViewer`.

### Context

Per moderator guidance in #361461 and coordination Issue #361676, this is the first migration PR to move existing versions from the old package ID to the new one. The rename is required for Oracle trademark compliance.

### Changes

- Copies the v3.3.0 manifest from `OraDBDumpViewer.OraDBDumpViewer` to `OpenDumpViewer.OpenDumpViewer`
- Updates `PackageIdentifier` and `PackageName` in all manifest files
- `InstallerUrl` and `InstallerSha256` remain unchanged (same binaries, GitHub redirects the old org URL)

### Related

- Migration Issue: #361676
- New v4.0.0 PR: #361462
- Closed deprecation PR: #361461

### Checklist
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-cli/blob/master/schemas/JSON/manifests/v1.6.0/)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/361678)