### PR TITLE
New package: joyint.joy version 0.16.2

### DIFF
--- a/manifests/j/joyint/joy/0.16.2/joyint.joy.installer.yaml
+++ b/manifests/j/joyint/joy/0.16.2/joyint.joy.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
 PackageIdentifier: joyint.joy
 PackageVersion: 0.16.2
 InstallerType: zip
@@ -14,4 +14,4 @@ Installers:
   InstallerUrl: https://github.com/joyint/joy/releases/download/v0.16.2/joy-cli-x86_64-pc-windows-msvc.zip
   InstallerSha256: E3A0552916E2609C88CC8766AB6052B665B58F1041A97166BE45F75EB15C5A0B
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.10.0

--- a/manifests/j/joyint/joy/0.16.2/joyint.joy.installer.yaml
+++ b/manifests/j/joyint/joy/0.16.2/joyint.joy.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: joyint.joy
+PackageVersion: 0.16.2
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: joy.exe
+  PortableCommandAlias: joy
+Commands:
+- joy
+ReleaseDate: 2026-06-11
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/joyint/joy/releases/download/v0.16.2/joy-cli-x86_64-pc-windows-msvc.zip
+  InstallerSha256: E3A0552916E2609C88CC8766AB6052B665B58F1041A97166BE45F75EB15C5A0B
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/j/joyint/joy/0.16.2/joyint.joy.locale.en-US.yaml
+++ b/manifests/j/joyint/joy/0.16.2/joyint.joy.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
 PackageIdentifier: joyint.joy
 PackageVersion: 0.16.2
 PackageLocale: en-US
@@ -17,4 +17,4 @@ Tags:
 - productivity
 - project-management
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.10.0

--- a/manifests/j/joyint/joy/0.16.2/joyint.joy.locale.en-US.yaml
+++ b/manifests/j/joyint/joy/0.16.2/joyint.joy.locale.en-US.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: joyint.joy
+PackageVersion: 0.16.2
+PackageLocale: en-US
+Publisher: Joydev GmbH
+PublisherUrl: https://joyint.com
+PublisherSupportUrl: https://github.com/joyint/joy/issues
+PackageName: joy
+PackageUrl: https://github.com/joyint/joy
+License: MIT
+LicenseUrl: https://github.com/joyint/joy/blob/main/LICENSE
+ShortDescription: Terminal-native, git-native product management for developers and AI.
+Moniker: joy
+Tags:
+- cli
+- git
+- productivity
+- project-management
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/j/joyint/joy/0.16.2/joyint.joy.yaml
+++ b/manifests/j/joyint/joy/0.16.2/joyint.joy.yaml
@@ -1,6 +1,6 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
 PackageIdentifier: joyint.joy
 PackageVersion: 0.16.2
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.10.0

--- a/manifests/j/joyint/joy/0.16.2/joyint.joy.yaml
+++ b/manifests/j/joyint/joy/0.16.2/joyint.joy.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: joyint.joy
+PackageVersion: 0.16.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Adds **joyint.joy** (joy, a terminal-native, git-native product management CLI) version 0.16.2.

- Portable package distributed as a zip; the nested `joy.exe` is Authenticode-signed via Microsoft Artifact Signing (publisher: Joydev GmbH).
- Architecture: x64.
- Manifests authored against schema 1.6.0.

Maintainer: Joydev GmbH / joyint.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/386796)