### PR TITLE
New version: bugtsa.AIPDLC version 0.1.1

### DIFF
--- a/manifests/b/bugtsa/AIPDLC/0.1.1/bugtsa.AIPDLC.installer.yaml
+++ b/manifests/b/bugtsa/AIPDLC/0.1.1/bugtsa.AIPDLC.installer.yaml
@@ -1,0 +1,20 @@
+PackageIdentifier: bugtsa.AIPDLC
+PackageVersion: 0.1.1
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: bin/ai-pdlc.exe
+    PortableCommandAlias: ai-pdlc
+  - RelativeFilePath: bin/ai-pdlc-mcp.exe
+    PortableCommandAlias: ai-pdlc-mcp
+UpgradeBehavior: install
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: OpenJS.NodeJS.LTS
+ReleaseDate: 2026-05-27
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/bugtsa/ai-pdlc/releases/download/v0.1.1/ai-pdlc-0.1.1-windows-portable.zip
+    InstallerSha256: 87360A611884F981324B9216A4185CD7AF79E2E615145C81E912D300B659B280
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/b/bugtsa/AIPDLC/0.1.1/bugtsa.AIPDLC.locale.en-US.yaml
+++ b/manifests/b/bugtsa/AIPDLC/0.1.1/bugtsa.AIPDLC.locale.en-US.yaml
@@ -1,0 +1,23 @@
+PackageIdentifier: bugtsa.AIPDLC
+PackageVersion: 0.1.1
+PackageLocale: en-US
+Publisher: Vladimir Polkhovtsev
+PublisherUrl: https://github.com/bugtsa
+PublisherSupportUrl: https://github.com/bugtsa/ai-pdlc/issues
+PackageUrl: https://github.com/bugtsa/ai-pdlc
+PackageName: AI-PDLC
+Moniker: ai-pdlc
+License: Apache-2.0
+LicenseUrl: https://github.com/bugtsa/ai-pdlc/blob/main/LICENSE
+ShortDescription: AI-PDLC CLI, Codex skill bundle, and local MCP server for Codex and Claude clients.
+Tags:
+  - ai-pdlc
+  - claude
+  - codex
+  - mcp
+ReleaseNotes: |-
+  - Adds Apache-2.0 licensing for public distribution.
+  - Replaces Windows .cmd launchers with native .exe launchers for portable installation.
+  - Continues to ship ai-pdlc doctor, setup-codex, setup-claude-code, and Claude Desktop MCP bundle support.
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/b/bugtsa/AIPDLC/0.1.1/bugtsa.AIPDLC.yaml
+++ b/manifests/b/bugtsa/AIPDLC/0.1.1/bugtsa.AIPDLC.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: bugtsa.AIPDLC
+PackageVersion: 0.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Summary
- adds `bugtsa.AIPDLC` version `0.1.1`
- sources the installer from the public GitHub release: https://github.com/bugtsa/ai-pdlc/releases/tag/v0.1.1
- uses a portable zip with native Windows `.exe` launchers
- declares `OpenJS.NodeJS.LTS` as a package dependency because the launchers execute bundled `.mjs` entrypoints via `node.exe`

## Validation
- verified YAML parses successfully
- verified the release asset URL is publicly downloadable
- verified the Windows portable archive contains `bin/ai-pdlc.exe` and `bin/ai-pdlc-mcp.exe`

## Notes
- manifest-only PR
- one package version in this PR

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/380155)