### PR TITLE
Corrected x64 InstallerUrl: mikf.gallery-dl version 1.32.2

### DIFF
--- a/manifests/m/mikf/gallery-dl/1.32.2/mikf.gallery-dl.installer.yaml
+++ b/manifests/m/mikf/gallery-dl/1.32.2/mikf.gallery-dl.installer.yaml
@@ -1,4 +1,3 @@
-# Created with YamlCreate.ps1 Dumplings Mod
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: mikf.gallery-dl
@@ -7,17 +6,17 @@ Platform:
 - Windows.Desktop
 InstallerType: portable
 ReleaseDate: 2026-06-06
-AppsAndFeaturesEntries:
-- DisplayName: gallery-dl (x64)
 Installers:
 - Architecture: x64
-  InstallerUrl: https://codeberg.org/mikf/gallery-dl/releases/download/v1.32.2/gallery-dl_x86.exe
-  InstallerSha256: 88A8A956956E5F5E5258AC2DD8BC0FCCD8B21639D8664D32DB0A645ECB8106FC
+  InstallerUrl: https://codeberg.org/mikf/gallery-dl/releases/download/v1.32.2/gallery-dl.exe
+  InstallerSha256: 0910e91108ff288b905a7ecd180b195a03eae611413c4e43d82c4bd7a441db61
   Commands:
   - gallery-dl
   Dependencies:
     PackageDependencies:
     - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+  AppsAndFeaturesEntries:
+  - DisplayName: gallery-dl (x64)
 - Architecture: x86
   InstallerUrl: https://codeberg.org/mikf/gallery-dl/releases/download/v1.32.2/gallery-dl_x86.exe
   InstallerSha256: 88A8A956956E5F5E5258AC2DD8BC0FCCD8B21639D8664D32DB0A645ECB8106FC
@@ -26,5 +25,7 @@ Installers:
   Dependencies:
     PackageDependencies:
     - PackageIdentifier: Microsoft.VCRedist.2015+.x86
+  AppsAndFeaturesEntries:
+  - DisplayName: gallery-dl (x86)
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/m/mikf/gallery-dl/1.32.2/mikf.gallery-dl.locale.en-US.yaml
+++ b/manifests/m/mikf/gallery-dl/1.32.2/mikf.gallery-dl.locale.en-US.yaml
@@ -1,4 +1,3 @@
-# Created with YamlCreate.ps1 Dumplings Mod
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: mikf.gallery-dl
@@ -12,7 +11,7 @@ PackageName: gallery-dl
 PackageUrl: https://github.com/mikf/gallery-dl
 License: GPL-2.0
 LicenseUrl: https://github.com/mikf/gallery-dl/blob/master/LICENSE
-Copyright: Copyright 2014-2026 Mike Fährmann
+Copyright: 2014-2026 Mike Fährmann
 ShortDescription: Command-line program to download image galleries and collections from several image hosting sites
 Description: gallery-dl is a command-line program to download image galleries and collections from several image hosting sites. It is a cross-platform tool with many configuration options and powerful filenaming capabilities.
 Tags:
@@ -24,56 +23,56 @@ Tags:
 - picture
 ReleaseNotes: |-
   Extractors
-  - Additions
-    - [shareimage] add gallery extractor (pr#143)
-  - 8chan
-    - fix IndexError: tuple index out of range (cb#113)
-  - bunkr
-    - fix file downloads (gh#142 gh#154 gh#9554)
-  - exhentai
-    - always forward search query parameters (cb#79)
-    - fix torrent downloads for parent galleries (gh#9507)
-    - unescape HTML entities in API metadata titles
-  - filester
-    - support mirror domains (gh#9501)
-    - add domain option (gh#9501)
-  - furaffinity
-    - fix metadata for Modern Theme (cb#101 pr#110)
-    - fix download URLs of non-image files (cb#115)
-  - gofile
-    - fix 401 Unauthorized (gh#133)
-  - instagram
-    - fix AttributeError when display_url is None (cb#104 pr#139)
-  - mangadex
-    - prevent KeyError: 'attributes'
-  - pixeldrain
-    - support URLs with .net TLD (cb#105)
-  - postype
-    - support URLs with language codes
-  - realbooru
-    - improve pagination end condition (gh#147)
-  - sankaku
-    - fix extended tag categories (gh#149)
-  - shimmie2
-    - improve pagination end condition (gh#9525)
-  - subscribestar
-    - support subscribestar.art URLs (cb#77)
-  - toyhouse
-    - fix & improve metadata extraction
-  - tumblr
-    - support blog ID URLs
-  - twitter
-    - try to improve max_id handling & prevent repeated previously seen messages (gh#9410 gh#9437)
-    - support poll_choice_images cards (gh#9511)
-    - prevent errors for external cards
-  - vipergirls
-    - fix domain not applying to cookies (gh#9500)
-    - improve error for restricted threads (gh#9500)
-    - use a different domain than viper.click for login (gh#9500)
-  - xfolio
-    - fix _logged_in and header errors (pr#83)
+  • Additions
+    • [shareimage] add gallery extractor (pr#143)
+  • 8chan
+    • fix IndexError：tuple index out of range (cb#113)
+  • bunkr
+    • fix file downloads (gh#142 gh#154 gh#9554)
+  • exhentai
+    • always forward search query parameters (cb#79)
+    • fix torrent downloads for parent galleries (gh#9507)
+    • unescape HTML entities in API metadata titles
+  • filester
+    • support mirror domains (gh#9501)
+    • add domain option (gh#9501)
+  • furaffinity
+    • fix metadata for Modern Theme (cb#101 pr#110)
+    • fix download URLs of non-image files (cb#115)
+  • gofile
+    • fix 401 Unauthorized (gh#133)
+  • instagram
+    • fix AttributeError when display_url is None (cb#104 pr#139)
+  • mangadex
+    • prevent KeyError：«attributes»
+  • pixeldrain
+    • support URLs with .net TLD (cb#105)
+  • postype
+    • support URLs with language codes
+  • realbooru
+    • improve pagination end condition (gh#147)
+  • sankaku
+    • fix extended tag categories (gh#149)
+  • shimmie2
+    • improve pagination end condition (gh#9525)
+  • subscribestar
+    • support subscribestar.art URLs (cb#77)
+  • toyhouse
+    • fix & improve metadata extraction
+  • tumblr
+    • support blog ID URLs
+  • twitter
+    • try to improve max_id handling & prevent repeated previously seen messages (gh#9410 gh#9437)
+    • support poll_choice_images cards (gh#9511)
+    • prevent errors for external cards
+  • vipergirls
+    • fix domain not applying to cookies (gh#9500)
+    • improve error for restricted threads (gh#9500)
+    • use a different domain than viper.click for login (gh#9500)
+  • xfolio
+    • fix _logged_in and header errors (pr#83)
   Scripts
-  - implement fmt.py
+  • implement fmt.py
 ReleaseNotesUrl: https://codeberg.org/mikf/gallery-dl/releases/tag/v1.32.2
 Documentations:
 - DocumentLabel: Wiki


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
* Fixed the x64 InstallerUrl, which for some reason had become the same as the x86 one.
* Fixed the DisplayName for x86.

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [ ] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/384947)