### PR TITLE
New package: swperb.imgcli version 0.3.0

### DIFF
--- a/manifests/s/swperb/imgcli/0.3.0/swperb.imgcli.installer.yaml
+++ b/manifests/s/swperb/imgcli/0.3.0/swperb.imgcli.installer.yaml
@@ -1,0 +1,13 @@
+PackageIdentifier: swperb.imgcli
+PackageVersion: 0.3.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: imgcli\imgcli.exe
+    PortableCommandAlias: imgcli
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/swperb/imgcli/releases/download/v0.3.0/imgcli-windows-x86_64.zip
+    InstallerSha256: E1C1E65A934D8D64604B029F3AD35BABBEE0BD93840C34B0A58010A6298279D3
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/swperb/imgcli/0.3.0/swperb.imgcli.locale.en-US.yaml
+++ b/manifests/s/swperb/imgcli/0.3.0/swperb.imgcli.locale.en-US.yaml
@@ -1,0 +1,25 @@
+PackageIdentifier: swperb.imgcli
+PackageVersion: 0.3.0
+PackageLocale: en-US
+Publisher: swperb
+PublisherUrl: https://github.com/swperb
+PublisherSupportUrl: https://github.com/swperb/imgcli/issues
+PackageName: imgcli
+PackageUrl: https://github.com/swperb/imgcli
+License: MIT
+LicenseUrl: https://github.com/swperb/imgcli/blob/main/LICENSE
+ShortDescription: ffmpeg-style image conversion & processing CLI — dependency-free, single binary.
+Description: |-
+  A tiny, dependency-free command-line tool to convert, resize, crop, filter and
+  composite images via an ffmpeg-style filtergraph. One small binary, no system
+  libraries. Reads/writes PNG, JPEG, BMP, TGA, GIF, PPM, and QOI.
+Tags:
+  - image
+  - image-conversion
+  - cli
+  - convert
+  - resize
+  - imagemagick
+  - ffmpeg
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/swperb/imgcli/0.3.0/swperb.imgcli.yaml
+++ b/manifests/s/swperb/imgcli/0.3.0/swperb.imgcli.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: swperb.imgcli
+PackageVersion: 0.3.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package

- **PackageIdentifier:** `swperb.imgcli`
- **Version:** 0.3.0
- **License:** MIT — https://github.com/swperb/imgcli
- **Installer:** portable `zip` with a nested `imgcli\imgcli.exe`, aliased to `imgcli`.

imgcli is a tiny, dependency-free command-line image tool (convert / resize / crop / filter / composite via an ffmpeg-style filtergraph). The Windows binary is a static mingw-w64 build published as a GitHub release asset; the `InstallerSha256` matches `imgcli-windows-x86_64.zip` from the v0.3.0 release.

### Checklist

- [x] This PR adds a **new package** (3-file manifest: version + installer + en-US locale).
- [x] Manifests use schema **1.6.0** and have been validated locally.
- [x] Installer URL is a stable release asset and the SHA256 matches.
- [x] I have read the [contributing guidelance](https://github.com/microsoft/winget-pkgs/blob/master/CONTRIBUTING.md).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/388202)