### PR TITLE
New package: MonzerOsman.YallaVideo version 1.1.2

### DIFF
--- a/manifests/m/MonzerOsman/YallaVideo/1.1.2/MonzerOsman.YallaVideo.installer.yaml
+++ b/manifests/m/MonzerOsman/YallaVideo/1.1.2/MonzerOsman.YallaVideo.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: MonzerOsman.YallaVideo
+PackageVersion: 1.1.2
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- silent
+- silentWithProgress
+- interactive
+UpgradeBehavior: install
+ReleaseDate: 2026-05-15
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/monzer15/yalla-video-releases/releases/download/v1.1.2/Yalla-Video-Setup-1.1.2.exe
+  InstallerSha256: B1C262D95FFEDBE39368C6FA53A6BF3CF26D2C6A7D3AD8E8B27AFACCA630D73B
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/MonzerOsman/YallaVideo/1.1.2/MonzerOsman.YallaVideo.installer.yaml
+++ b/manifests/m/MonzerOsman/YallaVideo/1.1.2/MonzerOsman.YallaVideo.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: MonzerOsman.YallaVideo
 PackageVersion: 1.1.2
@@ -18,4 +18,4 @@ Installers:
   InstallerUrl: https://github.com/monzer15/yalla-video-releases/releases/download/v1.1.2/Yalla-Video-Setup-1.1.2.exe
   InstallerSha256: B1C262D95FFEDBE39368C6FA53A6BF3CF26D2C6A7D3AD8E8B27AFACCA630D73B
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/m/MonzerOsman/YallaVideo/1.1.2/MonzerOsman.YallaVideo.locale.en-US.yaml
+++ b/manifests/m/MonzerOsman/YallaVideo/1.1.2/MonzerOsman.YallaVideo.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: MonzerOsman.YallaVideo
 PackageVersion: 1.1.2
@@ -22,4 +22,4 @@ Tags:
 - yt-dlp
 - playlist
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/m/MonzerOsman/YallaVideo/1.1.2/MonzerOsman.YallaVideo.locale.en-US.yaml
+++ b/manifests/m/MonzerOsman/YallaVideo/1.1.2/MonzerOsman.YallaVideo.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: MonzerOsman.YallaVideo
+PackageVersion: 1.1.2
+PackageLocale: en-US
+Publisher: Monzer Osman
+PublisherUrl: https://github.com/monzer15
+PublisherSupportUrl: https://github.com/monzer15/yalla-video-releases/issues
+Author: Monzer Osman
+PackageName: Yalla Video
+PackageUrl: https://github.com/monzer15/yalla-video-releases
+License: MIT
+LicenseUrl: https://github.com/monzer15/YallaVideo/blob/master/LICENSE
+Copyright: Copyright (c) 2026 Monzer Osman
+ShortDescription: Fast desktop video downloader for YouTube and 1000+ sites
+Description: Yalla Video is an Electron desktop app for downloading videos from YouTube and 1000+ other sites. Supports playlists, full channels, quality up to 8K, audio-only formats, and multi-language subtitles. yt-dlp and ffmpeg are bundled.
+Moniker: yalla-video
+Tags:
+- video
+- downloader
+- youtube
+- yt-dlp
+- playlist
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/MonzerOsman/YallaVideo/1.1.2/MonzerOsman.YallaVideo.yaml
+++ b/manifests/m/MonzerOsman/YallaVideo/1.1.2/MonzerOsman.YallaVideo.yaml
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: MonzerOsman.YallaVideo
 PackageVersion: 1.1.2
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/m/MonzerOsman/YallaVideo/1.1.2/MonzerOsman.YallaVideo.yaml
+++ b/manifests/m/MonzerOsman/YallaVideo/1.1.2/MonzerOsman.YallaVideo.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: MonzerOsman.YallaVideo
+PackageVersion: 1.1.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## 📖 Description

Adding MonzerOsman.YallaVideo version 1.1.2. Yalla Video is an Electron desktop video downloader for YouTube and 1000+ sites.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` — N/A, submitter is on Linux; relying on CI validation
- [ ] Tested manifest locally with `winget install --manifest <path>` — N/A, submitter is on Linux
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/375673)