### PR TITLE
New version: rtk-ai.rtk version 0.42.1

### DIFF
--- a/manifests/r/rtk-ai/rtk/0.42.1/rtk-ai.rtk.installer.yaml
+++ b/manifests/r/rtk-ai/rtk/0.42.1/rtk-ai.rtk.installer.yaml
@@ -1,0 +1,17 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: rtk-ai.rtk
+PackageVersion: 0.42.1
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: rtk.exe
+  PortableCommandAlias: rtk
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/rtk-ai/rtk/releases/download/v0.42.1/rtk-x86_64-pc-windows-msvc.zip
+  InstallerSha256: 5F292B031595405671B41E29AA5016931E8598949C25D9751F0EEBD2ECCEFE0B
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-06-03

--- a/manifests/r/rtk-ai/rtk/0.42.1/rtk-ai.rtk.locale.en-US.yaml
+++ b/manifests/r/rtk-ai/rtk/0.42.1/rtk-ai.rtk.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: rtk-ai.rtk
+PackageVersion: 0.42.1
+PackageLocale: en-US
+Publisher: rtk-ai
+PublisherUrl: https://www.rtk-ai.app
+PublisherSupportUrl: https://github.com/rtk-ai/rtk/issues
+PrivacyUrl: https://github.com/rtk-ai/rtk/blob/master/docs/TELEMETRY.md
+Author: rtk-ai
+PackageName: rtk
+PackageUrl: https://github.com/rtk-ai/rtk
+License: MIT License
+LicenseUrl: https://github.com/rtk-ai/rtk/blob/master/LICENSE
+Copyright: 2024 Patrick Szymkowiak
+ShortDescription: CLI proxy that reduces LLM token consumption by 60-90% on common dev commands. Single Rust binary, zero dependencies
+Description: CLI proxy that reduces LLM token consumption by 60-90% on common dev commands. Single Rust binary, zero dependencies
+Moniker: rtk
+Tags:
+- cli
+- llm
+- token
+- filter
+- productivity
+- rust-token-killer
+ReleaseNotesUrl: https://github.com/rtk-ai/rtk/releases/tag/v0.42.1
+InstallationNotes: Run `rtk init -g` to begin (installs `rtk` as a globally available hook for all `bash` commands)
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/rtk-ai/rtk/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/rtk-ai/rtk/0.42.1/rtk-ai.rtk.yaml
+++ b/manifests/r/rtk-ai/rtk/0.42.1/rtk-ai.rtk.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: rtk-ai.rtk
+PackageVersion: 0.42.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Summary

Adds rtk-ai.rtk version 0.42.1 to winget.

- Upstream release: https://github.com/rtk-ai/rtk/releases/tag/v0.42.1
- Installer: rtk-x86_64-pc-windows-msvc.zip (x64)
- SHA256: 5F292B031595405671B41E29AA5016931E8598949C25D9751F0EEBD2ECCEFE0B
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/383520)