### PR TITLE
New package: ahadulla.yoz version 0.1.0

### DIFF
--- a/manifests/a/ahadulla/yoz/0.1.0/ahadulla.yoz.installer.yaml
+++ b/manifests/a/ahadulla/yoz/0.1.0/ahadulla.yoz.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: ahadulla.yoz
+PackageVersion: 0.1.0
+MinimumOSVersion: 10.0.0.0
+Installers:
+  - Architecture: x64
+    InstallerType: msi
+    InstallerUrl: https://github.com/ahadulla/yoz/releases/download/v0.1.0/yoz-0.1.0-x86_64.msi
+    InstallerSha256: C69D0AF0637B8F0BED0EB1B55732E405CC66CAC42D8E78D38F3BC6B0528CDCAE
+    UpgradeBehavior: install
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/a/ahadulla/yoz/0.1.0/ahadulla.yoz.locale.en-US.yaml
+++ b/manifests/a/ahadulla/yoz/0.1.0/ahadulla.yoz.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: ahadulla.yoz
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Ahadulla
+PublisherUrl: https://github.com/ahadulla
+PackageName: yoz
+PackageUrl: https://github.com/ahadulla/yoz
+License: MIT
+LicenseUrl: https://github.com/ahadulla/yoz/blob/main/LICENSE
+ShortDescription: A simple, fast terminal text editor inspired by nano
+Description: |-
+  yoz is a terminal-based text editor written in Rust.
+  Nano-style, no modal editing — start typing immediately.
+  Features include multi-encoding support, clipboard, undo/redo,
+  search/replace, adaptive scroll, and draggable scrollbar.
+Tags:
+  - cli
+  - editor
+  - rust
+  - terminal
+  - text-editor
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/a/ahadulla/yoz/0.1.0/ahadulla.yoz.yaml
+++ b/manifests/a/ahadulla/yoz/0.1.0/ahadulla.yoz.yaml
@@ -1,0 +1,8 @@
+# Created using winget create
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: ahadulla.yoz
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package submission

- Package: ahadulla.yoz
- Version: 0.1.0
- URL: https://github.com/ahadulla/yoz
- License: MIT

### Description
yoz is a simple, fast terminal text editor written in Rust, inspired by nano. No modal editing — start typing immediately. Features include multi-encoding support (UTF-8, UTF-16, CP1251, CP1252, CP866), clipboard, undo/redo, search/replace, adaptive scroll, and draggable scrollbar.

### Checklist
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/creation?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/361838)