### PR TITLE
New package: Cingano.wtop version 1.1.1

### DIFF
--- a/manifests/c/Cingano/wtop/1.1.1/Cingano.wtop.installer.yaml
+++ b/manifests/c/Cingano/wtop/1.1.1/Cingano.wtop.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Cingano.wtop
+PackageVersion: 1.1.1
+InstallerType: portable
+Commands:
+  - wtop
+ReleaseDate: 2026-06-18
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/lorenzo-cingano/wtop/releases/download/v1.1.1/wtop.exe
+    InstallerSha256: 6A4297C3DAF0A92B0AFBD5E3873C1F83EF769C6F9DF657AE261F8595D14EB568
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/c/Cingano/wtop/1.1.1/Cingano.wtop.locale.en-US.yaml
+++ b/manifests/c/Cingano/wtop/1.1.1/Cingano.wtop.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Cingano.wtop
+PackageVersion: 1.1.1
+PackageLocale: en-US
+Publisher: Cingano Development
+PublisherUrl: https://github.com/lorenzo-cingano
+PublisherSupportUrl: https://github.com/lorenzo-cingano/wtop/issues
+Author: Cingano Development
+PackageName: wtop
+PackageUrl: https://github.com/lorenzo-cingano/wtop
+License: 0BSD
+LicenseUrl: https://github.com/lorenzo-cingano/wtop/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Cingano Development
+ShortDescription: An htop-style process viewer for Windows
+Description: |-
+  wtop is an htop-style process viewer for Windows, written in pure C using only
+  the Win32 API and the C standard library, with no external dependencies. It
+  shows per-core CPU meters, a memory meter, and a sortable, filterable process
+  table with tree view, process tagging, bulk kill, full mouse support, and an
+  I/O tab for live network and disk throughput.
+Moniker: wtop
+Tags:
+  - htop
+  - top
+  - process
+  - process-viewer
+  - task-manager
+  - system-monitor
+  - monitoring
+  - cli
+  - tui
+  - terminal
+ReleaseNotesUrl: https://github.com/lorenzo-cingano/wtop/releases/tag/v1.1.1
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/c/Cingano/wtop/1.1.1/Cingano.wtop.yaml
+++ b/manifests/c/Cingano/wtop/1.1.1/Cingano.wtop.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Cingano.wtop
+PackageVersion: 1.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
New package submission for **Cingano.wtop** version 1.1.1.

wtop is an htop-style process viewer for Windows, written in pure C using only the Win32 API and the C standard library, with no external dependencies. It is published under the BSD Zero-Clause License (0BSD), which permits redistribution.

- Upstream project: https://github.com/lorenzo-cingano/wtop
- Release: https://github.com/lorenzo-cingano/wtop/releases/tag/v1.1.1
- Installer: standalone `wtop.exe`, declared as `InstallerType: portable` (x64). winget creates the PATH alias `wtop`.

#### Validation

- [x] `winget validate --manifest <path>` passes for this manifest.
- [x] `InstallerSha256` matches the SHA256 of the released `wtop.exe`, verified against the live download from the release URL.

I am the author and owner of the upstream project. This is a first submission for the `Cingano` publisher.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/390097)