### PR TITLE
New version: GeziP.KBIntake version 2.1.1

### DIFF
--- a/manifests/g/GeziP/KBIntake/2.1.1/GeziP.KBIntake.installer.yaml
+++ b/manifests/g/GeziP/KBIntake/2.1.1/GeziP.KBIntake.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: GeziP.KBIntake
+PackageVersion: 2.1.1
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+ReleaseDate: 2026-05-06
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/GeziP/windows-rightclick-vault-import/releases/download/v2.1.1/KBIntake-Setup.exe
+    InstallerSha256: 91a4ec7a84030438174c3f066b8f09f288020d3ee7f65ef7de55cec1d4ba9ef7
+    Scope: user
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/g/GeziP/KBIntake/2.1.1/GeziP.KBIntake.locale.en-US.yaml
+++ b/manifests/g/GeziP/KBIntake/2.1.1/GeziP.KBIntake.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: GeziP.KBIntake
+PackageVersion: 2.1.1
+PackageLocale: en-US
+Publisher: GeziP
+PublisherUrl: https://github.com/GeziP
+PackageName: KBIntake
+PackageUrl: https://github.com/GeziP/windows-rightclick-vault-import
+Moniker: kbintake
+License: Proprietary
+ShortDescription: Windows-friendly local vault importer with Explorer integration and templates.
+Description: KBIntake imports files and folders into a local knowledge-base vault from PowerShell or the Windows Explorer right-click menu. Features include import templates, watch mode, TUI settings, and Obsidian integration.
+Tags:
+  - knowledge-base
+  - obsidian
+  - windows
+  - cli
+  - templates
+  - watch-mode
+  - tui
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/g/GeziP/KBIntake/2.1.1/GeziP.KBIntake.yaml
+++ b/manifests/g/GeziP/KBIntake/2.1.1/GeziP.KBIntake.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: GeziP.KBIntake
+PackageVersion: 2.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Pull request for GeziP.KBIntake version 2.1.1

This PR updates the KBIntake winget package from v1.0.1 to v2.1.1.

### Changes since v1.0.1

- Import template system with variable interpolation and conditional rendering
- Watch Mode with directory structure preservation
- TUI interactive settings
- zh-CN localization
- Windows 11 native context menu via COM DLL
- System tray icon with auto-start management
- Vault audit, clipboard import, quick tag injection
- Obsidian URI integration
- Default templates for first-run experience

### Checklist

- [x] Manifest schema validated (`ManifestVersion: 1.6.0`)
- [x] Installer URL points to GitHub Release v2.1.1
- [x] SHA256 hash matches the release asset
- [x] Silent install (`/S`) works (CI-validated)
- [x] No VC++ runtime dependency (static CRT)
- [x] `Scope: user` — per-user install, no admin required for install
- [x] Previous version v1.0.1 was already merged (#365473)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/369491)