### PR TITLE
Add SSC-STUDIO.LenovoLegionToolkit version 3.8.0

### DIFF
--- a/manifests/s/SSC-STUDIO/LenovoLegionToolkit/3.8.0/SSC-STUDIO.LenovoLegionToolkit.installer.yaml
+++ b/manifests/s/SSC-STUDIO/LenovoLegionToolkit/3.8.0/SSC-STUDIO.LenovoLegionToolkit.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: SSC-STUDIO.LenovoLegionToolkit
+PackageVersion: 3.8.0
+InstallerType: inno
+Scope: user
+UpgradeBehavior: install
+ReleaseDate: 2026-05-20
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/SSC-STUDIO/UniversalDeviceToolkit/releases/download/v3.8.0/LenovoLegionToolkit_v3.8.0_Setup.exe
+  InstallerSha256: DD0CC08BB641E5B6BD23082CCE72BC1030463E85E1C32DDB504967C0BEF43026
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/s/SSC-STUDIO/LenovoLegionToolkit/3.8.0/SSC-STUDIO.LenovoLegionToolkit.locale.en-US.yaml
+++ b/manifests/s/SSC-STUDIO/LenovoLegionToolkit/3.8.0/SSC-STUDIO.LenovoLegionToolkit.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: SSC-STUDIO.LenovoLegionToolkit
+PackageVersion: 3.8.0
+PackageLocale: en-US
+Publisher: SSC-STUDIO
+PublisherUrl: https://github.com/SSC-STUDIO
+PublisherSupportUrl: https://github.com/SSC-STUDIO/UniversalDeviceToolkit/issues
+PackageName: Universal Device Toolkit
+PackageUrl: https://github.com/SSC-STUDIO/UniversalDeviceToolkit
+License: GPL-3.0
+LicenseUrl: https://github.com/SSC-STUDIO/UniversalDeviceToolkit/blob/master/LICENSE
+Copyright: Copyright (C) Universal Device Toolkit contributors
+ShortDescription: Lightweight hardware control toolkit for supported Lenovo laptops.
+Description: Universal Device Toolkit is a lightweight, open-source utility for supported Lenovo Legion, LOQ, Ideapad Gaming, and related laptops. It provides access to power modes, battery settings, RGB controls, dGPU state, driver updates, CLI control, and plugin extensions without running a background service or collecting telemetry.
+Moniker: universaldevicetoolkit
+Tags:
+- lenovo
+- legion
+- loq
+- vantage
+- toolkit
+- rgb
+- laptop
+- hardware-control
+ReleaseNotesUrl: https://github.com/SSC-STUDIO/UniversalDeviceToolkit/releases/tag/v3.8.0
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/s/SSC-STUDIO/LenovoLegionToolkit/3.8.0/SSC-STUDIO.LenovoLegionToolkit.yaml
+++ b/manifests/s/SSC-STUDIO/LenovoLegionToolkit/3.8.0/SSC-STUDIO.LenovoLegionToolkit.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: SSC-STUDIO.LenovoLegionToolkit
+PackageVersion: 3.8.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Adds SSC-STUDIO.LenovoLegionToolkit version 3.8.0. The public product name changed to Universal Device Toolkit while keeping the legacy PackageIdentifier for upgrade compatibility. Installer source is the v3.8.0 GitHub Release compatibility alias.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/377160)