### PR TITLE
Add cataggar.wamr version 3.0.0-dev.8

### DIFF
--- a/manifests/c/cataggar/wamr/3.0.0-dev.8/cataggar.wamr.installer.yaml
+++ b/manifests/c/cataggar/wamr/3.0.0-dev.8/cataggar.wamr.installer.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: cataggar.wamr
+PackageVersion: 3.0.0-dev.8
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: wamr-3.0.0-dev.8-windows-x64\bin\wamr.exe
+  PortableCommandAlias: wamr
+- RelativeFilePath: wamr-3.0.0-dev.8-windows-x64\bin\wamrc.exe
+  PortableCommandAlias: wamrc
+Commands:
+- wamr
+- wamrc
+ReleaseDate: 2026-04-24
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/cataggar/wamr/releases/download/v3.0.0-dev.8/wamr-3.0.0-dev.8-windows-x64.zip
+  InstallerSha256: 7C9F2DB6B866DDF0D490C0A87E28AECAAD17AADE975B17363E13DD571EB45526
+- Architecture: arm64
+  InstallerUrl: https://github.com/cataggar/wamr/releases/download/v3.0.0-dev.8/wamr-3.0.0-dev.8-windows-arm64.zip
+  InstallerSha256: 8B5B9C5252990134CD9DB008F1EDF5EAE342AEAC41866112B9ABEE46F3F17630
+  NestedInstallerFiles:
+  - RelativeFilePath: wamr-3.0.0-dev.8-windows-arm64\bin\wamr.exe
+    PortableCommandAlias: wamr
+  - RelativeFilePath: wamr-3.0.0-dev.8-windows-arm64\bin\wamrc.exe
+    PortableCommandAlias: wamrc
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/cataggar/wamr/3.0.0-dev.8/cataggar.wamr.locale.en-US.yaml
+++ b/manifests/c/cataggar/wamr/3.0.0-dev.8/cataggar.wamr.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: cataggar.wamr
+PackageVersion: 3.0.0-dev.8
+PackageLocale: en-US
+Publisher: cataggar
+PublisherUrl: https://github.com/cataggar
+PublisherSupportUrl: https://github.com/cataggar/wamr/issues
+PackageName: wamr
+PackageUrl: https://github.com/cataggar/wamr
+License: Apache-2.0
+LicenseUrl: https://github.com/cataggar/wamr/blob/main/LICENSE
+ShortDescription: WebAssembly Micro Runtime — interpreter (wamr) and AOT compiler (wamrc).
+Description: |-
+  WebAssembly Micro Runtime distribution with two portable commands:
+    - wamr  — stack-based interpreter that decodes and runs a .wasm binary.
+    - wamrc — AOT (ahead-of-time) compiler that lowers a .wasm module to native code.
+  A fork of bytecodealliance/wasm-micro-runtime ported from C to Zig and maintained with AI assistance.
+Moniker: wamr
+Tags:
+- aot
+- compiler
+- interpreter
+- runtime
+- wasm
+- webassembly
+- zig
+ReleaseNotesUrl: https://github.com/cataggar/wamr/releases/tag/v3.0.0-dev.8
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/cataggar/wamr/3.0.0-dev.8/cataggar.wamr.yaml
+++ b/manifests/c/cataggar/wamr/3.0.0-dev.8/cataggar.wamr.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: cataggar.wamr
+PackageVersion: 3.0.0-dev.8
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## WebAssembly Micro Runtime — initial submission (wamr + wamrc)

Adds a single new package at version `3.0.0-dev.8`:

* **cataggar.wamr** — distribution of the WebAssembly Micro Runtime that wraps one GitHub-release zip (x64 and arm64) and exposes **two** portable command aliases:
  * `wamr` — stack-based interpreter
  * `wamrc` — AOT (ahead-of-time) compiler

This supersedes #364899, which submitted `cataggar.wamr` and `cataggar.wamrc` as two separate packages pointing at the same zip. Per upstream preference, the two tools are now a single winget package with two `PortableCommandAlias` entries.

Project: https://github.com/cataggar/wamr (Apache-2.0). A fork of
[bytecodealliance/wasm-micro-runtime](https://github.com/bytecodealliance/wasm-micro-runtime)
ported from C to Zig; 20,901/20,901 WebAssembly spec tests passing.

Windows binaries are Authenticode-signed by **Azure Trusted Signing** (publisher: cataggar).
Manifest structure mirrors the already-accepted `cataggar.ghr` package (schema 1.12.0).

### Checklist

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change? (Closing #364899 in favor of this PR.)
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/README.md#validation) your manifest locally with `winget validate --manifest <path>`? — authored on Linux; will validate on a Windows host if reviewers request
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? — same
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.12.md)?

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/364926)