### PR TITLE
New version: OpenCoworkAI.OpenCoDesign 0.2.0

### DIFF
--- a/manifests/o/OpenCoworkAI/OpenCoDesign/0.2.0/OpenCoworkAI.OpenCoDesign.installer.yaml
+++ b/manifests/o/OpenCoworkAI/OpenCoDesign/0.2.0/OpenCoworkAI.OpenCoDesign.installer.yaml
@@ -1,0 +1,16 @@
+PackageIdentifier: OpenCoworkAI.OpenCoDesign
+PackageVersion: 0.2.0
+InstallerType: nullsoft
+Scope: user
+UpgradeBehavior: install
+# electron-builder emits per-arch NSIS installers; winget gets separate
+# entries so ARM Windows users install the native build instead of emulating.
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/OpenCoworkAI/open-codesign/releases/download/v0.2.0/open-codesign-0.2.0-x64-setup.exe
+    InstallerSha256: 3BD0FD2506A63789B543F5206512D8858F06C025BCD7E0F8CB5A44A9AF327605
+  - Architecture: arm64
+    InstallerUrl: https://github.com/OpenCoworkAI/open-codesign/releases/download/v0.2.0/open-codesign-0.2.0-arm64-setup.exe
+    InstallerSha256: 44FB585F23BCE3DB9261B867D630742ECC91103F99C1FB79B6D35DB405C78DD0
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/o/OpenCoworkAI/OpenCoDesign/0.2.0/OpenCoworkAI.OpenCoDesign.installer.yaml
+++ b/manifests/o/OpenCoworkAI/OpenCoDesign/0.2.0/OpenCoworkAI.OpenCoDesign.installer.yaml
@@ -9,9 +9,9 @@ ReleaseDate: 2026-05-09
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/OpenCoworkAI/open-codesign/releases/download/v0.2.0/open-codesign-0.2.0-x64-setup.exe
-  InstallerSha256: 3BD0FD2506A63789B543F5206512D8858F06C025BCD7E0F8CB5A44A9AF327605
+  InstallerSha256: FE6AE0859284F84D45B56ADE1545E80E8BAEDCB376463D9CF61715A5785E7030
 - Architecture: arm64
   InstallerUrl: https://github.com/OpenCoworkAI/open-codesign/releases/download/v0.2.0/open-codesign-0.2.0-arm64-setup.exe
-  InstallerSha256: 44FB585F23BCE3DB9261B867D630742ECC91103F99C1FB79B6D35DB405C78DD0
+  InstallerSha256: E68951AF8D8DBE1F7E7D766BE4DA2D9ABE91B3D39297724AF931E46367595F55
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/o/OpenCoworkAI/OpenCoDesign/0.2.0/OpenCoworkAI.OpenCoDesign.installer.yaml
+++ b/manifests/o/OpenCoworkAI/OpenCoDesign/0.2.0/OpenCoworkAI.OpenCoDesign.installer.yaml
@@ -1,16 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
 PackageIdentifier: OpenCoworkAI.OpenCoDesign
 PackageVersion: 0.2.0
 InstallerType: nullsoft
 Scope: user
 UpgradeBehavior: install
-# electron-builder emits per-arch NSIS installers; winget gets separate
-# entries so ARM Windows users install the native build instead of emulating.
+ReleaseDate: 2026-05-09
 Installers:
-  - Architecture: x64
-    InstallerUrl: https://github.com/OpenCoworkAI/open-codesign/releases/download/v0.2.0/open-codesign-0.2.0-x64-setup.exe
-    InstallerSha256: 3BD0FD2506A63789B543F5206512D8858F06C025BCD7E0F8CB5A44A9AF327605
-  - Architecture: arm64
-    InstallerUrl: https://github.com/OpenCoworkAI/open-codesign/releases/download/v0.2.0/open-codesign-0.2.0-arm64-setup.exe
-    InstallerSha256: 44FB585F23BCE3DB9261B867D630742ECC91103F99C1FB79B6D35DB405C78DD0
+- Architecture: x64
+  InstallerUrl: https://github.com/OpenCoworkAI/open-codesign/releases/download/v0.2.0/open-codesign-0.2.0-x64-setup.exe
+  InstallerSha256: 3BD0FD2506A63789B543F5206512D8858F06C025BCD7E0F8CB5A44A9AF327605
+- Architecture: arm64
+  InstallerUrl: https://github.com/OpenCoworkAI/open-codesign/releases/download/v0.2.0/open-codesign-0.2.0-arm64-setup.exe
+  InstallerSha256: 44FB585F23BCE3DB9261B867D630742ECC91103F99C1FB79B6D35DB405C78DD0
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenCoworkAI/OpenCoDesign/0.2.0/OpenCoworkAI.OpenCoDesign.locale.en-US.yaml
+++ b/manifests/o/OpenCoworkAI/OpenCoDesign/0.2.0/OpenCoworkAI.OpenCoDesign.locale.en-US.yaml
@@ -1,0 +1,27 @@
+PackageIdentifier: OpenCoworkAI.OpenCoDesign
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: OpenCoworkAI
+PublisherUrl: https://github.com/OpenCoworkAI
+PublisherSupportUrl: https://github.com/OpenCoworkAI/open-codesign/issues
+PackageName: Open CoDesign
+PackageUrl: https://github.com/OpenCoworkAI/open-codesign
+License: MIT
+LicenseUrl: https://github.com/OpenCoworkAI/open-codesign/blob/main/LICENSE
+ShortDescription: Open-source desktop AI design tool — prompt to prototype, BYOK, local-first
+Description: |
+  Open CoDesign turns natural-language prompts into HTML/JSX prototypes,
+  slide decks, and marketing assets. It runs entirely on your laptop with
+  whichever AI provider you already pay for (Anthropic, OpenAI, Gemini,
+  DeepSeek, or any OpenAI-compatible relay — including keyless
+  IP-allowlisted proxies).
+Moniker: open-codesign
+Tags:
+  - ai
+  - design
+  - electron
+  - open-source
+  - prototyping
+ReleaseNotesUrl: https://github.com/OpenCoworkAI/open-codesign/releases/tag/v0.2.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/o/OpenCoworkAI/OpenCoDesign/0.2.0/OpenCoworkAI.OpenCoDesign.locale.en-US.yaml
+++ b/manifests/o/OpenCoworkAI/OpenCoDesign/0.2.0/OpenCoworkAI.OpenCoDesign.locale.en-US.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
 PackageIdentifier: OpenCoworkAI.OpenCoDesign
 PackageVersion: 0.2.0
 PackageLocale: en-US
@@ -5,11 +7,11 @@ Publisher: OpenCoworkAI
 PublisherUrl: https://github.com/OpenCoworkAI
 PublisherSupportUrl: https://github.com/OpenCoworkAI/open-codesign/issues
 PackageName: Open CoDesign
-PackageUrl: https://github.com/OpenCoworkAI/open-codesign
+PackageUrl: https://opencoworkai.github.io/open-codesign/
 License: MIT
 LicenseUrl: https://github.com/OpenCoworkAI/open-codesign/blob/main/LICENSE
-ShortDescription: Open-source desktop AI design tool — prompt to prototype, BYOK, local-first
-Description: |
+ShortDescription: Open-source desktop AI design tool — prompt to prototype, BYOK, local-first.
+Description: |-
   Open CoDesign turns natural-language prompts into HTML/JSX prototypes,
   slide decks, and marketing assets. It runs entirely on your laptop with
   whichever AI provider you already pay for (Anthropic, OpenAI, Gemini,
@@ -17,11 +19,11 @@ Description: |
   IP-allowlisted proxies).
 Moniker: open-codesign
 Tags:
-  - ai
-  - design
-  - electron
-  - open-source
-  - prototyping
+- ai
+- design
+- electron
+- open-source
+- prototyping
 ReleaseNotesUrl: https://github.com/OpenCoworkAI/open-codesign/releases/tag/v0.2.0
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenCoworkAI/OpenCoDesign/0.2.0/OpenCoworkAI.OpenCoDesign.yaml
+++ b/manifests/o/OpenCoworkAI/OpenCoDesign/0.2.0/OpenCoworkAI.OpenCoDesign.yaml
@@ -1,5 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
 PackageIdentifier: OpenCoworkAI.OpenCoDesign
 PackageVersion: 0.2.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenCoworkAI/OpenCoDesign/0.2.0/OpenCoworkAI.OpenCoDesign.yaml
+++ b/manifests/o/OpenCoworkAI/OpenCoDesign/0.2.0/OpenCoworkAI.OpenCoDesign.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: OpenCoworkAI.OpenCoDesign
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
- Adds OpenCoworkAI.OpenCoDesign version 0.2.0\n- Release: https://github.com/OpenCoworkAI/open-codesign/releases/tag/v0.2.0\n- Includes x64 and arm64 NSIS installers with SHA256 hashes from the release SHA256SUMS.txt
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/372310)