### PR TITLE
New version: aki-seven.ytdesktop version 1.0.1

### DIFF
--- a/manifests/a/aki-seven/ytdesktop/1.0.1/aki-seven.ytdesktop.installer.yaml
+++ b/manifests/a/aki-seven/ytdesktop/1.0.1/aki-seven.ytdesktop.installer.yaml
@@ -1,0 +1,16 @@
+PackageIdentifier: aki-seven.ytdesktop
+PackageVersion: 1.0.1
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+Installers:
+  - Architecture: x64
+    InstallerType: exe
+    InstallerUrl: https://github.com/aki-seven/ytdesktop/releases/download/v1.0.1/YouTube.Desktop.App-1.0.1.Setup.exe
+    InstallerSha256: 50F5EC35CD58B09309516724306D0A2F1127CAA3749DCE96AC4EC29046D3D03C
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/a/aki-seven/ytdesktop/1.0.1/aki-seven.ytdesktop.locale.en-US.yaml
+++ b/manifests/a/aki-seven/ytdesktop/1.0.1/aki-seven.ytdesktop.locale.en-US.yaml
@@ -1,0 +1,21 @@
+PackageIdentifier: aki-seven.ytdesktop
+PackageVersion: 1.0.1
+PackageLocale: en-US
+Publisher: aki-seven
+PublisherUrl: https://github.com/aki-seven
+PublisherSupportUrl: https://github.com/aki-seven/ytdesktop/issues
+PackageName: YouTube Desktop App
+PackageUrl: https://github.com/aki-seven/ytdesktop
+License: GPL-3.0-only
+LicenseUrl: https://github.com/aki-seven/ytdesktop/blob/main/LICENSE
+ShortDescription: A Desktop App for YouTube.
+Description: A desktop wrapper for YouTube with integrations (Discord Presence, Last.fm scrobbling, custom CSS, media keys, and more).
+Moniker: ytdesktop
+Tags:
+  - youtube
+  - electron
+  - desktop
+  - youtube-music
+  - media-player
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/a/aki-seven/ytdesktop/1.0.1/aki-seven.ytdesktop.yaml
+++ b/manifests/a/aki-seven/ytdesktop/1.0.1/aki-seven.ytdesktop.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: aki-seven.ytdesktop
+PackageVersion: 1.0.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## New version: aki-seven.ytdesktop version 1.0.1

Release: https://github.com/aki-seven/ytdesktop/releases/tag/v1.0.1

This updates the publisher from NovusTheory to aki-seven and adds built-in ad blocking.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/387697)