### PR TITLE
Add VictorMagne.CloudTray version 1.1.0

### DIFF
--- a/manifests/v/VictorMagne/CloudTray/1.1.0/VictorMagne.CloudTray.installer.yaml
+++ b/manifests/v/VictorMagne/CloudTray/1.1.0/VictorMagne.CloudTray.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: VictorMagne.CloudTray
+PackageVersion: 1.1.0
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: inno
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Victor-Magne/claudtray/releases/download/v1.1.0/CloudTray-1.1.0.exe
+    InstallerSha256: 83086A1D470ED210DBA9A71CE571C1B6AB081DE156A6EAA1815CA5E8EE864716
+    ProductCode: '{F3A7B2C1-8D4E-4F9A-B6C2-1E5D7A3F8B9C}_is1'
+    InstallerSwitches:
+      Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+      SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/v/VictorMagne/CloudTray/1.1.0/VictorMagne.CloudTray.locale.en-US.yaml
+++ b/manifests/v/VictorMagne/CloudTray/1.1.0/VictorMagne.CloudTray.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: VictorMagne.CloudTray
+PackageVersion: 1.1.0
+PackageLocale: en-US
+Publisher: Victor Magne
+PublisherUrl: https://github.com/Victor-Magne
+PublisherSupportUrl: https://github.com/Victor-Magne/claudtray/issues
+PackageName: CloudTray
+PackageUrl: https://github.com/Victor-Magne/claudtray
+License: MIT
+LicenseUrl: https://github.com/Victor-Magne/claudtray/blob/master/LICENSE
+Copyright: Copyright (c) 2025 Victor Magne
+ShortDescription: Real-time AI usage monitor in the Windows system tray
+Description: |-
+  CloudTray for Windows monitors your remaining quota for Claude Code and other AI
+  assistants (GitHub Copilot, Codex, Antigravity) directly from the system tray.
+  The tray icon changes colour (green / yellow / red / grey) based on your worst
+  remaining quota, and a click opens a detailed popover dashboard with per-provider
+  cards and reset countdowns. No admin rights required.
+Tags:
+  - ai
+  - claude
+  - claude-code
+  - copilot
+  - tray
+  - usage
+  - monitor
+ReleaseNotesUrl: https://github.com/Victor-Magne/claudtray/releases/tag/v1.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/v/VictorMagne/CloudTray/1.1.0/VictorMagne.CloudTray.yaml
+++ b/manifests/v/VictorMagne/CloudTray/1.1.0/VictorMagne.CloudTray.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: VictorMagne.CloudTray
+PackageVersion: 1.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Add VictorMagne.CloudTray version 1.1.0

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

### Notes
New version of CloudTray (a Windows system-tray AI usage monitor).

- The `InstallerUrl` points to the GitHub release asset for v1.1.0 and the `InstallerSha256` matches it exactly.
- The manifest structure is identical to the 1.0.0 submission (#390119), which passed automated validation; only the version, URL and SHA256 changed.
- This supersedes #390119, which is being closed in favour of this version.

Validation is left to the pipeline.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/390522)