### PR TITLE
New package: FrankManZhu.ZManagerCLI version 1.0.0

### DIFF
--- a/manifests/f/FrankManZhu/ZManagerCLI/1.0.0/FrankManZhu.ZManagerCLI.installer.yaml
+++ b/manifests/f/FrankManZhu/ZManagerCLI/1.0.0/FrankManZhu.ZManagerCLI.installer.yaml
@@ -1,0 +1,20 @@
+PackageIdentifier: FrankManZhu.ZManagerCLI
+PackageVersion: 1.0.0
+InstallerType: zip
+NestedInstallerType: portable
+ReleaseDate: 2026-05-17
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/frankmanzhu/zmanager/releases/download/v1.0.0/zm-x86_64-pc-windows-msvc.zip
+    InstallerSha256: 23de0dae29eeb801b614692aa6ece89ca739197f9d8a765811ead1fc12c67bba
+    NestedInstallerFiles:
+      - RelativeFilePath: zm.exe
+        PortableCommandAlias: zm
+  - Architecture: arm64
+    InstallerUrl: https://github.com/frankmanzhu/zmanager/releases/download/v1.0.0/zm-aarch64-pc-windows-msvc.zip
+    InstallerSha256: 3a328f491b91c0f3c278979b22cb02dea81f6329cfe905e5276be57049c59806
+    NestedInstallerFiles:
+      - RelativeFilePath: zm.exe
+        PortableCommandAlias: zm
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/f/FrankManZhu/ZManagerCLI/1.0.0/FrankManZhu.ZManagerCLI.locale.en-US.yaml
+++ b/manifests/f/FrankManZhu/ZManagerCLI/1.0.0/FrankManZhu.ZManagerCLI.locale.en-US.yaml
@@ -1,0 +1,22 @@
+PackageIdentifier: FrankManZhu.ZManagerCLI
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: Frank Zhu
+PublisherUrl: https://github.com/frankmanzhu
+PackageName: Z-Manager CLI
+PackageUrl: https://github.com/frankmanzhu/zmanager
+License: Apache-2.0
+LicenseUrl: https://github.com/frankmanzhu/zmanager/blob/v1.0.0/LICENSE
+ShortDescription: Fast, safe archive utility for ZIP, 7z, TAR.ZST, and broad extraction.
+Description: Z-Manager CLI extracts broad real-world archive formats safely and creates focused modern ZIP, TAR.ZST, and 7z archives.
+Tags:
+  - archive
+  - compression
+  - zip
+  - 7z
+  - tar
+  - zstd
+Commands:
+  - zm
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/f/FrankManZhu/ZManagerCLI/1.0.0/FrankManZhu.ZManagerCLI.yaml
+++ b/manifests/f/FrankManZhu/ZManagerCLI/1.0.0/FrankManZhu.ZManagerCLI.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: FrankManZhu.ZManagerCLI
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Adds Z-Manager CLI v1.0.0 as `FrankManZhu.ZManagerCLI`.

Package details:
- Command: `zm`
- Installer type: ZIP with portable nested installer
- Architectures: x64 and ARM64
- Publisher: Frank Zhu
- License: Apache-2.0

Validation performed:
- `winget validate .\manifests\f\FrankManZhu\ZManagerCLI\1.0.0`
- Verified x64 ZIP SHA256: `23de0dae29eeb801b614692aa6ece89ca739197f9d8a765811ead1fc12c67bba`
- Verified ARM64 ZIP SHA256: `3a328f491b91c0f3c278979b22cb02dea81f6329cfe905e5276be57049c59806`
- Smoke-tested x64 release binary: `zm --version` and `zm healthcheck`