### PR TITLE
New version: Pixibox.MCP version 1.0.0

### DIFF
--- a/manifests/p/Pixibox/MCP/1.0.0/Pixibox.MCP.installer.yaml
+++ b/manifests/p/Pixibox/MCP/1.0.0/Pixibox.MCP.installer.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# ─────────────────────────────────────────────────────────────────────────────
+# Installer manifest — Pixibox MCP Toolkit
+#
+# Submit to https://github.com/microsoft/winget-pkgs as:
+#   manifests/p/Pixibox/MCP/1.0.0/Pixibox.MCP.installer.yaml
+#
+# After PR merge users install with:
+#   winget install Pixibox.MCP
+# ─────────────────────────────────────────────────────────────────────────────
+
+PackageIdentifier: Pixibox.MCP
+PackageVersion: 1.0.0
+
+# Microsoft validates this URL is reachable + the SHA-256 matches.
+# Each release: bump PackageVersion, regenerate SHA256SUMS, update both fields.
+Installers:
+  - Architecture: x64
+    InstallerType: wix
+    InstallerUrl: https://pixibox.ai/downloads/Pixibox-MCP-1.0.0.msi
+    InstallerSha256: 46CD3019DCEC78E948912F4869A00D65881818DF7E8D0C80C33FDC28DAD17367
+    Scope: machine
+    InstallModes:
+      - interactive
+      - silent
+      - silentWithProgress
+    InstallerSwitches:
+      Silent: /quiet
+      SilentWithProgress: /passive
+      Log: /log "<LOGPATH>"
+    UpgradeBehavior: install
+    ProductCode: '{8EA88A57-85F7-42F3-B1C7-D856B431EE4B}'
+    AppsAndFeaturesEntries:
+      - DisplayName: Pixibox MCP
+        Publisher: Pixibox
+        ProductCode: '{8EA88A57-85F7-42F3-B1C7-D856B431EE4B}'
+        UpgradeCode: '{8EA88A57-85F7-42F3-B1C7-D856B431EE4B}'
+        InstallerType: wix
+
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/p/Pixibox/MCP/1.0.0/Pixibox.MCP.locale.en-US.yaml
+++ b/manifests/p/Pixibox/MCP/1.0.0/Pixibox.MCP.locale.en-US.yaml
@@ -1,0 +1,51 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# Default-locale manifest — visible metadata in winget search results.
+
+PackageIdentifier: Pixibox.MCP
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: Pixibox
+PublisherUrl: https://pixibox.ai
+PublisherSupportUrl: https://pixibox.ai/docs
+PrivacyUrl: https://pixibox.ai/privacy
+Author: Pixibox
+
+PackageName: Pixibox MCP Toolkit
+PackageUrl: https://pixibox.ai/mcp-toolkit
+License: Proprietary
+LicenseUrl: https://pixibox.ai/terms
+Copyright: Copyright (c) 2025 Pixibox.  All rights reserved.
+
+ShortDescription: AI 3D toolkit MCP server for Claude Desktop / Cursor / Codex / Antigravity.
+Description: |
+  Pixibox MCP Toolkit ships 35+ DCC adapters (Blender, Maya, Houdini, UE5, Unity,
+  Cinema 4D, ZBrush, Substance Painter / Designer, Photoshop, Premiere, After
+  Effects, Nuke, Resolve, Ableton, Logic Pro, AutoCAD, Fusion 360, Rhino 3D,
+  Bambu Studio, Toon Boom Harmony, Storyboard Pro, Moho, and more) plus an
+  activator card that registers them with Claude Desktop, Cursor, Codex CLI,
+  and Antigravity in one click.
+
+  Users paste a license key (PB-XXXX-XXXX-XXXX-XXXX), pick which DCC adapters
+  to install, and the toolkit writes the matching `claude_desktop_config.json`
+  / Cursor MCP config entries.  After that, Claude / Cursor / Codex can drive
+  any of the 35+ DCC tools through MCP tool-use.
+
+Tags:
+  - mcp
+  - claude
+  - cursor
+  - codex
+  - antigravity
+  - 3d
+  - blender
+  - maya
+  - houdini
+  - unreal
+  - unity
+  - ai
+  - dcc
+
+Moniker: pixibox-mcp
+
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/p/Pixibox/MCP/1.0.0/Pixibox.MCP.yaml
+++ b/manifests/p/Pixibox/MCP/1.0.0/Pixibox.MCP.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# Version manifest — the umbrella file that ties installer + locale together.
+
+PackageIdentifier: Pixibox.MCP
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
# Pixibox.MCP 1.0.0

Adding **Pixibox MCP Toolkit** — an AI 3D toolkit MCP server that bundles 35+ DCC adapters (Blender, Maya, Houdini, UE5, Unity, Cinema 4D, ZBrush, Substance Painter / Designer, Photoshop, Premiere, After Effects, Nuke, Resolve, Ableton, Logic Pro, AutoCAD, Fusion 360, Rhino 3D, Bambu Studio, Toon Boom Harmony, Storyboard Pro, Moho, …) plus an activator card that registers them with **Claude Desktop / Cursor / Codex CLI / Antigravity** in one click.

## Manifest summary

| Field | Value |
|---|---|
| `PackageIdentifier` | `Pixibox.MCP` |
| `PackageVersion` | `1.0.0` |
| `Architecture` | `x64` |
| `InstallerType` | `wix` |
| `InstallerUrl` | https://pixibox.ai/downloads/Pixibox-MCP-1.0.0.msi |
| `InstallerSha256` | `46CD3019DCEC78E948912F4869A00D65881818DF7E8D0C80C33FDC28DAD17367` |
| `Scope` | `machine` |
| `License` | Proprietary (https://pixibox.ai/terms) |
| `Publisher` | Pixibox |

## Verified locally

- [x] `aka.ms/winget-manifest.installer.1.6.0.schema.json` validates
- [x] `aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json` validates
- [x] `aka.ms/winget-manifest.version.1.6.0.schema.json` validates
- [x] `InstallerUrl` returns HTTP 200 (verified from public internet)
- [x] Downloaded MSI SHA-256 matches `InstallerSha256`
- [x] Silent install args verified: `/quiet /norestart` → exit 0
- [x] Upgrade-code GUID (`{8EA88A57-…EE4B}`) matches the WiX-built MSI

## Source

Build pipeline + manifests live at https://github.com/aerovfx/pixiebox.ai
under `mcp-suite/installer/` (build) and `windows-distribution/winget/` (manifests).

## Once approved

```powershell
winget install Pixibox.MCP
```

Thanks for reviewing!
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/371916)