### PR TITLE
Add fstubner.netscli version 0.2.0

### DIFF
--- a/manifests/f/fstubner/netscli/0.2.0/fstubner.netscli.installer.yaml
+++ b/manifests/f/fstubner/netscli/0.2.0/fstubner.netscli.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: fstubner.netscli
+PackageVersion: 0.2.0
+InstallerType: portable
+Commands:
+- netscli
+ReleaseDate: 2026-04-18
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/fstubner/netscli/releases/download/v0.2.0/netscli-windows-x86_64.exe
+  InstallerSha256: 790C0867BA035AD85704C7EBABA65ADE23FF9C9F4327FBE5B3F5F2515CFE3002
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/f/fstubner/netscli/0.2.0/fstubner.netscli.locale.en-US.yaml
+++ b/manifests/f/fstubner/netscli/0.2.0/fstubner.netscli.locale.en-US.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: fstubner.netscli
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: Felix Stubner
+PublisherUrl: https://github.com/fstubner
+PublisherSupportUrl: https://github.com/fstubner/netscli/issues
+Author: Felix Stubner
+PackageName: netscli
+PackageUrl: https://netscli.com
+License: MIT
+LicenseUrl: https://github.com/fstubner/netscli/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Felix Stubner
+ShortDescription: Network scanner with CLI, TUI, desktop app, and MCP server. Written in Rust.
+Description: |-
+  netscli is an open-source network scanner written in Rust. It discovers hosts
+  on a subnet, scans TCP ports, resolves DNS (including mDNS/Bonjour), reads
+  the ARP table with vendor lookup, and optionally captures packets via Npcap.
+  The same functionality is available from a command line, a terminal UI with
+  autocomplete, a desktop app, or a Model Context Protocol (MCP) server that
+  AI agents like Claude Code and Cursor can call directly.
+Moniker: netscli
+Tags:
+- network
+- scanner
+- cli
+- tui
+- mcp
+- rust
+- dns
+- port-scan
+- mdns
+- arp
+ReleaseNotes: |-
+  First major feature pass since v0.1.0. Adds mDNS/DNS-SD discovery, a typed
+  public API, shell completions, man pages, and sigstore-signed release
+  binaries.
+ReleaseNotesUrl: https://github.com/fstubner/netscli/releases/tag/v0.2.0
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/f/fstubner/netscli/0.2.0/fstubner.netscli.yaml
+++ b/manifests/f/fstubner/netscli/0.2.0/fstubner.netscli.yaml
@@ -1,0 +1,8 @@
+# Created with wingetcreate-style authoring (manual) for fstubner.netscli 0.2.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: fstubner.netscli
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## New package submission

Adds initial version of **fstubner.netscli** (0.2.0).

### Manifest summary

- **Package**: `fstubner.netscli`
- **Moniker**: `netscli` (so `winget install netscli` resolves)
- **Version**: 0.2.0
- **Installer**: portable (single-binary), x64
- **Source**: https://netscli.com ([repo](https://github.com/fstubner/netscli))
- **License**: MIT

### About

netscli is an open-source network scanner written in Rust. It discovers hosts on a subnet, scans TCP ports, resolves DNS (including mDNS/Bonjour), reads the ARP table with vendor lookup, and optionally captures packets. Available as a CLI, terminal UI, desktop app, and MCP server that AI agents can call directly.

### Checklist

- [x] Manifest validates with \`winget validate\`
- [x] Installer URL resolves to a public GitHub release asset
- [x] Installer SHA256 matches \`netscli-windows-x86_64.exe.sha256\` from the release
- [x] I am the publisher / I own \`fstubner.netscli\`

### Status

This PR is **draft** while I review locally. Will mark ready for review once I've verified the installer runs cleanly from a fresh winget install.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/363074)