### PR TITLE
New package: Sewandev.Reverbic version 1.2.0

### DIFF
--- a/manifests/s/Sewandev/Reverbic/1.2.0/Sewandev.Reverbic.installer.yaml
+++ b/manifests/s/Sewandev/Reverbic/1.2.0/Sewandev.Reverbic.installer.yaml
@@ -1,0 +1,14 @@
+PackageIdentifier: Sewandev.Reverbic
+PackageVersion: 1.2.0
+InstallerLocale: en-US
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: portable
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/sewandev/Reverbic/releases/download/v1.2.0/reverbic-v1.2.0-x86_64-windows.exe
+    InstallerSha256: 818a0b89bbdb5bd61ab080b9a272fe089790c0e7a606236cb0f0701d539dba98
+    PortableCommandAlias: reverbic
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/Sewandev/Reverbic/1.2.0/Sewandev.Reverbic.locale.en-US.yaml
+++ b/manifests/s/Sewandev/Reverbic/1.2.0/Sewandev.Reverbic.locale.en-US.yaml
@@ -1,0 +1,21 @@
+PackageIdentifier: Sewandev.Reverbic
+PackageVersion: 1.2.0
+PackageLocale: en-US
+Publisher: Sewandev
+PublisherUrl: https://github.com/sewandev
+PublisherSupportUrl: https://github.com/sewandev/Reverbic/issues
+PackageName: Reverbic
+PackageUrl: https://github.com/sewandev/Reverbic
+License: MIT
+LicenseUrl: https://github.com/sewandev/Reverbic/blob/main/LICENSE
+ShortDescription: Terminal radio player and Spotify remote for Windows
+Description: Reverbic is a terminal UI application for Windows that combines internet radio playback via RadioBrowser API with Spotify remote control. Built with Rust and ratatui.
+Tags:
+  - radio
+  - spotify
+  - terminal
+  - tui
+  - music
+  - rust
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/Sewandev/Reverbic/1.2.0/Sewandev.Reverbic.yaml
+++ b/manifests/s/Sewandev/Reverbic/1.2.0/Sewandev.Reverbic.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Sewandev.Reverbic
+PackageVersion: 1.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## New Package: Sewandev.Reverbic 1.2.0

**Package:** `Sewandev.Reverbic`
**Version:** `1.2.0`
**Type:** Portable executable

### Description
Reverbic is a terminal UI application for Windows that combines internet radio playback (RadioBrowser API) with Spotify remote control. Built with Rust and ratatui.

### Manifest details
- **Installer URL:** https://github.com/sewandev/Reverbic/releases/download/v1.2.0/reverbic-v1.2.0-x86_64-windows.exe
- **SHA256:** `818a0b89bbdb5bd61ab080b9a272fe089790c0e7a606236cb0f0701d539dba98`
- **Architecture:** x64
- **InstallerType:** portable

### Testing
```powershell
winget install --id Sewandev.Reverbic --version 1.2.0
```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/383443)