### PR TITLE
Fix Zint.Zint portable aliases for CLI and GUI.

### DIFF
--- a/manifests/z/Zint/Zint/2.15.0/Zint.Zint.installer.yaml
+++ b/manifests/z/Zint/Zint/2.15.0/Zint.Zint.installer.yaml
@@ -7,9 +7,12 @@ InstallerType: zip
 MinimumOSVersion: 10.0.0.0
 NestedInstallerType: portable
 NestedInstallerFiles:
-- RelativeFilePath: zint-2.15.0\qtZint.exe
+- RelativeFilePath: zint-2.15.0\zint.exe
   PortableCommandAlias: zint
-ArchiveBinariesDependOnPath: true
+- RelativeFilePath: zint-2.15.0\qtZint.exe
+  PortableCommandAlias: qtzint
+- RelativeFilePath: .\zint-2.15.0\qtZint.exe
+  PortableCommandAlias: zintgui
 Installers:
 - Architecture: x86
   InstallerUrl: https://deac-riga.dl.sourceforge.net/project/zint/zint/2.15.0/zint-2.15.0-win32.zip

--- a/manifests/z/Zint/Zint/2.16.0/Zint.Zint.installer.yaml
+++ b/manifests/z/Zint/Zint/2.16.0/Zint.Zint.installer.yaml
@@ -6,13 +6,16 @@ PackageVersion: 2.16.0
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
-- RelativeFilePath: zint-2.16.0/qtZint.exe
+- RelativeFilePath: zint-2.16.0/zint.exe
   PortableCommandAlias: zint
+- RelativeFilePath: zint-2.16.0/qtZint.exe
+  PortableCommandAlias: qtzint
+- RelativeFilePath: .\zint-2.16.0/qtZint.exe
+  PortableCommandAlias: zintgui
 Dependencies:
   PackageDependencies:
   - PackageIdentifier: Microsoft.VCRedist.2015+.x86
 ReleaseDate: 2025-12-19
-ArchiveBinariesDependOnPath: true
 Installers:
 - Architecture: x86
   InstallerUrl: https://sourceforge.net/projects/zint/files/zint/2.16.0/zint-2.16.0-win32.zip/download


### PR DESCRIPTION
Map zint.exe to zint, add qtzint and zintgui aliases for qtZint.exe using a path-variant entry, and remove ArchiveBinariesDependOnPath to restore expected alias behavior in 2.15.0 and 2.16.0.

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Is there a linked Issue?  If so, fill in the Issue number below.
   <!-- Example: Resolves #328283 -->
- Resolves #371000

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/371027)