### PR TITLE
New package: UweSieber.ComPortInfo version 1.2.6

### DIFF
--- a/manifests/u/UweSieber/ComPortInfo/1.2.6/UweSieber.ComPortInfo.installer.yaml
+++ b/manifests/u/UweSieber/ComPortInfo/1.2.6/UweSieber.ComPortInfo.installer.yaml
@@ -21,3 +21,4 @@ ManifestType: installer
 ManifestVersion: 1.10.0
 
 
+

--- a/manifests/u/UweSieber/ComPortInfo/1.2.6/UweSieber.ComPortInfo.installer.yaml
+++ b/manifests/u/UweSieber/ComPortInfo/1.2.6/UweSieber.ComPortInfo.installer.yaml
@@ -22,3 +22,4 @@ ManifestVersion: 1.10.0
 
 
 
+

--- a/manifests/u/UweSieber/ComPortInfo/1.2.6/UweSieber.ComPortInfo.installer.yaml
+++ b/manifests/u/UweSieber/ComPortInfo/1.2.6/UweSieber.ComPortInfo.installer.yaml
@@ -5,6 +5,7 @@ PackageIdentifier: UweSieber.ComPortInfo
 PackageVersion: 1.2.6
 InstallerType: zip
 NestedInstallerType: portable
+NestedInstallerFiles:
 - RelativeFilePath: ComPortInfo.exe
 ReleaseDate: 2026-05-17
 Installers:

--- a/manifests/u/UweSieber/ComPortInfo/1.2.6/UweSieber.ComPortInfo.installer.yaml
+++ b/manifests/u/UweSieber/ComPortInfo/1.2.6/UweSieber.ComPortInfo.installer.yaml
@@ -1,0 +1,22 @@
+# Created with komac v2.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: UweSieber.ComPortInfo
+PackageVersion: 1.2.6
+InstallerType: zip
+NestedInstallerType: portable
+- RelativeFilePath: ComPortInfo.exe
+ReleaseDate: 2026-05-17
+Installers:
+- Architecture: x86
+  NestedInstallerFiles:
+  InstallerUrl: https://www.uwe-sieber.de/files/ComPortInfo126_Win32.zip
+  InstallerSha256: 71915C4E57F216F9D833F822E9B3B3BF7EC2DC6A30B9735E3EE3FE3F05930ED2
+- Architecture: x64
+  NestedInstallerFiles:
+  InstallerUrl: https://www.uwe-sieber.de/files/ComPortInfo126_x64.zip
+  InstallerSha256: 4ED77AD5070C73C34543B76CE1C0F3C2304E10FD3E84168164D1F4617D2A61BC
+ManifestType: installer
+ManifestVersion: 1.10.0
+
+

--- a/manifests/u/UweSieber/ComPortInfo/1.2.6/UweSieber.ComPortInfo.locale.en-US.yaml
+++ b/manifests/u/UweSieber/ComPortInfo/1.2.6/UweSieber.ComPortInfo.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# Created with komac v2.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: UweSieber.ComPortInfo
+PackageVersion: 1.2.6
+PackageLocale: en-US
+Publisher: Uwe Sieber
+PublisherUrl: https://www.uwe-sieber.de/english.html
+PackageName: ComPortInfo
+PackageUrl: https://www.uwe-sieber.de/ComPortInfo_e.html
+License: Freeware
+LicenseUrl: https://www.uwe-sieber.de/ComPortInfo_e.html#download
+Copyright: (c) 2015-2026 Uwe Sieber, Freeware
+ShortDescription: Information about COM ports.
+Description: |-
+  COM Port Info belongs natively to ComPortMan, but is handy standalone too.
+
+  Features:
+  - Two views with COM ports and connection types (BusTypes)
+  - "Safely remove hardware"
+  - Restart devices to revive it after "safe removal" (if started with administrator previleges)
+  - COM port numbers change and swap (if started with administrator previleges)
+  - USB-Port reset (XP, Win8, 10, 11)
+  - Display of the "Port Parameters" (GetCommState), that's how the last application using this port left it behind and on failure it indicates that the port is in use
+  - Display of the "Default Port Parameters" (GetDefaultCommConfig), these are the parameters from the device manager
+  - Display of the "Port Properties" (GetCommProperties), these are the capabilities of the COM port hardware, e.g. supported signals and data rates
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0
+

--- a/manifests/u/UweSieber/ComPortInfo/1.2.6/UweSieber.ComPortInfo.yaml
+++ b/manifests/u/UweSieber/ComPortInfo/1.2.6/UweSieber.ComPortInfo.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: UweSieber.ComPortInfo
+PackageVersion: 1.2.6
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
<!-- PR Title Format: "New package: UweSieber.ComPortInfo version 1.2.6" -->

## 📖 Description
Update UweSieber.ComPortInfo to V1.2.6 with separate ZIP files for x86 and x64

## ✅ Checklist
- [x ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x ] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/376007)