### PR TITLE
New package: Filegram.FilegramDesktop version 0.2.5

### DIFF
--- a/manifests/f/Filegram/FilegramDesktop/0.2.5/Filegram.FilegramDesktop.installer.yaml
+++ b/manifests/f/Filegram/FilegramDesktop/0.2.5/Filegram.FilegramDesktop.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Filegram.FilegramDesktop
+PackageVersion: 0.2.5
+InstallerType: zip
+NestedInstallerType: portable
+ReleaseDate: 2026-06-15
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/filegram/filegram-desktop/releases/download/v0.2.5/filegram-windows-x86_64.zip
+  InstallerSha256: ABF902AEFD24DBD2C5EAD617F04EF7DD14CDC2E02B8A1AC203F70FC7EA11C7E2
+  NestedInstallerFiles:
+  - RelativeFilePath: filegram-windows-x86_64.exe
+    PortableCommandAlias: filegram
+- Architecture: x86
+  InstallerUrl: https://github.com/filegram/filegram-desktop/releases/download/v0.2.5/filegram-windows-i686.zip
+  InstallerSha256: DDA62C23E5131D013786C4B44BAA3726D2A6E0AEED35D259007634F94F67B020
+  NestedInstallerFiles:
+  - RelativeFilePath: filegram-windows-i686.exe
+    PortableCommandAlias: filegram
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Filegram/FilegramDesktop/0.2.5/Filegram.FilegramDesktop.locale.en-US.yaml
+++ b/manifests/f/Filegram/FilegramDesktop/0.2.5/Filegram.FilegramDesktop.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Filegram.FilegramDesktop
+PackageVersion: 0.2.5
+PackageLocale: en-US
+Publisher: Filegram
+PublisherUrl: https://github.com/filegram
+PublisherSupportUrl: https://github.com/filegram/filegram-desktop/issues
+Author: Filegram
+PackageName: Filegram
+PackageUrl: https://github.com/filegram/filegram-desktop
+License: MIT
+LicenseUrl: https://github.com/filegram/filegram-desktop/blob/master/LICENSE
+Copyright: Copyright (c) Filegram
+ShortDescription: Disk space analyzer with an interactive treemap
+Description: |-
+  Filegram is a desktop disk analyzer that scans a directory and visualizes file
+  sizes as an interactive treemap chart, letting you navigate the file tree and
+  quickly find what is taking up space.
+Moniker: filegram
+Tags:
+- disk
+- disk-analyzer
+- disk-usage
+- filesystem
+- rust
+- storage
+- treemap
+ReleaseNotes: |-
+  - Size brick labels on a font ladder; wrap and shrink to fit
+ReleaseNotesUrl: https://github.com/filegram/filegram-desktop/releases/tag/v0.2.5
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Filegram/FilegramDesktop/0.2.5/Filegram.FilegramDesktop.yaml
+++ b/manifests/f/Filegram/FilegramDesktop/0.2.5/Filegram.FilegramDesktop.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Filegram.FilegramDesktop
+PackageVersion: 0.2.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New package: Filegram.FilegramDesktop 0.2.5

Filegram — a desktop disk space analyzer (Rust + iced): scan a directory, view the
file tree with sizes, and explore an interactive treemap. Open source (MIT).

Upstream: https://github.com/filegram/filegram-desktop
Release:  https://github.com/filegram/filegram-desktop/releases/tag/v0.2.5

Portable install (zip → nested portable exe), architectures **x64** and **x86**.
Command alias: `filegram`.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.x schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

> Note: prepared on macOS, so `winget validate` / `winget install` were **not** run
> locally — relying on the repo's automated validation. The manifests parse as valid
> YAML and follow the 1.12.0 schema. The Windows installers are official release
> artifacts; the listed SHA256 values match the GitHub-reported asset digests.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/388273)