### PR TITLE
New version: FernandoTonon.QtMeshEditor version 2.28.0

### DIFF
--- a/manifests/f/FernandoTonon/QtMeshEditor/2.28.0/FernandoTonon.QtMeshEditor.installer.yaml
+++ b/manifests/f/FernandoTonon/QtMeshEditor/2.28.0/FernandoTonon.QtMeshEditor.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: FernandoTonon.QtMeshEditor
+PackageVersion: 2.28.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: bin\QtMeshEditor.exe
+    PortableCommandAlias: qtmesheditor
+  - RelativeFilePath: bin\qtmesh.exe
+    PortableCommandAlias: qtmesh
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/fernandotonon/QtMeshEditor/releases/download/2.28.0/QtMeshEditor-2.28.0-bin-Windows.zip
+    InstallerSha256: 050BEC5A8FFFC418C61000D679D680A62E290CB66D56FD8F7A5C7B2DA48A6754
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/FernandoTonon/QtMeshEditor/2.28.0/FernandoTonon.QtMeshEditor.locale.en-US.yaml
+++ b/manifests/f/FernandoTonon/QtMeshEditor/2.28.0/FernandoTonon.QtMeshEditor.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: FernandoTonon.QtMeshEditor
+PackageVersion: 2.28.0
+PackageLocale: en-US
+Publisher: Fernando Tonon
+PublisherUrl: https://github.com/fernandotonon
+PublisherSupportUrl: https://github.com/fernandotonon/QtMeshEditor/issues
+PackageName: QtMeshEditor
+PackageUrl: https://github.com/fernandotonon/QtMeshEditor
+License: MIT
+LicenseUrl: https://github.com/fernandotonon/QtMeshEditor/blob/master/License
+ShortDescription: Free 3D asset tool for indie game developers
+Description: |-
+  QtMeshEditor is a free 3D asset tool for indie game developers.
+  Merge animations from multiple files, convert between 40+ formats,
+  edit materials with AI, and inspect skeletons and bone weights.
+  Supports GUI, CLI (qtmesh), and REST API via MCP server.
+Tags:
+  - 3d
+  - mesh-editor
+  - animation
+  - fbx
+  - gltf
+  - ogre3d
+  - game-development
+  - material-editor
+Moniker: qtmesheditor
+ReleaseNotesUrl: https://github.com/fernandotonon/QtMeshEditor/releases/tag/2.28.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/FernandoTonon/QtMeshEditor/2.28.0/FernandoTonon.QtMeshEditor.yaml
+++ b/manifests/f/FernandoTonon/QtMeshEditor/2.28.0/FernandoTonon.QtMeshEditor.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: FernandoTonon.QtMeshEditor
+PackageVersion: 2.28.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Manifest for FernandoTonon.QtMeshEditor 2.28.0

Adds manifests for QtMeshEditor 2.28.0 — the Phase 4 bevel release.

- PackageIdentifier: FernandoTonon.QtMeshEditor
- PackageVersion: 2.28.0
- Upstream release: https://github.com/fernandotonon/QtMeshEditor/releases/tag/2.28.0
- Installer: https://github.com/fernandotonon/QtMeshEditor/releases/download/2.28.0/QtMeshEditor-2.28.0-bin-Windows.zip
- InstallerSha256: 050BEC5A8FFFC418C61000D679D680A62E290CB66D56FD8F7A5C7B2DA48A6754

Manifest format matches the previous version (2.20.0 and earlier). Submitted manually because our CI `wingetcreate --submit` keeps failing with "Failed to connect to GitHub" — tracked separately; we're retrying the automation in a follow-up PR in our own repo.

## Checklists

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-create#winget-manifest-linting) your manifest locally with `winget validate --manifest <path>`? (Generated by `scripts/update-winget.sh` which mirrors the format of prior accepted versions.)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/362955)