### PR TITLE
New package: AsimAftab.Odin version 0.2.0

### DIFF
--- a/manifests/a/AsimAftab/Odin/0.2.0/AsimAftab.Odin.installer.yaml
+++ b/manifests/a/AsimAftab/Odin/0.2.0/AsimAftab.Odin.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: AsimAftab.Odin
+PackageVersion: 0.2.0
+InstallerLocale: en-US
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: portable
+Scope: user
+Commands:
+  - odin
+ReleaseDate: 2026-05-11
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/AsimAftab/Project-Odin/releases/download/v0.2.0/odin.exe
+    InstallerSha256: B1A04333CD2B43BAB47EF44E794631418EBA3EF22E36B38F38908686AB84A027
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/a/AsimAftab/Odin/0.2.0/AsimAftab.Odin.locale.en-US.yaml
+++ b/manifests/a/AsimAftab/Odin/0.2.0/AsimAftab.Odin.locale.en-US.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: AsimAftab.Odin
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: Asim Aftab
+PublisherUrl: https://github.com/AsimAftab
+PublisherSupportUrl: https://github.com/AsimAftab/Project-Odin/issues
+Author: Asim Aftab
+PackageName: Odin
+PackageUrl: https://github.com/AsimAftab/Project-Odin
+License: MIT
+LicenseUrl: https://github.com/AsimAftab/Project-Odin/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Odin contributors
+ShortDescription: Windows developer workstation snapshot, restore, sync, and diagnostics CLI.
+Description: |-
+  Odin is a Windows-first developer environment management CLI. It snapshots the tools,
+  package managers, shell profiles, Git settings, VS Code extensions, terminal settings,
+  environment variables, and PATH state needed to recreate a workstation - then restores,
+  diffs, syncs to a private GitHub repo, and reports diagnostics. Includes process/port
+  management (ports, ps, kill) and a time-machine history (history, rollback).
+Moniker: odin
+Tags:
+  - cli
+  - backup
+  - restore
+  - developer-tools
+  - snapshot
+  - windows
+ReleaseNotesUrl: https://github.com/AsimAftab/Project-Odin/releases/tag/v0.2.0
+InstallationNotes: |-
+  Odin is now on PATH. Open a new terminal and run any odin command - the
+  workspace at %USERPROFILE%\.odin will be created automatically on first use.
+  For interactive setup with PATH validation and dependency checks, run:
+
+      odin init
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/a/AsimAftab/Odin/0.2.0/AsimAftab.Odin.yaml
+++ b/manifests/a/AsimAftab/Odin/0.2.0/AsimAftab.Odin.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# Mirrors the layout under microsoft/winget-pkgs/manifests/a/AsimAftab/Odin/0.2.0/.
+# For first-time submission run:  wingetcreate new https://github.com/AsimAftab/Project-Odin/releases/download/v0.2.0/odin.exe
+# Subsequent releases are auto-published by .github/workflows/winget.yml.
+
+PackageIdentifier: AsimAftab.Odin
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Reason for change

Initial submission of `AsimAftab.Odin` to the Windows Package Manager Community Repository.

**Odin** is a Windows-first developer environment management CLI. It snapshots installed tools, package managers, shell profiles, Git settings, VS Code extensions, terminal settings, environment variables, and PATH state, then restores, diffs, syncs to a private GitHub repo, and reports diagnostics. Also includes process/port management (`ports`, `ps`, `kill`) and time-machine history (`history`, `rollback`).

Project home: https://github.com/AsimAftab/Project-Odin
Release: https://github.com/AsimAftab/Project-Odin/releases/tag/v0.2.0

### Manifest validation

- `InstallerType: portable`, `Scope: user`, `Commands: [odin]` — single-file CLI; winget will create the symlink in `Links\` so `odin` is on PATH automatically.
- `InstallerSha256` was computed from the actual released asset (`odin.exe`, ~3.2 MB) and verified locally before submission.
- Schema: 1.6.0 across all three manifests (version, installer, locale.en-US).

### Microsoft Reviewers: [Open in CodeFlow](https://aka.ms/winget-codeflow?pullrequestid=)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/372699)