### PR TITLE
New version: Tvps.AGWClient version 0.1.0

### DIFF
--- a/manifests/t/Tvps/AGWClient/0.1.0/Tvps.AGWClient.installer.yaml
+++ b/manifests/t/Tvps/AGWClient/0.1.0/Tvps.AGWClient.installer.yaml
@@ -1,0 +1,15 @@
+PackageIdentifier: Tvps.AGWClient
+PackageVersion: 0.1.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/if414013/agent-gateway-releases/releases/download/v0.1.0/agw-client-0.1.0-win-x64.exe
+    InstallerSha256: CB6F800536AD5912E07703623545C62942CB093F6383DFD615345D628BDB93DD
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/t/Tvps/AGWClient/0.1.0/Tvps.AGWClient.locale.en-US.yaml
+++ b/manifests/t/Tvps/AGWClient/0.1.0/Tvps.AGWClient.locale.en-US.yaml
@@ -1,0 +1,20 @@
+PackageIdentifier: Tvps.AGWClient
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: tvps.tech
+PublisherUrl: https://tvps.tech
+PublisherSupportUrl: https://github.com/if414013/agent-gateway-releases/issues
+PackageName: AGW Client
+PackageUrl: https://github.com/if414013/agent-gateway-releases
+License: MIT
+LicenseUrl: https://github.com/if414013/agent-gateway-releases/blob/main/LICENSE
+ShortDescription: Agent Gateway desktop companion for wiring Claude Code, Codex, and Cowork.
+Tags:
+  - claude
+  - codex
+  - cli
+  - gateway
+  - ai
+Moniker: agw-client
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/Tvps/AGWClient/0.1.0/Tvps.AGWClient.yaml
+++ b/manifests/t/Tvps/AGWClient/0.1.0/Tvps.AGWClient.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Tvps.AGWClient
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Manifest Information

- **Package Identifier:** `Tvps.AGWClient`
- **Package Version:** `0.1.0`
- **Manifest schema:** `1.12.0`
- **Publisher:** tvps.tech
- **Source release:** https://github.com/if414013/agent-gateway-releases/releases/tag/v0.1.0
- **License:** MIT

## What is this

AGW Client is an Electron desktop app that wires three AI client CLIs (Claude Code, Codex, Claude Cowork) through a user-selected gateway provider for centralized auth and model routing.

This is the initial submission of the package to winget-pkgs.

## Checklist

- [x] Manifest files follow schema 1.12.0
- [x] Installer URL is reachable + serves the binary
- [x] Installer SHA256 (`CB6F800536AD5912E07703623545C62942CB093F6383DFD615345D628BDB93DD`) verified against the actual asset
- [x] InstallModes covers interactive + silent + silentWithProgress (NSIS supports all three)
- [x] Scope: user (per-user install, no admin required)
- [x] All required defaultLocale fields populated

## Note on signing

This v0.1.0 release is **unsigned**. SmartScreen will show "Unknown publisher" on first install. Signed releases are planned for v2 once the publisher cert is in place. The `Publisher` field (`tvps.tech`) is set in the NSIS installer metadata so it appears in Add/Remove Programs correctly.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/378760)