### PR TITLE
New package: dpaulos6.shell version 0.4.0

### DIFF
--- a/manifests/d/dpaulos6/shell/0.4.0/dpaulos6.shell.installer.yaml
+++ b/manifests/d/dpaulos6/shell/0.4.0/dpaulos6.shell.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: dpaulos6.shell
+PackageVersion: 0.4.0
+InstallerType: inno
+InstallerLocale: en-US
+Scope: user
+UpgradeBehavior: install
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/dpaulos6/shell.dpaulos.pt/releases/download/v0.4.0/PaulosShell-0.4.0-Setup.exe
+    InstallerSha256: 793E228FB13FA86E062DBFDF22DCE60BD7C07260C67DE37B7A0ADEF37F361621
+    InstallerSwitches:
+      Silent: /VERYSILENT /NORESTART
+      SilentWithProgress: /SP- /VERYSILENT /NORESTART
+ManifestType: installer
+ManifestVersion: 1.12.0
+
+
+

--- a/manifests/d/dpaulos6/shell/0.4.0/dpaulos6.shell.locale.en-US.yaml
+++ b/manifests/d/dpaulos6/shell/0.4.0/dpaulos6.shell.locale.en-US.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: dpaulos6.shell
+PackageVersion: 0.4.0
+PackageLocale: en-US
+PackageName: PaulosShell
+Publisher: dpaulos6
+PackageUrl: https://github.com/dpaulos6/shell.dpaulos.pt
+License: MIT
+LicenseUrl: https://github.com/dpaulos6/shell.dpaulos.pt/blob/v0.4.0/LICENSE
+Copyright: Copyright (c) Diogo Paulos. All rights reserved.
+ShortDescription: A safe, updateable PowerShell dev-shell toolkit with a paulos command center.
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0
+
+

--- a/manifests/d/dpaulos6/shell/0.4.0/dpaulos6.shell.yaml
+++ b/manifests/d/dpaulos6/shell/0.4.0/dpaulos6.shell.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: dpaulos6.shell
+PackageVersion: 0.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0
+
+


### PR DESCRIPTION
## 📖 Description

Adds `dpaulos6.shell` version `0.4.0` to the Windows Package Manager Community Repository.

Installer: Inno Setup  
Scope: user  
Silent install: `/VERYSILENT /NORESTART`

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/388431)