### PR TITLE
Deliro.Mt version 0.2.1

### DIFF
--- a/manifests/d/Deliro/Mt/0.2.1/Deliro.Mt.installer.yaml
+++ b/manifests/d/Deliro/Mt/0.2.1/Deliro.Mt.installer.yaml
@@ -1,0 +1,12 @@
+PackageIdentifier: Deliro.Mt
+PackageVersion: 0.2.1
+InstallerType: portable
+Commands:
+  - mt
+ReleaseDate: 2026-04-20
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/deliro/mt/releases/download/v0.2.1/mt-x86_64-pc-windows-msvc.exe
+    InstallerSha256: 635741267BEA9EA3C12ACE594D5AD24A3BBB48C22548DFA8B1423EE4E35A6F84
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/d/Deliro/Mt/0.2.1/Deliro.Mt.locale.en-US.yaml
+++ b/manifests/d/Deliro/Mt/0.2.1/Deliro.Mt.locale.en-US.yaml
@@ -1,0 +1,20 @@
+PackageIdentifier: Deliro.Mt
+PackageVersion: 0.2.1
+PackageLocale: en-US
+Publisher: Deliro
+PublisherUrl: https://github.com/deliro
+PublisherSupportUrl: https://github.com/deliro/mt/issues
+PackageName: mt
+PackageUrl: https://github.com/deliro/mt
+License: Apache-2.0 OR MIT
+LicenseUrl: https://github.com/deliro/mt/blob/master/LICENSE
+ShortDescription: Native desktop client for Meshtastic radios (BLE / Serial / TCP)
+Moniker: mt
+Tags:
+  - meshtastic
+  - lora
+  - ham-radio
+  - ble
+ReleaseNotesUrl: https://github.com/deliro/mt/releases/tag/v0.2.1
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/d/Deliro/Mt/0.2.1/Deliro.Mt.yaml
+++ b/manifests/d/Deliro/Mt/0.2.1/Deliro.Mt.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Deliro.Mt
+PackageVersion: 0.2.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Submission of Deliro.Mt 0.2.1 via release automation. Source: https://github.com/deliro/mt/releases/tag/v0.2.1
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/362799)