### PR TITLE
New package: jcardama.LeopardWM version 0.1.11

### DIFF
--- a/manifests/j/jcardama/LeopardWM/0.1.11/jcardama.LeopardWM.installer.yaml
+++ b/manifests/j/jcardama/LeopardWM/0.1.11/jcardama.LeopardWM.installer.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: jcardama.LeopardWM
+PackageVersion: 0.1.11
+InstallerLocale: en-US
+InstallerType: wix
+Scope: machine
+UpgradeBehavior: install
+Commands:
+- leopardwm
+- leopardwm-cli
+- lwm
+ReleaseDate: 2026-05-07
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles%/LeopardWM/bin'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/jcardama/LeopardWM/releases/download/v0.1.11/LeopardWM-0.1.11-x86_64.msi
+  InstallerSha256: CE4BC6BE492D610F0D7CE9492959FE488405FE8A244371787EAD73462A707FCC
+  ProductCode: '{BAD23C17-3603-4237-A1E6-F717E4FED022}'
+  AppsAndFeaturesEntries:
+  - ProductCode: '{BAD23C17-3603-4237-A1E6-F717E4FED022}'
+    UpgradeCode: '{EE10F2D5-DA80-43EA-B4D4-A0D37C69DE83}'
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/j/jcardama/LeopardWM/0.1.11/jcardama.LeopardWM.locale.en-US.yaml
+++ b/manifests/j/jcardama/LeopardWM/0.1.11/jcardama.LeopardWM.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: jcardama.LeopardWM
+PackageVersion: 0.1.11
+PackageLocale: en-US
+Publisher: jcardama
+PublisherUrl: https://github.com/jcardama
+PublisherSupportUrl: https://github.com/jcardama/LeopardWM/issues
+Author: jcardama
+PackageName: LeopardWM
+PackageUrl: https://github.com/jcardama/LeopardWM
+License: GPL-3.0-only
+LicenseUrl: https://github.com/jcardama/LeopardWM/blob/main/LICENSE
+ShortDescription: Scroll-first tiling window manager for Windows 10 and 11.
+Description: |-
+  LeopardWM is an open-source tiling window manager for Windows 10 and 11 that takes a scroll-first approach inspired by niri and PaperWM. Windows sit on a horizontal strip and the monitor acts as a viewport that scrolls over them, so navigation stays spatially consistent as windows are added — instead of constantly rebuilding split trees. Written in Rust on top of the Win32 API.
+Moniker: leopardwm
+Tags:
+- tiling
+- window-manager
+- scrollable
+- niri
+- paperwm
+- rust
+- windows
+- workspace
+ReleaseNotesUrl: https://github.com/jcardama/LeopardWM/releases/tag/v0.1.11
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/j/jcardama/LeopardWM/0.1.11/jcardama.LeopardWM.yaml
+++ b/manifests/j/jcardama/LeopardWM/0.1.11/jcardama.LeopardWM.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: jcardama.LeopardWM
+PackageVersion: 0.1.11
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Package
[jcardama.LeopardWM 0.1.11](https://github.com/jcardama/LeopardWM/releases/tag/v0.1.11)

LeopardWM is a scroll-first tiling window manager for Windows 10 and 11, inspired by niri and PaperWM. Written in Rust, GPL-3.0.

This is a new package; first version submitted to winget-pkgs. Subsequent versions will be auto-published via the [winget-releaser](https://github.com/vedantmgoyal9/winget-releaser) GitHub Action wired into the project's release workflow.

## Validation

- `winget validate --manifest .\manifests\j\jcardama\LeopardWM\0.1.11` — passed locally
- MSI is built via `cargo wix`; SignPath Foundation review pending so this release is unsigned
- `ProductCode` and `UpgradeCode` extracted directly from the released MSI
- Installs to `%ProgramFiles%\LeopardWM\bin` and adds the bin folder to system PATH
- Three CLI commands registered: `leopardwm` (daemon), `leopardwm-cli` (CLI), `lwm` (CLI alias)

## Checklist

- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://docs.microsoft.com/windows/package-manager/package/manifest#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-cli/blob/master/schemas/JSON/manifests/v1.6.0/)?