### PR TITLE
Add Echowire.Echowire version 1.20.0

### DIFF
--- a/manifests/e/Echowire/Echowire/1.20.0/Echowire.Echowire.installer.yaml
+++ b/manifests/e/Echowire/Echowire/1.20.0/Echowire.Echowire.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Echowire.Echowire
+PackageVersion: 1.20.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: /S /currentuser
+  SilentWithProgress: /S /currentuser
+UpgradeBehavior: install
+ReleaseDate: 2026-04-17
+Installers:
+- Architecture: x64
+  InstallerUrl: https://echowire.org/dl/desktop/stable/win32/x64/Echowire-1.20.0-x64.exe
+  InstallerSha256: 460B40969BBAA2B8DA5339273646958FCF6FDD2DBE983069C38322C455C522C0
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/e/Echowire/Echowire/1.20.0/Echowire.Echowire.locale.en-US.yaml
+++ b/manifests/e/Echowire/Echowire/1.20.0/Echowire.Echowire.locale.en-US.yaml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Echowire.Echowire
+PackageVersion: 1.20.0
+PackageLocale: en-US
+Publisher: Proudlock Technology LLC
+PublisherUrl: https://echowire.org
+PublisherSupportUrl: https://echowire.org/help
+Author: Proudlock Technology LLC
+PackageName: Echowire
+PackageUrl: https://echowire.org/download
+License: AGPL-3.0-or-later
+LicenseUrl: https://github.com/cproudlock/fluxer/blob/echowire/LICENSE
+Copyright: Copyright (c) 2026 Proudlock Technology LLC
+ShortDescription: Self-hosted, federated chat platform with voice, video, threads, and scheduled events.
+Description: |-
+  Echowire is a self-hosted, open-source chat platform offering Discord-style guilds,
+  channels, threads, scheduled events, voice and video calls with WebRTC, custom
+  soundboards, passkey authentication, and direct messages. Built for communities
+  that want full control of their data without compromising on features. Supports
+  federation between instances. AGPL-3.0 licensed.
+Moniker: echowire
+Tags:
+- chat
+- voice
+- video
+- messaging
+- voip
+- communities
+- self-hosted
+- federated
+- open-source
+- discord-alternative
+ReleaseNotesUrl: https://echowire.org
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/e/Echowire/Echowire/1.20.0/Echowire.Echowire.yaml
+++ b/manifests/e/Echowire/Echowire/1.20.0/Echowire.Echowire.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Echowire.Echowire
+PackageVersion: 1.20.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## What

Updates the winget manifest for **Echowire** (`Echowire.Echowire`) to version **1.20.0**.

## Changes from 1.17.0

- **Now code-signed** with Azure Trusted Signing (Proudlock Technology LLC certificate)
- Publisher updated to Proudlock Technology LLC
- Support URL updated to https://echowire.org/help
- Download URL updated to https://echowire.org/download

## Manifest details

- **PackageIdentifier:** `Echowire.Echowire`
- **PackageVersion:** `1.20.0`
- **InstallerType:** `nullsoft` (NSIS, `oneClick: false`, `perMachine: false`)
- **Architecture:** x64
- **Scope:** user
- **Silent install:** `/S /currentuser`
- **InstallerUrl:** `https://echowire.org/dl/desktop/stable/win32/x64/Echowire-1.20.0-x64.exe`
- **InstallerSha256:** `460B40969BBAA2B8DA5339273646958FCF6FDD2DBE983069C38322C455C522C0`
- **License:** `AGPL-3.0-or-later`

## Verification

- [x] SHA256 verified
- [x] Installer is now signed with Azure Trusted Signing (Proudlock Technology LLC)
- [x] Manifest schema 1.12.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/362410)