### PR TITLE
New package: Naplon_.KeyboardCleaner version 1.1

### DIFF
--- a/manifests/n/Naplon_/KeyboardCleaner/1.1/Naplon_.KeyboardCleaner.installer.yaml
+++ b/manifests/n/Naplon_/KeyboardCleaner/1.1/Naplon_.KeyboardCleaner.installer.yaml
@@ -1,0 +1,13 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Naplon_.KeyboardCleaner
+PackageVersion: "1.1"
+InstallerType: inno
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/naplon74/keyboard-cleaner/releases/download/V1.1/Keyboard_Cleaner-V1.1_Setup.exe
+  InstallerSha256: B5EF8EFDA9BA78E43A7683E0056BEDFD8ACD25704872EADAF075BCD278089E0C
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-06-16

--- a/manifests/n/Naplon_/KeyboardCleaner/1.1/Naplon_.KeyboardCleaner.locale.en-US.yaml
+++ b/manifests/n/Naplon_/KeyboardCleaner/1.1/Naplon_.KeyboardCleaner.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Naplon_.KeyboardCleaner
+PackageVersion: "1.1"
+PackageLocale: en-US
+Publisher: Naplon_
+PublisherUrl: https://github.com/naplon74
+PublisherSupportUrl: https://github.com/naplon74/keyboard-cleaner/issues
+Author: Naplon_
+PackageName: Keyboard Cleaner
+PackageUrl: https://github.com/naplon74/keyboard-cleaner
+License: MIT
+LicenseUrl: https://github.com/naplon74/keyboard-cleaner/blob/main/LICENSE
+Copyright: Copyright (c) 2025 Naplon_
+ShortDescription: Lock your keyboard for cleaning purpose.
+ReleaseNotesUrl: https://github.com/naplon74/keyboard-cleaner/releases/tag/V1.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/n/Naplon_/KeyboardCleaner/1.1/Naplon_.KeyboardCleaner.yaml
+++ b/manifests/n/Naplon_/KeyboardCleaner/1.1/Naplon_.KeyboardCleaner.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Naplon_.KeyboardCleaner
+PackageVersion: "1.1"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds `Naplon_.KeyboardCleaner` version `1.1` to WinGet.

Keyboard Cleaner is a small Windows utility that locks the keyboard for cleaning purposes.

## ✅ Checklist

- [x] Signed the Contributor License Agreement
- [x] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally
- [x] Tested manifest locally
- [x] Manifest conforms to the 1.12 schema