### PR TITLE
Update manifest: Docker.DockerDesktop version 4.74.0

### DIFF
--- a/manifests/d/Docker/DockerDesktop/4.78.0/Docker.DockerDesktop.installer.yaml
+++ b/manifests/d/Docker/DockerDesktop/4.78.0/Docker.DockerDesktop.installer.yaml
@@ -13,6 +13,7 @@ InstallModes:
 InstallerSwitches:
   Silent: install --quiet
   SilentWithProgress: install --quiet
+  Interactive: install
   Custom: --accept-license --backend=wsl-2 --no-windows-containers
 UpgradeBehavior: install
 ReleaseDate: 2026-06-12


### PR DESCRIPTION
## 📖 Description
Try to fix interactive installation.

Since 4.74.0 in #376651, in all new manifests Docker Installer argument `install` for interactive mode is missing, so `winget upgrade --interactive Docker.DockerDesktop` fails for every new version now.

Previous attempts were in #381609.
But all of them didn't pass Validation Pipeline with errors like `Validation-Installation-Error` or `Validation-Unattended-Failed`.


## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)
- Resolves #381599, #382298?

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/391365)