### PR TITLE
New version: tisun2.OofManager version 1.1.5

### DIFF
--- a/manifests/t/tisun2/OofManager/1.1.5/tisun2.OofManager.installer.yaml
+++ b/manifests/t/tisun2/OofManager/1.1.5/tisun2.OofManager.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: tisun2.OofManager
+PackageVersion: 1.1.5
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART
+UpgradeBehavior: install
+ReleaseDate: 2026-05-19
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/tisun2/OofManager/releases/download/v1.1.5/OofManagerSetup.exe
+    InstallerSha256: 0427BDB76E2CC8A1D8E36711F418E44848E6F5E365A3ABDB28E8C27C4AC91784
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/t/tisun2/OofManager/1.1.5/tisun2.OofManager.locale.en-US.yaml
+++ b/manifests/t/tisun2/OofManager/1.1.5/tisun2.OofManager.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: tisun2.OofManager
+PackageVersion: 1.1.5
+PackageLocale: en-US
+Publisher: tisun2
+PublisherUrl: https://github.com/tisun2
+PublisherSupportUrl: https://github.com/tisun2/OofManager/issues
+PackageName: OOF Manager
+PackageUrl: https://github.com/tisun2/OofManager
+License: MIT
+LicenseUrl: https://github.com/tisun2/OofManager/blob/main/LICENSE
+Copyright: Copyright (c) tisun2
+ShortDescription: Manage Microsoft 365 / Exchange Online Out-of-Office (Automatic Reply) settings without opening Outlook.
+Description: |-
+  OOF Manager is a lightweight Windows desktop tool that manages your Microsoft 365 mailbox's
+  Out-of-Office (Automatic Reply) state for you. Sign in once, configure your weekly work hours
+  and reply text, and OOF Manager auto-toggles your OOF on/off at the schedule boundaries.
+  It also pushes the next off-hours window to Exchange as a Scheduled OOF, so the server keeps
+  switching auto-replies even when this app is closed.
+Moniker: oofmanager
+Tags:
+  - exchange
+  - microsoft-365
+  - office-365
+  - out-of-office
+  - oof
+  - outlook
+  - autoreply
+ReleaseNotesUrl: https://github.com/tisun2/OofManager/releases/tag/v1.1.5
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/t/tisun2/OofManager/1.1.5/tisun2.OofManager.yaml
+++ b/manifests/t/tisun2/OofManager/1.1.5/tisun2.OofManager.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: tisun2.OofManager
+PackageVersion: 1.1.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Bump tisun2.OofManager to 1.1.5.

- Release: https://github.com/tisun2/OofManager/releases/tag/v1.1.5
- Installer SHA256: 0427BDB76E2CC8A1D8E36711F418E44848E6F5E365A3ABDB28E8C27C4AC91784
- Validated locally with `winget validate` (manifest validation succeeded) and `winget install --manifest`.

Changes since 1.1.4:
- Improve Power Automate solution import flow lookup.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/376209)