### PR TITLE
New package: packetThrower.Zorite version 0.1.0

### DIFF
--- a/manifests/p/packetThrower/Zorite/0.1.0/packetThrower.Zorite.installer.yaml
+++ b/manifests/p/packetThrower/Zorite/0.1.0/packetThrower.Zorite.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: packetThrower.Zorite
+PackageVersion: 0.1.0
+InstallerType: nullsoft
+InstallModes:
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-06-15
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/packetThrower/zorite/releases/download/v0.1.0/zorite_0.1.0_x64-setup.exe
+    InstallerSha256: 249CF597A860A8F0E410778CE1FD712444D63E119E1C0E86111EFB0849B7C269
+  - Architecture: arm64
+    InstallerUrl: https://github.com/packetThrower/zorite/releases/download/v0.1.0/zorite_0.1.0_arm64-setup.exe
+    InstallerSha256: 5E30BFEC74B2A8E65E0C6ABD85528FCF4D5543968F061A034CF1207F7B47D179
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/p/packetThrower/Zorite/0.1.0/packetThrower.Zorite.locale.en-US.yaml
+++ b/manifests/p/packetThrower/Zorite/0.1.0/packetThrower.Zorite.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: packetThrower.Zorite
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: packetThrower
+PublisherUrl: https://github.com/packetThrower
+PublisherSupportUrl: https://github.com/packetThrower/zorite/issues
+PackageName: Zorite
+PackageUrl: https://github.com/packetThrower/zorite
+License: GPL-3.0
+LicenseUrl: https://github.com/packetThrower/zorite/blob/main/LICENSE
+Copyright: Copyright (c) 2026 packetThrower
+ShortDescription: Local-first, Logseq-style daily-journal and outliner note app
+Description: |-
+  Zorite is a local-first daily-journal and outliner note app inspired by Logseq.
+  It stores notes as Markdown in a local SQLite database and pairs an infinite-scroll
+  journal with whiteboards, a PDF viewer, full-text search, and wiki-style page links
+  and aliases. Built in Rust on GPUI with a custom Markdown renderer.
+Moniker: zorite
+Tags:
+  - notes
+  - note-taking
+  - journal
+  - outliner
+  - markdown
+  - logseq
+  - productivity
+  - knowledge-base
+ReleaseNotesUrl: https://github.com/packetThrower/zorite/releases/tag/v0.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/p/packetThrower/Zorite/0.1.0/packetThrower.Zorite.yaml
+++ b/manifests/p/packetThrower/Zorite/0.1.0/packetThrower.Zorite.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: packetThrower.Zorite
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: `packetThrower.Zorite` version `0.1.0`

First submission of **Zorite** — a local-first, Logseq-style daily-journal and outliner note app (Rust + GPUI + SQLite, with a custom Markdown renderer).

- Publisher: https://github.com/packetThrower
- Repository: https://github.com/packetThrower/zorite
- Release: https://github.com/packetThrower/zorite/releases/tag/v0.1.0

Installers are NSIS (`nullsoft`) setup executables for **x64** and **arm64**, published as GitHub release assets.

#### Notes for reviewers
- [x] Adds a single new package with `version`, `installer`, and `defaultLocale` manifests (schema `1.6.0`).
- [x] `InstallerSha256` values were taken from the release's `SHA256SUMS` and verified against the published assets.
- [x] Installer URLs are public, immutable GitHub release-download assets.
- [ ] CLA — will be signed via the CLA bot once this PR is opened.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/387921)