### PR TITLE
New package: packetThrower.Zorite version 0.1.1

### DIFF
--- a/manifests/p/packetThrower/Zorite/0.1.1/packetThrower.Zorite.installer.yaml
+++ b/manifests/p/packetThrower/Zorite/0.1.1/packetThrower.Zorite.installer.yaml
@@ -1,19 +1,30 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: packetThrower.Zorite
 PackageVersion: 0.1.1
-InstallerType: nullsoft
+ReleaseDate: 2026-06-15
 InstallModes:
+  - interactive
   - silent
   - silentWithProgress
-UpgradeBehavior: install
-ReleaseDate: 2026-06-15
 Installers:
   - Architecture: x64
-    InstallerUrl: https://github.com/packetThrower/zorite/releases/download/v0.1.1/zorite_0.1.1_x64-setup.exe
-    InstallerSha256: 576625E3B434253C9D33A5F8A5E27D84DAE05E119B341CD1E9BE85082632D6C3
+    InstallerType: wix
+    InstallerUrl: https://github.com/packetThrower/zorite/releases/download/v0.1.1/Zorite_0.1.1_amd64_en-US.msi
+    InstallerSha256: E7D5A39C09640A71422421A11E9F1C0BACFA2F578087AEFD3E14CC80F6DAB0F8
+    ProductCode: '{59EBE92B-A9C6-45ED-9349-8DF9E7445439}'
+    Scope: machine
+    InstallerSwitches:
+      Silent: /quiet /norestart
+      SilentWithProgress: /passive /norestart
   - Architecture: arm64
-    InstallerUrl: https://github.com/packetThrower/zorite/releases/download/v0.1.1/zorite_0.1.1_arm64-setup.exe
-    InstallerSha256: F123BE43B8E4355BE981BD653EBA82027209B45AA907185F5AB0D784FEA67B94
+    InstallerType: wix
+    InstallerUrl: https://github.com/packetThrower/zorite/releases/download/v0.1.1/Zorite_0.1.1_arm64_en-US.msi
+    InstallerSha256: 3FBF96164FBEF0600F679AEB97C96A32F01091D47607211C89885CD36A6EE201
+    ProductCode: '{881F8008-2AB7-4B3C-9779-38B655641D00}'
+    Scope: machine
+    InstallerSwitches:
+      Silent: /quiet /norestart
+      SilentWithProgress: /passive /norestart
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/p/packetThrower/Zorite/0.1.1/packetThrower.Zorite.installer.yaml
+++ b/manifests/p/packetThrower/Zorite/0.1.1/packetThrower.Zorite.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: packetThrower.Zorite
+PackageVersion: 0.1.1
+InstallerType: nullsoft
+InstallModes:
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-06-15
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/packetThrower/zorite/releases/download/v0.1.1/zorite_0.1.1_x64-setup.exe
+    InstallerSha256: 576625E3B434253C9D33A5F8A5E27D84DAE05E119B341CD1E9BE85082632D6C3
+  - Architecture: arm64
+    InstallerUrl: https://github.com/packetThrower/zorite/releases/download/v0.1.1/zorite_0.1.1_arm64-setup.exe
+    InstallerSha256: F123BE43B8E4355BE981BD653EBA82027209B45AA907185F5AB0D784FEA67B94
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/p/packetThrower/Zorite/0.1.1/packetThrower.Zorite.locale.en-US.yaml
+++ b/manifests/p/packetThrower/Zorite/0.1.1/packetThrower.Zorite.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: packetThrower.Zorite
+PackageVersion: 0.1.1
+PackageLocale: en-US
+Publisher: packetThrower
+PublisherUrl: https://github.com/packetThrower
+PublisherSupportUrl: https://github.com/packetThrower/zorite/issues
+PackageName: Zorite
+PackageUrl: https://github.com/packetThrower/zorite
+License: GPL-3.0
+LicenseUrl: https://github.com/packetThrower/zorite/blob/main/LICENSE
+Copyright: Copyright (c) 2026 packetThrower
+ShortDescription: Local-first, Logseq-style daily-journal and outliner note app
+Description: |-
+  Zorite is a local-first daily-journal and outliner note app inspired by Logseq.
+  It stores notes as Markdown in a local SQLite database and pairs an infinite-scroll
+  journal with whiteboards, a PDF viewer, full-text search, and wiki-style page links
+  and aliases. Built in Rust on GPUI with a custom Markdown renderer.
+Moniker: zorite
+Tags:
+  - notes
+  - note-taking
+  - journal
+  - outliner
+  - markdown
+  - logseq
+  - productivity
+  - knowledge-base
+ReleaseNotesUrl: https://github.com/packetThrower/zorite/releases/tag/v0.1.1
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/p/packetThrower/Zorite/0.1.1/packetThrower.Zorite.locale.en-US.yaml
+++ b/manifests/p/packetThrower/Zorite/0.1.1/packetThrower.Zorite.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: packetThrower.Zorite
 PackageVersion: 0.1.1
@@ -6,27 +6,36 @@ PackageLocale: en-US
 Publisher: packetThrower
 PublisherUrl: https://github.com/packetThrower
 PublisherSupportUrl: https://github.com/packetThrower/zorite/issues
+Author: packetThrower
 PackageName: Zorite
 PackageUrl: https://github.com/packetThrower/zorite
-License: GPL-3.0
+License: GPL-3.0-or-later
 LicenseUrl: https://github.com/packetThrower/zorite/blob/main/LICENSE
-Copyright: Copyright (c) 2026 packetThrower
-ShortDescription: Local-first, Logseq-style daily-journal and outliner note app
+Copyright: © 2026 packetThrower / Zorite contributors
+CopyrightUrl: https://github.com/packetThrower/zorite/blob/main/LICENSE
+ShortDescription: A local-first outliner and daily-journal note app (Logseq-style).
 Description: |-
-  Zorite is a local-first daily-journal and outliner note app inspired by Logseq.
-  It stores notes as Markdown in a local SQLite database and pairs an infinite-scroll
-  journal with whiteboards, a PDF viewer, full-text search, and wiki-style page links
-  and aliases. Built in Rust on GPUI with a custom Markdown renderer.
+  Zorite is a cross-platform (macOS + Windows + Linux) local-first
+  daily-journal and outliner note app. Logseq-style: an infinite-scroll
+  journal of daily pages plus linked [[wiki-link]] pages, written in
+  Markdown and stored in a local SQLite database.
+
+  Embed and annotate PDFs, drop in images, and search across
+  everything — no cloud, no account; your notes stay on your machine.
 Moniker: zorite
 Tags:
   - notes
-  - note-taking
   - journal
   - outliner
   - markdown
   - logseq
-  - productivity
+  - note-taking
   - knowledge-base
+  - pdf
+  - local-first
 ReleaseNotesUrl: https://github.com/packetThrower/zorite/releases/tag/v0.1.1
+Documentations:
+  - DocumentLabel: Project page
+    DocumentUrl: https://github.com/packetThrower/zorite
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/p/packetThrower/Zorite/0.1.1/packetThrower.Zorite.yaml
+++ b/manifests/p/packetThrower/Zorite/0.1.1/packetThrower.Zorite.yaml
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: packetThrower.Zorite
 PackageVersion: 0.1.1
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/p/packetThrower/Zorite/0.1.1/packetThrower.Zorite.yaml
+++ b/manifests/p/packetThrower/Zorite/0.1.1/packetThrower.Zorite.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: packetThrower.Zorite
+PackageVersion: 0.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: `packetThrower.Zorite` version `0.1.1`

First winget submission of **Zorite** — a local-first, Logseq-style daily-journal and outliner note app (Rust + GPUI + SQLite, with a custom Markdown renderer).

- Publisher: https://github.com/packetThrower
- Repository: https://github.com/packetThrower/zorite
- Release: https://github.com/packetThrower/zorite/releases/tag/v0.1.1

Installers are NSIS (`nullsoft`) setup executables for **x64** and **arm64**, published as GitHub release assets.

This supersedes #387921 (version 0.1.0). That build failed the automated launch validation with `0xC0000135` (`STATUS_DLL_NOT_FOUND`) because the binary dynamically linked the Visual C++ runtime, which is absent on a clean image. 0.1.1 statically links the C runtime (`+crt-static`), so the executable is self-contained.

#### Notes for reviewers
- [x] Adds `version`, `installer`, and `defaultLocale` manifests (schema `1.6.0`).
- [x] `InstallerSha256` values verified against the release `SHA256SUMS`.
- [x] Installer URLs are public, immutable GitHub release-download assets.
- [ ] CLA — already signed (passed on the prior submission).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/388136)