### PR TITLE
New version: CareerSpike.Overlay version 1.0.0

### DIFF
--- a/manifests/c/CareerSpike/Overlay/1.0.0/CareerSpike.Overlay.installer.yaml
+++ b/manifests/c/CareerSpike/Overlay/1.0.0/CareerSpike.Overlay.installer.yaml
@@ -3,7 +3,7 @@
 PackageIdentifier: CareerSpike.Overlay
 PackageVersion: 1.0.0
 MinimumOSVersion: 10.0.0.0
-InstallerType: nsis
+InstallerType: nullsoft
 Scope: user
 InstallModes:
   - interactive

--- a/manifests/c/CareerSpike/Overlay/1.0.0/CareerSpike.Overlay.installer.yaml
+++ b/manifests/c/CareerSpike/Overlay/1.0.0/CareerSpike.Overlay.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: CareerSpike.Overlay
+PackageVersion: 1.0.0
+MinimumOSVersion: 10.0.0.0
+InstallerType: nsis
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/CareerSpike/overlay-releases/releases/download/v1.0.0/CareerSpike-Overlay-1.0.0-Setup.exe
+    InstallerSha256: 54D56EC1A224BFC5A7956711D5AFAC41156066D9C4A7F9848C1A2EBCFB89A8BD
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/c/CareerSpike/Overlay/1.0.0/CareerSpike.Overlay.locale.en-US.yaml
+++ b/manifests/c/CareerSpike/Overlay/1.0.0/CareerSpike.Overlay.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: CareerSpike.Overlay
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: CareerSpike
+PublisherUrl: https://careerspike.app
+PublisherSupportUrl: https://github.com/CareerSpike/overlay-releases/issues
+Author: CareerSpike
+PackageName: CareerSpike Overlay
+PackageUrl: https://github.com/CareerSpike/overlay-releases
+License: MIT
+Copyright: Copyright (c) 2026 CareerSpike
+ShortDescription: AI interview coach overlay that stays hidden from screen sharing.
+Description: |-
+  CareerSpike Overlay is a desktop window that captures a live interview
+  question via microphone or typed input and returns a concise AI-drafted
+  answer. The window is content-protected so it stays hidden when the user
+  shares their screen, making it safe to use during real interviews and
+  meetings. Supports manual, auto-listen, and streamed transcription modes.
+Tags:
+  - interview
+  - coach
+  - ai
+  - overlay
+  - transcription
+  - career
+ReleaseNotesUrl: https://github.com/CareerSpike/overlay-releases/releases/tag/v1.0.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/c/CareerSpike/Overlay/1.0.0/CareerSpike.Overlay.yaml
+++ b/manifests/c/CareerSpike/Overlay/1.0.0/CareerSpike.Overlay.yaml
@@ -1,0 +1,8 @@
+# Created with wingetcreate-compatible schema (v1.6.0)
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: CareerSpike.Overlay
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
# New package: `CareerSpike.Overlay` 1.0.0

Desktop overlay app for interview / meeting assistance. The window is content-protected so it stays hidden during screen sharing; users talk or type a question and get a concise AI answer back.

## Package

- **PackageIdentifier:** `CareerSpike.Overlay`
- **PackageVersion:** `1.0.0`
- **Publisher:** CareerSpike
- **License:** MIT
- **InstallerType:** `nsis` (electron-builder NSIS, per-user scope)
- **Silent switch:** `/S`
- **Architecture:** x64

## Release

Binary hosted publicly at https://github.com/CareerSpike/overlay-releases/releases/tag/v1.0.0. The `InstallerSha256` in the manifest matches the SHA256 of the uploaded `CareerSpike-Overlay-1.0.0-Setup.exe`.

## Checklist

- [x] I have read the [Contribution guidelines](https://github.com/microsoft/winget-pkgs/blob/master/CONTRIBUTING.md).
- [x] The manifest validates (validated locally against schema 1.6.0).
- [x] The installer hash was computed from the actual file served at \`InstallerUrl\`.
- [x] The installer has been tested to install silently with the documented switches.
- [x] No PII / sensitive data appears in the manifest.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/362979)