### PR TITLE
New package version: Finesssee.Win-CodexBar version 0.24.1

### DIFF
--- a/manifests/f/Finesssee/Win-CodexBar/0.24.1/Finesssee.Win-CodexBar.installer.yaml
+++ b/manifests/f/Finesssee/Win-CodexBar/0.24.1/Finesssee.Win-CodexBar.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Finesssee.Win-CodexBar
+PackageVersion: 0.24.1
+InstallerType: inno
+Scope: user
+UpgradeBehavior: install
+ProductCode: WinCodexBar_is1
+ReleaseDate: 2026-05-11
+AppsAndFeaturesEntries:
+- ProductCode: WinCodexBar_is1
+  DisplayName: CodexBar 0.24.1
+  DisplayVersion: 0.24.1
+  Publisher: CodexBar Contributors
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Finesssee/Win-CodexBar/releases/download/v0.24.1/CodexBar-0.24.1-Setup.exe
+  InstallerSha256: 5C57DCCC00B635600B84C311BCB8BBF696739AFC8F286E2099E13652CB11B4C3
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Finesssee/Win-CodexBar/0.24.1/Finesssee.Win-CodexBar.locale.en-US.yaml
+++ b/manifests/f/Finesssee/Win-CodexBar/0.24.1/Finesssee.Win-CodexBar.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Finesssee.Win-CodexBar
+PackageVersion: 0.24.1
+PackageLocale: en-US
+Publisher: CodexBar Contributors
+PublisherUrl: https://github.com/Finesssee
+PublisherSupportUrl: https://github.com/Finesssee/Win-CodexBar/issues
+Author: Finesssee
+PackageName: Win-CodexBar
+PackageUrl: https://github.com/Finesssee/Win-CodexBar
+License: MIT
+LicenseUrl: https://github.com/Finesssee/Win-CodexBar/blob/main/LICENSE
+Copyright: Copyright (c) CodexBar contributors
+ShortDescription: Windows-native menu bar app for OpenAI Codex and Claude Code usage stats.
+Description: Win-CodexBar is a Windows-native desktop app for viewing OpenAI Codex and Claude Code usage stats from a small Tauri shell.
+Moniker: win-codexbar
+Tags:
+- claude-code
+- codex
+- desktop
+- tauri
+- usage
+- windows
+ReleaseNotes: |-
+  v0.24.1 fixes the Windows installer so clean Windows machines install Microsoft Edge WebView2 Runtime before CodexBar launches. It also includes the v0.24 provider additions for Codebuff, DeepSeek, and Windsurf.
+ReleaseNotesUrl: https://github.com/Finesssee/Win-CodexBar/releases/tag/v0.24.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Finesssee/Win-CodexBar/0.24.1/Finesssee.Win-CodexBar.yaml
+++ b/manifests/f/Finesssee/Win-CodexBar/0.24.1/Finesssee.Win-CodexBar.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Finesssee.Win-CodexBar
+PackageVersion: 0.24.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Packages: Finesssee.Win-CodexBar

Validation:
- Verified GitHub release asset exists: https://github.com/Finesssee/Win-CodexBar/releases/download/v0.24.1/CodexBar-0.24.1-Setup.exe
- Verified installer SHA256: 5C57DCCC00B635600B84C311BCB8BBF696739AFC8F286E2099E13652CB11B4C3
- Verified installer type: Inno Setup
- Verified silent install switches on Windows Server 2025: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
- Verified installed registry version: CodexBar 0.24.1 / 0.24.1
- Verified installed exe product version: 0.24.1
- Verified Start Menu/Desktop shortcuts were created
- Verified Microsoft Edge WebView2 Runtime was present after installer bootstrap
- Verified app process stayed running/responding with zero recent CodexBar/WebView application errors
- Verified silent uninstall completed successfully

Note: local winget validate could not be run on the Windows Server validation VM because winget is not installed on that server image; relying on the winget validation pipeline for schema/package validation.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/372677)