### PR TITLE
New package: Materializr.Materializr version 1.0.0

### DIFF
--- a/manifests/m/Materializr/Materializr/1.0.0/Materializr.Materializr.installer.yaml
+++ b/manifests/m/Materializr/Materializr/1.0.0/Materializr.Materializr.installer.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Materializr.Materializr
+PackageVersion: 1.0.0
+# NSIS installer (packaging/windows/installer.nsi) → winget type "nullsoft",
+# which implies the "/S" silent switch. It installs machine-wide to
+# %ProgramFiles%\Materializr and requires elevation (RequestExecutionLevel admin).
+InstallerType: nullsoft
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/materializr-cad/materializr/releases/download/v1.0.0/Materializr-Setup.exe
+    InstallerSha256: C042E73386FC7505AC9F55CF90C6E2AE12456292BC33F26474F83A21242678D1
+    # The NSIS script writes these ARP values; the installer tags DisplayVersion
+    # with the tag name (leading "v") via /DAPPVERSION=${github.ref_name}.
+    AppsAndFeaturesEntries:
+      - DisplayName: Materializr
+        Publisher: Materializr
+        DisplayVersion: v1.0.0
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/Materializr/Materializr/1.0.0/Materializr.Materializr.locale.en-US.yaml
+++ b/manifests/m/Materializr/Materializr/1.0.0/Materializr.Materializr.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Materializr.Materializr
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: Materializr
+PublisherUrl: https://github.com/materializr-cad
+PublisherSupportUrl: https://github.com/materializr-cad/materializr/issues
+Author: Steve Bushwa
+PackageName: Materializr
+PackageUrl: https://github.com/materializr-cad/materializr
+License: GPL-3.0-or-later
+LicenseUrl: https://github.com/materializr-cad/materializr/blob/main/LICENSE
+Copyright: Copyright (C) Steve Bushwa
+ShortDescription: Parametric 3D CAD — sketch, model, and export STEP/STL/IGES/glTF.
+Description: |-
+  Materializr is an open-source parametric 3D CAD application: sketch on a plane,
+  extrude/revolve/loft into solids, fillet and chamfer, boolean operations, and a
+  parametric history you can edit and replay. It imports and exports STEP, STL,
+  IGES and glTF. The geometry kernel is OpenCASCADE; the UI is Dear ImGui on SDL2.
+Moniker: materializr
+Tags:
+  - 3d
+  - 3d-printing
+  - cad
+  - engineering
+  - modeling
+  - opencascade
+  - parametric
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/Materializr/Materializr/1.0.0/Materializr.Materializr.yaml
+++ b/manifests/m/Materializr/Materializr/1.0.0/Materializr.Materializr.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# Version manifest. Submit alongside the installer + locale manifests to
+# microsoft/winget-pkgs under: manifests/m/Materializr/Materializr/1.0.0/
+PackageIdentifier: Materializr.Materializr
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: `Materializr.Materializr` version `1.0.0`

Materializr is an open-source parametric 3D CAD application (OpenCASCADE kernel, Dear ImGui/SDL2 UI). First public Windows release.

- **Installer:** NSIS (`nullsoft`), x64, machine scope. Silent install via `/S`.
- **Source/installer:** https://github.com/materializr-cad/materializr/releases/tag/v1.0.0
- Manifests validated against the 1.6.0 schemas.

#### Checklist
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)? *(signing on this PR)*
- [x] This is a new package (not already in the repository).
- [x] Manifests validate against the winget 1.6.0 schemas.
- [x] Installer URL is a stable release asset with a matching SHA256.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/387366)