### PR TITLE
New package: ChrisMcLennan.tmnl version 0.0.4

### DIFF
--- a/manifests/c/ChrisMcLennan/tmnl/0.0.4/ChrisMcLennan.tmnl.installer.yaml
+++ b/manifests/c/ChrisMcLennan/tmnl/0.0.4/ChrisMcLennan.tmnl.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: ChrisMcLennan.tmnl
+PackageVersion: 0.0.4
+InstallerType: wix
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/chris-mclennan/tmnl/releases/download/v0.0.4/tmnl-rs-x86_64-pc-windows-msvc.msi
+    InstallerSha256: DD9EFB18AC05CA51DE5A6ACB8718E2102EA6DC8482CF8441C9B5D28047F64762
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/c/ChrisMcLennan/tmnl/0.0.4/ChrisMcLennan.tmnl.locale.en-US.yaml
+++ b/manifests/c/ChrisMcLennan/tmnl/0.0.4/ChrisMcLennan.tmnl.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: ChrisMcLennan.tmnl
+PackageVersion: 0.0.4
+PackageLocale: en-US
+Publisher: Chris McLennan
+PublisherUrl: https://github.com/chris-mclennan
+PublisherSupportUrl: https://github.com/chris-mclennan/tmnl/issues
+Author: Chris McLennan
+PackageName: tmnl
+PackageUrl: https://tmnl.sh
+License: MIT
+LicenseUrl: https://github.com/chris-mclennan/tmnl/blob/master/LICENSE-MIT
+ShortDescription: A GPU-rendered terminal with a structured-cell display protocol.
+Description: |-
+  tmnl is a GPU-rendered terminal — and a structured-cell display surface that apps can draw to directly.
+Tags:
+  - terminal
+  - gpu
+  - wgpu
+  - rust
+ReleaseNotesUrl: https://github.com/chris-mclennan/tmnl/releases/tag/v0.0.4
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/c/ChrisMcLennan/tmnl/0.0.4/ChrisMcLennan.tmnl.yaml
+++ b/manifests/c/ChrisMcLennan/tmnl/0.0.4/ChrisMcLennan.tmnl.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: ChrisMcLennan.tmnl
+PackageVersion: 0.0.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
New manifest for ChrisMcLennan.tmnl 0.0.4 — a Rust app from the [mnml family](https://github.com/chris-mclennan).

- Installer: x64 WiX MSI from the upstream GitHub release
- Generated from the published artifact (cargo-dist 0.32.0)
- Hand-written manifests; SHA256 verified against the release
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/382317)