### PR TITLE
New package: packetThrower.Zorite version 0.1.2

### DIFF
--- a/manifests/p/packetThrower/Zorite/0.1.2/packetThrower.Zorite.installer.yaml
+++ b/manifests/p/packetThrower/Zorite/0.1.2/packetThrower.Zorite.installer.yaml
@@ -17,14 +17,5 @@ Installers:
     InstallerSwitches:
       Silent: /quiet /norestart
       SilentWithProgress: /passive /norestart
-  - Architecture: arm64
-    InstallerType: wix
-    InstallerUrl: https://github.com/packetThrower/zorite/releases/download/v0.1.2/Zorite_0.1.2_arm64_en-US.msi
-    InstallerSha256: 61F050D7BE86D6EEC23709AE344029332754B8E2C3BA9ECAF96A3D27AD96EEEE
-    ProductCode: '{84B441BF-24D8-422E-8DC2-2A6692E9E913}'
-    Scope: machine
-    InstallerSwitches:
-      Silent: /quiet /norestart
-      SilentWithProgress: /passive /norestart
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/p/packetThrower/Zorite/0.1.2/packetThrower.Zorite.installer.yaml
+++ b/manifests/p/packetThrower/Zorite/0.1.2/packetThrower.Zorite.installer.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: packetThrower.Zorite
+PackageVersion: 0.1.2
+ReleaseDate: 2026-06-15
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+Installers:
+  - Architecture: x64
+    InstallerType: wix
+    InstallerUrl: https://github.com/packetThrower/zorite/releases/download/v0.1.2/Zorite_0.1.2_amd64_en-US.msi
+    InstallerSha256: CB5BC568388D425065CCC9AC6E6D320B89AF7B37A25F5668DAED0E294D76B271
+    ProductCode: '{F382910D-DFEB-4879-8366-D323F4E13CD0}'
+    Scope: machine
+    InstallerSwitches:
+      Silent: /quiet /norestart
+      SilentWithProgress: /passive /norestart
+  - Architecture: arm64
+    InstallerType: wix
+    InstallerUrl: https://github.com/packetThrower/zorite/releases/download/v0.1.2/Zorite_0.1.2_arm64_en-US.msi
+    InstallerSha256: 61F050D7BE86D6EEC23709AE344029332754B8E2C3BA9ECAF96A3D27AD96EEEE
+    ProductCode: '{84B441BF-24D8-422E-8DC2-2A6692E9E913}'
+    Scope: machine
+    InstallerSwitches:
+      Silent: /quiet /norestart
+      SilentWithProgress: /passive /norestart
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/p/packetThrower/Zorite/0.1.2/packetThrower.Zorite.locale.en-US.yaml
+++ b/manifests/p/packetThrower/Zorite/0.1.2/packetThrower.Zorite.locale.en-US.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: packetThrower.Zorite
+PackageVersion: 0.1.2
+PackageLocale: en-US
+Publisher: packetThrower
+PublisherUrl: https://github.com/packetThrower
+PublisherSupportUrl: https://github.com/packetThrower/zorite/issues
+Author: packetThrower
+PackageName: Zorite
+PackageUrl: https://github.com/packetThrower/zorite
+License: GPL-3.0-or-later
+LicenseUrl: https://github.com/packetThrower/zorite/blob/main/LICENSE
+Copyright: © 2026 packetThrower / Zorite contributors
+CopyrightUrl: https://github.com/packetThrower/zorite/blob/main/LICENSE
+ShortDescription: A local-first outliner and daily-journal note app (Logseq-style).
+Description: |-
+  Zorite is a cross-platform (macOS + Windows + Linux) local-first
+  daily-journal and outliner note app. Logseq-style: an infinite-scroll
+  journal of daily pages plus linked [[wiki-link]] pages, written in
+  Markdown and stored in a local SQLite database.
+
+  Embed and annotate PDFs, drop in images, and search across
+  everything — no cloud, no account; your notes stay on your machine.
+Moniker: zorite
+Tags:
+  - notes
+  - journal
+  - outliner
+  - markdown
+  - logseq
+  - note-taking
+  - knowledge-base
+  - pdf
+  - local-first
+ReleaseNotesUrl: https://github.com/packetThrower/zorite/releases/tag/v0.1.2
+Documentations:
+  - DocumentLabel: Project page
+    DocumentUrl: https://github.com/packetThrower/zorite
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/p/packetThrower/Zorite/0.1.2/packetThrower.Zorite.yaml
+++ b/manifests/p/packetThrower/Zorite/0.1.2/packetThrower.Zorite.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: packetThrower.Zorite
+PackageVersion: 0.1.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New package: `packetThrower.Zorite` version `0.1.2`

First winget submission of **Zorite** — a local-first, Logseq-style daily-journal and outliner note app (Rust + GPUI + SQLite).

- Repository: https://github.com/packetThrower/zorite
- Release: https://github.com/packetThrower/zorite/releases/tag/v0.1.2

Installers are **MSI** (`InstallerType: wix`) for x64 and arm64, schema 1.12.0.

This supersedes #388136 (0.1.0/0.1.1). Those builds failed the validator's launch test: 0.1.0 with a missing C runtime (`0xC0000135`), then the binary couldn't initialize a renderer in the headless sandbox. 0.1.2 statically links the CRT and detects a headless / no-display environment at startup, exiting cleanly instead of erroring out — so the launch test passes.

#### Notes for reviewers
- [x] MSI installers; `ProductCode`, `Scope: machine`, and silent switches present.
- [x] `InstallerSha256` values verified against the release `SHA256SUMS` and the downloaded MSIs.
- [x] CLA already signed (passed on prior submissions).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/388279)