### PR TITLE
Add RagIQ.RuntimeEngine version 1.0.0

### DIFF
--- a/manifests/r/RagIQ/RuntimeEngine/1.0.0/RagIQ.RuntimeEngine.installer.yaml
+++ b/manifests/r/RagIQ/RuntimeEngine/1.0.0/RagIQ.RuntimeEngine.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: RagIQ.RuntimeEngine
+PackageVersion: 1.0.0
+Installers:
+  - Architecture: x64
+    InstallerType: zip
+    InstallerUrl: https://github.com/kchandrakkdi-sudo/RagIQ-RuntimeEngine/releases/download/v1.0.0/RagIQ-RuntimeEngine.zip
+    InstallerSha256: 05973223f57bcf9af9049ec6055cd9fe65e3a07e3668e0c74bb9b42739b12289
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: RagIQ-RuntimeEngine.exe
+        PortableCommandAlias: RagIQ-RuntimeEngine
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/r/RagIQ/RuntimeEngine/1.0.0/RagIQ.RuntimeEngine.locale.en-US.yaml
+++ b/manifests/r/RagIQ/RuntimeEngine/1.0.0/RagIQ.RuntimeEngine.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: RagIQ.RuntimeEngine
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: RagIQ
+PublisherUrl: https://github.com/kchandrakkdi-sudo/RagIQ-RuntimeEngine
+PackageName: RagIQ RuntimeEngine
+License: MIT
+ShortDescription: Lightweight, highly optimized CPU runtime for GGUF models and embeddings.
+Description: RagIQ RuntimeEngine is a premium, lightweight, highly optimized GGUF inference engine built for CPU performance. It supports both on-demand text generation and high-throughput semantic embedding extraction.
+Moniker: ragiq
+Tags:
+  - llamacpp
+  - gguf
+  - inference
+  - embeddings
+  - slm
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/r/RagIQ/RuntimeEngine/1.0.0/RagIQ.RuntimeEngine.yaml
+++ b/manifests/r/RagIQ/RuntimeEngine/1.0.0/RagIQ.RuntimeEngine.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: RagIQ.RuntimeEngine
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Add Package: RagIQ.RuntimeEngine 1.0.0

**Package Identifier:** `RagIQ.RuntimeEngine`
**Version:** `1.0.0`
**Publisher:** RagIQ
**License:** MIT

### Description
RagIQ RuntimeEngine is a lightweight, highly optimized CPU-based GGUF inference engine. It supports on-demand text generation and high-throughput semantic embedding extraction without requiring a GPU.

### Installer Details
- **Type:** Portable ZIP (x64)
- **Nested EXE:** `RagIQ-RuntimeEngine.exe`
- **Command Alias:** `RagIQ-RuntimeEngine`

### Verification
- Statically linked binary compiled with target-feature=+crt-static to ensure zero external CRT runtime dependencies.
- Local sandbox install and execution tested and passed successfully on Windows using winget CLI.
- MIT License text successfully included in the release ZIP for legal compliance.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/390258)