### PR TITLE
New package: Chaoos404.Hyperlink version 0.1.1

### DIFF
--- a/manifests/c/Chaoos404/Hyperlink/0.1.1/Chaoos404.Hyperlink.installer.yaml
+++ b/manifests/c/Chaoos404/Hyperlink/0.1.1/Chaoos404.Hyperlink.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: Chaoos404.Hyperlink
+PackageVersion: 0.1.1
+InstallerType: zip
+NestedInstallerType: portable
+ArchiveBinariesDependOnPath: true
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Chaoos-404/HyperLink/releases/download/v0.1.1/Hyperlink-0.1.1-windows-x64.zip
+    InstallerSha256: E47CD25B62DA56F809692AC32A6808A73D7A05D27F7C6009B3F7788F920D1C15
+    NestedInstallerFiles:
+      - RelativeFilePath: Hyperlink-0.1.1-windows-x64\bin\hyperlink.exe
+        PortableCommandAlias: hyperlink
+      - RelativeFilePath: Hyperlink-0.1.1-windows-x64\bin\hyperlink_file.exe
+        PortableCommandAlias: hyperlink_file
+      - RelativeFilePath: Hyperlink-0.1.1-windows-x64\bin\hyperlink_bench.exe
+        PortableCommandAlias: hyperlink_bench
+      - RelativeFilePath: Hyperlink-0.1.1-windows-x64\bin\hyperlink_probe.exe
+        PortableCommandAlias: hyperlink_probe
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/c/Chaoos404/Hyperlink/0.1.1/Chaoos404.Hyperlink.locale.en-US.yaml
+++ b/manifests/c/Chaoos404/Hyperlink/0.1.1/Chaoos404.Hyperlink.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: Chaoos404.Hyperlink
+PackageVersion: 0.1.1
+PackageLocale: en-US
+Publisher: Chaoos-404
+PublisherUrl: https://github.com/Chaoos-404
+PublisherSupportUrl: https://github.com/Chaoos-404/HyperLink/issues
+Author: Hyperlink contributors
+PackageName: Hyperlink
+PackageUrl: https://github.com/Chaoos-404/HyperLink
+License: MIT
+LicenseUrl: https://github.com/Chaoos-404/HyperLink/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Hyperlink contributors
+ShortDescription: Cross-platform CLI for high-speed peer-to-peer file transfer over USB4 and Thunderbolt network links.
+Description: Hyperlink is a C++ CLI and library for peer-to-peer file transfer, benchmarking, and auto discovery over OS-exposed USB4 and Thunderbolt network links.
+Moniker: hyperlink
+Tags:
+  - file-transfer
+  - p2p
+  - thunderbolt
+  - usb4
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/c/Chaoos404/Hyperlink/0.1.1/Chaoos404.Hyperlink.yaml
+++ b/manifests/c/Chaoos404/Hyperlink/0.1.1/Chaoos404.Hyperlink.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: Chaoos404.Hyperlink
+PackageVersion: 0.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Adds Hyperlink 0.1.1 as a portable ZIP package.

Release: https://github.com/Chaoos-404/HyperLink/releases/tag/v0.1.1
Installer: https://github.com/Chaoos-404/HyperLink/releases/download/v0.1.1/Hyperlink-0.1.1-windows-x64.zip
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/392447)