### PR TITLE
New version: tisun2.OofManager version 1.1.13

### DIFF
--- a/manifests/t/tisun2/OofManager/1.1.13/tisun2.OofManager.installer.yaml
+++ b/manifests/t/tisun2/OofManager/1.1.13/tisun2.OofManager.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: tisun2.OofManager
+PackageVersion: 1.1.13
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART
+UpgradeBehavior: install
+ReleaseDate: 2026-06-17
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/tisun2/OofManager/releases/download/v1.1.13/OofManagerSetup.exe
+    InstallerSha256: A610557BC7B58FD5C16E8D20940ECF9E90D0AA99D889FB1DFE0EA68470F3F5A9
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/t/tisun2/OofManager/1.1.13/tisun2.OofManager.locale.en-US.yaml
+++ b/manifests/t/tisun2/OofManager/1.1.13/tisun2.OofManager.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: tisun2.OofManager
+PackageVersion: 1.1.13
+PackageLocale: en-US
+Publisher: tisun2
+PublisherUrl: https://github.com/tisun2
+PublisherSupportUrl: https://github.com/tisun2/OofManager/issues
+PackageName: OOF Manager
+PackageUrl: https://github.com/tisun2/OofManager
+License: MIT
+LicenseUrl: https://github.com/tisun2/OofManager/blob/main/LICENSE
+Copyright: Copyright (c) tisun2
+ShortDescription: Manage Microsoft 365 / Exchange Online Out-of-Office (Automatic Reply) settings without opening Outlook.
+Description: |-
+  OOF Manager is a lightweight Windows desktop tool that manages your Microsoft 365 mailbox's
+  Out-of-Office (Automatic Reply) state for you. Sign in once, configure your weekly work hours
+  and reply text, and OOF Manager auto-toggles your OOF on/off at the schedule boundaries.
+  It also pushes the next off-hours window to Exchange as a Scheduled OOF, so the server keeps
+  switching auto-replies even when this app is closed.
+Moniker: oofmanager
+Tags:
+  - exchange
+  - microsoft-365
+  - office-365
+  - out-of-office
+  - oof
+  - outlook
+  - autoreply
+ReleaseNotesUrl: https://github.com/tisun2/OofManager/releases/tag/v1.1.13
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/t/tisun2/OofManager/1.1.13/tisun2.OofManager.yaml
+++ b/manifests/t/tisun2/OofManager/1.1.13/tisun2.OofManager.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: tisun2.OofManager
+PackageVersion: 1.1.13
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Fix manual vacation flows not firing (1.1.13)

Fixes two bugs that could stop manual vacation cloud flows from running.

### Changes
- **One-shot trigger skipped (`Month` → `Hour`):** Vacation Start/End used a `Month`
  recurrence with `count: 1`, which Power Automate can skip unless the flow is set up
  a month in advance — so an *enabled* flow never fired at vacation start. Switched to
  an `Hour` frequency (not subject to that advance-setup rule); `count: 1` still pins it
  to a single run.
- **Silent-Off after import:** `Enable-Flow` reports success even when a connection
  reference is unbound, leaving the flow Off. The post-import enable path and the toggle
  loop now re-read live state and only report ready when the flow is actually On,
  otherwise guiding the user to bind connections.

### Action required
Re-run **"Set up vacation in cloud"** to refresh already-imported vacation flows.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/389150)