### PR TITLE
New package: OpenGeos.GeoLibre version 1.5.0

### DIFF
--- a/manifests/o/OpenGeos/GeoLibre/1.5.0/OpenGeos.GeoLibre.installer.yaml
+++ b/manifests/o/OpenGeos/GeoLibre/1.5.0/OpenGeos.GeoLibre.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: OpenGeos.GeoLibre
+PackageVersion: 1.5.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - silent
+  - silentWithProgress
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/opengeos/GeoLibre/releases/download/v1.5.0/GeoLibre.Desktop_1.5.0_x64-setup.exe
+    InstallerSha256: 94079516D877DEAC4F96B82F4B46D1EF607B7D4D996340556C6B902FFFC2F9C7
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/o/OpenGeos/GeoLibre/1.5.0/OpenGeos.GeoLibre.locale.en-US.yaml
+++ b/manifests/o/OpenGeos/GeoLibre/1.5.0/OpenGeos.GeoLibre.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: OpenGeos.GeoLibre
+PackageVersion: 1.5.0
+PackageLocale: en-US
+Publisher: OpenGeos
+PublisherUrl: https://github.com/opengeos
+PublisherSupportUrl: https://github.com/opengeos/GeoLibre/issues
+Author: GeoLibre Contributors
+PackageName: GeoLibre Desktop
+PackageUrl: https://geolibre.app/
+License: MIT
+LicenseUrl: https://github.com/opengeos/GeoLibre/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Qiusheng Wu
+ShortDescription: Lightweight, cloud-native GIS platform for visualizing and analyzing geospatial data
+Description: |-
+  GeoLibre is a lightweight, cloud-native desktop GIS for visualizing and
+  analyzing geospatial data, built on MapLibre with deck.gl for 3D and
+  point-cloud overlays. It loads vector and raster files, web services, 3D
+  Tiles, MBTiles, and cloud-native formats, and is extensible through a plugin
+  ecosystem.
+Moniker: geolibre
+Tags:
+  - gis
+  - geospatial
+  - map
+  - maplibre
+  - raster
+  - vector
+ReleaseNotesUrl: https://github.com/opengeos/GeoLibre/releases/tag/v1.5.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/o/OpenGeos/GeoLibre/1.5.0/OpenGeos.GeoLibre.yaml
+++ b/manifests/o/OpenGeos/GeoLibre/1.5.0/OpenGeos.GeoLibre.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: OpenGeos.GeoLibre
+PackageVersion: 1.5.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: `OpenGeos.GeoLibre` version `1.5.0`

[GeoLibre Desktop](https://geolibre.app/) is a lightweight, cloud-native GIS for visualizing and analyzing geospatial data (MIT, https://github.com/opengeos/GeoLibre).

- Installer: the official Tauri-built NSIS (`nullsoft`) setup `.exe` from the GitHub release, x64, per-user scope.
- Manifests validated locally against the v1.6.0 `version` / `installer` / `defaultLocale` JSON schemas.

#### Checklist
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>` or an equivalent schema check?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`? (No Windows machine available; relying on the automated sandbox validation.)
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/391085)