### PR TITLE
New package: ABowlOfEleven.hopscout version 0.1.0

### DIFF
--- a/manifests/a/ABowlOfEleven/hopscout/0.1.0/ABowlOfEleven.hopscout.installer.yaml
+++ b/manifests/a/ABowlOfEleven/hopscout/0.1.0/ABowlOfEleven.hopscout.installer.yaml
@@ -15,8 +15,8 @@ UpgradeBehavior: install
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/ABowlOfEleven/hopscout/releases/download/v0.1.0/hopscout-0.1.0-x64.msi
-    InstallerSha256: 00813AAFF36F07DF5315FB25DDE0D4A0601458AA1D42564B9BA8E77BF780810B
-    ProductCode: '{9D872B90-FBC4-4B8A-A097-FADFF6FCB65F}'
+    InstallerSha256: 20B4687F73AD8564DADD080949F39626E455750AF2BFA9B14D88F11F3EAA2B86
+    ProductCode: '{461B9B55-6CD4-4EC7-B615-4AA7264AA603}'
     AppsAndFeaturesEntries:
       - UpgradeCode: '{B6E2F0A1-7C43-4D58-9E10-2A6B5C8D4F31}'
         InstallerType: wix

--- a/manifests/a/ABowlOfEleven/hopscout/0.1.0/ABowlOfEleven.hopscout.installer.yaml
+++ b/manifests/a/ABowlOfEleven/hopscout/0.1.0/ABowlOfEleven.hopscout.installer.yaml
@@ -15,8 +15,8 @@ UpgradeBehavior: install
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/ABowlOfEleven/hopscout/releases/download/v0.1.0/hopscout-0.1.0-x64.msi
-    InstallerSha256: 20B4687F73AD8564DADD080949F39626E455750AF2BFA9B14D88F11F3EAA2B86
-    ProductCode: '{461B9B55-6CD4-4EC7-B615-4AA7264AA603}'
+    InstallerSha256: 5EABBA633EAC842D63DE32552A6441D206A218854D25ABC287AED66AB637271D
+    ProductCode: '{46FD95AE-F8B6-4696-96EF-A7D483F6E6DF}'
     AppsAndFeaturesEntries:
       - UpgradeCode: '{B6E2F0A1-7C43-4D58-9E10-2A6B5C8D4F31}'
         InstallerType: wix

--- a/manifests/a/ABowlOfEleven/hopscout/0.1.0/ABowlOfEleven.hopscout.installer.yaml
+++ b/manifests/a/ABowlOfEleven/hopscout/0.1.0/ABowlOfEleven.hopscout.installer.yaml
@@ -1,0 +1,25 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: ABowlOfEleven.hopscout
+PackageVersion: 0.1.0
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: wix
+Scope: user
+InstallModes:
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/ABowlOfEleven/hopscout/releases/download/v0.1.0/hopscout-0.1.0-x64.msi
+  InstallerSha256: 00813AAFF36F07DF5315FB25DDE0D4A0601458AA1D42564B9BA8E77BF780810B
+  ProductCode: '{9D872B90-FBC4-4B8A-A097-FADFF6FCB65F}'
+  AppsAndFeaturesEntries:
+  - UpgradeCode: '{B6E2F0A1-7C43-4D58-9E10-2A6B5C8D4F31}'
+    InstallerType: wix
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/a/ABowlOfEleven/hopscout/0.1.0/ABowlOfEleven.hopscout.installer.yaml
+++ b/manifests/a/ABowlOfEleven/hopscout/0.1.0/ABowlOfEleven.hopscout.installer.yaml
@@ -1,25 +1,24 @@
-# Created using wingetcreate 1.12.8.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: ABowlOfEleven.hopscout
 PackageVersion: 0.1.0
 InstallerLocale: en-US
 Platform:
-- Windows.Desktop
+  - Windows.Desktop
 MinimumOSVersion: 10.0.0.0
 InstallerType: wix
 Scope: user
 InstallModes:
-- silent
-- silentWithProgress
+  - silent
+  - silentWithProgress
 UpgradeBehavior: install
 Installers:
-- Architecture: x64
-  InstallerUrl: https://github.com/ABowlOfEleven/hopscout/releases/download/v0.1.0/hopscout-0.1.0-x64.msi
-  InstallerSha256: 00813AAFF36F07DF5315FB25DDE0D4A0601458AA1D42564B9BA8E77BF780810B
-  ProductCode: '{9D872B90-FBC4-4B8A-A097-FADFF6FCB65F}'
-  AppsAndFeaturesEntries:
-  - UpgradeCode: '{B6E2F0A1-7C43-4D58-9E10-2A6B5C8D4F31}'
-    InstallerType: wix
+  - Architecture: x64
+    InstallerUrl: https://github.com/ABowlOfEleven/hopscout/releases/download/v0.1.0/hopscout-0.1.0-x64.msi
+    InstallerSha256: 00813AAFF36F07DF5315FB25DDE0D4A0601458AA1D42564B9BA8E77BF780810B
+    ProductCode: '{9D872B90-FBC4-4B8A-A097-FADFF6FCB65F}'
+    AppsAndFeaturesEntries:
+      - UpgradeCode: '{B6E2F0A1-7C43-4D58-9E10-2A6B5C8D4F31}'
+        InstallerType: wix
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/a/ABowlOfEleven/hopscout/0.1.0/ABowlOfEleven.hopscout.locale.en-US.yaml
+++ b/manifests/a/ABowlOfEleven/hopscout/0.1.0/ABowlOfEleven.hopscout.locale.en-US.yaml
@@ -3,7 +3,7 @@
 PackageIdentifier: ABowlOfEleven.hopscout
 PackageVersion: 0.1.0
 PackageLocale: en-US
-Publisher: ABowlOfEleven
+Publisher: hopscout contributors
 PublisherUrl: https://github.com/ABowlOfEleven
 PublisherSupportUrl: https://github.com/ABowlOfEleven/hopscout/issues
 PackageName: hopscout

--- a/manifests/a/ABowlOfEleven/hopscout/0.1.0/ABowlOfEleven.hopscout.locale.en-US.yaml
+++ b/manifests/a/ABowlOfEleven/hopscout/0.1.0/ABowlOfEleven.hopscout.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: ABowlOfEleven.hopscout
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: ABowlOfEleven
+PublisherUrl: https://github.com/ABowlOfEleven
+PublisherSupportUrl: https://github.com/ABowlOfEleven/hopscout/issues
+PackageName: hopscout
+PackageUrl: https://github.com/ABowlOfEleven/hopscout
+License: MIT
+LicenseUrl: https://github.com/ABowlOfEleven/hopscout/blob/main/LICENSE
+ShortDescription: A modern, MTR-compatible traceroute and network monitor for Windows.
+Description: |-
+  hopscout is a live traceroute and network monitor for Windows with both a
+  terminal UI and a desktop GUI. It supports ICMP (no admin), UDP, and TCP-SYN
+  probing over IPv4 and IPv6, per-flow multipath discovery, path-change alerting,
+  reverse-DNS / ASN / geolocation enrichment, a world map and topology view, and
+  an MTR-compatible command line with report, JSON, and CSV output.
+Moniker: hopscout
+Tags:
+- traceroute
+- mtr
+- networking
+- ping
+- latency
+- cli
+ReleaseNotesUrl: https://github.com/ABowlOfEleven/hopscout/releases/tag/v0.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/a/ABowlOfEleven/hopscout/0.1.0/ABowlOfEleven.hopscout.locale.en-US.yaml
+++ b/manifests/a/ABowlOfEleven/hopscout/0.1.0/ABowlOfEleven.hopscout.locale.en-US.yaml
@@ -1,5 +1,4 @@
-# Created using wingetcreate 1.12.8.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: ABowlOfEleven.hopscout
 PackageVersion: 0.1.0
@@ -20,12 +19,12 @@ Description: |-
   an MTR-compatible command line with report, JSON, and CSV output.
 Moniker: hopscout
 Tags:
-- traceroute
-- mtr
-- networking
-- ping
-- latency
-- cli
+  - traceroute
+  - mtr
+  - networking
+  - ping
+  - latency
+  - cli
 ReleaseNotesUrl: https://github.com/ABowlOfEleven/hopscout/releases/tag/v0.1.0
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/a/ABowlOfEleven/hopscout/0.1.0/ABowlOfEleven.hopscout.yaml
+++ b/manifests/a/ABowlOfEleven/hopscout/0.1.0/ABowlOfEleven.hopscout.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: ABowlOfEleven.hopscout
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0

--- a/manifests/a/ABowlOfEleven/hopscout/0.1.0/ABowlOfEleven.hopscout.yaml
+++ b/manifests/a/ABowlOfEleven/hopscout/0.1.0/ABowlOfEleven.hopscout.yaml
@@ -1,8 +1,7 @@
-# Created using wingetcreate 1.12.8.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: ABowlOfEleven.hopscout
 PackageVersion: 0.1.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds **ABowlOfEleven.hopscout** version 0.1.0 (new package).

hopscout is a Windows-native, MTR-compatible traceroute and live network monitor with both a terminal UI and a desktop GUI. It probes with ICMP (no admin required), UDP, and TCP-SYN over IPv4 and IPv6, and adds per-flow multipath discovery, path-change alerting, and reverse-DNS / ASN / geolocation enrichment, with report, JSON, and CSV output.

- Installer: per-user WiX v5 MSI (x64), silent install supported
- License: MIT
- Source and releases: https://github.com/ABowlOfEleven/hopscout

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/386694)
