### PR TITLE
New version: itsnateai.CapsNumTray version 2.3.1

### DIFF
--- a/manifests/i/itsnateai/CapsNumTray/2.3.1/itsnateai.CapsNumTray.installer.yaml
+++ b/manifests/i/itsnateai/CapsNumTray/2.3.1/itsnateai.CapsNumTray.installer.yaml
@@ -1,0 +1,9 @@
+PackageIdentifier: itsnateai.CapsNumTray
+PackageVersion: 2.3.1
+InstallerType: portable
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/itsnateai/CaplockNumlock/releases/download/v2.3.1/CapsNumTray.exe
+    InstallerSha256: 8E8E03CDA0C0DDBCF65FE5DEA882636F7BC4CE6D76B98A06D270F6C76521CED0
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/i/itsnateai/CapsNumTray/2.3.1/itsnateai.CapsNumTray.locale.en-US.yaml
+++ b/manifests/i/itsnateai/CapsNumTray/2.3.1/itsnateai.CapsNumTray.locale.en-US.yaml
@@ -1,0 +1,29 @@
+PackageIdentifier: itsnateai.CapsNumTray
+PackageVersion: 2.3.1
+PackageLocale: en-US
+Publisher: itsnateai
+PublisherUrl: https://github.com/itsnateai
+PackageName: CapsNumTray
+PackageUrl: https://github.com/itsnateai/CaplockNumlock
+License: MIT
+LicenseUrl: https://github.com/itsnateai/CaplockNumlock/blob/main/LICENSE
+ShortDescription: Caps Lock, Num Lock, and Scroll Lock tray indicators for Windows
+Description: System tray indicators for Caps Lock, Num Lock, and Scroll Lock. Left-click to toggle, independent icons per key, light/dark theme support, DPI-aware, on-screen display.
+ReleaseNotes: |-
+  Battle-tested Long-Term Release.
+
+  CapsNumTray is now stable. If you're running an older version, open Settings → Update and the app will download, verify, and relaunch itself — no manual install, no reboot.
+
+  Includes a small polish to make the right-click menu consistent with the rest of the tray-app family: the CapsNumTray header is now bold, and Windows 11 menu spacing matches MicMute and MWBToggle.
+
+  This is the new LTR baseline.
+ReleaseNotesUrl: https://github.com/itsnateai/CaplockNumlock/releases/tag/v2.3.1
+Tags:
+  - capslock
+  - numlock
+  - scrolllock
+  - tray-indicator
+  - keyboard
+  - system-tray
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/i/itsnateai/CapsNumTray/2.3.1/itsnateai.CapsNumTray.yaml
+++ b/manifests/i/itsnateai/CapsNumTray/2.3.1/itsnateai.CapsNumTray.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: itsnateai.CapsNumTray
+PackageVersion: 2.3.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## itsnateai.CapsNumTray v2.3.1

**Battle-tested Long-Term Release.**

CapsNumTray is now stable. This release includes a small polish to make the right-click menu consistent with the rest of the tray-app family: the CapsNumTray header is now bold, and Windows 11 menu spacing matches sibling apps.

- Release: https://github.com/itsnateai/CaplockNumlock/releases/tag/v2.3.1
- SHA256: `8E8E03CDA0C0DDBCF65FE5DEA882636F7BC4CE6D76B98A06D270F6C76521CED0`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/364618)