### PR TITLE
New package: Filegram.FilegramDesktop version 0.2.6

### DIFF
--- a/manifests/f/Filegram/FilegramDesktop/0.2.6/Filegram.FilegramDesktop.installer.yaml
+++ b/manifests/f/Filegram/FilegramDesktop/0.2.6/Filegram.FilegramDesktop.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Filegram.FilegramDesktop
+PackageVersion: 0.2.6
+InstallerType: zip
+NestedInstallerType: portable
+ReleaseDate: 2026-06-16
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/filegram/filegram-desktop/releases/download/v0.2.6/filegram-windows-x86_64.zip
+  InstallerSha256: 60058D55DE6C62D170D6EE4109EE29592CB5C6B31509A62BB40DD61334D8F9FF
+  NestedInstallerFiles:
+  - RelativeFilePath: filegram-windows-x86_64.exe
+    PortableCommandAlias: filegram
+- Architecture: x86
+  InstallerUrl: https://github.com/filegram/filegram-desktop/releases/download/v0.2.6/filegram-windows-i686.zip
+  InstallerSha256: A5D103F401B54CA157EB2C778699AC214A92624A37B6B3CF6476961A40727103
+  NestedInstallerFiles:
+  - RelativeFilePath: filegram-windows-i686.exe
+    PortableCommandAlias: filegram
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Filegram/FilegramDesktop/0.2.6/Filegram.FilegramDesktop.locale.en-US.yaml
+++ b/manifests/f/Filegram/FilegramDesktop/0.2.6/Filegram.FilegramDesktop.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Filegram.FilegramDesktop
+PackageVersion: 0.2.6
+PackageLocale: en-US
+Publisher: Filegram
+PublisherUrl: https://github.com/filegram
+PublisherSupportUrl: https://github.com/filegram/filegram-desktop/issues
+Author: Filegram
+PackageName: Filegram
+PackageUrl: https://github.com/filegram/filegram-desktop
+License: MIT
+LicenseUrl: https://github.com/filegram/filegram-desktop/blob/master/LICENSE
+Copyright: Copyright (c) Filegram
+ShortDescription: Disk space analyzer with an interactive treemap
+Description: |-
+  Filegram is a desktop disk analyzer that scans a directory and visualizes file
+  sizes as an interactive treemap chart, letting you navigate the file tree and
+  quickly find what is taking up space.
+Moniker: filegram
+Tags:
+- disk
+- disk-analyzer
+- disk-usage
+- filesystem
+- rust
+- storage
+- treemap
+ReleaseNotes: |-
+  - Windows binaries now statically link the MSVC C runtime, so they run without
+    the Visual C++ Redistributable installed.
+ReleaseNotesUrl: https://github.com/filegram/filegram-desktop/releases/tag/v0.2.6
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Filegram/FilegramDesktop/0.2.6/Filegram.FilegramDesktop.yaml
+++ b/manifests/f/Filegram/FilegramDesktop/0.2.6/Filegram.FilegramDesktop.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Filegram.FilegramDesktop
+PackageVersion: 0.2.6
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New package: Filegram.FilegramDesktop 0.2.6

Filegram — a desktop disk space analyzer (Rust + iced): scan a directory, view the
file tree with sizes, and explore an interactive treemap. Open source (MIT).

Upstream: https://github.com/filegram/filegram-desktop
Release:  https://github.com/filegram/filegram-desktop/releases/tag/v0.2.6

Portable install (zip → nested portable exe), architectures **x64** and **x86**.
Command alias: `filegram`.

This supersedes my earlier 0.2.5 attempt (#388273), which I closed: validation
correctly flagged `STATUS_DLL_NOT_FOUND` (0xC0000135) because the binaries linked
the MSVC CRT dynamically and needed the VC++ Redistributable. Fixed at the source —
0.2.6 statically links the CRT, so the executables are self-contained.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.x schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

> Note: prepared on macOS, so `winget validate` / `winget install` were not run
> locally — relying on the repo's automated validation. Manifests parse as valid
> YAML and follow the 1.12.0 schema; the listed SHA256 values match the
> GitHub-reported release asset digests.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/388478)