### PR TITLE
New package: Materializr.Materializr version 1.1.0

### DIFF
--- a/manifests/m/Materializr/Materializr/1.1.0/Materializr.Materializr.installer.yaml
+++ b/manifests/m/Materializr/Materializr/1.1.0/Materializr.Materializr.installer.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Materializr.Materializr
+PackageVersion: 1.1.0
+# NSIS installer (packaging/windows/installer.nsi) → winget type "nullsoft",
+# which implies the "/S" silent switch. It installs machine-wide to
+# %ProgramFiles%\Materializr and requires elevation (RequestExecutionLevel admin).
+InstallerType: nullsoft
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/materializr-cad/materializr/releases/download/v1.1.0/Materializr-Setup.exe
+    InstallerSha256: D7741C0CED4D068CB090A9F33B46C1C3D4A085441C6DD8F4A23F4DAEBB5D8B3A
+    # The NSIS script writes these ARP values; the installer tags DisplayVersion
+    # with the tag name (leading "v") via /DAPPVERSION=${github.ref_name}.
+    AppsAndFeaturesEntries:
+      - DisplayName: Materializr
+        Publisher: Materializr
+        DisplayVersion: v1.1.0
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/Materializr/Materializr/1.1.0/Materializr.Materializr.locale.en-US.yaml
+++ b/manifests/m/Materializr/Materializr/1.1.0/Materializr.Materializr.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Materializr.Materializr
+PackageVersion: 1.1.0
+PackageLocale: en-US
+Publisher: Materializr
+PublisherUrl: https://github.com/materializr-cad
+PublisherSupportUrl: https://github.com/materializr-cad/materializr/issues
+Author: Steve Bushwa
+PackageName: Materializr
+PackageUrl: https://github.com/materializr-cad/materializr
+License: GPL-3.0-or-later
+LicenseUrl: https://github.com/materializr-cad/materializr/blob/main/LICENSE
+Copyright: Copyright (C) Steve Bushwa
+ShortDescription: Maker 3D CAD — the middle ground between Tinkercad and FreeCAD.
+Description: |-
+  Materializr is open-source 3D CAD for makers — the middle ground between
+  dead-simple tools like Tinkercad and full professional suites like FreeCAD.
+  Sketch on a plane, pull it into a solid (extrude, revolve, loft, sweep),
+  fillet and chamfer, run booleans, cut threads, and edit any step of the
+  history later. Sketches export to SVG at 1:1 mm for laser cutters and 2.5D
+  CNC; it imports STEP and IGES and exports STEP, STL, IGES, glTF and SVG. Real
+  B-rep solids on the OpenCASCADE kernel.
+Moniker: materializr
+Tags:
+  - 3d
+  - 3d-printing
+  - cad
+  - engineering
+  - laser
+  - modeling
+  - opencascade
+  - svg
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/Materializr/Materializr/1.1.0/Materializr.Materializr.yaml
+++ b/manifests/m/Materializr/Materializr/1.1.0/Materializr.Materializr.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# Version manifest. Submit alongside the installer + locale manifests to
+# microsoft/winget-pkgs under: manifests/m/Materializr/Materializr/1.1.0/
+PackageIdentifier: Materializr.Materializr
+PackageVersion: 1.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New version: Materializr.Materializr 1.1.0

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Manifests validate locally against the 1.6.0 schemas.

Open-source 3D CAD (`Materializr.Materializr`). Installer is the project's NSIS
`Materializr-Setup.exe` from the official GitHub release `v1.1.0`
(materializr-cad/materializr), x64, machine scope, silent via `/S`.

Supersedes the earlier 1.1.0... (this is the current release; the older 1.0.0 PR
is being closed in favor of this one).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/390105)