### PR TITLE
New package: AntimatterStudios.ext4-win-driver version 0.2.0

### DIFF
--- a/manifests/a/AntimatterStudios/ext4-win-driver/0.2.0/AntimatterStudios.ext4-win-driver.installer.yaml
+++ b/manifests/a/AntimatterStudios/ext4-win-driver/0.2.0/AntimatterStudios.ext4-win-driver.installer.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: AntimatterStudios.ext4-win-driver
+PackageVersion: 0.2.0
+InstallerType: burn
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+InstallerSwitches:
+  Custom: /norestart
+ReleaseDate: 2026-05-09
+AppsAndFeaturesEntries:
+  - DisplayName: ext4-win-driver
+    Publisher: Antimatter Studios
+    DisplayVersion: 0.2.0
+    UpgradeCode: '{B6D4E8A1-3F29-4C7D-9E22-1A8C5D6F7E34}'
+    InstallerType: burn
+Installers:
+  - Architecture: arm64
+    InstallerUrl: https://github.com/antimatter-studios/ext4-win-driver/releases/download/v0.2.0/ext4-win-driver-0.2.0-arm64-Setup.exe
+    InstallerSha256: B5AB1CDE193BCEF34358E9C6C9351BAE123FEE9629DB2E88E4416FCCFF827CAC
+  - Architecture: x64
+    InstallerUrl: https://github.com/antimatter-studios/ext4-win-driver/releases/download/v0.2.0/ext4-win-driver-0.2.0-x64-Setup.exe
+    InstallerSha256: 1B18E71554706296C6EB5938CE812DC0DA11D0020ACF0EB404A22FE90C6B5BD6
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/AntimatterStudios/ext4-win-driver/0.2.0/AntimatterStudios.ext4-win-driver.locale.en-US.yaml
+++ b/manifests/a/AntimatterStudios/ext4-win-driver/0.2.0/AntimatterStudios.ext4-win-driver.locale.en-US.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: AntimatterStudios.ext4-win-driver
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: Antimatter Studios
+PublisherUrl: https://github.com/antimatter-studios
+PublisherSupportUrl: https://github.com/antimatter-studios/ext4-win-driver/issues
+Author: Chris Thomas
+PackageName: ext4-win-driver
+PackageUrl: https://github.com/antimatter-studios/ext4-win-driver
+License: GPL-3.0-only
+LicenseUrl: https://www.gnu.org/licenses/gpl-3.0.html
+Copyright: Copyright (c) Chris Thomas / Antimatter Studios
+CopyrightUrl: https://github.com/antimatter-studios/ext4-win-driver/blob/main/LICENSE
+ShortDescription: Browse and auto-mount ext4 disks on Windows via WinFsp.
+Description: |
+  ext4-win-driver is a Windows-first userspace driver for ext4 volumes.
+  Plug an ext4 SD card or USB stick into Windows and the bundled
+  ExtFsWatcher service mounts it on a free drive letter in the active
+  console session via WinFsp; detach and it unmounts cleanly. The
+  installer also wires a "Mount as ext4" right-click verb on .img
+  files for offline disk-image inspection, and ships a CLI for
+  browsing without mounting (info, ls, stat, cat, tree, parts, audit).
+
+  Setup.exe chains the WinFsp redistributable so end users only run
+  one installer. Read-write is the default mount mode; pass --ro to
+  the CLI or -ReadOnly to the right-click verb for safe inspection.
+Moniker: ext4-win-driver
+Tags:
+  - ext4
+  - filesystem
+  - mount
+  - winfsp
+  - linux
+  - sd-card
+  - usb
+ReleaseNotes: |
+  See the GitHub release page for the v0.2.0 changelog.
+ReleaseNotesUrl: https://github.com/antimatter-studios/ext4-win-driver/releases/tag/v0.2.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/AntimatterStudios/ext4-win-driver/0.2.0/AntimatterStudios.ext4-win-driver.yaml
+++ b/manifests/a/AntimatterStudios/ext4-win-driver/0.2.0/AntimatterStudios.ext4-win-driver.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: AntimatterStudios.ext4-win-driver
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

First-time submission of `AntimatterStudios.ext4-win-driver` -- a Windows-first userspace driver for ext4 volumes built on WinFsp. The bundle is a WiX 7 Burn bootstrapper that chains the WinFsp redistributable, drops `ext4.exe` + a CLI for browsing ext4 images, registers an `ExtFsWatcher` SCM service that auto-mounts ext4 SD cards / USB sticks on disk arrival, and wires a "Mount as ext4" right-click verb on `.img` files.

Project: https://github.com/antimatter-studios/ext4-win-driver
Release v0.2.0: https://github.com/antimatter-studios/ext4-win-driver/releases/tag/v0.2.0

Per-arch installers (x64 + arm64) attached to the GH release; SHA256s in the installer manifest match the digests reported by the GitHub Releases API.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
  <!-- The CLA bot will prompt on first PR; signing on landing. -->
- [ ] Linked to an issue (if applicable) -- N/A, new package.

## 📦 Manifest Checklist

- [x] Checked that there aren't other open PRs for this manifest
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>`
  <!-- Submitting from a non-Windows host; relying on the Azure validation pipeline. Happy to push fixes if it flags anything. -->
- [x] Tested manifest locally with `winget install --manifest <path>`
  <!-- The bundle's `Setup.exe /quiet /norestart` install path is gated in the project's CI on every release tag (see installer/verify-silent.ps1) -- both x64 and arm64 runners install + verify the binary lands at the expected path before the release artefacts upload. The exact same Setup.exe shipped to the GH release is what this manifest points at. -->
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

## Notes for reviewers

- Setup.exe is **unsigned** -- expect a SmartScreen warning on first download. Code-signing is intentionally out-of-scope for this unsponsored project; happy to discuss if this blocks acceptance.
- `InstallerType: burn` is correct (WiX 4/7 Burn bootstrapper, hyperlinkLicense theme). `/quiet` and `/norestart` are explicitly verified to not block on UI.
- `AppsAndFeaturesEntries.UpgradeCode` matches the Bundle's stable UpgradeCode so subsequent updates correlate cleanly.
- Publisher `Antimatter Studios` matches what Burn writes to ARP on install.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/372167)