### PR TITLE
New version: Wangnov.CodexAppManager version 0.1.14

### DIFF
--- a/manifests/w/Wangnov/CodexAppManager/0.1.14/Wangnov.CodexAppManager.installer.yaml
+++ b/manifests/w/Wangnov/CodexAppManager/0.1.14/Wangnov.CodexAppManager.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Wangnov.CodexAppManager
+PackageVersion: 0.1.14
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- silent
+UpgradeBehavior: install
+ProductCode: Codex App Manager
+ReleaseDate: "2026-06-11"
+AppsAndFeaturesEntries:
+- DisplayName: Codex App Manager
+  Publisher: Wangnov
+  ProductCode: Codex App Manager
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Wangnov/Codex-App-Manager/releases/download/v0.1.14/CodexAppManager_0.1.14_x64-setup.exe
+  InstallerSha256: 9015CD34326B8CAE3157ABDB3DE333D60C640407B943BC6A80E6DDE2A46D798E
+  InstallationMetadata:
+    DefaultInstallLocation: '%LOCALAPPDATA%\Codex App Manager'
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/w/Wangnov/CodexAppManager/0.1.14/Wangnov.CodexAppManager.installer.yaml
+++ b/manifests/w/Wangnov/CodexAppManager/0.1.14/Wangnov.CodexAppManager.installer.yaml
@@ -9,6 +9,9 @@ InstallModes:
 InstallerSwitches:
   Silent: /S /P
 UpgradeBehavior: install
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.EdgeWebView2Runtime
 ProductCode: Codex App Manager
 ReleaseDate: "2026-06-11"
 AppsAndFeaturesEntries:

--- a/manifests/w/Wangnov/CodexAppManager/0.1.14/Wangnov.CodexAppManager.installer.yaml
+++ b/manifests/w/Wangnov/CodexAppManager/0.1.14/Wangnov.CodexAppManager.installer.yaml
@@ -6,6 +6,8 @@ InstallerType: nullsoft
 Scope: user
 InstallModes:
 - silent
+InstallerSwitches:
+  Silent: /S /P
 UpgradeBehavior: install
 ProductCode: Codex App Manager
 ReleaseDate: "2026-06-11"

--- a/manifests/w/Wangnov/CodexAppManager/0.1.14/Wangnov.CodexAppManager.locale.en-US.yaml
+++ b/manifests/w/Wangnov/CodexAppManager/0.1.14/Wangnov.CodexAppManager.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Wangnov.CodexAppManager
+PackageVersion: 0.1.14
+PackageLocale: en-US
+Publisher: Wangnov
+PublisherUrl: https://github.com/Wangnov
+PublisherSupportUrl: https://github.com/Wangnov/Codex-App-Manager/issues
+Author: Wangnov
+PackageName: Codex App Manager
+PackageUrl: https://github.com/Wangnov/Codex-App-Manager
+License: MIT
+LicenseUrl: https://github.com/Wangnov/Codex-App-Manager/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Wangnov
+ShortDescription: Codex App mirror install and update manager.
+Description: A manager app for installing and updating mirrored official Codex desktop app packages.
+Moniker: codex-app-manager
+Tags:
+- codex
+- installer
+- manager
+- mirror
+- openai
+- tauri
+- updater
+ReleaseNotesUrl: https://github.com/Wangnov/Codex-App-Manager/releases/tag/v0.1.14
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/w/Wangnov/CodexAppManager/0.1.14/Wangnov.CodexAppManager.yaml
+++ b/manifests/w/Wangnov/CodexAppManager/0.1.14/Wangnov.CodexAppManager.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Wangnov.CodexAppManager
+PackageVersion: 0.1.14
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### What changed
Adds the initial winget manifest for `Wangnov.CodexAppManager` version `0.1.14`.

### Installer
- Installer type: NSIS / nullsoft
- Architecture: x64
- Scope: user
- URL: https://github.com/Wangnov/Codex-App-Manager/releases/download/v0.1.14/CodexAppManager_0.1.14_x64-setup.exe
- SHA-256: 9015CD34326B8CAE3157ABDB3DE333D60C640407B943BC6A80E6DDE2A46D798E

### Validation
- Parsed all three YAML manifests locally.
- Validated all three manifests against the official 1.12.0 winget schemas.
- Verified the release asset URL is reachable and the downloaded SHA-256 matches the manifest.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/386457)