### PR TITLE
New version: M-Igashi.mp3rgain version 2.7.1

### DIFF
--- a/manifests/m/M-Igashi/mp3rgain/2.7.1/M-Igashi.mp3rgain.installer.yaml
+++ b/manifests/m/M-Igashi/mp3rgain/2.7.1/M-Igashi.mp3rgain.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgain
+PackageVersion: 2.7.1
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: mp3rgain.exe
+ReleaseDate: 2026-05-22
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/M-Igashi/mp3rgain/releases/download/v2.7.1/mp3rgain-v2.7.1-windows-x86_64.zip
+    InstallerSha256: 6044816729C520B2DBC9A17FE61AAA187AF264E01C5E30749049AD846C14D3DB
+  - Architecture: arm64
+    InstallerUrl: https://github.com/M-Igashi/mp3rgain/releases/download/v2.7.1/mp3rgain-v2.7.1-windows-arm64.zip
+    InstallerSha256: E2E8DB9FEE86F97BB778874BF57FD5C84A922358AA800A0E204D54881FDF793D
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/mp3rgain/2.7.1/M-Igashi.mp3rgain.locale.en-US.yaml
+++ b/manifests/m/M-Igashi/mp3rgain/2.7.1/M-Igashi.mp3rgain.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgain
+PackageVersion: 2.7.1
+PackageLocale: en-US
+Publisher: M-Igashi
+PublisherUrl: https://github.com/M-Igashi
+PublisherSupportUrl: https://github.com/M-Igashi/mp3rgain/issues
+Author: M-Igashi
+PackageName: mp3rgain
+PackageUrl: https://github.com/M-Igashi/mp3rgain
+License: MIT
+LicenseUrl: https://github.com/M-Igashi/mp3rgain/blob/master/LICENSE
+ShortDescription: Lossless MP3 volume adjustment - a modern mp3gain replacement written in Rust
+Description: |-
+  mp3rgain adjusts MP3 volume without re-encoding by modifying the global_gain field in each frame's side information.
+  This preserves audio quality while achieving permanent volume changes.
+  Features include ReplayGain analysis, AAC/M4A support, and full mp3gain command-line compatibility.
+Moniker: mp3rgain
+Tags:
+  - audio
+  - cli
+  - flac
+  - gain
+  - lossless
+  - mp3
+  - music
+  - normalize
+  - ogg
+  - replaygain
+  - rust
+  - volume
+ReleaseNotesUrl: https://github.com/M-Igashi/mp3rgain/releases/tag/v2.7.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/mp3rgain/2.7.1/M-Igashi.mp3rgain.yaml
+++ b/manifests/m/M-Igashi/mp3rgain/2.7.1/M-Igashi.mp3rgain.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgain
+PackageVersion: 2.7.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://docs.microsoft.com/windows/package-manager/package/manifest?tabs=minschema%2Ccompschema#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.12.md)?

Release: https://github.com/M-Igashi/mp3rgain/releases/tag/v2.7.1

## Changes in v2.7.1

- Code cleanup and deduplication across CLI and GUI
- Hot-path efficiency improvements in ReplayGain analysis (per-sample plane lookups, per-frame Vec allocations)
- Fix dry-run clipping prediction to floor max_safe_steps (matches the real apply path)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/378211)