### PR TITLE
Remove departed administrators from Moderation.md

### DIFF
--- a/doc/Moderation.md
+++ b/doc/Moderation.md
@@ -19,11 +19,9 @@ Our intent was not to introduce a numbers game for others to achieve and automat
 | **[@florelis](https://github.com/florelis)** |
 | **[@hackean-msft](https://github.com/hackean-msft)** |
 | **[@JohnMcPMS](https://github.com/JohnMcPMS)** |
-| **[@KevinLaMS](https://github.com/KevinLaMS)** |
 | **[@Madhusudhan-MSFT](https://github.com/Madhusudhan-MSFT)** |
 | **[@msftrubengu](https://github.com/msftrubengu)** |
 | **[@ranm-msft](https://github.com/ranm-msft)** |
-| **[@RDMacLachlan](https://github.com/RDMacLachlan)** |
 | **[@stephengillie](https://github.com/stephengillie)** |
 | **[@yao-msft](https://github.com/yao-msft)** |
 


### PR DESCRIPTION
## 📖 Description

Removes two departed members from the **Windows Package Manager Administrators** list in `doc/Moderation.md`:

- `@KevinLaMS`
- `@RDMacLachlan`

No other content is changed. This is documentation-only roster maintenance — no manifests are affected.

Authored with GitHub Copilot assistance.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Not applicable — administrative roster update -->

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [ ] This PR only modifies one (1) manifest <!-- N/A — documentation change, no manifest modified -->
- [ ] Validated manifest locally with `winget validate --manifest <path>` <!-- N/A -->
- [ ] Tested manifest locally with `winget install --manifest <path>` <!-- N/A -->
- [ ] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0) <!-- N/A -->

> **Note:** This is a documentation-only change to `doc/Moderation.md`; the manifest checklist items do not apply.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/393085)