### PR TITLE
New version: M-Igashi.headroom version 1.9.0

### DIFF
--- a/manifests/m/M-Igashi/headroom/1.9.0/M-Igashi.headroom.installer.yaml
+++ b/manifests/m/M-Igashi/headroom/1.9.0/M-Igashi.headroom.installer.yaml
@@ -1,0 +1,19 @@
+# Created with manual update
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.headroom
+PackageVersion: 1.9.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: headroom.exe
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Gyan.FFmpeg
+ReleaseDate: 2026-04-29
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/M-Igashi/headroom/releases/download/v1.9.0/headroom-v1.9.0-windows-x86_64.zip
+    InstallerSha256: 060A5015586D601C8BF0B37DE68BA555EE995F183A88960A143940B95A8970C4
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/headroom/1.9.0/M-Igashi.headroom.locale.en-US.yaml
+++ b/manifests/m/M-Igashi/headroom/1.9.0/M-Igashi.headroom.locale.en-US.yaml
@@ -1,0 +1,39 @@
+# Created with manual update
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.headroom
+PackageVersion: 1.9.0
+PackageLocale: en-US
+Publisher: M-Igashi
+PublisherUrl: https://github.com/M-Igashi
+PublisherSupportUrl: https://github.com/M-Igashi/headroom/issues
+Author: M-Igashi
+PackageName: headroom
+PackageUrl: https://github.com/M-Igashi/headroom
+License: MIT
+LicenseUrl: https://github.com/M-Igashi/headroom/blob/main/LICENSE
+ShortDescription: Audio loudness analyzer and gain adjustment tool for mastering and DJ workflows
+Description: |-
+  headroom analyzes audio files for loudness (LUFS) and headroom, then applies lossless gain adjustment.
+  It supports MP3, AAC/M4A, FLAC, AIFF, and WAV files.
+  Features include batch processing, ReplayGain analysis, lossless MP3 gain via mp3rgain, lossless AAC/M4A gain adjustment, and a scriptable non-interactive CLI mode for pipelines and CI.
+Moniker: headroom
+Tags:
+  - aac
+  - audio
+  - cli
+  - dj
+  - ffmpeg
+  - gain
+  - loudness
+  - lufs
+  - mastering
+  - mp3
+  - music
+  - normalize
+  - replaygain
+  - rust
+  - volume
+ReleaseNotesUrl: https://github.com/M-Igashi/headroom/releases/tag/v1.9.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/headroom/1.9.0/M-Igashi.headroom.yaml
+++ b/manifests/m/M-Igashi/headroom/1.9.0/M-Igashi.headroom.yaml
@@ -1,0 +1,8 @@
+# Created with manual update
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.headroom
+PackageVersion: 1.9.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New version: M-Igashi.headroom version 1.9.0

- Add update notification on startup: checks GitHub Releases once per 24 hours and prints the appropriate upgrade command (winget / Homebrew / cargo). Disable with `--no-update-check` or `HEADROOM_NO_UPDATE_CHECK=1`.
- Update mp3rgain from 2.2.1 to 2.3.0 (drop-in upgrade): fixes an AAC short-window spectral parser bug that previously caused some processed `.m4a` files to fail in ffmpeg, and speeds up AAC analysis 4-6×.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/366442)