### PR TITLE
New package: elpideus.DaVinciResolveRPC version 1.0.1

### DIFF
--- a/manifests/e/elpideus/DaVinciResolveRPC/1.0.1/elpideus.DaVinciResolveRPC.installer.yaml
+++ b/manifests/e/elpideus/DaVinciResolveRPC/1.0.1/elpideus.DaVinciResolveRPC.installer.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 PackageIdentifier: elpideus.DaVinciResolveRPC
 PackageVersion: 1.0.1
 InstallerLocale: en-US

--- a/manifests/e/elpideus/DaVinciResolveRPC/1.0.1/elpideus.DaVinciResolveRPC.installer.yaml
+++ b/manifests/e/elpideus/DaVinciResolveRPC/1.0.1/elpideus.DaVinciResolveRPC.installer.yaml
@@ -1,0 +1,18 @@
+PackageIdentifier: elpideus.DaVinciResolveRPC
+PackageVersion: 1.0.1
+InstallerLocale: en-US
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+  SilentWithProgress: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/elpideus/DavinciResolveRPC/releases/download/v1.0.1/DaVinciResolveRPC-Setup.exe
+    InstallerSha256: 42EAE1B481978DA3C57FC20BB3BBFE224EBB8009907D28EF4A07D54CF8821847
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/e/elpideus/DaVinciResolveRPC/1.0.1/elpideus.DaVinciResolveRPC.locale.en-US.yaml
+++ b/manifests/e/elpideus/DaVinciResolveRPC/1.0.1/elpideus.DaVinciResolveRPC.locale.en-US.yaml
@@ -1,0 +1,23 @@
+PackageIdentifier: elpideus.DaVinciResolveRPC
+PackageVersion: 1.0.1
+PackageLocale: en-US
+Publisher: elpideus
+PublisherUrl: https://github.com/elpideus
+PublisherSupportUrl: https://github.com/elpideus/DavinciResolveRPC/issues
+PackageName: DaVinci Resolve RPC
+PackageUrl: https://github.com/elpideus/DavinciResolveRPC
+License: GPL-3.0-only
+LicenseUrl: https://github.com/elpideus/DavinciResolveRPC/blob/main/LICENSE
+ShortDescription: Discord Rich Presence integration for DaVinci Resolve on Windows
+Description: |-
+  Runs silently in the system tray and shows your current DaVinci Resolve project
+  and active timeline on your Discord profile in real time. Supports automatic
+  startup with Windows and requires no administrator rights.
+Tags:
+  - discord
+  - davinci-resolve
+  - rich-presence
+  - tray
+Moniker: davinci-resolve-rpc
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/e/elpideus/DaVinciResolveRPC/1.0.1/elpideus.DaVinciResolveRPC.locale.en-US.yaml
+++ b/manifests/e/elpideus/DaVinciResolveRPC/1.0.1/elpideus.DaVinciResolveRPC.locale.en-US.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 PackageIdentifier: elpideus.DaVinciResolveRPC
 PackageVersion: 1.0.1
 PackageLocale: en-US

--- a/manifests/e/elpideus/DaVinciResolveRPC/1.0.1/elpideus.DaVinciResolveRPC.yaml
+++ b/manifests/e/elpideus/DaVinciResolveRPC/1.0.1/elpideus.DaVinciResolveRPC.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
 PackageIdentifier: elpideus.DaVinciResolveRPC
 PackageVersion: 1.0.1
 DefaultLocale: en-US

--- a/manifests/e/elpideus/DaVinciResolveRPC/1.0.1/elpideus.DaVinciResolveRPC.yaml
+++ b/manifests/e/elpideus/DaVinciResolveRPC/1.0.1/elpideus.DaVinciResolveRPC.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: elpideus.DaVinciResolveRPC
+PackageVersion: 1.0.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## Description
New package submission for DaVinci Resolve RPC - Discord Rich Presence integration for DaVinci Resolve on Windows.

- Runs silently in the system tray
- Shows current project and timeline on Discord profile in real time
- Per-user installation, no administrator rights needed
- Inno Setup installer with silent install support

## Package Info
- **Package identifier:** elpideus.DaVinciResolveRPC
- **Version:** 1.0.1
- **Installer type:** Inno Setup (user scope)
- **License:** GPL-3.0-only

## Manifest Validation Checklist
- [x] Have you signed the CLA?
- [x] Have you checked that there are no other open pull requests for the same package?
- [x] Have you validated your manifest locally with `winget validate`?
- [x] Have you tested your manifest locally with `winget install`?
- [x] Does your manifest conform to the 1.9.0 schema?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/384529)