### PR TITLE
New package: GioPalusa.SRTDownloader version 0.1.1

### DIFF
--- a/manifests/g/GioPalusa/SRTDownloader/0.1.1/GioPalusa.SRTDownloader.installer.yaml
+++ b/manifests/g/GioPalusa/SRTDownloader/0.1.1/GioPalusa.SRTDownloader.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: GioPalusa.SRTDownloader
+PackageVersion: 0.1.1
+InstallerType: portable
+Commands:
+- srt-download
+ReleaseDate: 2026-06-02
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/GioPalusa/SRT-downloader/releases/download/v0.1.1/srt-download-windows-x64.exe
+  InstallerSha256: CDF595C8D04FBA836B25B40973622339AE8C253FC7FE27A84D34D822E84B7FFF
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/g/GioPalusa/SRTDownloader/0.1.1/GioPalusa.SRTDownloader.locale.en-US.yaml
+++ b/manifests/g/GioPalusa/SRTDownloader/0.1.1/GioPalusa.SRTDownloader.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: GioPalusa.SRTDownloader
+PackageVersion: 0.1.1
+PackageLocale: en-US
+Publisher: Giovanni Palusa
+PublisherUrl: https://github.com/GioPalusa
+PublisherSupportUrl: https://github.com/GioPalusa/SRT-downloader/issues
+Author: Giovanni Palusa
+PackageName: SRT Downloader
+PackageUrl: https://github.com/GioPalusa/SRT-downloader
+License: MIT
+LicenseUrl: https://github.com/GioPalusa/SRT-downloader/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Giovanni Palusa
+ShortDescription: Download subtitles for local video files recursively.
+Description: A command-line tool that scans a folder tree, finds video files, searches subtitle providers, and saves subtitles next to each video.
+Moniker: srt-download
+Tags:
+- cli
+- srt
+- subtitle
+- subtitles
+- video
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/g/GioPalusa/SRTDownloader/0.1.1/GioPalusa.SRTDownloader.yaml
+++ b/manifests/g/GioPalusa/SRTDownloader/0.1.1/GioPalusa.SRTDownloader.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: GioPalusa.SRTDownloader
+PackageVersion: 0.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## New package: GioPalusa.SRTDownloader version 0.1.1

Initial submission of [SRT Downloader](https://github.com/GioPalusa/SRT-downloader) — a command-line tool that scans a folder tree, finds video files, searches subtitle providers, and saves subtitles next to each video.

- **InstallerType:** `portable` (single standalone `.exe`), command alias `srt-download`
- **Architecture:** x64
- **License:** MIT

### Validation
- [x] New package — no existing manifest for this identifier.
- [x] Manifests validated against the official WinGet **1.12.0** JSON schemas.
- [ ] `winget validate` / `winget install` not run locally (authored on macOS); relying on the automated validation pipeline.

> Supersedes #382285 (which targeted v0.1.0). v0.1.0 had a packaging bug that crashed the binary at runtime; v0.1.1 is verified working via an end-to-end scan in CI. The executable is an unsigned PyInstaller build, so a Defender/SmartScreen false positive during validation is possible.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/382402)