### PR TITLE
New package: Dmezhnov.KnitCalc version 1.8.24

### DIFF
--- a/manifests/d/Dmezhnov/KnitCalc/1.8.24/Dmezhnov.KnitCalc.installer.yaml
+++ b/manifests/d/Dmezhnov/KnitCalc/1.8.24/Dmezhnov.KnitCalc.installer.yaml
@@ -1,0 +1,16 @@
+PackageIdentifier: Dmezhnov.KnitCalc
+PackageVersion: '1.8.24'
+Platform:
+    - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+    - RelativeFilePath: knitcalc.exe
+      PortableCommandAlias: knitcalc
+Installers:
+    - Architecture: x64
+      InstallerUrl: 'https://github.com/dmezhnov/knitcalc/releases/download/v1.8.24+47/knitcalc-windows-x64-1.8.24+47.zip'
+      InstallerSha256: '3f917fac2b7fbcac14868677f1bbdc69303b013952d7f7e1b31713c7f1c0132e'
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/d/Dmezhnov/KnitCalc/1.8.24/Dmezhnov.KnitCalc.locale.en-US.yaml
+++ b/manifests/d/Dmezhnov/KnitCalc/1.8.24/Dmezhnov.KnitCalc.locale.en-US.yaml
@@ -1,0 +1,18 @@
+PackageIdentifier: Dmezhnov.KnitCalc
+PackageVersion: '1.8.24'
+PackageLocale: en-US
+Publisher: Dmitry Mezhnov
+PublisherUrl: https://github.com/dmezhnov
+PublisherSupportUrl: https://github.com/dmezhnov/knitcalc/issues
+PackageName: KnitCalc
+PackageUrl: https://github.com/dmezhnov/knitcalc
+License: MIT
+LicenseUrl: https://github.com/dmezhnov/knitcalc/blob/main/LICENSE
+ShortDescription: Knitting calculator
+Description: 'KnitCalc is a knitting calculator: gauge conversion, increases/decreases distribution, yarn estimation and project notes with photos.'
+Tags:
+    - knitting
+    - calculator
+    - craft
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/d/Dmezhnov/KnitCalc/1.8.24/Dmezhnov.KnitCalc.yaml
+++ b/manifests/d/Dmezhnov/KnitCalc/1.8.24/Dmezhnov.KnitCalc.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Dmezhnov.KnitCalc
+PackageVersion: '1.8.24'
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

First submission of KnitCalc (a knitting calculator, MIT-licensed, https://github.com/dmezhnov/knitcalc). The zip release asset is installed as a portable package. Local winget validation was not run (manifests authored on Linux); relying on pipeline validation.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/385992)