### PR TITLE
New package: ElCruncharino.NeoStego version 1.0.0

### DIFF
--- a/manifests/e/ElCruncharino/NeoStego/1.0.0/ElCruncharino.NeoStego.installer.yaml
+++ b/manifests/e/ElCruncharino/NeoStego/1.0.0/ElCruncharino.NeoStego.installer.yaml
@@ -12,5 +12,10 @@ Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/ElCruncharino/neostego/releases/download/v1.0.0/NeoStego-1.0.0.exe
     InstallerSha256: 69E4A463039661AE6B38AD7F6B6B5D95A2D046F96CC7BD0F4F23182CAB86A414
+    AppsAndFeaturesEntries:
+      - DisplayName: NeoStego
+        Publisher: Nick Haghiri
+        DisplayVersion: 1.0.0
+        InstallerType: inno
 ManifestType: installer
 ManifestVersion: 1.9.0

--- a/manifests/e/ElCruncharino/NeoStego/1.0.0/ElCruncharino.NeoStego.installer.yaml
+++ b/manifests/e/ElCruncharino/NeoStego/1.0.0/ElCruncharino.NeoStego.installer.yaml
@@ -1,0 +1,16 @@
+PackageIdentifier: ElCruncharino.NeoStego
+PackageVersion: 1.0.0
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: user
+ReleaseDate: 2026-06-16
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/ElCruncharino/neostego/releases/download/v1.0.0/NeoStego-1.0.0.exe
+    InstallerSha256: 69E4A463039661AE6B38AD7F6B6B5D95A2D046F96CC7BD0F4F23182CAB86A414
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/e/ElCruncharino/NeoStego/1.0.0/ElCruncharino.NeoStego.installer.yaml
+++ b/manifests/e/ElCruncharino/NeoStego/1.0.0/ElCruncharino.NeoStego.installer.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 PackageIdentifier: ElCruncharino.NeoStego
 PackageVersion: 1.0.0
 MinimumOSVersion: 10.0.0.0

--- a/manifests/e/ElCruncharino/NeoStego/1.0.0/ElCruncharino.NeoStego.installer.yaml
+++ b/manifests/e/ElCruncharino/NeoStego/1.0.0/ElCruncharino.NeoStego.installer.yaml
@@ -6,9 +6,12 @@ InstallerType: inno
 Scope: user
 ReleaseDate: 2026-06-16
 InstallModes:
-  - interactive
   - silent
   - silentWithProgress
+  - interactive
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/ElCruncharino/neostego/releases/download/v1.0.0/NeoStego-1.0.0.exe

--- a/manifests/e/ElCruncharino/NeoStego/1.0.0/ElCruncharino.NeoStego.locale.en-US.yaml
+++ b/manifests/e/ElCruncharino/NeoStego/1.0.0/ElCruncharino.NeoStego.locale.en-US.yaml
@@ -1,0 +1,22 @@
+PackageIdentifier: ElCruncharino.NeoStego
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: Nick Haghiri
+PublisherUrl: https://github.com/ElCruncharino
+PublisherSupportUrl: https://github.com/ElCruncharino/neostego/issues
+PackageName: NeoStego
+PackageUrl: https://github.com/ElCruncharino/neostego
+License: GPL-2.0
+LicenseUrl: https://github.com/ElCruncharino/neostego/blob/master/LICENSE
+Copyright: Copyright (c) 2007-2026 Samir Vaidya and Nick Haghiri
+ShortDescription: Steganography tool to hide data in images/audio and apply invisible watermarks.
+Description: NeoStego is a steganography application that hides data inside image and audio files and applies invisible watermarks. A modernized fork of OpenStego with content-adaptive (HILL+STC) and SI-UNIWARD algorithms, robust DWT-SVD watermarking, and a cross-platform UI.
+Moniker: neostego
+Tags:
+  - steganography
+  - watermarking
+  - security
+  - privacy
+  - hide-data
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/e/ElCruncharino/NeoStego/1.0.0/ElCruncharino.NeoStego.locale.en-US.yaml
+++ b/manifests/e/ElCruncharino/NeoStego/1.0.0/ElCruncharino.NeoStego.locale.en-US.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 PackageIdentifier: ElCruncharino.NeoStego
 PackageVersion: 1.0.0
 PackageLocale: en-US

--- a/manifests/e/ElCruncharino/NeoStego/1.0.0/ElCruncharino.NeoStego.yaml
+++ b/manifests/e/ElCruncharino/NeoStego/1.0.0/ElCruncharino.NeoStego.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: ElCruncharino.NeoStego
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0

--- a/manifests/e/ElCruncharino/NeoStego/1.0.0/ElCruncharino.NeoStego.yaml
+++ b/manifests/e/ElCruncharino/NeoStego/1.0.0/ElCruncharino.NeoStego.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
 PackageIdentifier: ElCruncharino.NeoStego
 PackageVersion: 1.0.0
 DefaultLocale: en-US


### PR DESCRIPTION
### New package: ElCruncharino.NeoStego 1.0.0

NeoStego is a cross-platform steganography application (a modernized fork of OpenStego). This adds the initial winget manifest.

- Installer: runtime-bundled Inno Setup `.exe` from GitHub Releases (per-user, x64).
- `InstallerType: inno`, SHA256 verified against the GitHub release asset digest.
- Manifests authored to schema 1.9.0 and validated locally as YAML.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] This is a new package (first submission).
- [x] Manifest validated locally.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/389056)