### PR TITLE
New version: tisun2.OofManager version 1.1.14

### DIFF
--- a/manifests/t/tisun2/OofManager/1.1.14/tisun2.OofManager.installer.yaml
+++ b/manifests/t/tisun2/OofManager/1.1.14/tisun2.OofManager.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: tisun2.OofManager
+PackageVersion: 1.1.14
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART
+UpgradeBehavior: install
+ReleaseDate: 2026-06-23
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/tisun2/OofManager/releases/download/v1.1.14/OofManagerSetup.exe
+    InstallerSha256: 85DF37D70CDA9FFC070AF6CAA12006EAA1B577C6DB1CB3DA288359092B60DDB1
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/t/tisun2/OofManager/1.1.14/tisun2.OofManager.locale.en-US.yaml
+++ b/manifests/t/tisun2/OofManager/1.1.14/tisun2.OofManager.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: tisun2.OofManager
+PackageVersion: 1.1.14
+PackageLocale: en-US
+Publisher: tisun2
+PublisherUrl: https://github.com/tisun2
+PublisherSupportUrl: https://github.com/tisun2/OofManager/issues
+PackageName: OOF Manager
+PackageUrl: https://github.com/tisun2/OofManager
+License: MIT
+LicenseUrl: https://github.com/tisun2/OofManager/blob/main/LICENSE
+Copyright: Copyright (c) tisun2
+ShortDescription: Manage Microsoft 365 / Exchange Online Out-of-Office (Automatic Reply) settings without opening Outlook.
+Description: |-
+  OOF Manager is a lightweight Windows desktop tool that manages your Microsoft 365 mailbox's
+  Out-of-Office (Automatic Reply) state for you. Sign in once, configure your weekly work hours
+  and reply text, and OOF Manager auto-toggles your OOF on/off at the schedule boundaries.
+  It also pushes the next off-hours window to Exchange as a Scheduled OOF, so the server keeps
+  switching auto-replies even when this app is closed.
+Moniker: oofmanager
+Tags:
+  - exchange
+  - microsoft-365
+  - office-365
+  - out-of-office
+  - oof
+  - outlook
+  - autoreply
+ReleaseNotesUrl: https://github.com/tisun2/OofManager/releases/tag/v1.1.14
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/t/tisun2/OofManager/1.1.14/tisun2.OofManager.yaml
+++ b/manifests/t/tisun2/OofManager/1.1.14/tisun2.OofManager.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: tisun2.OofManager
+PackageVersion: 1.1.14
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Fix vacation flows mis-targeting the weekly schedule flow

**Problem**
When setting up a cloud vacation, the Start/End flows bake in the weekly schedule flow's runtime id to pause it at vacation start and resume it at vacation end. The fallback resolver read a **shared** `PowerAutomate.Flow.*` cache that gets overwritten with a *vacation* flow's identity (it's re-read right after import) — without checking the cached display name. When the live weekly lookup missed, pause/resume targeted a vacation flow instead of the weekly flow.

**Symptoms**
- Weekly schedule flow was never re-enabled at vacation end.
- The vacation **Start** flow re-fired at vacation end (the End flow re-enabled it, and Power Automate ignores `count:1`, re-firing a past-start recurrence on enable).

**Fix**
Only adopt the cached environment + flow id when the cached display name matches the expected weekly flow; otherwise fall through to the existing "weekly schedule flow not found" prompt instead of silently using a wrong target.

**Notes**
- Already-imported vacation flows still carry the old target — re-run **Set up vacation in cloud** to regenerate them.
- Ships as **1.1.14** (version bump + winget manifests included).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/391830)