### PR TITLE
Updates Arm.ArmPerformanceLibraries to 26.01.1

### DIFF
--- a/manifests/a/Arm/ArmPerformanceLibraries/26.01.1/Arm.ArmPerformanceLibraries.installer.yaml
+++ b/manifests/a/Arm/ArmPerformanceLibraries/26.01.1/Arm.ArmPerformanceLibraries.installer.yaml
@@ -1,0 +1,21 @@
+# Created using wingetcreate 1.9.4.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Arm.ArmPerformanceLibraries
+PackageVersion: "26.01.1"
+InstallerLocale: en-US
+InstallerType: wix
+InstallModes:
+  - silent
+InstallerSwitches:
+  Silent: "/quiet /norestart"
+  Custom: "ACCEPT_EULA=1"
+ProductCode: "{DF560B3D-CDBF-46A1-A4F9-9EE87E636AAF}"
+AppsAndFeaturesEntries:
+  - DisplayVersion: "26.01.1"
+Installers:
+  - Architecture: arm64
+    InstallerUrl: https://developer.arm.com/-/cdn-downloads/permalink/Arm-Performance-Libraries/Version_26.01.1/arm-performance-libraries_26.01.1_Windows.msi
+    InstallerSha256: 8d069867e257b4a707b9a339a370c63b022b39ebeac2bdd872a18caf3af923c8
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/Arm/ArmPerformanceLibraries/26.01.1/Arm.ArmPerformanceLibraries.locale.en-US.yaml
+++ b/manifests/a/Arm/ArmPerformanceLibraries/26.01.1/Arm.ArmPerformanceLibraries.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created using wingetcreate 1.9.4.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Arm.ArmPerformanceLibraries
+PackageVersion: "26.01.1"
+PackageLocale: en-US
+Publisher: Arm
+PublisherUrl: https://www.arm.com/
+PackageName: Arm Performance Libraries
+PackageUrl: https://developer.arm.com/Tools%20and%20Software/Arm%20Performance%20Libraries
+License: Simplified End User License Agreement For Free Of Charge Arm Redistributables
+ShortDescription: Arm Performance Libraries provides optimized standard core math libraries
+Agreements:
+  - AgreementLabel: End User License Agreement for Arm Performance Libraries
+    AgreementUrl: https://developer.arm.com/documentation/109686/latest
+ManifestVersion: 1.12.0
+ManifestType: defaultLocale

--- a/manifests/a/Arm/ArmPerformanceLibraries/26.01.1/Arm.ArmPerformanceLibraries.yaml
+++ b/manifests/a/Arm/ArmPerformanceLibraries/26.01.1/Arm.ArmPerformanceLibraries.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.9.4.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Arm.ArmPerformanceLibraries
+PackageVersion: "26.01.1"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Updates Arm.ArmPerformanceLibraries to 26.01.1.

## 📖 Description
Updates Arm.ArmPerformanceLibraries to 26.01.1.

## ✅ Checklist
- [X] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [X] Linked to an issue (if applicable)
  - Resolves #377071

## 📦 Manifest Checklist

- [X] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [X] This PR only modifies one (1) manifest
- [X] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [X] Tested manifest locally with `winget install --manifest <path>`
- [X] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/377196)