### PR TITLE
New package: GeziP.KBIntake version 1.0.0

### DIFF
--- a/manifests/g/GeziP/KBIntake/1.0.0/GeziP.KBIntake.installer.yaml
+++ b/manifests/g/GeziP/KBIntake/1.0.0/GeziP.KBIntake.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: GeziP.KBIntake
+PackageVersion: 1.0.0
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+ReleaseDate: 2026-04-24
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/GeziP/windows-rightclick-vault-import/releases/download/v1.0.0/KBIntake-Setup.exe
+    InstallerSha256: B977CE43D9F4D768EFB820925F2CD7894EBD03B64377006E8B1348843B6C5A98
+    Scope: user
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/g/GeziP/KBIntake/1.0.0/GeziP.KBIntake.installer.yaml
+++ b/manifests/g/GeziP/KBIntake/1.0.0/GeziP.KBIntake.installer.yaml
@@ -12,6 +12,9 @@ InstallerSwitches:
   Silent: /S
   SilentWithProgress: /S
 ReleaseDate: 2026-04-24
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/GeziP/windows-rightclick-vault-import/releases/download/v1.0.0/KBIntake-Setup.exe

--- a/manifests/g/GeziP/KBIntake/1.0.0/GeziP.KBIntake.locale.en-US.yaml
+++ b/manifests/g/GeziP/KBIntake/1.0.0/GeziP.KBIntake.locale.en-US.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: GeziP.KBIntake
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: GeziP
+PublisherUrl: https://github.com/GeziP
+PackageName: KBIntake
+PackageUrl: https://github.com/GeziP/windows-rightclick-vault-import
+Moniker: kbintake
+License: Proprietary
+ShortDescription: Windows-friendly local vault importer with Explorer integration.
+Description: KBIntake imports files and folders into a local knowledge-base vault from PowerShell or the Windows Explorer right-click menu.
+Tags:
+  - knowledge-base
+  - obsidian
+  - windows
+  - cli
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/g/GeziP/KBIntake/1.0.0/GeziP.KBIntake.yaml
+++ b/manifests/g/GeziP/KBIntake/1.0.0/GeziP.KBIntake.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: GeziP.KBIntake
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
﻿### Package manifest

Adds KBIntake 1.0.0.

- PackageIdentifier: GeziP.KBIntake
- PackageVersion: 1.0.0
- InstallerType: nullsoft
- Scope: user
- InstallerUrl: https://github.com/GeziP/windows-rightclick-vault-import/releases/download/v1.0.0/KBIntake-Setup.exe

### Validation

Validated in the source repository with:

```powershell
winget validate --manifest .\installer\winget\1.0.0
```

Result: `Manifest validation succeeded.`

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/364698)