### PR TITLE
Remove explicit dependency `Microsoft.DSC` 3.2.0

### DIFF
--- a/manifests/m/Microsoft/DSC/3.2.0/Microsoft.DSC.installer.yaml
+++ b/manifests/m/Microsoft/DSC/3.2.0/Microsoft.DSC.installer.yaml
@@ -17,9 +17,6 @@ Installers:
   InstallerUrl: https://github.com/PowerShell/DSC/releases/download/v3.2.0/DSC-3.2.0-Win.msixbundle
   InstallerSha256: 55FBB42B56203C9117CFC8BAD43F9BB4228F4EB2CBFA06F28C7889E006F6581A
   SignatureSha256: 71E99B059C21749E38688FF58854979E7B2A80861441AE846B288EA87A187779
-  Dependencies:
-    PackageDependencies:
-    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
   PackageFamilyName: Microsoft.DesiredStateConfiguration_8wekyb3d8bbwe
 - Architecture: x64
   InstallerType: zip
@@ -29,9 +26,6 @@ Installers:
     PortableCommandAlias: dsc
   InstallerUrl: https://github.com/PowerShell/DSC/releases/download/v3.2.0/DSC-3.2.0-x86_64-pc-windows-msvc.zip
   InstallerSha256: 638F5E93197EBE64D6D15DE743773728E0F0ED22407BD4DECC69581E42D43194
-  Dependencies:
-    PackageDependencies:
-    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
   AppsAndFeaturesEntries:
   - DisplayName: DSC v3 (Portable x64)
 - Platform:
@@ -41,9 +35,6 @@ Installers:
   InstallerUrl: https://github.com/PowerShell/DSC/releases/download/v3.2.0/DSC-3.2.0-Win.msixbundle
   InstallerSha256: 55FBB42B56203C9117CFC8BAD43F9BB4228F4EB2CBFA06F28C7889E006F6581A
   SignatureSha256: 71E99B059C21749E38688FF58854979E7B2A80861441AE846B288EA87A187779
-  Dependencies:
-    PackageDependencies:
-    - PackageIdentifier: Microsoft.VCRedist.2015+.arm64
   PackageFamilyName: Microsoft.DesiredStateConfiguration_8wekyb3d8bbwe
 - Architecture: arm64
   InstallerType: zip
@@ -53,9 +44,6 @@ Installers:
     PortableCommandAlias: dsc
   InstallerUrl: https://github.com/PowerShell/DSC/releases/download/v3.2.0/DSC-3.2.0-aarch64-pc-windows-msvc.zip
   InstallerSha256: B4028A87E7EDF5CCD2EB6487529CD395A8311CEE88F31CCAD670EB1AB42DDF28
-  Dependencies:
-    PackageDependencies:
-    - PackageIdentifier: Microsoft.VCRedist.2015+.arm64
   AppsAndFeaturesEntries:
   - DisplayName: DSC v3 (Portable ARM64)
 ManifestType: installer


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
Removes `Microsoft.VCRedist.2015+` as explicit package dependency.

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #372565 372565

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/372568)