### PR TITLE
Remove niels9001 as temporary moderator

### DIFF
--- a/.github/policies/moderatorTriggers.yml
+++ b/.github/policies/moderatorTriggers.yml
@@ -45,9 +45,6 @@ configuration:
               - isActivitySender:
                   user: russellbanks
                   issueAuthor: False
-              - isActivitySender:
-                  user: niels9001
-                  issueAuthor: False
         then:
           # If the payload is an issue_Comment or a Pull_Request_Review_Comment
           - if:


### PR DESCRIPTION
## 📖 Description

Removes `niels9001` as a **temporary moderator** from `.github/policies/moderatorTriggers.yml`.

This reverts the temporary addition made in #381298. The `isActivitySender` block granting niels9001 moderator-trigger privileges is removed; no other moderators or rules are affected.

Documentation/policy-only change — no manifests are modified.

Authored with GitHub Copilot assistance.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Not applicable — reverts temporary moderator addition from #381298 -->

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [ ] This PR only modifies one (1) manifest <!-- N/A — policy change, no manifest modified -->
- [ ] Validated manifest locally with `winget validate --manifest <path>` <!-- N/A -->
- [ ] Tested manifest locally with `winget install --manifest <path>` <!-- N/A -->
- [ ] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0) <!-- N/A -->

> **Note:** This is a policy-only change to `.github/policies/moderatorTriggers.yml`; the manifest checklist items do not apply.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/393091)