### PR TITLE
New version: 0state.scafld version 2.4.7

### DIFF
--- a/manifests/0/0state/scafld/2.4.7/0state.scafld.installer.yaml
+++ b/manifests/0/0state/scafld/2.4.7/0state.scafld.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: 0state.scafld
+PackageVersion: 2.4.7
+InstallerLocale: en-US
+InstallerType: portable
+Commands:
+  - scafld
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/nilstate/scafld/releases/download/v2.4.7/scafld_2.4.7_windows_amd64.exe
+    InstallerSha256: e00dc54f3c1dc350b77f0ebbdf34ce29e50a333711d31f655e820aab3e2c910c
+  - Architecture: arm64
+    InstallerUrl: https://github.com/nilstate/scafld/releases/download/v2.4.7/scafld_2.4.7_windows_arm64.exe
+    InstallerSha256: 04eac16da51f65bfbeecc15bae61d0728841b2e5fb1a60a1148f5c4cb8eae85e
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/0/0state/scafld/2.4.7/0state.scafld.locale.en-US.yaml
+++ b/manifests/0/0state/scafld/2.4.7/0state.scafld.locale.en-US.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: 0state.scafld
+PackageVersion: 2.4.7
+PackageLocale: en-US
+Publisher: 0state
+PublisherUrl: https://0state.com
+PackageName: scafld
+License: MIT
+ShortDescription: Deterministic protocol for multi-phase agent work.
+PackageUrl: https://0state.com/scafld
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/0/0state/scafld/2.4.7/0state.scafld.yaml
+++ b/manifests/0/0state/scafld/2.4.7/0state.scafld.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: 0state.scafld
+PackageVersion: 2.4.7
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Updates 0state.scafld to 2.4.7.\n\nRelease: https://github.com/nilstate/scafld/releases/tag/v2.4.7\n\nThe manifests were staged with scafld's release script from the published package-managers-rendered.tar.gz artifact, and installer hashes were verified against the published checksums.txt.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/385258)