### PR TITLE
New package: NakabaLab.sshm version 1.0.1

### DIFF
--- a/manifests/n/NakabaLab/sshm/1.0.1/NakabaLab.sshm.installer.yaml
+++ b/manifests/n/NakabaLab/sshm/1.0.1/NakabaLab.sshm.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: NakabaLab.sshm
 PackageVersion: 1.0.1
@@ -13,4 +13,4 @@ Installers:
     InstallerUrl: https://github.com/nakaba-lab/ssh-manager-tui/releases/download/v1.0.1/sshm-1.0.1-x86_64-pc-windows-msvc.zip
     InstallerSha256: E21AD6C18965E3A6EAE565103C4B6CDBE084B056EADD76071BC47F4599AF9092
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/n/NakabaLab/sshm/1.0.1/NakabaLab.sshm.installer.yaml
+++ b/manifests/n/NakabaLab/sshm/1.0.1/NakabaLab.sshm.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: NakabaLab.sshm
+PackageVersion: 1.0.1
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: sshm.exe
+    PortableCommandAlias: sshm
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/nakaba-lab/ssh-manager-tui/releases/download/v1.0.1/sshm-1.0.1-x86_64-pc-windows-msvc.zip
+    InstallerSha256: E21AD6C18965E3A6EAE565103C4B6CDBE084B056EADD76071BC47F4599AF9092
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/n/NakabaLab/sshm/1.0.1/NakabaLab.sshm.locale.en-US.yaml
+++ b/manifests/n/NakabaLab/sshm/1.0.1/NakabaLab.sshm.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: NakabaLab.sshm
 PackageVersion: 1.0.1
@@ -17,4 +17,4 @@ Tags:
   - ssh-config
   - terminal
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/n/NakabaLab/sshm/1.0.1/NakabaLab.sshm.locale.en-US.yaml
+++ b/manifests/n/NakabaLab/sshm/1.0.1/NakabaLab.sshm.locale.en-US.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: NakabaLab.sshm
+PackageVersion: 1.0.1
+PackageLocale: en-US
+Publisher: nakaba-lab
+PublisherUrl: https://github.com/nakaba-lab/ssh-manager-tui
+Author: nakaba-lab
+PackageName: sshm
+PackageUrl: https://github.com/nakaba-lab/ssh-manager-tui
+License: MIT OR Apache-2.0
+ShortDescription: A TUI SSH host manager for ~/.ssh/config
+Moniker: sshm
+Tags:
+  - ssh
+  - tui
+  - ssh-config
+  - terminal
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/n/NakabaLab/sshm/1.0.1/NakabaLab.sshm.yaml
+++ b/manifests/n/NakabaLab/sshm/1.0.1/NakabaLab.sshm.yaml
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: NakabaLab.sshm
 PackageVersion: 1.0.1
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/n/NakabaLab/sshm/1.0.1/NakabaLab.sshm.yaml
+++ b/manifests/n/NakabaLab/sshm/1.0.1/NakabaLab.sshm.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: NakabaLab.sshm
+PackageVersion: 1.0.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package

- **PackageIdentifier:** `NakabaLab.sshm`
- **PackageVersion:** `1.0.1`
- **Type:** portable executable shipped inside a zip (`InstallerType: zip`, `NestedInstallerType: portable`, command alias `sshm`)

`sshm` is a Windows-first terminal UI (TUI) for browsing, editing, and connecting to the SSH hosts in `~/.ssh/config`. It reads and writes the real OpenSSH config losslessly. Open source under MIT OR Apache-2.0.

- Repository: https://github.com/nakaba-lab/ssh-manager-tui
- Release (with the referenced installer + `.sha256`): https://github.com/nakaba-lab/ssh-manager-tui/releases/tag/v1.0.1

### Checklist

- [x] Manifest validated locally: `winget validate --manifest <dir>` → **succeeded**
- [x] `InstallerSha256` matches the published asset (verified against the release `.sha256` sidecar and a local recompute)
- [x] Single architecture (x64); installer URL points at the immutable v1.0.1 release asset
- [x] Manifest schema version 1.6.0

#### Microsoft Reviewers: [Open in CodeFlow](https://portal.fluentpreview.microsoft.com/MSGHPR.html)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/385086)