### PR TITLE
New package: SamsidParty.OberonRemote.Client version 1.1.0.0

### DIFF
--- a/manifests/s/SamsidParty/OberonRemote/Client/1.1.0.0/SamsidParty.OberonRemote.Client.installer.yaml
+++ b/manifests/s/SamsidParty/OberonRemote/Client/1.1.0.0/SamsidParty.OberonRemote.Client.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: SamsidParty.OberonRemote.Client
+PackageVersion: 1.1.0.0
+ReleaseDate: 2025-03-18
+Platform:
+- Windows.Universal
+MinimumOSVersion: 10.0.22621.0
+InstallerType: msix
+PackageFamilyName: 55968SamsidGameStudios.OberonRemoteInput_r9j5xrxak4zje
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/SamsidParty/OberonRemote/releases/download/1.2.0/Oberon.Msixbundle
+  InstallerSha256: 8422B7C3E43EB9B6FA0D844F5A56CFFE70C74808AE3D61718A14B14628EC7A97
+  SignatureSha256: 4C0A8E30BBBC51BFD687C6DC29D178AFB275759C5C3ACD9902A6D8B05E598434
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/SamsidParty/OberonRemote/Client/1.1.0.0/SamsidParty.OberonRemote.Client.installer.yaml
+++ b/manifests/s/SamsidParty/OberonRemote/Client/1.1.0.0/SamsidParty.OberonRemote.Client.installer.yaml
@@ -5,7 +5,7 @@ PackageVersion: 1.1.0.0
 ReleaseDate: 2025-03-18
 Platform:
 - Windows.Universal
-MinimumOSVersion: 10.0.22621.0
+MinimumOSVersion: 10.0.22621.0 # Windows 11 22H2
 InstallerType: msix
 PackageFamilyName: 55968SamsidGameStudios.OberonRemoteInput_r9j5xrxak4zje
 Installers:

--- a/manifests/s/SamsidParty/OberonRemote/Client/1.1.0.0/SamsidParty.OberonRemote.Client.locale.en-US.yaml
+++ b/manifests/s/SamsidParty/OberonRemote/Client/1.1.0.0/SamsidParty.OberonRemote.Client.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: SamsidParty.OberonRemote.Client
+PackageVersion: 1.1.0.0
+PackageLocale: en-US
+Publisher: SamsidParty
+PackageName: Oberon Remote Input (Client)
+PackageUrl: https://github.com/SamsidParty/OberonRemote
+License: Custom (Freeware)
+LicenseUrl: https://raw.githubusercontent.com/SamsidParty/OberonRemote/refs/heads/main/LICENSE
+ShortDescription: Remote input for Xbox consoles, use any controller with your Xbox.
+Description: |-
+  Remote input for Xbox consoles, use any controller with your Xbox.
+
+  The client version of the app is intended for installation on post-2012 Xbox-branded consoles, so that controllers connected to the server version of the app on their PC, can have their inputs be forwarded to the corresponding client app. The client version's installer does however also install to completion on PC.
+Tags:
+- oberon-remote-client
+- oberon-remote-input
+- oberonremoteinput
+- oberon.remote
+- xbox-series
+- xboxseries
+- xbox-one
+- xboxone
+- controller-adapter
+- use-any-controllers
+- websocket
+- remote-input
+- remoteinput
+- lan-connections
+- 9pk5stjzff3s
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/SamsidParty/OberonRemote/Client/1.1.0.0/SamsidParty.OberonRemote.Client.yaml
+++ b/manifests/s/SamsidParty/OberonRemote/Client/1.1.0.0/SamsidParty.OberonRemote.Client.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: SamsidParty.OberonRemote.Client
+PackageVersion: 1.1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?  If so, fill in the Issue number below.
   <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---
Notes from me:
* Why the MSIXBundle file for 1.2.0 has 1.1.0.0 as its file version is unknown to me. And since it's an MSIX(Bundle) file, DisplayVersion cannot be applied.
* The corresponding `SamsidParty.OberonRemote.Server` app ran into a glitch on my end during testing, where the Winget installation of it would crash without printing any errors after the logging reached the `[CORE] Started applying motw using IAttachmentExecute to C:\Users\(...)\AppData\Local\Temp\WinGet\SamsidParty.OberonRemote.Server.1.2.0\6e4c72bd9198a058eac44db74bc5da5b09a37353af14c7d87830a3444d558135` part.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/364416)