### PR TITLE
New package: GioPalusa.SRTDownloader version 0.1.2

### DIFF
--- a/manifests/g/GioPalusa/SRTDownloader/0.1.2/GioPalusa.SRTDownloader.installer.yaml
+++ b/manifests/g/GioPalusa/SRTDownloader/0.1.2/GioPalusa.SRTDownloader.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: GioPalusa.SRTDownloader
+PackageVersion: 0.1.2
+InstallerType: portable
+Commands:
+- srt-download
+ReleaseDate: 2026-06-02
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/GioPalusa/SRT-downloader/releases/download/v0.1.2/srt-download-windows-x64.exe
+  InstallerSha256: 848702FF3EFBC8A9F70246200430F813C4507BAC0A5657BD03E7DFFD7205F480
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/g/GioPalusa/SRTDownloader/0.1.2/GioPalusa.SRTDownloader.locale.en-US.yaml
+++ b/manifests/g/GioPalusa/SRTDownloader/0.1.2/GioPalusa.SRTDownloader.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: GioPalusa.SRTDownloader
+PackageVersion: 0.1.2
+PackageLocale: en-US
+Publisher: Giovanni Palusa
+PublisherUrl: https://github.com/GioPalusa
+PublisherSupportUrl: https://github.com/GioPalusa/SRT-downloader/issues
+Author: Giovanni Palusa
+PackageName: SRT Downloader
+PackageUrl: https://github.com/GioPalusa/SRT-downloader
+License: MIT
+LicenseUrl: https://github.com/GioPalusa/SRT-downloader/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Giovanni Palusa
+ShortDescription: Download subtitles for local video files recursively.
+Description: A command-line tool that scans a folder tree, finds video files, searches subtitle providers, and saves subtitles next to each video.
+Moniker: srt-download
+Tags:
+- cli
+- srt
+- subtitle
+- subtitles
+- video
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/g/GioPalusa/SRTDownloader/0.1.2/GioPalusa.SRTDownloader.yaml
+++ b/manifests/g/GioPalusa/SRTDownloader/0.1.2/GioPalusa.SRTDownloader.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: GioPalusa.SRTDownloader
+PackageVersion: 0.1.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package: **GioPalusa.SRTDownloader** version **0.1.2** — [SRT Downloader](https://github.com/GioPalusa/SRT-downloader), a command-line tool that scans a folder tree, finds video files, searches subtitle providers, and saves subtitles next to each video.

- **InstallerType:** `portable` (single standalone `.exe`), command alias `srt-download`
- **Architecture:** x64
- **License:** MIT

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable) — N/A, new package

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` — authored on macOS; validated against the official 1.12.0 JSON schemas instead
- [x] Tested manifest locally with `winget install --manifest <path>` — see note below
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> Supersedes #382285 and #382402 (earlier versions). v0.1.2 is the current release, verified working via an end-to-end scan in CI on Windows. `winget validate`/`install` were not run locally because the manifest was authored on macOS; relying on the automated validation pipeline. The executable is an unsigned PyInstaller build, so a Defender/SmartScreen false positive during validation is possible.