### PR TITLE
New version: Feci.ParleyDeckCli version 1.28.1

### DIFF
--- a/manifests/f/Feci/ParleyDeckCli/1.28.1/Feci.ParleyDeckCli.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.28.1/Feci.ParleyDeckCli.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.28.1
+InstallerType: portable
+Commands:
+- parley
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.28.1/parley-v1.28.1-windows-x64.exe
+  InstallerSha256: 24EE03D9EFBA8A47DDAE860A1C407D2CA0BA0F0283659E0D951D15F96728A81C
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.28.1/parley-v1.28.1-windows-arm64.exe
+  InstallerSha256: 6F6E52320DE4D0578274D7E54D8620E92917C24AA5933EC216BB8CA7AC27E411
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.28.1/Feci.ParleyDeckCli.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.28.1/Feci.ParleyDeckCli.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.28.1
+PackageLocale: en-US
+Publisher: Feci
+PublisherUrl: https://github.com/feci
+PackageName: Parley Deck CLI
+PackageUrl: https://github.com/feci/parley-deck-cli
+License: Apache-2.0
+LicenseUrl: https://github.com/feci/parley-deck-cli/blob/main/LICENSE
+ShortDescription: CLI that orchestrates Parley Deck multi-agent cooperation workflows.
+Description: parley orchestrates multi-agent Parley Deck cooperation: deliberation rounds across local CLI agents, consensus/finalize/implementation, a live TUI, and retrospective optimization via `parley retro`.
+ReleaseNotesUrl: https://github.com/feci/parley-deck-cli/releases/tag/v1.28.1
+Tags:
+- ai
+- agents
+- agy
+- claude
+- cli
+- codex
+- consensus
+- multi-agent
+- orchestration
+- tui
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.28.1/Feci.ParleyDeckCli.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.28.1/Feci.ParleyDeckCli.locale.en-US.yaml
@@ -9,7 +9,7 @@ PackageUrl: https://github.com/feci/parley-deck-cli
 License: Apache-2.0
 LicenseUrl: https://github.com/feci/parley-deck-cli/blob/main/LICENSE
 ShortDescription: CLI that orchestrates Parley Deck multi-agent cooperation workflows.
-Description: parley orchestrates multi-agent Parley Deck cooperation: deliberation rounds across local CLI agents, consensus/finalize/implementation, a live TUI, and retrospective optimization via `parley retro`.
+Description: "parley orchestrates multi-agent Parley Deck cooperation: deliberation rounds across local CLI agents, consensus/finalize/implementation, a live TUI, and retrospective optimization via `parley retro`."
 ReleaseNotesUrl: https://github.com/feci/parley-deck-cli/releases/tag/v1.28.1
 Tags:
 - ai

--- a/manifests/f/Feci/ParleyDeckCli/1.28.1/Feci.ParleyDeckCli.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.28.1/Feci.ParleyDeckCli.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.28.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New version
- **Package**: Feci.ParleyDeckCli 1.28.1 (portable, command `parley`, x64+arm64)
- Installers are the published GitHub release assets for v1.28.1 (verified reachable; SHA256 from the .exe files).

- [x] CLA signed
- [x] No other open PRs for this manifest
- [x] Conforms to the 1.12 schema
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/389037)