### PR TITLE
Update willibrandon.dotsider to 0.14.0

### DIFF
--- a/manifests/w/willibrandon/dotsider/0.14.0/willibrandon.dotsider.installer.yaml
+++ b/manifests/w/willibrandon/dotsider/0.14.0/willibrandon.dotsider.installer.yaml
@@ -1,0 +1,27 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: willibrandon.dotsider
+PackageVersion: 0.14.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.18362.0
+InstallerType: msi
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/willibrandon/dotsider/releases/download/v0.14.0/dotsider-win-x64.msi
+  InstallerSha256: 62E9A78B014EE31DD54039BE7A4AEF71E6B162A4A450EF1DD69BA46104E70C80
+  ProductCode: '{52F95227-60D3-44F0-9E43-9525F20C167D}'
+- Architecture: arm64
+  InstallerUrl: https://github.com/willibrandon/dotsider/releases/download/v0.14.0/dotsider-win-arm64.msi
+  InstallerSha256: 5093179826DB709CC03BE9FD17BF8736A0CAC031DA0708BFAF41B29632DC9CEE
+  ProductCode: '{CDC3357E-8E2C-4A1D-852B-25574837A937}'
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-04-26

--- a/manifests/w/willibrandon/dotsider/0.14.0/willibrandon.dotsider.locale.en-US.yaml
+++ b/manifests/w/willibrandon/dotsider/0.14.0/willibrandon.dotsider.locale.en-US.yaml
@@ -1,0 +1,36 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: willibrandon.dotsider
+PackageVersion: 0.14.0
+PackageLocale: en-US
+Publisher: willibrandon
+PublisherUrl: https://github.com/willibrandon
+PublisherSupportUrl: https://github.com/willibrandon/dotsider/issues
+PackageName: dotsider
+PackageUrl: https://github.com/willibrandon/dotsider
+License: MIT
+LicenseUrl: https://github.com/willibrandon/dotsider/blob/main/LICENSE
+ShortDescription: A TUI for analyzing .NET assemblies
+Description: |-
+  dotsider is a terminal UI for analyzing .NET assemblies — structure, metadata,
+  IL disassembly, strings, hex dump, dependency graphs, size maps, and live
+  runtime tracing via EventPipe. It also supports assembly diffing and NuGet
+  package browsing.
+Tags:
+- dotnet
+- assembly
+- tui
+- il
+- metadata
+- pe
+- disassembler
+- cli
+- terminal
+- devtools
+ReleaseNotesUrl: https://github.com/willibrandon/dotsider/releases/tag/v0.14.0
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/willibrandon/dotsider/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/w/willibrandon/dotsider/0.14.0/willibrandon.dotsider.yaml
+++ b/manifests/w/willibrandon/dotsider/0.14.0/willibrandon.dotsider.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: willibrandon.dotsider
+PackageVersion: 0.14.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Update dotsider to version 0.14.0

## Release notes

https://github.com/willibrandon/dotsider/releases/tag/v0.14.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/365226)