### PR TITLE
New package: HushHQ.Hush version 0.1.38-mvp

### DIFF
--- a/manifests/h/HushHQ/Hush/0.1.38-mvp/HushHQ.Hush.installer.yaml
+++ b/manifests/h/HushHQ/Hush/0.1.38-mvp/HushHQ.Hush.installer.yaml
@@ -1,0 +1,17 @@
+# HUSHHQ-35. Winget installer manifest template.
+# Submit to microsoft/winget-pkgs as
+#   manifests/h/HushHQ/Hush/0.1.38-mvp/HushHQ.Hush.installer.yaml
+PackageIdentifier: HushHQ.Hush
+PackageVersion: 0.1.38-mvp
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/hushhq/hush-desktop/releases/download/v0.1.38-mvp/Hush.Setup.0.1.38-mvp.exe
+    InstallerSha256: 2E73923C5F78C5C5FC64959717B93318B0F8DBC2E648E86786BA1CB4AED6DA5A
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/h/HushHQ/Hush/0.1.38-mvp/HushHQ.Hush.locale.en-US.yaml
+++ b/manifests/h/HushHQ/Hush/0.1.38-mvp/HushHQ.Hush.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# HUSHHQ-35. Winget locale manifest template.
+PackageIdentifier: HushHQ.Hush
+PackageVersion: 0.1.38-mvp
+PackageLocale: en-US
+Publisher: HushHQ
+PublisherUrl: https://gethush.live
+PublisherSupportUrl: https://github.com/hushhq/hush-desktop/issues
+PackageName: Hush
+PackageUrl: https://gethush.live
+License: AGPL-3.0-only
+LicenseUrl: https://github.com/hushhq/hush-desktop/blob/main/LICENSE
+ShortDescription: End-to-end encrypted messenger.
+Description: |-
+  Hush is an open-source, end-to-end encrypted messenger. The
+  desktop client speaks the same protocol as the hosted web app
+  and works against any compatible Hush instance.
+Moniker: hush
+Tags:
+  - messenger
+  - chat
+  - e2ee
+  - encrypted
+  - electron
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/h/HushHQ/Hush/0.1.38-mvp/HushHQ.Hush.yaml
+++ b/manifests/h/HushHQ/Hush/0.1.38-mvp/HushHQ.Hush.yaml
@@ -1,0 +1,6 @@
+# HUSHHQ-35. Winget version manifest template.
+PackageIdentifier: HushHQ.Hush
+PackageVersion: 0.1.38-mvp
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Pull request has been created with [WinGet Releaser](https://github.com/vedantmgoyal2009/winget-releaser) :rocket:\n\n### Package metadata\n- PackageIdentifier: HushHQ.Hush\n- PackageVersion: 0.1.38-mvp\n- InstallerType: nullsoft\n- InstallerUrl: https://github.com/hushhq/hush-desktop/releases/download/v0.1.38-mvp/Hush.Setup.0.1.38-mvp.exe\n\n### Validation\n- Installer SHA256 copied from the published GitHub Release sha256sums.txt.\n- Installer URL returns HTTP 200.\n- Local winget validation was not run on this macOS host.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/379804)