### PR TITLE
New version: tsuchim.PriorityGear version 0.3.6

### DIFF
--- a/manifests/t/tsuchim/PriorityGear/0.3.6/tsuchim.PriorityGear.installer.yaml
+++ b/manifests/t/tsuchim/PriorityGear/0.3.6/tsuchim.PriorityGear.installer.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: tsuchim.PriorityGear
+PackageVersion: 0.3.6
+InstallerType: zip
+NestedInstallerType: exe
+NestedInstallerFiles:
+  - RelativeFilePath: PriorityGear.Setup.exe
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: --install --silent
+  SilentWithProgress: --install --silent
+UpgradeBehavior: install
+AppsAndFeaturesEntries:
+  - DisplayName: PriorityGear
+    DisplayVersion: 0.3.6
+    Publisher: Yuji Tsuchimoto
+    ProductCode: PriorityGear_v0.3.6
+    InstallerType: exe
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/tsuchim/priority-gear/releases/download/v0.3.6/PriorityGear-v0.3.6-win-x64-installer.zip
+    InstallerSha256: A981285C97B6EC30C493091526719841CE8C2344E743E3F77711D4854EA29D87
+    ProductCode: PriorityGear_v0.3.6
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/t/tsuchim/PriorityGear/0.3.6/tsuchim.PriorityGear.locale.en-US.yaml
+++ b/manifests/t/tsuchim/PriorityGear/0.3.6/tsuchim.PriorityGear.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: tsuchim.PriorityGear
+PackageVersion: 0.3.6
+PackageLocale: en-US
+Publisher: Yuji Tsuchimoto
+PublisherUrl: https://github.com/tsuchim
+PackageName: PriorityGear
+PackageUrl: https://github.com/tsuchim/priority-gear
+License: MIT
+LicenseUrl: https://github.com/tsuchim/priority-gear/blob/main/LICENSE
+ShortDescription: Process priority manager for Windows.
+Description: AutoGear-like process priority manager for Windows with User Mode rules and a System Mode LocalSystem service for approved machine rules.
+Moniker: prioritygear
+Tags:
+  - process
+  - priority
+  - windows
+  - system-service
+  - utility
+ReleaseNotesUrl: https://github.com/tsuchim/priority-gear/releases/tag/v0.3.6
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/t/tsuchim/PriorityGear/0.3.6/tsuchim.PriorityGear.yaml
+++ b/manifests/t/tsuchim/PriorityGear/0.3.6/tsuchim.PriorityGear.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: tsuchim.PriorityGear
+PackageVersion: 0.3.6
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Summary

Updates `tsuchim.PriorityGear` to version `0.3.6`.

## Release

- GitHub Release: https://github.com/tsuchim/priority-gear/releases/tag/v0.3.6
- Asset: `PriorityGear-v0.3.6-win-x64-installer.zip`
- Installer URL: https://github.com/tsuchim/priority-gear/releases/download/v0.3.6/PriorityGear-v0.3.6-win-x64-installer.zip
- SHA-256: `A981285C97B6EC30C493091526719841CE8C2344E743E3F77711D4854EA29D87`

## Validation

- `winget validate manifests\t\tsuchim\PriorityGear\0.3.6`: passed
- Install/uninstall validation was not performed on the live workstation because this package installs/updates a machine-scope service (`PriorityGear.Service`).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/381611)