### PR TITLE
New version: Tropibyte.cshw version 1.0.7.1

### DIFF
--- a/manifests/t/Tropibyte/cshw/1.0.7.1/Tropibyte.cshw.installer.yaml
+++ b/manifests/t/Tropibyte/cshw/1.0.7.1/Tropibyte.cshw.installer.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Tropibyte.cshw
+PackageVersion: 1.0.7.1
+MinimumOSVersion: 10.0.17763.0
+InstallerType: inno
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Commands:
+  - cshw
+FileExtensions:
+  - cshw
+  - csh
+ReleaseDate: 2026-05-27
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/tropibyte/cshw-releases/releases/download/v1.0.7.1/cshw-setup-1.0.7.1.exe
+    InstallerSha256: 4D7EFB291C2E76C2C43A636E240FD6C918589B37D1935AF014864980D2F7409E
+    ProductCode: '{CFE685C6-DC75-4996-AC4B-7BE4F4D5BCB6}_is1'
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/t/Tropibyte/cshw/1.0.7.1/Tropibyte.cshw.locale.en-US.yaml
+++ b/manifests/t/Tropibyte/cshw/1.0.7.1/Tropibyte.cshw.locale.en-US.yaml
@@ -1,0 +1,64 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Tropibyte.cshw
+PackageVersion: 1.0.7.1
+PackageLocale: en-US
+Publisher: Tropibyte, Inc.
+PublisherUrl: https://www.tropibyte.com
+PublisherSupportUrl: https://www.tropibyte.com/bugs.html
+PrivacyUrl: https://www.tropibyte.com
+Author: Tropibyte, Inc.
+PackageName: C Shell for Windows
+PackageUrl: https://www.tropibyte.com/cshw.html
+License: PolyForm Small Business 1.0.0
+LicenseUrl: https://polyformproject.org/licenses/small-business/1.0.0
+Copyright: Copyright (c) 2024-2026 Tropibyte, Inc.
+CopyrightUrl: https://www.tropibyte.com/cshw.html
+ShortDescription: A csh-style shell for Windows with concurrent pipelines, exact-rational bc/dc, native Win32, real concurrency, and built-in AI. One ~14 MB binary, no runtime.
+Description: |-
+  cshw is a native Windows command shell with csh/tcsh-flavored syntax. Familiar Unix
+  shell ergonomics meet first-class Win32 access -- no WSL, no Cygwin, no compatibility
+  layer. 110+ builtin commands cover file ops, text processing (grep with PCRE2, sed,
+  awk, sort with -t/-k, head/tail with -f), real concurrency primitives (coroutines,
+  mutex, semaphore, barrier, channel), Win32 calls (rundllproc, winapi, dllimport),
+  and built-in AI (OpenAI, Anthropic, Azure, Ollama, LM Studio). Runs your existing
+  .bat, .cmd, and .ps1 scripts unchanged. The bc/dc commands offer arbitrary-precision
+  arithmetic with an opt-in exact-rational tier (bc -x) including complex numbers and
+  small exact matrices. As of 1.0.7.0, pipelines run on parallel threads with
+  streaming early-termination; set pipemode = sequential restores the previous
+  semantics. Ships with a 21-chapter user guide.
+Moniker: cshw
+Tags:
+  - shell
+  - csh
+  - tcsh
+  - command-line
+  - cli
+  - terminal
+  - unix
+  - win32
+  - scripting
+  - developer-tools
+ReleaseNotes: |-
+  v1.0.7.1-alpha: cosmetic version-display fixes. `cshw --version` now prints
+  "C-Shell for Windows version 1.0.7.1" and exits (previously fell into REPL
+  mode -- noticed by the winget validator). The `ver` / `version` builtins
+  now show all four components ("1.0.7.1" instead of "1.0.7"). No behavior
+  changes; underlying shell is identical to 1.0.7.0.
+
+  v1.0.7.0-alpha (carried over): concurrent pipelines. Each segment of
+  `a | b | c` runs on its own thread with bounded Win32 pipes between
+  adjacent stages. Streaming early-termination -- `seq 1 10000000 | head -1`
+  now stops the producer near-instantly instead of running to completion.
+  External commands stream too via STARTF_USESTDHANDLES. Pipelines inside
+  procs see $1/$argv correctly. `set pipemode = sequential` preserved as
+  the user-selectable opt-out that restores 1.0.6.x semantics.
+
+  bc -x exact rationals plus matrix tier and complex numbers, POSIX dc with
+  conditional macros and register arrays, cascading settings layer
+  (settings.csh > HKCU > HKLM > built-in default), 79/79 test suites green
+  in both pipeline modes.
+ReleaseNotesUrl: https://github.com/tropibyte/cshw-releases/releases/tag/v1.0.7.1
+PurchaseUrl: https://www.tropibyte.com/cshw.html
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/Tropibyte/cshw/1.0.7.1/Tropibyte.cshw.yaml
+++ b/manifests/t/Tropibyte/cshw/1.0.7.1/Tropibyte.cshw.yaml
@@ -1,0 +1,8 @@
+# Created using cshw-winget hand-written manifest
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Tropibyte.cshw
+PackageVersion: 1.0.7.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Submission

- **Package identifier**: `Tropibyte.cshw`
- **Version**: 1.0.7.1
- **Installer**: Inno Setup, x64, machine scope
- **Download**: <https://github.com/tropibyte/cshw-releases/releases/download/v1.0.7.1/cshw-setup-1.0.7.1.exe>
- **SHA-256**: `4D7EFB291C2E76C2C43A636E240FD6C918589B37D1935AF014864980D2F7409E`
- **Manifest schema**: 1.12.0

## About this release

Cosmetic patch over 1.0.7.0. Two display fixes:

1. `cshw --version` now prints the version and exits cleanly. Previously the flag was unrecognized and cshw fell into REPL mode waiting for input — caught by @stephengillie's manual validation on the [1.0.7.0 PR](https://github.com/microsoft/winget-pkgs/pull/376779).
2. `ver` / `version` builtins now show all four components (`1.0.7.1` instead of `1.0.7`). The ARP table already showed the correct value; this just brings the in-shell display into line.

**No behavior changes.** Same signed installer pipeline, same `ProductCode`, same dependency profile (none — `/MT` static-linked since 1.0.4.x), same 79-suite test matrix passing.

## Checklist

- [x] `winget validate` clean
- [x] Manifest schema 1.12.0 (current)
- [x] SHA-256 matches the installer at the URL
- [x] License URL points to PolyForm Small Business 1.0.0
- [x] Code-signed by Tropibyte, Inc.
- [x] `cshw --version` now passes the standard validator check that 1.0.7.0 failed
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/380596)