### PR TITLE
New version: tisun2.OofManager version 1.1.2

### DIFF
--- a/manifests/t/tisun2/OofManager/1.1.2/tisun2.OofManager.installer.yaml
+++ b/manifests/t/tisun2/OofManager/1.1.2/tisun2.OofManager.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: tisun2.OofManager
+PackageVersion: 1.1.2
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART
+UpgradeBehavior: install
+ReleaseDate: 2026-05-09
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/tisun2/OofManager/releases/download/v1.1.2/OofManagerSetup.exe
+    InstallerSha256: C5276A1546B7A8B1693617EE4300A4462C2B4E782E957CD2B607A601272285C1
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/t/tisun2/OofManager/1.1.2/tisun2.OofManager.locale.en-US.yaml
+++ b/manifests/t/tisun2/OofManager/1.1.2/tisun2.OofManager.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: tisun2.OofManager
+PackageVersion: 1.1.2
+PackageLocale: en-US
+Publisher: tisun2
+PublisherUrl: https://github.com/tisun2
+PublisherSupportUrl: https://github.com/tisun2/OofManager/issues
+PackageName: OOF Manager
+PackageUrl: https://github.com/tisun2/OofManager
+License: MIT
+LicenseUrl: https://github.com/tisun2/OofManager/blob/main/LICENSE
+Copyright: Copyright (c) tisun2
+ShortDescription: Manage Microsoft 365 / Exchange Online Out-of-Office (Automatic Reply) settings without opening Outlook.
+Description: |-
+  OOF Manager is a lightweight Windows desktop tool that manages your Microsoft 365 mailbox's
+  Out-of-Office (Automatic Reply) state for you. Sign in once, configure your weekly work hours
+  and reply text, and OOF Manager auto-toggles your OOF on/off at the schedule boundaries.
+  It also pushes the next off-hours window to Exchange as a Scheduled OOF, so the server keeps
+  switching auto-replies even when this app is closed.
+Moniker: oofmanager
+Tags:
+  - exchange
+  - microsoft-365
+  - office-365
+  - out-of-office
+  - oof
+  - outlook
+  - autoreply
+ReleaseNotesUrl: https://github.com/tisun2/OofManager/releases/tag/v1.1.2
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/t/tisun2/OofManager/1.1.2/tisun2.OofManager.yaml
+++ b/manifests/t/tisun2/OofManager/1.1.2/tisun2.OofManager.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: tisun2.OofManager
+PackageVersion: 1.1.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
### Summary
Update **tisun2.OofManager** from 1.1.1 → **1.1.2**.

### Manifest validation
- [x] Manifests pass `winget validate`
- [x] Installer SHA256 matches the artifact attached to the GitHub Release
- [x] InstallerUrl points at an immutable GitHub Release asset
- [x] PackageIdentifier / Publisher / PackageName unchanged from prior versions

### Installer
- **Type:** Inno Setup, per-user (silent: `/VERYSILENT`)
- **URL:** https://github.com/tisun2/OofManager/releases/download/v1.1.2/OofManagerSetup.exe
- **SHA256:** `C5276A1546B7A8B1693617EE4300A4462C2B4E782E957CD2B607A601272285C1`

### Release notes
Upstream release: https://github.com/tisun2/OofManager/releases/tag/v1.1.2

- **New:** Long Vacation card has an *Auto-decline new meeting invitations* option that emits `Set-MailboxAutoReplyConfiguration -DeclineEventsForScheduledOOF` on Start vacation and clears it on End vacation.
- **UI:** Long Vacation setup collapsed into an Expander with a horizontal *From → To* row.
- **UI:** Cloud Sync wrapped in an *Always-on cloud schedule (Power Automate)* Expander; *Generate package* promoted to the single primary action; *Manual setup guide* demoted to a small text link.
- **UI:** Work Schedule flattened into a horizontal 7-day grid.
- **UI:** *Save Work Schedule* + *Sync now* merged into one adaptive *Apply to Outlook* / *Save & Apply* button (hidden when Work Schedule is off).
- **UI:** *Save current as template* moved into the My Templates card title.
- **Fix:** `EndVacationAsync` now clears prefs only after Exchange ack and uses a single `Set-MailboxAutoReplyConfiguration` call.

### Reviewer notes
No new dependencies, no install scope change, no manifest schema change. Diff vs 1.1.1 is `Version` + `InstallerSha256` + `InstallerUrl` + `ReleaseDate` + release notes URL.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/372257)