### PR TITLE
New version: ReactOS.RosBE version 20260424

### DIFF
--- a/manifests/r/ReactOS/RosBE/1.0.0/ReactOS.RosBE.installer.yaml
+++ b/manifests/r/ReactOS/RosBE/1.0.0/ReactOS.RosBE.installer.yaml
@@ -11,7 +11,7 @@ Installers:
     NestedInstallerFiles:
       - RelativeFilePath: rosbe.exe
         PortableCommandAlias: rosbe
-    InstallerUrl: https://github.com/ahmedarif193/winget-rosbe/releases/download/v1.0.0/rosbe-1.0.0-win-x64.zip
-    InstallerSha256: DDDBEB67D285C9A7323A55B0B8AEC0E7AA3184AD12BC52533A7A86722A151268
+    InstallerUrl: https://github.com/ahmedarif193/winget-rosbe/releases/download/v1.0.0/rosbe-bootstrapper-1.0.0-win-x64.zip
+    InstallerSha256: 0600477605C39935ABC57CFE8855DF10ACCD7973F2340F957C1F64500D5A2E15
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/r/ReactOS/RosBE/1.0.0/ReactOS.RosBE.installer.yaml
+++ b/manifests/r/ReactOS/RosBE/1.0.0/ReactOS.RosBE.installer.yaml
@@ -12,6 +12,6 @@ Installers:
       - RelativeFilePath: rosbe.exe
         PortableCommandAlias: rosbe
     InstallerUrl: https://github.com/ahmedarif193/winget-rosbe/releases/download/v1.0.0/rosbe-bootstrapper-1.0.0-win-x64.zip
-    InstallerSha256: 0600477605C39935ABC57CFE8855DF10ACCD7973F2340F957C1F64500D5A2E15
+    InstallerSha256: 76028120EC80AEEF085F82A2242EEECF48D6E92AF30AE78F9BF8B81686105FB1
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/r/ReactOS/RosBE/1.0.0/ReactOS.RosBE.installer.yaml
+++ b/manifests/r/ReactOS/RosBE/1.0.0/ReactOS.RosBE.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: ReactOS.RosBE
+PackageVersion: 1.0.0
+Installers:
+  - Architecture: x64
+    InstallerType: zip
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: rosbe.exe
+    InstallerUrl: https://github.com/ahmedarif193/winget-rosbe/releases/download/v1.0.0/rosbe-1.0.0-win-x64.zip
+    InstallerSha256: CF2D45754BA82B679AA56FB246382AB5B2570941D1F0DCF1CDE355DCB43CF092
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/r/ReactOS/RosBE/1.0.0/ReactOS.RosBE.installer.yaml
+++ b/manifests/r/ReactOS/RosBE/1.0.0/ReactOS.RosBE.installer.yaml
@@ -2,13 +2,16 @@
 
 PackageIdentifier: ReactOS.RosBE
 PackageVersion: 1.0.0
+Commands:
+  - rosbe
 Installers:
   - Architecture: x64
     InstallerType: zip
     NestedInstallerType: portable
     NestedInstallerFiles:
-      - RelativeFilePath: mingw-gcc\x86_64-w64-mingw32\bin\x86_64-w64-mingw32-gcc.exe
+      - RelativeFilePath: rosbe.exe
+        PortableCommandAlias: rosbe
     InstallerUrl: https://github.com/ahmedarif193/winget-rosbe/releases/download/v1.0.0/rosbe-1.0.0-win-x64.zip
-    InstallerSha256: 69436FB872AF75DAC01FC5D112A1F04F7ABEEADA376FB28A53F855E67A081529
+    InstallerSha256: DDDBEB67D285C9A7323A55B0B8AEC0E7AA3184AD12BC52533A7A86722A151268
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/r/ReactOS/RosBE/1.0.0/ReactOS.RosBE.installer.yaml
+++ b/manifests/r/ReactOS/RosBE/1.0.0/ReactOS.RosBE.installer.yaml
@@ -7,8 +7,8 @@ Installers:
     InstallerType: zip
     NestedInstallerType: portable
     NestedInstallerFiles:
-      - RelativeFilePath: rosbe.exe
+      - RelativeFilePath: mingw-gcc\x86_64-w64-mingw32\bin\x86_64-w64-mingw32-gcc.exe
     InstallerUrl: https://github.com/ahmedarif193/winget-rosbe/releases/download/v1.0.0/rosbe-1.0.0-win-x64.zip
-    InstallerSha256: CF2D45754BA82B679AA56FB246382AB5B2570941D1F0DCF1CDE355DCB43CF092
+    InstallerSha256: 69436FB872AF75DAC01FC5D112A1F04F7ABEEADA376FB28A53F855E67A081529
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/r/ReactOS/RosBE/1.0.0/ReactOS.RosBE.locale.en-US.yaml
+++ b/manifests/r/ReactOS/RosBE/1.0.0/ReactOS.RosBE.locale.en-US.yaml
@@ -18,7 +18,7 @@ Description: |-
 
   Bundled in this version:
     - LLVM-MinGW (Clang) 21.1.7   - llvm-mingw 20251202 (UCRT)
-    - MinGW-GCC                  15.2.0    - winlibs (UCRT, mingw-w64 14.0.0)
+    - MinGW-GCC                  15.2.0    - crosstool-NG Canadian-cross (UCRT)
     - CMake                      3.31.6
     - Ninja                      1.12.1
     - WinFlexBison (Flex+Bison)  2.5.25    - Flex 2.6.4 + Bison 3.8.2

--- a/manifests/r/ReactOS/RosBE/1.0.0/ReactOS.RosBE.locale.en-US.yaml
+++ b/manifests/r/ReactOS/RosBE/1.0.0/ReactOS.RosBE.locale.en-US.yaml
@@ -7,28 +7,33 @@ Publisher: Ahmed Arif
 PublisherUrl: https://github.com/ahmedarif193
 PublisherSupportUrl: https://github.com/ahmedarif193/winget-rosbe/issues
 Author: Ahmed Arif
-PackageName: RosBE Modern
+PackageName: RosBE
 PackageUrl: https://github.com/ahmedarif193/winget-rosbe
 License: MIT
 LicenseUrl: https://github.com/ahmedarif193/winget-rosbe/blob/main/LICENSE
-ShortDescription: Modernized ReactOS Build Environment (unofficial, preview)
+ShortDescription: RosBE bootstrapper and toolchain manager for ReactOS
 Description: |-
-  A modern, winget-installable build environment for ReactOS, bundling
-  the latest upstream toolchains.
+  A lightweight, winget-installable Rust bootstrapper for RosBE.
 
-  Bundled in this version:
+  `winget install` adds the `rosbe` command. Run `rosbe install` to
+  download and verify the RosBE toolchain bundle, then `rosbe enable`
+  to add the active toolchain directories to PATH.
+
+  Managed in this version:
     - LLVM-MinGW (Clang) 21.1.7   - llvm-mingw 20251202 (UCRT)
     - MinGW-GCC                  15.2.0    - crosstool-NG Canadian-cross (UCRT)
     - CMake                      3.31.6
     - Ninja                      1.12.1
     - WinFlexBison (Flex+Bison)  2.5.25    - Flex 2.6.4 + Bison 3.8.2
 
-  Not an official ReactOS release. Intended for preview / early adoption;
-  the goal is for this to become the default RosBE for upstream ReactOS
-  sources once validated.
+  `rosbe update` refreshes the toolchain bundle. `rosbe remove` removes
+  the installed bundle and PATH entries.
+
+  Not an official ReactOS release. Intended for preview / early adoption.
 Moniker: rosbe
 Tags:
   - reactos
+  - bootstrapper
   - build-environment
   - cross-compiler
   - llvm

--- a/manifests/r/ReactOS/RosBE/1.0.0/ReactOS.RosBE.locale.en-US.yaml
+++ b/manifests/r/ReactOS/RosBE/1.0.0/ReactOS.RosBE.locale.en-US.yaml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: ReactOS.RosBE
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: Ahmed Arif
+PublisherUrl: https://github.com/ahmedarif193
+PublisherSupportUrl: https://github.com/ahmedarif193/winget-rosbe/issues
+Author: Ahmed Arif
+PackageName: RosBE Modern
+PackageUrl: https://github.com/ahmedarif193/winget-rosbe
+License: MIT
+LicenseUrl: https://github.com/ahmedarif193/winget-rosbe/blob/main/LICENSE
+ShortDescription: Modernized ReactOS Build Environment (unofficial, preview)
+Description: |-
+  A modern, winget-installable build environment for ReactOS, bundling
+  the latest upstream toolchains.
+
+  Bundled in this version:
+    - LLVM-MinGW (Clang) 21.1.7   - llvm-mingw 20251202 (UCRT)
+    - MinGW-GCC                  15.2.0    - winlibs (UCRT, mingw-w64 14.0.0)
+    - CMake                      3.31.6
+    - Ninja                      1.12.1
+    - WinFlexBison (Flex+Bison)  2.5.25    - Flex 2.6.4 + Bison 3.8.2
+
+  Not an official ReactOS release. Intended for preview / early adoption;
+  the goal is for this to become the default RosBE for upstream ReactOS
+  sources once validated.
+Moniker: rosbe
+Tags:
+  - reactos
+  - build-environment
+  - cross-compiler
+  - llvm
+  - clang
+  - mingw
+  - gcc
+  - cmake
+  - ninja
+  - development
+  - operating-system
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/r/ReactOS/RosBE/1.0.0/ReactOS.RosBE.yaml
+++ b/manifests/r/ReactOS/RosBE/1.0.0/ReactOS.RosBE.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: ReactOS.RosBE
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package from [ReactOS RosBE](https://github.com/ahmedarif193/winget-rosbe)

- **Version**: `20260424`
- **Release**: https://github.com/ahmedarif193/winget-rosbe/releases/tag/v20260424
- **Bootstrapper SHA256 (x64)**: `370EE89000855BCF79D5EA23767D7BD9112CED641553EA7C73C44EBCCE4097FD`
- **Post-install**: `rosbe install` then `rosbe enable`

A lightweight, winget-installable Rust bootstrapper for [ReactOS](https://reactos.org). The `winget` package installs `rosbe`, and `rosbe install` later downloads and verifies the RosBE toolchain bundle on demand.

Managed toolchain versions:
- LLVM-MinGW `20251202`
- MinGW-GCC `15.2.0`
- CMake `3.31.6`
- Ninja `1.12.1`
- WinFlexBison `2.5.25`
- QEMU (Windows bundle) `11.0.0` (`20260422` build from qemu.weilnetz.de)

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.