### PR TITLE
Changed PackageName for consistency: Microsoft.VCRedist.2010.x86 version 10.0.40219

### DIFF
--- a/manifests/m/Microsoft/VCRedist/2010/x86/10.0.40219/Microsoft.VCRedist.2010.x86.locale.en-US.yaml
+++ b/manifests/m/Microsoft/VCRedist/2010/x86/10.0.40219/Microsoft.VCRedist.2010.x86.locale.en-US.yaml
@@ -9,14 +9,13 @@ PublisherUrl: https://www.microsoft.com/
 PublisherSupportUrl: https://support.microsoft.com/
 PrivacyUrl: https://www.microsoft.com/privacy/privacystatement
 Author: Microsoft Corporation
-PackageName: Microsoft Visual C++ 2010 x86 Redistributable
+PackageName: Microsoft Visual C++ 2010 Redistributable (x86)
 PackageUrl: https://www.microsoft.com/download/details.aspx?id=26999
 License: Freeware
 LicenseUrl: https://www.microsoft.com/legal/terms-of-use
-Copyright: Copyright © Microsoft Corporation
+Copyright: © Microsoft Corporation
 CopyrightUrl: https://www.microsoft.com/legal/intellectualproperty/trademarks
 ShortDescription: The Microsoft Visual C++ 2010 SP1 Redistributable Package (x86) installs runtime components of Visual C++ Libraries required to run 32-bit applications developed with Visual C++ 2010 SP1 on a computer that does not have Visual C++ 2010 SP1 installed.
-# Description:
 Moniker: vcredist2010x86
 Tags:
 - msvc
@@ -29,10 +28,5 @@ Tags:
 - msvcr100.dll
 - msvcp100.dll
 - kb2565063
-# ReleaseNotes:
-# ReleaseNotesUrl:
-# PurchaseUrl:
-# InstallationNotes:
-# Documentations:
 ManifestType: defaultLocale
 ManifestVersion: 1.9.0


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
* Changed PackageName from `Microsoft Visual C++ 2010 x86 Redistributable` to `Microsoft Visual C++ 2010 Redistributable (x86)` for consistency with other redist years. Because currently they are named like this:
<img width="1005" height="114" alt="image" src="https://github.com/user-attachments/assets/b4fbd2fe-3cf3-4f2e-91e6-645fdfcbfc3a" />

* Filesize-reducing measures.

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/372455)