### PR TITLE
New package: DeepenShrestha.Deepend version 0.1.1

### DIFF
--- a/manifests/d/DeepenShrestha/Deepend/0.1.1/DeepenShrestha.Deepend.installer.yaml
+++ b/manifests/d/DeepenShrestha/Deepend/0.1.1/DeepenShrestha.Deepend.installer.yaml
@@ -1,0 +1,29 @@
+# Created with wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: DeepenShrestha.Deepend
+PackageVersion: 0.1.1
+MinimumOSVersion: 10.0.0.0
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerType: nullsoft
+  InstallerUrl: https://github.com/deepen-stha/deepend-releases/releases/download/v0.1.1/Deepend_0.1.1_x64-setup.exe
+  InstallerSha256: D6DF997CD45F7762EF437FAE8363145BB436951E4D721D7F890A1E9C889549CF
+  Scope: machine
+  InstallerSwitches:
+    Silent: /S
+    SilentWithProgress: /S
+- Architecture: x64
+  InstallerType: wix
+  InstallerUrl: https://github.com/deepen-stha/deepend-releases/releases/download/v0.1.1/Deepend_0.1.1_x64_en-US.msi
+  InstallerSha256: 0D40DC6231215CE69B00140AE435F003D9E4CD28D8FAFE1F0EE72F9675BA696C
+  Scope: machine
+  InstallerLocale: en-US
+  ProductCode: '{8DB0F58A-FDC2-4436-A9B2-AD9C5B71FB80}'
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/d/DeepenShrestha/Deepend/0.1.1/DeepenShrestha.Deepend.locale.en-US.yaml
+++ b/manifests/d/DeepenShrestha/Deepend/0.1.1/DeepenShrestha.Deepend.locale.en-US.yaml
@@ -6,13 +6,13 @@ PackageVersion: 0.1.1
 PackageLocale: en-US
 Publisher: Deepen Shrestha
 PublisherUrl: https://github.com/deepen-stha
-PublisherSupportUrl: https://github.com/deepen-stha/deepend/issues
+PublisherSupportUrl: https://github.com/deepen-stha/deepend-releases/issues
 PackageName: Deepend
-PackageUrl: https://github.com/deepen-stha/deepend
+PackageUrl: https://github.com/deepen-stha/deepend-releases
 License: MIT
-LicenseUrl: https://github.com/deepen-stha/deepend/blob/main/LICENSE
+LicenseUrl: https://github.com/deepen-stha/deepend-releases/blob/main/LICENSE
 Copyright: Copyright (c) 2026 Deepen Shrestha
-CopyrightUrl: https://github.com/deepen-stha/deepend/blob/main/LICENSE
+CopyrightUrl: https://github.com/deepen-stha/deepend-releases/blob/main/LICENSE
 ShortDescription: Where everything comes together. The only software you'll ever need.
 Description: |-
   Deepend is a single, free, cross-platform desktop app that bundles every

--- a/manifests/d/DeepenShrestha/Deepend/0.1.1/DeepenShrestha.Deepend.locale.en-US.yaml
+++ b/manifests/d/DeepenShrestha/Deepend/0.1.1/DeepenShrestha.Deepend.locale.en-US.yaml
@@ -1,0 +1,49 @@
+# Created with wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: DeepenShrestha.Deepend
+PackageVersion: 0.1.1
+PackageLocale: en-US
+Publisher: Deepen Shrestha
+PublisherUrl: https://github.com/deepen-stha
+PublisherSupportUrl: https://github.com/deepen-stha/deepend/issues
+PackageName: Deepend
+PackageUrl: https://github.com/deepen-stha/deepend
+License: MIT
+LicenseUrl: https://github.com/deepen-stha/deepend/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Deepen Shrestha
+CopyrightUrl: https://github.com/deepen-stha/deepend/blob/main/LICENSE
+ShortDescription: Where everything comes together. The only software you'll ever need.
+Description: |-
+  Deepend is a single, free, cross-platform desktop app that bundles every
+  developer utility you reach for — JSON, text, PDF, API, and image tooling —
+  running 100% offline on your machine.
+
+  Studios:
+  - JSON Studio: Format, repair, diff, query, redact, convert
+  - Text Studio: Diff, hash, encode, regex, case, frequency, random
+  - PDF Toolkit: Merge, split, compress, protect, sign, convert
+  - API Studio: Request, cURL, status codes, code-gen, load test
+  - PixelForge: Image editor — compose pixels with precision
+
+  Built with Tauri (~10–15 MB installer, no embedded Chromium). Every tool
+  runs locally. No telemetry, no accounts, no network calls.
+Moniker: deepend
+Tags:
+- developer-tools
+- json
+- pdf
+- text
+- api
+- image
+- productivity
+- offline
+- tauri
+- utilities
+ReleaseNotes: |-
+  v0.1.1 — Branding refresh and version display.
+  - UI version display wired to package.json
+  - Unified Deepend logo across all platforms
+ReleaseNotesUrl: https://github.com/deepen-stha/deepend-releases/releases/tag/v0.1.1
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/d/DeepenShrestha/Deepend/0.1.1/DeepenShrestha.Deepend.yaml
+++ b/manifests/d/DeepenShrestha/Deepend/0.1.1/DeepenShrestha.Deepend.yaml
@@ -1,0 +1,8 @@
+# Created with wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: DeepenShrestha.Deepend
+PackageVersion: 0.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## New package: DeepenShrestha.Deepend version 0.1.1

Adds first version of **Deepend** — a free, cross-platform desktop app that bundles JSON, text, PDF, API, and image developer utilities, running 100% offline on the user machine. Built with Tauri (~3 MB installer, no embedded Chromium).

- Homepage: https://github.com/deepen-stha/deepend
- Release: https://github.com/deepen-stha/deepend-releases/releases/tag/v0.1.1
- License: MIT

## Installer details

| Architecture | Type | Scope |
|---|---|---|
| x64 | nullsoft (NSIS) | machine |
| x64 | wix (MSI) | machine |

Both installers verified against their published SHA-256 in the manifest.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-cli/blob/master/doc/Manifest.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`? (CI sandbox install will validate end-to-end.)
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-cli/tree/master/schemas/JSON/manifests/v1.6.0)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/367446)