### PR TITLE
Update Microsoft.DSC version 3.1.3

### DIFF
--- a/manifests/m/Microsoft/DSC/3.1.3/Microsoft.DSC.installer.yaml
+++ b/manifests/m/Microsoft/DSC/3.1.3/Microsoft.DSC.installer.yaml
@@ -21,7 +21,7 @@ Installers:
   NestedInstallerType: portable
   NestedInstallerFiles:
   - RelativeFilePath: dsc.exe
-    PortableCommandAlias: dsc
+    # PortableCommandAlias: dsc
   InstallerUrl: https://github.com/PowerShell/DSC/releases/download/v3.1.3/DSC-3.1.3-x86_64-pc-windows-msvc.zip
   InstallerSha256: 8176a6571a4b67d50565448d11f95b1d59b76896b6c6733ca5971464e4cf7ea0
   Dependencies:


### PR DESCRIPTION
Commenting out the alias as it isn't needed for a same-named execuatble. The thought is that this will work around the wingetcreate issue affecting the package. If this does not work around the issue, a follow on PR will be submitted updating one of the installers to use a relative path to itself.

---

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Is there a linked Issue?  If so, fill in the Issue number below.
  - microsoft/winget-create#660

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/367069)