### PR TITLE
New version: VoxRouter.VoxRouter version 0.2.1

### DIFF
--- a/manifests/v/VoxRouter/VoxRouter/0.2.1/VoxRouter.VoxRouter.installer.yaml
+++ b/manifests/v/VoxRouter/VoxRouter/0.2.1/VoxRouter.VoxRouter.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: VoxRouter.VoxRouter
+PackageVersion: 0.2.1
+InstallerType: portable
+Commands:
+- voxrouter
+ReleaseDate: 2026-04-29
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/voxrouter/cli/releases/download/v0.2.1/voxrouter-windows-x64.exe
+  InstallerSha256: ED2C9F50D60904176867711C998FE01E3FF75F3E9BB657636F89B78B71E13D9A
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/v/VoxRouter/VoxRouter/0.2.1/VoxRouter.VoxRouter.locale.en-US.yaml
+++ b/manifests/v/VoxRouter/VoxRouter/0.2.1/VoxRouter.VoxRouter.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: VoxRouter.VoxRouter
+PackageVersion: 0.2.1
+PackageLocale: en-US
+Publisher: VoxRouter
+PublisherUrl: https://voxrouter.ai
+PublisherSupportUrl: https://github.com/voxrouter/cli/issues
+Author: VoxRouter
+PackageName: VoxRouter CLI
+PackageUrl: https://voxrouter.ai
+License: MIT
+LicenseUrl: https://github.com/voxrouter/cli/blob/main/LICENSE
+Copyright: Copyright (c) 2026 VoxRouter
+ShortDescription: Official CLI for the VoxRouter TTS API.
+Description: |-
+  voxrouter is the official command-line interface for the VoxRouter text-to-speech
+  API. It provides a thin, scriptable wrapper around @voxrouter/sdk for both human
+  users and coding agents — every command supports --json, errors map to predictable
+  exit codes, and the surface mirrors the web dashboard one-to-one.
+
+  Quickstart:
+    voxrouter login          # device-code OAuth in your browser
+    voxrouter voices         # list available voices across providers
+    voxrouter speech "Hi"    # synthesize speech to stdout
+Tags:
+- cli
+- tts
+- text-to-speech
+- voice
+- voxrouter
+ReleaseNotesUrl: https://github.com/voxrouter/cli/releases/tag/v0.2.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/v/VoxRouter/VoxRouter/0.2.1/VoxRouter.VoxRouter.yaml
+++ b/manifests/v/VoxRouter/VoxRouter/0.2.1/VoxRouter.VoxRouter.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: VoxRouter.VoxRouter
+PackageVersion: 0.2.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-cli/blob/main/doc/tools/SandboxTest.md) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-cli/blob/main/doc/ManifestSpecv1.12.md)?

## Summary

First submission for **VoxRouter.VoxRouter** — the official CLI for the [VoxRouter](https://voxrouter.ai) text-to-speech API.

The CLI ships as a Bun-compiled native portable binary (Windows x64) hosted on GitHub Releases at https://github.com/voxrouter/cli/releases/tag/v0.2.1. SHA256 in the installer manifest comes from the release's `manifest.json` ([link](https://github.com/voxrouter/cli/releases/download/v0.2.1/manifest.json)).

After acceptance, users will be able to install with:

```pwsh
winget install VoxRouter.VoxRouter
```

## Notes

- This is a portable installer — single self-contained `.exe`. The `Commands` field exposes the `voxrouter` alias.
- The same binary is also distributed via `curl|bash` (https://voxrouter.ai/install), Homebrew (`voxrouter/tap`), and npm (`@voxrouter/cli`). All four channels resolve to the same release artifacts.
- Source: https://github.com/voxrouter/cli — MIT-licensed, public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/366560)