### PR TITLE
New version: Yovancas.ClaudeBarWin version 0.3.9

### DIFF
--- a/manifests/y/Yovancas/ClaudeBarWin/0.3.9/Yovancas.ClaudeBarWin.installer.yaml
+++ b/manifests/y/Yovancas/ClaudeBarWin/0.3.9/Yovancas.ClaudeBarWin.installer.yaml
@@ -8,6 +8,8 @@ InstallModes:
 - silent
 - silentWithProgress
 ReleaseDate: 2026-06-11
+Commands:
+- claudebarwin
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/Yovancas/claudebar-win/releases/download/v0.3.9/ClaudeBarWin-Setup-0.3.9.exe

--- a/manifests/y/Yovancas/ClaudeBarWin/0.3.9/Yovancas.ClaudeBarWin.installer.yaml
+++ b/manifests/y/Yovancas/ClaudeBarWin/0.3.9/Yovancas.ClaudeBarWin.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Yovancas.ClaudeBarWin
+PackageVersion: 0.3.9
+InstallerType: inno
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+ReleaseDate: 2026-06-11
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Yovancas/claudebar-win/releases/download/v0.3.9/ClaudeBarWin-Setup-0.3.9.exe
+  InstallerSha256: D736FEB88F238F42419136C7C44B6C97D370B4C11D6200F99D762A55E5462EFB
+  ProductCode: '{A7C3E1F2-5B8D-4E9A-9C1F-3D2E4F6A8B0C}_is1'
+  AppsAndFeaturesEntries:
+  - DisplayName: ClaudeBar for Windows
+    DisplayVersion: 0.3.9
+    Publisher: Yovan Castro
+    ProductCode: '{A7C3E1F2-5B8D-4E9A-9C1F-3D2E4F6A8B0C}_is1'
+    InstallerType: inno
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/y/Yovancas/ClaudeBarWin/0.3.9/Yovancas.ClaudeBarWin.locale.en-US.yaml
+++ b/manifests/y/Yovancas/ClaudeBarWin/0.3.9/Yovancas.ClaudeBarWin.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Yovancas.ClaudeBarWin
+PackageVersion: 0.3.9
+PackageLocale: en-US
+Publisher: Yovan Castro
+PublisherUrl: https://github.com/Yovancas
+PublisherSupportUrl: https://github.com/Yovancas/claudebar-win/issues
+PackageName: ClaudeBar for Windows
+PackageUrl: https://github.com/Yovancas/claudebar-win
+License: MIT
+LicenseUrl: https://github.com/Yovancas/claudebar-win/blob/main/LICENSE
+ShortDescription: System-tray monitor for Claude Code usage — real 5h/7d quota, pace prediction, usage charts, themes and 9 languages.
+Description: |-
+  ClaudeBar for Windows is a system-tray monitor for your Claude Code usage. It shows your real
+  5h and 7d quota from Anthropic's usage endpoint, predicts when you'll run out (pace), charts
+  usage over time (spend by model or real utilisation), shows service health, and supports themes
+  (incl. .itermcolors) and 9 languages. Self-contained, C#/.NET 9 + WinForms.
+ReleaseNotesUrl: https://github.com/Yovancas/claudebar-win/releases/tag/v0.3.9
+Tags:
+- claude
+- claude-code
+- anthropic
+- usage
+- quota
+- monitor
+- tray
+- system-tray
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/y/Yovancas/ClaudeBarWin/0.3.9/Yovancas.ClaudeBarWin.yaml
+++ b/manifests/y/Yovancas/ClaudeBarWin/0.3.9/Yovancas.ClaudeBarWin.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Yovancas.ClaudeBarWin
+PackageVersion: 0.3.9
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New version: Yovancas.ClaudeBarWin version 0.3.9

This PR adds the **installer** manifest for `Yovancas.ClaudeBarWin` v0.3.9.

The previously published manifest (v0.1.0) was a `portable` single-exe. Starting with v0.3.9 the package ships a proper **Inno Setup per-user installer** (`PrivilegesRequired=lowest`, installs to `%LOCALAPPDATA%\Programs\ClaudeBarWin`, no admin required).

- `InstallerType: inno`, `Scope: user`
- `InstallerSha256` verified against the GitHub release asset and the local build (both `D736FEB88F238F42419136C7C44B6C97D370B4C11D6200F99D762A55E5462EFB`)
- `ProductCode` / `AppsAndFeaturesEntries` set to the Inno uninstall key (`{A7C3E1F2-...}_is1`) for upgrade/uninstall correlation
- Validated locally with `winget validate` (succeeded)

#### Checklist
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/386846)