### PR TITLE
New version: Webadderall.Recordly version v1.2.1

### DIFF
--- a/manifests/w/Webadderall/Recordly/v1.2.1/Webadderall.Recordly.installer.yaml
+++ b/manifests/w/Webadderall/Recordly/v1.2.1/Webadderall.Recordly.installer.yaml
@@ -1,0 +1,23 @@
+# Created with GitHub Copilot manual WinGet recovery using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Webadderall.Recordly
+PackageVersion: v1.2.1
+InstallerLocale: en-US
+InstallerType: nullsoft
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ProductCode: f36b8f71-1b35-5edc-87fa-22dc73615358
+ReleaseDate: 2026-04-28
+AppsAndFeaturesEntries:
+- DisplayName: Recordly 1.2.1
+  ProductCode: f36b8f71-1b35-5edc-87fa-22dc73615358
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/webadderallorg/Recordly/releases/download/v1.2.1/Recordly-windows-x64.exe
+  InstallerSha256: 2473F947D96F68BB871383D00F8BE3750397720B910A6F85D48CFA3B452DBF74
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/w/Webadderall/Recordly/v1.2.1/Webadderall.Recordly.locale.en-US.yaml
+++ b/manifests/w/Webadderall/Recordly/v1.2.1/Webadderall.Recordly.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# Created with GitHub Copilot manual WinGet recovery using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Webadderall.Recordly
+PackageVersion: v1.2.1
+PackageLocale: en-US
+Publisher: webadderall
+PublisherUrl: https://recordly.dev/
+PublisherSupportUrl: https://ko-fi.com/webadderall
+Author: webadderall
+PackageName: Recordly
+PackageUrl: https://recordly.dev/
+License: AGPL-3.0
+LicenseUrl: https://github.com/webadderallorg/Recordly/blob/HEAD/LICENSE.md
+Copyright: Copyright (c) 2026 webadderall
+ShortDescription: Create polished screen recordings for free. An open-source screen recorder for Mac/Windows/Linux that adds auto-zooms, animated cursors, auto-captions and more to your videos.
+Description: Recordly is an open-source screen recorder and editor for walkthroughs, demos, tutorials, product videos, and social clips. Record a screen or window, jump straight into the editor, and export a polished result with cursor effects, zooms, backgrounds, annotations, webcam overlays, and more.
+Moniker: recordly
+Tags:
+- electron
+- free
+- linux
+- macos
+- open-source
+- screen-recorder
+- screen-studio
+- windows
+ReleaseNotes: Hotfix release that updates the in-app Discord invite link in the editor's Tutorial/Help panel. The previous invite had expired. No other changes from v1.2.0.
+ReleaseNotesUrl: https://github.com/webadderallorg/Recordly/releases/tag/v1.2.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/w/Webadderall/Recordly/v1.2.1/Webadderall.Recordly.yaml
+++ b/manifests/w/Webadderall/Recordly/v1.2.1/Webadderall.Recordly.yaml
@@ -1,0 +1,8 @@
+# Created with GitHub Copilot manual WinGet recovery using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Webadderall.Recordly
+PackageVersion: v1.2.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Summary
- add Webadderall.Recordly winget manifests for v1.2.1
- update installer URL to the published GitHub release asset
- update SHA256 and release notes for the hotfix release

## Validation
- ruby YAML parse for all three manifests
- git diff --check
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/366871)