### PR TITLE
New version: LMCP.LocalMCP version 3.0.169

### DIFF
--- a/manifests/l/LMCP/LocalMCP/3.0.169/LMCP.LocalMCP.installer.yaml
+++ b/manifests/l/LMCP/LocalMCP/3.0.169/LMCP.LocalMCP.installer.yaml
@@ -9,7 +9,7 @@ Scope: machine
 InstallerType: exe
 Installers:
   - Architecture: x64
-    InstallerUrl: https://download.local-mcp.com/lmcp-setup.exe
+    InstallerUrl: https://download.local-mcp.com/lmcp-setup-3.0.169.exe
     InstallerSha256: DAA37500B8EE56C2C8E8F447E7E5B3F8A7FE4A0B927F69F0808E83BF3C0AB80A
     InstallerLocale: en-US
     InstallerSwitches:

--- a/manifests/l/LMCP/LocalMCP/3.0.169/LMCP.LocalMCP.installer.yaml
+++ b/manifests/l/LMCP/LocalMCP/3.0.169/LMCP.LocalMCP.installer.yaml
@@ -13,7 +13,7 @@ Installers:
     InstallerSha256: DAA37500B8EE56C2C8E8F447E7E5B3F8A7FE4A0B927F69F0808E83BF3C0AB80A
     InstallerLocale: en-US
     InstallerSwitches:
-      Silent: /S
-      SilentWithProgress: /S
+      Silent: --silent
+      SilentWithProgress: --silent
 ManifestType: installer
 ManifestVersion: 1.9.0

--- a/manifests/l/LMCP/LocalMCP/3.0.169/LMCP.LocalMCP.installer.yaml
+++ b/manifests/l/LMCP/LocalMCP/3.0.169/LMCP.LocalMCP.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: LMCP.LocalMCP
+PackageVersion: 3.0.169
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+Scope: machine
+InstallerType: exe
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://download.local-mcp.com/lmcp-setup.exe
+    InstallerSha256: DAA37500B8EE56C2C8E8F447E7E5B3F8A7FE4A0B927F69F0808E83BF3C0AB80A
+    InstallerLocale: en-US
+    InstallerSwitches:
+      Silent: /S
+      SilentWithProgress: /S
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/l/LMCP/LocalMCP/3.0.169/LMCP.LocalMCP.locale.en-US.yaml
+++ b/manifests/l/LMCP/LocalMCP/3.0.169/LMCP.LocalMCP.locale.en-US.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: LMCP.LocalMCP
+PackageVersion: 3.0.169
+PackageLocale: en-US
+Publisher: LMCP
+PublisherUrl: https://www.local-mcp.com
+PublisherSupportUrl: https://github.com/lanchuske/local-mcp-releases/issues
+Author: Dario Lanchuske
+PackageName: LMCP
+PackageUrl: https://www.local-mcp.com
+License: Proprietary
+LicenseUrl: https://www.local-mcp.com/en/tos
+ShortDescription: Connect AI agents to your local apps — Outlook, Calendar, Teams, Excel, Word. 95+ tools, 100% local.
+Description: |-
+  LMCP is a native MCP server that connects AI agents (Claude, ChatGPT, Cursor, VS Code) to your local desktop apps.
+  Read and send email via Outlook, manage calendar events, read Teams messages, access OneDrive files,
+  create Excel and Word documents — all running locally on your machine.
+  No cloud processing, no API keys, no OAuth tokens. GDPR compliant by architecture.
+ReleaseNotes: |-
+  Meeting participants now visible in calendar events. When you ask Claude about your calendar, each event now includes the attendee list with names, emails, and their roles (organizer, required, optional). Perfect for meeting-prep workflows.
+  Local Studio improvements: sign in with Anthropic or OpenAI directly from the settings panel. The settings drawer has been redesigned to show connection status and let you disconnect providers individually.
+Tags:
+  - ai
+  - mcp
+  - automation
+  - email
+  - outlook
+  - teams
+  - onedrive
+  - excel
+  - productivity
+  - local
+  - privacy
+ReleaseNotesUrl: https://github.com/lanchuske/local-mcp-releases/releases
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/l/LMCP/LocalMCP/3.0.169/LMCP.LocalMCP.yaml
+++ b/manifests/l/LMCP/LocalMCP/3.0.169/LMCP.LocalMCP.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: LMCP.LocalMCP
+PackageVersion: 3.0.169
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
### New Version Submission

- Package: LMCP.LocalMCP
- Version: 3.0.169
- Installer: Go native setup (.exe), x64, machine scope
- URL: https://download.local-mcp.com/lmcp-setup.exe
- Publisher: LMCP (local-mcp.com)

### Changes in this version

- Calendar events now include attendee list with names, emails, and roles (organizer/required/optional)
- Local Studio: OAuth sign-in for Anthropic and OpenAI providers
- Settings drawer redesigned with live connection state

### Multi-file manifest (schema 1.9.0)

- `LMCP.LocalMCP.yaml` (version)
- `LMCP.LocalMCP.installer.yaml` (installer — updated from inno to exe type)
- `LMCP.LocalMCP.locale.en-US.yaml` (defaultLocale with ReleaseNotes)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/368511)