### PR TITLE
New package: unhappychoice.gittype version 0.10.0

### DIFF
--- a/manifests/u/unhappychoice/gittype/0.10.0/unhappychoice.gittype.installer.yaml
+++ b/manifests/u/unhappychoice/gittype/0.10.0/unhappychoice.gittype.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: unhappychoice.gittype
+PackageVersion: 0.10.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: gittype.exe
+    PortableCommandAlias: gittype
+Commands:
+  - gittype
+ReleaseDate: 2026-04-20
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/unhappychoice/gittype/releases/download/v0.10.0/gittype-v0.10.0-x86_64-pc-windows-msvc.zip
+    InstallerSha256: 62E625B18AD860235BF9E1A618525FB20B7E0BFF5614D142E2803629D163A8B8
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/u/unhappychoice/gittype/0.10.0/unhappychoice.gittype.locale.en-US.yaml
+++ b/manifests/u/unhappychoice/gittype/0.10.0/unhappychoice.gittype.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: unhappychoice.gittype
+PackageVersion: 0.10.0
+PackageLocale: en-US
+Publisher: unhappychoice
+PublisherUrl: https://github.com/unhappychoice
+PublisherSupportUrl: https://github.com/unhappychoice/gittype/issues
+PackageName: GitType
+PackageUrl: https://github.com/unhappychoice/gittype
+License: MIT
+LicenseUrl: https://github.com/unhappychoice/gittype/blob/main/LICENSE
+Copyright: Copyright (c) unhappychoice
+ShortDescription: A typing practice tool using your own code repositories
+Description: |-
+  GitType is a Rust CLI typing game that turns source code from real repositories
+  into typing challenges. It parses code with tree-sitter, renders a terminal UI,
+  tracks real-time WPM/accuracy/consistency metrics, and unlocks developer titles
+  through a ranking system. Multi-language support includes Rust, TypeScript,
+  JavaScript, Python, Go, Ruby, Swift, Kotlin, Java, PHP, C#, C, C++, Haskell,
+  Dart, Scala, Clojure, Elixir, Erlang, and Zig.
+Moniker: gittype
+Tags:
+  - cli
+  - code
+  - developer
+  - git
+  - practice
+  - terminal
+  - tui
+  - typing
+ReleaseNotesUrl: https://github.com/unhappychoice/gittype/releases/tag/v0.10.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/u/unhappychoice/gittype/0.10.0/unhappychoice.gittype.yaml
+++ b/manifests/u/unhappychoice/gittype/0.10.0/unhappychoice.gittype.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: unhappychoice.gittype
+PackageVersion: 0.10.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Reference Links

- Project: https://github.com/unhappychoice/gittype
- Release: https://github.com/unhappychoice/gittype/releases/tag/v0.10.0

## About this package

GitType is a Rust CLI typing game that turns source code from real repositories into typing challenges. It parses code with tree-sitter and renders a terminal UI with ratatui, supporting 20+ languages (Rust, TypeScript, JavaScript, Python, Go, Ruby, Swift, Kotlin, Java, PHP, C#, C, C++, Haskell, Dart, Scala, Clojure, Elixir, Erlang, Zig).

This is the first submission for this package. Subsequent versions will be submitted automatically via `vedantmgoyal9/winget-releaser` from the project's release workflow.

## Manifests

- [x] Have read the [Contributing Guide](https://github.com/microsoft/winget-pkgs/blob/master/CONTRIBUTING.md)
- [x] Manifests follow the [v1.6.0 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.6.0.md)
- [x] InstallerSha256 was computed from the actual release asset
- [x] InstallerUrl points to a stable, versioned GitHub Release asset
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/382074)