### PR TITLE
Add Yeelight.yeelight-home version 0.1.0

### DIFF
--- a/manifests/y/Yeelight/yeelight-home/0.1.0/Yeelight.yeelight-home.installer.yaml
+++ b/manifests/y/Yeelight/yeelight-home/0.1.0/Yeelight.yeelight-home.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: Yeelight.yeelight-home
+PackageVersion: 0.1.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: yeelight-home.exe
+  PortableCommandAlias: yeelight-home
+Commands:
+- yeelight-home
+ReleaseDate: 2026-06-24
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Yeelight/yeelight-home/releases/download/yeelight-home-v0.1.0/yeelight-home-windows-amd64.zip
+  InstallerSha256: 3A30F2781F22FBD55C7F00E973FF828A82B56AF60E0A5667F0400570132E1DC1
+- Architecture: arm64
+  InstallerUrl: https://github.com/Yeelight/yeelight-home/releases/download/yeelight-home-v0.1.0/yeelight-home-windows-arm64.zip
+  InstallerSha256: 07DE9DAF3F34FECBA6FAFD379CA235A4752FA47B14978854862D4F12CC988329
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/y/Yeelight/yeelight-home/0.1.0/Yeelight.yeelight-home.locale.en-US.yaml
+++ b/manifests/y/Yeelight/yeelight-home/0.1.0/Yeelight.yeelight-home.locale.en-US.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: Yeelight.yeelight-home
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Yeelight
+PublisherUrl: https://github.com/Yeelight
+PackageName: yeelight-home
+PackageUrl: https://github.com/Yeelight/yeelight-home
+License: Proprietary
+ShortDescription: Yeelight Home local Runtime CLI.
+Description: yeelight-home is the local Runtime CLI for Yeelight smart-home Skills. It keeps credentials on the user's machine and calls Yeelight cloud APIs through reviewed semantic adapters.
+Moniker: yeelight-home
+Tags:
+- yeelight
+- smart-home
+- cli
+- runtime
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/y/Yeelight/yeelight-home/0.1.0/Yeelight.yeelight-home.locale.zh-CN.yaml
+++ b/manifests/y/Yeelight/yeelight-home/0.1.0/Yeelight.yeelight-home.locale.zh-CN.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.10.0.schema.json
+
+PackageIdentifier: Yeelight.yeelight-home
+PackageVersion: 0.1.0
+PackageLocale: zh-CN
+Publisher: Yeelight
+PublisherUrl: https://github.com/Yeelight
+PackageName: yeelight-home
+PackageUrl: https://github.com/Yeelight/yeelight-home
+License: Proprietary
+ShortDescription: Yeelight Home 本地 Runtime CLI。
+Description: yeelight-home 是 Yeelight 智能家居 Skill 的本地 Runtime CLI。它在用户本机保存凭据，并通过经过审核的语义适配器调用 Yeelight 云端 API。
+Tags:
+- yeelight
+- smart-home
+- cli
+- runtime
+ManifestType: locale
+ManifestVersion: 1.10.0

--- a/manifests/y/Yeelight/yeelight-home/0.1.0/Yeelight.yeelight-home.yaml
+++ b/manifests/y/Yeelight/yeelight-home/0.1.0/Yeelight.yeelight-home.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: Yeelight.yeelight-home
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Adds the initial Winget manifest for Yeelight.yeelight-home 0.1.0. Release assets are published at https://github.com/Yeelight/yeelight-home/releases/tag/yeelight-home-v0.1.0.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/392555)