### PR TITLE
Update: SerZhyAle.DocHtmlTranslate to 26.0612.0124

### DIFF
--- a/manifests/s/SerZhyAle/DocHtmlTranslate/26.0612.0124/SerZhyAle.DocHtmlTranslate.installer.yaml
+++ b/manifests/s/SerZhyAle/DocHtmlTranslate/26.0612.0124/SerZhyAle.DocHtmlTranslate.installer.yaml
@@ -1,0 +1,19 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: SerZhyAle.DocHtmlTranslate
+PackageVersion: 26.0612.0124
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: doc-html-translate.exe
+  PortableCommandAlias: doc-html-translate
+- RelativeFilePath: doc-html-ui.exe
+  PortableCommandAlias: doc-html-ui
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/SerZhyAle/doc-html-translate/releases/download/v26.0612.0124/doc-html-translate-26.0612.0124-windows-x64.zip
+  InstallerSha256: 815999EE90693247D4E8941976907C120EFCDC6FB92AE47ADC5905EE4F9FBEB6
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-06-12

--- a/manifests/s/SerZhyAle/DocHtmlTranslate/26.0612.0124/SerZhyAle.DocHtmlTranslate.locale.en-US.yaml
+++ b/manifests/s/SerZhyAle/DocHtmlTranslate/26.0612.0124/SerZhyAle.DocHtmlTranslate.locale.en-US.yaml
@@ -1,0 +1,48 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: SerZhyAle.DocHtmlTranslate
+PackageVersion: 26.0612.0124
+PackageLocale: en-US
+Publisher: SZA
+PublisherUrl: https://github.com/SerZhyAle
+PublisherSupportUrl: https://github.com/SerZhyAle/doc-html-translate/issues
+Author: Serhii Zhyhunenko
+PackageName: doc-html-translate
+PackageUrl: https://github.com/SerZhyAle/doc-html-translate
+License: MIT
+LicenseUrl: https://github.com/SerZhyAle/doc-html-translate/blob/main/LICENSE
+Copyright: Copyright (c) 2026 SerZhyAle
+ShortDescription: Convert EPUB, PDF, TXT, MD, FB2, RTF, HTML, MOBI and AZW3 to local HTML, with optional Google or Ollama translation.
+Description: |-
+  doc-html-translate is a Windows command-line tool that converts documents (EPUB, PDF, TXT,
+  Markdown, FB2, RTF, HTML, MOBI, AZW3) into local HTML with generated navigation and a
+  table of contents. It can optionally translate extracted text via the Google Cloud Translation
+  API or a local Ollama model. Re-opening an already-converted book is instant. The package
+  ships both the CLI (doc-html-translate) and a small GUI launcher (doc-html-ui).
+  pdftotext is bundled inside the binary; MOBI and AZW3 conversion additionally requires
+  Calibre to be installed (non-DRM files only).
+Moniker: doc-html-translate
+Tags:
+- azw3
+- cli
+- convert
+- ebook
+- epub
+- fb2
+- google-translate
+- html
+- markdown
+- mobi
+- ollama
+- pdf
+- rtf
+- translation
+- txt
+- windows
+ReleaseNotesUrl: https://github.com/SerZhyAle/doc-html-translate/releases/tag/v26.0612.0124
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/SerZhyAle/doc-html-translate/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/SerZhyAle/DocHtmlTranslate/26.0612.0124/SerZhyAle.DocHtmlTranslate.yaml
+++ b/manifests/s/SerZhyAle/DocHtmlTranslate/26.0612.0124/SerZhyAle.DocHtmlTranslate.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: SerZhyAle.DocHtmlTranslate
+PackageVersion: 26.0612.0124
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Update `SerZhyAle.DocHtmlTranslate` to version `26.0612.0124`.

Release assets:
- https://github.com/SerZhyAle/doc-html-translate/releases/tag/v26.0612.0124
- https://github.com/SerZhyAle/doc-html-translate/releases/download/v26.0612.0124/doc-html-translate-26.0612.0124-windows-x64.zip

## Checklist

- [x] Signed the Contributor License Agreement
- [ ] Linked to an issue (not applicable)

## Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same manifest update
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest p:\WINDOWS\EPUB_2_HTML\winget`
- [x] Tested manifest locally with `winget install --manifest p:\WINDOWS\EPUB_2_HTML\winget --force`
- [x] Manifest conforms to the 1.12 schema
