### PR TITLE
Update Helvesec.RMUX to 0.6.0

### DIFF
--- a/manifests/h/Helvesec/RMUX/0.6.0/Helvesec.RMUX.installer.yaml
+++ b/manifests/h/Helvesec/RMUX/0.6.0/Helvesec.RMUX.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Helvesec.RMUX
+PackageVersion: 0.6.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: rmux-0.6.0-windows-x86_64\rmux.exe
+    PortableCommandAlias: rmux
+ReleaseDate: "2026-06-17"
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Helvesec/rmux/releases/download/v0.6.0/rmux-0.6.0-windows-x86_64.zip
+    InstallerSha256: A1A65DFA2F0A187F08D0C57FBDA68039488D7C54305DAA63BE0F3E2BB2ECA72E
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/h/Helvesec/RMUX/0.6.0/Helvesec.RMUX.locale.en-US.yaml
+++ b/manifests/h/Helvesec/RMUX/0.6.0/Helvesec.RMUX.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Helvesec.RMUX
+PackageVersion: 0.6.0
+PackageLocale: en-US
+Publisher: Helvesec
+PublisherUrl: https://github.com/Helvesec
+PublisherSupportUrl: https://github.com/Helvesec/rmux/issues
+Author: Helvesec
+PackageName: RMUX
+PackageUrl: https://rmux.io
+License: MIT OR Apache-2.0
+ShortDescription: Terminal multiplexer with a tmux-style CLI, daemon runtime, and native Windows support.
+Description: |-
+  RMUX is a terminal multiplexer with a tmux-style command line, daemon-backed persistent sessions, native Windows support, and a Rust SDK for automation.
+Moniker: rmux
+Tags:
+  - cli
+  - multiplexer
+  - rust
+  - terminal
+  - tmux
+ReleaseNotesUrl: https://github.com/Helvesec/rmux/releases/tag/v0.6.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/h/Helvesec/RMUX/0.6.0/Helvesec.RMUX.yaml
+++ b/manifests/h/Helvesec/RMUX/0.6.0/Helvesec.RMUX.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Helvesec.RMUX
+PackageVersion: 0.6.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Updates Helvesec.RMUX to v0.6.0.

Release: https://github.com/Helvesec/rmux/releases/tag/v0.6.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/389254)