### PR TITLE
New version: cadwal.BookDB version 1.1.0

### DIFF
--- a/manifests/c/cadwal/BookDB/1.1.0/cadwal.BookDB.installer.yaml
+++ b/manifests/c/cadwal/BookDB/1.1.0/cadwal.BookDB.installer.yaml
@@ -1,0 +1,26 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: cadwal.BookDB
+PackageVersion: 1.1.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: BookDB.Desktop.exe
+  PortableCommandAlias: bookdb
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.DotNet.Runtime.10
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/cadwal/BookDB/releases/download/v1.1.0/BookDB-v1.1.0-win-x64-fdd.zip
+  InstallerSha256: 63C756D79400FB8EDDF19D17A401E9F684FD3174D295CB0B937B6BCACAFD152F
+- Architecture: arm64
+  InstallerUrl: https://github.com/cadwal/BookDB/releases/download/v1.1.0/BookDB-v1.1.0-win-arm64-fdd.zip
+  InstallerSha256: 668DEB7A1BBD4FBDBCCD35A71A005E3447BE828E6DA63D4063891C79A13A920C
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-06-12

--- a/manifests/c/cadwal/BookDB/1.1.0/cadwal.BookDB.locale.en-US.yaml
+++ b/manifests/c/cadwal/BookDB/1.1.0/cadwal.BookDB.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: cadwal.BookDB
+PackageVersion: 1.1.0
+PackageLocale: en-US
+Publisher: cadwal
+PublisherUrl: https://github.com/cadwal
+PublisherSupportUrl: https://github.com/cadwal/BookDB/issues
+PackageName: BookDB
+PackageUrl: https://github.com/cadwal/BookDB
+License: MIT
+ShortDescription: A personal book catalog for Windows
+Description: A book catalog database for personal collections. Can import data from Readerware 4.
+Tags:
+- books
+- catalog
+- library
+ReleaseNotesUrl: https://github.com/cadwal/BookDB/releases/tag/v1.1.0
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/cadwal/BookDB/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/cadwal/BookDB/1.1.0/cadwal.BookDB.yaml
+++ b/manifests/c/cadwal/BookDB/1.1.0/cadwal.BookDB.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: cadwal.BookDB
+PackageVersion: 1.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
<!-- Describe what this PR changes. For manifest submissions, include the package name and version. -->
Adds cadwal.BookDB version 1.1.0 — a personal book catalog for Windows. First version with both x64 and ARM64 installers in the manifest. Release notes: https://github.com/cadwal/BookDB/releases/tag/v1.1.0

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/387156)
