### PR TITLE
New version: tisun2.OofManager version 1.1.9

### DIFF
--- a/manifests/t/tisun2/OofManager/1.1.9/tisun2.OofManager.installer.yaml
+++ b/manifests/t/tisun2/OofManager/1.1.9/tisun2.OofManager.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: tisun2.OofManager
+PackageVersion: 1.1.9
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART
+UpgradeBehavior: install
+ReleaseDate: 2026-05-28
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/tisun2/OofManager/releases/download/v1.1.9/OofManagerSetup.exe
+    InstallerSha256: B779E4CF29FC26B27D5BD6A4DF8A58AA07B68379A0B315974B79191DBB9094D7
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/t/tisun2/OofManager/1.1.9/tisun2.OofManager.locale.en-US.yaml
+++ b/manifests/t/tisun2/OofManager/1.1.9/tisun2.OofManager.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: tisun2.OofManager
+PackageVersion: 1.1.9
+PackageLocale: en-US
+Publisher: tisun2
+PublisherUrl: https://github.com/tisun2
+PublisherSupportUrl: https://github.com/tisun2/OofManager/issues
+PackageName: OOF Manager
+PackageUrl: https://github.com/tisun2/OofManager
+License: MIT
+LicenseUrl: https://github.com/tisun2/OofManager/blob/main/LICENSE
+Copyright: Copyright (c) tisun2
+ShortDescription: Manage Microsoft 365 / Exchange Online Out-of-Office (Automatic Reply) settings without opening Outlook.
+Description: |-
+  OOF Manager is a lightweight Windows desktop tool that manages your Microsoft 365 mailbox's
+  Out-of-Office (Automatic Reply) state for you. Sign in once, configure your weekly work hours
+  and reply text, and OOF Manager auto-toggles your OOF on/off at the schedule boundaries.
+  It also pushes the next off-hours window to Exchange as a Scheduled OOF, so the server keeps
+  switching auto-replies even when this app is closed.
+Moniker: oofmanager
+Tags:
+  - exchange
+  - microsoft-365
+  - office-365
+  - out-of-office
+  - oof
+  - outlook
+  - autoreply
+ReleaseNotesUrl: https://github.com/tisun2/OofManager/releases/tag/v1.1.9
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/t/tisun2/OofManager/1.1.9/tisun2.OofManager.yaml
+++ b/manifests/t/tisun2/OofManager/1.1.9/tisun2.OofManager.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: tisun2.OofManager
+PackageVersion: 1.1.9
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## New version: tisun2.OofManager 1.1.9

- [x] I have read the [contribution guide](https://github.com/microsoft/winget-pkgs/blob/master/CONTRIBUTING.md).
- [x] Manifests follow the [v1.10 schema](https://aka.ms/winget-manifest.installer.1.10.0.schema.json).
- [x] Installer URL points to the matching GitHub release asset.
- [x] `winget validate` passes locally.
- [x] Installer SHA256 verified against the published asset.

### Package
- **Identifier**: `tisun2.OofManager`
- **Version**: `1.1.9`
- **Installer type**: Inno Setup (user scope, x64)
- **Installer URL**: https://github.com/tisun2/OofManager/releases/download/v1.1.9/OofManagerSetup.exe
- **SHA256**: `B779E4CF29FC26B27D5BD6A4DF8A58AA07B68379A0B315974B79191DBB9094D7`
- **Release notes**: https://github.com/tisun2/OofManager/releases/tag/v1.1.9

### What's new in 1.1.9
Manual mode: when **Set up vacation in cloud** is clicked with a vacation start time already in the past, the cloud Start flow's one-shot trigger would never fire. The app now prompts to apply the work locally instead — push the vacation AutoReply to Outlook immediately, turn off the weekly Cloud Schedule flow, and still import the cloud package so the End flow restores normal state at the vacation end time.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/380614)