### PR TITLE
Update manifest: OSGeo.QGIS_LTR version 3.44.11

### DIFF
--- a/manifests/o/OSGeo/QGIS_LTR/3.44.11/OSGeo.QGIS_LTR.installer.yaml
+++ b/manifests/o/OSGeo/QGIS_LTR/3.44.11/OSGeo.QGIS_LTR.installer.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 Dumplings Mod
+# Created with komac v2.16.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: OSGeo.QGIS_LTR
@@ -16,16 +16,16 @@ FileExtensions:
 - qml
 - qpt
 ProductCode: '{C74BD9B1-9982-1014-90B6-AB3D19B37C45}'
-ReleaseDate: 2026-05-29
+ReleaseDate: 2026-06-04
 AppsAndFeaturesEntries:
 - DisplayName: QGIS 3.44.11 'Solothurn'
   ProductCode: '{C74BD9B1-9982-1014-90B6-AB3D19B37C45}'
   UpgradeCode: '{C74C3EB1-9982-1014-90B6-AB3D19B37C45}'
 InstallationMetadata:
-  DefaultInstallLocation: '%ProgramFiles%\QGIS 3.44.10'
+  DefaultInstallLocation: '%ProgramFiles%\QGIS 3.44.11'
 Installers:
 - Architecture: x64
   InstallerUrl: https://qgis.org/downloads/QGIS-OSGeo4W-3.44.11-1.msi
-  InstallerSha256: 062F58FD0F45FE94BE2D9EDA3316FC1D9109F2149F33BD1B15837D8DEE0909C1
+  InstallerSha256: A95D7F247F34152C0F77FB738CD214DF987D91E40F6FD6F9A98433CC2CF7DD18
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/o/OSGeo/QGIS_LTR/3.44.11/OSGeo.QGIS_LTR.locale.en-US.yaml
+++ b/manifests/o/OSGeo/QGIS_LTR/3.44.11/OSGeo.QGIS_LTR.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 Dumplings Mod
+# Created with komac v2.16.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: OSGeo.QGIS_LTR

--- a/manifests/o/OSGeo/QGIS_LTR/3.44.11/OSGeo.QGIS_LTR.locale.zh-CN.yaml
+++ b/manifests/o/OSGeo/QGIS_LTR/3.44.11/OSGeo.QGIS_LTR.locale.zh-CN.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 Dumplings Mod
+# Created with komac v2.16.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
 
 PackageIdentifier: OSGeo.QGIS_LTR

--- a/manifests/o/OSGeo/QGIS_LTR/3.44.11/OSGeo.QGIS_LTR.yaml
+++ b/manifests/o/OSGeo/QGIS_LTR/3.44.11/OSGeo.QGIS_LTR.yaml
@@ -1,4 +1,4 @@
-# Created with YamlCreate.ps1 Dumplings Mod
+# Created with komac v2.16.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: OSGeo.QGIS_LTR


### PR DESCRIPTION
## 📖 Description

- Correct the default installation location to match version 3.44.11.
- Update the installer SHA256 hash and release date.
- Switch the manifest generation tool to komac v2.16.0.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)
  - Resolves #388411

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.

## 🧪 Manual validation

<img width="2064" height="1050" alt="Image" src="https://github.com/user-attachments/assets/a68339da-eccd-4bb1-bd2d-87ff86456ce1" />

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/389418)