### PR TITLE
New version: Feci.ParleyDeckCli version 1.27.0

### DIFF
--- a/manifests/f/Feci/ParleyDeckCli/1.27.0/Feci.ParleyDeckCli.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.27.0/Feci.ParleyDeckCli.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.27.0
+InstallerType: portable
+Commands:
+- parley
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.27.0/parley-v1.27.0-windows-x64.exe
+  InstallerSha256: 531EC488CB79FA747F03B0F3E479EE5DC88D8A669D68F5613FF6058D0C7E3783
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.27.0/parley-v1.27.0-windows-arm64.exe
+  InstallerSha256: 5371C62B737BE2718722F6B6789807F6D824B85350B9BDBB9AABFFE4741BF6FC
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.27.0/Feci.ParleyDeckCli.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.27.0/Feci.ParleyDeckCli.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.27.0
+PackageLocale: en-US
+Publisher: Feci
+PublisherUrl: https://github.com/feci
+PackageName: Parley Deck CLI
+PackageUrl: https://github.com/feci/parley-deck-cli
+License: Apache-2.0
+LicenseUrl: https://github.com/feci/parley-deck-cli/blob/main/LICENSE
+ShortDescription: CLI that orchestrates Parley Deck multi-agent cooperation workflows.
+Description: parley orchestrates multi-agent Parley Deck cooperation: it kicks off ideas, runs deliberation rounds across local CLI agents, drives consensus/finalize/implementation, and shows live state in a TUI. Auto-drive is on by default and advances the protocol under every transport; the /run command advances on demand.
+ReleaseNotesUrl: https://github.com/feci/parley-deck-cli/releases/tag/v1.27.0
+Tags:
+- ai
+- agents
+- agy
+- claude
+- cli
+- codex
+- consensus
+- multi-agent
+- orchestration
+- tui
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.27.0/Feci.ParleyDeckCli.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.27.0/Feci.ParleyDeckCli.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.27.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New version

- **Package**: Feci.ParleyDeckCli 1.27.0
- **Type**: portable (command: `parley`), x64 + arm64
- **Installers**: GitHub release assets for v1.27.0 (verified reachable; SHA256 from the published `.exe` files)

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/388088)