### PR TITLE
New package: SkyLLC.UFFS version 0.5.102

### DIFF
--- a/manifests/s/SkyLLC/UFFS/0.5.102/SkyLLC.UFFS.installer.yaml
+++ b/manifests/s/SkyLLC/UFFS/0.5.102/SkyLLC.UFFS.installer.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: SkyLLC.UFFS
+PackageVersion: 0.5.102
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.19041.0
+InstallerType: zip
+NestedInstallerType: portable
+Scope: user
+InstallModes:
+- silent
+- silentWithProgress
+NestedInstallerFiles:
+- RelativeFilePath: uffs-windows-x64\uffs.exe
+  PortableCommandAlias: uffs
+- RelativeFilePath: uffs-windows-x64\uffsd.exe
+  PortableCommandAlias: uffsd
+- RelativeFilePath: uffs-windows-x64\uffsmcp.exe
+  PortableCommandAlias: uffsmcp
+- RelativeFilePath: uffs-windows-x64\uffs-mft.exe
+  PortableCommandAlias: uffs-mft
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/skyllc-ai/UltraFastFileSearch/releases/download/v0.5.102/uffs-windows-x64.zip
+  InstallerSha256: A450C316CD43557C217A912F0F1C93974836520673DD044CC2A42CC71385E5D5
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-05-20

--- a/manifests/s/SkyLLC/UFFS/0.5.102/SkyLLC.UFFS.locale.en-US.yaml
+++ b/manifests/s/SkyLLC/UFFS/0.5.102/SkyLLC.UFFS.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: SkyLLC.UFFS
+PackageVersion: 0.5.102
+PackageLocale: en-US
+Publisher: Sky, LLC
+PublisherUrl: https://github.com/skyllc-ai
+PublisherSupportUrl: https://github.com/skyllc-ai/UltraFastFileSearch/issues
+PackageName: UFFS - Ultra Fast File Search
+PackageUrl: https://github.com/skyllc-ai/UltraFastFileSearch
+License: MPL-2.0
+LicenseUrl: https://github.com/skyllc-ai/UltraFastFileSearch/blob/main/LICENSE
+ShortDescription: Benchmark-driven NTFS search engine for Windows
+Description: |-
+  UFFS reads the NTFS Master File Table directly, builds a compact persisted index,
+  and serves targeted queries in 0-3 ms daemon-side. One Rust engine for CLI, daemon,
+  TUI, and MCP agent workflows. Proven on 100M-record scale.
+Tags:
+- file-search
+- ntfs
+- windows
+- cli
+- rust
+- search
+- mft
+ReleaseNotesUrl: https://github.com/skyllc-ai/UltraFastFileSearch/releases/tag/v0.5.102
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/SkyLLC/UFFS/0.5.102/SkyLLC.UFFS.yaml
+++ b/manifests/s/SkyLLC/UFFS/0.5.102/SkyLLC.UFFS.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: SkyLLC.UFFS
+PackageVersion: 0.5.102
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package submission: **SkyLLC.UFFS** (UFFS - Ultra Fast File Search) v0.5.102.

UFFS is a benchmark-driven NTFS file-search engine for Windows that reads the Master File Table directly, builds a compact persisted index, and answers targeted queries in 0–3 ms daemon-side. The v0.5.102 Windows zip ships four portable executables — all aliased on PATH via `NestedInstallerFiles`:

- `uffs` — CLI search frontend
- `uffsd` — background daemon
- `uffsmcp` — MCP (Model Context Protocol) agent server
- `uffs-mft` — direct MFT reader / cache builder

Upstream release: https://github.com/skyllc-ai/UltraFastFileSearch/releases/tag/v0.5.102

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable) — N/A, new package

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same manifest update/change
- [x] This PR only modifies one (1) manifest (new package, 3 files in `manifests/s/SkyLLC/UFFS/0.5.102/`)
- [ ] Validated manifest locally with `winget validate --manifest <path>` — author is on macOS, where `winget` is unavailable; relying on automated validation in this repo
- [ ] Tested manifest locally with `winget install --manifest <path>` — same reason; will validate via wingetbot pipeline
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/378294)