### PR TITLE
General maintenance: CitrusSoda.ArcThumb version 0.7.2

### DIFF
--- a/manifests/c/CitrusSoda/ArcThumb/0.7.2/CitrusSoda.ArcThumb.installer.yaml
+++ b/manifests/c/CitrusSoda/ArcThumb/0.7.2/CitrusSoda.ArcThumb.installer.yaml
@@ -28,14 +28,14 @@ Installers:
   InstallerSwitches:
     Custom: /ALLUSERS
 FileExtensions:
-- cbz
+- azw
+- azw3
 - cb7
 - cbr
 - cbt
+- cbz
 - epub
 - fb2
 - mobi
-- azw
-- azw3
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/c/CitrusSoda/ArcThumb/0.7.2/CitrusSoda.ArcThumb.installer.yaml
+++ b/manifests/c/CitrusSoda/ArcThumb/0.7.2/CitrusSoda.ArcThumb.installer.yaml
@@ -1,8 +1,8 @@
-# Created using wingetcreate 1.12.8.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: CitrusSoda.ArcThumb
 PackageVersion: 0.7.2
+ReleaseDate: 2026-04-30
 InstallerType: inno
 InstallModes:
 - interactive
@@ -27,6 +27,15 @@ Installers:
   InstallerSha256: 9CE25F2C329CBF45101ECC0DC3D8F74152383113CD9852696B741C4CD2AFC64F
   InstallerSwitches:
     Custom: /ALLUSERS
+FileExtensions:
+- cbz
+- cb7
+- cbr
+- cbt
+- epub
+- fb2
+- mobi
+- azw
+- azw3
 ManifestType: installer
 ManifestVersion: 1.12.0
-ReleaseDate: 2026-04-30

--- a/manifests/c/CitrusSoda/ArcThumb/0.7.2/CitrusSoda.ArcThumb.locale.en-US.yaml
+++ b/manifests/c/CitrusSoda/ArcThumb/0.7.2/CitrusSoda.ArcThumb.locale.en-US.yaml
@@ -1,4 +1,3 @@
-# Created using wingetcreate 1.12.8.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: CitrusSoda.ArcThumb
@@ -12,16 +11,17 @@ PackageName: ArcThumb
 PackageUrl: https://citrussoda.com/en/arcthumb
 License: MIT OR Apache-2.0
 LicenseUrl: https://github.com/citrussoda-com/ArcThumb#license
-Copyright: Copyright (c) 2026 citrussoda-com
+Copyright: Copyright © 2026 citrussoda-com
 ShortDescription: Windows Explorer thumbnail and preview handler for archive files and ebooks.
 Description: "ArcThumb is a Windows Shell Extension that adds thumbnail icons and preview-pane previews to Windows Explorer for archive files and ebooks. When a supported file contains images, ArcThumb decodes the first one and shows it as the file's thumbnail; the preview pane renders a larger version. Supported containers: ZIP, 7Z, RAR, TAR and their media variants (CBZ, CB7, CBR, CBT), plus ebooks in EPUB, FB2, MOBI, AZW, and AZW3. Images inside are decoded from JPEG, PNG, GIF, BMP, TIFF, ICO, and WebP. Optional JPEG XL support is available in custom builds. ArcThumb is a Rust-based successor to CBX Shell and DarkThumbs. A bundled configuration GUI lets you toggle formats, set decode limits, and register or unregister the extension. Installs per-user by default with no administrator privileges; running the installer elevated registers the extension machine-wide instead, which is required when Explorer runs at high integrity (such as Windows Sandbox). Requires Windows 10 or later on x64."
 Moniker: arcthumb
 Tags:
-- thumbnail
+- ebook-thumbnails
 - preview
-- explorer
+- file-explorer
+- fileexplorer
 - shell-extension
-- archive
+- archives
 - ebook
 - zip
 - epub


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
* Tags maintenance:
* * Replaced `thumbnail` with `ebook-thumbnails`, to distinguish it from apps that handle image and/or video thumbnails.
* * Replaced `explorer` with `file-explorer` and `fileexplorer`, to distinguish it from apps that deal with other explorer tools than Windows File Explorer.
* * Replaced `archive` with `archives`, since ArcThumb is not on its own an archive (that I currently know of).
* Added an initial "FileExtensions" list.
* Replaced (c) with © for in-Winget professionality.

I've learnt over the past few months that it carries some reputational risk for me to edit a manifest that is usually handled by the app's dev(s), so I'll @ the dev to let them know about this PR: @remu1519

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [ ] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/375489)