### PR TITLE
New version: Nexaflow.SignalFoundry 0.3.26

### DIFF
--- a/manifests/n/Nexaflow/SignalFoundry/0.3.26/Nexaflow.SignalFoundry.installer.yaml
+++ b/manifests/n/Nexaflow/SignalFoundry/0.3.26/Nexaflow.SignalFoundry.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Nexaflow.SignalFoundry
+PackageVersion: 0.3.26
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+ArchiveBinariesDependOnPath: true
+NestedInstallerFiles:
+- RelativeFilePath: signal-foundry-cli-0.3.26\bin\sf.exe
+  PortableCommandAlias: sf
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/nexaflow-io/signal-foundry-cli-releases/releases/download/cli-v0.3.26/signal-foundry-cli-0.3.26-windows-x64.zip
+  InstallerSha256: 82b74495dcf1e6ac713979f875d1a9cd5c6c6feb51e515377a9dbb9bf2fcb7fa
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/n/Nexaflow/SignalFoundry/0.3.26/Nexaflow.SignalFoundry.locale.en-US.yaml
+++ b/manifests/n/Nexaflow/SignalFoundry/0.3.26/Nexaflow.SignalFoundry.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Nexaflow.SignalFoundry
+PackageVersion: 0.3.26
+PackageLocale: en-US
+Publisher: Nexaflow
+PublisherUrl: https://nexaflow.io
+PackageName: Signal Foundry CLI
+PackageUrl: https://signal-foundry.app
+License: Proprietary
+LicenseUrl: https://signal-foundry.app/terms-of-service
+ShortDescription: Agent-first CLI for the Signal Foundry data workspace.
+Moniker: sf
+Tags:
+- cli
+- data-workspace
+- agent
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/n/Nexaflow/SignalFoundry/0.3.26/Nexaflow.SignalFoundry.yaml
+++ b/manifests/n/Nexaflow/SignalFoundry/0.3.26/Nexaflow.SignalFoundry.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Nexaflow.SignalFoundry
+PackageVersion: 0.3.26
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Summary
- Adds Nexaflow.SignalFoundry version 0.3.26.
- Uses the public Signal Foundry CLI release artifact from nexaflow-io/signal-foundry-cli-releases.

### Artifact
- Release: https://github.com/nexaflow-io/signal-foundry-cli-releases/releases/tag/cli-v0.3.26
- Windows ZIP: https://github.com/nexaflow-io/signal-foundry-cli-releases/releases/download/cli-v0.3.26/signal-foundry-cli-0.3.26-windows-x64.zip
- SHA256: 82b74495dcf1e6ac713979f875d1a9cd5c6c6feb51e515377a9dbb9bf2fcb7fa

### Verification
- Public release workflow succeeded: https://github.com/nexaflow-io/signal-foundry/actions/runs/27682542326
- Generated winget manifest uses zip + portable sf.exe with bundled runtime.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/389351)