### PR TITLE
Wharflab.Tally version 0.44.0

### DIFF
--- a/manifests/w/Wharflab/Tally/0.44.0/Wharflab.Tally.installer.yaml
+++ b/manifests/w/Wharflab/Tally/0.44.0/Wharflab.Tally.installer.yaml
@@ -1,0 +1,24 @@
+# Created by tally release automation
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: Wharflab.Tally
+PackageVersion: 0.44.0
+Commands: &1
+- tally
+FileExtensions:
+- dockerfile
+- containerfile
+ReleaseDate: '2026-05-31'
+Installers:
+- Architecture: x64
+  InstallerType: portable
+  InstallerUrl: https://github.com/wharflab/tally/releases/download/v0.44.0/tally_0.44.0_Windows_x86_64.exe
+  InstallerSha256: A8928A3B9D3BC21A33182D13892BE820E52D973E05B9C02E9A0A1437AA54F47D
+  Commands: *1
+- Architecture: arm64
+  InstallerType: portable
+  InstallerUrl: https://github.com/wharflab/tally/releases/download/v0.44.0/tally_0.44.0_Windows_arm64.exe
+  InstallerSha256: 4071201E48859A7F9A5C47F72583DB2DFA8EFE3AD38D0E8CD8B3347A7E23C483
+  Commands: *1
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/w/Wharflab/Tally/0.44.0/Wharflab.Tally.locale.en-US.yaml
+++ b/manifests/w/Wharflab/Tally/0.44.0/Wharflab.Tally.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# Created by tally release automation
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: Wharflab.Tally
+PackageVersion: 0.44.0
+PackageLocale: en-US
+Publisher: Wharflab
+PublisherUrl: https://github.com/wharflab
+PublisherSupportUrl: https://github.com/wharflab/tally/issues
+PackageName: Tally
+PackageUrl: https://github.com/wharflab/tally
+ShortDescription: Dockerfile linter and formatter with first-class PowerShell and
+  Windows container support.
+Moniker: tally
+License: AGPL-3.0-only
+LicenseUrl: https://github.com/wharflab/tally/blob/main/LICENSE
+ReleaseNotesUrl: https://github.com/wharflab/tally/releases/tag/v0.44.0
+Documentations:
+- DocumentLabel: Docs
+  DocumentUrl: https://tally.wharflab.com/
+Tags:
+- docker
+- dockerfile
+- containerfile
+- linter
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/w/Wharflab/Tally/0.44.0/Wharflab.Tally.yaml
+++ b/manifests/w/Wharflab/Tally/0.44.0/Wharflab.Tally.yaml
@@ -1,0 +1,8 @@
+# Created by tally release automation
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: Wharflab.Tally
+PackageVersion: 0.44.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Publishing version v0.44.0 of [tally](https://github.com/wharflab/tally) to WinGet.

Tally is a Dockerfile linter and formatter written in Go, promoting modern container syntax and helping avoid common pitfalls.

[Changelog](https://github.com/wharflab/tally/releases/tag/v0.44.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/381940)