### PR TITLE
Re-added x64: FilesCommunity.Files version 4.1.1.0

### DIFF
--- a/manifests/f/FilesCommunity/Files/4.1.1.0/FilesCommunity.Files.installer.yaml
+++ b/manifests/f/FilesCommunity/Files/4.1.1.0/FilesCommunity.Files.installer.yaml
@@ -40,6 +40,10 @@ AppsAndFeaturesEntries:
 InstallationMetadata:
   DefaultInstallLocation: '%ProgramFiles%/WindowsApps/Files_4.0.37.0_x64__1y0xx7n9077q4'
 Installers:
+- Architecture: x64
+  InstallerUrl: https://cdn.files.community/files/stable/Files.Package/Files.Package_x64_arm64.msixbundle
+  InstallerSha256: 7FFB6E6861D8338329679C0C20D4F896EA73864B6F12B283081E643F4BB9BBF5
+  SignatureSha256: 8287F93C51F548A86B8ED1726F28BDB3F907C1E90B6CF56E0A87DE9ABC77C5CD
 - Architecture: arm64
   InstallerUrl: https://cdn.files.community/files/stable/Files.Package/Files.Package_x64_arm64.msixbundle
   InstallerSha256: 7FFB6E6861D8338329679C0C20D4F896EA73864B6F12B283081E643F4BB9BBF5

--- a/manifests/f/FilesCommunity/Files/4.1.1.0/FilesCommunity.Files.locale.en-GB.yaml
+++ b/manifests/f/FilesCommunity/Files/4.1.1.0/FilesCommunity.Files.locale.en-GB.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: FilesCommunity.Files
+PackageVersion: 4.1.1.0
+PackageLocale: en-GB
+ShortDescription: A modern file manager that helps users organise their files and folders.
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/f/FilesCommunity/Files/4.1.1.0/FilesCommunity.Files.locale.en-US.yaml
+++ b/manifests/f/FilesCommunity/Files/4.1.1.0/FilesCommunity.Files.locale.en-US.yaml
@@ -10,7 +10,12 @@ PackageName: Files
 PackageUrl: https://github.com/files-community/Files
 License: MIT
 LicenseUrl: https://github.com/files-community/Files/blob/main/LICENSE
-ShortDescription: A modern file manager that helps users organize their files and folders
+ShortDescription: A modern file manager that helps users organize their files and folders.
 Moniker: files
+Tags:
+- files-community
+- file-manager
+- filemanager
+- 9nghp3dx8hdx
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
* Fixed a remarkable blunder where Wingetbot seemingly forgot to include x64 in its recentmost update and thus it made the manifest ARM64-only.
* Added 4 tags while I was at it.
* Added trailing dot to ShortDescription for professionality.
* Added `(...).locale.en-GB.yaml`

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [ ] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/376302)