### PR TITLE
New version: Azizbek16l.mytools-osint version 4.2.1

### DIFF
--- a/manifests/a/Azizbek16l/mytools-osint/4.2.1/Azizbek16l.mytools-osint.installer.yaml
+++ b/manifests/a/Azizbek16l/mytools-osint/4.2.1/Azizbek16l.mytools-osint.installer.yaml
@@ -1,0 +1,13 @@
+PackageIdentifier: Azizbek16l.mytools-osint
+PackageVersion: 4.2.1
+InstallerType: portable
+Commands:
+  - osint
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Azizbek16l/mytools-osint/releases/download/v4.2.1/osint-windows-x64.exe
+    InstallerSha256: A8EC199D28494137DB6141668D774BA9EF27777CA6E027577A6876AFB2967B3B
+    ReleaseDate: 2026-05-26
+ReleaseDate: 2026-05-26
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/a/Azizbek16l/mytools-osint/4.2.1/Azizbek16l.mytools-osint.locale.en-US.yaml
+++ b/manifests/a/Azizbek16l/mytools-osint/4.2.1/Azizbek16l.mytools-osint.locale.en-US.yaml
@@ -1,0 +1,28 @@
+PackageIdentifier: Azizbek16l.mytools-osint
+PackageVersion: 4.2.1
+PackageLocale: en-US
+Publisher: Bluetm.uz
+PublisherUrl: https://bluetm.uz
+PublisherSupportUrl: https://github.com/Azizbek16l/mytools-osint/issues
+PackageName: mytools-osint
+PackageUrl: https://github.com/Azizbek16l/mytools-osint
+License: MIT
+LicenseUrl: https://github.com/Azizbek16l/mytools-osint/blob/main/LICENSE
+ShortDescription: OSINT CLI with entity-graph, auto-pivot, smart shell, active recon and AI explain
+Description: |
+  mytools-osint v4.2.1 is a personal-use OSINT toolkit:
+   * 45 modules across passive (Shodan InternetDB, crt.sh, CertSpotter, RIPEstat, HackerTarget, Wayback CDX, threat-intel) and active recon (route_discover, port_scan, WAF/CMS/GraphQL fingerprinting, favicon hash, subdomain takeover).
+   * v4.0 entity graph + auto-pivot, v4.1 active recon, v4.2 smart single-fire shell with 7 themes.
+   * Security + UX + QA polish in v4.2.1: OPSEC discipline, SSRF guards, URL-injection fixes, command palette + theme picker fixes, profile inclusion for the 6 new modules.
+   * Free APIs only, no paid keys required.
+   * Authorised security testing only.
+Moniker: osint
+Tags:
+  - osint
+  - cli
+  - security
+  - recon
+  - reconnaissance
+  - threat-intel
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/a/Azizbek16l/mytools-osint/4.2.1/Azizbek16l.mytools-osint.yaml
+++ b/manifests/a/Azizbek16l/mytools-osint/4.2.1/Azizbek16l.mytools-osint.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Azizbek16l.mytools-osint
+PackageVersion: 4.2.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
- [x] CLA signed (PR #379500)
- [x] Manifest validated
- [x] SHA-256 matches release artifact

### About v4.2.1
Security + UX + QA polish sweep over v4.2.0, driven by a parallel 3-agent audit. 14 distinct fixes:

**Security** — `--opsec` env-var typo bypass, `favicon_hash` SSRF guard (RFC1918/loopback/metadata), URL-injection in 4 modules, replace external `mmh3` with in-tree pure-Python.

**UX** — command palette no longer crashes on `p`, `--no-splash` properly declared, theme picker starts on current theme (no silent clobber) with proper ANSI swatches, main-menu `[T]` label collision resolved, env-vs-persisted theme precedence inverted to UNIX convention.

**QA** — 6 new v4.2 modules wired into red-team/domain-recon/active-recon profiles, `wayback_urls` 25s→12s timeout, `ripestat` private-IP gate, `subdomain_takeover` now catches direct-A takeovers (github.io, vercel.app).

### Verified
- ✅ SHA-256 `a8ec199d...` matches release artifact
- ✅ `osint --version` returns `4.2.1` on Windows 11
- ✅ 244 unit tests passing (14 new regression tests)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/379582)