### PR TITLE
Add version: Unifan.Carton version 0.3.0

### DIFF
--- a/manifests/u/Unifan/Carton/0.3.0/Unifan.Carton.installer.yaml
+++ b/manifests/u/Unifan/Carton/0.3.0/Unifan.Carton.installer.yaml
@@ -1,0 +1,17 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: Unifan.Carton
+PackageVersion: 0.3.0
+InstallerType: nullsoft
+Scope: user
+UpgradeBehavior: install
+ReleaseDate: 2026-06-02
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/821869798/carton/releases/download/v0.3.0/carton-0.3.0-win-x64-Setup.exe
+    InstallerSha256: C002D6FEC5F3E7CB5DE2FE63B514CCB1B6C7B58EFC23937A26ED62E2BD53CC69
+  - Architecture: arm64
+    InstallerUrl: https://github.com/821869798/carton/releases/download/v0.3.0/carton-0.3.0-win-arm64-Setup.exe
+    InstallerSha256: 99D4441E3417B6983965A73CEC5E79FF0655D2930A3E468F385B642D14653D25
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/u/Unifan/Carton/0.3.0/Unifan.Carton.locale.en-US.yaml
+++ b/manifests/u/Unifan/Carton/0.3.0/Unifan.Carton.locale.en-US.yaml
@@ -1,0 +1,23 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: Unifan.Carton
+PackageVersion: 0.3.0
+PackageLocale: en-US
+Publisher: Unifan
+PublisherUrl: https://github.com/821869798
+PublisherSupportUrl: https://github.com/821869798/carton/issues
+PackageName: carton
+PackageUrl: https://github.com/821869798/carton
+License: GPL-3.0
+LicenseUrl: https://github.com/821869798/carton/blob/main/LICENSE
+ShortDescription: A sing-box desktop client focused on performance and a workflow close to official SFM.
+Description: carton is a desktop client powered by sing-box. It aims to stay close to the official SFM experience while improving startup speed, responsiveness, and practical day-to-day workflows.
+Moniker: carton
+Tags:
+  - sing-box
+  - proxy
+  - desktop
+  - network
+ReleaseNotesUrl: https://github.com/821869798/carton/releases/tag/v0.3.0
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/u/Unifan/Carton/0.3.0/Unifan.Carton.yaml
+++ b/manifests/u/Unifan/Carton/0.3.0/Unifan.Carton.yaml
@@ -1,0 +1,7 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: Unifan.Carton
+PackageVersion: 0.3.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## Summary
- add winget manifests for Unifan.Carton 0.3.0
- include x64 and arm64 NSIS installers from the official GitHub release

## Validation
- winget validate --manifest manifests\u\Unifan\Carton\0.3.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/382707)