### PR TITLE
New version: datap-rs.DataPress version 0.4.22

### DIFF
--- a/manifests/d/datap-rs/DataPress/0.4.22/datap-rs.DataPress.installer.yaml
+++ b/manifests/d/datap-rs/DataPress/0.4.22/datap-rs.DataPress.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: datap-rs.DataPress
+PackageVersion: 0.4.22
+MinimumOSVersion: 10.0.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: datapress.exe
+    PortableCommandAlias: datapress
+Commands:
+  - datapress
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/jeroenflvr/datapress/releases/download/v0.4.22/datapress-v0.4.22-x86_64-pc-windows-msvc.zip
+    InstallerSha256: F0206399921A1ECFCA185D53CF8361686320B0E1B5550978127C4E2DC31A42EE
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/d/datap-rs/DataPress/0.4.22/datap-rs.DataPress.locale.en-US.yaml
+++ b/manifests/d/datap-rs/DataPress/0.4.22/datap-rs.DataPress.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: datap-rs.DataPress
+PackageVersion: 0.4.22
+PackageLocale: en-US
+Publisher: DataPress
+PublisherUrl: https://datap-rs.org
+PublisherSupportUrl: https://github.com/jeroenflvr/datapress/issues
+PackageName: DataPress
+PackageUrl: https://datap-rs.org
+License: MIT
+LicenseUrl: https://github.com/jeroenflvr/datapress/blob/main/LICENSE
+ShortDescription: Fast multi-backend (DuckDB / DataFusion) HTTP server over Parquet and Delta datasets.
+Description: >-
+  DataPress turns Parquet and Delta datasets in object storage into fast, typed
+  HTTP APIs — JSON and Arrow IPC — backed by DuckDB or Apache Arrow + DataFusion.
+  The single `datapress` binary bundles both engines and selects one at runtime
+  from `server.backend` in your datasets.toml.
+Moniker: datapress
+Tags:
+  - parquet
+  - delta
+  - duckdb
+  - datafusion
+  - arrow
+  - http-api
+  - rust
+  - data
+ReleaseNotesUrl: https://github.com/jeroenflvr/datapress/releases/tag/v0.4.22
+Documentation:
+  - DocumentLabel: Documentation
+    DocumentUrl: https://docs.datap-rs.org
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/d/datap-rs/DataPress/0.4.22/datap-rs.DataPress.yaml
+++ b/manifests/d/datap-rs/DataPress/0.4.22/datap-rs.DataPress.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: datap-rs.DataPress
+PackageVersion: 0.4.22
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Bootstrap / first submission of datap-rs.DataPress

- PackageIdentifier: datap-rs.DataPress
- PackageVersion: 0.4.22

This supersedes the earlier #384447 (0.4.4), whose binary depended on the VC++ runtime (VCRUNTIME140_1.dll) and crashed on a clean Windows. The 0.4.22 server binary is statically linked against the CRT and imports no VC++ runtime DLLs.

### Checklist
- [x] Manifest validated against schema 1.6.0
- [x] InstallerSha256 matches the released asset
- [x] Portable zip (nested datapress.exe) with command alias `datapress`

I will close #384447 in favor of this PR.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/387710)