### PR TITLE
New package: StruisICT.ClutterCutter version 0.3.0

### DIFF
--- a/manifests/s/StruisICT/ClutterCutter/0.3.0/StruisICT.ClutterCutter.installer.yaml
+++ b/manifests/s/StruisICT/ClutterCutter/0.3.0/StruisICT.ClutterCutter.installer.yaml
@@ -1,0 +1,14 @@
+# Created with: hand-authored
+PackageIdentifier: StruisICT.ClutterCutter
+PackageVersion: 0.3.0
+MinimumOSVersion: 10.0.0.0
+InstallerType: portable
+Commands:
+- cluttercutter
+ReleaseDate: 2026-05-13
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Struis112/ClutterCutter/releases/download/v0.3.0/ClutterCutter-rust.exe
+  InstallerSha256: CE5C7358137105308C2696D749B89A7FFD10C7F21781D86C56673285F4B563CC
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/StruisICT/ClutterCutter/0.3.0/StruisICT.ClutterCutter.locale.en-US.yaml
+++ b/manifests/s/StruisICT/ClutterCutter/0.3.0/StruisICT.ClutterCutter.locale.en-US.yaml
@@ -1,0 +1,36 @@
+# Created with: hand-authored
+PackageIdentifier: StruisICT.ClutterCutter
+PackageVersion: 0.3.0
+PackageLocale: en-US
+Publisher: Struis ICT
+PublisherUrl: https://struisict.com
+PublisherSupportUrl: https://github.com/Struis112/ClutterCutter/issues
+PackageName: ClutterCutter
+PackageUrl: https://github.com/Struis112/ClutterCutter
+License: MIT
+LicenseUrl: https://github.com/Struis112/ClutterCutter/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Struis ICT
+ShortDescription: Fast disk-usage browser with NTFS MFT scanning.
+Description: |-
+  ClutterCutter is a lightweight Windows disk-usage browser. On NTFS drives it
+  reads the Master File Table directly for very fast full-drive scans (roughly
+  one million files in six seconds), with a parallel FindFirstFileEx walker as
+  a fallback for non-NTFS drives and non-admin runs. Includes a treeview
+  drill-in, a Top-largest-files view, and an Oldest-files (by date modified)
+  view. Single self-contained ~315 KB exe; no installer, no .NET runtime.
+Moniker: cluttercutter
+Tags:
+- disk
+- disk-usage
+- ntfs
+- mft
+- treesize
+- utility
+- windows
+ReleaseNotes: |-
+  - Adds Rust port of ClutterCutter alongside the original C# build.
+  - Top-N largest files view (PR #10).
+  - Oldest files by last-modified view (PR #12).
+ReleaseNotesUrl: https://github.com/Struis112/ClutterCutter/releases/tag/v0.3.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/StruisICT/ClutterCutter/0.3.0/StruisICT.ClutterCutter.yaml
+++ b/manifests/s/StruisICT/ClutterCutter/0.3.0/StruisICT.ClutterCutter.yaml
@@ -1,0 +1,6 @@
+# Created with: hand-authored
+PackageIdentifier: StruisICT.ClutterCutter
+PackageVersion: 0.3.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## 📖 Description

Adds a new package: **StruisICT.ClutterCutter** version 0.3.0.

ClutterCutter is a lightweight Windows disk-usage browser. On NTFS drives it reads the Master File Table directly for very fast full-drive scans, with a parallel FindFirstFileEx walker as a fallback. Self-contained portable ~315 KB exe; no .NET runtime required.

Repository: https://github.com/Struis112/ClutterCutter
Release: https://github.com/Struis112/ClutterCutter/releases/tag/v0.3.0

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  - Resolves #N/A

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [ ] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/379587)