### PR TITLE
New version: Objz.Rmcl version 0.3.0

### DIFF
--- a/manifests/o/Objz/Rmcl/0.3.0/Objz.Rmcl.installer.yaml
+++ b/manifests/o/Objz/Rmcl/0.3.0/Objz.Rmcl.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: Objz.Rmcl
+PackageVersion: 0.3.0
+InstallerType: wix
+Scope: machine
+InstallerSwitches:
+  Silent: /quiet /norestart
+  SilentWithProgress: /passive /norestart
+UpgradeBehavior: install
+Commands:
+- rmcl
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/objz/rmcl/releases/download/v0.3.0/rmcl-x86_64-pc-windows-msvc.msi
+  InstallerSha256: 33EF152A88847B6DCCCCDE35308D9BE67F7218914E5FA252BB7DDF7B0F37ABCC
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/o/Objz/Rmcl/0.3.0/Objz.Rmcl.locale.en-US.yaml
+++ b/manifests/o/Objz/Rmcl/0.3.0/Objz.Rmcl.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: Objz.Rmcl
+PackageVersion: 0.3.0
+PackageLocale: en-US
+Publisher: objz
+PublisherUrl: https://github.com/objz
+PublisherSupportUrl: https://github.com/objz/rmcl/issues
+Author: objz
+PackageName: rmcl
+PackageUrl: https://github.com/objz/rmcl
+License: GPL-3.0-only
+LicenseUrl: https://github.com/objz/rmcl/blob/master/LICENSE
+Copyright: Copyright (c) objz
+ShortDescription: Minecraft launcher TUI
+Description: A fully featured Minecraft launcher TUI with Microsoft account authentication, instance management, mod loaders, imports, content management, and launch support.
+Moniker: rmcl
+Tags:
+- minecraft
+- launcher
+- cli
+- tui
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/o/Objz/Rmcl/0.3.0/Objz.Rmcl.yaml
+++ b/manifests/o/Objz/Rmcl/0.3.0/Objz.Rmcl.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: Objz.Rmcl
+PackageVersion: 0.3.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-cli/blob/master/doc/Manifest.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-cli/tree/master/schemas/JSON/manifests/v1.9.0)?

## New package: Objz.Rmcl 0.3.0

This is a renamed package. The project formerly published as `Objz.MclLauncher` has been renamed to `rmcl`. A separate PR will deprecate `Objz.MclLauncher` and point users here.

Upstream repository: https://github.com/objz/rmcl
Release: https://github.com/objz/rmcl/releases/tag/v0.3.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/374307)