### PR TITLE
New version: MasterSigner.Agent version 1.1.2

### DIFF
--- a/manifests/m/MasterSigner/Agent/1.1.2/MasterSigner.Agent.installer.yaml
+++ b/manifests/m/MasterSigner/Agent/1.1.2/MasterSigner.Agent.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: MasterSigner.Agent
+PackageVersion: 1.1.2
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: exe
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+InstallerSwitches:
+  Silent: --silent
+  SilentWithProgress: --silent
+UninstallBehavior: uninstaller
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://get.mastersigner.app/agent/windows-amd64.exe
+    InstallerSha256: BA2C8AE4E70E170493B847E9F71F0B0EC629351B44CA0B259F716AF95C05C676
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/MasterSigner/Agent/1.1.2/MasterSigner.Agent.locale.en-US.yaml
+++ b/manifests/m/MasterSigner/Agent/1.1.2/MasterSigner.Agent.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: MasterSigner.Agent
+PackageVersion: 1.1.2
+PackageLocale: en-US
+Publisher: MasterSigner
+PublisherUrl: https://mastersigner.app
+PublisherSupportUrl: https://mastersigner.app/download
+PackageName: Master Signer Agent
+PackageUrl: https://mastersigner.app/download
+License: Proprietary
+ShortDescription: Native messaging agent for Master Signer ICP-Brasil digital signature
+Description: |-
+  Master Signer Agent is a native messaging host that enables the Master Signer
+  browser extension to access hardware security tokens (A3 certificates) and perform
+  ICP-Brasil compliant digital signatures via PKCS#11.
+
+  Supports tokens from: SafeSign (AET/SERPRO), Feitian ePass, HID ActivClient,
+  Safeweb, Thales/Gemalto IDGo, WatchData, and other PKCS#11 compatible devices.
+Tags:
+  - certificate
+  - digital-signature
+  - icp-brasil
+  - pkcs11
+  - token
+  - signing
+ReleaseNotes: |-
+  Alinhamento de versão com extensão 1.1.2. Sem mudanças funcionais no agente —
+  versão acompanha o release unificado que corrige a quota de session storage
+  da extensão para PDFs grandes.
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/MasterSigner/Agent/1.1.2/MasterSigner.Agent.yaml
+++ b/manifests/m/MasterSigner/Agent/1.1.2/MasterSigner.Agent.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: MasterSigner.Agent
+PackageVersion: 1.1.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Bump MasterSigner.Agent → 1.1.2 (alinhado com extensão 1.1.2).

Sem mudanças funcionais no agente; alinhamento de versão unificado acompanhando o release da extensão que corrige a quota de chrome.storage.session para PDFs grandes.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/376750)