### PR TITLE
New version: M-Igashi.headroom version 1.10.0

### DIFF
--- a/manifests/m/M-Igashi/headroom/1.10.0/M-Igashi.headroom.installer.yaml
+++ b/manifests/m/M-Igashi/headroom/1.10.0/M-Igashi.headroom.installer.yaml
@@ -1,0 +1,19 @@
+# Created with manual update
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.headroom
+PackageVersion: 1.10.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: headroom.exe
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Gyan.FFmpeg
+ReleaseDate: 2026-05-08
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/M-Igashi/headroom/releases/download/v1.10.0/headroom-v1.10.0-windows-x86_64.zip
+    InstallerSha256: 9F9FE9513B74C7BD9AC7D7C954196FF863BDD96234345F6BB6B814571C8050E0
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/headroom/1.10.0/M-Igashi.headroom.locale.en-US.yaml
+++ b/manifests/m/M-Igashi/headroom/1.10.0/M-Igashi.headroom.locale.en-US.yaml
@@ -1,0 +1,39 @@
+# Created with manual update
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.headroom
+PackageVersion: 1.10.0
+PackageLocale: en-US
+Publisher: M-Igashi
+PublisherUrl: https://github.com/M-Igashi
+PublisherSupportUrl: https://github.com/M-Igashi/headroom/issues
+Author: M-Igashi
+PackageName: headroom
+PackageUrl: https://github.com/M-Igashi/headroom
+License: MIT
+LicenseUrl: https://github.com/M-Igashi/headroom/blob/main/LICENSE
+ShortDescription: Audio loudness analyzer and gain adjustment tool for mastering and DJ workflows
+Description: |-
+  headroom analyzes audio files for loudness (LUFS) and headroom, then applies lossless gain adjustment.
+  It supports MP3, AAC/M4A, FLAC, AIFF, and WAV files.
+  Features include batch processing, ReplayGain analysis, lossless MP3 gain via mp3rgain, lossless AAC/M4A gain adjustment, and a scriptable non-interactive CLI mode for pipelines and CI.
+Moniker: headroom
+Tags:
+  - aac
+  - audio
+  - cli
+  - dj
+  - ffmpeg
+  - gain
+  - loudness
+  - lufs
+  - mastering
+  - mp3
+  - music
+  - normalize
+  - replaygain
+  - rust
+  - volume
+ReleaseNotesUrl: https://github.com/M-Igashi/headroom/releases/tag/v1.10.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/headroom/1.10.0/M-Igashi.headroom.yaml
+++ b/manifests/m/M-Igashi/headroom/1.10.0/M-Igashi.headroom.yaml
@@ -1,0 +1,8 @@
+# Created with manual update
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.headroom
+PackageVersion: 1.10.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Reason for change

New release of [M-Igashi.headroom](https://github.com/M-Igashi/headroom) version 1.10.0.

## Changes

- Bumps mp3rgain from 2.3.0 to 2.5.0 (parallel-apply temp-file collision fix; faster AAC apply / ReplayGain pipelines)
- Uniform True Peak ceiling at -0.5 dBTP, configurable via `--tp-target` / `--tp-split-bitrate`

Release notes: https://github.com/M-Igashi/headroom/releases/tag/v1.10.0

## Manifest validation

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/HEAD/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.12.md)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/371398)