### PR TITLE
New package: owenlamont.ryl version 0.17.0

### DIFF
--- a/manifests/o/owenlamont/ryl/0.17.0/owenlamont.ryl.installer.yaml
+++ b/manifests/o/owenlamont/ryl/0.17.0/owenlamont.ryl.installer.yaml
@@ -1,5 +1,4 @@
-# Created using wingetcreate 1.12.8.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: owenlamont.ryl
 PackageVersion: 0.17.0
@@ -10,6 +9,7 @@ NestedInstallerFiles:
   PortableCommandAlias: ryl
 Commands:
 - ryl
+ReleaseDate: 2026-06-14
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/owenlamont/ryl/releases/download/v0.17.0/ryl-x86_64-pc-windows-msvc.zip
@@ -24,5 +24,4 @@ Installers:
     PackageDependencies:
     - PackageIdentifier: Microsoft.VCRedist.2015+.arm64
 ManifestType: installer
-ManifestVersion: 1.10.0
-ReleaseDate: 2026-06-14
+ManifestVersion: 1.12.0

--- a/manifests/o/owenlamont/ryl/0.17.0/owenlamont.ryl.installer.yaml
+++ b/manifests/o/owenlamont/ryl/0.17.0/owenlamont.ryl.installer.yaml
@@ -1,0 +1,28 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: owenlamont.ryl
+PackageVersion: 0.17.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: ryl.exe
+  PortableCommandAlias: ryl
+Commands:
+- ryl
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/owenlamont/ryl/releases/download/v0.17.0/ryl-x86_64-pc-windows-msvc.zip
+  InstallerSha256: B84E3D66B715B52FB846888A7C732BB4FDB8DAF6F3655B44AEB129D11955979D
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+- Architecture: arm64
+  InstallerUrl: https://github.com/owenlamont/ryl/releases/download/v0.17.0/ryl-aarch64-pc-windows-msvc.zip
+  InstallerSha256: FB928AE96D0E50244C6A959A8C0FA9B62D88A4E4AA066C4C49BC79A1C16F02F2
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.arm64
+ManifestType: installer
+ManifestVersion: 1.10.0
+ReleaseDate: 2026-06-14

--- a/manifests/o/owenlamont/ryl/0.17.0/owenlamont.ryl.locale.en-US.yaml
+++ b/manifests/o/owenlamont/ryl/0.17.0/owenlamont.ryl.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: owenlamont.ryl
+PackageVersion: 0.17.0
+PackageLocale: en-US
+Publisher: Owen Lamont
+PublisherUrl: https://github.com/owenlamont
+PublisherSupportUrl: https://github.com/owenlamont/ryl/issues
+Author: Owen Lamont
+PackageName: ryl
+PackageUrl: https://github.com/owenlamont/ryl
+License: MIT
+LicenseUrl: https://github.com/owenlamont/ryl/blob/main/LICENSE
+Copyright: Copyright (c) 2025 Owen Lamont
+ShortDescription: Fast YAML linter inspired by yamllint
+Description: ryl is a fast YAML linter written in Rust and inspired by yamllint. It implements yamllint's rule set plus ryl-only rules, uses a TOML-first configuration model, and supports safe auto-fixing (--fix), unified-diff previews (--diff), linting YAML embedded in Markdown, and multiple output formats including GitHub, JUnit, and GitLab Code Quality.
+Moniker: ryl
+Tags:
+- cli
+- lint
+- linter
+- rust
+- yaml
+- yamllint
+ReleaseNotesUrl: https://github.com/owenlamont/ryl/releases/tag/v0.17.0
+Documentations:
+- DocumentLabel: Docs
+  DocumentUrl: https://ryl-docs.pages.dev/
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/o/owenlamont/ryl/0.17.0/owenlamont.ryl.locale.en-US.yaml
+++ b/manifests/o/owenlamont/ryl/0.17.0/owenlamont.ryl.locale.en-US.yaml
@@ -1,5 +1,4 @@
-# Created using wingetcreate 1.12.8.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: owenlamont.ryl
 PackageVersion: 0.17.0
@@ -14,7 +13,12 @@ License: MIT
 LicenseUrl: https://github.com/owenlamont/ryl/blob/main/LICENSE
 Copyright: Copyright (c) 2025 Owen Lamont
 ShortDescription: Fast YAML linter inspired by yamllint
-Description: ryl is a fast YAML linter written in Rust and inspired by yamllint. It implements yamllint's rule set plus ryl-only rules, uses a TOML-first configuration model, and supports safe auto-fixing (--fix), unified-diff previews (--diff), linting YAML embedded in Markdown, and multiple output formats including GitHub, JUnit, and GitLab Code Quality.
+Description: >-
+  ryl is a fast YAML linter written in Rust and inspired by yamllint. It
+  implements yamllint's rule set plus ryl-only rules, uses a TOML-first
+  configuration model, and supports safe auto-fixing (--fix), unified-diff
+  previews (--diff), linting YAML embedded in Markdown, and multiple output
+  formats including GitHub, JUnit, and GitLab Code Quality.
 Moniker: ryl
 Tags:
 - cli
@@ -28,4 +32,4 @@ Documentations:
 - DocumentLabel: Docs
   DocumentUrl: https://ryl-docs.pages.dev/
 ManifestType: defaultLocale
-ManifestVersion: 1.10.0
+ManifestVersion: 1.12.0

--- a/manifests/o/owenlamont/ryl/0.17.0/owenlamont.ryl.yaml
+++ b/manifests/o/owenlamont/ryl/0.17.0/owenlamont.ryl.yaml
@@ -1,8 +1,7 @@
-# Created using wingetcreate 1.12.8.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: owenlamont.ryl
 PackageVersion: 0.17.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.10.0
+ManifestVersion: 1.12.0

--- a/manifests/o/owenlamont/ryl/0.17.0/owenlamont.ryl.yaml
+++ b/manifests/o/owenlamont/ryl/0.17.0/owenlamont.ryl.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: owenlamont.ryl
+PackageVersion: 0.17.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## 📖 Description

New package: `owenlamont.ryl` version 0.17.0. ryl is a fast YAML linter written in Rust (inspired by yamllint), shipped here as a portable zip containing `ryl.exe` for x64 and arm64.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/387703)
