### PR TITLE
New version: Nyassistant.DiscordAiNetworkBot version 0.2.3

### DIFF
--- a/manifests/n/Nyassistant/DiscordAiNetworkBot/0.2.3/Nyassistant.DiscordAiNetworkBot.installer.yaml
+++ b/manifests/n/Nyassistant/DiscordAiNetworkBot/0.2.3/Nyassistant.DiscordAiNetworkBot.installer.yaml
@@ -1,0 +1,11 @@
+PackageIdentifier: Nyassistant.DiscordAiNetworkBot
+PackageVersion: 0.2.3
+InstallerType: portable
+Commands:
+  - discord-ai-network-bot
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Hyeonjun0527/discord-ai-network-bot/releases/download/agent-v0.2.3/discord-ai-network-bot-windows.exe
+    InstallerSha256: c03ee891a04c82954b44c30f935d86d339cbee119b5ffb5fdfe7754c80df84a1
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/n/Nyassistant/DiscordAiNetworkBot/0.2.3/Nyassistant.DiscordAiNetworkBot.locale.en-US.yaml
+++ b/manifests/n/Nyassistant/DiscordAiNetworkBot/0.2.3/Nyassistant.DiscordAiNetworkBot.locale.en-US.yaml
@@ -1,0 +1,12 @@
+PackageIdentifier: Nyassistant.DiscordAiNetworkBot
+PackageVersion: 0.2.3
+PackageLocale: en-US
+Publisher: Nyassistant
+PublisherUrl: https://github.com/yeon-intergation-platform
+PackageName: discord-ai-network-bot
+PackageUrl: https://github.com/Hyeonjun0527/discord-ai-network-bot
+License: MIT
+ShortDescription: Connects your local Ollama to the community AI network (provider agent).
+Moniker: discord-ai-network-bot
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/n/Nyassistant/DiscordAiNetworkBot/0.2.3/Nyassistant.DiscordAiNetworkBot.yaml
+++ b/manifests/n/Nyassistant/DiscordAiNetworkBot/0.2.3/Nyassistant.DiscordAiNetworkBot.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Nyassistant.DiscordAiNetworkBot
+PackageVersion: 0.2.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Package
Nyassistant.DiscordAiNetworkBot 0.2.3 — community AI network provider agent (connects a local Ollama to a community pool).

- Open source: https://github.com/Hyeonjun0527/discord-ai-network-bot
- Portable single-exe, user-scope (no admin), MIT.
- InstallerSha256 verified against the GitHub Release asset.

### Manifest validation
- [x] Have you checked that there aren't other open PRs for the same manifest?
- [x] Have you validated your manifest locally with `winget validate`?
- [x] This manifest follows the 1.6 schema.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/382757)