### PR TITLE
Update Helvesec.RMUX to 0.6.1

### DIFF
--- a/manifests/h/Helvesec/RMUX/0.6.1/Helvesec.RMUX.installer.yaml
+++ b/manifests/h/Helvesec/RMUX/0.6.1/Helvesec.RMUX.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Helvesec.RMUX
+PackageVersion: 0.6.1
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: rmux-0.6.1-windows-x86_64\rmux.exe
+    PortableCommandAlias: rmux
+ReleaseDate: "2026-06-17"
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Helvesec/rmux/releases/download/v0.6.1/rmux-0.6.1-windows-x86_64.zip
+    InstallerSha256: 824A085488E36B3B253B0571D2150B7DAB0271511A87B8033E9C4F01690346F7
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/h/Helvesec/RMUX/0.6.1/Helvesec.RMUX.installer.yaml
+++ b/manifests/h/Helvesec/RMUX/0.6.1/Helvesec.RMUX.installer.yaml
@@ -8,6 +8,9 @@ NestedInstallerFiles:
   - RelativeFilePath: rmux-0.6.1-windows-x86_64\rmux.exe
     PortableCommandAlias: rmux
 ReleaseDate: "2026-06-17"
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/Helvesec/rmux/releases/download/v0.6.1/rmux-0.6.1-windows-x86_64.zip

--- a/manifests/h/Helvesec/RMUX/0.6.1/Helvesec.RMUX.locale.en-US.yaml
+++ b/manifests/h/Helvesec/RMUX/0.6.1/Helvesec.RMUX.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Helvesec.RMUX
+PackageVersion: 0.6.1
+PackageLocale: en-US
+Publisher: Helvesec
+PublisherUrl: https://github.com/Helvesec
+PublisherSupportUrl: https://github.com/Helvesec/rmux/issues
+Author: Helvesec
+PackageName: RMUX
+PackageUrl: https://rmux.io
+License: MIT OR Apache-2.0
+ShortDescription: Terminal multiplexer with a tmux-style CLI, daemon runtime, and native Windows support.
+Description: |-
+  RMUX is a terminal multiplexer with a tmux-style command line, daemon-backed persistent sessions, native Windows support, and a Rust SDK for automation.
+Moniker: rmux
+Tags:
+  - cli
+  - multiplexer
+  - rust
+  - terminal
+  - tmux
+ReleaseNotesUrl: https://github.com/Helvesec/rmux/releases/tag/v0.6.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/h/Helvesec/RMUX/0.6.1/Helvesec.RMUX.yaml
+++ b/manifests/h/Helvesec/RMUX/0.6.1/Helvesec.RMUX.yaml
@@ -1,28 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.singleton.1.10.0.schema.json
-PackageIdentifier: "Helvesec.RMUX"
-PackageVersion: "0.6.1"
-PackageLocale: "en-US"
-Publisher: "Helvesec"
-PublisherUrl: "https://github.com/Helvesec"
-PackageName: "RMUX"
-PackageUrl: "https://rmux.io"
-License: "MIT OR Apache-2.0"
-ShortDescription: "Terminal multiplexer with a tmux-style CLI, daemon runtime, and native Windows support."
-Moniker: "rmux"
-Tags:
-  - "terminal"
-  - "multiplexer"
-  - "tmux"
-  - "cli"
-  - "rust"
-Installers:
-  - Architecture: "x64"
-    InstallerType: "zip"
-    NestedInstallerType: "portable"
-    NestedInstallerFiles:
-      - RelativeFilePath: 'rmux-0.6.1-windows-x86_64\rmux.exe'
-        PortableCommandAlias: "rmux"
-    InstallerUrl: "https://github.com/Helvesec/rmux/releases/download/v0.6.1/rmux-0.6.1-windows-x86_64.zip"
-    InstallerSha256: "824a085488e36b3b253b0571d2150b7dab0271511a87b8033e9c4f01690346f7"
-ManifestType: "singleton"
-ManifestVersion: "1.10.0"
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Helvesec.RMUX
+PackageVersion: 0.6.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/manifests/h/Helvesec/RMUX/0.6.1/Helvesec.RMUX.yaml
+++ b/manifests/h/Helvesec/RMUX/0.6.1/Helvesec.RMUX.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.singleton.1.10.0.schema.json
+PackageIdentifier: "Helvesec.RMUX"
+PackageVersion: "0.6.1"
+PackageLocale: "en-US"
+Publisher: "Helvesec"
+PublisherUrl: "https://github.com/Helvesec"
+PackageName: "RMUX"
+PackageUrl: "https://rmux.io"
+License: "MIT OR Apache-2.0"
+ShortDescription: "Terminal multiplexer with a tmux-style CLI, daemon runtime, and native Windows support."
+Moniker: "rmux"
+Tags:
+  - "terminal"
+  - "multiplexer"
+  - "tmux"
+  - "cli"
+  - "rust"
+Installers:
+  - Architecture: "x64"
+    InstallerType: "zip"
+    NestedInstallerType: "portable"
+    NestedInstallerFiles:
+      - RelativeFilePath: 'rmux-0.6.1-windows-x86_64\rmux.exe'
+        PortableCommandAlias: "rmux"
+    InstallerUrl: "https://github.com/Helvesec/rmux/releases/download/v0.6.1/rmux-0.6.1-windows-x86_64.zip"
+    InstallerSha256: "824a085488e36b3b253b0571d2150b7dab0271511a87b8033e9c4f01690346f7"
+ManifestType: "singleton"
+ManifestVersion: "1.10.0"


### PR DESCRIPTION
Update Helvesec.RMUX to v0.6.1.

Release: https://github.com/Helvesec/rmux/releases/tag/v0.6.1
Manifest generated from the GitHub Release SHA256SUMS and validated with RMUX validate-winget-manifest.ps1.