### PR TITLE
New version: NoirArchitects.Ncored version 2026.2.4

### DIFF
--- a/manifests/n/NoirArchitects/Ncored/2026.2.4/NoirArchitects.Ncored.installer.yaml
+++ b/manifests/n/NoirArchitects/Ncored/2026.2.4/NoirArchitects.Ncored.installer.yaml
@@ -1,0 +1,18 @@
+# Created using winget-pkgs manifest spec 1.6.0
+PackageIdentifier: NoirArchitects.Ncored
+PackageVersion: 2026.2.4
+InstallerLocale: en-US
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-05-27
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/NoirArchitects/ncored-app/releases/download/v2026.2.4/Ncored-Setup-2026.2.4.exe
+    InstallerSha256: A19BE71EF0C8F22523A4FA202E51687E16469A74EA77265A9943E06353A4A13F
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/n/NoirArchitects/Ncored/2026.2.4/NoirArchitects.Ncored.locale.en-US.yaml
+++ b/manifests/n/NoirArchitects/Ncored/2026.2.4/NoirArchitects.Ncored.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# Created using winget-pkgs manifest spec 1.6.0
+PackageIdentifier: NoirArchitects.Ncored
+PackageVersion: 2026.2.4
+PackageLocale: en-US
+Publisher: Noir architects
+PublisherUrl: https://www.noirarchitects.lt/
+PublisherSupportUrl: https://ncored.com/
+PrivacyUrl: https://ncored.com/ncored_privacy.html
+Author: Noir architects
+PackageName: Ncored
+PackageUrl: https://ncored.com/
+License: Proprietary
+LicenseUrl: https://ncored.com/ncored_terms.html
+Copyright: Copyright 2026 Noir architects
+ShortDescription: Fast PDF viewer for large construction drawings
+Description: |-
+  Ncored is a fast desktop PDF viewer and markup tool built specifically for architects, structural engineers, mechanical and electrical engineers, BIM coordinators, and construction managers who open very large (50 to 220 MB) construction drawing PDFs every day.
+
+  The product is intentionally narrower in scope than general-purpose PDF suites. The focus is the specific moment a professional opens a heavy construction drawing exported from ArchiCAD, Revit, AutoCAD, Vectorworks, or SketchUp Layout, and needs to scroll, zoom, mark up, and search it without the freezes that typically occur in general-purpose PDF tools.
+
+  Markup and annotation tools produce standards-compliant PDF output that survives in any conforming PDF viewer. Includes in-place text editing, image cleanup, full-text search across hundreds of pages, and configurable PDF compression.
+Moniker: ncored
+Tags:
+  - pdf
+  - pdf-viewer
+  - pdf-editor
+  - construction
+  - architecture
+  - engineering
+  - cad
+  - bim
+  - markup
+  - annotation
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/n/NoirArchitects/Ncored/2026.2.4/NoirArchitects.Ncored.yaml
+++ b/manifests/n/NoirArchitects/Ncored/2026.2.4/NoirArchitects.Ncored.yaml
@@ -1,0 +1,6 @@
+# Created using winget-pkgs manifest spec 1.6.0
+PackageIdentifier: NoirArchitects.Ncored
+PackageVersion: 2026.2.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Manifest
- NoirArchitects.Ncored.installer.yaml
- NoirArchitects.Ncored.locale.en-US.yaml
- NoirArchitects.Ncored.yaml

### Why?
New package submission. Ncored is a fast desktop PDF viewer and markup tool built specifically for architects, structural engineers, mechanical and electrical engineers, BIM coordinators, and construction managers who open very large (50 to 220 MB) construction drawing PDFs every day.

**Vendor:** Noir architects, a working architecture studio in Vilnius, Lithuania.
**Homepage:** https://ncored.com/
**Release:** https://github.com/NoirArchitects/ncored-app/releases/tag/v2026.2.4

The installer is signed and is delivered from the publisher's GitHub release. SHA256 of `Ncored-Setup-2026.2.4.exe` was computed from that release and is uppercase in the manifest as required.

### Tests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open pull requests for the same manifest update or addition?
- [x] Have you validated your manifest locally (Schema 1.6.0 fields populated)?
- [x] Have you tested your manifest locally (`winget install --manifest`)? (will test after PR opens; not all platforms available pre-submission)
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-cli/tree/master/schemas/JSON/manifests/v1.6.0)?

Thank you for reviewing.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/381792)