### PR TITLE
New version: NovaFabric.NovaVoice version 0.2.0

### DIFF
--- a/manifests/n/NovaFabric/NovaVoice/0.2.0/NovaFabric.NovaVoice.installer.yaml
+++ b/manifests/n/NovaFabric/NovaVoice/0.2.0/NovaFabric.NovaVoice.installer.yaml
@@ -1,0 +1,31 @@
+# Installer manifest — points winget at the actual .exe.
+# To bump for a new release: update PackageVersion, the URL, and recompute
+# InstallerSha256 with `Get-FileHash <file> -Algorithm SHA256`.
+
+PackageIdentifier: NovaFabric.NovaVoice
+PackageVersion: 0.2.0
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+InstallerLocale: en-US
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+
+# Inno Setup recognises these. /SP- skips the "this will install..." prompt;
+# /NORESTART avoids a forced reboot prompt; /VERYSILENT suppresses progress
+# UI entirely (only used in silent mode).
+InstallerSwitches:
+  Silent: "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART"
+  SilentWithProgress: "/SILENT /SUPPRESSMSGBOXES /NORESTART"
+
+ReleaseDate: 2026-05-08
+
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/novafabric/novavoice/releases/download/v0.2.0/NovaVoice-0.2.0-windows-x64.exe
+    InstallerSha256: 3F306A9091A5327D7C2B5D8EAEDA33318FF73820FC5295BA23E01F269DA6C213
+
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/n/NovaFabric/NovaVoice/0.2.0/NovaFabric.NovaVoice.locale.en-US.yaml
+++ b/manifests/n/NovaFabric/NovaVoice/0.2.0/NovaFabric.NovaVoice.locale.en-US.yaml
@@ -1,0 +1,46 @@
+# Default-locale (en-US) manifest — descriptive metadata shown in winget search.
+
+PackageIdentifier: NovaFabric.NovaVoice
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: NovaFabric
+PublisherUrl: https://github.com/novafabric
+PublisherSupportUrl: https://github.com/novafabric/novavoice/issues
+Author: Mohsen Seyedkazemi Moghadam
+PackageName: NovaVoice
+PackageUrl: https://github.com/novafabric/novavoice
+License: Apache-2.0
+LicenseUrl: https://github.com/novafabric/novavoice/blob/main/LICENSE
+Copyright: Copyright (c) NovaFabric
+CopyrightUrl: https://github.com/novafabric/novavoice/blob/main/LICENSE
+ShortDescription: Local, offline voice dictation — hold a key, speak, release.
+Description: |-
+  NovaVoice is a local, offline voice-to-text dictation app for Windows.
+  Hold a key (Right Ctrl by default), speak, release — the transcribed text
+  appears in whatever window is focused. No cloud, no GPU. Powered by
+  faster-whisper running on the CPU.
+Moniker: novavoice
+Tags:
+  - voice
+  - dictation
+  - speech-to-text
+  - whisper
+  - accessibility
+  - offline
+  - local
+
+ReleaseNotes: |-
+  First Windows release. Shared codebase with macOS and Linux via a
+  platform-abstraction layer. Default hotkey is Right Ctrl (deliberately
+  not Right Alt to avoid AltGr collisions on European layouts).
+
+  This is an unsigned developer preview; SmartScreen will warn on first
+  launch. Code signing is planned before public beta.
+ReleaseNotesUrl: https://github.com/novafabric/novavoice/releases/tag/v0.2.0
+
+Documentations:
+  - DocumentLabel: Install guide
+    DocumentUrl: https://github.com/novafabric/novavoice/blob/main/docs/windows-install.md
+
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/n/NovaFabric/NovaVoice/0.2.0/NovaFabric.NovaVoice.yaml
+++ b/manifests/n/NovaFabric/NovaVoice/0.2.0/NovaFabric.NovaVoice.yaml
@@ -1,0 +1,16 @@
+# Version manifest — root file referenced by `winget` for this package.
+# See https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.6.md
+#
+# Submission flow:
+#   1. Fork microsoft/winget-pkgs.
+#   2. Place these three files at:
+#        manifests/n/NovaFabric/NovaVoice/0.2.0/
+#   3. Update the InstallerSha256 in the installer.yaml to match the SHA-256
+#      of the released .exe (run `Get-FileHash NovaVoice-0.2.0-windows-x64.exe`).
+#   4. Open a PR. The winget validation pipeline does the rest.
+
+PackageIdentifier: NovaFabric.NovaVoice
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Adds NovaFabric.NovaVoice 0.2.0.

NovaVoice is a local, offline voice-to-text dictation app. Hold a key
(Right Ctrl by default), speak, release — the transcribed text appears
in whatever window is focused. No cloud, no GPU. Powered by
[faster-whisper](https://github.com/SYSTRAN/faster-whisper) running on
the CPU.

- **Upstream**: https://github.com/novafabric/novavoice
- **License**: Apache-2.0
- **Release**: https://github.com/novafabric/novavoice/releases/tag/v0.2.0
- **Installer**: Inno Setup 6, user-scope (HKCU), no admin required
- **Architecture**: x64
- **Installer URL**: https://github.com/novafabric/novavoice/releases/download/v0.2.0/NovaVoice-0.2.0-windows-x64.exe
- **Installer SHA256**: 3F306A9091A5327D7C2B5D8EAEDA33318FF73820FC5295BA23E01F269DA6C213

This is a new package; no prior versions exist in winget-pkgs.

### Notes for reviewers

- v0.2.0 is an unsigned developer-preview build. SmartScreen will warn on
  first launch; users see "More info → Run anyway". Code signing is
  planned before public beta.
- The installer registers an HKCU\\Run autostart entry (gated on the
  optional installer task) and adds Start Menu shortcuts. Uninstall
  removes both.
- The bundled NovaVoice.exe dispatches by argv: `--tray` (default) /
  `--daemon` / `--cli`. Shortcuts use `--tray`.

### Manifest files

- `manifests/n/NovaFabric/NovaVoice/0.2.0/NovaFabric.NovaVoice.yaml`
- `manifests/n/NovaFabric/NovaVoice/0.2.0/NovaFabric.NovaVoice.installer.yaml`
- `manifests/n/NovaFabric/NovaVoice/0.2.0/NovaFabric.NovaVoice.locale.en-US.yaml`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/371427)