### PR TITLE
New package: BlackwellSystems.agent-lsp version 0.2.1

### DIFF
--- a/manifests/b/BlackwellSystems/agent-lsp/0.2.1/BlackwellSystems.agent-lsp.installer.yaml
+++ b/manifests/b/BlackwellSystems/agent-lsp/0.2.1/BlackwellSystems.agent-lsp.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: BlackwellSystems.agent-lsp
+PackageVersion: 0.2.1
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: agent-lsp.exe
+    PortableCommandAlias: agent-lsp
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/blackwell-systems/agent-lsp/releases/download/v0.2.1/agent-lsp_windows_amd64.zip
+    InstallerSha256: e73ea3f71824ef615026be9bf996cbfb57300b0ef9a7250bfb568a946e12f2e8
+  - Architecture: arm64
+    InstallerUrl: https://github.com/blackwell-systems/agent-lsp/releases/download/v0.2.1/agent-lsp_windows_arm64.zip
+    InstallerSha256: 486c49c6cce4d1341d04b7788ad334c7be7478184e61967c4473971fbca59ebd
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/b/BlackwellSystems/agent-lsp/0.2.1/BlackwellSystems.agent-lsp.locale.en-US.yaml
+++ b/manifests/b/BlackwellSystems/agent-lsp/0.2.1/BlackwellSystems.agent-lsp.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: BlackwellSystems.agent-lsp
+PackageVersion: 0.2.1
+PackageLocale: en-US
+Publisher: Blackwell Systems
+PublisherUrl: https://github.com/blackwell-systems
+PublisherSupportUrl: https://github.com/blackwell-systems/agent-lsp/issues
+PackageName: agent-lsp
+PackageUrl: https://github.com/blackwell-systems/agent-lsp
+License: MIT
+LicenseUrl: https://github.com/blackwell-systems/agent-lsp/blob/main/LICENSE
+ShortDescription: MCP server giving AI agents reliable access to language server protocol
+Description: agent-lsp is a stateful MCP server over real language servers. It keeps the language server's semantic index warm and adds a skill layer that turns multi-step code operations into single, correct workflows. 50 tools, 30 languages, persistent sessions.
+Tags:
+  - lsp
+  - mcp
+  - ai
+  - developer-tools
+  - language-server
+  - code-intelligence
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/b/BlackwellSystems/agent-lsp/0.2.1/BlackwellSystems.agent-lsp.yaml
+++ b/manifests/b/BlackwellSystems/agent-lsp/0.2.1/BlackwellSystems.agent-lsp.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: BlackwellSystems.agent-lsp
+PackageVersion: 0.2.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New Submission

- Package: BlackwellSystems.agent-lsp
- Version: 0.2.1
- URL: https://github.com/blackwell-systems/agent-lsp

### Description

agent-lsp is a stateful MCP server over real language servers. 50 tools, 30 languages, persistent sessions. Ships as a single Go binary.

### Changes from previous submission (PR #362633)

- Fixed exit code: binary now exits 0 (with usage help) when invoked with no arguments, instead of exit 1. This was causing Winget validation to fail.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/362660)