### PR TITLE
Wharflab.Tally version 0.35.2

### DIFF
--- a/manifests/w/Wharflab/Tally/0.35.2/Wharflab.Tally.installer.yaml
+++ b/manifests/w/Wharflab/Tally/0.35.2/Wharflab.Tally.installer.yaml
@@ -1,0 +1,26 @@
+# Created by tally release automation
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: Wharflab.Tally
+PackageVersion: 0.35.2
+Commands:
+- tally
+FileExtensions:
+- dockerfile
+- containerfile
+ReleaseDate: '2026-04-22'
+Installers:
+- Architecture: x64
+  InstallerType: portable
+  InstallerUrl: https://github.com/wharflab/tally/releases/download/v0.35.2/tally_0.35.2_Windows_x86_64.exe
+  InstallerSha256: A725C466756430C2F9B9C31A0ED6A40F099AB5D34E559A6DB15AAB7BD7F7275B
+  Commands:
+  - tally
+- Architecture: arm64
+  InstallerType: portable
+  InstallerUrl: https://github.com/wharflab/tally/releases/download/v0.35.2/tally_0.35.2_Windows_arm64.exe
+  InstallerSha256: 948FAF4CF60A6CB58F7C865DAAB3BCC2BD013C10CE95E9806117F8AFC3D1A97A
+  Commands:
+  - tally
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/w/Wharflab/Tally/0.35.2/Wharflab.Tally.locale.en-US.yaml
+++ b/manifests/w/Wharflab/Tally/0.35.2/Wharflab.Tally.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# Created by tally release automation
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: Wharflab.Tally
+PackageVersion: 0.35.2
+PackageLocale: en-US
+Publisher: Wharflab
+PublisherUrl: https://github.com/wharflab
+PublisherSupportUrl: https://github.com/wharflab/tally/issues
+PackageName: Tally
+PackageUrl: https://github.com/wharflab/tally
+ShortDescription: Dockerfile linter and formatter with first-class PowerShell and
+  Windows container support.
+Moniker: tally
+License: GPL-3.0-only
+LicenseUrl: https://github.com/wharflab/tally/blob/main/LICENSE
+ReleaseNotesUrl: https://github.com/wharflab/tally/releases/tag/v0.35.2
+Documentations:
+- DocumentLabel: Docs
+  DocumentUrl: https://tally.wharflab.com/
+Tags:
+- docker
+- dockerfile
+- containerfile
+- linter
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/w/Wharflab/Tally/0.35.2/Wharflab.Tally.yaml
+++ b/manifests/w/Wharflab/Tally/0.35.2/Wharflab.Tally.yaml
@@ -1,0 +1,8 @@
+# Created by tally release automation
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: Wharflab.Tally
+PackageVersion: 0.35.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Publishing version v0.35.2 of [tally](https://github.com/wharflab/tally) to WinGet.

Tally is a Dockerfile linter and formatter written in Go, promoting modern container syntax and helping avoid common pitfalls.

[Changelog](https://github.com/wharflab/tally/releases/tag/v0.35.2)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/363871)