### PR TITLE
Update tsuchim.ImeKeysForUS to version 0.1.4

### DIFF
--- a/manifests/t/tsuchim/ImeKeysForUS/0.1.4/tsuchim.ImeKeysForUS.installer.yaml
+++ b/manifests/t/tsuchim/ImeKeysForUS/0.1.4/tsuchim.ImeKeysForUS.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: tsuchim.ImeKeysForUS
+PackageVersion: 0.1.4
+InstallerType: wix
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-05-03
+AppsAndFeaturesEntries:
+  - DisplayName: IME Keys for US
+    Publisher: tsuchim
+    DisplayVersion: 0.1.4
+    ProductCode: "{4DB8DB34-23CE-4CD3-A4F2-80C1496FC468}"
+    UpgradeCode: "{C79D216B-8E33-45BF-976B-F52825D3A8E6}"
+    InstallerType: wix
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/tsuchim/ime-keys-for-us/releases/download/v0.1.4/IME-Keys-for-US-0.1.4-x64.msi
+    InstallerSha256: 65A42D604175F6CAAD27CBFF430A73E850E198E3093471173D41F78E141F8359
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/t/tsuchim/ImeKeysForUS/0.1.4/tsuchim.ImeKeysForUS.locale.en-US.yaml
+++ b/manifests/t/tsuchim/ImeKeysForUS/0.1.4/tsuchim.ImeKeysForUS.locale.en-US.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: tsuchim.ImeKeysForUS
+PackageVersion: 0.1.4
+PackageLocale: en-US
+Publisher: tsuchim
+PublisherUrl: https://github.com/tsuchim
+PackageName: IME Keys for US
+PackageUrl: https://github.com/tsuchim/ime-keys-for-us
+License: MIT
+LicenseUrl: https://github.com/tsuchim/ime-keys-for-us/blob/main/LICENSE
+ShortDescription: Explicit Japanese IME on/off keys for US keyboards on Windows.
+Description: IME Keys for US is a native Windows tray utility that maps standalone Left Alt and Right Alt taps to explicit Japanese IME OFF and IME ON operations while preserving normal Alt shortcuts.
+Moniker: ime-keys-for-us
+Tags:
+  - ime
+  - japanese
+  - keyboard
+  - win32
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/tsuchim/ImeKeysForUS/0.1.4/tsuchim.ImeKeysForUS.yaml
+++ b/manifests/t/tsuchim/ImeKeysForUS/0.1.4/tsuchim.ImeKeysForUS.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: tsuchim.ImeKeysForUS
+PackageVersion: 0.1.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Updates tsuchim.ImeKeysForUS to version 0.1.4. This release adds tray icon recovery behavior and includes explicit AppsAndFeaturesEntries metadata for reliable MSI upgrade detection. The installer is statically linked and does not require Microsoft.VCRedist.2015+.x64.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/367921)