### PR TITLE
fix: ChidiWilliams.Buzz 1.4.4 - switch to ZIP installer to include required .bin files

### DIFF
--- a/manifests/c/ChidiWilliams/Buzz/1.4.4/ChidiWilliams.Buzz.installer.yaml
+++ b/manifests/c/ChidiWilliams/Buzz/1.4.4/ChidiWilliams.Buzz.installer.yaml
@@ -1,26 +1,27 @@
-# Created with Devicie using komac v2.15.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: ChidiWilliams.Buzz
 PackageVersion: 1.4.4
 InstallerLocale: en-US
-InstallerType: inno
-ProductCode: '{574290A2-EF7C-4845-85F3-BFF2F011A580}_is1'
+InstallerType: zip
+NestedInstallerType: inno
+NestedInstallerFiles:
+- RelativeFilePath: Buzz-1.4.4-windows.exe
 ReleaseDate: 2026-03-14
 AppsAndFeaturesEntries:
 - ProductCode: '{574290A2-EF7C-4845-85F3-BFF2F011A580}_is1'
 ElevationRequirement: elevatesSelf
 Installers:
-- Architecture: x86
+- Architecture: x64
   Scope: user
-  InstallerUrl: https://github.com/chidiwilliams/buzz/releases/download/v1.4.4/Buzz-1.4.4-windows.exe
-  InstallerSha256: 863E9A0AFD19DECB8ED7A46877773E2F8F335EFBEF4EA7353D1834285545591D
+  InstallerUrl: https://sourceforge.net/projects/buzz-captions/files/Buzz-1.4.4-Windows-X64.zip/download
+  InstallerSha256: 4006EA246E7401DD1C1392ED24D65C0AE27DC2840207494BF240ADFEBBF37AA1
   InstallerSwitches:
     Custom: /CURRENTUSER
-- Architecture: x86
+- Architecture: x64
   Scope: machine
-  InstallerUrl: https://github.com/chidiwilliams/buzz/releases/download/v1.4.4/Buzz-1.4.4-windows.exe
-  InstallerSha256: 863E9A0AFD19DECB8ED7A46877773E2F8F335EFBEF4EA7353D1834285545591D
+  InstallerUrl: https://sourceforge.net/projects/buzz-captions/files/Buzz-1.4.4-Windows-X64.zip/download
+  InstallerSha256: 4006EA246E7401DD1C1392ED24D65C0AE27DC2840207494BF240ADFEBBF37AA1
   InstallerSwitches:
     Custom: /ALLUSERS
   InstallationMetadata:


### PR DESCRIPTION
## Description

The current manifest for ChidiWilliams.Buzz version 1.4.4 points to the standalone .exe installer from GitHub Releases. This installer is an Inno Setup multi-volume package that requires two companion .bin files to be present in the same directory at install time. Without them, the installer halts with exit code 5:

```
Asking user for new disk containing "Buzz-1.4.4-windows-1.bin".
The file "Buzz-1.4.4-windows-1.bin" could not be located in "...\WinGet\ChidiWilliams.Buzz.1.4.4".
Installer failed with exit code: 5
```

The upstream project distributes a ZIP archive on SourceForge containing all three files together. Switching to InstallerType: zip with NestedInstallerType: inno allows WinGet to download and extract the complete package before invoking the installer.

## Changes

- InstallerType: inno -> zip
- NestedInstallerType: inno
- NestedInstallerFiles: points to Buzz-1.4.4-windows.exe (root of ZIP)
- InstallerUrl: updated to SourceForge ZIP (Buzz-1.4.4-Windows-X64.zip)
- InstallerSha256: updated to match ZIP (4006EA246E7401DD1C1392ED24D65C0AE27DC2840207494BF240ADFEBBF37AA1)
- Architecture: corrected x86 -> x64 (ZIP is explicitly Windows-X64)
- Removed top-level ProductCode (retained in AppsAndFeaturesEntries)

## Validation

winget validate manifest/ -> Manifest validation succeeded.

## References

- Upstream release notes confirm SourceForge as the Windows distribution channel: https://github.com/chidiwilliams/buzz/releases/tag/v1.4.4
- ZIP source: https://sourceforge.net/projects/buzz-captions/files/Buzz-1.4.4-Windows-X64.zip/download
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/363890)