### PR TITLE
New version: PrimeBuild.LightCrosshair version 1.6.0

### DIFF
--- a/manifests/p/PrimeBuild/LightCrosshair/1.6.0/PrimeBuild.LightCrosshair.installer.yaml
+++ b/manifests/p/PrimeBuild/LightCrosshair/1.6.0/PrimeBuild.LightCrosshair.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/microsoft/winget-cli/master/schemas/json/manifests/v1.6.0/manifest.installer.schema.json
+
+PackageIdentifier: PrimeBuild.LightCrosshair
+PackageVersion: 1.6.0
+InstallerLocale: en-US
+InstallerType: exe
+Scope: user
+InstallModes:
+  - silent
+  - interactive
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART
+  Interactive: /SILENT
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/PrimeBuild-pc/LightCrosshair/releases/download/v1.6.0/LightCrosshair-Setup-1.6.0.exe
+    InstallerSha256: 414E50D3A6E24F107A48CF7A35E6C7E06A9CA4E2C3527912CC79C2BBF723EDD8
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/p/PrimeBuild/LightCrosshair/1.6.0/PrimeBuild.LightCrosshair.locale.en-US.yaml
+++ b/manifests/p/PrimeBuild/LightCrosshair/1.6.0/PrimeBuild.LightCrosshair.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/microsoft/winget-cli/master/schemas/json/manifests/v1.6.0/manifest.defaultLocale.schema.json
+
+PackageIdentifier: PrimeBuild.LightCrosshair
+PackageVersion: 1.6.0
+PackageLocale: en-US
+Publisher: PrimeBuild
+PublisherUrl: https://github.com/PrimeBuild
+PublisherSupportUrl: https://github.com/PrimeBuild-pc/LightCrosshair/issues
+PackageName: LightCrosshair
+PackageUrl: https://github.com/PrimeBuild-pc/LightCrosshair
+License: GPL-3.0
+LicenseUrl: https://github.com/PrimeBuild-pc/LightCrosshair/blob/main/LICENSE.md
+Copyright: Copyright (c) PrimeBuild
+ShortDescription: LightCrosshair is a Windows desktop application that provides a customizable crosshair overlay for gaming and other applications.
+Description: >-
+  LightCrosshair provides an on-screen crosshair overlay with FPS monitoring, frame timing,
+  GPU driver integration, and extensive customization options.
+Moniker: lightcrosshair
+Tags:
+  - crosshair
+  - overlay
+  - gaming
+  - fps
+  - gpu
+  - nvidia
+  - amd
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/p/PrimeBuild/LightCrosshair/1.6.0/PrimeBuild.LightCrosshair.yaml
+++ b/manifests/p/PrimeBuild/LightCrosshair/1.6.0/PrimeBuild.LightCrosshair.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/microsoft/winget-cli/master/schemas/json/manifests/v1.6.0/manifest.schema.json
+
+PackageIdentifier: PrimeBuild.LightCrosshair
+PackageVersion: 1.6.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Updates PrimeBuild.LightCrosshair to version 1.6.0.

Release: https://github.com/PrimeBuild-pc/LightCrosshair/releases/tag/v1.6.0

Installer:
https://github.com/PrimeBuild-pc/LightCrosshair/releases/download/v1.6.0/LightCrosshair-Setup-1.6.0.exe

Validation:
- winget validate passed
- Installer SHA256 updated
- GitHub release assets published
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/373245)