### PR TITLE
Fix invalid MSI switches in Mozilla.Thunderbird 102.5.1

### DIFF
--- a/manifests/m/Mozilla/Thunderbird/102.5.1/Mozilla.Thunderbird.installer.yaml
+++ b/manifests/m/Mozilla/Thunderbird/102.5.1/Mozilla.Thunderbird.installer.yaml
@@ -3,16 +3,13 @@
 
 PackageIdentifier: Mozilla.Thunderbird
 PackageVersion: 102.5.1
-InstallerSwitches:
-  Silent: -ms
-  SilentWithProgress: -ms
 UpgradeBehavior: install
 Commands:
 - thunderbird
 Installers:
 - InstallerLocale: en-US
   Architecture: x64
-  InstallerType: msi
+  InstallerType: wix
   InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/102.5.1/win64/en-US/Thunderbird%20Setup%20102.5.1.msi
   InstallerSha256: 53FD96D80CEA31D0F971CD1B2F77C4D6DE2B23793A1BE42763A7D5D61451FC34
   ProductCode: '{18D4D2F4-B394-48A2-8886-9C68180CEAD5}'
@@ -21,10 +18,13 @@ Installers:
   InstallerType: exe
   InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/102.5.1/win32/en-US/Thunderbird%20Setup%20102.5.1.exe
   InstallerSha256: A99DE4AFA3EE30B8E3B2DFBA6E645741895C7B1A12ADC575F28741BB90F3826B
+  InstallerSwitches:
+    Silent: -ms
+    SilentWithProgress: -ms
   ProductCode: '{18D4D2F4-B394-48A2-8886-9C68180CEAD5}'
 - InstallerLocale: en-GB
   Architecture: x64
-  InstallerType: msi
+  InstallerType: wix
   InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/102.5.1/win64/en-GB/Thunderbird%20Setup%20102.5.1.msi
   InstallerSha256: CF415B7775580FDA0F7842844048269621ED68FC800BF84D7F378D1A47E6E8E6
   ProductCode: '{18D4D2F4-B394-48A2-8886-9C68180CEAD5}'
@@ -33,10 +33,13 @@ Installers:
   InstallerType: exe
   InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/102.5.1/win32/en-GB/Thunderbird%20Setup%20102.5.1.exe
   InstallerSha256: CF10E72B145734A12DEC7064875777D16F929971D8943BA3DAF2716F95E0F029
+  InstallerSwitches:
+    Silent: -ms
+    SilentWithProgress: -ms
   ProductCode: '{18D4D2F4-B394-48A2-8886-9C68180CEAD5}'
 - InstallerLocale: de-DE
   Architecture: x64
-  InstallerType: msi
+  InstallerType: wix
   InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/102.5.1/win64/de/Thunderbird%20Setup%20102.5.1.msi
   InstallerSha256: 4E4A776244C8342217ED75E75FCE995CD75FE9BDEC1162BAC318D01AE101A790
   ProductCode: '{18D4D2F4-B394-48A2-8886-9C68180CEAD5}'
@@ -45,6 +48,9 @@ Installers:
   InstallerType: exe
   InstallerUrl: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/102.5.1/win32/de/Thunderbird%20Setup%20102.5.1.exe
   InstallerSha256: E5D87619403C2A997BE94BF73EECC55ABD910386574F406A142F39E361FABF1E
+  InstallerSwitches:
+    Silent: -ms
+    SilentWithProgress: -ms
   ProductCode: '{18D4D2F4-B394-48A2-8886-9C68180CEAD5}'
 ManifestType: installer
 ManifestVersion: 1.2.0

--- a/manifests/m/Mozilla/Thunderbird/102.5.1/Mozilla.Thunderbird.installer.yaml
+++ b/manifests/m/Mozilla/Thunderbird/102.5.1/Mozilla.Thunderbird.installer.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.1.2.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
 
 PackageIdentifier: Mozilla.Thunderbird
 PackageVersion: 102.5.1
@@ -53,5 +53,5 @@ Installers:
     SilentWithProgress: -ms
   ProductCode: '{18D4D2F4-B394-48A2-8886-9C68180CEAD5}'
 ManifestType: installer
-ManifestVersion: 1.2.0
+ManifestVersion: 1.5.0
 

--- a/manifests/m/Mozilla/Thunderbird/102.5.1/Mozilla.Thunderbird.locale.de-DE.yaml
+++ b/manifests/m/Mozilla/Thunderbird/102.5.1/Mozilla.Thunderbird.locale.de-DE.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.1.2.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.5.0.schema.json
 
 PackageIdentifier: Mozilla.Thunderbird
 PackageVersion: 102.5.1
@@ -16,5 +16,5 @@ LicenseUrl: https://www.mozilla.org/en-US/MPL/2.0/
 CopyrightUrl: https://www.mozilla.org/en-US/foundation/trademarks/policy/
 ShortDescription: Mozilla Thunderbird ist ein freies E-Mail-Programm und zugleich Personal Information Manager (mit CalDAV-Unterstützung), Feedreader, Newsreader sowie Messaging- und Chat-Client (XMPP und IRC).
 ManifestType: locale
-ManifestVersion: 1.2.0
+ManifestVersion: 1.5.0
 

--- a/manifests/m/Mozilla/Thunderbird/102.5.1/Mozilla.Thunderbird.locale.en-US.yaml
+++ b/manifests/m/Mozilla/Thunderbird/102.5.1/Mozilla.Thunderbird.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.1.2.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
 
 PackageIdentifier: Mozilla.Thunderbird
 PackageVersion: 102.5.1
@@ -21,5 +21,5 @@ Tags:
 - e-mail
 - mail
 ManifestType: defaultLocale
-ManifestVersion: 1.2.0
+ManifestVersion: 1.5.0
 

--- a/manifests/m/Mozilla/Thunderbird/102.5.1/Mozilla.Thunderbird.yaml
+++ b/manifests/m/Mozilla/Thunderbird/102.5.1/Mozilla.Thunderbird.yaml
@@ -1,9 +1,9 @@
 # Created using wingetcreate 1.1.2.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
 
 PackageIdentifier: Mozilla.Thunderbird
 PackageVersion: 102.5.1
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.2.0
+ManifestVersion: 1.5.0
 


### PR DESCRIPTION
- Remove top-level InstallerSwitches (Silent/SilentWithProgress: -ms) which was incorrectly applied to MSI installer types
- Change InstallerType from msi to wix for .msi installers
- Add per-installer InstallerSwitches (Silent/SilentWithProgress: -ms) only to EXE installers
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/361943)