### PR TITLE
New package: heartached.Noctis version 1.1.5

### DIFF
--- a/manifests/h/heartached/Noctis/1.1.5/heartached.Noctis.installer.yaml
+++ b/manifests/h/heartached/Noctis/1.1.5/heartached.Noctis.installer.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: heartached.Noctis
+PackageVersion: 1.1.5
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  SilentWithProgress: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+UpgradeBehavior: install
+AppsAndFeaturesEntries:
+  - DisplayName: Noctis
+    Publisher: heartached
+    DisplayVersion: 1.1.5
+    ProductCode: '{E8A3B5F1-7C2D-4A9E-B6F0-1D3E5A7C9B2F}_is1'
+    InstallerType: inno
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/heartached/Noctis/releases/download/v1.1.5/Noctis-v1.1.5-Setup.exe
+    InstallerSha256: 9CA7B23E8344690DE770794C3E5340539D1198554BFFF7169F127D861DCE91A4
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/h/heartached/Noctis/1.1.5/heartached.Noctis.locale.en-US.yaml
+++ b/manifests/h/heartached/Noctis/1.1.5/heartached.Noctis.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: heartached.Noctis
+PackageVersion: 1.1.5
+PackageLocale: en-US
+Publisher: heartached
+PublisherUrl: https://github.com/heartached
+PublisherSupportUrl: https://github.com/heartached/Noctis/issues
+PackageName: Noctis
+PackageUrl: https://github.com/heartached/Noctis
+License: MIT
+LicenseUrl: https://github.com/heartached/Noctis/blob/main/LICENSE
+Copyright: Copyright (c) 2026 heartached
+ShortDescription: A music player that respects what's yours.
+Description: |-
+  Noctis is a desktop music player for your local library — fast browsing,
+  synced lyrics, metadata editing, EQ, and more.
+Tags:
+  - music
+  - music-player
+  - audio
+  - player
+  - lyrics
+  - avalonia
+ReleaseNotesUrl: https://github.com/heartached/Noctis/releases/tag/v1.1.5
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/h/heartached/Noctis/1.1.5/heartached.Noctis.yaml
+++ b/manifests/h/heartached/Noctis/1.1.5/heartached.Noctis.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: heartached.Noctis
+PackageVersion: 1.1.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: `heartached.Noctis` version `1.1.5`

Noctis — a desktop music player for your local library (FLAC/ALAC/MP3/etc., synced lyrics, metadata editor, EQ, gapless/crossfade).

- Homepage / source: https://github.com/heartached/Noctis
- Installer: Inno Setup, per-user (`PrivilegesRequired=lowest`), silent install supported
- Installer asset: https://github.com/heartached/Noctis/releases/download/v1.1.5/Noctis-v1.1.5-Setup.exe

Future versions will be submitted automatically via komac from the project's release workflow.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/372783)