### PR TITLE
New package: eladser.mtop version 1.2.0

### DIFF
--- a/manifests/e/eladser/mtop/1.2.0/eladser.mtop.installer.yaml
+++ b/manifests/e/eladser/mtop/1.2.0/eladser.mtop.installer.yaml
@@ -1,0 +1,13 @@
+PackageIdentifier: eladser.mtop
+PackageVersion: 1.2.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: mtop.exe
+    PortableCommandAlias: mtop
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/eladser/mtop/releases/download/v1.2.0/mtop_1.2.0_windows_amd64.zip
+    InstallerSha256: 498feff1f6aa8914df8a27ff19ee8118851390de2d8392b20e459447a00f93f5
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/e/eladser/mtop/1.2.0/eladser.mtop.locale.en-US.yaml
+++ b/manifests/e/eladser/mtop/1.2.0/eladser.mtop.locale.en-US.yaml
@@ -1,0 +1,19 @@
+PackageIdentifier: eladser.mtop
+PackageVersion: 1.2.0
+PackageLocale: en-US
+Publisher: Elad Sertshuk
+PublisherUrl: https://github.com/eladser
+PackageName: mtop
+PackageUrl: https://github.com/eladser/mtop
+License: MIT
+LicenseUrl: https://github.com/eladser/mtop/blob/main/LICENSE
+ShortDescription: htop for your local AI
+Description: A terminal dashboard for local AI servers (Ollama, llama.cpp, LM Studio, vLLM). Shows loaded models and their VRAM, the GPU, and every request with its tok/s. Unloads models that overstay.
+Tags:
+  - ollama
+  - llamacpp
+  - tui
+  - local-llm
+  - gpu
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/e/eladser/mtop/1.2.0/eladser.mtop.yaml
+++ b/manifests/e/eladser/mtop/1.2.0/eladser.mtop.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: eladser.mtop
+PackageVersion: 1.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: eladser.mtop 1.2.0

mtop is a terminal dashboard for local AI servers (Ollama, llama.cpp, LM Studio, vLLM). https://github.com/eladser/mtop

- [x] Validated with `winget validate`
- [x] Installer tested locally (zip, nested portable exe)
- [x] SHA256 matches the GitHub release asset
- [x] I am the package owner