### PR TITLE
Add ThreadPilot 1.1.2 manifest for WinGet

### DIFF
--- a/manifests/p/PrimeBuild/ThreadPilot/1.1.2/PrimeBuild.ThreadPilot.installer.yaml
+++ b/manifests/p/PrimeBuild/ThreadPilot/1.1.2/PrimeBuild.ThreadPilot.installer.yaml
@@ -1,0 +1,10 @@
+PackageIdentifier: PrimeBuild.ThreadPilot
+PackageVersion: 1.1.2
+InstallerType: inno
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/PrimeBuild-pc/ThreadPilot/releases/download/v1.1.2/ThreadPilot_v1.1.2_Setup.exe
+    InstallerSha256: FAC3935BA126B01987B15CB323502EE8B6E91C957F22006BD9E62B8D57169790
+ManifestType: installer
+ManifestVersion: 1.4.0
+

--- a/manifests/p/PrimeBuild/ThreadPilot/1.1.2/PrimeBuild.ThreadPilot.locale.en-US.yaml
+++ b/manifests/p/PrimeBuild/ThreadPilot/1.1.2/PrimeBuild.ThreadPilot.locale.en-US.yaml
@@ -1,0 +1,20 @@
+PackageIdentifier: PrimeBuild.ThreadPilot
+PackageVersion: 1.1.2
+PackageLocale: en-US
+Publisher: Prime Build
+PublisherUrl: https://github.com/PrimeBuild-pc
+PublisherSupportUrl: https://github.com/PrimeBuild-pc/ThreadPilot/issues
+PackageName: ThreadPilot
+PackageUrl: https://github.com/PrimeBuild-pc/ThreadPilot
+License: AGPL-3.0-only
+LicenseUrl: https://github.com/PrimeBuild-pc/ThreadPilot/blob/main/LICENSE
+ShortDescription: Advanced Windows process and power plan manager.
+Description: ThreadPilot is a Process Lasso style utility for process affinity, priority, and power plan automation on Windows.
+Tags:
+  - windows
+  - process
+  - power-plan
+  - performance
+ManifestType: defaultLocale
+ManifestVersion: 1.4.0
+

--- a/manifests/p/PrimeBuild/ThreadPilot/1.1.2/PrimeBuild.ThreadPilot.yaml
+++ b/manifests/p/PrimeBuild/ThreadPilot/1.1.2/PrimeBuild.ThreadPilot.yaml
@@ -1,0 +1,6 @@
+PackageIdentifier: PrimeBuild.ThreadPilot
+PackageVersion: 1.1.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.4.0
+


### PR DESCRIPTION
This adds ThreadPilot 1.1.2 to the Windows Package Manager repository.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/370037)