### PR TITLE
Handle multi-line winget validate output in SandboxTest

### DIFF
--- a/Tools/SandboxTest.ps1
+++ b/Tools/SandboxTest.ps1
@@ -528,7 +528,11 @@ if (!$SkipManifestValidation -and ![String]::IsNullOrWhiteSpace($Manifest)) {
             Start-Sleep -Seconds 5 # Allow the user 5 seconds to read the warnings before moving on
         }
         default {
-            Write-Information $validateCommandOutput.Trim() # On the success, print an empty line after the command output
+            # Avoid writing a raw object array when `winget validate` returns multiple lines
+            $validateSuccessOutput = @($validateCommandOutput).ForEach({ $_.ToString().Trim() }).Where({ -not [String]::IsNullOrWhiteSpace($_) })
+            if ($validateSuccessOutput) {
+                Write-Information ($validateSuccessOutput -join [Environment]::NewLine)
+            }
         }
     }
 }


### PR DESCRIPTION
Current implementation does not gracefully handle multi-line output of `winget validate`

## Before

```powershell
.\Tools\SandboxTest.ps1 -Manifest <Path>
--> Validating Manifest
System.Object[]
--> Checking Dependencies
...
```

## After

```powershell
.\Tools\SandboxTest.ps1 -Manifest <Path>
--> Validating Manifest
Manifest has the following dependencies that were not validated; ensure that they are valid:
- Packages
Microsoft.VCRedist.2015+.x64
Microsoft.VCRedist.2015+.arm64
Manifest validation succeeded.
--> Checking Dependencies
...
```

cc @Trenly / @denelon

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/368912)