### PR TITLE
New package: SingTown.openmv-mcp version 2.3.1

### DIFF
--- a/manifests/s/SingTown/openmv-mcp/2.3.1/SingTown.openmv-mcp.installer.yaml
+++ b/manifests/s/SingTown/openmv-mcp/2.3.1/SingTown.openmv-mcp.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: SingTown.openmv-mcp
+PackageVersion: 2.3.1
+InstallerType: portable
+Commands:
+  - openmv_mcp_server
+ReleaseDate: 2026-04-18
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/SingTown/openmv-mcp/releases/download/v2.3.1/openmv_mcp_server-2.3.1-windows-x86_64.exe
+    InstallerSha256: 4ED5BC8B079E0092BF3BA2A54B0EEB23D5D9DE832730F74DEA21356AD15FE08F
+  - Architecture: arm64
+    InstallerUrl: https://github.com/SingTown/openmv-mcp/releases/download/v2.3.1/openmv_mcp_server-2.3.1-windows-arm64.exe
+    InstallerSha256: 0C3F9D04839B0C0D41819668750DD0427A50AA3B422C0085FEFB433867293049
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/SingTown/openmv-mcp/2.3.1/SingTown.openmv-mcp.locale.en-US.yaml
+++ b/manifests/s/SingTown/openmv-mcp/2.3.1/SingTown.openmv-mcp.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: SingTown.openmv-mcp
+PackageVersion: 2.3.1
+PackageLocale: en-US
+Publisher: SingTown
+PublisherUrl: https://github.com/SingTown
+PublisherSupportUrl: https://github.com/SingTown/openmv-mcp/issues
+Author: SingTown
+PackageName: OpenMV MCP Server
+PackageUrl: https://github.com/SingTown/openmv-mcp
+License: MIT
+LicenseUrl: https://github.com/SingTown/openmv-mcp/blob/main/LICENSE
+ShortDescription: MCP (Model Context Protocol) server for controlling OpenMV cameras.
+Description: |-
+  An MCP (Model Context Protocol) server for controlling OpenMV cameras
+  over HTTP + JSON-RPC 2.0. Exposes camera discovery, script upload,
+  terminal streaming, and MJPEG frame capture as MCP tools.
+Moniker: openmv-mcp
+Tags:
+  - mcp
+  - openmv
+  - camera
+  - embedded
+  - robotics
+ReleaseNotesUrl: https://github.com/SingTown/openmv-mcp/releases/tag/v2.3.1
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/SingTown/openmv-mcp/2.3.1/SingTown.openmv-mcp.yaml
+++ b/manifests/s/SingTown/openmv-mcp/2.3.1/SingTown.openmv-mcp.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: SingTown.openmv-mcp
+PackageVersion: 2.3.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary

- New package: **SingTown.openmv-mcp** version **2.3.1**
- InstallerType: `portable` (single-exe CLI, adds `openmv_mcp_server` to PATH)
- Architectures: x64, arm64
- License: MIT
- Upstream: https://github.com/SingTown/openmv-mcp

An MCP (Model Context Protocol) server for controlling OpenMV cameras over HTTP + JSON-RPC 2.0.

## Manifest checklist

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-cli/blob/master/schemas/JSON/manifests/v1.6.0)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/362649)