### PR TITLE
Wharflab.Tally version 0.41.0

### DIFF
--- a/manifests/w/Wharflab/Tally/0.41.0/Wharflab.Tally.installer.yaml
+++ b/manifests/w/Wharflab/Tally/0.41.0/Wharflab.Tally.installer.yaml
@@ -1,0 +1,24 @@
+# Created by tally release automation
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: Wharflab.Tally
+PackageVersion: 0.41.0
+Commands: &1
+- tally
+FileExtensions:
+- dockerfile
+- containerfile
+ReleaseDate: '2026-05-06'
+Installers:
+- Architecture: x64
+  InstallerType: portable
+  InstallerUrl: https://github.com/wharflab/tally/releases/download/v0.41.0/tally_0.41.0_Windows_x86_64.exe
+  InstallerSha256: 415963C66AFFD718F755703678E0DEBB726EE87480E5E9218521CBC1FA51AFE6
+  Commands: *1
+- Architecture: arm64
+  InstallerType: portable
+  InstallerUrl: https://github.com/wharflab/tally/releases/download/v0.41.0/tally_0.41.0_Windows_arm64.exe
+  InstallerSha256: 6A4BFF4D1F1803B57CC29DF744F39131B18EDDABFD8A57E71114FCB838C969CD
+  Commands: *1
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/w/Wharflab/Tally/0.41.0/Wharflab.Tally.locale.en-US.yaml
+++ b/manifests/w/Wharflab/Tally/0.41.0/Wharflab.Tally.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# Created by tally release automation
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: Wharflab.Tally
+PackageVersion: 0.41.0
+PackageLocale: en-US
+Publisher: Wharflab
+PublisherUrl: https://github.com/wharflab
+PublisherSupportUrl: https://github.com/wharflab/tally/issues
+PackageName: Tally
+PackageUrl: https://github.com/wharflab/tally
+ShortDescription: Dockerfile linter and formatter with first-class PowerShell and
+  Windows container support.
+Moniker: tally
+License: AGPL-3.0-only
+LicenseUrl: https://github.com/wharflab/tally/blob/main/LICENSE
+ReleaseNotesUrl: https://github.com/wharflab/tally/releases/tag/v0.41.0
+Documentations:
+- DocumentLabel: Docs
+  DocumentUrl: https://tally.wharflab.com/
+Tags:
+- docker
+- dockerfile
+- containerfile
+- linter
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/w/Wharflab/Tally/0.41.0/Wharflab.Tally.yaml
+++ b/manifests/w/Wharflab/Tally/0.41.0/Wharflab.Tally.yaml
@@ -1,0 +1,8 @@
+# Created by tally release automation
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: Wharflab.Tally
+PackageVersion: 0.41.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Publishing version v0.41.0 of [tally](https://github.com/wharflab/tally) to WinGet.

Tally is a Dockerfile linter and formatter written in Go, promoting modern container syntax and helping avoid common pitfalls.

[Changelog](https://github.com/wharflab/tally/releases/tag/v0.41.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/369992)