### PR TITLE
General maintenance: EYHN.SpaceThumbnails version 1.0.1

### DIFF
--- a/manifests/e/EYHN/SpaceThumbnails/1.0.1/EYHN.SpaceThumbnails.installer.yaml
+++ b/manifests/e/EYHN/SpaceThumbnails/1.0.1/EYHN.SpaceThumbnails.installer.yaml
@@ -1,12 +1,17 @@
-# Created with YamlCreate.ps1 v2.1.2 $debug=QUSU.7-2-2
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.1.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: EYHN.SpaceThumbnails
 PackageVersion: 1.0.1
+ReleaseDate: 2022-04-26
 MinimumOSVersion: 10.0.0.0
 InstallerType: wix
 Scope: machine
 UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/EYHN/space-thumbnails/releases/download/v1.0.1/space-thumbnails-installer.msi
+  InstallerSha256: 18AA1927B3C874B5E7FF00BC58973ECD34B7335085520CC884463226BAF7B027
+  ProductCode: '{9D678695-D74C-43BC-9147-DEAC1108B933}'
 FileExtensions:
 - 3ds
 - dae
@@ -18,11 +23,5 @@ FileExtensions:
 - stl
 - x3d
 - x3db
-ReleaseDate: 2022-04-26
-Installers:
-- Architecture: x64
-  InstallerUrl: https://github.com/EYHN/space-thumbnails/releases/download/v1.0.1/space-thumbnails-installer.msi
-  InstallerSha256: 18AA1927B3C874B5E7FF00BC58973ECD34B7335085520CC884463226BAF7B027
-  ProductCode: '{9D678695-D74C-43BC-9147-DEAC1108B933}'
 ManifestType: installer
-ManifestVersion: 1.1.0
+ManifestVersion: 1.12.0

--- a/manifests/e/EYHN/SpaceThumbnails/1.0.1/EYHN.SpaceThumbnails.locale.en-US.yaml
+++ b/manifests/e/EYHN/SpaceThumbnails/1.0.1/EYHN.SpaceThumbnails.locale.en-US.yaml
@@ -1,33 +1,33 @@
-# Created with YamlCreate.ps1 v2.1.2 $debug=QUSU.7-2-2
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.1.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: EYHN.SpaceThumbnails
 PackageVersion: 1.0.1
 PackageLocale: en-US
 Publisher: EYHN
-PublisherUrl: https://eyhn.in/
 PublisherSupportUrl: https://github.com/EYHN/space-thumbnails/issues
-# PrivacyUrl: 
 Author: EYHN
 PackageName: Space Thumbnails
 PackageUrl: https://github.com/EYHN/space-thumbnails
 License: Apache-2.0
 LicenseUrl: https://github.com/EYHN/space-thumbnails/blob/main/LICENSE
 Copyright: © 2022 EYHN
-# CopyrightUrl: 
 ShortDescription: Generates preview thumbnails for 3D model files.
-Description: Provide a Windows Explorer extensions that adds preview thumbnails for 3D model files.
-# Moniker: 
+Description: Provide a Windows Explorer extension that adds preview thumbnails for 3D model files.
 Tags:
-- 3d
-- file
-- model
-- preview
-- thumbnail
-# Agreements: 
+- 3d-file-model-thumbnails
+- 3dfilemodelthumbnails
+- 3d-files
+- 3dfiles
+- 3d-models
+- 3dmodels
+- previews
+- windows-explorer
+- windowsexplorer
+- windows-file-explorer
+- windowsfileexplorer
 ReleaseNotes: |-
   Fixed crash when rendering some glb models
   Use a more stable OpenGL backend when rendering glft and glb, at the cost that the background will be opaque and always black.
 ReleaseNotesUrl: https://github.com/EYHN/space-thumbnails/releases/tag/v1.0.1
 ManifestType: defaultLocale
-ManifestVersion: 1.1.0
+ManifestVersion: 1.12.0

--- a/manifests/e/EYHN/SpaceThumbnails/1.0.1/EYHN.SpaceThumbnails.locale.zh-CN.yaml
+++ b/manifests/e/EYHN/SpaceThumbnails/1.0.1/EYHN.SpaceThumbnails.locale.zh-CN.yaml
@@ -1,31 +1,16 @@
-# Created with YamlCreate.ps1 v2.1.2 $debug=QUSU.7-2-2
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.1.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
 
 PackageIdentifier: EYHN.SpaceThumbnails
 PackageVersion: 1.0.1
 PackageLocale: zh-CN
-Publisher: EYHN
-PublisherUrl: https://eyhn.in/
-PublisherSupportUrl: https://github.com/EYHN/space-thumbnails/issues
-# PrivacyUrl: 
-Author: EYHN
-PackageName: Space Thumbnails
-PackageUrl: https://github.com/EYHN/space-thumbnails
-License: Apache-2.0
-LicenseUrl: https://github.com/EYHN/space-thumbnails/blob/main/LICENSE
-Copyright: © 2022 EYHN
-# CopyrightUrl: 
 ShortDescription: 为 3D 模型文件生成预览缩略图
 Description: 提供 Windows 文件资源管理器加载项，为 3D 模型文件添加预览缩略图。
-# Moniker: 
 Tags:
 - 3d
 - 文件
 - 模型
 - 缩略图
 - 预览
-# Agreements: 
-# ReleaseNotes: 
 ReleaseNotesUrl: https://github.com/EYHN/space-thumbnails/releases/tag/v1.0.1
 ManifestType: locale
-ManifestVersion: 1.1.0
+ManifestVersion: 1.12.0

--- a/manifests/e/EYHN/SpaceThumbnails/1.0.1/EYHN.SpaceThumbnails.yaml
+++ b/manifests/e/EYHN/SpaceThumbnails/1.0.1/EYHN.SpaceThumbnails.yaml
@@ -1,8 +1,7 @@
-# Created with YamlCreate.ps1 v2.1.2 $debug=QUSU.7-2-2
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.1.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: EYHN.SpaceThumbnails
 PackageVersion: 1.0.1
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.1.0
+ManifestVersion: 1.12.0


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
* Tags:
* * Merged a lot of tags to distinguish it from apps that handle image/video/E-book thumbnails.
* * Added 4 tags to specify that it's for Windows File Explorer.
* * Changed relevant tags from singular to plural.
* Removed PublisherUrl, as its domain (eyhn•in) is dead.
* Upgraded ManifestVersion from 1.1.0 to 1.12.0.
* Removed lines in locale.zh-CN that are duplicates of those in locale.en-US, as they will show up when running `winget show EYHN.SpaceThumbnails --locale zh-CN` anyway.
* Fixed a grammar error in ShortDescription ("**a** Windows Explorer extension**s**")
* Filesize-reducing measures.

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/375497)