### PR TITLE
Microsoft.DirectXTex.Texdiag updated for May 2026 release

### DIFF
--- a/manifests/m/Microsoft/DirectXTex/Texdiag/2026.5.7/Microsoft.DirectXTex.Texdiag.installer.yaml
+++ b/manifests/m/Microsoft/DirectXTex/Texdiag/2026.5.7/Microsoft.DirectXTex.Texdiag.installer.yaml
@@ -1,0 +1,32 @@
+# Created with komac v2.12.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.DirectXTex.Texdiag
+PackageVersion: 2026.5.7
+InstallerType: portable
+Commands:
+- texdiag
+FileExtensions:
+- bmp
+- dds
+- hdr
+- jpg
+- jxr
+- png
+- tga
+ReleaseDate: 2026-05-07
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/microsoft/DirectXTex/releases/download/may2026/texdiag.exe
+  InstallerSha256: 411c303c98ba73e4423376f717ac139347dd749bf80a7fc1a22368ab1088ff56
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+- Architecture: arm64
+  InstallerUrl: https://github.com/microsoft/DirectXTex/releases/download/may2026/texdiag_arm64.exe
+  InstallerSha256: aa43a1d93a96c512fea5909975e2ef63310d98108d664c1d94d67f57831db97e
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.arm64
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/Microsoft/DirectXTex/Texdiag/2026.5.7/Microsoft.DirectXTex.Texdiag.locale.en-US.yaml
+++ b/manifests/m/Microsoft/DirectXTex/Texdiag/2026.5.7/Microsoft.DirectXTex.Texdiag.locale.en-US.yaml
@@ -1,0 +1,49 @@
+# Created with komac v2.12.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.DirectXTex.Texdiag
+PackageVersion: 2026.5.7
+PackageLocale: en-US
+Publisher: Microsoft Corporation
+PublisherUrl: https://www.microsoft.com/
+PublisherSupportUrl: https://github.com/microsoft/DirectXTex/issues
+Author: Microsoft Corporation
+PackageName: DirectX Texture Diagnostic Tool
+PackageUrl: https://github.com/microsoft/DirectXTex/wiki/Texdiag
+License: MIT
+LicenseUrl: https://github.com/microsoft/DirectXTex/raw/refs/heads/main/LICENSE
+Copyright: Copyright (c) Microsoft Corp.
+ShortDescription: Texdiag is a diagnostic command-line tool from Microsoft's DirectXTex library, designed for analyzing and debugging texture files (e.g., DDS, PNG, TGA).
+Description: |-
+  Texdiag is a diagnostic command-line tool from Microsoft's DirectXTex library, designed for analyzing and debugging texture files (e.g., DDS, PNG, TGA). Unlike texconv (conversion) and texassemble (texture combining), texdiag focuses on inspecting texture properties, validating data, and detecting errors.
+
+  Key Features:
+  - Texture Info Dump: Displays metadata (format, dimensions, mip levels, array size, etc.).
+  - Error Detection: Checks for corrupted or malformed texture files.
+  - Pixel Analysis: Examines specific pixel values (useful for debugging artifacts).
+  - Comparison Mode: Compares two textures (e.g., before/after compression).
+  - DDS Validation: Verifies if a DDS file follows format specifications.
+Moniker: texdiag
+Tags:
+- dds
+- direct3d
+- direct3d-texture-resources
+- directx
+- directx-11
+- directx-12
+- directxtex
+- microsoft
+- textures
+- wic-codec
+- xbox
+- command-line
+ReleaseNotesUrl: https://github.com/microsoft/DirectXTex/releases/tag/may2026
+Documentations:
+- DocumentLabel: Texdiag Wiki Page
+  DocumentUrl: https://github.com/microsoft/DirectXTex/wiki/Texdiag
+- DocumentLabel: DirectXTex Wiki
+  DocumentUrl: https://github.com/microsoft/DirectXTex/wiki
+- DocumentLabel: DirectXTex texture processing library
+  DocumentUrl: https://github.com/microsoft/DirectXTex
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/Microsoft/DirectXTex/Texdiag/2026.5.7/Microsoft.DirectXTex.Texdiag.yaml
+++ b/manifests/m/Microsoft/DirectXTex/Texdiag/2026.5.7/Microsoft.DirectXTex.Texdiag.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.12.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.DirectXTex.Texdiag
+PackageVersion: 2026.5.7
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description
The May 2026 release of DirectXTex is primarily to address a security bug report.

MSRC 113265 - DirectXTex - DirectXTexHDR.cpp:LoadFromHDRFile - Adaptive RLE OOB read via bad bounds-check

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/372571)