### PR TITLE
New version: Sewandev.Reverbic version 1.3.0

### DIFF
--- a/manifests/s/Sewandev/Reverbic/1.3.0/Sewandev.Reverbic.installer.yaml
+++ b/manifests/s/Sewandev/Reverbic/1.3.0/Sewandev.Reverbic.installer.yaml
@@ -1,0 +1,10 @@
+PackageIdentifier: Sewandev.Reverbic
+PackageVersion: 1.3.0
+MinimumOSVersion: 10.0.0.0
+InstallerType: portable
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/sewandev/Reverbic/releases/download/v1.3.0/reverbic-v1.3.0-x86_64-windows.exe
+    InstallerSha256: 9f795e09d8bef0a8ff8cf9fb48bf0db54b0a80bc0ce9757e5023579856cc91e0
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/Sewandev/Reverbic/1.3.0/Sewandev.Reverbic.locale.en-US.yaml
+++ b/manifests/s/Sewandev/Reverbic/1.3.0/Sewandev.Reverbic.locale.en-US.yaml
@@ -1,0 +1,23 @@
+PackageIdentifier: Sewandev.Reverbic
+PackageVersion: 1.3.0
+PackageLocale: en-US
+Publisher: Esteban Jaramillo
+PublisherUrl: https://github.com/sewandev
+PackageName: Reverbic
+PackageUrl: https://github.com/sewandev/Reverbic
+License: MIT
+LicenseUrl: https://github.com/sewandev/Reverbic/blob/main/LICENSE
+ShortDescription: Terminal radio player for Windows with Spotify integration and gaming overlay.
+Description: |-
+  Reverbic is a terminal-based radio player for Windows. Stream thousands of internet
+  radio stations, control Spotify remotely, and enjoy a floating Now Playing overlay
+  while gaming — all from the command line.
+Tags:
+  - radio
+  - spotify
+  - tui
+  - terminal
+  - audio
+ReleaseNotesUrl: https://github.com/sewandev/Reverbic/releases/tag/v1.3.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/Sewandev/Reverbic/1.3.0/Sewandev.Reverbic.yaml
+++ b/manifests/s/Sewandev/Reverbic/1.3.0/Sewandev.Reverbic.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Sewandev.Reverbic
+PackageVersion: 1.3.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Sewandev.Reverbic 1.3.0

- Redesigned Win32 gaming overlay: larger window (380x145px), 9 animated VU bars, real-time clock, bitrate, volume bar, and last 2 played tracks
- Gaming mode panel on the radio screensaver when a game is detected
- Favorites subtab now shows country, tags, and homepage URL
- Automatic enrichment of saved favorites with missing metadata on startup
- Fixed panic on Tokio shutdown when switching from Spotify to radio

SHA256: `9f795e09d8bef0a8ff8cf9fb48bf0db54b0a80bc0ce9757e5023579856cc91e0`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/383558)