### PR TITLE
New package: mulhamna.jirac-mcp version 2.0.1

### DIFF
--- a/manifests/m/mulhamna/jirac-mcp/2.0.1/mulhamna.jirac-mcp.installer.yaml
+++ b/manifests/m/mulhamna/jirac-mcp/2.0.1/mulhamna.jirac-mcp.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: mulhamna.jirac-mcp
+PackageVersion: 2.0.1
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: jirac-mcp-windows-x86_64.exe
+    PortableCommandAlias: jirac-mcp
+ReleaseDate: 2026-05-24
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/mulhamna/jira-commands/releases/download/jira-mcp-v2.0.1/jirac-mcp-windows-x86_64.zip
+    InstallerSha256: 437888c51fb8b3a3f92e3b4a1fbe835ca54f0b3eb0d5a8fdfd178d26755223db
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/m/mulhamna/jirac-mcp/2.0.1/mulhamna.jirac-mcp.locale.en-US.yaml
+++ b/manifests/m/mulhamna/jirac-mcp/2.0.1/mulhamna.jirac-mcp.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: mulhamna.jirac-mcp
+PackageVersion: 2.0.1
+PackageLocale: en-US
+Publisher: mulhamna
+PublisherUrl: https://github.com/mulhamna
+PublisherSupportUrl: https://github.com/mulhamna/jira-commands/issues
+Author: mulhamna
+PackageName: jirac-mcp
+PackageUrl: https://github.com/mulhamna/jira-commands
+License: MIT OR Apache-2.0
+LicenseUrl: https://github.com/mulhamna/jira-commands/blob/main/LICENSE
+ShortDescription: Jira MCP server for connecting Jira workflows to MCP-capable editors and agents.
+Description: jirac-mcp is a Rust-based Model Context Protocol server for Jira. It exposes Jira issue, transition, comment, worklog, attachment, and search workflows to MCP-capable clients, editors, and coding agents.
+Moniker: jirac-mcp
+Tags:
+  - jira
+  - atlassian
+  - mcp
+  - agent
+  - ai
+  - cli
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/m/mulhamna/jirac-mcp/2.0.1/mulhamna.jirac-mcp.yaml
+++ b/manifests/m/mulhamna/jirac-mcp/2.0.1/mulhamna.jirac-mcp.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: mulhamna.jirac-mcp
+PackageVersion: 2.0.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## Summary
- add a new WinGet manifest for `mulhamna.jirac-mcp` version `2.0.1`
- package the Windows x64 portable zip published from the `jira-mcp-v2.0.1` release
- expose the `jirac-mcp` command alias for MCP-focused installs on Windows

## Validation
- verified the release asset exists: `jirac-mcp-windows-x86_64.zip`
- verified the nested portable binary path: `jirac-mcp-windows-x86_64.exe`
- verified the archive SHA256: `437888c51fb8b3a3f92e3b4a1fbe835ca54f0b3eb0d5a8fdfd178d26755223db`
- checked the manifest diff with `git diff --cached --check`

## Notes
- `mulhamna.jirac` is already published separately for the main CLI/TUI package
- this PR adds the standalone MCP server package so Windows users can install `jirac-mcp` directly via WinGet

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/380242)