### PR TITLE
New package: Santo.WaktuSholatLeeds version 1.5.2

### DIFF
--- a/manifests/s/Santo/WaktuSholatLeeds/1.5.2/Santo.WaktuSholatLeeds.installer.yaml
+++ b/manifests/s/Santo/WaktuSholatLeeds/1.5.2/Santo.WaktuSholatLeeds.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Santo.WaktuSholatLeeds
+PackageVersion: 1.5.2
+InstallerLocale: en-US
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: msi
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-06-12
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Santo-UoL/waktu-sholat-leeds/releases/download/v1.5.2/WaktuSholatLeeds-1.5.2.msi
+    InstallerSha256: 72E19B1FD152AA8A4A5C8196E20A0EC339A71201487B0D32B95239B19954E6F9
+    ProductCode: '{AFEE4911-6BC7-4C7C-AFE2-AD5AAFB1CA0F}'
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/Santo/WaktuSholatLeeds/1.5.2/Santo.WaktuSholatLeeds.locale.en-US.yaml
+++ b/manifests/s/Santo/WaktuSholatLeeds/1.5.2/Santo.WaktuSholatLeeds.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Santo.WaktuSholatLeeds
+PackageVersion: 1.5.2
+PackageLocale: en-US
+Publisher: Santo
+PublisherUrl: https://github.com/Santo-UoL
+PublisherSupportUrl: https://github.com/Santo-UoL/waktu-sholat-leeds/issues
+PackageName: Waktu Sholat Leeds
+PackageUrl: https://github.com/Santo-UoL/waktu-sholat-leeds
+License: MIT
+LicenseUrl: https://github.com/Santo-UoL/waktu-sholat-leeds/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Santo
+ShortDescription: Daily Islamic prayer times for Leeds, UK with taskbar countdown and reminders
+Description: |-
+  Waktu Sholat Leeds displays the five daily Islamic prayer times for Leeds, UK
+  (based on the Leeds Grand Mosque calendar). The time remaining to the next
+  prayer is shown directly on the Windows taskbar, with a red blinking reminder
+  15 minutes before the adhan. The app runs quietly in the system tray, starts
+  with Windows, supports Indonesian and English, and updates itself from GitHub
+  releases. Free, open source, no ads, no tracking.
+Moniker: waktu-sholat-leeds
+Tags:
+  - adhan
+  - islam
+  - leeds
+  - prayer
+  - prayer-times
+  - salah
+  - sholat
+ReleaseNotesUrl: https://github.com/Santo-UoL/waktu-sholat-leeds/releases/tag/v1.5.2
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/Santo/WaktuSholatLeeds/1.5.2/Santo.WaktuSholatLeeds.yaml
+++ b/manifests/s/Santo/WaktuSholatLeeds/1.5.2/Santo.WaktuSholatLeeds.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Santo.WaktuSholatLeeds
+PackageVersion: 1.5.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package submission

- **PackageIdentifier:** Santo.WaktuSholatLeeds
- **PackageVersion:** 1.5.2

Waktu Sholat Leeds is a free, open-source Windows desktop app showing daily Islamic prayer times for Leeds, UK, with a taskbar countdown and reminders. Repository: https://github.com/Santo-UoL/waktu-sholat-leeds

-----

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? (The MSI itself was installed and tested manually on Windows 11 x64.)
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/387098)