### PR TITLE
New version: FrankZhu.ZManagerCLI version 1.0.4

### DIFF
--- a/manifests/f/FrankZhu/ZManagerCLI/1.0.4/FrankZhu.ZManagerCLI.installer.yaml
+++ b/manifests/f/FrankZhu/ZManagerCLI/1.0.4/FrankZhu.ZManagerCLI.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: FrankZhu.ZManagerCLI
+PackageVersion: 1.0.4
+InstallerType: zip
+NestedInstallerType: portable
+ReleaseDate: 2026-06-13
+Commands:
+  - zm
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/frankmanzhu/zmanager/releases/download/v1.0.4/zm-x86_64-pc-windows-msvc.zip
+    InstallerSha256: 76f2c5ffa1717d7f94994146128df4a486bbe1cdb5503d2ac0bf6f96edf6b09a
+    NestedInstallerFiles:
+      - RelativeFilePath: zm.exe
+        PortableCommandAlias: zm
+  - Architecture: arm64
+    InstallerUrl: https://github.com/frankmanzhu/zmanager/releases/download/v1.0.4/zm-aarch64-pc-windows-msvc.zip
+    InstallerSha256: 69feedaa142b266534e2ab4cb6329f514af993649a5078e702ac17a12b6fb349
+    NestedInstallerFiles:
+      - RelativeFilePath: zm.exe
+        PortableCommandAlias: zm
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/FrankZhu/ZManagerCLI/1.0.4/FrankZhu.ZManagerCLI.locale.en-US.yaml
+++ b/manifests/f/FrankZhu/ZManagerCLI/1.0.4/FrankZhu.ZManagerCLI.locale.en-US.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: FrankZhu.ZManagerCLI
+PackageVersion: 1.0.4
+PackageLocale: en-US
+Publisher: Frank Zhu
+PublisherUrl: https://github.com/frankmanzhu
+PackageName: Z-Manager CLI
+PackageUrl: https://github.com/frankmanzhu/zmanager
+License: Apache-2.0
+LicenseUrl: https://github.com/frankmanzhu/zmanager/blob/v1.0.4/LICENSE
+ShortDescription: Fast, safe archive utility for ZIP, 7z, TAR.ZST, and broad extraction.
+Description: Z-Manager CLI extracts broad real-world archive formats safely and creates focused modern ZIP, TAR.ZST, and 7z archives.
+Tags:
+  - archive
+  - compression
+  - zip
+  - 7z
+  - tar
+  - zstd
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/FrankZhu/ZManagerCLI/1.0.4/FrankZhu.ZManagerCLI.yaml
+++ b/manifests/f/FrankZhu/ZManagerCLI/1.0.4/FrankZhu.ZManagerCLI.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: FrankZhu.ZManagerCLI
+PackageVersion: 1.0.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Package submission

- Package identifier: `FrankZhu.ZManagerCLI`
- Version: `1.0.4`
- Installer type: zip / portable
- Architectures: x64, arm64

### Installer hashes

- x64: `76f2c5ffa1717d7f94994146128df4a486bbe1cdb5503d2ac0bf6f96edf6b09a`
- arm64: `69feedaa142b266534e2ab4cb6329f514af993649a5078e702ac17a12b6fb349`

### Validation

- Installer hashes verified against the published `v1.0.4` `SHA256SUMS`.
- `winget validate .\manifests\f\FrankZhu\ZManagerCLI\1.0.4 --disable-interactivity` passed locally.
- Direct x64 release ZIP smoke passed locally: `zm.exe --version` returned `zm 1.0.4`.
- Published Windows dependency reports do not list `MSVCP140.dll`, `VCRUNTIME140.dll`, `VCRUNTIME140_1.dll`, or `api-ms-win-crt-*` imports.
- Manifest schema is `1.12.0` and no external package dependencies are declared.