### PR TITLE
Add ShikeChen.JwksFetch version 1.2.2

### DIFF
--- a/manifests/s/ShikeChen/JwksFetch/1.2.2/ShikeChen.JwksFetch.installer.yaml
+++ b/manifests/s/ShikeChen/JwksFetch/1.2.2/ShikeChen.JwksFetch.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: ShikeChen.JwksFetch
+PackageVersion: 1.2.2
+InstallerType: portable
+Commands:
+- jwksfetch
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/ShikeChen-MS/JwtDecoder_local_cli/releases/download/v1.2.2/jwksfetch-1.2.2-win-x64.exe
+  InstallerSha256: FFBE92AD58A2D1877DF919C20B5D2792C0CD88768DCDEA7F05DE51B69ACA4C84
+- Architecture: arm64
+  InstallerUrl: https://github.com/ShikeChen-MS/JwtDecoder_local_cli/releases/download/v1.2.2/jwksfetch-1.2.2-win-arm64.exe
+  InstallerSha256: 5922D64BAE9C9CD9C77632E3BEB001375B116D39DB403E217F6516291A5ADD06
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/ShikeChen/JwksFetch/1.2.2/ShikeChen.JwksFetch.locale.en-US.yaml
+++ b/manifests/s/ShikeChen/JwksFetch/1.2.2/ShikeChen.JwksFetch.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: ShikeChen.JwksFetch
+PackageVersion: 1.2.2
+PackageLocale: en-US
+Publisher: ShikeChen
+PublisherUrl: https://github.com/ShikeChen-MS
+PublisherSupportUrl: https://github.com/ShikeChen-MS/JwtDecoder_local_cli/issues
+PackageName: JwksFetch
+PackageUrl: https://github.com/ShikeChen-MS/JwtDecoder_local_cli
+License: MIT
+LicenseUrl: https://github.com/ShikeChen-MS/JwtDecoder_local_cli/blob/master/LICENSE
+Copyright: Copyright (c) ShikeChen
+ShortDescription: Fetch a public verification key from a JWKS endpoint (or via OIDC discovery) and emit it as PEM.
+Description: |-
+  jwksfetch is a single Native AOT executable (no .NET runtime required) that retrieves a public
+  JSON Web Key from a remote JWKS endpoint or via OIDC discovery, then emits the key in PEM format
+  to stdout. Designed as a companion to jwtdecode: pipe jwksfetch output directly into
+  jwtdecode --verify --key-file - for end-to-end offline JWT verification after an initial key fetch.
+Moniker: jwksfetch
+Tags:
+- jwks
+- jwt
+- json-web-key
+- oidc
+- cli
+- security
+- cryptography
+ReleaseNotesUrl: https://github.com/ShikeChen-MS/JwtDecoder_local_cli/releases/tag/v1.2.2
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/ShikeChen/JwksFetch/1.2.2/ShikeChen.JwksFetch.yaml
+++ b/manifests/s/ShikeChen/JwksFetch/1.2.2/ShikeChen.JwksFetch.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: ShikeChen.JwksFetch
+PackageVersion: 1.2.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## New Package: ShikeChen.JwksFetch 1.2.2

Fetch a public verification key from a JWKS endpoint (or via OIDC discovery) and emit it as PEM — single Native AOT exe, no runtime needed.

- [x] Manifest validated with `winget validate`
- [x] Both x64 and arm64 Windows installers provided
- Package URL: https://github.com/ShikeChen-MS/JwtDecoder_local_cli
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/388374)