### PR TITLE
New package: randlee.sc-compose version 1.0.1

### DIFF
--- a/manifests/r/randlee/sc-compose/1.0.1/randlee.sc-compose.installer.yaml
+++ b/manifests/r/randlee/sc-compose/1.0.1/randlee.sc-compose.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: randlee.sc-compose
+PackageVersion: 1.0.1
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: sc-compose_1.0.1_x86_64-pc-windows-msvc\bin\sc-compose.exe
+  PortableCommandAlias: sc-compose
+ReleaseDate: 2026-04-20
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/randlee/sc-compose/releases/download/v1.0.1/sc-compose_1.0.1_x86_64-pc-windows-msvc.zip
+  InstallerSha256: 522A78902D21976CCB6F5EEAF156DC26B3E8C42EBFC736EAE9AD46BD8B4E6E45
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/r/randlee/sc-compose/1.0.1/randlee.sc-compose.locale.en-US.yaml
+++ b/manifests/r/randlee/sc-compose/1.0.1/randlee.sc-compose.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: randlee.sc-compose
+PackageVersion: 1.0.1
+PackageLocale: en-US
+Publisher: Rand Lee
+PublisherUrl: https://github.com/randlee
+PublisherSupportUrl: https://github.com/randlee/sc-compose/issues
+Author: Rand Lee
+PackageName: sc-compose
+PackageUrl: https://github.com/randlee/sc-compose
+License: MIT
+LicenseUrl: https://github.com/randlee/sc-compose/blob/main/LICENSE
+ShortDescription: Standalone CLI for template composition
+Description: |-
+  sc-compose is a standalone command-line tool for Jinja2-based template
+  composition. It wraps the sc-composer library to provide file and profile
+  rendering modes, frontmatter-driven configuration, and observability hooks
+  — with no external runtime dependencies.
+Moniker: sc-compose
+Tags:
+- cli
+- jinja2
+- rust
+- template
+- template-engine
+ReleaseNotesUrl: https://github.com/randlee/sc-compose/releases/tag/v1.0.1
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/r/randlee/sc-compose/1.0.1/randlee.sc-compose.yaml
+++ b/manifests/r/randlee/sc-compose/1.0.1/randlee.sc-compose.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: randlee.sc-compose
+PackageVersion: 1.0.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Package

- PackageIdentifier: `randlee.sc-compose`
- PackageVersion: `1.0.1`
- Installer: x64 portable (zip)
- Upstream release: https://github.com/randlee/sc-compose/releases/tag/v1.0.1

## What's this PR for?

Initial manifest submission. sc-compose is a standalone Rust CLI for Jinja2 template composition — this is the first version published to winget-pkgs. Once merged, subsequent releases will be automated via `vedantmgoyal2009/winget-releaser@v2` from the sc-compose GitHub Actions release workflow.

## Checkboxes

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://docs.microsoft.com/windows/package-manager/package/manifest?tabs=minschema%2Ccompschema#validate-your-manifest) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? _(submitter is on macOS; cross-platform validation via CI)_
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.6.md)?

## Resolves or Fixes

N/A — new package.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/362639)