### PR TITLE
New package: tg123.oci-to-wsl version 0.0.1

### DIFF
--- a/manifests/t/tg123/oci-to-wsl/0.0.1/tg123.oci-to-wsl.installer.yaml
+++ b/manifests/t/tg123/oci-to-wsl/0.0.1/tg123.oci-to-wsl.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: tg123.oci-to-wsl
+PackageVersion: 0.0.1
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: oci-to-wsl.exe
+    PortableCommandAlias: oci-to-wsl
+Commands:
+  - oci-to-wsl
+ReleaseDate: 2026-05-20
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/tg123/oci-to-wsl/releases/download/v0.0.1/oci-to-wsl_windows_x86_64.zip
+    InstallerSha256: 79772846F1CE4A38E5B2841EA2406A070F4DB64F3DBF3EA32F04B519111FD003
+  - Architecture: arm64
+    InstallerUrl: https://github.com/tg123/oci-to-wsl/releases/download/v0.0.1/oci-to-wsl_windows_arm64.zip
+    InstallerSha256: 362129BBACB20CC60D4F354333FE4AF545EA764CD30BD16D57FB28ADEA5DF5D1
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/t/tg123/oci-to-wsl/0.0.1/tg123.oci-to-wsl.locale.en-US.yaml
+++ b/manifests/t/tg123/oci-to-wsl/0.0.1/tg123.oci-to-wsl.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: tg123.oci-to-wsl
+PackageVersion: 0.0.1
+PackageLocale: en-US
+Publisher: tg123
+PublisherUrl: https://github.com/tg123
+PublisherSupportUrl: https://github.com/tg123/oci-to-wsl/issues
+PackageName: oci-to-wsl
+PackageUrl: https://github.com/tg123/oci-to-wsl
+License: MIT
+LicenseUrl: https://github.com/tg123/oci-to-wsl/blob/main/LICENSE
+Copyright: Copyright (c) tg123
+ShortDescription: Load an OCI container image into a WSL distribution
+Description: |-
+  oci-to-wsl pulls an OCI image from any container registry (or the local
+  Docker daemon) and imports it as a Windows Subsystem for Linux distribution
+  in a single command. It is a single, self-contained Windows binary with no
+  runtime dependencies.
+Moniker: oci-to-wsl
+Tags:
+  - wsl
+  - oci
+  - container
+  - docker
+  - registry
+ReleaseNotesUrl: https://github.com/tg123/oci-to-wsl/releases/tag/v0.0.1
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/t/tg123/oci-to-wsl/0.0.1/tg123.oci-to-wsl.yaml
+++ b/manifests/t/tg123/oci-to-wsl/0.0.1/tg123.oci-to-wsl.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: tg123.oci-to-wsl
+PackageVersion: 0.0.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
### Pull request type
- [x] New package: One brand new package

### Description
Adds [tg123.oci-to-wsl](https://github.com/tg123/oci-to-wsl) v0.0.1.

oci-to-wsl pulls an OCI image from any container registry (or the local Docker daemon) and imports it as a WSL distribution in one command.

Manifests were validated locally with `winget validate`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/381577)