### PR TITLE
New package: gum798.AnyClip version 1.1.0

### DIFF
--- a/manifests/g/gum798/AnyClip/1.1.0/gum798.AnyClip.installer.yaml
+++ b/manifests/g/gum798/AnyClip/1.1.0/gum798.AnyClip.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: gum798.AnyClip
+PackageVersion: 1.1.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: AnyClip.exe
+  PortableCommandAlias: anyclip
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/gum798/AnyClip/releases/download/v1.1.0/AnyClip-v1.1.0-windows-x64-native.zip
+  InstallerSha256: D0EC88AFBCDD3FF99234A799D27565A6B0F1580FE6BF33ADCEE903FE369CDF7C
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/g/gum798/AnyClip/1.1.0/gum798.AnyClip.locale.en-US.yaml
+++ b/manifests/g/gum798/AnyClip/1.1.0/gum798.AnyClip.locale.en-US.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: gum798.AnyClip
+PackageVersion: 1.1.0
+PackageLocale: en-US
+Publisher: gum798
+PublisherUrl: https://github.com/gum798
+PublisherSupportUrl: https://github.com/gum798/AnyClip/issues
+PackageName: AnyClip
+PackageUrl: https://github.com/gum798/AnyClip
+License: MIT
+ShortDescription: LAN clipboard sync between two computers
+Description: Bidirectional clipboard synchronization (text, images, files) between two computers on the same LAN, with mDNS auto-discovery and shared-token authentication.
+Tags:
+- clipboard
+- sync
+- lan
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/g/gum798/AnyClip/1.1.0/gum798.AnyClip.yaml
+++ b/manifests/g/gum798/AnyClip/1.1.0/gum798.AnyClip.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: gum798.AnyClip
+PackageVersion: 1.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package submission

- **PackageIdentifier:** gum798.AnyClip
- **PackageVersion:** 1.1.0
- Portable (zip-nested) x64 app: LAN clipboard sync between two computers (mDNS discovery, shared-token auth).
- Installer URL points to the GitHub release asset; SHA256 verified.

- [x] Manifests validated against the 1.6.0 schemas
- [x] This package does not already exist in the repository
- [x] I am the publisher or have permission to distribute (own project)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/387026)