### PR TITLE
New package: turutupa.yames version 0.4.1

### DIFF
--- a/manifests/t/turutupa/yames/0.4.1/turutupa.yames.yaml
+++ b/manifests/t/turutupa/yames/0.4.1/turutupa.yames.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.singleton.1.6.0.schema.json
+PackageIdentifier: turutupa.yames
+PackageVersion: 0.4.1
+PackageLocale: en-US
+Publisher: turutupa
+PublisherUrl: https://github.com/turutupa
+PackageName: Yames
+PackageUrl: https://turutupa.github.io/yames/
+License: MIT
+LicenseUrl: https://github.com/turutupa/yames/blob/main/LICENSE
+ShortDescription: Yet Another Metronome Everyone Skips — musician-grade floating metronome
+Description: |-
+  A free, open-source desktop metronome with an always-on-top floating widget,
+  sub-millisecond audio precision, zen mode with immersive visuals, drill practice mode,
+  tap tempo, and 10 beautiful themes.
+Tags:
+  - metronome
+  - music
+  - rhythm
+  - practice
+  - bpm
+  - tempo
+Installers:
+  - Architecture: x64
+    InstallerType: nsis
+    InstallerUrl: https://github.com/turutupa/yames/releases/download/v0.4.1/Yames_0.4.1_x64-setup.exe
+    InstallerSha256: 99ED91562CB91D51E480C14698711B00488D5236009BA398B771D1E7B875ADDD
+ManifestType: singleton
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Description

### New package submission

- **Package**: turutupa.yames
- **Version**: 0.4.1
- **URL**: https://github.com/turutupa/yames/releases/download/v0.4.1/Yames_0.4.1_x64-setup.exe
- **Homepage**: https://turutupa.github.io/yames/

Yames is a free, open-source desktop metronome for musicians with an always-on-top floating widget, sub-millisecond audio precision, zen mode, drill practice, and 10 themes.

Built with Rust + Tauri v2.

### Checklist
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there isn't already a PR for this package/version?
- [x] This PR only modifies one manifest
- [x] Have you validated your manifest locally with `winget validate --manifest`?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/367591)