### PR TITLE
New package: EinsVier.BlitzText version 0.4.0

### DIFF
--- a/manifests/e/EinsVier/BlitzText/0.4.0/EinsVier.BlitzText.installer.yaml
+++ b/manifests/e/EinsVier/BlitzText/0.4.0/EinsVier.BlitzText.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: EinsVier.BlitzText
+PackageVersion: 0.4.0
+InstallerType: wix
+Scope: user
+UpgradeBehavior: install
+ReleaseDate: 2026-06-05
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/EinsVier/blitztext-windows/releases/download/v0.4.0/BlitzText-Windows-0.4.0-win-x64.msi
+  InstallerSha256: D0D620996AD6B1A1FF02A181819A12B772DCAF1D90A138F1F05C1636F212DE20
+  ProductCode: '{71063B30-10A4-4A13-9B01-BCC31D4743BD}'
+  AppsAndFeaturesEntries:
+  - DisplayName: BlitzText Windows
+    Publisher: Micha
+    ProductCode: '{71063B30-10A4-4A13-9B01-BCC31D4743BD}'
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/e/EinsVier/BlitzText/0.4.0/EinsVier.BlitzText.installer.yaml
+++ b/manifests/e/EinsVier/BlitzText/0.4.0/EinsVier.BlitzText.installer.yaml
@@ -5,6 +5,10 @@ InstallerType: wix
 Scope: user
 UpgradeBehavior: install
 ReleaseDate: 2026-06-05
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.8
+    MinimumVersion: 8.0.0
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/EinsVier/blitztext-windows/releases/download/v0.4.0/BlitzText-Windows-0.4.0-win-x64.msi

--- a/manifests/e/EinsVier/BlitzText/0.4.0/EinsVier.BlitzText.locale.en-US.yaml
+++ b/manifests/e/EinsVier/BlitzText/0.4.0/EinsVier.BlitzText.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: EinsVier.BlitzText
+PackageVersion: 0.4.0
+PackageLocale: en-US
+Publisher: Micha
+PublisherUrl: https://github.com/EinsVier
+PublisherSupportUrl: https://github.com/EinsVier/blitztext-windows/issues
+Author: Micha
+PackageName: BlitzText Windows
+PackageUrl: https://github.com/EinsVier/blitztext-windows
+License: MIT
+LicenseUrl: https://github.com/EinsVier/blitztext-windows/blob/master/LICENSE
+Copyright: Copyright (c) Micha
+ShortDescription: Native Windows dictation app with transcription, rewrite workflows, hotkeys, and paste automation.
+Description: BlitzText Windows is a native Windows desktop app for recording speech with hotkeys, transcribing it, optionally rewriting it through configured AI providers, and copying or pasting the result into the active app.
+Moniker: blitztext
+Tags:
+- dictation
+- transcription
+- speech-to-text
+- hotkey
+- wpf
+- ai
+ReleaseNotes: Adds OpenRouter and Anthropic rewrite providers, a manual update check, and refreshed WiX MSI packaging.
+ReleaseNotesUrl: https://github.com/EinsVier/blitztext-windows/releases/tag/v0.4.0
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/e/EinsVier/BlitzText/0.4.0/EinsVier.BlitzText.yaml
+++ b/manifests/e/EinsVier/BlitzText/0.4.0/EinsVier.BlitzText.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: EinsVier.BlitzText
+PackageVersion: 0.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
### Package submission

Adds BlitzText Windows 0.4.0 to the Windows Package Manager community repository.

### Installer

- Type: WiX MSI
- Scope: user
- Architecture: x64
- Release: https://github.com/EinsVier/blitztext-windows/releases/tag/v0.4.0
- Installer URL: https://github.com/EinsVier/blitztext-windows/releases/download/v0.4.0/BlitzText-Windows-0.4.0-win-x64.msi
- SHA256: D0D620996AD6B1A1FF02A181819A12B772DCAF1D90A138F1F05C1636F212DE20

### Validation

- winget validate succeeded locally for the multi-file manifest.
- The release asset was downloaded directly and its SHA256 matched the manifest.