### PR TITLE
New version: M-Igashi.headroom version 1.8.0

### DIFF
--- a/manifests/m/M-Igashi/headroom/1.8.0/M-Igashi.headroom.installer.yaml
+++ b/manifests/m/M-Igashi/headroom/1.8.0/M-Igashi.headroom.installer.yaml
@@ -1,0 +1,19 @@
+# Created with manual update
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.headroom
+PackageVersion: 1.8.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: headroom.exe
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Gyan.FFmpeg
+ReleaseDate: 2026-04-17
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/M-Igashi/headroom/releases/download/v1.8.0/headroom-v1.8.0-windows-x86_64.zip
+    InstallerSha256: 8D9A681BFF1691D3BF555AC4AFBD70D1CD001186B7C08D7683F0479823988075
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/headroom/1.8.0/M-Igashi.headroom.locale.en-US.yaml
+++ b/manifests/m/M-Igashi/headroom/1.8.0/M-Igashi.headroom.locale.en-US.yaml
@@ -1,0 +1,39 @@
+# Created with manual update
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.headroom
+PackageVersion: 1.8.0
+PackageLocale: en-US
+Publisher: M-Igashi
+PublisherUrl: https://github.com/M-Igashi
+PublisherSupportUrl: https://github.com/M-Igashi/headroom/issues
+Author: M-Igashi
+PackageName: headroom
+PackageUrl: https://github.com/M-Igashi/headroom
+License: MIT
+LicenseUrl: https://github.com/M-Igashi/headroom/blob/main/LICENSE
+ShortDescription: Audio loudness analyzer and gain adjustment tool for mastering and DJ workflows
+Description: |-
+  headroom analyzes audio files for loudness (LUFS) and headroom, then applies lossless gain adjustment.
+  It supports MP3, AAC/M4A, FLAC, AIFF, and WAV files.
+  Features include batch processing, ReplayGain analysis, lossless MP3 gain via mp3rgain, lossless AAC/M4A gain adjustment, and a scriptable non-interactive CLI mode for pipelines and CI.
+Moniker: headroom
+Tags:
+  - aac
+  - audio
+  - cli
+  - dj
+  - ffmpeg
+  - gain
+  - loudness
+  - lufs
+  - mastering
+  - mp3
+  - music
+  - normalize
+  - replaygain
+  - rust
+  - volume
+ReleaseNotesUrl: https://github.com/M-Igashi/headroom/releases/tag/v1.8.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/headroom/1.8.0/M-Igashi.headroom.yaml
+++ b/manifests/m/M-Igashi/headroom/1.8.0/M-Igashi.headroom.yaml
@@ -1,0 +1,8 @@
+# Created with manual update
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.headroom
+PackageVersion: 1.8.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New version: M-Igashi.headroom version 1.8.0

- Add scriptable / non-interactive CLI mode (paths, globs, and flags `--lossless`, `--reencode`, `--backup`, `--report`, `--analyze-only`); bare `headroom` still runs the interactive wizard
- Update mp3rgain from 2.1.0 to 2.2.1 (drop-in upgrade; Symphonia 0.6 integration improves MP3 True Peak detection accuracy)
- Internal refactor: unified MP3/AAC re-encode helpers, simplified parallel analysis collection
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/361985)