### PR TITLE
New package: stescobedo92.azdash version 0.1.0

### DIFF
--- a/manifests/s/stescobedo92/azdash/0.1.0/stescobedo92.azdash.installer.yaml
+++ b/manifests/s/stescobedo92/azdash/0.1.0/stescobedo92.azdash.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: stescobedo92.azdash
+PackageVersion: 0.1.0
+MinimumOSVersion: 10.0.17763.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: azdash.exe
+    PortableCommandAlias: azdash
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/stescobedo92/az-dashboard/releases/download/v0.1.0/azdash-windows-x64.zip
+    InstallerSha256: 674771F2F61B82E9034C18ED504C12D3581BEE69E777CBC07FBA4588F4871DAE
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/stescobedo92/azdash/0.1.0/stescobedo92.azdash.locale.en-US.yaml
+++ b/manifests/s/stescobedo92/azdash/0.1.0/stescobedo92.azdash.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: stescobedo92.azdash
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Sergio Triana Escobedo
+PublisherUrl: https://github.com/stescobedo92
+Author: Sergio Triana Escobedo
+PackageName: azdash
+Moniker: azdash
+PackageUrl: https://github.com/stescobedo92/az-dashboard
+License: MIT
+LicenseUrl: https://github.com/stescobedo92/az-dashboard/blob/master/LICENSE
+ShortDescription: Azure cost, trend, and waste diagnostics CLI.
+Description: azdash is an Azure-focused C++23 CLI for Azure spending, six-month cost trends, and waste signals, rendered with FTXUI tables, JSON, CSV, or PDF reports.
+Tags:
+  - azure
+  - costs
+  - dashboard
+  - cli
+  - tui
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/stescobedo92/azdash/0.1.0/stescobedo92.azdash.yaml
+++ b/manifests/s/stescobedo92/azdash/0.1.0/stescobedo92.azdash.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: stescobedo92.azdash
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package submission

- **PackageIdentifier:** stescobedo92.azdash
- **PackageVersion:** 0.1.0
- **PackageUrl:** https://github.com/stescobedo92/az-dashboard
- **License:** MIT
- **Description:** Azure cost, trend, and waste diagnostics CLI.

### Checklist

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls?q=is%3Apr+stescobedo92.azdash) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Does your manifest conform to the 1.6 schema?

Validation performed:
- Verified manifest YAML parses successfully.
- Verified the remote installer SHA256 matches `674771F2F61B82E9034C18ED504C12D3581BEE69E777CBC07FBA4588F4871DAE`.
- Confirmed no open PR currently exists for `stescobedo92.azdash`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/379424)