### PR TITLE
New version: Sewandev.Reverbic version 1.1.0

### DIFF
--- a/manifests/s/Sewandev/Reverbic/1.1.0/Sewandev.Reverbic.installer.yaml
+++ b/manifests/s/Sewandev/Reverbic/1.1.0/Sewandev.Reverbic.installer.yaml
@@ -1,0 +1,10 @@
+PackageIdentifier: Sewandev.Reverbic
+PackageVersion: 1.1.0
+MinimumOSVersion: 10.0.0.0
+InstallerType: portable
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/sewandev/Reverbic/releases/download/v1.1.0/reverbic-v1.1.0-x86_64-windows.exe
+    InstallerSha256: 8E4D80DB62A99AEEB9C971F1671754571922402E2B8443D7AD45B6932221B413
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/Sewandev/Reverbic/1.1.0/Sewandev.Reverbic.installer.yaml
+++ b/manifests/s/Sewandev/Reverbic/1.1.0/Sewandev.Reverbic.installer.yaml
@@ -5,6 +5,6 @@ InstallerType: portable
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/sewandev/Reverbic/releases/download/v1.1.0/reverbic-v1.1.0-x86_64-windows.exe
-    InstallerSha256: 8E4D80DB62A99AEEB9C971F1671754571922402E2B8443D7AD45B6932221B413
+    InstallerSha256: 7D1CA9A10418C37623E2509E0854080840E5538ED5C21D85B4FB63FEB92C005C
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/s/Sewandev/Reverbic/1.1.0/Sewandev.Reverbic.locale.en-US.yaml
+++ b/manifests/s/Sewandev/Reverbic/1.1.0/Sewandev.Reverbic.locale.en-US.yaml
@@ -1,0 +1,23 @@
+PackageIdentifier: Sewandev.Reverbic
+PackageVersion: 1.1.0
+PackageLocale: en-US
+Publisher: Esteban Jaramillo
+PublisherUrl: https://github.com/sewandev
+PackageName: Reverbic
+PackageUrl: https://github.com/sewandev/Reverbic
+License: MIT
+LicenseUrl: https://github.com/sewandev/Reverbic/blob/main/LICENSE
+ShortDescription: Terminal radio player for Windows with Spotify integration and gaming overlay.
+Description: |-
+  Reverbic is a terminal-based radio player for Windows. Stream thousands of internet
+  radio stations, control Spotify remotely, and enjoy a floating Now Playing overlay
+  while gaming — all from the command line.
+Tags:
+  - radio
+  - spotify
+  - tui
+  - terminal
+  - audio
+ReleaseNotesUrl: https://github.com/sewandev/Reverbic/releases/tag/v1.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/Sewandev/Reverbic/1.1.0/Sewandev.Reverbic.yaml
+++ b/manifests/s/Sewandev/Reverbic/1.1.0/Sewandev.Reverbic.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Sewandev.Reverbic
+PackageVersion: 1.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## 📖 Description

New version of **Sewandev.Reverbic** — a terminal-based radio player and Spotify remote for Windows.

**Package:** `Sewandev.Reverbic`
**Version:** `1.1.0`
**Type:** Portable executable (x64)

### Changes in this version
- Progress bar in the Spotify overlay strip with elapsed/total time
- App logo visible in the main view when the terminal has enough space
- Contextual keybinding hints at the modal footer
- Configurable screensaver clock toggle
- Dead URL detection for radio stations (HTTP 404): no retries, immediate error
- Visual `!` indicator on favorites for dead station URLs
- YouTube tab placeholder (coming soon)
- Favorites shortcut changed from `F` to `Alt+F`
- Section separators now reflect player state via color

**Release:** https://github.com/sewandev/Reverbic/releases/tag/v1.1.0
**Changelog:** https://github.com/sewandev/Reverbic/blob/main/CHANGELOG.md

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
- N/A

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/383337)