### PR TITLE
Add Esubaalew.Run version 0.9.1

### DIFF
--- a/manifests/e/Esubaalew/Run/0.9.1/Esubaalew.Run.installer.yaml
+++ b/manifests/e/Esubaalew/Run/0.9.1/Esubaalew.Run.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Esubaalew.Run
+PackageVersion: 0.9.1
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: run.exe
+ReleaseDate: 2026-05-15
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Esubaalew/run/releases/download/v0.9.1/run-x86_64-pc-windows-msvc-v0.9.1.zip
+  InstallerSha256: 11F98C1E5C7C75722AF12675C3A1D5653860A5CF6282CE69A1E23EE16ABD2F86
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/e/Esubaalew/Run/0.9.1/Esubaalew.Run.installer.yaml
+++ b/manifests/e/Esubaalew/Run/0.9.1/Esubaalew.Run.installer.yaml
@@ -6,6 +6,7 @@ InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
 - RelativeFilePath: run.exe
+  PortableCommandAlias: run
 ReleaseDate: 2026-05-15
 Installers:
 - Architecture: x64

--- a/manifests/e/Esubaalew/Run/0.9.1/Esubaalew.Run.locale.en-US.yaml
+++ b/manifests/e/Esubaalew/Run/0.9.1/Esubaalew.Run.locale.en-US.yaml
@@ -9,7 +9,7 @@ PublisherSupportUrl: https://github.com/Esubaalew/run/issues
 PackageName: run
 PackageUrl: https://github.com/Esubaalew/run
 License: Apache-2.0
-LicenseUrl: https://github.com/Esubaalew/run/blob/HEAD/LICENSE
+LicenseUrl: https://github.com/Esubaalew/run/blob/v0.9.1/LICENSE
 ShortDescription: Universal multi-language runner and smart REPL
 Description: Run is a universal multi-language runner and smart REPL for executing code snippets, scripts, and interactive sessions across 25+ languages.
 Moniker: run

--- a/manifests/e/Esubaalew/Run/0.9.1/Esubaalew.Run.locale.en-US.yaml
+++ b/manifests/e/Esubaalew/Run/0.9.1/Esubaalew.Run.locale.en-US.yaml
@@ -1,0 +1,42 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Esubaalew.Run
+PackageVersion: 0.9.1
+PackageLocale: en-US
+Publisher: Esubaalew
+PublisherUrl: https://github.com/Esubaalew
+PublisherSupportUrl: https://github.com/Esubaalew/run/issues
+PackageName: run
+PackageUrl: https://github.com/Esubaalew/run
+License: Apache-2.0
+LicenseUrl: https://github.com/Esubaalew/run/blob/HEAD/LICENSE
+ShortDescription: Universal multi-language runner and smart REPL
+Description: Run is a universal multi-language runner and smart REPL for executing code snippets, scripts, and interactive sessions across 25+ languages.
+Moniker: run
+Tags:
+- cli
+- repl
+- runner
+- scripting
+ReleaseNotes: |-
+  v0.9.1 - 2026-05-15
+  Fixed
+  - Added run alias list so alias discovery is handled by the CLI instead of being misrouted as Python source.
+
+  v0.9.0 - 2026-05-14
+  Changed
+  - Bumped the crate for the full deep-strike release prep pass.
+  - Added workflow command summaries to run --help so doctor, cache, fmt, snippet, watch, and share are discoverable from Clap help output.
+  Fixed
+  - Rebuilt the global C++ precompiled-header cache per compiler identity, preventing stale .gch files from breaking C++ execution after Clang/Xcode upgrades.
+
+  v0.8.0 - 2026-05-13
+  Added
+  - Added run doctor, run cache, run fmt, run snippet, run watch, and run share workflows.
+  - Added --json execution output and --timeout handling.
+  Changed
+  - Replaced the legacy temp compile cache with a blake3, toolchain-aware cache.
+  - Moved REPL history to per-language XDG/AppData history files.
+ReleaseNotesUrl: https://github.com/Esubaalew/run/releases/tag/v0.9.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/e/Esubaalew/Run/0.9.1/Esubaalew.Run.yaml
+++ b/manifests/e/Esubaalew/Run/0.9.1/Esubaalew.Run.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Esubaalew.Run
+PackageVersion: 0.9.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Summary
- Add winget manifests for Esubaalew.Run 0.9.1.
- Point the x64 portable zip installer to the v0.9.1 GitHub release asset.
- Refresh release date, release notes, and installer SHA256.

## Validation
- Parsed all three YAML manifests successfully.
- Verified PackageVersion, InstallerUrl, and InstallerSha256 fields.
- Matched InstallerSha256 against the GitHub release asset digest.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/387969)