### PR TITLE
New package dependency: PerryTS.Perry version 0.5.178

### DIFF
--- a/manifests/p/PerryTS/Perry/0.5.178/PerryTS.Perry.installer.yaml
+++ b/manifests/p/PerryTS/Perry/0.5.178/PerryTS.Perry.installer.yaml
@@ -8,6 +8,9 @@ NestedInstallerType: portable
 NestedInstallerFiles:
 - RelativeFilePath: perry.exe
   PortableCommandAlias: perry
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: LLVM.LLVM
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/PerryTS/perry/releases/download/v0.5.178/perry-windows-x86_64.zip


### PR DESCRIPTION
## Description

Add `LLVM.LLVM` as a `PackageDependencies` entry for `PerryTS.Perry` v0.5.178.

### Motivation

Perry is a native TypeScript compiler (https://github.com/PerryTS/perry) that shells out to `clang` to turn its LLVM IR into native object files. Without LLVM on the system, `perry compile hello.ts` fails with a `clang not found` error on every fresh Windows install.

The Perry CLI already falls back to `C:\Program Files\LLVM\bin\clang.exe` and MSVC's bundled clang, plus `PERRY_LLVM_CLANG` as an explicit override, so the dependency only needs to exist on PATH — it doesn't need to be a specific version.

### Effect

After this PR, `winget install PerryTS.Perry` will pull `LLVM.LLVM` first, and the fresh install will work end-to-end. Reported by a user at https://github.com/PerryTS/perry/discussions/176.

### Checklist

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-create#building-the-client) your manifest locally with `winget validate --manifest <path>`?

### Notes

Adding the `Dependencies` block to v0.5.178 (the current latest) rather than a new version because `wingetcreate update` (used by Perry's release automation at [PerryTS/perry/.github/workflows/release-packages.yml](https://github.com/PerryTS/perry/blob/main/.github/workflows/release-packages.yml)) uses the latest published manifest as its template and preserves fields it doesn't explicitly mutate — so future Perry releases automatically carry this dependency forward without additional winget-pkgs PRs.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/364706)