### PR TITLE
Update: wnunezc.WSDD version 2.0.0

### DIFF
--- a/manifests/w/wnunezc/WSDD/2.0.0/wnunezc.WSDD.installer.yaml
+++ b/manifests/w/wnunezc/WSDD/2.0.0/wnunezc.WSDD.installer.yaml
@@ -9,12 +9,22 @@ InstallModes:
 - silent
 - silentWithProgress
 UpgradeBehavior: install
+ElevationRequirement: elevationRequired
 ProductCode: '{73620AD8-7224-439A-905C-A4FD610A3F0D}'
 AppsAndFeaturesEntries:
 - DisplayName: WSDD - WebStack Deployer for Docker
   Publisher: OpsZone Dev
   ProductCode: '{73620AD8-7224-439A-905C-A4FD610A3F0D}'
   UpgradeCode: '{C9CD77B6-E415-4341-934B-1F7D2866B716}'
+Dependencies:
+  WindowsFeatures:
+  - Microsoft-Windows-Subsystem-Linux
+  - VirtualMachinePlatform
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.PowerShell
+  - PackageIdentifier: Docker.DockerDesktop
+  - PackageIdentifier: Chocolatey.Chocolatey
+  - PackageIdentifier: FiloSottile.mkcert
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/wnunezc/wsdd-rust/releases/download/v2.0.0/wsdd-2.0.0-x86_64.msi

--- a/manifests/w/wnunezc/WSDD/2.0.0/wnunezc.WSDD.installer.yaml
+++ b/manifests/w/wnunezc/WSDD/2.0.0/wnunezc.WSDD.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: wnunezc.WSDD
+PackageVersion: 2.0.0
+InstallerType: wix
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{73620AD8-7224-439A-905C-A4FD610A3F0D}'
+AppsAndFeaturesEntries:
+- DisplayName: WSDD - WebStack Deployer for Docker
+  Publisher: OpsZone Dev
+  ProductCode: '{73620AD8-7224-439A-905C-A4FD610A3F0D}'
+  UpgradeCode: '{C9CD77B6-E415-4341-934B-1F7D2866B716}'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/wnunezc/wsdd-rust/releases/download/v2.0.0/wsdd-2.0.0-x86_64.msi
+  InstallerSha256: 41C593D02339909D7EE050B9C3A10A70E574CBDF7973A7DEE0AFA03F036E08AE
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-06-18

--- a/manifests/w/wnunezc/WSDD/2.0.0/wnunezc.WSDD.locale.en-US.yaml
+++ b/manifests/w/wnunezc/WSDD/2.0.0/wnunezc.WSDD.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: wnunezc.WSDD
+PackageVersion: 2.0.0
+PackageLocale: en-US
+Publisher: wnunezc
+PublisherUrl: https://github.com/wnunezc
+PublisherSupportUrl: https://github.com/wnunezc/wsdd-rust/issues
+PackageName: WSDD - WebStack Deployer for Docker
+PackageUrl: https://github.com/wnunezc/wsdd-rust
+License: MIT
+LicenseUrl: https://github.com/wnunezc/wsdd-rust/blob/main/LICENSE.md
+ShortDescription: Local Docker stack manager for PHP development on Windows.
+Description: WSDD is a Windows desktop application for provisioning and operating local Docker PHP stacks, with project storage modes, optional ngrok publishing, bundled resources, and environment helpers.
+Moniker: wsdd
+Tags:
+- docker
+- php
+- laravel
+- development
+- windows
+- ngrok
+ReleaseNotesUrl: https://github.com/wnunezc/wsdd-rust/releases/tag/v2.0.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/w/wnunezc/WSDD/2.0.0/wnunezc.WSDD.locale.en-US.yaml
+++ b/manifests/w/wnunezc/WSDD/2.0.0/wnunezc.WSDD.locale.en-US.yaml
@@ -21,5 +21,6 @@ Tags:
 - windows
 - ngrok
 ReleaseNotesUrl: https://github.com/wnunezc/wsdd-rust/releases/tag/v2.0.0
+InstallationNotes: WSDD requires administrator privileges and is intended for Windows desktop development environments with Docker Desktop, WSL 2 backend support, PowerShell 7.5 or newer, Chocolatey, mkcert, and a compatible desktop graphics environment for the eframe/egui UI. The MSI installs WSDD; first-run checks validate and guide the local runtime setup.
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0

--- a/manifests/w/wnunezc/WSDD/2.0.0/wnunezc.WSDD.yaml
+++ b/manifests/w/wnunezc/WSDD/2.0.0/wnunezc.WSDD.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: wnunezc.WSDD
+PackageVersion: 2.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Updates `wnunezc.WSDD` from `1.0.2` to `2.0.0` using the MSI published in the official GitHub Release.

Release: https://github.com/wnunezc/wsdd-rust/releases/tag/v2.0.0

## Checklist

- [x] Signed the Contributor License Agreement
- [x] Checked that there are no other open pull requests for this package update
- [x] This PR only adds the manifest for one package version
- [x] Installer URL points to the published stable release
- [x] SHA256 matches the published MSI
- [x] MSI ProductCode, UpgradeCode, version, publisher, and architecture were read from the published installer
- [x] Manifest conforms to schema 1.12
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/389928)