### PR TITLE
New version: Bytical.Nerva version 0.1.0

### DIFF
--- a/manifests/b/Bytical/Nerva/0.1.0/Bytical.Nerva.installer.yaml
+++ b/manifests/b/Bytical/Nerva/0.1.0/Bytical.Nerva.installer.yaml
@@ -1,0 +1,44 @@
+# Created with manual submission for first release of Nerva 0.1.0
+PackageIdentifier: Bytical.Nerva
+PackageVersion: 0.1.0
+InstallerLocale: en-US
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{8B5E28BC-02B6-48DA-BDA3-EB3BAD5162C7}'
+Installers:
+  - Architecture: x64
+    InstallerType: wix
+    Scope: machine
+    InstallerUrl: https://github.com/piyushptiwari1/nerva/releases/download/v0.1.0/Nerva_0.1.0_x64_en-US.msi
+    InstallerSha256: F6856A89BAABC071572613B631B1355EC8985D8DEAF2658FD236BEEFE1EBE5BE
+    AppsAndFeaturesEntries:
+      - DisplayName: Nerva
+        Publisher: Bytical Solutions Private Limited
+        DisplayVersion: 0.1.0
+        ProductCode: '{8B5E28BC-02B6-48DA-BDA3-EB3BAD5162C7}'
+        UpgradeCode: '{5D3F1B8E-9A4C-4D2E-9F5A-7B3C6E8D2A1C}'
+        InstallerType: wix
+  - Architecture: x64
+    InstallerType: nullsoft
+    Scope: user
+    InstallerUrl: https://github.com/piyushptiwari1/nerva/releases/download/v0.1.0/Nerva_0.1.0_x64-setup.exe
+    InstallerSha256: 8428EA3C96A6B1D3CA7F1ECC614373E67A7EBCC367A10D1AC80BC6F23CCDD7D0
+ReleaseDate: 2026-05-28
+ReleaseNotes: |-
+  Nerva 0.1.0 — first public release.
+  - Parallel focus timers (survive sleep/suspend/reboot)
+  - Sticky markdown notes with 250 ms autosave
+  - Habit heatmap with 4-state daily toggle + full-year grid
+  - Tasks with priority + due time + pop-out widget
+  - Command palette (Ctrl+Space) + global shortcuts
+  - Crash-safe local SQLite event store
+  Native Rust + Tauri, ~80 MB RAM, no telemetry, no account.
+ReleaseNotesUrl: https://github.com/piyushptiwari1/nerva/releases/tag/v0.1.0
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/b/Bytical/Nerva/0.1.0/Bytical.Nerva.locale.en-US.yaml
+++ b/manifests/b/Bytical/Nerva/0.1.0/Bytical.Nerva.locale.en-US.yaml
@@ -1,0 +1,45 @@
+# winget package manifest template for Nerva.
+#
+# This is consumed by winget-releaser (.github/workflows/release.yml) on every
+# tagged release. The action substitutes VERSION + InstallerSha256 + InstallerUrl
+# automatically and opens a PR against microsoft/winget-pkgs.
+#
+# After your FIRST signed release lands on GitHub, manually verify the PR is
+# correct and submit. Subsequent releases auto-PR.
+
+PackageIdentifier: Bytical.Nerva
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Bytical Solutions Private Limited
+PublisherUrl: https://bytical.ai
+PublisherSupportUrl: https://github.com/piyushptiwari1/nerva/issues
+PrivacyUrl: https://nerva.bytical.ai/privacy
+Author: Bytical Solutions Private Limited
+PackageName: Nerva
+PackageUrl: https://nerva.bytical.ai
+License: Apache-2.0
+LicenseUrl: https://github.com/piyushptiwari1/nerva/blob/main/LICENSE
+Copyright: © 2026 Bytical Solutions Private Limited
+ShortDescription: The focus workspace that never forgets
+Description: |-
+  Nerva is a native desktop focus workspace built for deep work. Parallel
+  timers that survive sleep and reboot, sticky markdown notes that float
+  above any window, a year-long habit heatmap, and tasks with priority
+  and due times. Offline-first. No telemetry. No account. Apache-2.0.
+Moniker: nerva
+Tags:
+  - productivity
+  - focus
+  - timer
+  - notes
+  - habits
+  - pomodoro
+  - deep-work
+  - offline
+  - markdown
+  - habit-tracker
+  - command-palette
+  - no-telemetry
+ReleaseNotesUrl: https://github.com/piyushptiwari1/nerva/releases
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/b/Bytical/Nerva/0.1.0/Bytical.Nerva.yaml
+++ b/manifests/b/Bytical/Nerva/0.1.0/Bytical.Nerva.yaml
@@ -1,0 +1,6 @@
+# Created with manual submission for first release of Nerva 0.1.0
+PackageIdentifier: Bytical.Nerva
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## New package submission

**Bytical.Nerva** v0.1.0 — first release.

Nerva is a native focus workspace: parallel timers that survive sleep/reboot, sticky markdown notes, year-long habit heatmap, tasks with pop-out, command palette, crash-safe local SQLite store. Native Rust + Tauri. No telemetry. Apache-2.0.

- Homepage: https://nerva.bytical.ai
- Source: https://github.com/piyushptiwari1/nerva
- Release: https://github.com/piyushptiwari1/nerva/releases/tag/v0.1.0
- Installers: MSI (machine) + NSIS .exe (user)
- Code-signed with self-signed Bytical certificate (publisher importable from https://nerva.bytical.ai/cert)

### Checklist
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://docs.microsoft.com/windows/package-manager/package/manifest#validation) your manifest locally with `winget validate --manifest <path>`?
  - Validated structurally via schema; ProductCode and UpgradeCode extracted from MSI via msitools.
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
  - Tested install via direct .msi double-click on Windows 11; winget local-manifest test pending CI.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/380643)