### PR TITLE
New package: wolfgangwarehaus.jellytoast version 0.1.0

### DIFF
--- a/manifests/w/wolfgangwarehaus/jellytoast/0.1.0/wolfgangwarehaus.jellytoast.installer.yaml
+++ b/manifests/w/wolfgangwarehaus/jellytoast/0.1.0/wolfgangwarehaus.jellytoast.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: wolfgangwarehaus.jellytoast
+PackageVersion: 0.1.0
+InstallerLocale: en-US
+InstallerType: inno
+Scope: user
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/wolfgangwarehaus/jellytoast/releases/download/v0.1.0/jellytoast-0.1.0-windows-x64-setup.exe
+    InstallerSha256: 00EF32312E6D4691A45BDC7AC998EA011FE716797539E692B7D4C758E4FEFF08
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/w/wolfgangwarehaus/jellytoast/0.1.0/wolfgangwarehaus.jellytoast.locale.en-US.yaml
+++ b/manifests/w/wolfgangwarehaus/jellytoast/0.1.0/wolfgangwarehaus.jellytoast.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: wolfgangwarehaus.jellytoast
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: wolfgangwarehaus
+PublisherUrl: https://github.com/wolfgangwarehaus
+PublisherSupportUrl: https://github.com/wolfgangwarehaus/jellytoast/issues
+PackageName: jellytoast
+PackageUrl: https://github.com/wolfgangwarehaus/jellytoast
+License: GPL-2.0-or-later
+LicenseUrl: https://github.com/wolfgangwarehaus/jellytoast/blob/main/LICENSE
+ShortDescription: A desktop music player for Jellyfin and Navidrome servers
+Description: |-
+  jellytoast is a desktop music player for Jellyfin, Navidrome and other
+  Subsonic-compatible servers: bit-perfect playback via mpv,
+  offline downloads, Chromecast/AirPlay/DLNA/Sonos/Snapcast casting,
+  system media keys, scrobbling, smart playlists, and a frosted-glass UI.
+Tags:
+  - music
+  - jellyfin
+  - navidrome
+  - subsonic
+  - audio-player
+  - chromecast
+Moniker: jellytoast
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/w/wolfgangwarehaus/jellytoast/0.1.0/wolfgangwarehaus.jellytoast.yaml
+++ b/manifests/w/wolfgangwarehaus/jellytoast/0.1.0/wolfgangwarehaus.jellytoast.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: wolfgangwarehaus.jellytoast
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Adds wolfgangwarehaus.jellytoast 0.1.0 — a desktop music player for Jellyfin / Navidrome (Subsonic) servers.

- Installer: Inno Setup (`inno`), per-user scope, x64.
- Installer URL points at the published GitHub release asset; `InstallerSha256` matches the release `SHA256SUMS`.
- Manifest schema 1.6.0; three-file multi-manifest (version / installer / defaultLocale).

Project: https://github.com/wolfgangwarehaus/jellytoast
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/389422)