### PR TITLE
New version: Splashtop.SplashtopBusiness version 3.8.200.0

### DIFF
--- a/manifests/s/Splashtop/SplashtopBusiness/3.8.200.0/Splashtop.SplashtopBusiness.installer.yaml
+++ b/manifests/s/Splashtop/SplashtopBusiness/3.8.200.0/Splashtop.SplashtopBusiness.installer.yaml
@@ -1,0 +1,25 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Splashtop.SplashtopBusiness
+PackageVersion: 3.8.200.0
+InstallerLocale: en-US
+InstallerType: exe
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: msiexec /norestart /i setup.msi CA_UPGRADE=1 /qn
+  SilentWithProgress: msiexec /norestart /i setup.msi CA_UPGRADE=1 /qn
+UpgradeBehavior: install
+AppsAndFeaturesEntries:
+- ProductCode: '{CD4EF8F2-8638-4A86-8C99-C585B3B47A25}'
+  InstallerType: msi
+Installers:
+- Architecture: x86
+  InstallerUrl: https://download.splashtop.com/winclient/STB/Splashtop_Business_Win_INSTALLER_v3.8.2.0.exe
+  InstallerSha256: 41D62864629BCF8603CF29693E500B18FB911B9A4879A57A35E64FCA257BBFD1
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/Splashtop/SplashtopBusiness/3.8.200.0/Splashtop.SplashtopBusiness.locale.en-US.yaml
+++ b/manifests/s/Splashtop/SplashtopBusiness/3.8.200.0/Splashtop.SplashtopBusiness.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Splashtop.SplashtopBusiness
+PackageVersion: 3.8.200.0
+PackageLocale: en-US
+Publisher: Splashtop Inc.
+PublisherUrl: https://www.splashtop.com/
+PublisherSupportUrl: https://www.splashtop.com/support
+PrivacyUrl: https://www.splashtop.com/legal/privacy-policy
+PackageName: Splashtop Business
+License: Proprietary
+Copyright: Copyright (c) Splashtop Inc. All Rights Reserved.
+ShortDescription: Splashtop Business - Secure Remote Access and Support
+Description: Splashtop Business provides secure remote access across your organization. Users can work from anywhere with remote access to their office computer from a laptop or mobile device. IT/Helpdesk teams have all the features they need to manage remote support.
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/Splashtop/SplashtopBusiness/3.8.200.0/Splashtop.SplashtopBusiness.yaml
+++ b/manifests/s/Splashtop/SplashtopBusiness/3.8.200.0/Splashtop.SplashtopBusiness.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Splashtop.SplashtopBusiness
+PackageVersion: 3.8.200.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Description

This PR adds the correct version manifest for **Splashtop Business 3.8.200.0**.

The previously submitted version `3.8.2.0` contains an incorrect version string. The correct product version is `3.8.200.0`. This submission adds the manifest with the corrected version number pointing to the same installer binary (same URL and SHA256 hash).

### Version correction context

Looking at the historical version pattern for this package:
- `3.5.400.0`, `3.5.600.0`, `3.5.800.0`
- `3.6.200.0`, `3.6.201.0`, `3.6.401.0`
- `3.7.202.0`, `3.7.203.0`, `3.7.400.0`, `3.7.402.0`, `3.7.403.0`

The version `3.8.200.0` follows the established naming convention. The `3.8.2.0` entry was submitted with an incorrect version number and should be removed in a separate PR.

### Microsoft Transparency

- [x] This PR corrects a version number error in the Splashtop Business package manifest
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/366572)