### PR TITLE
Move ByteDance.TraeSolo.CN 0.1.7 to ByteDance.TraeWork.CN 0.1.7

### DIFF
--- a/manifests/b/ByteDance/TraeWork/CN/0.1.7/ByteDance.TraeWork.CN.installer.yaml
+++ b/manifests/b/ByteDance/TraeWork/CN/0.1.7/ByteDance.TraeWork.CN.installer.yaml
@@ -1,0 +1,23 @@
+# Created with YamlCreate.ps1 v2.7.2 $debug=NVS1.CRLF.7-6-1.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: ByteDance.TraeWork.CN
+PackageVersion: 0.1.7
+InstallerType: inno
+Scope: user
+InstallerSwitches:
+  Custom: /mergetasks=!runcode
+UpgradeBehavior: install
+Protocols:
+- solo-cn
+ProductCode: '{953A2114-1972-4389-9722-1F54639F3958}_is1'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://lf-cdn.trae.ai/obj/trae-ai-us/pkg/app/releases/stable/2.3.24253/win32/TRAE_SOLO_CN-Setup-x64.exe
+  InstallerSha256: E1ACFD43871EE5E95468B812B27307E52AEDC3F9AB6A555C627CC080C1194043
+- InstallerLocale: zh-CN
+  Architecture: x64
+  InstallerUrl: https://lf-cdn.trae.com.cn/obj/trae-com-cn/pkg/app/releases/stable/2.3.24253/win32/TRAE_SOLO_CN-Setup-x64.exe
+  InstallerSha256: E1ACFD43871EE5E95468B812B27307E52AEDC3F9AB6A555C627CC080C1194043
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/b/ByteDance/TraeWork/CN/0.1.7/ByteDance.TraeWork.CN.locale.en-US.yaml
+++ b/manifests/b/ByteDance/TraeWork/CN/0.1.7/ByteDance.TraeWork.CN.locale.en-US.yaml
@@ -1,0 +1,38 @@
+# Created with YamlCreate.ps1 v2.7.2 $debug=NVS1.CRLF.7-6-1.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: ByteDance.TraeWork.CN
+PackageVersion: 0.1.7
+PackageLocale: en-US
+Publisher: Beijing Yinli Catapult Technology Co., Ltd.
+PublisherUrl: https://www.trae.cn/
+PublisherSupportUrl: https://docs.trae.cn/solo/support
+PrivacyUrl: https://www.trae.cn/privacy-policy
+Author: Beijing Yinli Catapult Technology Co., Ltd.
+PackageName: TRAE SOLO CN
+PackageUrl: https://www.trae.cn/ide/download
+License: Proprietary
+LicenseUrl: https://www.trae.cn/terms-of-service
+Copyright: Copyright © 2026. All rights reserved.
+# CopyrightUrl:
+ShortDescription: More than Coding
+Description: TRAE SOLO is an AI-native workspace that offers web, desktop, and mobile clients. It features two modes—More Than Coding (MTC) and Code—designed for different user groups. TRAE SOLO builds upon the original TRAE IDE SOLO mode with further enhanced capabilities, aiming to provide users with a unified, efficient, and customizable AI collaboration experience that covers scenarios ranging from professional development to everyday office work.
+# Moniker:
+Tags:
+- ai
+- code
+- coding
+- develop
+- development
+- large-language-model
+- llm
+- programming
+# ReleaseNotes:
+ReleaseNotesUrl: https://www.trae.cn/changelog
+# PurchaseUrl:
+# InstallationNotes:
+Documentations:
+- DocumentLabel: Documentation
+  DocumentUrl: https://docs.trae.cn/solo
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/b/ByteDance/TraeWork/CN/0.1.7/ByteDance.TraeWork.CN.locale.zh-CN.yaml
+++ b/manifests/b/ByteDance/TraeWork/CN/0.1.7/ByteDance.TraeWork.CN.locale.zh-CN.yaml
@@ -1,0 +1,37 @@
+# Created with YamlCreate.ps1 v2.7.2 $debug=NVS1.CRLF.7-6-1.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.10.0.schema.json
+
+PackageIdentifier: ByteDance.TraeWork.CN
+PackageVersion: 0.1.7
+PackageLocale: zh-CN
+# Publisher:
+# PublisherUrl:
+# PublisherSupportUrl:
+# PrivacyUrl:
+# Author:
+# PackageName:
+# PackageUrl:
+License: 专有软件
+# LicenseUrl:
+# Copyright:
+# CopyrightUrl:
+ShortDescription: More than Coding
+Description: TRAE SOLO 是一款 AI 原生工作台，提供网页版、桌面版和移动版三种形态，并设有为不同用户群体设计的 More Than Coding (MTC) 与 Code 双模式。TRAE SOLO 的能力在原有 TRAE IDE SOLO 模式的基础上得到了进一步提升，旨在为用户提供统一、高效、可定制的 AI 协作体验，覆盖从专业开发到日常办公的各类场景。​
+# Moniker:
+Tags:
+- ai
+- llm
+- 人工智能
+- 代码
+- 大语言模型
+- 开发
+- 编程
+# ReleaseNotes:
+# ReleaseNotesUrl:
+# PurchaseUrl:
+# InstallationNotes:
+Documentations:
+- DocumentLabel: 文档
+  DocumentUrl: https://docs.trae.cn/solo
+ManifestType: locale
+ManifestVersion: 1.10.0

--- a/manifests/b/ByteDance/TraeWork/CN/0.1.7/ByteDance.TraeWork.CN.yaml
+++ b/manifests/b/ByteDance/TraeWork/CN/0.1.7/ByteDance.TraeWork.CN.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.7.2 $debug=NVS1.CRLF.7-6-1.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: ByteDance.TraeWork.CN
+PackageVersion: 0.1.7
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
The application has been renamed to "TRAE Work" by its publisher
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/386236)