### PR TITLE
New version: ElCruncharino.NeoStego version 1.0.1

### DIFF
--- a/manifests/e/ElCruncharino/NeoStego/1.0.1/ElCruncharino.NeoStego.installer.yaml
+++ b/manifests/e/ElCruncharino/NeoStego/1.0.1/ElCruncharino.NeoStego.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: ElCruncharino.NeoStego
+PackageVersion: 1.0.1
+MinimumOSVersion: 10.0.0.0
+InstallerType: msi
+Scope: user
+ReleaseDate: 2026-06-17
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/ElCruncharino/neostego/releases/download/v1.0.1/NeoStego-1.0.1.msi
+    InstallerSha256: 58B90B837EA4E1754C3CEC1A192036B563318A2351ED627251FBE5C33886E391
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/e/ElCruncharino/NeoStego/1.0.1/ElCruncharino.NeoStego.locale.en-US.yaml
+++ b/manifests/e/ElCruncharino/NeoStego/1.0.1/ElCruncharino.NeoStego.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: ElCruncharino.NeoStego
+PackageVersion: 1.0.1
+PackageLocale: en-US
+Publisher: Nick Haghiri
+PublisherUrl: https://github.com/ElCruncharino
+PublisherSupportUrl: https://github.com/ElCruncharino/neostego/issues
+PackageName: NeoStego
+PackageUrl: https://github.com/ElCruncharino/neostego
+License: GPL-2.0
+LicenseUrl: https://github.com/ElCruncharino/neostego/blob/master/LICENSE
+Copyright: Copyright (c) 2007-2026 Samir Vaidya and Nick Haghiri
+ShortDescription: Steganography tool to hide data in images/audio and apply invisible watermarks.
+Description: NeoStego is a steganography application that hides data inside image and audio files and applies invisible watermarks. A modernized fork of OpenStego with content-adaptive (HILL+STC) and SI-UNIWARD algorithms, robust DWT-SVD watermarking, and a cross-platform UI.
+Moniker: neostego
+Tags:
+  - steganography
+  - watermarking
+  - security
+  - privacy
+  - hide-data
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/e/ElCruncharino/NeoStego/1.0.1/ElCruncharino.NeoStego.yaml
+++ b/manifests/e/ElCruncharino/NeoStego/1.0.1/ElCruncharino.NeoStego.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: ElCruncharino.NeoStego
+PackageVersion: 1.0.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Update NeoStego to 1.0.1. The Windows installer is now an **MSI** (was an Inno EXE in the closed 1.0.0 PR #389056), which installs silently by default — resolving the unattended-install failures seen previously.

- `InstallerType: msi`, x64, SHA256 verified against the GitHub release asset.
- Manifests authored to schema 1.9.0 and validated locally.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Manifest validated locally.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/389523)