### PR TITLE
AndVl1.gw version 0.2.5

### DIFF
--- a/manifests/a/AndVl1/gw/0.2.5/AndVl1.gw.installer.yaml
+++ b/manifests/a/AndVl1/gw/0.2.5/AndVl1.gw.installer.yaml
@@ -1,0 +1,24 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: AndVl1.gw
+PackageVersion: 0.2.5
+InstallerType: zip
+NestedInstallerType: portable
+Commands:
+- gw
+Installers:
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: gw-0.2.5-x86_64-pc-windows-msvc/gw.exe
+    PortableCommandAlias: gw
+  InstallerUrl: https://github.com/AndVl1/gw/releases/download/v0.2.5/gw-0.2.5-x86_64-pc-windows-msvc.zip
+  InstallerSha256: A9CD889F65B4CCC7CBD10E69C7155FE7C000F69E239E1A966E501B7DC1F6F798
+- Architecture: arm64
+  NestedInstallerFiles:
+  - RelativeFilePath: gw-0.2.5-aarch64-pc-windows-msvc/gw.exe
+    PortableCommandAlias: gw
+  InstallerUrl: https://github.com/AndVl1/gw/releases/download/v0.2.5/gw-0.2.5-aarch64-pc-windows-msvc.zip
+  InstallerSha256: 32996E59A8D18F590FEF00DD258F38878F681357A4B9A463F098842A8D055FA9
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/a/AndVl1/gw/0.2.5/AndVl1.gw.locale.en-US.yaml
+++ b/manifests/a/AndVl1/gw/0.2.5/AndVl1.gw.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: AndVl1.gw
+PackageVersion: 0.2.5
+PackageLocale: en-US
+Publisher: AndVl1
+PublisherUrl: https://github.com/AndVl1
+PublisherSupportUrl: https://github.com/AndVl1/gw/issues
+PackageName: gw
+PackageUrl: https://github.com/AndVl1/gw
+License: MIT
+LicenseUrl: https://github.com/AndVl1/gw/blob/main/LICENSE
+ShortDescription: Gradle output filter for AI coding agents.
+Description: |
+  gw wraps ./gradlew, strips noise (daemon banners, downloads, task lifecycle, deprecations),
+  forwards errors/warnings/status, prints a heartbeat, and saves the full log on disk.
+Tags:
+- gradle
+- kotlin
+- cli
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/a/AndVl1/gw/0.2.5/AndVl1.gw.yaml
+++ b/manifests/a/AndVl1/gw/0.2.5/AndVl1.gw.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: AndVl1.gw
+PackageVersion: 0.2.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## AndVl1.gw version 0.2.5

**Fixes:** This PR fixes the NestedInstallerFiles paths to correctly point to gw.exe inside the version-specific directories in the zip archives.

### Changes
- Fixed x64 installer: `gw-0.2.5-x86_64-pc-windows-msvc/gw.exe`
- Fixed arm64 installer: `gw-0.2.5-aarch64-pc-windows-msvc/gw.exe`

This replaces PR #366334 which had incorrect paths.

---
**Package:** gw - Gradle wrapper noise-stripping CLI
**Homepage:** https://github.com/AndVl1/gw
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/367511)