### PR TITLE
New package: SparshSam.OpenReader version 1.2.2

### DIFF
--- a/manifests/s/SparshSam/OpenReader/1.2.2/SparshSam.OpenReader.installer.yaml
+++ b/manifests/s/SparshSam/OpenReader/1.2.2/SparshSam.OpenReader.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: SparshSam.OpenReader
+PackageVersion: 1.2.2
+InstallerType: inno
+Scope: machine
+UpgradeBehavior: install
+FileExtensions:
+  - pdf
+ProductCode: '{D3A7F9E1-4B2C-4A8F-9E6D-1C5B3A7F9E01}_is1'
+ReleaseDate: 2026-06-18
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/sparshsam/openreader/releases/download/v1.2.2/OpenReader-Setup.exe
+    InstallerSha256: 2FC3EC8D7439B21379FBB82A7E4E4F5B15B8E32E678B98DDFC9A1743EED359B2
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/SparshSam/OpenReader/1.2.2/SparshSam.OpenReader.locale.en-US.yaml
+++ b/manifests/s/SparshSam/OpenReader/1.2.2/SparshSam.OpenReader.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: SparshSam.OpenReader
+PackageVersion: 1.2.2
+PackageLocale: en-US
+Publisher: Sparsh Sam
+PublisherUrl: https://github.com/sparshsam
+PublisherSupportUrl: https://github.com/sparshsam/openreader/issues
+Author: Sparsh Sam
+PackageName: OpenReader
+PackageUrl: https://github.com/sparshsam/openreader
+License: AGPL-3.0-only
+LicenseUrl: https://github.com/sparshsam/openreader/blob/main/LICENSE
+ShortDescription: A privacy-first, local-only PDF reader and utility for Windows.
+Description: OpenReader reads, searches, copies, merges, splits, extracts, and compresses PDF files locally without uploading documents.
+Moniker: openreader
+Tags:
+  - local-first
+  - pdf
+  - pdf-reader
+  - privacy
+ReleaseNotesUrl: https://github.com/sparshsam/openreader/releases/tag/v1.2.2
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/SparshSam/OpenReader/1.2.2/SparshSam.OpenReader.yaml
+++ b/manifests/s/SparshSam/OpenReader/1.2.2/SparshSam.OpenReader.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: SparshSam.OpenReader
+PackageVersion: 1.2.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Adds the initial community manifest for OpenReader 1.2.2 using the versioned Inno Setup installer. The manifest validates successfully with Windows Package Manager 1.28.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/391095)