### PR TITLE
SickSartori.SvgPreview version 2.0.1

### DIFF
--- a/manifests/s/SickSartori/SvgPreview/2.0.1/SickSartori.SvgPreview.installer.yaml
+++ b/manifests/s/SickSartori/SvgPreview/2.0.1/SickSartori.SvgPreview.installer.yaml
@@ -1,0 +1,22 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: SickSartori.SvgPreview
+PackageVersion: 2.0.1
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: machine
+InstallModes:
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{0C3C0E1A-DDC9-4E6F-9F0B-66FCC9C0437C}_is1'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/SickSartori/svg-preview/releases/download/v2.0.1/svg_preview_x64.exe
+  InstallerSha256: E0861C3393340360617DE183C02683492BD3D81178B6F99BBA462A5D71541062
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-06-17

--- a/manifests/s/SickSartori/SvgPreview/2.0.1/SickSartori.SvgPreview.locale.en-US.yaml
+++ b/manifests/s/SickSartori/SvgPreview/2.0.1/SickSartori.SvgPreview.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: SickSartori.SvgPreview
+PackageVersion: 2.0.1
+PackageLocale: en-US
+Publisher: Gabriel Sartori
+PublisherUrl: https://github.com/SickSartori
+PublisherSupportUrl: https://github.com/SickSartori/svg-preview/issues
+PackageName: SVG Preview
+PackageUrl: https://github.com/SickSartori/svg-preview
+License: LGPL-3.0
+LicenseUrl: https://github.com/SickSartori/svg-preview/blob/master/LICENSE.md
+ShortDescription: SVG thumbnails for Windows Explorer, rendered with resvg.
+Description: |-
+  Shell extension that renders SVG thumbnails in Windows Explorer using the
+  resvg engine, so files using clipPath, masks, filters, embedded images and
+  compressed .svgz render accurately. Modernized revival of the SVG Explorer
+  Extension by Tibold Kandrai.
+Moniker: svg-preview
+Tags:
+- explorer
+- shell-extension
+- svg
+- svgz
+- thumbnail
+- thumbnails
+- vector
+ReleaseNotesUrl: https://github.com/SickSartori/svg-preview/releases/tag/v2.0.1
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/SickSartori/svg-preview/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/SickSartori/SvgPreview/2.0.1/SickSartori.SvgPreview.yaml
+++ b/manifests/s/SickSartori/SvgPreview/2.0.1/SickSartori.SvgPreview.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: SickSartori.SvgPreview
+PackageVersion: 2.0.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update SVG Preview to 2.0.1. This maintenance release embeds a Win32 version resource in the DLL (product name, version, description and copyright now show in Explorer Properties). No rendering or functional changes from 2.0.0.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/389333)