### PR TITLE
Add version 1.3.1 for DanSherwin.DevLogBus

### DIFF
--- a/manifests/d/DanSherwin/DevLogBus/1.3.1/DanSherwin.DevLogBus.installer.yaml
+++ b/manifests/d/DanSherwin/DevLogBus/1.3.1/DanSherwin.DevLogBus.installer.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: DanSherwin.DevLogBus
+PackageVersion: 1.3.1
+InstallerType: zip
+ReleaseDate: 2026-05-31
+Installers:
+- Architecture: x64
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: devlogbus_v1.3.1_windows_amd64\devlogbus.exe
+    PortableCommandAlias: devlogbus
+  - RelativeFilePath: devlogbus_v1.3.1_windows_amd64\devlogbusd.exe
+    PortableCommandAlias: devlogbusd
+  - RelativeFilePath: devlogbus_v1.3.1_windows_amd64\devlogbus-journal-bridge.exe
+    PortableCommandAlias: devlogbus-journal-bridge
+  InstallerUrl: https://github.com/dan-sherwin/DevLogBus/releases/download/v1.3.1/devlogbus_v1.3.1_windows_amd64.zip
+  InstallerSha256: 2083823D0D706A4B9FB23682A1B5AEF858781B3AEB9A74F95923C9099A69B545
+- Architecture: arm64
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: devlogbus_v1.3.1_windows_arm64\devlogbus.exe
+    PortableCommandAlias: devlogbus
+  - RelativeFilePath: devlogbus_v1.3.1_windows_arm64\devlogbusd.exe
+    PortableCommandAlias: devlogbusd
+  - RelativeFilePath: devlogbus_v1.3.1_windows_arm64\devlogbus-journal-bridge.exe
+    PortableCommandAlias: devlogbus-journal-bridge
+  InstallerUrl: https://github.com/dan-sherwin/DevLogBus/releases/download/v1.3.1/devlogbus_v1.3.1_windows_arm64.zip
+  InstallerSha256: BB4DD613BB57195330ED6CAD05D21BFE5B637C105CCCBA164D782B52A832F2DB
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/d/DanSherwin/DevLogBus/1.3.1/DanSherwin.DevLogBus.locale.en-US.yaml
+++ b/manifests/d/DanSherwin/DevLogBus/1.3.1/DanSherwin.DevLogBus.locale.en-US.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: DanSherwin.DevLogBus
+PackageVersion: 1.3.1
+PackageLocale: en-US
+Publisher: Dan Sherwin
+PublisherUrl: https://github.com/dan-sherwin
+PublisherSupportUrl: https://github.com/dan-sherwin/DevLogBus/issues
+PackageName: DevLogBus
+PackageUrl: https://github.com/dan-sherwin/DevLogBus
+License: MIT
+LicenseUrl: https://github.com/dan-sherwin/DevLogBus/blob/main/LICENSE
+ShortDescription: Local-first structured log bus for development work.
+Description: DevLogBus lets local services, CLIs, Linux journal streams, and browser debugging events publish structured records into one live development log stream.
+Moniker: devlogbus
+Tags:
+- logging
+- development
+- cli
+- browser
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/d/DanSherwin/DevLogBus/1.3.1/DanSherwin.DevLogBus.yaml
+++ b/manifests/d/DanSherwin/DevLogBus/1.3.1/DanSherwin.DevLogBus.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: DanSherwin.DevLogBus
+PackageVersion: 1.3.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Pull request has been created with
- [x] WinGet Automation
- [ ] Manually

### Package
DanSherwin.DevLogBus version 1.3.1

### Validation
- Generated manifests from the v1.3.1 GitHub release checksums.
- Ran `winget validate --manifest` against the generated manifest folder on Windows 11; validation succeeded.

### Links
Release: https://github.com/dan-sherwin/DevLogBus/releases/tag/v1.3.1
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/381956)