### PR TITLE
Microsoft.DirectXTex.Texconv updated for May 2026 release

### DIFF
--- a/manifests/m/Microsoft/DirectXTex/Texconv/2026.5.7/Microsoft.DirectXTex.Texconv.installer.yaml
+++ b/manifests/m/Microsoft/DirectXTex/Texconv/2026.5.7/Microsoft.DirectXTex.Texconv.installer.yaml
@@ -1,0 +1,38 @@
+# Created with komac v2.12.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.DirectXTex.Texconv
+PackageVersion: 2026.5.7
+InstallerType: portable
+Commands:
+- texconv
+FileExtensions:
+- bmp
+- dds
+- hdr
+- heif
+- jpg
+- jxr
+- pfm
+- phm
+- png
+- ppm
+- tga
+- wepb
+ReleaseDate: 2026-05-07
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/microsoft/DirectXTex/releases/download/may2026/texconv.exe
+  InstallerSha256: dcfdec10244e02cf5037fba089c55fb7e1326b1c8181742d77d15fa5cb5eef06
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+- Architecture: arm64
+  InstallerUrl: https://github.com/microsoft/DirectXTex/releases/download/may2026/texconv_arm64.exe
+  InstallerSha256: 4cea9738f92dbadd5955d545edb67aa6ba1e9c3b24f32462bf2e1791cbe713f8
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.arm64
+ManifestType: installer
+ManifestVersion: 1.12.0
+

--- a/manifests/m/Microsoft/DirectXTex/Texconv/2026.5.7/Microsoft.DirectXTex.Texconv.locale.en-US.yaml
+++ b/manifests/m/Microsoft/DirectXTex/Texconv/2026.5.7/Microsoft.DirectXTex.Texconv.locale.en-US.yaml
@@ -1,0 +1,49 @@
+# Created with komac v2.12.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.DirectXTex.Texconv
+PackageVersion: 2026.5.7
+PackageLocale: en-US
+Publisher: Microsoft Corporation
+PublisherUrl: https://www.microsoft.com/
+PublisherSupportUrl: https://github.com/microsoft/DirectXTex/issues
+Author: Microsoft Corporation
+PackageName: DirectX Texture Converter
+PackageUrl: https://github.com/Microsoft/DirectXTex/wiki/Texconv
+License: MIT
+LicenseUrl: https://github.com/microsoft/DirectXTex/raw/refs/heads/main/LICENSE
+Copyright: Copyright (c) Microsoft Corp.
+ShortDescription: This DirectXTex sample is an implementation of the texconv command-line texture utility from the legacy DirectX SDK utilizing DirectXTex rather than D3DX.
+Description: |-
+  Texconv is a command-line texture conversion tool developed by Microsoft as part of the DirectXTex library. It is designed for processing and converting texture files (e.g., DDS, PNG, TGA, BMP, etc.) with support for various formats, mipmaps, compression, and other texture operations.
+
+  Key Features:
+  - Format Conversion: Supports common formats like DDS, PNG, JPEG, TGA, BMP, HDR, and more.
+  - Mipmap Generation: Automatically generates mipmaps for textures.
+  - Compression: Supports BC (Block Compression) formats (BC1-BC7) for DDS files.
+  - Cube Maps & Arrays: Handles texture arrays and cube maps.
+  - Metadata & Alpha Handling: Preserves or modifies alpha channels and metadata.
+  - HDR & WIC Support: Works with high dynamic range (HDR) images and Windows Imaging Component (WIC) codecs.
+Moniker: Texconv
+Tags:
+- dds
+- direct3d
+- directx
+- directx-11
+- directx-12
+- directxtex
+- microsoft
+- textures
+- wic-codec
+- xbox
+- command-line
+ReleaseNotesUrl: https://github.com/microsoft/DirectXTex/releases/tag/may2026
+Documentations:
+- DocumentLabel: Texconv Wiki Page
+  DocumentUrl: https://github.com/microsoft/DirectXTex/wiki/Texconv
+- DocumentLabel: DirectXTex Wiki
+  DocumentUrl: https://github.com/microsoft/DirectXTex/wiki
+- DocumentLabel: DirectXTex texture processing library
+  DocumentUrl: https://github.com/microsoft/DirectXTex
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/Microsoft/DirectXTex/Texconv/2026.5.7/Microsoft.DirectXTex.Texconv.yaml
+++ b/manifests/m/Microsoft/DirectXTex/Texconv/2026.5.7/Microsoft.DirectXTex.Texconv.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.12.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.DirectXTex.Texconv
+PackageVersion: 2026.5.7
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description
The May 2026 release of DirectXTex is primarily to address a security bug report.

MSRC 113265 - DirectXTex - DirectXTexHDR.cpp:LoadFromHDRFile - Adaptive RLE OOB read via bad bounds-check

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/372570)