### PR TITLE
New version: Augchan42.Transcriber version 2.0.0

### DIFF
--- a/manifests/a/Augchan42/Transcriber/2.0.0/Augchan42.Transcriber.installer.yaml
+++ b/manifests/a/Augchan42/Transcriber/2.0.0/Augchan42.Transcriber.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: Augchan42.Transcriber
+PackageVersion: 2.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: transcriber.exe
+    PortableCommandAlias: transcriber
+Commands:
+  - transcriber
+ReleaseDate: 2026-04-22
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/augchan42/transcriber/releases/download/v2.0.0/TranscriberPortable.zip
+    InstallerSha256: 64BFA21BF91C5147421FB6B9058C271877D4BD7BAC7B262A34CA01C66115393C
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/a/Augchan42/Transcriber/2.0.0/Augchan42.Transcriber.locale.en-US.yaml
+++ b/manifests/a/Augchan42/Transcriber/2.0.0/Augchan42.Transcriber.locale.en-US.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: Augchan42.Transcriber
+PackageVersion: 2.0.0
+PackageLocale: en-US
+Publisher: augchan42
+PublisherUrl: https://github.com/augchan42
+PublisherSupportUrl: https://github.com/augchan42/transcriber/issues
+PackageName: Transcriber
+PackageUrl: https://github.com/augchan42/transcriber
+License: MIT
+LicenseUrl: https://github.com/augchan42/transcriber/blob/main/LICENSE
+ShortDescription: Turn any video into subtitles. Offline speech-to-text using Whisper, with optional YouTube upload.
+Description: |-
+  Transcriber is a desktop GUI for turning video and audio files into .srt and
+  .txt subtitles using faster-whisper. It works fully offline after the first
+  model download, supports multiple languages including Cantonese/Chinese, and
+  has optional domain hints for improved accuracy on specialized content (I-Ching,
+  finance, philosophy, geopolitics, AI, etc.).
+
+  It can also compress videos for YouTube (H.264 via ffmpeg) and upload them
+  with resumable upload support. YouTube upload requires your own Google OAuth
+  credentials — see youtube-setup.md after install for a 5-minute walkthrough.
+
+  Includes bundled ffmpeg.exe and ffprobe.exe, so no extra install needed.
+Moniker: transcriber
+Tags:
+  - transcription
+  - subtitles
+  - srt
+  - whisper
+  - speech-to-text
+  - offline
+  - youtube
+  - ffmpeg
+  - cantonese
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/a/Augchan42/Transcriber/2.0.0/Augchan42.Transcriber.yaml
+++ b/manifests/a/Augchan42/Transcriber/2.0.0/Augchan42.Transcriber.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: Augchan42.Transcriber
+PackageVersion: 2.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Adds Augchan42.Transcriber 2.0.0.

- Portable zip with bundled ffmpeg/ffprobe
- Manifests validated locally with `winget validate`
- SHA256 and InstallerUrl verified against the GitHub release asset

Repo: https://github.com/augchan42/transcriber
Release: https://github.com/augchan42/transcriber/releases/tag/v2.0.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/363712)