### PR TITLE
New package: CrewHaus.CLI version 0.1.3

### DIFF
--- a/manifests/c/CrewHaus/CLI/0.1.3/CrewHaus.CLI.installer.yaml
+++ b/manifests/c/CrewHaus/CLI/0.1.3/CrewHaus.CLI.installer.yaml
@@ -1,0 +1,12 @@
+PackageIdentifier: CrewHaus.CLI
+PackageVersion: 0.1.3
+InstallerType: portable
+Commands:
+  - crewhaus
+ReleaseDate: 2026-06-15
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/crewhaus/factory/releases/download/v0.1.3/crewhaus-windows-x64-0.1.3.exe
+    InstallerSha256: 91915FE31A2B797CB69E4E9231C1CEAC79338C6FE3BD0174231A3FDC35795C44
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/c/CrewHaus/CLI/0.1.3/CrewHaus.CLI.locale.en-US.yaml
+++ b/manifests/c/CrewHaus/CLI/0.1.3/CrewHaus.CLI.locale.en-US.yaml
@@ -1,0 +1,25 @@
+PackageIdentifier: CrewHaus.CLI
+PackageVersion: 0.1.3
+PackageLocale: en-US
+Publisher: CrewHaus
+PublisherUrl: https://crewhaus.ai
+PublisherSupportUrl: https://github.com/crewhaus/factory/issues
+PackageName: crewhaus
+PackageUrl: https://github.com/crewhaus/factory
+License: Apache-2.0
+LicenseUrl: https://github.com/crewhaus/factory/blob/main/LICENSE
+Copyright: Copyright (c) Max Meier (StudioMax)
+ShortDescription: Modular meta-harness — compile a single spec into multiple agent runtimes.
+Description: CrewHaus compiles a single high-level harness spec (crewhaus.yaml) into multiple runtime targets — CLI agent, channel bot, RAG pipeline, multi-agent crew, eval harness, voice/realtime agent, browser/computer-use agent, and more.
+Moniker: crewhaus
+Tags:
+  - ai
+  - agent
+  - llm
+  - cli
+  - compiler
+  - meta-harness
+  - claude
+ReleaseNotesUrl: https://github.com/crewhaus/factory/releases/tag/v0.1.3
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/c/CrewHaus/CLI/0.1.3/CrewHaus.CLI.yaml
+++ b/manifests/c/CrewHaus/CLI/0.1.3/CrewHaus.CLI.yaml
@@ -1,0 +1,6 @@
+# Created for crewhaus 0.1.3
+PackageIdentifier: CrewHaus.CLI
+PackageVersion: 0.1.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## New package — CrewHaus.CLI 0.1.3

`crewhaus` is the open-source meta-harness compiler for AI agents (Apache-2.0). This adds the standalone Windows x64 portable binary.

- Installer: portable single binary from the official GitHub Release (`crewhaus-windows-x64-0.1.3.exe`)
- SHA256 verified against the published release asset
- Command alias: `crewhaus`
- Manifests: ManifestVersion 1.6.0 (version + installer + en-US locale)

### Checklist
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] This PR only modifies one (1) manifest
- [x] Manifests validate against the schema
- [x] Installer URL is the publisher's official release
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/388067)