### PR TITLE
New package: kayodante.Siphon version 0.7.2

### DIFF
--- a/manifests/k/kayodante/Siphon/0.7.2/kayodante.Siphon.installer.yaml
+++ b/manifests/k/kayodante/Siphon/0.7.2/kayodante.Siphon.installer.yaml
@@ -12,6 +12,7 @@ InstallerSwitches:
   Silent: /S
   SilentWithProgress: /S
 UpgradeBehavior: install
+Scope: user
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/kayodante/Win-siphonClaudeUsage/releases/download/v0.7.2/Siphon.Setup.0.7.2.exe

--- a/manifests/k/kayodante/Siphon/0.7.2/kayodante.Siphon.installer.yaml
+++ b/manifests/k/kayodante/Siphon/0.7.2/kayodante.Siphon.installer.yaml
@@ -13,6 +13,7 @@ InstallerSwitches:
   SilentWithProgress: /S
 UpgradeBehavior: install
 Scope: user
+ReleaseDate: 2026-05-14
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/kayodante/Win-siphonClaudeUsage/releases/download/v0.7.2/Siphon.Setup.0.7.2.exe

--- a/manifests/k/kayodante/Siphon/0.7.2/kayodante.Siphon.installer.yaml
+++ b/manifests/k/kayodante/Siphon/0.7.2/kayodante.Siphon.installer.yaml
@@ -1,0 +1,20 @@
+# Created using wingetcreate 1.6.5.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: kayodante.Siphon
+PackageVersion: 0.7.2
+InstallerLocale: en-US
+InstallerType: nullsoft
+InstallModes:
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/kayodante/Win-siphonClaudeUsage/releases/download/v0.7.2/Siphon.Setup.0.7.2.exe
+    InstallerSha256: 9DEFFEB5DCB3CE3F759BBE4D72DA9F619EEB2D7D5A8DD5F5DE94EF819090C308
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/k/kayodante/Siphon/0.7.2/kayodante.Siphon.installer.yaml
+++ b/manifests/k/kayodante/Siphon/0.7.2/kayodante.Siphon.installer.yaml
@@ -15,6 +15,6 @@ UpgradeBehavior: install
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/kayodante/Win-siphonClaudeUsage/releases/download/v0.7.2/Siphon.Setup.0.7.2.exe
-    InstallerSha256: 9DEFFEB5DCB3CE3F759BBE4D72DA9F619EEB2D7D5A8DD5F5DE94EF819090C308
+    InstallerSha256: 9deffeb5dcb3ce3f759bbe4d72da9f619eeb2d7d5a8dd5f5de94ef819090c308
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/k/kayodante/Siphon/0.7.2/kayodante.Siphon.installer.yaml
+++ b/manifests/k/kayodante/Siphon/0.7.2/kayodante.Siphon.installer.yaml
@@ -19,4 +19,4 @@ Installers:
     InstallerUrl: https://github.com/kayodante/Win-siphonClaudeUsage/releases/download/v0.7.2/Siphon.Setup.0.7.2.exe
     InstallerSha256: 9deffeb5dcb3ce3f759bbe4d72da9f619eeb2d7d5a8dd5f5de94ef819090c308
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/k/kayodante/Siphon/0.7.2/kayodante.Siphon.installer.yaml
+++ b/manifests/k/kayodante/Siphon/0.7.2/kayodante.Siphon.installer.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.6.5.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: kayodante.Siphon
 PackageVersion: 0.7.2

--- a/manifests/k/kayodante/Siphon/0.7.2/kayodante.Siphon.locale.en-US.yaml
+++ b/manifests/k/kayodante/Siphon/0.7.2/kayodante.Siphon.locale.en-US.yaml
@@ -7,6 +7,7 @@ PackageLocale: en-US
 Publisher: kayodante
 PublisherUrl: https://github.com/kayodante
 PublisherSupportUrl: https://github.com/kayodante/Win-siphonClaudeUsage/issues
+PrivacyUrl: https://github.com/kayodante/Win-siphonClaudeUsage/blob/main/docs/privacy-policy.md
 PackageName: Siphon
 PackageUrl: https://github.com/kayodante/Win-siphonClaudeUsage
 License: MIT
@@ -18,6 +19,7 @@ Description: |-
   and the Anthropic OAuth usage endpoint. No API keys required.
   Schedules a Windows toast notification for the exact moment your
   five-hour session quota resets — even if the app was closed during that window.
+Moniker: win-siphon
 Tags:
   - claude
   - claude-code

--- a/manifests/k/kayodante/Siphon/0.7.2/kayodante.Siphon.locale.en-US.yaml
+++ b/manifests/k/kayodante/Siphon/0.7.2/kayodante.Siphon.locale.en-US.yaml
@@ -13,12 +13,21 @@ PackageUrl: https://github.com/kayodante/Win-siphonClaudeUsage
 License: MIT
 LicenseUrl: https://github.com/kayodante/Win-siphonClaudeUsage/blob/main/LICENSE
 ShortDescription: Windows tray app that tracks Claude Code usage in real time.
-Description: |-
-  Siphon sits in your system tray and shows session quota, weekly limits,
-  and daily/monthly costs pulled directly from Claude Code's local files
-  and the Anthropic OAuth usage endpoint. No API keys required.
-  Schedules a Windows toast notification for the exact moment your
-  five-hour session quota resets — even if the app was closed during that window.
+Description: >-
+  Siphon is an unofficial, community-built Windows tray utility for developers
+  who use Claude Code. It sits in the system tray and surfaces the current 5-hour
+  session quota, the rolling weekly limit, and daily and monthly cost totals, reading
+  from the local Claude Code data files and the OAuth usage endpoint that
+  Claude Code itself uses for authentication.
+  
+  When a session quota reaches 100%, Siphon schedules a native Windows toast notification
+  for the exact reset time so the next usage window is not missed. If the application
+  is closed when the reset occurs, the missed notification fires on the next launch.
+  
+  An optional always-on-top floating widget keeps the key numbers visible during work,
+  and color-coded tray icons reflect the current quota level at a glance. The interface
+  is available in English and Brazilian Portuguese. Siphon is open source under
+  the MIT license and is not affiliated with, endorsed by, or sponsored by Anthropic.
 Moniker: win-siphon
 Tags:
   - claude

--- a/manifests/k/kayodante/Siphon/0.7.2/kayodante.Siphon.locale.en-US.yaml
+++ b/manifests/k/kayodante/Siphon/0.7.2/kayodante.Siphon.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# Created using wingetcreate 1.6.5.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: kayodante.Siphon
+PackageVersion: 0.7.2
+PackageLocale: en-US
+Publisher: kayodante
+PublisherUrl: https://github.com/kayodante
+PublisherSupportUrl: https://github.com/kayodante/Win-siphonClaudeUsage/issues
+PackageName: Siphon
+PackageUrl: https://github.com/kayodante/Win-siphonClaudeUsage
+License: MIT
+LicenseUrl: https://github.com/kayodante/Win-siphonClaudeUsage/blob/main/LICENSE
+ShortDescription: Windows tray app that tracks Claude Code usage in real time.
+Description: |-
+  Siphon sits in your system tray and shows session quota, weekly limits,
+  and daily/monthly costs pulled directly from Claude Code's local files
+  and the Anthropic OAuth usage endpoint. No API keys required.
+  Schedules a Windows toast notification for the exact moment your
+  five-hour session quota resets — even if the app was closed during that window.
+Tags:
+  - claude
+  - claude-code
+  - ai
+  - usage
+  - tray
+  - productivity
+  - anthropic
+ReleaseNotesUrl: https://github.com/kayodante/Win-siphonClaudeUsage/releases/tag/v0.7.2
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/k/kayodante/Siphon/0.7.2/kayodante.Siphon.locale.en-US.yaml
+++ b/manifests/k/kayodante/Siphon/0.7.2/kayodante.Siphon.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.6.5.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: kayodante.Siphon
 PackageVersion: 0.7.2

--- a/manifests/k/kayodante/Siphon/0.7.2/kayodante.Siphon.locale.en-US.yaml
+++ b/manifests/k/kayodante/Siphon/0.7.2/kayodante.Siphon.locale.en-US.yaml
@@ -39,4 +39,4 @@ Tags:
   - anthropic
 ReleaseNotesUrl: https://github.com/kayodante/Win-siphonClaudeUsage/releases/tag/v0.7.2
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/k/kayodante/Siphon/0.7.2/kayodante.Siphon.yaml
+++ b/manifests/k/kayodante/Siphon/0.7.2/kayodante.Siphon.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.6.5.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: kayodante.Siphon
+PackageVersion: 0.7.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0

--- a/manifests/k/kayodante/Siphon/0.7.2/kayodante.Siphon.yaml
+++ b/manifests/k/kayodante/Siphon/0.7.2/kayodante.Siphon.yaml
@@ -5,4 +5,4 @@ PackageIdentifier: kayodante.Siphon
 PackageVersion: 0.7.2
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/k/kayodante/Siphon/0.7.2/kayodante.Siphon.yaml
+++ b/manifests/k/kayodante/Siphon/0.7.2/kayodante.Siphon.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.6.5.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: kayodante.Siphon
 PackageVersion: 0.7.2


### PR DESCRIPTION
## Description

Add new package `kayodante.Siphon` version 0.7.2.

**Siphon** is a Windows tray app that tracks Claude Code usage in real time — session quota, weekly limits, and daily/monthly costs, pulled from Claude Code's local files and the Anthropic OAuth usage endpoint. Schedules a Windows toast notification for the exact moment the five-hour session quota resets.

- **Repository:** https://github.com/kayodante/Win-siphonClaudeUsage
- **License:** MIT
- **Installer type:** NSIS (nullsoft), per-user, no elevation required
- **Platform:** Windows 10+

## Validation

- [x] Manifest created with wingetcreate schema 1.6.0
- [x] SHA256 verified against GitHub Release asset
- [x] Installer runs silently with `/S`
- [x] No malware, no hacking tools — monitoring/productivity app
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/374710)