### PR TITLE
New package: bezzad.Downloader version 1.3.3

### DIFF
--- a/manifests/b/bezzad/Downloader/1.3.3/bezzad.Downloader.installer.yaml
+++ b/manifests/b/bezzad/Downloader/1.3.3/bezzad.Downloader.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: bezzad.Downloader
+PackageVersion: 1.3.3
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: Downloader.exe
+    PortableCommandAlias: downloader
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/bezzad/Downloader.Desktop/releases/download/v1.3.3/Downloader-win-x64.zip
+    InstallerSha256: FB28DF1B6C4D0AC7516FFE0C3E1B6610FF193CFA2DB0AD01BBE9F1FB6E766601
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/b/bezzad/Downloader/1.3.3/bezzad.Downloader.locale.en-US.yaml
+++ b/manifests/b/bezzad/Downloader/1.3.3/bezzad.Downloader.locale.en-US.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: bezzad.Downloader
+PackageVersion: 1.3.3
+PackageLocale: en-US
+Publisher: Behzad Khosravifar
+PublisherUrl: https://github.com/bezzad
+PackageName: Downloader
+PackageUrl: https://github.com/bezzad/Downloader.Desktop
+License: MIT
+LicenseUrl: https://github.com/bezzad/Downloader.Desktop/blob/main/LICENSE
+ShortDescription: Fast cross-platform multi-connection download manager.
+Moniker: downloader
+Tags:
+  - download
+  - download-manager
+  - downloader
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/b/bezzad/Downloader/1.3.3/bezzad.Downloader.yaml
+++ b/manifests/b/bezzad/Downloader/1.3.3/bezzad.Downloader.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: bezzad.Downloader
+PackageVersion: 1.3.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## New package: bezzad.Downloader 1.3.3

Downloader — a fast, free, open-source cross-platform multi-connection download manager (multipart, pause/resume, queues, scheduler, speed limits).

- Installer: portable `Downloader.exe` inside the official GitHub release zip (`Downloader-win-x64.zip`).
- Repo: https://github.com/bezzad/Downloader.Desktop
- Moniker: `downloader`

### Checklist
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] This is a new package (not previously in the repository).
- [x] Manifests validate against schema 1.6.0 and the installer URL/SHA256 point at the official signed-by-publisher GitHub release.
- [x] I verified the package installs and runs (portable zip → `downloader`).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/391296)