### PR TITLE
New version: mar1mo-41414.MineScale version 1.2.11

### DIFF
--- a/manifests/m/mar1mo-41414/MineScale/1.2.11/mar1mo-41414.MineScale.installer.yaml
+++ b/manifests/m/mar1mo-41414/MineScale/1.2.11/mar1mo-41414.MineScale.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: mar1mo-41414.MineScale
+PackageVersion: 1.2.11
+InstallerType: portable
+Commands:
+- mc-share-gui
+ReleaseDate: 2026-06-07
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/mar1mo-41414/MineScale/releases/download/v1.2.11/mc-share-gui-windows-x64.exe
+  InstallerSha256: 0DC4CC938CD73E1620CA9C182082BE0D837F105E1C4912C3099C0719B42FB4A8
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/mar1mo-41414/MineScale/1.2.11/mar1mo-41414.MineScale.locale.en-US.yaml
+++ b/manifests/m/mar1mo-41414/MineScale/1.2.11/mar1mo-41414.MineScale.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: mar1mo-41414.MineScale
+PackageVersion: 1.2.11
+PackageLocale: en-US
+Publisher: mar1mo-41414
+PublisherUrl: https://github.com/mar1mo-41414
+PublisherSupportUrl: https://github.com/mar1mo-41414/MineScale/issues
+Author: mar1mo-41414
+PackageName: MineScale
+PackageUrl: https://github.com/mar1mo-41414/MineScale
+License: MIT
+LicenseUrl: https://github.com/mar1mo-41414/MineScale/blob/main/LICENSE
+Copyright: Copyright (c) 2025 mar1mo-41414
+ShortDescription: Minecraft Java Edition P2P world sharing - no port forwarding, no accounts.
+Description: |-
+  MineScale lets two players share a Minecraft Java Edition world peer-to-peer
+  over an encrypted QUIC tunnel. No port forwarding, no account registration,
+  no monthly fees. The host runs a LAN world, sends a link, and the joiner's
+  Minecraft client sees it automatically in the multiplayer list.
+Moniker: minescale
+Tags:
+- gaming
+- minecraft
+- multiplayer
+- p2p
+ReleaseNotesUrl: https://github.com/mar1mo-41414/MineScale/releases/tag/v1.2.11
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/mar1mo-41414/MineScale/1.2.11/mar1mo-41414.MineScale.yaml
+++ b/manifests/m/mar1mo-41414/MineScale/1.2.11/mar1mo-41414.MineScale.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: mar1mo-41414.MineScale
+PackageVersion: 1.2.11
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Update MineScale to 1.2.11

Updates `mar1mo-41414.MineScale` from 1.2.3 to 1.2.11.

### Validation

- Downloaded installer from GitHub Releases:
  - https://github.com/mar1mo-41414/MineScale/releases/download/v1.2.11/mc-share-gui-windows-x64.exe
- Calculated SHA256:
  - `0DC4CC938CD73E1620CA9C182082BE0D837F105E1C4912C3099C0719B42FB4A8`
- Verified manifest YAML parses correctly
- Verified PackageIdentifier, PackageVersion, ManifestVersion, InstallerUrl, and InstallerSha256
- Installer type remains `portable`

Release notes:
https://github.com/mar1mo-41414/MineScale/releases/tag/v1.2.11

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/386836)