### PR TITLE
New package: NimaShafie.OxideSLOC version 1.5.6

### DIFF
--- a/manifests/n/NimaShafie/OxideSLOC/1.5.6/NimaShafie.OxideSLOC.installer.yaml
+++ b/manifests/n/NimaShafie/OxideSLOC/1.5.6/NimaShafie.OxideSLOC.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: NimaShafie.OxideSLOC
+PackageVersion: 1.5.6
+InstallerLocale: en-US
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: oxide-sloc.exe
+    PortableCommandAlias: oxide-sloc
+ReleaseDate: 2026-05-19
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/oxide-sloc/oxide-sloc/releases/download/v1.5.6/oxide-sloc-windows-x64.zip
+    InstallerSha256: 316E3B22059FBE47409065268A7B8A4F313C0CD945DBAE87864AB9EDB014F107
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/n/NimaShafie/OxideSLOC/1.5.6/NimaShafie.OxideSLOC.locale.en-US.yaml
+++ b/manifests/n/NimaShafie/OxideSLOC/1.5.6/NimaShafie.OxideSLOC.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: NimaShafie.OxideSLOC
+PackageVersion: 1.5.6
+PackageLocale: en-US
+Publisher: Nima Shafie
+PublisherUrl: https://github.com/NimaShafie
+PublisherSupportUrl: https://github.com/oxide-sloc/oxide-sloc/issues
+Author: Nima Shafie
+PackageName: oxide-sloc
+PackageUrl: https://github.com/oxide-sloc/oxide-sloc
+License: AGPL-3.0-or-later
+LicenseUrl: https://github.com/oxide-sloc/oxide-sloc/blob/main/LICENSE
+ShortDescription: Rust-based SLOC analysis and unit test metrics workbench
+Description: |-
+  oxide-sloc is a code metrics workbench that performs SLOC (Source Lines of Code) analysis
+  and unit test detection across 41 programming languages. It provides a CLI, a localhost web
+  UI, rich HTML reports, and PDF export. Features include language breakdown, IEEE 1045-1992
+  counting standards, git webhook integration, and test/production code separation.
+Moniker: oxide-sloc
+Tags:
+  - cli
+  - code-analysis
+  - developer-tools
+  - metrics
+  - rust
+  - sloc
+  - source-lines-of-code
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/n/NimaShafie/OxideSLOC/1.5.6/NimaShafie.OxideSLOC.yaml
+++ b/manifests/n/NimaShafie/OxideSLOC/1.5.6/NimaShafie.OxideSLOC.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: NimaShafie.OxideSLOC
+PackageVersion: 1.5.6
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

New package submission for oxide-sloc v1.5.6 — a Rust-based SLOC analysis and unit test metrics workbench with CLI, web UI, HTML reports, and PDF export. Supports 41 programming languages.

## Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Checked that there aren't other open pull requests for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest manifests/n/NimaShafie/OxideSLOC/1.5.6/`
- [x] Tested manifest locally with `winget install --manifest manifests/n/NimaShafie/OxideSLOC/1.5.6/`
- [x] Manifest conforms to the 1.12 schema