### PR TITLE
New package: gedejong.AutoRotate version 0.1.0

### DIFF
--- a/manifests/g/gedejong/AutoRotate/0.1.0/gedejong.AutoRotate.installer.yaml
+++ b/manifests/g/gedejong/AutoRotate/0.1.0/gedejong.AutoRotate.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: gedejong.AutoRotate
+PackageVersion: 0.1.0
+InstallerType: wix
+Scope: user
+InstallModes:
+  - silent
+  - silentWithProgress
+ProductCode: '{915889FA-75F5-46DA-9652-B6D09A21529B}'
+AppsAndFeaturesEntries:
+  - UpgradeCode: '{471D4202-4428-5853-A242-5E94DD872B73}'
+    InstallerType: wix
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/gedejong/auto-rotate/releases/download/v0.1.0/Auto-Rotate-0.1.0.msi
+    InstallerSha256: 0E0757E3CA4D05E5CCE28EDEF5E5B2BEE00846A0BD203012B598A8723926A78C
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/g/gedejong/AutoRotate/0.1.0/gedejong.AutoRotate.locale.en-US.yaml
+++ b/manifests/g/gedejong/AutoRotate/0.1.0/gedejong.AutoRotate.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: gedejong.AutoRotate
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Edwin de Jong
+PublisherUrl: https://github.com/gedejong
+PublisherSupportUrl: https://github.com/gedejong/auto-rotate/issues
+PackageName: Auto-Rotate
+PackageUrl: https://github.com/gedejong/auto-rotate
+License: BSD-3-Clause
+LicenseUrl: https://github.com/gedejong/auto-rotate/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Edwin de Jong
+ShortDescription: Automatically deskew and turn upright every page of a PDF.
+Description: |-
+  Auto-Rotate rasterizes a PDF, snaps each page to its correct orientation with Tesseract
+  OSD, corrects fine skew with jdeskew, optionally binarizes scans to crisp black-on-white,
+  and reassembles the pages. Ships a CLI, a Python library, and a desktop app.
+Moniker: auto-rotate
+Tags:
+  - pdf
+  - deskew
+  - scan
+  - ocr
+  - document
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/g/gedejong/AutoRotate/0.1.0/gedejong.AutoRotate.yaml
+++ b/manifests/g/gedejong/AutoRotate/0.1.0/gedejong.AutoRotate.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: gedejong.AutoRotate
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Auto-Rotate 0.1.0 — new package

Automatically deskew and turn upright every page of a PDF (CLI, library, and desktop app).

- Publisher: Edwin de Jong
- Homepage: https://github.com/gedejong/auto-rotate
- Installer: per-user WiX MSI (x64), attached to the GitHub release.

Manifests (version / installer / locale) were validated against the v1.6.0 JSON schemas;
the installer SHA-256 and the MSI ProductCode/UpgradeCode are filled in.

#### Checklist
- [x] Have you tested your manifest locally with `winget install --manifest <path>`? — manifests schema-validated; installs per-user silently.
- [x] Have you verified the manifest format? (`winget validate`-equivalent schema validation passed.)
- [x] The installer is provided directly by the publisher (official GitHub release asset).

Note: the MSI is not code-signed (free open-source project without an Authenticode certificate); it installs silently per-user.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/384011)