### PR TITLE
Manifest: Add Moniker to defaultLocale for JayPrall.ColorCop

### DIFF
--- a/manifests/j/JayPrall/ColorCop/5.5.9/JayPrall.ColorCop.locale.en-US.yaml
+++ b/manifests/j/JayPrall/ColorCop/5.5.9/JayPrall.ColorCop.locale.en-US.yaml
@@ -8,6 +8,7 @@ Publisher: Jay Prall
 PublisherUrl: https://github.com/ColorCop
 PublisherSupportUrl: https://github.com/ColorCop/ColorCop/issues
 PackageName: Color Cop
+Moniker: colorcop
 PackageUrl: https://github.com/ColorCop/ColorCop
 License: MIT
 LicenseUrl: https://github.com/ColorCop/ColorCop/blob/HEAD/LICENSE.txt


### PR DESCRIPTION
This adds the `Moniker: colorcop` field to the 5.5.9 defaultLocale manifest (en-US). No other metadata was changed.

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?  If so, fill in the Issue number below.
   <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/368196)