### PR TITLE
New version: RedEyeNetworks.Logivore version 0.12.1

### DIFF
--- a/manifests/r/RedEyeNetworks/Logivore/0.12.1/RedEyeNetworks.Logivore.installer.yaml
+++ b/manifests/r/RedEyeNetworks/Logivore/0.12.1/RedEyeNetworks.Logivore.installer.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: RedEyeNetworks.Logivore
+PackageVersion: 0.12.1
+InstallerType: inno
+Scope: machine
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  Custom: /NORESTART
+UpgradeBehavior: install
+Commands:
+- logivore
+Installers:
+- Architecture: x64
+  Scope: user
+  InstallerUrl: https://download.redeyenetworks.com/logivore/releases/0.12.1/logivore-win-x64-setup.exe
+  InstallerSha256: C95E13ED311185F3419451D536DAE16B214874349C26DE9EA2FC576D12878D25
+- Architecture: x64
+  Scope: machine
+  ElevationRequirement: elevatesSelf
+  InstallerUrl: https://download.redeyenetworks.com/logivore/releases/0.12.1/logivore-win-x64-machine-setup.exe
+  InstallerSha256: 05DFA1B0608C76BEBFAF615A7262BB98E8F83E9B5C4E7087E6402D60DFED4664
+- Architecture: arm64
+  Scope: user
+  InstallerUrl: https://download.redeyenetworks.com/logivore/releases/0.12.1/logivore-win-arm64-setup.exe
+  InstallerSha256: 8A12409604589182992D8FB2694C2E97A4E9899D2C5F1ED9C8D11877EB7AD2B3
+- Architecture: arm64
+  Scope: machine
+  ElevationRequirement: elevatesSelf
+  InstallerUrl: https://download.redeyenetworks.com/logivore/releases/0.12.1/logivore-win-arm64-machine-setup.exe
+  InstallerSha256: 0BB524753A7E14B19C0EC045B1E580FB099240D7E449B876BFD24DA2D0F7F594
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/r/RedEyeNetworks/Logivore/0.12.1/RedEyeNetworks.Logivore.locale.en-US.yaml
+++ b/manifests/r/RedEyeNetworks/Logivore/0.12.1/RedEyeNetworks.Logivore.locale.en-US.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: RedEyeNetworks.Logivore
+PackageVersion: 0.12.1
+PackageLocale: en-US
+Publisher: RedEye Network Solutions LLC
+PublisherUrl: https://redeyenetworks.com
+PublisherSupportUrl: https://redeyenetworks.com/support
+Author: RedEye Network Solutions LLC
+PackageName: Logivore
+PackageUrl: https://redeyenetworks.com
+License: Proprietary
+Copyright: Copyright 2026 RedEye Network Solutions LLC. All rights reserved.
+ShortDescription: Cross-platform desktop log analyzer with LILA, an AI assistant for log triage
+Description: |-
+  Logivore is a local-first, cross-platform desktop log analyzer for Windows,
+  macOS, and Linux. Parses dozens of log formats (plaintext, syslog, EVTX,
+  PAN-OS TSF, Veeam VBR, GlobalProtect, pcap), correlates events across
+  sources, and surfaces findings via LILA — an AI assistant that runs locally
+  with optional Anthropic Claude or Google Gemini provider integration.
+  Memory-tier-adaptive (Flash / Hybrid / Indexed) so any log size works on
+  any hardware. Trust-gated LLM boundary keeps PII tokenized before it leaves
+  the machine.
+Moniker: logivore
+Tags:
+- log-analysis
+- log-viewer
+- syslog
+- evtx
+- pan-os
+- veeam
+- pcap
+- ai
+- llm
+- claude
+- gemini
+- timeline
+- correlation
+- desktop
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/RedEyeNetworks/Logivore/0.12.1/RedEyeNetworks.Logivore.yaml
+++ b/manifests/r/RedEyeNetworks/Logivore/0.12.1/RedEyeNetworks.Logivore.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: RedEyeNetworks.Logivore
+PackageVersion: 0.12.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Logivore v0.12.1 — first stable since the v0.11.0 SKU split. Adopts Argus multi-vendor malware pre-submission, restores the launch path that had silently broken across every build since v0.11.0 (DI registration regression on `ILLMProvider`), and unships the single-file Windows publish layout in favor of the PowerToys / Notepad++ multi-file shape (apphost + sibling DLLs) to defeat PAN WildFire's packed-binary ML signature that was quarantining v0.10.x → v0.12.0 on Cortex XDR endpoints.

4-installer shape unchanged from earlier published versions (0.10.1, 0.11.0): user-scope + machine-scope × x64 + arm64, each Inno Setup EXE wrapped around a multi-file self-contained .NET 9 publish. Azure Trusted Signing on every binary.

Manifest composed during the v0.12.1 release pipeline run (run #25890457211, 2026-05-14) and pulled from the CI artifact; submission is being driven manually for this version because the previous `workflow_dispatch + submit_to_winget=true` gate prevented auto-submission. Future stable tags will auto-submit per redeyenetworks/logivore#449.

Previous Logivore versions on Microsoft Store / WinGet: 0.10.1 (#368676 merged), 0.11.0 merged. v0.12.0 PR (#374296) was closed in favor of this current-stable submission to skip past a transient Microsoft-side validation-runner env glitch.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/374865)