### PR TITLE
New version: M-Igashi.mp3rgain version 2.2.3

### DIFF
--- a/manifests/m/M-Igashi/mp3rgain/2.2.3/M-Igashi.mp3rgain.installer.yaml
+++ b/manifests/m/M-Igashi/mp3rgain/2.2.3/M-Igashi.mp3rgain.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgain
+PackageVersion: 2.2.3
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: mp3rgain.exe
+ReleaseDate: 2026-04-20
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/M-Igashi/mp3rgain/releases/download/v2.2.3/mp3rgain-v2.2.3-windows-x86_64.zip
+    InstallerSha256: E590872E023CE8284FE685F99C4118EE3F73050869C3A406DF71FF015013D370
+  - Architecture: arm64
+    InstallerUrl: https://github.com/M-Igashi/mp3rgain/releases/download/v2.2.3/mp3rgain-v2.2.3-windows-arm64.zip
+    InstallerSha256: 697E4C685CB83D903F5CA886B678E3BE16542F614F91605CFDB8F192C86CB77A
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/mp3rgain/2.2.3/M-Igashi.mp3rgain.locale.en-US.yaml
+++ b/manifests/m/M-Igashi/mp3rgain/2.2.3/M-Igashi.mp3rgain.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgain
+PackageVersion: 2.2.3
+PackageLocale: en-US
+Publisher: M-Igashi
+PublisherUrl: https://github.com/M-Igashi
+PublisherSupportUrl: https://github.com/M-Igashi/mp3rgain/issues
+Author: M-Igashi
+PackageName: mp3rgain
+PackageUrl: https://github.com/M-Igashi/mp3rgain
+License: MIT
+LicenseUrl: https://github.com/M-Igashi/mp3rgain/blob/master/LICENSE
+ShortDescription: Lossless MP3 volume adjustment - a modern mp3gain replacement written in Rust
+Description: |-
+  mp3rgain adjusts MP3 volume without re-encoding by modifying the global_gain field in each frame's side information.
+  This preserves audio quality while achieving permanent volume changes.
+  Features include ReplayGain analysis, AAC/M4A support, and full mp3gain command-line compatibility.
+Moniker: mp3rgain
+Tags:
+  - audio
+  - cli
+  - flac
+  - gain
+  - lossless
+  - mp3
+  - music
+  - normalize
+  - ogg
+  - replaygain
+  - rust
+  - volume
+ReleaseNotesUrl: https://github.com/M-Igashi/mp3rgain/releases/tag/v2.2.3
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/mp3rgain/2.2.3/M-Igashi.mp3rgain.yaml
+++ b/manifests/m/M-Igashi/mp3rgain/2.2.3/M-Igashi.mp3rgain.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgain
+PackageVersion: 2.2.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Metadata Verification
- [x] Checked the [PR Policies](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md)

Release notes: https://github.com/M-Igashi/mp3rgain/releases/tag/v2.2.3

Fixes a follow-up to the ID3v2 tag write bug from v2.2.2 (#115): ReplayGain TXXX frames could still go missing on MP3s whose pre-existing tags contained frames that failed the `id3` crate's v2.4 encode path beyond the 3-byte-ID case already filtered in v2.2.2. mp3rgain now test-encodes every existing frame individually and drops any that the crate refuses to serialize, so the ReplayGain metadata always makes it to disk.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/362708)