### PR TITLE
New version: lilideguo04-lgtm.AegisSOC version 2.30.3

### DIFF
--- a/manifests/l/lilideguo04-lgtm/AegisSOC/2.30.3/lilideguo04-lgtm.AegisSOC.installer.yaml
+++ b/manifests/l/lilideguo04-lgtm/AegisSOC/2.30.3/lilideguo04-lgtm.AegisSOC.installer.yaml
@@ -1,0 +1,28 @@
+﻿PackageIdentifier: lilideguo04-lgtm.AegisSOC
+PackageVersion: 2.30.3
+InstallerType: msi
+Scope: machine
+InstallerLocale: en-US
+ProductCode: '{B0A4B28D-2926-442D-9A48-601BD017270A}'
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-05-14
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/lilideguo04-lgtm/SOC/releases/download/v2.30.3/Aegis.SOC_2.30.3_x64_en-US.msi
+    InstallerSha256: 9CB9DA4266637481059A43A02EC8DD7F182407DEB798C30B23C157B627F4F29D
+    InstallerSwitches:
+      Silent: /qn /norestart
+      SilentWithProgress: /qb /norestart
+      Interactive: /qf /norestart
+    AppsAndFeaturesEntries:
+      - DisplayName: Aegis SOC
+        Publisher: lilideguo04-lgtm
+        DisplayVersion: 2.30.3
+        ProductCode: '{B0A4B28D-2926-442D-9A48-601BD017270A}'
+        UpgradeCode: '{D632C20B-370F-5181-B67F-EA9B53FCD6DF}'
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/l/lilideguo04-lgtm/AegisSOC/2.30.3/lilideguo04-lgtm.AegisSOC.locale.en-US.yaml
+++ b/manifests/l/lilideguo04-lgtm/AegisSOC/2.30.3/lilideguo04-lgtm.AegisSOC.locale.en-US.yaml
@@ -1,0 +1,30 @@
+﻿PackageIdentifier: lilideguo04-lgtm.AegisSOC
+PackageVersion: 2.30.3
+PackageLocale: en-US
+Publisher: lilideguo04-lgtm
+PublisherUrl: https://github.com/lilideguo04-lgtm
+PublisherSupportUrl: https://github.com/lilideguo04-lgtm/SOC/issues
+PackageName: Aegis SOC
+PackageUrl: https://github.com/lilideguo04-lgtm/SOC
+License: MIT
+LicenseUrl: https://github.com/lilideguo04-lgtm/SOC/blob/main/LICENSE
+ShortDescription: Personal Security Operations Center 鈥?visually stunning + actionable
+Description: |
+  Aegis SOC is a free, open-source personal Security Operations Center built on Tauri 2.
+  Features 60+ detection panels covering Sysmon / ETW / WinEvent / YARA / Sigma / UEBA,
+  29 panels integrated with 5-layer guarded reversible disposal actions, full local
+  privacy (0 cloud, 0 telemetry), and bilingual zh-CN + en-US UI.
+Moniker: aegis-soc
+Tags:
+  - security
+  - soc
+  - siem
+  - sysmon
+  - yara
+  - sigma
+  - threat-detection
+  - incident-response
+  - desktop
+  - tauri
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/l/lilideguo04-lgtm/AegisSOC/2.30.3/lilideguo04-lgtm.AegisSOC.yaml
+++ b/manifests/l/lilideguo04-lgtm/AegisSOC/2.30.3/lilideguo04-lgtm.AegisSOC.yaml
@@ -1,0 +1,5 @@
+﻿PackageIdentifier: lilideguo04-lgtm.AegisSOC
+PackageVersion: 2.30.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Reason for change

New manifest for `lilideguo04-lgtm.AegisSOC` v2.30.3 — first submission to WinGet.

## Package

- **Identifier**: lilideguo04-lgtm.AegisSOC
- **Version**: 2.30.3
- **Publisher**: lilideguo04-lgtm
- **URL**: https://github.com/lilideguo04-lgtm/SOC
- **License**: MIT
- **Description**: Personal Security Operations Center — visually stunning + actionable. 60+ detection panels covering Sysmon / ETW / WinEvent / YARA / Sigma / UEBA, 29 panels integrated with 5-layer guarded reversible disposal actions, full local privacy (0 cloud, 0 telemetry), bilingual zh-CN + en-US UI.

## Validation

- [x] Manifest validates with WinGet schema 1.6.0
- [x] InstallerSha256 computed from actual built .msi: `9CB9DA4266637481059A43A02EC8DD7F182407DEB798C30B23C157B627F4F29D`
- [x] ProductCode extracted from .msi via WindowsInstaller COM API: `{B0A4B28D-2926-442D-9A48-601BD017270A}`
- [x] UpgradeCode stable across versions: `{D632C20B-370F-5181-B67F-EA9B53FCD6DF}`
- [x] InstallerUrl points to public GitHub Release: https://github.com/lilideguo04-lgtm/SOC/releases/download/v2.30.3/Aegis.SOC_2.30.3_x64_en-US.msi
- [x] Installer requires UAC elevation (`requireAdministrator` manifest); /qb installer switch supports interactive install

## Test results

- All install modes (interactive / silent / silentWithProgress) work as expected on Win 10 22H2 + Win 11 23H2
- App launches successfully post-install with admin elevation
- Add/Remove Programs shows correct ProductCode

## Microsoft Reviewers — Reproduction

Local build pipeline:
```powershell
cd <SOC-repo>
npm run tauri:build:admin
# Output: src-tauri/target/release/bundle/msi/Aegis SOC_2.30.3_x64_en-US.msi
# SHA256: 9CB9DA4266637481059A43A02EC8DD7F182407DEB798C30B23C157B627F4F29D
```

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/374590)