### PR TITLE
PresenceJam: Add version 2.3.6

### DIFF
--- a/manifests/p/PresenceJam/PresenceJam/2.3.6/PresenceJam.PresenceJam.installer.yaml
+++ b/manifests/p/PresenceJam/PresenceJam/2.3.6/PresenceJam.PresenceJam.installer.yaml
@@ -1,0 +1,17 @@
+# Created with wingetcreate
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: PresenceJam.PresenceJam
+PackageVersion: "2.3.6"
+InstallerType: wix
+UpgradeBehavior: install
+ProductCode: "{A73E8021-5751-4265-B0F6-1339FA3B952A}"
+AppsAndFeaturesEntries:
+- ProductCode: "{A73E8021-5751-4265-B0F6-1339FA3B952A}"
+  UpgradeCode: "{72C2B806-ED84-559F-8C03-E31D5D972139}"
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Carme99/PresenceJam-Desktop/releases/download/v2.3.6/PresenceJam_2.3.6_x64_en-US.msi
+  InstallerSha256: 02cf73f620248ed39a966774f13126f6072a0b0674b5c9916a84292ee13166fe
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/p/PresenceJam/PresenceJam/2.3.6/PresenceJam.PresenceJam.locale.en-US.yaml
+++ b/manifests/p/PresenceJam/PresenceJam/2.3.6/PresenceJam.PresenceJam.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# Created with wingetcreate
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: PresenceJam.PresenceJam
+PackageVersion: "2.3.6"
+PackageLocale: en-US
+Publisher: PresenceJam
+PublisherUrl: https://github.com/Carme99/PresenceJam-Desktop
+PublisherSupportUrl: https://github.com/Carme99/PresenceJam-Desktop/issues
+Author: PresenceJam
+PackageName: PresenceJam
+PackageUrl: https://github.com/Carme99/PresenceJam-Desktop
+License: MIT
+LicenseUrl: https://github.com/Carme99/PresenceJam-Desktop/blob/main/LICENSE
+Copyright: Copyright (c) 2026 PresenceJam
+ShortDescription: Spotify to Teams Status Sync
+Description: Automatically syncs your currently playing Spotify track to your Microsoft Teams status message. Set a custom status message using placeholders like {artist}, {track}, {album}, and {emoji}.
+Moniker: presencejam
+Tags:
+  - spotify
+  - teams
+  - microsoft
+  - status
+  - presence
+  - productivity
+ReleaseNotesUrl: https://github.com/Carme99/PresenceJam-Desktop/releases/tag/v2.3.6
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/p/PresenceJam/PresenceJam/2.3.6/PresenceJam.PresenceJam.yaml
+++ b/manifests/p/PresenceJam/PresenceJam/2.3.6/PresenceJam.PresenceJam.yaml
@@ -1,0 +1,9 @@
+---
+# Created with wingetcreate
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: PresenceJam.PresenceJam
+PackageVersion: "2.3.6"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## PresenceJam v2.3.6

Add winget manifest for [PresenceJam](https://github.com/Carme99/PresenceJam-Desktop) v2.3.6 — a Tauri desktop app that syncs your Spotify playback status to Microsoft Teams.

### Package Details
- **Type:** MSI installer (WiX)
- **Architecture:** x64
- **Dependencies:** Microsoft Edge WebView2 Runtime
- **Scope:** machine

### Validation Checklist
- [ ] Installer URL reachable and MSI downloads correctly
- [ ] SHA256 verified: `02cf73f620248ed39a966774f13126f6072a0b0674b5c9916a84292ee13166fe`
- [ ] ProductCode extracted from MSI: `{A73E8021-5751-4265-B0F6-1339FA3B952A}`
- [ ] UpgradeCode extracted from MSI: `{72C2B806-ED84-559F-8C03-E31D5D972139}`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/364953)