### PR TITLE
New version: WATRIX.PietoTimer version 1.0.0

### DIFF
--- a/manifests/w/WATRIX/PietoTimer/1.0.0/WATRIX.PietoTimer.installer.yaml
+++ b/manifests/w/WATRIX/PietoTimer/1.0.0/WATRIX.PietoTimer.installer.yaml
@@ -1,0 +1,19 @@
+PackageIdentifier: WATRIX.PietoTimer
+PackageVersion: 1.0.0
+InstallerType: zip
+NestedInstallerType: nullsoft
+NestedInstallerFiles:
+- RelativeFilePath: PietoTimer-Windows\Pieto Timer Setup.exe
+  PortableCommandAlias: pieto-timer
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/watrix811/pieto-timer/releases/download/v1.0/PietoTimer-v1.0-Windows.zip
+  InstallerSha256: 74B2EBD9931861739D586804C5225532219B1F89F354E64F5540003285275309
+  InstallerLocale: ja-JP
+  Scope: user
+  InstallModes:
+  - silent
+  - silentWithProgress
+  ReleaseDate: 2026-04-28
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/w/WATRIX/PietoTimer/1.0.0/WATRIX.PietoTimer.locale.en-US.yaml
+++ b/manifests/w/WATRIX/PietoTimer/1.0.0/WATRIX.PietoTimer.locale.en-US.yaml
@@ -1,0 +1,36 @@
+PackageIdentifier: WATRIX.PietoTimer
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: WATRIX合同会社
+PublisherUrl: https://watrix.jp
+PublisherSupportUrl: https://github.com/watrix811/pieto-timer/issues
+PrivacyUrl: https://watrix.jp
+Author: WATRIX合同会社
+PackageName: Pieto Timer
+PackageUrl: https://pieto.watrix.co.jp/
+License: MIT
+LicenseUrl: https://github.com/watrix811/pieto-timer/blob/main/LICENSE
+Copyright: Copyright (c) 2026 WATRIX合同会社
+CopyrightUrl: https://github.com/watrix811/pieto-timer/blob/main/LICENSE
+ShortDescription: A visual focus timer with a circular dial — countdown, count-up, and Pomodoro in one app.
+Description: |-
+  Pieto Timer is a visual focus timer for macOS and Windows. The remaining time is shown as a shrinking pie sector on a circular dial, so you can sense "how much is left" at a glance, without reading numbers.
+
+  Features:
+  - Three modes: Countdown / Count-up / Pomodoro
+  - Smart scale: 1-min / 6-min / 12-min / 30-min / 60-min dial auto-selected
+  - Always-on-top window with adjustable opacity
+  - 13 system bell sounds
+  - Customizable Pomodoro work / short break / long break / cycles
+  - Launch at login
+Moniker: pieto-timer
+Tags:
+- timer
+- pomodoro
+- productivity
+- focus
+- countdown
+- stopwatch
+ReleaseNotesUrl: https://github.com/watrix811/pieto-timer/releases/tag/v1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/w/WATRIX/PietoTimer/1.0.0/WATRIX.PietoTimer.locale.ja-JP.yaml
+++ b/manifests/w/WATRIX/PietoTimer/1.0.0/WATRIX.PietoTimer.locale.ja-JP.yaml
@@ -1,0 +1,39 @@
+PackageIdentifier: WATRIX.PietoTimer
+PackageVersion: 1.0.0
+PackageLocale: ja-JP
+Publisher: WATRIX合同会社
+PublisherUrl: https://watrix.jp
+PublisherSupportUrl: https://github.com/watrix811/pieto-timer/issues
+PrivacyUrl: https://watrix.jp
+Author: WATRIX合同会社
+PackageName: Pieto Timer
+PackageUrl: https://pieto.watrix.co.jp/
+License: MIT
+LicenseUrl: https://github.com/watrix811/pieto-timer/blob/main/LICENSE
+Copyright: Copyright (c) 2026 WATRIX合同会社
+CopyrightUrl: https://github.com/watrix811/pieto-timer/blob/main/LICENSE
+ShortDescription: 残り時間を扇形で表示する円形ダイヤルのビジュアル集中タイマー。
+Description: |-
+  Pieto Timer は macOS と Windows に対応した無料のデスクトップタイマーです。残り時間を扇形で表現する円形ダイヤルで視覚的に時間がわかり、カウントダウン・カウントアップ・ポモドーロの 3 モードを 1 つのアプリで利用できます。
+
+  機能:
+  - 3 つのモード（カウントダウン / カウントアップ / ポモドーロ）
+  - スマートスケール（1分・6分・12分・30分・60分計を自動切替）
+  - 常に最前面に表示・透過率調整
+  - 13 種類のシステムベル音から選択
+  - ポモドーロ時間カスタマイズ（作業/短休憩/長休憩/サイクル数）
+  - ログイン時に自動起動
+Moniker: pieto-timer
+Tags:
+- timer
+- pomodoro
+- productivity
+- focus
+- countdown
+- stopwatch
+- 集中
+- タイマー
+- ポモドーロ
+ReleaseNotesUrl: https://github.com/watrix811/pieto-timer/releases/tag/v1.0
+ManifestType: locale
+ManifestVersion: 1.6.0

--- a/manifests/w/WATRIX/PietoTimer/1.0.0/WATRIX.PietoTimer.yaml
+++ b/manifests/w/WATRIX/PietoTimer/1.0.0/WATRIX.PietoTimer.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: WATRIX.PietoTimer
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Manifest Submission

Adding new package: **WATRIX.PietoTimer 1.0.0**

### Package details
- **Publisher**: WATRIX合同会社
- **Package**: Pieto Timer — visual focus timer (countdown / count-up / Pomodoro)
- **License**: MIT
- **Homepage**: https://pieto.watrix.co.jp/
- **Source**: https://github.com/watrix811/pieto-timer
- **Architecture**: x64
- **Installer type**: zip with nested NSIS installer
- **Installer URL**: https://github.com/watrix811/pieto-timer/releases/download/v1.0/PietoTimer-v1.0-Windows.zip

### Checklist
- [x] Manifest validated locally
- [x] Installer URL is publicly accessible (GitHub release asset)
- [x] SHA256 verified
- [x] License URL added
- [x] DefaultLocale (en-US) and ja-JP locale provided
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/365982)