### PR TITLE
Add FreakJS version 0.1.0

### DIFF
--- a/manifests/f/FreakJS/FreakJS/0.1.0/FreakJS.FreakJS.installer.yaml
+++ b/manifests/f/FreakJS/FreakJS/0.1.0/FreakJS.FreakJS.installer.yaml
@@ -3,12 +3,13 @@ PackageVersion: 0.1.0
 Platform:
   - Windows.Desktop
 MinimumOSVersion: 10.0.0.0
-Architecture: x64
-InstallerType: portable
-InstallerUrl: https://github.com/lucas-s-santos/FreakJS/releases/download/v0.1.0/freakjs-windows-x64.exe
-InstallerSha256: 3ca9e0aa0aca82b6aec1bf2433084a23b2465691b100b11c3f4e51683f37a565
-Commands:
-  - freakjs
-PortableCommandAlias: freakjs
+Installers:
+  - Architecture: x64
+    InstallerType: portable
+    InstallerUrl: https://github.com/lucas-s-santos/FreakJS/releases/download/v0.1.0/freakjs-windows-x64.exe
+    InstallerSha256: 3ca9e0aa0aca82b6aec1bf2433084a23b2465691b100b11c3f4e51683f37a565
+    Commands:
+      - freakjs
+    PortableCommandAlias: freakjs
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/f/FreakJS/FreakJS/0.1.0/FreakJS.FreakJS.installer.yaml
+++ b/manifests/f/FreakJS/FreakJS/0.1.0/FreakJS.FreakJS.installer.yaml
@@ -1,13 +1,10 @@
 PackageIdentifier: FreakJS.FreakJS
 PackageVersion: 0.1.0
-Platform:
-  - Windows.Desktop
-MinimumOSVersion: 10.0.0.0
 Installers:
   - Architecture: x64
     InstallerType: portable
     InstallerUrl: https://github.com/lucas-s-santos/FreakJS/releases/download/v0.1.0/freakjs-windows-x64.exe
-    InstallerSha256: 3ca9e0aa0aca82b6aec1bf2433084a23b2465691b100b11c3f4e51683f37a565
+    InstallerSha256: 3CA9E0AA0ACA82B6AEC1BF2433084A23B2465691B100B11C3F4E51683F37A565
     Commands:
       - freakjs
     PortableCommandAlias: freakjs

--- a/manifests/f/FreakJS/FreakJS/0.1.0/FreakJS.FreakJS.installer.yaml
+++ b/manifests/f/FreakJS/FreakJS/0.1.0/FreakJS.FreakJS.installer.yaml
@@ -9,10 +9,6 @@ InstallerUrl: https://github.com/lucas-s-santos/FreakJS/releases/download/v0.1.0
 InstallerSha256: 3ca9e0aa0aca82b6aec1bf2433084a23b2465691b100b11c3f4e51683f37a565
 Commands:
   - freakjs
-InstallModes:
-  - interactive
-  - silent
-  - silentWithProgress
 PortableCommandAlias: freakjs
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/f/FreakJS/FreakJS/0.1.0/FreakJS.FreakJS.installer.yaml
+++ b/manifests/f/FreakJS/FreakJS/0.1.0/FreakJS.FreakJS.installer.yaml
@@ -5,8 +5,5 @@ Installers:
     InstallerType: portable
     InstallerUrl: https://github.com/lucas-s-santos/FreakJS/releases/download/v0.1.0/freakjs-windows-x64.exe
     InstallerSha256: 3CA9E0AA0ACA82B6AEC1BF2433084A23B2465691B100B11C3F4E51683F37A565
-    Commands:
-      - freakjs
-    PortableCommandAlias: freakjs
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/f/FreakJS/FreakJS/0.1.0/FreakJS.FreakJS.installer.yaml
+++ b/manifests/f/FreakJS/FreakJS/0.1.0/FreakJS.FreakJS.installer.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 PackageIdentifier: FreakJS.FreakJS
 PackageVersion: 0.1.0
 Installers:

--- a/manifests/f/FreakJS/FreakJS/0.1.0/FreakJS.FreakJS.installer.yaml
+++ b/manifests/f/FreakJS/FreakJS/0.1.0/FreakJS.FreakJS.installer.yaml
@@ -1,0 +1,18 @@
+PackageIdentifier: FreakJS.FreakJS
+PackageVersion: 0.1.0
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+Architecture: x64
+InstallerType: portable
+InstallerUrl: https://github.com/lucas-s-santos/FreakJS/releases/download/v0.1.0/freakjs-windows-x64.exe
+InstallerSha256: 3ca9e0aa0aca82b6aec1bf2433084a23b2465691b100b11c3f4e51683f37a565
+Commands:
+  - freakjs
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+PortableCommandAlias: freakjs
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/f/FreakJS/FreakJS/0.1.0/FreakJS.FreakJS.locale.en-US.yaml
+++ b/manifests/f/FreakJS/FreakJS/0.1.0/FreakJS.FreakJS.locale.en-US.yaml
@@ -1,0 +1,21 @@
+PackageIdentifier: FreakJS.FreakJS
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: FreakJS
+PackageName: FreakJS
+License: MIT
+ShortDescription: Bun-native frontend framework — zero deps, edge-ready, free to deploy
+Description: |-
+  FreakJS is a minimal, security-first frontend framework built on Bun and W3C Web APIs.
+  Zero runtime npm dependencies. File-based routing. SSR + Edge Functions.
+  Deploys for free on Vercel, Netlify and Cloudflare Pages.
+Tags:
+  - bun
+  - frontend
+  - framework
+  - javascript
+  - typescript
+  - edge
+  - vercel
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/f/FreakJS/FreakJS/0.1.0/FreakJS.FreakJS.locale.en-US.yaml
+++ b/manifests/f/FreakJS/FreakJS/0.1.0/FreakJS.FreakJS.locale.en-US.yaml
@@ -3,6 +3,7 @@ PackageVersion: 0.1.0
 PackageLocale: en-US
 Publisher: FreakJS
 PackageName: FreakJS
+Moniker: freakjs
 License: MIT
 ShortDescription: Bun-native frontend framework — zero deps, edge-ready, free to deploy
 Description: |-

--- a/manifests/f/FreakJS/FreakJS/0.1.0/FreakJS.FreakJS.locale.en-US.yaml
+++ b/manifests/f/FreakJS/FreakJS/0.1.0/FreakJS.FreakJS.locale.en-US.yaml
@@ -2,14 +2,15 @@ PackageIdentifier: FreakJS.FreakJS
 PackageVersion: 0.1.0
 PackageLocale: en-US
 Publisher: FreakJS
+PublisherUrl: https://github.com/lucas-s-santos/FreakJS
 PackageName: FreakJS
+PackageUrl: https://github.com/lucas-s-santos/FreakJS
 Moniker: freakjs
 License: MIT
+LicenseUrl: https://github.com/lucas-s-santos/FreakJS/blob/main/LICENSE
+Copyright: Copyright (c) 2025 João Gabriel do Vale Souza & Lucas Silva dos Santos
 ShortDescription: Bun-native frontend framework — zero deps, edge-ready, free to deploy
-Description: |-
-  FreakJS is a minimal, security-first frontend framework built on Bun and W3C Web APIs.
-  Zero runtime npm dependencies. File-based routing. SSR + Edge Functions.
-  Deploys for free on Vercel, Netlify and Cloudflare Pages.
+Description: FreakJS is a minimal, security-first frontend framework built on Bun and W3C Web APIs. Zero runtime npm dependencies. File-based routing. SSR + Edge Functions. Deploys for free on Vercel, Netlify and Cloudflare Pages.
 Tags:
   - bun
   - frontend
@@ -17,6 +18,6 @@ Tags:
   - javascript
   - typescript
   - edge
-  - vercel
+  - ssr
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/f/FreakJS/FreakJS/0.1.0/FreakJS.FreakJS.locale.en-US.yaml
+++ b/manifests/f/FreakJS/FreakJS/0.1.0/FreakJS.FreakJS.locale.en-US.yaml
@@ -5,19 +5,14 @@ Publisher: FreakJS
 PublisherUrl: https://github.com/lucas-s-santos/FreakJS
 PackageName: FreakJS
 PackageUrl: https://github.com/lucas-s-santos/FreakJS
-Moniker: freakjs
 License: MIT
-LicenseUrl: https://github.com/lucas-s-santos/FreakJS/blob/main/LICENSE
-Copyright: Copyright (c) 2025 João Gabriel do Vale Souza & Lucas Silva dos Santos
-ShortDescription: Bun-native frontend framework — zero deps, edge-ready, free to deploy
-Description: FreakJS is a minimal, security-first frontend framework built on Bun and W3C Web APIs. Zero runtime npm dependencies. File-based routing. SSR + Edge Functions. Deploys for free on Vercel, Netlify and Cloudflare Pages.
+ShortDescription: Bun-native frontend framework - zero deps, edge-ready, free to deploy
+Description: FreakJS is a minimal, security-first frontend framework built on Bun and W3C Web APIs. Zero runtime npm dependencies. File-based routing. SSR plus Edge Functions.
 Tags:
   - bun
   - frontend
   - framework
   - javascript
   - typescript
-  - edge
-  - ssr
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0

--- a/manifests/f/FreakJS/FreakJS/0.1.0/FreakJS.FreakJS.locale.en-US.yaml
+++ b/manifests/f/FreakJS/FreakJS/0.1.0/FreakJS.FreakJS.locale.en-US.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 PackageIdentifier: FreakJS.FreakJS
 PackageVersion: 0.1.0
 PackageLocale: en-US
@@ -7,7 +8,7 @@ PackageName: FreakJS
 PackageUrl: https://github.com/lucas-s-santos/FreakJS
 License: MIT
 ShortDescription: Bun-native frontend framework - zero deps, edge-ready, free to deploy
-Description: FreakJS is a minimal, security-first frontend framework built on Bun and W3C Web APIs. Zero runtime npm dependencies. File-based routing. SSR plus Edge Functions.
+Description: FreakJS is a minimal frontend framework built on Bun. Zero runtime npm dependencies. File-based routing. SSR plus Edge Functions.
 Tags:
   - bun
   - frontend

--- a/manifests/f/FreakJS/FreakJS/0.1.0/FreakJS.FreakJS.yaml
+++ b/manifests/f/FreakJS/FreakJS/0.1.0/FreakJS.FreakJS.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: FreakJS.FreakJS
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0

--- a/manifests/f/FreakJS/FreakJS/0.1.0/FreakJS.FreakJS.yaml
+++ b/manifests/f/FreakJS/FreakJS/0.1.0/FreakJS.FreakJS.yaml
@@ -2,4 +2,4 @@ PackageIdentifier: FreakJS.FreakJS
 PackageVersion: 0.1.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/f/FreakJS/FreakJS/0.1.0/FreakJS.FreakJS.yaml
+++ b/manifests/f/FreakJS/FreakJS/0.1.0/FreakJS.FreakJS.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 PackageIdentifier: FreakJS.FreakJS
 PackageVersion: 0.1.0
 DefaultLocale: en-US


### PR DESCRIPTION
## FreakJS v0.1.0

Bun-native frontend framework — zero runtime dependencies, edge-ready, free to deploy on Vercel/Netlify.

- **Publisher:** FreakJS
- **License:** MIT
- **Homepage:** https://github.com/lucas-s-santos/FreakJS
- **Installer type:** portable (single binary, no install required)
- **Architecture:** x64

The binary is compiled with `bun build --compile` and has zero runtime npm dependencies.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/385089)