### PR TITLE
BTChargeTrayWatcher v3.0.0

### DIFF
--- a/manifests/p/peterandree/BTChargeTrayWatcher/3.0.0/peterandree.BTChargeTrayWatcher.installer.yaml
+++ b/manifests/p/peterandree/BTChargeTrayWatcher/3.0.0/peterandree.BTChargeTrayWatcher.installer.yaml
@@ -8,7 +8,7 @@ InstallerType: portable
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/peterandree/BTChargeTrayWatcher/releases/download/v3.0.0/BTChargeTrayWatcher.exe
-    InstallerSha256: D3C9A5128D2EA6EAB1798A13CE85EF48E358BFB49AF90EA682364A71798AFA2
+    InstallerSha256: 95b1d19148255bd20de361a54581fc54ffb027e3dc4a28554ed97ec9902a3034
     PortableCommandAlias: BTChargeTrayWatcher
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/p/peterandree/BTChargeTrayWatcher/3.0.0/peterandree.BTChargeTrayWatcher.installer.yaml
+++ b/manifests/p/peterandree/BTChargeTrayWatcher/3.0.0/peterandree.BTChargeTrayWatcher.installer.yaml
@@ -1,0 +1,14 @@
+PackageIdentifier: peterandree.BTChargeTrayWatcher
+PackageVersion: 3.0.0
+InstallerLocale: en-US
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.19041.0
+InstallerType: portable
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/peterandree/BTChargeTrayWatcher/releases/download/v3.0.0/BTChargeTrayWatcher.exe
+    InstallerSha256: D3C9A5128D2EA6EAB1798A13CE85EF48E358BFB49AF90EA682364A71798AFA2
+    PortableCommandAlias: BTChargeTrayWatcher
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/p/peterandree/BTChargeTrayWatcher/3.0.0/peterandree.BTChargeTrayWatcher.installer.yaml
+++ b/manifests/p/peterandree/BTChargeTrayWatcher/3.0.0/peterandree.BTChargeTrayWatcher.installer.yaml
@@ -8,7 +8,7 @@ InstallerType: portable
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/peterandree/BTChargeTrayWatcher/releases/download/v3.0.0/BTChargeTrayWatcher.exe
-    InstallerSha256: 95b1d19148255bd20de361a54581fc54ffb027e3dc4a28554ed97ec9902a3034
+    InstallerSha256: 45646915FE06D40D64055C2E736067C4A450CA3497234F703A230617E443A0CF
     PortableCommandAlias: BTChargeTrayWatcher
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/p/peterandree/BTChargeTrayWatcher/3.0.0/peterandree.BTChargeTrayWatcher.locale.en-US.yaml
+++ b/manifests/p/peterandree/BTChargeTrayWatcher/3.0.0/peterandree.BTChargeTrayWatcher.locale.en-US.yaml
@@ -1,0 +1,24 @@
+PackageIdentifier: peterandree.BTChargeTrayWatcher
+PackageVersion: 3.0.0
+PackageLocale: en-US
+Publisher: peterandree
+PackageName: BTChargeTrayWatcher
+License: MIT
+ShortDescription: Windows tray app that monitors Bluetooth device battery levels and alerts on low or high thresholds.
+Description: |-
+  BTChargeTrayWatcher sits in the system tray and continuously monitors the battery
+  levels of connected Bluetooth devices (headphones, keyboards, mice, etc.) and your
+  laptop battery. Desktop notifications are raised when a device crosses a configurable
+  low or high threshold. Hover over the tray icon to see current battery levels at a glance.
+  Version 2.0.0 adds ntfy.sh mobile push notification support: battery alerts and on-demand
+  charge status reports can be forwarded to any ntfy topic and received on Android or iPhone.
+Tags:
+  - bluetooth
+  - battery
+  - monitor
+  - tray
+  - notification
+  - ntfy
+  - mobile
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/p/peterandree/BTChargeTrayWatcher/3.0.0/peterandree.BTChargeTrayWatcher.yaml
+++ b/manifests/p/peterandree/BTChargeTrayWatcher/3.0.0/peterandree.BTChargeTrayWatcher.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: peterandree.BTChargeTrayWatcher
+PackageVersion: 3.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### BTChargeTrayWatcher v3.0.0
**Release date: 2026-05-27**

**Highlights**

- New version release for WinGet distribution.
- All dependencies and manifests updated for v3.0.0.
- Includes latest bug fixes, improvements, and compatibility updates.

**Installation**
Download BTChargeTrayWatcher.exe below, or install via WinGet after approval.

**SHA256**
D3C9A5128D2EA6EAB1798A13CE85EF48E358BFB49AF90EA682364A71798AFA2
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/380225)