### PR TITLE
New version: CloudCDN.Stratos version 0.0.13

### DIFF
--- a/manifests/c/CloudCDN/Stratos/0.0.13/CloudCDN.Stratos.installer.yaml
+++ b/manifests/c/CloudCDN/Stratos/0.0.13/CloudCDN.Stratos.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# SPDX-License-Identifier: MIT
+
+PackageIdentifier: CloudCDN.Stratos
+PackageVersion: 0.0.13
+InstallerType: portable
+Commands:
+  - stratos
+ReleaseDate: 2026-06-02
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/sebastienrousseau/stratos/releases/download/v0.0.13/stratos-win-x64.exe
+    InstallerSha256: CF443AA09FE90AC807EA3C8DD19E26206440A157C3E7D57D5E1C15AC7B0FC450
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: stratos-win-x64.exe
+        PortableCommandAlias: stratos
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/c/CloudCDN/Stratos/0.0.13/CloudCDN.Stratos.locale.en-US.yaml
+++ b/manifests/c/CloudCDN/Stratos/0.0.13/CloudCDN.Stratos.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# SPDX-License-Identifier: MIT
+
+PackageIdentifier: CloudCDN.Stratos
+PackageVersion: 0.0.13
+PackageLocale: en-US
+Publisher: CloudCDN
+PublisherUrl: https://cloudcdn.pro
+PublisherSupportUrl: https://github.com/sebastienrousseau/stratos/issues
+Author: Sebastien Rousseau
+PackageName: Stratos
+PackageUrl: https://github.com/sebastienrousseau/stratos
+License: MIT
+LicenseUrl: https://github.com/sebastienrousseau/stratos/blob/main/LICENSE
+ShortDescription: Official command-line client for CloudCDN.
+Description: |-
+  Stratos is the official command-line client and Node ESM library for CloudCDN.
+  ~30 commands across the full control plane (purge, signed URLs, assets, insights,
+  zones, tokens, webhooks, rules, storage, logs, AI, image transforms), an MCP
+  stdio server, OpenTelemetry export, OS-keychain auth, shell completions, and a
+  100%-tested zero-dependency single-file Node ≥ 20 implementation.
+Tags:
+  - cdn
+  - cli
+  - cloudcdn
+  - mcp
+  - opentelemetry
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/c/CloudCDN/Stratos/0.0.13/CloudCDN.Stratos.yaml
+++ b/manifests/c/CloudCDN/Stratos/0.0.13/CloudCDN.Stratos.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# SPDX-License-Identifier: MIT
+
+PackageIdentifier: CloudCDN.Stratos
+PackageVersion: 0.0.13
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary

Adds the first version of **CloudCDN.Stratos** (v0.0.13) to winget-pkgs.

Stratos is the official command-line client for [CloudCDN](https://cloudcdn.pro) — a single-file ESM Node.js script (also distributed as a self-contained Bun-compiled binary for users who don't have Node installed).

## Package details

- **Package identifier:** \`CloudCDN.Stratos\`
- **Package version:** \`0.0.13\`
- **Installer:** [\`stratos-win-x64.exe\`](https://github.com/sebastienrousseau/stratos/releases/download/v0.0.13/stratos-win-x64.exe) — portable, x64
- **Installer SHA-256:** \`CF443AA09FE90AC807EA3C8DD19E26206440A157C3E7D57D5E1C15AC7B0FC450\`
- **Manifest version:** 1.6.0
- **License:** MIT
- **Project home:** https://github.com/sebastienrousseau/stratos

## Provenance

The installer is signed by the release workflow at https://github.com/sebastienrousseau/stratos/actions, attested with SLSA L3 in-toto provenance ([\`stratos-v0.0.13.intoto.jsonl\`](https://github.com/sebastienrousseau/stratos/releases/download/v0.0.13/stratos-v0.0.13.intoto.jsonl)) and Sigstore keyless signatures ([\`.sig\` + \`.crt\` files](https://github.com/sebastienrousseau/stratos/releases/tag/v0.0.13)).

The manifests themselves are generated by [\`scripts/make-winget.mjs\`](https://github.com/sebastienrousseau/stratos/blob/main/scripts/make-winget.mjs) at release time and re-hashed by the [\`manifests\` job](https://github.com/sebastienrousseau/stratos/blob/main/.github/workflows/release.yml) once the Windows binary is built. Both YAMLs in this PR were extracted from \`winget-manifests.tar.gz\` attached to the v0.0.13 GitHub Release.

## Manifests checklist

- [x] I have read and agree to the [Contributing Guidelines](https://github.com/microsoft/winget-pkgs/blob/master/CONTRIBUTING.md).
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update / change?
- [x] This PR only modifies one (1) manifest.
- [x] I have ensured installer URLs work as expected (the installer is the same artifact verified by the upstream release's smoke-verify job).
- [x] I have included a signed/unsigned installer.
- [x] Have you verified your manifest? Run \`winget validate <path>\` after merge to confirm. (Local validation: \`scripts/make-winget.mjs\` generates against schema 1.6.0.)

Future versions will be auto-bumped via [\`vedantmgoyal9/winget-releaser@v2\`](https://github.com/vedantmgoyal9/winget-releaser) — this PR is the one-time manual seed.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/382755)