### PR TITLE
New version: packetThrower.Baudrun version 0.12.4

### DIFF
--- a/manifests/p/packetThrower/Baudrun/0.12.4/packetThrower.Baudrun.installer.yaml
+++ b/manifests/p/packetThrower/Baudrun/0.12.4/packetThrower.Baudrun.installer.yaml
@@ -1,0 +1,46 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+#
+# Installer manifest template. Fill in:
+#
+#   0.12.4              SemVer, no leading `v` (e.g. `0.12.0`)
+#   2026-05-21         ISO date the GitHub Release was cut
+#   5DABC4C48EB0579C839C12BB5513D0D17E6BCDC4562258AC99E68EB1C1382CF5     `Get-FileHash -Algorithm SHA256` of the amd64 .msi
+#   D0829465AD00CC53524BC5EA918B9691DE4C8D355BFD7D60705490A575E47AB7     same for the arm64 .msi
+#   {AB861629-8AF6-493F-B76A-778F6BBC0ED1}   '{GUID}' from the amd64 .msi (wingetcreate auto-detects)
+#   {9D96937E-829E-4EE7-96C3-FE4AEACD6547}   '{GUID}' from the arm64 .msi (wingetcreate auto-detects)
+#
+# Both architectures ship .msi installers (cargo-wix + system WiX
+# 3.14, see release.yml). MSI is preferred for winget because:
+#   * `ProductCode` lets winget reliably locate the install after
+#     it's applied — the `Validation-Executable-Error` we hit on
+#     v0.12.0's first submission traced back to cargo-packager's
+#     NSIS installer writing the uninstall key under HKCU instead
+#     of HKLM, which the validator's HKLM-scoped scan missed.
+#   * Apps & Features integration is automatic — Windows Installer
+#     writes `DisplayName`, `Publisher`, `DisplayVersion`,
+#     `InstallLocation`, etc. from the MSI's tables.
+#   * `Scope: machine` is honored by MSI tooling without per-tool
+#     configuration the way NSIS needs.
+# The portable NSIS .exe is still published as a Releases-page
+# artifact for users who'd rather skip an installer, but it's not
+# referenced from this manifest.
+
+PackageIdentifier: packetThrower.Baudrun
+PackageVersion: 0.12.4
+ReleaseDate: 2026-05-21
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+Installers:
+  - Architecture: x64
+    InstallerType: wix
+    InstallerUrl: https://github.com/packetThrower/Baudrun/releases/download/v0.12.4/Baudrun_0.12.4_amd64_en-US.msi
+    InstallerSha256: 5DABC4C48EB0579C839C12BB5513D0D17E6BCDC4562258AC99E68EB1C1382CF5
+    ProductCode: '{AB861629-8AF6-493F-B76A-778F6BBC0ED1}'
+    Scope: machine
+    InstallerSwitches:
+      Silent: /quiet /norestart
+      SilentWithProgress: /passive /norestart
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/p/packetThrower/Baudrun/0.12.4/packetThrower.Baudrun.locale.en-US.yaml
+++ b/manifests/p/packetThrower/Baudrun/0.12.4/packetThrower.Baudrun.locale.en-US.yaml
@@ -1,0 +1,48 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+#
+# Default-locale manifest for the winget-pkgs entry. Mostly static
+# across versions; the per-version submission updates `PackageVersion`
+# and `ReleaseNotesUrl` to match the new tag. Copy into
+# `manifests/p/packetThrower/Baudrun/<version>/` when preparing a PR.
+
+PackageIdentifier: packetThrower.Baudrun
+PackageVersion: 0.12.4
+PackageLocale: en-US
+Publisher: packetThrower
+PublisherUrl: https://github.com/packetThrower
+PublisherSupportUrl: https://github.com/packetThrower/Baudrun/issues
+Author: Will Lehnertz
+PackageName: Baudrun
+PackageUrl: https://packetthrower.github.io/Baudrun/
+License: GPL-3.0-or-later
+LicenseUrl: https://github.com/packetThrower/Baudrun/blob/main/LICENSE
+Copyright: Copyright (C) Will Lehnertz
+CopyrightUrl: https://github.com/packetThrower/Baudrun/blob/main/LICENSE
+ShortDescription: Serial terminal for network engineers.
+Description: |-
+  Baudrun is a cross-platform (macOS + Windows + Linux) serial
+  terminal for network devices. Built for switch consoles, router
+  CLIs, and other serial-attached gear.
+
+  Profile-based: each device gets a named profile storing port,
+  baud rate, framing, flow control, line ending, and optional
+  send-on-connect sequences. One-click connect; no
+  `screen /dev/cu.usbserial-...` from memory.
+Moniker: baudrun
+Tags:
+  - baud
+  - cisco
+  - console
+  - network
+  - networking
+  - rs-232
+  - serial
+  - switch
+  - terminal
+  - uart
+ReleaseNotesUrl: https://github.com/packetThrower/Baudrun/releases/tag/v0.12.4
+Documentations:
+  - DocumentLabel: Online docs
+    DocumentUrl: https://packetthrower.github.io/Baudrun/
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/p/packetThrower/Baudrun/0.12.4/packetThrower.Baudrun.yaml
+++ b/manifests/p/packetThrower/Baudrun/0.12.4/packetThrower.Baudrun.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+#
+# Version manifest template. Substitute `0.12.4` for the
+# stable SemVer (e.g. `0.12.0`) when preparing the per-version
+# directory under
+# `manifests/p/packetThrower/Baudrun/<version>/`. The `envsubst`
+# step in the README handles this.
+
+PackageIdentifier: packetThrower.Baudrun
+PackageVersion: 0.12.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Dropping arm64 from this submission for now — shipping x64 only.

arm64 .msi still ships on the [GitHub Release](https://github.com/packetThrower/Baudrun/releases/tag/v0.12.4) and works on real arm64 Windows hardware (verified locally on a Windows 11 arm64 UTM VM). arm64 winget users fall back to the x64 .msi via Windows 11's emulation, which runs Rust+MSVC binaries fine.

(Supersedes #376876, #377330, #377384.)

### Checklist

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-cli/blob/master/doc/Manifest.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-cli/tree/master/schemas/JSON/manifests/v1.12.0)?