### PR TITLE
Update itsnateai.SyncthingTray version 2.3.11 - deprecation notice (renamed to itsnateai.SyncthingPause)

### DIFF
--- a/manifests/i/itsnateai/SyncthingTray/2.3.11/itsnateai.SyncthingTray.locale.en-US.yaml
+++ b/manifests/i/itsnateai/SyncthingTray/2.3.11/itsnateai.SyncthingTray.locale.en-US.yaml
@@ -6,18 +6,36 @@ PackageVersion: 2.3.11
 PackageLocale: en-US
 Publisher: itsnateai
 PublisherUrl: https://github.com/itsnateai
-PublisherSupportUrl: https://github.com/itsnateai/synctray/issues
+PublisherSupportUrl: https://github.com/itsnateai/syncthingpause/issues
 PackageName: SyncthingTray
-PackageUrl: https://github.com/itsnateai/synctray
+PackageUrl: https://github.com/itsnateai/syncthingpause
 License: MIT
-LicenseUrl: https://github.com/itsnateai/synctray/blob/main/LICENSE
-ShortDescription: Lightweight system tray manager for Syncthing on Windows
-Description: System tray utility for monitoring and controlling Syncthing. Quick-access rescan, configurable click actions, sound notifications.
+LicenseUrl: https://github.com/itsnateai/syncthingpause/blob/main/LICENSE
+ShortDescription: '[Deprecated — renamed to itsnateai.SyncthingPause] Lightweight system tray manager for Syncthing on Windows.'
+Description: |-
+  This package has been renamed to itsnateai.SyncthingPause as of 2026-05-08 (v3.0.0) to avoid confusion with Martchus's Syncthing Tray (Qt-based, established in the Syncthing ecosystem since 2016). The new package is a direct continuation of this one — same code, same features, same maintainer.
+
+  Migration:
+    winget install itsnateai.SyncthingPause
+
+  The new app auto-migrates pause state, settings, and the Startup shortcut on first launch. Once you have confirmed your state migrated, uninstall this package:
+    winget uninstall itsnateai.SyncthingTray
+
+  No further versions will be published under itsnateai.SyncthingTray.
 Tags:
 - syncthing
 - file-sync
 - system-tray
 - backup
-ReleaseNotesUrl: https://github.com/itsnateai/synctray/releases/tag/v2.3.11
+- deprecated
+- renamed
+ReleaseNotes: |-
+  This package has been renamed to itsnateai.SyncthingPause. No further versions will be published here.
+
+  To migrate, run:
+    winget install itsnateai.SyncthingPause
+
+  Pause state, settings, and Startup shortcut auto-migrate on first launch of the new package.
+ReleaseNotesUrl: https://github.com/itsnateai/syncthingpause/blob/main/CHANGELOG.md
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Updates the `defaultLocale` manifest for `itsnateai.SyncthingTray` 2.3.11 (the latest version) to clearly mark the package as deprecated and direct users to its successor, `itsnateai.SyncthingPause`.

## Why

Version 3.0.0 of the project was renamed from `SyncthingTray` to `SyncthingPause` to avoid confusion with [Martchus's Syncthing Tray](https://github.com/Martchus/syncthingtray) — a Qt-based, cross-platform Syncthing tray app well-established in the Syncthing ecosystem since ~2016. The new package was just submitted as #372176 (`itsnateai.SyncthingPause` 3.0.0).

WinGet `PackageIdentifier` values are immutable, so `winget upgrade itsnateai.SyncthingTray` cannot carry users across the rename automatically. This PR updates the existing 2.3.11 metadata so `winget show itsnateai.SyncthingTray` and the WinGet store front-end communicate the rename clearly. No new versions will be published under `itsnateai.SyncthingTray`.

## What changed

Only `itsnateai.SyncthingTray.locale.en-US.yaml`:

- `ShortDescription` prefixed with `[Deprecated — renamed to itsnateai.SyncthingPause]`
- `Description` rewritten to explain the rename and provide migration instructions (`winget install itsnateai.SyncthingPause` then `winget uninstall itsnateai.SyncthingTray`)
- `ReleaseNotes` added with the same migration message
- Tags: added `deprecated`, `renamed`
- Updated URLs (`PublisherSupportUrl`, `PackageUrl`, `LicenseUrl`, `ReleaseNotesUrl`) to the new repo path (`syncthingpause`); the old `synctray` URLs already 301-redirect to the new repo, but pointing directly avoids long-term reliance on the redirect

The `installer.yaml` and version `yaml` files are unchanged. The installer URL still references `itsnateai/synctray/releases/download/v2.3.11/SyncthingTray.exe`, which 301-redirects to the renamed repo and continues to serve the same binary (SHA256 unchanged).

## Validation

- `winget validate --manifest manifests/i/itsnateai/SyncthingTray/2.3.11` → succeeded.
- The same maintainer (`itsnateai`) owns both packages and submitted both PRs.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/372179)