### PR TITLE
New version: 0state.scafld version 2.4.1

### DIFF
--- a/manifests/0/0state/scafld/2.4.1/0state.scafld.installer.yaml
+++ b/manifests/0/0state/scafld/2.4.1/0state.scafld.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: 0state.scafld
+PackageVersion: 2.4.1
+InstallerLocale: en-US
+InstallerType: portable
+Commands:
+  - scafld
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/nilstate/scafld/releases/download/v2.4.1/scafld_2.4.1_windows_amd64.exe
+    InstallerSha256: e7aceb8871c217f287d9999a7ab3a8bb6c8ab25b0ca6fae13a9c843d0791b994
+  - Architecture: arm64
+    InstallerUrl: https://github.com/nilstate/scafld/releases/download/v2.4.1/scafld_2.4.1_windows_arm64.exe
+    InstallerSha256: 9f91d8ea95edf2e3b2bc4544ed516ea68f74a4a1ad98b78b8c81f7b7f23967fb
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/0/0state/scafld/2.4.1/0state.scafld.locale.en-US.yaml
+++ b/manifests/0/0state/scafld/2.4.1/0state.scafld.locale.en-US.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: 0state.scafld
+PackageVersion: 2.4.1
+PackageLocale: en-US
+Publisher: 0state
+PackageName: scafld
+License: MIT
+ShortDescription: Markdown-native task execution framework CLI.
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/0/0state/scafld/2.4.1/0state.scafld.yaml
+++ b/manifests/0/0state/scafld/2.4.1/0state.scafld.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: 0state.scafld
+PackageVersion: 2.4.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Updates 0state.scafld to 2.4.1.

Release: https://github.com/nilstate/scafld/releases/tag/v2.4.1

Manifests were staged with scafld/scripts/prepare-winget-submission.sh from the published release artifact and verified against checksums.txt.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/373759)