### PR TITLE
New package: ChrisMcLennan.mnml version 0.1.2

### DIFF
--- a/manifests/c/ChrisMcLennan/mnml/0.1.2/ChrisMcLennan.mnml.installer.yaml
+++ b/manifests/c/ChrisMcLennan/mnml/0.1.2/ChrisMcLennan.mnml.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: ChrisMcLennan.mnml
+PackageVersion: 0.1.2
+InstallerType: wix
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/chris-mclennan/mnml/releases/download/v0.1.2/mnml-rs-x86_64-pc-windows-msvc.msi
+    InstallerSha256: 8637362324FEFC6046C81B1EA3D696B244551E6567B0CAE4F212B24D9D2E3AB2
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/c/ChrisMcLennan/mnml/0.1.2/ChrisMcLennan.mnml.locale.en-US.yaml
+++ b/manifests/c/ChrisMcLennan/mnml/0.1.2/ChrisMcLennan.mnml.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: ChrisMcLennan.mnml
+PackageVersion: 0.1.2
+PackageLocale: en-US
+Publisher: Chris McLennan
+PublisherUrl: https://github.com/chris-mclennan
+PublisherSupportUrl: https://github.com/chris-mclennan/mnml/issues
+Author: Chris McLennan
+PackageName: mnml
+PackageUrl: https://mnml.sh
+License: MIT
+LicenseUrl: https://github.com/chris-mclennan/mnml/blob/main/LICENSE-MIT
+ShortDescription: A NvChad-style terminal IDE in Rust.
+Description: |-
+  mnml is a terminal IDE: vim or standard editing, LSP, git, embedded HTTP/CDP/DAP, AI panes, headless test harness.
+Tags:
+  - editor
+  - ide
+  - tui
+  - rust
+  - terminal
+  - vim
+ReleaseNotesUrl: https://github.com/chris-mclennan/mnml/releases/tag/v0.1.2
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/c/ChrisMcLennan/mnml/0.1.2/ChrisMcLennan.mnml.yaml
+++ b/manifests/c/ChrisMcLennan/mnml/0.1.2/ChrisMcLennan.mnml.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: ChrisMcLennan.mnml
+PackageVersion: 0.1.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
New manifest for ChrisMcLennan.mnml 0.1.2 — a Rust app from the [mnml family](https://github.com/chris-mclennan).

- Installer: x64 WiX MSI from the upstream GitHub release
- Generated from the published artifact (cargo-dist 0.32.0)
- Hand-written manifests; SHA256 verified against the release
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/382315)