### PR TITLE
Update metadata: NoirArchitects.Ncored version 2026.2.4

### DIFF
--- a/manifests/n/NoirArchitects/Ncored/2026.2.4/NoirArchitects.Ncored.locale.en-US.yaml
+++ b/manifests/n/NoirArchitects/Ncored/2026.2.4/NoirArchitects.Ncored.locale.en-US.yaml
@@ -12,9 +12,9 @@ PackageUrl: https://ncored.com/
 License: Proprietary
 LicenseUrl: https://ncored.com/ncored_terms.html
 Copyright: Copyright 2026 Noir architects
-ShortDescription: Fast PDF viewer for large construction drawings
+ShortDescription: Fast PDF editor for large CAD and construction drawings
 Description: |-
-  Ncored is a fast desktop PDF viewer and markup tool built specifically for architects, structural engineers, mechanical and electrical engineers, BIM coordinators, and construction managers who open very large (50 to 220 MB) construction drawing PDFs every day.
+  Ncored is a fast desktop PDF editor built specifically for architects, structural engineers, mechanical and electrical engineers, BIM coordinators, and construction managers who open heavy construction drawing PDFs from 50-200 MB+ project sets every day.
 
   The product is intentionally narrower in scope than general-purpose PDF suites. The focus is the specific moment a professional opens a heavy construction drawing exported from ArchiCAD, Revit, AutoCAD, Vectorworks, or SketchUp Layout, and needs to scroll, zoom, mark up, and search it without the freezes that typically occur in general-purpose PDF tools.
 


### PR DESCRIPTION
Metadata-only update for NoirArchitects.Ncored 2026.2.4. No installer, hash or version changes.

As the publisher, correcting the en-US locale description:

- ShortDescription and Description said "PDF viewer"; the application is a PDF editor (in-place text editing is a core feature, as the existing third paragraph of the Description already states).
- Corrected an inaccurate file-size figure in the first paragraph.

All other fields, tags and URLs are unchanged.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/386963)