### PR TITLE
Manifest: Add Moniker for JayPrall.ColorCop

### DIFF
--- a/manifests/j/JayPrall/ColorCop/5.5.1/JayPrall.ColorCop.locale.en-US.yaml
+++ b/manifests/j/JayPrall/ColorCop/5.5.1/JayPrall.ColorCop.locale.en-US.yaml
@@ -2,6 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
 
 PackageIdentifier: JayPrall.ColorCop
+Moniker: colorcop
 PackageVersion: 5.5.1
 PackageLocale: en-US
 Publisher: Jay Prall

--- a/manifests/j/JayPrall/ColorCop/5.5.2/JayPrall.ColorCop.locale.en-US.yaml
+++ b/manifests/j/JayPrall/ColorCop/5.5.2/JayPrall.ColorCop.locale.en-US.yaml
@@ -2,6 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
 
 PackageIdentifier: JayPrall.ColorCop
+Moniker: colorcop
 PackageVersion: 5.5.2
 PackageLocale: en-US
 Publisher: Jay Prall


### PR DESCRIPTION
This updates the defaultLocale manifests for versions 5.5.1 and 5.5.2 to include the Moniker field (`colorcop`). No other metadata was modified.

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?  If so, fill in the Issue number below.
   <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/367944)