### PR TITLE
Update Microsoft.PowerShell 7.6.1.0 wix installers to use elevatesSelf

### DIFF
--- a/manifests/m/Microsoft/PowerShell/7.6.1.0/Microsoft.PowerShell.installer.yaml
+++ b/manifests/m/Microsoft/PowerShell/7.6.1.0/Microsoft.PowerShell.installer.yaml
@@ -43,27 +43,27 @@ Installers:
   ProductCode: '{7DB6AE45-EA0D-4E0A-A65A-2ECD74328B1E}'
   InstallerType: wix
   Scope: machine
-  ElevationRequirement: elevationRequired
+  ElevationRequirement: elevatesSelf
 - Architecture: x86
   InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.6.1/PowerShell-7.6.1-win-x86.msi
   InstallerSha256: 7DB70D349A081D8D29EB63A05A708F01C3AE21DDB9E348D9F9F6824462A89351
   ProductCode: '{1CD82E6C-4823-4F89-945E-46969710BBAE}'
   InstallerType: wix
   Scope: machine
-  ElevationRequirement: elevationRequired
+  ElevationRequirement: elevatesSelf
 - Architecture: arm
   InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.6.1/PowerShell-7.6.1-win-arm64.msi
   InstallerSha256: 027890171C7CBA1957111C9CE67AB5B5C274386E707CD40113F73B353C8115AE
   ProductCode: '{14260EE6-E5F6-4E31-AC24-B25642588781}'
   InstallerType: wix
   Scope: machine
-  ElevationRequirement: elevationRequired
+  ElevationRequirement: elevatesSelf
 - Architecture: arm64
   InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.6.1/PowerShell-7.6.1-win-arm64.msi
   InstallerSha256: 027890171C7CBA1957111C9CE67AB5B5C274386E707CD40113F73B353C8115AE
   ProductCode: '{14260EE6-E5F6-4E31-AC24-B25642588781}'
   InstallerType: wix
   Scope: machine
-  ElevationRequirement: elevationRequired
+  ElevationRequirement: elevatesSelf
 ManifestType: installer
 ManifestVersion: 1.12.0


### PR DESCRIPTION
Update Microsoft.PowerShell 7.6.1.0 wix installers to use `elevatesSelf`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/364622)