### PR TITLE
Fix: clsid2.mpc-hc 2.7.3 x64 installer URL

### DIFF
--- a/manifests/c/clsid2/mpc-hc/2.7.3/clsid2.mpc-hc.installer.yaml
+++ b/manifests/c/clsid2/mpc-hc/2.7.3/clsid2.mpc-hc.installer.yaml
@@ -148,8 +148,8 @@ Installers:
   - DisplayName: MPC-HC 2.7.3
     ProductCode: '{2624B969-7135-4EB1-B0F6-2D8C397B45F7}_is1'
 - Architecture: x64
-  InstallerUrl: https://github.com/clsid2/mpc-hc/releases/download/2.7.3/MPC-HC.2.7.3.x64.exe
-  InstallerSha256: C712D150621526AF1DCB8C26A928EF8FBDA7AAE5EB60D9439FC7DDB89F7EC7B8
+  InstallerUrl: https://github.com/clsid2/mpc-hc/releases/download/2.7.3/MPC-HC.2.7.3.2.x64.exe
+  InstallerSha256: A2F07D689FCBEF391EABA6994251CA05D3143E0260AB024052C0BD3D0E330B4A
   ProductCode: '{2ACBF1FA-F5C3-4B19-A774-B22A31F231B9}_is1'
   AppsAndFeaturesEntries:
   - DisplayName: MPC-HC 2.7.3 (64-bit)


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
<!-- Describe what this PR changes. For manifest submissions, include the package name and version. -->
Fixes the x64 installer URL for clsid2.mpc-hc version 2.7.3.

The manifest referenced MPC-HC.2.7.3.x64.exe, which does not exist in the upstream release assets. The official x64 installer is published as MPC-HC.2.7.3.2.x64.exe.

Updated the x64 InstallerUrl and corresponding InstallerSha256 value to match the official release.

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/390492)