### PR TITLE
NuengCoder.ntc version 2.0.0

### DIFF
--- a/manifests/n/NuengCoder/2.0.0/NuengCoder.ntc.installer.yaml
+++ b/manifests/n/NuengCoder/2.0.0/NuengCoder.ntc.installer.yaml
@@ -1,0 +1,12 @@
+PackageIdentifier: NuengCoder.ntc
+PackageVersion: 2.0.0
+InstallerLocale: en-US
+InstallerType: portable
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/NuengCoder/ntc/releases/download/v2.0.0/ntc-v2.0.0-windows-x86_64.zip
+    InstallerSha256: DABF4CBD516DF819C2E08E33DE593835CB139892AB0DD4603A4492670C9BFBFF
+    Commands:
+      - ntc
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/n/NuengCoder/2.0.0/NuengCoder.ntc.locale.en-US.yaml
+++ b/manifests/n/NuengCoder/2.0.0/NuengCoder.ntc.locale.en-US.yaml
@@ -1,0 +1,22 @@
+PackageIdentifier: NuengCoder.ntc
+PackageVersion: 2.0.0
+PackageLocale: en-US
+Publisher: NuengCoder
+Author: NuengCoder
+PackageName: ntc
+PackageUrl: https://github.com/NuengCoder/ntc
+License: MIT
+LicenseUrl: https://github.com/NuengCoder/ntc/blob/main/LICENSE
+ShortDescription: Navigate, Tree, Cat - A combined directory tree viewer and file concatenator
+Description: ntc is a CLI tool for navigating directories, viewing file trees, and concatenating file contents with a rich interactive shell featuring fuzzy search, backups, file watching, teleport points, and more.
+Tags:
+  - navigate
+  - tree
+  - cat
+  - file
+  - directory
+  - cli
+  - terminal
+  - shell
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/n/NuengCoder/2.0.0/NuengCoder.ntc.yaml
+++ b/manifests/n/NuengCoder/2.0.0/NuengCoder.ntc.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: NuengCoder.ntc
+PackageVersion: 2.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Updates NuengCoder.ntc to version 2.0.0

- Updated Windows x86_64 portable installer URL and SHA256
- Release: https://github.com/NuengCoder/ntc/releases/tag/v2.0.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/384698)