### PR TITLE
New version: BrightKitchen.PrintBridge version 2.0.19

### DIFF
--- a/manifests/b/BrightKitchen/PrintBridge/2.0.19/BrightKitchen.PrintBridge.installer.yaml
+++ b/manifests/b/BrightKitchen/PrintBridge/2.0.19/BrightKitchen.PrintBridge.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: BrightKitchen.PrintBridge
+PackageVersion: 2.0.19
+InstallerType: wix
+Scope: machine
+UpgradeBehavior: install
+ElevationRequirement: elevatesSelf
+InstallerSuccessCodes:
+  - 3010
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Karimrekiki/kds-print-bridge/releases/download/v2.0.19/BKPrintBridgeWinget-2.0.19.msi
+    InstallerSha256: B0ECF9CBA1EB138B2E7140F9E8A0CC067343DA6C8B5B702F63E34E92EDB4CCF8
+    ProductCode: '{A4C057A7-8B6D-5317-9CD2-F54FEE4CAA0F}'
+    AppsAndFeaturesEntries:
+      - DisplayName: Bright Kitchen Print Bridge
+        Publisher: BK One B.V.
+        DisplayVersion: 2.0.19
+        ProductCode: '{A4C057A7-8B6D-5317-9CD2-F54FEE4CAA0F}'
+        UpgradeCode: '{7F9620E8-6B9B-4B2F-8C44-62060B9A58D4}'
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/b/BrightKitchen/PrintBridge/2.0.19/BrightKitchen.PrintBridge.locale.en-US.yaml
+++ b/manifests/b/BrightKitchen/PrintBridge/2.0.19/BrightKitchen.PrintBridge.locale.en-US.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: BrightKitchen.PrintBridge
+PackageVersion: 2.0.19
+PackageLocale: en-US
+Publisher: BK One B.V.
+PackageName: Bright Kitchen Print Bridge
+PackageUrl: https://github.com/Karimrekiki/kds-print-bridge
+License: Proprietary
+ShortDescription: Bright Kitchen local print bridge service for receipt printers.
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/b/BrightKitchen/PrintBridge/2.0.19/BrightKitchen.PrintBridge.yaml
+++ b/manifests/b/BrightKitchen/PrintBridge/2.0.19/BrightKitchen.PrintBridge.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: BrightKitchen.PrintBridge
+PackageVersion: 2.0.19
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
### Pull request has been updated after validation feedback

- [x] I have tested the installation and uninstallation path locally/through project tests where available
- [x] I have verified the installer URL is publicly accessible
- [x] I have verified the SHA256 hash matches the published release asset

Release: https://github.com/Karimrekiki/kds-print-bridge/releases/tag/v2.0.19
Installer: https://github.com/Karimrekiki/kds-print-bridge/releases/download/v2.0.19/BKPrintBridgeWinget-2.0.19.msi

Fix notes:
- Previous validation run failed during dynamic installation scan after the MSI installed/staged auxiliary driver/WebView executables.
- Version 2.0.19 uses a winget-safe MSI: core bridge install only, no bundled driver payload tree, no driver/Chrome/power optional provisioning during package-manager installs, and post-install onboarding is skipped in winget mode.
- Manifest keeps PackageUrl, MSI ProductCode, AppsAndFeaturesEntries, and UpgradeCode for package matching.

SHA256: B0ECF9CBA1EB138B2E7140F9E8A0CC067343DA6C8B5B702F63E34E92EDB4CCF8