### PR TITLE
New package: Calimpio.BitChat version 1.0.0

### DIFF
--- a/manifests/c/Calimpio/BitChat/1.0.0/Calimpio.BitChat.installer.yaml
+++ b/manifests/c/Calimpio/BitChat/1.0.0/Calimpio.BitChat.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: Calimpio.BitChat
+PackageVersion: 1.0.0
+InstallerType: portable
+Commands:
+  - BitChat
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/calimpio/bitchat/releases/download/v1.0.0/BitChat_v1.0.0.zip
+    InstallerSha256: 136aebb885d373642a3a56d33b7f19c31ec8cb2e464a4400b17c059a2f513253
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/c/Calimpio/BitChat/1.0.0/Calimpio.BitChat.installer.yaml
+++ b/manifests/c/Calimpio/BitChat/1.0.0/Calimpio.BitChat.installer.yaml
@@ -7,7 +7,7 @@ Commands:
   - BitChat
 Installers:
   - Architecture: x64
-    InstallerUrl: https://github.com/calimpio/bitchat/releases/download/v1.0.0/BitChat_v1.0.0.zip
+    InstallerUrl: https://github.com/user-attachments/files/28670853/BitChat_v1.0.0.zip
     InstallerSha256: 136aebb885d373642a3a56d33b7f19c31ec8cb2e464a4400b17c059a2f513253
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/c/Calimpio/BitChat/1.0.0/Calimpio.BitChat.locale.en-US.yaml
+++ b/manifests/c/Calimpio/BitChat/1.0.0/Calimpio.BitChat.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
+
+PackageIdentifier: Calimpio.BitChat
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: Calimpio
+PackageName: BitChat
+PackageUrl: https://github.com/calimpio/bitchat
+License: MIT
+ShortDescription: Sovereign Cryptographic P2P Terminal.
+Description: A sovereign and private messaging terminal that uses SHA-256 cryptography and direct P2P networks without central servers.
+Tags:
+  - p2p
+  - chat
+  - crypto
+  - sovereign
+  - private
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/c/Calimpio/BitChat/1.0.0/Calimpio.BitChat.locale.es-ES.yaml
+++ b/manifests/c/Calimpio/BitChat/1.0.0/Calimpio.BitChat.locale.es-ES.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
+
+PackageIdentifier: Calimpio.BitChat
+PackageVersion: 1.0.0
+PackageLocale: es-ES
+Publisher: Calimpio
+PackageName: BitChat
+PackageUrl: https://github.com/calimpio/bitchat
+License: MIT
+ShortDescription: Terminal Soberana Criptográfica P2P.
+Description: Una terminal de mensajería soberana y privada que utiliza criptografía SHA-256 y redes P2P directas sin servidores centrales.
+Tags:
+  - p2p
+  - chat
+  - crypto
+  - sovereign
+  - private
+ManifestType: locale
+ManifestVersion: 1.6.0

--- a/manifests/c/Calimpio/BitChat/1.0.0/Calimpio.BitChat.yaml
+++ b/manifests/c/Calimpio/BitChat/1.0.0/Calimpio.BitChat.yaml
@@ -2,6 +2,6 @@
 
 PackageIdentifier: Calimpio.BitChat
 PackageVersion: 1.0.0
-DefaultLocale: es-ES
+DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.6.0

--- a/manifests/c/Calimpio/BitChat/1.0.0/Calimpio.BitChat.yaml
+++ b/manifests/c/Calimpio/BitChat/1.0.0/Calimpio.BitChat.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: Calimpio.BitChat
+PackageVersion: 1.0.0
+DefaultLocale: es-ES
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
# New package: Calimpio.BitChat version 1.0.0

## 📖 Description
Submission of the initial version of **BitChat**, a sovereign and private messaging terminal using SHA-256 cryptography and direct P2P networking.

- **Package Name:** BitChat
- **Publisher:** Calimpio
- **Version:** 1.0.0
- **Installer Type:** portable

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  - Resolves #

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest (Calimpio.BitChat 1.0.0)
- [x] Validated manifest locally with `winget validate`
- [x] Tested manifest locally with `winget install`
- [x] Manifest conforms to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0) (Note: Current manifests use 1.6.0 which is fully supported)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/384597)