### PR TITLE
New package: Jabe.yolomover version 2.0.0

### DIFF
--- a/manifests/j/Jabe/yolomover/2.0.0/Jabe.yolomover.installer.yaml
+++ b/manifests/j/Jabe/yolomover/2.0.0/Jabe.yolomover.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Jabe.yolomover
+PackageVersion: 2.0.0
+InstallerType: portable
+UpgradeBehavior: install
+Commands:
+  - yolomover
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+ReleaseDate: 2026-05-26
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Jabe/yolomover/releases/download/v2.0.0/yolomover-v2.0.0-x86_64-pc-windows-msvc.exe
+    InstallerSha256: FC32276D8ABBC67A558652F9340DA4297EB25351BCE00B6FB39187DEA5E3850E
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/j/Jabe/yolomover/2.0.0/Jabe.yolomover.locale.en-US.yaml
+++ b/manifests/j/Jabe/yolomover/2.0.0/Jabe.yolomover.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Jabe.yolomover
+PackageVersion: 2.0.0
+PackageLocale: en-US
+Publisher: Jabe
+PublisherUrl: https://github.com/Jabe
+PublisherSupportUrl: https://github.com/Jabe/yolomover/issues
+PackageName: yolomover
+PackageUrl: https://github.com/Jabe/yolomover
+License: MIT
+LicenseUrl: https://github.com/Jabe/yolomover/blob/master/LICENSE-MIT
+ShortDescription: Move the Windows Recovery partition to the end of the disk
+Description: |-
+  Move the Windows Recovery partition to the end of the disk so you can extend the boot volume — without manually chaining reagentc, a partition GUI, and extend every time.
+
+  Requires Windows 10/11, GPT system disk, and administrator elevation. Use inspect and plan before relocate and extend.
+Moniker: yolomover
+Tags:
+  - gpt
+  - partition
+  - recovery
+  - windows
+  - winre
+ReleaseNotes: |-
+  - Native extend — grow C: via IOCTL_DISK_GROW_PARTITION with best-effort FSCTL_EXTEND_VOLUME
+  - Partition-based verification — inspect/verify WinRE and extend success via on-disk checks
+  - Relocate + extend split — separate VM-tested relocate and extend steps
+  - WinRE registration — setreimage-first flow after recovery move
+ReleaseNotesUrl: https://github.com/Jabe/yolomover/releases/tag/v2.0.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/j/Jabe/yolomover/2.0.0/Jabe.yolomover.yaml
+++ b/manifests/j/Jabe/yolomover/2.0.0/Jabe.yolomover.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Jabe.yolomover
+PackageVersion: 2.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description
Adds winget manifest for **yolomover** 2.0.0 (`Jabe.yolomover`).

Portable x64 MSVC binary from [Jabe/yolomover v2.0.0](https://github.com/Jabe/yolomover/releases/tag/v2.0.0). 
Declares dependency on `Microsoft.VCRedist.2015+.x64`.

## ✅ Checklist
- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)
  - n/a - new package

## 📦 Manifest Checklist
- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `manifests/j/Jabe/yolomover/2.0.0`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/379583)