### PR TITLE
Add 0state.scafld 2.4.6

### DIFF
--- a/manifests/0/0state/scafld/2.4.6/0state.scafld.installer.yaml
+++ b/manifests/0/0state/scafld/2.4.6/0state.scafld.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: 0state.scafld
+PackageVersion: 2.4.6
+InstallerLocale: en-US
+InstallerType: portable
+Commands:
+  - scafld
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/nilstate/scafld/releases/download/v2.4.6/scafld_2.4.6_windows_amd64.exe
+    InstallerSha256: 5d9502e20182072c3809ebfc0f381857d5c4414c3f7b45fbf8bdce725dd4d527
+  - Architecture: arm64
+    InstallerUrl: https://github.com/nilstate/scafld/releases/download/v2.4.6/scafld_2.4.6_windows_arm64.exe
+    InstallerSha256: 7ef3e617b01a8f0fc3e055af560b904a2402e70f965c862e238d73621d749040
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/0/0state/scafld/2.4.6/0state.scafld.locale.en-US.yaml
+++ b/manifests/0/0state/scafld/2.4.6/0state.scafld.locale.en-US.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: 0state.scafld
+PackageVersion: 2.4.6
+PackageLocale: en-US
+Publisher: 0state
+PublisherUrl: https://0state.com
+PackageName: scafld
+License: MIT
+ShortDescription: Deterministic protocol for multi-phase agent work.
+PackageUrl: https://0state.com/scafld
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/0/0state/scafld/2.4.6/0state.scafld.yaml
+++ b/manifests/0/0state/scafld/2.4.6/0state.scafld.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: 0state.scafld
+PackageVersion: 2.4.6
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Adds the 0state.scafld 2.4.6 portable manifests from the published GitHub release assets.\n\nRelease: https://github.com/nilstate/scafld/releases/tag/v2.4.6
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/381975)