### PR TITLE
New version: mar1mo-41414.MineScale version 1.2.3

### DIFF
--- a/manifests/m/mar1mo-41414/MineScale/1.2.3/mar1mo-41414.MineScale.installer.yaml
+++ b/manifests/m/mar1mo-41414/MineScale/1.2.3/mar1mo-41414.MineScale.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: mar1mo-41414.MineScale
+PackageVersion: 1.2.3
+InstallerType: portable
+Commands:
+- mc-share-gui
+ReleaseDate: 2026-06-03
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/mar1mo-41414/MineScale/releases/download/v1.2.3/mc-share-gui-windows-x64.exe
+  InstallerSha256: 2114F6442086D2AC55504612D619BEE4AD2AD2A25E0514F58E7DA79133D18B65
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/mar1mo-41414/MineScale/1.2.3/mar1mo-41414.MineScale.locale.en-US.yaml
+++ b/manifests/m/mar1mo-41414/MineScale/1.2.3/mar1mo-41414.MineScale.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: mar1mo-41414.MineScale
+PackageVersion: 1.2.3
+PackageLocale: en-US
+Publisher: mar1mo-41414
+PublisherUrl: https://github.com/mar1mo-41414
+PublisherSupportUrl: https://github.com/mar1mo-41414/MineScale/issues
+Author: mar1mo-41414
+PackageName: MineScale
+PackageUrl: https://github.com/mar1mo-41414/MineScale
+License: MIT
+LicenseUrl: https://github.com/mar1mo-41414/MineScale/blob/main/LICENSE
+Copyright: Copyright (c) 2025 mar1mo-41414
+ShortDescription: Minecraft Java Edition P2P world sharing - no port forwarding, no accounts.
+Description: |-
+  MineScale lets two players share a Minecraft Java Edition world peer-to-peer
+  over an encrypted QUIC tunnel. No port forwarding, no account registration,
+  no monthly fees. The host runs a LAN world, sends a link, and the joiner's
+  Minecraft client sees it automatically in the multiplayer list.
+Moniker: minescale
+Tags:
+- gaming
+- minecraft
+- multiplayer
+- p2p
+ReleaseNotesUrl: https://github.com/mar1mo-41414/MineScale/releases/tag/v1.2.3
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/mar1mo-41414/MineScale/1.2.3/mar1mo-41414.MineScale.yaml
+++ b/manifests/m/mar1mo-41414/MineScale/1.2.3/mar1mo-41414.MineScale.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: mar1mo-41414.MineScale
+PackageVersion: 1.2.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## New package: MineScale 1.2.3

Manually authored manifest for mar1mo-41414.MineScale 1.2.3.

`wingetcreate new` rejected the source URL ("could not parse package")
because the .exe is a single-binary portable build with no installer
metadata to auto-detect; this PR provides the three manifest files
directly. The PE VS_VERSION_INFO is embedded as of v1.2.3.

## Summary

MineScale is a single-binary, portable Minecraft Java Edition P2P world
sharing tool. No installer, no port forwarding, no account, no fees.
Single .exe; users launch it, the GUI handles host/join setup, and the
shared world appears automatically in Minecraft's multiplayer list.

- Repo: https://github.com/mar1mo-41414/MineScale
- Release: https://github.com/mar1mo-41414/MineScale/releases/tag/v1.2.3
- License: MIT

## Validation

- [x] InstallerSha256 matches the released artifact
- [x] InstallerUrl resolves and returns 200
- [x] Installer is `portable` type (single .exe, no install steps)
- [x] PE VS_VERSION_INFO embedded (ProductName, ProductVersion, FileVersion)
- [x] Manifest passes schema 1.12.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/382940)