### PR TITLE
New version: Abdk4Moura.Filament version 0.2.0

### DIFF
--- a/manifests/a/Abdk4Moura/Filament/0.2.0/Abdk4Moura.Filament.installer.yaml
+++ b/manifests/a/Abdk4Moura/Filament/0.2.0/Abdk4Moura.Filament.installer.yaml
@@ -6,6 +6,9 @@ NestedInstallerType: portable
 NestedInstallerFiles:
   - RelativeFilePath: filament.exe
     PortableCommandAlias: filament
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
 ReleaseDate: "2026-06-07"
 Installers:
   - Architecture: x64

--- a/manifests/a/Abdk4Moura/Filament/0.2.0/Abdk4Moura.Filament.installer.yaml
+++ b/manifests/a/Abdk4Moura/Filament/0.2.0/Abdk4Moura.Filament.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Abdk4Moura.Filament
+PackageVersion: "0.2.0"
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: filament.exe
+    PortableCommandAlias: filament
+ReleaseDate: "2026-06-07"
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Abdk4Moura/filament/releases/download/cli-v0.2.0/filament-x86_64-pc-windows-msvc.zip
+    InstallerSha256: "68D246F69D434FE287039C201B50FDF714EB360ACC6CC53C1598788C334FA73D"
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/a/Abdk4Moura/Filament/0.2.0/Abdk4Moura.Filament.installer.yaml
+++ b/manifests/a/Abdk4Moura/Filament/0.2.0/Abdk4Moura.Filament.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 PackageIdentifier: Abdk4Moura.Filament
 PackageVersion: "0.2.0"
 InstallerType: zip
@@ -12,4 +12,4 @@ Installers:
     InstallerUrl: https://github.com/Abdk4Moura/filament/releases/download/cli-v0.2.0/filament-x86_64-pc-windows-msvc.zip
     InstallerSha256: "68D246F69D434FE287039C201B50FDF714EB360ACC6CC53C1598788C334FA73D"
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/a/Abdk4Moura/Filament/0.2.0/Abdk4Moura.Filament.locale.en-US.yaml
+++ b/manifests/a/Abdk4Moura/Filament/0.2.0/Abdk4Moura.Filament.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Abdk4Moura.Filament
+PackageVersion: "0.2.0"
+PackageLocale: en-US
+Publisher: Abdulkabir Agboola
+PublisherUrl: https://github.com/Abdk4Moura
+PublisherSupportUrl: https://github.com/Abdk4Moura/filament/issues
+PackageName: Filament
+PackageUrl: https://filament.autumated.com
+License: MIT
+LicenseUrl: https://github.com/Abdk4Moura/filament/blob/main/LICENSE
+ShortDescription: P2P file transfer between terminals and browsers - no upload, no account
+Description: |-
+  Filament sends files directly between devices over WebRTC. The other end
+  can be another terminal or any browser at filament.autumated.com - nothing
+  to install on the receiving phone or laptop. One-time speakable pairing
+  codes, resumable transfers that survive restarts, and visible routing
+  (local / direct / relayed). Self-hostable.
+Tags:
+  - file-transfer
+  - p2p
+  - webrtc
+  - airdrop
+  - file-sharing
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/a/Abdk4Moura/Filament/0.2.0/Abdk4Moura.Filament.locale.en-US.yaml
+++ b/manifests/a/Abdk4Moura/Filament/0.2.0/Abdk4Moura.Filament.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 PackageIdentifier: Abdk4Moura.Filament
 PackageVersion: "0.2.0"
 PackageLocale: en-US
@@ -23,4 +23,4 @@ Tags:
   - airdrop
   - file-sharing
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/a/Abdk4Moura/Filament/0.2.0/Abdk4Moura.Filament.yaml
+++ b/manifests/a/Abdk4Moura/Filament/0.2.0/Abdk4Moura.Filament.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Abdk4Moura.Filament
+PackageVersion: "0.2.0"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0

--- a/manifests/a/Abdk4Moura/Filament/0.2.0/Abdk4Moura.Filament.yaml
+++ b/manifests/a/Abdk4Moura/Filament/0.2.0/Abdk4Moura.Filament.yaml
@@ -1,6 +1,6 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 PackageIdentifier: Abdk4Moura.Filament
 PackageVersion: "0.2.0"
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Adds **Abdk4Moura.Filament 0.2.0** (portable zip, x64) — the latest stable CLI release (`cli-v0.2.0`). P2P file transfer CLI; binaries built and attested by GitHub Actions in https://github.com/Abdk4Moura/filament. Validated against manifest schema 1.6.0.

- Installer: `filament-x86_64-pc-windows-msvc.zip` (nested portable `filament.exe`, alias `filament`)
- InstallerSha256 verified against the release `SHA256SUMS` and the downloaded asset.

**Relationship to #384634:** This is a *new version* of the same package whose initial submission (`0.1.0`, New-Package) is open and validation-passed at #384634, awaiting moderator merge. This PR touches only `manifests/a/Abdk4Moura/Filament/0.2.0/` (separate files/directory), so it does not conflict with #384634. If moderation prefers the package's first version land first, this can wait on #384634.

- [x] I have read and agree to the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [x] Validation against the manifest schema (1.6.0) passes.
- [x] This is a new package version; manifests added under the correct versioned path.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/386622)