### PR TITLE
Update: Jabe.yolomover to 2.1.0

### DIFF
--- a/manifests/j/Jabe/yolomover/2.1.0/Jabe.yolomover.installer.yaml
+++ b/manifests/j/Jabe/yolomover/2.1.0/Jabe.yolomover.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Jabe.yolomover
+PackageVersion: 2.1.0
+InstallerType: portable
+UpgradeBehavior: install
+Commands:
+  - yolomover
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+ReleaseDate: 2026-05-28
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Jabe/yolomover/releases/download/v2.1.0/yolomover-v2.1.0-x86_64-pc-windows-msvc.exe
+    InstallerSha256: 1C21AF196319272882CD1A8963057544F2A31E2ED7F48A1B47B137514991CDFC
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/j/Jabe/yolomover/2.1.0/Jabe.yolomover.locale.en-US.yaml
+++ b/manifests/j/Jabe/yolomover/2.1.0/Jabe.yolomover.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Jabe.yolomover
+PackageVersion: 2.1.0
+PackageLocale: en-US
+Publisher: Jabe
+PublisherUrl: https://github.com/Jabe
+PublisherSupportUrl: https://github.com/Jabe/yolomover/issues
+PackageName: yolomover
+PackageUrl: https://github.com/Jabe/yolomover
+License: MIT
+LicenseUrl: https://github.com/Jabe/yolomover/blob/master/LICENSE-MIT
+ShortDescription: Move the Windows Recovery partition to the end of the disk
+Description: |-
+  Move the Windows Recovery partition to the end of the disk so you can extend the boot volume — without manually chaining reagentc, a partition GUI, and extend every time.
+
+  Requires Windows 10/11, GPT system disk, and administrator elevation. Use inspect and plan before relocate and extend.
+Moniker: yolomover
+Tags:
+  - gpt
+  - partition
+  - recovery
+  - windows
+  - winre
+ReleaseNotes: |-
+  - NTFS extend fixed — partition grow plus diskpart extend filesystem when FSCTL is unavailable
+  - Verifies filesystem size via FSCTL_GET_NTFS_VOLUME_DATA, not GPT alone
+  - NTFS-only repair when the partition grew but Explorer still shows the old size
+  - On 2.0.0, if C: in Explorer is smaller than in Disk Management, run `yolomover extend --yes` (no relocate needed)
+ReleaseNotesUrl: https://github.com/Jabe/yolomover/releases/tag/v2.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/j/Jabe/yolomover/2.1.0/Jabe.yolomover.yaml
+++ b/manifests/j/Jabe/yolomover/2.1.0/Jabe.yolomover.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Jabe.yolomover
+PackageVersion: 2.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds winget manifest for **yolomover** 2.1.0. NTFS extend fix and repair path for 2.0.0 partition/Explorer mismatch.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com) (prior PR)
- [x] Linked to an issue (if applicable) — N/A

## 📦 Manifest Checklist

- [x] Checked that there aren't other open PRs for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest manifests/j/Jabe/yolomover/2.1.0`
- [x] Tested manifest locally with `winget install --manifest manifests/j/Jabe/yolomover/2.1.0`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/382449)