### PR TITLE
New version: M-Igashi.mp3rgui version 2.2.3

### DIFF
--- a/manifests/m/M-Igashi/mp3rgui/2.2.3/M-Igashi.mp3rgui.installer.yaml
+++ b/manifests/m/M-Igashi/mp3rgui/2.2.3/M-Igashi.mp3rgui.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgui
+PackageVersion: 2.2.3
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: mp3rgui.exe
+ReleaseDate: 2026-04-20
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/M-Igashi/mp3rgain/releases/download/v2.2.3/mp3rgui-v2.2.3-windows-x86_64.zip
+    InstallerSha256: 3206CA270F041560C4E42013889978FAA81631B32010ED3664A68FEE4FC593F0
+  - Architecture: arm64
+    InstallerUrl: https://github.com/M-Igashi/mp3rgain/releases/download/v2.2.3/mp3rgui-v2.2.3-windows-arm64.zip
+    InstallerSha256: 4344C98C0505C277D234A40F8D45E8232A600111040CB0FC8FC5E63CA4A5FDB6
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/mp3rgui/2.2.3/M-Igashi.mp3rgui.locale.en-US.yaml
+++ b/manifests/m/M-Igashi/mp3rgui/2.2.3/M-Igashi.mp3rgui.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgui
+PackageVersion: 2.2.3
+PackageLocale: en-US
+Publisher: M-Igashi
+PublisherUrl: https://github.com/M-Igashi
+PublisherSupportUrl: https://github.com/M-Igashi/mp3rgain/issues
+Author: M-Igashi
+PackageName: mp3rgui
+PackageUrl: https://github.com/M-Igashi/mp3rgain
+License: MIT
+LicenseUrl: https://github.com/M-Igashi/mp3rgain/blob/master/LICENSE
+ShortDescription: GUI for lossless MP3 volume adjustment - a modern mp3gain replacement written in Rust
+Description: |-
+  mp3rgui is the graphical interface for mp3rgain, a lossless MP3 volume normalizer.
+  It provides an easy-to-use GUI for adjusting MP3 volume without re-encoding,
+  supporting ReplayGain analysis, AAC/M4A, FLAC, and OGG formats.
+Moniker: mp3rgui
+Tags:
+  - audio
+  - flac
+  - gain
+  - gui
+  - lossless
+  - mp3
+  - music
+  - normalize
+  - ogg
+  - replaygain
+  - rust
+  - volume
+ReleaseNotesUrl: https://github.com/M-Igashi/mp3rgain/releases/tag/v2.2.3
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/mp3rgui/2.2.3/M-Igashi.mp3rgui.yaml
+++ b/manifests/m/M-Igashi/mp3rgui/2.2.3/M-Igashi.mp3rgui.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgui
+PackageVersion: 2.2.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Metadata Verification
- [x] Checked the [PR Policies](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md)

Release: https://github.com/M-Igashi/mp3rgain/releases/tag/v2.2.3

Patch release for the mp3rgui 2.2.x series. mp3rgui itself is unchanged versus 2.2.2; the version bump ships the underlying mp3rgain library fix from v2.2.3 — ID3v2 ReplayGain tags could still fail to persist for some pre-existing tags even after the v2.2.2 fix, because the id3 crate's v2.4 encode path rejects more than just 3-byte frame IDs (e.g. content-type/ID mismatches that trip `Frame::validate`). The write now probe-encodes every existing frame individually and drops any the crate refuses to serialize, so `-s i` ReplayGain tags reliably make it to disk (fixes M-Igashi/mp3rgain#115).

Build profile is identical to the last merged mp3rgui PR (#362359): `lto = "thin"`, `codegen-units = 1`, `strip = "debuginfo"`, `+crt-static`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/362709)