### PR TITLE
New version: RedEyeNetworks.LogivoreForVeeam version 0.12.0

### DIFF
--- a/manifests/r/RedEyeNetworks/LogivoreForVeeam/0.12.0/RedEyeNetworks.LogivoreForVeeam.installer.yaml
+++ b/manifests/r/RedEyeNetworks/LogivoreForVeeam/0.12.0/RedEyeNetworks.LogivoreForVeeam.installer.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: RedEyeNetworks.LogivoreForVeeam
+PackageVersion: 0.12.0
+InstallerType: inno
+Scope: machine
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  Custom: /NORESTART
+UpgradeBehavior: install
+Commands:
+- logivoreforveeam
+Installers:
+- Architecture: x64
+  Scope: user
+  InstallerUrl: https://download.redeyenetworks.com/logivore-for-veeam/releases/0.12.0/logivore-for-veeam-win-x64-setup.exe
+  InstallerSha256: 4EF1148BCD4C5A2CF7F9BBB949A844C58579DC794B5106E04B325EC569FC91BA
+- Architecture: x64
+  Scope: machine
+  ElevationRequirement: elevatesSelf
+  InstallerUrl: https://download.redeyenetworks.com/logivore-for-veeam/releases/0.12.0/logivore-for-veeam-win-x64-machine-setup.exe
+  InstallerSha256: A05E9E33274751963AF89DD86B97391853F4029484CBE21E709ABB950EBC00E3
+- Architecture: arm64
+  Scope: user
+  InstallerUrl: https://download.redeyenetworks.com/logivore-for-veeam/releases/0.12.0/logivore-for-veeam-win-arm64-setup.exe
+  InstallerSha256: 3CD12FF15B7860D2B6EBB5F5AFC3DAE1C9C5EC09BBCB34F2E8E5EFF2BCFFE973
+- Architecture: arm64
+  Scope: machine
+  ElevationRequirement: elevatesSelf
+  InstallerUrl: https://download.redeyenetworks.com/logivore-for-veeam/releases/0.12.0/logivore-for-veeam-win-arm64-machine-setup.exe
+  InstallerSha256: C6220CDFC0A45279F38DFEC587995CF2987B9FBDBD64454CD345E35618259E38
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/r/RedEyeNetworks/LogivoreForVeeam/0.12.0/RedEyeNetworks.LogivoreForVeeam.locale.en-US.yaml
+++ b/manifests/r/RedEyeNetworks/LogivoreForVeeam/0.12.0/RedEyeNetworks.LogivoreForVeeam.locale.en-US.yaml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: RedEyeNetworks.LogivoreForVeeam
+PackageVersion: 0.12.0
+PackageLocale: en-US
+Publisher: RedEye Network Solutions LLC
+PublisherUrl: https://redeyenetworks.com
+PublisherSupportUrl: https://redeyenetworks.com/support
+Author: RedEye Network Solutions LLC
+PackageName: Logivore for Veeam
+PackageUrl: https://redeyenetworks.com
+License: Proprietary
+Copyright: Copyright 2026 RedEye Network Solutions LLC. All rights reserved.
+ShortDescription: Logivore plus Advanced Veeam Mode — collects, normalizes, and analyzes Veeam Backup and Replication logs end-to-end
+Description: |-
+  Logivore for Veeam is the Veeam-centric SKU of Logivore. Includes
+  everything in Logivore (cross-platform log analysis, LILA AI
+  assistant, memory-tier-adaptive parsing, local-first trust-gated
+  LLM boundary) plus Microsoft.PowerShell.SDK and a built-in
+  Advanced Veeam Mode that drives the Veeam VBR PowerShell cmdlets
+  to collect job/repository/proxy diagnostics on demand. Targeted
+  at Veeam backup administrators who need to triage failed jobs
+  against backup server, repository, and proxy logs in one
+  timeline.
+Moniker: logivore-for-veeam
+Tags:
+- veeam
+- vbr
+- backup
+- log-analysis
+- log-viewer
+- syslog
+- evtx
+- powershell
+- ai
+- llm
+- claude
+- gemini
+- timeline
+- correlation
+- desktop
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/RedEyeNetworks/LogivoreForVeeam/0.12.0/RedEyeNetworks.LogivoreForVeeam.yaml
+++ b/manifests/r/RedEyeNetworks/LogivoreForVeeam/0.12.0/RedEyeNetworks.LogivoreForVeeam.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: RedEyeNetworks.LogivoreForVeeam
+PackageVersion: 0.12.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Logivore for Veeam v0.12.0 — Veeam-edition variant of Logivore that bundles the Microsoft.PowerShell.SDK + Veeam VBR cmdlets for the Advanced Veeam Mode runspace. Two distinct installers per architecture (user-scope + machine-scope), matching the PowerToys / Notepad++ pattern.

The Base edition (RedEyeNetworks.Logivore) and Veeam edition (RedEyeNetworks.LogivoreForVeeam) ship from the same repo with distinct AppIds, install dirs, settings folders, and credential namespaces — they can coexist on the same machine.

Release notes: https://github.com/redeyenetworks/logivore/releases/tag/v0.12.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/374297)