### PR TITLE
Add RoyMejia.JamePrompt version 1.0.0

### DIFF
--- a/manifests/r/RoyMejia/JamePrompt/1.0.0/RoyMejia.JamePrompt.installer.yaml
+++ b/manifests/r/RoyMejia/JamePrompt/1.0.0/RoyMejia.JamePrompt.installer.yaml
@@ -1,0 +1,21 @@
+PackageIdentifier: RoyMejia.JamePrompt
+PackageVersion: 1.0.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: msi
+Scope: machine
+InstallModes:
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-05-08
+AppsAndFeaturesEntries:
+- DisplayName: JamePrompt
+  Publisher: Roy Mejia
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/roymejia2217/JamePrompt/releases/download/v1.0.0/JamePrompt-1.0.0-x64.msi
+  InstallerSha256: 740798A2A471DA3F689C42F0BC160685D6B5742CDBDF2D612C5B1049DA67F9B8
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/r/RoyMejia/JamePrompt/1.0.0/RoyMejia.JamePrompt.locale.en-US.yaml
+++ b/manifests/r/RoyMejia/JamePrompt/1.0.0/RoyMejia.JamePrompt.locale.en-US.yaml
@@ -1,0 +1,25 @@
+PackageIdentifier: RoyMejia.JamePrompt
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: Roy Mejia
+PublisherUrl: https://github.com/roymejia2217
+Author: Roy Mejia
+PackageName: JamePrompt
+PackageUrl: https://github.com/roymejia2217/JamePrompt
+License: MIT
+LicenseUrl: https://github.com/roymejia2217/JamePrompt/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Roy Mejia
+ShortDescription: Lightweight and minimal local prompt manager
+Description: JamePrompt is a lightweight local prompt manager with SQLite storage, global hotkeys, clipboard integration, autostart, and desktop tray support.
+Moniker: jame-prompt
+Tags:
+- ai
+- clipboard
+- hotkeys
+- local-first
+- productivity
+- prompt-manager
+- prompts
+- sqlite
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/RoyMejia/JamePrompt/1.0.0/RoyMejia.JamePrompt.yaml
+++ b/manifests/r/RoyMejia/JamePrompt/1.0.0/RoyMejia.JamePrompt.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: RoyMejia.JamePrompt
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Adds Winget manifests for JamePrompt 1.0.0 using the official GitHub Release MSI. The installer URL points to the publisher release asset and the SHA256 matches the published SHA256SUMS file from the v1.0.0 release.\n\nLocal note: this submission was prepared from Linux, so Windows-only validation with winget validate and Windows Sandbox was not run locally before opening the PR.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/372396)