### PR TITLE
Fix invalid MSI switches in Mozilla.Thunderbird 102.4.2

### DIFF
--- a/manifests/m/Mozilla/Thunderbird/102.4.2/Mozilla.Thunderbird.installer.yaml
+++ b/manifests/m/Mozilla/Thunderbird/102.4.2/Mozilla.Thunderbird.installer.yaml
@@ -3,16 +3,13 @@
 
 PackageIdentifier: Mozilla.Thunderbird
 PackageVersion: 102.4.2
-InstallerSwitches:
-  Silent: -ms
-  SilentWithProgress: -ms
 UpgradeBehavior: install
 Commands:
 - thunderbird
 Installers:
 - InstallerLocale: en-US
   Architecture: x64
-  InstallerType: msi
+  InstallerType: wix
   InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/102.4.2/win64/en-US/Thunderbird%20Setup%20102.4.2.msi
   InstallerSha256: B7336F13AF32C4C431399C9C3148FB924D4DA80FF075C0069353ACCBAEC3217D
   ProductCode: '{18D4D2F4-B394-48A2-8886-9C68180CEAD5}'
@@ -21,10 +18,13 @@ Installers:
   InstallerType: exe
   InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/102.4.2/win32/en-US/Thunderbird%20Setup%20102.4.2.exe
   InstallerSha256: 00D22D985B6EC800E7324E44A0C151AAD77395ACC477A01415AA7016B09836BA
+  InstallerSwitches:
+    Silent: -ms
+    SilentWithProgress: -ms
   ProductCode: '{18D4D2F4-B394-48A2-8886-9C68180CEAD5}'
 - InstallerLocale: en-GB
   Architecture: x64
-  InstallerType: msi
+  InstallerType: wix
   InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/102.4.2/win64/en-GB/Thunderbird%20Setup%20102.4.2.msi
   InstallerSha256: 22E1D463A4CC8A392560725CB3089DC20C818C4C55F84033292CA34EE1F057C1
   ProductCode: '{18D4D2F4-B394-48A2-8886-9C68180CEAD5}'
@@ -33,10 +33,13 @@ Installers:
   InstallerType: exe
   InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/102.4.2/win32/en-GB/Thunderbird%20Setup%20102.4.2.exe
   InstallerSha256: 1A3CB50E9EC8BA73BDBF3471857F05867801C41C565D25D028C24F7AB4C47EB3
+  InstallerSwitches:
+    Silent: -ms
+    SilentWithProgress: -ms
   ProductCode: '{18D4D2F4-B394-48A2-8886-9C68180CEAD5}'
 - InstallerLocale: de-DE
   Architecture: x64
-  InstallerType: msi
+  InstallerType: wix
   InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/102.4.2/win64/de/Thunderbird%20Setup%20102.4.2.msi
   InstallerSha256: 858F8276884532B08C93C38AA7D6B908254C0818D35E65A264C0E6194AED342F
   ProductCode: '{18D4D2F4-B394-48A2-8886-9C68180CEAD5}'
@@ -45,6 +48,9 @@ Installers:
   InstallerType: exe
   InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/102.4.2/win32/de/Thunderbird%20Setup%20102.4.2.exe
   InstallerSha256: BC15E868EC457CC9DAE9F926CE36C3F015CE017A3182E0BDB4D3C678A59F13DB
+  InstallerSwitches:
+    Silent: -ms
+    SilentWithProgress: -ms
   ProductCode: '{18D4D2F4-B394-48A2-8886-9C68180CEAD5}'
 ManifestType: installer
 ManifestVersion: 1.2.0

--- a/manifests/m/Mozilla/Thunderbird/102.4.2/Mozilla.Thunderbird.installer.yaml
+++ b/manifests/m/Mozilla/Thunderbird/102.4.2/Mozilla.Thunderbird.installer.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.1.2.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
 
 PackageIdentifier: Mozilla.Thunderbird
 PackageVersion: 102.4.2
@@ -53,5 +53,5 @@ Installers:
     SilentWithProgress: -ms
   ProductCode: '{18D4D2F4-B394-48A2-8886-9C68180CEAD5}'
 ManifestType: installer
-ManifestVersion: 1.2.0
+ManifestVersion: 1.5.0
 

--- a/manifests/m/Mozilla/Thunderbird/102.4.2/Mozilla.Thunderbird.locale.de-DE.yaml
+++ b/manifests/m/Mozilla/Thunderbird/102.4.2/Mozilla.Thunderbird.locale.de-DE.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.1.2.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.5.0.schema.json
 
 PackageIdentifier: Mozilla.Thunderbird
 PackageVersion: 102.4.2
@@ -23,5 +23,5 @@ Tags:
 - mail
 ReleaseNotesUrl: https://www.thunderbird.net/en-US/thunderbird/102.4.2/releasenotes/
 ManifestType: locale
-ManifestVersion: 1.2.0
+ManifestVersion: 1.5.0
 

--- a/manifests/m/Mozilla/Thunderbird/102.4.2/Mozilla.Thunderbird.locale.en-US.yaml
+++ b/manifests/m/Mozilla/Thunderbird/102.4.2/Mozilla.Thunderbird.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.1.2.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
 
 PackageIdentifier: Mozilla.Thunderbird
 PackageVersion: 102.4.2
@@ -22,5 +22,5 @@ Tags:
 - mail
 ReleaseNotesUrl: https://www.thunderbird.net/thunderbird/102.4.2/releasenotes/
 ManifestType: defaultLocale
-ManifestVersion: 1.2.0
+ManifestVersion: 1.5.0
 

--- a/manifests/m/Mozilla/Thunderbird/102.4.2/Mozilla.Thunderbird.yaml
+++ b/manifests/m/Mozilla/Thunderbird/102.4.2/Mozilla.Thunderbird.yaml
@@ -1,9 +1,9 @@
 # Created using wingetcreate 1.1.2.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
 
 PackageIdentifier: Mozilla.Thunderbird
 PackageVersion: 102.4.2
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.2.0
+ManifestVersion: 1.5.0
 


### PR DESCRIPTION
- Remove top-level InstallerSwitches (Silent/SilentWithProgress: -ms) which was incorrectly applied to MSI installer types
- Change InstallerType from msi to wix for .msi installers
- Add per-installer InstallerSwitches (Silent/SilentWithProgress: -ms) only to EXE installers
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/361940)