### PR TITLE
Add peterfei.Differ version 0.2.0

### DIFF
--- a/manifests/p/peterfei/Differ/0.2.0/peterfei.Differ.installer.yaml
+++ b/manifests/p/peterfei/Differ/0.2.0/peterfei.Differ.installer.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: peterfei.Differ
+PackageVersion: 0.2.0
+InstallerType: wix
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/peterfei/differ/releases/download/v0.2.0/Differ_0.2.0_x64_en-US.msi
+    InstallerSha256: 6429A62072BE4DCD0EEB0895197CB38A5404D33DC0B83728CE7B652A527C84D2
+    ProductCode: "{2FF1A02B-5122-4A44-B252-17D288F77928}"
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/p/peterfei/Differ/0.2.0/peterfei.Differ.locale.en-US.yaml
+++ b/manifests/p/peterfei/Differ/0.2.0/peterfei.Differ.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: peterfei.Differ
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: peterfei
+PublisherUrl: https://github.com/peterfei
+PublisherSupportUrl: https://github.com/peterfei/differ/issues
+Author: peterfei
+PackageName: Differ
+PackageUrl: https://github.com/peterfei/differ
+License: MIT
+LicenseUrl: https://github.com/peterfei/differ/blob/main/LICENSE
+ShortDescription: A visual diff tool with syntax-aware diffing, directory comparison, and three-way merge support
+Description: Differ is a modern desktop application for file comparison and merging. It supports side-by-side diff with syntax highlighting, three-way merge with conflict detection, recursive directory comparison, and AST-based syntax-aware hunk regrouping.
+Tags:
+  - diff
+  - merge
+  - comparison
+  - syntax
+  - tree-sitter
+  - tauri
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/p/peterfei/Differ/0.2.0/peterfei.Differ.yaml
+++ b/manifests/p/peterfei/Differ/0.2.0/peterfei.Differ.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: peterfei.Differ
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Summary
- Add new version manifest for `peterfei.Differ` version 0.2.0
- Package: Differ - A modern visual diff tool with syntax-aware diffing, directory comparison, and three-way merge support
- Built with Tauri v2 and SolidJS

## Manifest details
- **Version**: 0.2.0
- **Installer type**: MSI (wix)
- **Architecture**: x64
- **Publisher**: peterfei
- **License**: MIT

## Test plan
- [x] Manifest files follow winget-pkgs schema v1.12.0
- [x] Installer SHA256 verified against released MSI
- [x] ProductCode extracted from MSI package
- [x] Version manifest points to defaultLocale en-US

🤖 Generated with [Claude Code](https://claude.com/claude-code)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/385885)