### PR TITLE
New package: tombi-toml.tombi v0.11.0

### DIFF
--- a/manifests/t/tombi-toml/tombi/0.11.0/tombi-toml.tombi.installer.yaml
+++ b/manifests/t/tombi-toml/tombi/0.11.0/tombi-toml.tombi.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: tombi-toml.tombi
+PackageVersion: 0.11.0
+InstallerType: zip
+NestedInstallerType: portable
+Installers:
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: tombi.exe
+    PortableCommandAlias: tombi
+  InstallerUrl: https://github.com/tombi-toml/tombi/releases/download/v0.11.0/tombi-cli-0.11.0-x86_64-pc-windows-msvc.zip
+  InstallerSha256: 3F702350D274D63AE5BBA0F8E62098E901C3013A5A2AD25A2D6A61FA01251AD9
+- Architecture: arm64
+  NestedInstallerFiles:
+  - RelativeFilePath: tombi.exe
+    PortableCommandAlias: tombi
+  InstallerUrl: https://github.com/tombi-toml/tombi/releases/download/v0.11.0/tombi-cli-0.11.0-aarch64-pc-windows-msvc.zip
+  InstallerSha256: 6A7677475FC23D91145FAC74E2B4C3D547488F7752E8FA4FD21C14ADAEDECFE9
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-05-08

--- a/manifests/t/tombi-toml/tombi/0.11.0/tombi-toml.tombi.locale.en-US.yaml
+++ b/manifests/t/tombi-toml/tombi/0.11.0/tombi-toml.tombi.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: tombi-toml.tombi
+PackageVersion: 0.11.0
+PackageLocale: en-US
+Publisher: tombi-toml
+PublisherUrl: https://github.com/tombi-toml
+PublisherSupportUrl: https://github.com/tombi-toml/tombi/issues
+Author: tombi-toml
+PackageName: tombi
+PackageUrl: https://github.com/tombi-toml/tombi
+License: MIT
+LicenseUrl: https://github.com/tombi-toml/tombi/blob/main/LICENSE
+ShortDescription: TOML Formatter / Linter / Language Server
+Description: |-
+  Tombi (鳶) provides a Formatter, Linter, and Language Server for TOML files.
+  It helps you write and maintain clean, consistent TOML configurations.
+Tags:
+- toml
+- tombi
+- toml-linter
+- formatter
+- language-server
+- linter
+- lsp
+- cli
+ReleaseNotesUrl: https://github.com/tombi-toml/tombi/releases/tag/v0.11.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/tombi-toml/tombi/0.11.0/tombi-toml.tombi.yaml
+++ b/manifests/t/tombi-toml/tombi/0.11.0/tombi-toml.tombi.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: tombi-toml.tombi
+PackageVersion: 0.11.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adding [Tombi](https://github.com/tombi-toml/tombi) (鳶) - a TOML Toolkit providing Formatter, Linter, and Language Server.

Package: `tombi-toml.tombi` v0.11.0

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there are no other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>` (requires admin to enable LocalManifestFiles)
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)