### PR TITLE
New version: InstaZDLL.WaveFlow version 1.0.0

### DIFF
--- a/manifests/i/InstaZDLL/WaveFlow/1.0.0/InstaZDLL.WaveFlow.installer.yaml
+++ b/manifests/i/InstaZDLL/WaveFlow/1.0.0/InstaZDLL.WaveFlow.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: InstaZDLL.WaveFlow
+PackageVersion: 1.0.0
+MinimumOSVersion: 10.0.17763.0
+InstallModes:
+  - silent
+  - silentWithProgress
+  - interactive
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerType: nullsoft
+    Scope: user
+    InstallerUrl: https://github.com/InstaZDLL/WaveFlow/releases/download/v1.0.0/WaveFlow_1.0.0_windows-x86_64-setup.exe
+    InstallerSha256: 0B1D62F7F6AB24382A90E95EB3C219973BC6308F29FFBC798073E3589D8AFADA
+  - Architecture: x64
+    InstallerType: wix
+    Scope: machine
+    InstallerUrl: https://github.com/InstaZDLL/WaveFlow/releases/download/v1.0.0/WaveFlow_1.0.0_windows-x86_64.msi
+    InstallerSha256: D127A3592CC4703593804FA38E727C34147932D3910A1EA7F98CFF8F751BF528
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/i/InstaZDLL/WaveFlow/1.0.0/InstaZDLL.WaveFlow.locale.en-US.yaml
+++ b/manifests/i/InstaZDLL/WaveFlow/1.0.0/InstaZDLL.WaveFlow.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: InstaZDLL.WaveFlow
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: InstaZDLL
+PublisherUrl: https://github.com/InstaZDLL
+PublisherSupportUrl: https://github.com/InstaZDLL/WaveFlow/issues
+PrivacyUrl: https://github.com/InstaZDLL/WaveFlow/blob/main/.github/SECURITY.md
+Author: InstaZDLL
+PackageName: WaveFlow
+PackageUrl: https://waveflow.app
+License: GPL-3.0-only
+LicenseUrl: https://github.com/InstaZDLL/WaveFlow/blob/main/LICENSE
+Copyright: Copyright © 2026 InstaZDLL. Licensed under GPL-3.0-only.
+ShortDescription: Local-first music player with a Spotify-inspired UI.
+Description: |-
+  WaveFlow is a local music player desktop app built with Tauri 2 and React 19. It scans your local audio folders, organizes tracks by album/artist/genre, and plays them with a real-time audio engine — no streaming, no cloud, your music stays on your machine.
+
+  Features include smart playlists, BPM analysis, LRCLIB lyrics fetch, Last.fm scrobbling, Discord Rich Presence, DLNA streaming, a 6-band equalizer, A-B loop, sleep timer, mood radio, year-in-review Wrapped, and more.
+Moniker: waveflow
+Tags:
+  - audio
+  - desktop
+  - flac
+  - local-first
+  - lrclib
+  - music
+  - music-player
+  - replaygain
+  - spotify
+  - tauri
+ReleaseNotesUrl: https://github.com/InstaZDLL/WaveFlow/releases/tag/v1.0.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/i/InstaZDLL/WaveFlow/1.0.0/InstaZDLL.WaveFlow.yaml
+++ b/manifests/i/InstaZDLL/WaveFlow/1.0.0/InstaZDLL.WaveFlow.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: InstaZDLL.WaveFlow
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Reason for change

Initial submission of **WaveFlow** — a local-first music player desktop app built with Tauri 2 and React 19. Upstream release: https://github.com/InstaZDLL/WaveFlow/releases/tag/v1.0.0

The manifest declares both Windows installers built by the upstream CI:

- NSIS `*-setup.exe` (per-user install, scope: user)
- MSI `*.msi` (system-wide install, scope: machine)

Both are Authenticode-signed.

## Manifest

- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the 1.6 schema?

## Linked Issues

n/a — initial submission for a new package identifier.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/373712)