### PR TITLE
New version: M-Igashi.mp3rgui version 2.7.2

### DIFF
--- a/manifests/m/M-Igashi/mp3rgui/2.7.2/M-Igashi.mp3rgui.installer.yaml
+++ b/manifests/m/M-Igashi/mp3rgui/2.7.2/M-Igashi.mp3rgui.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgui
+PackageVersion: 2.7.2
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: mp3rgui.exe
+ReleaseDate: 2026-05-23
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/M-Igashi/mp3rgain/releases/download/v2.7.2/mp3rgui-v2.7.2-windows-x86_64.zip
+    InstallerSha256: D06D9625CC7C39CFB5DA1BEC83AD309D5D16CFF068D618DFB1ABE937AE506A45
+  - Architecture: arm64
+    InstallerUrl: https://github.com/M-Igashi/mp3rgain/releases/download/v2.7.2/mp3rgui-v2.7.2-windows-arm64.zip
+    InstallerSha256: 4111DEC7D16172DD9A7723B37B4182E9AAF1B0AC393873EF0B12CBAF36776111
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/mp3rgui/2.7.2/M-Igashi.mp3rgui.locale.en-US.yaml
+++ b/manifests/m/M-Igashi/mp3rgui/2.7.2/M-Igashi.mp3rgui.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgui
+PackageVersion: 2.7.2
+PackageLocale: en-US
+Publisher: M-Igashi
+PublisherUrl: https://github.com/M-Igashi
+PublisherSupportUrl: https://github.com/M-Igashi/mp3rgain/issues
+Author: M-Igashi
+PackageName: mp3rgui
+PackageUrl: https://github.com/M-Igashi/mp3rgain
+License: MIT
+LicenseUrl: https://github.com/M-Igashi/mp3rgain/blob/master/LICENSE
+ShortDescription: GUI for lossless MP3 volume adjustment - a modern mp3gain replacement written in Rust
+Description: |-
+  mp3rgui is the graphical interface for mp3rgain, a lossless MP3 volume normalizer.
+  It provides an easy-to-use GUI for adjusting MP3 volume without re-encoding,
+  supporting ReplayGain analysis, AAC/M4A, FLAC, and OGG formats.
+Moniker: mp3rgui
+Tags:
+  - audio
+  - flac
+  - gain
+  - gui
+  - lossless
+  - mp3
+  - music
+  - normalize
+  - ogg
+  - replaygain
+  - rust
+  - volume
+ReleaseNotesUrl: https://github.com/M-Igashi/mp3rgain/releases/tag/v2.7.2
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/mp3rgui/2.7.2/M-Igashi.mp3rgui.yaml
+++ b/manifests/m/M-Igashi/mp3rgui/2.7.2/M-Igashi.mp3rgui.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgui
+PackageVersion: 2.7.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Submission Checklist

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-create#validate-manifest) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.6.md)?

## Notes

mp3rgui v2.7.2 - GUI for mp3rgain. Code reuse and quality refactor. No user-facing behavior changes.

Supersedes #378216 (mp3rgui 2.7.1), which had a validation-installation-error and has been closed in favor of this submission.

Release: https://github.com/M-Igashi/mp3rgain/releases/tag/v2.7.2
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/378695)