### PR TITLE
Update willibrandon.dotsider-mcp to 0.16.0

### DIFF
--- a/manifests/w/willibrandon/dotsider-mcp/0.16.0/willibrandon.dotsider-mcp.installer.yaml
+++ b/manifests/w/willibrandon/dotsider-mcp/0.16.0/willibrandon.dotsider-mcp.installer.yaml
@@ -1,0 +1,27 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: willibrandon.dotsider-mcp
+PackageVersion: 0.16.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.18362.0
+InstallerType: msi
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/willibrandon/dotsider/releases/download/v0.16.0/dotsider-mcp-win-x64.msi
+  InstallerSha256: 68FEBAAEE1B8838FFE801114669C7F74D61D3D0D6134098EA5BB08FCAF8FEEEE
+  ProductCode: '{29C68B5F-C7D0-4BE7-B792-2C929E3C8AAC}'
+- Architecture: arm64
+  InstallerUrl: https://github.com/willibrandon/dotsider/releases/download/v0.16.0/dotsider-mcp-win-arm64.msi
+  InstallerSha256: 806276142FBC15E9AFF6D4E1002731F4E0673A75F4ADFF22AFA43792FEA5EEE1
+  ProductCode: '{136115FD-302D-4C26-99A7-C9CAF57E12A4}'
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-05-09

--- a/manifests/w/willibrandon/dotsider-mcp/0.16.0/willibrandon.dotsider-mcp.locale.en-US.yaml
+++ b/manifests/w/willibrandon/dotsider-mcp/0.16.0/willibrandon.dotsider-mcp.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: willibrandon.dotsider-mcp
+PackageVersion: 0.16.0
+PackageLocale: en-US
+Publisher: willibrandon
+PublisherUrl: https://github.com/willibrandon
+PublisherSupportUrl: https://github.com/willibrandon/dotsider/issues
+PackageName: dotsider-mcp
+PackageUrl: https://github.com/willibrandon/dotsider
+License: MIT
+LicenseUrl: https://github.com/willibrandon/dotsider/blob/main/LICENSE
+ShortDescription: MCP server for AI-assisted .NET assembly analysis
+Description: |-
+  dotsider-mcp is a standalone Model Context Protocol server that exposes
+  dotsider's .NET assembly analysis engine to AI coding assistants like
+  Claude Code, VS Code Copilot, and others. It provides 28 tools for
+  assembly analysis, IL disassembly, metadata inspection, dependency graphs,
+  size analysis, string extraction, diffing, and runtime tracing.
+Tags:
+- dotnet
+- assembly
+- mcp
+- ai
+- analysis
+- il
+- metadata
+- devtools
+ReleaseNotesUrl: https://github.com/willibrandon/dotsider/releases/tag/v0.16.0
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/willibrandon/dotsider/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/w/willibrandon/dotsider-mcp/0.16.0/willibrandon.dotsider-mcp.yaml
+++ b/manifests/w/willibrandon/dotsider-mcp/0.16.0/willibrandon.dotsider-mcp.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: willibrandon.dotsider-mcp
+PackageVersion: 0.16.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Update dotsider-mcp to version 0.16.0

## Release notes

https://github.com/willibrandon/dotsider/releases/tag/v0.16.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/372348)