### PR TITLE
New package: Schweik7.trafmon version 0.2.0

### DIFF
--- a/manifests/s/Schweik7/trafmon/0.2.0/Schweik7.trafmon.installer.yaml
+++ b/manifests/s/Schweik7/trafmon/0.2.0/Schweik7.trafmon.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Schweik7.trafmon
+PackageVersion: 0.2.0
+InstallerType: wix
+Scope: machine
+InstallModes:
+  - silent
+  - silentWithProgress
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Schweik7/trafmon/releases/download/v0.2.0/trafmon_0.2.0_x64_en-US.msi
+    InstallerSha256: 28964DFD074038AE9001AEFDA0D10FB35C7C65058BCE3D782A7B88D4B817E5A0
+    ProductCode: '{60731BC8-7B9C-4DAB-8AC6-7E4C129BB5FB}'
+    AppsAndFeaturesEntries:
+      - DisplayName: trafmon
+        Publisher: schweik
+        DisplayVersion: 0.2.0
+        ProductCode: '{60731BC8-7B9C-4DAB-8AC6-7E4C129BB5FB}'
+        UpgradeCode: '{E7029617-05FC-5FBB-A56C-77958242A505}'
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/Schweik7/trafmon/0.2.0/Schweik7.trafmon.locale.en-US.yaml
+++ b/manifests/s/Schweik7/trafmon/0.2.0/Schweik7.trafmon.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Schweik7.trafmon
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: Schweik7
+PublisherUrl: https://github.com/Schweik7
+PublisherSupportUrl: https://github.com/Schweik7/trafmon/issues
+Author: Schweik7
+PackageName: trafmon
+PackageUrl: https://github.com/Schweik7/trafmon
+License: MIT
+LicenseUrl: https://github.com/Schweik7/trafmon/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Schweik7
+ShortDescription: A tiny, frameless, always-on-top floating widget that shows live network speed.
+Description: |-
+  trafmon is a tiny, frameless, always-on-top Windows desktop widget that shows
+  live upload/download speed at a glance. Hovering reveals per-process network
+  speed (via ETW; requires running as Administrator). It supports day/night
+  themes, NIC selection, opacity control, and a Chinese/English UI.
+Moniker: trafmon
+Tags:
+- network
+- bandwidth
+- monitor
+- speed
+- tauri
+- widget
+InstallationNotes: Per-process network speed requires running as Administrator.
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/Schweik7/trafmon/0.2.0/Schweik7.trafmon.yaml
+++ b/manifests/s/Schweik7/trafmon/0.2.0/Schweik7.trafmon.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Schweik7.trafmon
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package

- **Package**: `Schweik7.trafmon`
- **Version**: `0.2.0`
- **Installer**: MSI (x64), from the official GitHub release
- **Homepage**: https://github.com/Schweik7/trafmon

trafmon is a tiny, frameless, always-on-top Windows desktop widget that shows live network speed, with per-process network speed on hover. Open source (MIT), built with Tauri v2.

#### Checklist
- [x] Manifest conforms to the 1.6.0 schema (`winget validate` passed locally)
- [x] InstallerSha256 matches the released MSI
- [x] ProductCode / UpgradeCode extracted from the MSI
- [ ] Automated sandbox install/uninstall validation (handled by CI)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/381117)