### PR TITLE
New version: packetThrower.PortFinder version 4.1.2

### DIFF
--- a/manifests/p/packetThrower/PortFinder/4.1.2/packetThrower.PortFinder.installer.yaml
+++ b/manifests/p/packetThrower/PortFinder/4.1.2/packetThrower.PortFinder.installer.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: packetThrower.PortFinder
+PackageVersion: 4.1.2
+ReleaseDate: 2026-05-20
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+Installers:
+  - Architecture: x64
+    InstallerType: wix
+    InstallerUrl: https://github.com/packetThrower/PortFinder/releases/download/v4.1.2/PortFinder_4.1.2_amd64_en-US.msi
+    InstallerSha256: 047052B992B90AB7BA189642FB9886A053B90F5CBB321EDE683EB34D158C567D
+    ProductCode: '{CF3F80DE-B7B9-43A8-8A6A-CD797C94827C}'
+    Scope: machine
+    InstallerSwitches:
+      Silent: /quiet /norestart
+      SilentWithProgress: /passive /norestart
+  - Architecture: arm64
+    InstallerType: wix
+    InstallerUrl: https://github.com/packetThrower/PortFinder/releases/download/v4.1.2/PortFinder_4.1.2_arm64_en-US.msi
+    InstallerSha256: D954FCD47944BCE2A7C2FBC6A47FEAC384D836ECCCE4A102E6071E59DAE4A0B7
+    ProductCode: '{0592C1A7-B3B5-40F4-AF13-9ED43BDD9F1C}'
+    Scope: machine
+    InstallerSwitches:
+      Silent: /quiet /norestart
+      SilentWithProgress: /passive /norestart
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/p/packetThrower/PortFinder/4.1.2/packetThrower.PortFinder.locale.en-US.yaml
+++ b/manifests/p/packetThrower/PortFinder/4.1.2/packetThrower.PortFinder.locale.en-US.yaml
@@ -1,0 +1,52 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: packetThrower.PortFinder
+PackageVersion: 4.1.2
+PackageLocale: en-US
+Publisher: packetThrower
+PublisherUrl: https://github.com/packetThrower
+PublisherSupportUrl: https://github.com/packetThrower/PortFinder/issues
+PrivacyUrl: https://github.com/packetThrower/PortFinder#privacy
+Author: Will Lehnertz
+PackageName: PortFinder
+PackageUrl: https://packetthrower.github.io/PortFinder/
+License: GPL-3.0-or-later
+LicenseUrl: https://github.com/packetThrower/PortFinder/blob/main/LICENSE
+Copyright: Copyright (C) Will Lehnertz
+CopyrightUrl: https://github.com/packetThrower/PortFinder/blob/main/LICENSE
+ShortDescription: Network switch port discovery tool using CDP / LLDP / MNDP.
+Description: |-
+  PortFinder identifies which switch, switchport, and VLAN your
+  machine is currently plugged into by listening for the discovery
+  packets the switch is already broadcasting. No agent on the
+  switch, no SNMP, no login — just a passive 30-second listen on
+  the wire.
+
+  Supported protocols:
+  - LLDP (universal: Aruba, HP, Juniper, Extreme, Cisco, MikroTik)
+  - CDP (Cisco)
+  - MNDP (MikroTik RouterOS fallback)
+
+  Ships a desktop GUI and a headless CLI in one binary. The CLI
+  takes `portfinder capture --interface <NIC> --protocol LLDP
+  [--json]`. Requires Npcap (with "Allow non-administrators to
+  capture" enabled) for non-administrator capture.
+Moniker: portfinder
+Tags:
+  - cdp
+  - discovery
+  - lldp
+  - mndp
+  - network
+  - networking
+  - npcap
+  - packet-capture
+  - pcap
+  - switch
+  - vlan
+ReleaseNotesUrl: https://github.com/packetThrower/PortFinder/releases/tag/v4.1.2
+Documentations:
+  - DocumentLabel: Online docs
+    DocumentUrl: https://packetthrower.github.io/PortFinder/
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/p/packetThrower/PortFinder/4.1.2/packetThrower.PortFinder.yaml
+++ b/manifests/p/packetThrower/PortFinder/4.1.2/packetThrower.PortFinder.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: packetThrower.PortFinder
+PackageVersion: 4.1.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
**Supersedes #376193**, which targeted v4.1.0 and was failing the validator's launch test on `STATUS_DLL_NOT_FOUND` (`0xC0000135`) for `VCRUNTIME140.dll`. The validator sandbox runs on a clean Windows image with no Visual C++ Redistributable installed, and every prior Rust+MSVC build of PortFinder dynamically linked against the redistributable's `VCRUNTIME140.dll` — so the Windows loader bailed before any PortFinder code ran.

v4.1.2 ships binaries that static-link the MSVC C runtime via `+crt-static` in `.cargo/config.toml`. The `.msi` is now self-contained at the CRT layer — no winget `Dependencies` block needed.

### Verification

On a Win11 ARM UTM VM with the v4.1.2 `.msi` installed, neither shipped binary imports `VCRUNTIME140.dll`:

```
PS> Test-VcRuntimeImport "C:\Program Files\PortFinder\PortFinder.exe"
C:\Program Files\PortFinder\PortFinder.exe : OK (no VCRUNTIME140 import)
PS> Test-VcRuntimeImport "C:\Program Files\PortFinder\portfinder-cli.exe"
C:\Program Files\PortFinder\portfinder-cli.exe : OK (no VCRUNTIME140 import)
```

The matching fix on our sibling app Baudrun was accepted by the validator on the same shape (#377170).

### Checklist

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change? (#376193 is being superseded by this one.)
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-cli/blob/master/doc/Manifest.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-cli/tree/master/schemas/JSON/manifests/v1.12.0)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/377322)