### PR TITLE
New version: ForthwithLLC.ForthwithCLI version 1.0.0

### DIFF
--- a/manifests/f/ForthwithLLC/ForthwithCLI/1.0.0/ForthwithLLC.ForthwithCLI.installer.yaml
+++ b/manifests/f/ForthwithLLC/ForthwithCLI/1.0.0/ForthwithLLC.ForthwithCLI.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ForthwithLLC.ForthwithCLI
+PackageVersion: 1.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: forthwith.exe
+  PortableCommandAlias: forthwith
+Commands:
+- forthwith
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Forthwith-LLC/forthwith-releases/releases/download/v1.0.0/forthwith_1.0.0_windows_amd64.zip
+  InstallerSha256: 19AAC9467DFC1FB7BAB676499B3D7336E9706E142AF8FA168CFCDA58BE74868E
+- Architecture: arm64
+  InstallerUrl: https://github.com/Forthwith-LLC/forthwith-releases/releases/download/v1.0.0/forthwith_1.0.0_windows_arm64.zip
+  InstallerSha256: 5029627065DFAD4CE6115A1DE080CC943859931C7BABC80E5A7272F3BBC4CDE9
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/ForthwithLLC/ForthwithCLI/1.0.0/ForthwithLLC.ForthwithCLI.locale.en-US.yaml
+++ b/manifests/f/ForthwithLLC/ForthwithCLI/1.0.0/ForthwithLLC.ForthwithCLI.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ForthwithLLC.ForthwithCLI
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: Forthwith LLC
+PublisherUrl: https://forthwith.dev
+PublisherSupportUrl: https://forthwith.dev/docs
+PackageName: Forthwith CLI
+PackageUrl: https://forthwith.dev
+License: Proprietary
+LicenseUrl: https://forthwith.dev/cli-license
+Copyright: Copyright (c) 2026 Forthwith LLC
+ShortDescription: Translate app strings and write localized resource files from the command line.
+Description: Scans app projects for localizable strings and writes translated framework files.
+Moniker: forthwith
+Tags:
+- cli
+- developer-tools
+- i18n
+- localization
+- translation
+Documentations:
+- DocumentLabel: Documentation
+  DocumentUrl: https://forthwith.dev/docs
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/ForthwithLLC/ForthwithCLI/1.0.0/ForthwithLLC.ForthwithCLI.yaml
+++ b/manifests/f/ForthwithLLC/ForthwithCLI/1.0.0/ForthwithLLC.ForthwithCLI.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ForthwithLLC.ForthwithCLI
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds the initial winget manifest for Forthwith CLI version 1.0.0.

Forthwith CLI is the command-line interface for Forthwith, published by Forthwith LLC.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest manifests\f\ForthwithLLC\ForthwithCLI\1.0.0`
- [ ] Tested manifest locally with `winget install --manifest manifests\f\ForthwithLLC\ForthwithCLI\1.0.0`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/389699)