### PR TITLE
spelling: allow installer-type acronyms (inno, nullsoft, UTF, wix)

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -2,7 +2,11 @@ automerge
 denelon
 dkbennett
 Icm
+inno
 LOCALAPPDATA
 misclicks
+nullsoft
 stephengillie
 img
+UTF
+wix


### PR DESCRIPTION
Adds four installer-related acronyms to the check-spelling allowlist:

- `inno` — Inno Setup
- `nullsoft` — NSIS (Nullsoft Scriptable Install System)
- `wix` — WiX Toolset
- `UTF` — Unicode Transformation Format

These regularly appear in installer manifests under `InstallerType` and similar fields. Splitting from the package PR per reviewer request (#368165).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/368231)