### PR TITLE
New version: MBrassey.agtop version 2.4.17

### DIFF
--- a/manifests/m/MBrassey/agtop/2.4.17/MBrassey.agtop.installer.yaml
+++ b/manifests/m/MBrassey/agtop/2.4.17/MBrassey.agtop.installer.yaml
@@ -1,0 +1,14 @@
+PackageIdentifier: MBrassey.agtop
+PackageVersion: 2.4.17
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: agtop-windows-x86_64\agtop.exe
+    PortableCommandAlias: agtop
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/MBrassey/agtop/releases/download/v2.4.17/agtop-windows-x86_64.zip
+    InstallerSha256: 03D4D210DB68EACCCF40F9EEF708F78AD199990240F15DA685CAE7E883D92C2A
+ReleaseDate: 2026-05-01
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/MBrassey/agtop/2.4.17/MBrassey.agtop.locale.en-US.yaml
+++ b/manifests/m/MBrassey/agtop/2.4.17/MBrassey.agtop.locale.en-US.yaml
@@ -1,0 +1,41 @@
+PackageIdentifier: MBrassey.agtop
+PackageVersion: 2.4.17
+PackageLocale: en-US
+Publisher: Matt Brassey
+PublisherUrl: https://github.com/MBrassey
+PublisherSupportUrl: https://github.com/MBrassey/agtop/issues
+Author: Matt Brassey
+PackageName: agtop
+PackageUrl: https://github.com/MBrassey/agtop
+License: MIT
+LicenseUrl: https://github.com/MBrassey/agtop/blob/main/LICENSE
+ShortDescription: Process monitor for AI coding agents (Claude Code, Codex, Aider, Gemini, Goose).
+Description: |-
+  agtop is a top-style ratatui TUI that walks /proc on Linux
+  (sysinfo on Windows / macOS / *BSD) plus the on-disk session
+  transcripts of Claude Code, OpenAI Codex, Block Goose, Aider,
+  and Google Gemini.  For each detected agent it reports CPU,
+  RSS, status, current tool / task, in-flight subagents,
+  cumulative token usage, estimated cost, context-window fill,
+  loaded skills, and a live transcript preview.
+
+  On Windows, writable-FD enumeration uses NtQuerySystemInformation
+  + DuplicateHandle to surface what files each agent has open.
+  Per-process IO byte counters come from sysinfo's disk_usage().
+Moniker: agtop
+Tags:
+  - agent
+  - ai
+  - aider
+  - claude
+  - cli
+  - codex
+  - gemini
+  - goose
+  - htop
+  - monitor
+  - process
+  - top
+  - tui
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/MBrassey/agtop/2.4.17/MBrassey.agtop.yaml
+++ b/manifests/m/MBrassey/agtop/2.4.17/MBrassey.agtop.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: MBrassey.agtop
+PackageVersion: 2.4.17
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## MBrassey.agtop 2.4.17

Adds agtop, a process monitor for AI coding agents, to winget.

agtop walks /proc on Linux (sysinfo on Windows) plus the on-disk
session transcripts of Claude Code, OpenAI Codex, Block Goose,
Aider, and Google Gemini, and reports per-agent CPU, RSS, status,
current tool, in-flight subagents, token usage, estimated cost,
context-window fill, and loaded skills in a top-style TUI.

### Windows-specific notes

- Writable-FD enumeration uses `NtQuerySystemInformation`
  (`SystemExtendedHandleInformation`) + `DuplicateHandle` +
  `GetFinalPathNameByHandleW` to surface what files each agent
  has open. Source: `src/writing_files.rs`.
- Per-process IO byte counters come from sysinfo's
  `Process::disk_usage().total_*`.
- Build matrix runs `cargo test --release` on windows-latest
  every push; the writable-FD self-test exercises the native
  path against the test process's own open file descriptor.

### Source / metadata

- Upstream: https://github.com/MBrassey/agtop
- License: MIT
- Installer: portable zip from the official GitHub Release
- Architecture: x64
- SHA256 verified against the release's SHA256SUMS

#### Author / Manifest checklist

- [x] I have read the [contributing guide](https://github.com/microsoft/winget-pkgs/blob/master/CONTRIBUTING.md)
- [x] Manifests follow the v1.6.0 schema
- [x] Installer URL points at the official GitHub Release
- [x] InstallerSha256 matches the release's SHA256SUMS
- [x] Three manifest files: version, installer, locale.en-US
- [x] Maintainer is the upstream author

I'm the upstream maintainer (`matt@brassey.io`) — happy to iterate
on any review feedback.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/372526)