### PR TITLE
New package: Rorkai.ASC version 1.6.1

### DIFF
--- a/manifests/r/Rorkai/ASC/1.6.1/Rorkai.ASC.installer.yaml
+++ b/manifests/r/Rorkai/ASC/1.6.1/Rorkai.ASC.installer.yaml
@@ -1,0 +1,12 @@
+# Created with App-Store-Connect-CLI/scripts/generate_winget_manifests.py
+PackageIdentifier: Rorkai.ASC
+PackageVersion: 1.6.1
+InstallerType: portable
+Commands:
+  - asc
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/rorkai/App-Store-Connect-CLI/releases/download/1.6.1/asc_1.6.1_windows_amd64.exe
+    InstallerSha256: 4BC3B1D44550C04797290FD04F8FF1C8B08D22EFFAD0C9997DE9D21A52299FD0
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/r/Rorkai/ASC/1.6.1/Rorkai.ASC.locale.en-US.yaml
+++ b/manifests/r/Rorkai/ASC/1.6.1/Rorkai.ASC.locale.en-US.yaml
@@ -1,0 +1,20 @@
+# Created with App-Store-Connect-CLI/scripts/generate_winget_manifests.py
+PackageIdentifier: Rorkai.ASC
+PackageVersion: 1.6.1
+PackageLocale: en-US
+Publisher: Rorkai
+PackageName: asc
+PackageUrl: https://github.com/rorkai/App-Store-Connect-CLI
+License: MIT
+LicenseUrl: https://github.com/rorkai/App-Store-Connect-CLI/blob/main/LICENSE
+ShortDescription: Fast, scriptable CLI for the App Store Connect API.
+Moniker: asc
+Tags:
+  - app-store-connect
+  - app-store-connect-api
+  - cli
+  - ios
+  - testflight
+ReleaseNotesUrl: https://github.com/rorkai/App-Store-Connect-CLI/releases/tag/1.6.1
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/r/Rorkai/ASC/1.6.1/Rorkai.ASC.yaml
+++ b/manifests/r/Rorkai/ASC/1.6.1/Rorkai.ASC.yaml
@@ -1,0 +1,6 @@
+# Created with App-Store-Connect-CLI/scripts/generate_winget_manifests.py
+PackageIdentifier: Rorkai.ASC
+PackageVersion: 1.6.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Description

Adds the first WinGet manifest for Rorkai.ASC version 1.5.1.

## Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Checked that there aren't other open pull requests for the same manifest update/change
- [x] This PR only modifies one manifest
- [x] Validated manifest locally with `winget validate --manifest manifests/r/Rorkai/ASC/1.5.1`
- [x] Tested manifest locally with `winget install --manifest manifests/r/Rorkai/ASC/1.5.1`
- [x] Manifest conforms to the 1.6 schema

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/377999)
