### PR TITLE
New package: QuattroProConverter.QuattroProConverter version 1.1.2

### DIFF
--- a/manifests/q/QuattroProConverter/QuattroProConverter/1.1.2/QuattroProConverter.QuattroProConverter.installer.yaml
+++ b/manifests/q/QuattroProConverter/QuattroProConverter/1.1.2/QuattroProConverter.QuattroProConverter.installer.yaml
@@ -1,0 +1,14 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: QuattroProConverter.QuattroProConverter
+PackageVersion: 1.1.2
+InstallerLocale: en-US
+InstallerType: wix
+ProductCode: '{692EF79F-BCAC-4B8B-8023-920AEC5608E0}'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://quattroproconverter.com/api/download
+  InstallerSha256: D91A04C5981250CD839C64C9832DF9C49B35D84B5FF4398EB9BAC9558BA38393
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/q/QuattroProConverter/QuattroProConverter/1.1.2/QuattroProConverter.QuattroProConverter.locale.en-US.yaml
+++ b/manifests/q/QuattroProConverter/QuattroProConverter/1.1.2/QuattroProConverter.QuattroProConverter.locale.en-US.yaml
@@ -1,0 +1,15 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: QuattroProConverter.QuattroProConverter
+PackageVersion: 1.1.2
+PackageLocale: en-US
+Publisher: Quattro Pro Converter
+PackageName: Quattro Pro Converter
+PackageUrl: https://quattroproconverter.com
+PublisherUrl: https://quattroproconverter.com
+PublisherSupportUrl: https://quattroproconverter.com/contact
+License: Proprietary
+ShortDescription: Convert legacy Quattro Pro spreadsheets to XLSX, PDF, HTML, Markdown, CSV, or XLS without uploading confidential finance, operations, engineering, or compliance data to the cloud.
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/q/QuattroProConverter/QuattroProConverter/1.1.2/QuattroProConverter.QuattroProConverter.yaml
+++ b/manifests/q/QuattroProConverter/QuattroProConverter/1.1.2/QuattroProConverter.QuattroProConverter.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: QuattroProConverter.QuattroProConverter
+PackageVersion: 1.1.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Submitting checklist

- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/signin) (CLA)? If not, sign in and complete the CLA, and the PR will get labeled `cla-not-required` or `cla-signed` automatically.
- [x] Have you validated that your manifest passes `winget validate` locally?
- [x] Have you tested that the package installs with `winget install` using this manifest?
- [x] Does the installer URL point to the correct location?
- [x] Does the SHA256 of the installer match the value in the manifest?

## Description

Adds the WinGet manifest for **Quattro Pro Converter** version **1.1.2**.

This supersedes/replaces closed #375214 with a cleaned-up submission:
- **InstallerUrl** uses the publisher domain only: `https://quattroproconverter.com/api/download`
- **InstallerSha256** verified from a direct download of that URL
- **PackageUrl** points to the product page: `https://quattroproconverter.com`

GitHub release and R2 direct links have been removed from the manifest.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/385686)