### PR TITLE
New package: Parslee.Car version 0.24.1

### DIFF
--- a/manifests/p/Parslee/Car/0.24.1/Parslee.Car.installer.yaml
+++ b/manifests/p/Parslee/Car/0.24.1/Parslee.Car.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Parslee.Car
+PackageVersion: 0.24.1
+InstallerType: zip
+NestedInstallerType: portable
+Commands:
+  - car
+  - car-server
+  - car-memgine-eval
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Parslee-ai/car-releases/releases/download/v0.24.1/car-win32-x64-msvc.zip
+    InstallerSha256: 2C58296388C0B4C9D0E61E7772DFEB3F152271DB40A02F90ED95F36F01A201B4
+    NestedInstallerFiles:
+      - RelativeFilePath: car.exe
+        PortableCommandAlias: car
+      - RelativeFilePath: car-server.exe
+        PortableCommandAlias: car-server
+      - RelativeFilePath: car-memgine-eval.exe
+        PortableCommandAlias: car-memgine-eval
+ReleaseDate: 2026-06-14
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/p/Parslee/Car/0.24.1/Parslee.Car.installer.yaml
+++ b/manifests/p/Parslee/Car/0.24.1/Parslee.Car.installer.yaml
@@ -7,6 +7,9 @@ Commands:
   - car
   - car-server
   - car-memgine-eval
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/Parslee-ai/car-releases/releases/download/v0.24.1/car-win32-x64-msvc.zip

--- a/manifests/p/Parslee/Car/0.24.1/Parslee.Car.locale.en-US.yaml
+++ b/manifests/p/Parslee/Car/0.24.1/Parslee.Car.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Parslee.Car
+PackageVersion: 0.24.1
+PackageLocale: en-US
+Publisher: Parslee AI
+PublisherUrl: https://github.com/Parslee-ai
+PublisherSupportUrl: https://github.com/Parslee-ai/car-releases/issues
+PackageName: Common Agent Runtime
+PackageUrl: https://github.com/Parslee-ai/car-releases
+License: Proprietary
+LicenseUrl: https://github.com/Parslee-ai/car-releases/blob/main/LICENSE
+ShortDescription: Deterministic execution layer for AI agents (CLI + server).
+Description: |-
+  Common Agent Runtime (CAR) is a deterministic execution layer for AI
+  agents: models propose actions and the runtime validates, verifies, and
+  executes them. This package provides the pre-built Windows x64 binaries —
+  the CLI (car), the WebSocket server (car-server), and the StateBench
+  evaluation bridge (car-memgine-eval).
+Tags:
+  - ai
+  - agent
+  - runtime
+  - llm
+  - cli
+ReleaseNotesUrl: https://github.com/Parslee-ai/car-releases/releases/tag/v0.24.1
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/p/Parslee/Car/0.24.1/Parslee.Car.yaml
+++ b/manifests/p/Parslee/Car/0.24.1/Parslee.Car.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Parslee.Car
+PackageVersion: 0.24.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package submission

- **Package:** `Parslee.Car`
- **Version:** 0.24.1
- **Publisher:** Parslee AI
- **Type:** zip installer with portable nested binaries (`car`, `car-server`, `car-memgine-eval`)
- **Architecture:** x64

Common Agent Runtime (CAR) — a deterministic execution layer for AI agents. This is the first submission of this package to winget-pkgs.

---

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

#### Validation performed

The manifests were verified against the released artifact, though not with the `winget` CLI directly (authored from a non-Windows environment — relying on the repository's automated Validation pipeline for the `winget validate` / sandbox-install gates):

- **Installer URL resolves** (HTTP 200) and **`InstallerSha256` matches the released asset byte-for-byte** — `car-win32-x64-msvc.zip`, 95,249,548 bytes, SHA256 `2C58296388C0B4C9D0E61E7772DFEB3F152271DB40A02F90ED95F36F01A201B4`.
- The three declared nested portable binaries (`car.exe`, `car-server.exe`, `car-memgine-eval.exe`) are present **at the zip root**, matching the `NestedInstallerFiles` relative paths.
- All three manifests (`version`, `installer`, `defaultLocale`) are authored against schema **1.6.0**, parse cleanly, and cross-reference consistently (matching `PackageIdentifier` + `PackageVersion`).

> Notes for the reviewer:
> - The binaries are **not yet Authenticode-signed** (signing pipeline is in progress upstream).
> - `License` is declared as `Proprietary` per the publisher's binary license.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/388307)