### PR TITLE
New version: RSSNext.Folo version 1.8.0

### DIFF
--- a/manifests/r/RSSNext/Folo/1.8.0/RSSNext.Folo.installer.yaml
+++ b/manifests/r/RSSNext/Folo/1.8.0/RSSNext.Folo.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: RSSNext.Folo
+PackageVersion: 1.8.0
+InstallerType: portable
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Commands:
+- Folo
+ReleaseDate: 2026-05-12
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/RSSNext/Folo/releases/download/desktop/v1.8.0/Folo-1.8.0-windows-x64.exe
+  InstallerSha256: 47D6A188066F3A7FBAA3710691B2CE83558D1D603E767A6A8D801EBD9A99C0CB
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/r/RSSNext/Folo/1.8.0/RSSNext.Folo.locale.en-US.yaml
+++ b/manifests/r/RSSNext/Folo/1.8.0/RSSNext.Folo.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: RSSNext.Folo
+PackageVersion: 1.8.0
+PackageLocale: en-US
+Publisher: Folo Team
+PublisherUrl: https://github.com/RSSNext
+PublisherSupportUrl: https://github.com/RSSNext/Folo/issues
+PackageName: Folo
+PackageUrl: https://github.com/RSSNext/Folo
+License: GPL-3.0
+LicenseUrl: https://github.com/RSSNext/Folo/blob/HEAD/LICENSE
+Copyright: Copyright (c) 2025 Folo Team
+ShortDescription: "\U0001F9E1 Follow everything in one place"
+Description: |
+  As they say, your thoughts are what you read - and we've been consuming noisy feeds for too long. Folo cuts through the noise, helping you curate, organize, and follow what matters most.
+Tags:
+- rss
+- feed
+- reader
+- follow
+- information
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/r/RSSNext/Folo/1.8.0/RSSNext.Folo.locale.en-US.yaml
+++ b/manifests/r/RSSNext/Folo/1.8.0/RSSNext.Folo.locale.en-US.yaml
@@ -12,12 +12,22 @@ LicenseUrl: https://github.com/RSSNext/Folo/blob/HEAD/LICENSE
 Copyright: Copyright (c) 2025 Folo Team
 ShortDescription: "\U0001F9E1 Follow everything in one place"
 Description: |
-  As they say, your thoughts are what you read - and we've been consuming noisy feeds for too long. Folo cuts through the noise, helping you curate, organize, and follow what matters most.
+  As they say, your thoughts are what you read - and we've been consuming noisy feeds for too long. Folo organizes content into one timeline, keeping you updated on what matters, noise-free. Share lists, explore collections, and enjoy distraction-free browsing.
 Tags:
-- rss
-- feed
+- ai
+- blockchain
 - reader
-- follow
-- information
+- rss
+- rss-reader
+ReleaseNotes: |-
+  Shiny new things
+  - Added an Eagle action to image context menus
+  No longer broken
+  - Fixed tray menu refreshes losing the active tray instance
+  - Fixed desktop auth cookies missing max-age persistence
+  - Fixed unavailable AI summaries breaking summary state
+  - Fixed final entries and mark-read footers near the end of entry lists
+  - Delayed feed error indicators to avoid premature error states
+ReleaseNotesUrl: https://github.com/RSSNext/Folo/releases/tag/desktop/v1.8.0
 ManifestType: defaultLocale
 ManifestVersion: 1.10.0

--- a/manifests/r/RSSNext/Folo/1.8.0/RSSNext.Folo.yaml
+++ b/manifests/r/RSSNext/Folo/1.8.0/RSSNext.Folo.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: RSSNext.Folo
+PackageVersion: 1.8.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Update RSSNext.Folo from 1.7.0 to 1.8.0.

Release: https://github.com/RSSNext/Folo/releases/tag/desktop/v1.8.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/375867)