### PR TITLE
Update Wox.Wox to 2.0.3

### DIFF
--- a/manifests/w/Wox/Wox/2.0.3/Wox.Wox.installer.yaml
+++ b/manifests/w/Wox/Wox/2.0.3/Wox.Wox.installer.yaml
@@ -1,0 +1,20 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Wox.Wox
+PackageVersion: 2.0.3
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: portable
+InstallModes:
+- silent
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Wox-launcher/Wox/releases/download/v2.0.3/wox-windows-amd64.exe
+  InstallerSha256: 3BDCC9BF0AF29CF15CE48433D64831CF477104002C8AF224079ED21CA393D863
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-04-26

--- a/manifests/w/Wox/Wox/2.0.3/Wox.Wox.installer.yaml
+++ b/manifests/w/Wox/Wox/2.0.3/Wox.Wox.installer.yaml
@@ -15,6 +15,6 @@ Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/Wox-launcher/Wox/releases/download/v2.0.3/wox-windows-amd64.exe
   InstallerSha256: 3BDCC9BF0AF29CF15CE48433D64831CF477104002C8AF224079ED21CA393D863
+ReleaseDate: 2026-04-26
 ManifestType: installer
 ManifestVersion: 1.12.0
-ReleaseDate: 2026-04-26

--- a/manifests/w/Wox/Wox/2.0.3/Wox.Wox.locale.en-US.yaml
+++ b/manifests/w/Wox/Wox/2.0.3/Wox.Wox.locale.en-US.yaml
@@ -11,9 +11,9 @@ Author: Wox-launcher
 PackageName: Wox
 PackageUrl: https://github.com/Wox-launcher/Wox
 License: GPL-3.0 license
-LicenseUrl: https://raw.githubusercontent.com/Wox-launcher/Wox/master/LICENSE
+LicenseUrl: https://raw.githubusercontent.com/Wox-launcher/Wox/v2.0.3/LICENSE
 Copyright: Copyright (c) 2026 Wox https://github.com/Wox-launcher/Wox
-CopyrightUrl: https://raw.githubusercontent.com/Wox-launcher/Wox/master/LICENSE
+CopyrightUrl: https://raw.githubusercontent.com/Wox-launcher/Wox/v2.0.3/LICENSE
 ShortDescription: WoX is a launcher for Windows that simply works. It's an alternative to Alfred and Launchy.
 Description: A full-featured launcher, access programs and web contents as you type. Be more productive ever since.
 Moniker: wox

--- a/manifests/w/Wox/Wox/2.0.3/Wox.Wox.locale.en-US.yaml
+++ b/manifests/w/Wox/Wox/2.0.3/Wox.Wox.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Wox.Wox
+PackageVersion: 2.0.3
+PackageLocale: en-US
+Publisher: Wox
+PublisherUrl: https://github.com/Wox-launcher/Wox
+PublisherSupportUrl: https://github.com/Wox-launcher/Wox/issues
+Author: Wox-launcher
+PackageName: Wox
+PackageUrl: https://github.com/Wox-launcher/Wox
+License: GPL-3.0 license
+LicenseUrl: https://raw.githubusercontent.com/Wox-launcher/Wox/master/LICENSE
+Copyright: Copyright (c) 2026 Wox https://github.com/Wox-launcher/Wox
+CopyrightUrl: https://raw.githubusercontent.com/Wox-launcher/Wox/master/LICENSE
+ShortDescription: WoX is a launcher for Windows that simply works. It's an alternative to Alfred and Launchy.
+Description: A full-featured launcher, access programs and web contents as you type. Be more productive ever since.
+Moniker: wox
+Tags:
+- alfred
+- launcher
+- launchy
+- spotlight
+ReleaseNotesUrl: https://github.com/Wox-launcher/Wox/releases/tag/v2.0.3
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/w/Wox/Wox/2.0.3/Wox.Wox.yaml
+++ b/manifests/w/Wox/Wox/2.0.3/Wox.Wox.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Wox.Wox
+PackageVersion: 2.0.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Updates Wox.Wox to the current stable release v2.0.3.

Changes:
- Update version to 2.0.3
- Change License from MIT to GPL-3.0
- Update installer URL to the official GitHub release asset
- Update PackageUrl from wox.one to https://github.com/Wox-launcher/Wox

I am the maintainer of Wox.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/365520)