### PR TITLE
New version: tisun2.OofManager version 1.1.12

### DIFF
--- a/manifests/t/tisun2/OofManager/1.1.12/tisun2.OofManager.installer.yaml
+++ b/manifests/t/tisun2/OofManager/1.1.12/tisun2.OofManager.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: tisun2.OofManager
+PackageVersion: 1.1.12
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART
+UpgradeBehavior: install
+ReleaseDate: 2026-06-12
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/tisun2/OofManager/releases/download/v1.1.12/OofManagerSetup.exe
+    InstallerSha256: 2F84FCF3784B4501C9CA3A2BEFA6045610F29C21067EB32A4BCD9C780423BD4D
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/t/tisun2/OofManager/1.1.12/tisun2.OofManager.locale.en-US.yaml
+++ b/manifests/t/tisun2/OofManager/1.1.12/tisun2.OofManager.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: tisun2.OofManager
+PackageVersion: 1.1.12
+PackageLocale: en-US
+Publisher: tisun2
+PublisherUrl: https://github.com/tisun2
+PublisherSupportUrl: https://github.com/tisun2/OofManager/issues
+PackageName: OOF Manager
+PackageUrl: https://github.com/tisun2/OofManager
+License: MIT
+LicenseUrl: https://github.com/tisun2/OofManager/blob/main/LICENSE
+Copyright: Copyright (c) tisun2
+ShortDescription: Manage Microsoft 365 / Exchange Online Out-of-Office (Automatic Reply) settings without opening Outlook.
+Description: |-
+  OOF Manager is a lightweight Windows desktop tool that manages your Microsoft 365 mailbox's
+  Out-of-Office (Automatic Reply) state for you. Sign in once, configure your weekly work hours
+  and reply text, and OOF Manager auto-toggles your OOF on/off at the schedule boundaries.
+  It also pushes the next off-hours window to Exchange as a Scheduled OOF, so the server keeps
+  switching auto-replies even when this app is closed.
+Moniker: oofmanager
+Tags:
+  - exchange
+  - microsoft-365
+  - office-365
+  - out-of-office
+  - oof
+  - outlook
+  - autoreply
+ReleaseNotesUrl: https://github.com/tisun2/OofManager/releases/tag/v1.1.12
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/t/tisun2/OofManager/1.1.12/tisun2.OofManager.yaml
+++ b/manifests/t/tisun2/OofManager/1.1.12/tisun2.OofManager.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: tisun2.OofManager
+PackageVersion: 1.1.12
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Summary

Updates `tisun2.OofManager` to version **1.1.12**.

- **Installer:** `OofManagerSetup.exe`
- **SHA256:** `2F84FCF3784B4501C9CA3A2BEFA6045610F29C21067EB32A4BCD9C780423BD4D`
- **Release:** https://github.com/tisun2/OofManager/releases/tag/v1.1.12

## Changes in this release

- **Vacation End now hands off to your normal off-hours AutoReply window** before resuming the Weekly Schedule flow. Previously, if a vacation ended outside working hours (e.g. Sunday morning), Outlook would show *no* AutoReply at all until the weekly flow's next recurrence fired — up to ~2 days. The End flow now writes the same per-day-of-week off-hours window the weekly flow uses, then starts the weekly flow back up.
- The Resume step runs regardless of the hand-off's outcome, so the weekly schedule always comes back on even if the AutoReply write transiently fails.
- Already-imported vacation flows from earlier versions are stale — re-run **"Set up vacation in cloud"** once to pick up the new End flow.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/386883)