### PR TITLE
New Package: build2.build2.MinGW version 0.18.1

### DIFF
--- a/manifests/b/build2/build2/MinGW/0.18.1/build2.build2.MinGW.installer.yaml
+++ b/manifests/b/build2/build2/MinGW/0.18.1/build2.build2.MinGW.installer.yaml
@@ -1,0 +1,25 @@
+# build2.build2.MinGW.installer.yaml
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: build2.build2.MinGW
+PackageVersion: 0.18.1
+InstallerLocale: en-US
+InstallerType: zip
+UpgradeBehavior: install
+ArchiveBinariesDependOnPath: true
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/build2/build2-toolchain/releases/download/v0.18.1/build2-toolchain-0.18.1-x86_64-windows10-mingw-gcc14.zip
+  InstallerSha256: bc6e12a44bc0c2903bcfe34316334bb5ecc5aeddba105b328bcb18bec0cbeba1
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: build2-toolchain-0.18.1-x86_64-windows10-mingw-gcc14/bin/b.exe
+    PortableCommandAlias: b
+  - RelativeFilePath: build2-toolchain-0.18.1-x86_64-windows10-mingw-gcc14/bin/bx.exe
+    PortableCommandAlias: bx
+  - RelativeFilePath: build2-toolchain-0.18.1-x86_64-windows10-mingw-gcc14/bin/bdep.exe
+    PortableCommandAlias: bdep
+  - RelativeFilePath: build2-toolchain-0.18.1-x86_64-windows10-mingw-gcc14/bin/bpkg.exe
+    PortableCommandAlias: bpkg
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/b/build2/build2/MinGW/0.18.1/build2.build2.MinGW.locale.en-US.yaml
+++ b/manifests/b/build2/build2/MinGW/0.18.1/build2.build2.MinGW.locale.en-US.yaml
@@ -1,0 +1,45 @@
+# build2.build2.MinGW.locale.en-US.yaml
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: build2.build2.MinGW
+PackageVersion: 0.18.1
+PackageLocale: en-US
+Publisher: The build2 authors
+PublisherUrl: https://build2.org/
+PublisherSupportUrl: https://lists.build2.org
+Author: The build2 authors
+PackageName: build2
+PackageUrl: https://build2.org/
+License: MIT
+LicenseUrl: https://git.build2.org/cgit/build2/plain/LICENSE
+Copyright: Copyright (c) 2014-2026 the build2 authors (see the AUTHORS file).
+CopyrightUrl: https://git.build2.org/cgit/build2/plain/AUTHORS
+ReleaseNotesUrl: https://build2.org/release/0.18.0.xhtml
+ShortDescription: C/C++ build system and package manager
+Description: |-
+  `build2` is an open source, cross-platform toolchain for building and
+  packaging C++ code. It aims to approximate Rust Cargo's convenience while
+  providing more depth and flexibility.
+  Published packages can be found on https://cppget.org
+Moniker: build2-mingw
+Tags:
+- build system
+- build toolchain
+- package manager
+- project manager
+- c
+- c++
+- cross-platform
+Documentations:
+  - DocumentLabel: build2
+    DocumentUrl: https://build2.org/doc.xhtml
+  - DocumentLabel: b(1)
+    DocumentUrl: https://build2.org/build2/doc/b.xhtml
+  - DocumentLabel: bx(1)
+    DocumentUrl: https://build2.org/build2/doc/bx.xhtml
+  - DocumentLabel: bdep(1)
+    DocumentUrl: https://build2.org/bdep/doc/bdep.xhtml
+  - DocumentLabel: bpkg(1)
+    DocumentUrl: https://build2.org/bpkg/doc/bpkg.xhtml
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/b/build2/build2/MinGW/0.18.1/build2.build2.MinGW.yaml
+++ b/manifests/b/build2/build2/MinGW/0.18.1/build2.build2.MinGW.yaml
@@ -1,0 +1,8 @@
+# build2.build2.MinGW.yaml
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: build2.build2.MinGW
+PackageVersion: 0.18.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Complements #361818 

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Is there a linked Issue?  If so, fill in the Issue number below.
  - N/A

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
  > Note: `build2.build2.MinGW` triggers a local archive malware scan false positive on the MinGW/GCC binaries. Install was verified with `--ignore-local-archive-malware-scan`.  
  > `ArchiveBinariesDependOnPath: true` is required due to the Windows symlink DLL resolution issue.
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/361818)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/361834)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/362705)