### PR TITLE
Add version: mulhamna.jirac version 0.14.0

### DIFF
--- a/manifests/m/mulhamna/jirac/0.14.0/mulhamna.jirac.installer.yaml
+++ b/manifests/m/mulhamna/jirac/0.14.0/mulhamna.jirac.installer.yaml
@@ -4,7 +4,7 @@ PackageVersion: 0.14.0
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
-  - RelativeFilePath: jirac.exe
+  - RelativeFilePath: jirac-windows-x86_64.exe
     PortableCommandAlias: jirac
 ReleaseDate: 2026-04-21
 Installers:

--- a/manifests/m/mulhamna/jirac/0.14.0/mulhamna.jirac.installer.yaml
+++ b/manifests/m/mulhamna/jirac/0.14.0/mulhamna.jirac.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: mulhamna.jirac
+PackageVersion: 0.14.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: jirac.exe
+    PortableCommandAlias: jirac
+ReleaseDate: 2026-04-21
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/mulhamna/jira-commands/releases/download/v0.14.0/jirac-windows-x86_64.zip
+    InstallerSha256: 07299BAB5B56213A421C6AC012D8EE9C42AFE90CD1CCFFF05395690E3884F7F2
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/m/mulhamna/jirac/0.14.0/mulhamna.jirac.locale.en-US.yaml
+++ b/manifests/m/mulhamna/jirac/0.14.0/mulhamna.jirac.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: mulhamna.jirac
+PackageVersion: 0.14.0
+PackageLocale: en-US
+Publisher: mulhamna
+PublisherUrl: https://github.com/mulhamna
+PublisherSupportUrl: https://github.com/mulhamna/jira-commands/issues
+Author: mulhamna
+PackageName: jirac
+PackageUrl: https://github.com/mulhamna/jira-commands
+License: MIT OR Apache-2.0
+LicenseUrl: https://github.com/mulhamna/jira-commands/blob/main/LICENSE
+ShortDescription: Jira terminal client with TUI, MCP support, and release archives for Windows, macOS, and Linux.
+Description: jirac is a Rust-based Jira CLI with interactive TUI flows, issue transitions, comments, worklogs, attachments, and jirac-mcp for editor and agent integrations.
+Moniker: jirac
+Tags:
+  - jira
+  - atlassian
+  - cli
+  - tui
+  - mcp
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/m/mulhamna/jirac/0.14.0/mulhamna.jirac.yaml
+++ b/manifests/m/mulhamna/jirac/0.14.0/mulhamna.jirac.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: mulhamna.jirac
+PackageVersion: 0.14.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## Summary

- add Winget manifests for `mulhamna.jirac` version `0.14.0`
- package points to the published GitHub release asset for `jirac-windows-x86_64.zip`
- installer SHA256 matches the published release archive

## Package details

- Package Identifier: `mulhamna.jirac`
- Package Version: `0.14.0`
- Installer Type: portable ZIP
- Command Alias: `jirac`

## Source release

- https://github.com/mulhamna/jira-commands/releases/tag/v0.14.0

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/363710)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/363710)