### PR TITLE
New package: rvben.rumdl version 0.1.90

### DIFF
--- a/manifests/r/rvben/rumdl/0.1.90/rvben.rumdl.installer.yaml
+++ b/manifests/r/rvben/rumdl/0.1.90/rvben.rumdl.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: rvben.rumdl
+PackageVersion: 0.1.90
+MinimumOSVersion: 10.0.17763.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: rumdl.exe
+    PortableCommandAlias: rumdl
+ReleaseDate: "2026-05-07"
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/rvben/rumdl/releases/download/v0.1.90/rumdl-v0.1.90-x86_64-pc-windows-msvc.zip
+    InstallerSha256: 2E9572A5DA202139B116E09DF48BD9E4081E9AF2D71193282CFA3F2ED294CA50
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/r/rvben/rumdl/0.1.90/rvben.rumdl.locale.en-US.yaml
+++ b/manifests/r/rvben/rumdl/0.1.90/rvben.rumdl.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: rvben.rumdl
+PackageVersion: 0.1.90
+PackageLocale: en-US
+Publisher: Ruben J. Jongejan
+PublisherUrl: https://github.com/rvben
+PublisherSupportUrl: https://github.com/rvben/rumdl/issues
+Author: Ruben J. Jongejan
+PackageName: rumdl
+PackageUrl: https://github.com/rvben/rumdl
+License: MIT
+LicenseUrl: https://github.com/rvben/rumdl/blob/main/LICENSE
+Copyright: Copyright (c) 2024-2025 Ruben J. Jongejan
+ShortDescription: A fast Markdown linter and formatter written in Rust.
+Description: |-
+  rumdl is a high-performance Markdown linter and formatter written in Rust.
+  It catches stylistic and structural issues in Markdown documents, fixes
+  them automatically where possible, and integrates with editors through
+  the Language Server Protocol. rumdl ships a comprehensive rule set,
+  intelligent caching for fast incremental runs, and is configured via
+  pyproject.toml or .rumdl.toml.
+Moniker: rumdl
+Tags:
+  - cli
+  - documentation
+  - formatter
+  - linter
+  - markdown
+  - markdown-linter
+  - rust
+  - static-analysis
+ReleaseNotesUrl: https://github.com/rvben/rumdl/releases/tag/v0.1.90
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/r/rvben/rumdl/0.1.90/rvben.rumdl.yaml
+++ b/manifests/r/rvben/rumdl/0.1.90/rvben.rumdl.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: rvben.rumdl
+PackageVersion: 0.1.90
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Adding new package: `rvben.rumdl`

`rumdl` is a high-performance Markdown linter and formatter written in Rust. It catches stylistic and structural issues in Markdown documents, fixes them automatically where possible, and integrates with editors through the Language Server Protocol.

- Repository: https://github.com/rvben/rumdl
- Documentation: https://rumdl.dev
- License: MIT
- Release: https://github.com/rvben/rumdl/releases/tag/v0.1.90

### Manifest details

- `InstallerType: zip` with `NestedInstallerType: portable` (rumdl ships as a single self-contained `rumdl.exe`)
- `PortableCommandAlias: rumdl` so users get `rumdl` on PATH after `winget install`
- `Architecture: x64` (rumdl currently does not ship aarch64 Windows binaries)
- `MinimumOSVersion: 10.0.17763.0`

### Validation

- [x] Manifests validated against the official JSON schemas (version, defaultLocale, installer @ 1.10.0).
- [x] InstallerSha256 verified against the v0.1.90 release zip (`2E9572A5DA202139B116E09DF48BD9E4081E9AF2D71193282CFA3F2ED294CA50`).
- [x] No other open PRs for `rvben.rumdl`.
- [ ] Local `winget validate` / `winget install --manifest` not run (no Windows machine available); happy to address any reviewer feedback.

### Microsoft Contributor License Agreement

- [x] I will sign the [Microsoft Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs) when prompted by the CLA bot.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/370922)