### PR TITLE
New package: myiam.Due2.CLI version 0.6.2

### DIFF
--- a/manifests/m/myiam/Due2CLI/0.6.2/myiam.Due2.CLI.installer.yaml
+++ b/manifests/m/myiam/Due2CLI/0.6.2/myiam.Due2.CLI.installer.yaml
@@ -1,0 +1,13 @@
+PackageIdentifier: myiam.Due2.CLI
+PackageVersion: 0.6.2
+MinimumOSVersion: 10.0.17763.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: due2-cli.exe
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/myiam-io/homebrew-tap/releases/download/due2-cli-v0.6.2/due2-cli-0.6.2-windows-x64.zip
+    InstallerSha256: acbd2b696c1b024dd8da5f1f4631e884771c301191396ece617ceed89016c855
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/myiam/Due2CLI/0.6.2/myiam.Due2.CLI.locale.en-US.yaml
+++ b/manifests/m/myiam/Due2CLI/0.6.2/myiam.Due2.CLI.locale.en-US.yaml
@@ -1,0 +1,11 @@
+PackageIdentifier: myiam.Due2.CLI
+PackageVersion: 0.6.2
+PackageLocale: en-US
+Publisher: myiam
+PublisherUrl: https://myiam.io
+PackageName: Due2 CLI
+PackageUrl: https://github.com/my-due2/due2-cli
+License: Proprietary
+ShortDescription: CLI tool for managing due items with end-to-end encryption
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/myiam/Due2CLI/0.6.2/myiam.Due2.CLI.yaml
+++ b/manifests/m/myiam/Due2CLI/0.6.2/myiam.Due2.CLI.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: myiam.Due2.CLI
+PackageVersion: 0.6.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New Submission

- Package: myiam.Due2.CLI
- Version: 0.6.2
- URL: https://github.com/myiam-io/homebrew-tap/releases/download/due2-cli-v0.6.2/due2-cli-0.6.2-windows-x64.zip
- InstallerType: zip (portable)

### Description

CLI tool for managing due items with end-to-end encryption.

### Manifest validation

- [x] Have you verified the manifest with `winget validate`?
- [x] Have you tested the installation with `winget install`?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/373919)