### PR TITLE
New package: Microsoft.Scribble version 1

### DIFF
--- a/manifests/m/Microsoft/Scribble/1/Microsoft.Scribble.installer.yaml
+++ b/manifests/m/Microsoft/Scribble/1/Microsoft.Scribble.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.Scribble
+PackageVersion: "1"
+MinimumOSVersion: 10.0.16299.0
+Platform:
+- Windows.Desktop
+InstallerType: zip # An .appx with a functional .exe inside.
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: scribble.exe
+ArchiveBinariesDependOnPath: true
+Installers:
+- Architecture: x86
+  InstallerUrl: https://media.githubusercontent.com/media/microsoft/msix-packaging/refs/heads/master/MsixCore/Tests/scribble.appx
+  InstallerSha256: d57e5862fa6c15a335ed82209dc068c7d1964d2c69c6f562a3b03dff287f4c56
+FileExtensions:
+- scb
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/Microsoft/Scribble/1/Microsoft.Scribble.locale.en-US.yaml
+++ b/manifests/m/Microsoft/Scribble/1/Microsoft.Scribble.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.Scribble
+PackageVersion: "1"
+PackageLocale: en-US
+Publisher: Microsoft
+PackageName: Scribble MFC Application
+License: Unclear (Freeware)
+ShortDescription: A basic tool to draw black-on-white with a mouse.
+Description: A basic tool to draw black-on-white with a mouse. Created in 1992 as a sample app to demonstrate the then-new Microsoft Foundation Class Library, this Winget package is based on a 2019 .appx recompiling of one of the various sample app versions, which in turn was created at some point between 1992 and 2001.
+Tags:
+- microsoft-scribble
+- microsoftscribble
+- microsoft-foundation-class-library
+- microsoftfoundationclasslibrary
+- microsoft-mfc
+- microsoftmfc
+- write-with-cursor
+- scb-files
+Documentations:
+- DocumentLabel: Source of Scribble's purpose(s)
+  DocumentUrl: https://hardcoresoftware.learningbyshipping.com/p/012-i-shipped-therefore-i-am
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/Microsoft/Scribble/1/Microsoft.Scribble.yaml
+++ b/manifests/m/Microsoft/Scribble/1/Microsoft.Scribble.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.Scribble
+PackageVersion: "1"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
Added Microsoft Scribble.

The program's history is apparently pretty complicated, and constitutes a very obscure bit of Microsoft history: It was first created back in 1992, specifically to be shown in a presentation of Foundation Class Library (https://hardcoresoftware.learningbyshipping.com/p/012-i-shipped-therefore-i-am); the app was apparently never officially publicly published. Then someone at Microsoft circa 2019 who I can only presume had access to its source code, built an .appx of it. The .appx version claims in its "About" to be based on a version with copyright date "1995-2001", though there are no known cases of Scribble being included with Windows 95 or any OS in the late 90's.

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/374557)