### PR TITLE
New package: Filamental.Filamental version 0.2.5

### DIFF
--- a/manifests/f/Filamental/Filamental/0.2.5/Filamental.Filamental.installer.yaml
+++ b/manifests/f/Filamental/Filamental/0.2.5/Filamental.Filamental.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Filamental.Filamental
+PackageVersion: 0.2.5
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+UpgradeBehavior: install
+ReleaseDate: 2026-06-09
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Scottnine/filamental/releases/download/v0.2.5/Filamental_0.2.5_x64-setup.exe
+  InstallerSha256: 8D694DD80CBD6AD602E0DBD5F3897AC71EA3401C97BFCEBDA8B9C1FAF57FCDBB
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Filamental/Filamental/0.2.5/Filamental.Filamental.locale.en-US.yaml
+++ b/manifests/f/Filamental/Filamental/0.2.5/Filamental.Filamental.locale.en-US.yaml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Filamental.Filamental
+PackageVersion: 0.2.5
+PackageLocale: en-US
+Publisher: Filamental
+PublisherUrl: https://filamental.space
+PublisherSupportUrl: https://github.com/Scottnine/filamental/issues
+Author: Scott Turnbull
+PackageName: Filamental
+PackageUrl: https://filamental.space
+License: Proprietary
+Copyright: Copyright (C) 2025 Filamental
+ShortDescription: A local-first 3D knowledge graph desktop application
+Description: |-
+  Filamental is a local-first 3D knowledge graph for Windows. Build and
+  navigate connected knowledge as a living visual network — nodes, edges,
+  and relationships rendered in interactive 3D space. Write Markdown notes
+  directly on nodes, attach files, filter by type, and connect Filamental
+  to Claude via MCP for live AI access to your vault. All data stays on
+  your machine as plain Markdown files.
+Tags:
+- graph
+- knowledge
+- knowledge-graph
+- markdown
+- notes
+- productivity
+- visualization
+ReleaseNotes: |-
+  - MCP extension support for live AI vault access
+  - AI Integrations panel improvements
+  - Help content updates
+ReleaseNotesUrl: https://github.com/Scottnine/filamental/releases/tag/v0.2.5
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Filamental/Filamental/0.2.5/Filamental.Filamental.yaml
+++ b/manifests/f/Filamental/Filamental/0.2.5/Filamental.Filamental.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Filamental.Filamental
+PackageVersion: 0.2.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

New package submission for Filamental v0.2.5 — a local-first 3D knowledge graph desktop application for Windows.

- Publisher: Filamental
- Package identifier: Filamental.Filamental
- Version: 0.2.5
- Installer type: NSIS (nullsoft), x64
- Installer URL: https://github.com/Scottnine/filamental/releases/download/v0.2.5/Filamental_0.2.5_x64-setup.exe

## Checklist

- [x] Checked that there aren't other open pull requests for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Manifest conforms to the 1.12 schema

## Notes

Installer is code-signed (Azure Trusted Signing, Public Trust). App requires Windows 10 1809+ (WebView2 runtime, bundled if absent).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/385391)