### PR TITLE
New package: qwerty-fr.qwerty-fr version 1.0.3.40

### DIFF
--- a/manifests/q/qwerty-fr/qwerty-fr/1.0.3.40/qwerty-fr.qwerty-fr.installer.yaml
+++ b/manifests/q/qwerty-fr/qwerty-fr/1.0.3.40/qwerty-fr.qwerty-fr.installer.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: qwerty-fr.qwerty-fr
+PackageVersion: 1.0.3.40
+InstallerType: zip
+NestedInstallerType: msi
+Scope: machine
+UpgradeBehavior: install
+ElevationRequirement: elevationRequired
+ReleaseDate: 2023-12-10
+Installers:
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: qwertyfr_amd64.msi
+  InstallerUrl: https://github.com/qwerty-fr/qwerty-fr/releases/download/v0.7.3/qwerty-fr_0.7.3_windows.zip
+  InstallerSha256: 28D4D20E9669A6F532ECFBF80BB86122B6DB2B325D9F8F68D4576EB5FCC888E8
+  ProductCode: '{8893AC91-4AC0-4EFB-BA90-F196F51297BA}'
+  AppsAndFeaturesEntries:
+  - DisplayName: French qwerty keyboard
+    DisplayVersion: 1.0.3.40
+    Publisher: Julien Blitte
+    ProductCode: '{8893AC91-4AC0-4EFB-BA90-F196F51297BA}'
+    UpgradeCode: '{3AB51080-6362-4474-9830-D776265CE91E}'
+    InstallerType: msi
+- Architecture: x86
+  NestedInstallerFiles:
+  - RelativeFilePath: qwertyfr_i386.msi
+  InstallerUrl: https://github.com/qwerty-fr/qwerty-fr/releases/download/v0.7.3/qwerty-fr_0.7.3_windows.zip
+  InstallerSha256: 28D4D20E9669A6F532ECFBF80BB86122B6DB2B325D9F8F68D4576EB5FCC888E8
+  ProductCode: '{8893AC91-4AC0-4EFB-BA90-F196F51297BA}'
+  AppsAndFeaturesEntries:
+  - DisplayName: French qwerty keyboard
+    DisplayVersion: 1.0.3.40
+    Publisher: Julien Blitte
+    ProductCode: '{8893AC91-4AC0-4EFB-BA90-F196F51297BA}'
+    UpgradeCode: '{5DE4B72F-EA60-4255-A543-4AD007756B84}'
+    InstallerType: msi
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/q/qwerty-fr/qwerty-fr/1.0.3.40/qwerty-fr.qwerty-fr.locale.en-US.yaml
+++ b/manifests/q/qwerty-fr/qwerty-fr/1.0.3.40/qwerty-fr.qwerty-fr.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: qwerty-fr.qwerty-fr
+PackageVersion: 1.0.3.40
+PackageLocale: en-US
+Publisher: Julien Blitte
+PublisherUrl: https://github.com/qwerty-fr
+PublisherSupportUrl: https://github.com/qwerty-fr/qwerty-fr/issues
+Author: qwerty-fr contributors
+PackageName: QWERTY-fr
+PackageUrl: https://qwerty-fr.org/
+License: MIT
+LicenseUrl: https://github.com/qwerty-fr/qwerty-fr/blob/v0.7.3/LICENSE
+Copyright: Copyright (c) 2022 Paul <devnoname120>, Julien Blitte
+ShortDescription: QWERTY keyboard layout with extra symbols and diacritics for French.
+Description: |-
+  QWERTY-fr is a keyboard layout based on QWERTY with extra symbols and
+  diacritics so that typing both French and English is easy and fast.
+Moniker: qwerty-fr
+Tags:
+- french
+- input-method
+- keyboard
+- keyboard-layout
+- layout
+- qwerty
+ReleaseNotesUrl: https://github.com/qwerty-fr/qwerty-fr/releases/tag/v0.7.3
+InstallationNotes: |-
+  After installation, open Windows language settings and select the keyboard
+  layout named "French qwerty keyboard" in your current language package.
+Documentations:
+- DocumentLabel: Installation instructions
+  DocumentUrl: https://github.com/qwerty-fr/qwerty-fr#-installation
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/q/qwerty-fr/qwerty-fr/1.0.3.40/qwerty-fr.qwerty-fr.yaml
+++ b/manifests/q/qwerty-fr/qwerty-fr/1.0.3.40/qwerty-fr.qwerty-fr.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: qwerty-fr.qwerty-fr
+PackageVersion: 1.0.3.40
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Adds qwerty-fr.qwerty-fr version 1.0.3.40.

## Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)
  - Resolves https://github.com/qwerty-fr/qwerty-fr/issues/101

## Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/375806)