### PR TITLE
New package: CloudCDN.Stratos version 0.0.19

### DIFF
--- a/manifests/c/CloudCDN/Stratos/0.0.19/CloudCDN.Stratos.installer.yaml
+++ b/manifests/c/CloudCDN/Stratos/0.0.19/CloudCDN.Stratos.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# SPDX-License-Identifier: MIT
+
+PackageIdentifier: CloudCDN.Stratos
+PackageVersion: 0.0.19
+InstallerType: portable
+Commands:
+  - stratos
+ReleaseDate: 2026-06-14
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/sebastienrousseau/stratos/releases/download/v0.0.19/stratos-win-x64.exe
+    InstallerSha256: 318A6807F5E34A18AAC5E35E198DDFFCE1116A86487AA3607A6A46DE71F1EA0F
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: stratos-win-x64.exe
+        PortableCommandAlias: stratos
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/CloudCDN/Stratos/0.0.19/CloudCDN.Stratos.locale.en-US.yaml
+++ b/manifests/c/CloudCDN/Stratos/0.0.19/CloudCDN.Stratos.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# SPDX-License-Identifier: MIT
+
+PackageIdentifier: CloudCDN.Stratos
+PackageVersion: 0.0.19
+PackageLocale: en-US
+Publisher: CloudCDN
+PublisherUrl: https://cloudcdn.pro
+PublisherSupportUrl: https://github.com/sebastienrousseau/stratos/issues
+Author: Sebastien Rousseau
+PackageName: Stratos
+PackageUrl: https://github.com/sebastienrousseau/stratos
+License: MIT
+LicenseUrl: https://github.com/sebastienrousseau/stratos/blob/main/LICENSE
+ShortDescription: Official command-line client for CloudCDN.
+Description: |-
+  Stratos is the official command-line client and Node ESM library for CloudCDN.
+  ~30 commands across the full control plane (purge, signed URLs, assets, insights,
+  zones, tokens, webhooks, rules, storage, logs, AI, image transforms), an MCP
+  stdio server, OpenTelemetry export, OS-keychain auth, shell completions, and a
+  100%-tested zero-dependency single-file Node ≥ 20 implementation.
+Tags:
+  - cdn
+  - cli
+  - cloudcdn
+  - mcp
+  - opentelemetry
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/CloudCDN/Stratos/0.0.19/CloudCDN.Stratos.yaml
+++ b/manifests/c/CloudCDN/Stratos/0.0.19/CloudCDN.Stratos.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# SPDX-License-Identifier: MIT
+
+PackageIdentifier: CloudCDN.Stratos
+PackageVersion: 0.0.19
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
First-version submission for `CloudCDN.Stratos`. Supersedes the prior attempt at v0.0.13 (microsoft/winget-pkgs#382755, closed unmerged after manual validation found `stratos --version` produced empty output).

## What changed since the v0.0.13 attempt

The silent-stdout bug was a script-entrypoint-guard mismatch inside the Bun-compiled binary — the upstream Stratos's `stratos.mjs` checked `fileURLToPath(import.meta.url) === process.argv[1]`, but in a `bun --compile` artefact the former resolves into `$bunfs` and never equals the .exe path on disk. So `main()` never ran and every stdio write was dead code.

Root cause writeup: [Stratos CHANGELOG v0.0.19 entry](https://github.com/sebastienrousseau/stratos/blob/main/CHANGELOG.md#0019--2026-06-14).

Fix: `typeof Bun !== 'undefined'` in addition to the Node check. Verified end-to-end by the upstream release pipeline's `smoke-verify (windows-latest, binary-win-x64)` cell, which downloads the published `.exe` from each new GitHub release and asserts the version banner — exactly the manual test the v0.0.13 review correctly did by hand.

## Verification recipe

```powershell
PS> winget install CloudCDN.Stratos --accept-source-agreements --accept-package-agreements
PS> stratos --version
stratos v0.0.19
PS> stratos --help
# Prints root help text
PS> Get-ARPTable stratos | Format-Table DisplayName, DisplayVersion
DisplayName  DisplayVersion
-----------  --------------
Stratos      0.0.19
```

## Manifest specifics

| Field | Value |
|---|---|
| Manifest schema | 1.12.0 |
| Installer type | portable |
| Architecture | x64 |
| Installer URL | `https://github.com/sebastienrousseau/stratos/releases/download/v0.0.19/stratos-win-x64.exe` |
| Installer SHA-256 | (in the manifest; matches the GitHub-attached artefact) |
| PortableCommandAlias | `stratos` |

## Upstream provenance

- Source: https://github.com/sebastienrousseau/stratos
- Release: https://github.com/sebastienrousseau/stratos/releases/tag/v0.0.19
- SLSA L3 attestation: `stratos-v0.0.19.intoto.jsonl` (attached to release)
- Cosign keyless signature: `.sig` + `.crt` for `stratos-win-x64.exe` (attached to release)
- npm provenance: `npm audit signatures @cloudcdn/stratos@0.0.19`
- OpenSSF Scorecard: [view](https://scorecard.dev/viewer/?uri=github.com/sebastienrousseau/stratos)

## What lands after this merges

The Stratos release pipeline's existing `winget-submit` job auto-bumps every subsequent release via `vedantmgoyal9/winget-releaser@v2`, so this is a one-time manual submission. From v0.0.20 onwards the bot opens the PR.

CC @stephengillie — many thanks for the careful review on PR #382755 that surfaced this bug.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/387880)