### PR TITLE
Add OpsZone.MFA-Forge version 1.0.0

### DIFF
--- a/manifests/o/OpsZone/MFA-Forge/1.0.0/OpsZone.MFA-Forge.installer.yaml
+++ b/manifests/o/OpsZone/MFA-Forge/1.0.0/OpsZone.MFA-Forge.installer.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: OpsZone.MFA-Forge
+PackageVersion: 1.0.0
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: wix
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: uninstallPrevious
+ProductCode: '{478BA0BB-9295-46EF-BAEE-0DC1B7B67D66}'
+ReleaseDate: 2026-05-08
+AppsAndFeaturesEntries:
+- DisplayName: MFA-Forge
+  Publisher: OpsZone
+  ProductCode: '{478BA0BB-9295-46EF-BAEE-0DC1B7B67D66}'
+InstallationMetadata:
+  DefaultInstallLocation: '%LocalAppData%\MFA-Forge'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/wnunezc/MFA-Forge/releases/download/v1.0.0/MFA-Forge-1.0.0-x64.msi
+  InstallerSha256: 4551CEBF7492E68808DF1204916AB24A503F9E2422AC0636CEFABC9E6BD95455
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/o/OpsZone/MFA-Forge/1.0.0/OpsZone.MFA-Forge.locale.en-US.yaml
+++ b/manifests/o/OpsZone/MFA-Forge/1.0.0/OpsZone.MFA-Forge.locale.en-US.yaml
@@ -9,7 +9,7 @@ PublisherSupportUrl: https://github.com/wnunezc/MFA-Forge/issues
 PackageName: MFA-Forge
 PackageUrl: https://github.com/wnunezc/MFA-Forge
 License: MIT
-LicenseUrl: https://github.com/wnunezc/MFA-Forge/blob/HEAD/LICENSE
+LicenseUrl: https://github.com/wnunezc/MFA-Forge/blob/HEAD/LICENSE.md
 ShortDescription: Secure local-first MFA token manager for Windows with encrypted vault, GUI, CLI, agent, and MCP surfaces.
 Description: MFA-Forge is a secure MFA token manager written in Rust. It provides a Windows desktop GUI, a human CLI, a local agent session over stdio, a minimal local MCP server over stdio, and an encrypted local vault with bounded audit and reporting flows.
 Moniker: mfa-forge

--- a/manifests/o/OpsZone/MFA-Forge/1.0.0/OpsZone.MFA-Forge.locale.en-US.yaml
+++ b/manifests/o/OpsZone/MFA-Forge/1.0.0/OpsZone.MFA-Forge.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: OpsZone.MFA-Forge
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: OpsZone
+PublisherUrl: https://github.com/wnunezc
+PublisherSupportUrl: https://github.com/wnunezc/MFA-Forge/issues
+PackageName: MFA-Forge
+PackageUrl: https://github.com/wnunezc/MFA-Forge
+License: MIT
+LicenseUrl: https://github.com/wnunezc/MFA-Forge/blob/HEAD/LICENSE
+ShortDescription: Secure local-first MFA token manager for Windows with encrypted vault, GUI, CLI, agent, and MCP surfaces.
+Description: MFA-Forge is a secure MFA token manager written in Rust. It provides a Windows desktop GUI, a human CLI, a local agent session over stdio, a minimal local MCP server over stdio, and an encrypted local vault with bounded audit and reporting flows.
+Moniker: mfa-forge
+Tags:
+- mfa
+- totp
+- authenticator
+- security
+- rust
+- desktop
+ReleaseNotesUrl: https://github.com/wnunezc/MFA-Forge/releases/tag/v1.0.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/o/OpsZone/MFA-Forge/1.0.0/OpsZone.MFA-Forge.yaml
+++ b/manifests/o/OpsZone/MFA-Forge/1.0.0/OpsZone.MFA-Forge.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: OpsZone.MFA-Forge
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Summary
- add WinGet manifests for `OpsZone.MFA-Forge` version `1.0.0`
- point the installer to the public GitHub release asset `MFA-Forge-1.0.0-x64.msi`
- include the published SHA256 and WiX/MSI user-scope metadata

## Validation
- `winget validate --manifest D:/OpsZone/DevWorkspace/Projects/Desktop/MFA-Forge/target/winget --disable-interactivity`
- release: https://github.com/wnunezc/MFA-Forge/releases/tag/v1.0.0
- installer sha256: `4551CEBF7492E68808DF1204916AB24A503F9E2422AC0636CEFABC9E6BD95455`

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/372143)