### PR TITLE
Remove Validation-Guide label on certain events

### DIFF
--- a/.github/policies/labelAdded.manualValidationCompleted.yml
+++ b/.github/policies/labelAdded.manualValidationCompleted.yml
@@ -32,6 +32,8 @@ configuration:
               label: Validation-No-Executables
           - removeLabel:
               label: Validation-Executable-Error
+          - removeLabel:
+              label: Validation-Guide
         # The policy service should trigger even when the label was added by the policy service
         triggerOnOwnActions: true
 onFailure:

--- a/.github/policies/labelAdded.validationCompleted.yml
+++ b/.github/policies/labelAdded.validationCompleted.yml
@@ -35,6 +35,8 @@ configuration:
 
 
                 Template: msftbot/requiresApproval/moderator
+          - removeLabel:
+              label: Validation-Guide
         # The policy service should trigger even when the label was added by the policy service
         triggerOnOwnActions: true
 onFailure:

--- a/.github/policies/labelManagement.issueUpdated.yml
+++ b/.github/policies/labelManagement.issueUpdated.yml
@@ -402,8 +402,6 @@ configuration:
               label: Validation-Unattended-Failed
           - removeLabel:
               label: Version-Parameter-Mismatch
-          - removeLabel:
-              label: Validation-Guide
       - description: Remove status labels when a PR is re-run
         if:
           - payloadType: Issue_Comment

--- a/.github/policies/labelManagement.issueUpdated.yml
+++ b/.github/policies/labelManagement.issueUpdated.yml
@@ -402,6 +402,8 @@ configuration:
               label: Validation-Unattended-Failed
           - removeLabel:
               label: Version-Parameter-Mismatch
+          - removeLabel:
+              label: Validation-Guide
       - description: Remove status labels when a PR is re-run
         if:
           - payloadType: Issue_Comment


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
<!-- Describe what this PR changes. For manifest submissions, include the package name and version. -->
Remove https://github.com/microsoft/winget-pkgs/labels/Validation-Guide label if https://github.com/microsoft/winget-pkgs/labels/Validation-Completed or https://github.com/microsoft/winget-pkgs/labels/Manual-Validation-Completed is assigned, as said label is no longer relevant at that point.

cc @Trenly @denelon
## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [ ] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [ ] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/374497)