### PR TITLE
New package: DimitarRadenkov.Pointframe version 5.1.1

### DIFF
--- a/manifests/d/DimitarRadenkov/Pointframe/5.1.1/DimitarRadenkov.Pointframe.installer.yaml
+++ b/manifests/d/DimitarRadenkov/Pointframe/5.1.1/DimitarRadenkov.Pointframe.installer.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: DimitarRadenkov.Pointframe
+PackageVersion: 5.1.1
+InstallerLocale: en-US
+InstallerType: inno
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+ProductCode: '{A3F2C1D0-8B4E-4F7A-9C6D-0E5B2A1F3E8C}_is1'
+ReleaseDate: 2026-04-19
+AppsAndFeaturesEntries:
+  - Publisher: Dimitris
+    ProductCode: '{A3F2C1D0-8B4E-4F7A-9C6D-0E5B2A1F3E8C}_is1'
+ElevationRequirement: elevatesSelf
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles%\Pointframe'
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/dimitar-radenkov/Pointframe/releases/download/v5.1.1/Pointframe-5.1.1-Setup.exe
+    InstallerSha256: E1284B20DB203CF55FD56A9F4E3F5CD4F7F4F4C11FBAACC1B87491AF159BF695
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/d/DimitarRadenkov/Pointframe/5.1.1/DimitarRadenkov.Pointframe.installer.yaml
+++ b/manifests/d/DimitarRadenkov/Pointframe/5.1.1/DimitarRadenkov.Pointframe.installer.yaml
@@ -11,11 +11,11 @@ InstallModes:
 InstallerSwitches:
   Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
   SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
-ProductCode: '{A3F2C1D0-8B4E-4F7A-9C6D-0E5B2A1F3E8C}_is1'
+ProductCode: '{67DE561D-F02A-4E9F-AF4A-44D98A092D54}_is1'
 ReleaseDate: 2026-04-19
 AppsAndFeaturesEntries:
   - Publisher: Dimitris
-    ProductCode: '{A3F2C1D0-8B4E-4F7A-9C6D-0E5B2A1F3E8C}_is1'
+    ProductCode: '{67DE561D-F02A-4E9F-AF4A-44D98A092D54}_is1'
 ElevationRequirement: elevatesSelf
 InstallationMetadata:
   DefaultInstallLocation: '%ProgramFiles%\Pointframe'

--- a/manifests/d/DimitarRadenkov/Pointframe/5.1.1/DimitarRadenkov.Pointframe.locale.en-US.yaml
+++ b/manifests/d/DimitarRadenkov/Pointframe/5.1.1/DimitarRadenkov.Pointframe.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: DimitarRadenkov.Pointframe
+PackageVersion: 5.1.1
+PackageLocale: en-US
+Publisher: Dimitar Radenkov
+PublisherUrl: https://github.com/dimitar-radenkov
+PublisherSupportUrl: https://github.com/dimitar-radenkov/Pointframe/issues
+PackageName: Pointframe
+PackageUrl: https://github.com/dimitar-radenkov/Pointframe
+License: MIT
+LicenseUrl: https://github.com/dimitar-radenkov/Pointframe/blob/master/LICENSE
+Copyright: Copyright (c) Dimitar Radenkov
+ShortDescription: Open-source Windows screen capture and recording tool with OCR and annotation
+Description: |-
+  Pointframe is a lightweight Windows screen capture and annotation tool.
+  Press Print Screen to draw a region, annotate with arrows, shapes, text, blur,
+  and numbered steps, then copy to clipboard, pin as a floating always-on-top window,
+  or record your screen to MP4 with optional microphone audio. Includes built-in OCR
+  to extract text from any screenshot. No subscription, no telemetry.
+Moniker: pointframe
+Tags:
+  - annotation
+  - ocr
+  - screen-capture
+  - screen-recorder
+  - screenshot
+  - windows
+  - wpf
+ReleaseNotes: |-
+  First Pointframe-branded winget package submission.
+  Full Changelog: https://github.com/dimitar-radenkov/Pointframe/compare/v5.0.3...v5.1.1
+ReleaseNotesUrl: https://github.com/dimitar-radenkov/Pointframe/releases/tag/v5.1.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/d/DimitarRadenkov/Pointframe/5.1.1/DimitarRadenkov.Pointframe.yaml
+++ b/manifests/d/DimitarRadenkov/Pointframe/5.1.1/DimitarRadenkov.Pointframe.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: DimitarRadenkov.Pointframe
+PackageVersion: 5.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Summary
- add the initial WinGet package manifests for `DimitarRadenkov.Pointframe`
- publish version `5.1.1`
- point the installer manifest at the GitHub release asset for `Pointframe-5.1.1-Setup.exe`

## Context
This is the first Pointframe-branded package submission after the project rename from SnippingTool. Historical `DimitarRadenkov.SnippingTool` manifests remain intact; future automated updates will target `DimitarRadenkov.Pointframe` once this initial package exists upstream.

## Validation
- installer URL is live
- SHA-256 matches the published release asset digest
- local `winget validate --manifest` succeeded for the submitted manifest directory

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/362456)