### PR TITLE
New package: Feci.ParleyDeckCli version 1.26.0

### DIFF
--- a/manifests/f/Feci/ParleyDeckCli/1.26.0/Feci.ParleyDeckCli.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.26.0/Feci.ParleyDeckCli.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.26.0
+InstallerType: portable
+Commands:
+- parley
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.26.0/parley-v1.26.0-windows-x64.exe
+  InstallerSha256: 7D01499750FC414CD6FC9CA16DE8D478CA649865DCE8B65738D7422BC22291BC
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.26.0/parley-v1.26.0-windows-arm64.exe
+  InstallerSha256: 5943CFF7A6E20A5EF1CB3AFA89A8118958BC8CE0A0C02E70D6817B69E1A435FC
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.26.0/Feci.ParleyDeckCli.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.26.0/Feci.ParleyDeckCli.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.26.0
+PackageLocale: en-US
+Publisher: Feci
+PublisherUrl: https://github.com/feci
+PackageName: Parley Deck CLI
+PackageUrl: https://github.com/feci/parley-deck-cli
+License: Apache-2.0
+LicenseUrl: https://github.com/feci/parley-deck-cli/blob/main/LICENSE
+ShortDescription: CLI that orchestrates Parley Deck multi-agent cooperation workflows.
+Description: parley orchestrates multi-agent Parley Deck cooperation: it kicks off ideas, runs deliberation rounds across local CLI agents, drives consensus/finalize/implementation, and shows live state in a TUI. Auto-drive is on by default; the /run command advances the protocol on demand.
+ReleaseNotesUrl: https://github.com/feci/parley-deck-cli/releases/tag/v1.26.0
+Tags:
+- ai
+- agents
+- agy
+- claude
+- cli
+- codex
+- consensus
+- multi-agent
+- orchestration
+- tui
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.26.0/Feci.ParleyDeckCli.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.26.0/Feci.ParleyDeckCli.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.26.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New package

- **Package**: Feci.ParleyDeckCli 1.26.0
- **Type**: portable (command: `parley`), x64 + arm64
- **Installers**: GitHub release assets for v1.26.0 (verified reachable; SHA256 computed from the published `.exe` files)

parley orchestrates multi-agent Parley Deck cooperation workflows.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? (manifest authored to the 1.12.0 schema; CI validation will confirm)
- [x] Have you tested your manifest locally with `winget install --manifest <path>`? (assets are the same portable .exe shipped on the GitHub release)
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/387488)