### PR TITLE
Fix closeBlockingIssue id and extend cleanEmailReply scope

### DIFF
--- a/.github/policies/labelManagement.issueUpdated.yml
+++ b/.github/policies/labelManagement.issueUpdated.yml
@@ -88,7 +88,10 @@ configuration:
         triggerOnOwnActions: true
       - description: Clean email replies on every comment
         if:
-          - payloadType: Issue_Comment
+          - or:
+              - payloadType: Issue_Comment
+              - payloadType: Pull_Request_Review
+              - payloadType: Pull_Request_Review_Comment
         then:
           - cleanEmailReply
       - description: Approve pull requests that have completed validation and have been approved by a moderator
@@ -197,6 +200,24 @@ configuration:
           - addLabel:
               label: Needs-Attention # This will automatically assign the ICM Users
       - description: >-
+          If an author agrees to the CLA on a Pull Request
+          * Remove the Needs-CLA Label
+        if:
+          - or:
+              - payloadType: Pull_Request_Review
+              - payloadType: Pull_Request_Review_Comment
+              - payloadType: Issue_Comment
+          - isActivitySender:
+              issueAuthor: True
+          - hasLabel:
+              label: Needs-CLA
+          - commentContains:
+              pattern: '@microsoft-github-policy-service agree'
+              isRegex: False
+        then:
+          - removeLabel:
+              label: Needs-CLA
+      - description: >-
           When changes are requested on a pull request
           * Disable automerge
           * Label with Changes-Requested
@@ -296,6 +317,8 @@ configuration:
           - removeLabel:
               label: Manifest-Version-Error
           - removeLabel:
+              label: Manual-Validation-Completed
+          - removeLabel:
               label: Moderator-Approved
           - removeLabel:
               label: Needs-Attention
@@ -344,6 +367,8 @@ configuration:
           - removeLabel:
               label: Unexpected-File
           - removeLabel:
+              label: Validate-Domain-Installer
+          - removeLabel:
               label: Validation-Completed
           - removeLabel:
               label: Validation-Defender-Error
@@ -386,7 +411,7 @@ configuration:
                   pattern: 'Validation Pipeline Run'
                   isRegex: false
               - commentContains:
-                  pattern: '@[Ww]ingetbot\s[Rr]un'
+                  pattern: '(?in)@wingetbot\srun'
                   isRegex: true
           - not:
               isActivitySender:
@@ -419,6 +444,7 @@ configuration:
                   user: russellbanks
         then:
           # Don't remove Changes-Requested here because it is just a re-run, no new commits have been added
+          # Don't remove Manual-Validation-Completed here because it is just a re-run, no new commits have been added
           - removeLabel:
               label: Author-Not-Authorized
           - removeLabel:

--- a/.github/policies/scheduledSearch.closeBlockingIssue.yml
+++ b/.github/policies/scheduledSearch.closeBlockingIssue.yml
@@ -1,4 +1,4 @@
-id: scheduledSearch.closeAreaExternal
+id: scheduledSearch.closeBlockingIssue
 name: GitOps.PullRequestIssueManagement
 description: Close stale pull requests marked with "Blocking-Issue"
 owner:


### PR DESCRIPTION
## 📖 Description
Created with GitHub Copilot assistance.

Update policy bot files to fix the `closeBlockingIssue` rule id and extend `cleanEmailReply` handling for pull request review activity.

## 🔗 References
Resolves #368470

## ✅ Checklist
- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)

## 📋 Issue Type
- [ ] Bug fix
- [ ] Feature
- [x] Task
