### PR TITLE
New version: kiloscheffer.dbxignore version 1.0.5

### DIFF
--- a/manifests/k/kiloscheffer/dbxignore/1.0.5/kiloscheffer.dbxignore.installer.yaml
+++ b/manifests/k/kiloscheffer/dbxignore/1.0.5/kiloscheffer.dbxignore.installer.yaml
@@ -1,0 +1,26 @@
+# Created with WinGet Releaser using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: kiloscheffer.dbxignore
+PackageVersion: 1.0.5
+InstallerLocale: en-US
+InstallerType: inno
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: dbxignore.exe
+  PortableCommandAlias: dbxignore
+- RelativeFilePath: dbxignorew.exe
+  PortableCommandAlias: dbxignorew
+Scope: machine
+ProductCode: '{35E9C42C-3C83-499F-A9DD-0DF94440D7BC}_is1'
+ReleaseDate: 2026-05-23
+AppsAndFeaturesEntries:
+- ProductCode: '{35E9C42C-3C83-499F-A9DD-0DF94440D7BC}_is1'
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles%\dbxignore'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/kiloscheffer/dbxignore/releases/download/v1.0.5/dbxignore-setup.exe
+  InstallerSha256: 876A340B6BC8B6B2AE48C3E975E84DBCBC0A92E9517BDCB6246E37FD23986700
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/k/kiloscheffer/dbxignore/1.0.5/kiloscheffer.dbxignore.locale.en-US.yaml
+++ b/manifests/k/kiloscheffer/dbxignore/1.0.5/kiloscheffer.dbxignore.locale.en-US.yaml
@@ -1,0 +1,41 @@
+# Created with WinGet Releaser using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: kiloscheffer.dbxignore
+PackageVersion: 1.0.5
+PackageLocale: en-US
+Publisher: Kilo Scheffer
+PublisherUrl: https://github.com/kiloscheffer
+PublisherSupportUrl: https://github.com/kiloscheffer/dbxignore/issues
+Author: Kilo Scheffer
+PackageName: dbxignore
+PackageUrl: https://github.com/kiloscheffer/dbxignore
+License: MIT
+LicenseUrl: https://github.com/kiloscheffer/dbxignore/blob/HEAD/LICENSE
+Copyright: Copyright (c) 2026 Kilo Scheffer
+ShortDescription: Hierarchical .dropboxignore files for Dropbox
+Description: dbxignore applies the Dropbox ignore marker to paths that match a .dropboxignore file. .dropboxignore files use gitignore syntax and can be placed in any folder under a Dropbox root; matching paths are excluded from Dropbox sync. Markers are written using NTFS alternate data streams on Windows.
+Moniker: dbxignore
+Tags:
+- cli
+- dropbox
+- gitignore
+- ignore
+- sync
+ReleaseNotes: |-
+  What's Changed
+  - ci(deps): bump the actions-minor-patch group with 2 updates by @dependabot[bot] in #277
+  - docs: host the install one-liner at dbxignore.com by @kiloscheffer in #278
+  - ci(release): drop wheel and sdist from GitHub Release assets by @kiloscheffer in #279
+  - feat: add a Windows PowerShell install script by @kiloscheffer in #280
+  - docs: restructure the installation section by @kiloscheffer in #281
+  - fix: pass install.ps1 switches via scriptblock, not env vars by @kiloscheffer in #282
+  - feat: scrub state and logs on plain uninstall; add --keep-logs by @kiloscheffer in #283
+  - docs: refine Requirements bullet and Python install section by @kiloscheffer in #284
+  - docs(platform-support): rephrase Linux row around the glibc floor by @kiloscheffer in #286
+  - docs(install): hoist Windows installer above the one-line script by @kiloscheffer in #287
+  - docs(readme): split uninstalling commands into copyable code blocks by @kiloscheffer in #288
+  Full Changelog: v1.0.4...v1.0.5
+ReleaseNotesUrl: https://github.com/kiloscheffer/dbxignore/releases/tag/v1.0.5
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/k/kiloscheffer/dbxignore/1.0.5/kiloscheffer.dbxignore.yaml
+++ b/manifests/k/kiloscheffer/dbxignore/1.0.5/kiloscheffer.dbxignore.yaml
@@ -1,0 +1,8 @@
+# Created with WinGet Releaser using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: kiloscheffer.dbxignore
+PackageVersion: 1.0.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Automated submission for kiloscheffer.dbxignore 1.0.5.

Release: https://github.com/kiloscheffer/dbxignore/releases/tag/v1.0.5

Manifests generated by winget-releaser/komac during the v1.0.5 release build (release.yml publish-winget job). The branch was pushed to the fork by that workflow; the cross-repo PR-creation step failed due to a PAT scope gap, so opening the PR manually here.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/378516)