### PR TITLE
New version: JimmyLv.BibiGPT version 4.463.0

### DIFF
--- a/manifests/j/JimmyLv/BibiGPT/4.463.0/JimmyLv.BibiGPT.installer.yaml
+++ b/manifests/j/JimmyLv/BibiGPT/4.463.0/JimmyLv.BibiGPT.installer.yaml
@@ -1,0 +1,14 @@
+# Created using winget create
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: JimmyLv.BibiGPT
+PackageVersion: 4.463.0
+InstallerType: nullsoft
+UpgradeBehavior: install
+ReleaseDate: 2026-06-04
+Installers:
+- Architecture: x64
+  InstallerUrl: https://bibigpt-apps.oss-cn-beijing.aliyuncs.com/desktop-releases/BibiGPT-4.463.0-windows-x86_64.exe
+  InstallerSha256: 1C1AC7E68ECC16702BAD4FAAB834C1966FEBF17645677906E6467814611F81C6
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/j/JimmyLv/BibiGPT/4.463.0/JimmyLv.BibiGPT.locale.en-US.yaml
+++ b/manifests/j/JimmyLv/BibiGPT/4.463.0/JimmyLv.BibiGPT.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# Created using winget create
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: JimmyLv.BibiGPT
+PackageVersion: 4.463.0
+PackageLocale: en-US
+Publisher: JimmyLv
+PublisherUrl: https://bibigpt.co
+PublisherSupportUrl: https://github.com/JimmyLv/BibiGPT-v1/issues
+PackageName: BibiGPT
+PackageUrl: https://bibigpt.co/apps/desktop
+License: MIT
+LicenseUrl: https://bibigpt.co/terms-of-use
+ShortDescription: AI-powered video and audio content summarization assistant
+Description: BibiGPT is an AI-powered desktop application that summarizes video and audio content from YouTube, Bilibili, podcasts, and local files. Features include one-click summarization, visual frame analysis, subtitle embedding, and folder monitoring.
+Moniker: bibigpt
+Tags:
+- ai
+- audio
+- bilibili
+- summarization
+- video
+- youtube
+- prc
+- china
+ReleaseNotes: Visual analysis & summarization | Folder monitoring
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/j/JimmyLv/BibiGPT/4.463.0/JimmyLv.BibiGPT.locale.zh-CN.yaml
+++ b/manifests/j/JimmyLv/BibiGPT/4.463.0/JimmyLv.BibiGPT.locale.zh-CN.yaml
@@ -1,0 +1,25 @@
+# Created using winget create
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.9.0.schema.json
+
+PackageIdentifier: JimmyLv.BibiGPT
+PackageVersion: 4.463.0
+PackageLocale: zh-CN
+Publisher: JimmyLv
+PublisherUrl: https://bibigpt.co
+PublisherSupportUrl: https://github.com/JimmyLv/BibiGPT-v1/issues
+PackageName: BibiGPT
+PackageUrl: https://bibigpt.co/apps/desktop
+License: MIT
+LicenseUrl: https://bibigpt.co/terms-of-use
+ShortDescription: AI 视频/音频内容总结助手
+Description: BibiGPT 是一款 AI 驱动的桌面应用，支持总结 YouTube、Bilibili、播客及本地文件的视频和音频内容。功能包括一键总结、视觉逐帧分析、字幕压制和文件夹自动监控。
+Tags:
+- ai
+- bilibili
+- youtube
+- 总结
+- 视频
+- 音频
+ReleaseNotes: 视觉化分析与总结丨文件夹监控
+ManifestType: locale
+ManifestVersion: 1.9.0

--- a/manifests/j/JimmyLv/BibiGPT/4.463.0/JimmyLv.BibiGPT.yaml
+++ b/manifests/j/JimmyLv/BibiGPT/4.463.0/JimmyLv.BibiGPT.yaml
@@ -1,0 +1,8 @@
+# Created using winget create
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: JimmyLv.BibiGPT
+PackageVersion: 4.463.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Update **JimmyLv.BibiGPT** to version **4.463.0**.

- Previously published winget version: `4.257.0`
- Installer type: NSIS (nullsoft), x64
- `InstallerSha256` computed from the live published installer and verified
- Manifests use schema `1.9.0`, derived from the previously validated `4.257.0` manifest — only `PackageVersion`, `InstallerUrl`, `InstallerSha256` and `ReleaseDate` changed

This brings the package up to date after several months of releases.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)? (signed for the earlier 4.257.0 PR)
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update?
- [ ] Validated locally with `winget validate` — not run (authored on macOS, no Windows/winget available); relying on the repository's automated validation workflow.
- [x] This PR only adds one (1) package version manifest.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/383542)