### PR TITLE
Add OpsZone.WSDD version 1.0.0

### DIFF
--- a/manifests/o/OpsZone/WSDD/1.0.0/OpsZone.WSDD.installer.yaml
+++ b/manifests/o/OpsZone/WSDD/1.0.0/OpsZone.WSDD.installer.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: OpsZone.WSDD
+PackageVersion: 1.0.0
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: wix
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: uninstallPrevious
+ProductCode: '{01378CB1-A367-4EB1-8F24-9DD79231B008}'
+ReleaseDate: 2026-04-18
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles%\\WSDD'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/wnunezc/wsdd-rust/releases/download/v1.0.0/wsdd-1.0.0-x86_64.msi
+  InstallerSha256: 9003C4D182DAE14AA77686A5902A86C6EA4DD2AAC556AAD81075937B670F998B
+  AppsAndFeaturesEntries:
+  - DisplayName: WSDD - WebStack Deployer for Docker
+    Publisher: OpsZone Dev
+    ProductCode: '{01378CB1-A367-4EB1-8F24-9DD79231B008}'
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/o/OpsZone/WSDD/1.0.0/OpsZone.WSDD.locale.en-US.yaml
+++ b/manifests/o/OpsZone/WSDD/1.0.0/OpsZone.WSDD.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: OpsZone.WSDD
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: OpsZone Dev
+PublisherUrl: https://github.com/wnunezc
+PublisherSupportUrl: https://github.com/wnunezc/wsdd-rust/issues
+PackageName: WSDD - WebStack Deployer for Docker
+PackageUrl: https://github.com/wnunezc/wsdd-rust
+License: MIT
+LicenseUrl: https://github.com/wnunezc/wsdd-rust/blob/HEAD/LICENSE.md
+ShortDescription: Windows desktop application for managing local PHP and Docker stacks with SSL, hosts automation, and multi-version PHP.
+Description: WSDD is a Windows-first local stack manager for PHP and Docker development. It automates dependency checks, configures the Docker stack, provisions per-project PHP containers, manages local SSL and hosts entries, and centralizes project operations in a desktop application.
+Moniker: wsdd
+Tags:
+- php
+- docker
+- ssl
+- local-development
+- webstack
+- windows
+ReleaseNotesUrl: https://github.com/wnunezc/wsdd-rust/releases/tag/v1.0.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/o/OpsZone/WSDD/1.0.0/OpsZone.WSDD.yaml
+++ b/manifests/o/OpsZone/WSDD/1.0.0/OpsZone.WSDD.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: OpsZone.WSDD
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Summary
- add WinGet manifests for `OpsZone.WSDD` version `1.0.0`
- point the installer to the public GitHub release asset `wsdd-1.0.0-x86_64.msi`
- include the published SHA256 and WiX/MSI machine-scope metadata

## Validation
- `winget validate --manifest D:/OpsZone/DevWorkspace/Projects/Desktop/WSDD/target/winget --disable-interactivity`
- release: https://github.com/wnunezc/wsdd-rust/releases/tag/v1.0.0
- installer sha256: `9003C4D182DAE14AA77686A5902A86C6EA4DD2AAC556AAD81075937B670F998B`

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/372150)