### PR TITLE
New version: deltaforge.cli version 1.0.4

### DIFF
--- a/manifests/d/deltaforge/cli/1.0.4/deltaforge.cli.installer.yaml
+++ b/manifests/d/deltaforge/cli/1.0.4/deltaforge.cli.installer.yaml
@@ -1,0 +1,13 @@
+PackageIdentifier: deltaforge.cli
+PackageVersion: 1.0.4
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: deltaforge-cli.exe
+    PortableCommandAlias: deltaforge-cli
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/deltaforge-org/delta-forge/releases/download/v1.0.4/deltaforge-cli-1.0.4-windows-x64.zip
+  InstallerSha256: 08B9F04BFD13BCC5830284AA5B6B5C202193D1D40EF54D1057237625481D2244
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/d/deltaforge/cli/1.0.4/deltaforge.cli.locale.en-US.yaml
+++ b/manifests/d/deltaforge/cli/1.0.4/deltaforge.cli.locale.en-US.yaml
@@ -1,0 +1,19 @@
+PackageIdentifier: deltaforge.cli
+PackageVersion: 1.0.4
+PackageLocale: en-US
+Publisher: DeltaForge
+PublisherUrl: https://deltaforge.org
+PublisherSupportUrl: https://deltaforge.org/pages/contact.html
+PackageName: deltaforge-cli
+Moniker: deltaforge-cli
+PackageUrl: https://deltaforge.org
+License: Proprietary
+LicenseUrl: https://deltaforge.org/pages/terms-of-service.html
+Copyright: Copyright (c) 2026 DeltaForge
+ShortDescription: Query Delta Lake and Apache Iceberg in place from your terminal: no warehouse, no cluster, no copy pipeline
+Tags:
+  - cli
+  - data
+  - delta-forge
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/d/deltaforge/cli/1.0.4/deltaforge.cli.yaml
+++ b/manifests/d/deltaforge/cli/1.0.4/deltaforge.cli.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: deltaforge.cli
+PackageVersion: 1.0.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Adds/updates manifests for deltaforge.cli 1.0.4.

All artifacts are downloaded from:
https://github.com/deltaforge-org/delta-forge/releases/download/v1.0.4/

Publisher homepage: https://deltaforge.org
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/385768)