### PR TITLE
New version: Feci.ParleyDeckCli version 1.30.0

### DIFF
--- a/manifests/f/Feci/ParleyDeckCli/1.30.0/Feci.ParleyDeckCli.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.30.0/Feci.ParleyDeckCli.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.30.0
+InstallerType: portable
+Commands:
+- parley
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.30.0/parley-v1.30.0-windows-x64.exe
+  InstallerSha256: 88420D894A8ED3B2A8399E888605567BF466E12446F0744C67FADBC6127F88B5
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.30.0/parley-v1.30.0-windows-arm64.exe
+  InstallerSha256: F01F6B7B4E176F091EC06F95B78C197889184A154A18058582282D49874B253D
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.30.0/Feci.ParleyDeckCli.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.30.0/Feci.ParleyDeckCli.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.30.0
+PackageLocale: en-US
+Publisher: Feci
+PublisherUrl: https://github.com/feci
+PackageName: Parley Deck CLI
+PackageUrl: https://github.com/feci/parley-deck-cli
+License: Apache-2.0
+LicenseUrl: https://github.com/feci/parley-deck-cli/blob/main/LICENSE
+ShortDescription: CLI that orchestrates Parley Deck multi-agent cooperation workflows.
+Description: "parley orchestrates multi-agent Parley Deck cooperation: deliberation rounds across local CLI agents, consensus and finalize, implementation with living execution plans, a live TUI, retrospective optimization, and a pre-idea readiness check (parley preflight)."
+ReleaseNotesUrl: https://github.com/feci/parley-deck-cli/releases/tag/v1.30.0
+Tags:
+- ai
+- agents
+- cli
+- codex
+- consensus
+- multi-agent
+- orchestration
+- preflight
+- tui
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.30.0/Feci.ParleyDeckCli.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.30.0/Feci.ParleyDeckCli.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.30.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update for Feci.ParleyDeckCli to 1.30.0. Portable Go CLI (x64+arm64); installer URLs point at the v1.30.0 GitHub release; SHA256 verified; schema 1.12.0; Description quoted (YAML colon-space safe).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/390542)