### PR TITLE
Microsoft.DirectXTex.Texassemble updated for May 2026 release

### DIFF
--- a/manifests/m/Microsoft/DirectXTex/Texassemble/2026.5.7/Microsoft.DirectXTex.Texassemble.installer.yaml
+++ b/manifests/m/Microsoft/DirectXTex/Texassemble/2026.5.7/Microsoft.DirectXTex.Texassemble.installer.yaml
@@ -1,0 +1,32 @@
+# Created with komac v2.12.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.DirectXTex.Texassemble
+PackageVersion: 2026.5.7
+InstallerType: portable
+Commands:
+- texassemble
+FileExtensions:
+- bmp
+- dds
+- hdr
+- jpg
+- jxr
+- png
+- tga
+ReleaseDate: 2026-05-07
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/microsoft/DirectXTex/releases/download/may2026/texassemble.exe
+  InstallerSha256: 324721a80cf954eccfd888a6c587f6602146f043a01d0181af25884c549e8f46
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+- Architecture: arm64
+  InstallerUrl: https://github.com/microsoft/DirectXTex/releases/download/may2026/texassemble_arm64.exe
+  InstallerSha256: e8293f4e285f2039388f52a80b107f58f466b403084ee0a69930a1f9efd5003c
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.arm64
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/Microsoft/DirectXTex/Texassemble/2026.5.7/Microsoft.DirectXTex.Texassemble.locale.en-US.yaml
+++ b/manifests/m/Microsoft/DirectXTex/Texassemble/2026.5.7/Microsoft.DirectXTex.Texassemble.locale.en-US.yaml
@@ -1,0 +1,50 @@
+# Created with komac v2.12.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.DirectXTex.Texassemble
+PackageVersion: 2026.5.7
+PackageLocale: en-US
+Publisher: Microsoft Corporation
+PublisherUrl: https://www.microsoft.com/
+PublisherSupportUrl: https://github.com/microsoft/DirectXTex/issues
+Author: Microsoft Corporation
+PackageName: DirectX Texture Assembler
+PackageUrl: https://github.com/microsoft/DirectXTex/wiki/Texassemble
+License: MIT
+LicenseUrl: https://github.com/microsoft/DirectXTex/raw/refs/heads/main/LICENSE
+Copyright: Copyright (c) Microsoft Corp.
+ShortDescription: Texassemble is a command-line tool from Microsoft's DirectXTex library, designed for assembling and processing texture arrays, cubemaps, volume maps, and other complex texture types.
+Description: |-
+  Texassemble is a command-line tool from Microsoft's DirectXTex library, designed for assembling and processing texture arrays, cubemaps, volume maps, and other complex texture types. It works alongside texconv (which handles single-texture operations) to create combined texture resources.
+
+  Key Features:
+  - Texture Arrays: Combines multiple 2D textures into a single texture array (.dds).
+  - Cubemaps: Assembles six faces (or a strip) into a cubemap texture.
+  - Volume Maps: Constructs 3D textures from a series of 2D slices.
+  - Mipmap Support: Generates mipmaps for assembled textures.
+  - Format Conversion: Supports standard formats (DDS, PNG, TGA, etc.) and block compression (BC1-BC7).
+  - Alpha & Metadata Handling: Preserves transparency and metadata where applicable.
+Moniker: texassemble
+Tags:
+- dds
+- direct3d
+- direct3d-texture-resources
+- directx
+- directx-11
+- directx-12
+- directxtex
+- microsoft
+- textures
+- wic-codec
+- xbox
+- command-line
+ReleaseNotesUrl: https://github.com/microsoft/DirectXTex/releases/tag/may2026
+Documentations:
+- DocumentLabel: Texassemble Wiki Page
+  DocumentUrl: https://github.com/microsoft/DirectXTex/wiki/Texassemble
+- DocumentLabel: DirectXTex Wiki
+  DocumentUrl: https://github.com/microsoft/DirectXTex/wiki
+- DocumentLabel: DirectXTex texture processing library
+  DocumentUrl: https://github.com/microsoft/DirectXTex
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/Microsoft/DirectXTex/Texassemble/2026.5.7/Microsoft.DirectXTex.Texassemble.yaml
+++ b/manifests/m/Microsoft/DirectXTex/Texassemble/2026.5.7/Microsoft.DirectXTex.Texassemble.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.12.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.DirectXTex.Texassemble
+PackageVersion: 2026.5.7
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description
The May 2026 release of DirectXTex is primarily to address a security bug report.

MSRC 113265 - DirectXTex - DirectXTexHDR.cpp:LoadFromHDRFile - Adaptive RLE OOB read via bad bounds-check

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/372569)