### PR TITLE
New version: Cybrium tools (cyweb / cysense / cywave / cyprobe / cymail / cyguard / cydeep) — initial submission

### DIFF
--- a/manifests/c/Cybrium/Cydeep/0.1.5/Cybrium.Cydeep.installer.yaml
+++ b/manifests/c/Cybrium/Cydeep/0.1.5/Cybrium.Cydeep.installer.yaml
@@ -1,0 +1,13 @@
+# Created with: Cybrium initial submission
+PackageIdentifier: Cybrium.Cydeep
+PackageVersion: 0.1.5
+InstallerLocale: en-US
+InstallerType: portable
+Commands:
+- cydeep
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/cybrium-ai/cydeep/releases/download/v0.1.5/cydeep-windows-amd64.exe
+  InstallerSha256: AB54584138C40467253EF2C7C41C02AFB9A3F34B6890C08F9FC258FEA3FA1D2D
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/c/Cybrium/Cydeep/0.1.5/Cybrium.Cydeep.locale.en-US.yaml
+++ b/manifests/c/Cybrium/Cydeep/0.1.5/Cybrium.Cydeep.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# Created with: Cybrium initial submission
+PackageIdentifier: Cybrium.Cydeep
+PackageVersion: 0.1.5
+PackageLocale: en-US
+Publisher: Cybrium Security Inc.
+PublisherUrl: https://cybrium.ai
+PublisherSupportUrl: https://github.com/cybrium-ai/cydeep/issues
+PrivacyUrl: https://cybrium.ai/privacy
+Author: Cybrium Security Inc.
+PackageName: cydeep
+PackageUrl: https://github.com/cybrium-ai/cydeep
+License: MIT
+LicenseUrl: https://github.com/cybrium-ai/cydeep/blob/main/LICENSE
+Copyright: Copyright (c) Cybrium Security Inc.
+ShortDescription: Cybrium deep packet inspection scanner
+Description: |-
+  Deep packet inspection with protocol-aware reconstruction and content analysis.
+Moniker: cydeep
+Tags:
+- cli
+- security
+- cybrium
+- rust
+ReleaseNotesUrl: https://github.com/cybrium-ai/cydeep/releases/tag/v0.1.5
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/c/Cybrium/Cydeep/0.1.5/Cybrium.Cydeep.yaml
+++ b/manifests/c/Cybrium/Cydeep/0.1.5/Cybrium.Cydeep.yaml
@@ -1,0 +1,6 @@
+# Created with: Cybrium initial submission
+PackageIdentifier: Cybrium.Cydeep
+PackageVersion: 0.1.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0

--- a/manifests/c/Cybrium/Cyguard/0.1.5/Cybrium.Cyguard.installer.yaml
+++ b/manifests/c/Cybrium/Cyguard/0.1.5/Cybrium.Cyguard.installer.yaml
@@ -1,0 +1,13 @@
+# Created with: Cybrium initial submission
+PackageIdentifier: Cybrium.Cyguard
+PackageVersion: 0.1.5
+InstallerLocale: en-US
+InstallerType: portable
+Commands:
+- cyguard
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/cybrium-ai/cyguard/releases/download/v0.1.5/cyguard-windows-amd64.exe
+  InstallerSha256: E978976A4767CAD2DE3D250DD777F0E0B7E078246FB424DFBFF1A07EDF602AA6
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/c/Cybrium/Cyguard/0.1.5/Cybrium.Cyguard.locale.en-US.yaml
+++ b/manifests/c/Cybrium/Cyguard/0.1.5/Cybrium.Cyguard.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# Created with: Cybrium initial submission
+PackageIdentifier: Cybrium.Cyguard
+PackageVersion: 0.1.5
+PackageLocale: en-US
+Publisher: Cybrium Security Inc.
+PublisherUrl: https://cybrium.ai
+PublisherSupportUrl: https://github.com/cybrium-ai/cyguard/issues
+PrivacyUrl: https://cybrium.ai/privacy
+Author: Cybrium Security Inc.
+PackageName: cyguard
+PackageUrl: https://github.com/cybrium-ai/cyguard
+License: MIT
+LicenseUrl: https://github.com/cybrium-ai/cyguard/blob/main/LICENSE
+Copyright: Copyright (c) Cybrium Security Inc.
+ShortDescription: Cybrium host hardening posture scanner
+Description: |-
+  Host hardening posture against CIS, STIG and vendor benchmarks, with reports and remediation.
+Moniker: cyguard
+Tags:
+- cli
+- security
+- cybrium
+- rust
+ReleaseNotesUrl: https://github.com/cybrium-ai/cyguard/releases/tag/v0.1.5
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/c/Cybrium/Cyguard/0.1.5/Cybrium.Cyguard.yaml
+++ b/manifests/c/Cybrium/Cyguard/0.1.5/Cybrium.Cyguard.yaml
@@ -1,0 +1,6 @@
+# Created with: Cybrium initial submission
+PackageIdentifier: Cybrium.Cyguard
+PackageVersion: 0.1.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0

--- a/manifests/c/Cybrium/Cymail/0.1.7/Cybrium.Cymail.installer.yaml
+++ b/manifests/c/Cybrium/Cymail/0.1.7/Cybrium.Cymail.installer.yaml
@@ -1,0 +1,13 @@
+# Created with: Cybrium initial submission
+PackageIdentifier: Cybrium.Cymail
+PackageVersion: 0.1.7
+InstallerLocale: en-US
+InstallerType: portable
+Commands:
+- cymail
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/cybrium-ai/cymail/releases/download/v0.1.7/cymail-windows-amd64.exe
+  InstallerSha256: D129319119E7FD9B7B29B0D6FFADD293F365284120EA596BA3BC3B7B742B1A6A
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/c/Cybrium/Cymail/0.1.7/Cybrium.Cymail.locale.en-US.yaml
+++ b/manifests/c/Cybrium/Cymail/0.1.7/Cybrium.Cymail.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# Created with: Cybrium initial submission
+PackageIdentifier: Cybrium.Cymail
+PackageVersion: 0.1.7
+PackageLocale: en-US
+Publisher: Cybrium Security Inc.
+PublisherUrl: https://cybrium.ai
+PublisherSupportUrl: https://github.com/cybrium-ai/cymail/issues
+PrivacyUrl: https://cybrium.ai/privacy
+Author: Cybrium Security Inc.
+PackageName: cymail
+PackageUrl: https://github.com/cybrium-ai/cymail
+License: MIT
+LicenseUrl: https://github.com/cybrium-ai/cymail/blob/main/LICENSE
+Copyright: Copyright (c) Cybrium Security Inc.
+ShortDescription: Cybrium email security scanner
+Description: |-
+  SPF, DKIM, DMARC, MTA-STS scoring and mail-domain posture validator.
+Moniker: cymail
+Tags:
+- cli
+- security
+- cybrium
+- rust
+ReleaseNotesUrl: https://github.com/cybrium-ai/cymail/releases/tag/v0.1.7
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/c/Cybrium/Cymail/0.1.7/Cybrium.Cymail.yaml
+++ b/manifests/c/Cybrium/Cymail/0.1.7/Cybrium.Cymail.yaml
@@ -1,0 +1,6 @@
+# Created with: Cybrium initial submission
+PackageIdentifier: Cybrium.Cymail
+PackageVersion: 0.1.7
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0

--- a/manifests/c/Cybrium/Cyprobe/0.2.3/Cybrium.Cyprobe.installer.yaml
+++ b/manifests/c/Cybrium/Cyprobe/0.2.3/Cybrium.Cyprobe.installer.yaml
@@ -1,0 +1,13 @@
+# Created with: Cybrium initial submission
+PackageIdentifier: Cybrium.Cyprobe
+PackageVersion: 0.2.3
+InstallerLocale: en-US
+InstallerType: portable
+Commands:
+- cyprobe
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/cybrium-ai/cyprobe/releases/download/v0.2.3/cyprobe-windows-amd64.exe
+  InstallerSha256: 7ED2ACC931C4550C27DE753265B4BD6848FDB3E37CEB5E1F18FBA49A129C816D
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/c/Cybrium/Cyprobe/0.2.3/Cybrium.Cyprobe.locale.en-US.yaml
+++ b/manifests/c/Cybrium/Cyprobe/0.2.3/Cybrium.Cyprobe.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# Created with: Cybrium initial submission
+PackageIdentifier: Cybrium.Cyprobe
+PackageVersion: 0.2.3
+PackageLocale: en-US
+Publisher: Cybrium Security Inc.
+PublisherUrl: https://cybrium.ai
+PublisherSupportUrl: https://github.com/cybrium-ai/cyprobe/issues
+PrivacyUrl: https://cybrium.ai/privacy
+Author: Cybrium Security Inc.
+PackageName: cyprobe
+PackageUrl: https://github.com/cybrium-ai/cyprobe
+License: MIT
+LicenseUrl: https://github.com/cybrium-ai/cyprobe/blob/main/LICENSE
+Copyright: Copyright (c) Cybrium Security Inc.
+ShortDescription: Cybrium OT / IoT discovery scanner
+Description: |-
+  OT / ICS / IoT discovery probe with passive Modbus, BACnet and DNP3 fingerprinting.
+Moniker: cyprobe
+Tags:
+- cli
+- security
+- cybrium
+- rust
+ReleaseNotesUrl: https://github.com/cybrium-ai/cyprobe/releases/tag/v0.2.3
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/c/Cybrium/Cyprobe/0.2.3/Cybrium.Cyprobe.yaml
+++ b/manifests/c/Cybrium/Cyprobe/0.2.3/Cybrium.Cyprobe.yaml
@@ -1,0 +1,6 @@
+# Created with: Cybrium initial submission
+PackageIdentifier: Cybrium.Cyprobe
+PackageVersion: 0.2.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0

--- a/manifests/c/Cybrium/Cysense/0.2.2/Cybrium.Cysense.installer.yaml
+++ b/manifests/c/Cybrium/Cysense/0.2.2/Cybrium.Cysense.installer.yaml
@@ -1,0 +1,13 @@
+# Created with: Cybrium initial submission
+PackageIdentifier: Cybrium.Cysense
+PackageVersion: 0.2.2
+InstallerLocale: en-US
+InstallerType: portable
+Commands:
+- cysense
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/cybrium-ai/cysense/releases/download/v0.2.2/cysense-windows-amd64.exe
+  InstallerSha256: D09A1BC7A13E264246E1EB1B3AD04711E62B216F6EBB69CFF630F486F30017D1
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/c/Cybrium/Cysense/0.2.2/Cybrium.Cysense.locale.en-US.yaml
+++ b/manifests/c/Cybrium/Cysense/0.2.2/Cybrium.Cysense.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# Created with: Cybrium initial submission
+PackageIdentifier: Cybrium.Cysense
+PackageVersion: 0.2.2
+PackageLocale: en-US
+Publisher: Cybrium Security Inc.
+PublisherUrl: https://cybrium.ai
+PublisherSupportUrl: https://github.com/cybrium-ai/cysense/issues
+PrivacyUrl: https://cybrium.ai/privacy
+Author: Cybrium Security Inc.
+PackageName: cysense
+PackageUrl: https://github.com/cybrium-ai/cysense
+License: MIT
+LicenseUrl: https://github.com/cybrium-ai/cysense/blob/main/LICENSE
+Copyright: Copyright (c) Cybrium Security Inc.
+ShortDescription: Cybrium network sensor
+Description: |-
+  Passive network sensor with packet capture, DNS / DHCP fingerprinting, and live discovery.
+Moniker: cysense
+Tags:
+- cli
+- security
+- cybrium
+- rust
+ReleaseNotesUrl: https://github.com/cybrium-ai/cysense/releases/tag/v0.2.2
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/c/Cybrium/Cysense/0.2.2/Cybrium.Cysense.yaml
+++ b/manifests/c/Cybrium/Cysense/0.2.2/Cybrium.Cysense.yaml
@@ -1,0 +1,6 @@
+# Created with: Cybrium initial submission
+PackageIdentifier: Cybrium.Cysense
+PackageVersion: 0.2.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0

--- a/manifests/c/Cybrium/Cywave/0.2.0/Cybrium.Cywave.installer.yaml
+++ b/manifests/c/Cybrium/Cywave/0.2.0/Cybrium.Cywave.installer.yaml
@@ -1,0 +1,13 @@
+# Created with: Cybrium initial submission
+PackageIdentifier: Cybrium.Cywave
+PackageVersion: 0.2.0
+InstallerLocale: en-US
+InstallerType: portable
+Commands:
+- cywave
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/cybrium-ai/cywave/releases/download/v0.2.0/cywave-windows-amd64.exe
+  InstallerSha256: 828B54C65DB30258CA3BEDC7D02E46E4E98A06CC7D78A6F1B52E9730B4319313
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/c/Cybrium/Cywave/0.2.0/Cybrium.Cywave.locale.en-US.yaml
+++ b/manifests/c/Cybrium/Cywave/0.2.0/Cybrium.Cywave.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# Created with: Cybrium initial submission
+PackageIdentifier: Cybrium.Cywave
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: Cybrium Security Inc.
+PublisherUrl: https://cybrium.ai
+PublisherSupportUrl: https://github.com/cybrium-ai/cywave/issues
+PrivacyUrl: https://cybrium.ai/privacy
+Author: Cybrium Security Inc.
+PackageName: cywave
+PackageUrl: https://github.com/cybrium-ai/cywave
+License: MIT
+LicenseUrl: https://github.com/cybrium-ai/cywave/blob/main/LICENSE
+Copyright: Copyright (c) Cybrium Security Inc.
+ShortDescription: Cybrium wireless / RF posture scanner
+Description: |-
+  Wi-Fi, Bluetooth and RF posture scanner with rogue-AP detection and signal mapping.
+Moniker: cywave
+Tags:
+- cli
+- security
+- cybrium
+- rust
+ReleaseNotesUrl: https://github.com/cybrium-ai/cywave/releases/tag/v0.2.0
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/c/Cybrium/Cywave/0.2.0/Cybrium.Cywave.yaml
+++ b/manifests/c/Cybrium/Cywave/0.2.0/Cybrium.Cywave.yaml
@@ -1,0 +1,6 @@
+# Created with: Cybrium initial submission
+PackageIdentifier: Cybrium.Cywave
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0

--- a/manifests/c/Cybrium/Cyweb/0.10.5/Cybrium.Cyweb.installer.yaml
+++ b/manifests/c/Cybrium/Cyweb/0.10.5/Cybrium.Cyweb.installer.yaml
@@ -1,0 +1,13 @@
+# Created with: Cybrium initial submission
+PackageIdentifier: Cybrium.Cyweb
+PackageVersion: 0.10.5
+InstallerLocale: en-US
+InstallerType: portable
+Commands:
+- cyweb
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/cybrium-ai/cyweb/releases/download/v0.10.5/cyweb-windows-amd64.exe
+  InstallerSha256: 403561885FC09CAEEE8145891EA66F82F197CEFF97B42D72C0DE2665C44BEE48
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/c/Cybrium/Cyweb/0.10.5/Cybrium.Cyweb.locale.en-US.yaml
+++ b/manifests/c/Cybrium/Cyweb/0.10.5/Cybrium.Cyweb.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# Created with: Cybrium initial submission
+PackageIdentifier: Cybrium.Cyweb
+PackageVersion: 0.10.5
+PackageLocale: en-US
+Publisher: Cybrium Security Inc.
+PublisherUrl: https://cybrium.ai
+PublisherSupportUrl: https://github.com/cybrium-ai/cyweb/issues
+PrivacyUrl: https://cybrium.ai/privacy
+Author: Cybrium Security Inc.
+PackageName: cyweb
+PackageUrl: https://github.com/cybrium-ai/cyweb
+License: MIT
+LicenseUrl: https://github.com/cybrium-ai/cyweb/blob/main/LICENSE
+Copyright: Copyright (c) Cybrium Security Inc.
+ShortDescription: Cybrium web vulnerability scanner
+Description: |-
+  Fast YAML-rule web vulnerability scanner with CVE detection, baseline diffing, and integrated reporting.
+Moniker: cyweb
+Tags:
+- cli
+- security
+- cybrium
+- rust
+ReleaseNotesUrl: https://github.com/cybrium-ai/cyweb/releases/tag/v0.10.5
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/c/Cybrium/Cyweb/0.10.5/Cybrium.Cyweb.yaml
+++ b/manifests/c/Cybrium/Cyweb/0.10.5/Cybrium.Cyweb.yaml
@@ -1,0 +1,6 @@
+# Created with: Cybrium initial submission
+PackageIdentifier: Cybrium.Cyweb
+PackageVersion: 0.10.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0


### PR DESCRIPTION
Adds Winget manifests for the **Cybrium command-line tool family** — seven security CLIs.

## Tools in this submission

| Package | Version | Description |
|---|---|---|
| `Cybrium.Cyweb`    | 0.10.5  | Web vulnerability scanner |
| `Cybrium.Cysense`  | 0.2.2   | Network sensor |
| `Cybrium.Cywave`   | 0.2.0   | Wireless / RF posture scanner |
| `Cybrium.Cyprobe`  | 0.2.3   | OT / IoT discovery probe |
| `Cybrium.Cymail`   | 0.1.7   | Email security scanner |
| `Cybrium.Cyguard`  | 0.1.5   | Host hardening posture |
| `Cybrium.Cydeep`   | 0.1.5   | Deep packet inspection |

## Signing

Every binary is **Authenticode-signed by Cybrium Inc** via Azure Trusted Signing. `Get-AuthenticodeSignature` reports `Status = Valid`, `SignerCertificate.Subject = CN=Cybrium Inc, …`.

## Checklist

- [x] I have read the contributing guide.
- [x] I have signed the CLA agreement (Cybrium Security Inc.).
- [x] All manifest fields populated; SHA-256 values fetched from live release assets.
- [x] Installer URLs verified reachable on GitHub Releases.
- [x] InstallerType `portable` (single signed `.exe`, no MSI).
- [x] `Commands` field set so users can run `<tool>` after install.
- [x] Manifest version `1.5.0`.
- [x] No test installer; binaries are real production releases.

## Verification

```powershell
winget install Cybrium.Cyweb
winget install Cybrium.Cysense
# etc.
```

## License

All tools are MIT-licensed. See each repo's LICENSE file:
- https://github.com/cybrium-ai/cyweb/blob/main/LICENSE
- … (others linked in each `PackageUrl`)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/381380)