### PR TITLE
Fix download links for Hibbiki.Chromium version 149.0.7827.156

### DIFF
--- a/manifests/h/Hibbiki/Chromium/149.0.7827.156/Hibbiki.Chromium.installer.yaml
+++ b/manifests/h/Hibbiki/Chromium/149.0.7827.156/Hibbiki.Chromium.installer.yaml
@@ -18,14 +18,14 @@ ReleaseDate: 2026-06-18
 Installers:
 - Architecture: x64
   Scope: user
-  InstallerUrl: https://github.com/Hibbiki/chromium-win64/releases/download/v149.0.7827.156-r162507/mini_installer.exe
+  InstallerUrl: https://github.com/Hibbiki/chromium-win64/releases/download/v149.0.7827.156-r1625079/mini_installer.exe
   InstallerSha256: 0C49F0B0EBF751DCFAF07E583A00BF6E748D17A4772BDF9A7AE5916073166793
   InstallerSwitches:
     Silent: /silent /install
     SilentWithProgress: /silent /install
 - Architecture: x64
   Scope: machine
-  InstallerUrl: https://github.com/Hibbiki/chromium-win64/releases/download/v149.0.7827.156-r162507/mini_installer.exe
+  InstallerUrl: https://github.com/Hibbiki/chromium-win64/releases/download/v149.0.7827.156-r1625079/mini_installer.exe
   InstallerSha256: 0C49F0B0EBF751DCFAF07E583A00BF6E748D17A4772BDF9A7AE5916073166793
   InstallerSwitches:
     Custom: --system-level

--- a/manifests/h/Hibbiki/Chromium/149.0.7827.156/Hibbiki.Chromium.locale.en-US.yaml
+++ b/manifests/h/Hibbiki/Chromium/149.0.7827.156/Hibbiki.Chromium.locale.en-US.yaml
@@ -23,6 +23,6 @@ ReleaseNotes: |-
   a02f9f181d01f7252ab98efd090286a901a0d94c ../out/mini_installer.exe
   59dfad743e7ac609a4ff0441772bfa44472bca8f ../out/chrome.7z
   ebcb2b0c45e1a55c727ed97b4d827e50e17473ea ../out/policy_templates.zip
-ReleaseNotesUrl: https://github.com/Hibbiki/chromium-win64/releases/tag/v149.0.7827.156-r162507
+ReleaseNotesUrl: https://github.com/Hibbiki/chromium-win64/releases/tag/v149.0.7827.156-r1625079
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
<!-- Describe what this PR changes. For manifest submissions, include the package name and version. -->

Fixes download URL for Hibbiki.Chromium version 149.0.7827.156. The SHA256 remains unchanged. This was caused by truncated tag name being used during automated publish process. The truncated tag can not be kept as-is because other updater software depends on proper tag existing.

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #390190

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/390191)