### PR TITLE
New version: MasterSigner.Agent version 1.1.1

### DIFF
--- a/manifests/m/MasterSigner/Agent/1.1.1/MasterSigner.Agent.installer.yaml
+++ b/manifests/m/MasterSigner/Agent/1.1.1/MasterSigner.Agent.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: MasterSigner.Agent
+PackageVersion: 1.1.1
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: exe
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+InstallerSwitches:
+  Silent: --silent
+  SilentWithProgress: --silent
+UninstallBehavior: uninstaller
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://get.mastersigner.app/agent/windows-amd64.exe
+    InstallerSha256: 722FAAEF757DFF581AC7F4324F46259F710A9EB4214EFFFA76C4970CA56D8A3C
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/MasterSigner/Agent/1.1.1/MasterSigner.Agent.locale.en-US.yaml
+++ b/manifests/m/MasterSigner/Agent/1.1.1/MasterSigner.Agent.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: MasterSigner.Agent
+PackageVersion: 1.1.1
+PackageLocale: en-US
+Publisher: MasterSigner
+PublisherUrl: https://mastersigner.app
+PublisherSupportUrl: https://mastersigner.app/download
+PackageName: Master Signer Agent
+PackageUrl: https://mastersigner.app/download
+License: Proprietary
+ShortDescription: Native messaging agent for Master Signer ICP-Brasil digital signature
+Description: |-
+  Master Signer Agent is a native messaging host that enables the Master Signer
+  browser extension to access hardware security tokens (A3 certificates) and perform
+  ICP-Brasil compliant digital signatures via PKCS#11.
+
+  Supports tokens from: SafeSign (AET/SERPRO), Feitian ePass, HID ActivClient,
+  Safeweb, Thales/Gemalto IDGo, WatchData, and other PKCS#11 compatible devices.
+Tags:
+  - certificate
+  - digital-signature
+  - icp-brasil
+  - pkcs11
+  - token
+  - signing
+ReleaseNotes: |-
+  Correção de race condition na comunicação extensão ↔ agente durante assinatura
+  de payloads grandes (PDFs > 50KB). Limpeza de IDs de teste no manifesto de
+  Native Messaging — agora aceita apenas o ID oficial da extensão na Chrome Web Store.
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/MasterSigner/Agent/1.1.1/MasterSigner.Agent.yaml
+++ b/manifests/m/MasterSigner/Agent/1.1.1/MasterSigner.Agent.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: MasterSigner.Agent
+PackageVersion: 1.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Patch release of MasterSigner.Agent — native messaging host for the Master Signer browser extension (ICP-Brasil digital signature, A1/A3).

### Changes
- Fixed race condition in extension ↔ agent communication during signing of large payloads (PDFs >50KB).
- Cleaned up Native Messaging manifest: now only the official Master Signer Chrome Web Store extension ID (`jffodcpfpcpjlnfoibhenjledhiccacm`) is accepted; removed leftover test/dev extension IDs.

### Installer
- `windows-amd64.exe` — SHA256: `722FAAEF757DFF581AC7F4324F46259F710A9EB4214EFFFA76C4970CA56D8A3C`
- URL: `https://get.mastersigner.app/agent/windows-amd64.exe`

### Checklist
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://docs.microsoft.com/windows/package-manager/package/manifest#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.6.md)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/376104)