### PR TITLE
Move ByteDance.TraeSolo.CN 2.3.27638 to ByteDance.TraeWork.CN 2.3.27638

### DIFF
--- a/manifests/b/ByteDance/TraeWork/CN/2.3.27638/ByteDance.TraeWork.CN.installer.yaml
+++ b/manifests/b/ByteDance/TraeWork/CN/2.3.27638/ByteDance.TraeWork.CN.installer.yaml
@@ -1,0 +1,24 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: ByteDance.TraeWork.CN
+PackageVersion: 2.3.27638
+InstallerType: inno
+Scope: user
+InstallerSwitches:
+  Custom: /mergetasks=!runcode
+UpgradeBehavior: install
+Protocols:
+- solo-cn
+ProductCode: '{953A2114-1972-4389-9722-1F54639F3958}_is1'
+ReleaseDate: 2026-05-14
+Installers:
+- Architecture: x64
+  InstallerUrl: https://lf-cdn.trae.ai/obj/trae-ai-us/pkg/app/releases/stable/2.3.27638/win32/TRAE_SOLO_CN-Setup-x64.exe
+  InstallerSha256: B0390A80F3812450D0C9B473AAD93E032D44F749674C1827DD51E9DB3020BA39
+- InstallerLocale: zh-CN
+  Architecture: x64
+  InstallerUrl: https://lf-cdn.trae.com.cn/obj/trae-com-cn/pkg/app/releases/stable/2.3.27638/win32/TRAE_SOLO_CN-Setup-x64.exe
+  InstallerSha256: B0390A80F3812450D0C9B473AAD93E032D44F749674C1827DD51E9DB3020BA39
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/b/ByteDance/TraeWork/CN/2.3.27638/ByteDance.TraeWork.CN.locale.en-US.yaml
+++ b/manifests/b/ByteDance/TraeWork/CN/2.3.27638/ByteDance.TraeWork.CN.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: ByteDance.TraeWork.CN
+PackageVersion: 2.3.27638
+PackageLocale: en-US
+Publisher: Beijing Yinli Catapult Technology Co., Ltd.
+PublisherUrl: https://www.trae.cn/
+PublisherSupportUrl: https://docs.trae.cn/solo/support
+PrivacyUrl: https://www.trae.cn/privacy-policy
+Author: Beijing Yinli Catapult Technology Co., Ltd.
+PackageName: TRAE SOLO CN
+PackageUrl: https://www.trae.cn/ide/download
+License: Proprietary
+LicenseUrl: https://www.trae.cn/terms-of-service
+Copyright: Copyright © 2026. All rights reserved.
+ShortDescription: More than Coding
+Description: TRAE SOLO is an AI-native workspace that offers web, desktop, and mobile clients. It features two modes—More Than Coding (MTC) and Code—designed for different user groups. TRAE SOLO builds upon the original TRAE IDE SOLO mode with further enhanced capabilities, aiming to provide users with a unified, efficient, and customizable AI collaboration experience that covers scenarios ranging from professional development to everyday office work.
+Tags:
+- ai
+- code
+- coding
+- develop
+- development
+- large-language-model
+- llm
+- programming
+ReleaseNotesUrl: https://www.trae.cn/changelog
+Documentations:
+- DocumentLabel: Documentation
+  DocumentUrl: https://docs.trae.cn/solo
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/b/ByteDance/TraeWork/CN/2.3.27638/ByteDance.TraeWork.CN.locale.zh-CN.yaml
+++ b/manifests/b/ByteDance/TraeWork/CN/2.3.27638/ByteDance.TraeWork.CN.locale.zh-CN.yaml
@@ -1,0 +1,22 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.10.0.schema.json
+
+PackageIdentifier: ByteDance.TraeWork.CN
+PackageVersion: 2.3.27638
+PackageLocale: zh-CN
+License: 专有软件
+ShortDescription: More than Coding
+Description: TRAE SOLO 是一款 AI 原生工作台，提供网页版、桌面版和移动版三种形态，并设有为不同用户群体设计的 More Than Coding (MTC) 与 Code 双模式。TRAE SOLO 的能力在原有 TRAE IDE SOLO 模式的基础上得到了进一步提升，旨在为用户提供统一、高效、可定制的 AI 协作体验，覆盖从专业开发到日常办公的各类场景。​
+Tags:
+- ai
+- llm
+- 人工智能
+- 代码
+- 大语言模型
+- 开发
+- 编程
+Documentations:
+- DocumentLabel: 文档
+  DocumentUrl: https://docs.trae.cn/solo
+ManifestType: locale
+ManifestVersion: 1.10.0

--- a/manifests/b/ByteDance/TraeWork/CN/2.3.27638/ByteDance.TraeWork.CN.yaml
+++ b/manifests/b/ByteDance/TraeWork/CN/2.3.27638/ByteDance.TraeWork.CN.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: ByteDance.TraeWork.CN
+PackageVersion: 2.3.27638
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
The application has been renamed to "TRAE Work" by its publisher
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/386239)