### PR TITLE
New version: BrightKitchen.PrintBridge version 2.0.27

### DIFF
--- a/manifests/b/BrightKitchen/PrintBridge/2.0.27/BrightKitchen.PrintBridge.installer.yaml
+++ b/manifests/b/BrightKitchen/PrintBridge/2.0.27/BrightKitchen.PrintBridge.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: BrightKitchen.PrintBridge
+PackageVersion: 2.0.27
+InstallerType: wix
+Scope: machine
+UpgradeBehavior: install
+ElevationRequirement: elevatesSelf
+InstallerSuccessCodes:
+  - 3010
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Karimrekiki/kds-print-bridge/releases/download/v2.0.27/BKPrintBridgeWinget-2.0.27.msi
+    InstallerSha256: F5A8AC90D1C713E82CCDB782ED809AD5A6409D1B83C23611AF1A4C3AB80C6BA9
+    ProductCode: '{93195A45-12B8-5C11-86C4-7B95011F3094}'
+    AppsAndFeaturesEntries:
+      - DisplayName: Bright Kitchen Print Bridge
+        Publisher: BK One B.V.
+        DisplayVersion: 2.0.27
+        ProductCode: '{93195A45-12B8-5C11-86C4-7B95011F3094}'
+        UpgradeCode: '{7F9620E8-6B9B-4B2F-8C44-62060B9A58D4}'
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/b/BrightKitchen/PrintBridge/2.0.27/BrightKitchen.PrintBridge.locale.en-US.yaml
+++ b/manifests/b/BrightKitchen/PrintBridge/2.0.27/BrightKitchen.PrintBridge.locale.en-US.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: BrightKitchen.PrintBridge
+PackageVersion: 2.0.27
+PackageLocale: en-US
+Publisher: BK One B.V.
+PackageName: Bright Kitchen Print Bridge
+PackageUrl: https://github.com/Karimrekiki/kds-print-bridge
+License: Proprietary
+ShortDescription: Bright Kitchen local print bridge service for receipt printers.
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/b/BrightKitchen/PrintBridge/2.0.27/BrightKitchen.PrintBridge.yaml
+++ b/manifests/b/BrightKitchen/PrintBridge/2.0.27/BrightKitchen.PrintBridge.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: BrightKitchen.PrintBridge
+PackageVersion: 2.0.27
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
### Pull request checklist

- [x] I have checked that this package version is not already submitted.
- [x] Installer URL points to the immutable GitHub release asset for v2.0.27.
- [x] Installer SHA256 was generated from the signed release MSI.

### Package

BrightKitchen.PrintBridge 2.0.27
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/377753)