### PR TITLE
Make all triggers case insensitive and non-capturing

### DIFF
--- a/.github/policies/labelManagement.issueOpened.yml
+++ b/.github/policies/labelManagement.issueOpened.yml
@@ -154,7 +154,7 @@ configuration:
           - isAction:
               action: Opened
           - bodyContains:
-              pattern: (?i)hash[\s-](mismatch|does\snot\smatch)
+              pattern: (?in)hash[\s-](mismatch|does\snot\smatch)
               isRegex: True
         then:
           - addLabel:

--- a/.github/policies/labelManagement.issueOpened.yml
+++ b/.github/policies/labelManagement.issueOpened.yml
@@ -154,7 +154,7 @@ configuration:
           - isAction:
               action: Opened
           - bodyContains:
-              pattern: (?in)hash[\s-](mismatch|does\snot\smatch)
+              pattern: (?i)hash[\s-](mismatch|does\snot\smatch)
               isRegex: True
         then:
           - addLabel:

--- a/.github/policies/labelManagement.issueUpdated.yml
+++ b/.github/policies/labelManagement.issueUpdated.yml
@@ -408,7 +408,7 @@ configuration:
                   pattern: 'Validation Pipeline Run'
                   isRegex: false
               - commentContains:
-                  pattern: '@[Ww]ingetbot\s[Rr]un'
+                  pattern: '(?in)@wingetbot\srun'
                   isRegex: true
           - not:
               isActivitySender:

--- a/.github/policies/microsoftMVPTriggers.yml
+++ b/.github/policies/microsoftMVPTriggers.yml
@@ -29,7 +29,7 @@ configuration:
               # Manual-Validation-Completed
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[mM]anual[\s-][vV]alidation[\s-][cC]ompleted'
+                      pattern: '(?in)\[policy\]\s+manual[\s-]validation[\s-]completed'
                       isRegex: True
                 then:
                   - addLabel:

--- a/.github/policies/microsoftMVPTriggers.yml
+++ b/.github/policies/microsoftMVPTriggers.yml
@@ -29,7 +29,7 @@ configuration:
               # Manual-Validation-Completed
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+manual[\s-]validation[\s-]completed'
+                      pattern: '(?in)\[Policy\]\s+Manual[\s-]Validation[\s-]Completed'
                       isRegex: True
                 then:
                   - addLabel:

--- a/.github/policies/moderatorTriggers.yml
+++ b/.github/policies/moderatorTriggers.yml
@@ -59,7 +59,7 @@ configuration:
               # Area-Bots
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+area[\s-]bots'
+                      pattern: '(?in)\[Policy\]\s+Area[\s-]Bots'
                       isRegex: True
                 then:
                   - addLabel:
@@ -67,7 +67,7 @@ configuration:
               # Area-Client
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+area[\s-]client'
+                      pattern: '(?in)\[Policy\]\s+Area[\s-]Client'
                       isRegex: True
                 then:
                   - addLabel:
@@ -75,7 +75,7 @@ configuration:
               # Area-External
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+area[\s-]external'
+                      pattern: '(?in)\[Policy\]\s+Area[\s-]External'
                       isRegex: True
                 then:
                   - addLabel:
@@ -83,7 +83,7 @@ configuration:
               # Area-Manifest
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+area[\s-]manifest'
+                      pattern: '(?in)\[Policy\]\s+Area[\s-]Manifest'
                       isRegex: True
                 then:
                   - addLabel:
@@ -91,7 +91,7 @@ configuration:
               # Area-Matching
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+area[\s-]matching'
+                      pattern: '(?in)\[Policy\]\s+Area[\s-]Matching'
                       isRegex: True
                 then:
                   - addLabel:
@@ -99,7 +99,7 @@ configuration:
               # Area-Publish-Pipeline
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+area[\s-]publish(ing)?[\s-]pipeline'
+                      pattern: '(?in)\[Policy\]\s+Area[\s-]Publish(ing)?[\s-]Pipeline'
                       isRegex: True
                 then:
                   - addLabel:
@@ -107,7 +107,7 @@ configuration:
               # Area-Rebuild-Pipeline
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+area[\s-]rebuild[\s-]pipeline'
+                      pattern: '(?in)\[Policy\]\s+Area[\s-]Rebuild[\s-]Pipeline'
                       isRegex: True
                 then:
                   - addLabel:
@@ -115,7 +115,7 @@ configuration:
               # Area-Scope
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+area[\s-]scope'
+                      pattern: '(?in)\[Policy\]\s+Area[\s-]Scope'
                       isRegex: True
                 then:
                   - addLabel:
@@ -123,7 +123,7 @@ configuration:
               # Area-Validation-Pipeline
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+area[\s-]validation[\s-]pipeline'
+                      pattern: '(?in)\[Policy\]\s+Area[\s-]Validation[\s-]Pipeline'
                       isRegex: True
                 then:
                   - addLabel:
@@ -131,7 +131,7 @@ configuration:
               # Blocking-Issue
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+blocking[\s-]issue'
+                      pattern: '(?in)\[Policy\]\s+Blocking[\s-]Issue'
                       isRegex: True
                 then:
                   - removeLabel:
@@ -143,7 +143,7 @@ configuration:
               # Dependencies
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+dependencies'
+                      pattern: '(?in)\[Policy\]\s+Dependencies'
                       isRegex: True
                 then:
                   - addLabel:
@@ -151,7 +151,7 @@ configuration:
               # DriverInstall
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+driver[\s-]install'
+                      pattern: '(?in)\[Policy\]\s+Driver[\s-]Install'
                       isRegex: True
                 then:
                   - addLabel:
@@ -159,7 +159,7 @@ configuration:
               # DSC
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+dsc'
+                      pattern: '(?in)\[Policy\]\s+DSC'
                       isRegex: True
                 then:
                   - addLabel:
@@ -167,7 +167,7 @@ configuration:
               # Error-Hash-Mismatch
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+error[\s-]hash[\s-]mismatch'
+                      pattern: '(?in)\[Policy\]\s+Error[\s-]Hash[\s-]Mismatch'
                       isRegex: True
                 then:
                   - addLabel:
@@ -175,7 +175,7 @@ configuration:
               # Error-Installer-Availability
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+error[\s-]installer[\s-]availability'
+                      pattern: '(?in)\[Policy\]\s+Error[\s-]Installer[\s-]Availability'
                       isRegex: True
                 then:
                   - addLabel:
@@ -183,7 +183,7 @@ configuration:
               # Hardware
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+hardware'
+                      pattern: '(?in)\[Policy\]\s+Hardware'
                       isRegex: True
                 then:
                   - addLabel:
@@ -191,7 +191,7 @@ configuration:
               # Help-Wanted
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+help[\s-]wanted'
+                      pattern: '(?in)\[Policy\]\s+Help[\s-]Wanted'
                       isRegex: True
                 then:
                   - addLabel:
@@ -199,7 +199,7 @@ configuration:
               # Highest-Version-Removal
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+highest[\s-]version([\s-]removal)?'
+                      pattern: '(?in)\[Policy\]\s+Highest[\s-]Version([\s-]Removal)?'
                       isRegex: True
                 then:
                   - addLabel:
@@ -207,7 +207,7 @@ configuration:
               # Icon
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+icon'
+                      pattern: '(?in)\[Policy\]\s+Icon'
                       isRegex: True
                 then:
                   - addLabel:
@@ -215,7 +215,7 @@ configuration:
               # In-PR
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+in[\s-]pr'
+                      pattern: '(?in)\[Policy\]\s+In[\s-]PR'
                       isRegex: True
                 then:
                   - addLabel:
@@ -223,7 +223,7 @@ configuration:
               # Installer-Error
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+installer[\s-]error'
+                      pattern: '(?in)\[Policy\]\s+Installer[\s-]Error'
                       isRegex: True
                 then:
                   - addLabel:
@@ -231,7 +231,7 @@ configuration:
               # Installer-Issue
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+installer[\s-]issue'
+                      pattern: '(?in)\[Policy\]\s+Installer[\s-]Issue'
                       isRegex: True
                 then:
                   - addLabel:
@@ -241,7 +241,7 @@ configuration:
               # Interactive-Only-Download
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+interactive[\s-]only[\s-]download'
+                      pattern: '(?in)\[Policy\]\s+Interactive[\s-]Only[\s-]Download'
                       isRegex: True
                 then:
                   - addLabel:
@@ -249,7 +249,7 @@ configuration:
               # Interactive-Only-Installer
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+interactive[\s-]only[\s-]installer'
+                      pattern: '(?in)\[Policy\]\s+Interactive[\s-]Only[\s-]Installer'
                       isRegex: True
                 then:
                   - addLabel:
@@ -257,7 +257,7 @@ configuration:
               # Issue-Bug
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+issue[\s-]bug'
+                      pattern: '(?in)\[Policy\]\s+Issue[\s-]Bug'
                       isRegex: True
                 then:
                   - addLabel:
@@ -265,7 +265,7 @@ configuration:
               # Issue-Docs
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+issue[\s-]doc(s)?'
+                      pattern: '(?in)\[Policy\]\s+Issue[\s-]Doc(s)?'
                       isRegex: True
                 then:
                   - addLabel:
@@ -273,7 +273,7 @@ configuration:
               # Issue-Feature
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+issue[\s-]feature'
+                      pattern: '(?in)\[Policy\]\s+Issue[\s-]Feature'
                       isRegex: True
                 then:
                   - addLabel:
@@ -281,7 +281,7 @@ configuration:
               # Last-Version-Removal
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+last[\s-]version([\s-]removal)?'
+                      pattern: '(?in)\[Policy\]\s+Last[\s-]Version([\s-]Removal)?'
                       isRegex: True
                 then:
                   - addLabel:
@@ -289,7 +289,7 @@ configuration:
               # License-Blocks-Install
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+license[\s-]blocks([\s-]install)?'
+                      pattern: '(?in)\[Policy\]\s+License[\s-]Blocks([\s-]Install)?'
                       isRegex: True
                 then:
                   - addLabel:
@@ -297,7 +297,7 @@ configuration:
               # Manifest-Singleton-Deprecated
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+(manifest[\s-])?singleton[\s-]deprecated'
+                      pattern: '(?in)\[Policy\]\s+(Manifest[\s-])?Singleton[\s-]Deprecated'
                       isRegex: True
                 then:
                   - addLabel:
@@ -305,7 +305,7 @@ configuration:
               # Moderator-Approved
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+moderator[\s-]approved'
+                      pattern: '(?in)\[Policy\]\s+Moderator[\s-]Approved'
                       isRegex: True
                 then:
                   - addLabel:
@@ -313,7 +313,7 @@ configuration:
               # Needs-Attention
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+needs[\s-]attention'
+                      pattern: '(?in)\[Policy\]\s+Needs[\s-]Attention'
                       isRegex: True
                 then:
                   - addLabel:
@@ -327,7 +327,7 @@ configuration:
               # Needs-Author-Feedback
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+needs[\s-]author[\s-]feedback'
+                      pattern: '(?in)\[Policy\]\s+Needs[\s-]Author[\s-]Feedback'
                       isRegex: True
                 then:
                   - addLabel:
@@ -335,7 +335,7 @@ configuration:
               # Needs-CLA
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+needs[\s-]cla'
+                      pattern: '(?in)\[Policy\]\s+Needs[\s-]CLA'
                       isRegex: True
                 then:
                   - addLabel:
@@ -343,7 +343,7 @@ configuration:
               # Needs-Manual-Merge
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+needs[\s-]manual[\s-]merge'
+                      pattern: '(?in)\[Policy\]\s+Needs[\s-]Manual[\s-]Merge'
                       isRegex: True
                 then:
                   - addLabel:
@@ -351,7 +351,7 @@ configuration:
               # Needs-Review
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+needs[\s-]review'
+                      pattern: '(?in)\[Policy\]\s+Needs[\s-]Review'
                       isRegex: True
                 then:
                   - addLabel:
@@ -359,7 +359,7 @@ configuration:
               # Network-Blocker
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+network[\s-]block(?:er|ed)'
+                      pattern: '(?in)\[Policy\]\s+Network[\s-]Block(?:er|ed)'
                       isRegex: True
                 then:
                   - addLabel:
@@ -367,7 +367,7 @@ configuration:
               # Package-Metadata
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+package[\s-]metadata'
+                      pattern: '(?in)\[Policy\]\s+Package[\s-]Metadata'
                       isRegex: True
                 then:
                   - addLabel:
@@ -375,7 +375,7 @@ configuration:
               # Package-Request
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+package[\s-]request'
+                      pattern: '(?in)\[Policy\]\s+Package[\s-]Request'
                       isRegex: True
                 then:
                   - addLabel:
@@ -383,7 +383,7 @@ configuration:
               # Package-Update
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+package[\s-]update'
+                      pattern: '(?in)\[Policy\]\s+Package[\s-]Update'
                       isRegex: True
                 then:
                   - addLabel:
@@ -391,7 +391,7 @@ configuration:
               # portable-archive
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+portable[\s-]archive'
+                      pattern: '(?in)\[Policy\]\s+Portable[\s-]Archive'
                       isRegex: True
                 then:
                   - addLabel:
@@ -399,7 +399,7 @@ configuration:
               # portable-jar
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+portable[\s-]jar'
+                      pattern: '(?in)\[Policy\]\s+Portable[\s-]JAR'
                       isRegex: True
                 then:
                   - addLabel:
@@ -407,7 +407,7 @@ configuration:
               # PSA
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+psa'
+                      pattern: '(?in)\[Policy\]\s+PSA'
                       isRegex: True
                 then:
                   - addLabel:
@@ -415,7 +415,7 @@ configuration:
               # Scripted-Application
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+script(ed)?[\s-]application'
+                      pattern: '(?in)\[Policy\]\s+Script(ed)?[\s-]Application'
                       isRegex: True
                 then:
                   - addLabel:
@@ -423,7 +423,7 @@ configuration:
               # Testing
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+test(ing)?'
+                      pattern: '(?in)\[Policy\]\s+Test(ing)?'
                       isRegex: True
                 then:
                   - addLabel:
@@ -431,7 +431,7 @@ configuration:
               # Upgrade-Issue
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+upgrade[\s-]issue'
+                      pattern: '(?in)\[Policy\]\s+Upgrade[\s-]Issue'
                       isRegex: True
                 then:
                   - addLabel:
@@ -439,7 +439,7 @@ configuration:
               # Validation-Skip-Automations
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+validation[\s-]skip[\s-]automations'
+                      pattern: '(?in)\[Policy\]\s+Validation[\s-]Skip[\s-]Automations'
                       isRegex: True
                 then:
                   - addLabel:
@@ -447,7 +447,7 @@ configuration:
               # Version-Parameter-Mismatch
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+version[\s-]parameter[\s-]mismatch'
+                      pattern: '(?in)\[Policy\]\s+Version[\s-]Parameter[\s-]Mismatch'
                       isRegex: True
                 then:
                   - addLabel:
@@ -455,7 +455,7 @@ configuration:
               # Windows Features
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+windows[\s-]?feature(s)?'
+                      pattern: '(?in)\[Policy\]\s+Windows[\s-]?Feature(s)?'
                       isRegex: True
                 then:
                   - addLabel:
@@ -463,7 +463,7 @@ configuration:
               # Zip-Binary
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+zip[\s-]binary'
+                      pattern: '(?in)\[Policy\]\s+Zip[\s-]Binary'
                       isRegex: True
                 then:
                   - addLabel:
@@ -471,7 +471,7 @@ configuration:
               # Unblocked
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+unblocked'
+                      pattern: '(?in)\[Policy\]\s+Unblocked'
                       isRegex: True
                 then:
                   - removeLabel:
@@ -479,7 +479,7 @@ configuration:
               # Reset-Feedback
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+reset\s+feedback'
+                      pattern: '(?in)\[Policy\]\s+Reset\s+Feedback'
                       isRegex: True
                 then:
                   - removeLabel:
@@ -493,7 +493,7 @@ configuration:
               # Reset-Labels
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+reset[\s-]+labels'
+                      pattern: '(?in)\[Policy\]\s+Reset[\s-]+Labels'
                       isRegex: True
                 then:
                   - removeLabel:

--- a/.github/policies/moderatorTriggers.yml
+++ b/.github/policies/moderatorTriggers.yml
@@ -644,7 +644,7 @@ configuration:
               # Close with reason <>;
               - if:
                   - commentContains:
-                      pattern: "(?in)Close\\s+with\\s+reason\\s*:[\\w\\s\\-\\(\\)\\[\\]\\{\\}\\\\\\/.+=@\\#$%&^*`~|'\",<>?]*(?=;)"
+                      pattern: '(?sin)Close\s+with\s+Reason\s*:.+;'
                       isRegex: True
                 then:
                   - closeIssue
@@ -659,7 +659,7 @@ configuration:
               # Reopen with reason <>;
               - if:
                   - commentContains:
-                      pattern: "(?in)Reopen\\s+with\\s+reason\\s*:[\\w\\s\\-\\(\\)\\[\\]\\{\\}\\\\\\/.+=@\\#$%&^*`~|'\",<>?]*(?=;)"
+                      pattern: '(?sin)Reopen\s+with\s+Reason\s*:.+;'
                       isRegex: True
                 then:
                   - reopenIssue

--- a/.github/policies/moderatorTriggers.yml
+++ b/.github/policies/moderatorTriggers.yml
@@ -59,7 +59,7 @@ configuration:
               # Area-Bots
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[aA]rea[\s-][bB]ots'
+                      pattern: '(?in)\[policy\]\s+area[\s-]bots'
                       isRegex: True
                 then:
                   - addLabel:
@@ -67,7 +67,7 @@ configuration:
               # Area-Client
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[aA]rea[\s-][cC]lient'
+                      pattern: '(?in)\[policy\]\s+area[\s-]client'
                       isRegex: True
                 then:
                   - addLabel:
@@ -75,7 +75,7 @@ configuration:
               # Area-External
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[aA]rea[\s-][eE]xternal'
+                      pattern: '(?in)\[policy\]\s+area[\s-]external'
                       isRegex: True
                 then:
                   - addLabel:
@@ -83,7 +83,7 @@ configuration:
               # Area-Manifest
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[aA]rea[\s-][mM]anifest'
+                      pattern: '(?in)\[policy\]\s+area[\s-]manifest'
                       isRegex: True
                 then:
                   - addLabel:
@@ -91,7 +91,7 @@ configuration:
               # Area-Matching
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[aA]rea[\s-][mM]atching'
+                      pattern: '(?in)\[policy\]\s+area[\s-]matching'
                       isRegex: True
                 then:
                   - addLabel:
@@ -99,7 +99,7 @@ configuration:
               # Area-Publish-Pipeline
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[aA]rea[\s-][Pp]ublish(ing)?[\s-][pP]ipeline'
+                      pattern: '(?in)\[policy\]\s+area[\s-]publish(ing)?[\s-]pipeline'
                       isRegex: True
                 then:
                   - addLabel:
@@ -107,7 +107,7 @@ configuration:
               # Area-Rebuild-Pipeline
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[aA]rea[\s-][Rr]ebuild[\s-][pP]ipeline'
+                      pattern: '(?in)\[policy\]\s+area[\s-]rebuild[\s-]pipeline'
                       isRegex: True
                 then:
                   - addLabel:
@@ -115,7 +115,7 @@ configuration:
               # Area-Scope
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[aA]rea[\s-][sS]cope'
+                      pattern: '(?in)\[policy\]\s+area[\s-]scope'
                       isRegex: True
                 then:
                   - addLabel:
@@ -123,7 +123,7 @@ configuration:
               # Area-Validation-Pipeline
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[aA]rea[\s-][vV]alidation[\s-][pP]ipeline'
+                      pattern: '(?in)\[policy\]\s+area[\s-]validation[\s-]pipeline'
                       isRegex: True
                 then:
                   - addLabel:
@@ -131,7 +131,7 @@ configuration:
               # Blocking-Issue
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[bB]locking[\s-][iI]ssue'
+                      pattern: '(?in)\[policy\]\s+blocking[\s-]issue'
                       isRegex: True
                 then:
                   - removeLabel:
@@ -143,7 +143,7 @@ configuration:
               # Dependencies
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[dD]ependencies'
+                      pattern: '(?in)\[policy\]\s+dependencies'
                       isRegex: True
                 then:
                   - addLabel:
@@ -151,7 +151,7 @@ configuration:
               # DriverInstall
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[Dd]river[\s-][Ii]nstall'
+                      pattern: '(?in)\[policy\]\s+driver[\s-]install'
                       isRegex: True
                 then:
                   - addLabel:
@@ -159,7 +159,7 @@ configuration:
               # DSC
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[Dd][Ss][Cc]'
+                      pattern: '(?in)\[policy\]\s+dsc'
                       isRegex: True
                 then:
                   - addLabel:
@@ -167,7 +167,7 @@ configuration:
               # Error-Hash-Mismatch
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[eE]rror[\s-][hH]ash[\s-][mM]ismatch'
+                      pattern: '(?in)\[policy\]\s+error[\s-]hash[\s-]mismatch'
                       isRegex: True
                 then:
                   - addLabel:
@@ -175,7 +175,7 @@ configuration:
               # Error-Installer-Availability
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[Ee]rror[\s-][Ii]nstaller[\s-][Aa]vailability'
+                      pattern: '(?in)\[policy\]\s+error[\s-]installer[\s-]availability'
                       isRegex: True
                 then:
                   - addLabel:
@@ -183,7 +183,7 @@ configuration:
               # Hardware
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[hH]ardware'
+                      pattern: '(?in)\[policy\]\s+hardware'
                       isRegex: True
                 then:
                   - addLabel:
@@ -191,7 +191,7 @@ configuration:
               # Help-Wanted
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[hH]elp[\s-][wW]anted'
+                      pattern: '(?in)\[policy\]\s+help[\s-]wanted'
                       isRegex: True
                 then:
                   - addLabel:
@@ -199,7 +199,7 @@ configuration:
               # Highest-Version-Removal
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[Hh]ighest[\s-][Vv]ersion([\s-][Rr]emoval)?'
+                      pattern: '(?in)\[policy\]\s+highest[\s-]version([\s-]removal)?'
                       isRegex: True
                 then:
                   - addLabel:
@@ -207,7 +207,7 @@ configuration:
               # Icon
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[Ii]con'
+                      pattern: '(?in)\[policy\]\s+icon'
                       isRegex: True
                 then:
                   - addLabel:
@@ -215,7 +215,7 @@ configuration:
               # In-PR
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[Ii]n[\s-][Pp][Rr]'
+                      pattern: '(?in)\[policy\]\s+in[\s-]pr'
                       isRegex: True
                 then:
                   - addLabel:
@@ -223,7 +223,7 @@ configuration:
               # Installer-Error
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[iI]nstaller[\s-][Ee]rror'
+                      pattern: '(?in)\[policy\]\s+installer[\s-]error'
                       isRegex: True
                 then:
                   - addLabel:
@@ -231,7 +231,7 @@ configuration:
               # Installer-Issue
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[iI]nstaller[\s-][iI]ssue'
+                      pattern: '(?in)\[policy\]\s+installer[\s-]issue'
                       isRegex: True
                 then:
                   - addLabel:
@@ -241,7 +241,7 @@ configuration:
               # Interactive-Only-Download
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[iI]nteractive[\s-][oO]nly[\s-][Dd]ownload'
+                      pattern: '(?in)\[policy\]\s+interactive[\s-]only[\s-]download'
                       isRegex: True
                 then:
                   - addLabel:
@@ -249,7 +249,7 @@ configuration:
               # Interactive-Only-Installer
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[iI]nteractive[\s-][oO]nly[\s-][iI]nstaller'
+                      pattern: '(?in)\[policy\]\s+interactive[\s-]only[\s-]installer'
                       isRegex: True
                 then:
                   - addLabel:
@@ -257,7 +257,7 @@ configuration:
               # Issue-Bug
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[iI]ssue[\s-][bB]ug'
+                      pattern: '(?in)\[policy\]\s+issue[\s-]bug'
                       isRegex: True
                 then:
                   - addLabel:
@@ -265,7 +265,7 @@ configuration:
               # Issue-Docs
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[iI]ssue[\s-][dD]ocs'
+                      pattern: '(?in)\[policy\]\s+issue[\s-]doc(s)?'
                       isRegex: True
                 then:
                   - addLabel:
@@ -273,7 +273,7 @@ configuration:
               # Issue-Feature
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[iI]ssue[\s-][fF]eature'
+                      pattern: '(?in)\[policy\]\s+issue[\s-]feature'
                       isRegex: True
                 then:
                   - addLabel:
@@ -281,7 +281,7 @@ configuration:
               # Last-Version-Removal
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[Ll]ast[\s-][Vv]ersion([\s-][Rr]emoval)?'
+                      pattern: '(?in)\[policy\]\s+last[\s-]version([\s-]removal)?'
                       isRegex: True
                 then:
                   - addLabel:
@@ -289,7 +289,7 @@ configuration:
               # License-Blocks-Install
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[Ll]icense[\s-][Bb]locks([\s-][Ii]nstall)?'
+                      pattern: '(?in)\[policy\]\s+license[\s-]blocks([\s-]install)?'
                       isRegex: True
                 then:
                   - addLabel:
@@ -297,7 +297,7 @@ configuration:
               # Manifest-Singleton-Deprecated
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+([Mm]anifest[\s-])?[Ss]ingleton[\s-][Dd]eprecated'
+                      pattern: '(?in)\[policy\]\s+(manifest[\s-])?singleton[\s-]deprecated'
                       isRegex: True
                 then:
                   - addLabel:
@@ -305,7 +305,7 @@ configuration:
               # Moderator-Approved
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[mM]oderator[\s-][Aa]pproved'
+                      pattern: '(?in)\[policy\]\s+moderator[\s-]approved'
                       isRegex: True
                 then:
                   - addLabel:
@@ -313,7 +313,7 @@ configuration:
               # Needs-Attention
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[Nn]eeds[\s-][Aa]ttention'
+                      pattern: '(?in)\[policy\]\s+needs[\s-]attention'
                       isRegex: True
                 then:
                   - addLabel:
@@ -327,7 +327,7 @@ configuration:
               # Needs-Author-Feedback
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[Nn]eeds[\s-][Aa]uthor[\s-][fF]eedback'
+                      pattern: '(?in)\[policy\]\s+needs[\s-]author[\s-]feedback'
                       isRegex: True
                 then:
                   - addLabel:
@@ -335,7 +335,7 @@ configuration:
               # Needs-CLA
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[Nn]eeds[\s-][Cc][Ll][Aa]'
+                      pattern: '(?in)\[policy\]\s+needs[\s-]cla'
                       isRegex: True
                 then:
                   - addLabel:
@@ -343,7 +343,7 @@ configuration:
               # Needs-Manual-Merge
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[Nn]eeds[\s-][Mm]anual[\s-][mM]erge'
+                      pattern: '(?in)\[policy\]\s+needs[\s-]manual[\s-]merge'
                       isRegex: True
                 then:
                   - addLabel:
@@ -351,7 +351,7 @@ configuration:
               # Needs-Review
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[Nn]eeds[\s-][Rr]eview'
+                      pattern: '(?in)\[policy\]\s+needs[\s-]review'
                       isRegex: True
                 then:
                   - addLabel:
@@ -359,7 +359,7 @@ configuration:
               # Network-Blocker
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[Nn]etwork[\s-][Bb]lock(?:er|ed)'
+                      pattern: '(?in)\[policy\]\s+network[\s-]block(?:er|ed)'
                       isRegex: True
                 then:
                   - addLabel:
@@ -367,7 +367,7 @@ configuration:
               # Package-Metadata
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[pP]ackage[\s-][mM]etadata'
+                      pattern: '(?in)\[policy\]\s+package[\s-]metadata'
                       isRegex: True
                 then:
                   - addLabel:
@@ -375,7 +375,7 @@ configuration:
               # Package-Request
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[pP]ackage[\s-][rR]equest'
+                      pattern: '(?in)\[policy\]\s+package[\s-]request'
                       isRegex: True
                 then:
                   - addLabel:
@@ -383,7 +383,7 @@ configuration:
               # Package-Update
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[pP]ackage[\s-][uU]pdate'
+                      pattern: '(?in)\[policy\]\s+package[\s-]update'
                       isRegex: True
                 then:
                   - addLabel:
@@ -391,7 +391,7 @@ configuration:
               # portable-archive
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[pP]ortable[\s-][aA]rchive'
+                      pattern: '(?in)\[policy\]\s+portable[\s-]archive'
                       isRegex: True
                 then:
                   - addLabel:
@@ -399,7 +399,7 @@ configuration:
               # portable-jar
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[pP]ortable[\s-][jJ][aA][rR]'
+                      pattern: '(?in)\[policy\]\s+portable[\s-]jar'
                       isRegex: True
                 then:
                   - addLabel:
@@ -407,7 +407,7 @@ configuration:
               # PSA
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[Pp][Ss][Aa]'
+                      pattern: '(?in)\[policy\]\s+psa'
                       isRegex: True
                 then:
                   - addLabel:
@@ -415,7 +415,7 @@ configuration:
               # Scripted-Application
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[Ss]cript(ed)?[\s-][Aa]pplication'
+                      pattern: '(?in)\[policy\]\s+script(ed)?[\s-]application'
                       isRegex: True
                 then:
                   - addLabel:
@@ -423,7 +423,7 @@ configuration:
               # Testing
               - if:
                   - commentContains:
-                      pattern: '(?i)\[policy\]\s+test(ing)?'
+                      pattern: '(?in)\[policy\]\s+test(ing)?'
                       isRegex: True
                 then:
                   - addLabel:
@@ -431,7 +431,7 @@ configuration:
               # Upgrade-Issue
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[uU]pgrade[\s-][iI]ssue'
+                      pattern: '(?in)\[policy\]\s+upgrade[\s-]issue'
                       isRegex: True
                 then:
                   - addLabel:
@@ -439,7 +439,7 @@ configuration:
               # Validation-Skip-Automations
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[vV]alidation[\s-][sS]kip[\s-][aA]utomations'
+                      pattern: '(?in)\[policy\]\s+validation[\s-]skip[\s-]automations'
                       isRegex: True
                 then:
                   - addLabel:
@@ -447,7 +447,7 @@ configuration:
               # Version-Parameter-Mismatch
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[vV]ersion[\s-][pP]arameter[\s-][mM]ismatch'
+                      pattern: '(?in)\[policy\]\s+version[\s-]parameter[\s-]mismatch'
                       isRegex: True
                 then:
                   - addLabel:
@@ -455,7 +455,7 @@ configuration:
               # Windows Features
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[wW]indows[\s-]?[fF]eature(s)?'
+                      pattern: '(?in)\[policy\]\s+windows[\s-]?feature(s)?'
                       isRegex: True
                 then:
                   - addLabel:
@@ -463,7 +463,7 @@ configuration:
               # Zip-Binary
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[zZ]ip[\s-][bB]inary'
+                      pattern: '(?in)\[policy\]\s+zip[\s-]binary'
                       isRegex: True
                 then:
                   - addLabel:
@@ -471,7 +471,7 @@ configuration:
               # Unblocked
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[uU]nblocked'
+                      pattern: '(?in)\[policy\]\s+unblocked'
                       isRegex: True
                 then:
                   - removeLabel:
@@ -479,7 +479,7 @@ configuration:
               # Reset-Feedback
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[rR]eset\s+[fF]eedback'
+                      pattern: '(?in)\[policy\]\s+reset\s+feedback'
                       isRegex: True
                 then:
                   - removeLabel:
@@ -493,7 +493,7 @@ configuration:
               # Reset-Labels
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[rR]eset[\s-]+[lL]abels'
+                      pattern: '(?in)\[policy\]\s+reset[\s-]+labels'
                       isRegex: True
                 then:
                   - removeLabel:
@@ -618,7 +618,7 @@ configuration:
               # Duplicate of #
               - if:
                   - commentContains:
-                      pattern: Duplicate\s+of\s+\#?\s*\d+
+                      pattern: (?in)Duplicate\s+of\s+\#?\s*\d+
                       isRegex: True
                 then:
                   - addReply:
@@ -644,7 +644,7 @@ configuration:
               # Close with reason <>;
               - if:
                   - commentContains:
-                      pattern: "[cC]lose\\s+[wW]ith\\s+[rR]eason\\s*:[\\w\\s\\-\\(\\)\\[\\]\\{\\}\\\\\\/.+=@\\#$%&^*`~|'\",<>?]*(?=;)"
+                      pattern: "(?in)Close\\s+with\\s+reason\\s*:[\\w\\s\\-\\(\\)\\[\\]\\{\\}\\\\\\/.+=@\\#$%&^*`~|'\",<>?]*(?=;)"
                       isRegex: True
                 then:
                   - closeIssue
@@ -659,7 +659,7 @@ configuration:
               # Reopen with reason <>;
               - if:
                   - commentContains:
-                      pattern: "[rR]eopen\\s+[wW]ith\\s+[rR]eason\\s*:[\\w\\s\\-\\(\\)\\[\\]\\{\\}\\\\\\/.+=@\\#$%&^*`~|'\",<>?]*(?=;)"
+                      pattern: "(?in)Reopen\\s+with\\s+reason\\s*:[\\w\\s\\-\\(\\)\\[\\]\\{\\}\\\\\\/.+=@\\#$%&^*`~|'\",<>?]*(?=;)"
                       isRegex: True
                 then:
                   - reopenIssue

--- a/.github/policies/superModeratorTriggers.yml
+++ b/.github/policies/superModeratorTriggers.yml
@@ -36,7 +36,7 @@ configuration:
               # Force-Merge
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+force[\s-]merge'
+                      pattern: '(?in)\[Policy\]\s+Force[\s-]Merge'
                       isRegex: True
                   - isPullRequest
                 then:
@@ -56,7 +56,7 @@ configuration:
               # Manually-Validated
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+manually[\s-]validated'
+                      pattern: '(?in)\[Policy\]\s+Manually[\s-]Validated'
                       isRegex: True
                   - isPullRequest
                 then:
@@ -75,7 +75,7 @@ configuration:
               # Needs-Review
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+needs[\s-]review'
+                      pattern: '(?in)\[Policy\]\s+Needs[\s-]Review'
                       isRegex: True
                 then:
                   - addLabel:
@@ -83,7 +83,7 @@ configuration:
               # Validation-Defender-Error
               - if:
                   - commentContains:
-                      pattern: '(?in)\[policy\]\s+validation[\s-]defender[\s-]error'
+                      pattern: '(?in)\[Policy\]\s+Validation[\s-]Defender[\s-]Error'
                       isRegex: True
                 then:
                   - addLabel:

--- a/.github/policies/superModeratorTriggers.yml
+++ b/.github/policies/superModeratorTriggers.yml
@@ -36,7 +36,7 @@ configuration:
               # Force-Merge
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[Ff]orce[\s-][Mm]erge'
+                      pattern: '(?in)\[policy\]\s+force[\s-]merge'
                       isRegex: True
                   - isPullRequest
                 then:
@@ -56,7 +56,7 @@ configuration:
               # Manually-Validated
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[Mm]anually[\s-][Vv]alidated'
+                      pattern: '(?in)\[policy\]\s+manually[\s-]validated'
                       isRegex: True
                   - isPullRequest
                 then:
@@ -75,7 +75,7 @@ configuration:
               # Needs-Review
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[nN]eeds[\s-][rR]eview'
+                      pattern: '(?in)\[policy\]\s+needs[\s-]review'
                       isRegex: True
                 then:
                   - addLabel:
@@ -83,7 +83,7 @@ configuration:
               # Validation-Defender-Error
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[vV]alidation[\s-][dD]efender[\s-][eE]rror'
+                      pattern: '(?in)\[policy\]\s+validation[\s-]defender[\s-]error'
                       isRegex: True
                 then:
                   - addLabel:

--- a/doc/Moderation.md
+++ b/doc/Moderation.md
@@ -124,7 +124,7 @@ Sometimes a label is misapplied or needs to be removed to keep things clean. Thi
 
 In order to help keep the issues queues clean, moderators are able to close/re-open pull requests and issues. It is important to exercise discretion when closing/re-opening, ensuring that it is done with good reason.
 > [!IMPORTANT]
-> The ending semicolon is required. Using a URL in the reason is not supported
+> The ending semicolon is required.
 
 ### Marking Issues as Duplicate
 


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?

This PR updates the policy bot rules to minorly simplify the triggers used to apply labels to packages and perform other tasks. While this PR has minimal effect on the actual triggers themselves, it does a few things.

First, it makes all of the triggers fully case-insensitive. This helps to ensure triggers are correctly interpreted even with casing typos. For example, it used to be that `duplicate of #<id>` would not trigger because the `D` was not capitalized, or that `[Policy] Needs ATtention` would not trigger because the  `T` was capitalized. This should make it a little easier for moderators to no longer have to worry about being so precise with the casing of the triggers. 

Second, it adds the non-capturing flag. While most of the expressions do not use capture groups, a few of them do. Since the capturing groups aren't needed for anything other than qualifying a group for quantification. This very minorly reduces the compute load by reducing the need for backtracking and storing the capture group. While minor, across several issues all at the same time, it should save a few fractions of a second.

Finally, it completely re-writes the trigger for opening or closing a PR so that the reason can include newlines, hyperlinks, emojis, and basically anything through the use of the `s` flag, which should treat the comment to be treated as a single-line, allowing `.+` to match with newline characters as part of the match.

---

@denelon @mdanish-kh

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/367586)