### PR TITLE
Wharflab.Tally version 0.35.1

### DIFF
--- a/manifests/w/Wharflab/Tally/0.35.1/Wharflab.Tally.installer.yaml
+++ b/manifests/w/Wharflab/Tally/0.35.1/Wharflab.Tally.installer.yaml
@@ -1,0 +1,26 @@
+# Created by tally release automation
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: Wharflab.Tally
+PackageVersion: 0.35.1
+Commands:
+- tally
+FileExtensions:
+- dockerfile
+- containerfile
+ReleaseDate: '2026-04-21'
+Installers:
+- Architecture: x64
+  InstallerType: portable
+  InstallerUrl: https://github.com/wharflab/tally/releases/download/v0.35.1/tally_0.35.1_Windows_x86_64.exe
+  InstallerSha256: BE91127F1FD1E3611203C44CC2BCD3EB307EFD8B08059992157E89C804BFE599
+  Commands:
+  - tally
+- Architecture: arm64
+  InstallerType: portable
+  InstallerUrl: https://github.com/wharflab/tally/releases/download/v0.35.1/tally_0.35.1_Windows_arm64.exe
+  InstallerSha256: 0ABCAE39DC25F027F9C752381A9B28283C778E5447FB70EED9606ABEA81F9A28
+  Commands:
+  - tally
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/w/Wharflab/Tally/0.35.1/Wharflab.Tally.locale.en-US.yaml
+++ b/manifests/w/Wharflab/Tally/0.35.1/Wharflab.Tally.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# Created by tally release automation
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: Wharflab.Tally
+PackageVersion: 0.35.1
+PackageLocale: en-US
+Publisher: Wharflab
+PublisherUrl: https://github.com/wharflab
+PublisherSupportUrl: https://github.com/wharflab/tally/issues
+PackageName: Tally
+PackageUrl: https://github.com/wharflab/tally
+ShortDescription: Dockerfile linter and formatter with first-class PowerShell and
+  Windows container support.
+Moniker: tally
+License: GPL-3.0-only
+LicenseUrl: https://github.com/wharflab/tally/blob/main/LICENSE
+ReleaseNotesUrl: https://github.com/wharflab/tally/releases/tag/v0.35.1
+Documentations:
+- DocumentLabel: Docs
+  DocumentUrl: https://tally.wharflab.com/
+Tags:
+- docker
+- dockerfile
+- containerfile
+- linter
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/w/Wharflab/Tally/0.35.1/Wharflab.Tally.yaml
+++ b/manifests/w/Wharflab/Tally/0.35.1/Wharflab.Tally.yaml
@@ -1,0 +1,8 @@
+# Created by tally release automation
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: Wharflab.Tally
+PackageVersion: 0.35.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Publishing version v0.35.1 of [tally](https://github.com/wharflab/tally) to WinGet.

Tally is a Dockerfile linter and formatter written in Go, promoting modern container syntax and helping avoid common pitfalls.

[Changelog](https://github.com/wharflab/tally/releases/tag/v0.35.1)
