### PR TITLE
New package: joyint.jyn version 0.6.6

### DIFF
--- a/manifests/j/joyint/jyn/0.6.6/joyint.jyn.installer.yaml
+++ b/manifests/j/joyint/jyn/0.6.6/joyint.jyn.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
 PackageIdentifier: joyint.jyn
 PackageVersion: 0.6.6
 InstallerType: zip
@@ -14,4 +14,4 @@ Installers:
   InstallerUrl: https://github.com/joyint/jyn/releases/download/v0.6.6/jyn-cli-x86_64-pc-windows-msvc.zip
   InstallerSha256: EE217A3CCDB6C41E66985E3CB15408327BFB26187F1F9C7BE51A89A1AA585066
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.10.0

--- a/manifests/j/joyint/jyn/0.6.6/joyint.jyn.installer.yaml
+++ b/manifests/j/joyint/jyn/0.6.6/joyint.jyn.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: joyint.jyn
+PackageVersion: 0.6.6
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: jyn.exe
+  PortableCommandAlias: jyn
+Commands:
+- jyn
+ReleaseDate: 2026-06-11
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/joyint/jyn/releases/download/v0.6.6/jyn-cli-x86_64-pc-windows-msvc.zip
+  InstallerSha256: EE217A3CCDB6C41E66985E3CB15408327BFB26187F1F9C7BE51A89A1AA585066
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/j/joyint/jyn/0.6.6/joyint.jyn.locale.en-US.yaml
+++ b/manifests/j/joyint/jyn/0.6.6/joyint.jyn.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
 PackageIdentifier: joyint.jyn
 PackageVersion: 0.6.6
 PackageLocale: en-US
@@ -18,4 +18,4 @@ Tags:
 - task-manager
 - todo
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.10.0

--- a/manifests/j/joyint/jyn/0.6.6/joyint.jyn.locale.en-US.yaml
+++ b/manifests/j/joyint/jyn/0.6.6/joyint.jyn.locale.en-US.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: joyint.jyn
+PackageVersion: 0.6.6
+PackageLocale: en-US
+Publisher: Joydev GmbH
+PublisherUrl: https://joyint.com
+PublisherSupportUrl: https://github.com/joyint/jyn/issues
+PackageName: jyn
+PackageUrl: https://github.com/joyint/jyn
+License: MIT
+LicenseUrl: https://github.com/joyint/jyn/blob/main/LICENSE
+ShortDescription: Terminal-native personal task manager with recurring tasks and CalDAV sync.
+Moniker: jyn
+Tags:
+- caldav
+- cli
+- productivity
+- task-manager
+- todo
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/j/joyint/jyn/0.6.6/joyint.jyn.yaml
+++ b/manifests/j/joyint/jyn/0.6.6/joyint.jyn.yaml
@@ -1,6 +1,6 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
 PackageIdentifier: joyint.jyn
 PackageVersion: 0.6.6
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.10.0

--- a/manifests/j/joyint/jyn/0.6.6/joyint.jyn.yaml
+++ b/manifests/j/joyint/jyn/0.6.6/joyint.jyn.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: joyint.jyn
+PackageVersion: 0.6.6
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Adds **joyint.jyn** (jyn, a terminal-native personal task manager with recurring tasks and CalDAV sync) version 0.6.6.

- Portable package distributed as a zip; the nested `jyn.exe` is Authenticode-signed via Microsoft Artifact Signing (publisher: Joydev GmbH).
- Architecture: x64.
- Manifests authored against schema 1.6.0.

Maintainer: Joydev GmbH / joyint.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/386814)