### PR TITLE
Add wnunezc.Codex-Chat-Vault version 1.0.2

### DIFF
--- a/manifests/w/wnunezc/Codex-Chat-Vault/1.0.2/wnunezc.Codex-Chat-Vault.installer.yaml
+++ b/manifests/w/wnunezc/Codex-Chat-Vault/1.0.2/wnunezc.Codex-Chat-Vault.installer.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: wnunezc.Codex-Chat-Vault
+PackageVersion: 1.0.2
+InstallerType: wix
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+ReleaseDate: 2026-05-25
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/wnunezc/codex-chat-vault/releases/download/v1.0.2/codex-chat-vault-1.0.2-x86_64.msi
+    InstallerSha256: 43D028E1E143A14CBE1B65B1A9CC35FB30B659F791801C1D44F1189C7C0305B3
+    ProductCode: '{BE3D0BF2-16A7-48F4-A95A-D22A77313756}'
+    AppsAndFeaturesEntries:
+      - DisplayName: Codex Chat Vault
+        Publisher: wnunezc
+        ProductCode: '{BE3D0BF2-16A7-48F4-A95A-D22A77313756}'
+        UpgradeCode: '{57C97B1E-B974-4BB2-857A-ADBFF1210F54}'
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/w/wnunezc/Codex-Chat-Vault/1.0.2/wnunezc.Codex-Chat-Vault.locale.en-US.yaml
+++ b/manifests/w/wnunezc/Codex-Chat-Vault/1.0.2/wnunezc.Codex-Chat-Vault.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: wnunezc.Codex-Chat-Vault
+PackageVersion: 1.0.2
+PackageLocale: en-US
+Publisher: wnunezc
+PublisherUrl: https://github.com/wnunezc
+PublisherSupportUrl: https://github.com/wnunezc/codex-chat-vault/issues
+PackageName: Codex Chat Vault
+PackageUrl: https://github.com/wnunezc/codex-chat-vault
+License: MIT
+LicenseUrl: https://github.com/wnunezc/codex-chat-vault/blob/main/LICENSE
+ShortDescription: Windows desktop utility to inspect, back up, and clean local Codex chat and session files.
+Moniker: codex-chat-vault
+ReleaseNotesUrl: https://github.com/wnunezc/codex-chat-vault/releases/tag/v1.0.2
+Tags:
+  - codex
+  - backup
+  - cleanup
+  - jsonl
+  - desktop
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/w/wnunezc/Codex-Chat-Vault/1.0.2/wnunezc.Codex-Chat-Vault.yaml
+++ b/manifests/w/wnunezc/Codex-Chat-Vault/1.0.2/wnunezc.Codex-Chat-Vault.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: wnunezc.Codex-Chat-Vault
+PackageVersion: 1.0.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Summary
- add wnunezc.Codex-Chat-Vault version 1.0.2
- preserve the Microsoft.VCRedist.2015+.x64 prerequisite used for winget distribution
- republish under the normalized wnunezc.* package namespace

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/379433)