### PR TITLE
Update Microsoft.PowerShell 7.6.0.0 wix installers to use elevatesSelf

### DIFF
--- a/manifests/m/Microsoft/PowerShell/7.6.0.0/Microsoft.PowerShell.installer.yaml
+++ b/manifests/m/Microsoft/PowerShell/7.6.0.0/Microsoft.PowerShell.installer.yaml
@@ -43,20 +43,20 @@ Installers:
   ProductCode: '{18AF003E-70BD-4CD0-874C-D53E4D0B9708}'
   InstallerType: wix
   Scope: machine
-  ElevationRequirement: elevationRequired
+  ElevationRequirement: elevatesSelf
 - Architecture: arm
   InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.6.0/PowerShell-7.6.0-win-arm64.msi
   InstallerSha256: 565AFDEF6E4E20B26117D0D467C2647D96EA49F1F7D3FC542D29D18B742F1A9B
   ProductCode: '{4B719655-6808-400E-AABC-64CA1CE773F2}'
   InstallerType: wix
   Scope: machine
-  ElevationRequirement: elevationRequired
+  ElevationRequirement: elevatesSelf
 - Architecture: arm64
   InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.6.0/PowerShell-7.6.0-win-arm64.msi
   InstallerSha256: 565AFDEF6E4E20B26117D0D467C2647D96EA49F1F7D3FC542D29D18B742F1A9B
   ProductCode: '{4B719655-6808-400E-AABC-64CA1CE773F2}'
   InstallerType: wix
   Scope: machine
-  ElevationRequirement: elevationRequired
+  ElevationRequirement: elevatesSelf
 ManifestType: installer
 ManifestVersion: 1.12.0


### PR DESCRIPTION
Update Microsoft.PowerShell 7.6.0.0 wix installers to use elevatesSelf, as done for 7.6.1.0 in PR #364622 

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?  If so, fill in the Issue number below.
   <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/365610)