### PR TITLE
New package: SourceBox.SearchBox version 0.3.15

### DIFF
--- a/manifests/s/SourceBox/SearchBox/0.3.15/SourceBox.SearchBox.installer.yaml
+++ b/manifests/s/SourceBox/SearchBox/0.3.15/SourceBox.SearchBox.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: SourceBox.SearchBox
+PackageVersion: 0.3.15
+InstallerLocale: en-US
+InstallerType: wix
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-06-02
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/SourceBox-LLC/SearchBox/releases/download/v0.3.15/SearchBox-0.3.15-x86_64.msi
+    InstallerSha256: 57E7C97A26F2DD41436F459D099614219DBC6E8189D02DE657699DC3F698A4C6
+    ProductCode: '{AE82AFBF-B2CE-4900-9062-5F3EFC4BDCD4}'
+  - Architecture: arm64
+    InstallerUrl: https://github.com/SourceBox-LLC/SearchBox/releases/download/v0.3.15/SearchBox-0.3.15-aarch64.msi
+    InstallerSha256: BB7D2CD11E685E56D8E148B91F826B00CE5BD4BC36A9992572E482D61ADF2C99
+    ProductCode: '{F8E6CEAE-630F-4E97-82FB-00F8859E16A9}'
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/SourceBox/SearchBox/0.3.15/SourceBox.SearchBox.locale.en-US.yaml
+++ b/manifests/s/SourceBox/SearchBox/0.3.15/SourceBox.SearchBox.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: SourceBox.SearchBox
+PackageVersion: 0.3.15
+PackageLocale: en-US
+Publisher: SourceBox LLC
+PublisherUrl: https://www.sourceboxai.com/
+PublisherSupportUrl: https://github.com/SourceBox-LLC/SearchBox/issues
+PackageName: SearchBox
+PackageUrl: https://github.com/SourceBox-LLC/SearchBox
+License: AGPL-3.0-or-later
+LicenseUrl: https://github.com/SourceBox-LLC/SearchBox/blob/master/LICENSE
+ShortDescription: Private, local-first document search — search your own files like a search engine.
+Description: |-
+  SearchBox is a local-first document search app that indexes your files — folders,
+  ZIP and ZIM (Kiwix/Wikipedia) archives, and qBittorrent downloads — and lets you
+  search across them instantly from a clean web UI. It includes an optional
+  AES-256 encrypted vault and local AI summaries via Ollama. Nothing leaves your
+  machine by default; the bundled Meilisearch engine and all data stay local.
+Moniker: searchbox
+Tags:
+  - search
+  - document-search
+  - full-text-search
+  - local-first
+  - privacy
+  - offline
+  - desktop
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/SourceBox/SearchBox/0.3.15/SourceBox.SearchBox.yaml
+++ b/manifests/s/SourceBox/SearchBox/0.3.15/SourceBox.SearchBox.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: SourceBox.SearchBox
+PackageVersion: 0.3.15
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: SourceBox.SearchBox version 0.3.15

Supersedes #382262 (v0.3.0). v0.3.15 ships a **self-contained MSI** — it now bundles the Visual C++ runtime app-local, which resolves the clean-VM `STATUS_DLL_NOT_FOUND` (0xC0000135) that failed validation on the previous submission. No dependency declaration is needed.

- **Repo:** https://github.com/SourceBox-LLC/SearchBox (free, open-source, AGPL-3.0-or-later)
- **Installers:** the official x64 and arm64 MSIs from the v0.3.15 GitHub release, with SHA256 and per-architecture `ProductCode` pinned.
- Manifests validated locally with `winget validate` (succeeded).

This is the first version of a new package.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/382841)