### PR TITLE
New version: DeltaForge.CLI version 1.0.6

### DIFF
--- a/manifests/d/DeltaForge/CLI/1.0.6/DeltaForge.CLI.installer.yaml
+++ b/manifests/d/DeltaForge/CLI/1.0.6/DeltaForge.CLI.installer.yaml
@@ -1,0 +1,11 @@
+PackageIdentifier: DeltaForge.CLI
+PackageVersion: 1.0.6
+InstallerType: wix
+
+
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/deltaforge-org/delta-forge/releases/download/v1.0.6/deltaforge-cli-1.0.6-windows-x64.msi
+  InstallerSha256: DF9ECC08AD82CFD9EB78BCB8B3651DEDE8D941D3BC2E009D3BA303BEB35D7083
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/d/DeltaForge/CLI/1.0.6/DeltaForge.CLI.locale.en-US.yaml
+++ b/manifests/d/DeltaForge/CLI/1.0.6/DeltaForge.CLI.locale.en-US.yaml
@@ -1,0 +1,27 @@
+PackageIdentifier: DeltaForge.CLI
+PackageVersion: 1.0.6
+PackageLocale: en-US
+Publisher: DeltaForge
+PublisherUrl: https://deltaforge.org
+PublisherSupportUrl: https://deltaforge.org/pages/contact.html
+PackageName: 'DeltaForge CLI'
+Moniker: 'deltaforge-cli'
+PackageUrl: https://deltaforge.org
+License: Proprietary
+LicenseUrl: https://deltaforge.org/pages/terms-of-service.html
+Copyright: 'Copyright (c) 2026 DeltaForge'
+ShortDescription: 'Query Delta Lake and Apache Iceberg in place from your terminal: no warehouse, no cluster, no copy pipeline'
+Tags:
+  - cli
+  - command-line
+  - delta-forge
+  - delta-lake
+  - iceberg
+  - sql
+  - graph
+  - cypher
+  - geospatial
+  - adbc
+  - odbc
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/d/DeltaForge/CLI/1.0.6/DeltaForge.CLI.yaml
+++ b/manifests/d/DeltaForge/CLI/1.0.6/DeltaForge.CLI.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: DeltaForge.CLI
+PackageVersion: 1.0.6
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Adds the DeltaForge.CLI 1.0.6 manifest with a signed MSI installer.

Installer asset:
https://github.com/deltaforge-org/delta-forge/releases/download/v1.0.6/deltaforge-cli-1.0.6-windows-x64.msi

Publisher homepage: https://deltaforge.org
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/388785)