### PR TITLE
Remove x86 installers for GIMP 3.2.4

### DIFF
--- a/manifests/g/GIMP/GIMP/3/3.2.4.0/GIMP.GIMP.3.installer.yaml
+++ b/manifests/g/GIMP/GIMP/3/3.2.4.0/GIMP.GIMP.3.installer.yaml
@@ -1,4 +1,3 @@
-# Created with YamlCreate.ps1 Dumplings Mod
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: GIMP.GIMP.3

--- a/manifests/g/GIMP/GIMP/3/3.2.4.0/GIMP.GIMP.3.installer.yaml
+++ b/manifests/g/GIMP/GIMP/3/3.2.4.0/GIMP.GIMP.3.installer.yaml
@@ -86,17 +86,5 @@ Installers:
   InstallerSha256: EC31D757DD82831D201FFCF47FFEAC4175DF739E0C02D5122E89AEEADFB988CC
   InstallerSwitches:
     Custom: /ALLUSERS
-- Architecture: arm64
-  Scope: user
-  InstallerUrl: https://download.gimp.org/gimp/v3.2/windows/gimp-3.2.4-setup.exe
-  InstallerSha256: EC31D757DD82831D201FFCF47FFEAC4175DF739E0C02D5122E89AEEADFB988CC
-  InstallerSwitches:
-    Custom: /CURRENTUSER
-- Architecture: arm64
-  Scope: machine
-  InstallerUrl: https://download.gimp.org/gimp/v3.2/windows/gimp-3.2.4-setup.exe
-  InstallerSha256: EC31D757DD82831D201FFCF47FFEAC4175DF739E0C02D5122E89AEEADFB988CC
-  InstallerSwitches:
-    Custom: /ALLUSERS
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/g/GIMP/GIMP/3/3.2.4.0/GIMP.GIMP.3.installer.yaml
+++ b/manifests/g/GIMP/GIMP/3/3.2.4.0/GIMP.GIMP.3.installer.yaml
@@ -74,25 +74,25 @@ FileExtensions:
 ProductCode: GIMP-3_is1
 ReleaseDate: 2026-04-18
 Installers:
-- Architecture: x86
+- Architecture: x64
   Scope: user
   InstallerUrl: https://download.gimp.org/gimp/v3.2/windows/gimp-3.2.4-setup.exe
   InstallerSha256: EC31D757DD82831D201FFCF47FFEAC4175DF739E0C02D5122E89AEEADFB988CC
   InstallerSwitches:
     Custom: /CURRENTUSER
-- Architecture: x86
+- Architecture: x64
   Scope: machine
   InstallerUrl: https://download.gimp.org/gimp/v3.2/windows/gimp-3.2.4-setup.exe
   InstallerSha256: EC31D757DD82831D201FFCF47FFEAC4175DF739E0C02D5122E89AEEADFB988CC
   InstallerSwitches:
     Custom: /ALLUSERS
-- Architecture: x64
+- Architecture: arm64
   Scope: user
   InstallerUrl: https://download.gimp.org/gimp/v3.2/windows/gimp-3.2.4-setup.exe
   InstallerSha256: EC31D757DD82831D201FFCF47FFEAC4175DF739E0C02D5122E89AEEADFB988CC
   InstallerSwitches:
     Custom: /CURRENTUSER
-- Architecture: x64
+- Architecture: arm64
   Scope: machine
   InstallerUrl: https://download.gimp.org/gimp/v3.2/windows/gimp-3.2.4-setup.exe
   InstallerSha256: EC31D757DD82831D201FFCF47FFEAC4175DF739E0C02D5122E89AEEADFB988CC


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?  If so, fill in the Issue number below.
   <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

Reason: End of 32-bit binaries distribution (https://www.gimp.org/release-notes/gimp-3.2.html)

<img width="895" height="632" alt="image" src="https://github.com/user-attachments/assets/bc8fb23e-667b-4510-a8c3-a00457e1f028" />

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/362626)