### PR TITLE
New package: Finesssee.Win-CodexBar version 0.32.2

### DIFF
--- a/manifests/f/Finesssee/Win-CodexBar/0.32.2/Finesssee.Win-CodexBar.installer.yaml
+++ b/manifests/f/Finesssee/Win-CodexBar/0.32.2/Finesssee.Win-CodexBar.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Finesssee.Win-CodexBar
+PackageVersion: 0.32.2
+InstallerType: inno
+Scope: user
+UpgradeBehavior: install
+ProductCode: WinCodexBar_is1
+ReleaseDate: 2026-06-01
+AppsAndFeaturesEntries:
+- ProductCode: WinCodexBar_is1
+  DisplayName: CodexBar 0.32.2
+  DisplayVersion: 0.32.2
+  Publisher: CodexBar Contributors
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Finesssee/Win-CodexBar/releases/download/v0.32.2/CodexBar-0.32.2-Setup.exe
+  InstallerSha256: 4B2EC99DA24DBB16A7E7FF2B513E6AD6409BF17AA6DB71EB9CD30B130D046BA1
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Finesssee/Win-CodexBar/0.32.2/Finesssee.Win-CodexBar.locale.en-US.yaml
+++ b/manifests/f/Finesssee/Win-CodexBar/0.32.2/Finesssee.Win-CodexBar.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Finesssee.Win-CodexBar
+PackageVersion: 0.32.2
+PackageLocale: en-US
+Publisher: CodexBar Contributors
+PublisherUrl: https://github.com/Finesssee
+PublisherSupportUrl: https://github.com/Finesssee/Win-CodexBar/issues
+Author: Finesssee
+PackageName: Win-CodexBar
+PackageUrl: https://github.com/Finesssee/Win-CodexBar
+License: MIT
+LicenseUrl: https://github.com/Finesssee/Win-CodexBar/blob/main/LICENSE
+Copyright: Copyright (c) CodexBar contributors
+ShortDescription: Windows-native menu bar app for OpenAI Codex and Claude Code usage stats.
+Description: Win-CodexBar is a Windows-native desktop app for viewing OpenAI Codex and Claude Code usage stats from a small Tauri shell.
+Moniker: win-codexbar
+Tags:
+- claude-code
+- codex
+- desktop
+- tauri
+- usage
+- windows
+ReleaseNotes: |-
+  v0.32.2 ports upstream CodexBar performance and tray polish into Win-CodexBar, including faster local Codex token-cost scanning for large session log folders and more comfortable compact tray card spacing.
+ReleaseNotesUrl: https://github.com/Finesssee/Win-CodexBar/releases/tag/v0.32.2
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Finesssee/Win-CodexBar/0.32.2/Finesssee.Win-CodexBar.yaml
+++ b/manifests/f/Finesssee/Win-CodexBar/0.32.2/Finesssee.Win-CodexBar.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Finesssee.Win-CodexBar
+PackageVersion: 0.32.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Summary
- Add Finesssee.Win-CodexBar version 0.32.2 manifest.

## Validation
- Verified installer URL resolves from the GitHub release.
- Verified installer SHA256: `4B2EC99DA24DBB16A7E7FF2B513E6AD6409BF17AA6DB71EB9CD30B130D046BA1`.
- Parsed all three YAML manifests locally with Ruby Psych.

## Release
- https://github.com/Finesssee/Win-CodexBar/releases/tag/v0.32.2

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/381998)