### PR TITLE
Microsoft.WindowsAppRuntime.1.8 version 1.8.8 - drop zip installers

### DIFF
--- a/manifests/m/Microsoft/WindowsAppRuntime/1/8/1.8.8/Microsoft.WindowsAppRuntime.1.8.installer.yaml
+++ b/manifests/m/Microsoft/WindowsAppRuntime/1/8/1.8.8/Microsoft.WindowsAppRuntime.1.8.installer.yaml
@@ -3,83 +3,30 @@
 
 PackageIdentifier: Microsoft.WindowsAppRuntime.1.8
 PackageVersion: 1.8.8
+InstallerType: exe
 InstallModes:
 - silent
 - silentWithProgress
+InstallerSwitches:
+  Silent: --quiet
+  SilentWithProgress: --quiet
+UpgradeBehavior: install
 PackageFamilyName: Microsoft.WindowsAppRuntime.1.8_8wekyb3d8bbwe
+AppsAndFeaturesEntries:
+- DisplayName: WindowsAppRuntime.1.8
+  DisplayVersion: 8000.859.21.0
+  InstallerType: msix
+ElevationRequirement: elevationRequired
 Installers:
-- Platform:
-  - Windows.Universal
-  - Windows.Desktop
-  Architecture: x64
-  InstallerType: zip
-  NestedInstallerType: msix
-  NestedInstallerFiles:
-  - RelativeFilePath: MSIX\win10-x64\Microsoft.WindowsAppRuntime.1.8.msix
-  InstallerUrl: https://download.microsoft.com/download/9dd9de00-6b17-4777-a3b8-693cdfaaf85b/Microsoft.WindowsAppRuntime.Redist.1.8.260508005.zip
-  InstallerSha256: 2D291D290E34376F98BFCBD07E917134CD3B2F1E8FC364B1032752822387AC1D
-  SignatureSha256: A01A40A59F7273490CE21BB352499F0C541F92E01130B0EBFB8CBDE9E14C8C50
 - Architecture: x64
-  InstallerType: exe
   InstallerUrl: https://download.microsoft.com/download/eab8bdb8-8bad-4057-a315-7a88372e689b/WindowsAppRuntimeInstall-x64.exe
   InstallerSha256: B271A789809D15E57D49EF4518CEEF90B8614626DC04FF5D89906CCA8843CDF3
-  InstallerSwitches:
-    Silent: --quiet
-    SilentWithProgress: --quiet
-  UpgradeBehavior: install
-  AppsAndFeaturesEntries:
-  - DisplayName: WindowsAppRuntime.1.8
-    DisplayVersion: 8000.859.21.0
-    InstallerType: msix
-  ElevationRequirement: elevationRequired
-- Platform:
-  - Windows.Universal
-  - Windows.Desktop
-  Architecture: arm64
-  InstallerType: zip
-  NestedInstallerType: msix
-  NestedInstallerFiles:
-  - RelativeFilePath: MSIX\win10-arm64\Microsoft.WindowsAppRuntime.1.8.msix
-  InstallerUrl: https://download.microsoft.com/download/9dd9de00-6b17-4777-a3b8-693cdfaaf85b/Microsoft.WindowsAppRuntime.Redist.1.8.260508005.zip
-  InstallerSha256: 2D291D290E34376F98BFCBD07E917134CD3B2F1E8FC364B1032752822387AC1D
-  SignatureSha256: 7BA0B21BDA9EC047A650DE0DE33AE75ACDC2A7DBB1122410F7AC59A0348693EB
 - Architecture: arm64
-  InstallerType: exe
   InstallerUrl: https://download.microsoft.com/download/7599003c-b5c3-4470-a470-329066069ae6/WindowsAppRuntimeInstall-arm64.exe
   InstallerSha256: 62F6E635121EFD529C20944BCFF3328455AFD6A8130CBFA0410D8E4E26490C31
-  InstallerSwitches:
-    Silent: --quiet
-    SilentWithProgress: --quiet
-  UpgradeBehavior: install
-  AppsAndFeaturesEntries:
-  - DisplayName: WindowsAppRuntime.1.8
-    DisplayVersion: 8000.859.21.0
-    InstallerType: msix
-  ElevationRequirement: elevationRequired
-- Platform:
-  - Windows.Universal
-  - Windows.Desktop
-  Architecture: x86
-  InstallerType: zip
-  NestedInstallerType: msix
-  NestedInstallerFiles:
-  - RelativeFilePath: MSIX\win10-x86\Microsoft.WindowsAppRuntime.1.8.msix
-  InstallerUrl: https://download.microsoft.com/download/9dd9de00-6b17-4777-a3b8-693cdfaaf85b/Microsoft.WindowsAppRuntime.Redist.1.8.260508005.zip
-  InstallerSha256: 2D291D290E34376F98BFCBD07E917134CD3B2F1E8FC364B1032752822387AC1D
-  SignatureSha256: CF40D66FE0DD3B0EF87E1A69F2D26AD27E69DDB0EAA1321A554C30651C047D49
 - Architecture: x86
-  InstallerType: exe
   InstallerUrl: https://download.microsoft.com/download/6b9c35ec-d08e-43c3-9d17-83286877973e/WindowsAppRuntimeInstall-x86.exe
   InstallerSha256: 0A53DD83BB5D0738B25D31F2367D65749DD2FD2BEB530D638742D1027F5597EF
-  InstallerSwitches:
-    Silent: --quiet
-    SilentWithProgress: --quiet
-  UpgradeBehavior: install
-  AppsAndFeaturesEntries:
-  - DisplayName: WindowsAppRuntime.1.8
-    DisplayVersion: 8000.859.21.0
-    InstallerType: msix
-  ElevationRequirement: elevationRequired
 ManifestType: installer
 ManifestVersion: 1.10.0
 ReleaseDate: 2026-05-12


### PR DESCRIPTION
The 3 zip installer entries (x64/arm64/x86) added in #376596 wrap the Redist .zip containing the MSIX. Per maintainer feedback we are reverting to the long-standing 3-exe shape used in 1.5.x through 1.8.6, matching other Microsoft packages (PowerShell, .NET SDK).

<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
<!-- Describe what this PR changes. For manifest submissions, include the package name and version. -->

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/378090)