### PR TITLE
New version: Ruffle.Ruffle.Nightly 0.3.0.26149

### DIFF
--- a/manifests/r/Ruffle/Ruffle/Nightly/0.3.0.26149/Ruffle.Ruffle.Nightly.installer.yaml
+++ b/manifests/r/Ruffle/Ruffle/Nightly/0.3.0.26149/Ruffle.Ruffle.Nightly.installer.yaml
@@ -1,0 +1,49 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Ruffle.Ruffle.Nightly
+PackageVersion: 0.3.0.26149
+InstallerLocale: en-US
+InstallerType: zip
+Installers:
+- Architecture: x86
+  NestedInstallerType: wix
+  NestedInstallerFiles:
+  - RelativeFilePath: setup.msi
+  InstallerUrl: https://github.com/ruffle-rs/ruffle/releases/download/nightly-2026-05-29/ruffle-nightly-2026_05_29-windows-x86_32.zip
+  InstallerSha256: 76AC1FAEA9D3249B7FB61591FE6170EB69D529AF008F746997D5EC16CFD22F44
+  ProductCode: '{C2708FAA-7DD5-4B20-B7BC-6B48963A8CB7}'
+  AppsAndFeaturesEntries:
+  - DisplayName: Ruffle
+    Publisher: Ruffle LLC
+    DisplayVersion: 0.3.0.26149
+    ProductCode: '{C2708FAA-7DD5-4B20-B7BC-6B48963A8CB7}'
+    UpgradeCode: '{C6A4BA50-FA08-4B87-9B55-D81A1C730D25}'
+- Architecture: x86
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: ruffle.exe
+  InstallerUrl: https://github.com/ruffle-rs/ruffle/releases/download/nightly-2026-05-29/ruffle-nightly-2026_05_29-windows-x86_32.zip
+  InstallerSha256: 76AC1FAEA9D3249B7FB61591FE6170EB69D529AF008F746997D5EC16CFD22F44
+- Architecture: x64
+  NestedInstallerType: wix
+  NestedInstallerFiles:
+  - RelativeFilePath: setup.msi
+  InstallerUrl: https://github.com/ruffle-rs/ruffle/releases/download/nightly-2026-05-29/ruffle-nightly-2026_05_29-windows-x86_64.zip
+  InstallerSha256: E61954133E7F74420E649063271532F6D4C79B91B26C2E9D898721B4D990F975
+  ProductCode: '{AE5FE994-4046-4E7B-B690-3E80A2D3A85E}'
+  AppsAndFeaturesEntries:
+  - DisplayName: Ruffle
+    Publisher: Ruffle LLC
+    DisplayVersion: 0.3.0.26149
+    ProductCode: '{AE5FE994-4046-4E7B-B690-3E80A2D3A85E}'
+    UpgradeCode: '{C6A4BA50-FA08-4B87-9B55-D81A1C730D25}'
+- Architecture: x64
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: ruffle.exe
+  InstallerUrl: https://github.com/ruffle-rs/ruffle/releases/download/nightly-2026-05-29/ruffle-nightly-2026_05_29-windows-x86_64.zip
+  InstallerSha256: E61954133E7F74420E649063271532F6D4C79B91B26C2E9D898721B4D990F975
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-05-29

--- a/manifests/r/Ruffle/Ruffle/Nightly/0.3.0.26149/Ruffle.Ruffle.Nightly.locale.en-US.yaml
+++ b/manifests/r/Ruffle/Ruffle/Nightly/0.3.0.26149/Ruffle.Ruffle.Nightly.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Ruffle.Ruffle.Nightly
+PackageVersion: 0.3.0.26149
+PackageLocale: en-US
+Publisher: Ruffle
+PublisherUrl: https://github.com/ruffle-rs
+PublisherSupportUrl: https://github.com/ruffle-rs/ruffle/issues
+PackageName: Ruffle
+PackageUrl: https://github.com/ruffle-rs/ruffle
+License: Apache-2.0 + MIT
+LicenseUrl: https://github.com/ruffle-rs/ruffle/blob/HEAD/LICENSE.md
+ShortDescription: A Flash Player emulator written in Rust
+Tags:
+- emulator
+- flash
+- hacktoberfest
+- reimplementation
+- rust
+- swf
+ReleaseNotesUrl: https://github.com/ruffle-rs/ruffle/releases/tag/nightly-2026-05-29
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/ruffle-rs/ruffle/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/Ruffle/Ruffle/Nightly/0.3.0.26149/Ruffle.Ruffle.Nightly.yaml
+++ b/manifests/r/Ruffle/Ruffle/Nightly/0.3.0.26149/Ruffle.Ruffle.Nightly.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Ruffle.Ruffle.Nightly
+PackageVersion: 0.3.0.26149
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION

## 📖 Description
Adds a new (latest) version of Ruffle nightly build: 0.3.0.26149

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/381049)