### PR TITLE
New package: Wangnov.CodexAppManager version 0.1.10

### DIFF
--- a/manifests/w/Wangnov/CodexAppManager/0.1.10/Wangnov.CodexAppManager.installer.yaml
+++ b/manifests/w/Wangnov/CodexAppManager/0.1.10/Wangnov.CodexAppManager.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Wangnov.CodexAppManager
+PackageVersion: 0.1.10
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Wangnov/Codex-App-Manager/releases/download/v0.1.10/CodexAppManager_0.1.10_x64-setup.exe
+    InstallerSha256: 75705F3FF9F1FCAC5ADF118618EDAE8BABCF32F3C73109B434F69608EE506C02
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/w/Wangnov/CodexAppManager/0.1.10/Wangnov.CodexAppManager.locale.en-US.yaml
+++ b/manifests/w/Wangnov/CodexAppManager/0.1.10/Wangnov.CodexAppManager.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Wangnov.CodexAppManager
+PackageVersion: 0.1.10
+PackageLocale: en-US
+Publisher: Wangnov
+PublisherUrl: https://github.com/Wangnov
+PublisherSupportUrl: https://github.com/Wangnov/Codex-App-Manager/issues
+PackageName: Codex App Manager
+PackageUrl: https://github.com/Wangnov/Codex-App-Manager
+License: MIT
+LicenseUrl: https://github.com/Wangnov/Codex-App-Manager/blob/main/LICENSE
+ShortDescription: Installer, updater, and uninstaller for the official Codex desktop app.
+Description: A cross-platform desktop client to install, incrementally update, and cleanly uninstall the official Codex desktop app, with built-in self-update.
+Moniker: codex-app-manager
+Tags:
+  - codex
+  - openai
+  - installer
+  - updater
+  - tauri
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/w/Wangnov/CodexAppManager/0.1.10/Wangnov.CodexAppManager.yaml
+++ b/manifests/w/Wangnov/CodexAppManager/0.1.10/Wangnov.CodexAppManager.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Wangnov.CodexAppManager
+PackageVersion: 0.1.10
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## New package: `Wangnov.CodexAppManager` version `0.1.10`

Codex App Manager — a cross-platform desktop client to install, update, and uninstall the official Codex desktop app (with built-in self-update).

- Installer: signed-by-updater NSIS (`nullsoft`), per-user scope, x64.
- Source: https://github.com/Wangnov/Codex-App-Manager (MIT).

### Checklist
- [x] Manifests validated locally (YAML well-formed, schema 1.6.0).
- [x] Installer URL is a stable GitHub release asset; SHA256 matches.
- [x] This PR adds one new package version.
- [x] I have read and agree to the Contribution Guidelines.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/385142)