### PR TITLE
Don't add blocking issue on scripted application

### DIFF
--- a/.github/policies/labelAdded.scriptedApplication.yml
+++ b/.github/policies/labelAdded.scriptedApplication.yml
@@ -31,8 +31,6 @@ configuration:
           - assignTo:
               author: True
           - addLabel:
-              label: Blocking-Issue
-          - addLabel:
               label: Needs-Author-Feedback
         # The policy service should trigger even when the label was added by the policy service
         triggerOnOwnActions: true


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
The auto-close won't work if a PR is labeled with Blocking Issue. Since scripted application PRs should probably be closed automatically if there is no response, there's no sense to label them as a blocked issue - especially since Needs-Author-Feedback and Needs-Attention generally block merges

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

@denelon
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/381309)