### PR TITLE
Fix incorrect manifest: tomcoolpxl.CoolWSL version 1.0.4

### DIFF
--- a/manifests/t/tomcoolpxl/CoolWSL/1.0.4/tomcoolpxl.CoolWSL.installer.yaml
+++ b/manifests/t/tomcoolpxl/CoolWSL/1.0.4/tomcoolpxl.CoolWSL.installer.yaml
@@ -13,8 +13,7 @@ AppsAndFeaturesEntries:
   UpgradeCode: '{6D2A8580-57C6-4267-A6F7-5F29B671E6C3}'
 Dependencies:
   PackageDependencies:
-    - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.10
-
+  - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.10
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/tomcoolpxl/CoolWSL/releases/download/v1.0.4/CoolWSL-1.0.4-win-x64.msi

--- a/manifests/t/tomcoolpxl/CoolWSL/1.0.4/tomcoolpxl.CoolWSL.installer.yaml
+++ b/manifests/t/tomcoolpxl/CoolWSL/1.0.4/tomcoolpxl.CoolWSL.installer.yaml
@@ -4,7 +4,7 @@ PackageIdentifier: tomcoolpxl.CoolWSL
 PackageVersion: 1.0.4
 InstallerType: wix
 Scope: machine
-ElevationRequirement: elevationRequired
+ElevationRequirement: elevatesSelf
 ProductCode: '{5CD1B2D5-7EFF-4814-92B3-F218A7A8286D}'
 AppsAndFeaturesEntries:
 - DisplayName: CoolWSL
@@ -13,7 +13,8 @@ AppsAndFeaturesEntries:
   UpgradeCode: '{6D2A8580-57C6-4267-A6F7-5F29B671E6C3}'
 Dependencies:
   PackageDependencies:
-  - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.10
+    - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.10
+
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/tomcoolpxl/CoolWSL/releases/download/v1.0.4/CoolWSL-1.0.4-win-x64.msi


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?  If so, fill in the Issue number below.
   
  - Resolves #[Issue Number]

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest `?
- [x] Have you tested your manifest locally with `winget install --manifest `?
- [x] Does your manifest conform to the [1.10 installer schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: `` is the directory's name containing the manifest you're submitting.

This changes `ElevationRequirement` from `elevationRequired` to `elevatesSelf` for the existing 1.0.4 WiX/MSI manifest.

The 1.10 installer schema defines `elevatesSelf` for installers that request elevation themselves, which matches this MSI. This also follows the active WinGet elevation handoff issue for MSI installs: microsoft/winget-cli#6173.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/368818)