### PR TITLE
New package: GrooveLabs.OmniDialer version 26.603.1020

### DIFF
--- a/manifests/g/GrooveLabs/OmniDialer/26.603.1020/GrooveLabs.OmniDialer.installer.yaml
+++ b/manifests/g/GrooveLabs/OmniDialer/26.603.1020/GrooveLabs.OmniDialer.installer.yaml
@@ -1,0 +1,14 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: GrooveLabs.OmniDialer
+PackageVersion: "26.603.1020"
+InstallerType: nullsoft
+InstallModes:
+  - silent
+  - silentWithProgress
+Installers:
+  - Architecture: x64
+    Scope: user
+    InstallerUrl: https://groove-dialer.s3-us-west-2.amazonaws.com/electron/Groove%20OmniDialer%20Setup%2026.603.1020.exe
+    InstallerSha256: 2C7C2B995F222C27A53AB9BFC4E501BC122F156D9074841ADA84805BB22859A2
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/g/GrooveLabs/OmniDialer/26.603.1020/GrooveLabs.OmniDialer.locale.en-US.yaml
+++ b/manifests/g/GrooveLabs/OmniDialer/26.603.1020/GrooveLabs.OmniDialer.locale.en-US.yaml
@@ -1,0 +1,11 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: GrooveLabs.OmniDialer
+PackageVersion: "26.603.1020"
+PackageLocale: en-US
+Publisher: "Groove Labs, Inc."
+PackageName: Groove OmniDialer
+License: Proprietary
+ShortDescription: Softphone and dialer for sales and contact-centre agents
+Moniker: groove-omnidialer
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/g/GrooveLabs/OmniDialer/26.603.1020/GrooveLabs.OmniDialer.yaml
+++ b/manifests/g/GrooveLabs/OmniDialer/26.603.1020/GrooveLabs.OmniDialer.yaml
@@ -1,0 +1,6 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: GrooveLabs.OmniDialer
+PackageVersion: "26.603.1020"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
﻿### New package: GrooveLabs.OmniDialer version 26.603.1020

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] This PR only modifies one (1) manifest.
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally?

The installer is Groove's own signed release (signed "Groove Labs, Inc.", served direct over HTTPS).
It installs per-user silently via the NSIS `/S` switch (exit code 0, registers in Add/Remove Programs)
and uninstalls cleanly. Note: `winget install --manifest` stalled at the Mark-of-the-Web step in my
local test VM (Defender scan under x64-on-ARM emulation), so install/uninstall were verified by invoking
the manifest's silent switch directly; the validation pipeline will exercise the full install path on a
clean VM. Related Fleet request: fleetdm/fleet#46879.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/385068)