### PR TITLE
Remove scope: GnuPG.GnuPG version 2.5.20

### DIFF
--- a/manifests/g/GnuPG/GnuPG/2.5.20/GnuPG.GnuPG.installer.yaml
+++ b/manifests/g/GnuPG/GnuPG/2.5.20/GnuPG.GnuPG.installer.yaml
@@ -1,10 +1,9 @@
-# Created with YamlCreate.ps1 Dumplings Mod
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: GnuPG.GnuPG
 PackageVersion: 2.5.20
+ReleaseDate: 2026-05-13
 InstallerType: nullsoft
-Scope: machine
 UpgradeBehavior: install
 Commands:
 - dirmngr
@@ -24,7 +23,6 @@ Commands:
 - keyboxd
 - scdaemon
 ProductCode: GnuPG
-ReleaseDate: 2026-05-13
 ElevationRequirement: elevatesSelf
 Installers:
 - Architecture: x64


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
Removes `Scope: machine`. Based directly on the following quote from #374622: *"I have a local installation but the package is scoped to Machine. I've confirmed that the installer linked in the repository will update a local installation."*

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #374622.

## 📦 Manifest Checklist

- [ ] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/375086)