### PR TITLE
Update Tiled.Tiled to version 1.12.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The **Windows Package Manager** is an [open source client](https://github.com/mi
 # Documentation
 
 Please check the [overview](doc/README.md) for detailed topics. Common topics for the WinGet Community repository are available below:
+
 * [Authoring a manifest](doc/README.md#authoring-a-manifest)
 * [Testing a manifest](doc/README.md#testing-a-manifest)
 * [First-time contributor checklist](doc/FirstContribution.md)
@@ -26,7 +27,7 @@ Please check the [overview](doc/README.md) for detailed topics. Common topics fo
 
 # Contributing
 
-This project welcomes contributions and suggestions. Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and do, grant us the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
+This project welcomes contributions and suggestions. Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and do, grant us the rights to use your contribution. For details, visit <https://cla.opensource.microsoft.com>.
 
 When you submit a pull request, a CLA bot will automatically determine whether you need to provide a CLA and decorate the PR appropriately (e.g., status check, comment). Follow the instructions provided by the bot. You will only need to do this once across all Microsoft repositories using our CLA.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ The **Windows Package Manager** is an [open source client](https://github.com/mi
 # Documentation
 
 Please check the [overview](doc/README.md) for detailed topics. Common topics for the WinGet Community repository are available below:
-
 * [Authoring a manifest](doc/README.md#authoring-a-manifest)
 * [Testing a manifest](doc/README.md#testing-a-manifest)
 * [First-time contributor checklist](doc/FirstContribution.md)
@@ -27,7 +26,7 @@ Please check the [overview](doc/README.md) for detailed topics. Common topics fo
 
 # Contributing
 
-This project welcomes contributions and suggestions. Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and do, grant us the rights to use your contribution. For details, visit <https://cla.opensource.microsoft.com>.
+This project welcomes contributions and suggestions. Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and do, grant us the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
 
 When you submit a pull request, a CLA bot will automatically determine whether you need to provide a CLA and decorate the PR appropriately (e.g., status check, comment). Follow the instructions provided by the bot. You will only need to do this once across all Microsoft repositories using our CLA.
 

--- a/manifests/t/Tiled/Tiled/1.12.2/Tiled.Tiled.installer.yaml
+++ b/manifests/t/Tiled/Tiled/1.12.2/Tiled.Tiled.installer.yaml
@@ -1,0 +1,27 @@
+# Copied from v1.11.2 and updated by kerrjnr, NZST(UTC+12) 2026-05-28.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: Tiled.Tiled
+PackageVersion: 1.12.2
+InstallerLocale: en-US
+InstallerType: wix
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+AppsAndFeaturesEntries:
+- UpgradeCode: '{F7EEDD05-BBFC-4D6A-9BF6-98D3BA77F327}'
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/mapeditor/tiled/releases/download/v1.12.2/Tiled-1.12.2_Windows-7-8_x86.msi
+  InstallerSha256: F3A7C5D77EF4FFD5B97397FE50C886B11E50128F4FC1BEACEEAC8CD8E0EE7046
+  ProductCode: '{54F80EA1-1E0C-4B0D-A2E4-7A9F65A3FB58}'
+- Architecture: x64
+  InstallerUrl: https://github.com/mapeditor/tiled/releases/download/v1.12.2/Tiled-1.12.2_Windows-10%2B_x86_64.msi
+  InstallerSha256: 11A0E6C97CC105E07A57EA9995F2704617986722DE4AB699D286DAB0D2BECC3F
+  ProductCode: '{219697BD-72DB-4A2C-9C68-A4F0D6C84382}'
+ManifestType: installer
+ManifestVersion: 1.9.0
+ReleaseDate: 2026-05-27

--- a/manifests/t/Tiled/Tiled/1.12.2/Tiled.Tiled.locale.en-US.yaml
+++ b/manifests/t/Tiled/Tiled/1.12.2/Tiled.Tiled.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# Copied from v1.11.2 and updated by kerrjnr, NZST(UTC+12) 2026-05-28.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: Tiled.Tiled
+PackageVersion: 1.12.2
+PackageLocale: en-US
+Publisher: mapeditor.org
+PublisherUrl: https://github.com/mapeditor/tiled
+PublisherSupportUrl: https://github.com/mapeditor/tiled/issues
+Author: Thorbjørn Lindeijer
+PackageName: Tiled
+PackageUrl: https://www.mapeditor.org
+License: GPL 2.0 or later
+LicenseUrl: https://github.com/mapeditor/tiled/raw/master/COPYING
+CopyrightUrl: https://github.com/mapeditor/tiled/raw/master/COPYING
+ShortDescription: Tiled is a 2D level editor for game developers to create and edit map tiles for game content.
+Description: |-
+  Tiled is a 2D level editor that helps you develop the content of your game.
+  Its primary feature is to edit tile maps of various forms, but it also supports free image placement as well as powerful ways to annotate your level with extra information used by the game.
+Moniker: tiled
+Tags:
+- cross-platform
+- editor
+- foss
+- gamedev
+- graphics
+- tiled
+- tilemap
+ReleaseNotesUrl: https://github.com/mapeditor/tiled/releases/tag/v1.12.2
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/mapeditor/tiled/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/t/Tiled/Tiled/1.12.2/Tiled.Tiled.yaml
+++ b/manifests/t/Tiled/Tiled/1.12.2/Tiled.Tiled.yaml
@@ -1,0 +1,8 @@
+# Copied from v1.11.2 and updated by kerrjnr, NZST(UTC+12) 2026-05-28.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: Tiled.Tiled
+PackageVersion: 1.12.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
- Add manifests for 1.12.2 (x64 and x86 MSI)
- Update Author
- Update ProductCode and UpgradeCode from official MSIs
- Update ReleaseNotesUrl to v1.12.2 announcement
- Confirm SHA256 values with Get-FileHash
- Sync with manifest schema version 1.9.0

## 📖 Description


This update brings Tiled.Tiled up to date with the current upstream release.
For details, see:
[Release Announcement and Changelog for v1.12.2](https://github.com/mapeditor/tiled/releases/tag/v1.12.2)

Let me know if revisions are needed—thanks for reviewing!

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/380611)