### PR TITLE
New package: Haxllo.Nex version 1.0.1

### DIFF
--- a/manifests/h/Haxllo/Nex/1.0.1/Haxllo.Nex.installer.yaml
+++ b/manifests/h/Haxllo/Nex/1.0.1/Haxllo.Nex.installer.yaml
@@ -11,5 +11,8 @@ Installers:
   InstallerSwitches:
     Silent: /VERYSILENT /ALLUSERS /SUPPRESSMSGBOXES /NORESTART /SP-
     SilentWithProgress: /SILENT /ALLUSERS /SUPPRESSMSGBOXES /NORESTART /SP-
+  AppsAndFeaturesEntries:
+  - DisplayName: Nex
+    Publisher: Haxllo
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/h/Haxllo/Nex/1.0.1/Haxllo.Nex.installer.yaml
+++ b/manifests/h/Haxllo/Nex/1.0.1/Haxllo.Nex.installer.yaml
@@ -12,7 +12,7 @@ Installers:
     Silent: /VERYSILENT /ALLUSERS /SUPPRESSMSGBOXES /NORESTART /SP-
     SilentWithProgress: /SILENT /ALLUSERS /SUPPRESSMSGBOXES /NORESTART /SP-
   AppsAndFeaturesEntries:
-  - DisplayName: Nex
-    Publisher: Haxllo
+    - DisplayName: Nex
+      Publisher: Haxllo
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/h/Haxllo/Nex/1.0.1/Haxllo.Nex.installer.yaml
+++ b/manifests/h/Haxllo/Nex/1.0.1/Haxllo.Nex.installer.yaml
@@ -1,0 +1,15 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Haxllo.Nex
+PackageVersion: 1.0.1
+InstallerType: inno
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/haxllo/nex/releases/download/1.0.1/nex-1.0.1-windows-x64-setup.exe
+  InstallerSha256: 331AF309BCCDFD0BF5EB41AEC8271355CEAD2A04AA2B7C107E0B4C394312AEDE
+  InstallerSwitches:
+    Silent: /VERYSILENT /ALLUSERS /SUPPRESSMSGBOXES /NORESTART /SP-
+    SilentWithProgress: /SILENT /ALLUSERS /SUPPRESSMSGBOXES /NORESTART /SP-
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/h/Haxllo/Nex/1.0.1/Haxllo.Nex.installer.yaml
+++ b/manifests/h/Haxllo/Nex/1.0.1/Haxllo.Nex.installer.yaml
@@ -9,8 +9,8 @@ Installers:
   InstallerUrl: https://github.com/haxllo/nex/releases/download/1.0.1/nex-1.0.1-windows-x64-setup.exe
   InstallerSha256: 331AF309BCCDFD0BF5EB41AEC8271355CEAD2A04AA2B7C107E0B4C394312AEDE
   InstallerSwitches:
-    Silent: /VERYSILENT /ALLUSERS /SUPPRESSMSGBOXES /NORESTART /SP-
-    SilentWithProgress: /SILENT /ALLUSERS /SUPPRESSMSGBOXES /NORESTART /SP-
+    Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+    SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
   AppsAndFeaturesEntries:
     - DisplayName: Nex
       Publisher: Haxllo

--- a/manifests/h/Haxllo/Nex/1.0.1/Haxllo.Nex.locale.en-US.yaml
+++ b/manifests/h/Haxllo/Nex/1.0.1/Haxllo.Nex.locale.en-US.yaml
@@ -1,0 +1,12 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Haxllo.Nex
+PackageVersion: 1.0.1
+PackageLocale: en-US
+Publisher: Haxllo
+PackageName: Nex
+License: MIT
+ShortDescription: A keyboard-first launcher for Windows. Press a global hotkey to quickly find and launch applications, files, folders, and custom actions.
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/h/Haxllo/Nex/1.0.1/Haxllo.Nex.yaml
+++ b/manifests/h/Haxllo/Nex/1.0.1/Haxllo.Nex.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Haxllo.Nex
+PackageVersion: 1.0.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Adding Haxllo.Nex version 1.0.1 — a keyboard-first launcher for Windows.

## Checklist

- [x] Signed the Contributor License Agreement
- [x] Checked that there aren't other open pull requests for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the 1.12 schema