### PR TITLE
New version: 0state.scafld version 2.3.9

### DIFF
--- a/manifests/0/0state/scafld/2.3.9/0state.scafld.installer.yaml
+++ b/manifests/0/0state/scafld/2.3.9/0state.scafld.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: 0state.scafld
+PackageVersion: 2.3.9
+InstallerLocale: en-US
+InstallerType: portable
+Commands:
+  - scafld
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/nilstate/scafld/releases/download/v2.3.9/scafld_2.3.9_windows_amd64.exe
+    InstallerSha256: a911a1fa881dbcb9b26cb77caa23a924d5ca73aa1baaa3106acb1ca1d2ffc20b
+  - Architecture: arm64
+    InstallerUrl: https://github.com/nilstate/scafld/releases/download/v2.3.9/scafld_2.3.9_windows_arm64.exe
+    InstallerSha256: 723f66f00bb305acafbcede8a72e1837c8393273c17ddf7fa814702515c6d544
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/0/0state/scafld/2.3.9/0state.scafld.locale.en-US.yaml
+++ b/manifests/0/0state/scafld/2.3.9/0state.scafld.locale.en-US.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: 0state.scafld
+PackageVersion: 2.3.9
+PackageLocale: en-US
+Publisher: 0state
+PackageName: scafld
+License: MIT
+ShortDescription: Markdown-native task execution framework CLI.
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/0/0state/scafld/2.3.9/0state.scafld.yaml
+++ b/manifests/0/0state/scafld/2.3.9/0state.scafld.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: 0state.scafld
+PackageVersion: 2.3.9
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Updates 0state.scafld to 2.3.9.

Release: https://github.com/nilstate/scafld/releases/tag/v2.3.9