### PR TITLE
MNardit.Beetroot version 1.6.6

### DIFF
--- a/manifests/m/MNardit/Beetroot/1.6.6/MNardit.Beetroot.installer.yaml
+++ b/manifests/m/MNardit/Beetroot/1.6.6/MNardit.Beetroot.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: MNardit.Beetroot
+PackageVersion: 1.6.6
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/mnardit/beetroot-releases/releases/download/v1.6.6/Beetroot_1.6.6_x64-setup.exe
+    InstallerSha256: D11683DAA88E5488CA4256AAF057F7EBFF48FBBC85661B8CE12469FA09CEEEB5
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/MNardit/Beetroot/1.6.6/MNardit.Beetroot.locale.en-US.yaml
+++ b/manifests/m/MNardit/Beetroot/1.6.6/MNardit.Beetroot.locale.en-US.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: MNardit.Beetroot
+PackageVersion: 1.6.6
+PackageLocale: en-US
+Publisher: MNardit
+PublisherUrl: https://github.com/mnardit
+Author: MNardit
+PackageName: Beetroot
+PackageUrl: https://github.com/mnardit/beetroot-releases
+License: Proprietary
+LicenseUrl: https://github.com/mnardit/beetroot-releases/blob/main/LICENSE
+ShortDescription: Lightweight clipboard manager for Windows with AI-powered text transforms
+Description: |-
+  Beetroot is a modern clipboard manager for Windows that runs in the system tray.
+  Features:
+  - Unlimited clipboard history (text and images)
+  - Global hotkey (Ctrl+`) to instantly access history
+  - Fuzzy and regex search
+  - AI-powered text transforms via OpenAI (10 built-in + custom prompts)
+  - OCR text extraction from images (native Windows engine)
+  - Notes on clipboard items
+  - Pin window on top or follow cursor mode
+  - Multi-select batch operations
+  - 9 themes + custom accent color
+  - 26 languages
+  - Automatic database backup and recovery
+  - Customizable UI and code fonts
+  - Auto-update with option to disable for fully offline operation
+  - Plain text paste hotkey
+  - Non-QWERTY keyboard layout support (AZERTY, QWERTZ, AltGr) with instant layout detection
+ReleaseNotesUrl: https://github.com/mnardit/beetroot-releases/releases/tag/v1.6.6
+Tags:
+  - clipboard
+  - clipboard-manager
+  - productivity
+  - tauri
+  - windows
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/MNardit/Beetroot/1.6.6/MNardit.Beetroot.yaml
+++ b/manifests/m/MNardit/Beetroot/1.6.6/MNardit.Beetroot.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: MNardit.Beetroot
+PackageVersion: 1.6.6
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](https://github.com/microsoft/winget-pkgs/blob/master/CONTRIBUTING.md).
- [x] I have tested my manifest locally with `winget validate` and `winget install`.
- [x] I have ensured that the manifests follow the [naming convention](https://github.com/microsoft/winget-pkgs/blob/master/doc/CONTRIBUTING-AS-A-MAINTAINER.md#manifest-naming-convention).

### Manifest

`manifests/m/MNardit/Beetroot/1.6.6/`

### Notes

Beetroot 1.6.6 — Windows clipboard manager. Bug fixes for Excel/Word/PowerPoint cell capture (text not screenshot), 1Password/KeePass entry skip reliability, Microsoft Store autostart, WCAG contrast for custom accents, and many smaller clipboard edge cases.

Release notes: https://github.com/mnardit/beetroot-releases/releases/tag/v1.6.6
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/367823)