### PR TITLE
Add AGNTCY.shadictl version 0.1.1

### DIFF
--- a/manifests/a/AGNTCY/shadictl/0.1.1/AGNTCY.shadictl.installer.yaml
+++ b/manifests/a/AGNTCY/shadictl/0.1.1/AGNTCY.shadictl.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: AGNTCY.shadictl
+PackageVersion: 0.1.1
+InstallerType: zip
+NestedInstallerType: portable
+Commands:
+- shadictl
+ReleaseDate: 2026-04-20
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/agntcy/shadi/releases/download/agntcy-shadi-cli-v0.1.1/shadictl-v0.1.1-x86_64-pc-windows-msvc.zip
+  InstallerSha256: 14535EE5B155AC974A9BB4575E82B172801503A6E8D2EAB5F43AE8BACFC7FDD7
+  NestedInstallerFiles:
+  - RelativeFilePath: shadictl-v0.1.1-x86_64-pc-windows-msvc\shadictl.exe
+    PortableCommandAlias: shadictl
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/AGNTCY/shadictl/0.1.1/AGNTCY.shadictl.locale.en-US.yaml
+++ b/manifests/a/AGNTCY/shadictl/0.1.1/AGNTCY.shadictl.locale.en-US.yaml
@@ -1,0 +1,27 @@
+        # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+        PackageIdentifier: AGNTCY.shadictl
+        PackageVersion: 0.1.1
+        PackageLocale: en-US
+        Publisher: AGNTCY
+        PublisherUrl: https://github.com/agntcy
+        PublisherSupportUrl: https://github.com/agntcy/shadi/issues
+        Author: AGNTCY Contributors
+        PackageName: shadictl
+        PackageUrl: https://github.com/agntcy/shadi
+        License: Apache-2.0
+        LicenseUrl: https://github.com/agntcy/shadi/blob/agntcy-shadi-cli-v0.1.1/LICENSE.md
+        ShortDescription: Command-line interface for SHADI policy, secrets, memory, and SLIM operations.
+        Moniker: shadictl
+        Tags:
+- agent
+- cli
+- sandbox
+- security
+- slim
+        Documentations:
+        - DocumentLabel: Documentation
+          DocumentUrl: https://agntcy.github.io/shadi
+        ReleaseNotesUrl: https://github.com/agntcy/shadi/releases/tag/agntcy-shadi-cli-v0.1.1
+        ManifestType: defaultLocale
+        ManifestVersion: 1.12.0

--- a/manifests/a/AGNTCY/shadictl/0.1.1/AGNTCY.shadictl.yaml
+++ b/manifests/a/AGNTCY/shadictl/0.1.1/AGNTCY.shadictl.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: AGNTCY.shadictl
+PackageVersion: 0.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Summary
Add WinGet manifests for AGNTCY.shadictl version 0.1.1.

## Release
- Release: https://github.com/agntcy/shadi/releases/tag/agntcy-shadi-cli-v0.1.1
- Package Identifier: AGNTCY.shadictl
- Version: 0.1.1

Generated from the release automation branch pushed to agntcy/winget-pkgs.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/363199)