### PR TITLE
Add ripsync v1.2.0

### DIFF
--- a/manifests/b/beeboyd/ripsync/1.2.0/beeboyd.ripsync.installer.yaml
+++ b/manifests/b/beeboyd/ripsync/1.2.0/beeboyd.ripsync.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: beeboyd.ripsync
+PackageVersion: 1.2.0
+InstallerType: zip
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+   - Architecture: x64
+     InstallerUrl: https://github.com/beeboyd/ripsync/releases/download/v1.2.0/ripsync-v1.2.0-x86_64-pc-windows-msvc.zip
+     InstallerSha256: a59981beb41f118295b16dd795a089e211865ea95ebb26183396c04f5e43689d
+     ProductCode: ""
+   - Architecture: arm64
+     InstallerUrl: https://github.com/beeboyd/ripsync/releases/download/v1.2.0/ripsync-v1.2.0-aarch64-pc-windows-msvc.zip
+     InstallerSha256: 04a5c26626a453d5f6560ba567096e6a56130fd29058bc595c74445cc3296a2c
+     ProductCode: ""
+ManifestType: installer
+ManifestVersion: 1.6.0
+

--- a/manifests/b/beeboyd/ripsync/1.2.0/beeboyd.ripsync.locale.en-US.yaml
+++ b/manifests/b/beeboyd/ripsync/1.2.0/beeboyd.ripsync.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: beeboyd.ripsync
+PackageVersion: 1.2.0
+PackageLocale: en-US
+Publisher: beeboyd
+PublisherUrl: https://github.com/beeboyd
+PublisherSupportUrl: https://github.com/beeboyd/ripsync/issues
+PackageName: ripsync
+PackageUrl: https://github.com/beeboyd/ripsync
+License: MIT OR Apache-2.0
+LicenseUrl: https://raw.githubusercontent.com/beeboyd/ripsync/main/LICENSE-MIT
+Copyright: Copyright (c) 2026 ripsync contributors
+ShortDescription: A fast, memory-safe local directory sync tool.
+Description: |-
+  ripsync mirrors a source directory into a destination using copy-on-write
+  reflinks where available, a persistent index for quick re-syncs, an operator
+  TUI, and optional post-copy verification. Its destination-containment checks
+  reject the symlink path-traversal bug class by construction.
+Moniker: ripsync
+Tags:
+  - rsync
+  - sync
+  - backup
+  - filesystem
+  - cli
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0
+

--- a/manifests/b/beeboyd/ripsync/1.2.0/beeboyd.ripsync.yaml
+++ b/manifests/b/beeboyd/ripsync/1.2.0/beeboyd.ripsync.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: beeboyd.ripsync
+PackageVersion: 1.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0
+


### PR DESCRIPTION
Add ripsync v1.2.0 to winget package manager.

**Package:** ripsync v1.2.0  
**Description:** Fast, memory-safe rsync replacement with 2.2× performance on standard hardware, 480× on modern filesystems with copy-on-write support.

**Features:**
- Parallel delta hashing (Rayon)
- Persistent index for fast re-syncs
- SSH + local sync
- Cross-platform (Linux/macOS/Windows)
- Memory-safe (Rust, no buffer overflows)
- Safe deletion (refuses empty sources)

**Release:** https://github.com/BeeBoyD/ripsync/releases/tag/v1.2.0

**Manifests:**
- manifests/b/beeboyd/ripsync/1.2.0/beeboyd.ripsync.yaml
- manifests/b/beeboyd/ripsync/1.2.0/beeboyd.ripsync.installer.yaml
- manifests/b/beeboyd/ripsync/1.2.0/beeboyd.ripsync.locale.en-US.yaml
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/391224)