### PR TITLE
New package: turutupa.yames version 0.5.1

### DIFF
--- a/manifests/t/turutupa/yames/0.5.1/turutupa.yames.installer.yaml
+++ b/manifests/t/turutupa/yames/0.5.1/turutupa.yames.installer.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: turutupa.yames
+PackageVersion: 0.5.1
+InstallerType: nsis
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/turutupa/yames/releases/download/v0.5.1/Yames_0.5.1_x64-setup.exe
+    InstallerSha256: 79D847E32A036B10AC065177DC587CACEEEFAC2DD4C29D84CA6B344928156D3B
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/t/turutupa/yames/0.5.1/turutupa.yames.locale.en-US.yaml
+++ b/manifests/t/turutupa/yames/0.5.1/turutupa.yames.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: turutupa.yames
+PackageVersion: 0.5.1
+PackageLocale: en-US
+Publisher: turutupa
+PublisherUrl: https://github.com/turutupa
+PackageName: Yames
+PackageUrl: https://turutupa.github.io/yames/
+License: MIT
+LicenseUrl: https://github.com/turutupa/yames/blob/main/LICENSE
+ShortDescription: Yet Another Metronome Everyone Skips — musician-grade floating metronome
+Description: |-
+  A free, open-source desktop metronome with an always-on-top floating widget,
+  sub-millisecond audio precision, zen mode with immersive visuals, drill practice mode,
+  tap tempo, and 10 beautiful themes.
+Tags:
+  - metronome
+  - music
+  - rhythm
+  - practice
+  - bpm
+  - tempo
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/t/turutupa/yames/0.5.1/turutupa.yames.yaml
+++ b/manifests/t/turutupa/yames/0.5.1/turutupa.yames.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: turutupa.yames
+PackageVersion: 0.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Package: turutupa.yames v0.5.1

Yet Another Metronome Everyone Skips — a free, open-source desktop metronome built with Rust and Tauri.

- Updated from previously closed PR #367595 (v0.4.1 had a Defender false positive)
- New version with bug fixes

**Homepage:** https://turutupa.github.io/yames/
**GitHub:** https://github.com/turutupa/yames
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/368672)