### PR TITLE
New package: gehariharan.TokenWatcher version 0.1.0

### DIFF
--- a/manifests/g/gehariharan/TokenWatcher/0.1.0/gehariharan.TokenWatcher.installer.yaml
+++ b/manifests/g/gehariharan/TokenWatcher/0.1.0/gehariharan.TokenWatcher.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: gehariharan.TokenWatcher
+PackageVersion: 0.1.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-04-29
+
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/gehariharan/Tokenwatcher/releases/download/v0.1.0/TokenWatcher-Setup-0.1.0.exe
+    InstallerSha256: 8BEB36D1396E063CCD182B7141D9B9100EB5CE6619D537D088D9246CE4B3E21E
+
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/g/gehariharan/TokenWatcher/0.1.0/gehariharan.TokenWatcher.locale.en-US.yaml
+++ b/manifests/g/gehariharan/TokenWatcher/0.1.0/gehariharan.TokenWatcher.locale.en-US.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: gehariharan.TokenWatcher
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Geha Hariharan
+PublisherUrl: https://github.com/gehariharan
+PublisherSupportUrl: https://github.com/gehariharan/Tokenwatcher/issues
+PackageName: TokenWatcher
+PackageUrl: https://github.com/gehariharan/Tokenwatcher
+License: MIT
+LicenseUrl: https://github.com/gehariharan/Tokenwatcher/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Geha Hariharan
+ShortDescription: Windows system-tray app showing OpenAI Codex and Claude usage limits at a glance.
+Description: |-
+  TokenWatcher is the Windows alternative to CodexBar (macOS). A lightweight
+  system-tray app that shows your OpenAI Codex and Claude rate-limit windows
+  (5h / 7d) live, including reset times and plan info. Hover the tray icon to
+  open a side panel - no clicks needed.
+
+  Features:
+   - Live OpenAI Codex 5h / 7d window utilization
+   - Live Claude 5h / 7d / Sonnet / Opus window utilization
+   - One-time Edge sign-in for claude.ai (DPAPI-encrypted, never leaves your machine)
+   - Toggle each provider on/off in settings
+   - No telemetry, no third-party servers
+Moniker: tokenwatcher
+Tags:
+  - openai
+  - claude
+  - codex
+  - chatgpt
+  - tray
+  - electron
+  - rate-limit
+  - usage
+  - codexbar
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/g/gehariharan/TokenWatcher/0.1.0/gehariharan.TokenWatcher.yaml
+++ b/manifests/g/gehariharan/TokenWatcher/0.1.0/gehariharan.TokenWatcher.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: gehariharan.TokenWatcher
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Pull request type
- [x] New package: gehariharan.TokenWatcher
- [ ] New version
- [ ] Update metadata
- [ ] Package removal

## Manifests version
1.6.0

## Microsoft Reviewers note
This is a new package submission for **TokenWatcher**, a Windows system-tray app that displays live OpenAI Codex and Claude usage limits. It is the Windows counterpart to the macOS app *CodexBar* (Finesssee.Win-CodexBar exists but is a different project).

- Source: https://github.com/gehariharan/Tokenwatcher
- License: MIT
- Installer: x64 NSIS installer published to GitHub Releases
- SHA256 verified locally with `Get-FileHash -Algorithm SHA256`
- Validated with `winget validate` — `Manifest validation succeeded`

## Checklist
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)? *(Will sign when prompted by the bot.)*
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested the manifest by running `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.6.md)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/366699)