### PR TITLE
New version: M-Igashi.mp3rgui version 2.7.0

### DIFF
--- a/manifests/m/M-Igashi/mp3rgui/2.7.0/M-Igashi.mp3rgui.installer.yaml
+++ b/manifests/m/M-Igashi/mp3rgui/2.7.0/M-Igashi.mp3rgui.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgui
+PackageVersion: 2.7.0
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: mp3rgui.exe
+ReleaseDate: 2026-05-22
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/M-Igashi/mp3rgain/releases/download/v2.7.0/mp3rgui-v2.7.0-windows-x86_64.zip
+    InstallerSha256: 08AF17FDF3E0DCB90C47DFDBFD5320F2B1FAD0DAABF33426B4339A7DF1EEB822
+  - Architecture: arm64
+    InstallerUrl: https://github.com/M-Igashi/mp3rgain/releases/download/v2.7.0/mp3rgui-v2.7.0-windows-arm64.zip
+    InstallerSha256: 53371CC449BB83E383647464DFAB5CED05DF6FBBE4D601C7454CE0E4E9E7A605
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/mp3rgui/2.7.0/M-Igashi.mp3rgui.locale.en-US.yaml
+++ b/manifests/m/M-Igashi/mp3rgui/2.7.0/M-Igashi.mp3rgui.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgui
+PackageVersion: 2.7.0
+PackageLocale: en-US
+Publisher: M-Igashi
+PublisherUrl: https://github.com/M-Igashi
+PublisherSupportUrl: https://github.com/M-Igashi/mp3rgain/issues
+Author: M-Igashi
+PackageName: mp3rgui
+PackageUrl: https://github.com/M-Igashi/mp3rgain
+License: MIT
+LicenseUrl: https://github.com/M-Igashi/mp3rgain/blob/master/LICENSE
+ShortDescription: GUI for lossless MP3 volume adjustment - a modern mp3gain replacement written in Rust
+Description: |-
+  mp3rgui is the graphical interface for mp3rgain, a lossless MP3 volume normalizer.
+  It provides an easy-to-use GUI for adjusting MP3 volume without re-encoding,
+  supporting ReplayGain analysis, AAC/M4A, FLAC, and OGG formats.
+Moniker: mp3rgui
+Tags:
+  - audio
+  - flac
+  - gain
+  - gui
+  - lossless
+  - mp3
+  - music
+  - normalize
+  - ogg
+  - replaygain
+  - rust
+  - volume
+ReleaseNotesUrl: https://github.com/M-Igashi/mp3rgain/releases/tag/v2.7.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/mp3rgui/2.7.0/M-Igashi.mp3rgui.yaml
+++ b/manifests/m/M-Igashi/mp3rgui/2.7.0/M-Igashi.mp3rgui.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgui
+PackageVersion: 2.7.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## New version submission

Adds version **2.7.0** of `M-Igashi.mp3rgui` (graphical frontend for mp3rgain).

### Manifest verification

- [x] `winget validate manifests/m/M-Igashi/mp3rgui/2.7.0` passes
- [x] SHA256 checksums match release assets
- [x] All metadata is consistent with the previous published version

### Release notes

See https://github.com/M-Igashi/mp3rgain/releases/tag/v2.7.0

Highlights: GUI now runs every batch operation on background threads (no more freeze during analysis/apply) and has full menu surface parity with the CLI — Undo, Check / Delete Stored Tags, Find Max Amplitude, Apply Manual Gain, Apply Channel Gain, Dry Run. New `Stored RG` column shows existing ReplayGain / undo tags. The GUI now writes undo + ReplayGain tags through the unified library API, so files modified via the GUI can be reverted with `mp3rgain -u` and the gain is visible to foobar2000 / Winamp / Rockbox.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/377903)