### PR TITLE
New version: RedEyeNetworks.LogivoreForVeeam version 0.16.2

### DIFF
--- a/manifests/r/RedEyeNetworks/LogivoreForVeeam/0.16.2/RedEyeNetworks.LogivoreForVeeam.installer.yaml
+++ b/manifests/r/RedEyeNetworks/LogivoreForVeeam/0.16.2/RedEyeNetworks.LogivoreForVeeam.installer.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: RedEyeNetworks.LogivoreForVeeam
+PackageVersion: 0.16.2
+InstallerType: inno
+Scope: machine
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  Custom: /NORESTART
+UpgradeBehavior: install
+Commands:
+- logivoreforveeam
+Installers:
+- Architecture: x64
+  Scope: user
+  InstallerUrl: https://download.redeyenetworks.com/logivore-for-veeam/releases/0.16.2/logivore-for-veeam-win-x64-setup.exe
+  InstallerSha256: FA21770A7FCB7A3BEAA2575FCD7B1902400A8A621A6A1FD8748BD79394103B84
+- Architecture: x64
+  Scope: machine
+  ElevationRequirement: elevatesSelf
+  InstallerUrl: https://download.redeyenetworks.com/logivore-for-veeam/releases/0.16.2/logivore-for-veeam-win-x64-machine-setup.exe
+  InstallerSha256: FB79AD2F5408C4936F8839E418B847E36CD008D95219F6255F939F6F1F5D7019
+- Architecture: arm64
+  Scope: user
+  InstallerUrl: https://download.redeyenetworks.com/logivore-for-veeam/releases/0.16.2/logivore-for-veeam-win-arm64-setup.exe
+  InstallerSha256: 4DF5AA21519F7167684DE367EA69851EB5489F408AE95855E13E9BE0BFBCC482
+- Architecture: arm64
+  Scope: machine
+  ElevationRequirement: elevatesSelf
+  InstallerUrl: https://download.redeyenetworks.com/logivore-for-veeam/releases/0.16.2/logivore-for-veeam-win-arm64-machine-setup.exe
+  InstallerSha256: 8A2EC479F6272E20D9E4F36046FAADAA334BF5278331B5DDAA5814BD8CBD1F9B
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/r/RedEyeNetworks/LogivoreForVeeam/0.16.2/RedEyeNetworks.LogivoreForVeeam.locale.en-US.yaml
+++ b/manifests/r/RedEyeNetworks/LogivoreForVeeam/0.16.2/RedEyeNetworks.LogivoreForVeeam.locale.en-US.yaml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: RedEyeNetworks.LogivoreForVeeam
+PackageVersion: 0.16.2
+PackageLocale: en-US
+Publisher: RedEye Network Solutions LLC
+PublisherUrl: https://redeyenetworks.com
+PublisherSupportUrl: https://redeyenetworks.com/support
+Author: RedEye Network Solutions LLC
+PackageName: Logivore for Veeam
+PackageUrl: https://redeyenetworks.com
+License: Proprietary
+Copyright: Copyright 2026 RedEye Network Solutions LLC. All rights reserved.
+ShortDescription: Logivore plus Advanced Veeam Mode — collects, normalizes, and analyzes Veeam Backup and Replication logs end-to-end
+Description: |-
+  Logivore for Veeam is the Veeam-centric SKU of Logivore. Includes
+  everything in Logivore (cross-platform log analysis, LILA AI
+  assistant, memory-tier-adaptive parsing, local-first trust-gated
+  LLM boundary) plus Microsoft.PowerShell.SDK and a built-in
+  Advanced Veeam Mode that drives the Veeam VBR PowerShell cmdlets
+  to collect job/repository/proxy diagnostics on demand. Targeted
+  at Veeam backup administrators who need to triage failed jobs
+  against backup server, repository, and proxy logs in one
+  timeline.
+Moniker: logivore-for-veeam
+Tags:
+- veeam
+- vbr
+- backup
+- log-analysis
+- log-viewer
+- syslog
+- evtx
+- powershell
+- ai
+- llm
+- claude
+- gemini
+- timeline
+- correlation
+- desktop
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/RedEyeNetworks/LogivoreForVeeam/0.16.2/RedEyeNetworks.LogivoreForVeeam.yaml
+++ b/manifests/r/RedEyeNetworks/LogivoreForVeeam/0.16.2/RedEyeNetworks.LogivoreForVeeam.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: RedEyeNetworks.LogivoreForVeeam
+PackageVersion: 0.16.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Logivore for Veeam v0.16.2 — the Veeam-centric SKU of Logivore, separated from the base package per the v0.11.0 SKU split. Ships as a distinct WinGet package (`RedEyeNetworks.LogivoreForVeeam`) with its own settings folder, credential namespace, install directory, and Argus appcast endpoint so it can coexist with the base `RedEyeNetworks.Logivore` package on the same machine.

Mirror of the base RedEyeNetworks.Logivore 4-installer shape (user + machine × x64 + arm64), each Inno Setup EXE wrapped around a single-file self-contained .NET 9 publish that includes Microsoft.PowerShell.SDK for the Advanced Veeam Mode runspace.

The split was driven by Cortex XDR / CrowdStrike behavioral signatures on the embedded PowerShell SDK + self-extract + auto-launch combo — see the v0.11.0 release notes for the full rationale.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/392119)