### PR TITLE
New package: turutupa.yames version 0.4.1

### DIFF
--- a/manifests/t/turutupa/yames/0.4.1/turutupa.yames.installer.yaml
+++ b/manifests/t/turutupa/yames/0.4.1/turutupa.yames.installer.yaml
@@ -1,11 +1,11 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 PackageIdentifier: turutupa.yames
 PackageVersion: 0.4.1
+InstallerType: nsis
 UpgradeBehavior: install
 Installers:
-  - Architecture: x64
-    InstallerType: nsis
-    InstallerUrl: https://github.com/turutupa/yames/releases/download/v0.4.1/Yames_0.4.1_x64-setup.exe
-    InstallerSha256: 99ED91562CB91D51E480C14698711B00488D5236009BA398B771D1E7B875ADDD
+- Architecture: x64
+  InstallerUrl: https://github.com/turutupa/yames/releases/download/v0.4.1/Yames_0.4.1_x64-setup.exe
+  InstallerSha256: 99ED91562CB91D51E480C14698711B00488D5236009BA398B771D1E7B875ADDD
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/t/turutupa/yames/0.4.1/turutupa.yames.installer.yaml
+++ b/manifests/t/turutupa/yames/0.4.1/turutupa.yames.installer.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 PackageIdentifier: turutupa.yames
 PackageVersion: 0.4.1
-InstallerType: nsis
+InstallerType: nullsoft
 UpgradeBehavior: install
 Installers:
 - Architecture: x64

--- a/manifests/t/turutupa/yames/0.4.1/turutupa.yames.installer.yaml
+++ b/manifests/t/turutupa/yames/0.4.1/turutupa.yames.installer.yaml
@@ -1,10 +1,11 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 PackageIdentifier: turutupa.yames
 PackageVersion: 0.4.1
+UpgradeBehavior: install
 Installers:
   - Architecture: x64
     InstallerType: nsis
     InstallerUrl: https://github.com/turutupa/yames/releases/download/v0.4.1/Yames_0.4.1_x64-setup.exe
     InstallerSha256: 99ED91562CB91D51E480C14698711B00488D5236009BA398B771D1E7B875ADDD
 ManifestType: installer
-ManifestVersion: 1.9.0
+ManifestVersion: 1.12.0

--- a/manifests/t/turutupa/yames/0.4.1/turutupa.yames.installer.yaml
+++ b/manifests/t/turutupa/yames/0.4.1/turutupa.yames.installer.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: turutupa.yames
+PackageVersion: 0.4.1
+Installers:
+  - Architecture: x64
+    InstallerType: nsis
+    InstallerUrl: https://github.com/turutupa/yames/releases/download/v0.4.1/Yames_0.4.1_x64-setup.exe
+    InstallerSha256: 99ED91562CB91D51E480C14698711B00488D5236009BA398B771D1E7B875ADDD
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/t/turutupa/yames/0.4.1/turutupa.yames.locale.en-US.yaml
+++ b/manifests/t/turutupa/yames/0.4.1/turutupa.yames.locale.en-US.yaml
@@ -4,6 +4,7 @@ PackageVersion: 0.4.1
 PackageLocale: en-US
 Publisher: turutupa
 PublisherUrl: https://github.com/turutupa
+Author: Alberto Delgado
 PackageName: Yames
 PackageUrl: https://turutupa.github.io/yames/
 License: MIT
@@ -20,5 +21,6 @@ Tags:
   - practice
   - bpm
   - tempo
+ReleaseNotesUrl: https://github.com/turutupa/yames/releases/tag/v0.4.1
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0

--- a/manifests/t/turutupa/yames/0.4.1/turutupa.yames.locale.en-US.yaml
+++ b/manifests/t/turutupa/yames/0.4.1/turutupa.yames.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: turutupa.yames
+PackageVersion: 0.4.1
+PackageLocale: en-US
+Publisher: turutupa
+PublisherUrl: https://github.com/turutupa
+PackageName: Yames
+PackageUrl: https://turutupa.github.io/yames/
+License: MIT
+LicenseUrl: https://github.com/turutupa/yames/blob/main/LICENSE
+ShortDescription: Yet Another Metronome Everyone Skips - musician-grade floating metronome
+Description: |-
+  A free, open-source desktop metronome with an always-on-top floating widget,
+  sub-millisecond audio precision, zen mode with immersive visuals, drill practice mode,
+  tap tempo, and 10 beautiful themes. Built with Rust + Tauri v2.
+Tags:
+  - metronome
+  - music
+  - rhythm
+  - practice
+  - bpm
+  - tempo
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/t/turutupa/yames/0.4.1/turutupa.yames.locale.en-US.yaml
+++ b/manifests/t/turutupa/yames/0.4.1/turutupa.yames.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 PackageIdentifier: turutupa.yames
 PackageVersion: 0.4.1
 PackageLocale: en-US
@@ -21,4 +21,4 @@ Tags:
   - bpm
   - tempo
 ManifestType: defaultLocale
-ManifestVersion: 1.9.0
+ManifestVersion: 1.12.0

--- a/manifests/t/turutupa/yames/0.4.1/turutupa.yames.yaml
+++ b/manifests/t/turutupa/yames/0.4.1/turutupa.yames.yaml
@@ -1,6 +1,6 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 PackageIdentifier: turutupa.yames
 PackageVersion: 0.4.1
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.9.0
+ManifestVersion: 1.12.0

--- a/manifests/t/turutupa/yames/0.4.1/turutupa.yames.yaml
+++ b/manifests/t/turutupa/yames/0.4.1/turutupa.yames.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: turutupa.yames
+PackageVersion: 0.4.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## New package submission

- Package: turutupa.yames
- Version: 0.4.1
- URL: https://github.com/turutupa/yames/releases/download/v0.4.1/Yames_0.4.1_x64-setup.exe
- Homepage: https://turutupa.github.io/yames/

Yames is a free, open-source desktop metronome for musicians with an always-on-top floating widget, sub-millisecond audio precision, zen mode, drill practice, and 10 themes. Built with Rust + Tauri v2.

### Checklist

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there isn't already a PR for this package/version?
- [x] This PR only modifies one manifest
- [x] Have you validated your manifest locally with `winget validate --manifest`?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/367595)