### PR TITLE
New version: Aiacos.AjazzControlCenter version 0.1.1

### DIFF
--- a/manifests/a/Aiacos/AjazzControlCenter/0.1.1/Aiacos.AjazzControlCenter.installer.yaml
+++ b/manifests/a/Aiacos/AjazzControlCenter/0.1.1/Aiacos.AjazzControlCenter.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Aiacos.AjazzControlCenter
+PackageVersion: 0.1.1
+InstallerType: wix
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+ProductCode: '{722843FB-8862-4EAB-9640-AF078C3B550D}'
+UpgradeBehavior: install
+ReleaseDate: 2026-05-23
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Aiacos/ajazz-control-center/releases/download/v0.1.1/ajazz-control-center-0.1.1-win64.msi
+    InstallerSha256: DD09A90A8944F5909C0F520FF68091D3F7F4B12B76F43D1DDEB35BDBF8F3D829
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/a/Aiacos/AjazzControlCenter/0.1.1/Aiacos.AjazzControlCenter.locale.en-US.yaml
+++ b/manifests/a/Aiacos/AjazzControlCenter/0.1.1/Aiacos.AjazzControlCenter.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Aiacos.AjazzControlCenter
+PackageVersion: 0.1.1
+PackageLocale: en-US
+Publisher: AJAZZ Control Center contributors
+PublisherUrl: https://github.com/Aiacos
+PublisherSupportUrl: https://github.com/Aiacos/ajazz-control-center/issues
+PackageName: AJAZZ Control Center
+PackageUrl: https://github.com/Aiacos/ajazz-control-center
+License: GPL-3.0-or-later
+LicenseUrl: https://github.com/Aiacos/ajazz-control-center/blob/main/LICENSE
+Copyright: Copyright (c) AJAZZ Control Center contributors
+ShortDescription: Open, cross-platform control center for AJAZZ devices (Stream Docks, keyboards, mice).
+Description: |-
+  AJAZZ Control Center is a modern, open, cross-platform control center for AJAZZ
+  (and Mirabox-OEM) devices — Stream Dock macropads, mechanical keyboards and
+  gaming mice — with a Qt 6 / QML interface and a sandboxed Python plugin system
+  compatible with Stream Deck plugins.
+Moniker: ajazz-control-center
+Tags:
+  - ajazz
+  - mirabox
+  - streamdeck
+  - keyboard
+  - mouse
+  - rgb
+  - hid
+ReleaseNotesUrl: https://github.com/Aiacos/ajazz-control-center/releases/tag/v0.1.1
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/a/Aiacos/AjazzControlCenter/0.1.1/Aiacos.AjazzControlCenter.yaml
+++ b/manifests/a/Aiacos/AjazzControlCenter/0.1.1/Aiacos.AjazzControlCenter.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Aiacos.AjazzControlCenter
+PackageVersion: 0.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Pull Request Checklist

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the 1.6 schema?

### Notes

New version **0.1.1** of `Aiacos.AjazzControlCenter`.

Fixes the installer regression in **0.1.0** (#378692): the 0.1.0 MSI shipped without the Qt runtime and failed to launch with *"The code execution cannot proceed because Qt6Widgets.dll was not found."* The 0.1.1 MSI bundles the full Qt runtime via `windeployqt` (verified in CI). This submission supersedes #378692.

- `InstallerSha256` matches the release `SHA256SUMS`.
- `ProductCode` matches the published 0.1.1 MSI.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/383969)