### PR TITLE
New package: OleBhartvigsen.FanFolder version 1.1.7

### DIFF
--- a/manifests/o/OleBhartvigsen/FanFolder/1.1.7/OleBhartvigsen.FanFolder.installer.yaml
+++ b/manifests/o/OleBhartvigsen/FanFolder/1.1.7/OleBhartvigsen.FanFolder.installer.yaml
@@ -1,33 +1,33 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
-PackageIdentifier: OleBhartvigsen.FanFolder
-PackageVersion: 1.1.7
-InstallerLocale: en-US
-Platform:
-  - Windows.Desktop
-MinimumOSVersion: 10.0.17763.0
-InstallerType: msi
-InstallModes:
-  - silent
-  - silentWithProgress
-UpgradeBehavior: install
-Installers:
-  - Architecture: x64
-    InstallerUrl: https://github.com/olebhartvigsen/FanFolder/releases/download/v1.1.7/FanFolderSetup-x64.msi
-    InstallerSha256: FA6E5F358366D3B79DDC6D8C3238BBB30FB78C2E960C92792771D6BF060E415F
-    ProductCode: '{A9EAFC62-CB82-4D32-8ED9-2A9A5352F181}'
-    Scope: user
-    ElevationRequirement: elevationProhibited
-    InstallerSwitches:
-      Silent: /quiet /norestart
-      SilentWithProgress: /passive /norestart
-  - Architecture: arm64
-    InstallerUrl: https://github.com/olebhartvigsen/FanFolder/releases/download/v1.1.7/FanFolderSetup-arm64.msi
-    InstallerSha256: 8493425AF1B08A2A97EB8AEE015F80545EE073D05520809C83155C236D482D30
-    ProductCode: '{833264AD-08B6-48AE-A240-7347DBC01967}'
-    Scope: user
-    ElevationRequirement: elevationProhibited
-    InstallerSwitches:
-      Silent: /quiet /norestart
-      SilentWithProgress: /passive /norestart
-ManifestType: installer
-ManifestVersion: 1.9.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: OleBhartvigsen.FanFolder
+PackageVersion: 1.1.7
+InstallerLocale: en-US
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: msi
+InstallModes:
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/olebhartvigsen/FanFolder/releases/download/v1.1.7/FanFolderSetup-x64.msi
+    InstallerSha256: FA6E5F358366D3B79DDC6D8C3238BBB30FB78C2E960C92792771D6BF060E415F
+    ProductCode: '{A9EAFC62-CB82-4D32-8ED9-2A9A5352F181}'
+    Scope: user
+    ElevationRequirement: elevationProhibited
+    InstallerSwitches:
+      Silent: /quiet /norestart
+      SilentWithProgress: /passive /norestart
+  - Architecture: arm64
+    InstallerUrl: https://github.com/olebhartvigsen/FanFolder/releases/download/v1.1.7/FanFolderSetup-arm64.msi
+    InstallerSha256: 8493425AF1B08A2A97EB8AEE015F80545EE073D05520809C83155C236D482D30
+    ProductCode: '{833264AD-08B6-48AE-A240-7347DBC01967}'
+    Scope: user
+    ElevationRequirement: elevationProhibited
+    InstallerSwitches:
+      Silent: /quiet /norestart
+      SilentWithProgress: /passive /norestart
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/o/OleBhartvigsen/FanFolder/1.1.7/OleBhartvigsen.FanFolder.installer.yaml
+++ b/manifests/o/OleBhartvigsen/FanFolder/1.1.7/OleBhartvigsen.FanFolder.installer.yaml
@@ -1,33 +1,33 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
-PackageIdentifier: OleBhartvigsen.FanFolder
-PackageVersion: 1.1.7
-InstallerLocale: en-US
-Platform:
-  - Windows.Desktop
-MinimumOSVersion: 10.0.17763.0
-InstallerType: msi
-InstallModes:
-  - silent
-  - silentWithProgress
-UpgradeBehavior: install
-Installers:
-  - Architecture: x64
-    InstallerUrl: https://github.com/olebhartvigsen/FanFolder/releases/download/v1.1.7/FanFolderSetup-x64.msi
-    InstallerSha256: FA6E5F358366D3B79DDC6D8C3238BBB30FB78C2E960C92792771D6BF060E415F
-    ProductCode: '{A9EAFC62-CB82-4D32-8ED9-2A9A5352F181}'
-    Scope: user
-    ElevationRequirement: elevationProhibited
-    InstallerSwitches:
-      Silent: /quiet /norestart
-      SilentWithProgress: /passive /norestart
-  - Architecture: arm64
-    InstallerUrl: https://github.com/olebhartvigsen/FanFolder/releases/download/v1.1.7/FanFolderSetup-arm64.msi
-    InstallerSha256: 8493425AF1B08A2A97EB8AEE015F80545EE073D05520809C83155C236D482D30
-    ProductCode: '{833264AD-08B6-48AE-A240-7347DBC01967}'
-    Scope: user
-    ElevationRequirement: elevationProhibited
-    InstallerSwitches:
-      Silent: /quiet /norestart
-      SilentWithProgress: /passive /norestart
-ManifestType: installer
-ManifestVersion: 1.9.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: OleBhartvigsen.FanFolder
+PackageVersion: 1.1.7
+InstallerLocale: en-US
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: msi
+InstallModes:
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/olebhartvigsen/FanFolder/releases/download/v1.1.7/FanFolderSetup-x64.msi
+    InstallerSha256: FA6E5F358366D3B79DDC6D8C3238BBB30FB78C2E960C92792771D6BF060E415F
+    ProductCode: '{A9EAFC62-CB82-4D32-8ED9-2A9A5352F181}'
+    Scope: user
+    ElevationRequirement: elevationProhibited
+    InstallerSwitches:
+      Silent: /quiet /norestart
+      SilentWithProgress: /passive /norestart
+  - Architecture: arm64
+    InstallerUrl: https://github.com/olebhartvigsen/FanFolder/releases/download/v1.1.7/FanFolderSetup-arm64.msi
+    InstallerSha256: 8493425AF1B08A2A97EB8AEE015F80545EE073D05520809C83155C236D482D30
+    ProductCode: '{833264AD-08B6-48AE-A240-7347DBC01967}'
+    Scope: user
+    ElevationRequirement: elevationProhibited
+    InstallerSwitches:
+      Silent: /quiet /norestart
+      SilentWithProgress: /passive /norestart
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/o/OleBhartvigsen/FanFolder/1.1.7/OleBhartvigsen.FanFolder.installer.yaml
+++ b/manifests/o/OleBhartvigsen/FanFolder/1.1.7/OleBhartvigsen.FanFolder.installer.yaml
@@ -16,7 +16,6 @@ Installers:
     InstallerSha256: FA6E5F358366D3B79DDC6D8C3238BBB30FB78C2E960C92792771D6BF060E415F
     ProductCode: '{A9EAFC62-CB82-4D32-8ED9-2A9A5352F181}'
     Scope: user
-    ElevationRequirement: elevationProhibited
     InstallerSwitches:
       Silent: /quiet /norestart
       SilentWithProgress: /passive /norestart
@@ -25,7 +24,6 @@ Installers:
     InstallerSha256: 8493425AF1B08A2A97EB8AEE015F80545EE073D05520809C83155C236D482D30
     ProductCode: '{833264AD-08B6-48AE-A240-7347DBC01967}'
     Scope: user
-    ElevationRequirement: elevationProhibited
     InstallerSwitches:
       Silent: /quiet /norestart
       SilentWithProgress: /passive /norestart

--- a/manifests/o/OleBhartvigsen/FanFolder/1.1.7/OleBhartvigsen.FanFolder.installer.yaml
+++ b/manifests/o/OleBhartvigsen/FanFolder/1.1.7/OleBhartvigsen.FanFolder.installer.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: OleBhartvigsen.FanFolder
+PackageVersion: 1.1.7
+InstallerLocale: en-US
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: msi
+InstallModes:
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/olebhartvigsen/FanFolder/releases/download/v1.1.7/FanFolderSetup-x64.msi
+    InstallerSha256: FA6E5F358366D3B79DDC6D8C3238BBB30FB78C2E960C92792771D6BF060E415F
+    ProductCode: '{A9EAFC62-CB82-4D32-8ED9-2A9A5352F181}'
+    Scope: user
+    ElevationRequirement: elevationProhibited
+    InstallerSwitches:
+      Silent: /quiet /norestart
+      SilentWithProgress: /passive /norestart
+  - Architecture: arm64
+    InstallerUrl: https://github.com/olebhartvigsen/FanFolder/releases/download/v1.1.7/FanFolderSetup-arm64.msi
+    InstallerSha256: 8493425AF1B08A2A97EB8AEE015F80545EE073D05520809C83155C236D482D30
+    ProductCode: '{833264AD-08B6-48AE-A240-7347DBC01967}'
+    Scope: user
+    ElevationRequirement: elevationProhibited
+    InstallerSwitches:
+      Silent: /quiet /norestart
+      SilentWithProgress: /passive /norestart
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/o/OleBhartvigsen/FanFolder/1.1.7/OleBhartvigsen.FanFolder.locale.en-US.yaml
+++ b/manifests/o/OleBhartvigsen/FanFolder/1.1.7/OleBhartvigsen.FanFolder.locale.en-US.yaml
@@ -1,0 +1,54 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: OleBhartvigsen.FanFolder
+PackageVersion: 1.1.7
+PackageLocale: en-US
+Publisher: Ole Bhartvigsen
+PublisherUrl: https://github.com/olebhartvigsen
+PublisherSupportUrl: https://github.com/olebhartvigsen/FanFolder/issues
+Author: Ole Bhartvigsen
+PackageName: FanFolder
+PackageUrl: https://github.com/olebhartvigsen/FanFolder
+License: Proprietary
+LicenseUrl: https://github.com/olebhartvigsen/FanFolder/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Ole Bulow Hartvigsen
+CopyrightUrl: https://github.com/olebhartvigsen/FanFolder/blob/main/LICENSE
+ShortDescription: Animated fan folder popup for the Windows taskbar.
+Description: |-
+  FanFolder turns any folder into an animated, arc-shaped popup on the Windows
+  taskbar. Click the taskbar icon and the most recently modified items in a
+  configured folder fan out in a smooth animation. Open items, use the full
+  Windows shell context menu (right-click), or drag them into other applications.
+
+  Works with local folders as well as cloud-synced folders such as OneDrive,
+  Dropbox and Google Drive — always showing the latest files.
+
+  Key features:
+  - Multiple animation styles: Fan, Glide, Spring, Fade or None.
+  - Sort by date modified, date created or name, with optional filename regex filter.
+  - Configurable item count, folder path and display options via tray menu or registry.
+  - Full Windows shell context menu and drag-and-drop support.
+  - Per-user MSI install, no admin rights required.
+  - Native x64 and ARM64 builds.
+  - Small footprint and low memory usage.
+Moniker: fanfolder
+Tags:
+- taskbar
+- productivity
+- launcher
+- fan
+- folder
+- utility
+- shell
+- files
+ReleaseNotes: |-
+  Highlights in 1.1.7:
+  - Added 13 new UI languages — Russian, Hindi, Turkish, Hebrew, Czech, Finnish, Hungarian, Greek, Vietnamese, Indonesian, Ukrainian, Romanian, and Thai — bringing the total to 29 supported languages.
+  - Fixed the fan opening against the edge of a secondary monitor when launched via Alt+Tab; it now anchors correctly to the taskbar button on whichever monitor you're on.
+  - Only one FanFolder instance can run at a time — upgrading no longer leaves two copies fighting over the taskbar icon.
+  - Installer now closes any running FanFolder before upgrading, so you get the new version cleanly without needing to reboot or sign out.
+  - Fan now opens noticeably faster on repeat uses: icons are pre-converted in the background so reopening the fan skips hundreds of milliseconds of work on the UI thread.
+  - Eliminated a stability issue where rapidly opening and closing the fan could slowly leak memory and window handles over long sessions.
+  - Idle CPU usage is now effectively 0% — removed a diagnostic log that was quietly writing to disk on every mouse click and animation tick in Release builds.
+ReleaseNotesUrl: https://github.com/olebhartvigsen/FanFolder/releases/tag/v1.1.7
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/o/OleBhartvigsen/FanFolder/1.1.7/OleBhartvigsen.FanFolder.locale.en-US.yaml
+++ b/manifests/o/OleBhartvigsen/FanFolder/1.1.7/OleBhartvigsen.FanFolder.locale.en-US.yaml
@@ -1,45 +1,45 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
-PackageIdentifier: OleBhartvigsen.FanFolder
-PackageVersion: 1.1.7
-PackageLocale: en-US
-Publisher: Ole Bhartvigsen
-PublisherUrl: https://github.com/olebhartvigsen
-PublisherSupportUrl: https://github.com/olebhartvigsen/FanFolder/issues
-Author: Ole Bhartvigsen
-PackageName: FanFolder
-PackageUrl: https://github.com/olebhartvigsen/FanFolder
-License: Proprietary
-LicenseUrl: https://github.com/olebhartvigsen/FanFolder/blob/main/LICENSE
-Copyright: Copyright (c) 2026 Ole Bulow Hartvigsen
-CopyrightUrl: https://github.com/olebhartvigsen/FanFolder/blob/main/LICENSE
-ShortDescription: Animated fan folder popup for the Windows taskbar.
-Description: |-
-  FanFolder turns any folder into an animated, arc-shaped popup on the Windows
-  taskbar. Click the taskbar icon and the most recently modified items in a
-  configured folder fan out in a smooth animation. Open items, use the full
-  Windows shell context menu (right-click), or drag them into other applications.
-
-  Works with local folders as well as cloud-synced folders such as OneDrive,
-  Dropbox and Google Drive — always showing the latest files.
-
-  Key features:
-  - Multiple animation styles: Fan, Glide, Spring, Fade or None.
-  - Sort by date modified, date created or name, with optional filename regex filter.
-  - Configurable item count, folder path and display options via tray menu or registry.
-  - Full Windows shell context menu and drag-and-drop support.
-  - Per-user MSI install, no admin rights required.
-  - Native x64 and ARM64 builds.
-  - Small footprint and low memory usage.
-Moniker: fanfolder
-Tags:
-- taskbar
-- productivity
-- launcher
-- fan
-- folder
-- utility
-- shell
-- files
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: OleBhartvigsen.FanFolder
+PackageVersion: 1.1.7
+PackageLocale: en-US
+Publisher: Ole Bhartvigsen
+PublisherUrl: https://github.com/olebhartvigsen
+PublisherSupportUrl: https://github.com/olebhartvigsen/FanFolder/issues
+Author: Ole Bhartvigsen
+PackageName: FanFolder
+PackageUrl: https://github.com/olebhartvigsen/FanFolder
+License: Proprietary
+LicenseUrl: https://github.com/olebhartvigsen/FanFolder/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Ole Bulow Hartvigsen
+CopyrightUrl: https://github.com/olebhartvigsen/FanFolder/blob/main/LICENSE
+ShortDescription: Animated fan folder popup for the Windows taskbar.
+Description: |-
+  FanFolder turns any folder into an animated, arc-shaped popup on the Windows
+  taskbar. Click the taskbar icon and the most recently modified items in a
+  configured folder fan out in a smooth animation. Open items, use the full
+  Windows shell context menu (right-click), or drag them into other applications.
+
+  Works with local folders as well as cloud-synced folders such as OneDrive,
+  Dropbox and Google Drive — always showing the latest files.
+
+  Key features:
+  - Multiple animation styles: Fan, Glide, Spring, Fade or None.
+  - Sort by date modified, date created or name, with optional filename regex filter.
+  - Configurable item count, folder path and display options via tray menu or registry.
+  - Full Windows shell context menu and drag-and-drop support.
+  - Per-user MSI install, no admin rights required.
+  - Native x64 and ARM64 builds.
+  - Small footprint and low memory usage.
+Moniker: fanfolder
+Tags:
+- taskbar
+- productivity
+- launcher
+- fan
+- folder
+- utility
+- shell
+- files
 ReleaseNotes: |-
   Highlights in 1.1.7:
   - Added 13 new UI languages — Russian, Hindi, Turkish, Hebrew, Czech, Finnish, Hungarian, Greek, Vietnamese, Indonesian, Ukrainian, Romanian, and Thai — bringing the total to 29 supported languages.
@@ -49,6 +49,6 @@ ReleaseNotes: |-
   - Fan now opens noticeably faster on repeat uses: icons are pre-converted in the background so reopening the fan skips hundreds of milliseconds of work on the UI thread.
   - Eliminated a stability issue where rapidly opening and closing the fan could slowly leak memory and window handles over long sessions.
   - Idle CPU usage is now effectively 0% — removed a diagnostic log that was quietly writing to disk on every mouse click and animation tick in Release builds.
-ReleaseNotesUrl: https://github.com/olebhartvigsen/FanFolder/releases/tag/v1.1.7
-ManifestType: defaultLocale
-ManifestVersion: 1.9.0
+ReleaseNotesUrl: https://github.com/olebhartvigsen/FanFolder/releases/tag/v1.1.7
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/o/OleBhartvigsen/FanFolder/1.1.7/OleBhartvigsen.FanFolder.locale.en-US.yaml
+++ b/manifests/o/OleBhartvigsen/FanFolder/1.1.7/OleBhartvigsen.FanFolder.locale.en-US.yaml
@@ -1,45 +1,45 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
-PackageIdentifier: OleBhartvigsen.FanFolder
-PackageVersion: 1.1.7
-PackageLocale: en-US
-Publisher: Ole Bhartvigsen
-PublisherUrl: https://github.com/olebhartvigsen
-PublisherSupportUrl: https://github.com/olebhartvigsen/FanFolder/issues
-Author: Ole Bhartvigsen
-PackageName: FanFolder
-PackageUrl: https://github.com/olebhartvigsen/FanFolder
-License: Proprietary
-LicenseUrl: https://github.com/olebhartvigsen/FanFolder/blob/main/LICENSE
-Copyright: Copyright (c) 2026 Ole Bulow Hartvigsen
-CopyrightUrl: https://github.com/olebhartvigsen/FanFolder/blob/main/LICENSE
-ShortDescription: Animated fan folder popup for the Windows taskbar.
-Description: |-
-  FanFolder turns any folder into an animated, arc-shaped popup on the Windows
-  taskbar. Click the taskbar icon and the most recently modified items in a
-  configured folder fan out in a smooth animation. Open items, use the full
-  Windows shell context menu (right-click), or drag them into other applications.
-
-  Works with local folders as well as cloud-synced folders such as OneDrive,
-  Dropbox and Google Drive — always showing the latest files.
-
-  Key features:
-  - Multiple animation styles: Fan, Glide, Spring, Fade or None.
-  - Sort by date modified, date created or name, with optional filename regex filter.
-  - Configurable item count, folder path and display options via tray menu or registry.
-  - Full Windows shell context menu and drag-and-drop support.
-  - Per-user MSI install, no admin rights required.
-  - Native x64 and ARM64 builds.
-  - Small footprint and low memory usage.
-Moniker: fanfolder
-Tags:
-- taskbar
-- productivity
-- launcher
-- fan
-- folder
-- utility
-- shell
-- files
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: OleBhartvigsen.FanFolder
+PackageVersion: 1.1.7
+PackageLocale: en-US
+Publisher: Ole Bhartvigsen
+PublisherUrl: https://github.com/olebhartvigsen
+PublisherSupportUrl: https://github.com/olebhartvigsen/FanFolder/issues
+Author: Ole Bhartvigsen
+PackageName: FanFolder
+PackageUrl: https://github.com/olebhartvigsen/FanFolder
+License: Proprietary
+LicenseUrl: https://github.com/olebhartvigsen/FanFolder/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Ole Bulow Hartvigsen
+CopyrightUrl: https://github.com/olebhartvigsen/FanFolder/blob/main/LICENSE
+ShortDescription: Animated fan folder popup for the Windows taskbar.
+Description: |-
+  FanFolder turns any folder into an animated, arc-shaped popup on the Windows
+  taskbar. Click the taskbar icon and the most recently modified items in a
+  configured folder fan out in a smooth animation. Open items, use the full
+  Windows shell context menu (right-click), or drag them into other applications.
+
+  Works with local folders as well as cloud-synced folders such as OneDrive,
+  Dropbox and Google Drive — always showing the latest files.
+
+  Key features:
+  - Multiple animation styles: Fan, Glide, Spring, Fade or None.
+  - Sort by date modified, date created or name, with optional filename regex filter.
+  - Configurable item count, folder path and display options via tray menu or registry.
+  - Full Windows shell context menu and drag-and-drop support.
+  - Per-user MSI install, no admin rights required.
+  - Native x64 and ARM64 builds.
+  - Small footprint and low memory usage.
+Moniker: fanfolder
+Tags:
+- taskbar
+- productivity
+- launcher
+- fan
+- folder
+- utility
+- shell
+- files
 ReleaseNotes: |-
   Highlights in 1.1.7:
   - Added 13 new UI languages — Russian, Hindi, Turkish, Hebrew, Czech, Finnish, Hungarian, Greek, Vietnamese, Indonesian, Ukrainian, Romanian, and Thai — bringing the total to 29 supported languages.
@@ -49,6 +49,6 @@ ReleaseNotes: |-
   - Fan now opens noticeably faster on repeat uses: icons are pre-converted in the background so reopening the fan skips hundreds of milliseconds of work on the UI thread.
   - Eliminated a stability issue where rapidly opening and closing the fan could slowly leak memory and window handles over long sessions.
   - Idle CPU usage is now effectively 0% — removed a diagnostic log that was quietly writing to disk on every mouse click and animation tick in Release builds.
-ReleaseNotesUrl: https://github.com/olebhartvigsen/FanFolder/releases/tag/v1.1.7
-ManifestType: defaultLocale
-ManifestVersion: 1.9.0
+ReleaseNotesUrl: https://github.com/olebhartvigsen/FanFolder/releases/tag/v1.1.7
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/o/OleBhartvigsen/FanFolder/1.1.7/OleBhartvigsen.FanFolder.yaml
+++ b/manifests/o/OleBhartvigsen/FanFolder/1.1.7/OleBhartvigsen.FanFolder.yaml
@@ -1,6 +1,6 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
-PackageIdentifier: OleBhartvigsen.FanFolder
-PackageVersion: 1.1.7
-DefaultLocale: en-US
-ManifestType: version
-ManifestVersion: 1.9.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: OleBhartvigsen.FanFolder
+PackageVersion: 1.1.7
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0

--- a/manifests/o/OleBhartvigsen/FanFolder/1.1.7/OleBhartvigsen.FanFolder.yaml
+++ b/manifests/o/OleBhartvigsen/FanFolder/1.1.7/OleBhartvigsen.FanFolder.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: OleBhartvigsen.FanFolder
+PackageVersion: 1.1.7
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0

--- a/manifests/o/OleBhartvigsen/FanFolder/1.1.7/OleBhartvigsen.FanFolder.yaml
+++ b/manifests/o/OleBhartvigsen/FanFolder/1.1.7/OleBhartvigsen.FanFolder.yaml
@@ -1,6 +1,6 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
-PackageIdentifier: OleBhartvigsen.FanFolder
-PackageVersion: 1.1.7
-DefaultLocale: en-US
-ManifestType: version
-ManifestVersion: 1.9.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: OleBhartvigsen.FanFolder
+PackageVersion: 1.1.7
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## New package: OleBhartvigsen.FanFolder 1.1.7

Initial submission of **FanFolder**, an animated fan-shaped folder popup for the Windows taskbar.

- Upstream project: https://github.com/olebhartvigsen/FanFolder
- Release notes: https://github.com/olebhartvigsen/FanFolder/releases/tag/v1.1.7
- Installer type: MSI (per-user install, no elevation required)
- Architectures: x64, arm64

### Manifests

- `manifests/o/OleBhartvigsen/FanFolder/1.1.7/OleBhartvigsen.FanFolder.yaml`
- `manifests/o/OleBhartvigsen/FanFolder/1.1.7/OleBhartvigsen.FanFolder.installer.yaml`
- `manifests/o/OleBhartvigsen/FanFolder/1.1.7/OleBhartvigsen.FanFolder.locale.en-US.yaml`

### Checklist

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-create#hash-generation-and-manifest-validation) your manifest locally with `winget validate --manifest <path>`? *(schema verified; CI will re-validate)*
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.9.md)?

### Notes

SHA256 hashes and ProductCodes were generated by CI directly from the MSIs that are published with the GitHub release. Both installers are per-user (`Scope: user`, `ElevationRequirement: elevationProhibited`) and install to `%LOCALAPPDATA%\FanFolder`.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/363974)