### PR TITLE
New version: igorls.context-builder version 0.9.0

### DIFF
--- a/manifests/i/igorls/context-builder/0.9.0/igorls.context-builder.installer.yaml
+++ b/manifests/i/igorls/context-builder/0.9.0/igorls.context-builder.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: igorls.context-builder
+PackageVersion: 0.9.0
+InstallerType: zip
+ReleaseDate: 2026-06-04
+Installers:
+- Architecture: x64
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: context-builder.exe
+    PortableCommandAlias: context-builder
+  InstallerUrl: https://github.com/igorls/context-builder/releases/download/v0.9.0/context-builder-x86_64-pc-windows-msvc.zip
+  InstallerSha256: BA67926662FB489A1EBB5F7DEB51FC2C0200E246031D4411E4798C8DC5FB760D
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/i/igorls/context-builder/0.9.0/igorls.context-builder.installer.yaml
+++ b/manifests/i/igorls/context-builder/0.9.0/igorls.context-builder.installer.yaml
@@ -1,9 +1,8 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: igorls.context-builder
 PackageVersion: 0.9.0
 InstallerType: zip
-ReleaseDate: 2026-06-04
 Installers:
 - Architecture: x64
   NestedInstallerType: portable
@@ -13,4 +12,5 @@ Installers:
   InstallerUrl: https://github.com/igorls/context-builder/releases/download/v0.9.0/context-builder-x86_64-pc-windows-msvc.zip
   InstallerSha256: BA67926662FB489A1EBB5F7DEB51FC2C0200E246031D4411E4798C8DC5FB760D
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-06-04

--- a/manifests/i/igorls/context-builder/0.9.0/igorls.context-builder.installer.yaml
+++ b/manifests/i/igorls/context-builder/0.9.0/igorls.context-builder.installer.yaml
@@ -3,14 +3,14 @@
 PackageIdentifier: igorls.context-builder
 PackageVersion: 0.9.0
 InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: context-builder.exe
+  PortableCommandAlias: context-builder
+ReleaseDate: 2026-06-04
 Installers:
 - Architecture: x64
-  NestedInstallerType: portable
-  NestedInstallerFiles:
-  - RelativeFilePath: context-builder.exe
-    PortableCommandAlias: context-builder
   InstallerUrl: https://github.com/igorls/context-builder/releases/download/v0.9.0/context-builder-x86_64-pc-windows-msvc.zip
   InstallerSha256: BA67926662FB489A1EBB5F7DEB51FC2C0200E246031D4411E4798C8DC5FB760D
 ManifestType: installer
 ManifestVersion: 1.12.0
-ReleaseDate: 2026-06-04

--- a/manifests/i/igorls/context-builder/0.9.0/igorls.context-builder.locale.en-US.yaml
+++ b/manifests/i/igorls/context-builder/0.9.0/igorls.context-builder.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: igorls.context-builder
 PackageVersion: 0.9.0
@@ -28,4 +28,4 @@ Tags:
 - rust
 ReleaseNotesUrl: https://github.com/igorls/context-builder/releases/tag/v0.9.0
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/i/igorls/context-builder/0.9.0/igorls.context-builder.locale.en-US.yaml
+++ b/manifests/i/igorls/context-builder/0.9.0/igorls.context-builder.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: igorls.context-builder
+PackageVersion: 0.9.0
+PackageLocale: en-US
+Publisher: igorls
+PublisherUrl: https://github.com/igorls
+PublisherSupportUrl: https://github.com/igorls/context-builder/issues
+Author: Igor Lins e Silva
+PackageName: Context Builder
+PackageUrl: https://github.com/igorls/context-builder
+License: MIT
+LicenseUrl: https://github.com/igorls/context-builder/blob/master/LICENSE
+ShortDescription: A blazing-fast CLI for creating LLM context from your entire codebase
+Description: |-
+  Context Builder generates a single, structured markdown file from any codebase directory.
+  The output is optimized for LLM consumption with relevance-based file ordering, AST-aware
+  code signatures via Tree-Sitter, automatic token budgeting, and smart defaults.
+Moniker: context-builder
+Tags:
+- cli
+- llm
+- ai
+- codebase
+- context
+- tree-sitter
+- developer-tools
+- rust
+ReleaseNotesUrl: https://github.com/igorls/context-builder/releases/tag/v0.9.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/i/igorls/context-builder/0.9.0/igorls.context-builder.locale.en-US.yaml
+++ b/manifests/i/igorls/context-builder/0.9.0/igorls.context-builder.locale.en-US.yaml
@@ -26,6 +26,7 @@ Tags:
 - tree-sitter
 - developer-tools
 - rust
+ReleaseNotes: 'Full Changelog: v0.8.3-1...v0.9.0'
 ReleaseNotesUrl: https://github.com/igorls/context-builder/releases/tag/v0.9.0
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0

--- a/manifests/i/igorls/context-builder/0.9.0/igorls.context-builder.yaml
+++ b/manifests/i/igorls/context-builder/0.9.0/igorls.context-builder.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: igorls.context-builder
+PackageVersion: 0.9.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0

--- a/manifests/i/igorls/context-builder/0.9.0/igorls.context-builder.yaml
+++ b/manifests/i/igorls/context-builder/0.9.0/igorls.context-builder.yaml
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: igorls.context-builder
 PackageVersion: 0.9.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Updates the existing package **igorls.context-builder** to version **0.9.0** (the "Trustworthy Output" release). The installer is the portable `context-builder-x86_64-pc-windows-msvc.zip` from the [v0.9.0 GitHub Release](https://github.com/igorls/context-builder/releases/tag/v0.9.0); manifests use schema **1.12.0**. `InstallerSha256` was checked against the published release `SHA256SUMS`.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)