### PR TITLE
New package: OpenCow42.metaBrain version 1.1.2

### DIFF
--- a/manifests/o/OpenCow42/metaBrain/1.1.2/OpenCow42.metaBrain.installer.yaml
+++ b/manifests/o/OpenCow42/metaBrain/1.1.2/OpenCow42.metaBrain.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: OpenCow42.metaBrain
+PackageVersion: 1.1.2
+InstallerType: zip
+NestedInstallerType: portable
+ReleaseDate: 2026-05-21
+Installers:
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: mb.exe
+    PortableCommandAlias: mb
+  InstallerUrl: https://github.com/OpenCow42/metaBrain/releases/download/1.1.2/metabrain-1.1.2-windows-x86_64.zip
+  InstallerSha256: FBF5AD4F49336FAC171E1196DFFB6F50BF69A2AE3B507CD9B7AD368DB6CB688D
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenCow42/metaBrain/1.1.2/OpenCow42.metaBrain.locale.en-US.yaml
+++ b/manifests/o/OpenCow42/metaBrain/1.1.2/OpenCow42.metaBrain.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: OpenCow42.metaBrain
+PackageVersion: 1.1.2
+PackageLocale: en-US
+Publisher: OpenCow42
+PublisherUrl: https://github.com/OpenCow42
+PublisherSupportUrl: https://github.com/OpenCow42/metaBrain/issues
+Author: OpenCow42
+PackageName: metaBrain
+PackageUrl: https://github.com/OpenCow42/metaBrain
+License: MIT
+LicenseUrl: https://github.com/OpenCow42/metaBrain/blob/1.1.2/LICENSE
+Copyright: Copyright (c) OpenCow42
+ShortDescription: Local document memory store CLI for agents and tools
+Description: metaBrain is a local document memory for agents and tools. It stores notes, source snippets, task context, metadata, tags, links, and version history in a compact LevelDB-backed database through the mb command-line tool.
+Moniker: mb
+Tags:
+- ai
+- cli
+- database
+- documents
+- leveldb
+- memory
+- notes
+- search
+ReleaseNotesUrl: https://github.com/OpenCow42/metaBrain/releases/tag/1.1.2
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenCow42/metaBrain/1.1.2/OpenCow42.metaBrain.yaml
+++ b/manifests/o/OpenCow42/metaBrain/1.1.2/OpenCow42.metaBrain.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: OpenCow42.metaBrain
+PackageVersion: 1.1.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Submission

Adds a new portable package manifest for OpenCow42.metaBrain version 1.1.2.

### Validation

- Windows artifact URL: https://github.com/OpenCow42/metaBrain/releases/download/1.1.2/metabrain-1.1.2-windows-x86_64.zip
- SHA256 verified on Windows: FBF5AD4F49336FAC171E1196DFFB6F50BF69A2AE3B507CD9B7AD368DB6CB688D
- Archive layout verified: mb.exe is at the zip root.
- Ran `winget validate --manifest C:\Users\opencow\winget-metabrain\1.1.2 --disable-interactivity` on Windows: validation succeeded.

### Notes

This is a portable zip package. The manifest maps `mb.exe` to the `mb` command alias.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/377542)