### PR TITLE
fix(CharacterArc): correct x64 installer URL, add arm64 entries for v1.10.1 and v1.10.2

### DIFF
--- a/manifests/u/uu201/CharacterArc/1.10.1/uu201.CharacterArc.installer.yaml
+++ b/manifests/u/uu201/CharacterArc/1.10.1/uu201.CharacterArc.installer.yaml
@@ -12,11 +12,23 @@ ReleaseDate: 2026-06-21
 Installers:
 - Architecture: x64
   Scope: user
+  InstallerUrl: https://github.com/uu201/character-arc/releases/download/v1.10.1/CharacterArc-1.10.1-x64-setup.exe
+  InstallerSha256: 7F937440D4BAA165E27A9403ECF4714EC794252CD1CC5189ADC04698BF276C23
+  InstallerSwitches:
+    Custom: /currentuser
+- Architecture: x64
+  Scope: machine
+  InstallerUrl: https://github.com/uu201/character-arc/releases/download/v1.10.1/CharacterArc-1.10.1-x64-setup.exe
+  InstallerSha256: 7F937440D4BAA165E27A9403ECF4714EC794252CD1CC5189ADC04698BF276C23
+  InstallerSwitches:
+    Custom: /allusers
+- Architecture: arm64
+  Scope: user
   InstallerUrl: https://github.com/uu201/character-arc/releases/download/v1.10.1/CharacterArc-1.10.1-arm64-setup.exe
   InstallerSha256: 414F0C639E77C20050718712E712CB60DB6FD4400515DACAB157F06B57D6186A
   InstallerSwitches:
     Custom: /currentuser
-- Architecture: x64
+- Architecture: arm64
   Scope: machine
   InstallerUrl: https://github.com/uu201/character-arc/releases/download/v1.10.1/CharacterArc-1.10.1-arm64-setup.exe
   InstallerSha256: 414F0C639E77C20050718712E712CB60DB6FD4400515DACAB157F06B57D6186A

--- a/manifests/u/uu201/CharacterArc/1.10.2/uu201.CharacterArc.installer.yaml
+++ b/manifests/u/uu201/CharacterArc/1.10.2/uu201.CharacterArc.installer.yaml
@@ -12,11 +12,23 @@ ReleaseDate: 2026-06-23
 Installers:
 - Architecture: x64
   Scope: user
+  InstallerUrl: https://github.com/uu201/character-arc/releases/download/v1.10.2/CharacterArc-1.10.2-x64-setup.exe
+  InstallerSha256: 399B45E47C6610E14F7DEFAE8D44FCC481EF9A7FCC497135E61EF719BACE7A3A
+  InstallerSwitches:
+    Custom: /currentuser
+- Architecture: x64
+  Scope: machine
+  InstallerUrl: https://github.com/uu201/character-arc/releases/download/v1.10.2/CharacterArc-1.10.2-x64-setup.exe
+  InstallerSha256: 399B45E47C6610E14F7DEFAE8D44FCC481EF9A7FCC497135E61EF719BACE7A3A
+  InstallerSwitches:
+    Custom: /allusers
+- Architecture: arm64
+  Scope: user
   InstallerUrl: https://github.com/uu201/character-arc/releases/download/v1.10.2/CharacterArc-1.10.2-arm64-setup.exe
   InstallerSha256: 35DEFAF6A12D8AAF2A19B316451B86FD924ECE4B91E3ECA0E13F809527AD8F04
   InstallerSwitches:
     Custom: /currentuser
-- Architecture: x64
+- Architecture: arm64
   Scope: machine
   InstallerUrl: https://github.com/uu201/character-arc/releases/download/v1.10.2/CharacterArc-1.10.2-arm64-setup.exe
   InstallerSha256: 35DEFAF6A12D8AAF2A19B316451B86FD924ECE4B91E3ECA0E13F809527AD8F04


### PR DESCRIPTION
The v1.10.1 and v1.10.2 manifests declared `Architecture: x64` but pointed to the ARM64 installer URL and SHA256. This caused x64 users to receive the ARM64 build.

Changes:
- **1.10.1**: x64 URL → `CharacterArc-1.10.1-x64-setup.exe`, add arm64 entries
- **1.10.2**: x64 URL → `CharacterArc-1.10.2-x64-setup.exe`, add arm64 entries

Verification:
- x64 SHA256 confirmed against GitHub release assets
- arm64 entries use the previously incorrect URLs (which were actually correct for arm64)
- arm64 was missing entirely, now added
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/392302)