### PR TITLE
New package: KickA.SleepTimer 3.6.0

### DIFF
--- a/manifests/k/KickA/SleepTimer/3.6.0/KickA.SleepTimer.yaml
+++ b/manifests/k/KickA/SleepTimer/3.6.0/KickA.SleepTimer.yaml
@@ -1,0 +1,37 @@
+﻿# Winget manifest for Sleep Timer (portable)
+PackageIdentifier: KickA.SleepTimer
+PackageVersion: 3.6.0
+PackageLocale: en-US
+Publisher: KickA
+PublisherUrl: https://github.com/Z3r0DayZion-install
+PublisherSupportUrl: https://github.com/Z3r0DayZion-install/ForgeCore_OS/issues
+PrivacyUrl: https://github.com/Z3r0DayZion-install/ForgeCore_OS
+Author: KickA
+PackageName: Sleep Timer
+PackageUrl: https://github.com/Z3r0DayZion-install/ForgeCore_OS
+License: MIT
+LicenseUrl: https://github.com/Z3r0DayZion-install/ForgeCore_OS/releases/download/v3.6.0/LICENSE
+Copyright: Copyright (c) KickA
+ShortDescription: Bedtime countdown for Windows â€” shutdown, sleep, or restart on a timer.
+Description: >-
+  Sleep Timer is a lightweight Windows bedtime countdown. Open it, the timer runs,
+  and your PC shuts down, sleeps, or restarts when time is up. Features include
+  system tray, snooze, 5-minute warning, and Ctrl+Shift+S emergency cancel.
+Moniker: sleep-timer
+Tags:
+  - sleep
+  - timer
+  - shutdown
+  - bedtime
+ReleaseDate: 2026-06-02
+Installers:
+  - Architecture: x64
+    InstallerType: portable
+    InstallerUrl: https://github.com/Z3r0DayZion-install/ForgeCore_OS/releases/download/v3.6.0/SleepTimer.exe
+    InstallerSha256: F48BDA15C5099177983CDD30A4A128393253CA642317E339B62365630AE6D934
+    PortableCommandAlias:
+      - Command: sleeptimer
+        Portable: true
+ManifestType: singleton
+ManifestVersion: 1.6.0
+

--- a/manifests/k/KickA/SleepTimer/3.6.0/KickA.SleepTimer.yaml
+++ b/manifests/k/KickA/SleepTimer/3.6.0/KickA.SleepTimer.yaml
@@ -29,9 +29,6 @@ Installers:
     InstallerType: portable
     InstallerUrl: https://github.com/Z3r0DayZion-install/ForgeCore_OS/releases/download/v3.6.0/SleepTimer.exe
     InstallerSha256: F48BDA15C5099177983CDD30A4A128393253CA642317E339B62365630AE6D934
-    PortableCommandAlias:
-      - Command: sleeptimer
-        Portable: true
 ManifestType: singleton
 ManifestVersion: 1.6.0
 


### PR DESCRIPTION
## Sleep Timer 3.6.0

Portable bedtime countdown for Windows.

- **Publisher:** KickA
- **Source:** https://github.com/Z3r0DayZion-install/ForgeCore_OS
- **Release:** https://github.com/Z3r0DayZion-install/ForgeCore_OS/releases/tag/v3.6.0

### Validation
\\\powershell
winget validate --manifest manifests/k/KickA/SleepTimer/3.6.0/KickA.SleepTimer.yaml
\\\

Made with [Cursor](https://cursor.com)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/382774)