### PR TITLE
New package: OutBlade.NeonHarbor version 1.4.0

### DIFF
--- a/manifests/o/OutBlade/NeonHarbor/1.4.0/OutBlade.NeonHarbor.installer.yaml
+++ b/manifests/o/OutBlade/NeonHarbor/1.4.0/OutBlade.NeonHarbor.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: OutBlade.NeonHarbor
+PackageVersion: 1.4.0
+InstallerLocale: en-US
+InstallerType: inno
+Scope: user
+UpgradeBehavior: install
+ReleaseDate: 2026-06-11
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/OutBlade/neon-harbor/releases/download/v1.4.0/NeonHarborSetup.exe
+  InstallerSha256: B676972D54D148A1F9C8A851A4799D0B864FB19C0D4E972C2AFC0D109381EB6D
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/o/OutBlade/NeonHarbor/1.4.0/OutBlade.NeonHarbor.locale.en-US.yaml
+++ b/manifests/o/OutBlade/NeonHarbor/1.4.0/OutBlade.NeonHarbor.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: OutBlade.NeonHarbor
+PackageVersion: 1.4.0
+PackageLocale: en-US
+Publisher: OutBlade
+PublisherUrl: https://github.com/OutBlade
+PublisherSupportUrl: https://github.com/OutBlade/neon-harbor/issues
+PackageName: Neon Harbor
+PackageUrl: https://github.com/OutBlade/neon-harbor
+License: MIT
+LicenseUrl: https://github.com/OutBlade/neon-harbor/blob/main/LICENSE
+ShortDescription: Open world night city driving game with missions, police heat and a harbor.
+Description: |-
+  Neon Harbor is an open world action driving game set in a procedurally
+  generated neon night city. Steal cars, run missions and taxi fares,
+  outdrive the police, find the hidden cats. Includes nitro, stunt ramps,
+  a monorail, four synthesized radio stations and a built-in auto updater.
+  Native builds for x64 and Windows on ARM.
+Tags:
+- game
+- open-world
+- driving
+- godot
+- arm64
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/o/OutBlade/NeonHarbor/1.4.0/OutBlade.NeonHarbor.yaml
+++ b/manifests/o/OutBlade/NeonHarbor/1.4.0/OutBlade.NeonHarbor.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: OutBlade.NeonHarbor
+PackageVersion: 1.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package submission

- PackageIdentifier: OutBlade.NeonHarbor
- PackageVersion: 1.4.0
- Open source game (MIT), repository: https://github.com/OutBlade/neon-harbor
- Installer: Inno Setup, per-user scope, bundles x64 and ARM64 binaries and installs the matching one
- `winget validate --manifest` passes locally

- [x] Have you signed the Contributor License Agreement?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the 1.6 schema?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/386774)