### PR TITLE
New version: M-Igashi.headroom version 2.0.0

### DIFF
--- a/manifests/m/M-Igashi/headroom/2.0.0/M-Igashi.headroom.installer.yaml
+++ b/manifests/m/M-Igashi/headroom/2.0.0/M-Igashi.headroom.installer.yaml
@@ -1,0 +1,19 @@
+# Created with manual update
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.headroom
+PackageVersion: 2.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: headroom.exe
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Gyan.FFmpeg
+ReleaseDate: 2026-05-18
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/M-Igashi/headroom/releases/download/v2.0.0/headroom-v2.0.0-windows-x86_64.zip
+    InstallerSha256: 1EAB0BCA25210497EE539C369715F1B426653F96598C126C395934ABAB91CD57
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/headroom/2.0.0/M-Igashi.headroom.locale.en-US.yaml
+++ b/manifests/m/M-Igashi/headroom/2.0.0/M-Igashi.headroom.locale.en-US.yaml
@@ -1,0 +1,41 @@
+# Created with manual update
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.headroom
+PackageVersion: 2.0.0
+PackageLocale: en-US
+Publisher: M-Igashi
+PublisherUrl: https://github.com/M-Igashi
+PublisherSupportUrl: https://github.com/M-Igashi/headroom/issues
+Author: M-Igashi
+PackageName: headroom
+PackageUrl: https://github.com/M-Igashi/headroom
+License: MIT
+LicenseUrl: https://github.com/M-Igashi/headroom/blob/main/LICENSE
+ShortDescription: Audio loudness analyzer, gain adjustment, and Rekordbox playlist sorter for mastering and DJ workflows
+Description: |-
+  headroom analyzes audio files for loudness (LUFS) and headroom, then applies lossless gain adjustment.
+  It supports MP3, AAC/M4A, FLAC, AIFF, and WAV files.
+  Features include batch processing, ReplayGain analysis, lossless MP3 gain via mp3rgain, lossless AAC/M4A gain adjustment, and a scriptable non-interactive CLI mode for pipelines and CI.
+  v2.0.0 adds the rbsort subcommand, which sorts a Rekordbox collection.xml export by Camelot Key and BPM for harmonic mixing prep — no audio touched, no ffmpeg required.
+Moniker: headroom
+Tags:
+  - aac
+  - audio
+  - cli
+  - dj
+  - ffmpeg
+  - gain
+  - loudness
+  - lufs
+  - mastering
+  - mp3
+  - music
+  - normalize
+  - rekordbox
+  - replaygain
+  - rust
+  - volume
+ReleaseNotesUrl: https://github.com/M-Igashi/headroom/releases/tag/v2.0.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/headroom/2.0.0/M-Igashi.headroom.yaml
+++ b/manifests/m/M-Igashi/headroom/2.0.0/M-Igashi.headroom.yaml
@@ -1,0 +1,8 @@
+# Created with manual update
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.headroom
+PackageVersion: 2.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://docs.microsoft.com/windows/package-manager/package/manifest?tabs=minschema%2Ccompschema#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12.0 schema](https://github.com/microsoft/winget-cli/blob/master/schemas/JSON/manifests/v1.12.0/)?

## Description

Update `M-Igashi.headroom` to version **2.0.0**.

This is a **major release** of headroom. v2.0.0 adds a new CLI subcommand surface; the headline feature is `rbsort`, which sorts a Rekordbox `collection.xml` export by Camelot Key then BPM and writes the result into a new `Sorted (Key+BPM)/` folder for re-import.

The audio loudness analysis side is 100% backward-compatible with 1.x — the version bump reflects the new subcommand surface, not a breaking change.

- Release: https://github.com/M-Igashi/headroom/releases/tag/v2.0.0
- Windows installer: `headroom-v2.0.0-windows-x86_64.zip` (zip with `headroom.exe`)
- SHA256: `1EAB0BCA25210497EE539C369715F1B426653F96598C126C395934ABAB91CD57`
- Dependency on `Gyan.FFmpeg` is unchanged (still required for the loudness analyzer; `rbsort` itself does not need ffmpeg, but other subcommands do).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/375952)