### PR TITLE
Add x64 installer configuration to AutoGRToolkit

### DIFF
--- a/manifests/g/Giancan/AutoGRToolkit/6.0.0.0/Giancan.AutoGRToolkit.installer.yaml
+++ b/manifests/g/Giancan/AutoGRToolkit/6.0.0.0/Giancan.AutoGRToolkit.installer.yaml
@@ -13,5 +13,13 @@ Installers:
     InstallerSwitches:
       Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
       SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+      
+  - Architecture: x64
+    InstallerType: inno
+    InstallerUrl: https://github.com/giancan/AutoGR-Toolkit/releases/download/v6.0/AutoGRT-Setup_v6.0_win-x64.exe
+    InstallerSha256: a208a393afd2773f4c1213b335b3177500ab64026c84af3d25b8ad77a73108f5
+    InstallerSwitches:
+      Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+      SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
 ManifestType: installer
 ManifestVersion: 1.12.0


### PR DESCRIPTION
The x86 installer was already approved and merged in PR https://github.com/microsoft/winget-pkgs/pull/346568.
This PR adds the x64 variant to the same manifest.

Note: the x64 installer is larger and it failed the automated size/download
check. A manual review has been arranged with a winget support team member.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/365475)