### PR TITLE
Stardock.Start11.v2 version 2.7.2.0

### DIFF
--- a/manifests/s/Stardock/Start11/v2/2.7.2.0/Stardock.Start11.v2.installer.yaml
+++ b/manifests/s/Stardock/Start11/v2/2.7.2.0/Stardock.Start11.v2.installer.yaml
@@ -1,0 +1,26 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Stardock.Start11.v2
+PackageVersion: 2.7.2.0
+Platform:
+- Windows.Desktop
+InstallerType: exe
+Scope: machine
+InstallModes:
+- interactive
+- silent
+InstallerSwitches:
+  Silent: /s
+  SilentWithProgress: /s
+InstallerSuccessCodes:
+- 3010
+- 9
+UpgradeBehavior: install
+ProductCode: Stardock Start11
+Installers:
+- Architecture: x64
+  InstallerUrl: https://stardock.cachefly.net/software/Start11/v2/Start11v2_Setup.exe
+  InstallerSha256: 3A54D9656E0DD83496B3198510F2C9F80785BD4E39C3AD048924DC1E016F3938
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/Stardock/Start11/v2/2.7.2.0/Stardock.Start11.v2.installer.yaml
+++ b/manifests/s/Stardock/Start11/v2/2.7.2.0/Stardock.Start11.v2.installer.yaml
@@ -19,7 +19,7 @@ InstallerSuccessCodes:
 UpgradeBehavior: install
 ProductCode: Stardock Start11
 Installers:
-- Architecture: x64
+- Architecture: x86
   InstallerUrl: https://stardock.cachefly.net/software/Start11/v2/Start11v2_Setup.exe
   InstallerSha256: 3A54D9656E0DD83496B3198510F2C9F80785BD4E39C3AD048924DC1E016F3938
 ManifestType: installer

--- a/manifests/s/Stardock/Start11/v2/2.7.2.0/Stardock.Start11.v2.locale.en-US.yaml
+++ b/manifests/s/Stardock/Start11/v2/2.7.2.0/Stardock.Start11.v2.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Stardock.Start11.v2
+PackageVersion: 2.7.2.0
+PackageLocale: en-US
+Publisher: Stardock Software, Inc.
+PublisherUrl: https://www.stardock.com/
+PublisherSupportUrl: https://www.stardock.com/support/
+PrivacyUrl: https://www.stardock.com/policies/privacy
+Author: Stardock Software, Inc.
+PackageName: Stardock Start11
+PackageUrl: https://www.stardock.com/products/start11/
+License: Proprietary
+LicenseUrl: https://www.stardock.com/support/software-eula
+Copyright: (c) Stardock Software, Inc. All rights reserved.
+CopyrightUrl: https://www.stardock.com/support/software-eula
+ShortDescription: Customize the Start Menu and Taskbar in Windows 10/11
+Moniker: start11
+PurchaseUrl: https://www.stardock.com/products/start11/download
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/Stardock/Start11/v2/2.7.2.0/Stardock.Start11.v2.yaml
+++ b/manifests/s/Stardock/Start11/v2/2.7.2.0/Stardock.Start11.v2.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Stardock.Start11.v2
+PackageVersion: 2.7.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Update **Stardock.Start11.v2** to version **2.7.2.0**. Submitted by Stardock (publisher).

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
