### PR TITLE
New version: Feci.ParleyDeckCli version 1.5.4

### DIFF
--- a/manifests/f/Feci/ParleyDeckCli/1.10.0/Feci.ParleyDeckCli.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.10.0/Feci.ParleyDeckCli.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.10.0
+InstallerType: portable
+Commands:
+- parley
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.10.0/parley-v1.10.0-windows-x64.exe
+  InstallerSha256: 96082214EF4A1CD55201716294DF909B3B75F21857B215BC20EC7FF416ED17A8
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.10.0/parley-v1.10.0-windows-arm64.exe
+  InstallerSha256: 3854EE22BE40F5D79D7F79D3D64E5DF33E811AAD36E1497F822B104099110A41
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.10.0/Feci.ParleyDeckCli.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.10.0/Feci.ParleyDeckCli.locale.en-US.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 PackageIdentifier: Feci.ParleyDeckCli
-PackageVersion: 1.6.0
+PackageVersion: 1.10.0
 PackageLocale: en-US
 Publisher: Feci
 PublisherUrl: https://github.com/feci
@@ -10,7 +10,7 @@ License: Apache-2.0
 LicenseUrl: https://github.com/feci/parley-deck-cli/blob/main/LICENSE
 ShortDescription: CLI for Parley Deck multi-agent workflows.
 Description: Creates and maintains Parley Deck workspaces, discovers local agent CLIs, runs cooperation rounds, tracks HITL questions, manages consensus signoffs, drives the COOPERATION.md §12 pipeline (parley pipeline), and emits repository context for agents.
-ReleaseNotesUrl: https://github.com/feci/parley-deck-cli/releases/tag/v1.6.0
+ReleaseNotesUrl: https://github.com/feci/parley-deck-cli/releases/tag/v1.10.0
 Tags:
 - ai
 - agents

--- a/manifests/f/Feci/ParleyDeckCli/1.10.0/Feci.ParleyDeckCli.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.10.0/Feci.ParleyDeckCli.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.10.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.5.4/Feci.ParleyDeckCli.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.5.4/Feci.ParleyDeckCli.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.5.4
+InstallerType: portable
+Commands:
+- parley
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.5.4/parley-v1.5.4-windows-x64.exe
+  InstallerSha256: 9F15CAF5E3029717B2F1D15CAD3F46D480D5DE613E482F987986C0A407B63630
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.5.4/parley-v1.5.4-windows-arm64.exe
+  InstallerSha256: A9435AA6D3874593956655FA8F645C488B6B0B02C3B0F6DA845E22C40B227C8D
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.5.4/Feci.ParleyDeckCli.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.5.4/Feci.ParleyDeckCli.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.5.4
+PackageLocale: en-US
+Publisher: Feci
+PublisherUrl: https://github.com/feci
+PackageName: Parley Deck CLI
+PackageUrl: https://github.com/feci/parley-deck-cli
+License: Apache-2.0
+LicenseUrl: https://github.com/feci/parley-deck-cli/blob/main/LICENSE
+ShortDescription: CLI for Parley Deck multi-agent workflows.
+Description: Creates and maintains Parley Deck workspaces, discovers local agent CLIs, starts or resumes cooperation rounds, tracks human-in-the-loop questions, manages consensus signoffs, and emits repository context for agents.
+ReleaseNotesUrl: https://github.com/feci/parley-deck-cli/releases/tag/v1.5.4
+Tags:
+- ai
+- agents
+- cli
+- codex
+- collaboration
+- multi-agent
+- parley
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.5.4/Feci.ParleyDeckCli.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.5.4/Feci.ParleyDeckCli.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.5.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.6.0/Feci.ParleyDeckCli.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.6.0/Feci.ParleyDeckCli.installer.yaml
@@ -1,6 +1,4 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
-# InstallerSha256 values are placeholders: fill from the immutable GitHub release
-# assets (gh release view v1.6.0 --json assets) before opening the winget-pkgs PR.
 PackageIdentifier: Feci.ParleyDeckCli
 PackageVersion: 1.6.0
 InstallerType: portable
@@ -9,9 +7,9 @@ Commands:
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.6.0/parley-v1.6.0-windows-x64.exe
-  InstallerSha256: PLACEHOLDER-FILL-FROM-RELEASE-ASSET
+  InstallerSha256: AF0260698F411D0874F26B0EFEF47BDACD84F3FADF907DD7FA7994B06761086E
 - Architecture: arm64
   InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.6.0/parley-v1.6.0-windows-arm64.exe
-  InstallerSha256: PLACEHOLDER-FILL-FROM-RELEASE-ASSET
+  InstallerSha256: A233A7A1253AD97FB59CFB6642BBDC09DA92548B40F5AD5EBF152D414ECF7610
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.6.0/Feci.ParleyDeckCli.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.6.0/Feci.ParleyDeckCli.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# InstallerSha256 values are placeholders: fill from the immutable GitHub release
+# assets (gh release view v1.6.0 --json assets) before opening the winget-pkgs PR.
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.6.0
+InstallerType: portable
+Commands:
+- parley
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.6.0/parley-v1.6.0-windows-x64.exe
+  InstallerSha256: PLACEHOLDER-FILL-FROM-RELEASE-ASSET
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.6.0/parley-v1.6.0-windows-arm64.exe
+  InstallerSha256: PLACEHOLDER-FILL-FROM-RELEASE-ASSET
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.6.0/Feci.ParleyDeckCli.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.6.0/Feci.ParleyDeckCli.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.6.0
+PackageLocale: en-US
+Publisher: Feci
+PublisherUrl: https://github.com/feci
+PackageName: Parley Deck CLI
+PackageUrl: https://github.com/feci/parley-deck-cli
+License: Apache-2.0
+LicenseUrl: https://github.com/feci/parley-deck-cli/blob/main/LICENSE
+ShortDescription: CLI for Parley Deck multi-agent workflows.
+Description: Creates and maintains Parley Deck workspaces, discovers local agent CLIs, starts or resumes cooperation rounds, tracks human-in-the-loop questions, manages consensus signoffs, runs the §12 pipeline driver, and emits repository context for agents.
+ReleaseNotesUrl: https://github.com/feci/parley-deck-cli/releases/tag/v1.6.0
+Tags:
+- ai
+- agents
+- cli
+- codex
+- collaboration
+- multi-agent
+- parley
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.6.0/Feci.ParleyDeckCli.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.6.0/Feci.ParleyDeckCli.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.6.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.7.0/Feci.ParleyDeckCli.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.7.0/Feci.ParleyDeckCli.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# InstallerSha256 values are placeholders: fill from the immutable GitHub release
+# assets (gh release view v1.7.0 --json assets) before opening the winget-pkgs PR.
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.7.0
+InstallerType: portable
+Commands:
+- parley
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.7.0/parley-v1.7.0-windows-x64.exe
+  InstallerSha256: PLACEHOLDER-FILL-FROM-RELEASE-ASSET
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.7.0/parley-v1.7.0-windows-arm64.exe
+  InstallerSha256: PLACEHOLDER-FILL-FROM-RELEASE-ASSET
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.7.0/Feci.ParleyDeckCli.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.7.0/Feci.ParleyDeckCli.installer.yaml
@@ -1,6 +1,4 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
-# InstallerSha256 values are placeholders: fill from the immutable GitHub release
-# assets (gh release view v1.7.0 --json assets) before opening the winget-pkgs PR.
 PackageIdentifier: Feci.ParleyDeckCli
 PackageVersion: 1.7.0
 InstallerType: portable
@@ -9,9 +7,9 @@ Commands:
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.7.0/parley-v1.7.0-windows-x64.exe
-  InstallerSha256: PLACEHOLDER-FILL-FROM-RELEASE-ASSET
+  InstallerSha256: 456694B4B55BCBB0479F8CD662FA583225164EE80730C7964C2CECD037AB7171
 - Architecture: arm64
   InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.7.0/parley-v1.7.0-windows-arm64.exe
-  InstallerSha256: PLACEHOLDER-FILL-FROM-RELEASE-ASSET
+  InstallerSha256: 98ED1CD00BC648BC95AB9A2CD755D70E9DD32C7C4AC173375FF134A927D8C4C4
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.7.0/Feci.ParleyDeckCli.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.7.0/Feci.ParleyDeckCli.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.7.0
+PackageLocale: en-US
+Publisher: Feci
+PublisherUrl: https://github.com/feci
+PackageName: Parley Deck CLI
+PackageUrl: https://github.com/feci/parley-deck-cli
+License: Apache-2.0
+LicenseUrl: https://github.com/feci/parley-deck-cli/blob/main/LICENSE
+ShortDescription: CLI for Parley Deck multi-agent workflows.
+Description: Creates and maintains Parley Deck workspaces, discovers local agent CLIs, starts or resumes cooperation rounds, tracks human-in-the-loop questions, manages consensus signoffs, runs the §12 pipeline driver, and emits repository context for agents.
+ReleaseNotesUrl: https://github.com/feci/parley-deck-cli/releases/tag/v1.7.0
+Tags:
+- ai
+- agents
+- cli
+- codex
+- collaboration
+- multi-agent
+- parley
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.7.0/Feci.ParleyDeckCli.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.7.0/Feci.ParleyDeckCli.locale.en-US.yaml
@@ -9,7 +9,7 @@ PackageUrl: https://github.com/feci/parley-deck-cli
 License: Apache-2.0
 LicenseUrl: https://github.com/feci/parley-deck-cli/blob/main/LICENSE
 ShortDescription: CLI for Parley Deck multi-agent workflows.
-Description: Creates and maintains Parley Deck workspaces, discovers local agent CLIs, starts or resumes cooperation rounds, tracks human-in-the-loop questions, manages consensus signoffs, runs the §12 pipeline driver, and emits repository context for agents.
+Description: Creates and maintains Parley Deck workspaces, discovers local agent CLIs, runs cooperation rounds, tracks HITL questions, manages consensus signoffs, drives the COOPERATION.md §12 pipeline (parley pipeline), and emits repository context for agents.
 ReleaseNotesUrl: https://github.com/feci/parley-deck-cli/releases/tag/v1.7.0
 Tags:
 - ai

--- a/manifests/f/Feci/ParleyDeckCli/1.7.0/Feci.ParleyDeckCli.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.7.0/Feci.ParleyDeckCli.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.7.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.8.0/Feci.ParleyDeckCli.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.8.0/Feci.ParleyDeckCli.installer.yaml
@@ -1,6 +1,4 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
-# InstallerSha256 values are placeholders: fill from the immutable GitHub release
-# assets (gh release view v1.8.0 --json assets) before opening the winget-pkgs PR.
 PackageIdentifier: Feci.ParleyDeckCli
 PackageVersion: 1.8.0
 InstallerType: portable
@@ -9,9 +7,9 @@ Commands:
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.8.0/parley-v1.8.0-windows-x64.exe
-  InstallerSha256: PLACEHOLDER-FILL-FROM-RELEASE-ASSET
+  InstallerSha256: 5F5639E3298A5969402D5769DE3477791518FEA52EFD6992EEA59D943584883D
 - Architecture: arm64
   InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.8.0/parley-v1.8.0-windows-arm64.exe
-  InstallerSha256: PLACEHOLDER-FILL-FROM-RELEASE-ASSET
+  InstallerSha256: 3B5042EE96953B1707B71B02A27C97E7A195C010CFA491E6A776C1D22B7FCCD0
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.8.0/Feci.ParleyDeckCli.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.8.0/Feci.ParleyDeckCli.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# InstallerSha256 values are placeholders: fill from the immutable GitHub release
+# assets (gh release view v1.8.0 --json assets) before opening the winget-pkgs PR.
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.8.0
+InstallerType: portable
+Commands:
+- parley
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.8.0/parley-v1.8.0-windows-x64.exe
+  InstallerSha256: PLACEHOLDER-FILL-FROM-RELEASE-ASSET
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.8.0/parley-v1.8.0-windows-arm64.exe
+  InstallerSha256: PLACEHOLDER-FILL-FROM-RELEASE-ASSET
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.8.0/Feci.ParleyDeckCli.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.8.0/Feci.ParleyDeckCli.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.8.0
+PackageLocale: en-US
+Publisher: Feci
+PublisherUrl: https://github.com/feci
+PackageName: Parley Deck CLI
+PackageUrl: https://github.com/feci/parley-deck-cli
+License: Apache-2.0
+LicenseUrl: https://github.com/feci/parley-deck-cli/blob/main/LICENSE
+ShortDescription: CLI for Parley Deck multi-agent workflows.
+Description: Creates and maintains Parley Deck workspaces, discovers local agent CLIs, starts or resumes cooperation rounds, tracks human-in-the-loop questions, manages consensus signoffs, runs the §12 pipeline driver, and emits repository context for agents.
+ReleaseNotesUrl: https://github.com/feci/parley-deck-cli/releases/tag/v1.8.0
+Tags:
+- ai
+- agents
+- cli
+- codex
+- collaboration
+- multi-agent
+- parley
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.8.0/Feci.ParleyDeckCli.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.8.0/Feci.ParleyDeckCli.locale.en-US.yaml
@@ -9,7 +9,7 @@ PackageUrl: https://github.com/feci/parley-deck-cli
 License: Apache-2.0
 LicenseUrl: https://github.com/feci/parley-deck-cli/blob/main/LICENSE
 ShortDescription: CLI for Parley Deck multi-agent workflows.
-Description: Creates and maintains Parley Deck workspaces, discovers local agent CLIs, starts or resumes cooperation rounds, tracks human-in-the-loop questions, manages consensus signoffs, runs the §12 pipeline driver, and emits repository context for agents.
+Description: Creates and maintains Parley Deck workspaces, discovers local agent CLIs, runs cooperation rounds, tracks HITL questions, manages consensus signoffs, drives the COOPERATION.md §12 pipeline (parley pipeline), and emits repository context for agents.
 ReleaseNotesUrl: https://github.com/feci/parley-deck-cli/releases/tag/v1.8.0
 Tags:
 - ai

--- a/manifests/f/Feci/ParleyDeckCli/1.8.0/Feci.ParleyDeckCli.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.8.0/Feci.ParleyDeckCli.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.8.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.9.0/Feci.ParleyDeckCli.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.9.0/Feci.ParleyDeckCli.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.9.0
+InstallerType: portable
+Commands:
+- parley
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.9.0/parley-v1.9.0-windows-x64.exe
+  InstallerSha256: 822432F70409C6918CB2F0FA7919D80259905415E8373C937E394301FBD7F482
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.9.0/parley-v1.9.0-windows-arm64.exe
+  InstallerSha256: 4C856908B053826177DEBA229662FAFD9C859BF8A68C0762B933C78726E8A168
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.9.0/Feci.ParleyDeckCli.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.9.0/Feci.ParleyDeckCli.locale.en-US.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 PackageIdentifier: Feci.ParleyDeckCli
-PackageVersion: 1.6.0
+PackageVersion: 1.9.0
 PackageLocale: en-US
 Publisher: Feci
 PublisherUrl: https://github.com/feci
@@ -10,7 +10,7 @@ License: Apache-2.0
 LicenseUrl: https://github.com/feci/parley-deck-cli/blob/main/LICENSE
 ShortDescription: CLI for Parley Deck multi-agent workflows.
 Description: Creates and maintains Parley Deck workspaces, discovers local agent CLIs, runs cooperation rounds, tracks HITL questions, manages consensus signoffs, drives the COOPERATION.md §12 pipeline (parley pipeline), and emits repository context for agents.
-ReleaseNotesUrl: https://github.com/feci/parley-deck-cli/releases/tag/v1.6.0
+ReleaseNotesUrl: https://github.com/feci/parley-deck-cli/releases/tag/v1.9.0
 Tags:
 - ai
 - agents

--- a/manifests/f/Feci/ParleyDeckCli/1.9.0/Feci.ParleyDeckCli.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.9.0/Feci.ParleyDeckCli.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.9.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Package\nFeci.ParleyDeckCli 1.5.4\n\n### Release\nhttps://github.com/feci/parley-deck-cli/releases/tag/v1.5.4\n\n### Validation\n- Parsed manifests with Ruby YAML parser.\n- Downloaded both portable Windows assets and verified SHA256 hashes against manifest values.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/380228)