### PR TITLE
New version: Feci.ParleyDeckCli version 1.28.0

### DIFF
--- a/manifests/f/Feci/ParleyDeckCli/1.28.0/Feci.ParleyDeckCli.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.28.0/Feci.ParleyDeckCli.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.28.0
+InstallerType: portable
+Commands:
+- parley
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.28.0/parley-v1.28.0-windows-x64.exe
+  InstallerSha256: 3B0C5CB6DC63BAB0E9932808752069D37223B72521819530D986E9BA6E3A774B
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.28.0/parley-v1.28.0-windows-arm64.exe
+  InstallerSha256: D7E3015BD3F0C11A3FA7303B30A87A9A5E236D0046CA43FB39C4541B2D756C34
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.28.0/Feci.ParleyDeckCli.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.28.0/Feci.ParleyDeckCli.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.28.0
+PackageLocale: en-US
+Publisher: Feci
+PublisherUrl: https://github.com/feci
+PackageName: Parley Deck CLI
+PackageUrl: https://github.com/feci/parley-deck-cli
+License: Apache-2.0
+LicenseUrl: https://github.com/feci/parley-deck-cli/blob/main/LICENSE
+ShortDescription: CLI that orchestrates Parley Deck multi-agent cooperation workflows.
+Description: parley orchestrates multi-agent Parley Deck cooperation: deliberation rounds across local CLI agents, consensus/finalize/implementation, a live TUI, and (new in 1.28.0) retrospective optimization via `parley retro`.
+ReleaseNotesUrl: https://github.com/feci/parley-deck-cli/releases/tag/v1.28.0
+Tags:
+- ai
+- agents
+- agy
+- claude
+- cli
+- codex
+- consensus
+- multi-agent
+- orchestration
+- tui
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.28.0/Feci.ParleyDeckCli.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.28.0/Feci.ParleyDeckCli.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.28.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New version

- **Package**: Feci.ParleyDeckCli 1.28.0
- **Type**: portable (command: `parley`), x64 + arm64
- **Installers**: GitHub release assets for v1.28.0 (verified reachable; SHA256 from the published `.exe` files)

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/389017)