### PR TITLE
New version: Rorkai.ASC version 1.7.0

### DIFF
--- a/manifests/r/Rorkai/ASC/1.7.0/Rorkai.ASC.installer.yaml
+++ b/manifests/r/Rorkai/ASC/1.7.0/Rorkai.ASC.installer.yaml
@@ -1,0 +1,12 @@
+# Created with App-Store-Connect-CLI/scripts/generate_winget_manifests.py
+PackageIdentifier: Rorkai.ASC
+PackageVersion: 1.7.0
+InstallerType: portable
+Commands:
+  - asc
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/rorkai/App-Store-Connect-CLI/releases/download/1.7.0/asc_1.7.0_windows_amd64.exe
+    InstallerSha256: 7902F9EFF700F1A0FDEA352DCC965F76F3A257FC3F9F0E684A75B8A60BC11D4E
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/r/Rorkai/ASC/1.7.0/Rorkai.ASC.locale.en-US.yaml
+++ b/manifests/r/Rorkai/ASC/1.7.0/Rorkai.ASC.locale.en-US.yaml
@@ -1,0 +1,20 @@
+# Created with App-Store-Connect-CLI/scripts/generate_winget_manifests.py
+PackageIdentifier: Rorkai.ASC
+PackageVersion: 1.7.0
+PackageLocale: en-US
+Publisher: Rorkai
+PackageName: asc
+PackageUrl: https://github.com/rorkai/App-Store-Connect-CLI
+License: MIT
+LicenseUrl: https://github.com/rorkai/App-Store-Connect-CLI/blob/main/LICENSE
+ShortDescription: Fast, scriptable CLI for the App Store Connect API.
+Moniker: asc
+Tags:
+  - app-store-connect
+  - app-store-connect-api
+  - cli
+  - ios
+  - testflight
+ReleaseNotesUrl: https://github.com/rorkai/App-Store-Connect-CLI/releases/tag/1.7.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/r/Rorkai/ASC/1.7.0/Rorkai.ASC.yaml
+++ b/manifests/r/Rorkai/ASC/1.7.0/Rorkai.ASC.yaml
@@ -1,0 +1,6 @@
+# Created with App-Store-Connect-CLI/scripts/generate_winget_manifests.py
+PackageIdentifier: Rorkai.ASC
+PackageVersion: 1.7.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## New package version

- PackageIdentifier: Rorkai.ASC
- PackageVersion: 1.7.0
- InstallerType: portable
- InstallerUrl: https://github.com/rorkai/App-Store-Connect-CLI/releases/download/1.7.0/asc_1.7.0_windows_amd64.exe
- InstallerSha256: 7902F9EFF700F1A0FDEA352DCC965F76F3A257FC3F9F0E684A75B8A60BC11D4E
- Release: https://github.com/rorkai/App-Store-Connect-CLI/releases/tag/1.7.0

## Validation

- Verified the Windows release asset SHA256 against the GitHub release digest, `asc_1.7.0_checksums.txt`, and a fresh local download.
- Verified the downloaded asset is a Windows x64 console executable.
- Microsoft validation has passed URL validation, manifest policy validation, catalog validation, duplicate hash verification, and static installer scan for this asset.
- Force-pushed the branch to a single clean commit from current `microsoft/winget-pkgs` `master` to retrigger dynamic installation validation.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/381592)
