### PR TITLE
Update: dixieflatline76.Spice to 2.5.8

### DIFF
--- a/manifests/d/dixieflatline76/Spice/2.5.8/dixieflatline76.Spice.installer.yaml
+++ b/manifests/d/dixieflatline76/Spice/2.5.8/dixieflatline76.Spice.installer.yaml
@@ -1,0 +1,13 @@
+PackageIdentifier: dixieflatline76.Spice
+PackageVersion: 2.5.8
+Installers:
+  - Architecture: x64
+    InstallerType: exe
+    InstallerUrl: https://github.com/dixieflatline76/Spice/releases/download/v2.5.8/Spice-Setup-2.5.8-windows-amd64.exe
+    InstallerSha256: 016BB5D25B2E4DC5AF5DF7F2F071704C6863FB83C973FC17607CFA17C1F80218
+    UpgradeBehavior: install
+    InstallerSwitches:
+      Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+      SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/d/dixieflatline76/Spice/2.5.8/dixieflatline76.Spice.locale.en-US.yaml
+++ b/manifests/d/dixieflatline76/Spice/2.5.8/dixieflatline76.Spice.locale.en-US.yaml
@@ -1,0 +1,16 @@
+PackageIdentifier: dixieflatline76.Spice
+PackageVersion: 2.5.8
+PackageLocale: en-US
+Publisher: dixieflatline76
+PackageName: Spice
+License: PolyForm Noncommercial 1.0.0
+ShortDescription: A highly-concurrent, plugin-driven desktop environment engine.
+Moniker: spice
+Tags:
+  - wallpaper
+  - desktop
+  - customization
+  - go
+  - engine
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/d/dixieflatline76/Spice/2.5.8/dixieflatline76.Spice.yaml
+++ b/manifests/d/dixieflatline76/Spice/2.5.8/dixieflatline76.Spice.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: dixieflatline76.Spice
+PackageVersion: 2.5.8
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0


### PR DESCRIPTION
## 📖 Description

Update dixieflatline76.Spice to version 2.5.8.

### Changes in this release:
- Restored "Start with Windows" support for MSIX installs via `StartupTask` extension
- Added "Manage in Windows Settings" button for all Windows users to toggle startup behavior
- Added Help menu entry to the system tray
- Updated support page with user guide reference
- Fixed ButtonItem `VisibleIf` not hiding label/help text on non-Windows platforms
- 4 new i18n keys translated across all 10 supported languages

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  - N/A

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/385230)