### PR TITLE
New package: ShoneAnstey.Inkstone version 0.8.0

### DIFF
--- a/manifests/s/ShoneAnstey/Inkstone/0.8.0/ShoneAnstey.Inkstone.installer.yaml
+++ b/manifests/s/ShoneAnstey/Inkstone/0.8.0/ShoneAnstey.Inkstone.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: ShoneAnstey.Inkstone
+PackageVersion: 0.8.0
+InstallerLocale: en-US
+InstallerType: inno
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{B6E2D7C0-1F4A-4E8C-9A1D-7C3E5A9B0D21}_is1'
+ReleaseDate: 2026-06-11
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/ShoneAnstey/Inkstone/releases/download/v0.8.0/Inkstone-Setup.exe
+  InstallerSha256: 59708F2436EAB3032E29AC09720F5DAB274B583D23BD32F88AD51E841EFFED05
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/s/ShoneAnstey/Inkstone/0.8.0/ShoneAnstey.Inkstone.locale.en-US.yaml
+++ b/manifests/s/ShoneAnstey/Inkstone/0.8.0/ShoneAnstey.Inkstone.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: ShoneAnstey.Inkstone
+PackageVersion: 0.8.0
+PackageLocale: en-US
+Publisher: XPC
+PublisherUrl: https://github.com/ShoneAnstey
+PublisherSupportUrl: https://github.com/ShoneAnstey/Inkstone/issues
+PackageName: Inkstone
+PackageUrl: https://github.com/ShoneAnstey/Inkstone
+License: Unlicense
+LicenseUrl: https://github.com/ShoneAnstey/Inkstone/blob/main/LICENSE
+ShortDescription: A fast, lightweight PDF reader with signing, form filling, and highlighting.
+Description: |-
+  Inkstone is a no-bloat PDF reader and Fill & Sign tool.
+  View, search, and print PDFs; fill forms with the typewriter tool;
+  highlight text; and stamp a handwritten signature from a photo of
+  paper — the background is removed automatically. No account, no
+  cloud, no subscription.
+Moniker: inkstone
+Tags:
+- pdf
+- pdf-reader
+- pdf-viewer
+- sign
+- signature
+- fill-and-sign
+- highlight
+ReleaseNotesUrl: https://github.com/ShoneAnstey/Inkstone/releases/tag/v0.8.0
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/s/ShoneAnstey/Inkstone/0.8.0/ShoneAnstey.Inkstone.yaml
+++ b/manifests/s/ShoneAnstey/Inkstone/0.8.0/ShoneAnstey.Inkstone.yaml
@@ -1,0 +1,8 @@
+# Created using manual authoring
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: ShoneAnstey.Inkstone
+PackageVersion: 0.8.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
New package submission: **ShoneAnstey.Inkstone 0.8.0** — a lightweight PDF reader and Fill & Sign tool (Inno Setup, per-user, x64).

Note: this app was previously submitted as ShoneAnstey.XPDF 0.7.0 (#386283, closed before merge). It has been renamed to Inkstone to avoid confusion with Glyph & Cog's Xpdf; the old identifier was never published, so this is a clean new package rather than a rename.

- InstallerUrl: https://github.com/ShoneAnstey/Inkstone/releases/download/v0.8.0/Inkstone-Setup.exe
- SHA256 verified against the published release asset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/386762)