### PR TITLE
New version: Feci.ParleyDeckCli version 1.10.0

### DIFF
--- a/manifests/f/Feci/ParleyDeckCli/1.10.0/Feci.ParleyDeckCli.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.10.0/Feci.ParleyDeckCli.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.10.0
+InstallerType: portable
+Commands:
+- parley
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.10.0/parley-v1.10.0-windows-x64.exe
+  InstallerSha256: 96082214EF4A1CD55201716294DF909B3B75F21857B215BC20EC7FF416ED17A8
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.10.0/parley-v1.10.0-windows-arm64.exe
+  InstallerSha256: 3854EE22BE40F5D79D7F79D3D64E5DF33E811AAD36E1497F822B104099110A41
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.10.0/Feci.ParleyDeckCli.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.10.0/Feci.ParleyDeckCli.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.10.0
+PackageLocale: en-US
+Publisher: Feci
+PublisherUrl: https://github.com/feci
+PackageName: Parley Deck CLI
+PackageUrl: https://github.com/feci/parley-deck-cli
+License: Apache-2.0
+LicenseUrl: https://github.com/feci/parley-deck-cli/blob/main/LICENSE
+ShortDescription: CLI for Parley Deck multi-agent workflows.
+Description: Creates and maintains Parley Deck workspaces, discovers local agent CLIs, runs cooperation rounds, tracks HITL questions, manages consensus signoffs, drives the COOPERATION.md §12 pipeline (parley pipeline), and emits repository context for agents.
+ReleaseNotesUrl: https://github.com/feci/parley-deck-cli/releases/tag/v1.10.0
+Tags:
+- ai
+- agents
+- cli
+- codex
+- collaboration
+- multi-agent
+- parley
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.10.0/Feci.ParleyDeckCli.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.10.0/Feci.ParleyDeckCli.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.10.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Manifest for Feci.ParleyDeckCli version 1.10.0

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] This PR adds a new version of an existing package (manifests under `manifests/f/Feci/ParleyDeckCli/1.10.0/`).
- [x] Manifest follows schema 1.12.0 (version + installer + defaultLocale).

#### Package
`Feci.ParleyDeckCli` — CLI for Parley Deck multi-agent cooperation workflows (drives the COOPERATION.md §12 pipeline). Apache-2.0.

#### Installers
Portable, cross-compiled Go binaries attached to the immutable GitHub release `v1.10.0`:
- x64: `parley-v1.10.0-windows-x64.exe`
- arm64: `parley-v1.10.0-windows-arm64.exe`

`InstallerSha256` values are computed from those release assets.

Note: built via `GOOS=windows go build` (no installer; `InstallerType: portable`, command `parley`).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/382801)