### PR TITLE
New package: nakaba-lab.wslm version 1.0.0

### DIFF
--- a/manifests/n/nakaba-lab/wslm/1.0.0/nakaba-lab.wslm.installer.yaml
+++ b/manifests/n/nakaba-lab/wslm/1.0.0/nakaba-lab.wslm.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 PackageIdentifier: nakaba-lab.wslm
 PackageVersion: 1.0.0
 Platform:
@@ -13,4 +13,4 @@ Installers:
   InstallerUrl: https://github.com/nakaba-lab/wsl-manager-tui/releases/download/v1.0.0/wslm-x86_64-pc-windows-msvc.exe
   InstallerSha256: 2596571A3D40E415AA23DA9B60FACDF132A208FE501A1598C8DCD2A6CE7E8B41
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/n/nakaba-lab/wslm/1.0.0/nakaba-lab.wslm.installer.yaml
+++ b/manifests/n/nakaba-lab/wslm/1.0.0/nakaba-lab.wslm.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: nakaba-lab.wslm
+PackageVersion: 1.0.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: portable
+Commands:
+- wslm
+ReleaseDate: 2026-06-08
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/nakaba-lab/wsl-manager-tui/releases/download/v1.0.0/wslm-x86_64-pc-windows-msvc.exe
+  InstallerSha256: 2596571A3D40E415AA23DA9B60FACDF132A208FE501A1598C8DCD2A6CE7E8B41
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/n/nakaba-lab/wslm/1.0.0/nakaba-lab.wslm.locale.en-US.yaml
+++ b/manifests/n/nakaba-lab/wslm/1.0.0/nakaba-lab.wslm.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 PackageIdentifier: nakaba-lab.wslm
 PackageVersion: 1.0.0
 PackageLocale: en-US
@@ -26,4 +26,4 @@ Tags:
 - ratatui
 - cli
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/n/nakaba-lab/wslm/1.0.0/nakaba-lab.wslm.locale.en-US.yaml
+++ b/manifests/n/nakaba-lab/wslm/1.0.0/nakaba-lab.wslm.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: nakaba-lab.wslm
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: nakaba-lab
+PublisherUrl: https://github.com/nakaba-lab
+PublisherSupportUrl: https://github.com/nakaba-lab/wsl-manager-tui/issues
+PackageName: wslm
+PackageUrl: https://github.com/nakaba-lab/wsl-manager-tui
+License: MIT OR Apache-2.0
+LicenseUrl: https://github.com/nakaba-lab/wsl-manager-tui/blob/main/LICENSE-MIT
+Copyright: Copyright (c) 2026 nakaba-lab
+ShortDescription: A terminal UI to manage Windows Subsystem for Linux (WSL) distributions.
+Description: |-
+  wslm is a single self-contained terminal UI (Rust + ratatui) to manage WSL distributions on
+  Windows from one screen: list distros with state, version and on-disk size; start/stop them;
+  open shells inline or in a new Windows Terminal tab; watch live WSL VM memory/CPU gauges with
+  sparklines; do managed export/import (tar/vhdx); install distros from the online catalog; and
+  edit .wslconfig / wsl.conf. State detection is locale-independent and there is no telemetry.
+Moniker: wslm
+Tags:
+- wsl
+- tui
+- terminal
+- windows
+- ratatui
+- cli
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/n/nakaba-lab/wslm/1.0.0/nakaba-lab.wslm.yaml
+++ b/manifests/n/nakaba-lab/wslm/1.0.0/nakaba-lab.wslm.yaml
@@ -1,6 +1,6 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 PackageIdentifier: nakaba-lab.wslm
 PackageVersion: 1.0.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/n/nakaba-lab/wslm/1.0.0/nakaba-lab.wslm.yaml
+++ b/manifests/n/nakaba-lab/wslm/1.0.0/nakaba-lab.wslm.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: nakaba-lab.wslm
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: `nakaba-lab.wslm` version 1.0.0

**wslm** — a single self-contained terminal UI (Rust + ratatui) to manage Windows Subsystem for
Linux (WSL) distributions from one screen: list distros with state/version/disk, start/stop, open
shells, watch live VM memory/CPU, managed export/import, online install, and `.wslconfig`/`wsl.conf`
editing.

- **Installer type:** portable (single x64 `.exe`)
- **Command:** `wslm`
- **Repository:** https://github.com/nakaba-lab/wsl-manager-tui
- **Release:** https://github.com/nakaba-lab/wsl-manager-tui/releases/tag/v1.0.0
- **License:** MIT OR Apache-2.0

---

- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)? (the CLA bot will prompt the submitter to sign if not already done)
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? (passed)
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: this is a new, community-maintained open-source package. The installer is an unsigned portable
executable published from the project's GitHub Releases; SHA256 in the manifest matches the
release's `SHA256SUMS`.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/385480)