### PR TITLE
New package: SourceBox.SearchBox version 0.3.16

### DIFF
--- a/manifests/s/SourceBox/SearchBox/0.3.16/SourceBox.SearchBox.installer.yaml
+++ b/manifests/s/SourceBox/SearchBox/0.3.16/SourceBox.SearchBox.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: SourceBox.SearchBox
+PackageVersion: 0.3.16
+InstallerLocale: en-US
+InstallerType: wix
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-06-03
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/SourceBox-LLC/SearchBox/releases/download/v0.3.16/SearchBox-0.3.16-x86_64.msi
+    InstallerSha256: ACB2D6A9CB21571F185EE3CB6908F262BC78E53F00F688D60C6F281494ACA8C0
+    ProductCode: '{2D9B39F0-C6B2-45D9-B497-10C473A4853D}'
+  - Architecture: arm64
+    InstallerUrl: https://github.com/SourceBox-LLC/SearchBox/releases/download/v0.3.16/SearchBox-0.3.16-aarch64.msi
+    InstallerSha256: A4733920D92D98F570ED2A4C835BF6BFFD7FE27FBC06B70BD6127EC1B62BE4B3
+    ProductCode: '{4629D886-6387-49B6-A364-CE7F2E87BA23}'
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/SourceBox/SearchBox/0.3.16/SourceBox.SearchBox.locale.en-US.yaml
+++ b/manifests/s/SourceBox/SearchBox/0.3.16/SourceBox.SearchBox.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: SourceBox.SearchBox
+PackageVersion: 0.3.16
+PackageLocale: en-US
+Publisher: SourceBox LLC
+PublisherUrl: https://www.sourceboxai.com/
+PublisherSupportUrl: https://github.com/SourceBox-LLC/SearchBox/issues
+PackageName: SearchBox
+PackageUrl: https://github.com/SourceBox-LLC/SearchBox
+License: AGPL-3.0-or-later
+LicenseUrl: https://github.com/SourceBox-LLC/SearchBox/blob/master/LICENSE
+ShortDescription: Private, local-first document search — search your own files like a search engine.
+Description: |-
+  SearchBox is a local-first document search app that indexes your files — folders,
+  ZIP and ZIM (Kiwix/Wikipedia) archives, and qBittorrent downloads — and lets you
+  search across them instantly from a clean web UI. It includes an optional
+  AES-256 encrypted vault and local AI summaries via Ollama. Nothing leaves your
+  machine by default; the bundled Meilisearch engine and all data stay local.
+Moniker: searchbox
+Tags:
+  - search
+  - document-search
+  - full-text-search
+  - local-first
+  - privacy
+  - offline
+  - desktop
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/SourceBox/SearchBox/0.3.16/SourceBox.SearchBox.yaml
+++ b/manifests/s/SourceBox/SearchBox/0.3.16/SourceBox.SearchBox.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: SourceBox.SearchBox
+PackageVersion: 0.3.16
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: SourceBox.SearchBox version 0.3.16

Supersedes #382841 (v0.3.15). v0.3.16 is a security release — it binds the app and its bundled Meilisearch index to loopback only (they previously listened on all interfaces) and generates a private per-install Meilisearch key, so I'd like the first version installable via winget to be this one rather than 0.3.15.

- **Repo:** https://github.com/SourceBox-LLC/SearchBox (free, open-source, AGPL-3.0-or-later)
- **Installers:** the official x64 and arm64 MSIs from the v0.3.16 GitHub release, SHA256 + per-architecture `ProductCode` pinned. The MSI is self-contained (bundles the VC++ runtime), so no dependency declaration is needed.
- Manifests validated locally with `winget validate` (succeeded).

The CLA was already accepted on #382841, so it carries over to this PR. This is the first version of a new package.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/383316)