### PR TITLE
New version: DeltaForge.CLI version 1.0.5

### DIFF
--- a/manifests/d/DeltaForge/CLI/1.0.5/DeltaForge.CLI.installer.yaml
+++ b/manifests/d/DeltaForge/CLI/1.0.5/DeltaForge.CLI.installer.yaml
@@ -1,0 +1,14 @@
+PackageIdentifier: DeltaForge.CLI
+PackageVersion: 1.0.5
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: deltaforge-cli.exe
+    PortableCommandAlias: deltaforge-cli
+
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/deltaforge-org/delta-forge/releases/download/v1.0.5/deltaforge-cli-1.0.5-windows-x64.zip
+  InstallerSha256: D969590CA81BDA628D197A52A82F267521A7A4D7B1AB7D9FFA0CF0FD32E4B6B0
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/d/DeltaForge/CLI/1.0.5/DeltaForge.CLI.locale.en-US.yaml
+++ b/manifests/d/DeltaForge/CLI/1.0.5/DeltaForge.CLI.locale.en-US.yaml
@@ -1,0 +1,27 @@
+PackageIdentifier: DeltaForge.CLI
+PackageVersion: 1.0.5
+PackageLocale: en-US
+Publisher: DeltaForge
+PublisherUrl: https://deltaforge.org
+PublisherSupportUrl: https://deltaforge.org/pages/contact.html
+PackageName: 'DeltaForge CLI'
+Moniker: 'deltaforge-cli'
+PackageUrl: https://deltaforge.org
+License: Proprietary
+LicenseUrl: https://deltaforge.org/pages/terms-of-service.html
+Copyright: 'Copyright (c) 2026 DeltaForge'
+ShortDescription: 'Query Delta Lake and Apache Iceberg in place from your terminal: no warehouse, no cluster, no copy pipeline'
+Tags:
+  - cli
+  - command-line
+  - delta-forge
+  - delta-lake
+  - iceberg
+  - sql
+  - graph
+  - cypher
+  - geospatial
+  - adbc
+  - odbc
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/d/DeltaForge/CLI/1.0.5/DeltaForge.CLI.yaml
+++ b/manifests/d/DeltaForge/CLI/1.0.5/DeltaForge.CLI.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: DeltaForge.CLI
+PackageVersion: 1.0.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Adds/updates manifests for DeltaForge.CLI 1.0.5.

All artifacts are downloaded from:
https://github.com/deltaforge-org/delta-forge/releases/download/v1.0.5/

Publisher homepage: https://deltaforge.org
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/387027)