### PR TITLE
New version: itsnateai.SyncthingTray version 2.2.6

### DIFF
--- a/manifests/i/itsnateai/SyncthingTray/2.2.6/itsnateai.SyncthingTray.installer.yaml
+++ b/manifests/i/itsnateai/SyncthingTray/2.2.6/itsnateai.SyncthingTray.installer.yaml
@@ -1,0 +1,9 @@
+PackageIdentifier: itsnateai.SyncthingTray
+PackageVersion: 2.2.6
+InstallerType: portable
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/itsnateai/synctray/releases/download/v2.2.6/SyncthingTray.exe
+    InstallerSha256: 5D8AC3F964C058E6BBDDBFE003C53CD0EE22337F827A31024655B6321956EA9E
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/i/itsnateai/SyncthingTray/2.2.6/itsnateai.SyncthingTray.locale.en-US.yaml
+++ b/manifests/i/itsnateai/SyncthingTray/2.2.6/itsnateai.SyncthingTray.locale.en-US.yaml
@@ -1,0 +1,18 @@
+PackageIdentifier: itsnateai.SyncthingTray
+PackageVersion: 2.2.6
+PackageLocale: en-US
+Publisher: itsnateai
+PublisherUrl: https://github.com/itsnateai
+PackageName: SyncthingTray
+PackageUrl: https://github.com/itsnateai/synctray
+License: MIT
+LicenseUrl: https://github.com/itsnateai/synctray/blob/main/LICENSE
+ShortDescription: Lightweight system tray manager for Syncthing on Windows
+Description: System tray utility for monitoring and controlling Syncthing. Quick-access rescan, configurable click actions, sound notifications.
+Tags:
+  - syncthing
+  - file-sync
+  - system-tray
+  - backup
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/i/itsnateai/SyncthingTray/2.2.6/itsnateai.SyncthingTray.yaml
+++ b/manifests/i/itsnateai/SyncthingTray/2.2.6/itsnateai.SyncthingTray.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: itsnateai.SyncthingTray
+PackageVersion: 2.2.6
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Adds SyncthingTray v2.2.6.

- Portable x64 single-file exe
- Release: https://github.com/itsnateai/synctray/releases/tag/v2.2.6
- SHA256 published alongside binary in release assets

### Checklist
- [x] I have read the [contribution guidelines](https://github.com/microsoft/winget-pkgs/blob/master/CONTRIBUTING.md).
- [x] I have verified that the installer works as expected.
- [x] I have tested the manifest using `winget validate --manifest <path>`.
- [x] Installer SHA256 matches the binary on the release page.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/361763)