### PR TITLE
New package: cataggar.ghr version 0.1.6

### DIFF
--- a/manifests/c/cataggar/ghr/0.1.6/cataggar.ghr.installer.yaml
+++ b/manifests/c/cataggar/ghr/0.1.6/cataggar.ghr.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: cataggar.ghr
+PackageVersion: 0.1.6
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: ghr-0.1.6-windows-x64\bin\ghr.exe
+  PortableCommandAlias: ghr
+Commands:
+- ghr
+ReleaseDate: 2026-04-16
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/cataggar/ghr/releases/download/v0.1.6/ghr-0.1.6-windows-x64.zip
+  InstallerSha256: 95B28B98272215588F266AD5DB3D291DE649033F0675F4115CFBA8A380648CBD
+- Architecture: arm64
+  InstallerUrl: https://github.com/cataggar/ghr/releases/download/v0.1.6/ghr-0.1.6-windows-arm64.zip
+  InstallerSha256: 976AF471CC6F8FA4354CE3B9AB35CFD0DF7B2A5D7A23F44BA8F74CEBB31E4C17
+  NestedInstallerFiles:
+  - RelativeFilePath: ghr-0.1.6-windows-arm64\bin\ghr.exe
+    PortableCommandAlias: ghr
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/cataggar/ghr/0.1.6/cataggar.ghr.locale.en-US.yaml
+++ b/manifests/c/cataggar/ghr/0.1.6/cataggar.ghr.locale.en-US.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: cataggar.ghr
+PackageVersion: 0.1.6
+PackageLocale: en-US
+Publisher: cataggar
+PublisherUrl: https://github.com/cataggar
+PublisherSupportUrl: https://github.com/cataggar/ghr/issues
+PackageName: ghr
+PackageUrl: https://github.com/cataggar/ghr
+License: MIT
+LicenseUrl: https://github.com/cataggar/ghr/blob/main/LICENSE
+ShortDescription: An installer for GitHub releases.
+Moniker: ghr
+Tags:
+- cli
+- github
+- installer
+ReleaseNotesUrl: https://github.com/cataggar/ghr/releases/tag/v0.1.6
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/cataggar/ghr/0.1.6/cataggar.ghr.yaml
+++ b/manifests/c/cataggar/ghr/0.1.6/cataggar.ghr.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: cataggar.ghr
+PackageVersion: 0.1.6
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Package update

- **PackageIdentifier**: cataggar.ghr
- **PackageVersion**: 0.1.6
- **Moniker**: ghr

New release with Authenticode-signed binaries (Azure Trusted Signing, subject `CN=Cameron Taggart`). This should resolve the SmartScreen/Mark-of-the-Web hang observed on 0.1.5 during `winget install` (see #361597).

### Checklist

- [x] CLA signed
- [x] One manifest only
- [x] `winget validate --manifest` succeeded
- [x] Conforms to 1.12 schema

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/361697)