### PR TITLE
Add gtms-code.psez version 1.0.0

### DIFF
--- a/manifests/g/gtms-code/psez/1.0.0/gtms-code.psez.installer.yaml
+++ b/manifests/g/gtms-code/psez/1.0.0/gtms-code.psez.installer.yaml
@@ -1,0 +1,12 @@
+PackageIdentifier: gtms-code.psez
+PackageVersion: 1.0.0
+InstallerLocale: en-US
+InstallerType: portable
+Commands:
+  - psez
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/gtms-code/psez/releases/download/v1.0.0/psez.exe
+    InstallerSha256: 86461A08FF8AF3F1ED85D1923F67D53F276DC0E6E4B13CE3A6D28B9635EBB021
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/g/gtms-code/psez/1.0.0/gtms-code.psez.locale.en-US.yaml
+++ b/manifests/g/gtms-code/psez/1.0.0/gtms-code.psez.locale.en-US.yaml
@@ -1,0 +1,27 @@
+PackageIdentifier: gtms-code.psez
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: gtms-code
+PublisherUrl: https://github.com/gtms-code
+PackageName: psez
+PackageUrl: https://github.com/gtms-code/psez
+License: GPL-3.0
+LicenseUrl: https://github.com/gtms-code/psez/blob/main/LICENSE
+ShortDescription: Modeless CUI text editor for Windows PowerShell and SSH (ConPTY) environments with Japanese/CJK support
+Description: |-
+  psez is a modeless CUI text editor that works safely on Windows PowerShell,
+  Command Prompt, and SSH (ConPTY) environments.
+  It solves the well-known crash bug where backspacing full-width (CJK) characters
+  in editors like nano or micro causes SSH connections to crash on Windows ConPTY.
+  Features include Japanese/CJK text editing, UTF-8/Shift-JIS/EUC-JP auto-detection,
+  system clipboard integration, undo, word wrap, and atomic file saving.
+Tags:
+  - text-editor
+  - terminal
+  - cli
+  - japanese
+  - cjk
+  - ssh
+  - conpty
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/g/gtms-code/psez/1.0.0/gtms-code.psez.yaml
+++ b/manifests/g/gtms-code/psez/1.0.0/gtms-code.psez.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: gtms-code.psez
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Add gtms-code.psez version 1.0.0

### Description
psez is a modeless CUI text editor for Windows PowerShell, Command Prompt, and SSH (ConPTY) environments.

It solves the well-known crash bug where backspacing full-width (CJK) characters in editors like nano or micro causes SSH connections to crash on Windows ConPTY.

### Package Info
- **Publisher:** gtms-code
- **Package:** psez
- **Version:** 1.0.0
- **License:** GPL-3.0
- **Type:** Portable
- **Architecture:** x64

### Links
- Homepage: https://github.com/gtms-code/psez
- Release: https://github.com/gtms-code/psez/releases/tag/v1.0.0

### Validation
- [x] SHA256 verified
- [x] Installer URL accessible
- [x] Portable installer type
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/382141)