### PR TITLE
Update Microsoft.PowerShell 7.5.5.0 wix installers to use elevatesSelf

### DIFF
--- a/manifests/m/Microsoft/PowerShell/7.5.5.0/Microsoft.PowerShell.installer.yaml
+++ b/manifests/m/Microsoft/PowerShell/7.5.5.0/Microsoft.PowerShell.installer.yaml
@@ -43,27 +43,27 @@ Installers:
   ProductCode: '{634F4903-28DC-4BA6-A39F-4B3E394D4E36}'
   InstallerType: wix
   Scope: machine
-  ElevationRequirement: elevationRequired
+  ElevationRequirement: elevatesSelf
 - Architecture: x86
   InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.5.5/PowerShell-7.5.5-win-x86.msi
   InstallerSha256: B5990F906B07A20D14CFA1ED49ACDFAF29BE074053B160B7B19E4AD74D5CF881
   ProductCode: '{DD1B208F-EB56-48F5-824B-7D9DE2A4DA75}'
   InstallerType: wix
   Scope: machine
-  ElevationRequirement: elevationRequired
+  ElevationRequirement: elevatesSelf
 - Architecture: arm
   InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.5.5/PowerShell-7.5.5-win-arm64.msi
   InstallerSha256: 95B77CBB815F8E03E974B0313D684305AF2CE415E05871C9B55543785D5A551E
   ProductCode: '{DB5A442C-A57F-4BDF-92B5-F32C93B84D1C}'
   InstallerType: wix
   Scope: machine
-  ElevationRequirement: elevationRequired
+  ElevationRequirement: elevatesSelf
 - Architecture: arm64
   InstallerUrl: https://github.com/PowerShell/PowerShell/releases/download/v7.5.5/PowerShell-7.5.5-win-arm64.msi
   InstallerSha256: 95B77CBB815F8E03E974B0313D684305AF2CE415E05871C9B55543785D5A551E
   ProductCode: '{DB5A442C-A57F-4BDF-92B5-F32C93B84D1C}'
   InstallerType: wix
   Scope: machine
-  ElevationRequirement: elevationRequired
+  ElevationRequirement: elevatesSelf
 ManifestType: installer
 ManifestVersion: 1.12.0


### PR DESCRIPTION
Update Microsoft.PowerShell 7.5.5.0 wix installers to use elevatesSelf, as done for 7.6.1.0 in PR https://github.com/microsoft/winget-pkgs/pull/364622

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?  If so, fill in the Issue number below.
   <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/365616)