### PR TITLE
New package: Feci.ParleyDeckSkill version 1.0.4

### DIFF
--- a/manifests/f/Feci/ParleyDeckSkill/1.0.4/Feci.ParleyDeckSkill.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/1.0.4/Feci.ParleyDeckSkill.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 1.0.4
+InstallerType: portable
+Commands:
+- parley-deck-skill
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-skill/releases/download/v1.0.4/parley-deck-skill-v1.0.4-windows-x64.exe
+  InstallerSha256: 7725808D4C4A3841F2E7C781082FD1F1BF7668F514A5571C4973F3D81CE5F602
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-skill/releases/download/v1.0.4/parley-deck-skill-v1.0.4-windows-arm64.exe
+  InstallerSha256: C6A960EDF574CD34E89D3125CFCDC1A73E83F9D1025EDEF7B6C9D407B057479E
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckSkill/1.0.4/Feci.ParleyDeckSkill.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/1.0.4/Feci.ParleyDeckSkill.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 1.0.4
+PackageLocale: en-US
+Publisher: Feci
+PublisherUrl: https://github.com/feci
+PackageName: Parley Deck Skill
+PackageUrl: https://github.com/feci/parley-deck-skill
+License: Apache-2.0
+LicenseUrl: https://github.com/feci/parley-deck-skill/blob/main/LICENSE
+ShortDescription: Installer for the Parley Deck multi-agent cooperation skill.
+Description: Installs the vendor-neutral Parley Deck AI cooperation skill into Codex, Claude Code, Gemini CLI, or a custom skill directory.
+Tags:
+- ai
+- agents
+- cli
+- codex
+- claude
+- gemini
+- multi-agent
+- skill
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckSkill/1.0.4/Feci.ParleyDeckSkill.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/1.0.4/Feci.ParleyDeckSkill.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 1.0.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Adds WinGet manifests for Feci.ParleyDeckSkill version 1.0.4.

Installer type: portable  
Command: parley-deck-skill  
Release assets: https://github.com/feci/parley-deck-skill/releases/tag/v1.0.4

The package installs the standalone Parley Deck Skill installer executable. Users can then run:

```powershell
parley-deck-skill install --target all --force
```

YAML parsing was checked locally; full WinGet validation is expected to run in the winget-pkgs CI.