### PR TITLE
Filegram.FilegramDesktop version 0.2.7

### DIFF
--- a/manifests/f/Filegram/FilegramDesktop/0.2.7/Filegram.FilegramDesktop.installer.yaml
+++ b/manifests/f/Filegram/FilegramDesktop/0.2.7/Filegram.FilegramDesktop.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Filegram.FilegramDesktop
+PackageVersion: 0.2.7
+InstallerType: inno
+ReleaseDate: 2026-06-23
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/filegram/filegram-desktop/releases/download/v0.2.7/filegram-windows-x86_64-setup.exe
+  InstallerSha256: D016A0F57C7E9B1F016A02CA9B0EABF529FEE1F4A55C86ED2DBF9F8C3C9CB4AC
+- Architecture: x86
+  InstallerUrl: https://github.com/filegram/filegram-desktop/releases/download/v0.2.7/filegram-windows-i686-setup.exe
+  InstallerSha256: 0BB884380387E92CC592739C2B1A89A8A5D9A9EAC9B081B97596716264EAF843
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Filegram/FilegramDesktop/0.2.7/Filegram.FilegramDesktop.locale.en-US.yaml
+++ b/manifests/f/Filegram/FilegramDesktop/0.2.7/Filegram.FilegramDesktop.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Filegram.FilegramDesktop
+PackageVersion: 0.2.7
+PackageLocale: en-US
+Publisher: Filegram
+PublisherUrl: https://github.com/filegram
+PublisherSupportUrl: https://github.com/filegram/filegram-desktop/issues
+Author: Filegram
+PackageName: Filegram
+PackageUrl: https://github.com/filegram/filegram-desktop
+License: MIT
+LicenseUrl: https://github.com/filegram/filegram-desktop/blob/master/LICENSE
+Copyright: Copyright (c) Filegram
+ShortDescription: Disk space analyzer with an interactive treemap
+Description: |-
+  Filegram is a desktop disk analyzer that scans a directory and visualizes file
+  sizes as an interactive treemap chart, letting you navigate the file tree and
+  quickly find what is taking up space.
+Moniker: filegram
+Tags:
+- disk
+- disk-analyzer
+- disk-usage
+- filesystem
+- rust
+- storage
+- treemap
+ReleaseNotes: |-
+  - Switched the Windows package to an Inno Setup installer. Filegram now lands
+    in the Start Menu, registers an App Paths entry, and appears in Apps &
+    Features, so it is reachable from Windows Search and uninstalls cleanly.
+ReleaseNotesUrl: https://github.com/filegram/filegram-desktop/releases/tag/v0.2.7
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Filegram/FilegramDesktop/0.2.7/Filegram.FilegramDesktop.yaml
+++ b/manifests/f/Filegram/FilegramDesktop/0.2.7/Filegram.FilegramDesktop.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Filegram.FilegramDesktop
+PackageVersion: 0.2.7
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## What is this PR?
Adds Filegram.FilegramDesktop 0.2.7 to the Windows Package Manager Community repository.

The 0.2.7 release switches from a portable zip to an Inno Setup installer. The new installer drops a Start Menu shortcut, registers `App Paths` and an Apps & Features entry, and runs silently under the default winget switches for `InstallerType: inno`. Both architectures point at the new `*-setup.exe` assets.

- Installer assets:
  - x64: https://github.com/filegram/filegram-desktop/releases/download/v0.2.7/filegram-windows-x86_64-setup.exe
  - x86: https://github.com/filegram/filegram-desktop/releases/download/v0.2.7/filegram-windows-i686-setup.exe

## Microsoft Reviewers: Open in CodeFlow
- [ ] I have read the contribution guide and followed the style and process guidelines
- [ ] I have tested my manifest using `winget validate`
- [ ] I have tested my manifest locally using `winget install --manifest`
- [ ] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/392141)