### PR TITLE
New package: SwiftLaw.CLI version 0.7.0

### DIFF
--- a/manifests/s/SwiftLaw/CLI/0.7.0/SwiftLaw.CLI.installer.yaml
+++ b/manifests/s/SwiftLaw/CLI/0.7.0/SwiftLaw.CLI.installer.yaml
@@ -1,0 +1,11 @@
+PackageIdentifier: SwiftLaw.CLI
+PackageVersion: 0.7.0
+InstallerType: portable
+Commands:
+  - swiftlaw
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/SwiftLaw-Conductor/homebrew-tap/releases/download/cli-v0.7.0/swiftlaw-windows-x64.exe
+    InstallerSha256: BEBF22315EEF27AE5A48F9DA7297F28D2B4A8471E5A9CFA507270A117CF3E5F5
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/SwiftLaw/CLI/0.7.0/SwiftLaw.CLI.locale.en-US.yaml
+++ b/manifests/s/SwiftLaw/CLI/0.7.0/SwiftLaw.CLI.locale.en-US.yaml
@@ -1,0 +1,23 @@
+PackageIdentifier: SwiftLaw.CLI
+PackageVersion: 0.7.0
+PackageLocale: en-US
+Publisher: SwiftLaw
+PublisherUrl: https://tryswiftlaw.com
+PackageName: SwiftLaw CLI
+PackageUrl: https://github.com/SwiftLaw-Conductor/homebrew-tap
+License: Proprietary
+Copyright: © SwiftLaw
+ShortDescription: A law firm in your CLI — agentic legal assistant for fund-formation documents.
+Description: |-
+  Draft, edit, and redline fund-formation documents with an AI agent from the
+  terminal. Self-contained binary — no Node, Python, API keys, or AWS. Authenticate
+  with a personal CLI token (swiftlaw login); inference is proxied through the
+  SwiftLaw backend.
+Moniker: swiftlaw
+Tags:
+  - legal
+  - cli
+  - ai
+  - documents
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/SwiftLaw/CLI/0.7.0/SwiftLaw.CLI.yaml
+++ b/manifests/s/SwiftLaw/CLI/0.7.0/SwiftLaw.CLI.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: SwiftLaw.CLI
+PackageVersion: 0.7.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## 📖 Description

New package submission: **SwiftLaw.CLI 0.7.0** — a proprietary legal-drafting CLI agent (self-contained portable exe, Bun-compiled; no runtime dependencies). Binary is published on the public releases of https://github.com/SwiftLaw-Conductor/homebrew-tap (the macOS/Linux distribution channel for the same tool).

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` (authored on macOS — relying on pipeline validation; sha256 of the installer verified against the published `SHA256SUMS`)
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the schema (portable installer, single x64 installer entry)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/386759)