### PR TITLE
New version: shikomi-dev.shikomi version 0.1.0

### DIFF
--- a/manifests/s/shikomi-dev/shikomi/0.1.0/shikomi-dev.shikomi.installer.yaml
+++ b/manifests/s/shikomi-dev/shikomi/0.1.0/shikomi-dev.shikomi.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: shikomi-dev.shikomi
+PackageVersion: 0.1.0
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: "10.0.19041.0"
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+Installers:
+  - Architecture: x64
+    InstallerType: msi
+    InstallerUrl: https://github.com/shikomi-dev/shikomi/releases/download/v0.1.0/shikomi_0.1.0_x64_en-US.msi
+    InstallerSha256: 44c734de11a6555e9762aa0940ee65ecc795ffef2d539fb1b9abf177294bb14d
+    UpgradeBehavior: install
+  - Architecture: x64
+    InstallerType: nullsoft
+    InstallerUrl: https://github.com/shikomi-dev/shikomi/releases/download/v0.1.0/shikomi_0.1.0_x64-setup.exe
+    InstallerSha256: 7bec66d42980aa99eae270e90f74aaa17bbc475560f3d8a00a6a260f556b4eec
+    UpgradeBehavior: install
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/shikomi-dev/shikomi/0.1.0/shikomi-dev.shikomi.locale.en-US.yaml
+++ b/manifests/s/shikomi-dev/shikomi/0.1.0/shikomi-dev.shikomi.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: shikomi-dev.shikomi
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: shikomi Contributors
+PublisherUrl: https://github.com/shikomi-dev
+PackageName: shikomi
+PackageUrl: https://github.com/shikomi-dev/shikomi
+License: MIT
+LicenseUrl: https://github.com/shikomi-dev/shikomi/blob/main/LICENSE
+ShortDescription: Global hotkey clipboard manager — paste registered strings into any app instantly
+Description: |-
+  shikomi (仕込み) is a multi-platform clipboard manager that pastes pre-registered strings
+  into the foreground app via a global hotkey. Supports plain-text vault (OS permission-protected)
+  and optional Argon2id + AES-256-GCM encryption.
+Tags:
+  - clipboard
+  - hotkey
+  - productivity
+  - password-manager
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/shikomi-dev/shikomi/0.1.0/shikomi-dev.shikomi.yaml
+++ b/manifests/s/shikomi-dev/shikomi/0.1.0/shikomi-dev.shikomi.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: shikomi-dev.shikomi
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary

Add winget manifest for shikomi-dev.shikomi version 0.1.0 (initial submission).

## Package details

- **Package name**: shikomi (仕込み)
- **Publisher**: shikomi Contributors
- **Source repository**: https://github.com/shikomi-dev/shikomi
- **Release**: https://github.com/shikomi-dev/shikomi/releases/tag/v0.1.0
- **License**: MIT
- **Description**: Global hotkey clipboard manager — paste registered strings into any app instantly.
- **Architecture**: x64
- **Installer types**: MSI and NSIS (both provided as the project ships both bundlers via Tauri v2)

## Installer SHA256 verification

- MSI: `44c734de11a6555e9762aa0940ee65ecc795ffef2d539fb1b9abf177294bb14d` — verified against published `SHA256SUMS.txt` and direct download
- NSIS: `7bec66d42980aa99eae270e90f74aaa17bbc475560f3d8a00a6a260f556b4eec` — verified against published `SHA256SUMS.txt`

Source of truth: https://github.com/shikomi-dev/shikomi/releases/download/v0.1.0/SHA256SUMS.txt

## Note about code signing

This is an MVP release (v0.1.0). The installers are not yet code-signed; SmartScreen will display a warning. EV/OV code signing is tracked as a follow-up at the project level. This does not block winget acceptance per existing winget-pkgs policy on unsigned installers.

## Validation status

Manifest YAML structure validated against the 1.6 schema and parsed successfully with PyYAML and `actionlint`. **Local `winget validate` and `winget install --manifest` were NOT run** because the submitter does not have access to a Windows environment for this initial submission. Reviewer's `windows-latest`-based validation pipeline (`vedantmgoyal9/winget-releaser` etc.) is requested for full pre-merge verification.

---

This PR is being submitted manually because `vedantmgoyal9/winget-releaser` action requires an existing version of the package in winget-pkgs to operate, which is not the case for the initial submission. After this PR is merged, subsequent versions will be automated via the action in the source repository's CI (https://github.com/shikomi-dev/shikomi/blob/main/.github/workflows/package-publish.yml).

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest (3 files comprising one version manifest set)
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`? **Not run — no Windows environment**
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? **Not run — no Windows environment**
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.6.md)?