### PR TITLE
New version: NakabaLab.sshm version 1.0.2

### DIFF
--- a/manifests/n/NakabaLab/sshm/1.0.2/NakabaLab.sshm.installer.yaml
+++ b/manifests/n/NakabaLab/sshm/1.0.2/NakabaLab.sshm.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: NakabaLab.sshm
+PackageVersion: 1.0.2
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: sshm.exe
+    PortableCommandAlias: sshm
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/nakaba-lab/ssh-manager-tui/releases/download/v1.0.2/sshm-1.0.2-x86_64-pc-windows-msvc.zip
+    InstallerSha256: 2BF95BEECC1491F4C5604745A758C21024DE266D0D9DB927878CBEEE76C55179
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/n/NakabaLab/sshm/1.0.2/NakabaLab.sshm.locale.en-US.yaml
+++ b/manifests/n/NakabaLab/sshm/1.0.2/NakabaLab.sshm.locale.en-US.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: NakabaLab.sshm
+PackageVersion: 1.0.2
+PackageLocale: en-US
+Publisher: nakaba-lab
+PublisherUrl: https://github.com/nakaba-lab/ssh-manager-tui
+Author: nakaba-lab
+PackageName: sshm
+PackageUrl: https://github.com/nakaba-lab/ssh-manager-tui
+License: MIT OR Apache-2.0
+ShortDescription: A TUI SSH host manager for ~/.ssh/config
+Moniker: sshm
+Tags:
+  - ssh
+  - tui
+  - ssh-config
+  - terminal
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/n/NakabaLab/sshm/1.0.2/NakabaLab.sshm.yaml
+++ b/manifests/n/NakabaLab/sshm/1.0.2/NakabaLab.sshm.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: NakabaLab.sshm
+PackageVersion: 1.0.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Version update
- **PackageIdentifier:** `NakabaLab.sshm`
- **PackageVersion:** `1.0.2` (previous: 1.0.1)
- **Type:** portable exe inside a zip (`InstallerType: zip`, `NestedInstallerType: portable`, alias `sshm`)

Upstream change: liveness probing now skips hosts behind a `ProxyCommand` (not just `ProxyJump`).

- Repository: https://github.com/nakaba-lab/ssh-manager-tui
- Release: https://github.com/nakaba-lab/ssh-manager-tui/releases/tag/v1.0.2

### Checklist
- [x] Validated locally: `winget validate` → succeeds
- [x] `InstallerSha256` matches the published asset (verified vs the `.sha256` sidecar and a local recompute)
- [x] Manifest schema 1.12.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/389343)