### PR TITLE
New package: WolftacDigital.Spectre version 0.1.1

### DIFF
--- a/manifests/w/WolftacDigital/Spectre/0.1.1/WolftacDigital.Spectre.installer.yaml
+++ b/manifests/w/WolftacDigital/Spectre/0.1.1/WolftacDigital.Spectre.installer.yaml
@@ -1,0 +1,13 @@
+PackageIdentifier: WolftacDigital.Spectre
+PackageVersion: 0.1.1
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: bin\spectre.exe
+    PortableCommandAlias: spectre
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/WolftacDigital/Spectre/releases/download/v0.1.1/spectre-0.1.1-x64.zip
+    InstallerSha256: 43F2C68D814960CCE4E5A6884242B00FCA70BE6354E5B3F4812153A753BCF274
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/w/WolftacDigital/Spectre/0.1.1/WolftacDigital.Spectre.locale.en-US.yaml
+++ b/manifests/w/WolftacDigital/Spectre/0.1.1/WolftacDigital.Spectre.locale.en-US.yaml
@@ -1,0 +1,19 @@
+PackageIdentifier: WolftacDigital.Spectre
+PackageVersion: 0.1.1
+PackageLocale: en-US
+Publisher: Wolftac Digital
+PublisherUrl: https://github.com/WolftacDigital
+PublisherSupportUrl: https://github.com/WolftacDigital/Spectre/issues
+PackageName: Spectre
+PackageUrl: https://github.com/WolftacDigital/Spectre
+License: MIT
+LicenseUrl: https://github.com/WolftacDigital/Spectre/blob/main/LICENSE
+ShortDescription: A fast, native Windows terminal built on Ghostty's core.
+Description: Spectre is a native Win32 terminal emulator built on the Ghostty terminal core (VT emulation, GPU rendering, themes, config system), forked from InsipidPoint/ghostty-windows. ConPTY-based, with tabs, splits, a quick terminal, and Ghostty config compatibility.
+Moniker: spectre
+Tags:
+- console
+- ghostty
+- terminal
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/w/WolftacDigital/Spectre/0.1.1/WolftacDigital.Spectre.yaml
+++ b/manifests/w/WolftacDigital/Spectre/0.1.1/WolftacDigital.Spectre.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: WolftacDigital.Spectre
+PackageVersion: 0.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren''t other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? (validation succeeded, winget v1.28.240)
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? (could not enable LocalManifestFiles without admin on the build machine; the exact zip referenced by InstallerUrl was downloaded anonymously, hash-verified, extracted, and the nested bin\spectre.exe installed and tested extensively)
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

New package: Spectre — a fast, native Windows terminal emulator built on the Ghostty terminal core (fork of InsipidPoint/ghostty-windows). Portable zip with nested portable exe. Release asset is on a public GitHub release with a SHA256 sidecar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/385959)