### PR TITLE
New package: OpenADT.OpenADT version 1.0.3

### DIFF
--- a/manifests/o/OpenADT/OpenADT/1.0.3/OpenADT.OpenADT.installer.yaml
+++ b/manifests/o/OpenADT/OpenADT/1.0.3/OpenADT.OpenADT.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: OpenADT.OpenADT
+PackageVersion: 1.0.3
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: openadt-1.0.3/openadt.exe
+    PortableCommandAlias: openadt
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/abapify/openadt/releases/download/v1.0.3/openadt-1.0.3.zip
+    InstallerSha256: 7899317CDEB762749A8296092967260F9970F81EF5FD798F8DEC3303C341D6B7
+Commands:
+  - openadt
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: EclipseAdoptium.Temurin.21.JDK
+ReleaseDate: 2026-05-23
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/o/OpenADT/OpenADT/1.0.3/OpenADT.OpenADT.locale.en-US.yaml
+++ b/manifests/o/OpenADT/OpenADT/1.0.3/OpenADT.OpenADT.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: OpenADT.OpenADT
+PackageVersion: 1.0.3
+PackageLocale: en-US
+Publisher: OpenADT
+PublisherUrl: https://github.com/abapify/openadt
+PublisherSupportUrl: https://github.com/abapify/openadt/issues
+PackageName: OpenADT
+PackageUrl: https://github.com/abapify/openadt
+License: Apache-2.0
+LicenseUrl: https://github.com/abapify/openadt/blob/main/LICENSE
+ShortDescription: Local bridge for SAP ADT traffic
+Description: |
+  OpenADT is a local CLI and HTTP proxy for SAP ABAP Development Tools (ADT) traffic on Windows, Linux, and macOS.
+  It does not bundle SAP JCo, Secure Login Client, or landscape data. Install SAP prerequisites separately when your transport needs them.
+Moniker: openadt
+Tags:
+  - sap
+  - abap
+  - adt
+  - proxy
+  - cli
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/o/OpenADT/OpenADT/1.0.3/OpenADT.OpenADT.yaml
+++ b/manifests/o/OpenADT/OpenADT/1.0.3/OpenADT.OpenADT.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: OpenADT.OpenADT
+PackageVersion: 1.0.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## Summary

Adds winget manifest for [OpenADT](https://github.com/abapify/openadt) **1.0.3**.

OpenADT is a local CLI and HTTP proxy for SAP ADT traffic. The package ships as a portable ZIP (`openadt.jar` + `openadt.exe` launcher). SAP JCo / Secure Login are **not** bundled.

## Manifest

- **PackageIdentifier:** `OpenADT.OpenADT`
- **Version:** `1.0.3`
- **Installer:** GitHub Release ZIP (portable nested installer)
- **Dependency:** `EclipseAdoptium.Temurin.21.JDK`

## Validation

- `winget validate --manifest manifests/o/OpenADT/OpenADT/1.0.3` succeeded locally
- Release URL: https://github.com/abapify/openadt/releases/download/v1.0.3/openadt-1.0.3.zip

## Test plan

- [ ]/wingetbot validation passes
- [ ] `winget install --id OpenADT.OpenADT` (after merge)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/378764)