### PR TITLE
Register esrp-winget-prod[bot] as owner for Microsoft.Gaming.GDK

### DIFF
--- a/manifests/m/Microsoft/Gaming/GDK/.package
+++ b/manifests/m/Microsoft/Gaming/GDK/.package
@@ -1,0 +1,11 @@
+{
+    "schemaVersion": "0.1",
+    "owners":
+    [
+        {
+            "type": "Bot",
+            "login": "esrp-winget-prod[bot]",
+            "id": 273969822
+        }
+    ]
+}


### PR DESCRIPTION
Adds .package file to register esrp-winget-prod[bot] (ID: 273969822) as owner of the Microsoft.Gaming.GDK
 manifest directory.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/384302)