### PR TITLE
New version: Feci.ParleyDeckSkill version 1.3.1

### DIFF
--- a/manifests/f/Feci/ParleyDeckSkill/1.3.1/Feci.ParleyDeckSkill.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/1.3.1/Feci.ParleyDeckSkill.installer.yaml
@@ -7,9 +7,9 @@ Commands:
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/feci/parley-deck-skill/releases/download/v1.3.1/parley-deck-skill-v1.3.1-windows-x64.exe
-  InstallerSha256: 3655F13F6998444089850A00D24C0ACF0313AF5B190299E00010AB4AA250675A
+  InstallerSha256: 33A694535E86AEEBCBAB56A45B59EE3DB10B67F58FD987EC6AEFE5CB536F0A85
 - Architecture: arm64
   InstallerUrl: https://github.com/feci/parley-deck-skill/releases/download/v1.3.1/parley-deck-skill-v1.3.1-windows-arm64.exe
-  InstallerSha256: DFDC80661FA5B1C574C9C4C999EC0AEDCBCB5EFA9721A777CC9C2378347B0430
+  InstallerSha256: B99C5B19ED076D0FB05926E6D0785CADE24C8DE1DB7C77C0DB8290939F7A32C4
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckSkill/1.3.1/Feci.ParleyDeckSkill.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/1.3.1/Feci.ParleyDeckSkill.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 1.3.1
+InstallerType: portable
+Commands:
+- parley-deck-skill
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-skill/releases/download/v1.3.1/parley-deck-skill-v1.3.1-windows-x64.exe
+  InstallerSha256: 3655F13F6998444089850A00D24C0ACF0313AF5B190299E00010AB4AA250675A
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-skill/releases/download/v1.3.1/parley-deck-skill-v1.3.1-windows-arm64.exe
+  InstallerSha256: DFDC80661FA5B1C574C9C4C999EC0AEDCBCB5EFA9721A777CC9C2378347B0430
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckSkill/1.3.1/Feci.ParleyDeckSkill.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/1.3.1/Feci.ParleyDeckSkill.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 1.3.1
+PackageLocale: en-US
+Publisher: Feci
+PublisherUrl: https://github.com/feci
+PackageName: Parley Deck Skill
+PackageUrl: https://github.com/feci/parley-deck-skill
+License: Apache-2.0
+LicenseUrl: https://github.com/feci/parley-deck-skill/blob/main/LICENSE
+ShortDescription: Installer for the Parley Deck multi-agent cooperation skill.
+Description: Installs the vendor-neutral Parley Deck AI cooperation skill (incl. COOPERATION.md §12 pipeline blocks) into Codex, Claude Code, Antigravity CLI, legacy Gemini CLI, Hermes, or a custom skill directory.
+ReleaseNotesUrl: https://github.com/feci/parley-deck-skill/releases/tag/v1.3.1
+Tags:
+- ai
+- agents
+- agy
+- antigravity
+- cli
+- codex
+- claude
+- gemini
+- multi-agent
+- skill
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckSkill/1.3.1/Feci.ParleyDeckSkill.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/1.3.1/Feci.ParleyDeckSkill.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 1.3.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Manifest for Feci.ParleyDeckSkill version 1.3.1

- [x] Signed the Contributor License Agreement.
- [x] New version of an existing package (`manifests/f/Feci/ParleyDeckSkill/1.3.1/`).
- [x] Schema 1.12.0 (version + installer + defaultLocale).

#### Package
`Feci.ParleyDeckSkill` — installer for the vendor-neutral Parley Deck multi-agent cooperation skill (incl. COOPERATION.md §12 pipeline). Apache-2.0.

#### Installers
Portable Windows binaries attached to the immutable GitHub release `v1.3.1` (built with @yao-pkg/pkg):
- x64: `parley-deck-skill-v1.3.1-windows-x64.exe`
- arm64: `parley-deck-skill-v1.3.1-windows-arm64.exe`

`InstallerSha256` computed from those release assets. `InstallerType: portable`, command `parley-deck-skill`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/382803)