### PR TITLE
New package: thereisnotime.xxUSBSentinel version 2.0.5

### DIFF
--- a/manifests/t/thereisnotime/xxUSBSentinel/2.0.5/thereisnotime.xxUSBSentinel.installer.yaml
+++ b/manifests/t/thereisnotime/xxUSBSentinel/2.0.5/thereisnotime.xxUSBSentinel.installer.yaml
@@ -1,0 +1,13 @@
+PackageIdentifier: thereisnotime.xxUSBSentinel
+PackageVersion: 2.0.5
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: portable
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/thereisnotime/xxUSBSentinel/releases/download/v2.0.5/xxusbsentinel-v2.0.5-windows-x86_64.exe
+    InstallerSha256: C80230C7DB764C8FFF2E18F9681278F01E2F9EAB590F61D63754C18939E08BCD
+    PortableCommandAlias: xxusbsentinel
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/t/thereisnotime/xxUSBSentinel/2.0.5/thereisnotime.xxUSBSentinel.locale.en-US.yaml
+++ b/manifests/t/thereisnotime/xxUSBSentinel/2.0.5/thereisnotime.xxUSBSentinel.locale.en-US.yaml
@@ -1,0 +1,19 @@
+PackageIdentifier: thereisnotime.xxUSBSentinel
+PackageVersion: 2.0.5
+PackageLocale: en-US
+Publisher: thereisnotime
+PublisherUrl: https://github.com/thereisnotime
+PublisherSupportUrl: https://github.com/thereisnotime/xxUSBSentinel/issues
+PackageName: xxUSBSentinel
+PackageUrl: https://github.com/thereisnotime/xxUSBSentinel
+License: PolyForm Noncommercial License 1.0.0
+LicenseUrl: https://github.com/thereisnotime/xxUSBSentinel/blob/master/LICENSE
+ShortDescription: USB kill-switch — shuts down the PC when a mapped USB device is removed
+Description: Map any USB device as a kill-switch key. When it is removed while the sentinel is armed, the machine shuts down immediately. Designed to make recovering encrypted drive keys as hard as possible if someone physically seizes your machine.
+Tags:
+  - security
+  - usb
+  - kill-switch
+  - shutdown
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/t/thereisnotime/xxUSBSentinel/2.0.5/thereisnotime.xxUSBSentinel.yaml
+++ b/manifests/t/thereisnotime/xxUSBSentinel/2.0.5/thereisnotime.xxUSBSentinel.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: thereisnotime.xxUSBSentinel
+PackageVersion: 2.0.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## New package submission

- **Package:** thereisnotime.xxUSBSentinel
- **Version:** 2.0.5
- **URL:** https://github.com/thereisnotime/xxUSBSentinel

USB kill-switch for Linux and Windows. Maps any USB device as a key — when removed while armed, the machine shuts down immediately.

### Manifest type
Portable executable (single `.exe`, no installer).

### Verification
- SHA256 of installer verified against GitHub release artifact
- Release: https://github.com/thereisnotime/xxUSBSentinel/releases/tag/v2.0.5
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/373902)