### PR TITLE
New version: LMCP.LocalMCP version 3.0.171

### DIFF
--- a/manifests/l/LMCP/LocalMCP/3.0.171/LMCP.LocalMCP.installer.yaml
+++ b/manifests/l/LMCP/LocalMCP/3.0.171/LMCP.LocalMCP.installer.yaml
@@ -5,7 +5,7 @@ PackageVersion: 3.0.171
 Platform:
   - Windows.Desktop
 MinimumOSVersion: 10.0.17763.0
-Scope: machine
+Scope: user
 InstallerType: inno
 Installers:
   - Architecture: x64

--- a/manifests/l/LMCP/LocalMCP/3.0.171/LMCP.LocalMCP.installer.yaml
+++ b/manifests/l/LMCP/LocalMCP/3.0.171/LMCP.LocalMCP.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: LMCP.LocalMCP
+PackageVersion: 3.0.171
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+Scope: machine
+InstallerType: inno
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://download.local-mcp.com/lmcp-setup-3.0.171.exe
+    InstallerSha256: E4B383C6D9D159E8383EDBB94A0791C96E9CE9C529B94927E6F6AD80C5AD7E5B
+    InstallerLocale: en-US
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/l/LMCP/LocalMCP/3.0.171/LMCP.LocalMCP.locale.en-US.yaml
+++ b/manifests/l/LMCP/LocalMCP/3.0.171/LMCP.LocalMCP.locale.en-US.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: LMCP.LocalMCP
+PackageVersion: 3.0.171
+PackageLocale: en-US
+Publisher: LMCP
+PublisherUrl: https://www.local-mcp.com
+PublisherSupportUrl: https://github.com/lanchuske/local-mcp-releases/issues
+Author: Dario Lanchuske
+PackageName: LMCP
+PackageUrl: https://www.local-mcp.com
+License: Proprietary
+LicenseUrl: https://www.local-mcp.com/en/tos
+ShortDescription: Connect AI agents to your local apps — Outlook, Calendar, Teams, Excel, Word. 95+ tools, 100% local.
+Description: |-
+  LMCP is a native MCP server that connects AI agents (Claude, ChatGPT, Cursor, VS Code) to your local desktop apps.
+  Read and send email via Outlook, manage calendar events, read Teams messages, access OneDrive files,
+  create Excel and Word documents — all running locally on your machine.
+  No cloud processing, no API keys, no OAuth tokens. GDPR compliant by architecture.
+ReleaseNotes: |-
+  Fixed an issue on Windows where the server could get stuck in a not-running state after an automatic update.
+  Calendar filter improvements: events can now be filtered by calendar name.
+Tags:
+  - ai
+  - mcp
+  - automation
+  - email
+  - outlook
+  - teams
+  - onedrive
+  - excel
+  - productivity
+  - local
+  - privacy
+ReleaseNotesUrl: https://github.com/lanchuske/local-mcp-releases/releases
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/l/LMCP/LocalMCP/3.0.171/LMCP.LocalMCP.yaml
+++ b/manifests/l/LMCP/LocalMCP/3.0.171/LMCP.LocalMCP.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: LMCP.LocalMCP
+PackageVersion: 3.0.171
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
### New Version Submission

- Package: LMCP.LocalMCP
- Version: 3.0.171
- Installer: Inno Setup (.exe), x64, machine scope
- URL: https://download.local-mcp.com/lmcp-setup-3.0.171.exe
- Publisher: LMCP (local-mcp.com)

### Changes in this version

- Fixed an issue on Windows where the server could get stuck in a not-running state after an automatic update
- Calendar filter improvements: events can now be filtered by calendar name

### Fix from previous PR (#368511)

Changed `InstallerType` from `exe` to `inno` — the installer is built with Inno Setup 6.x, so winget can detect and pass the correct silent switches (`/VERYSILENT /SUPPRESSMSGBOXES`) automatically without needing explicit `InstallerSwitches`.

### Multi-file manifest (schema 1.9.0)

- `LMCP.LocalMCP.yaml` (version)
- `LMCP.LocalMCP.installer.yaml` (installer — corrected to inno type)
- `LMCP.LocalMCP.locale.en-US.yaml` (defaultLocale with ReleaseNotes)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/368673)