### PR TITLE
Update Microsoft.PowerShell 7.5.6.0 wix installers to use elevatesSelf

### DIFF
--- a/manifests/m/Microsoft/PowerShell/7.5.6.0/Microsoft.PowerShell.installer.yaml
+++ b/manifests/m/Microsoft/PowerShell/7.5.6.0/Microsoft.PowerShell.installer.yaml
@@ -43,27 +43,27 @@ Installers:
   ProductCode: '{F42B395F-9A9C-4827-8F02-DF8A3F6B7369}'
   InstallerType: wix
   Scope: machine
-  ElevationRequirement: elevationRequired
+  ElevationRequirement: elevatesSelf
 - Architecture: x86
   InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.5.6/PowerShell-7.5.6-win-x86.msi
   InstallerSha256: 2F98E3ADB97334740842FE27EE4CA26317F07791303888D7075D36003A65E45A
   ProductCode: '{31E16F60-6E38-4F05-A8FA-91717B13EAEB}'
   InstallerType: wix
   Scope: machine
-  ElevationRequirement: elevationRequired
+  ElevationRequirement: elevatesSelf
 - Architecture: arm
   InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.5.6/PowerShell-7.5.6-win-arm64.msi
   InstallerSha256: 246FAC070F14E97548511A3CA9C6B5E52B22AC84BD69EA9B51E6478A8C9FE309
   ProductCode: '{EC555F2A-A0C3-4F6C-8D16-A58B5102398B}'
   InstallerType: wix
   Scope: machine
-  ElevationRequirement: elevationRequired
+  ElevationRequirement: elevatesSelf
 - Architecture: arm64
   InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.5.6/PowerShell-7.5.6-win-arm64.msi
   InstallerSha256: 246FAC070F14E97548511A3CA9C6B5E52B22AC84BD69EA9B51E6478A8C9FE309
   ProductCode: '{EC555F2A-A0C3-4F6C-8D16-A58B5102398B}'
   InstallerType: wix
   Scope: machine
-  ElevationRequirement: elevationRequired
+  ElevationRequirement: elevatesSelf
 ManifestType: installer
 ManifestVersion: 1.12.0


### PR DESCRIPTION
Update Microsoft.PowerShell 7.5.6.0 wix installers to use elevatesSelf, as done for 7.6.1.0 in PR https://github.com/microsoft/winget-pkgs/pull/364622

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?  If so, fill in the Issue number below.
   <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/365613)