### PR TITLE
New version: Mockzilla.Mockzilla version 2.5.5

### DIFF
--- a/manifests/m/Mockzilla/Mockzilla/2.5.5/Mockzilla.Mockzilla.installer.yaml
+++ b/manifests/m/Mockzilla/Mockzilla/2.5.5/Mockzilla.Mockzilla.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Mockzilla.Mockzilla
+PackageVersion: 2.5.5
+InstallerType: portable
+Commands:
+- mockzilla
+ReleaseDate: 2026-05-15
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/mockzilla/mockzilla/releases/download/v2.5.5/mockzilla-v2.5.5-windows-amd64.exe
+  InstallerSha256: A93A05D36A60C220CA9D0B5DBBEDE7E4314EE3ACF3F4346ADBC2D7DA5ABD9B1F
+- Architecture: arm64
+  InstallerUrl: https://github.com/mockzilla/mockzilla/releases/download/v2.5.5/mockzilla-v2.5.5-windows-arm64.exe
+  InstallerSha256: DA3B6075787E0EA4434CE4270EECB58E2D4F254696900AE2B709E50A39456786
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/Mockzilla/Mockzilla/2.5.5/Mockzilla.Mockzilla.locale.en-US.yaml
+++ b/manifests/m/Mockzilla/Mockzilla/2.5.5/Mockzilla.Mockzilla.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Mockzilla.Mockzilla
+PackageVersion: 2.5.5
+PackageLocale: en-US
+Publisher: Mockzilla
+PublisherUrl: https://github.com/mockzilla
+PublisherSupportUrl: https://github.com/mockzilla/mockzilla/issues
+PackageName: Mockzilla
+PackageUrl: https://github.com/mockzilla/mockzilla
+License: MIT
+LicenseUrl: https://github.com/mockzilla/mockzilla/blob/main/LICENSE
+ShortDescription: Generate API mocks with meaningful responses, configurable latency, error codes and more
+Description: Mockzilla is an OpenAPI mock engine that generates API mocks with meaningful responses, configurable latency, error codes and more.
+Moniker: mockzilla
+Tags:
+- api
+- mock
+- mocking
+- openapi
+- testing
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/Mockzilla/Mockzilla/2.5.5/Mockzilla.Mockzilla.yaml
+++ b/manifests/m/Mockzilla/Mockzilla/2.5.5/Mockzilla.Mockzilla.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Mockzilla.Mockzilla
+PackageVersion: 2.5.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Mockzilla.Mockzilla 2.5.5 (new package)

Adds Mockzilla, an OpenAPI mock engine CLI distributed as a portable Windows executable.

- Homepage: https://mockzilla.github.io/mockzilla/
- Source: https://github.com/mockzilla/mockzilla
- Release: https://github.com/mockzilla/mockzilla/releases/tag/v2.5.5
- License: MIT
- Architectures: x64, arm64
- InstallerType: portable

### Manifest checklist

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://docs.microsoft.com/windows/package-manager/package/manifest#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-cli/blob/master/schemas/JSON/manifests/v1.12.0)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/375204)