### PR TITLE
New package: RedEyeNetworks.LogivoreForVeeam version 0.12.1

### DIFF
--- a/manifests/r/RedEyeNetworks/LogivoreForVeeam/0.12.1/RedEyeNetworks.LogivoreForVeeam.installer.yaml
+++ b/manifests/r/RedEyeNetworks/LogivoreForVeeam/0.12.1/RedEyeNetworks.LogivoreForVeeam.installer.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: RedEyeNetworks.LogivoreForVeeam
+PackageVersion: 0.12.1
+InstallerType: inno
+Scope: machine
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  Custom: /NORESTART
+UpgradeBehavior: install
+Commands:
+- logivoreforveeam
+Installers:
+- Architecture: x64
+  Scope: user
+  InstallerUrl: https://download.redeyenetworks.com/logivore-for-veeam/releases/0.12.1/logivore-for-veeam-win-x64-setup.exe
+  InstallerSha256: 09130D8529B7FECAC768853059CAF3F345669C73D4C38E24616E8FABBE4E0FE6
+- Architecture: x64
+  Scope: machine
+  ElevationRequirement: elevatesSelf
+  InstallerUrl: https://download.redeyenetworks.com/logivore-for-veeam/releases/0.12.1/logivore-for-veeam-win-x64-machine-setup.exe
+  InstallerSha256: 9F76D01A580074467E8711599180DF2038C4D9395FE4ABB63DD8250875265051
+- Architecture: arm64
+  Scope: user
+  InstallerUrl: https://download.redeyenetworks.com/logivore-for-veeam/releases/0.12.1/logivore-for-veeam-win-arm64-setup.exe
+  InstallerSha256: A370F36ECC4F86955C4CEF0E822E82E7D16C3F7FBBD10F14D0D5679799BC4DBB
+- Architecture: arm64
+  Scope: machine
+  ElevationRequirement: elevatesSelf
+  InstallerUrl: https://download.redeyenetworks.com/logivore-for-veeam/releases/0.12.1/logivore-for-veeam-win-arm64-machine-setup.exe
+  InstallerSha256: 08EA1688DAB0A0C03D27A1FE2728988C15B6E67742A2C99B8A8182492717AA6C
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/r/RedEyeNetworks/LogivoreForVeeam/0.12.1/RedEyeNetworks.LogivoreForVeeam.locale.en-US.yaml
+++ b/manifests/r/RedEyeNetworks/LogivoreForVeeam/0.12.1/RedEyeNetworks.LogivoreForVeeam.locale.en-US.yaml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: RedEyeNetworks.LogivoreForVeeam
+PackageVersion: 0.12.1
+PackageLocale: en-US
+Publisher: RedEye Network Solutions LLC
+PublisherUrl: https://redeyenetworks.com
+PublisherSupportUrl: https://redeyenetworks.com/support
+Author: RedEye Network Solutions LLC
+PackageName: Logivore for Veeam
+PackageUrl: https://redeyenetworks.com
+License: Proprietary
+Copyright: Copyright 2026 RedEye Network Solutions LLC. All rights reserved.
+ShortDescription: Logivore plus Advanced Veeam Mode — collects, normalizes, and analyzes Veeam Backup and Replication logs end-to-end
+Description: |-
+  Logivore for Veeam is the Veeam-centric SKU of Logivore. Includes
+  everything in Logivore (cross-platform log analysis, LILA AI
+  assistant, memory-tier-adaptive parsing, local-first trust-gated
+  LLM boundary) plus Microsoft.PowerShell.SDK and a built-in
+  Advanced Veeam Mode that drives the Veeam VBR PowerShell cmdlets
+  to collect job/repository/proxy diagnostics on demand. Targeted
+  at Veeam backup administrators who need to triage failed jobs
+  against backup server, repository, and proxy logs in one
+  timeline.
+Moniker: logivore-for-veeam
+Tags:
+- veeam
+- vbr
+- backup
+- log-analysis
+- log-viewer
+- syslog
+- evtx
+- powershell
+- ai
+- llm
+- claude
+- gemini
+- timeline
+- correlation
+- desktop
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/RedEyeNetworks/LogivoreForVeeam/0.12.1/RedEyeNetworks.LogivoreForVeeam.yaml
+++ b/manifests/r/RedEyeNetworks/LogivoreForVeeam/0.12.1/RedEyeNetworks.LogivoreForVeeam.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: RedEyeNetworks.LogivoreForVeeam
+PackageVersion: 0.12.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Logivore for Veeam v0.12.1 — first stable submission of the Veeam-centric SKU, separated from the base Logivore package per the v0.11.0 SKU split.

The previous `New package:` PR (#373316, v0.11.0) was closed as stale because the v0.11.0 build was incorrectly stamping `0.10.2-rc.1` into its assembly version (a SemVer-stamping bug fixed in redeyenetworks/logivore PR #268 / commit `d9e567f`, included in v0.12.1). With the version-stamping fix in place, the installed package now displays the correct `0.12.1` version, matching the manifest.

LogivoreForVeeam ships as a distinct WinGet package (`RedEyeNetworks.LogivoreForVeeam`) with its own settings folder (`%APPDATA%\LogivoreForVeeam\`), credential namespace (`LogivoreForVeeam:`), install directory, and Argus appcast endpoint (`/v1/appcast/logivore-for-veeam`) so it can coexist with the base `RedEyeNetworks.Logivore` package on the same machine. Distinct Inno Setup AppIds (B7A2E4C1 for Base, D9F2A8B3 for Veeam) per the Microsoft moderator guidance from #373316.

Mirror of the base RedEyeNetworks.Logivore 4-installer shape (user-scope + machine-scope × x64 + arm64), each Inno Setup EXE wrapped around a multi-file self-contained .NET 9 publish that includes Microsoft.PowerShell.SDK for the Advanced Veeam Mode runspace. Multi-file shape (PowerToys / Notepad++ pattern) defeats the packed-binary ML signature on PAN WildFire that has been quarantining the Base SKU's monolithic EXE on Cortex XDR endpoints — extra-important for the Veeam SKU because it embeds the PSH SDK at ~200 MB total.

The driver for splitting the SKU in the first place was Cortex XDR / CrowdStrike behavioral-detection on the embedded PowerShell SDK + self-extract + auto-launch combo; isolating the higher-risk shape to the ~5% Veeam audience keeps the Base ~80 MB SKU clean for the ~95% audience that doesn't need PSH. See redeyenetworks/logivore `docs/edr-reputation-playbook.md` for the full rationale.

Azure Trusted Signing on every binary (12 EXEs: 4 portable + 4 user-scope + 4 machine-scope across Base + Veeam × x64 + arm64).

Pre-submitted to VirusTotal, WildFire (PAN), and Hybrid Analysis (CrowdStrike-owned) on every stable tag via redeyenetworks/Argus's `release-malware-submission.yml` reusable workflow — verdict-link section is appended to each GitHub Release body.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/374866)