### PR TITLE
New package: WarpSend.WarpSend version 0.1.0.202606062131

### DIFF
--- a/manifests/w/WarpSend/WarpSend/0.1.0.202606062131/WarpSend.WarpSend.installer.yaml
+++ b/manifests/w/WarpSend/WarpSend/0.1.0.202606062131/WarpSend.WarpSend.installer.yaml
@@ -1,0 +1,25 @@
+# Installer manifest — tells WinGet how to fetch + register the binary.
+#
+# `portable` installer type is the WinGet equivalent of a brew "binary"
+# formula: WinGet downloads the .zip, extracts to its own packages dir,
+# and registers a shim (`warpsend.exe`) on PATH. No MSI / NSIS needed,
+# no admin rights, no SmartScreen prompt for the installer itself.
+PackageIdentifier: WarpSend.WarpSend
+PackageVersion: 0.1.0.202606062131
+
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: warpsend.exe
+    PortableCommandAlias: warpsend
+
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://download.warpsend.io/downloads/879d3509ee08/warpsend-x86_64-pc-windows-gnu.fa3e9f04fca8.zip
+    InstallerSha256: fa3e9f04fca88566eefa4f65b1a87e0e4aef9e0e130c35a9bf2b4b2266d42c4e
+  - Architecture: arm64
+    InstallerUrl: https://download.warpsend.io/downloads/879d3509ee08/warpsend-aarch64-pc-windows-gnullvm.4668ccce02a0.zip
+    InstallerSha256: 4668ccce02a0eb9b4c9d67a52c2f602b82219e13d96a9955bd0a5e02e45059cb
+
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/w/WarpSend/WarpSend/0.1.0.202606062131/WarpSend.WarpSend.locale.en-US.yaml
+++ b/manifests/w/WarpSend/WarpSend/0.1.0.202606062131/WarpSend.WarpSend.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# Locale manifest — user-facing description shown in `winget show` and
+# the WinGet website. Required because the version manifest declares
+# DefaultLocale: en-US.
+PackageIdentifier: WarpSend.WarpSend
+PackageVersion: 0.1.0.202606062131
+PackageLocale: en-US
+Publisher: WarpSend
+PublisherUrl: https://warpsend.io
+Author: WarpSend
+PackageName: WarpSend
+PackageUrl: https://warpsend.io
+License: MIT
+ShortDescription: NAS-to-NAS large file transfer over Cloudflare R2.
+Description: |-
+  WarpSend is a thin CLI for moving large files between NAS / Linux / macOS
+  endpoints across regions, using Cloudflare R2 as a relay. After
+  installation, run `warpsend run` to bootstrap the local agent and open
+  the management UI.
+Tags:
+  - file-transfer
+  - nas
+  - cloudflare
+  - cli
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0
+# Optional URL fields (PublisherSupportUrl, LicenseUrl, ReleaseNotesUrl)
+# are intentionally omitted. The source repo is private, so the GitHub
+# /LICENSE and /releases pages 404, and there is no public /support
+# subpath on warpsend.io yet. wingetbot validates every URL — adding a
+# field that 404s blocks the PR. Add them back if/when these pages
+# become public.

--- a/manifests/w/WarpSend/WarpSend/0.1.0.202606062131/WarpSend.WarpSend.yaml
+++ b/manifests/w/WarpSend/WarpSend/0.1.0.202606062131/WarpSend.WarpSend.yaml
@@ -1,0 +1,8 @@
+# Version manifest — top-level descriptor for the package version.
+# Rendered by scripts/update-winget-manifest.sh; do not edit the generated
+# version/ subdirectory by hand.
+PackageIdentifier: WarpSend.WarpSend
+PackageVersion: 0.1.0.202606062131
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: WarpSend.WarpSend 0.1.0.202606062131

WarpSend is a thin CLI for moving large files between NAS / Linux / macOS endpoints across regions, using Cloudflare R2 as a relay. Installs as a `portable` package (x64 + arm64), registering a `warpsend` shim on PATH.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest?
- [x] Manifests rendered from a template by the package owner's tooling; structure, installer URLs (live), and SHA256 verified manually. Authoritative validation is left to this repo's automated checks (manifest schema + installer download/hash).
- First submission for this package; subsequent versions will be auto-submitted via wingetcreate.

Installer URLs are content-addressed and served from `https://download.warpsend.io`.