### PR TITLE
New package: Darknetzz.rustdl version 0.7.0

### DIFF
--- a/manifests/d/Darknetzz/rustdl/0.7.0/Darknetzz.rustdl.installer.yaml
+++ b/manifests/d/Darknetzz/rustdl/0.7.0/Darknetzz.rustdl.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: Darknetzz.rustdl
+PackageVersion: 0.7.0
+InstallerType: portable
+Commands:
+  - rustdl
+ReleaseDate: 2026-06-14
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Darknetzz/rustdl/releases/download/rustdl-v0.7.0/rustdl.exe
+    InstallerSha256: 654DC5B7823C5D671DB52954BEF1C4370281B123911DC33F44590BBF9ED512AF
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/d/Darknetzz/rustdl/0.7.0/Darknetzz.rustdl.locale.en-US.yaml
+++ b/manifests/d/Darknetzz/rustdl/0.7.0/Darknetzz.rustdl.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: Darknetzz.rustdl
+PackageVersion: 0.7.0
+PackageLocale: en-US
+Publisher: Darknetzz
+PublisherUrl: https://github.com/Darknetzz
+PublisherSupportUrl: https://github.com/Darknetzz/rustdl/issues
+PackageName: rustdl
+PackageUrl: https://github.com/Darknetzz/rustdl
+License: MIT
+LicenseUrl: https://github.com/Darknetzz/rustdl/blob/dev/LICENSE
+ShortDescription: Desktop GUI for yt-dlp with Video Converter and LAN web UI
+Description: |-
+  rustdl is a desktop application for managing yt-dlp download queues, with an optional LAN web UI and a built-in Video Converter (ffmpeg).
+Moniker: rustdl
+Tags:
+  - downloader
+  - ffmpeg
+  - gui
+  - yt-dlp
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/d/Darknetzz/rustdl/0.7.0/Darknetzz.rustdl.yaml
+++ b/manifests/d/Darknetzz/rustdl/0.7.0/Darknetzz.rustdl.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: Darknetzz.rustdl
+PackageVersion: 0.7.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## New package: Darknetzz.rustdl 0.7.0

Desktop GUI for yt-dlp with Video Converter and LAN web UI.

- **Publisher:** Darknetzz
- **Release:** https://github.com/Darknetzz/rustdl/releases/tag/rustdl-v0.7.0
- **Installer:** portable x64 ustdl.exe from GitHub Releases
- **License:** MIT

Validated locally with \winget validate --manifest manifests/d/Darknetzz/rustdl/0.7.0\.

Made with [Cursor](https://cursor.com)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/387826)