### PR TITLE
New version: NetaGigSystems.CommandDictateFree version 1.0.3

### DIFF
--- a/manifests/n/NetaGigSystems/CommandDictateFree/1.0.3/NetaGigSystems.CommandDictateFree.installer.yaml
+++ b/manifests/n/NetaGigSystems/CommandDictateFree/1.0.3/NetaGigSystems.CommandDictateFree.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: NetaGigSystems.CommandDictateFree
+PackageVersion: 1.0.3
+InstallerLocale: en-US
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Nubulizer/Command-Dictate-App/releases/download/v1.0.3/CommandDictateFreeSetup-1.0.3.exe
+    InstallerSha256: 8455199D91A2C9BDDBC355AEA3DAF2FD366116DA8BB47B5AD857C6A67DE73648
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/n/NetaGigSystems/CommandDictateFree/1.0.3/NetaGigSystems.CommandDictateFree.locale.en-US.yaml
+++ b/manifests/n/NetaGigSystems/CommandDictateFree/1.0.3/NetaGigSystems.CommandDictateFree.locale.en-US.yaml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: NetaGigSystems.CommandDictateFree
+PackageVersion: 1.0.3
+PackageLocale: en-US
+Publisher: NetaGig Systems
+PublisherUrl: https://netagig.com
+PublisherSupportUrl: https://netagig.com/support
+PrivacyUrl: https://netagig.com/privacy
+PackageName: Command Dictate Free
+PackageUrl: https://netagig.com/command
+License: Freeware
+LicenseUrl: https://netagig.com/terms
+Copyright: Copyright (C) 2026 NetaGig Systems
+ShortDescription: Free local, offline dictation for Windows. No account, no cloud.
+Description: |-
+  Command Dictate Free is a free Windows dictation app that runs entirely on
+  your computer. Click into any text field, press Ctrl+Shift to start
+  recording, speak, and press Ctrl+Shift again to stop; your words are typed
+  at the cursor. Speech recognition runs locally with a bundled Whisper
+  model, so dictation works fully offline and your voice never leaves your
+  PC. No account, no subscription, and no trial: the app is unlocked. It runs
+  from the system tray, supports reusable voice-triggered text snippets, and
+  installs per-user without administrator rights.
+Moniker: command-dictate-free
+Tags:
+  - dictation
+  - speech-to-text
+  - voice-typing
+  - offline
+  - privacy
+  - whisper
+  - accessibility
+  - productivity
+ReleaseNotesUrl: https://github.com/Nubulizer/Command-Dictate-App/releases/tag/v1.0.3
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/n/NetaGigSystems/CommandDictateFree/1.0.3/NetaGigSystems.CommandDictateFree.yaml
+++ b/manifests/n/NetaGigSystems/CommandDictateFree/1.0.3/NetaGigSystems.CommandDictateFree.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: NetaGigSystems.CommandDictateFree
+PackageVersion: 1.0.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
### New version: NetaGigSystems.CommandDictateFree version 1.0.3

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.9.0)?

Reliability hotfix release. Installer URL and SHA256 point to the official NetaGig Systems GitHub release asset (v1.0.3). This mirrors the merged 1.0.2 manifest with only the version, installer URL, SHA256, and release-notes URL updated.

Note: `winget install` test box left unchecked — validated against the schema and the live release asset; the winget CLI was not available in the authoring environment to run a full local install.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/389756)