### PR TITLE
New package: OpenCLICollective.cr version 0.1.50

### DIFF
--- a/manifests/o/OpenCLICollective/cr/0.1.50/OpenCLICollective.cr.installer.yaml
+++ b/manifests/o/OpenCLICollective/cr/0.1.50/OpenCLICollective.cr.installer.yaml
@@ -1,0 +1,20 @@
+# Created manually from upstream package metadata
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: OpenCLICollective.cr
+PackageVersion: 0.1.50
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: cr.exe
+  PortableCommandAlias: cr
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/open-cli-collective/codereview-cli/releases/download/v0.1.50/cr_v0.1.50_windows_amd64.zip
+  InstallerSha256: 9D4021709672AC3DF45131818CB91C4010C52D023356EB895FFEC033DD2E8AEE
+- Architecture: arm64
+  InstallerUrl: https://github.com/open-cli-collective/codereview-cli/releases/download/v0.1.50/cr_v0.1.50_windows_arm64.zip
+  InstallerSha256: 4D9884F3C22D07909DB29E6473E0FDDFF15E773B702B585BC818A8A0EB2990E1
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-06-03

--- a/manifests/o/OpenCLICollective/cr/0.1.50/OpenCLICollective.cr.locale.en-US.yaml
+++ b/manifests/o/OpenCLICollective/cr/0.1.50/OpenCLICollective.cr.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# Created manually from upstream package metadata
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: OpenCLICollective.cr
+PackageVersion: 0.1.50
+PackageLocale: en-US
+Publisher: Open CLI Collective
+PublisherUrl: https://github.com/open-cli-collective
+PublisherSupportUrl: https://github.com/open-cli-collective/codereview-cli/issues
+PackageName: Code Review CLI
+PackageUrl: https://github.com/open-cli-collective/codereview-cli
+License: MIT
+LicenseUrl: https://github.com/open-cli-collective/codereview-cli/blob/main/LICENSE
+ShortDescription: Automated pull-request review CLI
+Description: |-
+  cr runs automated pull-request reviews, records review state locally, posts
+  review output back to GitHub, and keeps durable metadata to resume, repair,
+  inspect, and prune review runs.
+Tags:
+- code-review
+- pull-request
+- github
+- cli
+- automation
+ReleaseNotesUrl: https://github.com/open-cli-collective/codereview-cli/releases/tag/v0.1.50
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenCLICollective/cr/0.1.50/OpenCLICollective.cr.yaml
+++ b/manifests/o/OpenCLICollective/cr/0.1.50/OpenCLICollective.cr.yaml
@@ -1,0 +1,8 @@
+# Created manually from upstream package metadata
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: OpenCLICollective.cr
+PackageVersion: 0.1.50
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

New package: OpenCLICollective.cr version 0.1.50.

Release: https://github.com/open-cli-collective/codereview-cli/releases/tag/v0.1.50

## Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  - N/A

## Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> Note: `winget` validation and install testing were not run locally because this submission was prepared from macOS. Basic YAML syntax and Git whitespace validation passed locally.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/383129)