### PR TITLE
Add OpenCoworkAI.OpenCoDesign version 0.1.2

### DIFF
--- a/manifests/o/OpenCoworkAI/OpenCoDesign/0.1.2/OpenCoworkAI.OpenCoDesign.installer.yaml
+++ b/manifests/o/OpenCoworkAI/OpenCoDesign/0.1.2/OpenCoworkAI.OpenCoDesign.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: OpenCoworkAI.OpenCoDesign
+PackageVersion: 0.1.2
+InstallerType: nullsoft
+Scope: user
+UpgradeBehavior: install
+ReleaseDate: 2026-04-21
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/OpenCoworkAI/open-codesign/releases/download/v0.1.2/open-codesign-0.1.2-x64-setup.exe
+  InstallerSha256: 328768B7DBB400CD7D15267037ACD4AC03B64F15CD3D6EB1C80E58F5ABE82E74
+- Architecture: arm64
+  InstallerUrl: https://github.com/OpenCoworkAI/open-codesign/releases/download/v0.1.2/open-codesign-0.1.2-arm64-setup.exe
+  InstallerSha256: D6C475044C10D8F66A7F0F65DBABF2B488061235D29CDCFB7DB3F116C0466CDC
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenCoworkAI/OpenCoDesign/0.1.2/OpenCoworkAI.OpenCoDesign.locale.en-US.yaml
+++ b/manifests/o/OpenCoworkAI/OpenCoDesign/0.1.2/OpenCoworkAI.OpenCoDesign.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: OpenCoworkAI.OpenCoDesign
+PackageVersion: 0.1.2
+PackageLocale: en-US
+Publisher: OpenCoworkAI
+PublisherUrl: https://github.com/OpenCoworkAI
+PublisherSupportUrl: https://github.com/OpenCoworkAI/open-codesign/issues
+PackageName: Open CoDesign
+PackageUrl: https://opencoworkai.github.io/open-codesign/
+License: MIT
+LicenseUrl: https://github.com/OpenCoworkAI/open-codesign/blob/main/LICENSE
+ShortDescription: Open-source desktop AI design tool — prompt to prototype, BYOK, local-first.
+Description: |-
+  Open CoDesign turns natural-language prompts into HTML/JSX prototypes,
+  slide decks, and marketing assets. It runs entirely on your laptop with
+  whichever AI provider you already pay for (Anthropic, OpenAI, Gemini,
+  DeepSeek, or any OpenAI-compatible relay — including keyless
+  IP-allowlisted proxies).
+Moniker: open-codesign
+Tags:
+- ai
+- design
+- electron
+- open-source
+- prototyping
+ReleaseNotesUrl: https://github.com/OpenCoworkAI/open-codesign/releases/tag/v0.1.2
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenCoworkAI/OpenCoDesign/0.1.2/OpenCoworkAI.OpenCoDesign.yaml
+++ b/manifests/o/OpenCoworkAI/OpenCoDesign/0.1.2/OpenCoworkAI.OpenCoDesign.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: OpenCoworkAI.OpenCoDesign
+PackageVersion: 0.1.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
  ## [Policy](https://github.com/microsoft/winget-pkgs/blob/master/POLICY.md) and
  [Guidelines](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md)

  - [x] I have read the Contribution Guidelines and Policies
  - [x] Installer SHA256 values match the installer hosted on the release URL
  - [x] Manifest does NOT contain fields marked for internal use

  ## What is this PR doing?

  Adding initial manifest for **Open CoDesign v0.1.2** — an open-source, local-first desktop AI
  design tool that turns natural-language prompts into HTML prototypes, slide decks, and
  marketing assets. MIT-licensed, electron-based, BYOK (Anthropic / OpenAI / Gemini / DeepSeek /
   any OpenAI-compatible endpoint).

  - Homepage: https://opencoworkai.github.io/open-codesign/
  - Source: https://github.com/OpenCoworkAI/open-codesign
  - Release: https://github.com/OpenCoworkAI/open-codesign/releases/tag/v0.1.2

  ## Installer details

  Two per-arch NSIS installers (electron-builder output). SHA256 values pulled from the signed
  `SHA256SUMS.txt` attached to the GitHub Release.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/363055)