### PR TITLE
New package: WarpSend.WarpSend version 7daa83861a5e

### DIFF
--- a/manifests/w/WarpSend/WarpSend/7daa83861a5e/WarpSend.WarpSend.installer.yaml
+++ b/manifests/w/WarpSend/WarpSend/7daa83861a5e/WarpSend.WarpSend.installer.yaml
@@ -1,0 +1,25 @@
+# Installer manifest — tells WinGet how to fetch + register the binary.
+#
+# `portable` installer type is the WinGet equivalent of a brew "binary"
+# formula: WinGet downloads the .zip, extracts to its own packages dir,
+# and registers a shim (`warpsend.exe`) on PATH. No MSI / NSIS needed,
+# no admin rights, no SmartScreen prompt for the installer itself.
+PackageIdentifier: WarpSend.WarpSend
+PackageVersion: 7daa83861a5e
+
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: warpsend.exe
+    PortableCommandAlias: warpsend
+
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://download.warpsend.io/downloads/7daa83861a5e/warpsend-x86_64-pc-windows-gnu.zip
+    InstallerSha256: f981bd3090778897d1930973bb9f74a42f339398aac240a8227d1002b7f415bd
+  - Architecture: arm64
+    InstallerUrl: https://download.warpsend.io/downloads/7daa83861a5e/warpsend-aarch64-pc-windows-gnullvm.zip
+    InstallerSha256: c9223a50be2a2f606b4e063ec7fe976499bd3338ae5b0685c6226699fd2bd534
+
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/w/WarpSend/WarpSend/7daa83861a5e/WarpSend.WarpSend.locale.en-US.yaml
+++ b/manifests/w/WarpSend/WarpSend/7daa83861a5e/WarpSend.WarpSend.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# Locale manifest — user-facing description shown in `winget show` and
+# the WinGet website. Required because the version manifest declares
+# DefaultLocale: en-US.
+PackageIdentifier: WarpSend.WarpSend
+PackageVersion: 7daa83861a5e
+PackageLocale: en-US
+Publisher: WarpSend
+PublisherUrl: https://warpsend.io
+Author: WarpSend
+PackageName: WarpSend
+PackageUrl: https://warpsend.io
+License: MIT
+ShortDescription: NAS-to-NAS large file transfer over Cloudflare R2.
+Description: |-
+  WarpSend is a thin CLI for moving large files between NAS / Linux / macOS
+  endpoints across regions, using Cloudflare R2 as a relay. After
+  installation, run `warpsend run` to bootstrap the local agent and open
+  the management UI.
+Tags:
+  - file-transfer
+  - nas
+  - cloudflare
+  - cli
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0
+# Optional URL fields (PublisherSupportUrl, LicenseUrl, ReleaseNotesUrl)
+# are intentionally omitted. The source repo is private, so the GitHub
+# /LICENSE and /releases pages 404, and there is no public /support
+# subpath on warpsend.io yet. wingetbot validates every URL — adding a
+# field that 404s blocks the PR. Add them back if/when these pages
+# become public.

--- a/manifests/w/WarpSend/WarpSend/7daa83861a5e/WarpSend.WarpSend.yaml
+++ b/manifests/w/WarpSend/WarpSend/7daa83861a5e/WarpSend.WarpSend.yaml
@@ -1,0 +1,8 @@
+# Version manifest — top-level descriptor for the package version.
+# Rendered by scripts/update-winget-manifest.sh; do not edit the generated
+# version/ subdirectory by hand.
+PackageIdentifier: WarpSend.WarpSend
+PackageVersion: 7daa83861a5e
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: `WarpSend.WarpSend` version `7daa83861a5e`

WarpSend is a thin CLI for NAS-to-NAS large file transfer over Cloudflare R2.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Manifests validated locally (ManifestVersion 1.6.0, `zip` + `portable` nested installer).
- [x] Installer URLs reachable; `InstallerSha256` matches the downloaded artifacts for both x64 and arm64.
- [x] Nested installer file `warpsend.exe` confirmed present at archive root.

Installer type: `zip` → `portable` (downloads the CLI zip, registers a `warpsend` shim on PATH).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/382147)