### PR TITLE
New package: TaskSlinger.TaskSlinger version 0.8.0

### DIFF
--- a/manifests/t/TaskSlinger/TaskSlinger/0.8.0/TaskSlinger.TaskSlinger.installer.yaml
+++ b/manifests/t/TaskSlinger/TaskSlinger/0.8.0/TaskSlinger.TaskSlinger.installer.yaml
@@ -1,0 +1,31 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: TaskSlinger.TaskSlinger
+PackageVersion: 0.8.0
+InstallerType: exe
+Scope: user
+InstallModes:
+- silent
+InstallerSwitches:
+  Silent: --internal-install 3
+  SilentWithProgress: --internal-install 3
+UpgradeBehavior: install
+ProductCode: TaskSlinger
+AppsAndFeaturesEntries:
+- DisplayName: TaskSlinger
+  Publisher: TaskSlinger
+  DisplayVersion: v0.8.0
+  ProductCode: TaskSlinger
+InstallationMetadata:
+  DefaultInstallLocation: '%LocalAppData%\TaskSlinger'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://taskslinger.net/download/v0.8.0/winget/x64.exe
+  InstallerSha256: 65EDA8EE8D75C1B0B386FE446FA4A7469E38CE8178AE5879BD79434465408A29
+- Architecture: arm64
+  InstallerUrl: https://taskslinger.net/download/v0.8.0/winget/arm64.exe
+  InstallerSha256: 9B73518B052A78D411BA17C2B498C09F1BA4650F1BAC089AF9D47A374AF2A082
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-05-29

--- a/manifests/t/TaskSlinger/TaskSlinger/0.8.0/TaskSlinger.TaskSlinger.locale.en-US.yaml
+++ b/manifests/t/TaskSlinger/TaskSlinger/0.8.0/TaskSlinger.TaskSlinger.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: TaskSlinger.TaskSlinger
+PackageVersion: 0.8.0
+PackageLocale: en-US
+Publisher: TaskSlinger
+PublisherUrl: https://taskslinger.net/
+PublisherSupportUrl: https://github.com/TaskSlinger/TaskSlinger/issues
+Author: Thomas Klemenc
+PackageName: TaskSlinger
+PackageUrl: https://taskslinger.net/
+License: Proprietary
+Copyright: Copyright (C) 2026 TaskSlinger
+ShortDescription: A fast, native Windows Task Manager replacement.
+Description: TaskSlinger is a native Windows Task Manager replacement built in C++ and Win32 with a custom Direct3D interface, fast startup, process monitoring, performance graphs, services, startup apps, and network connections.
+Moniker: taskslinger
+Tags:
+- process-manager
+- system-monitor
+- task-manager
+- windows
+ReleaseNotesUrl: https://github.com/thomasklemenc/TaskSlinger/releases/tag/v0.8.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/TaskSlinger/TaskSlinger/0.8.0/TaskSlinger.TaskSlinger.locale.en-US.yaml
+++ b/manifests/t/TaskSlinger/TaskSlinger/0.8.0/TaskSlinger.TaskSlinger.locale.en-US.yaml
@@ -20,6 +20,5 @@ Tags:
 - system-monitor
 - task-manager
 - windows
-ReleaseNotesUrl: https://github.com/thomasklemenc/TaskSlinger/releases/tag/v0.8.0
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0

--- a/manifests/t/TaskSlinger/TaskSlinger/0.8.0/TaskSlinger.TaskSlinger.yaml
+++ b/manifests/t/TaskSlinger/TaskSlinger/0.8.0/TaskSlinger.TaskSlinger.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: TaskSlinger.TaskSlinger
+PackageVersion: 0.8.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Adds TaskSlinger 0.8.0 as a new user-scope WinGet package with signed x64 and ARM64 installers.

TaskSlinger ships one hybrid portable/self-installer EXE per architecture. WinGet invokes `--internal-install 3`, which installs the app and creates Desktop and Start Menu shortcuts without adding TaskSlinger to PATH or setting it as the default Task Manager.

## Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (not applicable for this new package submission)

## Manifest Checklist

- [x] Checked that there are no other open pull requests for `TaskSlinger.TaskSlinger`
- [x] This PR only modifies one package manifest
- [x] Validated locally with `winget validate --manifest <path>`
- [x] Tested locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

## Local Test Coverage

- Installed, reinstalled, and quietly uninstalled the x64 manifest with official WinGet v1.29.240
- Verified installer hash/signature, ARP metadata, install path, Desktop shortcut, Start Menu shortcut, no PATH mutation, no Task Manager override, and no post-install launch
- Passed TaskSlinger's installer regression matrix and the v0.7.17-to-v0.8.0 upgrade matrix using the deployed x64 binary
- Downloaded the ARM64 entry through WinGet and verified its manifest hash and Authenticode signature