### PR TITLE
Add gkAgent.gkIndexer version 1.0.0

### DIFF
--- a/manifests/g/gkAgent/gkIndexer/1.0.0/gkAgent.gkIndexer.installer.yaml
+++ b/manifests/g/gkAgent/gkIndexer/1.0.0/gkAgent.gkIndexer.installer.yaml
@@ -11,5 +11,5 @@ Scope: user
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/gkAgent/gkIndexer/releases/download/v1.0.0/gkindexer.exe
-    InstallerSha256: D84ACE9CFBDEA5638705830350E9AD68078C0E243D46C6F5D6A4ECA2A22E46B4
+    InstallerSha256: 18E9C199EA96825B236E79F3C39C676DB5111ED4616D2F49ED6D8E296AC8979E
     PortableCommandAlias: gkindexer

--- a/manifests/g/gkAgent/gkIndexer/1.0.0/gkAgent.gkIndexer.installer.yaml
+++ b/manifests/g/gkAgent/gkIndexer/1.0.0/gkAgent.gkIndexer.installer.yaml
@@ -1,0 +1,15 @@
+PackageIdentifier: gkAgent.gkIndexer
+PackageVersion: 1.0.0
+ManifestType: installer
+ManifestVersion: 1.6.0
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.19041.0
+Architecture: x64
+InstallerType: portable
+Scope: user
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/gkAgent/gkIndexer/releases/download/v1.0.0/gkindexer.exe
+    InstallerSha256: D84ACE9CFBDEA5638705830350E9AD68078C0E243D46C6F5D6A4ECA2A22E46B4
+    PortableCommandAlias: gkindexer

--- a/manifests/g/gkAgent/gkIndexer/1.0.0/gkAgent.gkIndexer.locale.ja-JP.yaml
+++ b/manifests/g/gkAgent/gkIndexer/1.0.0/gkAgent.gkIndexer.locale.ja-JP.yaml
@@ -1,0 +1,21 @@
+PackageIdentifier: gkAgent.gkIndexer
+PackageVersion: 1.0.0
+PackageLocale: ja-JP
+ManifestType: locale
+ManifestVersion: 1.6.0
+PackageName: gkIndexer
+Publisher: gkAgent
+ShortDescription: 社内ファイルサーバー & ローカル全文検索デスクトップアプリ
+Description: |-
+  Rust + Tantivy で動くローカル全文検索アプリ。インストール不要の .exe 1ファイル。
+  UNCネットワーク共有対応。txt / md / csv / pdf / xlsx 等に対応。
+  FREE版はフォルダ3件まで無料。PRO版（¥980）で全機能利用可能。
+License: MIT
+PublisherUrl: https://gkagent.jp/
+PublisherSupportUrl: https://gkagent.jp/contact.html
+ReleaseNotesUrl: https://github.com/gkAgent/gkIndexer/releases/tag/v1.0.0
+Tags:
+  - 全文検索
+  - ファイル検索
+  - 社内
+  - ローカル

--- a/manifests/g/gkAgent/gkIndexer/1.0.0/gkAgent.gkIndexer.yaml
+++ b/manifests/g/gkAgent/gkIndexer/1.0.0/gkAgent.gkIndexer.yaml
@@ -1,0 +1,25 @@
+PackageIdentifier: gkAgent.gkIndexer
+PackageVersion: 1.0.0
+DefaultLocale: ja-JP
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0
+PackageName: gkIndexer
+Publisher: gkAgent
+PublisherUrl: https://gkagent.jp/
+PublisherSupportUrl: https://gkagent.jp/contact.html
+License: MIT
+LicenseUrl: https://github.com/gkAgent/gkIndexer/blob/main/LICENSE
+Copyright: Copyright (c) 2026 gkAgent
+ShortDescription: 社内ファイルサーバー & ローカル全文検索デスクトップアプリ
+Description: |-
+  Rust + Tantivy で動くローカル全文検索アプリ。
+  インストール不要の .exe 1ファイル。UNCネットワーク共有対応。
+  txt / md / csv / pdf / xlsx / ソースコード等に対応。
+  FREE版はフォルダ3件まで無料。PRO版（¥980）で全機能利用可能。
+Tags:
+  - search
+  - fulltext
+  - productivity
+  - japanese
+  - file-search
+ReleaseNotesUrl: https://github.com/gkAgent/gkIndexer/releases/tag/v1.0.0


### PR DESCRIPTION
## gkAgent.gkIndexer v1.0.0

### Package info
- **Package Identifier**: gkAgent.gkIndexer
- **Version**: 1.0.0
- **Publisher**: gkAgent
- **License**: MIT
- **Homepage**: https://gkagent.jp/

### Description
社内ファイルサーバー & ローカル全文検索デスクトップアプリ。
Rust + Tantivy で動作。インストール不要の portable exe。UNCネットワーク共有対応。

### Installer
- Type: portable
- Architecture: x64
- SHA256: D84ACE9CFBDEA5638705830350E9AD68078C0E243D46C6F5D6A4ECA2A22E46B4
- URL: https://github.com/gkAgent/gkIndexer/releases/download/v1.0.0/gkindexer.exe

### Checklist
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there are no other open pull requests for the same package update/version?
- [x] Have you validated your manifest(s) with `winget validate --manifest <path>`?
- [x] Have you tested your manifest(s) locally with `winget install --manifest <path>`?
- [x] If the installer is an `.exe`, have you verified that it is not a UWP or MSIX app?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/372474)