### PR TITLE
Added additional installer: Microsoft.VCRedist.2015+.x64 version 14.51.36247.0

### DIFF
--- a/manifests/m/Microsoft/VCRedist/2015+/x64/14.51.36247.0/Microsoft.VCRedist.2015+.x64.installer.yaml
+++ b/manifests/m/Microsoft/VCRedist/2015+/x64/14.51.36247.0/Microsoft.VCRedist.2015+.x64.installer.yaml
@@ -28,5 +28,6 @@ Installers:
   InstallerSha256: 843068991DAAA1F73AD9F6239BCE4D0F6A07A51F18C37EA2A867E9BECA71295C
   UnsupportedOSArchitectures:
   - x64
+  - arm64
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/m/Microsoft/VCRedist/2015+/x64/14.51.36247.0/Microsoft.VCRedist.2015+.x64.installer.yaml
+++ b/manifests/m/Microsoft/VCRedist/2015+/x64/14.51.36247.0/Microsoft.VCRedist.2015+.x64.installer.yaml
@@ -26,5 +26,7 @@ Installers:
 - Architecture: x86
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/ebdab8e5-1d7b-4d9f-a11b-cbb1720c3b12/843068991DAAA1F73AD9F6239BCE4D0F6A07A51F18C37EA2A867E9BECA71295C/VC_redist.x64.exe
   InstallerSha256: 843068991DAAA1F73AD9F6239BCE4D0F6A07A51F18C37EA2A867E9BECA71295C
+  UnsupportedOSArchitectures:
+  - x64
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/m/Microsoft/VCRedist/2015+/x64/14.51.36247.0/Microsoft.VCRedist.2015+.x64.installer.yaml
+++ b/manifests/m/Microsoft/VCRedist/2015+/x64/14.51.36247.0/Microsoft.VCRedist.2015+.x64.installer.yaml
@@ -24,5 +24,8 @@ Installers:
   Architecture: x64
   InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/ebdab8e5-1d7b-4d9f-a11b-cbb1720c3b12/843068991DAAA1F73AD9F6239BCE4D0F6A07A51F18C37EA2A867E9BECA71295C/VC_redist.x64.exe
   InstallerSha256: 843068991DAAA1F73AD9F6239BCE4D0F6A07A51F18C37EA2A867E9BECA71295C
+- Architecture: x86
+  InstallerUrl: https://download.visualstudio.microsoft.com/download/pr/ebdab8e5-1d7b-4d9f-a11b-cbb1720c3b12/843068991DAAA1F73AD9F6239BCE4D0F6A07A51F18C37EA2A867E9BECA71295C/VC_redist.x64.exe
+  InstallerSha256: 843068991DAAA1F73AD9F6239BCE4D0F6A07A51F18C37EA2A867E9BECA71295C
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/m/Microsoft/VCRedist/2015+/x64/14.51.36247.0/Microsoft.VCRedist.2015+.x64.installer.yaml
+++ b/manifests/m/Microsoft/VCRedist/2015+/x64/14.51.36247.0/Microsoft.VCRedist.2015+.x64.installer.yaml
@@ -1,4 +1,3 @@
-# Created with YamlCreate.ps1 Dumplings Mod
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: Microsoft.VCRedist.2015+.x64


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
I noticed by chance in my W10 x86 VM today that, for some otherworldly reason, the v14 x64 runtime is in fact able to install normally on an x86 OS.

So I figured I should update the manifest accordingly.

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [ ] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/388059)