### PR TITLE
New version: packetThrower.Baudrun version 0.12.2

### DIFF
--- a/manifests/p/packetThrower/Baudrun/0.12.2/packetThrower.Baudrun.installer.yaml
+++ b/manifests/p/packetThrower/Baudrun/0.12.2/packetThrower.Baudrun.installer.yaml
@@ -1,0 +1,55 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+#
+# Installer manifest template. Fill in:
+#
+#   0.12.2              SemVer, no leading `v` (e.g. `0.12.0`)
+#   2026-05-20         ISO date the GitHub Release was cut
+#   A4F7B88FEC86D79471DEEFE4713533949CB612C717DBE3E1A7CABE8BA004D807     `Get-FileHash -Algorithm SHA256` of the amd64 .msi
+#   D3C0D0434C6E1BAB06E52DE4D4E7B77FD6092042F44BBF66D3329765CB3E5375     same for the arm64 .msi
+#   {7C2F7D53-4E9E-4647-8438-F528ABA6E544}   '{GUID}' from the amd64 .msi (wingetcreate auto-detects)
+#   {A6698FFF-6821-4B32-AF2A-B75C4B56288C}   '{GUID}' from the arm64 .msi (wingetcreate auto-detects)
+#
+# Both architectures ship .msi installers (cargo-wix + system WiX
+# 3.14, see release.yml). MSI is preferred for winget because:
+#   * `ProductCode` lets winget reliably locate the install after
+#     it's applied — the `Validation-Executable-Error` we hit on
+#     v0.12.0's first submission traced back to cargo-packager's
+#     NSIS installer writing the uninstall key under HKCU instead
+#     of HKLM, which the validator's HKLM-scoped scan missed.
+#   * Apps & Features integration is automatic — Windows Installer
+#     writes `DisplayName`, `Publisher`, `DisplayVersion`,
+#     `InstallLocation`, etc. from the MSI's tables.
+#   * `Scope: machine` is honored by MSI tooling without per-tool
+#     configuration the way NSIS needs.
+# The portable NSIS .exe is still published as a Releases-page
+# artifact for users who'd rather skip an installer, but it's not
+# referenced from this manifest.
+
+PackageIdentifier: packetThrower.Baudrun
+PackageVersion: 0.12.2
+ReleaseDate: 2026-05-20
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+Installers:
+  - Architecture: x64
+    InstallerType: wix
+    InstallerUrl: https://github.com/packetThrower/Baudrun/releases/download/v0.12.2/Baudrun_0.12.2_amd64_en-US.msi
+    InstallerSha256: A4F7B88FEC86D79471DEEFE4713533949CB612C717DBE3E1A7CABE8BA004D807
+    ProductCode: '{7C2F7D53-4E9E-4647-8438-F528ABA6E544}'
+    Scope: machine
+    InstallerSwitches:
+      Silent: /quiet /norestart
+      SilentWithProgress: /passive /norestart
+  - Architecture: arm64
+    InstallerType: wix
+    InstallerUrl: https://github.com/packetThrower/Baudrun/releases/download/v0.12.2/Baudrun_0.12.2_arm64_en-US.msi
+    InstallerSha256: D3C0D0434C6E1BAB06E52DE4D4E7B77FD6092042F44BBF66D3329765CB3E5375
+    ProductCode: '{A6698FFF-6821-4B32-AF2A-B75C4B56288C}'
+    Scope: machine
+    InstallerSwitches:
+      Silent: /quiet /norestart
+      SilentWithProgress: /passive /norestart
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/p/packetThrower/Baudrun/0.12.2/packetThrower.Baudrun.locale.en-US.yaml
+++ b/manifests/p/packetThrower/Baudrun/0.12.2/packetThrower.Baudrun.locale.en-US.yaml
@@ -1,0 +1,48 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+#
+# Default-locale manifest for the winget-pkgs entry. Mostly static
+# across versions; the per-version submission updates `PackageVersion`
+# and `ReleaseNotesUrl` to match the new tag. Copy into
+# `manifests/p/packetThrower/Baudrun/<version>/` when preparing a PR.
+
+PackageIdentifier: packetThrower.Baudrun
+PackageVersion: 0.12.2
+PackageLocale: en-US
+Publisher: packetThrower
+PublisherUrl: https://github.com/packetThrower
+PublisherSupportUrl: https://github.com/packetThrower/Baudrun/issues
+Author: Will Lehnertz
+PackageName: Baudrun
+PackageUrl: https://packetthrower.github.io/Baudrun/
+License: GPL-3.0-or-later
+LicenseUrl: https://github.com/packetThrower/Baudrun/blob/main/LICENSE
+Copyright: Copyright (C) Will Lehnertz
+CopyrightUrl: https://github.com/packetThrower/Baudrun/blob/main/LICENSE
+ShortDescription: Serial terminal for network engineers.
+Description: |-
+  Baudrun is a cross-platform (macOS + Windows + Linux) serial
+  terminal for network devices. Built for switch consoles, router
+  CLIs, and other serial-attached gear.
+
+  Profile-based: each device gets a named profile storing port,
+  baud rate, framing, flow control, line ending, and optional
+  send-on-connect sequences. One-click connect; no
+  `screen /dev/cu.usbserial-...` from memory.
+Moniker: baudrun
+Tags:
+  - baud
+  - cisco
+  - console
+  - network
+  - networking
+  - rs-232
+  - serial
+  - switch
+  - terminal
+  - uart
+ReleaseNotesUrl: https://github.com/packetThrower/Baudrun/releases/tag/v0.12.2
+Documentations:
+  - DocumentLabel: Online docs
+    DocumentUrl: https://packetthrower.github.io/Baudrun/
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/p/packetThrower/Baudrun/0.12.2/packetThrower.Baudrun.yaml
+++ b/manifests/p/packetThrower/Baudrun/0.12.2/packetThrower.Baudrun.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+#
+# Version manifest template. Substitute `0.12.2` for the
+# stable SemVer (e.g. `0.12.0`) when preparing the per-version
+# directory under
+# `manifests/p/packetThrower/Baudrun/<version>/`. The `envsubst`
+# step in the README handles this.
+
+PackageIdentifier: packetThrower.Baudrun
+PackageVersion: 0.12.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
v0.12.2 patch release.

The MSI now static-links the MSVC C runtime via `+crt-static` in `.cargo/config.toml`, so `Baudrun.exe` is self-contained at the CRT layer — no `Dependencies` block needed in the manifest. Same fix our sibling app PortFinder shipped on its v4.1.2 submission (#377322).

This supersedes #376876 (v0.12.1), which was failing the validator's launch test on `STATUS_DLL_NOT_FOUND` (`0xC0000135`) for `VCRUNTIME140.dll` — the validator sandbox is a clean Windows image with no Visual C++ Redistributable, and the v0.12.1 binary dynamically linked against it. v0.12.2 fixes that at the binary level instead of declaring a vcredist dependency. We'll close #376876 once this lands.

### Checklist

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change? (Will close #376876 in favor of this.)
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-cli/blob/master/doc/Manifest.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-cli/tree/master/schemas/JSON/manifests/v1.12.0)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/377330)