### PR TITLE
New package: CcisneDev.Calculatrix version 0.7.1

### DIFF
--- a/manifests/c/CcisneDev/Calculatrix/0.7.1/CcisneDev.Calculatrix.installer.yaml
+++ b/manifests/c/CcisneDev/Calculatrix/0.7.1/CcisneDev.Calculatrix.installer.yaml
@@ -7,6 +7,9 @@ MinimumOSVersion: 10.0.0.0
 InstallerType: inno
 UpgradeBehavior: install
 ReleaseDate: 2026-05-30
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.VCRedist.2015+.x64
 Installers:
 - Architecture: x64
   Scope: machine

--- a/manifests/c/CcisneDev/Calculatrix/0.7.1/CcisneDev.Calculatrix.installer.yaml
+++ b/manifests/c/CcisneDev/Calculatrix/0.7.1/CcisneDev.Calculatrix.installer.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: CcisneDev.Calculatrix
+PackageVersion: 0.7.1
+InstallerLocale: en-US
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+UpgradeBehavior: install
+ReleaseDate: 2026-05-30
+Installers:
+- Architecture: x64
+  Scope: machine
+  InstallerUrl: https://github.com/ccisnedev/calculatrix/releases/download/v0.7.1/Calculatrix-windows-x64-0.7.1-setup.exe
+  InstallerSha256: 102BFCA7BA35D664AB689A0B69787342F6EEAA3AD51D8A230C9FDBC3C87CF610
+  InstallerSwitches:
+    Silent: /VERYSILENT /SP- /NORESTART
+    SilentWithProgress: /SILENT /SP- /NORESTART
+    Custom: /ALLUSERS
+  ProductCode: CcisneDev.Calculatrix_is1
+  AppsAndFeaturesEntries:
+  - DisplayName: Calculatrix version 0.7.1
+    DisplayVersion: 0.7.1
+    Publisher: ccisne.dev
+    ProductCode: CcisneDev.Calculatrix_is1
+- Architecture: x64
+  Scope: user
+  InstallerUrl: https://github.com/ccisnedev/calculatrix/releases/download/v0.7.1/Calculatrix-windows-x64-0.7.1-setup.exe
+  InstallerSha256: 102BFCA7BA35D664AB689A0B69787342F6EEAA3AD51D8A230C9FDBC3C87CF610
+  InstallerSwitches:
+    Silent: /VERYSILENT /SP- /NORESTART
+    SilentWithProgress: /SILENT /SP- /NORESTART
+    Custom: /CURRENTUSER
+  ProductCode: CcisneDev.Calculatrix_is1
+  AppsAndFeaturesEntries:
+  - DisplayName: Calculatrix version 0.7.1
+    DisplayVersion: 0.7.1
+    Publisher: ccisne.dev
+    ProductCode: CcisneDev.Calculatrix_is1
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/CcisneDev/Calculatrix/0.7.1/CcisneDev.Calculatrix.locale.en-US.yaml
+++ b/manifests/c/CcisneDev/Calculatrix/0.7.1/CcisneDev.Calculatrix.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: CcisneDev.Calculatrix
+PackageVersion: 0.7.1
+PackageLocale: en-US
+Publisher: ccisne.dev
+PublisherUrl: https://ccisne.dev/
+PublisherSupportUrl: https://github.com/ccisnedev/calculatrix/issues
+PrivacyUrl: https://ccisne.dev/legal/calculatrix/privacy/
+Author: Cristian Cisneros
+PackageName: Calculatrix
+PackageUrl: https://github.com/ccisnedev/calculatrix
+License: MIT
+LicenseUrl: https://github.com/ccisnedev/calculatrix/blob/main/LICENSE
+ShortDescription: RPN matrix calculator for Windows.
+Description: Calculatrix is a matrix-first RPN calculator for Windows built with Flutter.
+Moniker: calculatrix
+Tags:
+- calculator
+- flutter
+- mathematics
+- matrix
+- rpn
+ReleaseNotesUrl: https://github.com/ccisnedev/calculatrix/releases/tag/v0.7.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/CcisneDev/Calculatrix/0.7.1/CcisneDev.Calculatrix.yaml
+++ b/manifests/c/CcisneDev/Calculatrix/0.7.1/CcisneDev.Calculatrix.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: CcisneDev.Calculatrix
+PackageVersion: 0.7.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description
Adds the initial manifest for CcisneDev.Calculatrix version 0.7.1.

Local validation performed:
- winget validate --manifest manifests/c/CcisneDev/Calculatrix/0.7.1
- SandboxTest.ps1 from microsoft/winget-pkgs completed with exit code 0 against this manifest
- The published v0.7.1 installer was also validated separately for current-user and all-users silent install/uninstall behavior

Note: Direct host execution of winget install --manifest is blocked on this machine because the LocalManifestFiles client feature can only be enabled by an administrator. The official SandboxTest flow above was used instead.

## Checklist
- [ ] Signed the Contributor License Agreement
- [ ] Linked to an issue (if applicable)

## Manifest Checklist
- [x] Checked that there aren't other open pull requests for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with winget validate --manifest manifests/c/CcisneDev/Calculatrix/0.7.1
- [x] Tested manifest locally with winget install --manifest manifests/c/CcisneDev/Calculatrix/0.7.1 via Tools/SandboxTest.ps1
- [x] Manifest conforms to the 1.12 schema

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/381654)