### PR TITLE
New version: Hanselman.WingetTUI version 0.11.0

### DIFF
--- a/manifests/h/Hanselman/WingetTUI/0.11.0/Hanselman.WingetTUI.installer.yaml
+++ b/manifests/h/Hanselman/WingetTUI/0.11.0/Hanselman.WingetTUI.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: Hanselman.WingetTUI
+PackageVersion: 0.11.0
+InstallerType: zip
+NestedInstallerType: portable
+UpgradeBehavior: uninstallPrevious
+Commands:
+- winget-tui
+Installers:
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: winget-tui-0.11.0-x64\winget-tui.exe
+    PortableCommandAlias: winget-tui
+  InstallerUrl: https://github.com/shanselman/winget-tui/releases/download/v0.11.0/winget-tui-0.11.0-x64.zip
+  InstallerSha256: 7c915c81093611c6b54ad65ff20bf1ea95f7b170d8b2dafd801c2982eabc4915
+- Architecture: arm64
+  NestedInstallerFiles:
+  - RelativeFilePath: winget-tui-0.11.0-arm64\winget-tui.exe
+    PortableCommandAlias: winget-tui
+  InstallerUrl: https://github.com/shanselman/winget-tui/releases/download/v0.11.0/winget-tui-0.11.0-arm64.zip
+  InstallerSha256: 700e33d6223deb88cc7684c491fa6fd653074f71e98fa754781fefbc77f4d83d
+ManifestType: installer
+ManifestVersion: 1.10.0
+ReleaseDate: 2026-05-18

--- a/manifests/h/Hanselman/WingetTUI/0.11.0/Hanselman.WingetTUI.locale.en-US.yaml
+++ b/manifests/h/Hanselman/WingetTUI/0.11.0/Hanselman.WingetTUI.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: Hanselman.WingetTUI
+PackageVersion: 0.11.0
+PackageLocale: en-US
+Publisher: Scott Hanselman
+PublisherUrl: https://www.hanselman.com/
+PublisherSupportUrl: https://github.com/shanselman/winget-tui/issues
+Author: Scott Hanselman
+PackageName: winget-tui
+PackageUrl: https://github.com/shanselman/winget-tui
+License: MIT
+ShortDescription: Terminal UI for Windows Package Manager (winget).
+Description: A keyboard-first terminal interface for searching, installing, uninstalling, and upgrading Windows packages with winget.
+Moniker: winget-tui
+Tags:
+- winget
+- terminal
+- tui
+- package-manager
+- windows
+ReleaseNotesUrl: https://github.com/shanselman/winget-tui/releases/tag/v0.11.0
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/h/Hanselman/WingetTUI/0.11.0/Hanselman.WingetTUI.yaml
+++ b/manifests/h/Hanselman/WingetTUI/0.11.0/Hanselman.WingetTUI.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: Hanselman.WingetTUI
+PackageVersion: 0.11.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
### Changes
- Adds initial Winget manifest for Hanselman.WingetTUI version 0.11.0.
- Uses versioned portable ZIP assets from the GitHub release.
- Provides x64 and arm64 installers with the winget-tui command alias.

Release: https://github.com/shanselman/winget-tui/releases/tag/v0.11.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/375827)