### PR TITLE
New package: BlackwellSystems.mcp-assert version 0.6.0

### DIFF
--- a/manifests/b/BlackwellSystems/mcp-assert/0.6.0/BlackwellSystems.mcp-assert.installer.yaml
+++ b/manifests/b/BlackwellSystems/mcp-assert/0.6.0/BlackwellSystems.mcp-assert.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: BlackwellSystems.mcp-assert
+PackageVersion: 0.6.0
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: mcp-assert.exe
+    PortableCommandAlias: mcp-assert
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/blackwell-systems/mcp-assert/releases/download/v0.6.0/mcp-assert_0.6.0_windows_amd64.zip
+    InstallerSha256: F5AE0C8E39070A31E84C63BA6ABB6F331B7213AC25BC553D9E5C1DDF086C5B40
+  - Architecture: arm64
+    InstallerUrl: https://github.com/blackwell-systems/mcp-assert/releases/download/v0.6.0/mcp-assert_0.6.0_windows_arm64.zip
+    InstallerSha256: 20BF9742CD8C03C1A25E8A2C89D82609D519B389CA0EE428774ECDEA5EDAC4BD
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/b/BlackwellSystems/mcp-assert/0.6.0/BlackwellSystems.mcp-assert.locale.en-US.yaml
+++ b/manifests/b/BlackwellSystems/mcp-assert/0.6.0/BlackwellSystems.mcp-assert.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: BlackwellSystems.mcp-assert
+PackageVersion: 0.6.0
+PackageLocale: en-US
+Publisher: Blackwell Systems
+PublisherUrl: https://github.com/blackwell-systems
+PackageName: mcp-assert
+PackageUrl: https://github.com/blackwell-systems/mcp-assert
+License: MIT
+LicenseUrl: https://github.com/blackwell-systems/mcp-assert/blob/main/LICENSE
+ShortDescription: Deterministic correctness testing for MCP servers. CLI, CI, and zero-config audit.
+Description: |-
+  A single Go binary that connects to your MCP server over stdio, SSE, or HTTP, calls your tools, and asserts the results. Define assertions in YAML, run them in CI. Works with servers written in Go, TypeScript, Python, Rust, Java, or anything else that speaks MCP.
+Tags:
+  - cli
+  - developer-tools
+  - mcp
+  - model-context-protocol
+  - testing
+ReleaseNotesUrl: https://github.com/blackwell-systems/mcp-assert/releases/tag/v0.6.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/b/BlackwellSystems/mcp-assert/0.6.0/BlackwellSystems.mcp-assert.yaml
+++ b/manifests/b/BlackwellSystems/mcp-assert/0.6.0/BlackwellSystems.mcp-assert.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: BlackwellSystems.mcp-assert
+PackageVersion: 0.6.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package submission

- **PackageIdentifier:** BlackwellSystems.mcp-assert
- **PackageVersion:** 0.6.0
- **InstallerType:** zip (portable)
- **Architectures:** x64, arm64

### Description

mcp-assert is a deterministic correctness testing tool for MCP (Model Context Protocol) servers. A single Go binary that connects to any MCP server over stdio, SSE, or HTTP, calls tools, and asserts the results. Define assertions in YAML, run them in CI.

- GitHub: https://github.com/blackwell-systems/mcp-assert
- Also available via: npm, pip, Homebrew, Scoop, Go install
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/365431)