### PR TITLE
New version: ReactOS.RosBE version 20260424

### DIFF
--- a/manifests/r/ReactOS/RosBE/20260424/ReactOS.RosBE.installer.yaml
+++ b/manifests/r/ReactOS/RosBE/20260424/ReactOS.RosBE.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: ReactOS.RosBE
+PackageVersion: 20260424
+Commands:
+  - rosbe
+Installers:
+  - Architecture: x64
+    InstallerType: zip
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: rosbe.exe
+        PortableCommandAlias: rosbe
+    InstallerUrl: https://github.com/ahmedarif193/winget-rosbe/releases/download/v20260424/rosbe-bootstrapper-20260424-win-x64.zip
+    InstallerSha256: 370EE89000855BCF79D5EA23767D7BD9112CED641553EA7C73C44EBCCE4097FD
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/r/ReactOS/RosBE/20260424/ReactOS.RosBE.locale.en-US.yaml
+++ b/manifests/r/ReactOS/RosBE/20260424/ReactOS.RosBE.locale.en-US.yaml
@@ -1,0 +1,49 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: ReactOS.RosBE
+PackageVersion: 20260424
+PackageLocale: en-US
+Publisher: Ahmed Arif
+PublisherUrl: https://github.com/ahmedarif193
+PublisherSupportUrl: https://github.com/ahmedarif193/winget-rosbe/issues
+Author: Ahmed Arif
+PackageName: RosBE
+PackageUrl: https://github.com/ahmedarif193/winget-rosbe
+License: MIT
+LicenseUrl: https://github.com/ahmedarif193/winget-rosbe/blob/main/LICENSE
+ShortDescription: RosBE bootstrapper and toolchain manager for ReactOS
+Description: |-
+  A lightweight, winget-installable Rust bootstrapper for RosBE.
+
+  `winget install` adds the `rosbe` command. Run `rosbe install` to
+  download and verify the RosBE toolchain bundle, then `rosbe enable`
+  to add the active toolchain directories to PATH.
+
+  Managed in this version:
+    - LLVM-MinGW (Clang) 21.1.7   - llvm-mingw 20251202 (UCRT)
+    - MinGW-GCC                  15.2.0    - crosstool-NG Canadian-cross (UCRT)
+    - CMake                      3.31.6
+    - Ninja                      1.12.1
+    - WinFlexBison (Flex+Bison)  2.5.25    - Flex 2.6.4 + Bison 3.8.2
+    - QEMU (Windows bundle)      11.0.0    - qemu.weilnetz.de build 20260422
+
+  `rosbe update` refreshes the toolchain bundle. `rosbe remove` removes
+  the installed bundle and PATH entries.
+
+  Not an official ReactOS release. Intended for preview / early adoption.
+Moniker: rosbe
+Tags:
+  - reactos
+  - bootstrapper
+  - build-environment
+  - cross-compiler
+  - llvm
+  - clang
+  - mingw
+  - gcc
+  - cmake
+  - ninja
+  - development
+  - operating-system
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/r/ReactOS/RosBE/20260424/ReactOS.RosBE.yaml
+++ b/manifests/r/ReactOS/RosBE/20260424/ReactOS.RosBE.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: ReactOS.RosBE
+PackageVersion: 20260424
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package from [ReactOS RosBE](https://github.com/ahmedarif193/winget-rosbe)

- **Version**: `20260424`
- **Release**: https://github.com/ahmedarif193/winget-rosbe/releases/tag/v20260424
- **Bootstrapper SHA256 (x64)**: `370EE89000855BCF79D5EA23767D7BD9112CED641553EA7C73C44EBCCE4097FD`
- **Post-install**: `rosbe install` then `rosbe enable`

A lightweight, winget-installable Rust bootstrapper for [ReactOS](https://reactos.org). The `winget` package installs `rosbe`, and `rosbe install` later downloads and verifies the RosBE toolchain bundle on demand.

Managed toolchain versions:
- LLVM-MinGW `20251202`
- MinGW-GCC `15.2.0`
- CMake `3.31.6`
- Ninja `1.12.1`
- WinFlexBison `2.5.25`
- QEMU (Windows bundle) `11.0.0` (`20260422` build from qemu.weilnetz.de)

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/364735)