### PR TITLE
Fix installer SHA256 checksums for Giancan.AutoGRToolkit 6.1.0.0

### DIFF
--- a/manifests/g/Giancan/AutoGRToolkit/6.1.0.0/Giancan.AutoGRToolkit.installer.yaml
+++ b/manifests/g/Giancan/AutoGRToolkit/6.1.0.0/Giancan.AutoGRToolkit.installer.yaml
@@ -10,14 +10,14 @@ Installers:
   - Architecture: x86
     InstallerType: inno
     InstallerUrl: https://github.com/giancan/AutoGR-Toolkit/releases/download/v6.1.0.0/AutoGRT-Setup_v6.1_win-x86.exe
-    InstallerSha256: 65bd9df4ba28c3d6d1800ffd41cf1c116dba4c5a1625fe0f3524dfc9a2927b0a
+    InstallerSha256: 114692abd30a6e18d2429d401fef2187b55172fa09dfec96e43c946f70d0a882
     InstallerSwitches:
       Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
       SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
   - Architecture: x64
     InstallerType: inno
     InstallerUrl: https://github.com/giancan/AutoGR-Toolkit/releases/download/v6.1.0.0/AutoGRT-Setup_v6.1_win-x64.exe
-    InstallerSha256: d3f6deeab5f947385bf1b5e48f9174754b10acd703e3c42e36d31c9254766101
+    InstallerSha256: f9a7a71a690191853e28759bb224d701619f2a489ecfd02f8c856b1e073387cc
     InstallerSwitches:
       Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
       SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-


### PR DESCRIPTION
Corrects SHA256 checksums for both x86 and x64 installers.
Previous hashes were incorrect due to a rebuild after the initial submission.

x86: 114692abd30a6e18d2429d401fef2187b55172fa09dfec96e43c946f70d0a882
x64: f9a7a71a690191853e28759bb224d701619f2a489ecfd02f8c856b1e073387cc
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/384392)