### PR TITLE
Add Sanqiu.Cliai version 0.2.1

### DIFF
--- a/manifests/s/Sanqiu/Cliai/0.2.1/Sanqiu.Cliai.installer.yaml
+++ b/manifests/s/Sanqiu/Cliai/0.2.1/Sanqiu.Cliai.installer.yaml
@@ -1,0 +1,16 @@
+﻿PackageIdentifier: Sanqiu.Cliai
+PackageVersion: 0.2.1
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: cliai.exe
+    PortableCommandAlias: cliai
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/xjwm5685-ui/cliai/releases/download/v0.2.1/cliai_Windows_x86_64.zip
+    InstallerSha256: 5AD1D13C48AAEC89C359523182847AEEB14FA8F986F3F5B6AB29A4B0A871D3B2
+  - Architecture: arm64
+    InstallerUrl: https://github.com/xjwm5685-ui/cliai/releases/download/v0.2.1/cliai_Windows_ARM64.zip
+    InstallerSha256: 11FA740CC599B6454313BC85E37E1C12F890378EEC6D990195D5BF1231BB2551
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/s/Sanqiu/Cliai/0.2.1/Sanqiu.Cliai.installer.yaml
+++ b/manifests/s/Sanqiu/Cliai/0.2.1/Sanqiu.Cliai.installer.yaml
@@ -1,4 +1,5 @@
-﻿PackageIdentifier: Sanqiu.Cliai
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: Sanqiu.Cliai
 PackageVersion: 0.2.1
 InstallerType: zip
 NestedInstallerType: portable

--- a/manifests/s/Sanqiu/Cliai/0.2.1/Sanqiu.Cliai.locale.zh-CN.yaml
+++ b/manifests/s/Sanqiu/Cliai/0.2.1/Sanqiu.Cliai.locale.zh-CN.yaml
@@ -1,4 +1,5 @@
-﻿PackageIdentifier: Sanqiu.Cliai
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: Sanqiu.Cliai
 PackageVersion: 0.2.1
 PackageLocale: zh-CN
 Publisher: Sanqiu

--- a/manifests/s/Sanqiu/Cliai/0.2.1/Sanqiu.Cliai.locale.zh-CN.yaml
+++ b/manifests/s/Sanqiu/Cliai/0.2.1/Sanqiu.Cliai.locale.zh-CN.yaml
@@ -1,0 +1,19 @@
+﻿PackageIdentifier: Sanqiu.Cliai
+PackageVersion: 0.2.1
+PackageLocale: zh-CN
+Publisher: Sanqiu
+PublisherUrl: https://github.com/xjwm5685-ui/cliai
+PackageName: cliai
+PackageUrl: https://github.com/xjwm5685-ui/cliai
+License: MIT
+LicenseUrl: https://github.com/xjwm5685-ui/cliai/blob/main/LICENSE
+ShortDescription: Hybrid command prediction CLI for PowerShell
+Moniker: cliai
+Tags:
+  - cli
+  - powershell
+  - winget
+  - ai
+  - productivity
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/s/Sanqiu/Cliai/0.2.1/Sanqiu.Cliai.yaml
+++ b/manifests/s/Sanqiu/Cliai/0.2.1/Sanqiu.Cliai.yaml
@@ -1,4 +1,5 @@
-﻿PackageIdentifier: Sanqiu.Cliai
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: Sanqiu.Cliai
 PackageVersion: 0.2.1
 DefaultLocale: zh-CN
 ManifestType: version

--- a/manifests/s/Sanqiu/Cliai/0.2.1/Sanqiu.Cliai.yaml
+++ b/manifests/s/Sanqiu/Cliai/0.2.1/Sanqiu.Cliai.yaml
@@ -1,0 +1,5 @@
+﻿PackageIdentifier: Sanqiu.Cliai
+PackageVersion: 0.2.1
+DefaultLocale: zh-CN
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Summary
- Add winget manifests for Sanqiu.Cliai 0.2.1
- Include x64 and arm64 portable zip installers
- Point to the GitHub Release assets for v0.2.1

## Release assets
- x64: https://github.com/xjwm5685-ui/cliai/releases/download/v0.2.1/cliai_Windows_x86_64.zip
- arm64: https://github.com/xjwm5685-ui/cliai/releases/download/v0.2.1/cliai_Windows_ARM64.zip

## Notes
- Installer type: zip
- Nested installer type: portable
- Command alias: cliai
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/368169)