### PR TITLE
New version: v2fly.v2ray-core version 5.49.0

### DIFF
--- a/manifests/v/v2fly/v2ray-core/5.49.0/v2fly.v2ray-core.installer.yaml
+++ b/manifests/v/v2fly/v2ray-core/5.49.0/v2fly.v2ray-core.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: v2fly.v2ray-core
+PackageVersion: 5.49.0
+InstallerType: zip
+NestedInstallerType: portable
+ReleaseDate: 2026-04-12
+NestedInstallerFiles:
+- RelativeFilePath: v2ray.exe
+  PortableCommandAlias: v2ray
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/v2fly/v2ray-core/releases/download/v5.49.0/v2ray-windows-32.zip
+  InstallerSha256: 763BA11EADEE5422730ED5E3B982A7D6B9B2E6AADED87BB1DA12853DCD4392F3
+- Architecture: x64
+  InstallerUrl: https://github.com/v2fly/v2ray-core/releases/download/v5.49.0/v2ray-windows-64.zip
+  InstallerSha256: 1A535FA7A009FD0A6BAA6B00C9CCD595ED0B175B8B8E11E4A5BDC7E71D919BAE
+- Architecture: arm64
+  InstallerUrl: https://github.com/v2fly/v2ray-core/releases/download/v5.49.0/v2ray-windows-arm64-v8a.zip
+  InstallerSha256: 781E819DA0813062BF2B6CBDC4FF6AEACBF481DF9A56452D7AA5291B82F5BEAB
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/v/v2fly/v2ray-core/5.49.0/v2fly.v2ray-core.locale.en-US.yaml
+++ b/manifests/v/v2fly/v2ray-core/5.49.0/v2fly.v2ray-core.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: v2fly.v2ray-core
+PackageVersion: 5.49.0
+PackageLocale: en-US
+Publisher: v2fly
+PublisherUrl: https://www.v2fly.org
+PublisherSupportUrl: https://github.com/v2fly/v2ray-core/issues
+Author: v2fly
+PackageName: v2ray-core
+PackageUrl: https://github.com/v2fly/v2ray-core
+License: MIT
+LicenseUrl: https://github.com/v2fly/v2ray-core/blob/master/LICENSE
+Copyright: Copyright (c) v2fly
+CopyrightUrl: https://github.com/v2fly/v2ray-core/blob/master/LICENSE
+ShortDescription: A platform for building proxies to bypass network restrictions.
+Moniker: v2ray
+Description: Project V is a set of network tools that help you to build your own computer network. It secures your network connections and thus protects your privacy.
+Tags:
+- network
+- proxy
+- vpn
+- v2ray
+ReleaseNotesUrl: https://github.com/v2fly/v2ray-core/releases/tag/v5.49.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/v/v2fly/v2ray-core/5.49.0/v2fly.v2ray-core.yaml
+++ b/manifests/v/v2fly/v2ray-core/5.49.0/v2fly.v2ray-core.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: v2fly.v2ray-core
+PackageVersion: 5.49.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description
Adds **v2fly.v2ray-core** version **5.49.0**.

Upstream release: https://github.com/v2fly/v2ray-core/releases/tag/v5.49.0 (published 2026-04-12)

> Note: The SHA256 values in the upstream signed `Release` file do **not** match the actual downloaded zip artifacts — a long-standing upstream issue (see [v2fly/v2ray-core#3049](https://github.com/v2fly/v2ray-core/issues/3049)). The `InstallerSha256` values in this manifest are computed from the **actual downloaded zip bytes** and verified locally.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable) — N/A

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls?q=is%3Apr+v2fly.v2ray-core+5.49.0) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally (JSON schema 1.12.0 + SHA256 re-download verification)
- [ ] Tested manifest locally with `winget install --manifest <path>` — no Windows host available
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/375800)