### PR TITLE
New package: Devlikebear.Linetta version 0.9.0

### DIFF
--- a/manifests/d/Devlikebear/Linetta/0.9.0/Devlikebear.Linetta.installer.yaml
+++ b/manifests/d/Devlikebear/Linetta/0.9.0/Devlikebear.Linetta.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Devlikebear.Linetta
+PackageVersion: 0.9.0
+InstallerType: nullsoft
+Scope: user
+UpgradeBehavior: install
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/devlikebear/linetta/releases/download/v0.9.0/Linetta_0.9.0_x64-setup.exe
+    InstallerSha256: 87013F192031FFA879E0714FFF125FB3A3B68D8FC00B886D11A3856D40D70351
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/d/Devlikebear/Linetta/0.9.0/Devlikebear.Linetta.locale.en-US.yaml
+++ b/manifests/d/Devlikebear/Linetta/0.9.0/Devlikebear.Linetta.locale.en-US.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Devlikebear.Linetta
+PackageVersion: 0.9.0
+PackageLocale: en-US
+Publisher: devlikebear
+PublisherUrl: https://github.com/devlikebear
+Author: devlikebear
+PackageName: Linetta
+PackageUrl: https://github.com/devlikebear/linetta
+License: Proprietary
+ShortDescription: Local-first desktop writing app for long-form fiction.
+Moniker: linetta
+Tags:
+  - desktop
+  - fiction
+  - writing
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/d/Devlikebear/Linetta/0.9.0/Devlikebear.Linetta.yaml
+++ b/manifests/d/Devlikebear/Linetta/0.9.0/Devlikebear.Linetta.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Devlikebear.Linetta
+PackageVersion: 0.9.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## New package: Devlikebear.Linetta 0.9.0

First submission of **Linetta**, a local-first desktop writing app for long-form fiction. I am the package publisher (devlikebear).

- Installer: NSIS (nullsoft), x64, user scope, silent `/S`
- InstallerUrl points to the signed GitHub Release asset for v0.9.0
- InstallerSha256 verified against the release `SHA256SUMS`

### Checklist
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/tools/SandboxTest.md) your manifest locally with `winget validate --manifest <path>`? (rendered from versioned templates; SHA cross-checked against release SHA256SUMS)
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? (no Windows host available; relying on the winget-pkgs validation pipeline)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/392258)