### PR TITLE
Update tsuchim.ImeKeysForUS to version 0.1.6

### DIFF
--- a/manifests/t/tsuchim/ImeKeysForUS/0.1.6/tsuchim.ImeKeysForUS.installer.yaml
+++ b/manifests/t/tsuchim/ImeKeysForUS/0.1.6/tsuchim.ImeKeysForUS.installer.yaml
@@ -12,12 +12,11 @@ ReleaseDate: 2026-05-03
 AppsAndFeaturesEntries:
   - DisplayName: IME Keys for US
     Publisher: tsuchim
-    DisplayVersion: 0.1.6
     ProductCode: "{534F1D62-1ADB-4D7E-83FD-547DAF6B1042}"
     UpgradeCode: "{C79D216B-8E33-45BF-976B-F52825D3A8E6}"
-    InstallerType: wix
 Installers:
   - Architecture: x64
+    ProductCode: "{534F1D62-1ADB-4D7E-83FD-547DAF6B1042}"
     InstallerUrl: https://github.com/tsuchim/ime-keys-for-us/releases/download/v0.1.6/IME-Keys-for-US-0.1.6-x64.msi
     InstallerSha256: 0443169022BD41018E85D00AF4B49DFFABEDFB8FA8708D9AB900BEA70DE93984
 ManifestType: installer

--- a/manifests/t/tsuchim/ImeKeysForUS/0.1.6/tsuchim.ImeKeysForUS.installer.yaml
+++ b/manifests/t/tsuchim/ImeKeysForUS/0.1.6/tsuchim.ImeKeysForUS.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: tsuchim.ImeKeysForUS
+PackageVersion: 0.1.6
+InstallerType: wix
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-05-03
+AppsAndFeaturesEntries:
+  - DisplayName: IME Keys for US
+    Publisher: tsuchim
+    DisplayVersion: 0.1.6
+    ProductCode: "{534F1D62-1ADB-4D7E-83FD-547DAF6B1042}"
+    UpgradeCode: "{C79D216B-8E33-45BF-976B-F52825D3A8E6}"
+    InstallerType: wix
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/tsuchim/ime-keys-for-us/releases/download/v0.1.6/IME-Keys-for-US-0.1.6-x64.msi
+    InstallerSha256: 0443169022BD41018E85D00AF4B49DFFABEDFB8FA8708D9AB900BEA70DE93984
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/t/tsuchim/ImeKeysForUS/0.1.6/tsuchim.ImeKeysForUS.locale.en-US.yaml
+++ b/manifests/t/tsuchim/ImeKeysForUS/0.1.6/tsuchim.ImeKeysForUS.locale.en-US.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: tsuchim.ImeKeysForUS
+PackageVersion: 0.1.6
+PackageLocale: en-US
+Publisher: tsuchim
+PublisherUrl: https://github.com/tsuchim
+PackageName: IME Keys for US
+PackageUrl: https://github.com/tsuchim/ime-keys-for-us
+License: MIT
+LicenseUrl: https://github.com/tsuchim/ime-keys-for-us/blob/main/LICENSE
+ShortDescription: Explicit Japanese IME on/off keys for US keyboards on Windows.
+Description: IME Keys for US is a native Windows tray utility that maps standalone Left Alt and Right Alt taps to explicit Japanese IME OFF and IME ON operations while preserving normal Alt shortcuts.
+Moniker: ime-keys-for-us
+Tags:
+  - ime
+  - japanese
+  - keyboard
+  - win32
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/tsuchim/ImeKeysForUS/0.1.6/tsuchim.ImeKeysForUS.yaml
+++ b/manifests/t/tsuchim/ImeKeysForUS/0.1.6/tsuchim.ImeKeysForUS.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: tsuchim.ImeKeysForUS
+PackageVersion: 0.1.6
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Updates tsuchim.ImeKeysForUS to version 0.1.6. This release removes arbitrary lower and upper bounds from the DoubleTapMs setting while keeping parser safety checks, uses USER_TIMER_MAXIMUM for the parser safety limit, and adds an explicit Start Menu shortcut icon in the MSI. The installer is the no-suffix locally Authenticode-signed MSI and includes AppsAndFeaturesEntries metadata for reliable MSI upgrade detection.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/368114)