### PR TITLE
Fix invalid MSI switches in Mozilla.Thunderbird 102.5.0

### DIFF
--- a/manifests/m/Mozilla/Thunderbird/102.5.0/Mozilla.Thunderbird.installer.yaml
+++ b/manifests/m/Mozilla/Thunderbird/102.5.0/Mozilla.Thunderbird.installer.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.1.2.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
 
 PackageIdentifier: Mozilla.Thunderbird
 PackageVersion: 102.5.0
@@ -53,5 +53,5 @@ Installers:
     SilentWithProgress: -ms
   ProductCode: '{18D4D2F4-B394-48A2-8886-9C68180CEAD5}'
 ManifestType: installer
-ManifestVersion: 1.2.0
+ManifestVersion: 1.5.0
 

--- a/manifests/m/Mozilla/Thunderbird/102.5.0/Mozilla.Thunderbird.installer.yaml
+++ b/manifests/m/Mozilla/Thunderbird/102.5.0/Mozilla.Thunderbird.installer.yaml
@@ -3,16 +3,13 @@
 
 PackageIdentifier: Mozilla.Thunderbird
 PackageVersion: 102.5.0
-InstallerSwitches:
-  Silent: -ms
-  SilentWithProgress: -ms
 UpgradeBehavior: install
 Commands:
 - thunderbird
 Installers:
 - InstallerLocale: en-US
   Architecture: x64
-  InstallerType: msi
+  InstallerType: wix
   InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/102.5.0/win64/en-US/Thunderbird%20Setup%20102.5.0.msi
   InstallerSha256: FC932B8744E3FAC2DC6B9738CC9838382C99C6EF40044EC13AF7DA77E798339C
   ProductCode: '{18D4D2F4-B394-48A2-8886-9C68180CEAD5}'
@@ -21,10 +18,13 @@ Installers:
   InstallerType: exe
   InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/102.5.0/win32/en-US/Thunderbird%20Setup%20102.5.0.exe
   InstallerSha256: 7AEEDDD172455299B3A5FB26E90055BD09A330800E691C279E8E636328E7585E
+  InstallerSwitches:
+    Silent: -ms
+    SilentWithProgress: -ms
   ProductCode: '{18D4D2F4-B394-48A2-8886-9C68180CEAD5}'
 - InstallerLocale: en-GB
   Architecture: x64
-  InstallerType: msi
+  InstallerType: wix
   InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/102.5.0/win64/en-GB/Thunderbird%20Setup%20102.5.0.msi
   InstallerSha256: 9D5560FDEF2BB8346982AAFF10996851B5E4D7C089C100629CC2FB99DFDC96AC
   ProductCode: '{18D4D2F4-B394-48A2-8886-9C68180CEAD5}'
@@ -33,10 +33,13 @@ Installers:
   InstallerType: exe
   InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/102.5.0/win32/en-GB/Thunderbird%20Setup%20102.5.0.exe
   InstallerSha256: 166B912E269EC36801B2517A7930BB60F1A4E7DB22F476C06395DEA7C454DD11
+  InstallerSwitches:
+    Silent: -ms
+    SilentWithProgress: -ms
   ProductCode: '{18D4D2F4-B394-48A2-8886-9C68180CEAD5}'
 - InstallerLocale: de-DE
   Architecture: x64
-  InstallerType: msi
+  InstallerType: wix
   InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/102.5.0/win64/de/Thunderbird%20Setup%20102.5.0.msi
   InstallerSha256: EC95B231F187C6E3693800F6E32A66974F6562D4991E9AFA2A01FDE532E11863
   ProductCode: '{18D4D2F4-B394-48A2-8886-9C68180CEAD5}'
@@ -45,6 +48,9 @@ Installers:
   InstallerType: exe
   InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/102.5.0/win32/de/Thunderbird%20Setup%20102.5.0.exe
   InstallerSha256: 5B0C873E66B41590C7BC29D63E90B20DB2C1E6997F276F80CF94CE8E96564957
+  InstallerSwitches:
+    Silent: -ms
+    SilentWithProgress: -ms
   ProductCode: '{18D4D2F4-B394-48A2-8886-9C68180CEAD5}'
 ManifestType: installer
 ManifestVersion: 1.2.0

--- a/manifests/m/Mozilla/Thunderbird/102.5.0/Mozilla.Thunderbird.locale.de-DE.yaml
+++ b/manifests/m/Mozilla/Thunderbird/102.5.0/Mozilla.Thunderbird.locale.de-DE.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.1.2.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.5.0.schema.json
 
 PackageIdentifier: Mozilla.Thunderbird
 PackageVersion: 102.5.0
@@ -16,5 +16,5 @@ LicenseUrl: https://www.mozilla.org/en-US/MPL/2.0/
 CopyrightUrl: https://www.mozilla.org/en-US/foundation/trademarks/policy/
 ShortDescription: Mozilla Thunderbird ist ein freies E-Mail-Programm und zugleich Personal Information Manager (mit CalDAV-Unterstützung), Feedreader, Newsreader sowie Messaging- und Chat-Client (XMPP und IRC).
 ManifestType: locale
-ManifestVersion: 1.2.0
+ManifestVersion: 1.5.0
 

--- a/manifests/m/Mozilla/Thunderbird/102.5.0/Mozilla.Thunderbird.locale.en-US.yaml
+++ b/manifests/m/Mozilla/Thunderbird/102.5.0/Mozilla.Thunderbird.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.1.2.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
 
 PackageIdentifier: Mozilla.Thunderbird
 PackageVersion: 102.5.0
@@ -21,5 +21,5 @@ Tags:
 - e-mail
 - mail
 ManifestType: defaultLocale
-ManifestVersion: 1.2.0
+ManifestVersion: 1.5.0
 

--- a/manifests/m/Mozilla/Thunderbird/102.5.0/Mozilla.Thunderbird.yaml
+++ b/manifests/m/Mozilla/Thunderbird/102.5.0/Mozilla.Thunderbird.yaml
@@ -1,9 +1,9 @@
 # Created using wingetcreate 1.1.2.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
 
 PackageIdentifier: Mozilla.Thunderbird
 PackageVersion: 102.5.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.2.0
+ManifestVersion: 1.5.0
 


### PR DESCRIPTION
- Remove top-level InstallerSwitches (Silent/SilentWithProgress: -ms) which was incorrectly applied to MSI installer types
- Change InstallerType from msi to wix for .msi installers
- Add per-installer InstallerSwitches (Silent/SilentWithProgress: -ms) only to EXE installers
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/361941)