### PR TITLE
Update SerZhyAle.FileDO to version 2606120121

### DIFF
--- a/manifests/s/SerZhyAle/FileDO/2606120121/SerZhyAle.FileDO.installer.yaml
+++ b/manifests/s/SerZhyAle/FileDO/2606120121/SerZhyAle.FileDO.installer.yaml
@@ -1,0 +1,23 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: SerZhyAle.FileDO
+PackageVersion: "2606120121"
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: filedo.exe
+  PortableCommandAlias: filedo
+- RelativeFilePath: filedo_check.exe
+  PortableCommandAlias: filedo_check
+- RelativeFilePath: filedo_fill.exe
+  PortableCommandAlias: filedo_fill
+- RelativeFilePath: filedo_test.exe
+  PortableCommandAlias: filedo_test
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/SerZhyAle/FileDO/releases/download/v2606120121/FileDO-2606120121-windows-x64.zip
+  InstallerSha256: B27592262868AA9E550BABC5D3D930CE933BFC604C88A48F4CD30CAB75D55F83
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-06-12

--- a/manifests/s/SerZhyAle/FileDO/2606120121/SerZhyAle.FileDO.locale.en-US.yaml
+++ b/manifests/s/SerZhyAle/FileDO/2606120121/SerZhyAle.FileDO.locale.en-US.yaml
@@ -1,0 +1,42 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: SerZhyAle.FileDO
+PackageVersion: "2606120121"
+PackageLocale: en-US
+Publisher: SZA
+PublisherUrl: https://github.com/SerZhyAle
+PublisherSupportUrl: https://github.com/SerZhyAle/FileDO/issues
+Author: Serhii Zhyhunenko
+PackageName: FileDO
+PackageUrl: https://github.com/SerZhyAle/FileDO
+License: MIT
+LicenseUrl: https://github.com/SerZhyAle/FileDO/blob/main/LICENSE
+Copyright: Copyright (c) 2025 sza
+CopyrightUrl: https://github.com/SerZhyAle/FileDO/blob/main/LICENSE
+ShortDescription: Windows CLI for storage testing, fake-capacity detection, secure wipe, and duplicate management.
+Description: |-
+  FileDO is a fast Windows command-line tool for working with storage devices, folders, and network shares.
+  It detects fake USB/SD cards by writing and verifying real data, benchmarks read/write speeds, securely
+  wipes free space at multi-GB/s, finds and manages duplicate files via MD5 with hash caching, and copies
+  large trees with progress and timeout protection.
+Moniker: filedo
+Tags:
+- benchmark
+- cli
+- disk
+- duplicates
+- fake-capacity
+- file-manager
+- hash
+- md5
+- portable
+- sd-card
+- secure-erase
+- speed-test
+- storage
+- usb
+- wipe
+ReleaseNotesUrl: https://github.com/SerZhyAle/FileDO/releases/tag/v2606120121
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/SerZhyAle/FileDO/2606120121/SerZhyAle.FileDO.yaml
+++ b/manifests/s/SerZhyAle/FileDO/2606120121/SerZhyAle.FileDO.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: SerZhyAle.FileDO
+PackageVersion: "2606120121"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Update **SerZhyAle.FileDO** to version **2606120121** (portable zip, x64).

FileDO is an existing package; this PR adds the new version. Highlights of this
release of the CLI:

- **`wipe`** now requires an explicit `Type WIPE to continue` confirmation, with
  stronger guardrails for drive/share roots, reparse points (junctions/symlinks)
  and the system TEMP folder (never bypassed by `--force`).
- **Duplicate detection** validates cached hashes by size **and** modification
  time (no more false matches when a file changes but keeps the same size) and
  restores real worker-pool parallelism for hashing.
- **Faster large-tree copy** — redundant directory walks are merged so copying
  starts sooner.

Manifest changes: new `PackageVersion`, `InstallerUrl`, `InstallerSha256` and
`ReleaseDate`. The SHA256 was verified against the published
`FileDO-2606120121-windows-x64.zip` GitHub release asset.

Release: https://github.com/SerZhyAle/FileDO/releases/tag/v2606120121

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
