### PR TITLE
Fix invalid MSI switch in Perforce.P4V 234.255.8838

### DIFF
--- a/manifests/p/Perforce/P4V/234.255.8838/Perforce.P4V.installer.yaml
+++ b/manifests/p/Perforce/P4V/234.255.8838/Perforce.P4V.installer.yaml
@@ -6,7 +6,7 @@ PackageVersion: 234.255.8838
 InstallerLocale: en-US
 MinimumOSVersion: 10.0.0.0
 InstallerSwitches:
-  Silent: /s
+  Silent: /quiet
   SilentWithProgress: /passive
   Custom: /norestart
 UpgradeBehavior: install


### PR DESCRIPTION
Change Silent installer switch from /s (invalid for msiexec) to /quiet.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/361944)