### PR TITLE
New package: AlexReich.SitePix version 1.0.0

### DIFF
--- a/manifests/a/AlexReich/SitePix/1.0.0/AlexReich.SitePix.installer.yaml
+++ b/manifests/a/AlexReich/SitePix/1.0.0/AlexReich.SitePix.installer.yaml
@@ -1,5 +1,4 @@
 # Installer manifest for winget-pkgs.
-# 1.0.0 and 198751D90C8830E8DDE3106D981762BAF9C7565990FBC1DA16FCD2AF061833E8 are substituted by the release workflow.
 PackageIdentifier: AlexReich.SitePix
 PackageVersion: 1.0.0
 MinimumOSVersion: 10.0.17763.0
@@ -10,10 +9,10 @@ InstallModes:
   - silent
   - silentWithProgress
 UpgradeBehavior: install
-ReleaseDate: 2026-04-24
+ReleaseDate: 2026-05-01
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/alexreich/SitePix/releases/download/v1.0.0/SitePix-Setup-1.0.0.exe
-    InstallerSha256: 198751D90C8830E8DDE3106D981762BAF9C7565990FBC1DA16FCD2AF061833E8
+    InstallerSha256: 4EE962321293810FAE6A4EE8430ECE729B5739EE41F707A2A4C3E30A1990BEEB
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/a/AlexReich/SitePix/1.0.0/AlexReich.SitePix.installer.yaml
+++ b/manifests/a/AlexReich/SitePix/1.0.0/AlexReich.SitePix.installer.yaml
@@ -1,0 +1,19 @@
+# Installer manifest for winget-pkgs.
+# 1.0.0 and 198751D90C8830E8DDE3106D981762BAF9C7565990FBC1DA16FCD2AF061833E8 are substituted by the release workflow.
+PackageIdentifier: AlexReich.SitePix
+PackageVersion: 1.0.0
+MinimumOSVersion: 10.0.17763.0
+InstallerType: inno
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-04-24
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/alexreich/SitePix/releases/download/v1.0.0/SitePix-Setup-1.0.0.exe
+    InstallerSha256: 198751D90C8830E8DDE3106D981762BAF9C7565990FBC1DA16FCD2AF061833E8
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/a/AlexReich/SitePix/1.0.0/AlexReich.SitePix.locale.en-US.yaml
+++ b/manifests/a/AlexReich/SitePix/1.0.0/AlexReich.SitePix.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# Default-locale manifest for winget-pkgs.
+# 1.0.0 is substituted by the release workflow.
+PackageIdentifier: AlexReich.SitePix
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: Alex Reich
+PublisherUrl: https://github.com/alexreich
+PublisherSupportUrl: https://github.com/alexreich/SitePix/issues
+PackageName: SitePix
+PackageUrl: https://github.com/alexreich/SitePix
+License: CC-BY-4.0
+LicenseUrl: https://github.com/alexreich/SitePix/blob/main/LICENSE
+ShortDescription: Pulls large photos from WordPress-style news blogs into a folder your screensaver can use.
+Description: |-
+  SitePix downloads large images from any WordPress-style news blog with
+  dated permalinks and standard <article> / OpenGraph conventions, overlays
+  optional title/date text, and drops them in a folder the OS screensaver
+  or desktop slideshow can point at. Originally built for kadampa.org —
+  now profile-driven via JSON, so the same engine can feed off any
+  compatible site.
+Tags:
+  - sitepix
+  - screensaver
+  - wallpaper
+  - photos
+  - scraper
+  - wordpress
+ReleaseNotesUrl: https://github.com/alexreich/SitePix/releases/tag/v1.0.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/a/AlexReich/SitePix/1.0.0/AlexReich.SitePix.yaml
+++ b/manifests/a/AlexReich/SitePix/1.0.0/AlexReich.SitePix.yaml
@@ -1,0 +1,7 @@
+# Version manifest for winget-pkgs (top-level)
+# Tokens 1.0.0 are substituted by the release workflow.
+PackageIdentifier: AlexReich.SitePix
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Adds AlexReich.SitePix 1.0.0 (Inno Setup, x64).

SitePix downloads photos from WordPress-style news sites for use as desktop wallpaper. Source: https://github.com/alexreich/SitePix

Checklist for Pull Requests
- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?  If so, fill in the Issue number below.
   <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

Manifests
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/364980)