### PR TITLE
New package: Framefilter.Keyroost version 0.6.0

### DIFF
--- a/manifests/f/Framefilter/Keyroost/0.6.0/Framefilter.Keyroost.installer.yaml
+++ b/manifests/f/Framefilter/Keyroost/0.6.0/Framefilter.Keyroost.installer.yaml
@@ -7,6 +7,9 @@ NestedInstallerFiles:
     PortableCommandAlias: keyroostctl
   - RelativeFilePath: keyroost.exe
     PortableCommandAlias: keyroost
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/framefilter/keyroost/releases/download/v0.6.0/keyroost-v0.6.0-windows-x86_64.zip

--- a/manifests/f/Framefilter/Keyroost/0.6.0/Framefilter.Keyroost.installer.yaml
+++ b/manifests/f/Framefilter/Keyroost/0.6.0/Framefilter.Keyroost.installer.yaml
@@ -1,0 +1,15 @@
+PackageIdentifier: Framefilter.Keyroost
+PackageVersion: "0.6.0"
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: keyroostctl.exe
+    PortableCommandAlias: keyroostctl
+  - RelativeFilePath: keyroost.exe
+    PortableCommandAlias: keyroost
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/framefilter/keyroost/releases/download/v0.6.0/keyroost-v0.6.0-windows-x86_64.zip
+    InstallerSha256: "2351A70840F779586FF986020A85928B786B9DBC293E0EFC201FF7E58C13995D"
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/f/Framefilter/Keyroost/0.6.0/Framefilter.Keyroost.locale.en-US.yaml
+++ b/manifests/f/Framefilter/Keyroost/0.6.0/Framefilter.Keyroost.locale.en-US.yaml
@@ -1,0 +1,16 @@
+PackageIdentifier: Framefilter.Keyroost
+PackageVersion: "0.6.0"
+PackageLocale: en-US
+Publisher: framefilter
+PackageName: keyroost
+License: MIT OR Apache-2.0
+PackageUrl: https://github.com/framefilter/keyroost
+ShortDescription: Program Token2 Molto2 TOTP tokens and manage FIDO2/OATH/OpenPGP/PIV security keys.
+Moniker: keyroost
+Tags:
+  - totp
+  - 2fa
+  - fido2
+  - security-key
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/f/Framefilter/Keyroost/0.6.0/Framefilter.Keyroost.yaml
+++ b/manifests/f/Framefilter/Keyroost/0.6.0/Framefilter.Keyroost.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Framefilter.Keyroost
+PackageVersion: "0.6.0"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: `Framefilter.Keyroost` version 0.6.0

keyroost — an independent, open-source Rust toolchain for hardware security keys
(FIDO2/CTAP2, OATH, OpenPGP, PIV) and Token2 Molto2 TOTP tokens. Ships a CLI
(`keyroostctl`) and a desktop GUI (`keyroost`).

- Homepage: https://github.com/framefilter/keyroost
- License: MIT OR Apache-2.0
- Installer: portable executables inside a zip (`keyroostctl.exe`, `keyroost.exe`)

#### Checklist
- [x] Microsoft CLA — the winget bot prompts on first PR; will sign via its comment.
- [x] This is a new package (first submission).
- [x] Manifest version 1.6.0.
- [x] `InstallerSha256` matches the published release artifact's SHA-256.
- [x] Installer URL points at an official GitHub release asset.
- [x] Manifests validated locally.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/390300)