### PR TITLE
New package: BrightKitchen.PrintBridge version 2.0.12

### DIFF
--- a/manifests/b/BrightKitchen/PrintBridge/2.0.12/BrightKitchen.PrintBridge.installer.yaml
+++ b/manifests/b/BrightKitchen/PrintBridge/2.0.12/BrightKitchen.PrintBridge.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: BrightKitchen.PrintBridge
+PackageVersion: 2.0.12
+InstallerType: wix
+Scope: machine
+UpgradeBehavior: install
+ElevationRequirement: elevatesSelf
+InstallerSuccessCodes:
+  - 3010
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Karimrekiki/kds-print-bridge/releases/download/v2.0.12/BKPrintBridgeWinget-2.0.12.msi
+    InstallerSha256: 75BD2F1992DF9E55EF0C6E817C4663BD9A2932DD96A9170CD5ED8AB930CC8AED
+    AppsAndFeaturesEntries:
+      - DisplayName: Bright Kitchen Print Bridge
+        Publisher: BK One B.V.
+        DisplayVersion: 2.0.12
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/b/BrightKitchen/PrintBridge/2.0.12/BrightKitchen.PrintBridge.installer.yaml
+++ b/manifests/b/BrightKitchen/PrintBridge/2.0.12/BrightKitchen.PrintBridge.installer.yaml
@@ -11,9 +11,5 @@ Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/Karimrekiki/kds-print-bridge/releases/download/v2.0.12/BKPrintBridgeWinget-2.0.12.msi
     InstallerSha256: 75BD2F1992DF9E55EF0C6E817C4663BD9A2932DD96A9170CD5ED8AB930CC8AED
-    AppsAndFeaturesEntries:
-      - DisplayName: Bright Kitchen Print Bridge
-        Publisher: BK One B.V.
-        DisplayVersion: 2.0.12
 ManifestType: installer
 ManifestVersion: 1.9.0

--- a/manifests/b/BrightKitchen/PrintBridge/2.0.12/BrightKitchen.PrintBridge.locale.en-US.yaml
+++ b/manifests/b/BrightKitchen/PrintBridge/2.0.12/BrightKitchen.PrintBridge.locale.en-US.yaml
@@ -4,6 +4,7 @@ PackageVersion: 2.0.12
 PackageLocale: en-US
 Publisher: BK One B.V.
 PackageName: Bright Kitchen Print Bridge
+PackageUrl: https://www.brightkitchen.one
 License: Proprietary
 ShortDescription: Bright Kitchen local print bridge service for receipt printers.
 ManifestType: defaultLocale

--- a/manifests/b/BrightKitchen/PrintBridge/2.0.12/BrightKitchen.PrintBridge.locale.en-US.yaml
+++ b/manifests/b/BrightKitchen/PrintBridge/2.0.12/BrightKitchen.PrintBridge.locale.en-US.yaml
@@ -4,7 +4,7 @@ PackageVersion: 2.0.12
 PackageLocale: en-US
 Publisher: BK One B.V.
 PackageName: Bright Kitchen Print Bridge
-PackageUrl: https://www.brightkitchen.one
+PackageUrl: https://github.com/Karimrekiki/kds-print-bridge
 License: Proprietary
 ShortDescription: Bright Kitchen local print bridge service for receipt printers.
 ManifestType: defaultLocale

--- a/manifests/b/BrightKitchen/PrintBridge/2.0.12/BrightKitchen.PrintBridge.locale.en-US.yaml
+++ b/manifests/b/BrightKitchen/PrintBridge/2.0.12/BrightKitchen.PrintBridge.locale.en-US.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: BrightKitchen.PrintBridge
+PackageVersion: 2.0.12
+PackageLocale: en-US
+Publisher: BK One B.V.
+PackageName: Bright Kitchen Print Bridge
+License: Proprietary
+ShortDescription: Bright Kitchen local print bridge service for receipt printers.
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/b/BrightKitchen/PrintBridge/2.0.12/BrightKitchen.PrintBridge.yaml
+++ b/manifests/b/BrightKitchen/PrintBridge/2.0.12/BrightKitchen.PrintBridge.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: BrightKitchen.PrintBridge
+PackageVersion: 2.0.12
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
### Package submission

Adds `BrightKitchen.PrintBridge` version `2.0.12`.

- Package identifier: `BrightKitchen.PrintBridge`
- Installer type: WiX/MSI
- Scope: machine
- Publisher/Manufacturer: `BK One B.V.`
- Installer URL: https://github.com/Karimrekiki/kds-print-bridge/releases/download/v2.0.12/BKPrintBridgeWinget-2.0.12.msi
- SHA256: `75BD2F1992DF9E55EF0C6E817C4663BD9A2932DD96A9170CD5ED8AB930CC8AED`

The release asset is a signed versioned MSI intended for winget-managed Bright Kitchen Print Bridge installs and upgrades.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/371684)