### PR TITLE
New version: Feci.ParleyDeckSkill version 1.2.0

### DIFF
--- a/manifests/f/Feci/ParleyDeckSkill/1.2.0/Feci.ParleyDeckSkill.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/1.2.0/Feci.ParleyDeckSkill.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 1.2.0
+InstallerType: portable
+Commands:
+- parley-deck-skill
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-skill/releases/download/v1.2.0/parley-deck-skill-v1.2.0-windows-x64.exe
+  InstallerSha256: EC870045A13E7E6A3DB4B115980ED644847380076A4DFC71CC20F687E5C6FBDE
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-skill/releases/download/v1.2.0/parley-deck-skill-v1.2.0-windows-arm64.exe
+  InstallerSha256: CD7F6D84D8932ADFBD3B5D3F1EAFB1818A165B5C010AB118AE9838E858BF4ED6
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckSkill/1.2.0/Feci.ParleyDeckSkill.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/1.2.0/Feci.ParleyDeckSkill.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 1.2.0
+PackageLocale: en-US
+Publisher: Feci
+PublisherUrl: https://github.com/feci
+PackageName: Parley Deck Skill
+PackageUrl: https://github.com/feci/parley-deck-skill
+License: Apache-2.0
+LicenseUrl: https://github.com/feci/parley-deck-skill/blob/main/LICENSE
+ShortDescription: Installer for the Parley Deck multi-agent cooperation skill.
+Description: Installs the vendor-neutral Parley Deck AI cooperation skill into Codex, Claude Code, Antigravity CLI, legacy Gemini CLI, or a custom skill directory.
+Tags:
+- ai
+- agents
+- agy
+- antigravity
+- cli
+- codex
+- claude
+- gemini
+- multi-agent
+- skill
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckSkill/1.2.0/Feci.ParleyDeckSkill.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/1.2.0/Feci.ParleyDeckSkill.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 1.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Updates Feci.ParleyDeckSkill to 1.2.0.\n\nRelease: https://github.com/feci/parley-deck-skill/releases/tag/v1.2.0\n\nNotes:\n- Adds Antigravity CLI target support in the upstream package.\n- Portable Windows x64 and arm64 asset hashes are included from the GitHub release.\n\nValidation: manifest files prepared locally; winget CLI is not available on this macOS host for local winget validate.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/380205)