### PR TITLE
New package: LocalTV.Remote version 0.1.1

### DIFF
--- a/manifests/l/LocalTV/Remote/0.1.1/LocalTV.Remote.installer.yaml
+++ b/manifests/l/LocalTV/Remote/0.1.1/LocalTV.Remote.installer.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 PackageIdentifier: LocalTV.Remote
 PackageVersion: 0.1.1
 InstallerLocale: en-US
@@ -13,4 +14,4 @@ Installers:
     InstallerSha256: 903B888509C72D1728DE2E9EF704F6D210E312FFE4375D29A0EBEECCF53E76AA
     ProductCode: '{A3B7C2D1-E4F5-6789-ABCD-EF0123456789}_is1'
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/l/LocalTV/Remote/0.1.1/LocalTV.Remote.installer.yaml
+++ b/manifests/l/LocalTV/Remote/0.1.1/LocalTV.Remote.installer.yaml
@@ -1,0 +1,16 @@
+PackageIdentifier: LocalTV.Remote
+PackageVersion: 0.1.1
+InstallerLocale: en-US
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/creationsofm7/localtv-remote/releases/download/v0.1.1/LocalTVRemote-Setup-0.1.1.exe
+    InstallerSha256: 903B888509C72D1728DE2E9EF704F6D210E312FFE4375D29A0EBEECCF53E76AA
+    ProductCode: '{A3B7C2D1-E4F5-6789-ABCD-EF0123456789}_is1'
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/l/LocalTV/Remote/0.1.1/LocalTV.Remote.locale.en-US.yaml
+++ b/manifests/l/LocalTV/Remote/0.1.1/LocalTV.Remote.locale.en-US.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 PackageIdentifier: LocalTV.Remote
 PackageVersion: 0.1.1
 PackageLocale: en-US
@@ -25,4 +26,4 @@ Tags:
   - tray
 ReleaseNotesUrl: https://github.com/creationsofm7/localtv-remote/releases/tag/v0.1.1
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/l/LocalTV/Remote/0.1.1/LocalTV.Remote.locale.en-US.yaml
+++ b/manifests/l/LocalTV/Remote/0.1.1/LocalTV.Remote.locale.en-US.yaml
@@ -1,0 +1,28 @@
+PackageIdentifier: LocalTV.Remote
+PackageVersion: 0.1.1
+PackageLocale: en-US
+Publisher: LocalTV
+PublisherUrl: https://github.com/creationsofm7/localtv-remote
+PublisherSupportUrl: https://github.com/creationsofm7/localtv-remote/issues
+Author: Mudit Pandey
+PackageName: LocalTV Remote
+PackageUrl: https://github.com/creationsofm7/localtv-remote
+License: Apache-2.0
+LicenseUrl: https://github.com/creationsofm7/localtv-remote/blob/main/LICENSE
+ShortDescription: Lightweight phone-as-remote-mouse/keyboard daemon for Windows
+Description: |-
+  Turn your phone into a wireless mouse, keyboard, scroll wheel, and volume
+  control for your Windows PC. Pair over LAN by scanning a QR code — no
+  accounts, no cloud, no Chromium. Under 27 MB installer.
+Moniker: localtv-remote
+Tags:
+  - remote
+  - mouse
+  - keyboard
+  - lan
+  - phone
+  - control
+  - tray
+ReleaseNotesUrl: https://github.com/creationsofm7/localtv-remote/releases/tag/v0.1.1
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/l/LocalTV/Remote/0.1.1/LocalTV.Remote.yaml
+++ b/manifests/l/LocalTV/Remote/0.1.1/LocalTV.Remote.yaml
@@ -1,5 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 PackageIdentifier: LocalTV.Remote
 PackageVersion: 0.1.1
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/l/LocalTV/Remote/0.1.1/LocalTV.Remote.yaml
+++ b/manifests/l/LocalTV/Remote/0.1.1/LocalTV.Remote.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: LocalTV.Remote
+PackageVersion: 0.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## 📖 Description
New package: **LocalTV.Remote** version 0.1.1

Open-source phone-as-remote-mouse/keyboard daemon for Windows. Inno Setup installer, user scope, x64.
Source & releases: https://github.com/creationsofm7/localtv-remote

## ✅ Checklist
- [ ] Signed the Contributor License Agreement (will agree via the CLA bot on this PR)
- [ ] Linked to an issue (not applicable — new package)

## 📦 Manifest Checklist
- [x] Checked that there aren''t other open pull requests for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` (passed, no warnings)
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the 1.12 schema
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/390960)