### PR TITLE
Update Chyckenwing.Chickenwing to version 0.1.2

### DIFF
--- a/manifests/c/Chyckenwing/Chickenwing/0.1.2/Chyckenwing.Chickenwing.installer.yaml
+++ b/manifests/c/Chyckenwing/Chickenwing/0.1.2/Chyckenwing.Chickenwing.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: Chyckenwing.Chickenwing
+PackageVersion: 0.1.2
+InstallerType: zip
+ReleaseDate: 2026-05-08
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: chickenwing-windows-x64-v0.1.2\chickenwing.exe
+  PortableCommandAlias: chickenwing
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/chyckenwing/chickenwing/releases/download/v0.1.2/chickenwing-windows-x64-v0.1.2.zip
+  InstallerSha256: 63799A527EF6143570095D53FFD6FB37DA537894A8873FBDA2F3A5E9BEEC11DB
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/c/Chyckenwing/Chickenwing/0.1.2/Chyckenwing.Chickenwing.locale.en-US.yaml
+++ b/manifests/c/Chyckenwing/Chickenwing/0.1.2/Chyckenwing.Chickenwing.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: Chyckenwing.Chickenwing
+PackageVersion: 0.1.2
+PackageLocale: en-US
+Publisher: Chyckenwing
+PublisherUrl: https://github.com/chyckenwing
+PublisherSupportUrl: https://github.com/chyckenwing/chickenwing/issues
+Author: Chyckenwing
+PackageName: Chickenwing
+PackageUrl: https://github.com/chyckenwing/chickenwing
+License: Proprietary
+ShortDescription: Terminal-first YouTube downloader powered by yt-dlp.
+Description: >-
+  Chickenwing is a fast terminal downloader for YouTube links and search-driven downloads. It supports direct video downloads, audio mode, a dedicated download folder, and a self-contained console-style launch experience.
+Moniker: chickenwing
+Tags:
+- youtube
+- downloader
+- yt-dlp
+- audio
+- video
+- cli
+ReleaseNotes: Bundle ffmpeg into the Windows package so Chickenwing installs as a self-contained downloader.
+ReleaseNotesUrl: https://github.com/chyckenwing/chickenwing/releases/tag/v0.1.2
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/c/Chyckenwing/Chickenwing/0.1.2/Chyckenwing.Chickenwing.yaml
+++ b/manifests/c/Chyckenwing/Chickenwing/0.1.2/Chyckenwing.Chickenwing.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: Chyckenwing.Chickenwing
+PackageVersion: 0.1.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary
- update Chickenwing to 0.1.2
- bundle ffmpeg directly into the Windows package
- remove the separate ffmpeg dependency from the WinGet install path
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/371503)