### PR TITLE
New version: atani.ctxpack version 0.4.0

### DIFF
--- a/manifests/a/atani/ctxpack/0.4.0/atani.ctxpack.installer.yaml
+++ b/manifests/a/atani/ctxpack/0.4.0/atani.ctxpack.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: atani.ctxpack
+PackageVersion: 0.4.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: ctxpack.exe
+    PortableCommandAlias: ctxpack
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/atani/ctxpack/releases/download/ctxpack-v0.4.0/ctxpack_0.4.0_windows_amd64.zip
+    InstallerSha256: 69F78A73D41BA111D06899DAD70A5F8D8112F87830E8D6146B6A890614F71740
+  - Architecture: arm64
+    InstallerUrl: https://github.com/atani/ctxpack/releases/download/ctxpack-v0.4.0/ctxpack_0.4.0_windows_arm64.zip
+    InstallerSha256: D899ED304D1A8B64AF57061D331FABF80F75A03C5B29F4AB35715BADFFB77733
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/a/atani/ctxpack/0.4.0/atani.ctxpack.locale.en-US.yaml
+++ b/manifests/a/atani/ctxpack/0.4.0/atani.ctxpack.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: atani.ctxpack
+PackageVersion: 0.4.0
+PackageLocale: en-US
+Publisher: Akira Taniwaki
+PublisherUrl: https://github.com/atani
+PublisherSupportUrl: https://github.com/atani/ctxpack/issues
+Author: Akira Taniwaki
+PackageName: CtxPack
+PackageUrl: https://github.com/atani/ctxpack
+License: MIT
+LicenseUrl: https://github.com/atani/ctxpack/blob/main/LICENSE
+ShortDescription: Token-aware context extraction for AI agents
+Description: CtxPack turns noisy web pages, HTML, or Markdown into compact context that AI agents can safely consume while tracking token savings.
+Moniker: ctxpack
+Tags:
+  - ai
+  - ai-agents
+  - cli
+  - context
+  - markdown
+  - tokens
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/a/atani/ctxpack/0.4.0/atani.ctxpack.yaml
+++ b/manifests/a/atani/ctxpack/0.4.0/atani.ctxpack.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: atani.ctxpack
+PackageVersion: 0.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
#### New version: atani.ctxpack 0.4.0

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Manifests are generated by the project's release pipeline. The installer `Sha256` values were verified against the release `checksums.txt` for `ctxpack-v0.4.0`.

This supersedes [#386020](https://github.com/microsoft/winget-pkgs/pull/386020), which added 0.3.0; that PR is being closed in favor of shipping the latest release (0.4.0) directly as the first published version.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/386481)