### PR TITLE
SethColeman.Oddmon version 0.2.0

### DIFF
--- a/manifests/s/SethColeman/Oddmon/0.2.0/SethColeman.Oddmon.installer.yaml
+++ b/manifests/s/SethColeman/Oddmon/0.2.0/SethColeman.Oddmon.installer.yaml
@@ -1,0 +1,16 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: SethColeman.Oddmon
+PackageVersion: 0.2.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: oddmon.exe
+  PortableCommandAlias: oddmon
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/SethColeman/oddmon/releases/download/v0.2.0/oddmon-0.2.0-win-x64.zip
+  InstallerSha256: 2B2997DD2FDBFEE05DA316A13CE625C2E941261D9AEB757FA5165316B8D01515
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/SethColeman/Oddmon/0.2.0/SethColeman.Oddmon.locale.en-US.yaml
+++ b/manifests/s/SethColeman/Oddmon/0.2.0/SethColeman.Oddmon.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: SethColeman.Oddmon
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: Seth Coleman
+PublisherUrl: https://github.com/SethColeman
+Author: Seth Coleman
+PackageName: oddmon
+PackageUrl: https://github.com/SethColeman/oddmon
+License: MIT
+LicenseUrl: https://github.com/SethColeman/oddmon/blob/main/LICENSE
+ShortDescription: An auditory (and visual) monitor that gives your PC its old drive sounds and front-panel LEDs back.
+Description: "oddmon is a lightweight Windows tray utility that brings back the auditory and visual cues of older computers, tied to what your machine is actually doing: a tray HDD-activity LED (green/red/amber on real disk I/O), a power-aware Turbo LED, looped CC0 hard-drive seek sounds, and an optional always-on-top desktop LED panel. Sounds auto-mute while you're in a call (mic in use) and during a configurable quiet-hours window. No telemetry."
+Moniker: oddmon
+Tags:
+- tray
+- nostalgia
+- retro
+- hdd
+- led
+- sound
+- monitor
+- skeuomorphic
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/SethColeman/Oddmon/0.2.0/SethColeman.Oddmon.yaml
+++ b/manifests/s/SethColeman/Oddmon/0.2.0/SethColeman.Oddmon.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: SethColeman.Oddmon
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION

Adds **SethColeman.Oddmon** version **0.2.0** as a new package.

oddmon is a lightweight, open-source (MIT) Windows tray utility that brings back
the auditory and visual cues of older PCs, tied to real system activity: a tray
HDD-activity LED, a power-aware Turbo LED, looped CC0 hard-drive seek sounds, an
optional always-on-top desktop LED panel, and meeting/quiet-hours auto-mute.

- Project: https://github.com/SethColeman/oddmon
- Installer: portable `.zip` (self-contained, no .NET install needed), x64
- License: MIT


