### PR TITLE
Fix invalid MSI switch in Maxprograms.TMXValidator 2.7.0

### DIFF
--- a/manifests/m/Maxprograms/TMXValidator/2.7.0/Maxprograms.TMXValidator.installer.yaml
+++ b/manifests/m/Maxprograms/TMXValidator/2.7.0/Maxprograms.TMXValidator.installer.yaml
@@ -14,6 +14,6 @@ Installers:
   InstallerUrl: https://www.maxprograms.com/downloads/TMXValidator/TMXValidator-2.7.0_64bit.msi
   InstallerSha256: 6371C7ECED279B3C9981864127047E03539F285CC931188527CBC3549226DD6F
 InstallerSwitches:
-  Silent: /s
+  Silent: /quiet
 ManifestType: installer
 ManifestVersion: 1.9.0


### PR DESCRIPTION
Change Silent installer switch from /s (invalid for msiexec) to /quiet.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/361939)