### PR TITLE
New version: Feci.ParleyDeckCli version 1.31.0

### DIFF
--- a/manifests/f/Feci/ParleyDeckCli/1.31.0/Feci.ParleyDeckCli.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.31.0/Feci.ParleyDeckCli.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.31.0
+InstallerType: portable
+Commands:
+- parley
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.31.0/parley-v1.31.0-windows-x64.exe
+  InstallerSha256: 3F6D3D5F668B642598DA5915A80605B2CD402029F1865FCC46C974469242846A
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.31.0/parley-v1.31.0-windows-arm64.exe
+  InstallerSha256: 96B23D52B5A141BB51A7E540260A2326227B61DD534F027C32EA64AAAD125686
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.31.0/Feci.ParleyDeckCli.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.31.0/Feci.ParleyDeckCli.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.31.0
+PackageLocale: en-US
+Publisher: Feci
+PublisherUrl: https://github.com/feci
+PackageName: Parley Deck CLI
+PackageUrl: https://github.com/feci/parley-deck-cli
+License: Apache-2.0
+LicenseUrl: https://github.com/feci/parley-deck-cli/blob/main/LICENSE
+ShortDescription: CLI that orchestrates Parley Deck multi-agent cooperation workflows.
+Description: "parley orchestrates multi-agent Parley Deck cooperation: deliberation rounds across local CLI agents, consensus and finalize, implementation with living execution plans, a live TUI, retrospective optimization, a pre-idea readiness check (parley preflight), a human-braked outer loop (COOPERATION.md section 14 plus the one-shot parley loop tick), and central per-user defaults at ~/.parley/agents.toml (per-agent model and reasoning, plus a [defaults] policy block for ping tier, transport, and roster-change policy)."
+ReleaseNotesUrl: https://github.com/feci/parley-deck-cli/releases/tag/v1.31.0
+Tags:
+- ai
+- agents
+- automation
+- cli
+- codex
+- consensus
+- loop
+- multi-agent
+- orchestration
+- preflight
+- tui
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.31.0/Feci.ParleyDeckCli.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.31.0/Feci.ParleyDeckCli.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.31.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Manifest update

- **Package:** Feci.ParleyDeckCli
- **Version:** 1.31.0
- Portable installer; x64 + arm64 Windows binaries from the GitHub release `v1.31.0`.

This release adds the four-tier loop-engineering program (verification honesty, loop budgets, close-decision integrity, and a human-braked outer loop with the new one-shot `parley loop tick`).

### Checklist
- [x] Manifest version 1.12.0
- [x] InstallerSha256 verified against the uploaded release binaries
- [x] Description quoted (contains colon-space)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/392518)