### PR TITLE
New package: CavemanSoft.CaveButler version 1.0

### DIFF
--- a/manifests/c/CavemanSoft/CaveButler/1.0/CavemanSoft.CaveButler.installer.yaml
+++ b/manifests/c/CavemanSoft/CaveButler/1.0/CavemanSoft.CaveButler.installer.yaml
@@ -13,5 +13,11 @@ Installers:
 - Architecture: x64
   InstallerUrl: https://cavemansoft.com/CaveButler/releases/1.0/CaveButler-1.0-setup.exe
   InstallerSha256: EE91C6974A0F84D8881C924CF058C2BED15D649E00FDB344AB7AE3424E6E2441
+  ProductCode: '{BDA869EF-226D-433B-B615-C68FE3C9599E}_is1'
+  AppsAndFeaturesEntries:
+  - DisplayName: CaveButler version 1.0
+    DisplayVersion: "1.0"
+    Publisher: CavemanSoft
+    ProductCode: '{BDA869EF-226D-433B-B615-C68FE3C9599E}_is1'
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/c/CavemanSoft/CaveButler/1.0/CavemanSoft.CaveButler.installer.yaml
+++ b/manifests/c/CavemanSoft/CaveButler/1.0/CavemanSoft.CaveButler.installer.yaml
@@ -4,11 +4,10 @@
 PackageIdentifier: CavemanSoft.CaveButler
 PackageVersion: "1.0"
 InstallerType: inno
-NestedInstallerType: inno
 Scope: user
 InstallerSwitches:
-  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
-  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
 Installers:
 - Architecture: x64
   InstallerUrl: https://cavemansoft.com/CaveButler/releases/1.0/CaveButler-1.0-setup.exe

--- a/manifests/c/CavemanSoft/CaveButler/1.0/CavemanSoft.CaveButler.installer.yaml
+++ b/manifests/c/CavemanSoft/CaveButler/1.0/CavemanSoft.CaveButler.installer.yaml
@@ -1,0 +1,17 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: CavemanSoft.CaveButler
+PackageVersion: "1.0"
+InstallerType: inno
+NestedInstallerType: inno
+Scope: user
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART
+Installers:
+- Architecture: x64
+  InstallerUrl: https://cavemansoft.com/CaveButler/releases/1.0/CaveButler-1.0-setup.exe
+  InstallerSha256: EE91C6974A0F84D8881C924CF058C2BED15D649E00FDB344AB7AE3424E6E2441
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/CavemanSoft/CaveButler/1.0/CavemanSoft.CaveButler.installer.yaml
+++ b/manifests/c/CavemanSoft/CaveButler/1.0/CavemanSoft.CaveButler.installer.yaml
@@ -11,7 +11,7 @@ InstallerSwitches:
 Installers:
 - Architecture: x64
   InstallerUrl: https://cavemansoft.com/CaveButler/releases/1.0/CaveButler-1.0-setup.exe
-  InstallerSha256: DA333DACF3484030F059C93CBA2C8D5B6E17DED874A85BF5728C4DA64C39F4FA
+  InstallerSha256: 0A6E60CA93E886E77523FC9960660DA95BB7D35F376D0352A55E7085229F8489
   ProductCode: '{BDA869EF-226D-433B-B615-C68FE3C9599E}_is1'
   AppsAndFeaturesEntries:
   - DisplayName: CaveButler

--- a/manifests/c/CavemanSoft/CaveButler/1.0/CavemanSoft.CaveButler.installer.yaml
+++ b/manifests/c/CavemanSoft/CaveButler/1.0/CavemanSoft.CaveButler.installer.yaml
@@ -14,7 +14,7 @@ Installers:
   InstallerSha256: DA333DACF3484030F059C93CBA2C8D5B6E17DED874A85BF5728C4DA64C39F4FA
   ProductCode: '{BDA869EF-226D-433B-B615-C68FE3C9599E}_is1'
   AppsAndFeaturesEntries:
-  - DisplayName: CaveButler version 1.0
+  - DisplayName: CaveButler
     DisplayVersion: "1.0"
     Publisher: CavemanSoft
     ProductCode: '{BDA869EF-226D-433B-B615-C68FE3C9599E}_is1'

--- a/manifests/c/CavemanSoft/CaveButler/1.0/CavemanSoft.CaveButler.installer.yaml
+++ b/manifests/c/CavemanSoft/CaveButler/1.0/CavemanSoft.CaveButler.installer.yaml
@@ -11,7 +11,7 @@ InstallerSwitches:
 Installers:
 - Architecture: x64
   InstallerUrl: https://cavemansoft.com/CaveButler/releases/1.0/CaveButler-1.0-setup.exe
-  InstallerSha256: EE91C6974A0F84D8881C924CF058C2BED15D649E00FDB344AB7AE3424E6E2441
+  InstallerSha256: DA333DACF3484030F059C93CBA2C8D5B6E17DED874A85BF5728C4DA64C39F4FA
   ProductCode: '{BDA869EF-226D-433B-B615-C68FE3C9599E}_is1'
   AppsAndFeaturesEntries:
   - DisplayName: CaveButler version 1.0

--- a/manifests/c/CavemanSoft/CaveButler/1.0/CavemanSoft.CaveButler.locale.en-US.yaml
+++ b/manifests/c/CavemanSoft/CaveButler/1.0/CavemanSoft.CaveButler.locale.en-US.yaml
@@ -1,0 +1,12 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: CavemanSoft.CaveButler
+PackageVersion: "1.0"
+PackageLocale: en-US
+Publisher: CavemanSoft
+PackageName: CaveButler
+License: Proprietary
+ShortDescription: CaveButler is a Windows automation app that watches your folders and applies customizable rules to organize files automatically, saving time on repetitive file management.
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/CavemanSoft/CaveButler/1.0/CavemanSoft.CaveButler.yaml
+++ b/manifests/c/CavemanSoft/CaveButler/1.0/CavemanSoft.CaveButler.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: CavemanSoft.CaveButler
+PackageVersion: "1.0"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds a new manifest for `CavemanSoft.CaveButler` version `1.0`.

Manifest path:
`manifests/c/CavemanSoft/CaveButler/1.0/`

Installer details:
- InstallerType: `inno`
- Architecture: `x64`
- Scope: `user`
- Installer URL points to the published CaveButler 1.0 setup binary.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
