### PR TITLE
New package: SerZhyAle.CyrFlip version 26.6.16.1459

### DIFF
--- a/manifests/s/SerZhyAle/CyrFlip/26.6.16.1459/SerZhyAle.CyrFlip.installer.yaml
+++ b/manifests/s/SerZhyAle/CyrFlip/26.6.16.1459/SerZhyAle.CyrFlip.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: SerZhyAle.CyrFlip
+PackageVersion: 26.6.16.1459
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallModes:
+  - silent
+  - silentWithProgress
+Installers:
+  - Architecture: x64
+    InstallerType: zip
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: CyrFlip.exe
+        PortableCommandAlias: cyrflip
+    InstallerUrl: https://github.com/SerZhyAle/CyrFlip/releases/download/v26.6.16.1459/CyrFlip-26.6.16.1459-windows-x64.zip
+    InstallerSha256: 5033A7EB1E3A75B05A125548A97EF1765C51187312CD81F94380BF344B50D7EA
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/SerZhyAle/CyrFlip/26.6.16.1459/SerZhyAle.CyrFlip.locale.en-US.yaml
+++ b/manifests/s/SerZhyAle/CyrFlip/26.6.16.1459/SerZhyAle.CyrFlip.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: SerZhyAle.CyrFlip
+PackageVersion: 26.6.16.1459
+PackageLocale: en-US
+Publisher: SerZhyAle
+PublisherUrl: https://github.com/SerZhyAle
+PublisherSupportUrl: https://github.com/SerZhyAle/CyrFlip/issues
+PackageName: CyrFlip
+PackageUrl: https://github.com/SerZhyAle/CyrFlip
+License: MIT
+LicenseUrl: https://github.com/SerZhyAle/CyrFlip/blob/main/LICENSE
+Copyright: Copyright (c) 2026 SerZhyAle
+ShortDescription: Live EN/RU/UK layout indicator at the caret, plus one-key transliteration between QWERTY and ЙЦУКЕН.
+Description: >-
+  CyrFlip is a tiny Windows tray utility with two features: it shows the active keyboard
+  layout (EN/RU/UK) right next to the blinking text caret so you always know which layout
+  you are typing in, and it transliterates selected text between QWERTY and ЙЦУКЕН in place
+  via a global hotkey. All settings live in the tray menu: toggle the caret overlay or the
+  cursor indicator, switch to a coloured dot style, or reassign the hotkey without restarting.
+  Ships as a single portable exe with no installer and no runtime dependencies.
+Moniker: cyrflip
+Tags:
+  - keyboard
+  - keyboard-layout
+  - transliteration
+  - cyrillic
+  - qwerty
+  - йцукен
+  - productivity
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/SerZhyAle/CyrFlip/26.6.16.1459/SerZhyAle.CyrFlip.locale.ru-RU.yaml
+++ b/manifests/s/SerZhyAle/CyrFlip/26.6.16.1459/SerZhyAle.CyrFlip.locale.ru-RU.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+PackageIdentifier: SerZhyAle.CyrFlip
+PackageVersion: 26.6.16.1459
+PackageLocale: ru-RU
+Publisher: SerZhyAle
+PublisherUrl: https://github.com/SerZhyAle
+PublisherSupportUrl: https://github.com/SerZhyAle/CyrFlip/issues
+PackageName: CyrFlip
+PackageUrl: https://github.com/SerZhyAle/CyrFlip
+License: MIT
+ShortDescription: Индикатор раскладки EN/RU/UK у курсора + исправление текста, набранного не в той раскладке, по горячей клавише.
+Description: >-
+  CyrFlip - крошечная утилита в трее для Windows с двумя функциями: показывает активную
+  раскладку клавиатуры (EN/RU/UK) прямо рядом с мигающим курсором ввода, и транслитерирует
+  выделенный текст между QWERTY и ЙЦУКЕН прямо на месте по нажатию горячей клавиши. Все
+  настройки - в меню трея: переключить оверлей каретки или индикатор мыши, включить точечный
+  стиль маркера, или сменить горячую клавишу без перезапуска. Один портативный exe, без
+  установщика и без зависимостей.
+Tags:
+  - клавиатура
+  - раскладка
+  - транслитерация
+  - кириллица
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/s/SerZhyAle/CyrFlip/26.6.16.1459/SerZhyAle.CyrFlip.locale.uk-UA.yaml
+++ b/manifests/s/SerZhyAle/CyrFlip/26.6.16.1459/SerZhyAle.CyrFlip.locale.uk-UA.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+PackageIdentifier: SerZhyAle.CyrFlip
+PackageVersion: 26.6.16.1459
+PackageLocale: uk-UA
+Publisher: SerZhyAle
+PublisherUrl: https://github.com/SerZhyAle
+PublisherSupportUrl: https://github.com/SerZhyAle/CyrFlip/issues
+PackageName: CyrFlip
+PackageUrl: https://github.com/SerZhyAle/CyrFlip
+License: MIT
+ShortDescription: Індикатор розкладки EN/RU/UK біля каретки + виправлення тексту в неправильній розкладці за гарячою клавішею.
+Description: >-
+  CyrFlip - крихітна утиліта в системному треї для Windows з двома функціями: показує активну
+  розкладку клавіатури (EN/RU/UK) прямо поруч із миготливим курсором введення, і транслітерує
+  виділений текст між QWERTY та ЙЦУКЕН прямо на місці за гарячою клавішею. Усі налаштування -
+  у меню трею: перемкнути оверлей каретки або індикатор миші, увімкнути точковий стиль маркера,
+  або змінити гарячу клавішу без перезапуску. Один портативний exe, без встановлення та залежностей.
+Tags:
+  - клавіатура
+  - розкладка
+  - транслітерація
+  - кирилиця
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/s/SerZhyAle/CyrFlip/26.6.16.1459/SerZhyAle.CyrFlip.yaml
+++ b/manifests/s/SerZhyAle/CyrFlip/26.6.16.1459/SerZhyAle.CyrFlip.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: SerZhyAle.CyrFlip
+PackageVersion: 26.6.16.1459
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package submission: **SerZhyAle.CyrFlip** version **26.6.16.1459**.

CyrFlip is a tiny Windows tray utility with two features:

1. **Live layout indicator at the caret** – shows EN / RU / UK right next to the blinking text caret (and optionally the I-beam cursor) so you always know which layout you're about to type in.
2. **One-key transliteration** – select text typed in the wrong layout, press the hotkey (default **Ctrl+Shift+F12**), and it's transliterated in place (QWERTY ↔ ЙЦУКЕН).

All settings (feature toggles, hotkey, dot vs. label style) are in the tray menu. Settings persist to the Windows Registry. Ships as a **single portable `CyrFlip.exe`** with no dependencies (.NET Framework 4.8, preinstalled on Windows 10/11).

| | |
|---|---|
| **Package** | `SerZhyAle.CyrFlip` |
| **Version** | `26.6.16.1459` |
| **Installer** | `zip` → nested `portable` (`CyrFlip.exe`, command alias `cyrflip`) |
| **Architecture** | x64 |
| **Source** | https://github.com/SerZhyAle/CyrFlip |
| **Release** | https://github.com/SerZhyAle/CyrFlip/releases/tag/v26.6.16.1459 |
| **License** | MIT |

Locales: `en-US` (default), `ru-RU`, `uk-UA`.

This replaces the previously closed PR #386817 (version 26.6.12.0021) — closed in favour of this updated version with feature toggles, hotkey dialog, and registry-based settings.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  - N/A — new package, no related issue.

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` — **passed** (no errors).
- [x] Tested manifest locally with `winget install --manifest <path>` — installed successfully; hash verified, archive extracted, `cyrflip` alias registered.
- [x] Manifest conforms to schema (`ManifestVersion 1.12.0`; `winget validate` succeeds).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/388542)