### PR TITLE
Updated nrfutil with correct SHA-256 and version number

### DIFF
--- a/manifests/n/NordicSemiconductor/nrfutil/8.2.0/NordicSemiconductor.nrfutil.installer.yaml
+++ b/manifests/n/NordicSemiconductor/nrfutil/8.2.0/NordicSemiconductor.nrfutil.installer.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 
 PackageIdentifier: NordicSemiconductor.nrfutil
-PackageVersion: 8.0.0
+PackageVersion: 8.2.0
 InstallerType: portable
 Commands:
 - nrfutil
@@ -12,6 +12,6 @@ Dependencies:
 Installers:
 - Architecture: x64
   InstallerUrl: https://files.nordicsemi.com/ui/api/v1/download?repoKey=swtools&path=external/nrfutil/executables/x86_64-pc-windows-msvc/nrfutil.exe&isNativeBrowsing=false
-  InstallerSha256: D89C3A2BFC2367A8F8669E07502F83ECDFADF428CF538F9E35E942C198C49D1E
+  InstallerSha256: 1D291D8A9D6BB5BEC18454F8D95064AED7F62E8997EC1C4511F13BDF1124C037
 ManifestType: installer
 ManifestVersion: 1.9.0

--- a/manifests/n/NordicSemiconductor/nrfutil/8.2.0/NordicSemiconductor.nrfutil.locale.en-US.yaml
+++ b/manifests/n/NordicSemiconductor/nrfutil/8.2.0/NordicSemiconductor.nrfutil.locale.en-US.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 
 PackageIdentifier: NordicSemiconductor.nrfutil
-PackageVersion: 8.0.0
+PackageVersion: 8.2.0
 PackageLocale: en-US
 Publisher: Nordic Semiconductor
 PackageName: nrfutil

--- a/manifests/n/NordicSemiconductor/nrfutil/8.2.0/NordicSemiconductor.nrfutil.yaml
+++ b/manifests/n/NordicSemiconductor/nrfutil/8.2.0/NordicSemiconductor.nrfutil.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
 
 PackageIdentifier: NordicSemiconductor.nrfutil
-PackageVersion: 8.0.0
+PackageVersion: 8.2.0
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.9.0


### PR DESCRIPTION
The SHA-256 in the manifest pointed to the previous version of nrfutil, and the semver-named directory referred to version 8.0.0 rather than 8.2.0, both of which have been corrected here.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/370764)