### PR TITLE
New package: Yoki.Yoki version 1.2.8.1

### DIFF
--- a/manifests/y/Yoki/Yoki/1.2.8.1/Yoki.Yoki.installer.yaml
+++ b/manifests/y/Yoki/Yoki/1.2.8.1/Yoki.Yoki.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Yoki.Yoki
+PackageVersion: 1.2.8.1
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: portable
+Commands:
+- yoki
+ReleaseDate: 2026-04-21
+Installers:
+- Architecture: x64
+  InstallerUrl: https://yoki.run/api/releases/download?version=1.2.8.1
+  InstallerSha256: EF9F841103F6E58960F4830D1A831751981CF090E458949009766DBBC35C1CB9
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/y/Yoki/Yoki/1.2.8.1/Yoki.Yoki.locale.en-US.yaml
+++ b/manifests/y/Yoki/Yoki/1.2.8.1/Yoki.Yoki.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Yoki.Yoki
+PackageVersion: 1.2.8.1
+PackageLocale: en-US
+Publisher: Yoki
+PublisherUrl: https://yoki.run
+PublisherSupportUrl: https://yoki.run
+Author: Ismail Chukmaev
+PackageName: Yoki Launcher
+PackageUrl: https://yoki.run
+License: Proprietary
+LicenseUrl: https://yoki.run/terms
+Copyright: Copyright 2026 Ismail Chukmaev. All rights reserved.
+ShortDescription: Fast Windows launcher for apps, files, system settings, AI chat, and more.
+Description: |-
+  Yoki is a Windows productivity launcher opened with Alt+Space. Fuzzy-search apps
+  and files, open system settings, run a calculator or unit/currency converter,
+  pick emoji, manage clipboard history, kill processes, control monitor brightness,
+  check weather, and chat with AI. Plugins, quick notes, timers, and custom search
+  engines are built in.
+Moniker: yoki
+Tags:
+- launcher
+- productivity
+- search
+- spotlight
+- raycast
+- windows
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/y/Yoki/Yoki/1.2.8.1/Yoki.Yoki.yaml
+++ b/manifests/y/Yoki/Yoki/1.2.8.1/Yoki.Yoki.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Yoki.Yoki
+PackageVersion: 1.2.8.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Yoki Launcher 1.2.8.0

Yoki is a Windows productivity launcher (Alt+Space) with app and file search, system settings, a calculator and unit/currency converter, clipboard history, process manager, emoji picker, monitor brightness control, weather, and AI chat.

**Homepage:** https://yoki.run  
**Release:** https://github.com/yoki-run/yoki/releases/tag/v1.2.8.0

### Notes
- Portable single-exe (Wails-built Go/WebView2 app). `InstallerType: portable`, `Commands: [yoki]`.
- The installer is served from the vendor's own domain, version-pinned:  
  `https://yoki.run/api/releases/download?version=1.2.8.0`  
  The page streams the binary from the private GitHub release through a server-side token, so the URL is public and stable but the source repo stays private.
- `winget validate` passes locally.

### Checklist
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-create#winget-manifest-validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.6.md)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/363611)