### PR TITLE
New package: toevi.WinMD version 1.0.0

### DIFF
--- a/manifests/t/toevi/WinMD/1.0.0/toevi.WinMD.installer.yaml
+++ b/manifests/t/toevi/WinMD/1.0.0/toevi.WinMD.installer.yaml
@@ -10,7 +10,6 @@ Installers:
   InstallerUrl: https://github.com/toevi/WinMD/releases/download/v1.0.0/WinMD-Setup.exe
   InstallerSha256: 85EDA9A09BF3764656CE6ACC6FFDFF07AADECEA5D8AF2AE3AFE873931DE48DBE
   AppsAndFeaturesEntries:
-  - DisplayName: WinMD (wersja 1.0)
-    Publisher: tmfgroup
+  - Publisher: tmfgroup
 ManifestType: installer
 ManifestVersion: 1.9.0

--- a/manifests/t/toevi/WinMD/1.0.0/toevi.WinMD.installer.yaml
+++ b/manifests/t/toevi/WinMD/1.0.0/toevi.WinMD.installer.yaml
@@ -9,5 +9,8 @@ Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/toevi/WinMD/releases/download/v1.0.0/WinMD-Setup.exe
   InstallerSha256: 85EDA9A09BF3764656CE6ACC6FFDFF07AADECEA5D8AF2AE3AFE873931DE48DBE
+  AppsAndFeaturesEntries:
+  - DisplayName: WinMD (wersja 1.0)
+    Publisher: tmfgroup
 ManifestType: installer
 ManifestVersion: 1.9.0

--- a/manifests/t/toevi/WinMD/1.0.0/toevi.WinMD.installer.yaml
+++ b/manifests/t/toevi/WinMD/1.0.0/toevi.WinMD.installer.yaml
@@ -1,0 +1,13 @@
+# Created using wingetcreate 1.6.5.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: toevi.WinMD
+PackageVersion: 1.0.0
+MinimumOSVersion: 10.0.19041.0
+InstallerType: inno
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/toevi/WinMD/releases/download/v1.0.0/WinMD-Setup.exe
+  InstallerSha256: 85EDA9A09BF3764656CE6ACC6FFDFF07AADECEA5D8AF2AE3AFE873931DE48DBE
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/t/toevi/WinMD/1.0.0/toevi.WinMD.locale.en-US.yaml
+++ b/manifests/t/toevi/WinMD/1.0.0/toevi.WinMD.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# Created using wingetcreate 1.6.5.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: toevi.WinMD
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: toevi
+PublisherUrl: https://github.com/toevi
+PublisherSupportUrl: https://github.com/toevi/WinMD/issues
+PackageName: WinMD
+PackageUrl: https://github.com/toevi/WinMD
+License: MIT
+LicenseUrl: https://github.com/toevi/WinMD/blob/master/LICENSE
+Copyright: Copyright (c) 2026 Tomek Maselko
+ShortDescription: Lightweight Markdown editor and viewer for Windows
+Description: |-
+  WinMD is a lightweight Markdown editor and viewer for Windows built with WinUI 3 and Windows App SDK.
+  It features a live HTML preview rendered by Markdig with a GitHub-style stylesheet (light and dark theme),
+  a formatting toolbar, PDF export via WebView2, find/replace in both the editor and the rendered preview,
+  undo/redo with keystroke coalescing, and .md file association for opening files from Explorer.
+Moniker: winmd
+Tags:
+- markdown
+- markdown-editor
+- markdown-viewer
+- text-editor
+- winui
+- winui3
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/t/toevi/WinMD/1.0.0/toevi.WinMD.yaml
+++ b/manifests/t/toevi/WinMD/1.0.0/toevi.WinMD.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.6.5.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: toevi.WinMD
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## New package submission

**Package:** toevi.WinMD
**Version:** 1.0.0
**Type:** New package

### Description

WinMD is a lightweight Markdown editor and viewer for Windows built with WinUI 3 and Windows App SDK 1.8 (unpackaged .exe, no MSIX required).

### Manifest information

- **Installer type:** Inno Setup
- **Architecture:** x64
- **Min OS version:** Windows 10 19041
- **License:** MIT
- **Publisher URL:** https://github.com/toevi

### Validation

- [x] `winget validate` passes (Manifest validation succeeded.)
- [x] SHA256 verified against the GitHub Release asset
- [x] Installer URL is a stable GitHub Release asset
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/389759)