### PR TITLE
New version: StruisICT.InLook version 0.5.0

### DIFF
--- a/manifests/s/StruisICT/InLook/0.5.0/StruisICT.InLook.installer.yaml
+++ b/manifests/s/StruisICT/InLook/0.5.0/StruisICT.InLook.installer.yaml
@@ -12,6 +12,16 @@ InstallModes:
   - silentWithProgress
 UpgradeBehavior: install
 ReleaseDate: 2026-05-25
+Dependencies:
+  PackageDependencies:
+    # WebView2 Runtime — ships preinstalled on Windows 11 and 10 22H2+, but
+    # winget's clean-room validator (and older Windows) needs it for wry to
+    # load WebView2Loader.dll. Without this, inlook.exe exits with
+    # STATUS_DLL_NOT_FOUND (0xC0000135) on first launch.
+    - PackageIdentifier: Microsoft.EdgeWebView2Runtime
+    # Microsoft Visual C++ 2015-2022 redistributable — same reason; rustc
+    # links dynamically against vcruntime140.dll / msvcp140.dll.
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/StruisICT/InLook/releases/download/v0.5.0/inlook-0.5.0-x86_64.msi

--- a/manifests/s/StruisICT/InLook/0.5.0/StruisICT.InLook.installer.yaml
+++ b/manifests/s/StruisICT/InLook/0.5.0/StruisICT.InLook.installer.yaml
@@ -1,0 +1,28 @@
+# Created using wingetcreate methodology (hand-authored — Sharprompt non-interactive workaround)
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: StruisICT.InLook
+PackageVersion: 0.5.0
+InstallerLocale: en-US
+InstallerType: wix
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-05-25
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Struis112/InLook/releases/download/v0.5.0/inlook-0.5.0-x86_64.msi
+    InstallerSha256: CE56112F5D65C803982F7DEB6B0D99574ADEBBB23FBD6C6859CCD6EDF161BC3B
+    ProductCode: '{C4F8397A-D959-4575-B531-337BF9EDCB19}'
+    AppsAndFeaturesEntries:
+      - DisplayName: InLook
+        Publisher: Struis ICT
+        DisplayVersion: 0.5.0
+        ProductCode: '{C4F8397A-D959-4575-B531-337BF9EDCB19}'
+        UpgradeCode: '{8E5A3C2B-1D4F-4E7A-9B6C-7D8E9F0A1B2C}'
+        InstallerType: wix
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/StruisICT/InLook/0.5.0/StruisICT.InLook.installer.yaml
+++ b/manifests/s/StruisICT/InLook/0.5.0/StruisICT.InLook.installer.yaml
@@ -14,7 +14,7 @@ UpgradeBehavior: install
 ReleaseDate: 2026-05-25
 Installers:
   - Architecture: x64
-    InstallerUrl: https://github.com/Struis112/InLook/releases/download/v0.5.0/inlook-0.5.0-x86_64.msi
+    InstallerUrl: https://github.com/StruisICT/InLook/releases/download/v0.5.0/inlook-0.5.0-x86_64.msi
     InstallerSha256: CE56112F5D65C803982F7DEB6B0D99574ADEBBB23FBD6C6859CCD6EDF161BC3B
     ProductCode: '{C4F8397A-D959-4575-B531-337BF9EDCB19}'
     AppsAndFeaturesEntries:

--- a/manifests/s/StruisICT/InLook/0.5.0/StruisICT.InLook.locale.en-US.yaml
+++ b/manifests/s/StruisICT/InLook/0.5.0/StruisICT.InLook.locale.en-US.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: StruisICT.InLook
+PackageVersion: 0.5.0
+PackageLocale: en-US
+Publisher: Struis ICT
+PublisherUrl: https://struisict.com
+PublisherSupportUrl: https://github.com/Struis112/InLook/issues
+Author: Struis ICT
+PackageName: InLook
+PackageUrl: https://github.com/Struis112/InLook
+License: MIT OR Apache-2.0
+LicenseUrl: https://github.com/Struis112/InLook/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Struis ICT
+ShortDescription: Fast, free .eml email viewer
+Description: |-
+  InLook is a small, fast viewer for .eml email files (the standard RFC 822
+  / MIME format used by Outlook, Thunderbird, and most other mail clients
+  when saving a single message to disk). It renders headers, body (HTML or
+  plain text), and attachments, with embedded HTML sandboxed under a strict
+  Content Security Policy — no remote loads, no tracking pixels. Follows
+  the system light/dark theme, registers as the default .eml handler, and
+  never touches the network. Free Software from Struis ICT.
+Moniker: inlook
+Tags:
+  - eml
+  - email
+  - viewer
+  - mail
+  - message
+ReleaseNotes: |-
+  - Bundle app icon and auto-generate macOS .icns
+  - Follow system dark/light theme
+  - Fix MSI ProductVersion drift (was reporting 0.1.0 in Add/Remove Programs)
+  - Update help URL to canonical struisict.com
+ReleaseNotesUrl: https://github.com/Struis112/InLook/releases/tag/v0.5.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/StruisICT/InLook/0.5.0/StruisICT.InLook.locale.en-US.yaml
+++ b/manifests/s/StruisICT/InLook/0.5.0/StruisICT.InLook.locale.en-US.yaml
@@ -5,12 +5,12 @@ PackageVersion: 0.5.0
 PackageLocale: en-US
 Publisher: Struis ICT
 PublisherUrl: https://struisict.com
-PublisherSupportUrl: https://github.com/Struis112/InLook/issues
+PublisherSupportUrl: https://github.com/StruisICT/InLook/issues
 Author: Struis ICT
 PackageName: InLook
-PackageUrl: https://github.com/Struis112/InLook
+PackageUrl: https://github.com/StruisICT/InLook
 License: MIT OR Apache-2.0
-LicenseUrl: https://github.com/Struis112/InLook/blob/main/LICENSE
+LicenseUrl: https://github.com/StruisICT/InLook/blob/main/LICENSE
 Copyright: Copyright (c) 2026 Struis ICT
 ShortDescription: Fast, free .eml email viewer
 Description: |-
@@ -33,6 +33,6 @@ ReleaseNotes: |-
   - Follow system dark/light theme
   - Fix MSI ProductVersion drift (was reporting 0.1.0 in Add/Remove Programs)
   - Update help URL to canonical struisict.com
-ReleaseNotesUrl: https://github.com/Struis112/InLook/releases/tag/v0.5.0
+ReleaseNotesUrl: https://github.com/StruisICT/InLook/releases/tag/v0.5.0
 ManifestType: defaultLocale
 ManifestVersion: 1.6.0

--- a/manifests/s/StruisICT/InLook/0.5.0/StruisICT.InLook.yaml
+++ b/manifests/s/StruisICT/InLook/0.5.0/StruisICT.InLook.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: StruisICT.InLook
+PackageVersion: 0.5.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New version

**Package:** `StruisICT.InLook`
**Version:** `0.5.0`
**Installer:** signed: **no**, type: `wix` (cargo-wix), arch: `x64`, scope: `machine`

---

### What is this?

[InLook](https://github.com/Struis112/InLook) is a small, fast, free EML email viewer from Struis ICT. It opens `.eml` files (RFC 822 / MIME — the format Outlook, Thunderbird, etc. save when you drag a single message to disk) in a sandboxed WebView with a strict Content Security Policy. No network, no remote loads, no tracking pixels.

- **Source:** https://github.com/Struis112/InLook
- **License:** MIT OR Apache-2.0
- **Release:** https://github.com/Struis112/InLook/releases/tag/v0.5.0

---

### Manifest checklist

- [x] Manifests validate locally (`winget validate` → "Manifest validation succeeded.")
- [x] Installer URL points at a stable GitHub Release asset
- [x] SHA256 matches the released MSI (`ce56112f5d65c803982f7deb6b0d99574adebbb23fbd6c6859ccd6edf161bc3b`)
- [x] `ProductCode` matches the MSI's `ARP` entry
- [x] `UpgradeCode` is stable across versions (so future bumps install cleanly)
- [x] `ManifestVersion: 1.6.0`
- [x] First submission of `StruisICT.InLook` to winget-pkgs
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/379422)