### PR TITLE
New version: WarpSend.WarpSend version 18e442f

### DIFF
--- a/manifests/w/WarpSend/WarpSend/18e442f/WarpSend.WarpSend.installer.yaml
+++ b/manifests/w/WarpSend/WarpSend/18e442f/WarpSend.WarpSend.installer.yaml
@@ -1,0 +1,22 @@
+# Installer manifest — tells WinGet how to fetch + register the binary.
+#
+# `portable` installer type is the WinGet equivalent of a brew "binary"
+# formula: WinGet downloads the .zip, extracts to its own packages dir,
+# and registers a shim (`warpsend.exe`) on PATH. No MSI / NSIS needed,
+# no admin rights, no SmartScreen prompt for the installer itself.
+PackageIdentifier: WarpSend.WarpSend
+PackageVersion: 18e442f
+
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: warpsend.exe
+    PortableCommandAlias: warpsend
+
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://app.warpsend.io/_agent/downloads/warpsend-x86_64-pc-windows-gnu.zip
+    InstallerSha256: 19941dd308039194def0549f1355ba0f55d9a1faa93f19ddf3d4fe7c38259f1b
+
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/w/WarpSend/WarpSend/18e442f/WarpSend.WarpSend.locale.en-US.yaml
+++ b/manifests/w/WarpSend/WarpSend/18e442f/WarpSend.WarpSend.locale.en-US.yaml
@@ -6,12 +6,10 @@ PackageVersion: 18e442f
 PackageLocale: en-US
 Publisher: WarpSend
 PublisherUrl: https://warpsend.io
-PublisherSupportUrl: https://warpsend.io/support
 Author: WarpSend
 PackageName: WarpSend
 PackageUrl: https://warpsend.io
 License: MIT
-LicenseUrl: https://github.com/ychiu1211/warpsend/blob/main/LICENSE
 ShortDescription: NAS-to-NAS large file transfer over Cloudflare R2.
 Description: |-
   WarpSend is a thin CLI for moving large files between NAS / Linux / macOS
@@ -23,6 +21,11 @@ Tags:
   - nas
   - cloudflare
   - cli
-ReleaseNotesUrl: https://github.com/ychiu1211/warpsend/releases
 ManifestType: defaultLocale
 ManifestVersion: 1.6.0
+# Optional URL fields (PublisherSupportUrl, LicenseUrl, ReleaseNotesUrl)
+# are intentionally omitted. The source repo is private, so the GitHub
+# /LICENSE and /releases pages 404, and there is no public /support
+# subpath on warpsend.io yet. wingetbot validates every URL — adding a
+# field that 404s blocks the PR. Add them back if/when these pages
+# become public.

--- a/manifests/w/WarpSend/WarpSend/18e442f/WarpSend.WarpSend.locale.en-US.yaml
+++ b/manifests/w/WarpSend/WarpSend/18e442f/WarpSend.WarpSend.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# Locale manifest — user-facing description shown in `winget show` and
+# the WinGet website. Required because the version manifest declares
+# DefaultLocale: en-US.
+PackageIdentifier: WarpSend.WarpSend
+PackageVersion: 18e442f
+PackageLocale: en-US
+Publisher: WarpSend
+PublisherUrl: https://warpsend.io
+PublisherSupportUrl: https://warpsend.io/support
+Author: WarpSend
+PackageName: WarpSend
+PackageUrl: https://warpsend.io
+License: MIT
+LicenseUrl: https://github.com/ychiu1211/warpsend/blob/main/LICENSE
+ShortDescription: NAS-to-NAS large file transfer over Cloudflare R2.
+Description: |-
+  WarpSend is a thin CLI for moving large files between NAS / Linux / macOS
+  endpoints across regions, using Cloudflare R2 as a relay. After
+  installation, run `warpsend run` to bootstrap the local agent and open
+  the management UI.
+Tags:
+  - file-transfer
+  - nas
+  - cloudflare
+  - cli
+ReleaseNotesUrl: https://github.com/ychiu1211/warpsend/releases
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/w/WarpSend/WarpSend/18e442f/WarpSend.WarpSend.yaml
+++ b/manifests/w/WarpSend/WarpSend/18e442f/WarpSend.WarpSend.yaml
@@ -1,0 +1,8 @@
+# Version manifest — top-level descriptor for the package version.
+# Rendered by scripts/update-winget-manifest.sh; do not edit the generated
+# version/ subdirectory by hand.
+PackageIdentifier: WarpSend.WarpSend
+PackageVersion: 18e442f
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Initial submission for WarpSend.WarpSend

WarpSend is a thin CLI for moving large files between NAS / Linux / macOS endpoints across regions, using Cloudflare R2 as a relay. After installation, end users run \`warpsend run\` to bootstrap the local agent and open the management UI.

## Manifest details

- **Package:** WarpSend.WarpSend
- **Version:** 18e442f (7-char git short SHA — Cargo.toml version is frozen at 0.1.0; runtime build identification flows through the warpsend-build-info crate)
- **Architecture:** x64
- **InstallerType:** zip with NestedInstallerType: portable (registers a \`warpsend\` shim on PATH, no MSI/NSIS, no admin rights)
- **InstallerUrl:** https://app.warpsend.io/_agent/downloads/warpsend-x86_64-pc-windows-gnu.zip
- **InstallerSha256:** 19941dd308039194def0549f1355ba0f55d9a1faa93f19ddf3d4fe7c38259f1b

## Code signing

The binary is **not code-signed**. End users will see a SmartScreen prompt on first launch (one-click bypass). Documented trade-off; reputation will build over time. We may revisit with an OV cert if Windows install volume justifies the recurring cost.

## Verified locally

- Manifest schema validated against ManifestVersion 1.6.0
- InstallerSha256 matches the actual file at the InstallerUrl
- Zip contains exactly \`warpsend.exe\` at the top level (matches \`RelativeFilePath: warpsend.exe\`)

## Publisher identity

I'm the author of warpsend.io. Happy to confirm via DNS TXT record on warpsend.io or by emailing wingetpkgs@microsoft.com from an @warpsend.io address if needed for first-time publisher verification.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/362278)