### PR TITLE
New version: ConvergentSystems.Gitignore version 1.6.0

### DIFF
--- a/manifests/c/ConvergentSystems/Gitignore/1.6.0/ConvergentSystems.Gitignore.installer.yaml
+++ b/manifests/c/ConvergentSystems/Gitignore/1.6.0/ConvergentSystems.Gitignore.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: ConvergentSystems.Gitignore
+PackageVersion: 1.6.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: gitignore.exe
+    PortableCommandAlias: gitignore
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/convergent-systems-co/gitignore/releases/download/v1.6.0/gitignore-v1.6.0-windows-amd64.zip
+    InstallerSha256: C0EE4105168FC57368352C17EFA18F9206F14893368C37107B98F8E5355F70AD
+ReleaseDate: 2026-05-01
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/c/ConvergentSystems/Gitignore/1.6.0/ConvergentSystems.Gitignore.locale.en-US.yaml
+++ b/manifests/c/ConvergentSystems/Gitignore/1.6.0/ConvergentSystems.Gitignore.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: ConvergentSystems.Gitignore
+PackageVersion: 1.6.0
+PackageLocale: en-US
+Publisher: Convergent Systems
+PublisherUrl: https://convergent-systems.co
+PublisherSupportUrl: https://github.com/convergent-systems-co/gitignore/issues
+PackageName: gitignore
+PackageUrl: https://gitignore.convergent-systems.co
+License: MIT
+LicenseUrl: https://github.com/convergent-systems-co/gitignore/blob/main/LICENSE
+ShortDescription: A free CLI for managing .gitignore files
+Description: |-
+  A free, open-source command-line tool for managing .gitignore files.
+  Templates from GitHub and Toptal, local overrides for project-specific
+  patterns, and an MCP server mode that lets AI coding assistants manage
+  ignore rules directly.
+Tags:
+  - cli
+  - git
+  - gitignore
+  - mcp
+ReleaseNotesUrl: https://github.com/convergent-systems-co/gitignore/releases/tag/v1.6.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/c/ConvergentSystems/Gitignore/1.6.0/ConvergentSystems.Gitignore.yaml
+++ b/manifests/c/ConvergentSystems/Gitignore/1.6.0/ConvergentSystems.Gitignore.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: ConvergentSystems.Gitignore
+PackageVersion: 1.6.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## New version: ConvergentSystems.Gitignore version 1.6.0

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/HEAD/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?

### Package details
- Identifier: `ConvergentSystems.Gitignore`
- Version: `1.6.0`
- Architecture: x64
- InstallerType: zip → portable (nested `gitignore.exe`)
- Source: https://github.com/convergent-systems-co/gitignore (MIT)
- Marketing site: https://gitignore.convergent-systems.co

A free, open-source CLI for managing `.gitignore` files. First submission of this package.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/367473)