### PR TITLE
New package: VibesDJ.Vibes version 0.11.1

### DIFF
--- a/manifests/v/VibesDJ/Vibes/0.11.1/VibesDJ.Vibes.installer.yaml
+++ b/manifests/v/VibesDJ/Vibes/0.11.1/VibesDJ.Vibes.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: VibesDJ.Vibes
+PackageVersion: 0.11.1
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+UpgradeBehavior: install
+ReleaseDate: 2026-04-24
+ReleaseNotesUrl: https://github.com/benmdg/vibes-releases/releases/tag/v0.11.1
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/benmdg/vibes-releases/releases/download/v0.11.1/Vibes_0.11.1_x64-setup.exe
+    InstallerSha256: 56AE82BD352D9F473FA289F69C1BCA998F6BA75F8D93921AB8C811A9180606EA
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/v/VibesDJ/Vibes/0.11.1/VibesDJ.Vibes.locale.en-US.yaml
+++ b/manifests/v/VibesDJ/Vibes/0.11.1/VibesDJ.Vibes.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: VibesDJ.Vibes
+PackageVersion: 0.11.1
+PackageLocale: en-US
+Publisher: VibesDJ
+PublisherUrl: https://vibesdj.io/
+PackageName: Vibes
+PackageUrl: https://vibesdj.io/
+License: Proprietary
+LicenseUrl: https://vibesdj.io/terms
+Copyright: Copyright (c) VibesDJ
+ShortDescription: DJ library organizer that sorts tracks by mood, energy, and technique.
+Description: |-
+  Vibes is a DJ library organizer that helps DJs sort and prepare tracks by mood,
+  energy, and technique. Native Windows app with a focused, dark UI and auto-updates.
+  Alternative to Rekordbox, Serato, Engine DJ, and Lexicon DJ for library preparation.
+Moniker: vibes
+Tags:
+  - audio
+  - dj
+  - dj-software
+  - library
+  - mixing
+  - music
+  - playlist
+  - tracks
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/v/VibesDJ/Vibes/0.11.1/VibesDJ.Vibes.yaml
+++ b/manifests/v/VibesDJ/Vibes/0.11.1/VibesDJ.Vibes.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: VibesDJ.Vibes
+PackageVersion: 0.11.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary

Adds `VibesDJ.Vibes` to the Windows Package Manager community repository as the canonical brand-aligned package identifier for Vibes.

This is a **rebrand** of the existing `BenModigell.Vibes` package (merged in [#364762](https://github.com/microsoft/winget-pkgs/pull/364762)) — same product, same installer, same publisher, just published under the brand identifier `VibesDJ` so the install command becomes `winget install VibesDJ.Vibes` instead of using a personal name.

- **Homepage:** https://vibesdj.io/
- **Publisher:** VibesDJ
- **Product:** Vibes — a DJ library organizer that sorts tracks by mood, energy, and technique
- **Installer type:** NSIS (Nullsoft, `/S` silent switch supported)
- **Scope:** user
- **Architectures:** x64
- **License:** Proprietary (commercial)

## Why a separate manifest instead of editing `BenModigell.Vibes`

Winget's package identifier is part of the directory layout (`manifests/<l>/<Publisher>/<Package>/<version>/`) so renaming requires a new manifest tree. Both packages will coexist briefly; once `VibesDJ.Vibes` is merged the original `BenModigell.Vibes` will be removed via a separate PR (or marked deprecated, whichever the maintainers prefer).

## Checklist

- [x] Manifest matches schema 1.6.0
- [x] InstallerSha256 matches the real EXE on GitHub Releases v0.11.1 (verified locally)
- [x] InstallerSwitches.Silent: `/S` (NSIS standard, identical to BenModigell.Vibes)
- [x] License + LicenseUrl + PublisherUrl set
- [x] Tags include `dj`, `dj-software`, `music`, `audio`
- [x] CLA already signed on PR #364762

## Notes

The installer URL points to a public mirror (`benmdg/vibes-releases`) that hosts the installer built by the source repo's CI. Same source as BenModigell.Vibes — only the package identifier and Publisher metadata differ.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/365747)