### PR TITLE
New package: v2matosevic.WinSnipper version 0.5.0

### DIFF
--- a/manifests/v/v2matosevic/WinSnipper/0.5.0/v2matosevic.WinSnipper.installer.yaml
+++ b/manifests/v/v2matosevic/WinSnipper/0.5.0/v2matosevic.WinSnipper.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: v2matosevic.WinSnipper
+PackageVersion: 0.5.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: portable
+Commands:
+- winsnipper
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.8
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/v2matosevic/WinSnipper/releases/download/v0.5.0/WinSnipper.exe
+  InstallerSha256: EB50BCB5C71EE33A0F2F7D7415E8276A9B6778BF0870CFDC864225855092F754
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/v/v2matosevic/WinSnipper/0.5.0/v2matosevic.WinSnipper.locale.en-US.yaml
+++ b/manifests/v/v2matosevic/WinSnipper/0.5.0/v2matosevic.WinSnipper.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: v2matosevic.WinSnipper
+PackageVersion: 0.5.0
+PackageLocale: en-US
+Publisher: Marko Matošević
+PublisherUrl: https://github.com/v2matosevic
+PublisherSupportUrl: https://github.com/v2matosevic/WinSnipper/issues
+PackageName: WinSnipper
+PackageUrl: https://github.com/v2matosevic/WinSnipper
+License: MIT
+LicenseUrl: https://github.com/v2matosevic/WinSnipper/blob/master/LICENSE
+ShortDescription: Ultra-lightweight Win+Shift+S replacement - snip, floating thumbnail, annotate, paste.
+Description: |-
+  WinSnipper replaces the built-in Windows snip with a faster flow: press the
+  hotkey, drag a region, and the snip is saved, copied to the clipboard, and
+  pinned as a small floating thumbnail. Click the thumbnail to annotate
+  (rectangle, freehand, ellipse, arrow, text, numbered step badges,
+  redact/pixelate, crop) or drag it straight into any app as a file.
+  No confirmation dialogs anywhere - closing the editor saves silently and
+  refreshes the clipboard. Built for fast feedback loops, especially pasting
+  annotated screenshots into AI coding chats.
+Moniker: winsnipper
+Tags:
+- annotation
+- capture
+- ocr
+- productivity
+- screen-capture
+- screenshot
+- snip
+- snipping-tool
+ReleaseNotesUrl: https://github.com/v2matosevic/WinSnipper/releases/tag/v0.5.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/v/v2matosevic/WinSnipper/0.5.0/v2matosevic.WinSnipper.yaml
+++ b/manifests/v/v2matosevic/WinSnipper/0.5.0/v2matosevic.WinSnipper.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: v2matosevic.WinSnipper
+PackageVersion: 0.5.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package submission

- **Package**: v2matosevic.WinSnipper 0.5.0
- **Type**: portable (single-file exe)
- **Project**: https://github.com/v2matosevic/WinSnipper — MIT-licensed, open source
- **What it is**: ultra-lightweight Win+Shift+S replacement — region snip, floating thumbnail, annotation editor (rect/draw/arrow/text/step badges/redact), clipboard-first workflow
- **Installer**: https://github.com/v2matosevic/WinSnipper/releases/download/v0.5.0/WinSnipper.exe (~0.25 MB), depends on Microsoft.DotNet.DesktopRuntime.8

- [x] Manifests validate against schema 1.6.0
- [x] License and URLs verified
- [x] This PR only adds one new package version
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/386835)