### PR TITLE
New version: Sewandev.Reverbic version 1.5.7

### DIFF
--- a/manifests/s/Sewandev/Reverbic/1.5.7/Sewandev.Reverbic.installer.yaml
+++ b/manifests/s/Sewandev/Reverbic/1.5.7/Sewandev.Reverbic.installer.yaml
@@ -1,0 +1,10 @@
+﻿PackageIdentifier: Sewandev.Reverbic
+PackageVersion: 1.5.7
+MinimumOSVersion: 10.0.0.0
+InstallerType: portable
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/sewandev/Reverbic/releases/download/v1.5.7/reverbic-v1.5.7-x86_64-windows.exe
+    InstallerSha256: BC7D54A73F0436CF69BFA79E8F77F5E0F225465523CC15A07BDE7C59C3445424
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/Sewandev/Reverbic/1.5.7/Sewandev.Reverbic.locale.en-US.yaml
+++ b/manifests/s/Sewandev/Reverbic/1.5.7/Sewandev.Reverbic.locale.en-US.yaml
@@ -1,0 +1,23 @@
+﻿PackageIdentifier: Sewandev.Reverbic
+PackageVersion: 1.5.7
+PackageLocale: en-US
+Publisher: Esteban Jaramillo
+PublisherUrl: https://github.com/sewandev
+PackageName: Reverbic
+PackageUrl: https://github.com/sewandev/Reverbic
+License: MIT
+LicenseUrl: https://github.com/sewandev/Reverbic/blob/main/LICENSE
+ShortDescription: Terminal radio player for Windows with Spotify integration and gaming overlay.
+Description: |-
+  Reverbic is a terminal-based radio player for Windows. Stream thousands of internet
+  radio stations, control Spotify remotely, and enjoy a floating Now Playing overlay
+  while gaming — all from the command line.
+Tags:
+  - radio
+  - spotify
+  - tui
+  - terminal
+  - audio
+ReleaseNotesUrl: https://github.com/sewandev/Reverbic/releases/tag/v1.5.7
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/Sewandev/Reverbic/1.5.7/Sewandev.Reverbic.yaml
+++ b/manifests/s/Sewandev/Reverbic/1.5.7/Sewandev.Reverbic.yaml
@@ -1,0 +1,5 @@
+﻿PackageIdentifier: Sewandev.Reverbic
+PackageVersion: 1.5.7
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## New version: Sewandev.Reverbic 1.5.7

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Microsoft Reviewers: [Open `1ES Resource Tracking`](https://aka.ms/1eswiki)

### Notes
Portable single-exe (x64). Static MSVC CRT since 1.5.7, so no `Microsoft.VCRedist` dependency is required (verified with `dumpbin /dependents`: no `VCRUNTIME140.dll`).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/391113)