### PR TITLE
New version: Nexaflow.SignalFoundry 0.3.25

### DIFF
--- a/manifests/n/Nexaflow/SignalFoundry/0.3.25/Nexaflow.SignalFoundry.installer.yaml
+++ b/manifests/n/Nexaflow/SignalFoundry/0.3.25/Nexaflow.SignalFoundry.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Nexaflow.SignalFoundry
+PackageVersion: 0.3.25
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+ArchiveBinariesDependOnPath: true
+NestedInstallerFiles:
+- RelativeFilePath: signal-foundry-cli-0.3.25\bin\sf.exe
+  PortableCommandAlias: sf
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/nexaflow-io/signal-foundry-cli-releases/releases/download/cli-v0.3.25/signal-foundry-cli-0.3.25-windows-x64.zip
+  InstallerSha256: 33e895706e332da4488d3dbbbc39d53835683d747c23b429fd8ab9c00baa21f4
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/n/Nexaflow/SignalFoundry/0.3.25/Nexaflow.SignalFoundry.locale.en-US.yaml
+++ b/manifests/n/Nexaflow/SignalFoundry/0.3.25/Nexaflow.SignalFoundry.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Nexaflow.SignalFoundry
+PackageVersion: 0.3.25
+PackageLocale: en-US
+Publisher: Nexaflow
+PublisherUrl: https://nexaflow.io
+PackageName: Signal Foundry CLI
+PackageUrl: https://signal-foundry.app
+License: Proprietary
+LicenseUrl: https://signal-foundry.app/terms-of-service
+ShortDescription: Agent-first CLI for the Signal Foundry data workspace.
+Moniker: sf
+Tags:
+- cli
+- data-workspace
+- agent
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/n/Nexaflow/SignalFoundry/0.3.25/Nexaflow.SignalFoundry.yaml
+++ b/manifests/n/Nexaflow/SignalFoundry/0.3.25/Nexaflow.SignalFoundry.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Nexaflow.SignalFoundry
+PackageVersion: 0.3.25
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Pull request has been created with [WinGet Automation](https://github.com/microsoft/winget-pkgs/blob/master/doc/README.md)\n\nUpdates Nexaflow.SignalFoundry to 0.3.25.\n\nRelease: https://github.com/nexaflow-io/signal-foundry-cli-releases/releases/tag/cli-v0.3.25\nWindows ZIP SHA256: 33e895706e332da4488d3dbbbc39d53835683d747c23b429fd8ab9c00baa21f4\n\n0.3.25 supersedes the open 0.3.24 submission because it fixes search routing issues found in post-release user testing.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/385396)