### PR TITLE
New package: NetaGigSystems.CommandDictateFree version 1.0.2

### DIFF
--- a/manifests/n/NetaGigSystems/CommandDictateFree/1.0.2/NetaGigSystems.CommandDictateFree.installer.yaml
+++ b/manifests/n/NetaGigSystems/CommandDictateFree/1.0.2/NetaGigSystems.CommandDictateFree.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: NetaGigSystems.CommandDictateFree
+PackageVersion: 1.0.2
+InstallerLocale: en-US
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Nubulizer/Command-Dictate-App/releases/download/v1.0.2/CommandDictateFreeSetup-1.0.2.exe
+    InstallerSha256: FB6B5D02DFB0A29C8E56D3D8C2B3BD9EE33CB5CB4EF408E8C19F879B6E89C9FA
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/n/NetaGigSystems/CommandDictateFree/1.0.2/NetaGigSystems.CommandDictateFree.locale.en-US.yaml
+++ b/manifests/n/NetaGigSystems/CommandDictateFree/1.0.2/NetaGigSystems.CommandDictateFree.locale.en-US.yaml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: NetaGigSystems.CommandDictateFree
+PackageVersion: 1.0.2
+PackageLocale: en-US
+Publisher: NetaGig Systems
+PublisherUrl: https://netagig.com
+PublisherSupportUrl: https://netagig.com/support
+PrivacyUrl: https://netagig.com/privacy
+PackageName: Command Dictate Free
+PackageUrl: https://netagig.com/command
+License: Freeware
+LicenseUrl: https://netagig.com/terms
+Copyright: Copyright (C) 2026 NetaGig Systems
+ShortDescription: Free local, offline dictation for Windows. No account, no cloud.
+Description: |-
+  Command Dictate Free is a free Windows dictation app that runs entirely on
+  your computer. Click into any text field, press Ctrl+Shift to start
+  recording, speak, and press Ctrl+Shift again to stop; your words are typed
+  at the cursor. Speech recognition runs locally with a bundled Whisper
+  model, so dictation works fully offline and your voice never leaves your
+  PC. No account, no subscription, and no trial: the app is unlocked. It runs
+  from the system tray, supports reusable voice-triggered text snippets, and
+  installs per-user without administrator rights.
+Moniker: command-dictate-free
+Tags:
+  - dictation
+  - speech-to-text
+  - voice-typing
+  - offline
+  - privacy
+  - whisper
+  - accessibility
+  - productivity
+ReleaseNotesUrl: https://github.com/Nubulizer/Command-Dictate-App/releases/tag/v1.0.2
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/n/NetaGigSystems/CommandDictateFree/1.0.2/NetaGigSystems.CommandDictateFree.yaml
+++ b/manifests/n/NetaGigSystems/CommandDictateFree/1.0.2/NetaGigSystems.CommandDictateFree.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: NetaGigSystems.CommandDictateFree
+PackageVersion: 1.0.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Adds Command Dictate Free 1.0.2.

- Free local/offline dictation app for Windows by NetaGig Systems
- Installer is the versioned GitHub release asset (no `latest` URL, no redirect)
- Inno installer, user-scope install (no admin required)
- SHA256 comes from the published 1.0.2 release manifest
- Silent install/uninstall verified locally with standard Inno switches

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/386808)