### PR TITLE
Add version: OpenDumpViewer.OpenDumpViewer version 1.2.12 (migrated from OraDBDumpViewer)

### DIFF
--- a/manifests/o/OpenDumpViewer/OpenDumpViewer/1.2.12/OpenDumpViewer.OpenDumpViewer.installer.yaml
+++ b/manifests/o/OpenDumpViewer/OpenDumpViewer/1.2.12/OpenDumpViewer.OpenDumpViewer.installer.yaml
@@ -1,0 +1,23 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: OpenDumpViewer.OpenDumpViewer
+PackageVersion: 1.2.12
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: msi
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/OraDB-DUMP-Viewer/OraDB-DUMP-Viewer/releases/download/v1.2.12/OraDBDumpViewer_v1.2.12_installer_x64.msi
+  InstallerSha256: 20941ED59F838FE19037581782A55C2B760D39EFC6AC51AA182BB33D1633213D
+- Architecture: arm64
+  InstallerUrl: https://github.com/OraDB-DUMP-Viewer/OraDB-DUMP-Viewer/releases/download/v1.2.12/OraDBDumpViewer_v1.2.12_installer_arm64.msi
+  InstallerSha256: DA2AC6D8312A767910622D36F5B35E6F8CE5BEF2E8C5010472D7644656DFC4C6
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/o/OpenDumpViewer/OpenDumpViewer/1.2.12/OpenDumpViewer.OpenDumpViewer.locale.ja-JP.yaml
+++ b/manifests/o/OpenDumpViewer/OpenDumpViewer/1.2.12/OpenDumpViewer.OpenDumpViewer.locale.ja-JP.yaml
@@ -1,0 +1,19 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: OpenDumpViewer.OpenDumpViewer
+PackageVersion: 1.2.12
+PackageLocale: ja-JP
+Publisher: YANAI Taketo
+PublisherUrl: https://www.odv.dev/
+PackageName: Open DUMP Viewer for Oracle database
+PackageUrl: https://www.odv.dev/
+License: Proprietary
+ShortDescription: Oracle EXP/EXPDP DUMPファイルビューア
+Tags:
+- oracle
+- dump
+- viewer
+- database
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/o/OpenDumpViewer/OpenDumpViewer/1.2.12/OpenDumpViewer.OpenDumpViewer.yaml
+++ b/manifests/o/OpenDumpViewer/OpenDumpViewer/1.2.12/OpenDumpViewer.OpenDumpViewer.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: OpenDumpViewer.OpenDumpViewer
+PackageVersion: 1.2.12
+DefaultLocale: ja-JP
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Migrating v1.2.12 from `OraDBDumpViewer.OraDBDumpViewer` to `OpenDumpViewer.OpenDumpViewer` per #361676 (Oracle trademark compliance). PackageIdentifier and PackageName updated; InstallerUrl and InstallerSha256 unchanged.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/362026)