### PR TITLE
New version: RTF22.VOCIX version 1.3.5

### DIFF
--- a/manifests/r/RTF22/VOCIX/1.3.5/RTF22.VOCIX.installer.yaml
+++ b/manifests/r/RTF22/VOCIX/1.3.5/RTF22.VOCIX.installer.yaml
@@ -1,0 +1,15 @@
+PackageIdentifier: RTF22.VOCIX
+PackageVersion: 1.3.5
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: VOCIX\VOCIX.exe
+    PortableCommandAlias: vocix
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/RTF22/VOCIX/releases/download/v1.3.5/VOCIX-v1.3.5-win-x64.zip
+    InstallerSha256: A54D7F750B88A0C8A5855936844C0C6E39CADE74EBF418B4EB523E060055F4F7
+ReleaseDate: 2026-04-25
+
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/r/RTF22/VOCIX/1.3.5/RTF22.VOCIX.locale.en-US.yaml
+++ b/manifests/r/RTF22/VOCIX/1.3.5/RTF22.VOCIX.locale.en-US.yaml
@@ -1,0 +1,28 @@
+PackageIdentifier: RTF22.VOCIX
+PackageVersion: 1.3.5
+PackageLocale: en-US
+Publisher: RTF22
+PublisherUrl: https://github.com/RTF22
+PublisherSupportUrl: https://github.com/RTF22/VOCIX/issues
+PackageName: VOCIX
+PackageUrl: https://github.com/RTF22/VOCIX
+License: MIT
+LicenseUrl: https://github.com/RTF22/VOCIX/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Jens Fricke
+ShortDescription: Local voice dictation for Windows with global hotkey — Whisper STT + Claude text transformation.
+Description: |-
+  VOCIX (Voice Capture & Intelligent eXpression) is a local voice dictation app for Windows 11 with a global hotkey. Capture speech, transcribe it offline with faster-whisper, optionally transform it via Claude (Business or Rage mode), and insert the result system-wide at the cursor position — in any application.
+  Push-to-talk via Pause key (no standard binding in Windows / browsers / Office / IDEs — safe everywhere), three modes (Clean / Business / Rage), system tray with colour-coded microphone icon, multilingual UI (German / English), optional offline translation to English (any Whisper-supported language → EN), RDP mode, fully portable — no Python required.
+Moniker: vocix
+Tags:
+  - dictation
+  - speech-to-text
+  - voice
+  - whisper
+  - claude
+  - productivity
+  - accessibility
+  - windows
+ReleaseNotesUrl: https://github.com/RTF22/VOCIX/releases/tag/v1.3.5
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/r/RTF22/VOCIX/1.3.5/RTF22.VOCIX.yaml
+++ b/manifests/r/RTF22/VOCIX/1.3.5/RTF22.VOCIX.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: RTF22.VOCIX
+PackageVersion: 1.3.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
New version of RTF22.VOCIX.

This release rebuilds the PyInstaller bundle **without UPX compression**, which is the most common root cause of `Trojan:Script/Wacatac.H!ml` heuristic detections on Python bundles. The previous v1.3.4 PR (#363958, now closed) hit that exact false-positive in the Defender validator.

- Source: https://github.com/RTF22/VOCIX
- Release: https://github.com/RTF22/VOCIX/releases/tag/v1.3.5
- License: MIT (OSS, reproducible build via `vocix.spec`)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/365046)