### PR TITLE
New version: Jabe.yolomover version 2.1.1

### DIFF
--- a/manifests/j/Jabe/yolomover/2.1.1/Jabe.yolomover.installer.yaml
+++ b/manifests/j/Jabe/yolomover/2.1.1/Jabe.yolomover.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Jabe.yolomover
+PackageVersion: 2.1.1
+InstallerType: portable
+UpgradeBehavior: install
+Commands:
+  - yolomover
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+ReleaseDate: 2026-06-15
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Jabe/yolomover/releases/download/v2.1.1/yolomover-v2.1.1-x86_64-pc-windows-msvc.exe
+    InstallerSha256: 12D71FDCF7F00E621A2B98B5874F2295B7F1632A3F357BB08A0352B23959B488
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/j/Jabe/yolomover/2.1.1/Jabe.yolomover.locale.en-US.yaml
+++ b/manifests/j/Jabe/yolomover/2.1.1/Jabe.yolomover.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Jabe.yolomover
+PackageVersion: 2.1.1
+PackageLocale: en-US
+Publisher: Jabe
+PublisherUrl: https://github.com/Jabe
+PublisherSupportUrl: https://github.com/Jabe/yolomover/issues
+PackageName: yolomover
+PackageUrl: https://github.com/Jabe/yolomover
+License: MIT
+LicenseUrl: https://github.com/Jabe/yolomover/blob/master/LICENSE-MIT
+ShortDescription: Move the Windows Recovery partition to the end of the disk
+Description: |-
+  Move the Windows Recovery partition to the end of the disk so you can extend the boot volume — without manually chaining reagentc, a partition GUI, and extend every time.
+
+  Requires Windows 10/11, GPT system disk, and administrator elevation. Use inspect and plan before relocate and extend.
+Moniker: yolomover
+Tags:
+  - gpt
+  - partition
+  - recovery
+  - windows
+  - winre
+ReleaseNotes: |-
+  - Volume lock and dismount now engage before the recovery partition is relocated
+  - Fixed a crash on disks with multi-extent volumes or non-standard GPT layouts
+  - Correct WinRE re-registration when the recovery partition precedes the system volume
+  - Storage stack is refreshed immediately after the partition table is rewritten
+ReleaseNotesUrl: https://github.com/Jabe/yolomover/releases/tag/v2.1.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/j/Jabe/yolomover/2.1.1/Jabe.yolomover.yaml
+++ b/manifests/j/Jabe/yolomover/2.1.1/Jabe.yolomover.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Jabe.yolomover
+PackageVersion: 2.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Update yolomover (`Jabe.yolomover`) to version **2.1.1**.

Adds three manifests under `manifests/j/Jabe/yolomover/2.1.1/` (portable, x64). Field-for-field identical to the accepted 2.1.0 manifests except version, release date, installer URL, installer SHA256, and release notes. The installer URL resolves (HTTP 200) and its SHA256 matches the bytes served. Validated and installed locally on a Windows VM.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/388028)