### PR TITLE
New package: NakabaLab.wslm version 1.0.0

### DIFF
--- a/manifests/n/NakabaLab/wslm/1.0.0/NakabaLab.wslm.installer.yaml
+++ b/manifests/n/NakabaLab/wslm/1.0.0/NakabaLab.wslm.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: NakabaLab.wslm
+PackageVersion: 1.0.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: portable
+Commands:
+- wslm
+ReleaseDate: 2026-06-08
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/nakaba-lab/wsl-manager-tui/releases/download/v1.0.0/wslm-x86_64-pc-windows-msvc.exe
+  InstallerSha256: 2596571A3D40E415AA23DA9B60FACDF132A208FE501A1598C8DCD2A6CE7E8B41
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/n/NakabaLab/wslm/1.0.0/NakabaLab.wslm.locale.en-US.yaml
+++ b/manifests/n/NakabaLab/wslm/1.0.0/NakabaLab.wslm.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: NakabaLab.wslm
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: nakaba-lab
+PublisherUrl: https://github.com/nakaba-lab
+PublisherSupportUrl: https://github.com/nakaba-lab/wsl-manager-tui/issues
+Author: nakaba-lab
+PackageName: wslm
+PackageUrl: https://github.com/nakaba-lab/wsl-manager-tui
+License: MIT OR Apache-2.0
+LicenseUrl: https://github.com/nakaba-lab/wsl-manager-tui/blob/main/LICENSE-MIT
+Copyright: Copyright (c) 2026 nakaba-lab
+ShortDescription: A terminal UI to manage Windows Subsystem for Linux (WSL) distributions.
+Description: |-
+  wslm is a single self-contained terminal UI (Rust + ratatui) to manage WSL distributions on
+  Windows from one screen: list distros with state, version and on-disk size; start/stop them;
+  open shells inline or in a new Windows Terminal tab; watch live WSL VM memory/CPU gauges with
+  sparklines; do managed export/import (tar/vhdx); install distros from the online catalog; and
+  edit .wslconfig / wsl.conf. State detection is locale-independent and there is no telemetry.
+Moniker: wslm
+Tags:
+- wsl
+- tui
+- terminal
+- windows
+- ratatui
+- cli
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/n/NakabaLab/wslm/1.0.0/NakabaLab.wslm.yaml
+++ b/manifests/n/NakabaLab/wslm/1.0.0/NakabaLab.wslm.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: NakabaLab.wslm
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New package: `NakabaLab.wslm` version 1.0.0

**wslm** — a single self-contained terminal UI (Rust + ratatui) to manage Windows Subsystem for
Linux (WSL) distributions: list distros with state/version/disk, start/stop, open shells, watch
live VM memory/CPU, managed export/import, online install, and `.wslconfig`/`wsl.conf` editing.

This standardizes the publisher identifier to match my other package `NakabaLab.sshm` — it replaces
the previously-published `nakaba-lab.wslm` (same app/installer), which is being removed in a
companion PR. Installer is unchanged (portable x64 exe from the project's GitHub release).

- **Installer type:** portable (single x64 `.exe`), command `wslm`
- **Repository:** https://github.com/nakaba-lab/wsl-manager-tui
- **License:** MIT OR Apache-2.0
- Manifest schema 1.12.0; `winget validate` passed locally.

- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)? (CLA bot will prompt if needed)
- [x] Validated locally with `winget validate`.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/389354)