### PR TITLE
New package: Evolith.Evolith version 0.1.0

### DIFF
--- a/manifests/e/Evolith/Evolith/0.1.0/Evolith.Evolith.installer.yaml
+++ b/manifests/e/Evolith/Evolith/0.1.0/Evolith.Evolith.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: Evolith.Evolith
+PackageVersion: 0.1.0
+MinimumOSVersion: 10.0.17763.0
+InstallerType: zip
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/thulasiramk-2310/Evolith/releases/download/v0.1.0/evolith-windows-x64.zip
+    InstallerSha256: 6F5C1A40B8281EB8D2DE9F0968B7B79F57337B1A8DD9573C0B0AF1C38482E46D
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: evolith.exe
+        PortableCommandAlias: evolith
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/e/Evolith/Evolith/0.1.0/Evolith.Evolith.installer.yaml
+++ b/manifests/e/Evolith/Evolith/0.1.0/Evolith.Evolith.installer.yaml
@@ -8,6 +8,9 @@ Scope: user
 InstallModes:
   - interactive
   - silent
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/thulasiramk-2310/Evolith/releases/download/v0.1.0/evolith-windows-x64.zip

--- a/manifests/e/Evolith/Evolith/0.1.0/Evolith.Evolith.locale.en-US.yaml
+++ b/manifests/e/Evolith/Evolith/0.1.0/Evolith.Evolith.locale.en-US.yaml
@@ -6,7 +6,7 @@ PackageLocale: en-US
 Publisher: Evolith
 PublisherUrl: https://github.com/thulasiramk-2310/Evolith
 PublisherSupportUrl: https://github.com/thulasiramk-2310/Evolith/issues
-Author: Thulasiram K
+Author: thulasiramk-2310
 PackageName: Evolith
 PackageUrl: https://github.com/thulasiramk-2310/Evolith
 License: MIT

--- a/manifests/e/Evolith/Evolith/0.1.0/Evolith.Evolith.locale.en-US.yaml
+++ b/manifests/e/Evolith/Evolith/0.1.0/Evolith.Evolith.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: Evolith.Evolith
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Evolith
+PublisherUrl: https://github.com/thulasiramk-2310/Evolith
+PublisherSupportUrl: https://github.com/thulasiramk-2310/Evolith/issues
+Author: Thulasiram K
+PackageName: Evolith
+PackageUrl: https://github.com/thulasiramk-2310/Evolith
+License: MIT
+LicenseUrl: https://github.com/thulasiramk-2310/Evolith/blob/main/LICENSE
+ShortDescription: Project Memory Doctor — understand what was built in any git repository
+Description: |-
+  Evolith reads your git history and answers three questions: what features were
+  actually built, how well Evolith understands the project history, and whether
+  anything sensitive has leaked into the repository. Runs entirely offline — no
+  network calls, no data uploaded.
+
+  Quick start:
+    evolith init
+    evolith collect git
+    evolith features rebuild
+    evolith doctor
+Tags:
+  - cli
+  - developer-tools
+  - git
+  - project-management
+  - security
+ReleaseNotesUrl: https://github.com/thulasiramk-2310/Evolith/releases/tag/v0.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/e/Evolith/Evolith/0.1.0/Evolith.Evolith.yaml
+++ b/manifests/e/Evolith/Evolith/0.1.0/Evolith.Evolith.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: Evolith.Evolith
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## New package submission

**Package:** Evolith.Evolith  
**Version:** 0.1.0  
**License:** MIT  

### What is Evolith?

Evolith is a command-line Project Memory Doctor. It reads your git history and tells you what features were built, how well the history is understandable, and whether any credentials have leaked into tracked files. Runs entirely offline.

### Verification

- Installer type: `zip` (portable)
- Binary: `evolith.exe` → registered as `evolith` command alias
- SHA256 verified against the GitHub Release artifact
- No admin required — installs to `%LOCALAPPDATA%\Evolith\bin\`

### Quick start after install

```
winget install Evolith.Evolith
cd your-project
evolith init
evolith collect git
evolith features rebuild
evolith doctor
```

### Links

- Repository: https://github.com/thulasiramk-2310/Evolith
- Release: https://github.com/thulasiramk-2310/Evolith/releases/tag/v0.1.0
- License: https://github.com/thulasiramk-2310/Evolith/blob/main/LICENSE
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/391661)