### PR TITLE
New package: Trappist.AgentCat version 26.23.0

### DIFF
--- a/manifests/t/Trappist/AgentCat/26.23.0/Trappist.AgentCat.installer.yaml
+++ b/manifests/t/Trappist/AgentCat/26.23.0/Trappist.AgentCat.installer.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: Trappist.AgentCat
+PackageVersion: 26.23.0
+InstallerLocale: en-US
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/yong076/agent-cat-releases/releases/download/v26.23.0/AgentCat-26.23.0-windows-x64-setup.exe
+    InstallerSha256: F4408095760B14982F5CA31EF6ED117983B41FC7AB9BA0E865EC8CE18CA67C5F
+    ProductCode: Agent Cat
+    AppsAndFeaturesEntries:
+      - DisplayName: Agent Cat
+        DisplayVersion: 26.23.0
+        Publisher: trappist
+        ProductCode: Agent Cat
+        InstallerType: nullsoft
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/t/Trappist/AgentCat/26.23.0/Trappist.AgentCat.locale.en-US.yaml
+++ b/manifests/t/Trappist/AgentCat/26.23.0/Trappist.AgentCat.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: Trappist.AgentCat
+PackageVersion: 26.23.0
+PackageLocale: en-US
+Publisher: trappist
+PublisherUrl: https://agentcat.app
+PublisherSupportUrl: https://github.com/yong076/agent-cat-releases/issues
+PackageName: Agent Cat
+PackageUrl: https://agentcat.app
+License: Proprietary
+Copyright: Copyright (c) trappist
+ShortDescription: Menu-bar companion that tracks your local AI coding agent usage — token counts, quotas, CPU/memory, and history — with a reactive mascot.
+Description: |-
+  Agent Cat is a lightweight desktop companion that monitors the AI coding
+  agents running on your machine. It surfaces token usage, plan quotas, CPU and
+  memory, project breakdowns, and historical trends in a compact dashboard, with
+  an animated mascot that reacts to how hard your agents are working.
+Moniker: agentcat
+Tags:
+  - ai
+  - cli
+  - coding
+  - dashboard
+  - developer-tools
+  - menu-bar
+  - monitor
+  - productivity
+  - token-usage
+  - usage
+ReleaseNotesUrl: https://github.com/yong076/agent-cat-releases/releases/tag/v26.23.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/t/Trappist/AgentCat/26.23.0/Trappist.AgentCat.yaml
+++ b/manifests/t/Trappist/AgentCat/26.23.0/Trappist.AgentCat.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: Trappist.AgentCat
+PackageVersion: 26.23.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: `Trappist.AgentCat` 26.23.0

Agent Cat — a menu-bar companion that monitors local AI coding agent usage (token counts, plan quotas, CPU/memory, project breakdowns, history) with a reactive mascot.

- Installer: NSIS (`nullsoft`), x64, from the official public GitHub release (`yong076/agent-cat-releases`).
- Silent install: `/S`; per-user `Scope: user`.
- `winget validate` passes locally.
- `ProductCode` / Apps & Features entry (`Agent Cat`) derived from a real installation.
- Manifest hand-authored against schema 1.6.0.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/383007)