### PR TITLE
Removed InstallerLocale: StirlingTools.StirlingPDF version 2.11.0

### DIFF
--- a/manifests/s/StirlingTools/StirlingPDF/2.11.0/StirlingTools.StirlingPDF.installer.yaml
+++ b/manifests/s/StirlingTools/StirlingPDF/2.11.0/StirlingTools.StirlingPDF.installer.yaml
@@ -3,7 +3,6 @@
 
 PackageIdentifier: StirlingTools.StirlingPDF
 PackageVersion: 2.11.0
-InstallerLocale: en-US
 InstallerType: wix
 Scope: machine
 UpgradeBehavior: install


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
Removes `InstallerLocale: en-US` in an attempt to fix an update bug.

Note that due to how sheer broken the `InstallerLocale` manifest functionality is (LibreOffice users have learned that the hard ways), it's hard to tell in advance if it'll work better, work the same, or somehow work worse.

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Hopefully resolves #377780.

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/378113)