### PR TITLE
Add package for 2604 Xbox Live developer tools

### DIFF
--- a/manifests/m/Microsoft/Gaming/XboxLiveDeveloperTools/1.2604.0/Microsoft.Gaming.XboxLiveDeveloperTools.installer.yaml
+++ b/manifests/m/Microsoft/Gaming/XboxLiveDeveloperTools/1.2604.0/Microsoft.Gaming.XboxLiveDeveloperTools.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.Gaming.XboxLiveDeveloperTools
+PackageVersion: 1.2604.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: DevEntitlementTool.exe
+- RelativeFilePath: GlobalStorage.exe
+- RelativeFilePath: MultiplayerSessionHistoryViewer.exe
+- RelativeFilePath: XblConfig.exe
+- RelativeFilePath: XblConnectedStorage.exe
+- RelativeFilePath: XblDevAccount.exe
+- RelativeFilePath: XblPCSandbox.exe
+- RelativeFilePath: XblPlayerDataReset.exe
+- RelativeFilePath: XblTestAccountGui.exe
+- RelativeFilePath: XblTraceAnalyzer.exe
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/microsoft/xbox-live-developer-tools/releases/download/2604/XboxLiveTools-2604-20260514.zip
+  InstallerSha256: C1C80DF1D0A068F60A32CA81AC87E9DE9037634F03D06DB1F3936AAE9255913B
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/Microsoft/Gaming/XboxLiveDeveloperTools/1.2604.0/Microsoft.Gaming.XboxLiveDeveloperTools.locale.en-US.yaml
+++ b/manifests/m/Microsoft/Gaming/XboxLiveDeveloperTools/1.2604.0/Microsoft.Gaming.XboxLiveDeveloperTools.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.Gaming.XboxLiveDeveloperTools
+PackageVersion: 1.2604.0
+PackageLocale: en-US
+Publisher: Microsoft Corporation
+PublisherUrl: https://github.com/microsoft
+PublisherSupportUrl: https://github.com/microsoft/xbox-live-developer-tools/issues
+PackageName: Xbox Live Developer Tools
+PackageUrl: https://github.com/microsoft/xbox-live-developer-tools/releases
+License: MIT
+Copyright: Copyright (c) Microsoft Corporation. All rights reserved.
+ShortDescription: Tools to help develop and test games that interact with Xbox services.
+Tags:
+- game-development
+- gamedevelopment
+- xbox-live-developer-tools
+- xbox-live-tools
+- xboxlivetools
+- microsoft-xbox-live-tooling-api
+- microsoftxboxlivetoolingapi
+- Microsoft.Xbox.Service.DevTools
+- id@xbox
+- xbox-live-creators-program
+- xboxlivecreatorsprogram
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/Microsoft/Gaming/XboxLiveDeveloperTools/1.2604.0/Microsoft.Gaming.XboxLiveDeveloperTools.yaml
+++ b/manifests/m/Microsoft/Gaming/XboxLiveDeveloperTools/1.2604.0/Microsoft.Gaming.XboxLiveDeveloperTools.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.Gaming.XboxLiveDeveloperTools
+PackageVersion: 1.2604.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
This is part 3 of 3 changes that I'm working on:

1. Remove the existing Xbox Live Developer Tools package - it doesn't match the versioning scheme we want to use going forward - https://github.com/microsoft/winget-pkgs/pull/392201 
2. Re-add the existing Xbox Live Developer Tools package with updated version + metadata - https://github.com/microsoft/winget-pkgs/pull/392209
3. Add an Xbox Live Developer Tools package for the 2604 release
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/392253)