### PR TITLE
Update: Objz.MclLauncher version 0.2.5 (deprecation — renamed to Objz.Rmcl)

### DIFF
--- a/manifests/o/Objz/MclLauncher/0.2.5/Objz.MclLauncher.installer.yaml
+++ b/manifests/o/Objz/MclLauncher/0.2.5/Objz.MclLauncher.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: Objz.MclLauncher
+PackageVersion: 0.2.5
+InstallerType: wix
+Scope: machine
+InstallerSwitches:
+  Silent: /quiet /norestart
+  SilentWithProgress: /passive /norestart
+UpgradeBehavior: install
+Commands:
+- mcl
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/objz/rmcl/releases/download/v0.2.4/mcl-launcher-x86_64-pc-windows-msvc.msi
+  InstallerSha256: 7B94FE350EEB25E8868904105C02A3820FCFA639D8713D5D6E3414EC21BFB1D9
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/o/Objz/MclLauncher/0.2.5/Objz.MclLauncher.locale.en-US.yaml
+++ b/manifests/o/Objz/MclLauncher/0.2.5/Objz.MclLauncher.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: Objz.MclLauncher
+PackageVersion: 0.2.5
+PackageLocale: en-US
+Publisher: objz
+PublisherUrl: https://github.com/objz
+PublisherSupportUrl: https://github.com/objz/rmcl/issues
+Author: objz
+PackageName: mcl-launcher (DEPRECATED)
+PackageUrl: https://github.com/objz/rmcl
+License: GPL-3.0-only
+LicenseUrl: https://github.com/objz/rmcl/blob/master/LICENSE
+Copyright: Copyright (c) objz
+ShortDescription: DEPRECATED — renamed to Objz.Rmcl. Run: winget install Objz.Rmcl
+Description: |-
+  This package has been renamed. mcl-launcher is no longer maintained under this identifier.
+  Install the new package instead: winget install Objz.Rmcl
+  Upstream: https://github.com/objz/rmcl
+ReleaseNotes: |-
+  mcl-launcher has been renamed to rmcl.
+  Please uninstall this package and install Objz.Rmcl instead:
+    winget uninstall Objz.MclLauncher
+    winget install Objz.Rmcl
+  Your existing on-disk data (~/.config/mcl/, %APPDATA%\mcl\, etc.) is
+  automatically migrated by the new rmcl binary on first launch.
+ReleaseNotesUrl: https://github.com/objz/rmcl
+Moniker: mcl
+Tags:
+- deprecated
+- minecraft
+- launcher
+- cli
+- tui
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/o/Objz/MclLauncher/0.2.5/Objz.MclLauncher.yaml
+++ b/manifests/o/Objz/MclLauncher/0.2.5/Objz.MclLauncher.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: Objz.MclLauncher
+PackageVersion: 0.2.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-cli/blob/master/doc/Manifest.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-cli/tree/master/schemas/JSON/manifests/v1.9.0)?

## Deprecation: Objz.MclLauncher 0.2.5

This package has been renamed to `Objz.Rmcl`. As WinGet has no formal deprecation field in the stable schema, this PR submits a final 0.2.5 version of `Objz.MclLauncher` whose `ShortDescription`, `Description`, and `ReleaseNotes` clearly indicate the rename and direct users to the new identifier.

The installer URL points at the existing v0.2.4 MSI (still hosted on the upstream release, accessed via GitHub's repo-rename redirect) so anyone who installs this version still gets a working binary while seeing the deprecation prominently.

- New package PR: https://github.com/microsoft/winget-pkgs/pull/374307
- Upstream repository: https://github.com/objz/rmcl
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/374309)