### PR TITLE
Update AudioCodes.SyslogViewer.locale.en-US.yaml to correct PackageName

### DIFF
--- a/manifests/a/AudioCodes/SyslogViewer/2.31/AudioCodes.SyslogViewer.locale.en-US.yaml
+++ b/manifests/a/AudioCodes/SyslogViewer/2.31/AudioCodes.SyslogViewer.locale.en-US.yaml
@@ -9,7 +9,7 @@ PublisherUrl: https://www.audiocodes.com/
 PublisherSupportUrl: https://www.audiocodes.com/services-support
 PrivacyUrl: https://www.audiocodes.com/corporate/privacy-policy
 Author: AudioCodes Ltd.
-PackageName: SBC Configuration Wizard
+PackageName: AudioCodes Syslog Viewer
 PackageUrl: https://tools.audiocodes.com/install/
 License: Freeware
 LicenseUrl: https://www.audiocodes.com/media/14061/audiocodes-end-user-software-license-agreement.pdf


### PR DESCRIPTION
**The PackageName value is wrong, it display a different software's name (SBC Configuration Wizard). This one is correct**

Checklist for Pull Requests
- [] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Is there a linked Issue?  If so, fill in the Issue number below.
   <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/367501)