### PR TITLE
New package: ClawContributors.ClawVCS version 0.1.0

### DIFF
--- a/manifests/c/ClawContributors/ClawVCS/0.1.0/ClawContributors.ClawVCS.installer.yaml
+++ b/manifests/c/ClawContributors/ClawVCS/0.1.0/ClawContributors.ClawVCS.installer.yaml
@@ -1,0 +1,19 @@
+PackageIdentifier: ClawContributors.ClawVCS
+PackageVersion: 0.1.0
+InstallerType: msi
+Scope: machine
+UpgradeBehavior: install
+ReleaseDate: 2026-05-01
+AppsAndFeaturesEntries:
+- DisplayName: Claw VCS
+  Publisher: Claw contributors
+  DisplayVersion: 0.1.0
+  ProductCode: '{EB51BD78-B3B3-4ACB-BE4B-27F6CC43A94B}'
+  UpgradeCode: '{A0125272-4F24-4EBE-8DE9-805BA0342C28}'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Shree-git/claw-vcs/releases/download/v0.1.0/claw-x86_64-pc-windows-msvc.msi
+  InstallerSha256: 17854E710A9B4F3443B0C2F63619DBACFCD644284F4F409E24764B04583D8B81
+  ProductCode: '{EB51BD78-B3B3-4ACB-BE4B-27F6CC43A94B}'
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/ClawContributors/ClawVCS/0.1.0/ClawContributors.ClawVCS.locale.en-US.yaml
+++ b/manifests/c/ClawContributors/ClawVCS/0.1.0/ClawContributors.ClawVCS.locale.en-US.yaml
@@ -1,0 +1,24 @@
+PackageIdentifier: ClawContributors.ClawVCS
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Claw contributors
+PublisherUrl: https://github.com/Shree-git
+PublisherSupportUrl: https://github.com/Shree-git/claw-vcs/issues
+Author: Shree-git
+PackageName: Claw VCS
+PackageUrl: https://github.com/Shree-git/claw-vcs
+License: MIT
+LicenseUrl: https://github.com/Shree-git/claw-vcs/blob/main/LICENSE
+ShortDescription: Intent-native version control for human + AI code.
+Description: Claw VCS is an intent-native version control system that records intent, change, revision, evidence, and policy as first-class objects for human and AI collaboration.
+ReleaseNotesUrl: https://github.com/Shree-git/claw-vcs/releases/tag/v0.1.0
+Tags:
+- ai
+- cli
+- git
+- provenance
+- rust
+- terminal
+- vcs
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/ClawContributors/ClawVCS/0.1.0/ClawContributors.ClawVCS.yaml
+++ b/manifests/c/ClawContributors/ClawVCS/0.1.0/ClawContributors.ClawVCS.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: ClawContributors.ClawVCS
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Summary
- add the initial WinGet manifest for Claw VCS 0.1.0
- use the published x64 MSI from the GitHub release
- include ProductCode and UpgradeCode metadata from the installer

## Source
- Release: https://github.com/Shree-git/claw-vcs/releases/tag/v0.1.0
- MSI: https://github.com/Shree-git/claw-vcs/releases/download/v0.1.0/claw-x86_64-pc-windows-msvc.msi
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/367531)