### PR TITLE
New package: Yovancas.ClaudeBarWin version 0.1.0

### DIFF
--- a/manifests/y/Yovancas/ClaudeBarWin/0.1.0/Yovancas.ClaudeBarWin.installer.yaml
+++ b/manifests/y/Yovancas/ClaudeBarWin/0.1.0/Yovancas.ClaudeBarWin.installer.yaml
@@ -1,0 +1,12 @@
+PackageIdentifier: Yovancas.ClaudeBarWin
+PackageVersion: 0.1.0
+InstallerType: portable
+Commands:
+- claudebarwin
+ReleaseDate: 2026-05-28
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Yovancas/claudebar-win/releases/download/v0.1.0/ClaudeBarWin.exe
+  InstallerSha256: F470488287A2E2C0E22E950AC04DD501E4732349328510981103DF870053BECA
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/y/Yovancas/ClaudeBarWin/0.1.0/Yovancas.ClaudeBarWin.locale.en-US.yaml
+++ b/manifests/y/Yovancas/ClaudeBarWin/0.1.0/Yovancas.ClaudeBarWin.locale.en-US.yaml
@@ -1,0 +1,21 @@
+PackageIdentifier: Yovancas.ClaudeBarWin
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Yovan Castro
+PublisherUrl: https://github.com/Yovancas
+PublisherSupportUrl: https://github.com/Yovancas/claudebar-win/issues
+PackageName: ClaudeBar for Windows
+PackageUrl: https://github.com/Yovancas/claudebar-win
+License: MIT
+LicenseUrl: https://github.com/Yovancas/claudebar-win/blob/main/LICENSE
+ShortDescription: System-tray monitor for Claude Code usage with real 5h/7d quota, pace prediction, usage charts, themes and 9 languages.
+Tags:
+- claude
+- claude-code
+- anthropic
+- usage
+- quota
+- monitor
+- tray
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/y/Yovancas/ClaudeBarWin/0.1.0/Yovancas.ClaudeBarWin.yaml
+++ b/manifests/y/Yovancas/ClaudeBarWin/0.1.0/Yovancas.ClaudeBarWin.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Yovancas.ClaudeBarWin
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: Yovancas.ClaudeBarWin 0.1.0

ClaudeBar for Windows — a system-tray monitor for Claude Code usage (real 5h/7d quota, pace prediction, usage charts, themes, 9 languages). Open-source (MIT): https://github.com/Yovancas/claudebar-win

- Installer type: **portable** (single self-contained .exe, no .NET prerequisite).
- Architecture: x64.
- Manifest schema 1.6.0.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] This is a new package.
- [x] Manifest validated locally.

Note: the installer is an unsigned portable executable.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/380749)