### PR TITLE
New version: Finesssee.Win-CodexBar version 0.32.7

### DIFF
--- a/manifests/f/Finesssee/Win-CodexBar/0.32.7/Finesssee.Win-CodexBar.installer.yaml
+++ b/manifests/f/Finesssee/Win-CodexBar/0.32.7/Finesssee.Win-CodexBar.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Finesssee.Win-CodexBar
+PackageVersion: 0.32.7
+InstallerType: inno
+Scope: user
+UpgradeBehavior: install
+ProductCode: WinCodexBar_is1
+ReleaseDate: 2026-06-08
+AppsAndFeaturesEntries:
+- ProductCode: WinCodexBar_is1
+  DisplayName: CodexBar 0.32.7
+  DisplayVersion: 0.32.7
+  Publisher: CodexBar Contributors
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Finesssee/Win-CodexBar/releases/download/v0.32.7/CodexBar-0.32.7-Setup.exe
+  InstallerSha256: 5B4A5D8A76552F7755075DA6805999D3E0D36B9EAB16B0FF440F1C9F3F213ECD
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Finesssee/Win-CodexBar/0.32.7/Finesssee.Win-CodexBar.locale.en-US.yaml
+++ b/manifests/f/Finesssee/Win-CodexBar/0.32.7/Finesssee.Win-CodexBar.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Finesssee.Win-CodexBar
+PackageVersion: 0.32.7
+PackageLocale: en-US
+Publisher: CodexBar Contributors
+PublisherUrl: https://github.com/Finesssee
+PublisherSupportUrl: https://github.com/Finesssee/Win-CodexBar/issues
+Author: Finesssee
+PackageName: Win-CodexBar
+PackageUrl: https://github.com/Finesssee/Win-CodexBar
+License: MIT
+LicenseUrl: https://github.com/Finesssee/Win-CodexBar/blob/main/LICENSE
+Copyright: Copyright (c) CodexBar contributors
+ShortDescription: Windows-native menu bar app for OpenAI Codex and Claude Code usage stats.
+Description: Win-CodexBar is a Windows-native desktop app for viewing OpenAI Codex and Claude Code usage stats from a small Tauri shell.
+Moniker: win-codexbar
+Tags:
+- claude-code
+- codex
+- desktop
+- tauri
+- usage
+- windows
+ReleaseNotes: |-
+  v0.32.7 fixes Cursor usage percentage parsing, prevents Cursor bonus-credit breakdown totals from distorting fallback percentages, and expands Alibaba Coding Plan regional support with canonical region-based cookie, dashboard, gateway, and SEC_TOKEN handling.
+ReleaseNotesUrl: https://github.com/Finesssee/Win-CodexBar/releases/tag/v0.32.7
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Finesssee/Win-CodexBar/0.32.7/Finesssee.Win-CodexBar.yaml
+++ b/manifests/f/Finesssee/Win-CodexBar/0.32.7/Finesssee.Win-CodexBar.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Finesssee.Win-CodexBar
+PackageVersion: 0.32.7
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Packages: Finesssee.Win-CodexBar

Validation:
- Verified installer SHA256: 5B4A5D8A76552F7755075DA6805999D3E0D36B9EAB16B0FF440F1C9F3F213ECD
- Verified installer type: Inno Setup
- Ran `winget validate C:\code\winget-manifest\Finesssee.Win-CodexBar\0.32.7` successfully on Windows

Release: https://github.com/Finesssee/Win-CodexBar/releases/tag/v0.32.7

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/385023)