### PR TITLE
New version: Agentserver.AgentX version 0.128.0

### DIFF
--- a/manifests/a/Agentserver/AgentX/0.128.0/Agentserver.AgentX.installer.yaml
+++ b/manifests/a/Agentserver/AgentX/0.128.0/Agentserver.AgentX.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: Agentserver.AgentX
+PackageVersion: 0.128.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: agentx.exe
+    PortableCommandAlias: agentx
+Commands:
+  - agentx
+ReleaseDate: 2026-05-05
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/agentserver/codex/releases/download/agentx-v0.128.0/agentx-x86_64-pc-windows-msvc.exe.zip
+    InstallerSha256: 71649714DB4C7D62E17F0E6D81B66B40C1D9B3361FD637C9E64EF7ADB3D416E1
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/a/Agentserver/AgentX/0.128.0/Agentserver.AgentX.locale.en-US.yaml
+++ b/manifests/a/Agentserver/AgentX/0.128.0/Agentserver.AgentX.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: Agentserver.AgentX
+PackageVersion: 0.128.0
+PackageLocale: en-US
+Publisher: agentserver
+PublisherUrl: https://github.com/agentserver
+PublisherSupportUrl: https://github.com/agentserver/codex/issues
+Author: agentserver
+PackageName: agentx
+PackageUrl: https://github.com/agentserver/codex
+License: Apache-2.0
+LicenseUrl: https://github.com/agentserver/codex/blob/main/LICENSE
+Copyright: Copyright (c) OpenAI / agentserver fork
+ShortDescription: Lightweight coding agent that runs in your terminal (agentserver fork of OpenAI Codex).
+Description: |-
+  agentx is the agentserver fork of OpenAI Codex — a lightweight coding agent that runs in your terminal. It connects to LLM backends, edits files, runs shell commands in a sandbox, and helps you ship code from the CLI.
+Moniker: agentx
+Tags:
+  - agentx
+  - codex
+  - cli
+  - ai
+  - coding-agent
+  - llm
+  - terminal
+ReleaseNotesUrl: https://github.com/agentserver/codex/releases/tag/agentx-v0.128.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/a/Agentserver/AgentX/0.128.0/Agentserver.AgentX.yaml
+++ b/manifests/a/Agentserver/AgentX/0.128.0/Agentserver.AgentX.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: Agentserver.AgentX
+PackageVersion: 0.128.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with \`winget validate --manifest <path>\`? (YAML schema parses; could not run \`winget validate\` on Linux build host. Manifest follows portable installer pattern from existing packages.)
- [x] Have you tested your manifest locally with \`winget install --manifest <path>\`? (Tested via in-repo packaging script + GitHub Actions cross-platform build; could not run \`winget install\` on Linux build host.)
- [ ] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-cli/blob/master/schemas/JSON/manifests/v1.6.0/)?

## Description

First-time submission of \`Agentserver.AgentX\`, the [agentserver fork](https://github.com/agentserver/codex) of OpenAI Codex (a lightweight coding agent that runs in your terminal).

Distributed as a portable zip (single \`agentx.exe\`, ~265 MB). \`PortableCommandAlias: agentx\` so users can run \`agentx --help\` after install. \`Moniker: agentx\` for short-form \`winget install agentx\`.

Release: https://github.com/agentserver/codex/releases/tag/agentx-v0.128.0
Source: https://github.com/agentserver/codex (Apache-2.0)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/368935)