### PR TITLE
Bytical.Nerva version 0.1.1

### DIFF
--- a/manifests/b/Bytical/Nerva/0.1.1/Bytical.Nerva.installer.yaml
+++ b/manifests/b/Bytical/Nerva/0.1.1/Bytical.Nerva.installer.yaml
@@ -1,0 +1,42 @@
+# Created with manual submission for Nerva 0.1.1 bug-fix release
+PackageIdentifier: Bytical.Nerva
+PackageVersion: 0.1.1
+InstallerLocale: en-US
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{656FF4A2-4588-4E86-811B-A54A8141D895}'
+Installers:
+  - Architecture: x64
+    InstallerType: wix
+    Scope: machine
+    InstallerUrl: https://github.com/piyushptiwari1/nerva/releases/download/v0.1.1/Nerva_0.1.1_x64_en-US.msi
+    InstallerSha256: BA87938BD6C1DAFBCCF51535C7540C56D9471BCCF8B391E00CB12265761DDD1E
+    AppsAndFeaturesEntries:
+      - DisplayName: Nerva
+        Publisher: Bytical Solutions Private Limited
+        DisplayVersion: 0.1.1
+        ProductCode: '{656FF4A2-4588-4E86-811B-A54A8141D895}'
+        UpgradeCode: '{5D3F1B8E-9A4C-4D2E-9F5A-7B3C6E8D2A1C}'
+        InstallerType: wix
+  - Architecture: x64
+    InstallerType: nullsoft
+    Scope: user
+    InstallerUrl: https://github.com/piyushptiwari1/nerva/releases/download/v0.1.1/Nerva_0.1.1_x64-setup.exe
+    InstallerSha256: 85DD9E89C29CE7DDF3B63FBF0174965999917E43D104B64617834F02F8B4075A
+ReleaseDate: 2026-05-28
+ReleaseNotes: |-
+  Nerva 0.1.1 — bug-fix release.
+  - Windows: fix popout windows opening blank and freezing the main app
+  - Tray icon now has a real right-click menu (Show Nerva, New Timer, Quit)
+  - Popouts stay on the virtual desktop where opened (no longer follow you)
+  - New pin button per popout to opt-in to always-on-top
+  - Closing the main window hides it; restore via tray, quit via tray menu
+ReleaseNotesUrl: https://github.com/piyushptiwari1/nerva/releases/tag/v0.1.1
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/b/Bytical/Nerva/0.1.1/Bytical.Nerva.locale.en-US.yaml
+++ b/manifests/b/Bytical/Nerva/0.1.1/Bytical.Nerva.locale.en-US.yaml
@@ -1,0 +1,36 @@
+PackageIdentifier: Bytical.Nerva
+PackageVersion: 0.1.1
+PackageLocale: en-US
+Publisher: Bytical Solutions Private Limited
+PublisherUrl: https://bytical.ai
+PublisherSupportUrl: https://github.com/piyushptiwari1/nerva/issues
+PrivacyUrl: https://nerva.bytical.ai/privacy
+Author: Bytical Solutions Private Limited
+PackageName: Nerva
+PackageUrl: https://nerva.bytical.ai
+License: Apache-2.0
+LicenseUrl: https://github.com/piyushptiwari1/nerva/blob/main/LICENSE
+Copyright: © 2026 Bytical Solutions Private Limited
+ShortDescription: The focus workspace that never forgets
+Description: |-
+  Nerva is a native desktop focus workspace built for deep work. Parallel
+  timers that survive sleep and reboot, sticky markdown notes that float
+  above any window, a year-long habit heatmap, and tasks with priority
+  and due times. Offline-first. No telemetry. No account. Apache-2.0.
+Moniker: nerva
+Tags:
+  - productivity
+  - focus
+  - timer
+  - notes
+  - habits
+  - pomodoro
+  - deep-work
+  - offline
+  - markdown
+  - habit-tracker
+  - command-palette
+  - no-telemetry
+ReleaseNotesUrl: https://github.com/piyushptiwari1/nerva/releases/tag/v0.1.1
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/b/Bytical/Nerva/0.1.1/Bytical.Nerva.yaml
+++ b/manifests/b/Bytical/Nerva/0.1.1/Bytical.Nerva.yaml
@@ -1,0 +1,6 @@
+# Created with manual submission for Nerva 0.1.1 bug-fix release
+PackageIdentifier: Bytical.Nerva
+PackageVersion: 0.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Bug-fix release.

Release notes: https://github.com/piyushptiwari1/nerva/releases/tag/v0.1.1

Fixes vs 0.1.0:
- Windows: fix popout windows opening blank and freezing the main app
- Tray icon now has a programmatic right-click menu (Show / New Timer / Quit)
- Popouts stay on the virtual desktop where opened (no more cross-desktop sticky)
- New pin button per popout for opt-in always-on-top
- Closing the main window hides it instead of orphaning the user

Verified on a clean Windows 11 VM via `winget install --manifest manifests/b/Bytical/Nerva/0.1.1`.

Both installers (MSI machine-scope, NSIS user-scope) signed with the same Bytical code-signing cert as 0.1.0 (SHA-1 thumbprint BCE904A5A627892A0116E4D6E17D980532490AAC).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/380657)