### PR TITLE
Reduce Number of Synced Labels

### DIFF
--- a/.github/policies/labelManagement.issueUpdated.yml
+++ b/.github/policies/labelManagement.issueUpdated.yml
@@ -144,16 +144,6 @@ configuration:
         then:
           - labelSync:
               pattern: Blocking-Issue
-          - labelSync:
-              pattern: Hardware
-          - labelSync:
-              pattern: Area-External
-          - labelSync:
-              pattern: Installer-Issue
-          - labelSync:
-              pattern: Interactive-Only-Installer
-          - inPrLabel:
-              label: In-PR
       - description: Remove "Help-Wanted" and "Needs-Triage" labels when an issue goes into PR
         if:
           - payloadType: Issues


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
This PR reduces the number of labels that get synced from an issue to a PR when the PR is linked to the issue. This addresses a concern / confusion raised in #329218 and obsoletes #333533 (as without the syncing, the labels can only be applied by the pipeline results). 

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)
  - Obsoletes #333533

@denelon
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/378270)