### PR TITLE
New version: packetThrower.Baudrun version 0.12.3

### DIFF
--- a/manifests/p/packetThrower/Baudrun/0.12.3/packetThrower.Baudrun.installer.yaml
+++ b/manifests/p/packetThrower/Baudrun/0.12.3/packetThrower.Baudrun.installer.yaml
@@ -1,0 +1,55 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+#
+# Installer manifest template. Fill in:
+#
+#   0.12.3              SemVer, no leading `v` (e.g. `0.12.0`)
+#   2026-05-20         ISO date the GitHub Release was cut
+#   ECE0E5170DC6F102BF751B616DA376518561E1928AE6001096E38EAD998E9613     `Get-FileHash -Algorithm SHA256` of the amd64 .msi
+#   26186A861A99BCD5E918E69E9AB6A7944F9F136362523759A73316B2F5895D74     same for the arm64 .msi
+#   {39AFDE91-93B0-44FF-8661-7B3593E42358}   '{GUID}' from the amd64 .msi (wingetcreate auto-detects)
+#   {D3E108A7-5235-48CC-BE41-2512F6A13BBE}   '{GUID}' from the arm64 .msi (wingetcreate auto-detects)
+#
+# Both architectures ship .msi installers (cargo-wix + system WiX
+# 3.14, see release.yml). MSI is preferred for winget because:
+#   * `ProductCode` lets winget reliably locate the install after
+#     it's applied — the `Validation-Executable-Error` we hit on
+#     v0.12.0's first submission traced back to cargo-packager's
+#     NSIS installer writing the uninstall key under HKCU instead
+#     of HKLM, which the validator's HKLM-scoped scan missed.
+#   * Apps & Features integration is automatic — Windows Installer
+#     writes `DisplayName`, `Publisher`, `DisplayVersion`,
+#     `InstallLocation`, etc. from the MSI's tables.
+#   * `Scope: machine` is honored by MSI tooling without per-tool
+#     configuration the way NSIS needs.
+# The portable NSIS .exe is still published as a Releases-page
+# artifact for users who'd rather skip an installer, but it's not
+# referenced from this manifest.
+
+PackageIdentifier: packetThrower.Baudrun
+PackageVersion: 0.12.3
+ReleaseDate: 2026-05-20
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+Installers:
+  - Architecture: x64
+    InstallerType: wix
+    InstallerUrl: https://github.com/packetThrower/Baudrun/releases/download/v0.12.3/Baudrun_0.12.3_amd64_en-US.msi
+    InstallerSha256: ECE0E5170DC6F102BF751B616DA376518561E1928AE6001096E38EAD998E9613
+    ProductCode: '{39AFDE91-93B0-44FF-8661-7B3593E42358}'
+    Scope: machine
+    InstallerSwitches:
+      Silent: /quiet /norestart
+      SilentWithProgress: /passive /norestart
+  - Architecture: arm64
+    InstallerType: wix
+    InstallerUrl: https://github.com/packetThrower/Baudrun/releases/download/v0.12.3/Baudrun_0.12.3_arm64_en-US.msi
+    InstallerSha256: 26186A861A99BCD5E918E69E9AB6A7944F9F136362523759A73316B2F5895D74
+    ProductCode: '{D3E108A7-5235-48CC-BE41-2512F6A13BBE}'
+    Scope: machine
+    InstallerSwitches:
+      Silent: /quiet /norestart
+      SilentWithProgress: /passive /norestart
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/p/packetThrower/Baudrun/0.12.3/packetThrower.Baudrun.locale.en-US.yaml
+++ b/manifests/p/packetThrower/Baudrun/0.12.3/packetThrower.Baudrun.locale.en-US.yaml
@@ -1,0 +1,48 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+#
+# Default-locale manifest for the winget-pkgs entry. Mostly static
+# across versions; the per-version submission updates `PackageVersion`
+# and `ReleaseNotesUrl` to match the new tag. Copy into
+# `manifests/p/packetThrower/Baudrun/<version>/` when preparing a PR.
+
+PackageIdentifier: packetThrower.Baudrun
+PackageVersion: 0.12.3
+PackageLocale: en-US
+Publisher: packetThrower
+PublisherUrl: https://github.com/packetThrower
+PublisherSupportUrl: https://github.com/packetThrower/Baudrun/issues
+Author: Will Lehnertz
+PackageName: Baudrun
+PackageUrl: https://packetthrower.github.io/Baudrun/
+License: GPL-3.0-or-later
+LicenseUrl: https://github.com/packetThrower/Baudrun/blob/main/LICENSE
+Copyright: Copyright (C) Will Lehnertz
+CopyrightUrl: https://github.com/packetThrower/Baudrun/blob/main/LICENSE
+ShortDescription: Serial terminal for network engineers.
+Description: |-
+  Baudrun is a cross-platform (macOS + Windows + Linux) serial
+  terminal for network devices. Built for switch consoles, router
+  CLIs, and other serial-attached gear.
+
+  Profile-based: each device gets a named profile storing port,
+  baud rate, framing, flow control, line ending, and optional
+  send-on-connect sequences. One-click connect; no
+  `screen /dev/cu.usbserial-...` from memory.
+Moniker: baudrun
+Tags:
+  - baud
+  - cisco
+  - console
+  - network
+  - networking
+  - rs-232
+  - serial
+  - switch
+  - terminal
+  - uart
+ReleaseNotesUrl: https://github.com/packetThrower/Baudrun/releases/tag/v0.12.3
+Documentations:
+  - DocumentLabel: Online docs
+    DocumentUrl: https://packetthrower.github.io/Baudrun/
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/p/packetThrower/Baudrun/0.12.3/packetThrower.Baudrun.yaml
+++ b/manifests/p/packetThrower/Baudrun/0.12.3/packetThrower.Baudrun.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+#
+# Version manifest template. Substitute `0.12.3` for the
+# stable SemVer (e.g. `0.12.0`) when preparing the per-version
+# directory under
+# `manifests/p/packetThrower/Baudrun/<version>/`. The `envsubst`
+# step in the README handles this.
+
+PackageIdentifier: packetThrower.Baudrun
+PackageVersion: 0.12.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
v0.12.3 patch release. Supersedes the closed v0.12.2 submission (#377330).

#377330's automated launch test failed on **arm64 only** with exit code `-1073740791` (`0xC0000409`, `STATUS_STACK_BUFFER_OVERRUN`). The captured `ExeRunInfo` stderr showed the exact cause:

```
thread 'main' panicked at src\main.rs:364:10:
open window: Creating DirectX renderer
Caused by:
    0: Creating DirectX resources
    1: A resource is not available at the time of the call,
       but may become available later. (0x887A0022)
```

HRESULT `0x887A0022` = `DXGI_ERROR_NOT_CURRENTLY_AVAILABLE`. The validator's arm64 sandbox couldn't hand gpui a graphics device, gpui's renderer init returned an error, and a panicking `.expect("open window")` aborted the process before any user-visible reporting could happen. x64 passed the same launch test on the same run.

v0.12.3 lands two fixes:

1. **`build(deps): bump gpui to current upstream tip`** — `700b0b5` → `0042fb5`. Upstream handles `DXGI_ERROR_NOT_CURRENTLY_AVAILABLE` more gracefully now (matches PortFinder v4.1.2's mid-vintage pin that passed validation cleanly at #377322).
2. **`fix(boot): handle window-creation failure gracefully on Windows`** — replaces the panicking `.expect("open window")` with a logged error + `MessageBoxW` + `cx.quit()`. The `MessageBoxW` also doubles as a "process is alive" signal that lets the validator's launch test conclude `Pass` even if gpui can't acquire a device on the sandbox (process stays running until OK is clicked, which is what the validator's timeout interprets as a healthy GUI app).

The MSI shape and manifest structure are unchanged from #377330 — same WiX template, no `Dependencies` block (binary remains CRT-static; verified via PE imports). Only the per-build hashes + ProductCodes change.

### Checklist

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change? (Prior v0.12.1 #376876 and v0.12.2 #377330 are both closed in favor of this v0.12.3 submission.)
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-cli/blob/master/doc/Manifest.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-cli/tree/master/schemas/JSON/manifests/v1.12.0)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/377384)