### PR TITLE
New package: ChrisMcLennan.mixr version 0.1.3

### DIFF
--- a/manifests/c/ChrisMcLennan/mixr/0.1.3/ChrisMcLennan.mixr.installer.yaml
+++ b/manifests/c/ChrisMcLennan/mixr/0.1.3/ChrisMcLennan.mixr.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: ChrisMcLennan.mixr
+PackageVersion: 0.1.3
+InstallerType: wix
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/chris-mclennan/mixr/releases/download/v0.1.3/mixr-rs-x86_64-pc-windows-msvc.msi
+    InstallerSha256: BF25A6392D0C55EC4B9B8130BD8CC2E7BD6356D6910B02D73ED32DBE9A6AF19A
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/c/ChrisMcLennan/mixr/0.1.3/ChrisMcLennan.mixr.locale.en-US.yaml
+++ b/manifests/c/ChrisMcLennan/mixr/0.1.3/ChrisMcLennan.mixr.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: ChrisMcLennan.mixr
+PackageVersion: 0.1.3
+PackageLocale: en-US
+Publisher: Chris McLennan
+PublisherUrl: https://github.com/chris-mclennan
+PublisherSupportUrl: https://github.com/chris-mclennan/mixr/issues
+Author: Chris McLennan
+PackageName: mixr
+PackageUrl: https://mixr.sh
+License: MIT
+LicenseUrl: https://github.com/chris-mclennan/mixr/blob/main/LICENSE-MIT
+ShortDescription: Lean terminal DJ app for electronic music.
+Description: |-
+  mixr is a lean terminal DJ app for electronic music — Beatport streaming, AI-assisted mixing, hardware controllers.
+Tags:
+  - dj
+  - music
+  - audio
+  - tui
+  - rust
+  - terminal
+  - beatport
+ReleaseNotesUrl: https://github.com/chris-mclennan/mixr/releases/tag/v0.1.3
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/c/ChrisMcLennan/mixr/0.1.3/ChrisMcLennan.mixr.yaml
+++ b/manifests/c/ChrisMcLennan/mixr/0.1.3/ChrisMcLennan.mixr.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: ChrisMcLennan.mixr
+PackageVersion: 0.1.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
New manifest for ChrisMcLennan.mixr 0.1.3 — a Rust app from the [mnml family](https://github.com/chris-mclennan).

- Installer: x64 WiX MSI from the upstream GitHub release
- Generated from the published artifact (cargo-dist 0.32.0)
- Hand-written manifests; SHA256 verified against the release
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/382316)