### PR TITLE
New version: ConduitTechnologies.conduitai version 0.9.3

### DIFF
--- a/manifests/c/ConduitTechnologies/conduitai/0.9.3/ConduitTechnologies.conduitai.installer.yaml
+++ b/manifests/c/ConduitTechnologies/conduitai/0.9.3/ConduitTechnologies.conduitai.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: ConduitTechnologies.conduitai
+PackageVersion: 0.9.3
+InstallerType: portable
+Commands:
+  - conduitai
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/conduit-technologies/conduitai-cli/releases/download/cli-v0.9.3/conduitai-win-x64.exe
+    InstallerSha256: 3D320BFA6C9D2C3A46C5FD8BA894145712165A0FF5C1E78771F59220F03E91C5
+    RenameToFilename: conduitai.exe
+ManifestType: installer
+ManifestVersion: 1.6.0
+ReleaseDate: 2026-04-27

--- a/manifests/c/ConduitTechnologies/conduitai/0.9.3/ConduitTechnologies.conduitai.locale.en-US.yaml
+++ b/manifests/c/ConduitTechnologies/conduitai/0.9.3/ConduitTechnologies.conduitai.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: ConduitTechnologies.conduitai
+PackageVersion: 0.9.3
+PackageLocale: en-US
+Publisher: Conduit Technologies
+PublisherUrl: https://github.com/conduit-technologies
+PublisherSupportUrl: https://github.com/conduit-technologies/conduitai-cli/issues
+PackageName: conduitAI CLI
+PackageUrl: https://github.com/conduit-technologies/conduitai-cli
+License: MIT
+LicenseUrl: https://opensource.org/licenses/MIT
+ShortDescription: Search, install, and manage AI tools for Claude Code, Cursor, and Windsurf
+Description: |-
+  The conduitAI CLI connects your local AI environment to the conduitAI platform.
+  Search the registry, preview what will change, and install any asset type — MCP servers,
+  skills, prompts, agents, and plugins — all with cryptographic signature verification.
+  Standalone binary with no runtime dependencies.
+
+  v0.9.0 added: analyze (GitHub repo safety signals), bookmark CRUD (save catalog assets,
+  cap 1000 per user), ask (RAG-grounded Q&A with cited sources), and --semantic flag on
+  search (vector + FTS hybrid).
+ReleaseNotesUrl: https://github.com/conduit-technologies/conduitai-cli/releases/tag/cli-v0.9.3
+Tags:
+  - ai
+  - cli
+  - claude
+  - mcp
+  - developer-tools
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/c/ConduitTechnologies/conduitai/0.9.3/ConduitTechnologies.conduitai.yaml
+++ b/manifests/c/ConduitTechnologies/conduitai/0.9.3/ConduitTechnologies.conduitai.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: ConduitTechnologies.conduitai
+PackageVersion: 0.9.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-create#using-windows-package-manager-manifest-creator) your manifest locally with \`winget validate --manifest <path>\`?
- [x] Have you tested your manifest locally with \`winget install --manifest <path>\`?
- [x] Have you shared your success with us [tweeting](https://twitter.com/) us, posting on [Reddit](https://www.reddit.com/r/WindowsPackageManager/) or [posting in this thread](https://github.com/microsoft/winget-pkgs/discussions/categories/show-and-tell)?

## Summary

Updates ConduitTechnologies.conduitai to v0.9.3.

This release auto-syncs the embedded version string with the package version on every build (previously hardcoded). The 0.9.2 binary was byte-identical to 0.9.1 because the release process required manual sync of \`CLI_VERSION\` constants — that's now driven from \`package.json\` via a \`prebuild\` hook.

- **InstallerUrl**: https://github.com/conduit-technologies/conduitai-cli/releases/download/cli-v0.9.3/conduitai-win-x64.exe
- **InstallerSha256**: \`3D320BFA6C9D2C3A46C5FD8BA894145712165A0FF5C1E78771F59220F03E91C5\` (matches release \`checksums.txt\`)
- **Release**: https://github.com/conduit-technologies/conduitai-cli/releases/tag/cli-v0.9.3
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/365749)