### PR TITLE
Update SakiStudio.SakiSSH → SakiStudio.SakiAgentSSH.Client + .Daemon version 7.0.0

### DIFF
--- a/manifests/s/SakiStudio/SakiAgentSSH/Client/7.0.0/SakiStudio.SakiAgentSSH.Client.installer.yaml
+++ b/manifests/s/SakiStudio/SakiAgentSSH/Client/7.0.0/SakiStudio.SakiAgentSSH.Client.installer.yaml
@@ -1,0 +1,13 @@
+# Created using winget-pkgs YAML schema
+PackageIdentifier: SakiStudio.SakiAgentSSH.Client
+PackageVersion: 7.0.0
+InstallerType: portable
+ReleaseDate: 2026-06-16
+Commands:
+  - sakissh
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Saki-tw/SakiSSH-Saki-Agent-Secure-Stream/releases/download/v7.0.0/sakissh.exe
+    InstallerSha256: 9C442957350FD4944C0B7F94AE049E4AA7286D794C39285FEA740DB18746A5A1
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/SakiStudio/SakiAgentSSH/Client/7.0.0/SakiStudio.SakiAgentSSH.Client.locale.en-US.yaml
+++ b/manifests/s/SakiStudio/SakiAgentSSH/Client/7.0.0/SakiStudio.SakiAgentSSH.Client.locale.en-US.yaml
@@ -1,0 +1,40 @@
+# Created using winget-pkgs YAML schema
+PackageIdentifier: SakiStudio.SakiAgentSSH.Client
+PackageVersion: 7.0.0
+PackageLocale: en-US
+Publisher: Saki Studio
+PublisherUrl: http://saki-studio.com.tw
+PublisherSupportUrl: https://github.com/Saki-tw/SakiSSH-Saki-Agent-Secure-Stream/issues
+Author: Chang Hua
+PackageName: SakiAgentSSH Client
+PackageUrl: https://github.com/Saki-tw/SakiSSH-Saki-Agent-Secure-Stream
+License: MIT
+LicenseUrl: https://github.com/Saki-tw/SakiSSH-Saki-Agent-Secure-Stream/blob/main/release/LICENSE
+ReleaseDate: 2026-06-16
+ShortDescription: Agent-native remote execution CLI over gRPC with Total Response Mapping
+Description: |-
+  SakiAgentSSH Client connects to a SakiAgentSSH Daemon over gRPC to execute
+  commands on remote machines. It implements SASS protocol v1.4: Total Response Mapping for complete
+  output capture, Safety Gradient for progressive permission control, and Transparent
+  Branching for parallel execution paths. Features bidirectional stdout/stderr
+  streaming, zero-dependency portable binary, and agent-native CLI design.
+  From the same developer as SakiStudio.SakiVi (VI-SakiWin64).
+ReleaseNotes: |-
+  v7.0.0 (implements SASS protocol v1.4)
+  - Total Response Mapping: complete output capture with structured metadata
+  - Safety Gradient: progressive permission control on client side
+  - Transparent Branching: parallel execution paths with automatic merging
+  - Enhanced connection reliability and retry logic
+  - Improved gRPC streaming performance
+ReleaseNotesUrl: https://github.com/Saki-tw/SakiSSH-Saki-Agent-Secure-Stream/releases/tag/v7.0.0
+Tags:
+  - agent
+  - grpc
+  - remote-execution
+  - client
+  - ssh-alternative
+  - cli
+  - total-response-mapping
+  - safety-gradient
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/SakiStudio/SakiAgentSSH/Client/7.0.0/SakiStudio.SakiAgentSSH.Client.locale.zh-Hant.yaml
+++ b/manifests/s/SakiStudio/SakiAgentSSH/Client/7.0.0/SakiStudio.SakiAgentSSH.Client.locale.zh-Hant.yaml
@@ -1,0 +1,31 @@
+# Created using winget-pkgs YAML schema
+PackageIdentifier: SakiStudio.SakiAgentSSH.Client
+PackageVersion: 7.0.0
+PackageLocale: zh-Hant
+Publisher: Saki Studio
+PackageName: SakiAgentSSH 客戶端
+ReleaseDate: 2026-06-16
+ShortDescription: Agent 原生遠端執行 CLI (gRPC)，支援完整回應映射
+Description: |-
+  SakiAgentSSH Client 透過 gRPC 連線至 SakiAgentSSH Daemon，在遠端機器上執行指令。
+  實作 SASS 協議 v1.4，含「完整回應映射」完整擷取輸出與結構化中繼資料、「安全梯度」客戶端漸進式
+  權限控制、以及「透明分支」平行執行路徑與自動合併。
+  支援雙向 stdout/stderr 串流、零依賴可攜式二進位、Agent 原生 CLI 設計。
+  來自 SakiStudio.SakiVi (VI-SakiWin64) 同一開發者。
+ReleaseNotes: |-
+  v7.0.0（實作 SASS 協議 v1.4）
+  - 完整回應映射：完整輸出擷取與結構化中繼資料
+  - 安全梯度：客戶端漸進式權限控制
+  - 透明分支：平行執行路徑與自動合併
+  - 增強連線可靠性與重試邏輯
+  - 改善 gRPC 串流效能
+ReleaseNotesUrl: https://github.com/Saki-tw/SakiSSH-Saki-Agent-Secure-Stream/releases/tag/v7.0.0
+Tags:
+  - agent
+  - grpc
+  - 遠端執行
+  - 客戶端
+  - 完整回應映射
+  - 安全梯度
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/s/SakiStudio/SakiAgentSSH/Client/7.0.0/SakiStudio.SakiAgentSSH.Client.yaml
+++ b/manifests/s/SakiStudio/SakiAgentSSH/Client/7.0.0/SakiStudio.SakiAgentSSH.Client.yaml
@@ -1,0 +1,6 @@
+# Created using winget-pkgs YAML schema
+PackageIdentifier: SakiStudio.SakiAgentSSH.Client
+PackageVersion: 7.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/manifests/s/SakiStudio/SakiAgentSSH/Daemon/7.0.0/SakiStudio.SakiAgentSSH.Daemon.installer.yaml
+++ b/manifests/s/SakiStudio/SakiAgentSSH/Daemon/7.0.0/SakiStudio.SakiAgentSSH.Daemon.installer.yaml
@@ -1,0 +1,13 @@
+# Created using winget-pkgs YAML schema
+PackageIdentifier: SakiStudio.SakiAgentSSH.Daemon
+PackageVersion: 7.0.0
+InstallerType: portable
+ReleaseDate: 2026-06-16
+Commands:
+  - sakisshd
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Saki-tw/SakiSSH-Saki-Agent-Secure-Stream/releases/download/v7.0.0/sakisshd.exe
+    InstallerSha256: BDF8388FE697D4384932920F13E279074D4D7651363D6FDDB1B1F166F0061CB3
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/SakiStudio/SakiAgentSSH/Daemon/7.0.0/SakiStudio.SakiAgentSSH.Daemon.locale.en-US.yaml
+++ b/manifests/s/SakiStudio/SakiAgentSSH/Daemon/7.0.0/SakiStudio.SakiAgentSSH.Daemon.locale.en-US.yaml
@@ -1,0 +1,40 @@
+# Created using winget-pkgs YAML schema
+PackageIdentifier: SakiStudio.SakiAgentSSH.Daemon
+PackageVersion: 7.0.0
+PackageLocale: en-US
+Publisher: Saki Studio
+PublisherUrl: http://saki-studio.com.tw
+PublisherSupportUrl: https://github.com/Saki-tw/SakiSSH-Saki-Agent-Secure-Stream/issues
+Author: Chang Hua
+PackageName: SakiAgentSSH Daemon
+PackageUrl: https://github.com/Saki-tw/SakiSSH-Saki-Agent-Secure-Stream
+License: MIT
+LicenseUrl: https://github.com/Saki-tw/SakiSSH-Saki-Agent-Secure-Stream/blob/main/release/LICENSE
+ReleaseDate: 2026-06-16
+ShortDescription: Agent-native cross-machine execution daemon over gRPC with Total Response Mapping
+Description: |-
+  SakiAgentSSH Daemon listens for gRPC commands from AI agents, enabling secure
+  cross-machine execution without SSH. It implements SASS protocol v1.4: Total Response Mapping for
+  complete output capture, Safety Gradient for progressive permission escalation,
+  and Transparent Branching for parallel execution paths. Features CIDR whitelist
+  ACL, bidirectional stdout/stderr streaming, and zero-dependency portable binary.
+  From the same developer as SakiStudio.SakiVi (VI-SakiWin64).
+ReleaseNotes: |-
+  v7.0.0 (implements SASS protocol v1.4)
+  - Total Response Mapping: complete output capture with structured metadata
+  - Safety Gradient: progressive permission escalation based on trust level
+  - Transparent Branching: parallel execution paths with automatic merging
+  - Enhanced CIDR ACL with IPv6 support
+  - Improved gRPC streaming performance
+ReleaseNotesUrl: https://github.com/Saki-tw/SakiSSH-Saki-Agent-Secure-Stream/releases/tag/v7.0.0
+Tags:
+  - agent
+  - grpc
+  - remote-execution
+  - daemon
+  - ssh-alternative
+  - cli
+  - total-response-mapping
+  - safety-gradient
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/SakiStudio/SakiAgentSSH/Daemon/7.0.0/SakiStudio.SakiAgentSSH.Daemon.locale.zh-Hant.yaml
+++ b/manifests/s/SakiStudio/SakiAgentSSH/Daemon/7.0.0/SakiStudio.SakiAgentSSH.Daemon.locale.zh-Hant.yaml
@@ -1,0 +1,31 @@
+# Created using winget-pkgs YAML schema
+PackageIdentifier: SakiStudio.SakiAgentSSH.Daemon
+PackageVersion: 7.0.0
+PackageLocale: zh-Hant
+Publisher: Saki Studio
+PackageName: SakiAgentSSH 守護進程
+ReleaseDate: 2026-06-16
+ShortDescription: Agent 原生跨機器執行守護進程 (gRPC)，支援完整回應映射
+Description: |-
+  SakiAgentSSH Daemon 監聽來自 AI Agent 的 gRPC 指令，實現無需 SSH 的安全跨機器執行。
+  實作 SASS 協議 v1.4，含「完整回應映射」完整擷取輸出與結構化中繼資料、「安全梯度」基於信任等級的
+  漸進式權限提升、以及「透明分支」平行執行路徑與自動合併。
+  支援 CIDR 白名單存取控制（含 IPv6）、雙向 stdout/stderr 串流、零依賴可攜式二進位。
+  來自 SakiStudio.SakiVi (VI-SakiWin64) 同一開發者。
+ReleaseNotes: |-
+  v7.0.0（實作 SASS 協議 v1.4）
+  - 完整回應映射：完整輸出擷取與結構化中繼資料
+  - 安全梯度：基於信任等級的漸進式權限提升
+  - 透明分支：平行執行路徑與自動合併
+  - 增強 CIDR ACL 支援 IPv6
+  - 改善 gRPC 串流效能
+ReleaseNotesUrl: https://github.com/Saki-tw/SakiSSH-Saki-Agent-Secure-Stream/releases/tag/v7.0.0
+Tags:
+  - agent
+  - grpc
+  - 遠端執行
+  - daemon
+  - 完整回應映射
+  - 安全梯度
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/s/SakiStudio/SakiAgentSSH/Daemon/7.0.0/SakiStudio.SakiAgentSSH.Daemon.yaml
+++ b/manifests/s/SakiStudio/SakiAgentSSH/Daemon/7.0.0/SakiStudio.SakiAgentSSH.Daemon.yaml
@@ -1,0 +1,6 @@
+# Created using winget-pkgs YAML schema
+PackageIdentifier: SakiStudio.SakiAgentSSH.Daemon
+PackageVersion: 7.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Update

- **PackageIdentifier**: SakiStudio.SakiSSH
- **PackageVersion**: 7.0.0
- **Previous version**: 1.4.0

Version bump aligned with the SASS 7.0 protocol update. Now includes both daemon (`sakisshd`) and client (`sakissh`) in a single zip bundle.

#### What changed
- Updated from single daemon-only portable to a zip containing both daemon and client
- Protocol implementation updated to SASS v1.4 (draft-sakistudio-sass-07)
- Total Response Mapping, Safety Gradient, Transparent Branching
- Enhanced CIDR ACL with IPv6 support

From the same developer as [SakiStudio.SakiVI](https://github.com/microsoft/winget-pkgs/tree/master/manifests/s/SakiStudio/SakiVI).