### PR TITLE
New version: packetThrower.Baudrun version 0.12.1

### DIFF
--- a/manifests/p/packetThrower/Baudrun/0.12.1/packetThrower.Baudrun.installer.yaml
+++ b/manifests/p/packetThrower/Baudrun/0.12.1/packetThrower.Baudrun.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: =https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 #
 # Installer manifest template. Fill in:
 #

--- a/manifests/p/packetThrower/Baudrun/0.12.1/packetThrower.Baudrun.installer.yaml
+++ b/manifests/p/packetThrower/Baudrun/0.12.1/packetThrower.Baudrun.installer.yaml
@@ -1,0 +1,55 @@
+# yaml-language-server: =https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+#
+# Installer manifest template. Fill in:
+#
+#   0.12.1              SemVer, no leading `v` (e.g. `0.12.0`)
+#   2026-05-19         ISO date the GitHub Release was cut
+#   5A8E7C3D1A3CC61C41F1F3A61757B33A64D2FD8776F00EB3508058B5696DB81F     `Get-FileHash -Algorithm SHA256` of the amd64 .msi
+#   466B8D5DE3034A061EBA91A1E7C4D8FC4932B84370BBB740F3C75DC737E3A13F     same for the arm64 .msi
+#   {6DA249C7-57F7-49DE-AB7D-9DB7297A68C3}   '{GUID}' from the amd64 .msi (wingetcreate auto-detects)
+#   {F66EBAF5-BE4F-4EA0-A2C3-B319ABE19CD0}   '{GUID}' from the arm64 .msi (wingetcreate auto-detects)
+#
+# Both architectures ship .msi installers (cargo-wix + system WiX
+# 3.14, see release.yml). MSI is preferred for winget because:
+#   * `ProductCode` lets winget reliably locate the install after
+#     it's applied — the `Validation-Executable-Error` we hit on
+#     v0.12.0's first submission traced back to cargo-packager's
+#     NSIS installer writing the uninstall key under HKCU instead
+#     of HKLM, which the validator's HKLM-scoped scan missed.
+#   * Apps & Features integration is automatic — Windows Installer
+#     writes `DisplayName`, `Publisher`, `DisplayVersion`,
+#     `InstallLocation`, etc. from the MSI's tables.
+#   * `Scope: machine` is honored by MSI tooling without per-tool
+#     configuration the way NSIS needs.
+# The portable NSIS .exe is still published as a Releases-page
+# artifact for users who'd rather skip an installer, but it's not
+# referenced from this manifest.
+
+PackageIdentifier: packetThrower.Baudrun
+PackageVersion: 0.12.1
+ReleaseDate: 2026-05-19
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+Installers:
+  - Architecture: x64
+    InstallerType: wix
+    InstallerUrl: https://github.com/packetThrower/Baudrun/releases/download/v0.12.1/Baudrun_0.12.1_amd64_en-US.msi
+    InstallerSha256: 5A8E7C3D1A3CC61C41F1F3A61757B33A64D2FD8776F00EB3508058B5696DB81F
+    ProductCode: '{6DA249C7-57F7-49DE-AB7D-9DB7297A68C3}'
+    Scope: machine
+    InstallerSwitches:
+      Silent: /quiet /norestart
+      SilentWithProgress: /passive /norestart
+  - Architecture: arm64
+    InstallerType: wix
+    InstallerUrl: https://github.com/packetThrower/Baudrun/releases/download/v0.12.1/Baudrun_0.12.1_arm64_en-US.msi
+    InstallerSha256: 466B8D5DE3034A061EBA91A1E7C4D8FC4932B84370BBB740F3C75DC737E3A13F
+    ProductCode: '{F66EBAF5-BE4F-4EA0-A2C3-B319ABE19CD0}'
+    Scope: machine
+    InstallerSwitches:
+      Silent: /quiet /norestart
+      SilentWithProgress: /passive /norestart
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/p/packetThrower/Baudrun/0.12.1/packetThrower.Baudrun.installer.yaml
+++ b/manifests/p/packetThrower/Baudrun/0.12.1/packetThrower.Baudrun.installer.yaml
@@ -12,11 +12,11 @@
 # Both architectures ship .msi installers (cargo-wix + system WiX
 # 3.14, see release.yml). MSI is preferred for winget because:
 #   * `ProductCode` lets winget reliably locate the install after
-#     it's applied — the `Validation-Executable-Error` we hit on
+#     it's applied â€” the `Validation-Executable-Error` we hit on
 #     v0.12.0's first submission traced back to cargo-packager's
 #     NSIS installer writing the uninstall key under HKCU instead
 #     of HKLM, which the validator's HKLM-scoped scan missed.
-#   * Apps & Features integration is automatic — Windows Installer
+#   * Apps & Features integration is automatic â€” Windows Installer
 #     writes `DisplayName`, `Publisher`, `DisplayVersion`,
 #     `InstallLocation`, etc. from the MSI's tables.
 #   * `Scope: machine` is honored by MSI tooling without per-tool
@@ -42,6 +42,9 @@ Installers:
     InstallerSwitches:
       Silent: /quiet /norestart
       SilentWithProgress: /passive /norestart
+    Dependencies:
+      PackageDependencies:
+        - PackageIdentifier: Microsoft.VCRedist.2015+.x64
   - Architecture: arm64
     InstallerType: wix
     InstallerUrl: https://github.com/packetThrower/Baudrun/releases/download/v0.12.1/Baudrun_0.12.1_arm64_en-US.msi
@@ -51,5 +54,8 @@ Installers:
     InstallerSwitches:
       Silent: /quiet /norestart
       SilentWithProgress: /passive /norestart
+    Dependencies:
+      PackageDependencies:
+        - PackageIdentifier: Microsoft.VCRedist.2015+.arm64
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/p/packetThrower/Baudrun/0.12.1/packetThrower.Baudrun.locale.en-US.yaml
+++ b/manifests/p/packetThrower/Baudrun/0.12.1/packetThrower.Baudrun.locale.en-US.yaml
@@ -1,0 +1,48 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+#
+# Default-locale manifest for the winget-pkgs entry. Mostly static
+# across versions; the per-version submission updates `PackageVersion`
+# and `ReleaseNotesUrl` to match the new tag. Copy into
+# `manifests/p/packetThrower/Baudrun/<version>/` when preparing a PR.
+
+PackageIdentifier: packetThrower.Baudrun
+PackageVersion: 0.12.1
+PackageLocale: en-US
+Publisher: packetThrower
+PublisherUrl: https://github.com/packetThrower
+PublisherSupportUrl: https://github.com/packetThrower/Baudrun/issues
+Author: Will Lehnertz
+PackageName: Baudrun
+PackageUrl: https://packetthrower.github.io/Baudrun/
+License: GPL-3.0-or-later
+LicenseUrl: https://github.com/packetThrower/Baudrun/blob/main/LICENSE
+Copyright: Copyright (C) Will Lehnertz
+CopyrightUrl: https://github.com/packetThrower/Baudrun/blob/main/LICENSE
+ShortDescription: Serial terminal for network engineers.
+Description: |-
+  Baudrun is a cross-platform (macOS + Windows + Linux) serial
+  terminal for network devices. Built for switch consoles, router
+  CLIs, and other serial-attached gear.
+
+  Profile-based: each device gets a named profile storing port,
+  baud rate, framing, flow control, line ending, and optional
+  send-on-connect sequences. One-click connect; no
+  `screen /dev/cu.usbserial-...` from memory.
+Moniker: baudrun
+Tags:
+  - baud
+  - cisco
+  - console
+  - network
+  - networking
+  - rs-232
+  - serial
+  - switch
+  - terminal
+  - uart
+ReleaseNotesUrl: https://github.com/packetThrower/Baudrun/releases/tag/v0.12.1
+Documentations:
+  - DocumentLabel: Online docs
+    DocumentUrl: https://packetthrower.github.io/Baudrun/
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/p/packetThrower/Baudrun/0.12.1/packetThrower.Baudrun.yaml
+++ b/manifests/p/packetThrower/Baudrun/0.12.1/packetThrower.Baudrun.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: =https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 #
 # Version manifest template. Substitute `0.12.1` for the
 # stable SemVer (e.g. `0.12.0`) when preparing the per-version

--- a/manifests/p/packetThrower/Baudrun/0.12.1/packetThrower.Baudrun.yaml
+++ b/manifests/p/packetThrower/Baudrun/0.12.1/packetThrower.Baudrun.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: =https://aka.ms/winget-manifest.version.1.12.0.schema.json
+#
+# Version manifest template. Substitute `0.12.1` for the
+# stable SemVer (e.g. `0.12.0`) when preparing the per-version
+# directory under
+# `manifests/p/packetThrower/Baudrun/<version>/`. The `envsubst`
+# step in the README handles this.
+
+PackageIdentifier: packetThrower.Baudrun
+PackageVersion: 0.12.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Summary
- New version submission for `packetThrower.Baudrun` at `0.12.1`.
- Both architectures (x64, arm64) now ship as `.msi` (via cargo-wix + WiX 3.14). Supersedes the v0.12.0 submission in #376207, which carried an arm64 NSIS entry whose install registered under HKCU and tripped `Validation-Executable-Error`.
- Each MSI: `InstallScope=perMachine`, explicit `ARPINSTALLLOCATION`, stable `UpgradeCode` (`{9F53E1BD-...}`) across versions for clean major-upgrade behavior, per-build `ProductCode`. Files install to `C:\Program Files\Baudrun\`.

## Verification
Verified locally before submission:
- x64 (Windows 11): `msiexec /i /quiet` succeeds, `Baudrun.exe` at `C:\Program Files\Baudrun\Baudrun.exe`, registry entry under `HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\{6DA249C7-57F7-49DE-AB7D-9DB7297A68C3}` with `InstallLocation=C:\Program Files\Baudrun\`.
- arm64 (Windows 11 on ARM): same flow, `ProductCode={F66EBAF5-BE4F-4EA0-A2C3-B319ABE19CD0}`, also under HKLM.
- Apps & Features shows the Baudrun icon (via `ARPPRODUCTICON`), Modify/Repair buttons hidden (`ARPNOMODIFY`/`ARPNOREPAIR`).
- App launches cleanly on both architectures.

Closing #376207 in favor of this submission.

## Repo
https://github.com/packetThrower/Baudrun
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/376876)