### PR TITLE
Cloudbrew hopsmd 1.0.0

### DIFF
--- a/manifests/c/CloudBrew/HopsMD/1.0.0/CloudBrew.HopsMD.installer.yaml
+++ b/manifests/c/CloudBrew/HopsMD/1.0.0/CloudBrew.HopsMD.installer.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
 PackageIdentifier: CloudBrew.HopsMD
 PackageVersion: 1.0.0
 InstallerLocale: en-US

--- a/manifests/c/CloudBrew/HopsMD/1.0.0/CloudBrew.HopsMD.installer.yaml
+++ b/manifests/c/CloudBrew/HopsMD/1.0.0/CloudBrew.HopsMD.installer.yaml
@@ -1,0 +1,24 @@
+PackageIdentifier: CloudBrew.HopsMD
+PackageVersion: 1.0.0
+InstallerLocale: en-US
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Scope: machine
+ReleaseDate: 2026-05-19
+Installers:
+  - Architecture: x64
+    InstallerType: nullsoft
+    InstallerUrl: https://github.com/lootwitch/HopsMD/releases/download/v1.0.0/HopsMD_1.0.0_x64-setup.exe
+    InstallerSha256: 4875F1EDABE8F1EB00C51299635375002A51D9887AF657F26F28E0FE397EEF14
+  - Architecture: x64
+    InstallerType: wix
+    InstallerUrl: https://github.com/lootwitch/HopsMD/releases/download/v1.0.0/HopsMD_1.0.0_x64_en-US.msi
+    InstallerSha256: EC4D376C3B01C0C602F80695D41C2F16B30B43744D2BDF2333E2C143584D1041
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/c/CloudBrew/HopsMD/1.0.0/CloudBrew.HopsMD.locale.en-US.yaml
+++ b/manifests/c/CloudBrew/HopsMD/1.0.0/CloudBrew.HopsMD.locale.en-US.yaml
@@ -1,0 +1,28 @@
+PackageIdentifier: CloudBrew.HopsMD
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: CloudBrew
+PublisherUrl: https://github.com/lootwitch
+PublisherSupportUrl: https://github.com/lootwitch/HopsMD/issues
+Author: Ludwig Biermann
+PackageName: HopsMD
+PackageUrl: https://github.com/lootwitch/HopsMD
+License: MIT
+LicenseUrl: https://github.com/lootwitch/HopsMD/blob/main/LICENSE
+Copyright: © 2026 Ludwig Biermann
+ShortDescription: Local Markdown & Mermaid viewer.
+Description: |-
+  HopsMD is a lightweight, offline-first reader for Markdown documentation
+  with live MermaidJS diagram rendering. It is a side project of the
+  CloudBrew family — brewed with Tauri v2 + Angular 21 — and themed
+  throughout with a love letter to a properly poured pint of beer.
+Moniker: hopsmd
+Tags:
+  - markdown
+  - mermaid
+  - viewer
+  - documentation
+  - tauri
+ReleaseNotesUrl: https://github.com/lootwitch/HopsMD/releases/tag/v1.0.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/c/CloudBrew/HopsMD/1.0.0/CloudBrew.HopsMD.locale.en-US.yaml
+++ b/manifests/c/CloudBrew/HopsMD/1.0.0/CloudBrew.HopsMD.locale.en-US.yaml
@@ -25,4 +25,4 @@ Tags:
   - tauri
 ReleaseNotesUrl: https://github.com/lootwitch/HopsMD/releases/tag/v1.0.0
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/c/CloudBrew/HopsMD/1.0.0/CloudBrew.HopsMD.locale.en-US.yaml
+++ b/manifests/c/CloudBrew/HopsMD/1.0.0/CloudBrew.HopsMD.locale.en-US.yaml
@@ -1,0 +1,29 @@
+PackageIdentifier: CloudBrew.HopsMD
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: CloudBrew
+PublisherUrl: https://github.com/lootwitch
+PublisherSupportUrl: https://github.com/lootwitch/HopsMD/issues
+Author: Ludwig Biermann
+PackageName: HopsMD
+PackageUrl: https://github.com/lootwitch/HopsMD
+License: MIT
+LicenseUrl: https://github.com/lootwitch/HopsMD/blob/main/LICENSE
+Copyright: © 2026 Ludwig Biermann
+ShortDescription: Local Markdown & Mermaid viewer.
+Description: |-
+  HopsMD is a lightweight, offline-first reader for Markdown documentation
+  with live MermaidJS diagram rendering. It is a side project of the
+  CloudBrew family — brewed with Tauri v2 + Angular 21 — and themed
+  throughout with a love letter to a properly poured pint of beer.
+Moniker: hopsmd
+Tags:
+  - markdown
+  - mermaid
+  - viewer
+  - documentation
+  - tauri
+  - cloudbrew
+ReleaseNotesUrl: https://github.com/lootwitch/HopsMD/releases/tag/v1.0.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/c/CloudBrew/HopsMD/1.0.0/CloudBrew.HopsMD.locale.en-US.yaml
+++ b/manifests/c/CloudBrew/HopsMD/1.0.0/CloudBrew.HopsMD.locale.en-US.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
 PackageIdentifier: CloudBrew.HopsMD
 PackageVersion: 1.0.0
 PackageLocale: en-US

--- a/manifests/c/CloudBrew/HopsMD/1.0.0/CloudBrew.HopsMD.yaml
+++ b/manifests/c/CloudBrew/HopsMD/1.0.0/CloudBrew.HopsMD.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: CloudBrew.HopsMD
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0

--- a/manifests/c/CloudBrew/HopsMD/1.0.0/CloudBrew.HopsMD.yaml
+++ b/manifests/c/CloudBrew/HopsMD/1.0.0/CloudBrew.HopsMD.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
 PackageIdentifier: CloudBrew.HopsMD
 PackageVersion: 1.0.0
 DefaultLocale: en-US


### PR DESCRIPTION
 ## 📖 Description

  Initial submission for **CloudBrew.HopsMD** version 1.0.0 — a lightweight,
  local-first Markdown and MermaidJS viewer for Windows. MIT-licensed, built
  on Tauri 2 and Angular 21.

  - Project: https://github.com/lootwitch/HopsMD
  - Release: https://github.com/lootwitch/HopsMD/releases/tag/v1.0.0

  Installer SHA256 hashes verified against the published GitHub release artefacts:
  - NSIS: `4875F1ED…F397EEF14`
  - MSI:  `EC4D376C…584D1041`

  This is the very first version for this package; subsequent updates will be
  submitted automatically via `winget-releaser`.

  ## ✅ Checklist

  - [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
  - [x] Linked to an issue (if applicable)
    - N/A — initial package submission, no related issue.

  ## 📦 Manifest Checklist

  - [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
  - [x] This PR only modifies one (1) manifest
  - [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
  - [x] Tested manifest locally with `winget install --manifest <path>`
  - [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/376606)