### PR TITLE
Package Update: Flowersauce.FSClicker v1.3.1

### DIFF
--- a/manifests/f/Flowersauce/FSClicker/1.3.1/Flowersauce.FSClicker.installer.yaml
+++ b/manifests/f/Flowersauce/FSClicker/1.3.1/Flowersauce.FSClicker.installer.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Flowersauce.FSClicker
+PackageVersion: 1.3.1
+InstallerType: exe
+Scope: user
+InstallModes:
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: --silent
+  SilentWithProgress: --silent
+UpgradeBehavior: install
+ProductCode: Flowersauce.FSClicker
+AppsAndFeaturesEntries:
+- DisplayName: FSClicker
+  DisplayVersion: 1.3.1
+  Publisher: Flowersauce
+  ProductCode: Flowersauce.FSClicker
+  InstallerType: exe
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/flowersauce/FSClicker/releases/download/v1.3.1/FSClicker-v1.3.1-windows-x64-setup.exe
+  InstallerSha256: fbdc997e895b6b9b58948866ec77830f4dc9d0686601338cc6212250c9a4bf0f
+  ProductCode: Flowersauce.FSClicker
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Flowersauce/FSClicker/1.3.1/Flowersauce.FSClicker.locale.en-US.yaml
+++ b/manifests/f/Flowersauce/FSClicker/1.3.1/Flowersauce.FSClicker.locale.en-US.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Flowersauce.FSClicker
+PackageVersion: 1.3.1
+PackageLocale: en-US
+Publisher: Flowersauce
+PublisherUrl: https://github.com/flowersauce
+PublisherSupportUrl: https://github.com/flowersauce/FSClicker/issues
+PackageName: FSClicker
+PackageUrl: https://github.com/flowersauce/FSClicker
+License: MIT
+LicenseUrl: https://github.com/flowersauce/FSClicker/blob/main/LICENSE
+ShortDescription: A lightweight auto clicker for Windows.
+Tags:
+- auto-clicker
+- clicker
+- input
+- windows
+ReleaseNotesUrl: https://github.com/flowersauce/FSClicker/releases/tag/v1.3.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Flowersauce/FSClicker/1.3.1/Flowersauce.FSClicker.yaml
+++ b/manifests/f/Flowersauce/FSClicker/1.3.1/Flowersauce.FSClicker.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Flowersauce.FSClicker
+PackageVersion: 1.3.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
  Package update for Flowersauce.FSClicker to version 1.3.1.

  - Updated installer URL to the v1.3.1 GitHub Release
  - Updated InstallerSha256
  - Validated locally with `winget validate`
  - Tested local install and uninstall with `winget install --manifest` and `winget uninstall --product-code`

  Checklist:
  - [x] Have you checked that there aren't other open pull requests for the same package update?
  - [x] This PR only modifies one (1) manifest
  - [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
  - [x] Have you tested your manifest locally with `winget install --manifest <path>`?
  - [x] Does your manifest conform to the schema?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/361803)