### PR TITLE
New package: cataggar.wamr and cataggar.wamrc version 3.0.0-dev.8

### DIFF
--- a/manifests/c/cataggar/wamr/3.0.0-dev.8/cataggar.wamr.installer.yaml
+++ b/manifests/c/cataggar/wamr/3.0.0-dev.8/cataggar.wamr.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: cataggar.wamr
+PackageVersion: 3.0.0-dev.8
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: wamr-3.0.0-dev.8-windows-x64\bin\wamr.exe
+  PortableCommandAlias: wamr
+Commands:
+- wamr
+ReleaseDate: 2026-04-24
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/cataggar/wamr/releases/download/v3.0.0-dev.8/wamr-3.0.0-dev.8-windows-x64.zip
+  InstallerSha256: 7C9F2DB6B866DDF0D490C0A87E28AECAAD17AADE975B17363E13DD571EB45526
+- Architecture: arm64
+  InstallerUrl: https://github.com/cataggar/wamr/releases/download/v3.0.0-dev.8/wamr-3.0.0-dev.8-windows-arm64.zip
+  InstallerSha256: 8B5B9C5252990134CD9DB008F1EDF5EAE342AEAC41866112B9ABEE46F3F17630
+  NestedInstallerFiles:
+  - RelativeFilePath: wamr-3.0.0-dev.8-windows-arm64\bin\wamr.exe
+    PortableCommandAlias: wamr
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/cataggar/wamr/3.0.0-dev.8/cataggar.wamr.locale.en-US.yaml
+++ b/manifests/c/cataggar/wamr/3.0.0-dev.8/cataggar.wamr.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: cataggar.wamr
+PackageVersion: 3.0.0-dev.8
+PackageLocale: en-US
+Publisher: cataggar
+PublisherUrl: https://github.com/cataggar
+PublisherSupportUrl: https://github.com/cataggar/wamr/issues
+PackageName: wamr
+PackageUrl: https://github.com/cataggar/wamr
+License: Apache-2.0
+LicenseUrl: https://github.com/cataggar/wamr/blob/main/LICENSE
+ShortDescription: WebAssembly Micro Runtime interpreter.
+Description: |-
+  wamr decodes and runs a WebAssembly binary file using a stack-based interpreter.
+  A fork of bytecodealliance/wasm-micro-runtime ported from C to Zig and maintained with AI assistance.
+Moniker: wamr
+Tags:
+- interpreter
+- runtime
+- wasm
+- webassembly
+- zig
+ReleaseNotesUrl: https://github.com/cataggar/wamr/releases/tag/v3.0.0-dev.8
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/cataggar/wamr/3.0.0-dev.8/cataggar.wamr.yaml
+++ b/manifests/c/cataggar/wamr/3.0.0-dev.8/cataggar.wamr.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: cataggar.wamr
+PackageVersion: 3.0.0-dev.8
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/manifests/c/cataggar/wamrc/3.0.0-dev.8/cataggar.wamrc.installer.yaml
+++ b/manifests/c/cataggar/wamrc/3.0.0-dev.8/cataggar.wamrc.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: cataggar.wamrc
+PackageVersion: 3.0.0-dev.8
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: wamr-3.0.0-dev.8-windows-x64\bin\wamrc.exe
+  PortableCommandAlias: wamrc
+Commands:
+- wamrc
+ReleaseDate: 2026-04-24
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/cataggar/wamr/releases/download/v3.0.0-dev.8/wamr-3.0.0-dev.8-windows-x64.zip
+  InstallerSha256: 7C9F2DB6B866DDF0D490C0A87E28AECAAD17AADE975B17363E13DD571EB45526
+- Architecture: arm64
+  InstallerUrl: https://github.com/cataggar/wamr/releases/download/v3.0.0-dev.8/wamr-3.0.0-dev.8-windows-arm64.zip
+  InstallerSha256: 8B5B9C5252990134CD9DB008F1EDF5EAE342AEAC41866112B9ABEE46F3F17630
+  NestedInstallerFiles:
+  - RelativeFilePath: wamr-3.0.0-dev.8-windows-arm64\bin\wamrc.exe
+    PortableCommandAlias: wamrc
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/cataggar/wamrc/3.0.0-dev.8/cataggar.wamrc.locale.en-US.yaml
+++ b/manifests/c/cataggar/wamrc/3.0.0-dev.8/cataggar.wamrc.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: cataggar.wamrc
+PackageVersion: 3.0.0-dev.8
+PackageLocale: en-US
+Publisher: cataggar
+PublisherUrl: https://github.com/cataggar
+PublisherSupportUrl: https://github.com/cataggar/wamr/issues
+PackageName: wamrc
+PackageUrl: https://github.com/cataggar/wamr
+License: Apache-2.0
+LicenseUrl: https://github.com/cataggar/wamr/blob/main/LICENSE
+ShortDescription: WebAssembly Micro Runtime AOT compiler.
+Description: |-
+  wamrc is the AOT (ahead-of-time) compiler for the WebAssembly Micro Runtime: it compiles a .wasm module to native code.
+  A fork of bytecodealliance/wasm-micro-runtime ported from C to Zig and maintained with AI assistance.
+Moniker: wamrc
+Tags:
+- aot
+- compiler
+- wasm
+- webassembly
+- zig
+ReleaseNotesUrl: https://github.com/cataggar/wamr/releases/tag/v3.0.0-dev.8
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/cataggar/wamrc/3.0.0-dev.8/cataggar.wamrc.yaml
+++ b/manifests/c/cataggar/wamrc/3.0.0-dev.8/cataggar.wamrc.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: cataggar.wamrc
+PackageVersion: 3.0.0-dev.8
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## WebAssembly Micro Runtime — initial submission

Adds two new packages at version `3.0.0-dev.8`:

- **cataggar.wamr** — WebAssembly Micro Runtime interpreter
- **cataggar.wamrc** — AOT (ahead-of-time) compiler

Project: <https://github.com/cataggar/wamr> (Apache-2.0). A fork of
[bytecodealliance/wasm-micro-runtime](https://github.com/bytecodealliance/wasm-micro-runtime)
ported from C to Zig; 20,901/20,901 WebAssembly spec tests passing.

### Installers

Both packages wrap the same GitHub-release zip (x64 and arm64) and expose a single
portable command via `PortableCommandAlias` (`wamr` / `wamrc`).

Windows binaries are Authenticode-signed by **Azure Trusted Signing** (publisher: cataggar).
Manifest structure mirrors the already-accepted `cataggar.ghr` package (schema 1.12.0).

### Checklist

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/README.md#validation) your manifest locally with `winget validate --manifest <path>`? — authored on Linux; will validate on a Windows host if reviewers request
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? — same
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.12.md)?

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/364899)