### PR TITLE
New package: RigSmith.Rig version 1.0.0

### DIFF
--- a/manifests/r/RigSmith/Rig/1.0.0/RigSmith.Rig.installer.yaml
+++ b/manifests/r/RigSmith/Rig/1.0.0/RigSmith.Rig.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 PackageIdentifier: RigSmith.Rig
 PackageVersion: 1.0.0
 InstallerType: zip
@@ -17,4 +17,4 @@ Installers:
     InstallerUrl: https://github.com/rigsmith/rigsmith/releases/download/v1.0.0/rig_1.0.0_windows_arm64.zip
     InstallerSha256: 26511CD267CC2992DD7B7E3B612C09044BFC02ECEE5B4561ABEBBAF1B33FD1C3
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/r/RigSmith/Rig/1.0.0/RigSmith.Rig.installer.yaml
+++ b/manifests/r/RigSmith/Rig/1.0.0/RigSmith.Rig.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: RigSmith.Rig
+PackageVersion: 1.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: rig.exe
+    PortableCommandAlias: rig
+Commands:
+  - rig
+ReleaseDate: 2026-06-21
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/rigsmith/rigsmith/releases/download/v1.0.0/rig_1.0.0_windows_amd64.zip
+    InstallerSha256: 7D33995246D9A838968774291769FA8447CE27ACAA668D5DED9DFC443280A53A
+  - Architecture: arm64
+    InstallerUrl: https://github.com/rigsmith/rigsmith/releases/download/v1.0.0/rig_1.0.0_windows_arm64.zip
+    InstallerSha256: 26511CD267CC2992DD7B7E3B612C09044BFC02ECEE5B4561ABEBBAF1B33FD1C3
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/r/RigSmith/Rig/1.0.0/RigSmith.Rig.locale.en-US.yaml
+++ b/manifests/r/RigSmith/Rig/1.0.0/RigSmith.Rig.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 PackageIdentifier: RigSmith.Rig
 PackageVersion: 1.0.0
 PackageLocale: en-US
@@ -20,4 +20,4 @@ Tags:
   - go
   - rust
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/r/RigSmith/Rig/1.0.0/RigSmith.Rig.locale.en-US.yaml
+++ b/manifests/r/RigSmith/Rig/1.0.0/RigSmith.Rig.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: RigSmith.Rig
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: RigSmith
+PublisherUrl: https://rigsmith.dev
+PublisherSupportUrl: https://github.com/rigsmith/rigsmith/issues
+Author: John Campion Jr
+PackageName: Rig
+PackageUrl: https://rigsmith.dev
+License: MIT
+LicenseUrl: https://github.com/rigsmith/rigsmith/blob/main/LICENSE
+Copyright: Copyright (c) 2026 John Campion Jr
+ShortDescription: Convention-first dev launcher across .NET, Node, Go, and Rust
+Moniker: rig
+Tags:
+  - cli
+  - developer-tools
+  - dotnet
+  - go
+  - rust
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/r/RigSmith/Rig/1.0.0/RigSmith.Rig.yaml
+++ b/manifests/r/RigSmith/Rig/1.0.0/RigSmith.Rig.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: RigSmith.Rig
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0

--- a/manifests/r/RigSmith/Rig/1.0.0/RigSmith.Rig.yaml
+++ b/manifests/r/RigSmith/Rig/1.0.0/RigSmith.Rig.yaml
@@ -1,6 +1,6 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 PackageIdentifier: RigSmith.Rig
 PackageVersion: 1.0.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## New package: RigSmith.Rig 1.0.0

`rig` — convention-first dev launcher across .NET, Node, Go, and Rust.

- Portable CLI shipped as a per-arch `.zip` (x64 + arm64); installed as a `portable` nested installer exposing the `rig` command.
- Installers are the official GitHub release assets; `InstallerSha256` taken from the release `checksums.txt`.
- Windows binaries are code-signed via Azure Trusted Signing.
- Project: https://rigsmith.dev — Repo: https://github.com/rigsmith/rigsmith (MIT).

### Checklist
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] This PR only modifies one (1) package
- [x] Manifests follow the 1.6.0 schema
- [x] SHA256 values match the linked installers

First submission for this publisher; happy to provide ownership verification for rigsmith.dev / the project if requested.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/391193)