### PR TITLE
Add ShipOrBleed.Mindswap version 3.3.0

### DIFF
--- a/manifests/s/ShipOrBleed/Mindswap/3.3.0/ShipOrBleed.Mindswap.installer.yaml
+++ b/manifests/s/ShipOrBleed/Mindswap/3.3.0/ShipOrBleed.Mindswap.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: ShipOrBleed.Mindswap
 PackageVersion: 3.3.0
@@ -18,4 +18,4 @@ Installers:
     PackageDependencies:
     - PackageIdentifier: OpenJS.NodeJS.LTS
 ManifestType: installer
-ManifestVersion: 1.10.0
+ManifestVersion: 1.12.0

--- a/manifests/s/ShipOrBleed/Mindswap/3.3.0/ShipOrBleed.Mindswap.installer.yaml
+++ b/manifests/s/ShipOrBleed/Mindswap/3.3.0/ShipOrBleed.Mindswap.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: ShipOrBleed.Mindswap
+PackageVersion: 3.3.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: mindswap.cmd
+  PortableCommandAlias: mindswap
+Commands:
+- mindswap
+ReleaseDate: 2026-05-02
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ShipOrBleed/mindswap/releases/download/v3.3.0/mindswap-win-portable-3.3.0.zip
+  InstallerSha256: B0940497EBE47AD364024A805CCB6620965531795940A468490098AE1BDDAEDA
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: OpenJS.NodeJS.LTS
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/s/ShipOrBleed/Mindswap/3.3.0/ShipOrBleed.Mindswap.locale.en-US.yaml
+++ b/manifests/s/ShipOrBleed/Mindswap/3.3.0/ShipOrBleed.Mindswap.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: ShipOrBleed.Mindswap
 PackageVersion: 3.3.0
@@ -20,4 +20,4 @@ Tags:
 - developer-tools
 - productivity
 ManifestType: defaultLocale
-ManifestVersion: 1.10.0
+ManifestVersion: 1.12.0

--- a/manifests/s/ShipOrBleed/Mindswap/3.3.0/ShipOrBleed.Mindswap.locale.en-US.yaml
+++ b/manifests/s/ShipOrBleed/Mindswap/3.3.0/ShipOrBleed.Mindswap.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: ShipOrBleed.Mindswap
+PackageVersion: 3.3.0
+PackageLocale: en-US
+Publisher: ShipOrBleed
+PublisherUrl: https://github.com/ShipOrBleed
+PublisherSupportUrl: https://github.com/ShipOrBleed/mindswap/issues
+Author: ShipOrBleed
+PackageName: Mindswap
+PackageUrl: https://github.com/ShipOrBleed/mindswap
+License: MIT
+ShortDescription: Your AI's black box recorder. Auto-track project state so any AI tool picks up where the last one stopped.
+Description: Local-first AI context and memory CLI for cross-tool coding continuity, project handoff, structured memory, and MCP-powered workflows.
+Moniker: mindswap
+Tags:
+- ai
+- cli
+- mcp
+- developer-tools
+- productivity
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/s/ShipOrBleed/Mindswap/3.3.0/ShipOrBleed.Mindswap.yaml
+++ b/manifests/s/ShipOrBleed/Mindswap/3.3.0/ShipOrBleed.Mindswap.yaml
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: ShipOrBleed.Mindswap
 PackageVersion: 3.3.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.10.0
+ManifestVersion: 1.12.0

--- a/manifests/s/ShipOrBleed/Mindswap/3.3.0/ShipOrBleed.Mindswap.yaml
+++ b/manifests/s/ShipOrBleed/Mindswap/3.3.0/ShipOrBleed.Mindswap.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: ShipOrBleed.Mindswap
+PackageVersion: 3.3.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Summary
- add WinGet manifests for ShipOrBleed.Mindswap 3.3.0
- publish portable installer wrapper for the npm-distributed CLI
- depend on OpenJS.NodeJS.LTS because mindswap runs via Node.js and npx

## Release asset
- https://github.com/ShipOrBleed/mindswap/releases/download/v3.3.0/mindswap-win-portable-3.3.0.zip

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/368268)