### PR TITLE
New version: rtk-ai.rtk version 0.39.0

### DIFF
--- a/manifests/r/rtk-ai/rtk/0.39.0/rtk-ai.rtk.installer.yaml
+++ b/manifests/r/rtk-ai/rtk/0.39.0/rtk-ai.rtk.installer.yaml
@@ -1,0 +1,16 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: rtk-ai.rtk
+PackageVersion: 0.39.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: rtk.exe
+  PortableCommandAlias: rtk
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/rtk-ai/rtk/releases/download/v0.39.0/rtk-x86_64-pc-windows-msvc.zip
+  InstallerSha256: AAD430C14D82B4470F14BDB9695E8CD97AEAC97444BD087BD70BE161CED09CB7
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/r/rtk-ai/rtk/0.39.0/rtk-ai.rtk.locale.en-US.yaml
+++ b/manifests/r/rtk-ai/rtk/0.39.0/rtk-ai.rtk.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: rtk-ai.rtk
+PackageVersion: 0.39.0
+PackageLocale: en-US
+Publisher: rtk-ai
+PublisherUrl: https://www.rtk-ai.app
+PrivacyUrl: https://github.com/rtk-ai/rtk/blob/master/docs/TELEMETRY.md
+Author: rtk-ai
+PackageName: rtk
+PackageUrl: https://github.com/rtk-ai/rtk
+License: MIT License
+LicenseUrl: https://github.com/rtk-ai/rtk/blob/master/LICENSE
+Copyright: 2024 Patrick Szymkowiak
+ShortDescription: CLI proxy that reduces LLM token consumption by 60-90% on common dev commands. Single Rust binary, zero dependencies
+Description: CLI proxy that reduces LLM token consumption by 60-90% on common dev commands. Single Rust binary, zero dependencies
+Moniker: rtk
+Tags:
+- cli
+- llm
+- token
+- filter
+- productivity
+- rust-token-killer
+ReleaseNotesUrl: https://github.com/rtk-ai/rtk/releases/latest
+InstallationNotes: Run `rtk init -g` to begin (installs `rtk` as a globally available hook for all `bash` commands)
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/rtk-ai/rtk/0.39.0/rtk-ai.rtk.yaml
+++ b/manifests/r/rtk-ai/rtk/0.39.0/rtk-ai.rtk.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: rtk-ai.rtk
+PackageVersion: 0.39.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## New Manifest

- **Package Identifier:** rtk-ai.rtk
- **Package Version:** 0.39.0

Adds manifests for `rtk-ai.rtk` version 0.39.0.

Source: https://github.com/rtk-ai/rtk/releases/tag/v0.39.0

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://docs.microsoft.com/windows/package-manager/package/manifest#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.12.md)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/372277)