### PR TITLE
New package: nicoavanzdev.dtach-rs version 0.1.1

### DIFF
--- a/manifests/n/nicoavanzdev/dtach-rs/0.1.1/nicoavanzdev.dtach-rs.installer.yaml
+++ b/manifests/n/nicoavanzdev/dtach-rs/0.1.1/nicoavanzdev.dtach-rs.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: nicoavanzdev.dtach-rs
+PackageVersion: 0.1.1
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: dtach-rs.exe
+    PortableCommandAlias: dtach-rs
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/NicoAvanzDev/dtach-rs/releases/download/v0.1.1/dtach-rs-x86_64-pc-windows-msvc.zip
+    InstallerSha256: 84c56e44c4e9aab6f5ef2df343f34a74d4fcde8281a86d584c01267c566152fd
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/n/nicoavanzdev/dtach-rs/0.1.1/nicoavanzdev.dtach-rs.locale.en-US.yaml
+++ b/manifests/n/nicoavanzdev/dtach-rs/0.1.1/nicoavanzdev.dtach-rs.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: nicoavanzdev.dtach-rs
+PackageVersion: 0.1.1
+PackageLocale: en-US
+Publisher: Nicolo Avanzini
+PublisherUrl: https://github.com/NicoAvanzDev
+PublisherSupportUrl: https://github.com/NicoAvanzDev/dtach-rs/issues
+PackageName: dtach-rs
+PackageUrl: https://github.com/NicoAvanzDev/dtach-rs
+License: MIT
+LicenseUrl: https://github.com/NicoAvanzDev/dtach-rs/blob/HEAD/LICENSE
+ShortDescription: A cross-platform Rust clone of dtach for detachable terminal sessions
+Moniker: dtach-rs
+Tags:
+  - terminal
+  - pty
+  - detach
+  - session
+ReleaseNotesUrl: https://github.com/NicoAvanzDev/dtach-rs/releases/tag/v0.1.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/n/nicoavanzdev/dtach-rs/0.1.1/nicoavanzdev.dtach-rs.yaml
+++ b/manifests/n/nicoavanzdev/dtach-rs/0.1.1/nicoavanzdev.dtach-rs.yaml
@@ -1,26 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
 PackageIdentifier: nicoavanzdev.dtach-rs
 PackageVersion: 0.1.1
-PackageName: dtach-rs
-Publisher: Nicolo Avanzini
-License: MIT
-PackageLocale: en-US
-ShortDescription: A cross-platform Rust clone of dtach for detachable terminal sessions
-Moniker: dtach-rs
-Tags:
-  - terminal
-  - pty
-  - detach
-  - session
-Installers:
-  - Architecture: x64
-    InstallerType: zip
-    InstallerUrl: https://github.com/NicoAvanzDev/dtach-rs/releases/download/v0.1.1/dtach-rs-x86_64-pc-windows-msvc.zip
-    InstallerSha256: 84c56e44c4e9aab6f5ef2df343f34a74d4fcde8281a86d584c01267c566152fd
-    NestedInstallerType: portable
-    NestedInstallerFiles:
-      - RelativeFilePath: dtach-rs.exe
-        PortableCommandAlias: dtach-rs
-    Commands:
-      - dtach-rs
-ManifestType: singleton
+DefaultLocale: en-US
+ManifestType: version
 ManifestVersion: 1.12.0

--- a/manifests/n/nicoavanzdev/dtach-rs/0.1.1/nicoavanzdev.dtach-rs.yaml
+++ b/manifests/n/nicoavanzdev/dtach-rs/0.1.1/nicoavanzdev.dtach-rs.yaml
@@ -1,0 +1,26 @@
+PackageIdentifier: nicoavanzdev.dtach-rs
+PackageVersion: 0.1.1
+PackageName: dtach-rs
+Publisher: Nicolo Avanzini
+License: MIT
+PackageLocale: en-US
+ShortDescription: A cross-platform Rust clone of dtach for detachable terminal sessions
+Moniker: dtach-rs
+Tags:
+  - terminal
+  - pty
+  - detach
+  - session
+Installers:
+  - Architecture: x64
+    InstallerType: zip
+    InstallerUrl: https://github.com/NicoAvanzDev/dtach-rs/releases/download/v0.1.1/dtach-rs-x86_64-pc-windows-msvc.zip
+    InstallerSha256: 84c56e44c4e9aab6f5ef2df343f34a74d4fcde8281a86d584c01267c566152fd
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: dtach-rs.exe
+        PortableCommandAlias: dtach-rs
+    Commands:
+      - dtach-rs
+ManifestType: singleton
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Summary
- add initial WinGet manifest for dtach-rs 0.1.1
- publish the Windows x64 portable zip from the GitHub release
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/368826)