### PR TITLE
New version: NeuralNomadsAI.CodeNomad version 0.16.0

### DIFF
--- a/manifests/n/NeuralNomadsAI/CodeNomad/0.16.0/NeuralNomadsAI.CodeNomad.installer.yaml
+++ b/manifests/n/NeuralNomadsAI/CodeNomad/0.16.0/NeuralNomadsAI.CodeNomad.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: NeuralNomadsAI.CodeNomad
+PackageVersion: 0.16.0
+InstallerType: zip
+NestedInstallerType: nullsoft
+NestedInstallerFiles:
+- RelativeFilePath: nsis/CodeNomad_0.16.0_x64-setup.exe
+ReleaseDate: 2026-05-14
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/NeuralNomadsAI/CodeNomad/releases/download/v0.16.0/CodeNomad-Tauri-windows-x64-0.16.0.zip
+  InstallerSha256: 554E89D6A8DE0780B4A4C6C4B4DE5ADEBE866642C3183596665AE0352667F0BD
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/n/NeuralNomadsAI/CodeNomad/0.16.0/NeuralNomadsAI.CodeNomad.locale.en-US.yaml
+++ b/manifests/n/NeuralNomadsAI/CodeNomad/0.16.0/NeuralNomadsAI.CodeNomad.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: NeuralNomadsAI.CodeNomad
+PackageVersion: 0.16.0
+PackageLocale: en-US
+Publisher: NeuralNomadsAI
+PublisherUrl: https://github.com/NeuralNomadsAI
+PublisherSupportUrl: https://github.com/NeuralNomadsAI/CodeNomad/issues
+PackageName: CodeNomad
+PackageUrl: https://github.com/NeuralNomadsAI/CodeNomad
+License: MIT
+LicenseUrl: https://github.com/NeuralNomadsAI/CodeNomad/blob/HEAD/LICENSE
+ShortDescription: CodeNomad is the command center that puts AI coding on steroids.
+Description: CodeNomad is the command center that puts AI coding on steroids.
+Tags:
+- ai
+- code
+- coding
+- development
+ReleaseNotesUrl: https://github.com/NeuralNomadsAI/CodeNomad/releases/tag/v0.16.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/n/NeuralNomadsAI/CodeNomad/0.16.0/NeuralNomadsAI.CodeNomad.yaml
+++ b/manifests/n/NeuralNomadsAI/CodeNomad/0.16.0/NeuralNomadsAI.CodeNomad.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: NeuralNomadsAI.CodeNomad
+PackageVersion: 0.16.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Summary
- Add the initial winget manifests for `NeuralNomadsAI.CodeNomad` version `0.16.0`.
- Package the Windows Tauri release as a ZIP with a nested NSIS installer entry.
- Validate the manifest locally with `winget validate` before submission.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/374575)