### PR TITLE
fix release notes for `detachhead.rebased` version 1.0.9

### DIFF
--- a/manifests/d/detachhead/rebased/1.0.9/detachhead.rebased.locale.en-US.yaml
+++ b/manifests/d/detachhead/rebased/1.0.9/detachhead.rebased.locale.en-US.yaml
@@ -18,8 +18,6 @@ ReleaseNotes: |-
   What's Changed
   - publish to homebrew for macOS (#147, #148)
   - publish to winget (#145)
-  Caution
-  this is a prerelease because i am still testing the github actions to update the winget & homebrew packages. they currently don't work yet
 ReleaseNotesUrl: https://github.com/DetachHead/rebased/releases/tag/1.0.9
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0


### PR DESCRIPTION
this was temporarily added to the github release while i was testing my github actions workflow. i didn't realize it got added here too.

now that my CI seems to be working this notice is no longer relevant

Checklist for Pull Requests
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?  If so, fill in the Issue number below.
   <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

Manifests
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/362691)