### PR TITLE
New version: AIWander.AI-Hands version 1.0.1

### DIFF
--- a/manifests/a/AIWander/AI-Hands/1.0.1/AIWander.AI-Hands.installer.yaml
+++ b/manifests/a/AIWander/AI-Hands/1.0.1/AIWander.AI-Hands.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 PackageIdentifier: AIWander.AI-Hands
 PackageVersion: 1.0.1
 InstallerType: portable
@@ -19,4 +19,4 @@ Installers:
     Commands:
       - hands
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/a/AIWander/AI-Hands/1.0.1/AIWander.AI-Hands.installer.yaml
+++ b/manifests/a/AIWander/AI-Hands/1.0.1/AIWander.AI-Hands.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: AIWander.AI-Hands
+PackageVersion: 1.0.1
+InstallerType: portable
+Commands:
+  - hands
+ReleaseDate: 2026-05-15
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/AIWander/AI-Hands/releases/download/v1.0.1/hands-v1.0.1-x64.exe
+    InstallerSha256: 88408a9845cc88c0348b37328c6bb166515509f385adf8fa1459fc9fe103cc29
+    InstallerType: portable
+    Commands:
+      - hands
+  - Architecture: arm64
+    InstallerUrl: https://github.com/AIWander/AI-Hands/releases/download/v1.0.1/hands-v1.0.1-aarch64.exe
+    InstallerSha256: b1a3d1fc7a955b3268305a6f17ee7c0ec225f6a0f8a6980a4b4ad1577a59b23c
+    InstallerType: portable
+    Commands:
+      - hands
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/a/AIWander/AI-Hands/1.0.1/AIWander.AI-Hands.locale.en-US.yaml
+++ b/manifests/a/AIWander/AI-Hands/1.0.1/AIWander.AI-Hands.locale.en-US.yaml
@@ -1,0 +1,50 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: AIWander.AI-Hands
+PackageVersion: 1.0.1
+PackageLocale: en-US
+Publisher: AIWander
+PublisherUrl: https://github.com/AIWander
+PublisherSupportUrl: https://github.com/AIWander/AI-Hands/issues
+PackageName: AI-Hands
+PackageUrl: https://github.com/AIWander/AI-Hands
+License: MIT
+LicenseUrl: https://github.com/AIWander/AI-Hands/blob/main/LICENSE
+ShortDescription: Single-binary MCP server for browser + Windows UI + vision/OCR automation
+Description: |
+  AI-Hands is a single Rust binary MCP (Model Context Protocol) server that exposes
+  three primitive subsystems plus a meta-orchestration layer for agentic browser and
+  desktop automation:
+
+  - Browser via chromiumoxide CDP (attach to existing Chrome, accessibility-first)
+  - Windows UI Automation via native UIA
+  - Vision (screenshot + OCR via Tesseract; PaddleOCR planned)
+  - Meta-tools: hands_click, hands_navigate, hands_find, hands_verify,
+    hands_self_record (Item 8+), hands_verify_expectations (Item 13),
+    hands_summarize_run (Item 14), vision_cache (Item 9)
+
+  Lean by design: 184 MB per session vs Playwright MCP's 320 MB. BYOM
+  (bring-your-own-model) — works with Claude, Codex, Gemini, GPT, or any
+  MCP-compatible client.
+
+  Post-install, run installers/scripts/register-hands.ps1 to wire AI-Hands
+  into Claude Desktop's MCP config (with backup-first).
+
+Moniker: ai-hands
+Tags:
+  - mcp
+  - automation
+  - browser-automation
+  - rust
+  - claude
+  - ai
+  - ocr
+  - accessibility
+  - uia
+ReleaseNotesUrl: https://github.com/AIWander/AI-Hands/releases/tag/v1.0.1
+Documentation:
+  - DocumentLabel: README
+    DocumentUrl: https://github.com/AIWander/AI-Hands#readme
+  - DocumentLabel: CHANGELOG
+    DocumentUrl: https://github.com/AIWander/AI-Hands/blob/main/CHANGELOG.md
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/a/AIWander/AI-Hands/1.0.1/AIWander.AI-Hands.locale.en-US.yaml
+++ b/manifests/a/AIWander/AI-Hands/1.0.1/AIWander.AI-Hands.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 PackageIdentifier: AIWander.AI-Hands
 PackageVersion: 1.0.1
 PackageLocale: en-US
@@ -47,4 +47,4 @@ Documentation:
   - DocumentLabel: CHANGELOG
     DocumentUrl: https://github.com/AIWander/AI-Hands/blob/main/CHANGELOG.md
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/a/AIWander/AI-Hands/1.0.1/AIWander.AI-Hands.locale.en-US.yaml
+++ b/manifests/a/AIWander/AI-Hands/1.0.1/AIWander.AI-Hands.locale.en-US.yaml
@@ -7,7 +7,7 @@ PublisherUrl: https://github.com/AIWander
 PublisherSupportUrl: https://github.com/AIWander/AI-Hands/issues
 PackageName: AI-Hands
 PackageUrl: https://github.com/AIWander/AI-Hands
-License: MIT
+License: Apache-2.0
 LicenseUrl: https://github.com/AIWander/AI-Hands/blob/main/LICENSE
 ShortDescription: Single-binary MCP server for browser + Windows UI + vision/OCR automation
 Description: |

--- a/manifests/a/AIWander/AI-Hands/1.0.1/AIWander.AI-Hands.yaml
+++ b/manifests/a/AIWander/AI-Hands/1.0.1/AIWander.AI-Hands.yaml
@@ -1,6 +1,6 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 PackageIdentifier: AIWander.AI-Hands
 PackageVersion: 1.0.1
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/a/AIWander/AI-Hands/1.0.1/AIWander.AI-Hands.yaml
+++ b/manifests/a/AIWander/AI-Hands/1.0.1/AIWander.AI-Hands.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: AIWander.AI-Hands
+PackageVersion: 1.0.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New version: AIWander.AI-Hands version 1.0.1

Single-binary MCP (Model Context Protocol) server for browser automation + Windows UI Automation + vision/OCR. Portable installer, x64 + arm64.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] This PR only modifies one (1) manifest

Manifests: `manifests/a/AIWander/AI-Hands/1.0.1/` (version + installer + locale, schema 1.6.0). InstallerType `portable`, Commands alias `hands`. SHA256 + URLs pinned to the public v1.0.1 GitHub release.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/381950)