### PR TITLE
New package: kunobi-ninja.kache.Unstable version 0.7.0-rc.3

### DIFF
--- a/manifests/k/kunobi-ninja/kache/Unstable/0.7.0-rc.3/kunobi-ninja.kache.Unstable.installer.yaml
+++ b/manifests/k/kunobi-ninja/kache/Unstable/0.7.0-rc.3/kunobi-ninja.kache.Unstable.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: kunobi-ninja.kache.Unstable
+PackageVersion: 0.7.0-rc.3
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: portable
+Commands:
+  - kache
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/kunobi-ninja/kache/releases/download/v0.7.0-rc.3/kache-x86_64-pc-windows-msvc.exe
+    InstallerSha256: 4BFB990A79ED93B037B5DF8CB4978C991E60A45D990946FCA4BFB473CFF57EC5
+  - Architecture: arm64
+    InstallerUrl: https://github.com/kunobi-ninja/kache/releases/download/v0.7.0-rc.3/kache-aarch64-pc-windows-msvc.exe
+    InstallerSha256: 093EA0081FE101AA416988F4172CE1E2A116F62F222EE2EF36247B307A9BBDB4
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/k/kunobi-ninja/kache/Unstable/0.7.0-rc.3/kunobi-ninja.kache.Unstable.locale.en-US.yaml
+++ b/manifests/k/kunobi-ninja/kache/Unstable/0.7.0-rc.3/kunobi-ninja.kache.Unstable.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: kunobi-ninja.kache.Unstable
+PackageVersion: 0.7.0-rc.3
+PackageLocale: en-US
+Publisher: Kunobi Ninja
+PublisherUrl: https://kunobi.com
+PublisherSupportUrl: https://kunobi.com/contact
+Author: Zondax AG
+PackageName: kache (Unstable)
+PackageUrl: https://github.com/kunobi-ninja/kache
+License: Apache-2.0
+LicenseUrl: https://github.com/kunobi-ninja/kache/blob/main/LICENSE
+Copyright: 2026 Zondax AG
+ShortDescription: Content-addressed zero-copy build cache for Rust, C/C++ and more (unstable channel)
+Description: kache is a content-addressed, zero-copy build cache for Rust, C/C++ and more. It avoids file copies and wasted disk by hardlinking artifacts locally and sharing them via S3-compatible object storage. This is the pre-release (RC/beta) channel.
+Moniker: kache
+Tags:
+  - build
+  - build-cache
+  - cache
+  - ci
+  - compiler
+  - developer-tools
+  - rust
+  - rustc
+ReleaseNotesUrl: https://github.com/kunobi-ninja/kache/releases/tag/v0.7.0-rc.3
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/k/kunobi-ninja/kache/Unstable/0.7.0-rc.3/kunobi-ninja.kache.Unstable.yaml
+++ b/manifests/k/kunobi-ninja/kache/Unstable/0.7.0-rc.3/kunobi-ninja.kache.Unstable.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: kunobi-ninja.kache.Unstable
+PackageVersion: 0.7.0-rc.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
### New package
- **PackageIdentifier:** kunobi-ninja.kache.Unstable
- **PackageVersion:** 0.7.0-rc.3
- **InstallerType:** portable (bare signed .exe, x64 + arm64)

kache is a content-addressed, zero-copy build cache for Rust, C/C++ and more. Pre-release (RC/beta) channel.

This supersedes #390656, which placed the manifests under `manifests/k/kunobi-ninja/kache.Unstable/...`. Validation correctly rejected that path:

> The manifest file path must match PackageIdentifier and PackageVersion properties from manifest. actual `...kache.Unstable\0.7.0-rc.3`, expected `...kache\Unstable\0.7.0-rc.3`

The three-segment identifier `kunobi-ninja.kache.Unstable` must map each dot-segment to its own directory, so the manifests now live under `manifests/k/kunobi-ninja/kache/Unstable/0.7.0-rc.3/`. Manifest content is otherwise identical to #390656.

- [x] I have signed the [CLA](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [x] Manifest content unchanged from the validated #390656; installer SHA256s re-verified against the published release assets.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/391573)