### PR TITLE
Add Jawollo07.SPL version 1.0.0

### DIFF
--- a/manifests/j/Jawollo07/SPL/1.0.0/Jawollo07.SPL.yaml
+++ b/manifests/j/Jawollo07/SPL/1.0.0/Jawollo07.SPL.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.singleton.1.6.0.schema.json
+PackageIdentifier: Jawollo07.SPL
+PackageVersion: 1.0.0
+PackageName: SPL Editor
+Publisher: Jawollo07
+PackageUrl: https://github.com/Jawollo07/spl
+License: MIT # Oder deine gewählte Lizenz
+ShortDescription: Ein Editor für die Programmiersprache SPL.
+Moniker: spl
+Tags:
+  - avalonia
+  - development
+  - spl
+Installers:
+  - Architecture: x64
+    InstallerType: portable
+    InstallerUrl: https://github.com/Jawollo07/SPL/releases/download/v1.0.0/SPL-v1.0.0-win-x64.zip
+    InstallerSha256: c2f60f79aeeda598f61b0243d64c8e48b15d9faff839f256c690979b7258cf67
+    Commands:
+      - spl
+ManifestType: singleton
+ManifestVersion: 1.6.0


### PR DESCRIPTION
New package: Jawollo07.SPL version 1.0.0
## 📖 Description
This PR adds the initial manifest for the `Jawollo07.SPL` package at version `1.0.0`. It provides a portable installation of the SPL Editor for Windows x64.

## ✅ Checklist
- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist
- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/383052)