### PR TITLE
New version: LANCommander.Server version 2.1.0

### DIFF
--- a/manifests/l/LANCommander/Server/2.1.0/LANCommander.Server.installer.yaml
+++ b/manifests/l/LANCommander/Server/2.1.0/LANCommander.Server.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: LANCommander.Server
+PackageVersion: 2.1.0
+InstallerType: inno
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/LANCommander/LANCommander/releases/download/v2.1.0/LANCommander.Server-2.1.0-x64-Setup.exe
+  InstallerSha256: 7D34B8527F9AC89E5921F94AAF556F0EB0E6850019AFE1DAAD07505A6A57616B
+- Architecture: arm64
+  InstallerUrl: https://github.com/LANCommander/LANCommander/releases/download/v2.1.0/LANCommander.Server-2.1.0-arm64-Setup.exe
+  InstallerSha256: FBF86E8EEC53C8E46C4CD2DA8016443B199C92F13F29BD50BF954F6B0A21F841
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/l/LANCommander/Server/2.1.0/LANCommander.Server.locale.en-US.yaml
+++ b/manifests/l/LANCommander/Server/2.1.0/LANCommander.Server.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: LANCommander.Server
+PackageVersion: 2.1.0
+PackageLocale: en-US
+Author: Pat Hartl
+Publisher: LANCommander LLC
+PublisherUrl: https://github.com/LANCommander
+PublisherSupportUrl: https://github.com/LANCommander/LANCommander/issues
+PackageName: LANCommander Server
+PackageUrl: https://github.com/LANCommander/LANCommander
+Copyright: Copyright (c) LANCommander LLC
+License: MIT
+ShortDescription: |
+  LANCommander is a self-hosted game distribution platform designed for LAN parties and personal libraries.
+  This server software is your central repository for games, redistributables, saves, and users.
+ReleaseNotesUrl: https://github.com/LANCommander/LANCommander/releases/tag/v2.1.0
+Documentations:
+- DocumentLabel: Documentation
+  DocumentUrl: https://docs.lancommander.app
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/l/LANCommander/Server/2.1.0/LANCommander.Server.yaml
+++ b/manifests/l/LANCommander/Server/2.1.0/LANCommander.Server.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: LANCommander.Server
+PackageVersion: 2.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## Summary

- Updates LANCommander.Server to version 2.1.0
- Adds arm64 architecture installer alongside existing x64

## Changes

- New version: 2.1.0
- Added arm64 installer support
- Updated release notes URL
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/384541)