### PR TITLE
New Package: chautnus.RightWheel version 2.10.3

### DIFF
--- a/manifests/c/chautnus/RightWheel/2.10.3/chautnus.RightWheel.installer.yaml
+++ b/manifests/c/chautnus/RightWheel/2.10.3/chautnus.RightWheel.installer.yaml
@@ -1,0 +1,13 @@
+PackageIdentifier: chautnus.RightWheel
+PackageVersion: 2.10.3
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: portable
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/chautnus/RightWheel/releases/download/v2.10.3/RightWheel.exe
+    InstallerSha256: 1D4CC62C03A17429825A9ECDB871418489E42FF7CEB55CBBF38BC623867F9449
+    NestedInstallerType: portable
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/c/chautnus/RightWheel/2.10.3/chautnus.RightWheel.locale.en-US.yaml
+++ b/manifests/c/chautnus/RightWheel/2.10.3/chautnus.RightWheel.locale.en-US.yaml
@@ -1,0 +1,21 @@
+PackageIdentifier: chautnus.RightWheel
+PackageVersion: 2.10.3
+PackageLocale: en-US
+Publisher: chautnus
+PackageName: RightWheel
+PackageUrl: https://chautnus.github.io/RightWheel/
+License: Proprietary
+LicenseUrl: https://chautnus.github.io/RightWheel/
+ShortDescription: Mouse shortcut panel for Windows — hold right-click and scroll to launch apps, shortcuts, commands and URLs.
+Description: RightWheel is a portable Windows utility that turns your mouse into a shortcut panel. Hold right-click and scroll up or down, a panel appears — pick an item to launch apps, trigger keyboard shortcuts, run shell commands, or open URLs instantly without touching the keyboard.
+Tags:
+  - mouse
+  - shortcut
+  - launcher
+  - productivity
+  - utility
+  - windows
+  - hotkey
+ReleaseNotesUrl: https://github.com/chautnus/RightWheel/releases/tag/v2.10.3
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/c/chautnus/RightWheel/2.10.3/chautnus.RightWheel.yaml
+++ b/manifests/c/chautnus/RightWheel/2.10.3/chautnus.RightWheel.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: chautnus.RightWheel
+PackageVersion: 2.10.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## New Package: chautnus.RightWheel

**RightWheel** is a portable Windows utility that turns your mouse into a shortcut panel. Hold right-click and scroll up or down, a panel appears - pick an item to launch apps, trigger keyboard shortcuts, run shell commands, or open URLs instantly without touching the keyboard.

- **Publisher:** chautnus
- **Version:** 2.10.3
- **Homepage:** https://chautnus.github.io/RightWheel/
- **Release:** https://github.com/chautnus/RightWheel/releases/tag/v2.10.3
- **Installer type:** portable (x64)
- **License:** Proprietary (30-day free trial)

### Validation Checklist
- [x] Manifests pass winget validate
- [x] SHA256 matches the release asset
- [x] Installer URL is publicly accessible
- [x] Package does not already exist in winget-pkgs
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/374287)