### PR TITLE
New version: lainx86.InterpKit version 2.0.0

### DIFF
--- a/manifests/l/lainx86/InterpKit/2.0.0/lainx86.InterpKit.installer.yaml
+++ b/manifests/l/lainx86/InterpKit/2.0.0/lainx86.InterpKit.installer.yaml
@@ -1,0 +1,16 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: lainx86.InterpKit
+PackageVersion: 2.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: interpkit.exe
+  PortableCommandAlias: interpkit
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/lainx86/InterpKit/releases/download/v2.0.0/InterpKit-v2.0.0-Windows-x64.zip
+  InstallerSha256: EC6DEEF940A70054F26D958D6F2F6580C2C8E8856E98EA1DEAE24783E4CF68B9
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/l/lainx86/InterpKit/2.0.0/lainx86.InterpKit.locale.en-US.yaml
+++ b/manifests/l/lainx86/InterpKit/2.0.0/lainx86.InterpKit.locale.en-US.yaml
@@ -1,0 +1,12 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: lainx86.InterpKit
+PackageVersion: 2.0.0
+PackageLocale: en-US
+Publisher: lainx86
+PackageName: InterpKit
+License: MIT License
+ShortDescription: CLI tool for d/L0 to d/L function table lookup and interpolation
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/l/lainx86/InterpKit/2.0.0/lainx86.InterpKit.yaml
+++ b/manifests/l/lainx86/InterpKit/2.0.0/lainx86.InterpKit.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: lainx86.InterpKit
+PackageVersion: 2.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update: lainx86.InterpKit to 2.0.0

## 📖 Description
Updates InterpKit to version 2.0.0.

This release updates the Windows x64 portable ZIP installer URL and SHA256 checksum for the v2.0.0 GitHub release.

## ✅ Checklist
- [ x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)


## 📦 Manifest Checklist

- [x ] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [ x] This PR only modifies one (1) manifest
- [ x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x ] Tested manifest locally with `winget install --manifest <path>`
- [x ] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/372688)