### PR TITLE
Microsoft.WindowsAppRuntime.1.8 version 1.8.8

### DIFF
--- a/manifests/m/Microsoft/WindowsAppRuntime/1/8/1.8.8/Microsoft.WindowsAppRuntime.1.8.installer.yaml
+++ b/manifests/m/Microsoft/WindowsAppRuntime/1/8/1.8.8/Microsoft.WindowsAppRuntime.1.8.installer.yaml
@@ -1,0 +1,85 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: Microsoft.WindowsAppRuntime.1.8
+PackageVersion: 1.8.8
+InstallModes:
+- silent
+- silentWithProgress
+PackageFamilyName: Microsoft.WindowsAppRuntime.1.8_8wekyb3d8bbwe
+Installers:
+- Platform:
+  - Windows.Universal
+  - Windows.Desktop
+  Architecture: x64
+  InstallerType: zip
+  NestedInstallerType: msix
+  NestedInstallerFiles:
+  - RelativeFilePath: MSIX\win10-x64\Microsoft.WindowsAppRuntime.1.8.msix
+  InstallerUrl: https://download.microsoft.com/download/9dd9de00-6b17-4777-a3b8-693cdfaaf85b/Microsoft.WindowsAppRuntime.Redist.1.8.260508005.zip
+  InstallerSha256: 2D291D290E34376F98BFCBD07E917134CD3B2F1E8FC364B1032752822387AC1D
+  SignatureSha256: A01A40A59F7273490CE21BB352499F0C541F92E01130B0EBFB8CBDE9E14C8C50
+- Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://download.microsoft.com/download/eab8bdb8-8bad-4057-a315-7a88372e689b/WindowsAppRuntimeInstall-x64.exe
+  InstallerSha256: B271A789809D15E57D49EF4518CEEF90B8614626DC04FF5D89906CCA8843CDF3
+  InstallerSwitches:
+    Silent: --quiet
+    SilentWithProgress: --quiet
+  UpgradeBehavior: install
+  AppsAndFeaturesEntries:
+  - DisplayName: WindowsAppRuntime.1.8
+    DisplayVersion: 8000.859.21.0
+    InstallerType: msix
+  ElevationRequirement: elevationRequired
+- Platform:
+  - Windows.Universal
+  - Windows.Desktop
+  Architecture: arm64
+  InstallerType: zip
+  NestedInstallerType: msix
+  NestedInstallerFiles:
+  - RelativeFilePath: MSIX\win10-arm64\Microsoft.WindowsAppRuntime.1.8.msix
+  InstallerUrl: https://download.microsoft.com/download/9dd9de00-6b17-4777-a3b8-693cdfaaf85b/Microsoft.WindowsAppRuntime.Redist.1.8.260508005.zip
+  InstallerSha256: 2D291D290E34376F98BFCBD07E917134CD3B2F1E8FC364B1032752822387AC1D
+  SignatureSha256: 7BA0B21BDA9EC047A650DE0DE33AE75ACDC2A7DBB1122410F7AC59A0348693EB
+- Architecture: arm64
+  InstallerType: exe
+  InstallerUrl: https://download.microsoft.com/download/7599003c-b5c3-4470-a470-329066069ae6/WindowsAppRuntimeInstall-arm64.exe
+  InstallerSha256: 62F6E635121EFD529C20944BCFF3328455AFD6A8130CBFA0410D8E4E26490C31
+  InstallerSwitches:
+    Silent: --quiet
+    SilentWithProgress: --quiet
+  UpgradeBehavior: install
+  AppsAndFeaturesEntries:
+  - DisplayName: WindowsAppRuntime.1.8
+    DisplayVersion: 8000.859.21.0
+    InstallerType: msix
+  ElevationRequirement: elevationRequired
+- Platform:
+  - Windows.Universal
+  - Windows.Desktop
+  Architecture: x86
+  InstallerType: zip
+  NestedInstallerType: msix
+  NestedInstallerFiles:
+  - RelativeFilePath: MSIX\win10-x86\Microsoft.WindowsAppRuntime.1.8.msix
+  InstallerUrl: https://download.microsoft.com/download/9dd9de00-6b17-4777-a3b8-693cdfaaf85b/Microsoft.WindowsAppRuntime.Redist.1.8.260508005.zip
+  InstallerSha256: 2D291D290E34376F98BFCBD07E917134CD3B2F1E8FC364B1032752822387AC1D
+  SignatureSha256: CF40D66FE0DD3B0EF87E1A69F2D26AD27E69DDB0EAA1321A554C30651C047D49
+- Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://download.microsoft.com/download/6b9c35ec-d08e-43c3-9d17-83286877973e/WindowsAppRuntimeInstall-x86.exe
+  InstallerSha256: 0A53DD83BB5D0738B25D31F2367D65749DD2FD2BEB530D638742D1027F5597EF
+  InstallerSwitches:
+    Silent: --quiet
+    SilentWithProgress: --quiet
+  UpgradeBehavior: install
+  AppsAndFeaturesEntries:
+  - DisplayName: WindowsAppRuntime.1.8
+    DisplayVersion: 8000.859.21.0
+    InstallerType: msix
+  ElevationRequirement: elevationRequired
+ManifestType: installer
+ManifestVersion: 1.10.0
+ReleaseDate: 2026-05-12

--- a/manifests/m/Microsoft/WindowsAppRuntime/1/8/1.8.8/Microsoft.WindowsAppRuntime.1.8.locale.en-US.yaml
+++ b/manifests/m/Microsoft/WindowsAppRuntime/1/8/1.8.8/Microsoft.WindowsAppRuntime.1.8.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: Microsoft.WindowsAppRuntime.1.8
+PackageVersion: 1.8.8
+PackageLocale: en-US
+Publisher: Microsoft Corporation
+PublisherUrl: https://www.microsoft.com/
+PublisherSupportUrl: https://support.microsoft.com/
+PrivacyUrl: https://privacy.microsoft.com/privacystatement
+Author: Microsoft Corporation
+PackageName: Windows App Runtime 1.8
+PackageUrl: https://learn.microsoft.com/windows/apps/windows-app-sdk/downloads
+License: Proprietary
+LicenseUrl: https://www.microsoft.com/legal/terms-of-use
+Copyright: Copyright(c) Microsoft Corporation. All rights reserved.
+CopyrightUrl: https://www.microsoft.com/legal/intellectualproperty/trademarks
+ShortDescription: Microsoft Windows App Runtime 1.8
+Moniker: windowsappsdk-1.8
+ReleaseNotesUrl: https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/release-notes/windows-app-sdk-1-8?pivots=stable#version-188-18260508005
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/m/Microsoft/WindowsAppRuntime/1/8/1.8.8/Microsoft.WindowsAppRuntime.1.8.locale.zh-CN.yaml
+++ b/manifests/m/Microsoft/WindowsAppRuntime/1/8/1.8.8/Microsoft.WindowsAppRuntime.1.8.locale.zh-CN.yaml
@@ -1,0 +1,20 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.10.0.schema.json
+
+PackageIdentifier: Microsoft.WindowsAppRuntime.1.8
+PackageVersion: 1.8.8
+PackageLocale: zh-CN
+Publisher: Microsoft Corporation
+PublisherUrl: https://www.microsoft.com/
+PublisherSupportUrl: https://support.microsoft.com/
+PrivacyUrl: https://privacy.microsoft.com/zh-cn/privacystatement
+Author: Microsoft Corporation
+PackageName: Windows App Runtime 1.8
+PackageUrl: https://learn.microsoft.com/zh-cn/windows/apps/windows-app-sdk/downloads
+License: 专有软件
+LicenseUrl: https://www.microsoft.com/legal/terms-of-use
+Copyright: Copyright(c) Microsoft Corporation. All rights reserved.
+CopyrightUrl: https://www.microsoft.com/legal/intellectualproperty/trademarks
+ShortDescription: Microsoft Windows 应用运行时 1.8
+ManifestType: locale
+ManifestVersion: 1.10.0

--- a/manifests/m/Microsoft/WindowsAppRuntime/1/8/1.8.8/Microsoft.WindowsAppRuntime.1.8.yaml
+++ b/manifests/m/Microsoft/WindowsAppRuntime/1/8/1.8.8/Microsoft.WindowsAppRuntime.1.8.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: Microsoft.WindowsAppRuntime.1.8
+PackageVersion: 1.8.8
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## 📖 Description

Manual submission of **Microsoft.WindowsAppRuntime.1.8 version 1.8.8**.

This PR is submitted manually because our automated pipeline currently can't produce a 6-installer manifest (it only knows about the 3 EXE installers via `aka.ms` shortcuts). It re-introduces the **x86 zip** installer that was commented out in #367378 after the automated validator flagged the x86 EXE with `STATUS_STACK_BUFFER_OVERRUN` / `bad allocation`.

Per @stephengillie's follow-up in #367378, that exit-code-to-symbol mapping is likely incorrect — the same MSIX content ships and validates successfully via the x86 EXE installer, so the x86 zip variant should pass as well. We need parity across x86 / x64 / arm64 for downstream consumers.

**Manifest contents (6 installers, matching the shape published at 8000.836.2153.0):**
- x64 zip → MSIX, x64 exe
- arm64 zip → MSIX, arm64 exe
- **x86 zip → MSIX (re-enabled)**, x86 exe

All `InstallerSha256` / `SignatureSha256` values were computed locally from the official `download.microsoft.com` Redist zip (`Microsoft.WindowsAppRuntime.Redist.1.8.260508005.zip`). `winget validate` passes locally.

CC @stephengillie @agniuks — if the x86 zip is flagged again by automated validation, please help override / re-validate (see prior discussion in #367378).

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)
  - Related: #367378

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the winget manifest schema (1.10.0)