### PR TITLE
Update: kayapater.VideoDownloader 1.6.0 installer hash

### DIFF
--- a/manifests/k/kayapater/VideoDownloader/1.6.0/kayapater.VideoDownloader.installer.yaml
+++ b/manifests/k/kayapater/VideoDownloader/1.6.0/kayapater.VideoDownloader.installer.yaml
@@ -17,16 +17,16 @@ Dependencies:
   PackageDependencies:
   - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.8
     MinimumVersion: 8.0.0
-ProductCode: '{FA8AD240-60A8-4C0A-B9AA-CD11FA9214E4}'
+ProductCode: '{395A6A58-A591-4E48-95FE-F056D7729151}'
 AppsAndFeaturesEntries:
 - DisplayName: Video Downloader
   Publisher: kayapater
   DisplayVersion: 1.6.0
-  UpgradeCode: '{A1B2C3D4-E5F6-7890-ABCD-123456789ABC}'
+  UpgradeCode: '{A1B2C3D4-E5F6-4789-ABCD-123456789012}'
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/kayapater/video-downloader/releases/download/v1.6.0/VideoDownloader-v1.6.0-Setup.msi
-  InstallerSha256: 6D218C16CEAA0E76C8C08A181D6B2F295ABC7802779B293A65EDC02E753CA92C
+  InstallerSha256: 0BB8C818444FA7CDDA441B732F8D7ADD2073EF5030096DDE801712A9DD9B1A5E
 ManifestType: installer
 ManifestVersion: 1.12.0
-ReleaseDate: 2026-05-20
+ReleaseDate: 2026-05-21


### PR DESCRIPTION
## Description\nRefreshes the existing 1.6.0 installer manifest after replacing the GitHub release MSI asset.\n\n## Changes\n- Updated InstallerSha256 for v1.6.0 MSI\n- Updated ProductCode to match rebuilt MSI\n- Updated UpgradeCode to match rebuilt MSI\n- Updated ReleaseDate\n\n## Validation\n- winget validate --manifest manifests/k/kayapater/VideoDownloader/1.6.0\n\nInstaller URL remains the same:\nhttps://github.com/kayapater/video-downloader/releases/download/v1.6.0/VideoDownloader-v1.6.0-Setup.msi
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/377396)