### PR TITLE
New package: DigableSolutions.Luotsi version 0.1.0-rc.5

### DIFF
--- a/manifests/d/DigableSolutions/Luotsi/0.1.0-rc.5/DigableSolutions.Luotsi.installer.yaml
+++ b/manifests/d/DigableSolutions/Luotsi/0.1.0-rc.5/DigableSolutions.Luotsi.installer.yaml
@@ -1,0 +1,16 @@
+PackageIdentifier: DigableSolutions.Luotsi
+PackageVersion: 0.1.0-rc.5
+Installers:
+- Architecture: x64
+  InstallerType: zip
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: luotsi.exe
+    PortableCommandAlias: luotsi
+  InstallerUrl: https://github.com/digablesolutions/luotsi/releases/download/v0.1.0-rc.5/luotsi-cli-0.1.0-rc.5-win-x64.zip
+  InstallerSha256: 27CD9510B1DE9FEF40F4A74EBC1484ABA70EFE6E8CA8803BE3F3CF52DD0E4C12
+  Scope: user
+  Commands:
+  - luotsi
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/d/DigableSolutions/Luotsi/0.1.0-rc.5/DigableSolutions.Luotsi.locale.en-US.yaml
+++ b/manifests/d/DigableSolutions/Luotsi/0.1.0-rc.5/DigableSolutions.Luotsi.locale.en-US.yaml
@@ -1,0 +1,30 @@
+PackageIdentifier: DigableSolutions.Luotsi
+PackageVersion: 0.1.0-rc.5
+PackageLocale: en-US
+Publisher: Digable Solutions
+PublisherUrl: https://github.com/digablesolutions
+PublisherSupportUrl: https://github.com/digablesolutions/luotsi/issues
+Author: Digable Solutions
+PackageName: Luotsi
+PackageUrl: https://digablesolutions.github.io/luotsi/
+License: Proprietary
+Copyright: Copyright (c) Digable Solutions
+ShortDescription: Host-driven Android automation CLI for AI agents, engineers, and CI.
+Description: Luotsi runs against real Android devices over adb, exposes structured JSON and JSONL sessions, supports live view and scenario playbooks, and preserves replay artifacts for later triage.
+Moniker: luotsi
+Tags:
+- android
+- adb
+- automation
+- cli
+- jsonl
+- device-lab
+- live-view
+- replay
+Documentations:
+- DocumentLabel: Docs hub
+  DocumentUrl: https://digablesolutions.github.io/luotsi/docs/
+ReleaseNotesUrl: https://github.com/digablesolutions/luotsi/releases/tag/v0.1.0-rc.5
+InstallationNotes: Open a new terminal after install, then run luotsi --version or luotsi doctor --device <serial>.
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/d/DigableSolutions/Luotsi/0.1.0-rc.5/DigableSolutions.Luotsi.yaml
+++ b/manifests/d/DigableSolutions/Luotsi/0.1.0-rc.5/DigableSolutions.Luotsi.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: DigableSolutions.Luotsi
+PackageVersion: 0.1.0-rc.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Summary
- add a manifest for Luotsi 0.1.0-rc.5
- package the Windows x64 portable zip from the GitHub prerelease
- expose the luotsi portable command alias

## Source
- Release: https://github.com/digablesolutions/luotsi/releases/tag/v0.1.0-rc.5
- Docs: https://digablesolutions.github.io/luotsi/

## Notes
- This submission targets the current prerelease tag 0.1.0-rc.5.
- The upstream repository does not currently publish a license file, so the manifest uses Proprietary for now.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/378947)