### PR TITLE
Move ByteDance.TraeSolo 2.3.25935 to ByteDance.TraeWork 2.3.25935

### DIFF
--- a/manifests/b/ByteDance/TraeWork/2.3.25935/ByteDance.TraeWork.installer.yaml
+++ b/manifests/b/ByteDance/TraeWork/2.3.25935/ByteDance.TraeWork.installer.yaml
@@ -1,0 +1,24 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: ByteDance.TraeWork
+PackageVersion: 2.3.25935
+InstallerType: inno
+Scope: user
+InstallerSwitches:
+  Custom: /mergetasks=!runcode
+UpgradeBehavior: install
+Protocols:
+- solo
+ProductCode: '{8F316A45-DB23-480D-A345-3B00ECBCE79D}_is1'
+ReleaseDate: 2026-05-10
+Installers:
+- Architecture: x64
+  InstallerUrl: https://lf-cdn.trae.ai/obj/trae-ai-us/pkg/app/releases/stable/2.3.25935/win32/TRAE_SOLO-Setup-x64.exe
+  InstallerSha256: AA3ECE75344D630797D3C8E052237A85A700DA07E9818772CEF38721F6664BA1
+- InstallerLocale: zh-CN
+  Architecture: x64
+  InstallerUrl: https://lf-cdn.trae.com.cn/obj/trae-com-cn/pkg/app/releases/stable/2.3.25935/win32/TRAE_SOLO-Setup-x64.exe
+  InstallerSha256: AA3ECE75344D630797D3C8E052237A85A700DA07E9818772CEF38721F6664BA1
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/b/ByteDance/TraeWork/2.3.25935/ByteDance.TraeWork.locale.en-US.yaml
+++ b/manifests/b/ByteDance/TraeWork/2.3.25935/ByteDance.TraeWork.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: ByteDance.TraeWork
+PackageVersion: 2.3.25935
+PackageLocale: en-US
+Publisher: SPRING (SG) PTE. LTD
+PublisherUrl: https://www.trae.ai/
+PublisherSupportUrl: https://docs.trae.ai/docs/support
+PrivacyUrl: https://www.trae.ai/privacy-policy
+Author: SPRING (SG) PTE. LTD.
+PackageName: TRAE SOLO
+PackageUrl: https://www.trae.ai/download
+License: Proprietary
+LicenseUrl: https://www.trae.ai/terms-of-service
+Copyright: Copyright © 2026. All rights reserved.
+ShortDescription: More than Coding
+Description: TRAE SOLO is an AI-native workspace that offers web, desktop, and mobile clients. It features two modes—More Than Coding (MTC) and Code—designed for different user groups. TRAE SOLO builds upon the original TRAE IDE SOLO mode with further enhanced capabilities, aiming to provide users with a unified, efficient, and customizable AI collaboration experience that covers scenarios ranging from professional development to everyday office work.
+Tags:
+- ai
+- code
+- coding
+- develop
+- development
+- large-language-model
+- llm
+- programming
+ReleaseNotesUrl: https://www.trae.ai/changelog
+Documentations:
+- DocumentLabel: Documentation
+  DocumentUrl: https://docs.trae.ai/solo
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/b/ByteDance/TraeWork/2.3.25935/ByteDance.TraeWork.locale.zh-CN.yaml
+++ b/manifests/b/ByteDance/TraeWork/2.3.25935/ByteDance.TraeWork.locale.zh-CN.yaml
@@ -1,0 +1,22 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.10.0.schema.json
+
+PackageIdentifier: ByteDance.TraeWork
+PackageVersion: 2.3.25935
+PackageLocale: zh-CN
+License: 专有软件
+ShortDescription: More than Coding
+Description: TRAE SOLO 是一款 AI 原生工作台，提供网页版、桌面版和移动版三种形态，并设有为不同用户群体设计的 More Than Coding (MTC) 与 Code 双模式。TRAE SOLO 的能力在原有 TRAE IDE SOLO 模式的基础上得到了进一步提升，旨在为用户提供统一、高效、可定制的 AI 协作体验，覆盖从专业开发到日常办公的各类场景。​
+Tags:
+- ai
+- llm
+- 人工智能
+- 代码
+- 大语言模型
+- 开发
+- 编程
+Documentations:
+- DocumentLabel: 文档
+  DocumentUrl: https://docs.trae.ai/solo
+ManifestType: locale
+ManifestVersion: 1.10.0

--- a/manifests/b/ByteDance/TraeWork/2.3.25935/ByteDance.TraeWork.yaml
+++ b/manifests/b/ByteDance/TraeWork/2.3.25935/ByteDance.TraeWork.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: ByteDance.TraeWork
+PackageVersion: 2.3.25935
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
The application has been renamed to "TRAE Work" by its publisher
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/386218)