### PR TITLE
Update FabioColor.FadedBalancerDCTL to 1.6.4

### DIFF
--- a/manifests/f/FabioColor/FadedBalancerDCTL/1.6.4/FabioColor.FadedBalancerDCTL.installer.yaml
+++ b/manifests/f/FabioColor/FadedBalancerDCTL/1.6.4/FabioColor.FadedBalancerDCTL.installer.yaml
@@ -1,0 +1,17 @@
+# Created by Codex
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: FabioColor.FadedBalancerDCTL
+PackageVersion: 1.6.4
+InstallerType: inno
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/fabiocolor/Faded-Balancer-DCTL/releases/download/v1.6.4/FadedBalancerDCTL-Setup-1.6.4.exe
+  InstallerSha256: 1978BB0D178A49E11C4017C4E33A24EA83EF0E1B91BA49F1EE00844C049CCAFA
+  Scope: machine
+  InstallerSwitches:
+    Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+    SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+ManifestType: installer
+ManifestVersion: 1.9.0
+ReleaseDate: 2026-06-12

--- a/manifests/f/FabioColor/FadedBalancerDCTL/1.6.4/FabioColor.FadedBalancerDCTL.locale.en-US.yaml
+++ b/manifests/f/FabioColor/FadedBalancerDCTL/1.6.4/FabioColor.FadedBalancerDCTL.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# Created by Codex
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: FabioColor.FadedBalancerDCTL
+PackageVersion: 1.6.4
+PackageLocale: en-US
+Publisher: Fabio Color
+PublisherUrl: https://github.com/fabiocolor
+PublisherSupportUrl: https://github.com/fabiocolor/Faded-Balancer-DCTL/issues
+PackageName: Faded Balancer DCTL
+PackageUrl: https://github.com/fabiocolor/Faded-Balancer-DCTL
+License: MIT
+LicenseUrl: https://github.com/fabiocolor/Faded-Balancer-DCTL/blob/main/LICENSE
+ShortDescription: DaVinci Resolve DCTL to rebalance faded film scans.
+Description: Faded Balancer DCTL is a DaVinci Resolve DCTL for balancing RGB channels and correcting faded film scans.
+Moniker: fadedbalancerdctl
+Tags:
+- davinci
+- dctl
+- film
+- restoration
+ReleaseNotesUrl: https://github.com/fabiocolor/Faded-Balancer-DCTL/releases/tag/v1.6.4
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/f/FabioColor/FadedBalancerDCTL/1.6.4/FabioColor.FadedBalancerDCTL.yaml
+++ b/manifests/f/FabioColor/FadedBalancerDCTL/1.6.4/FabioColor.FadedBalancerDCTL.yaml
@@ -1,0 +1,8 @@
+# Created by Codex
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: FabioColor.FadedBalancerDCTL
+PackageVersion: 1.6.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## Description

Resubmission of #387070 for `FabioColor.FadedBalancerDCTL` version `1.6.4`. The previous PR was closed by stale policy after validation required author feedback.

This update uses the direct Inno installer `.exe` from the `v1.6.4` GitHub release and follows the accepted `1.6.3` manifest layout.

Previous validation context from #387070:
- Initial validation reported a Defender detection on the installer asset: `Trojan:Win32/Wacatac.H!ml`.
- A later rerun labeled the PR with `Validation-Installation-Error`.

Package context: this is a DaVinci Resolve DCTL plugin/add-on, so it does not expose a standalone app UI/About dialog. Version can be validated through winget package metadata and the release asset URL.

## Checklist

- [x] Signed the Contributor License Agreement
- [x] Checked that there aren't other open pull requests for the same manifest update/change
- [x] This PR only modifies one manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest follows the existing accepted package pattern for `1.6.3`

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/391341)
