### PR TITLE
Update spelling for instructions changes

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -1,6 +1,8 @@
 automerge
 denelon
 dkbennett
+freeware
+GPLv
 Icm
 inno
 LOCALAPPDATA

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -1,7 +1,7 @@
 automerge
 denelon
 dkbennett
-freeware
+Freeware
 GPLv
 Icm
 inno


### PR DESCRIPTION
Updates to the manifest review instructions caused forks with spell check enabled to start having failures, this resolves that.

https://github.com/Trenly/winget-pkgs/actions/runs/25298657969

@denelon

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/368328)