### PR TITLE
OpenCLICollective.slack-chat-cli version 3.1.45

### DIFF
--- a/manifests/o/OpenCLICollective/slack-chat-cli/3.1.45/OpenCLICollective.slack-chat-cli.installer.yaml
+++ b/manifests/o/OpenCLICollective/slack-chat-cli/3.1.45/OpenCLICollective.slack-chat-cli.installer.yaml
@@ -1,0 +1,20 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: OpenCLICollective.slack-chat-cli
+PackageVersion: 3.1.45
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: slck.exe
+  PortableCommandAlias: slck
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/open-cli-collective/slack-chat-api/releases/download/v3.1.45/slck_v3.1.45_windows_amd64.zip
+  InstallerSha256: 05E464974E47DE3AB2B27FA5F9F57F1D40282965C351EACEDDFF888D5A08769A
+- Architecture: arm64
+  InstallerUrl: https://github.com/open-cli-collective/slack-chat-api/releases/download/v3.1.45/slck_v3.1.45_windows_arm64.zip
+  InstallerSha256: EA1BCBD0FD2927232CCF76A76C96260A263773E02C5C9CFCE482AD115F71C146
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-04-29

--- a/manifests/o/OpenCLICollective/slack-chat-cli/3.1.45/OpenCLICollective.slack-chat-cli.locale.en-US.yaml
+++ b/manifests/o/OpenCLICollective/slack-chat-cli/3.1.45/OpenCLICollective.slack-chat-cli.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: OpenCLICollective.slack-chat-cli
+PackageVersion: 3.1.45
+PackageLocale: en-US
+Publisher: Open CLI Collective
+PublisherUrl: https://github.com/open-cli-collective
+PublisherSupportUrl: https://github.com/open-cli-collective/slack-chat-api/issues
+PackageName: Slack Chat API CLI
+PackageUrl: https://github.com/open-cli-collective/slack-chat-api
+License: MIT
+LicenseUrl: https://github.com/open-cli-collective/slack-chat-api/blob/main/LICENSE
+ShortDescription: Command-line interface for Slack Web API
+Description: |-
+  A lightweight CLI for interacting with the Slack Web API. Provides direct
+  API access for automation and scripting including sending messages, managing
+  channels, listing users, viewing message history, and searching messages/files.
+Tags:
+- slack
+- cli
+- api
+- messaging
+- automation
+- chat
+ReleaseNotesUrl: https://github.com/open-cli-collective/slack-chat-api/releases/tag/v3.1.45
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/open-cli-collective/slack-chat-api/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenCLICollective/slack-chat-cli/3.1.45/OpenCLICollective.slack-chat-cli.yaml
+++ b/manifests/o/OpenCLICollective/slack-chat-cli/3.1.45/OpenCLICollective.slack-chat-cli.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: OpenCLICollective.slack-chat-cli
+PackageVersion: 3.1.45
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Automated winget manifest update for OpenCLICollective.slack-chat-cli version 3.1.45.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/366760)