### PR TITLE
New package: Tylergibbs1.Substrate version 0.3.4

### DIFF
--- a/manifests/t/Tylergibbs1/Substrate/0.3.4/Tylergibbs1.Substrate.installer.yaml
+++ b/manifests/t/Tylergibbs1/Substrate/0.3.4/Tylergibbs1.Substrate.installer.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Tylergibbs1.Substrate
+PackageVersion: 0.3.4
+InstallerType: nullsoft
+Scope: user
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/tylergibbs1/substrate/releases/download/v0.3.4/Substrate-Setup-0.3.4.exe
+    InstallerSha256: 8843D00BCF7BA30E9B507AAE30667A008FD23E93BAA68E88C50BA17A7266952B
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/t/Tylergibbs1/Substrate/0.3.4/Tylergibbs1.Substrate.locale.en-US.yaml
+++ b/manifests/t/Tylergibbs1/Substrate/0.3.4/Tylergibbs1.Substrate.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Tylergibbs1.Substrate
+PackageVersion: 0.3.4
+PackageLocale: en-US
+Publisher: Tyler Gibbs
+PublisherUrl: https://github.com/tylergibbs1
+PublisherSupportUrl: https://github.com/tylergibbs1/substrate/issues
+PackageName: Substrate
+PackageUrl: https://github.com/tylergibbs1/substrate
+License: MIT
+LicenseUrl: https://github.com/tylergibbs1/substrate/blob/main/LICENSE
+ShortDescription: Desktop app for AI-generated raster slide decks where the prompt is the only editable artifact.
+Description: |-
+  Substrate generates raster slide decks with an image model. The only editable
+  artifacts are two prompts (a per-slide prompt and a deck-level main design
+  prompt) which both a human (in the UI) and an agent (over MCP) can co-author.
+Moniker: substrate
+Tags:
+- ai
+- slides
+- presentations
+- deck
+- electron
+- mcp
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/t/Tylergibbs1/Substrate/0.3.4/Tylergibbs1.Substrate.yaml
+++ b/manifests/t/Tylergibbs1/Substrate/0.3.4/Tylergibbs1.Substrate.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Tylergibbs1.Substrate
+PackageVersion: 0.3.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## New package: Tylergibbs1.Substrate version 0.3.4

[Substrate](https://github.com/tylergibbs1/substrate) — a desktop app for AI-generated raster slide decks where the prompt is the only editable artifact.

- **Installer:** electron-builder NSIS, per-user scope (no admin), x64, published on GitHub Releases.
- **InstallerSha256** verified against the published release asset's digest (`8843D00B…`).
- Manifests authored by hand against schema 1.6.0; `LicenseUrl` resolves (MIT).

### Notes
- First submission for this package.
- The installer is not yet Authenticode-signed; a signed build is planned for a future version.

---
- [x] This is a new package
- [x] Have read the [contribution guidelines](https://github.com/microsoft/winget-pkgs/blob/master/CONTRIBUTING.md)
- [x] Manifest validates against the v1.6.0 schema

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/386902)