### PR TITLE
New Version: Omnissa.WorkspaceONE.Tunnel version 26.03

### DIFF
--- a/manifests/o/Omnissa/WorkspaceONE/Tunnel/26.03/Omnissa.WorkspaceONE.Tunnel.installer.yaml
+++ b/manifests/o/Omnissa/WorkspaceONE/Tunnel/26.03/Omnissa.WorkspaceONE.Tunnel.installer.yaml
@@ -1,0 +1,37 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: Omnissa.WorkspaceONE.Tunnel
+PackageVersion: 26.03
+InstallerType: exe
+Scope: machine
+InstallModes:
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: /install /quiet /norestart
+  SilentWithProgress: /install /passive /norestart
+ExpectedReturnCodes:
+- InstallerReturnCode: 3010
+  ReturnResponse: rebootRequiredToFinish
+Installers:
+- Architecture: x64
+  InstallerUrl: https://packages.omnissa.com/winapps/WS1/Tunnel/WorkspaceOneTunnelInstaller.x64.2603.1472.exe
+  InstallerSha256: 73B972DC145C72E476C483FEEA3E3BE870C0FDD1094CCD343C723B11A7CAB4B1
+  ElevationRequirement: elevationRequired
+  AppsAndFeaturesEntries:
+      - DisplayName: Workspace ONE Tunnel
+        DisplayVersion: 26.3.0.1472
+        Publisher: Omnissa, LLC.
+        ProductCode: '{FDEAA83D-3495-4C74-AF6F-F346AE456C4E}'
+- Architecture: arm64
+  InstallerUrl: https://packages.omnissa.com/winapps/WS1/Tunnel/WorkspaceOneTunnelInstaller.arm64.2603.110.exe
+  InstallerSha256: DB4F2EDE51D15CC2C3A9352778D3C67A4D6A786196DE3C428A128FE5113D0B75
+  ElevationRequirement: elevationRequired
+  AppsAndFeaturesEntries:
+      - DisplayName: Workspace ONE Tunnel
+        DisplayVersion: 26.3.0.110
+        Publisher: Omnissa, LLC.
+        ProductCode: '{01E46687-9C24-4D8C-A8CD-6E6C3637B1B7}'
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/o/Omnissa/WorkspaceONE/Tunnel/26.03/Omnissa.WorkspaceONE.Tunnel.locale.en-US.yaml
+++ b/manifests/o/Omnissa/WorkspaceONE/Tunnel/26.03/Omnissa.WorkspaceONE.Tunnel.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: Omnissa.WorkspaceONE.Tunnel
+PackageVersion: 26.03
+PackageLocale: en-US
+Publisher: Omnissa, LLC.
+PublisherUrl: https://www.omnissa.com
+PublisherSupportUrl: https://customerconnect.omnissa.com
+PrivacyUrl: https://www.omnissa.com/trust-center/#privacy-notices
+Author: Omnissa, LLC.
+PackageName: Workspace ONE Tunnel
+License: Omnissa General Terms
+LicenseUrl: https://www.omnissa.com/general-terms
+Copyright: Copyright (c) Omnissa, LLC.. All rights reserved.
+CopyrightUrl: https://www.omnissa.com/copyright-claims
+ShortDescription: Workspace ONE Tunnel is a Zero Trust network access (ZTNA) solution that is used to replace legacy VPN architectures.
+Description: Omnissa Workspace ONE Tunnel is used to securely provide either Per-App or Full Device VPN capabilities across all your employees’ devices and delivered with a modern Zero Trust architecture.
+Moniker: Tunnel
+Tags:
+- workspace-one, tunnel, omnissa, vpn, ws1
+ReleaseNotes: Omnissa Release notes
+ReleaseNotesUrl: https://docs.omnissa.com/bundle/Workspace_ONE_Tunnel_Windows-RN/page/Tunnel-Windows-ReleaseNotes.html
+Documentations:
+- DocumentLabel: Omnissa Documentation
+  DocumentUrl: https://docs.omnissa.com/bundle/Workspace_ONE_TunnelVSaaS/page/TunnelOverview.html
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/o/Omnissa/WorkspaceONE/Tunnel/26.03/Omnissa.WorkspaceONE.Tunnel.yaml
+++ b/manifests/o/Omnissa/WorkspaceONE/Tunnel/26.03/Omnissa.WorkspaceONE.Tunnel.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: Omnissa.WorkspaceONE.Tunnel
+PackageVersion: 26.03
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Add Winget manifests for Omnissa Workspace ONE Tunnel v26.03. This includes a version manifest, a default en-US locale manifest (publisher, descriptions, docs and release notes links), and an installer manifest with x64 and arm64 installers, silent/install switches, elevation requirement, and expected reboot return code. Manifests created with wingetcreate 1.10.3.0.

<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
Added x64 and ARM64 versions of Workspace ONE Tunnel 2603

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [x ] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x ] This PR only modifies one (1) manifest
- [x ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x ] Tested manifest locally with `winget install --manifest <path>`
- [x ] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/386621)