### PR TITLE
New version: NakabaLab.sshm version 1.1.1

### DIFF
--- a/manifests/n/NakabaLab/sshm/1.1.1/NakabaLab.sshm.installer.yaml
+++ b/manifests/n/NakabaLab/sshm/1.1.1/NakabaLab.sshm.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: NakabaLab.sshm
+PackageVersion: 1.1.1
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: sshm.exe
+    PortableCommandAlias: sshm
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/nakaba-lab/ssh-manager-tui/releases/download/v1.1.1/sshm-1.1.1-x86_64-pc-windows-msvc.zip
+    InstallerSha256: 7FDF9CC3811A192F50C17789582AB10B964B7CD6FDF67C379CD3D6150BF1EB80
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/n/NakabaLab/sshm/1.1.1/NakabaLab.sshm.locale.en-US.yaml
+++ b/manifests/n/NakabaLab/sshm/1.1.1/NakabaLab.sshm.locale.en-US.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: NakabaLab.sshm
+PackageVersion: 1.1.1
+PackageLocale: en-US
+Publisher: nakaba-lab
+PublisherUrl: https://github.com/nakaba-lab/ssh-manager-tui
+Author: nakaba-lab
+PackageName: sshm
+PackageUrl: https://github.com/nakaba-lab/ssh-manager-tui
+License: MIT OR Apache-2.0
+ShortDescription: A TUI SSH host manager for ~/.ssh/config
+Moniker: sshm
+Tags:
+  - ssh
+  - tui
+  - ssh-config
+  - terminal
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/n/NakabaLab/sshm/1.1.1/NakabaLab.sshm.yaml
+++ b/manifests/n/NakabaLab/sshm/1.1.1/NakabaLab.sshm.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: NakabaLab.sshm
+PackageVersion: 1.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Automated version update for NakabaLab.sshm (sshm — a TUI SSH host manager for ~/.ssh/config).

- PackageVersion: 1.1.1
- Installer: GitHub Release v1.1.1 zip (portable, sshm.exe), SHA256 verified end-to-end against the published .sha256 sidecar.
- Manifests validated with `winget validate` (ManifestVersion 1.12.0).

This is a version update for an existing package (CLA signed).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/390855)