### PR TITLE
New version: RedEyeNetworks.Logivore version 0.10.1

### DIFF
--- a/manifests/r/RedEyeNetworks/Logivore/0.10.1/RedEyeNetworks.Logivore.installer.yaml
+++ b/manifests/r/RedEyeNetworks/Logivore/0.10.1/RedEyeNetworks.Logivore.installer.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: RedEyeNetworks.Logivore
+PackageVersion: 0.10.1
+InstallerType: inno
+Scope: machine
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  Custom: /NORESTART
+UpgradeBehavior: install
+Commands:
+- logivore
+Installers:
+- Architecture: x64
+  Scope: user
+  InstallerUrl: https://download.redeyenetworks.com/logivore/releases/0.10.1/logivore-win-x64-setup.exe
+  InstallerSha256: 4BEA26D9517107DF908FF2E136915F93182159E72DE01B6F01C521D59AF3DB98
+- Architecture: x64
+  Scope: machine
+  ElevationRequirement: elevatesSelf
+  InstallerUrl: https://download.redeyenetworks.com/logivore/releases/0.10.1/logivore-win-x64-machine-setup.exe
+  InstallerSha256: FDBD42D57C970B308EB5E642B29907AFAE0B61DB972FFB28884E86181034E7BA
+- Architecture: arm64
+  Scope: user
+  InstallerUrl: https://download.redeyenetworks.com/logivore/releases/0.10.1/logivore-win-arm64-setup.exe
+  InstallerSha256: 14A8063876ADD05FF82C18735107E305B091717F079C360C88DFCB7D616F0A46
+- Architecture: arm64
+  Scope: machine
+  ElevationRequirement: elevatesSelf
+  InstallerUrl: https://download.redeyenetworks.com/logivore/releases/0.10.1/logivore-win-arm64-machine-setup.exe
+  InstallerSha256: 0B02484230AD2B576C0D58B4C4FEDC250D9C7E25F8EA4F4F2815ADBBDD6B5258
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/r/RedEyeNetworks/Logivore/0.10.1/RedEyeNetworks.Logivore.installer.yaml
+++ b/manifests/r/RedEyeNetworks/Logivore/0.10.1/RedEyeNetworks.Logivore.installer.yaml
@@ -15,20 +15,20 @@ Installers:
 - Architecture: x64
   Scope: user
   InstallerUrl: https://download.redeyenetworks.com/logivore/releases/0.10.1/logivore-win-x64-setup.exe
-  InstallerSha256: 4BEA26D9517107DF908FF2E136915F93182159E72DE01B6F01C521D59AF3DB98
+  InstallerSha256: 6D151C0D7E60DC27EAC7B0725777BA89F5C7C5EDB054C3FCC5A69D352CFA117E
 - Architecture: x64
   Scope: machine
   ElevationRequirement: elevatesSelf
   InstallerUrl: https://download.redeyenetworks.com/logivore/releases/0.10.1/logivore-win-x64-machine-setup.exe
-  InstallerSha256: FDBD42D57C970B308EB5E642B29907AFAE0B61DB972FFB28884E86181034E7BA
+  InstallerSha256: 05DBA9C716EB11BC35EF32A7735C8322AAED0D9672601FD2F7AE7ACE85A5DAD7
 - Architecture: arm64
   Scope: user
   InstallerUrl: https://download.redeyenetworks.com/logivore/releases/0.10.1/logivore-win-arm64-setup.exe
-  InstallerSha256: 14A8063876ADD05FF82C18735107E305B091717F079C360C88DFCB7D616F0A46
+  InstallerSha256: C81BC02E5F58057A5EC086AD171902C4EEDC36A94B381CEBCE6DA1BFA43C3DAC
 - Architecture: arm64
   Scope: machine
   ElevationRequirement: elevatesSelf
   InstallerUrl: https://download.redeyenetworks.com/logivore/releases/0.10.1/logivore-win-arm64-machine-setup.exe
-  InstallerSha256: 0B02484230AD2B576C0D58B4C4FEDC250D9C7E25F8EA4F4F2815ADBBDD6B5258
+  InstallerSha256: D84F303A31A6E63743F698EABDC4CD97F8C0D4D6B4D7BF8020FBD9130747679E
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/r/RedEyeNetworks/Logivore/0.10.1/RedEyeNetworks.Logivore.locale.en-US.yaml
+++ b/manifests/r/RedEyeNetworks/Logivore/0.10.1/RedEyeNetworks.Logivore.locale.en-US.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: RedEyeNetworks.Logivore
+PackageVersion: 0.10.1
+PackageLocale: en-US
+Publisher: RedEye Network Solutions LLC
+PublisherUrl: https://redeyenetworks.com
+PublisherSupportUrl: https://redeyenetworks.com/support
+Author: RedEye Network Solutions LLC
+PackageName: Logivore
+PackageUrl: https://redeyenetworks.com
+License: Proprietary
+Copyright: Copyright 2026 RedEye Network Solutions LLC. All rights reserved.
+ShortDescription: Cross-platform desktop log analyzer with LILA, an AI assistant for log triage
+Description: |-
+  Logivore is a local-first, cross-platform desktop log analyzer for Windows,
+  macOS, and Linux. Parses dozens of log formats (plaintext, syslog, EVTX,
+  PAN-OS TSF, Veeam VBR, GlobalProtect, pcap), correlates events across
+  sources, and surfaces findings via LILA — an AI assistant that runs locally
+  with optional Anthropic Claude or Google Gemini provider integration.
+  Memory-tier-adaptive (Flash / Hybrid / Indexed) so any log size works on
+  any hardware. Trust-gated LLM boundary keeps PII tokenized before it leaves
+  the machine.
+Moniker: logivore
+Tags:
+- log-analysis
+- log-viewer
+- syslog
+- evtx
+- pan-os
+- veeam
+- pcap
+- ai
+- llm
+- claude
+- gemini
+- timeline
+- correlation
+- desktop
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/RedEyeNetworks/Logivore/0.10.1/RedEyeNetworks.Logivore.yaml
+++ b/manifests/r/RedEyeNetworks/Logivore/0.10.1/RedEyeNetworks.Logivore.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: RedEyeNetworks.Logivore
+PackageVersion: 0.10.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Logivore v0.10.1 ships two distinct installers per architecture (user-scope + machine-scope), matching the Microsoft.PowerToys + Notepad++.Notepad++ convention. Each (architecture, scope) tuple maps to a unique Inno Setup EXE with a single, deterministic `PrivilegesRequired` value, so Microsoft's dynamic-scan validation has unambiguous install behavior to verify per installer entry.

Manifest construction is done in Logivore's release.yml as a hand-built heredoc (not `wingetcreate update`) so the 4-entry shape is locked from version 1 — the previous wingetcreate-based flow inherited shape from the latest published manifest, which couldn't grow installer-entry count cleanly.

The same `Logivore.iss` `AppId` is shared across user-scope and machine-scope builds so an existing HKCU install (user-scope) and HKLM install (machine-scope) each match the appropriate manifest installer entry on `winget upgrade`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/368676)