### PR TITLE
Docutaz 2.1.1

### DIFF
--- a/manifests/i/Illimitable/Docutaz/2.1.1/Illimitable.Docutaz.installer.yaml
+++ b/manifests/i/Illimitable/Docutaz/2.1.1/Illimitable.Docutaz.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 PackageIdentifier: Illimitable.Docutaz
 PackageVersion: 2.1.1
 InstallerType: nullsoft
@@ -11,4 +11,4 @@ Installers:
     InstallerUrl: https://github.com/Illimitable-Consulting-Private-Limited/docutaz/releases/download/v2.1.1/docutaz-2.1.1-windows-x86_64-setup.exe
     InstallerSha256: FB28EA849C0C0A7DD16EBC56949F796461903A8C4002D7C3A59D569A824BA4C9
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/i/Illimitable/Docutaz/2.1.1/Illimitable.Docutaz.installer.yaml
+++ b/manifests/i/Illimitable/Docutaz/2.1.1/Illimitable.Docutaz.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Illimitable.Docutaz
+PackageVersion: 2.1.1
+InstallerType: nullsoft
+Scope: machine
+InstallModes:
+  - silent
+  - silentWithProgress
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Illimitable-Consulting-Private-Limited/docutaz/releases/download/v2.1.1/docutaz-2.1.1-windows-x86_64-setup.exe
+    InstallerSha256: FB28EA849C0C0A7DD16EBC56949F796461903A8C4002D7C3A59D569A824BA4C9
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/i/Illimitable/Docutaz/2.1.1/Illimitable.Docutaz.locale.en-US.yaml
+++ b/manifests/i/Illimitable/Docutaz/2.1.1/Illimitable.Docutaz.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 PackageIdentifier: Illimitable.Docutaz
 PackageVersion: 2.1.1
 PackageLocale: en-US
@@ -24,4 +24,4 @@ Tags:
   - gui
   - dba
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/i/Illimitable/Docutaz/2.1.1/Illimitable.Docutaz.locale.en-US.yaml
+++ b/manifests/i/Illimitable/Docutaz/2.1.1/Illimitable.Docutaz.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Illimitable.Docutaz
+PackageVersion: 2.1.1
+PackageLocale: en-US
+Publisher: Illimitable Consulting Private Limited
+PublisherUrl: https://illimitable.in
+PublisherSupportUrl: https://github.com/Illimitable-Consulting-Private-Limited/docutaz/issues
+PackageName: Docutaz
+PackageUrl: https://illimitable-consulting-private-limited.github.io/docutaz/
+License: GPL-3.0-only
+LicenseUrl: https://github.com/Illimitable-Consulting-Private-Limited/docutaz/blob/main/LICENSE
+ShortDescription: Cross-platform MongoDB management tool (MongoDB 8+ GUI).
+Description: >-
+  Docutaz is a cross-platform desktop GUI for MongoDB 8+, a maintained fork of
+  Robomongo / Robo 3T. It provides a shell, query editor, result tree/table/text
+  views, query history, connection environment colours, and connection
+  management including mongodb+srv:// (Atlas) support.
+Moniker: docutaz
+Tags:
+  - mongodb
+  - mongo
+  - database
+  - nosql
+  - gui
+  - dba
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/i/Illimitable/Docutaz/2.1.1/Illimitable.Docutaz.yaml
+++ b/manifests/i/Illimitable/Docutaz/2.1.1/Illimitable.Docutaz.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Illimitable.Docutaz
+PackageVersion: 2.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0

--- a/manifests/i/Illimitable/Docutaz/2.1.1/Illimitable.Docutaz.yaml
+++ b/manifests/i/Illimitable/Docutaz/2.1.1/Illimitable.Docutaz.yaml
@@ -1,6 +1,6 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 PackageIdentifier: Illimitable.Docutaz
 PackageVersion: 2.1.1
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Title:
New package: Illimitable.Docutaz version 2.1.1

Body:
## 📖 Description

New package submission: **Illimitable.Docutaz** version **2.1.1**.

Docutaz — a cross-platform desktop GUI for MongoDB 8+, a maintained fork of
Robomongo / Robo 3T. Initial submission of the package.

- Installer: NSIS (nullsoft), x64, machine scope, silent install via `/S`
- License: GPL-3.0-only
- Release: https://github.com/Illimitable-Consulting-Private-Limited/docutaz/releases/tag/v2.1.1

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  - N/A

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/387716)