### PR TITLE
New package: dishanagalawatta.SkillManager v1.8.0

### DIFF
--- a/manifests/d/dishanagalawatta/SkillManager/1.8.0/dishanagalawatta.SkillManager.installer.yaml
+++ b/manifests/d/dishanagalawatta/SkillManager/1.8.0/dishanagalawatta.SkillManager.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: dishanagalawatta.SkillManager
+PackageVersion: 1.8.0
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: inno
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ProductCode: "{{5A1B8C9D-E0F2-4A3B-8C7D-6E5F4A3B2C1D}}_is1"
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/dishanagalawatta/SkillManager/releases/download/v1.8.0/SkillManager_Setup.exe
+    InstallerSha256: 81460F5277138407AA2ED82F388DCD04BCF9E7A1737E5C84BA3338D2C315E1AA
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/d/dishanagalawatta/SkillManager/1.8.0/dishanagalawatta.SkillManager.locale.en-US.yaml
+++ b/manifests/d/dishanagalawatta/SkillManager/1.8.0/dishanagalawatta.SkillManager.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: dishanagalawatta.SkillManager
+PackageVersion: 1.8.0
+PackageLocale: en-US
+Publisher: dishanagalawatta
+PublisherUrl: https://github.com/dishanagalawatta/SkillManager
+PublisherSupportUrl: https://github.com/dishanagalawatta/SkillManager/issues
+Author: Don Dishan Kanchuka Agalawatta
+PackageName: SkillManager
+PackageUrl: https://github.com/dishanagalawatta/SkillManager
+License: MIT
+LicenseUrl: https://github.com/dishanagalawatta/SkillManager/blob/main/LICENSE
+ShortDescription: A professional tool for managing reusable agent skills across repositories.
+Description: SkillManager is a Windows desktop application built with PySide6/QML that provides a workspace to manage, sync, and deploy AI agent skills across multiple project repositories. Features include quick copy, surgical sync, background app updates, screenshot redaction, and a central searchable library.
+Tags:
+  - ai
+  - skills
+  - agent
+  - pyside6
+  - windows
+ReleaseNotesUrl: https://github.com/dishanagalawatta/SkillManager/releases/tag/v1.8.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/d/dishanagalawatta/SkillManager/1.8.0/dishanagalawatta.SkillManager.yaml
+++ b/manifests/d/dishanagalawatta/SkillManager/1.8.0/dishanagalawatta.SkillManager.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: dishanagalawatta.SkillManager
+PackageVersion: 1.8.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## New package: dishanagalawatta.SkillManager

**Publisher:** dishanagalawatta
**Package:** SkillManager
**Version:** 1.8.0
**Installer:** Inno Setup (x64)
**License:** MIT

A professional tool for managing reusable agent skills across repositories. Built with PySide6/QML for Windows.

### Installer hash
\81460F5277138407AA2ED82F388DCD04BCF9E7A1737E5C84BA3338D2C315E1AA\

### Checklist
- [x] I have read the [Contributing Guide](https://github.com/microsoft/winget-pkgs/blob/master/CONTRIBUTING.md)
- [x] This PR uses a non-commercial license (MIT)
- [x] Installer hash verified
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/391299)