### PR TITLE
New package: UnitaryLab.CLI version 0.1.0

### DIFF
--- a/manifests/u/UnitaryLab/CLI/0.1.0/UnitaryLab.CLI.installer.yaml
+++ b/manifests/u/UnitaryLab/CLI/0.1.0/UnitaryLab.CLI.installer.yaml
@@ -1,0 +1,14 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: UnitaryLab.CLI
+PackageVersion: 0.1.0
+InstallerType: portable
+Commands:
+- unitarylab
+Installers:
+- Architecture: x64
+  InstallerUrl: https://assets.unitarylab.com/unitarylab-windows-x86_64.exe
+  InstallerSha256: D6A4EEFDD396D13ED5AD40423DED76E44D3A8F44E21A211D4DFA57C9DAB4AD50
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/u/UnitaryLab/CLI/0.1.0/UnitaryLab.CLI.locale.en-US.yaml
+++ b/manifests/u/UnitaryLab/CLI/0.1.0/UnitaryLab.CLI.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: UnitaryLab.CLI
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Shanghai Unitary Lab Technology Co., Ltd.
+PublisherUrl: https://unitarylab.com
+Author: Shanghai Unitary Lab Technology Co., Ltd.
+PackageName: UnitaryLab CLI
+PackageUrl: https://github.com/unitarylab/unitarylab-agent
+License: Unitary Lab Closed-Source Software Non-Commercial Use License Agreement
+LicenseUrl: https://github.com/unitarylab/unitarylab-agent/blob/main/LICENSE.en
+Copyright: Copyright (c) Shanghai Unitary Lab Technology Co., Ltd.
+ShortDescription: Local command-line quantum computing agent from UnitaryLab.
+Description: UnitaryLab CLI is a local terminal command-line tool for UnitaryLab Agent. By running the unitarylab command, users can enter an interactive REPL environment where the Agent assists with model conversations, file reading and writing, and built-in skills such as quantum algorithms, quantum simulation, and PDE solving.
+Moniker: unitarylab
+Tags:
+- '- cli'
+- '- agent'
+- '- llm'
+- '- quantum'
+- '- quantum-computing'
+- '- quantum-algorithms'
+- '- quantum-simulation'
+- '- pde'
+- '- repl'
+- '- terminal'
+ReleaseNotes: Initial release of UnitaryLab CLI for Windows, including the local REPL interface, model conversation support, file operations, and built-in quantum algorithm and PDE solving skills.
+ReleaseNotesUrl: https://github.com/unitarylab/unitarylab-agent/releases/tag/v0.1.0
+InstallationNotes: Run "unitarylab" in a terminal to start the interactive REPL.
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/u/UnitaryLab/CLI/0.1.0/UnitaryLab.CLI.yaml
+++ b/manifests/u/UnitaryLab/CLI/0.1.0/UnitaryLab.CLI.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: UnitaryLab.CLI
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description
Adds the initial WinGet manifest for **UnitaryLab.CLI version 0.1.0**.

UnitaryLab CLI is a local terminal command-line tool for UnitaryLab Agent. It provides an interactive REPL environment through the `unitarylab` command, supporting model conversations, file operations, and built-in skills such as quantum algorithms, quantum simulation, and PDE solving.

This manifest uses a portable Windows x64 installer and exposes the following command alias after installation:

```powershell
unitarylab

Package details:

Package Identifier: UnitaryLab.CLI
Package Version: 0.1.0
Publisher: Shanghai Unitary Lab Technology Co., Ltd.
Installer Type: portable
Architecture: x64

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (not applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest manifests/u/UnitaryLab/CLI/0.1.0` 
- [x] Tested manifest locally with `winget install --manifest manifests/u/UnitaryLab/CLI/0.1.0`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `manifests/u/UnitaryLab/CLI/0.1.0` is the directory containing the submitted manifest.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/377505)