### PR TITLE
KickA.LightsOut 4.3.0

### DIFF
--- a/manifests/k/KickA/LightsOut/4.3.0/KickA.LightsOut.yaml
+++ b/manifests/k/KickA/LightsOut/4.3.0/KickA.LightsOut.yaml
@@ -1,0 +1,46 @@
+﻿# Winget manifest for Lights Out (portable)
+PackageIdentifier: KickA.LightsOut
+PackageVersion: 4.3.0
+PackageLocale: en-US
+Publisher: KickA
+PublisherUrl: https://github.com/Z3r0DayZion-install
+PublisherSupportUrl: https://github.com/Z3r0DayZion-install/ForgeCore_OS/issues
+PrivacyUrl: https://github.com/Z3r0DayZion-install/ForgeCore_OS/blob/main/windsurf-project/SECURITY.md
+Author: KickA
+PackageName: Lights Out
+PackageUrl: https://github.com/Z3r0DayZion-install/LightsOut
+License: MIT
+LicenseUrl: https://github.com/Z3r0DayZion-install/ForgeCore_OS/blob/main/windsurf-project/LICENSE
+Copyright: Copyright (c) KickA
+ShortDescription: The bedtime shutdown timer for Windows.
+Description: >-
+  Lights Out is a lightweight bedtime countdown for Windows. Open it, the timer auto-starts,
+  and your PC shuts down, sleeps, or restarts when time is up. Features include a live tray
+  progress ring, end-time clock, punch animation, snooze, emergency cancel (Ctrl+Shift+S),
+  optional LuxGrid RGB events, CLI automation, graceful shutdown toggle, and a local audit log with no telemetry.
+Moniker: lights-out
+Tags:
+  - lights-out
+  - sleep
+  - timer
+  - shutdown
+  - bedtime
+  - ritual
+ReleaseDate: 2026-06-02
+Installers:
+  - Architecture: x64
+    InstallerType: portable
+    InstallerUrl: https://github.com/Z3r0DayZion-install/ForgeCore_OS/releases/download/v4.3.0/SleepTimer.exe
+    InstallerSha256: 91549F9EE523C532035CC9A487A976664DB504FF702C526F0EA9B081D5D4AC4C
+ManifestType: singleton
+ManifestVersion: 1.6.0
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
## Lights Out 4.3.0

The bedtime shutdown timer for Windows.

Publisher: KickA
Release: https://github.com/Z3r0DayZion-install/ForgeCore_OS/releases/tag/v4.3.0
Portable: SleepTimer.exe (~130 KB)

Manifests:
- manifests/k/KickA/LightsOut/4.3.0/KickA.LightsOut.yaml

Validation:
```powershell
winget validate --manifest manifests/k/KickA/LightsOut/4.3.0/KickA.LightsOut.yaml
```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/382913)