### PR TITLE
Add xtop 0.1.1 (static CRT linked)

### DIFF
--- a/manifests/m/MengshengWu/xtop/0.1.1/MengshengWu.xtop.installer.yaml
+++ b/manifests/m/MengshengWu/xtop/0.1.1/MengshengWu.xtop.installer.yaml
@@ -1,0 +1,25 @@
+PackageIdentifier: MengshengWu.xtop
+PackageVersion: 0.1.1
+InstallerType: zip
+NestedInstallerType: portable
+Installers:
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: xtop.exe
+    PortableCommandAlias: xtop
+  InstallerUrl: https://github.com/mengshengwu/xtop/releases/download/v0.1.1/xtop-x86_64-pc-windows-msvc.zip
+  InstallerSha256: ABFB889B1D81DA47F5CA74AF544CDEE4D991B4B35EADB075FAA3E7A9DB0B777B
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+- Architecture: arm64
+  NestedInstallerFiles:
+  - RelativeFilePath: xtop.exe
+    PortableCommandAlias: xtop
+  InstallerUrl: https://github.com/mengshengwu/xtop/releases/download/v0.1.1/xtop-aarch64-pc-windows-msvc.zip
+  InstallerSha256: 64EF34018BD76891C175E4AB3E15F2210E9FD493E4ECCF2AC6A08688FB5234B5
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.arm64
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/MengshengWu/xtop/0.1.1/MengshengWu.xtop.installer.yaml
+++ b/manifests/m/MengshengWu/xtop/0.1.1/MengshengWu.xtop.installer.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
 PackageIdentifier: MengshengWu.xtop
 PackageVersion: 0.1.1
 InstallerType: zip

--- a/manifests/m/MengshengWu/xtop/0.1.1/MengshengWu.xtop.locale.en-US.yaml
+++ b/manifests/m/MengshengWu/xtop/0.1.1/MengshengWu.xtop.locale.en-US.yaml
@@ -1,0 +1,16 @@
+PackageIdentifier: MengshengWu.xtop
+PackageVersion: 0.1.1
+PackageLocale: en-US
+Publisher: Mengsheng Wu
+PackageName: xtop
+License: MIT OR Apache-2.0
+ShortDescription: Live GPU and NPU monitoring TUI for Windows
+PackageUrl: https://github.com/mengshengwu/xtop
+Tags:
+  - cli
+  - gpu
+  - monitor
+  - npu
+  - tui
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/MengshengWu/xtop/0.1.1/MengshengWu.xtop.locale.en-US.yaml
+++ b/manifests/m/MengshengWu/xtop/0.1.1/MengshengWu.xtop.locale.en-US.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
 PackageIdentifier: MengshengWu.xtop
 PackageVersion: 0.1.1
 PackageLocale: en-US

--- a/manifests/m/MengshengWu/xtop/0.1.1/MengshengWu.xtop.yaml
+++ b/manifests/m/MengshengWu/xtop/0.1.1/MengshengWu.xtop.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
 PackageIdentifier: MengshengWu.xtop
 PackageVersion: 0.1.1
 DefaultLocale: en-US

--- a/manifests/m/MengshengWu/xtop/0.1.1/MengshengWu.xtop.yaml
+++ b/manifests/m/MengshengWu/xtop/0.1.1/MengshengWu.xtop.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: MengshengWu.xtop
+PackageVersion: 0.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Summary

Add xtop v0.1.1 with static C Runtime linking. This version eliminates external runtime dependencies by statically linking the MSVC C Runtime, making it compatible with any Windows environment without requiring external DLL dependencies.

## Changes

- Binary: `xtop-x86_64-pc-windows-msvc.zip` (SHA256: `abfb889b1d81da47f5ca74af544cdee4d991b4b35eadb075faa3e7a9db0b777b`)
- Binary: `xtop-aarch64-pc-windows-msvc.zip` (SHA256: `64ef34018bd76891c175e4ab3e15f2210e9fd493e4eccf2ac6a08688fb5234b5`)

## Background

v0.1.0 had external CRT dependencies (VCRUNTIME140.dll). This release resolves that by using static linking, following the approach of other Rust CLI tools like ripgrep.

## Testing

The binary has been verified to:
- Build successfully with static CRT linking
- Have zero external C Runtime dependencies
- Work correctly with GPU/NPU telemetry on Windows

Release: https://github.com/mengshengwu/xtop/releases/tag/v0.1.1
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/381098)