### PR TITLE
New version: tsuchim.ImeKeysForUS version 0.1.9

### DIFF
--- a/manifests/t/tsuchim/ImeKeysForUS/0.1.9/tsuchim.ImeKeysForUS.installer.yaml
+++ b/manifests/t/tsuchim/ImeKeysForUS/0.1.9/tsuchim.ImeKeysForUS.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: tsuchim.ImeKeysForUS
+PackageVersion: 0.1.9
+InstallerType: wix
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-05-18
+AppsAndFeaturesEntries:
+  - DisplayName: IME Keys for US
+    Publisher: tsuchim
+    ProductCode: "{B1B03117-5C5E-4DFF-998C-97DF9244142C}"
+    UpgradeCode: "{C79D216B-8E33-45BF-976B-F52825D3A8E6}"
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/tsuchim/ime-keys-for-us/releases/download/v0.1.9/IME-Keys-for-US-0.1.9-x64.msi
+    InstallerSha256: 9D74B6EB11D954F0FC812C7CEBD5C3858EB4DEC959C52F480709799E1BDD28C7
+    ProductCode: "{B1B03117-5C5E-4DFF-998C-97DF9244142C}"
+ManifestType: installer
+ManifestVersion: 1.12.0
+

--- a/manifests/t/tsuchim/ImeKeysForUS/0.1.9/tsuchim.ImeKeysForUS.locale.en-US.yaml
+++ b/manifests/t/tsuchim/ImeKeysForUS/0.1.9/tsuchim.ImeKeysForUS.locale.en-US.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: tsuchim.ImeKeysForUS
+PackageVersion: 0.1.9
+PackageLocale: en-US
+Publisher: tsuchim
+PublisherUrl: https://github.com/tsuchim
+PackageName: IME Keys for US
+PackageUrl: https://github.com/tsuchim/ime-keys-for-us
+License: MIT
+LicenseUrl: https://github.com/tsuchim/ime-keys-for-us/blob/main/LICENSE
+ShortDescription: Explicit Japanese IME on/off keys for US keyboards on Windows.
+Description: IME Keys for US is a native Windows tray utility that maps standalone Left Alt and Right Alt taps to explicit Japanese IME OFF and IME ON operations while preserving normal Alt shortcuts.
+Moniker: ime-keys-for-us
+Tags:
+  - ime
+  - japanese
+  - keyboard
+  - win32
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0
+

--- a/manifests/t/tsuchim/ImeKeysForUS/0.1.9/tsuchim.ImeKeysForUS.yaml
+++ b/manifests/t/tsuchim/ImeKeysForUS/0.1.9/tsuchim.ImeKeysForUS.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: tsuchim.ImeKeysForUS
+PackageVersion: 0.1.9
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0
+


### PR DESCRIPTION
- [x] I have read and understood the [Contribution Guidelines](https://github.com/microsoft/winget-pkgs/blob/master/CONTRIBUTING.md).
- [x] I have tested my manifest locally with `winget validate`.
- [x] I have verified that the installer URL is stable and points to the signed GitHub Release MSI.

## Package

`tsuchim.ImeKeysForUS` version `0.1.9`

## Installer

Signed MSI:

https://github.com/tsuchim/ime-keys-for-us/releases/download/v0.1.9/IME-Keys-for-US-0.1.9-x64.msi

SHA256:

`9D74B6EB11D954F0FC812C7CEBD5C3858EB4DEC959C52F480709799E1BDD28C7`

MSI metadata:

- ProductCode: `{B1B03117-5C5E-4DFF-998C-97DF9244142C}`
- UpgradeCode: `{C79D216B-8E33-45BF-976B-F52825D3A8E6}`

## Validation

```powershell
winget validate manifests\t\tsuchim\ImeKeysForUS\0.1.9
```

Result: passed.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/376001)