### PR TITLE
Update: JPEXS.FFDec to 26.2.1

### DIFF
--- a/manifests/j/JPEXS/FFDec/26.2.1/JPEXS.FFDec.installer.yaml
+++ b/manifests/j/JPEXS/FFDec/26.2.1/JPEXS.FFDec.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: JPEXS.FFDec
+PackageVersion: 26.2.1
+InstallerType: wix
+ProductCode: '{E2F3B71A-988F-4E1D-A763-4E828D5C5469}'
+UpgradeBehavior: install
+FileExtensions:
+- abc
+- gfx
+- iggy
+- swc
+- swf
+- swt
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Oracle.JavaRuntimeEnvironment
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/jindrapetrik/jpexs-decompiler/releases/download/version26.2.1/ffdec_26.2.1.msi
+  InstallerSha256: 95C86739FF4D56DC96344687C3EB7056C76637F614F83D28FDFFAD29B53CADE1
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/j/JPEXS/FFDec/26.2.1/JPEXS.FFDec.locale.en-US.yaml
+++ b/manifests/j/JPEXS/FFDec/26.2.1/JPEXS.FFDec.locale.en-US.yaml
@@ -1,0 +1,55 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: JPEXS.FFDec
+PackageVersion: 26.2.1
+PackageLocale: en-US
+Publisher: JPEXS
+PublisherUrl: https://www.jpexs.com
+# PublisherSupportUrl: 
+# PrivacyUrl: 
+Author: JPEXS
+PackageName: JPEXS Free Flash Decompiler
+PackageUrl: https://github.com/jindrapetrik/jpexs-decompiler
+License: GPLv3
+LicenseUrl: https://github.com/jindrapetrik/jpexs-decompiler/blob/master/license.txt
+# Copyright: 
+# CopyrightUrl: 
+ShortDescription: JPEXS Free Flash Decompiler (FFDec) is opensource flash SWF decompiler and editor. Extract resources, convert SWF to FLA, edit ActionScript, replace images, sounds, texts, fonts and more. Various output formats available.
+Description: |
+  JPEXS Free Flash Decompiler (FFDec) is opensource flash SWF decompiler and editor. Extract resources, convert SWF to FLA, edit ActionScript, replace images, sounds, texts or fonts. Various output formats available.
+
+  Key Features:
+  - Exporting scripts, images, shapes, movies, sounds, fonts...
+  - SWF to FLA conversion
+  - SWF to XML export and import again
+  - Various output formats like SVG or HTML5 Canvas
+  - Displaying ActionScript source code.
+  - Experimental direct editing of ActionScript source
+  - Editing via assembler source
+  - Integrated ActionScript debugger - step, breakpoints, set variables
+  - Both ActionScript 1/2 and AS3 support
+  - Clicking decompiled source highlights P-code associated instruction and vice-versa
+  - Replacing images, editing texts, fonts and other tags
+  - Displaying SWF resources (shapes, sprites, fonts, buttons...)
+  - Hexadecimal dump view with color hilighting also available
+  - Java based code which supports multiple platforms
+  - Multilanguage support (see language list)
+  - Can decompile some kinds of obfuscated code too
+Moniker: ffdec
+Tags:
+- abc
+- actionscript
+- decompiler
+- disassembler
+- editor
+- flash
+- free
+- opensource
+- swf
+# ReleaseNotes: 
+# ReleaseNotesUrl: 
+# PurchaseUrl: 
+# InstallationNotes: 
+# Documentations: 
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/j/JPEXS/FFDec/26.2.1/JPEXS.FFDec.yaml
+++ b/manifests/j/JPEXS/FFDec/26.2.1/JPEXS.FFDec.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: JPEXS.FFDec
+PackageVersion: 26.2.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## 📖 Description
Updates JPEXS.FFDec to version 26.2.1

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/379022)