### PR TITLE
New version: Sewandev.Reverbic version 1.5.4

### DIFF
--- a/manifests/s/Sewandev/Reverbic/1.5.4/Sewandev.Reverbic.installer.yaml
+++ b/manifests/s/Sewandev/Reverbic/1.5.4/Sewandev.Reverbic.installer.yaml
@@ -1,0 +1,10 @@
+PackageIdentifier: Sewandev.Reverbic
+PackageVersion: 1.5.4
+MinimumOSVersion: 10.0.0.0
+InstallerType: portable
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/sewandev/Reverbic/releases/download/v1.5.4/reverbic-v1.5.4-x86_64-windows.exe
+    InstallerSha256: 896E9A8C3C2371827E8B8475D4648547DB7DB354AC70B8467AA16546FD078F79
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/Sewandev/Reverbic/1.5.4/Sewandev.Reverbic.installer.yaml
+++ b/manifests/s/Sewandev/Reverbic/1.5.4/Sewandev.Reverbic.installer.yaml
@@ -2,6 +2,9 @@ PackageIdentifier: Sewandev.Reverbic
 PackageVersion: 1.5.4
 MinimumOSVersion: 10.0.0.0
 InstallerType: portable
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/sewandev/Reverbic/releases/download/v1.5.4/reverbic-v1.5.4-x86_64-windows.exe

--- a/manifests/s/Sewandev/Reverbic/1.5.4/Sewandev.Reverbic.locale.en-US.yaml
+++ b/manifests/s/Sewandev/Reverbic/1.5.4/Sewandev.Reverbic.locale.en-US.yaml
@@ -1,0 +1,23 @@
+PackageIdentifier: Sewandev.Reverbic
+PackageVersion: 1.5.4
+PackageLocale: en-US
+Publisher: Esteban Jaramillo
+PublisherUrl: https://github.com/sewandev
+PackageName: Reverbic
+PackageUrl: https://github.com/sewandev/Reverbic
+License: MIT
+LicenseUrl: https://github.com/sewandev/Reverbic/blob/main/LICENSE
+ShortDescription: Terminal radio player for Windows with Spotify integration and gaming overlay.
+Description: |-
+  Reverbic is a terminal-based radio player for Windows. Stream thousands of internet
+  radio stations, control Spotify remotely, and enjoy a floating Now Playing overlay
+  while gaming — all from the command line.
+Tags:
+  - radio
+  - spotify
+  - tui
+  - terminal
+  - audio
+ReleaseNotesUrl: https://github.com/sewandev/Reverbic/releases/tag/v1.5.4
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/Sewandev/Reverbic/1.5.4/Sewandev.Reverbic.yaml
+++ b/manifests/s/Sewandev/Reverbic/1.5.4/Sewandev.Reverbic.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Sewandev.Reverbic
+PackageVersion: 1.5.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New version: Sewandev.Reverbic version 1.5.4

- [x] This is a new version of an existing package
- [x] Manifest format matches the existing accepted manifests (based on the 1.5.3 submission)
- [x] Installer URL and SHA256 verified against the GitHub release `v1.5.4`

Portable x64 installer published at https://github.com/sewandev/Reverbic/releases/tag/v1.5.4
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/387671)