### PR TITLE
New package: paimonchan.paimon-mcp-fetch version 0.1.2

### DIFF
--- a/manifests/p/paimonchan/paimon-mcp-fetch/0.1.2/paimonchan.paimon-mcp-fetch.installer.yaml
+++ b/manifests/p/paimonchan/paimon-mcp-fetch/0.1.2/paimonchan.paimon-mcp-fetch.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: paimonchan.paimon-mcp-fetch
+PackageVersion: 0.1.2
+InstallerType: portable
+Commands:
+- paimon-mcp-fetch-windows-amd64
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/paimonchan/paimon-mcp-fetch/releases/download/v0.1.2/paimon-mcp-fetch-windows-amd64.exe
+  InstallerSha256: 62BED19EC00A14F0FD1862755908960CA23565699F638A7F0066F690AA0942A5
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/p/paimonchan/paimon-mcp-fetch/0.1.2/paimonchan.paimon-mcp-fetch.locale.en-US.yaml
+++ b/manifests/p/paimonchan/paimon-mcp-fetch/0.1.2/paimonchan.paimon-mcp-fetch.locale.en-US.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: paimonchan.paimon-mcp-fetch
+PackageVersion: 0.1.2
+PackageLocale: en-US
+Publisher: paimonchan
+PublisherUrl: https://github.com/paimonchan
+PackageName: paimon-mcp-fetch
+PackageUrl: https://github.com/paimonchan/paimon-mcp-fetch
+License: MIT
+LicenseUrl: https://github.com/paimonchan/paimon-mcp-fetch/blob/master/LICENSE
+ShortDescription: Web content fetching MCP server
+Tags:
+- mcp
+- fetch
+- web
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/p/paimonchan/paimon-mcp-fetch/0.1.2/paimonchan.paimon-mcp-fetch.yaml
+++ b/manifests/p/paimonchan/paimon-mcp-fetch/0.1.2/paimonchan.paimon-mcp-fetch.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: paimonchan.paimon-mcp-fetch
+PackageVersion: 0.1.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
This PR adds the manifest for paimon-mcp-fetch v0.1.2.

**Package:** paimonchan.paimon-mcp-fetch
**Version:** 0.1.2
**Installer Type:** portable
**Architecture:** x64
**License:** MIT

Web content fetching MCP server built with Go. Fetches web pages and extracts clean markdown content.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/367479)