### PR TITLE
PresenceJam: Add version 2.5.0

### DIFF
--- a/manifests/p/PresenceJam/PresenceJam/2.5.0/PresenceJam.PresenceJam.installer.yaml
+++ b/manifests/p/PresenceJam/PresenceJam/2.5.0/PresenceJam.PresenceJam.installer.yaml
@@ -1,0 +1,18 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: PresenceJam.PresenceJam
+PackageVersion: 2.5.0
+InstallerType: wix
+UpgradeBehavior: install
+ProductCode: '{BE023815-047D-4E93-A003-FBBC4973E7FA}'
+AppsAndFeaturesEntries:
+- ProductCode: '{BE023815-047D-4E93-A003-FBBC4973E7FA}'
+  UpgradeCode: '{72C2B806-ED84-559F-8C03-E31D5D972139}'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Carme99/PresenceJam-Desktop/releases/download/v2.5.0/PresenceJam_2.5.0_x64_en-US.msi
+  InstallerSha256: 0A6132934A8479AD69FF2F2FDD2D082CF01809A296BCE52B64B4C0B91F5F54AF
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-05-30

--- a/manifests/p/PresenceJam/PresenceJam/2.5.0/PresenceJam.PresenceJam.locale.en-US.yaml
+++ b/manifests/p/PresenceJam/PresenceJam/2.5.0/PresenceJam.PresenceJam.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: PresenceJam.PresenceJam
+PackageVersion: 2.5.0
+PackageLocale: en-US
+Publisher: PresenceJam
+PublisherUrl: https://github.com/Carme99/PresenceJam-Desktop
+PublisherSupportUrl: https://github.com/Carme99/PresenceJam-Desktop/issues
+Author: PresenceJam
+PackageName: PresenceJam
+PackageUrl: https://github.com/Carme99/PresenceJam-Desktop
+License: MIT
+LicenseUrl: https://github.com/Carme99/PresenceJam-Desktop/blob/main/LICENSE
+Copyright: Copyright (c) 2026 PresenceJam
+ShortDescription: Spotify to Teams Status Sync
+Description: Automatically syncs your currently playing Spotify track to your Microsoft Teams status message. Set a custom status message using placeholders like {artist}, {track}, {album}, and {emoji}.
+Moniker: presencejam
+Tags:
+- spotify
+- teams
+- microsoft
+- status
+- presence
+- productivity
+ReleaseNotesUrl: https://github.com/Carme99/PresenceJam-Desktop/releases/tag/v2.5.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/p/PresenceJam/PresenceJam/2.5.0/PresenceJam.PresenceJam.yaml
+++ b/manifests/p/PresenceJam/PresenceJam/2.5.0/PresenceJam.PresenceJam.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: PresenceJam.PresenceJam
+PackageVersion: 2.5.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Add winget manifest for PresenceJam v2.5.0. Package: PresenceJam.PresenceJam, Installer: MSI, SHA256 verified, License: MIT.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/366774)

Changes:
- Add v2.5.0 installer manifest under manifests/p/PresenceJam/PresenceJam/2.5.0/
- SHA256: 0A6132934A8479AD69FF2F2FDD2D082CF01809A296BCE52B64B4C0B91F5F54AF
- URL: https://github.com/Carme99/PresenceJam-Desktop/releases/download/v2.5.0/PresenceJam_2.5.0_x64_en-US.msi
- Release notes: https://github.com/Carme99/PresenceJam-Desktop/releases/tag/v2.5.0

Based on existing v2.4.1 merged manifest (#366774). No schema changes.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/381887)