### PR TITLE
New version: Finesssee.Win-CodexBar version 0.32.5

### DIFF
--- a/manifests/f/Finesssee/Win-CodexBar/0.32.5/Finesssee.Win-CodexBar.installer.yaml
+++ b/manifests/f/Finesssee/Win-CodexBar/0.32.5/Finesssee.Win-CodexBar.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Finesssee.Win-CodexBar
+PackageVersion: 0.32.5
+InstallerType: inno
+Scope: user
+UpgradeBehavior: install
+ProductCode: WinCodexBar_is1
+ReleaseDate: 2026-06-02
+AppsAndFeaturesEntries:
+- ProductCode: WinCodexBar_is1
+  DisplayName: CodexBar 0.32.5
+  DisplayVersion: 0.32.5
+  Publisher: CodexBar Contributors
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Finesssee/Win-CodexBar/releases/download/v0.32.5/CodexBar-0.32.5-Setup.exe
+  InstallerSha256: 970F710F1BEEF70BA893888595924D316D67630E369033F135AEE886F641ADBC
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Finesssee/Win-CodexBar/0.32.5/Finesssee.Win-CodexBar.locale.en-US.yaml
+++ b/manifests/f/Finesssee/Win-CodexBar/0.32.5/Finesssee.Win-CodexBar.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Finesssee.Win-CodexBar
+PackageVersion: 0.32.5
+PackageLocale: en-US
+Publisher: CodexBar Contributors
+PublisherUrl: https://github.com/Finesssee
+PublisherSupportUrl: https://github.com/Finesssee/Win-CodexBar/issues
+Author: Finesssee
+PackageName: Win-CodexBar
+PackageUrl: https://github.com/Finesssee/Win-CodexBar
+License: MIT
+LicenseUrl: https://github.com/Finesssee/Win-CodexBar/blob/main/LICENSE
+Copyright: Copyright (c) CodexBar contributors
+ShortDescription: Windows-native menu bar app for OpenAI Codex and Claude Code usage stats.
+Description: Win-CodexBar is a Windows-native desktop app for viewing OpenAI Codex and Claude Code usage stats from a small Tauri shell.
+Moniker: win-codexbar
+Tags:
+- claude-code
+- codex
+- desktop
+- tauri
+- usage
+- windows
+ReleaseNotes: |-
+  v0.32.5 fixes targeted upstream provider issues: GitHub Copilot Business token-based billing zero-entitlement quota rows no longer show misleading 0% used usage, and OpenAI Web login/Cloudflare blocking states are prioritized over public-route detection.
+ReleaseNotesUrl: https://github.com/Finesssee/Win-CodexBar/releases/tag/v0.32.5
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Finesssee/Win-CodexBar/0.32.5/Finesssee.Win-CodexBar.yaml
+++ b/manifests/f/Finesssee/Win-CodexBar/0.32.5/Finesssee.Win-CodexBar.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Finesssee.Win-CodexBar
+PackageVersion: 0.32.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Packages
Finesssee.Win-CodexBar

Validation
Verified installer SHA256: 970F710F1BEEF70BA893888595924D316D67630E369033F135AEE886F641ADBC
Verified installer URL: https://github.com/Finesssee/Win-CodexBar/releases/download/v0.32.5/CodexBar-0.32.5-Setup.exe
Verified installer type: Inno Setup
Release: https://github.com/Finesssee/Win-CodexBar/releases/tag/v0.32.5

Notes
This update fixes targeted upstream provider issues for GitHub Copilot Business token-based billing quota display and OpenAI Web login/Cloudflare blocking-state classification.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/382516)