### PR TITLE
Update package: M-Igashi.mp3rgain version 2.3.1

### DIFF
--- a/manifests/m/M-Igashi/mp3rgain/2.3.1/M-Igashi.mp3rgain.installer.yaml
+++ b/manifests/m/M-Igashi/mp3rgain/2.3.1/M-Igashi.mp3rgain.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgain
+PackageVersion: 2.3.1
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: mp3rgain.exe
+ReleaseDate: 2026-05-02
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/M-Igashi/mp3rgain/releases/download/v2.3.1/mp3rgain-v2.3.1-windows-x86_64.zip
+    InstallerSha256: 727E507937034AB0ACA287238B50C362377C2FEF0367A7F49E729697E6759DAE
+  - Architecture: arm64
+    InstallerUrl: https://github.com/M-Igashi/mp3rgain/releases/download/v2.3.1/mp3rgain-v2.3.1-windows-arm64.zip
+    InstallerSha256: E37252AA75C33750E0E57D20DF30E3B1D6FE8F2AE7B51A9CA5F4F41753AEDE35
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/mp3rgain/2.3.1/M-Igashi.mp3rgain.locale.en-US.yaml
+++ b/manifests/m/M-Igashi/mp3rgain/2.3.1/M-Igashi.mp3rgain.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgain
+PackageVersion: 2.3.1
+PackageLocale: en-US
+Publisher: M-Igashi
+PublisherUrl: https://github.com/M-Igashi
+PublisherSupportUrl: https://github.com/M-Igashi/mp3rgain/issues
+Author: M-Igashi
+PackageName: mp3rgain
+PackageUrl: https://github.com/M-Igashi/mp3rgain
+License: MIT
+LicenseUrl: https://github.com/M-Igashi/mp3rgain/blob/master/LICENSE
+ShortDescription: Lossless MP3 volume adjustment - a modern mp3gain replacement written in Rust
+Description: |-
+  mp3rgain adjusts MP3 volume without re-encoding by modifying the global_gain field in each frame's side information.
+  This preserves audio quality while achieving permanent volume changes.
+  Features include ReplayGain analysis, AAC/M4A support, and full mp3gain command-line compatibility.
+Moniker: mp3rgain
+Tags:
+  - audio
+  - cli
+  - flac
+  - gain
+  - lossless
+  - mp3
+  - music
+  - normalize
+  - ogg
+  - replaygain
+  - rust
+  - volume
+ReleaseNotesUrl: https://github.com/M-Igashi/mp3rgain/releases/tag/v2.3.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/mp3rgain/2.3.1/M-Igashi.mp3rgain.yaml
+++ b/manifests/m/M-Igashi/mp3rgain/2.3.1/M-Igashi.mp3rgain.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgain
+PackageVersion: 2.3.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Manifest update for M-Igashi.mp3rgain v2.3.1

This release adds the official multi-arch Docker image on GHCR (#123) plus internal code-reuse / quality / efficiency cleanups (shared `is_supported_audio_path()` helper between CLI and GUI fixing GUI silently dropping `.mp4` files, removed `to_uppercase()` allocations in APE tag access, dedup'd `parse_undo_gain`, etc.). CI maintenance bumps for `dtolnay/rust-toolchain` and `github/codeql-action`.

Release notes: https://github.com/M-Igashi/mp3rgain/releases/tag/v2.3.1

## Validation

- [x] I have read the [contribution guide](https://github.com/microsoft/winget-pkgs/blob/master/CONTRIBUTING.md)
- [x] Manifests follow the [1.12 schema](https://aka.ms/winget-manifest.installer.1.12.0.schema.json)
- [x] SHA256 checksums verified against published release artifacts
- [x] Tested locally with \`winget validate\`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/367847)