### PR TITLE
New package: AccolyteByte.GriffinPowerMate version 1.2.0

### DIFF
--- a/manifests/a/AccolyteByte/GriffinPowerMate/1.2.0/AccolyteByte.GriffinPowerMate.installer.yaml
+++ b/manifests/a/AccolyteByte/GriffinPowerMate/1.2.0/AccolyteByte.GriffinPowerMate.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: AccolyteByte.GriffinPowerMate
+PackageVersion: 1.2.0
+InstallerType: portable
+InstallModes:
+  - interactive
+  - silent
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/accolytebyte/griffinpowermate/releases/download/v1.2.0/PowerMate.exe
+    InstallerSha256: 463D4199F3E71E0D45CC356159574A5C5E7F3DE166F548400BDD84DA33E20A5B
+    InstallerType: portable
+    NestedInstallerType: portable
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/a/AccolyteByte/GriffinPowerMate/1.2.0/AccolyteByte.GriffinPowerMate.locale.en-US.yaml
+++ b/manifests/a/AccolyteByte/GriffinPowerMate/1.2.0/AccolyteByte.GriffinPowerMate.locale.en-US.yaml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: AccolyteByte.GriffinPowerMate
+PackageVersion: 1.2.0
+PackageLocale: en-US
+Publisher: AccolyteByte
+PublisherUrl: https://github.com/accolytebyte
+PublisherSupportUrl: https://github.com/accolytebyte/griffinpowermate/issues
+PackageName: Griffin PowerMate
+PackageUrl: https://github.com/accolytebyte/griffinpowermate
+License: BSD-3-Clause
+LicenseUrl: https://github.com/accolytebyte/griffinpowermate/blob/main/LICENSE
+ShortDescription: Windows 11 controller for the Griffin PowerMate USB knob
+Description: |-
+  A fully-customizable Windows 11 driver and GUI for the Griffin PowerMate USB
+  knob (discontinued 2018). Supports every knob interaction — rotate left/right,
+  single/double/triple press, long press, and press-while-rotating — with
+  per-application profiles, rich action bindings (volume, media, mute, keyboard
+  shortcuts, macros, scroll, launch), full LED control, a translucent on-screen
+  display overlay, and a system tray icon.
+
+  Requires the WinUSB driver to be installed via Zadig (see README).
+Moniker: griffinpowermate
+Tags:
+  - griffin
+  - powermate
+  - usb
+  - knob
+  - controller
+  - volume
+  - media
+  - windows11
+  - winusb
+  - customtkinter
+ReleaseNotes: |-
+  v1.2.0 — Translucent OSD overlay
+  - Added a translucent two-line on-screen display (gesture + bound action)
+    that appears bottom-right above the taskbar on every knob event.
+  - Added OSD settings tab: enable/disable, opacity, duration, background color,
+    font family/color/size (8-24pt), and a Preview button.
+  - Settings persist under a new osd block in config.json and apply live.
+ReleaseNotesUrl: https://github.com/accolytebyte/griffinpowermate/releases/tag/v1.2.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/a/AccolyteByte/GriffinPowerMate/1.2.0/AccolyteByte.GriffinPowerMate.yaml
+++ b/manifests/a/AccolyteByte/GriffinPowerMate/1.2.0/AccolyteByte.GriffinPowerMate.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: AccolyteByte.GriffinPowerMate
+PackageVersion: 1.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Description
This PR adds a new package manifest for Griffin PowerMate — a Windows 11 controller for the Griffin PowerMate USB knob.

## Package Details
- **Package Identifier:** AccolyteByte.GriffinPowerMate
- **Version:** 1.2.0
- **License:** BSD-3-Clause
- **Publisher:** AccolyteByte
- **Release URL:** https://github.com/accolytebyte/griffinpowermate/releases/tag/v1.2.0

## Validation
- [x] Manifest validated with `winget validate --manifest`
- [x] Package installs and runs correctly on Windows 11
- [x] SHA-256 verified: `463D4199F3E71E0D45CC356159574A5C5E7F3DE166F548400BDD84DA33E20A5B`

## Notes
The installer type is `portable` — the EXE is a single self-contained PyInstaller bundle. It requires the WinUSB driver to be installed via Zadig for the USB knob to function (documented in the README and release notes).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/384691)