### PR TITLE
New package: SourceBox.SearchBox version 0.3.0

### DIFF
--- a/manifests/s/SourceBox/SearchBox/0.3.0/SourceBox.SearchBox.installer.yaml
+++ b/manifests/s/SourceBox/SearchBox/0.3.0/SourceBox.SearchBox.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: SourceBox.SearchBox
+PackageVersion: 0.3.0
+InstallerLocale: en-US
+InstallerType: wix
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-06-01
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/SourceBox-LLC/SearchBox/releases/download/v0.3.0/SearchBox-0.3.0-x86_64.msi
+    InstallerSha256: 80F857AFA6EC3A5F8E30C479191EFB17078B709815479C7BDA50773AAB6379BE
+    ProductCode: '{F93AD8B4-74EF-43AE-9621-BA5038B1106A}'
+  - Architecture: arm64
+    InstallerUrl: https://github.com/SourceBox-LLC/SearchBox/releases/download/v0.3.0/SearchBox-0.3.0-aarch64.msi
+    InstallerSha256: 3A0BC1AF4AE72942BFC83D5B6DC4B8522EB7945AC4DE1FF4D53004D6C2C1C147
+    ProductCode: '{071D78C1-736B-43A5-B5EB-2D82B2AF2E4D}'
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/SourceBox/SearchBox/0.3.0/SourceBox.SearchBox.locale.en-US.yaml
+++ b/manifests/s/SourceBox/SearchBox/0.3.0/SourceBox.SearchBox.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: SourceBox.SearchBox
+PackageVersion: 0.3.0
+PackageLocale: en-US
+Publisher: SourceBox LLC
+PublisherUrl: https://www.sourceboxai.com/
+PublisherSupportUrl: https://github.com/SourceBox-LLC/SearchBox/issues
+PackageName: SearchBox
+PackageUrl: https://github.com/SourceBox-LLC/SearchBox
+License: AGPL-3.0-or-later
+LicenseUrl: https://github.com/SourceBox-LLC/SearchBox/blob/master/LICENSE
+ShortDescription: Private, local-first document search — search your own files like a search engine.
+Description: |-
+  SearchBox is a local-first document search app that indexes your files — folders,
+  ZIP and ZIM (Kiwix/Wikipedia) archives, and qBittorrent downloads — and lets you
+  search across them instantly from a clean web UI. It includes an optional
+  AES-256 encrypted vault and local AI summaries via Ollama. Nothing leaves your
+  machine by default; the bundled Meilisearch engine and all data stay local.
+Moniker: searchbox
+Tags:
+  - search
+  - document-search
+  - full-text-search
+  - local-first
+  - privacy
+  - offline
+  - desktop
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/SourceBox/SearchBox/0.3.0/SourceBox.SearchBox.yaml
+++ b/manifests/s/SourceBox/SearchBox/0.3.0/SourceBox.SearchBox.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: SourceBox.SearchBox
+PackageVersion: 0.3.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: SourceBox.SearchBox version 0.3.0

SearchBox is a free, open-source, local-first document search app — a Rust backend with a bundled Meilisearch engine and a native WebView2 desktop window. Licensed AGPL-3.0-or-later.

- **Repo:** https://github.com/SourceBox-LLC/SearchBox
- **Installers:** the official x64 and arm64 MSIs from the v0.3.0 GitHub release, with SHA256 pinned and per-architecture `ProductCode`.
- Manifests validated locally with `winget validate` (succeeded).

This is the first version of a new package.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/382262)