### PR TITLE
New package: UtmostBoundary.hijri version 0.3.0

### DIFF
--- a/manifests/u/UtmostBoundary/hijri/0.3.0/UtmostBoundary.hijri.installer.yaml
+++ b/manifests/u/UtmostBoundary/hijri/0.3.0/UtmostBoundary.hijri.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: UtmostBoundary.hijri
+PackageVersion: 0.3.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: hijri.exe
+    PortableCommandAlias: hijri
+Commands:
+  - hijri
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/UtmostBoundary/hijri/releases/download/v0.3.0/hijri-x86_64-pc-windows-msvc.zip
+    InstallerSha256: 990560320AFD223E2BF23808A6BCE10722428E3973370DD9FDDDCD9B6EDE3BED
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/u/UtmostBoundary/hijri/0.3.0/UtmostBoundary.hijri.locale.en-US.yaml
+++ b/manifests/u/UtmostBoundary/hijri/0.3.0/UtmostBoundary.hijri.locale.en-US.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: UtmostBoundary.hijri
+PackageVersion: 0.3.0
+PackageLocale: en-US
+Publisher: UtmostBoundary
+PublisherUrl: https://github.com/UtmostBoundary
+PublisherSupportUrl: https://github.com/UtmostBoundary/hijri/issues
+PackageName: hijri
+PackageUrl: https://github.com/UtmostBoundary/hijri
+License: MIT
+LicenseUrl: https://github.com/UtmostBoundary/hijri/blob/main/LICENSE
+ShortDescription: A friendly, cal-like command-line tool for Hijri (Islamic) dates (Umm al-Qura).
+Tags:
+  - hijri
+  - islamic
+  - calendar
+  - cli
+  - umm-al-qura
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/u/UtmostBoundary/hijri/0.3.0/UtmostBoundary.hijri.yaml
+++ b/manifests/u/UtmostBoundary/hijri/0.3.0/UtmostBoundary.hijri.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: UtmostBoundary.hijri
+PackageVersion: 0.3.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package

- **Package:** `UtmostBoundary.hijri`
- **Version:** 0.3.0
- A friendly, `cal`-like command-line tool for Hijri (Islamic) dates (Umm al-Qura). https://github.com/UtmostBoundary/hijri

### Manifest checklist

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest?
- [x] This is a new package; manifests validated against the 1.6.0 schema.
- [x] Installer is a portable `.zip` containing `hijri.exe`; SHA256 verified.
- [x] Have you tested your manifest locally with `winget install --manifest <path>`? — N/A (authored from verified release artifacts; installer URL + SHA256 confirmed).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/390990)