### PR TITLE
New package: Passportogo.Voio version 3.0.11

### DIFF
--- a/manifests/p/Passportogo/Voio/3.0.11/Passportogo.Voio.installer.yaml
+++ b/manifests/p/Passportogo/Voio/3.0.11/Passportogo.Voio.installer.yaml
@@ -1,0 +1,16 @@
+PackageIdentifier: Passportogo.Voio
+PackageVersion: 3.0.11
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+InstallModes:
+  - interactive
+  - silent
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Elicohen1000/voio-releases/releases/download/v3.0.11/Voio_3.0.11_x64-setup.exe
+    InstallerSha256: 8665fbe42744fcd944589189a60185c6a4183782ef0184342d5a211207bac1bd
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/p/Passportogo/Voio/3.0.11/Passportogo.Voio.locale.en-US.yaml
+++ b/manifests/p/Passportogo/Voio/3.0.11/Passportogo.Voio.locale.en-US.yaml
@@ -1,0 +1,19 @@
+PackageIdentifier: Passportogo.Voio
+PackageVersion: 3.0.11
+PackageLocale: en-US
+Publisher: Passportogo Ltd
+PublisherUrl: https://www.tryvoio.app
+PublisherSupportUrl: https://www.tryvoio.app/support
+PackageName: Voio
+PackageUrl: https://www.tryvoio.app
+License: Proprietary
+ShortDescription: AI-powered writing assistant for Windows
+Description: Voio is an AI-powered writing assistant that works across all your Windows apps. It helps you write, correct, and improve text anywhere on your screen using keyboard shortcuts.
+Tags:
+  - ai
+  - writing
+  - productivity
+  - assistant
+  - text
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/p/Passportogo/Voio/3.0.11/Passportogo.Voio.locale.en-US.yaml
+++ b/manifests/p/Passportogo/Voio/3.0.11/Passportogo.Voio.locale.en-US.yaml
@@ -3,7 +3,7 @@ PackageVersion: 3.0.11
 PackageLocale: en-US
 Publisher: Passportogo Ltd
 PublisherUrl: https://www.tryvoio.app
-PublisherSupportUrl: https://www.tryvoio.app/support
+PublisherSupportUrl: https://www.tryvoio.app
 PackageName: Voio
 PackageUrl: https://www.tryvoio.app
 License: Proprietary

--- a/manifests/p/Passportogo/Voio/3.0.11/Passportogo.Voio.yaml
+++ b/manifests/p/Passportogo/Voio/3.0.11/Passportogo.Voio.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Passportogo.Voio
+PackageVersion: 3.0.11
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
New package submission

Package: Passportogo.Voio
Version: 3.0.11
Publisher: Passportogo Ltd
Product: Voio - AI-powered writing assistant for Windows
Website: https://www.tryvoio.app

Installer: x64 NSIS, EV-signed (Certum EV, CN=Passportogo Ltd), SHA256: 8665fbe42744fcd944589189a60185c6a4183782ef0184342d5a211207bac1bd, VirusTotal 0/71 clean.

Manifest validated with winget validate - no errors.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/382881)