### PR TITLE
New version: CitrusSoda.ArcThumb version 0.10.0

### DIFF
--- a/manifests/c/CitrusSoda/ArcThumb/0.10.0/CitrusSoda.ArcThumb.installer.yaml
+++ b/manifests/c/CitrusSoda/ArcThumb/0.10.0/CitrusSoda.ArcThumb.installer.yaml
@@ -1,0 +1,42 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: CitrusSoda.ArcThumb
+PackageVersion: 0.10.0
+InstallerType: inno
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+FileExtensions:
+- azw
+- azw3
+- cb7
+- cbr
+- cbt
+- cbz
+- epub
+- fb2
+- mobi
+AppsAndFeaturesEntries:
+- DisplayName: ArcThumb 0.7.1
+  Publisher: citrussoda-com
+  DisplayVersion: 0.10.0
+  ProductCode: '{DFE16BE0-6554-4F21-BB11-51601FD3FEC8}_is1'
+  InstallerType: inno
+Installers:
+- Architecture: x64
+  Scope: user
+  InstallerUrl: https://github.com/citrussoda-com/ArcThumb/releases/download/v0.10.0/ArcThumb-Setup.exe
+  InstallerSha256: 5B87BDA101D79C21C02C7963C5606B68C19A293945BE67656662E67361D22BAD
+  InstallerSwitches:
+    Custom: /CURRENTUSER
+- Architecture: x64
+  Scope: machine
+  InstallerUrl: https://github.com/citrussoda-com/ArcThumb/releases/download/v0.10.0/ArcThumb-Setup.exe
+  InstallerSha256: 5B87BDA101D79C21C02C7963C5606B68C19A293945BE67656662E67361D22BAD
+  InstallerSwitches:
+    Custom: /ALLUSERS
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-06-06

--- a/manifests/c/CitrusSoda/ArcThumb/0.10.0/CitrusSoda.ArcThumb.locale.en-US.yaml
+++ b/manifests/c/CitrusSoda/ArcThumb/0.10.0/CitrusSoda.ArcThumb.locale.en-US.yaml
@@ -1,0 +1,38 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: CitrusSoda.ArcThumb
+PackageVersion: 0.10.0
+PackageLocale: en-US
+Publisher: citrussoda-com
+PublisherUrl: https://citrussoda.com
+PublisherSupportUrl: https://github.com/citrussoda-com/ArcThumb/issues
+Author: CitrusSoda
+PackageName: ArcThumb
+PackageUrl: https://citrussoda.com/en/arcthumb
+License: MIT OR Apache-2.0
+LicenseUrl: https://github.com/citrussoda-com/ArcThumb#license
+Copyright: Copyright © 2026 citrussoda-com
+ShortDescription: Windows Explorer thumbnail and preview handler for archive files and ebooks.
+Description: "ArcThumb is a Windows Shell Extension that adds thumbnail icons and preview-pane previews to Windows Explorer for archive files and ebooks. When a supported file contains images, ArcThumb decodes the first one and shows it as the file's thumbnail; the preview pane renders a larger version. Supported containers: ZIP, 7Z, RAR, TAR and their media variants (CBZ, CB7, CBR, CBT), plus ebooks in EPUB, FB2, MOBI, AZW, and AZW3. Images inside are decoded from JPEG, PNG, GIF, BMP, TIFF, ICO, and WebP. Optional JPEG XL support is available in custom builds. ArcThumb is a Rust-based successor to CBX Shell and DarkThumbs. A bundled configuration GUI lets you toggle formats, set decode limits, and register or unregister the extension. Installs per-user by default with no administrator privileges; running the installer elevated registers the extension machine-wide instead, which is required when Explorer runs at high integrity (such as Windows Sandbox). Requires Windows 10 or later on x64."
+Moniker: arcthumb
+Tags:
+- ebook-thumbnails
+- preview
+- file-explorer
+- fileexplorer
+- shell-extension
+- archives
+- ebook
+- zip
+- epub
+- cbz
+- cbxshell
+- darkthumbs
+ReleaseNotesUrl: https://github.com/citrussoda-com/ArcThumb/releases/tag/v0.10.0
+InstallationNotes: Thumbnails will appear for supported archive and ebook files in Windows Explorer. If existing thumbnails do not refresh, restart Windows Explorer or clear the thumbnail cache. Open "ArcThumb Configuration" from the Start Menu to customize supported formats.
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/citrussoda-com/ArcThumb/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/CitrusSoda/ArcThumb/0.10.0/CitrusSoda.ArcThumb.yaml
+++ b/manifests/c/CitrusSoda/ArcThumb/0.10.0/CitrusSoda.ArcThumb.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: CitrusSoda.ArcThumb
+PackageVersion: 0.10.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->
Publisher submission — I maintain CitrusSoda.ArcThumb. Updates the package from 0.9.0 to 0.10.0.

Highlights in this release:
- Lift the file-size cap for ZIP/7z archives, replaced with an entry-count limit (#31)
- Fix the Sort and Cover config dropdowns reverting to their default value when the settings window is reopened (#36)
- Bump jxl-oxide 0.12.5 → 0.12.6

Full release notes: https://github.com/citrussoda-com/ArcThumb/releases/tag/v0.10.0

## 📖 Description
<!-- Describe what this PR changes. For manifest submissions, include the package name and version. -->

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/384575)