### PR TITLE
OpenCLICollective.cfl version 1.0.38

### DIFF
--- a/manifests/o/OpenCLICollective/cfl/1.0.38/OpenCLICollective.cfl.installer.yaml
+++ b/manifests/o/OpenCLICollective/cfl/1.0.38/OpenCLICollective.cfl.installer.yaml
@@ -1,0 +1,20 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: OpenCLICollective.cfl
+PackageVersion: 1.0.38
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: cfl.exe
+  PortableCommandAlias: cfl
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/open-cli-collective/atlassian-cli/releases/download/cfl-v1.0.38/cfl_1.0.38_windows_amd64.zip
+  InstallerSha256: 04066055B890E398F66DF75DFA41382C1DA01E9D94F646E4E80B0866997FCE79
+- Architecture: arm64
+  InstallerUrl: https://github.com/open-cli-collective/atlassian-cli/releases/download/cfl-v1.0.38/cfl_1.0.38_windows_arm64.zip
+  InstallerSha256: E2EADCE81F7B81FA4DA41C77599F3DE0EE04ED45D1296262783082B4AE83D627
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-04-28

--- a/manifests/o/OpenCLICollective/cfl/1.0.38/OpenCLICollective.cfl.locale.en-US.yaml
+++ b/manifests/o/OpenCLICollective/cfl/1.0.38/OpenCLICollective.cfl.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: OpenCLICollective.cfl
+PackageVersion: 1.0.38
+PackageLocale: en-US
+Publisher: Open CLI Collective
+PublisherUrl: https://github.com/open-cli-collective
+PublisherSupportUrl: https://github.com/open-cli-collective/confluence-cli/issues
+PackageName: Confluence CLI
+PackageUrl: https://github.com/open-cli-collective/confluence-cli
+License: MIT
+LicenseUrl: https://github.com/open-cli-collective/confluence-cli/blob/main/LICENSE
+ShortDescription: Command-line interface for Atlassian Confluence Cloud
+Description: |-
+  A CLI tool for managing Confluence pages with a markdown-first workflow.
+  Features include page creation, editing, viewing, and deletion with automatic
+  markdown-to-Confluence conversion. Supports attachments, search via CQL,
+  and common Confluence macros (TOC, panels, expand).
+Tags:
+- confluence
+- atlassian
+- cli
+- markdown
+- wiki
+- documentation
+ReleaseNotesUrl: https://github.com/open-cli-collective/atlassian-cli/releases/tag/cfl-v1.0.38
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/open-cli-collective/confluence-cli/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenCLICollective/cfl/1.0.38/OpenCLICollective.cfl.yaml
+++ b/manifests/o/OpenCLICollective/cfl/1.0.38/OpenCLICollective.cfl.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: OpenCLICollective.cfl
+PackageVersion: 1.0.38
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Automated winget manifest update for OpenCLICollective.cfl version 1.0.38.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/366766)