### PR TITLE
Make label check a bit more lax for validation files

### DIFF
--- a/.github/policies/labelManagement.issueOpened.yml
+++ b/.github/policies/labelManagement.issueOpened.yml
@@ -218,12 +218,13 @@ configuration:
                 pattern: ^$
           - filesMatchPattern:
                 pattern: ^.*\.validation
-          - not:
-              activitySenderHasPermission:
-                permission: Admin
-          - not:
-              isActivitySender:
-                user: wingetbot
+          - and:
+            - not:
+                activitySenderHasPermission:
+                  permission: Admin
+            - not:
+                isActivitySender:
+                  user: wingetbot
         then:
           - addLabel:
               label: Author-Not-Authorized


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
Since Wingetbot is not an admin, it seems to have been triggering this rule. Updating the rule so that you have to be not an admin and not wingetbot, which should prevent the error

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

@denelon
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/389609)