### PR TITLE
New version: Feci.ParleyDeckSkill version 1.3.5

### DIFF
--- a/manifests/f/Feci/ParleyDeckSkill/1.3.5/Feci.ParleyDeckSkill.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/1.3.5/Feci.ParleyDeckSkill.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 1.3.5
+InstallerType: portable
+Commands:
+- parley-deck-skill
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-skill/releases/download/v1.3.5/parley-deck-skill-v1.3.5-windows-x64.exe
+  InstallerSha256: C18D4A662CA1D3F371AE6C91ABC2E9B9E8F66A2AC2C03C1755DF40E885E5F794
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-skill/releases/download/v1.3.5/parley-deck-skill-v1.3.5-windows-arm64.exe
+  InstallerSha256: 0E2DAAA6F7F34D306EC4E67165E90FB4C26CC7F45737FBD0D57A2CD057670191
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckSkill/1.3.5/Feci.ParleyDeckSkill.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/1.3.5/Feci.ParleyDeckSkill.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 1.3.5
+PackageLocale: en-US
+Publisher: Feci
+PublisherUrl: https://github.com/feci
+PackageName: Parley Deck Skill
+PackageUrl: https://github.com/feci/parley-deck-skill
+License: Apache-2.0
+LicenseUrl: https://github.com/feci/parley-deck-skill/blob/main/LICENSE
+ShortDescription: Installer for the Parley Deck multi-agent cooperation skill.
+Description: "Installs the vendor-neutral Parley Deck AI cooperation skill into Codex, Claude Code, Antigravity CLI, legacy Gemini CLI, Hermes, or a custom skill directory. v1.3.5 documents the ~/.parley/agents.toml [defaults] policy block (ping tier, preferred transport, roster-change policy, speed and timeouts) that the facilitator honors per project."
+ReleaseNotesUrl: https://github.com/feci/parley-deck-skill/releases/tag/v1.3.5
+Tags:
+- ai
+- agents
+- agy
+- antigravity
+- cli
+- codex
+- claude
+- gemini
+- multi-agent
+- skill
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckSkill/1.3.5/Feci.ParleyDeckSkill.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/1.3.5/Feci.ParleyDeckSkill.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 1.3.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Automated submission for Feci.ParleyDeckSkill 1.3.5. Portable installer; x64 + arm64 verified against the GitHub release assets (sha256 match).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/390899)