### PR TITLE
Added Microsoft Accessibility Insights to flaggedPackages.yml.

### DIFF
--- a/.github/policies/flaggedPackages.yml
+++ b/.github/policies/flaggedPackages.yml
@@ -171,7 +171,7 @@ configuration:
                   pattern: "(?in)Microsoft[ .]Accessibility[ -]?Insights"
                   isRegex: true
               - bodyContains:
-                  pattern: "(?in)Microsoft\\.Accessibility-?Insights"
+                  pattern: "(?in)Microsoft[.]Accessibility-?Insights"
                   IsRegex: true
         then:
           - addLabel:

--- a/.github/policies/flaggedPackages.yml
+++ b/.github/policies/flaggedPackages.yml
@@ -168,14 +168,17 @@ configuration:
                   isRegex: true
               # Microsoft Accessibility Insights
               - titleContains:
-                  pattern: "(?in)Microsoft[ .]Accessibility[ -]?Insights"
-                  isRegex: true
+                  pattern: Microsoft.AccessibilityInsights
+                  isRegex: False
+              - titleContains:
+                  pattern: Microsoft.Accessibility-Insights
+                  isRegex: False
               - bodyContains:
                   pattern: Microsoft.AccessibilityInsights
-                  IsRegex: false
+                  IsRegex: False
               - bodyContains:
                   pattern: Microsoft.Accessibility-Insights
-                  IsRegex: false
+                  IsRegex: False
         then:
           - addLabel:
               label: Package-Flagged

--- a/.github/policies/flaggedPackages.yml
+++ b/.github/policies/flaggedPackages.yml
@@ -166,6 +166,13 @@ configuration:
               - bodyContains:
                   pattern: "(?in)[Uμ]torrent"
                   isRegex: true
+              # Microsoft Accessibility Insights
+              - titleContains:
+                  pattern: "(?in)Microsoft[ .]Accessibility[ -]?Insights"
+                  isRegex: true
+              - bodyContains:
+                  pattern: "(?in)Microsoft\.Accessibility-?Insights"
+                  IsRegex: true
         then:
           - addLabel:
               label: Package-Flagged
@@ -179,6 +186,8 @@ configuration:
                 | Package Name                     | Block Reason                                                                                                                                                                           | Reference                   |
 
                 | -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------- |
+
+                | Microsoft Accessibility Insights | Publisher has requested removal                                                                                                                                                        | #59885
 
                 | Filezilla Client                 | Redistribution not allowed by license                                                                                                                                                  | #78578                      |
 

--- a/.github/policies/flaggedPackages.yml
+++ b/.github/policies/flaggedPackages.yml
@@ -171,8 +171,11 @@ configuration:
                   pattern: "(?in)Microsoft[ .]Accessibility[ -]?Insights"
                   isRegex: true
               - bodyContains:
-                  pattern: "(?in)Microsoft.Accessibility-?Insights"
-                  IsRegex: true
+                  pattern: Microsoft.AccessibilityInsights
+                  IsRegex: false
+              - bodyContains:
+                  pattern: Microsoft.Accessibility-Insights
+                  IsRegex: false
         then:
           - addLabel:
               label: Package-Flagged

--- a/.github/policies/flaggedPackages.yml
+++ b/.github/policies/flaggedPackages.yml
@@ -171,7 +171,7 @@ configuration:
                   pattern: "(?in)Microsoft[ .]Accessibility[ -]?Insights"
                   isRegex: true
               - bodyContains:
-                  pattern: "(?in)Microsoft\.Accessibility-?Insights"
+                  pattern: "(?in)Microsoft\\.Accessibility-?Insights"
                   IsRegex: true
         then:
           - addLabel:

--- a/.github/policies/flaggedPackages.yml
+++ b/.github/policies/flaggedPackages.yml
@@ -171,7 +171,7 @@ configuration:
                   pattern: "(?in)Microsoft[ .]Accessibility[ -]?Insights"
                   isRegex: true
               - bodyContains:
-                  pattern: "(?in)Microsoft[.]Accessibility-?Insights"
+                  pattern: "(?in)Microsoft.Accessibility-?Insights"
                   IsRegex: true
         then:
           - addLabel:


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
I learned about #59885 just now. Despite it being from back in 2023, and that development on their app ceased in 2025, the dev was angry enough back in 2023 that the dev got the point across to me three years later, at least.

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.