### PR TITLE
New package: TooruTora.tora version 0.1.0

### DIFF
--- a/manifests/t/TooruTora/tora/0.1.0/TooruTora.tora.installer.yaml
+++ b/manifests/t/TooruTora/tora/0.1.0/TooruTora.tora.installer.yaml
@@ -1,0 +1,20 @@
+# Created with the WinGet 1.6 manifest schema.
+PackageIdentifier: TooruTora.tora
+PackageVersion: 0.1.0
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.19044.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: tora.exe
+    PortableCommandAlias: tora
+Commands:
+  - tora
+Architecture: x64
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/TooruTora/tora-wm/releases/download/v0.1.0/tora-v0.1.0-x86_64-pc-windows-msvc.zip
+    InstallerSha256: C85CAB3AD47EAEE07E2EC28B00C67ED3F49F7659B72A898A6E06766DE7FE844B
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/t/TooruTora/tora/0.1.0/TooruTora.tora.locale.en-US.yaml
+++ b/manifests/t/TooruTora/tora/0.1.0/TooruTora.tora.locale.en-US.yaml
@@ -1,0 +1,32 @@
+PackageIdentifier: TooruTora.tora
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: TooruTora
+PublisherUrl: https://github.com/TooruTora
+PublisherSupportUrl: https://github.com/TooruTora/tora-wm/issues
+PackageName: tora
+PackageUrl: https://github.com/TooruTora/tora-wm
+License: MIT OR Apache-2.0
+LicenseUrl: https://github.com/TooruTora/tora-wm/blob/main/LICENSE-MIT
+ShortDescription: Lightweight tiling window manager for Windows, driven by CLI + IPC.
+Description: |-
+  tora is a tiling window manager for Windows 10 / 11 written in Rust.
+  A single tora.exe binary owns layout and per-monitor workspaces; every
+  feature that can live outside the core (borders, transparency, sloppy
+  focus, per-app rules) ships as a separate addon process that opts in
+  via the daemon's named-pipe IPC. Bring your own hotkey daemon
+  (AutoHotkey, whkd, PowerToys) and bind keys to "tora <subcommand>".
+Tags:
+  - tiling
+  - window-manager
+  - rust
+  - windows
+  - tora
+ReleaseNotesUrl: https://github.com/TooruTora/tora-wm/releases/tag/v0.1.0
+Documentations:
+  - DocumentLabel: README
+    DocumentUrl: https://github.com/TooruTora/tora-wm/blob/main/README.md
+  - DocumentLabel: Migration from komorebi
+    DocumentUrl: https://github.com/TooruTora/tora-wm/blob/main/docs/migration.md
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/t/TooruTora/tora/0.1.0/TooruTora.tora.yaml
+++ b/manifests/t/TooruTora/tora/0.1.0/TooruTora.tora.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: TooruTora.tora
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Reference Linked Issues

None.

## Validation

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-cli/blob/master/schemas/JSON/manifests/v1.6.0/)?

## Description

Adds a new package: [tora](https://github.com/TooruTora/tora-wm) v0.1.0 — a lightweight tiling window manager for Windows, written in Rust.

A single `tora.exe` binary owns layout and per-monitor workspaces; every feature that can live outside the core (borders, transparency, sloppy focus, per-app rules) ships as a separate addon process. Users bring their own hotkey daemon (AutoHotkey, whkd, PowerToys) and bind keys to `tora <subcommand>`.

### Installer details

- Type: zip (nested portable, exposes `tora.exe` as command alias `tora`)
- Architecture: x64 only
- Installer URL: `https://github.com/TooruTora/tora-wm/releases/download/v0.1.0/tora-v0.1.0-x86_64-pc-windows-msvc.zip`
- SHA256: `C85CAB3AD47EAEE07E2EC28B00C67ED3F49F7659B72A898A6E06766DE7FE844B`
- License: MIT OR Apache-2.0
- MinimumOSVersion: 10.0.19044.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/375442)