### PR TITLE
New package: datap-rs.DataPress version 0.4.4

### DIFF
--- a/manifests/d/datap-rs/DataPress/0.4.4/datap-rs.DataPress.installer.yaml
+++ b/manifests/d/datap-rs/DataPress/0.4.4/datap-rs.DataPress.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: datap-rs.DataPress
+PackageVersion: 0.4.4
+MinimumOSVersion: 10.0.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: datapress.exe
+    PortableCommandAlias: datapress
+Commands:
+  - datapress
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/jeroenflvr/datapress/releases/download/v0.4.4/datapress-v0.4.4-x86_64-pc-windows-msvc.zip
+    InstallerSha256: 672009103EF36CF6546229F6C3E89DD18C6A028FFE96FA34774FC1DEAB39FB4A
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/d/datap-rs/DataPress/0.4.4/datap-rs.DataPress.locale.en-US.yaml
+++ b/manifests/d/datap-rs/DataPress/0.4.4/datap-rs.DataPress.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: datap-rs.DataPress
+PackageVersion: 0.4.4
+PackageLocale: en-US
+Publisher: DataPress
+PublisherUrl: https://datap-rs.org
+PublisherSupportUrl: https://github.com/jeroenflvr/datapress/issues
+PackageName: DataPress
+PackageUrl: https://datap-rs.org
+License: MIT
+LicenseUrl: https://github.com/jeroenflvr/datapress/blob/main/LICENSE
+ShortDescription: Fast multi-backend (DuckDB / DataFusion) HTTP server over Parquet and Delta datasets.
+Description: >-
+  DataPress turns Parquet and Delta datasets in object storage into fast, typed
+  HTTP APIs — JSON and Arrow IPC — backed by DuckDB or Apache Arrow + DataFusion.
+  The single `datapress` binary bundles both engines and selects one at runtime
+  from `server.backend` in your datasets.toml.
+Moniker: datapress
+Tags:
+  - parquet
+  - delta
+  - duckdb
+  - datafusion
+  - arrow
+  - http-api
+  - rust
+  - data
+ReleaseNotesUrl: https://github.com/jeroenflvr/datapress/releases/tag/v0.4.4
+Documentation:
+  - DocumentLabel: Documentation
+    DocumentUrl: https://docs.datap-rs.org
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/d/datap-rs/DataPress/0.4.4/datap-rs.DataPress.yaml
+++ b/manifests/d/datap-rs/DataPress/0.4.4/datap-rs.DataPress.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: datap-rs.DataPress
+PackageVersion: 0.4.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
New package: datap-rs.DataPress version 0.4.4

## 📖 Description
DataPress is a small Rust data server for teams that already have columnar files and need a dependable way to publish them: JSON for applications, Arrow IPC for analytics clients, health probes for orchestrators, and a Python package for notebooks, jobs, and embedded services.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)


## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/384447)