### PR TITLE
New version: AHKFlow.CLI version 0.1.3

### DIFF
--- a/manifests/a/AHKFlow/CLI/0.1.3/AHKFlow.CLI.installer.yaml
+++ b/manifests/a/AHKFlow/CLI/0.1.3/AHKFlow.CLI.installer.yaml
@@ -1,0 +1,17 @@
+# Created from AHKFlowApp repo (s205109/AHKFlowApp), backlog item 031.
+PackageIdentifier: AHKFlow.CLI
+PackageVersion: 0.1.3
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: ahkflow.exe
+    PortableCommandAlias: ahkflow
+Commands:
+  - ahkflow
+ReleaseDate: 2026-05-19
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/s205109/AHKFlowApp/releases/download/v0.1.3/ahkflow-win-x64.zip
+    InstallerSha256: 495BBF8A26989BE8A73542DF22331050DE57260C0F0ACD99216424F5A027548F
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/a/AHKFlow/CLI/0.1.3/AHKFlow.CLI.locale.en-US.yaml
+++ b/manifests/a/AHKFlow/CLI/0.1.3/AHKFlow.CLI.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# Created from AHKFlowApp repo (s205109/AHKFlowApp), backlog item 031.
+PackageIdentifier: AHKFlow.CLI
+PackageVersion: 0.1.3
+PackageLocale: en-US
+Publisher: AHKFlow
+PublisherUrl: https://github.com/s205109/AHKFlowApp
+PublisherSupportUrl: https://github.com/s205109/AHKFlowApp/issues
+PackageName: AHKFlow CLI
+PackageUrl: https://github.com/s205109/AHKFlowApp
+License: MIT
+LicenseUrl: https://github.com/s205109/AHKFlowApp/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Bart Segers
+ShortDescription: Command-line tool for managing AutoHotkey hotstrings and hotkeys.
+Description: |-
+  AHKFlow CLI is a Windows command-line tool for managing AutoHotkey hotstrings and hotkeys
+  via the AHKFlow service. Sign in with `ahkflow login`, then manage your hotstrings from
+  the terminal without leaving your shell.
+Moniker: ahkflow
+Tags:
+  - autohotkey
+  - ahk
+  - hotstring
+  - hotkey
+  - cli
+  - windows
+  - productivity
+ReleaseNotes: |-
+  v0.1.3: Fix `ahkflow --version` self-report to match the installer's PackageVersion.
+  Previously the binary reported the SDK fallback `1.0.0+<sha>` because the CLI project
+  was missing the MinVer package reference; the installed version (ARP / `winget list`)
+  was unaffected.
+ReleaseNotesUrl: https://github.com/s205109/AHKFlowApp/releases/tag/v0.1.3
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/a/AHKFlow/CLI/0.1.3/AHKFlow.CLI.yaml
+++ b/manifests/a/AHKFlow/CLI/0.1.3/AHKFlow.CLI.yaml
@@ -1,0 +1,6 @@
+# Created from AHKFlowApp repo (s205109/AHKFlowApp), backlog item 031.
+PackageIdentifier: AHKFlow.CLI
+PackageVersion: 0.1.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
New version submission for `AHKFlow.CLI`.

Source: https://github.com/s205109/AHKFlowApp/releases/tag/v0.1.3

## What's new in v0.1.3

Fixes the cosmetic `--version` mismatch raised by the validator on PR #374595 (v0.1.2): `ahkflow --version` now reports `0.1.3+<sha>` instead of the SDK fallback `1.0.0+<sha>`. The CLI project was missing the MinVer package reference that the rest of the solution uses, so `AssemblyInformationalVersion` was falling back to the SDK default. The manifest's `PackageVersion`, ARP's `DisplayVersion`, and `winget list` were always correct — only the binary's self-report was wrong.

The release workflow now also asserts the binary's reported SemVer matches the release tag before uploading, and refuses to overwrite an existing release asset for the same tag — so the installer SHA256 is stable for the lifetime of `v0.1.3`.

## Manifest checklist

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://docs.microsoft.com/windows/package-manager/package/manifest#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.6.md)?

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/376318)