### PR TITLE
Add AntimatterStudios.ext4-win-driver version 0.1.0

### DIFF
--- a/manifests/a/AntimatterStudios/ext4-win-driver/0.1.0/AntimatterStudios.ext4-win-driver.installer.yaml
+++ b/manifests/a/AntimatterStudios/ext4-win-driver/0.1.0/AntimatterStudios.ext4-win-driver.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: AntimatterStudios.ext4-win-driver
+PackageVersion: 0.1.0
+InstallerType: burn
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-05-08
+Installers:
+  - Architecture: arm64
+    InstallerUrl: https://github.com/antimatter-studios/ext4-win-driver/releases/download/v0.1.0/ext4-win-driver-0.1.0-arm64-Setup.exe
+    InstallerSha256: 5CDA072B13625F877BA8866052DFC46E7C4F348958E3164D3E45E7047311F8AA
+  - Architecture: x64
+    InstallerUrl: https://github.com/antimatter-studios/ext4-win-driver/releases/download/v0.1.0/ext4-win-driver-0.1.0-x64-Setup.exe
+    InstallerSha256: BEBC7A8782B645008DB44AEFB972B715BE6E25F077B158D144836D0A32B1BC1A
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/a/AntimatterStudios/ext4-win-driver/0.1.0/AntimatterStudios.ext4-win-driver.locale.en-US.yaml
+++ b/manifests/a/AntimatterStudios/ext4-win-driver/0.1.0/AntimatterStudios.ext4-win-driver.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: AntimatterStudios.ext4-win-driver
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Antimatter Studios
+PublisherUrl: https://github.com/antimatter-studios
+PublisherSupportUrl: https://github.com/antimatter-studios/ext4-win-driver/issues
+PackageName: ext4-win-driver
+PackageUrl: https://github.com/antimatter-studios/ext4-win-driver
+License: GPL-3.0-only
+LicenseUrl: https://www.gnu.org/licenses/gpl-3.0.html
+ShortDescription: Browse and auto-mount ext4 disks on Windows via WinFsp.
+Description: |
+  ext4-win-driver is a Windows-first userspace driver for ext4 volumes.
+  Plug an ext4 SD card or USB stick into Windows and the bundled
+  ExtFsWatcher service mounts it on a free drive letter in the active
+  console session via WinFsp; detach and it unmounts cleanly. The
+  installer also wires a "Mount as ext4" right-click verb on .img
+  files for offline disk-image inspection, and ships a CLI for
+  browsing without mounting (info, ls, stat, cat, tree, parts, audit).
+
+  Setup.exe chains the WinFsp redistributable so end users only run
+  one installer. Read-write is the default mount mode; pass --ro to
+  the CLI or -ReadOnly to the right-click verb for safe inspection.
+Tags:
+  - ext4
+  - filesystem
+  - mount
+  - winfsp
+  - linux
+  - sd-card
+  - usb
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/a/AntimatterStudios/ext4-win-driver/0.1.0/AntimatterStudios.ext4-win-driver.yaml
+++ b/manifests/a/AntimatterStudios/ext4-win-driver/0.1.0/AntimatterStudios.ext4-win-driver.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: AntimatterStudios.ext4-win-driver
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Description

First submission for `AntimatterStudios.ext4-win-driver` -- a userspace ext4 driver + auto-mount service for Windows, built on [WinFsp](https://github.com/winfsp/winfsp).

Plug an ext4 SD card or USB stick into Windows and the bundled `ExtFsWatcher` service mounts it on a free drive letter via WinFsp; detach and it unmounts cleanly. The installer also wires a "Mount as ext4" right-click verb on .img files and ships a CLI for browsing without mounting.

## Manifest type

This pull request is for a new manifest.

## Manifest version

1.6.0

## Checklist

- [x] I have reviewed the [Contributing guide](https://github.com/microsoft/winget-pkgs/blob/master/CONTRIBUTING.md)
- [x] I have read the [Authoring Manifests](https://github.com/microsoft/winget-pkgs/blob/master/doc/AuthoringManifests.md) guide
- [x] Manifests have been validated locally via `winget validate`-style schema check
- [x] Installer SHA256s computed from the released artefacts on the project's GitHub Releases page
- [x] License (GPL-3.0-only) is correctly declared, with full text at the project root and an MSI-side LICENSE.txt redirecting to gnu.org

## Architectures

Both x64 and arm64 Setup.exe are attached to the [v0.1.0 release](https://github.com/antimatter-studios/ext4-win-driver/releases/tag/v0.1.0). Built by the project's release CI workflow against the GPL-3-licensed [winfsp-rs](https://github.com/antimatter-studios/winfsp-rs) fork.

## Known limitations

- Installer is unsigned. If unsigned Burn bundles are problematic for review, happy to coordinate -- code-signing infrastructure is on the roadmap.
- The CLI binary is shipped read-only inside the MSI's per-machine install folder; no privileged elevation prompts beyond the standard MSI elevation.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/371874)