### PR TITLE
Update OONI.OONI-Probe to 3.10.1

### DIFF
--- a/manifests/o/OONI/OONI-Probe/3.10.1/OONI.OONI-Probe.installer.yaml
+++ b/manifests/o/OONI/OONI-Probe/3.10.1/OONI.OONI-Probe.installer.yaml
@@ -1,0 +1,18 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: OONI.OONI-Probe
+PackageVersion: 3.10.1
+InstallerLocale: en-US
+InstallerType: nullsoft
+ProductCode: 0c6806a3-69ec-5f88-a85e-dcb363cd5bae
+AppsAndFeaturesEntries:
+- DisplayName: OONI Probe 3.10.1
+  ProductCode: 0c6806a3-69ec-5f88-a85e-dcb363cd5bae
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/ooni/probe-desktop/releases/download/v3.10.1/OONI-Probe-Setup-3.10.1.exe
+  InstallerSha256: 2D5EBA88935D266BAE60B15FE1F548E52AFD96107458F067CABCF2F48E16C189
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-04-23

--- a/manifests/o/OONI/OONI-Probe/3.10.1/OONI.OONI-Probe.locale.en-US.yaml
+++ b/manifests/o/OONI/OONI-Probe/3.10.1/OONI.OONI-Probe.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: OONI.OONI-Probe
+PackageVersion: 3.10.1
+PackageLocale: en-US
+Publisher: Open Observatory of Network Interference
+PublisherUrl: https://github.com/ooni
+PublisherSupportUrl: https://github.com/ooni/probe-desktop/issues
+PackageName: OONI Probe
+PackageUrl: https://github.com/ooni/probe-desktop
+License: BSD-3-Clause
+LicenseUrl: https://github.com/ooni/probe-desktop/blob/HEAD/LICENSE.md
+Copyright: Copyright © 2024 Open Observatory of Network Interference
+ShortDescription: OONI Probe is a free and open source software designed to measure internet censorship and other forms of network interference.
+Tags:
+- desktop-app
+- electron
+- hacktoberfest
+- macos
+- nextjs
+- ooni
+- ooniprobe
+- reactjs
+- windows
+ReleaseNotes: |-
+  What's Changed
+  - chore: bump probeVersion from `3.26.0` to `3.29.0` by @aanorbel in #353
+  - Implement update prompt in main area by @majakomel in #355
+  - feat: add update prompt by @aanorbel in #354
+
+  Full Changelog: v3.10.0...v3.10.1
+ReleaseNotesUrl: https://github.com/ooni/probe-desktop/releases/tag/v3.10.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/o/OONI/OONI-Probe/3.10.1/OONI.OONI-Probe.yaml
+++ b/manifests/o/OONI/OONI-Probe/3.10.1/OONI.OONI-Probe.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: OONI.OONI-Probe
+PackageVersion: 3.10.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Updates OONI.OONI-Probe from 3.10.0 to 3.10.1.

Release: https://github.com/ooni/probe-desktop/releases/tag/v3.10.1
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/381655)