### PR TITLE
Add RbDevOps.HMPraxis version 1.0.8

### DIFF
--- a/manifests/r/RbDevOps/HMPraxis/1.0.8/RbDevOps.HMPraxis.installer.yaml
+++ b/manifests/r/RbDevOps/HMPraxis/1.0.8/RbDevOps.HMPraxis.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: RbDevOps.HMPraxis
+PackageVersion: 1.0.8
+InstallerType: nullsoft
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+UpgradeBehavior: install
+ReleaseDate: 2026-05-14
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://downloads.rb-devops.com/releases/hm-praxis/1.0.8/windows/x64/HM%20Praxis_1.0.8_x64-setup.exe
+    InstallerSha256: 9F384CF0EDCFECD949D8AEFBA7DF32C03C3B2537D680AC5275E2D00BFED8E1EF
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/r/RbDevOps/HMPraxis/1.0.8/RbDevOps.HMPraxis.locale.en-US.yaml
+++ b/manifests/r/RbDevOps/HMPraxis/1.0.8/RbDevOps.HMPraxis.locale.en-US.yaml
@@ -8,7 +8,7 @@ PublisherSupportUrl: https://rb-devops.com/support
 PrivacyUrl: https://rb-devops.com/privacy
 Author: RbDevOps
 PackageName: HM Praxis
-PackageUrl: https://rb-devops.com/hm-praxis
+PackageUrl: https://rb-devops.com/products/hm-praxis
 License: Proprietary
 LicenseUrl: https://rb-devops.com/terms
 Copyright: Copyright (c) RbDevOps
@@ -28,6 +28,6 @@ Tags:
   - appointments
   - desktop
   - local-first
-ReleaseNotesUrl: https://rb-devops.com/hm-praxis
+ReleaseNotesUrl: https://rb-devops.com/products/hm-praxis
 ManifestType: defaultLocale
 ManifestVersion: 1.10.0

--- a/manifests/r/RbDevOps/HMPraxis/1.0.8/RbDevOps.HMPraxis.locale.en-US.yaml
+++ b/manifests/r/RbDevOps/HMPraxis/1.0.8/RbDevOps.HMPraxis.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: RbDevOps.HMPraxis
+PackageVersion: 1.0.8
+PackageLocale: en-US
+Publisher: RbDevOps
+PublisherUrl: https://rb-devops.com
+PublisherSupportUrl: https://rb-devops.com/support
+PrivacyUrl: https://rb-devops.com/privacy
+Author: RbDevOps
+PackageName: HM Praxis
+PackageUrl: https://rb-devops.com/hm-praxis
+License: Proprietary
+LicenseUrl: https://rb-devops.com/terms
+Copyright: Copyright (c) RbDevOps
+ShortDescription: Local-first Healthcare Management Praxis for solo and small clinics.
+Description: |-
+  HM Praxis is a desktop-native, local-first healthcare practice management application
+  for solo practitioners and small clinics. Patient records, appointments, prescriptions,
+  treatment plans, and billing run on your machine without requiring constant cloud
+  connectivity. Per-clinic data stays on your devices; LAN sync keeps a small team in step.
+Moniker: hm-praxis
+Tags:
+  - healthcare
+  - practice-management
+  - emr
+  - ehr
+  - patients
+  - appointments
+  - desktop
+  - local-first
+ReleaseNotesUrl: https://rb-devops.com/hm-praxis
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/r/RbDevOps/HMPraxis/1.0.8/RbDevOps.HMPraxis.yaml
+++ b/manifests/r/RbDevOps/HMPraxis/1.0.8/RbDevOps.HMPraxis.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: RbDevOps.HMPraxis
+PackageVersion: 1.0.8
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Adds version 1.0.8 of RbDevOps.HMPraxis.

- Installer hosted at downloads.rb-devops.com (R2 custom domain), publicly reachable
- SHA256 verified against live binary
- Manifests rendered from templates in repo apps/hm-praxis/winget/
- Schema 1.10.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/374472)