### PR TITLE
Add haxllo.partboot version 0.2.0

### DIFF
--- a/manifests/h/Haxllo/PartBoot/0.2.0/Haxllo.PartBoot.installer.yaml
+++ b/manifests/h/Haxllo/PartBoot/0.2.0/Haxllo.PartBoot.installer.yaml
@@ -1,0 +1,11 @@
+PackageIdentifier: haxllo.partboot
+PackageVersion: 0.2.0
+Installers:
+- Architecture: x64
+  InstallerType: portable
+  InstallerUrl: https://github.com/haxllo/partboot/releases/download/v0.2.0/partboot.exe
+  InstallerSha256: D6288BFD6287743EE048E3339DA322BC5ACE592F23AB1022B22816E74806F45E
+  Commands:
+  - partboot
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/h/Haxllo/PartBoot/0.2.0/Haxllo.PartBoot.locale.en-US.yaml
+++ b/manifests/h/Haxllo/PartBoot/0.2.0/Haxllo.PartBoot.locale.en-US.yaml
@@ -1,0 +1,22 @@
+PackageIdentifier: haxllo.partboot
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: haxllo
+PackageName: partboot
+PackageUrl: https://github.com/haxllo/partboot
+License: MIT
+ShortDescription: Disk-resident ISO boot manager prototype for Linux-first multi-ISO workflows.
+Moniker: partboot
+Tags:
+- boot
+- grub
+- iso
+- linux
+- uefi
+ReleaseNotes: |-
+  - Added full-screen interactive start flow with keyboard navigation.
+  - Added Linux-family aware multi-ISO extraction in guided flow.
+  - Improved confirmation and progress feedback for install steps.
+ReleaseNotesUrl: https://github.com/haxllo/partboot/releases/tag/v0.2.0
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/h/Haxllo/PartBoot/0.2.0/Haxllo.PartBoot.yaml
+++ b/manifests/h/Haxllo/PartBoot/0.2.0/Haxllo.PartBoot.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: haxllo.partboot
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0

--- a/manifests/h/haxllo/partboot/0.2.0/haxllo.partboot.installer.yaml
+++ b/manifests/h/haxllo/partboot/0.2.0/haxllo.partboot.installer.yaml
@@ -1,0 +1,11 @@
+PackageIdentifier: haxllo.partboot
+PackageVersion: 0.2.0
+Installers:
+- Architecture: x64
+  InstallerType: portable
+  InstallerUrl: https://github.com/haxllo/partboot/releases/download/v0.2.0/partboot.exe
+  InstallerSha256: D6288BFD6287743EE048E3339DA322BC5ACE592F23AB1022B22816E74806F45E
+  Commands:
+  - partboot
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/h/haxllo/partboot/0.2.0/haxllo.partboot.locale.en-US.yaml
+++ b/manifests/h/haxllo/partboot/0.2.0/haxllo.partboot.locale.en-US.yaml
@@ -1,0 +1,22 @@
+PackageIdentifier: haxllo.partboot
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: haxllo
+PackageName: partboot
+PackageUrl: https://github.com/haxllo/partboot
+License: MIT
+ShortDescription: Disk-resident ISO boot manager prototype for Linux-first multi-ISO workflows.
+Moniker: partboot
+Tags:
+- boot
+- grub
+- iso
+- linux
+- uefi
+ReleaseNotes: |-
+  - Added full-screen interactive start flow with keyboard navigation.
+  - Added Linux-family aware multi-ISO extraction in guided flow.
+  - Improved confirmation and progress feedback for install steps.
+ReleaseNotesUrl: https://github.com/haxllo/partboot/releases/tag/v0.2.0
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/h/haxllo/partboot/0.2.0/haxllo.partboot.yaml
+++ b/manifests/h/haxllo/partboot/0.2.0/haxllo.partboot.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: haxllo.partboot
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Summary
- Add WinGet manifests for haxllo.partboot 0.2.0
- Source installer: https://github.com/haxllo/partboot/releases/download/v0.2.0/partboot.exe

## Validation
- SHA256 updated for 0.2.0 portable binary
- Includes version, installer, and locale manifests
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/373156)