### PR TITLE
New package: WinNGS.FlashDEG version 1.1.0

### DIFF
--- a/manifests/w/WinNGS/FlashDEG/1.1.0/WinNGS.FlashDEG.installer.yaml
+++ b/manifests/w/WinNGS/FlashDEG/1.1.0/WinNGS.FlashDEG.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: WinNGS.FlashDEG
+PackageVersion: 1.1.0
+InstallerType: msi
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: /qn
+  SilentWithProgress: /passive
+UpgradeBehavior: install
+Commands:
+- flashdeg
+- flashdeg-gui
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/tus-kondolab/flashdeg/releases/download/v1.1.0/flashdeg-1.1.0-windows-x86_64.msi
+  InstallerSha256: A922272FCF6367C25C1EE60549A202F72579810D1538CEC519F7E4BC71729CE5
+  ProductCode: '{27D6B43F-5E96-4995-956B-D84B7CBD88E4}'
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/w/WinNGS/FlashDEG/1.1.0/WinNGS.FlashDEG.installer.yaml
+++ b/manifests/w/WinNGS/FlashDEG/1.1.0/WinNGS.FlashDEG.installer.yaml
@@ -14,6 +14,9 @@ UpgradeBehavior: install
 Commands:
 - flashdeg
 - flashdeg-gui
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.EdgeWebView2Runtime
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/tus-kondolab/flashdeg/releases/download/v1.1.0/flashdeg-1.1.0-windows-x86_64.msi

--- a/manifests/w/WinNGS/FlashDEG/1.1.0/WinNGS.FlashDEG.locale.en-US.yaml
+++ b/manifests/w/WinNGS/FlashDEG/1.1.0/WinNGS.FlashDEG.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: WinNGS.FlashDEG
+PackageVersion: 1.1.0
+PackageLocale: en-US
+Publisher: WinNGS
+PublisherUrl: https://github.com/tus-kondolab
+PublisherSupportUrl: https://github.com/tus-kondolab/flashdeg/issues
+Author: tus-kondolab
+PackageName: FlashDEG
+PackageUrl: https://github.com/tus-kondolab/flashdeg
+License: MIT
+LicenseUrl: https://github.com/tus-kondolab/flashdeg/blob/main/LICENSE
+Copyright: Copyright (c) 2026 tus-kondolab
+ShortDescription: Fast, lightweight bulk RNA-seq differential expression analysis.
+Description: FlashDEG is a fast, lightweight implementation of the DESeq2 algorithm for bulk RNA-seq differential expression analysis. This package provides the FlashDEG command-line engine and desktop GUI for x86_64 Windows systems.
+Moniker: flashdeg
+Tags:
+- bioinformatics
+- genomics
+- ngs
+- rnaseq
+- differential-expression
+ReleaseNotes: FlashDEG 1.1.0 Windows release with the command-line engine and desktop GUI in a single MSI installer.
+ReleaseNotesUrl: https://github.com/tus-kondolab/flashdeg/releases/tag/v1.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/w/WinNGS/FlashDEG/1.1.0/WinNGS.FlashDEG.yaml
+++ b/manifests/w/WinNGS/FlashDEG/1.1.0/WinNGS.FlashDEG.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: WinNGS.FlashDEG
+PackageVersion: 1.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Adds WinNGS.FlashDEG 1.1.0 to the winget community repository.\n\nValidation performed:\n- winget validate .\\manifests\\w\\WinNGS\\FlashDEG\\1.1.0\n- Verified the GitHub Release MSI SHA256 matches InstallerSha256.\n\nInstaller:\n- https://github.com/tus-kondolab/flashdeg/releases/download/v1.1.0/flashdeg-1.1.0-windows-x86_64.msi
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/388203)