### PR TITLE
New version: eddacraft.anvil version 0.4.0-beta

### DIFF
--- a/manifests/e/eddacraft/anvil/0.4.0-beta/eddacraft.anvil.installer.yaml
+++ b/manifests/e/eddacraft/anvil/0.4.0-beta/eddacraft.anvil.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: eddacraft.anvil
+PackageVersion: '0.4.0-beta'
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: anvil.exe
+    PortableCommandAlias: anvil
+Installers:
+  - Architecture: x64
+    InstallerUrl: 'https://github.com/EddaCraft/anvil/releases/download/v0.4.0-beta/eddacraft-anvil-x86_64-pc-windows-msvc.zip'
+    InstallerSha256: 'EA7D128EA9744C51570AA4112086D10FBB0E99180808AE76FC80BA6ACE0915BC'
+  - Architecture: arm64
+    InstallerUrl: 'https://github.com/EddaCraft/anvil/releases/download/v0.4.0-beta/eddacraft-anvil-aarch64-pc-windows-msvc.zip'
+    InstallerSha256: '797DA28B477541664B423567DAF27352CF743790FE378C20F095E9BFBBDB6B99'
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/e/eddacraft/anvil/0.4.0-beta/eddacraft.anvil.installer.yaml
+++ b/manifests/e/eddacraft/anvil/0.4.0-beta/eddacraft.anvil.installer.yaml
@@ -9,10 +9,10 @@ NestedInstallerFiles:
     PortableCommandAlias: anvil
 Installers:
   - Architecture: x64
-    InstallerUrl: 'https://github.com/EddaCraft/anvil/releases/download/v0.4.0-beta/eddacraft-anvil-x86_64-pc-windows-msvc.zip'
+    InstallerUrl: 'https://github.com/eddacraft/anvil/releases/download/v0.4.0-beta/eddacraft-anvil-x86_64-pc-windows-msvc.zip'
     InstallerSha256: 'EA7D128EA9744C51570AA4112086D10FBB0E99180808AE76FC80BA6ACE0915BC'
   - Architecture: arm64
-    InstallerUrl: 'https://github.com/EddaCraft/anvil/releases/download/v0.4.0-beta/eddacraft-anvil-aarch64-pc-windows-msvc.zip'
+    InstallerUrl: 'https://github.com/eddacraft/anvil/releases/download/v0.4.0-beta/eddacraft-anvil-aarch64-pc-windows-msvc.zip'
     InstallerSha256: '797DA28B477541664B423567DAF27352CF743790FE378C20F095E9BFBBDB6B99'
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/e/eddacraft/anvil/0.4.0-beta/eddacraft.anvil.locale.en-US.yaml
+++ b/manifests/e/eddacraft/anvil/0.4.0-beta/eddacraft.anvil.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: eddacraft.anvil
+PackageVersion: '0.4.0-beta'
+PackageLocale: en-US
+Publisher: eddacraft
+PublisherUrl: https://eddacraft.ai
+PackageName: Anvil
+PackageUrl: https://github.com/eddacraft/anvil
+License: Proprietary
+ShortDescription: Deterministic guardrails for AI-assisted development workflows
+Tags:
+  - ai
+  - cli
+  - developer-tools
+  - guardrails
+Icons:
+  - IconUrl: https://github.com/eddacraft/anvil/releases/download/v0.4.0-beta/anvil-icon-256.png
+    IconFileType: png
+    IconResolution: '256x256'
+    IconTheme: default
+    IconSha256: '6A79D63F58210C7467159B414F6DDAC5A7D545A0A5B3B90E6728535DC988778C'
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/e/eddacraft/anvil/0.4.0-beta/eddacraft.anvil.locale.en-US.yaml
+++ b/manifests/e/eddacraft/anvil/0.4.0-beta/eddacraft.anvil.locale.en-US.yaml
@@ -14,11 +14,5 @@ Tags:
   - cli
   - developer-tools
   - guardrails
-Icons:
-  - IconUrl: https://github.com/eddacraft/anvil/releases/download/v0.4.0-beta/anvil-icon-256.png
-    IconFileType: png
-    IconResolution: '256x256'
-    IconTheme: default
-    IconSha256: '6A79D63F58210C7467159B414F6DDAC5A7D545A0A5B3B90E6728535DC988778C'
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0

--- a/manifests/e/eddacraft/anvil/0.4.0-beta/eddacraft.anvil.yaml
+++ b/manifests/e/eddacraft/anvil/0.4.0-beta/eddacraft.anvil.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: eddacraft.anvil
+PackageVersion: '0.4.0-beta'
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## eddacraft.anvil v0.4.0-beta

Adds version `0.4.0-beta` of `eddacraft.anvil`.

- **Source:** https://github.com/EddaCraft/anvil/releases/tag/v0.4.0-beta
- **Architectures:** x64, arm64
- **Installer type:** zip with portable nested executable

### Manifest validation

- [x] Manifest schema 1.12.0
- [x] Installer SHA256 verified against published `.sha256` companion files
- [x] Icon SHA256 computed from the published `anvil-icon-256.png`


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/365186)