### PR TITLE
Update version: WhirlwindFX.SignalRgb version 2.5.66

### DIFF
--- a/manifests/w/WhirlwindFX/SignalRgb/2.5.66/WhirlwindFX.SignalRgb.installer.yaml
+++ b/manifests/w/WhirlwindFX/SignalRgb/2.5.66/WhirlwindFX.SignalRgb.installer.yaml
@@ -1,0 +1,20 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: WhirlwindFX.SignalRgb
+PackageVersion: 2.5.66
+MinimumOSVersion: 10.0.0.0
+InstallerType: exe
+InstallerSwitches:
+  Silent: --silent
+  SilentWithProgress: --silent
+ProductCode: VortxEngine
+ReleaseDate: 2026-06-04
+InstallationMetadata:
+  DefaultInstallLocation: '%LocalAppData%\VortxEngine'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://release.signalrgb.com/Install_SignalRgb.exe
+  InstallerSha256: FB3183AE9130B26E8B694A9B3207FF1084528F3F26DE15263147DA92A227BC18
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/w/WhirlwindFX/SignalRgb/2.5.66/WhirlwindFX.SignalRgb.locale.en-US.yaml
+++ b/manifests/w/WhirlwindFX/SignalRgb/2.5.66/WhirlwindFX.SignalRgb.locale.en-US.yaml
@@ -1,0 +1,18 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: WhirlwindFX.SignalRgb
+PackageVersion: 2.5.66
+PackageLocale: en-US
+Publisher: WhirlwindFX
+PublisherUrl: https://www.signalrgb.com/about
+PublisherSupportUrl: https://www.signalrgb.com/contact
+PrivacyUrl: https://www.signalrgb.com/privacy
+PackageName: SignalRgb
+PackageUrl: https://www.signalrgb.com/
+License: Proprietary
+LicenseUrl: https://www.signalrgb.com/terms
+Copyright: ©2022 WhirlwindFX
+ShortDescription: SignalRGB lets you control and sync your favorite RGB devices with one free application.
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/w/WhirlwindFX/SignalRgb/2.5.66/WhirlwindFX.SignalRgb.yaml
+++ b/manifests/w/WhirlwindFX/SignalRgb/2.5.66/WhirlwindFX.SignalRgb.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: WhirlwindFX.SignalRgb
+PackageVersion: 2.5.66
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)
  - Resolves #383273

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.

## 🧪 Manual validation

> [!WARNING]
> 
> It seems this package can't be installed inside a VM instance. It repeatedly shows "installation required" for necessary hardware driver and background services.
> 
> <img width="506" height="179" alt="Image" src="https://github.com/user-attachments/assets/d6b961ee-31ac-4071-b69e-3afa2c5f87d1" />

<img width="1439" height="640" alt="Image" src="https://github.com/user-attachments/assets/43f2a8e8-18e5-4039-b760-c667b3bb7b02" />
<img width="2064" height="1050" alt="Image" src="https://github.com/user-attachments/assets/61497625-7be2-42a7-8fc6-2343ab807376" />
<img width="2064" height="1440" alt="Image" src="https://github.com/user-attachments/assets/d7f50c52-496d-4c06-a66b-d64b910fe23a" />

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/383907)