### PR TITLE
New package: GeziP.KBIntake version 1.0.1

### DIFF
--- a/manifests/g/GeziP/KBIntake/1.0.1/GeziP.KBIntake.installer.yaml
+++ b/manifests/g/GeziP/KBIntake/1.0.1/GeziP.KBIntake.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: GeziP.KBIntake
+PackageVersion: 1.0.1
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+ReleaseDate: 2026-04-27
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/GeziP/windows-rightclick-vault-import/releases/download/v1.0.1/KBIntake-Setup.exe
+    InstallerSha256: 1F62DD989E824E13B0B10325C5858BE6AAAFCAEC083B109A39BA0CF1F8ADD9B7
+    Scope: user
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/g/GeziP/KBIntake/1.0.1/GeziP.KBIntake.locale.en-US.yaml
+++ b/manifests/g/GeziP/KBIntake/1.0.1/GeziP.KBIntake.locale.en-US.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: GeziP.KBIntake
+PackageVersion: 1.0.1
+PackageLocale: en-US
+Publisher: GeziP
+PublisherUrl: https://github.com/GeziP
+PackageName: KBIntake
+PackageUrl: https://github.com/GeziP/windows-rightclick-vault-import
+Moniker: kbintake
+License: Proprietary
+ShortDescription: Windows-friendly local vault importer with Explorer integration.
+Description: KBIntake imports files and folders into a local knowledge-base vault from PowerShell or the Windows Explorer right-click menu.
+Tags:
+  - knowledge-base
+  - obsidian
+  - windows
+  - cli
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/g/GeziP/KBIntake/1.0.1/GeziP.KBIntake.yaml
+++ b/manifests/g/GeziP/KBIntake/1.0.1/GeziP.KBIntake.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: GeziP.KBIntake
+PackageVersion: 1.0.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary
- Add GeziP.KBIntake version 1.0.1
- Update installer URL to the v1.0.1 GitHub release asset
- Update SHA256 for the new installer
- Remove the previous VC++ runtime dependency approach; 1.0.1 uses the fixed installer packaging

## Validation
- `winget validate --manifest .\installer\winget\1.0.1`
- Result: `Manifest validation succeeded.`
- GitHub Actions installer validation for v1.0.1 release passed on a clean Windows runner
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/365473)