### PR TITLE
New version: RedEyeNetworks.HopMatrix version 1.6.1

### DIFF
--- a/manifests/r/RedEyeNetworks/HopMatrix/1.6.1/RedEyeNetworks.HopMatrix.installer.yaml
+++ b/manifests/r/RedEyeNetworks/HopMatrix/1.6.1/RedEyeNetworks.HopMatrix.installer.yaml
@@ -1,0 +1,51 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: RedEyeNetworks.HopMatrix
+PackageVersion: 1.6.1
+InstallerType: inno
+Scope: machine
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  Custom: /NORESTART
+UpgradeBehavior: install
+Commands:
+- HopMatrix
+Installers:
+- Architecture: x64
+  Scope: user
+  InstallerSwitches:
+    Silent: /CURRENTUSER /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+    SilentWithProgress: /CURRENTUSER /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+    Custom: /CURRENTUSER /NORESTART
+  InstallerUrl: https://download.redeyenetworks.com/hopmatrix/releases/1.6.1/HopMatrix-win-x64-setup.exe
+  InstallerSha256: 90E9113107DE468CA846EEEDA3C2162771792FB932E0F2185416C495E2395149
+- Architecture: x64
+  Scope: machine
+  ElevationRequirement: elevatesSelf
+  InstallerSwitches:
+    Silent: /ALLUSERS /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+    SilentWithProgress: /ALLUSERS /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+    Custom: /ALLUSERS /NORESTART
+  InstallerUrl: https://download.redeyenetworks.com/hopmatrix/releases/1.6.1/HopMatrix-win-x64-setup.exe
+  InstallerSha256: 90E9113107DE468CA846EEEDA3C2162771792FB932E0F2185416C495E2395149
+- Architecture: arm64
+  Scope: user
+  InstallerSwitches:
+    Silent: /CURRENTUSER /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+    SilentWithProgress: /CURRENTUSER /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+    Custom: /CURRENTUSER /NORESTART
+  InstallerUrl: https://download.redeyenetworks.com/hopmatrix/releases/1.6.1/HopMatrix-win-arm64-setup.exe
+  InstallerSha256: 7E9C7577E8D66A6253C378C640DB8A0501F60DED026E0AE6C1F0F2D8572DA402
+- Architecture: arm64
+  Scope: machine
+  ElevationRequirement: elevatesSelf
+  InstallerSwitches:
+    Silent: /ALLUSERS /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+    SilentWithProgress: /ALLUSERS /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+    Custom: /ALLUSERS /NORESTART
+  InstallerUrl: https://download.redeyenetworks.com/hopmatrix/releases/1.6.1/HopMatrix-win-arm64-setup.exe
+  InstallerSha256: 7E9C7577E8D66A6253C378C640DB8A0501F60DED026E0AE6C1F0F2D8572DA402
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/r/RedEyeNetworks/HopMatrix/1.6.1/RedEyeNetworks.HopMatrix.locale.en-US.yaml
+++ b/manifests/r/RedEyeNetworks/HopMatrix/1.6.1/RedEyeNetworks.HopMatrix.locale.en-US.yaml
@@ -1,0 +1,39 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: RedEyeNetworks.HopMatrix
+PackageVersion: 1.6.1
+PackageLocale: en-US
+Publisher: RedEye Network Solutions LLC
+PublisherUrl: https://redeyenetworks.com
+PublisherSupportUrl: https://redeyenetworks.com/support
+Author: RedEye Network Solutions LLC
+PackageName: HopMatrix
+PackageUrl: https://redeyenetworks.com
+License: Proprietary
+Copyright: Copyright 2025-2026 RedEye Network Solutions LLC. All rights reserved.
+ShortDescription: Visual multi-path traceroute, network monitoring, and analysis platform
+Description: |-
+  HopMatrix is a portable, single-executable, cross-platform network analysis platform
+  with eight operational modes: Trace, Monitor, iPerf, OUI/MAC Lookup, SNMP, Multicast,
+  L2 Inspector, and Quick Tools. Features continuous multi-path traceroute with real-time
+  topology visualization, 256-endpoint fleet monitoring, iperf3-compatible bandwidth
+  testing, SNMP v1/v2c/v3 discovery, and multicast/CDP/LLDP analysis.
+Moniker: hopmatrix
+Tags:
+- traceroute
+- network
+- monitoring
+- bandwidth
+- iperf
+- snmp
+- multicast
+- network-analysis
+- pathping
+- topology
+- cdp
+- lldp
+- nmap
+- oui
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/RedEyeNetworks/HopMatrix/1.6.1/RedEyeNetworks.HopMatrix.yaml
+++ b/manifests/r/RedEyeNetworks/HopMatrix/1.6.1/RedEyeNetworks.HopMatrix.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: RedEyeNetworks.HopMatrix
+PackageVersion: 1.6.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Resubmission of v1.6.1 dual-scope manifest. Original PR (#367367) validation pipeline stalled with `Internal-Error-Dynamic-Scan + Retry-1 + Needs-Attention` labels after the consistency check cleared; closing+reopening to refresh the queue per the user's prior experience that resubmissions tend to clear faster.

Manifest is byte-for-byte identical to the v3 push that locally validated (`winget validate --manifest` passed) and cleared wingetbot's Manifest-Metadata-Consistency check on the original PR. Source-of-truth copy archived at [redeyenetworks/HopMatrix:docs/winget-pinned-manifests/1.6.1/](https://github.com/redeyenetworks/HopMatrix/tree/main/docs/winget-pinned-manifests/1.6.1).

Dual-scope shape: 4 installer entries ((x64 user, x64 machine, arm64 user, arm64 machine)) on the same Inno Setup EXE, with `/CURRENTUSER` and `/ALLUSERS` switches respectively. `PrivilegesRequiredOverridesAllowed=dialog` in the .iss auto-allows commandline scope overrides. Same convention as Microsoft.PowerToys + Notepad++.Notepad++ for the `ElevationRequirement: elevatesSelf` machine variants.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/367435)