### PR TITLE
New package: dagaza.Qube version 1.0.0

### DIFF
--- a/manifests/d/dagaza/Qube/1.0.0/dagaza.Qube.installer.yaml
+++ b/manifests/d/dagaza/Qube/1.0.0/dagaza.Qube.installer.yaml
@@ -1,0 +1,12 @@
+PackageIdentifier: dagaza.Qube
+PackageVersion: 1.0.0
+InstallerType: inno
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/dagaza/Qube/releases/download/v1.0.0/Qube-1.0.0-Setup.exe
+    InstallerSha256: F89F5A1F3231C2918EB15F272D80CCF736936FA7B75937455F14857360ECE553
+    InstallerSwitches:
+      Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+      SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/d/dagaza/Qube/1.0.0/dagaza.Qube.locale.en-US.yaml
+++ b/manifests/d/dagaza/Qube/1.0.0/dagaza.Qube.locale.en-US.yaml
@@ -1,0 +1,24 @@
+PackageIdentifier: dagaza.Qube
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: dagaza
+PublisherUrl: https://github.com/dagaza
+PackageName: Qube
+License: MIT
+LicenseUrl: https://github.com/dagaza/Qube/blob/main/LICENSE
+ShortDescription: Local hardware-accelerated AI desktop assistant
+Description: >-
+  Qube is a fully local, privacy-first, voice-to-voice AI desktop assistant.
+  It integrates speech-to-text, text-to-speech, retrieval-augmented generation,
+  and local LLM inference into a native PyQt6 desktop shell.
+PackageUrl: https://github.com/dagaza/Qube
+Tags:
+  - ai
+  - assistant
+  - local
+  - privacy
+  - voice
+  - llm
+  - desktop
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/d/dagaza/Qube/1.0.0/dagaza.Qube.yaml
+++ b/manifests/d/dagaza/Qube/1.0.0/dagaza.Qube.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: dagaza.Qube
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary
- Add WinGet manifests for **Qube** (dagaza.Qube) version 1.0.0
- Local, privacy-first AI desktop assistant
- Inno Setup x64 installer from GitHub Releases

## Installer
- URL: https://github.com/dagaza/Qube/releases/download/v1.0.0/Qube-1.0.0-Setup.exe
- SHA256: F89F5A1F3231C2918EB15F272D80CCF736936FA7B75937455F14857360ECE553

## Validation
- winget validate --manifest manifests/d/dagaza/Qube/1.0.0

## Test plan
- [ ] Automated PR validation passes
- [ ] After merge: winget install -e --id dagaza.Qube

Made with [Cursor](https://cursor.com)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/384099)