### PR TITLE
Add HarshJha.YTuff version 1.0.4

### DIFF
--- a/manifests/h/HarshJha/YTuff/1.0.4/HarshJha.YTuff.installer.yaml
+++ b/manifests/h/HarshJha/YTuff/1.0.4/HarshJha.YTuff.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: HarshJha.YTuff
+PackageVersion: 1.0.4
+InstallerType: msi
+Scope: machine
+ReleaseDate: 2026-05-09
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/life2harsh/ytuff/releases/download/v1.0.4/ytuff-windows-x64.msi
+    InstallerSha256: 2B0F2396BF06A92794C5F3EF9FC088C596D5B9BCE50D6AE43C6E56896F8CAB11
+    ProductCode: '{439A181C-FA7B-41F7-94BF-151B0735FD5F}'
+    AppsAndFeaturesEntries:
+      - DisplayName: YTuff
+        DisplayVersion: 1.0.4
+        Publisher: Harsh Jha
+        ProductCode: '{439A181C-FA7B-41F7-94BF-151B0735FD5F}'
+        UpgradeCode: '{A1A9D65A-2539-49EC-BFA2-6B06366E5E5D}'
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/h/HarshJha/YTuff/1.0.4/HarshJha.YTuff.locale.en-US.yaml
+++ b/manifests/h/HarshJha/YTuff/1.0.4/HarshJha.YTuff.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: HarshJha.YTuff
+PackageVersion: 1.0.4
+PackageLocale: en-US
+Publisher: Harsh Jha
+PublisherUrl: https://github.com/life2harsh
+PublisherSupportUrl: https://github.com/life2harsh/ytuff/issues
+Author: Harsh Jha
+PackageName: YTuff
+PackageUrl: https://github.com/life2harsh/ytuff
+License: GPL-3.0-or-later
+LicenseUrl: https://github.com/life2harsh/ytuff/blob/main/LICENSE
+ShortDescription: Terminal music player for local files and YouTube Music.
+Description: YTuff is a terminal music player for local files and YouTube Music with a full TUI, background playback daemon, playlists, downloads, lyrics, artwork, media controls, and local library scanning.
+Moniker: ytuff
+Tags:
+  - music
+  - player
+  - terminal
+  - tui
+  - youtube
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/h/HarshJha/YTuff/1.0.4/HarshJha.YTuff.yaml
+++ b/manifests/h/HarshJha/YTuff/1.0.4/HarshJha.YTuff.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: HarshJha.YTuff
+PackageVersion: 1.0.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Summary
- add `HarshJha.YTuff` version `1.0.4`
- switch the Windows package to the new MSI installer
- point the manifest at the live `ytuff-windows-x64.msi` release asset

## Validation
- `winget validate --manifest manifests/h/HarshJha/YTuff/1.0.4 --verbose`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/372397)