### PR TITLE
New package: herm1t.ReKey version 1.0.0

### DIFF
--- a/manifests/h/herm1t/ReKey/1.0.0/herm1t.ReKey.installer.yaml
+++ b/manifests/h/herm1t/ReKey/1.0.0/herm1t.ReKey.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: herm1t.ReKey
+PackageVersion: 1.0.0
+Installers:
+- Architecture: x64
+  InstallerLocale: en-US
+  InstallerType: msi
+  InstallerUrl: https://github.com/herm1t0/ReKey/releases/download/v1.0.0/ReKey.msi
+  InstallerSha256: 6C180C4C0ABC3546B386A31751ED63FC5F80DDC052CA8A080D9C2AB771EE0465
+  Scope: machine
+  InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+  UpgradeBehavior: install
+  ReleaseDate: 2026-05-23
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/h/herm1t/ReKey/1.0.0/herm1t.ReKey.locale.en-US.yaml
+++ b/manifests/h/herm1t/ReKey/1.0.0/herm1t.ReKey.locale.en-US.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: herm1t.ReKey
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: herm1t
+PackageName: ReKey
+License: MIT
+ShortDescription: A low-level keyboard remapper that intercepts keys system-wide via WH_KEYBOARD_LL hook.
+Tags:
+- keyboard
+- remapper
+- keybind
+- hook
+ReleaseDate: 2026-05-23
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/h/herm1t/ReKey/1.0.0/herm1t.ReKey.yaml
+++ b/manifests/h/herm1t/ReKey/1.0.0/herm1t.ReKey.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: herm1t.ReKey
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
New package: herm1t.ReKey version 1.0.0

## 📖 Description
New package submission for ReKey - a low-level keyboard remapper that intercepts keys system-wide via WH_KEYBOARD_LL hook.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
