### PR TITLE
New version: zhitong.SoloMD version 1.0.0

### DIFF
--- a/manifests/z/zhitong/SoloMD/1.0.0/zhitong.SoloMD.installer.yaml
+++ b/manifests/z/zhitong/SoloMD/1.0.0/zhitong.SoloMD.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: zhitong.SoloMD
+PackageVersion: 1.0.0
+MinimumOSVersion: 10.0.17763.0
+InstallerType: wix
+UpgradeBehavior: install
+FileExtensions:
+- md
+- markdown
+- mdown
+- mkd
+- txt
+ReleaseDate: 2026-04-19
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/zhitongblog/solomd/releases/download/v1.0.0/SoloMD_1.0.0_x64_en-US.msi
+  InstallerSha256: AECF415F429213E13A7B3598D7E3A11EE0BE0BE9A0C227846BF2684BDA5AABBC
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/z/zhitong/SoloMD/1.0.0/zhitong.SoloMD.locale.en-US.yaml
+++ b/manifests/z/zhitong/SoloMD/1.0.0/zhitong.SoloMD.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: zhitong.SoloMD
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: zhitong
+PublisherUrl: https://github.com/zhitongblog
+PublisherSupportUrl: https://github.com/zhitongblog/solomd/issues
+PackageName: SoloMD
+PackageUrl: https://solomd.app
+License: MIT
+LicenseUrl: https://github.com/zhitongblog/solomd/blob/main/LICENSE
+Copyright: Copyright (c) 2026 xiangdong li
+ShortDescription: A lightweight Markdown and plain text editor
+Description: |-
+  SoloMD is a free, open-source, cross-platform Markdown + plain text editor
+  built with Tauri 2 + Vue 3 + CodeMirror 6. Under 15 MB installed. First
+  1.0 release — also available on iOS / Mac App Store.
+Moniker: solomd
+Tags:
+- editor
+- markdown
+- text-editor
+- tauri
+- vim
+ReleaseNotesUrl: https://github.com/zhitongblog/solomd/releases/tag/v1.0.0
+Documentations:
+- DocumentLabel: Website
+  DocumentUrl: https://solomd.app
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/z/zhitong/SoloMD/1.0.0/zhitong.SoloMD.yaml
+++ b/manifests/z/zhitong/SoloMD/1.0.0/zhitong.SoloMD.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: zhitong.SoloMD
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Adds the 1.0.0 manifest for zhitong.SoloMD.

- Version: 1.0.0 (first stable / major release — also now on iOS App Store and Mac App Store)
- Installer: x64 Wix MSI from https://github.com/zhitongblog/solomd/releases/tag/v1.0.0
- Supersedes my earlier open PRs #361313 (v0.1.10), #361772 (v0.1.11), #361882 (v0.1.12) — I'll close them after this one is merged.

### Checks

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://learn.microsoft.com/en-us/windows/package-manager/package/manifest?tabs=manifestproperties#validate-manifest) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.9.md)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/362474)