### PR TITLE
New version: SigmaShake.SSG version 1.0.2

### DIFF
--- a/manifests/s/SigmaShake/SSG/1.0.2/SigmaShake.SSG.installer.yaml
+++ b/manifests/s/SigmaShake/SSG/1.0.2/SigmaShake.SSG.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: SigmaShake.SSG
+PackageVersion: 1.0.2
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+# SigmaShake SSG is now subscription-only (open-channel distribution discontinued
+# 2026-06-17). This package ships a small stub ssg.exe that prints a pointer to
+# https://sigmashake.com/pricing instead of the CLI. The real, licensed ssg is
+# delivered from the subscriber's account, not from a public package manager.
+NestedInstallerFiles:
+  - RelativeFilePath: ssg.exe
+    PortableCommandAlias: ssg
+Commands:
+  - ssg
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://download.sigmashake.com/winget/ssg-win32-x64.zip
+    InstallerSha256: 19D0379C5FB80FCE6290F2DB0BD2DB4E7FB732E1096060395CA241013577CC12
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/SigmaShake/SSG/1.0.2/SigmaShake.SSG.locale.en-US.yaml
+++ b/manifests/s/SigmaShake/SSG/1.0.2/SigmaShake.SSG.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: SigmaShake.SSG
+PackageVersion: 1.0.2
+PackageLocale: en-US
+Publisher: SigmaShake
+PublisherUrl: https://sigmashake.com
+PublisherSupportUrl: https://sigmashake.com
+PackageName: ssg
+PackageUrl: https://sigmashake.com/pricing
+License: Proprietary
+LicenseUrl: https://sigmashake.com
+ShortDescription: SigmaShake SSG is now subscription-only - subscribe to install.
+Description: |-
+  SigmaShake SSG (the AI agent governance CLI) is now a paid, subscription-only
+  product. Free open-channel distribution was discontinued on 2026-06-17, so this
+  winget package no longer ships the CLI. Installing it provides a small stub that
+  points you to the subscription. Subscribe via https://sigmashake.com/pricing and
+  install the licensed ssg from your account (https://accounts.sigmashake.com).
+Moniker: ssg
+Tags:
+  - ai
+  - governance
+  - agent
+  - safety
+  - cli
+  - rules
+ReleaseNotes: |-
+  Open-channel distribution discontinued 2026-06-17. ssg is now subscription-only;
+  this winget package installs a stub that points to the subscription instead of
+  the CLI. Subscribe via https://sigmashake.com/pricing.
+ReleaseNotesUrl: https://sigmashake.com/pricing
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/SigmaShake/SSG/1.0.2/SigmaShake.SSG.yaml
+++ b/manifests/s/SigmaShake/SSG/1.0.2/SigmaShake.SSG.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: SigmaShake.SSG
+PackageVersion: 1.0.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
SigmaShake.SSG is now a paid, subscription-only product; open-channel distribution was discontinued on 2026-06-17. The existing versions installers point to GitHub release assets that are no longer public, so "winget install SigmaShake.SSG" fails with a download error.

This adds version 1.0.2 whose installer is a small portable stub that prints a pointer to the subscription page (https://sigmashake.com/pricing) instead of shipping the CLI, mirroring the publisher other discontinued channels. Submitted by the publisher (SigmaShake); the stub is hosted on the publisher CDN and the SHA256 matches the URL.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/390189)