### PR TITLE
New version: Feci.ParleyDeckCli version 1.30.5

### DIFF
--- a/manifests/f/Feci/ParleyDeckCli/1.30.5/Feci.ParleyDeckCli.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.30.5/Feci.ParleyDeckCli.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.30.5
+InstallerType: portable
+Commands:
+- parley
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.30.5/parley-v1.30.5-windows-x64.exe
+  InstallerSha256: 5EAD6287C50C6AA001E31A14E70852CCE205CE0A9B460FCFEB38BCAA3067C9B6
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.30.5/parley-v1.30.5-windows-arm64.exe
+  InstallerSha256: 8347D823CBB0296281E5D89BE5E03E2C33E0A6EBE8009D90DE5C7189FA4CDA52
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.30.5/Feci.ParleyDeckCli.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.30.5/Feci.ParleyDeckCli.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.30.5
+PackageLocale: en-US
+Publisher: Feci
+PublisherUrl: https://github.com/feci
+PackageName: Parley Deck CLI
+PackageUrl: https://github.com/feci/parley-deck-cli
+License: Apache-2.0
+LicenseUrl: https://github.com/feci/parley-deck-cli/blob/main/LICENSE
+ShortDescription: CLI that orchestrates Parley Deck multi-agent cooperation workflows.
+Description: "parley orchestrates multi-agent Parley Deck cooperation: deliberation rounds across local CLI agents, consensus and finalize, implementation with living execution plans, a live TUI, retrospective optimization, a pre-idea readiness check (parley preflight), and central per-user defaults at ~/.parley/agents.toml (per-agent model and reasoning, plus a [defaults] policy block for ping tier, transport, and roster-change policy)."
+ReleaseNotesUrl: https://github.com/feci/parley-deck-cli/releases/tag/v1.30.5
+Tags:
+- ai
+- agents
+- cli
+- codex
+- consensus
+- multi-agent
+- orchestration
+- preflight
+- tui
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.30.5/Feci.ParleyDeckCli.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.30.5/Feci.ParleyDeckCli.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.30.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Automated submission for Feci.ParleyDeckCli 1.30.5. Portable CLI; x64 + arm64 verified against the GitHub release assets (sha256 match).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/390898)