### PR TITLE
New package: solpbc.Solstone version 0.2.0

### DIFF
--- a/manifests/s/solpbc/Solstone/0.2.0/solpbc.Solstone.installer.yaml
+++ b/manifests/s/solpbc/Solstone/0.2.0/solpbc.Solstone.installer.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: solpbc.Solstone
+PackageVersion: 0.2.0
+MinimumOSVersion: 10.0.18362.0
+Scope: user
+InstallerType: exe
+InstallModes:
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: "--silent"
+  SilentWithProgress: "--silent"
+UpgradeBehavior: install
+ReleaseDate: 2026-06-23
+AppsAndFeaturesEntries:
+  - DisplayName: Solstone
+    Publisher: sol pbc
+    DisplayVersion: 0.2.0
+    InstallerType: exe
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/solpbc/solstone-windows/releases/download/v0.2.0/Solstone-win-Setup.exe
+    InstallerSha256: 3D5C427FF802C34731908EE408FDE0ADC84E572ED3513E748B7CA32B36996DAF
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/s/solpbc/Solstone/0.2.0/solpbc.Solstone.locale.en-US.yaml
+++ b/manifests/s/solpbc/Solstone/0.2.0/solpbc.Solstone.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: solpbc.Solstone
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: sol pbc
+PublisherUrl: https://solpbc.org
+PublisherSupportUrl: https://support.solpbc.org
+PackageName: Solstone
+PackageUrl: https://solstone.app
+License: AGPL-3.0-only
+LicenseUrl: https://github.com/solpbc/solstone-windows/blob/main/LICENSE
+Copyright: Copyright (c) 2026 sol pbc
+ShortDescription: A Windows-native observer for solstone — a per-user, non-elevated, tray-resident app that gathers screen and system audio (plus the microphone when one is present) into local, owner-controlled segments for your journal.
+Description: |-
+  solstone is an open-source, privacy-respecting way to collect and gain insight from your own
+  personal data. The Windows observer is a per-user, non-elevated, tray-resident app that gathers
+  what happens on your PC — screen and system audio, plus the microphone when one is present — into
+  local, owner-controlled segments for your journal.
+
+  Everything stays yours: there is no analytics, telemetry, tracking, or crash reporting, and
+  nothing phones home. State is always earned — the app never shows "observing" unless it truly is.
+  Updates are delivered by the app itself.
+Moniker: solstone
+Tags:
+  - solstone
+  - observer
+  - journal
+  - privacy
+  - personal-data
+  - self-determination
+  - open-source
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/s/solpbc/Solstone/0.2.0/solpbc.Solstone.yaml
+++ b/manifests/s/solpbc/Solstone/0.2.0/solpbc.Solstone.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: solpbc.Solstone
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
### New package: `solpbc.Solstone` version `0.2.0`

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.9.0)?

#### Notes

First submission of **Solstone** — an open-source (AGPL-3.0), privacy-respecting Windows observer for [solstone](https://solstone.app). Per-user, non-elevated, tray-resident; no telemetry, nothing phones home.

- Publisher: **sol pbc** (a public benefit corporation), source at https://github.com/solpbc/solstone-windows
- Installer: OV code-signed (DigiCert), per-user, **Velopack** `Setup.exe` with `--silent` support; installs to `%LocalAppData%\Solstone`.
- `AppsAndFeaturesEntries` provided so version detection / `winget upgrade` resolve against the per-user ARP entry.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/392222)