### PR TITLE
New version: itsnateai.MWBToggle version 2.5.2

### DIFF
--- a/manifests/i/itsnateai/MWBToggle/2.5.2/itsnateai.MWBToggle.installer.yaml
+++ b/manifests/i/itsnateai/MWBToggle/2.5.2/itsnateai.MWBToggle.installer.yaml
@@ -1,0 +1,15 @@
+# Created with manual editing
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: itsnateai.MWBToggle
+PackageVersion: 2.5.2
+InstallerType: portable
+UpgradeBehavior: uninstallPrevious
+ReleaseDate: 2026-04-17
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/itsnateai/MousewithoutBordersToggle/releases/download/v2.5.2/MWBToggle.exe
+    InstallerSha256: 98E2B190FBCD3654EBC3AE5AD602FE6F0D1A87AFFFEA7EB6B7D50A6DE09493D7
+    PortableCommandAlias: mwbtoggle
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/i/itsnateai/MWBToggle/2.5.2/itsnateai.MWBToggle.locale.en-US.yaml
+++ b/manifests/i/itsnateai/MWBToggle/2.5.2/itsnateai.MWBToggle.locale.en-US.yaml
@@ -1,0 +1,38 @@
+# Created with manual editing
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: itsnateai.MWBToggle
+PackageVersion: 2.5.2
+PackageLocale: en-US
+Publisher: itsnateai
+PublisherUrl: https://github.com/itsnateai
+PublisherSupportUrl: https://github.com/itsnateai/MousewithoutBordersToggle/issues
+Author: itsnateai
+PackageName: MWBToggle
+PackageUrl: https://github.com/itsnateai/MousewithoutBordersToggle
+License: MIT
+LicenseUrl: https://github.com/itsnateai/MousewithoutBordersToggle/blob/main/LICENSE
+Copyright: Copyright (c) 2026 itsNate
+ShortDescription: Toggle Mouse Without Borders clipboard and file sharing on/off
+Description: |-
+  Stop Mouse Without Borders from intercepting local copy/paste, prevent lag on large file copies. Hotkey plus tray icon, zero CPU when idle. Pinned OSD bubble above the system tray confirms every toggle.
+Moniker: mwbtoggle
+Tags:
+  - mouse-without-borders
+  - clipboard
+  - system-tray
+  - productivity
+  - tray
+  - toggle
+  - powertoys
+ReleaseNotes: |-
+  v2.5.2 — Microsoft-user LTR hardening:
+  - OSD tooltip works for top/left/right taskbars (fixes v2.5.1 regression)
+  - Update downloads re-validate the allowlist on every redirect hop
+  - Run-at-Startup shortcut self-heals after winget upgrade
+  - Enter and Esc now work in every dialog
+  - Screen-reader descriptions on all dialog buttons
+  - Explorer file properties now show Product, Company, Copyright, and File Version
+ReleaseNotesUrl: https://github.com/itsnateai/MousewithoutBordersToggle/releases/tag/v2.5.2
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/i/itsnateai/MWBToggle/2.5.2/itsnateai.MWBToggle.yaml
+++ b/manifests/i/itsnateai/MWBToggle/2.5.2/itsnateai.MWBToggle.yaml
@@ -1,0 +1,8 @@
+# Created with manual editing
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: itsnateai.MWBToggle
+PackageVersion: 2.5.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary

New version of `itsnateai.MWBToggle` — **2.5.2**. This is the new LTR (Long-Term Release). Supersedes the stale PR #361664 (2.5.0) — see note below.

## What's new in the manifest vs v2.4.3

- **`UpgradeBehavior: uninstallPrevious`** — required for a running tray app. Without this, `winget upgrade` fails with "file in use" because the running exe holds a lock on itself (portable installer type, no uninstaller to stop it first).
- **`PortableCommandAlias: mwbtoggle`** — enables terminal invocation after install.
- **Richer locale fields** — `Moniker`, `Author`, `Copyright`, `PublisherSupportUrl`, `ReleaseNotes`, `ReleaseNotesUrl`.

## Integrity

- `InstallerUrl`: https://github.com/itsnateai/MousewithoutBordersToggle/releases/download/v2.5.2/MWBToggle.exe
- `InstallerSha256`: `98E2B190FBCD3654EBC3AE5AD602FE6F0D1A87AFFFEA7EB6B7D50A6DE09493D7` — matches the SHA256SUMS asset published alongside the exe on the v2.5.2 GitHub Release.

## Supersedes

Please close #361664 (v2.5.0) in favor of this PR. v2.5.0 and v2.5.1 were transitional; existing v2.4.3 users should skip directly to v2.5.2.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/microsoft/winget-pkgs/blob/master/CONTRIBUTING.md).
- [x] This is a new version manifest for an existing package I publish.
- [x] I have verified the `InstallerSha256` against the published release's `SHA256SUMS`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/361764)