### PR TITLE
Update willibrandon.dotsider-mcp to 0.12.2

### DIFF
--- a/manifests/w/willibrandon/dotsider-mcp/0.12.2/willibrandon.dotsider-mcp.installer.yaml
+++ b/manifests/w/willibrandon/dotsider-mcp/0.12.2/willibrandon.dotsider-mcp.installer.yaml
@@ -1,0 +1,27 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: willibrandon.dotsider-mcp
+PackageVersion: 0.12.2
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.18362.0
+InstallerType: msi
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/willibrandon/dotsider/releases/download/v0.12.2/dotsider-mcp-win-x64.msi
+  InstallerSha256: 2986205E48EB9DA56875536DE36BFFDC2193B42A2DACCB07B024F9A23F46BCC7
+  ProductCode: '{129E4792-D867-4EE4-825A-D9BF5B1D6C61}'
+- Architecture: arm64
+  InstallerUrl: https://github.com/willibrandon/dotsider/releases/download/v0.12.2/dotsider-mcp-win-arm64.msi
+  InstallerSha256: 10CC90DA69A7AEBEC16D11B3EE95386D2E210BD43B5E9F0E13B381763EE92D02
+  ProductCode: '{D5CA7C0E-942F-47A6-AA9C-10189BD5483A}'
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-04-18

--- a/manifests/w/willibrandon/dotsider-mcp/0.12.2/willibrandon.dotsider-mcp.locale.en-US.yaml
+++ b/manifests/w/willibrandon/dotsider-mcp/0.12.2/willibrandon.dotsider-mcp.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: willibrandon.dotsider-mcp
+PackageVersion: 0.12.2
+PackageLocale: en-US
+Publisher: willibrandon
+PublisherUrl: https://github.com/willibrandon
+PublisherSupportUrl: https://github.com/willibrandon/dotsider/issues
+PackageName: dotsider-mcp
+PackageUrl: https://github.com/willibrandon/dotsider
+License: MIT
+LicenseUrl: https://github.com/willibrandon/dotsider/blob/main/LICENSE
+ShortDescription: MCP server for AI-assisted .NET assembly analysis
+Description: |-
+  dotsider-mcp is a standalone Model Context Protocol server that exposes
+  dotsider's .NET assembly analysis engine to AI coding assistants like
+  Claude Code, VS Code Copilot, and others. It provides 28 tools for
+  assembly analysis, IL disassembly, metadata inspection, dependency graphs,
+  size analysis, string extraction, diffing, and runtime tracing.
+Tags:
+- dotnet
+- assembly
+- mcp
+- ai
+- analysis
+- il
+- metadata
+- devtools
+ReleaseNotesUrl: https://github.com/willibrandon/dotsider/releases/tag/v0.12.2
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/willibrandon/dotsider/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/w/willibrandon/dotsider-mcp/0.12.2/willibrandon.dotsider-mcp.yaml
+++ b/manifests/w/willibrandon/dotsider-mcp/0.12.2/willibrandon.dotsider-mcp.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: willibrandon.dotsider-mcp
+PackageVersion: 0.12.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Update dotsider-mcp to version 0.12.2

## Release notes

https://github.com/willibrandon/dotsider/releases/tag/v0.12.2
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/362095)