### PR TITLE
New package: MarcoSumari.IngePresupuestos version 2.4.20

### DIFF
--- a/manifests/m/MarcoSumari/IngePresupuestos/2.4.20/MarcoSumari.IngePresupuestos.installer.yaml
+++ b/manifests/m/MarcoSumari/IngePresupuestos/2.4.20/MarcoSumari.IngePresupuestos.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: MarcoSumari.IngePresupuestos
+PackageVersion: 2.4.20
+InstallerLocale: es-PE
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: inno
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://downloads.ingepresupuestos.com/v2.4.20/ingepresupuestos-setup-v2.4.20.exe
+    InstallerSha256: ACBA139029E08B9DF16D2CEE61E7771B809DA7E2244F5468FADF38BB518AE10D
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/MarcoSumari/IngePresupuestos/2.4.20/MarcoSumari.IngePresupuestos.locale.es-PE.yaml
+++ b/manifests/m/MarcoSumari/IngePresupuestos/2.4.20/MarcoSumari.IngePresupuestos.locale.es-PE.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: MarcoSumari.IngePresupuestos
+PackageVersion: 2.4.20
+PackageLocale: es-PE
+Publisher: Marco Sumari
+PublisherUrl: https://ingepresupuestos.com
+PublisherSupportUrl: https://ingepresupuestos.com
+PrivacyUrl: https://docs.ingepresupuestos.com/privacidad
+Author: Ing. Marco Sumari
+PackageName: IngePresupuestos
+PackageUrl: https://ingepresupuestos.com
+License: Proprietary
+Copyright: Copyright (c) Marco Sumari
+ShortDescription: Presupuestos de obra con ACU, cronograma Gantt valorizado y 13 reportes profesionales.
+Description: |-
+  IngePresupuestos es el software de presupuestos de obra para ingenieros y
+  arquitectos. Elabora presupuestos con Análisis de Costos Unitarios (ACU),
+  cronogramas valorizados (Gantt con ruta crítica y CPM), fórmula polinómica e
+  índices INEI, metrados (incluido acero), y 13 reportes profesionales
+  exportables a PDF, Excel, Word, ODS y ODT. Importa tus presupuestos existentes
+  de S10, PowerCost y Delphin, además de Excel e IFC. Incluye un asistente con
+  inteligencia artificial opcional (con tu propia clave). Descarga gratuita;
+  licencia premium para la exportación editable. Tus datos quedan en tu equipo.
+Moniker: ingepresupuestos
+Tags:
+  - presupuestos
+  - construccion
+  - acu
+  - cronograma
+  - metrados
+  - s10
+  - ingenieria-civil
+  - obra
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/MarcoSumari/IngePresupuestos/2.4.20/MarcoSumari.IngePresupuestos.yaml
+++ b/manifests/m/MarcoSumari/IngePresupuestos/2.4.20/MarcoSumari.IngePresupuestos.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: MarcoSumari.IngePresupuestos
+PackageVersion: 2.4.20
+DefaultLocale: es-PE
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: MarcoSumari.IngePresupuestos 2.4.20

- Manifest version: 1.6.0
- Installer type: inno (Inno Setup), x64, scope machine
- Installer is publicly hosted and the SHA256 in the manifest matches the file.

#### Checklist
- [x] This is a new package (first version submitted).
- [x] Manifest follows the 1.6.0 schema.
- [x] InstallerSha256 was computed from the exact published installer.
- [x] Installer URL is a stable, versioned, publicly downloadable link.

Note: this is a full-trust Win32 desktop application (Python/Qt, packaged with Inno Setup). The installer supports silent install via Inno Setup standard switches.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/388765)