### PR TITLE
Add SSC-STUDIO.LenovoLegionToolkit version 3.6.16

### DIFF
--- a/manifests/s/SSC-STUDIO/LenovoLegionToolkit/3.6.16/SSC-STUDIO.LenovoLegionToolkit.installer.yaml
+++ b/manifests/s/SSC-STUDIO/LenovoLegionToolkit/3.6.16/SSC-STUDIO.LenovoLegionToolkit.installer.yaml
@@ -1,0 +1,15 @@
+# Created with komac v2.12.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: SSC-STUDIO.LenovoLegionToolkit
+PackageVersion: 3.6.16
+InstallerType: inno
+Scope: user
+UpgradeBehavior: install
+ReleaseDate: 2026-05-18
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/SSC-STUDIO/LenovoLegionToolkit/releases/download/v3.6.16/LenovoLegionToolkit_v3.6.16_Setup.exe
+  InstallerSha256: 07407704427BB5B9B9E87C5A256C41FE60A423537D3B16C0BCB2AE0FE27C7ACF
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/s/SSC-STUDIO/LenovoLegionToolkit/3.6.16/SSC-STUDIO.LenovoLegionToolkit.locale.en-US.yaml
+++ b/manifests/s/SSC-STUDIO/LenovoLegionToolkit/3.6.16/SSC-STUDIO.LenovoLegionToolkit.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# Created with komac v2.12.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: SSC-STUDIO.LenovoLegionToolkit
+PackageVersion: 3.6.16
+PackageLocale: en-US
+Publisher: SSC-STUDIO
+PublisherUrl: https://github.com/SSC-STUDIO
+PublisherSupportUrl: https://github.com/SSC-STUDIO/LenovoLegionToolkit/issues
+PackageName: Lenovo Legion Toolkit
+PackageUrl: https://github.com/SSC-STUDIO/LenovoLegionToolkit
+License: GPL-3.0
+LicenseUrl: https://github.com/SSC-STUDIO/LenovoLegionToolkit/blob/master/LICENSE
+Copyright: Copyright (C) Lenovo Legion Toolkit contributors
+ShortDescription: Lightweight Lenovo Vantage and Hotkeys replacement for Lenovo Legion laptops.
+Description: Lenovo Legion Toolkit is a lightweight, open-source utility for Lenovo Legion, LOQ, Ideapad Gaming, and related laptops. It provides access to power modes, battery settings, RGB controls, dGPU state, driver updates, CLI control, and plugin extensions without running a background service or collecting telemetry.
+Moniker: lenovolegiontoolkit
+Tags:
+- lenovo
+- legion
+- vantage
+- toolkit
+- rgb
+- laptop
+- hardware-control
+ReleaseNotesUrl: https://github.com/SSC-STUDIO/LenovoLegionToolkit/releases/tag/v3.6.16
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/s/SSC-STUDIO/LenovoLegionToolkit/3.6.16/SSC-STUDIO.LenovoLegionToolkit.yaml
+++ b/manifests/s/SSC-STUDIO/LenovoLegionToolkit/3.6.16/SSC-STUDIO.LenovoLegionToolkit.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.12.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: SSC-STUDIO.LenovoLegionToolkit
+PackageVersion: 3.6.16
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Summary
- add SSC-STUDIO.LenovoLegionToolkit 3.6.16 manifests
- source installer from the GitHub release asset
- use release SHA256: 07407704427BB5B9B9E87C5A256C41FE60A423537D3B16C0BCB2AE0FE27C7ACF

## Validation
- winget validate manifests/s/SSC-STUDIO/LenovoLegionToolkit/3.6.16
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/376024)