### PR TITLE
Improve headers and wording in doc/private/README.md

### DIFF
--- a/doc/private/README.md
+++ b/doc/private/README.md
@@ -2,15 +2,21 @@
 
 Microsoft is working with multiple partners to develop protocols or an API to enable third-party repositories.
 
-## List of third-party repositories
-- **[winget-extras](https://github.com/pl4nty/winget-extras)** public winget repository by [pl4nty](https://github.com/pl4nty). Specializes in packages that were rejected from winget-pkgs for various reasons
+## Third-party repository implementations
 
-- **[Cloudflight](https://github.com/cloudflightio/winget-pkgs)** public winget repository by [cloudflightio](https://github.com/cloudflightio). Hosted by the developer of, and distributes, `Cloudflight.DockerInWSL`
+The following projects let you host your own, private winget repository:
 
-## List of repository creation tools
 - **[winget.Pro](https://winget.pro)** open source private winget repository with a hosted option
 - **[WinGetty](https://wingetty.dev)** open source private winget repository with a hosted option and multi-user support
 - **[Winget-Repo](https://winget-repo.io/)** open source private winget repository with client management and other unique features
 - **[rewinged](https://github.com/jantari/rewinged)** open source private winget repository creator
 
-- More coming soon. Please feel welcome to submit a pull request to add your company's third-party repository offering to this list.
+## Third-party repositories
+
+These public repositories offer additional packages that are not included in winget-pkgs:
+
+- **[winget-extras](https://github.com/pl4nty/winget-extras)** public winget repository by [pl4nty](https://github.com/pl4nty). Specializes in packages that were rejected from winget-pkgs for various reasons
+
+- **[Cloudflight](https://github.com/cloudflightio/winget-pkgs)** public winget repository by [cloudflightio](https://github.com/cloudflightio). Hosted by the developer of, and distributes, `Cloudflight.DockerInWSL`
+
+Please feel welcome to submit a pull request to add your company's third-party repository offering to this list.


### PR DESCRIPTION
The project homepage [github.com/microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) links to the file I am changing here as being about "private" repositories:

> If you are interested in exploring private repositories offering private WinGet package hosting, see [private repositories](https://github.com/microsoft/winget-pkgs/blob/master/doc/private/README.md).

Yesterday's PR #386450 however put several _public_ repositories at the top of this file. This goes against the intention of github.com/microsoft/winget-pkgs, and also against the meaning of the path of the file (doc/_private_/README.md).

This PR removes the potential confusion by making the headers clearer and changing the order of sections so the file's primary topic (private repositories) gets shown first.

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
