### PR TITLE
New version: Semibanbi.CrConnector version 0.1.0

### DIFF
--- a/manifests/s/Semibanbi/CrConnector/0.1.0/Semibanbi.CrConnector.installer.yaml
+++ b/manifests/s/Semibanbi/CrConnector/0.1.0/Semibanbi.CrConnector.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Semibanbi.CrConnector
+PackageVersion: 0.1.0
+InstallerLocale: en-US
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: cr-connector-windows-x64.exe
+    PortableCommandAlias: cr-connector
+Scope: user
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/darkhtk/claude-remote-platform/releases/download/v0.1.0/cr-connector-windows-x64.zip
+    InstallerSha256: 0DEFAACB8145BFC66A1EFAD248DA492439E4569B4B04CD7E609530A501F7CCD6
+    UpgradeBehavior: install
+    ReleaseDate: 2026-04-29
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/Semibanbi/CrConnector/0.1.0/Semibanbi.CrConnector.locale.en-US.yaml
+++ b/manifests/s/Semibanbi/CrConnector/0.1.0/Semibanbi.CrConnector.locale.en-US.yaml
@@ -8,8 +8,8 @@ PublisherSupportUrl: https://github.com/darkhtk/claude-remote-platform/issues
 Author: semibanbi
 PackageName: cr-connector
 PackageUrl: https://github.com/darkhtk/claude-remote-platform
-License: AGPL-3.0-or-later
-LicenseUrl: https://github.com/darkhtk/claude-remote-platform/blob/main/LICENSE
+License: Apache-2.0
+LicenseUrl: https://github.com/darkhtk/claude-remote-platform/blob/master/LICENSE
 Copyright: Copyright (c) semibanbi
 ShortDescription: Pair this PC with the Remote for Claude site and host claude CLI behaviors locally.
 Description: |-

--- a/manifests/s/Semibanbi/CrConnector/0.1.0/Semibanbi.CrConnector.locale.en-US.yaml
+++ b/manifests/s/Semibanbi/CrConnector/0.1.0/Semibanbi.CrConnector.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Semibanbi.CrConnector
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Semibanbi
+PublisherUrl: https://claude-remote-platform-site.semibanbi.workers.dev
+PublisherSupportUrl: https://github.com/darkhtk/claude-remote-platform/issues
+Author: semibanbi
+PackageName: cr-connector
+PackageUrl: https://github.com/darkhtk/claude-remote-platform
+License: AGPL-3.0-or-later
+LicenseUrl: https://github.com/darkhtk/claude-remote-platform/blob/main/LICENSE
+Copyright: Copyright (c) semibanbi
+ShortDescription: Pair this PC with the Remote for Claude site and host claude CLI behaviors locally.
+Description: |-
+  cr-connector is the small daemon that lets the Remote for Claude site
+  reach the claude CLI on your own PC. After pairing it via a one-time
+  code from the site, the daemon listens locally and keeps an outbound
+  WebSocket open so the browser / mobile app can drive claude on your
+  machine — your code, your tokens, your filesystem, never on our
+  servers.
+Moniker: cr-connector
+Tags:
+  - claude
+  - cli
+  - daemon
+  - developer-tools
+  - productivity
+ReleaseNotesUrl: https://github.com/darkhtk/claude-remote-platform/releases/tag/v0.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/Semibanbi/CrConnector/0.1.0/Semibanbi.CrConnector.yaml
+++ b/manifests/s/Semibanbi/CrConnector/0.1.0/Semibanbi.CrConnector.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Semibanbi.CrConnector
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Manifest type & validation
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-cli/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-cli/tree/master/schemas/JSON/manifests/v1.6.0)?

## Package details
**Package:** Semibanbi.CrConnector
**Version:** 0.1.0
**Publisher URL:** https://claude-remote-platform-site.semibanbi.workers.dev
**Source repo:** https://github.com/darkhtk/claude-remote-platform
**Release:** https://github.com/darkhtk/claude-remote-platform/releases/tag/v0.1.0

## What this is
cr-connector is the small daemon that lets the Remote for Claude site reach the claude CLI on the user's own PC. After pairing via a one-time code from the site, the daemon listens locally and keeps an outbound WebSocket open so the browser / mobile app can drive claude on the user's machine — code, tokens, and filesystem stay on the PC.

This is the first manifest submission for this publisher / package.

## Installer
- **InstallerType:** zip with NestedInstallerType: portable
- **Architecture:** x64
- **Installer URL:** https://github.com/darkhtk/claude-remote-platform/releases/download/v0.1.0/cr-connector-windows-x64.zip
- **Scope:** user
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/366526)