### PR TITLE
Slight maintenance: jedisct1.minisign version 0.12

### DIFF
--- a/manifests/j/jedisct1/minisign/0.12/jedisct1.minisign.locale.en-US.yaml
+++ b/manifests/j/jedisct1/minisign/0.12/jedisct1.minisign.locale.en-US.yaml
@@ -1,4 +1,3 @@
-# Created with komac v2.10.1
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 
 PackageIdentifier: jedisct1.minisign
@@ -12,13 +11,12 @@ PackageName: Minisign
 PackageUrl: https://github.com/jedisct1/minisign
 License: ISC
 LicenseUrl: https://github.com/jedisct1/minisign/blob/HEAD/LICENSE
-Copyright: Copyright (c) Frank Denis
+Copyright: © Frank Denis
 CopyrightUrl: https://github.com/jedisct1/minisign/blob/master/LICENSE
-ShortDescription: A dead simple tool to sign files and verify digital signatures.
-Description: Minisign is a dead simple tool to sign files and verify signatures. It is portable, lightweight, and uses the highly secure Ed25519 public-key signature system.
+ShortDescription: A dead-simple tool to sign files and verify digital signatures.
+Description: Minisign is a dead-simple tool to sign files and verify signatures. It is portable, lightweight, and uses the highly secure Ed25519 public-key signature system.
 Moniker: minisign
 Tags:
-- crypto
 - cryptography
 - ed25519
 - gpg


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
* Removed the `crypto` tag. The aim is to distinguish better between `cryptography` and `cryptocurrency` when running `winget search crypto`.
* Added 2 dashes, as I had to do a double take to read the descriptions' use of "dead" as the intended "deadass" and not as "discontinued (software)".
* Replaced (c) with © for professionality.

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/372068)