### PR TITLE
Update Pwlot.ChunkyMonkey version 0.7.0

### DIFF
--- a/manifests/p/Pwlot/ChunkyMonkey/0.7.0/Pwlot.ChunkyMonkey.installer.yaml
+++ b/manifests/p/Pwlot/ChunkyMonkey/0.7.0/Pwlot.ChunkyMonkey.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: Pwlot.ChunkyMonkey
+PackageVersion: 0.7.0
+InstallerType: inno
+Scope: user
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/pwlot/ChunkyMonkey/releases/download/v0.7.0/ChunkyMonkeySetup.exe
+  InstallerSha256: F0FC92F0CCA2D59BFE4FD3D4D0AA879753B850CA36BF7B3708CECA64B5778972
+InstallerSwitches:
+  Silent: /VERYSILENT /NORESTART
+  SilentWithProgress: /SILENT /NORESTART
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/p/Pwlot/ChunkyMonkey/0.7.0/Pwlot.ChunkyMonkey.locale.en-US.yaml
+++ b/manifests/p/Pwlot/ChunkyMonkey/0.7.0/Pwlot.ChunkyMonkey.locale.en-US.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: Pwlot.ChunkyMonkey
+PackageVersion: 0.7.0
+PackageLocale: en-US
+Publisher: Pwlot
+PublisherUrl: https://www.pwlot.com
+PackageName: ChunkyMonkey
+PackageUrl: https://chunkymonkey.dev
+License: Proprietary
+ShortDescription: Git/LFS desktop app and CLI for large game, ML, media, and research repos.
+Description: ChunkyMonkey auto-chunks large Git commits, checks Git LFS risk, and helps push large repositories with progress and safer smaller steps.
+Tags:
+- git
+- git-lfs
+- gamedev
+- machine-learning
+- cli
+- large-files
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/p/Pwlot/ChunkyMonkey/0.7.0/Pwlot.ChunkyMonkey.yaml
+++ b/manifests/p/Pwlot/ChunkyMonkey/0.7.0/Pwlot.ChunkyMonkey.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: Pwlot.ChunkyMonkey
+PackageVersion: 0.7.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Updates Pwlot.ChunkyMonkey to 0.7.0. Installer URL and SHA-256 come from the public GitHub Release. Also updates PackageUrl to chunkymonkey.dev.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/372617)