### PR TITLE
Update tsuchim.ImeKeysForUS to version 0.1.8

### DIFF
--- a/manifests/t/tsuchim/ImeKeysForUS/0.1.8/tsuchim.ImeKeysForUS.installer.yaml
+++ b/manifests/t/tsuchim/ImeKeysForUS/0.1.8/tsuchim.ImeKeysForUS.installer.yaml
@@ -12,13 +12,12 @@ ReleaseDate: 2026-05-08
 AppsAndFeaturesEntries:
   - DisplayName: IME Keys for US
     Publisher: tsuchim
-    DisplayVersion: 0.1.8
     ProductCode: "{09C8C6F6-0EFD-498F-8C23-B91F4D8F23AC}"
     UpgradeCode: "{C79D216B-8E33-45BF-976B-F52825D3A8E6}"
-    InstallerType: wix
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/tsuchim/ime-keys-for-us/releases/download/v0.1.8/IME-Keys-for-US-0.1.8-x64.msi
     InstallerSha256: 624B15C7FD20C071974C6744ED48E2E7B27576316DD4D2EDC31015D54E35D4DA
+    ProductCode: "{09C8C6F6-0EFD-498F-8C23-B91F4D8F23AC}"
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/t/tsuchim/ImeKeysForUS/0.1.8/tsuchim.ImeKeysForUS.installer.yaml
+++ b/manifests/t/tsuchim/ImeKeysForUS/0.1.8/tsuchim.ImeKeysForUS.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: tsuchim.ImeKeysForUS
+PackageVersion: 0.1.8
+InstallerType: wix
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-05-08
+AppsAndFeaturesEntries:
+  - DisplayName: IME Keys for US
+    Publisher: tsuchim
+    DisplayVersion: 0.1.8
+    ProductCode: "{09C8C6F6-0EFD-498F-8C23-B91F4D8F23AC}"
+    UpgradeCode: "{C79D216B-8E33-45BF-976B-F52825D3A8E6}"
+    InstallerType: wix
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/tsuchim/ime-keys-for-us/releases/download/v0.1.8/IME-Keys-for-US-0.1.8-x64.msi
+    InstallerSha256: 624B15C7FD20C071974C6744ED48E2E7B27576316DD4D2EDC31015D54E35D4DA
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/t/tsuchim/ImeKeysForUS/0.1.8/tsuchim.ImeKeysForUS.locale.en-US.yaml
+++ b/manifests/t/tsuchim/ImeKeysForUS/0.1.8/tsuchim.ImeKeysForUS.locale.en-US.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: tsuchim.ImeKeysForUS
+PackageVersion: 0.1.8
+PackageLocale: en-US
+Publisher: tsuchim
+PublisherUrl: https://github.com/tsuchim
+PackageName: IME Keys for US
+PackageUrl: https://github.com/tsuchim/ime-keys-for-us
+License: MIT
+LicenseUrl: https://github.com/tsuchim/ime-keys-for-us/blob/main/LICENSE
+ShortDescription: Explicit Japanese IME on/off keys for US keyboards on Windows.
+Description: IME Keys for US is a native Windows tray utility that maps standalone Left Alt and Right Alt taps to explicit Japanese IME OFF and IME ON operations while preserving normal Alt shortcuts.
+Moniker: ime-keys-for-us
+Tags:
+  - ime
+  - japanese
+  - keyboard
+  - win32
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/tsuchim/ImeKeysForUS/0.1.8/tsuchim.ImeKeysForUS.yaml
+++ b/manifests/t/tsuchim/ImeKeysForUS/0.1.8/tsuchim.ImeKeysForUS.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: tsuchim.ImeKeysForUS
+PackageVersion: 0.1.8
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Updates tsuchim.ImeKeysForUS to version 0.1.8. This release keeps explicit IME ON/OFF behavior, includes the immediate Alt-release IME request path, and addresses follow-up review comments from the 0.1.7 preparation. The installer URL points to the no-suffix locally Authenticode-signed MSI, the executable is statically linked, and AppsAndFeaturesEntries is included for MSI upgrade detection.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/371826)