### PR TITLE
New package: Finesssee.Win-CodexBar version 0.23.7

### DIFF
--- a/manifests/f/Finesssee/Win-CodexBar/0.23.7/Finesssee.Win-CodexBar.installer.yaml
+++ b/manifests/f/Finesssee/Win-CodexBar/0.23.7/Finesssee.Win-CodexBar.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Finesssee.Win-CodexBar
+PackageVersion: 0.23.7
+InstallerType: inno
+Scope: user
+UpgradeBehavior: install
+ProductCode: WinCodexBar_is1
+ReleaseDate: 2026-05-03
+AppsAndFeaturesEntries:
+- ProductCode: WinCodexBar_is1
+  DisplayName: CodexBar 0.23.7
+  DisplayVersion: 0.23.7
+  Publisher: CodexBar Contributors
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Finesssee/Win-CodexBar/releases/download/v0.23.7/CodexBar-0.23.7-Setup.exe
+  InstallerSha256: 327EFC5A9D837294EAA187ADE274A480ACD7A95FF0D99CBC4701EAB4C10C1677
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Finesssee/Win-CodexBar/0.23.7/Finesssee.Win-CodexBar.locale.en-US.yaml
+++ b/manifests/f/Finesssee/Win-CodexBar/0.23.7/Finesssee.Win-CodexBar.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Finesssee.Win-CodexBar
+PackageVersion: 0.23.7
+PackageLocale: en-US
+Publisher: CodexBar Contributors
+PublisherUrl: https://github.com/Finesssee
+PublisherSupportUrl: https://github.com/Finesssee/Win-CodexBar/issues
+Author: Finesssee
+PackageName: Win-CodexBar
+PackageUrl: https://github.com/Finesssee/Win-CodexBar
+License: MIT
+LicenseUrl: https://github.com/Finesssee/Win-CodexBar/blob/main/LICENSE
+Copyright: Copyright (c) CodexBar contributors
+ShortDescription: Windows-native menu bar app for OpenAI Codex and Claude Code usage stats.
+Description: Win-CodexBar is a Windows-native desktop app for viewing OpenAI Codex and Claude Code usage stats from a small Tauri shell.
+Moniker: win-codexbar
+Tags:
+- claude-code
+- codex
+- desktop
+- tauri
+- usage
+- windows
+ReleaseNotes: |-
+  v0.23.7 fixes Claude CLI hit-limit short-form parsing, improves Claude CLI usage parsing tolerance, and hardens the Tauri desktop shell with a content security policy, narrower capabilities, and safer external URL opening.
+ReleaseNotesUrl: https://github.com/Finesssee/Win-CodexBar/releases/tag/v0.23.7
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Finesssee/Win-CodexBar/0.23.7/Finesssee.Win-CodexBar.yaml
+++ b/manifests/f/Finesssee/Win-CodexBar/0.23.7/Finesssee.Win-CodexBar.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Finesssee.Win-CodexBar
+PackageVersion: 0.23.7
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Packages
Finesssee.Win-CodexBar

Validation
- Verified installer URL: https://github.com/Finesssee/Win-CodexBar/releases/download/v0.23.7/CodexBar-0.23.7-Setup.exe
- Verified installer SHA256: 327EFC5A9D837294EAA187ADE274A480ACD7A95FF0D99CBC4701EAB4C10C1677
- Verified installer type: Inno Setup
- Ran `winget validate C:\code\winget-v0.23.7\Finesssee.Win-CodexBar` successfully on Windows

Release
- https://github.com/Finesssee/Win-CodexBar/releases/tag/v0.23.7
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/368254)