### PR TITLE
Update Virtuworks.MSPControlAutopilot.installer.yaml

### DIFF
--- a/manifests/v/Virtuworks/MSPControlAutopilot/2.0.114/Virtuworks.MSPControlAutopilot.installer.yaml
+++ b/manifests/v/Virtuworks/MSPControlAutopilot/2.0.114/Virtuworks.MSPControlAutopilot.installer.yaml
@@ -3,6 +3,7 @@
 
 PackageIdentifier: Virtuworks.MSPControlAutopilot
 PackageVersion: 2.0.114
+UpgradeBehavior: install
 InstallerType: exe
 InstallerSwitches:
   Silent: /q


### PR DESCRIPTION
Add UpgradeBehavior: install to fix upgrade failing with "install technology is different" error when upgrading via winget.

Checklist for Pull Requests
- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?  If so, fill in the Issue number below.
   <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

Manifests
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/368352)