### PR TITLE
Add drkbugs.rusticker version 1.1.5

### DIFF
--- a/manifests/d/drkbugs/rusticker/1.1.5/drkbugs.rusticker.installer.yaml
+++ b/manifests/d/drkbugs/rusticker/1.1.5/drkbugs.rusticker.installer.yaml
@@ -10,7 +10,7 @@ Commands:
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/drkblog/rusticker/releases/download/v1.1.5/rusticker-v1.1.5-windows-x64.zip
-    InstallerSha256: d73838a2015a798da8fcabf10fd11a132dec57381a25a1316ac21130981e1583
+    InstallerSha256: de1c1a385d4072645f3ee562a4ff117d9022e37a32c1de279234d936590cfd11
     NestedInstallerFiles:
       - RelativeFilePath: rusticker.exe
         PortableCommandAlias: rusticker

--- a/manifests/d/drkbugs/rusticker/1.1.5/drkbugs.rusticker.installer.yaml
+++ b/manifests/d/drkbugs/rusticker/1.1.5/drkbugs.rusticker.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: drkbugs.rusticker
+PackageVersion: 1.1.5
+MinimumOSVersion: 10.0.0.0
+InstallerType: zip
+NestedInstallerType: portable
+Commands:
+  - rusticker
+  - stickerize
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/drkblog/rusticker/releases/download/v1.1.5/rusticker-v1.1.5-windows-x64.zip
+    InstallerSha256: d73838a2015a798da8fcabf10fd11a132dec57381a25a1316ac21130981e1583
+    NestedInstallerFiles:
+      - RelativeFilePath: rusticker.exe
+        PortableCommandAlias: rusticker
+      - RelativeFilePath: stickerize.exe
+        PortableCommandAlias: stickerize
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/d/drkbugs/rusticker/1.1.5/drkbugs.rusticker.locale.en-US.yaml
+++ b/manifests/d/drkbugs/rusticker/1.1.5/drkbugs.rusticker.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+PackageIdentifier: drkbugs.rusticker
+PackageVersion: 1.1.5
+PackageLocale: en-US
+Publisher: drkbugs
+PublisherUrl: https://github.com/drkblog
+PublisherSupportUrl: https://github.com/drkblog/rusticker/issues
+Author: drkbugs
+PackageName: rusticker
+PackageUrl: https://github.com/drkblog/rusticker
+License: MIT
+LicenseUrl: https://github.com/drkblog/rusticker/blob/main/LICENSE
+Copyright: Copyright (c) 2026 drkbugs
+ShortDescription: A command-line tool for generating A4 grid layouts of stickers in PDF format and removing background from images.
+Description: rusticker is a high-precision CLI layout tool for generating sticker sheets. It prints transparent raster images with custom contour outlines for easy die-cutting.
+Moniker: rusticker
+Tags:
+  - sticker
+  - pdf
+  - layout
+  - CLI
+  - print
+  - background-remover
+  - birefnet
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/d/drkbugs/rusticker/1.1.5/drkbugs.rusticker.locale.en-US.yaml
+++ b/manifests/d/drkbugs/rusticker/1.1.5/drkbugs.rusticker.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 PackageIdentifier: drkbugs.rusticker
 PackageVersion: 1.1.5
 PackageLocale: en-US

--- a/manifests/d/drkbugs/rusticker/1.1.5/drkbugs.rusticker.yaml
+++ b/manifests/d/drkbugs/rusticker/1.1.5/drkbugs.rusticker.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: drkbugs.rusticker
+PackageVersion: 1.1.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
New package: drkbugs.rusticker version 1.1.5

## 📖 Description
Manifest submission for drkbugs.rusticker version 1.1.5

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)


## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/392709)