### PR TITLE
New package: edwardlthompson.SpatialLabsOptimizer version 1.0.1

### DIFF
--- a/manifests/e/edwardlthompson/SpatialLabsOptimizer/1.0.1/edwardlthompson.SpatialLabsOptimizer.installer.yaml
+++ b/manifests/e/edwardlthompson/SpatialLabsOptimizer/1.0.1/edwardlthompson.SpatialLabsOptimizer.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: edwardlthompson.SpatialLabsOptimizer
+PackageVersion: 1.0.1
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.19041.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: SpatialLabsOptimizer.exe
+    PortableCommandAlias: spatiallabs-optimizer
+  - RelativeFilePath: SpatialLabsOptimizer.ElevatedHelper.exe
+Scope: user
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/edwardlthompson/3d-game-optimizer/releases/download/SpatialLabsOptimizer-v1.0.1/SpatialLabsOptimizer-1.0.1-win-x64.zip
+    InstallerSha256: aa8414d4071e3439095080f43f8d15eaeb726c1c1858cd692412d0a2f4d4933f
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/e/edwardlthompson/SpatialLabsOptimizer/1.0.1/edwardlthompson.SpatialLabsOptimizer.locale.en-US.yaml
+++ b/manifests/e/edwardlthompson/SpatialLabsOptimizer/1.0.1/edwardlthompson.SpatialLabsOptimizer.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: edwardlthompson.SpatialLabsOptimizer
+PackageVersion: 1.0.1
+PackageLocale: en-US
+Publisher: Edward Thompson
+PublisherUrl: https://github.com/edwardlthompson
+PublisherSupportUrl: https://github.com/edwardlthompson/3d-game-optimizer/issues
+PackageName: 3D Game Optimizer
+PackageUrl: https://github.com/edwardlthompson/3d-game-optimizer
+License: MIT
+LicenseUrl: https://github.com/edwardlthompson/3d-game-optimizer/blob/main/LICENSE
+ShortDescription: One-click glasses-free 3D PC gaming hub for SpatialLabs and Odyssey 3D displays
+Description: Discovery-first Steam library, silent toolchain setup, and zero-friction Play in 3D launch for SpatialLabs and Samsung Odyssey 3D monitors.
+Moniker: 3d-game-optimizer
+Tags:
+  - 3d
+  - gaming
+  - steam
+  - spatiallabs
+  - winui
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/e/edwardlthompson/SpatialLabsOptimizer/1.0.1/edwardlthompson.SpatialLabsOptimizer.yaml
+++ b/manifests/e/edwardlthompson/SpatialLabsOptimizer/1.0.1/edwardlthompson.SpatialLabsOptimizer.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: edwardlthompson.SpatialLabsOptimizer
+PackageVersion: 1.0.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary

Adds **3D Game Optimizer** (SpatialLabs Optimizer) v1.0.1 — a glasses-free 3D PC gaming hub for SpatialLabs and Samsung Odyssey 3D displays.

- **PackageIdentifier:** \dwardlthompson.SpatialLabsOptimizer\
- **Installer:** self-contained win-x64 zip (portable)
- **Release:** https://github.com/edwardlthompson/3d-game-optimizer/releases/tag/SpatialLabsOptimizer-v1.0.1
- **SHA256:** \a8414d4071e3439095080f43f8d15eaeb726c1c1858cd692412d0a2f4d4933f\

## Checklist

- [x] Manifest follows 1.6.0 multi-file schema
- [x] InstallerSha256 verified against release artifact digest
- [ ] **Note:** Source repo is currently private — validation may fail until the release URL is publicly accessible. Maintainer will make the repo public before merge if required.

## Test plan

- [ ] \winget validate\ on manifest triplet
- [ ] \winget install edwardlthompson.SpatialLabsOptimizer\ after merge

Made with [Cursor](https://cursor.com)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/387878)