### PR TITLE
Fix invalid MSI switch in Pharoproject.PharoLauncher 3.0.1

### DIFF
--- a/manifests/p/Pharoproject/PharoLauncher/3.0.1/Pharoproject.PharoLauncher.installer.yaml
+++ b/manifests/p/Pharoproject/PharoLauncher/3.0.1/Pharoproject.PharoLauncher.installer.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.2.5.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.4.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
 
 PackageIdentifier: Pharoproject.PharoLauncher
 PackageVersion: 3.0.1
@@ -11,4 +11,4 @@ Installers:
   InstallerSha256: A91D6CE1A47FC8CAA7CD644717CA0FE5971C806E4BE7C617441E6FA665AEC7DD
   ProductCode: '{AF4F82A9-ED2B-4697-8FF4-F7D84021A836}'
 ManifestType: installer
-ManifestVersion: 1.4.0
+ManifestVersion: 1.5.0

--- a/manifests/p/Pharoproject/PharoLauncher/3.0.1/Pharoproject.PharoLauncher.installer.yaml
+++ b/manifests/p/Pharoproject/PharoLauncher/3.0.1/Pharoproject.PharoLauncher.installer.yaml
@@ -9,8 +9,6 @@ Installers:
   InstallerType: msi
   InstallerUrl: https://files.pharo.org/pharo-launcher/3.0.1/pharo-launcher-3.0.1.msi
   InstallerSha256: A91D6CE1A47FC8CAA7CD644717CA0FE5971C806E4BE7C617441E6FA665AEC7DD
-  InstallerSwitches:
-    InstallLocation: C:\Program Files\Pharo Launcher
   ProductCode: '{AF4F82A9-ED2B-4697-8FF4-F7D84021A836}'
 ManifestType: installer
 ManifestVersion: 1.4.0

--- a/manifests/p/Pharoproject/PharoLauncher/3.0.1/Pharoproject.PharoLauncher.locale.en-US.yaml
+++ b/manifests/p/Pharoproject/PharoLauncher/3.0.1/Pharoproject.PharoLauncher.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.2.5.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.4.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
 
 PackageIdentifier: Pharoproject.PharoLauncher
 PackageVersion: 3.0.1
@@ -9,4 +9,4 @@ PackageName: PharoLauncher
 License: MIT License
 ShortDescription: Pharo is a pure object-oriented programming language and a powerful environment, focused on simplicity and immediate feedback
 ManifestType: defaultLocale
-ManifestVersion: 1.4.0
+ManifestVersion: 1.5.0

--- a/manifests/p/Pharoproject/PharoLauncher/3.0.1/Pharoproject.PharoLauncher.yaml
+++ b/manifests/p/Pharoproject/PharoLauncher/3.0.1/Pharoproject.PharoLauncher.yaml
@@ -1,8 +1,8 @@
 # Created using wingetcreate 1.2.5.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.4.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
 
 PackageIdentifier: Pharoproject.PharoLauncher
 PackageVersion: 3.0.1
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.4.0
+ManifestVersion: 1.5.0


### PR DESCRIPTION
Remove InstallerSwitches.InstallLocation with hardcoded path which was not a valid msiexec switch format.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/361945)