### PR TITLE
Add ShikeChen.JwtDecoder version 1.2.2

### DIFF
--- a/manifests/s/ShikeChen/JwtDecoder/1.2.2/ShikeChen.JwtDecoder.installer.yaml
+++ b/manifests/s/ShikeChen/JwtDecoder/1.2.2/ShikeChen.JwtDecoder.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: ShikeChen.JwtDecoder
+PackageVersion: 1.2.2
+InstallerType: portable
+Commands:
+- jwtdecode
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/ShikeChen-MS/JwtDecoder_local_cli/releases/download/v1.2.2/jwtdecode-1.2.2-win-x64.exe
+  InstallerSha256: BFD9F0A4C92926F63AE2527F40ED2634EF706927574A962A7282E9B161166339
+- Architecture: arm64
+  InstallerUrl: https://github.com/ShikeChen-MS/JwtDecoder_local_cli/releases/download/v1.2.2/jwtdecode-1.2.2-win-arm64.exe
+  InstallerSha256: 08DE153843DD88ABF40AD668A3C923ABA52363312E79DF029F8E027135F0FF87
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/ShikeChen/JwtDecoder/1.2.2/ShikeChen.JwtDecoder.locale.en-US.yaml
+++ b/manifests/s/ShikeChen/JwtDecoder/1.2.2/ShikeChen.JwtDecoder.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: ShikeChen.JwtDecoder
+PackageVersion: 1.2.2
+PackageLocale: en-US
+Publisher: ShikeChen
+PublisherUrl: https://github.com/ShikeChen-MS
+PublisherSupportUrl: https://github.com/ShikeChen-MS/JwtDecoder_local_cli/issues
+PackageName: JwtDecoder
+PackageUrl: https://github.com/ShikeChen-MS/JwtDecoder_local_cli
+License: MIT
+LicenseUrl: https://github.com/ShikeChen-MS/JwtDecoder_local_cli/blob/master/LICENSE
+Copyright: Copyright (c) ShikeChen
+ShortDescription: Offline JWT decoder and (optional) signature verifier — single native exe, no runtime needed.
+Description: |-
+  jwtdecode is a single ~2.5 MB Native AOT executable (no .NET runtime required) that decodes JSON
+  Web Tokens fully offline. It supports every major JOSE algorithm family (HS/RS/PS/ES 256/384/512),
+  query expressions for extracting individual claims, expiry / not-before validation, and
+  signature verification from key files or stdin. Works as a standalone command or in pipelines.
+Moniker: jwtdecode
+Tags:
+- jwt
+- json-web-token
+- decoder
+- cli
+- security
+- cryptography
+ReleaseNotesUrl: https://github.com/ShikeChen-MS/JwtDecoder_local_cli/releases/tag/v1.2.2
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/ShikeChen/JwtDecoder/1.2.2/ShikeChen.JwtDecoder.yaml
+++ b/manifests/s/ShikeChen/JwtDecoder/1.2.2/ShikeChen.JwtDecoder.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: ShikeChen.JwtDecoder
+PackageVersion: 1.2.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## New Package: ShikeChen.JwtDecoder 1.2.2

Offline JWT decoder and signature verifier — single Native AOT exe, no runtime needed.

- [x] Manifest validated with `winget validate`
- [x] Both x64 and arm64 Windows installers provided
- Package URL: https://github.com/ShikeChen-MS/JwtDecoder_local_cli
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/388373)