### PR TITLE
Fix incorrect url: xdpxi.sponge version 1.0.5 cdn.xdpxi.net:8716 to cdn.xdpxi.net

### DIFF
--- a/manifests/x/xdpxi/sponge/1.0.5/xdpxi.sponge.installer.yaml
+++ b/manifests/x/xdpxi/sponge/1.0.5/xdpxi.sponge.installer.yaml
@@ -6,7 +6,7 @@ PackageVersion: 1.0.5
 InstallerType: inno
 Installers:
   - Architecture: x64
-    InstallerUrl: http://cdn.xdpxi.net:8716/sponge/1.0.5/sponge-1.0.5-installer.exe
+    InstallerUrl: http://cdn.xdpxi.net/sponge/1.0.5/sponge-1.0.5-installer.exe
     InstallerSha256: 49343884170B21DFB140C089D7C59989078F206C1D2204E84AA48A2BD02C001E
 ManifestType: installer
 ManifestVersion: 1.10.0


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
Fixes xdpxi.sponge version 1.0.5's incorrect url from cdn.xdpxi.net:8716 to cdn.xdpxi.net.

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/371374)