### PR TITLE
New version: tisun2.OofManager version 1.1.7

### DIFF
--- a/manifests/t/tisun2/OofManager/1.1.7/tisun2.OofManager.installer.yaml
+++ b/manifests/t/tisun2/OofManager/1.1.7/tisun2.OofManager.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: tisun2.OofManager
+PackageVersion: 1.1.7
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART
+UpgradeBehavior: install
+ReleaseDate: 2026-05-20
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/tisun2/OofManager/releases/download/v1.1.7/OofManagerSetup.exe
+    InstallerSha256: FEA648D4D2C6DA988D0DC4D32B66697FC91B2B98AD0D1F44BCE04BA45B59D734
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/t/tisun2/OofManager/1.1.7/tisun2.OofManager.locale.en-US.yaml
+++ b/manifests/t/tisun2/OofManager/1.1.7/tisun2.OofManager.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: tisun2.OofManager
+PackageVersion: 1.1.7
+PackageLocale: en-US
+Publisher: tisun2
+PublisherUrl: https://github.com/tisun2
+PublisherSupportUrl: https://github.com/tisun2/OofManager/issues
+PackageName: OOF Manager
+PackageUrl: https://github.com/tisun2/OofManager
+License: MIT
+LicenseUrl: https://github.com/tisun2/OofManager/blob/main/LICENSE
+Copyright: Copyright (c) tisun2
+ShortDescription: Manage Microsoft 365 / Exchange Online Out-of-Office (Automatic Reply) settings without opening Outlook.
+Description: |-
+  OOF Manager is a lightweight Windows desktop tool that manages your Microsoft 365 mailbox's
+  Out-of-Office (Automatic Reply) state for you. Sign in once, configure your weekly work hours
+  and reply text, and OOF Manager auto-toggles your OOF on/off at the schedule boundaries.
+  It also pushes the next off-hours window to Exchange as a Scheduled OOF, so the server keeps
+  switching auto-replies even when this app is closed.
+Moniker: oofmanager
+Tags:
+  - exchange
+  - microsoft-365
+  - office-365
+  - out-of-office
+  - oof
+  - outlook
+  - autoreply
+ReleaseNotesUrl: https://github.com/tisun2/OofManager/releases/tag/v1.1.7
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/t/tisun2/OofManager/1.1.7/tisun2.OofManager.yaml
+++ b/manifests/t/tisun2/OofManager/1.1.7/tisun2.OofManager.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: tisun2.OofManager
+PackageVersion: 1.1.7
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## New version: tisun2.OofManager 1.1.7

Bumps `tisun2.OofManager` from 1.1.6 to 1.1.7.

### What's new for users

- **Faster auto-reply scheduling after first setup.** Cloud schedule status checks and on/off toggles now skip the slow environment scan once the Power Automate flow has been imported, so the app feels snappy on subsequent launches.
- Minor polish on the OOF settings page.

Full release notes: https://github.com/tisun2/OofManager/releases/tag/v1.1.7

### Manifest validation

- [x] Manifests generated with the project's release script and pass `winget validate`
- [x] Installer SHA256 matches the asset attached to the GitHub release  
      `FEA648D4D2C6DA988D0DC4D32B66697FC91B2B98AD0D1F44BCE04BA45B59D734`
- [x] `InstallerUrl` points at the published release asset (`v1.1.7/OofManagerSetup.exe`)
- [x] Tested locally with `winget install --manifest manifests/t/tisun2/OofManager/1.1.7`

### Microsoft Reviewers

- Same publisher (`tisun2`) and `PackageIdentifier` as the previously merged 1.1.6 manifest — no schema changes.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/376957)