### PR TITLE
New package: ashishpatel26.RAMKeeper version 1.1.0

### DIFF
--- a/manifests/a/ashishpatel26/RAMKeeper/1.1.0/ashishpatel26.RAMKeeper.installer.yaml
+++ b/manifests/a/ashishpatel26/RAMKeeper/1.1.0/ashishpatel26.RAMKeeper.installer.yaml
@@ -3,7 +3,6 @@ PackageIdentifier: ashishpatel26.RAMKeeper
 PackageVersion: 1.1.0
 MinimumOSVersion: 10.0.0.0
 InstallerType: portable
-ElevationRequirement: requireAdmin
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/ashishpatel26/RAMKeeper/releases/download/v1.1.0/RAMKeeper.exe

--- a/manifests/a/ashishpatel26/RAMKeeper/1.1.0/ashishpatel26.RAMKeeper.installer.yaml
+++ b/manifests/a/ashishpatel26/RAMKeeper/1.1.0/ashishpatel26.RAMKeeper.installer.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: ashishpatel26.RAMKeeper
+PackageVersion: 1.1.0
+MinimumOSVersion: 10.0.0.0
+InstallerType: portable
+ElevationRequirement: requireAdmin
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/ashishpatel26/RAMKeeper/releases/download/v1.1.0/RAMKeeper.exe
+    InstallerSha256: 1c410ba742c4b109031a31bf303a26a8f93123f37e1ab3b2546f2807a30ab680
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/a/ashishpatel26/RAMKeeper/1.1.0/ashishpatel26.RAMKeeper.locale.en-US.yaml
+++ b/manifests/a/ashishpatel26/RAMKeeper/1.1.0/ashishpatel26.RAMKeeper.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: ashishpatel26.RAMKeeper
+PackageVersion: 1.1.0
+PackageLocale: en-US
+Publisher: Ashish Patel
+PublisherUrl: https://github.com/ashishpatel26
+PublisherSupportUrl: https://github.com/ashishpatel26/RAMKeeper/issues
+PackageName: RAMKeeper
+PackageUrl: https://github.com/ashishpatel26/RAMKeeper
+License: MIT
+LicenseUrl: https://github.com/ashishpatel26/RAMKeeper/blob/main/LICENSE
+ShortDescription: Lightweight Windows RAM cleaner — 163 KB static binary, status window, hotkey, auto-clean, process exclusions
+Description: |-
+  RAMKeeper is a lightweight (163 KB) Windows RAM cleaner that purges the standby/cached memory
+  list via NtSetSystemInformation, immediately reclaiming memory without rebooting. Runs silently
+  in the system tray. Features: status window with RAM sparkline and clean history, global hotkey
+  Ctrl+Alt+R, auto-clean (threshold/interval/idle/scheduled), process exclusions, per-clean log,
+  balloon notifications, start-with-Windows. No runtime dependencies, no installer required.
+Moniker: ramkeeper
+Tags:
+  - ram
+  - memory
+  - cleaner
+  - optimizer
+  - tray
+  - windows
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/a/ashishpatel26/RAMKeeper/1.1.0/ashishpatel26.RAMKeeper.yaml
+++ b/manifests/a/ashishpatel26/RAMKeeper/1.1.0/ashishpatel26.RAMKeeper.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: ashishpatel26.RAMKeeper
+PackageVersion: 1.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Description

New package submission: RAMKeeper v1.1.0 — lightweight (62 KB) portable Windows RAM cleaner.

Purges the standby/cached memory list via `NtSetSystemInformation`, immediately reclaiming memory. Runs silently in the system tray.

## Package details

- **Type:** Portable EXE
- **ElevationRequirement:** requireAdmin
- **Architecture:** x64
- **Size:** ~62 KB, no runtime deps (static MSVC build)
- **Source:** https://github.com/ashishpatel26/RAMKeeper (MIT)

## Verification

SHA-256: `1c410ba742c4b109031a31bf303a26a8f93123f37e1ab3b2546f2807a30ab680`
URL: https://github.com/ashishpatel26/RAMKeeper/releases/download/v1.1.0/RAMKeeper.exe
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/389514)