### PR TITLE
New package: Helvesec.RMUX version 0.5.0

### DIFF
--- a/manifests/h/Helvesec/RMUX/0.5.0/Helvesec.RMUX.installer.yaml
+++ b/manifests/h/Helvesec/RMUX/0.5.0/Helvesec.RMUX.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Helvesec.RMUX
+PackageVersion: 0.5.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: rmux-0.5.0-windows-x86_64\rmux.exe
+    PortableCommandAlias: rmux
+ReleaseDate: "2026-06-04"
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Helvesec/rmux/releases/download/v0.5.0/rmux-0.5.0-windows-x86_64.zip
+    InstallerSha256: FBC42E6F82AE63E72C69120D85EE0E81C97C95412D24BBC38E8E3D0B8614FD57
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/h/Helvesec/RMUX/0.5.0/Helvesec.RMUX.locale.en-US.yaml
+++ b/manifests/h/Helvesec/RMUX/0.5.0/Helvesec.RMUX.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Helvesec.RMUX
+PackageVersion: 0.5.0
+PackageLocale: en-US
+Publisher: Helvesec
+PublisherUrl: https://github.com/Helvesec
+PublisherSupportUrl: https://github.com/Helvesec/rmux/issues
+Author: Helvesec
+PackageName: RMUX
+PackageUrl: https://rmux.io
+License: MIT OR Apache-2.0
+ShortDescription: Terminal multiplexer with a tmux-style CLI, daemon runtime, and native Windows support.
+Description: |-
+  RMUX is a terminal multiplexer with a tmux-style command line, daemon-backed persistent sessions, native Windows support, and a Rust SDK for automation.
+Moniker: rmux
+Tags:
+  - cli
+  - multiplexer
+  - rust
+  - terminal
+  - tmux
+ReleaseNotesUrl: https://github.com/Helvesec/rmux/releases/tag/v0.5.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/h/Helvesec/RMUX/0.5.0/Helvesec.RMUX.yaml
+++ b/manifests/h/Helvesec/RMUX/0.5.0/Helvesec.RMUX.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Helvesec.RMUX
+PackageVersion: 0.5.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description

Adds RMUX 0.5.0 (`Helvesec.RMUX`) as a portable ZIP package.

RMUX is a terminal multiplexer with a tmux-style command line, daemon-backed persistent sessions, and native Windows support.

- Website: https://rmux.io
- Repository: https://github.com/Helvesec/rmux
- Release: https://github.com/Helvesec/rmux/releases/tag/v0.5.0

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.