### PR TITLE
Standardize PR template with emoji sections and issue types

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,16 @@
 ## 📖 Description
 <!-- Describe what this PR changes. For manifest submissions, include the package name and version. -->
 
-## 🔗 References
-<!-- Link related issues. Use "Resolves #1234" to auto-close. -->
-
 ## ✅ Checklist
 <!-- Place an "x" between the brackets to check an item. e.g: [x] -->
 
 - [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
 - [ ] Linked to an issue (if applicable)
+  <!-- Example: Resolves #328283 -->
+  - Resolves #[Issue Number]
 
 ## 📦 Manifest Checklist
+
 - [ ] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
 - [ ] This PR only modifies one (1) manifest
 - [ ] Validated manifest locally with `winget validate --manifest <path>`
@@ -18,9 +18,3 @@
 - [ ] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
 
 > **Note:** `<path>` is the directory containing the manifest you're submitting.
-
-## 📋 Issue Type
-<!-- Select the type that best describes this PR -->
-- [ ] Bug fix
-- [ ] Feature
-- [ ] Task

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,26 @@
-Checklist for Pull Requests
-- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
-- [ ] Is there a linked Issue?  If so, fill in the Issue number below.
-   <!-- Example: Resolves #328283 -->
-  - Resolves #[Issue Number]
+## 📖 Description
+<!-- Describe what this PR changes. For manifest submissions, include the package name and version. -->
 
-Manifests
-- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
+## 🔗 References
+<!-- Link related issues. Use "Resolves #1234" to auto-close. -->
+
+## ✅ Checklist
+<!-- Place an "x" between the brackets to check an item. e.g: [x] -->
+
+- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
+- [ ] Linked to an issue (if applicable)
+
+## 📦 Manifest Checklist
+- [ ] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
 - [ ] This PR only modifies one (1) manifest
-- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
-- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
-- [ ] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?
+- [ ] Validated manifest locally with `winget validate --manifest <path>`
+- [ ] Tested manifest locally with `winget install --manifest <path>`
+- [ ] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
 
-Note: `<path>` is the directory's name containing the manifest you're submitting.
+> **Note:** `<path>` is the directory containing the manifest you're submitting.
 
----
+## 📋 Issue Type
+<!-- Select the type that best describes this PR -->
+- [ ] Bug fix
+- [ ] Feature
+- [ ] Task

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,5 @@
+<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->
+
 ## 📖 Description
 <!-- Describe what this PR changes. For manifest submissions, include the package name and version. -->
 
@@ -13,7 +15,7 @@
 
 - [ ] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
 - [ ] This PR only modifies one (1) manifest
-- [ ] Validated manifest locally with `winget validate --manifest <path>`
+- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
 - [ ] Tested manifest locally with `winget install --manifest <path>`
 - [ ] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
 

--- a/Tools/YamlCreate.ps1
+++ b/Tools/YamlCreate.ps1
@@ -236,7 +236,7 @@ if ($Settings) {
   exit
 }
 
-$ScriptHeader = '# Created with YamlCreate.ps1 v2.7.1'
+$ScriptHeader = '# Created with YamlCreate.ps1 v2.7.2'
 $ManifestVersion = '1.12.0'
 $PSDefaultParameterValues = @{ '*:Encoding' = 'UTF8' }
 $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
@@ -1981,8 +1981,8 @@ Function Read-PRBody {
     # | Where-Object { $_ -like '-*[ ]*' }))
     if ($_line -like '-*[ ]*' ) {
       $_showMenu = $true
-      switch -Wildcard ( $_line ) {
-        '*CLA*' {
+      switch -Regex ( $_line ) {
+        '(?i)CLA' {
           if ($ScriptSettings.SignedCLA -eq 'true') {
             $PrBodyContent = $PrBodyContent.Replace($_line, $_line.Replace('[ ]', '[x]'))
             $_showMenu = $false
@@ -1997,7 +1997,7 @@ Function Read-PRBody {
           }
         }
 
-        '*open `[pull requests`]*' {
+        '(?i)open \[pull requests\]' {
           $_menu = @{
             Prompt        = "Have you checked that there aren't other open pull requests for the same manifest update/change?"
             Entries       = @('[Y] Yes'; '*[N] No')
@@ -2007,7 +2007,7 @@ Function Read-PRBody {
           }
         }
 
-        '*winget validate*' {
+        '(?i)winget validate' {
           if ($? -and $(Get-Command 'winget' -ErrorAction SilentlyContinue)) {
             $PrBodyContent = $PrBodyContent.Replace($_line, $_line.Replace('[ ]', '[x]'))
             $_showMenu = $false
@@ -2024,7 +2024,7 @@ Function Read-PRBody {
           }
         }
 
-        '*tested your manifest*' {
+        '(?i)tested .* ?manifest' {
           if ($script:SandboxTest -eq '0') {
             $PrBodyContent = $PrBodyContent.Replace($_line, $_line.Replace('[ ]', '[x]'))
             $_showMenu = $false
@@ -2041,7 +2041,7 @@ Function Read-PRBody {
           }
         }
 
-        '*schema*' {
+        '(?i)schema' {
           if ($script:Option -ne 'RemoveManifest') {
             $_Match = ($_line | Select-String -Pattern 'https://+.+(?=\))').Matches.Value
             $_menu = @{
@@ -2056,12 +2056,12 @@ Function Read-PRBody {
           }
         }
 
-        '*only modifies one*' {
+        '(?i)(only)? modifies one' {
           $PrBodyContent = $PrBodyContent.Replace($_line, $_line.Replace('[ ]', '[x]'))
           $_showMenu = $false
         }
 
-        '*linked issue*' {
+        '(?i)linked .* ?issue' {
           # Linked issues is handled as a separate prompt below so that the issue numbers can be gathered
           $_showMenu = $false
         }


### PR DESCRIPTION
## 📖 Description

Simplify and modernize the pull request template with emoji section headers while keeping it practical for this repo's primary use case (manifest submissions).

**Changes from the original template:**
- Add `📖 Description` section for optional context
- Update `✅ Checklist` with emoji header and cleaner formatting
- Update `📦 Manifest Checklist` with emoji header
- Keep `Resolves #[Issue Number]` fill-in for YamlCreate compatibility
- Remove verbose question-style checkbox text in favor of concise labels

**What was intentionally left out** (per feedback from @Trenly and @Dragon1573):
- No `📋 Issue Type` section — the distinction between bug/feature/task is blurry for manifest submissions
- No separate `🔗 References` section — redundant with the Resolves # in the checklist

Resolves #368333

## 🔍 Validation

Verified template renders correctly in GitHub's PR creation UI.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue

Created with GitHub Copilot assistance.
