### PR TITLE
Add moderator activity and inactivity policy to Moderation.md

### DIFF
--- a/doc/Moderation.md
+++ b/doc/Moderation.md
@@ -84,7 +84,16 @@ Moderators are expected to continue behaving in a manner consistent with what le
 
 Moderator status reflects ongoing, active participation in the project. A moderator is considered active if they have reviewed at least ten (10) pull requests covering at least ten (10) different packages within the trailing twelve (12) months.
 
-The core team periodically reviews moderators who fall below this activity bar. Removal is not automatic; each case is considered individually so that context — such as a temporary break or contributions in other areas of the project — can be taken into account. Activity in other Windows Package Manager repositories (for example, [winget-cli](https://github.com/microsoft/winget-cli), [winget-cli-restsource](https://github.com/microsoft/winget-cli-restsource), and [winget-dsc](https://github.com/microsoft/winget-dsc)) may also be taken into consideration during this review. When a moderator is removed for inactivity, it is not a reflection on the quality of their past contributions, which remain appreciated.
+The core team periodically reviews moderators who fall below this activity bar. Removal is not automatic; each case is considered individually so that context — such as a temporary break or contributions in other areas of the project — can be taken into account. When a moderator is removed for inactivity, it is not a reflection on the quality of their past contributions, which remain appreciated.
+
+Activity in other Windows Package Manager repositories may also be taken into consideration during this review, including:
+
+* [winget-cli](https://github.com/microsoft/winget-cli) — the WinGet client (CLI, PowerShell modules, and COM API)
+* [winget-cli-restsource](https://github.com/microsoft/winget-cli-restsource) — reference implementation for a REST-based winget package source
+* [winget-command-not-found](https://github.com/microsoft/winget-command-not-found) — PowerShell 7 module that recommends packages for unrecognized commands
+* [winget-create](https://github.com/microsoft/winget-create) — the Windows Package Manager Manifest Creator (`wingetcreate`)
+* [winget-dsc](https://github.com/microsoft/winget-dsc) — WinGet DSC resources and sample configurations
+* [winget-studio](https://github.com/microsoft/winget-studio) — WinGet Studio
 
 A moderator who has been removed for inactivity and later wishes to resume may be reinstated on request, at the discretion of the core team, without going through the nomination process again.
 

--- a/doc/Moderation.md
+++ b/doc/Moderation.md
@@ -80,6 +80,14 @@ Matrix Room Alias (for all other homeservers): `#Microsoft_winget-pkgs:gitter.im
 
 Moderators are expected to continue behaving in a manner consistent with what led to their nomination. In addition, they are given the ability to approve PRs for manifests. This should not be seen as the goal, however. The goal is to help ensure high-quality manifests and to help the community with package submission. They may request to discontinue this responsibility at any time and for any reason, and it will be honored.
 
+### Maintaining Moderator Status
+
+Moderator status reflects ongoing, active participation in the project. A moderator is considered active if they have approved at least one pull request within the trailing twelve (12) months.
+
+The core team periodically reviews moderators who fall below this activity bar. Removal is not automatic; each case is considered individually so that context — such as a temporary break or contributions in other areas of the project — can be taken into account. When a moderator is removed for inactivity, it is not a reflection on the quality of their past contributions, which remain appreciated.
+
+A moderator who has been removed for inactivity and later wishes to resume may be reinstated on request, at the discretion of the core team, without going through the nomination process again.
+
 ### Reviewing Pull Requests
 
 Moderators should review PRs to ensure the metadata is accurate and that the Windows Package Manager will behave predictably with the given manifest. This includes checking the metadata and testing the installation of packages. Ideally, common issues will be documented and referred to for the sake of consistency. This might also include tips and tooling to help with the process. Some users are new to GitHub and may need a bit more support. We've all been new to Git at one point.

--- a/doc/Moderation.md
+++ b/doc/Moderation.md
@@ -82,9 +82,9 @@ Moderators are expected to continue behaving in a manner consistent with what le
 
 ### Maintaining Moderator Status
 
-Moderator status reflects ongoing, active participation in the project. A moderator is considered active if they have approved at least one pull request within the trailing twelve (12) months.
+Moderator status reflects ongoing, active participation in the project. A moderator is considered active if they have reviewed at least ten (10) pull requests covering at least ten (10) different packages within the trailing twelve (12) months.
 
-The core team periodically reviews moderators who fall below this activity bar. Removal is not automatic; each case is considered individually so that context — such as a temporary break or contributions in other areas of the project — can be taken into account. When a moderator is removed for inactivity, it is not a reflection on the quality of their past contributions, which remain appreciated.
+The core team periodically reviews moderators who fall below this activity bar. Removal is not automatic; each case is considered individually so that context — such as a temporary break or contributions in other areas of the project — can be taken into account. Activity in other Windows Package Manager repositories (for example, [winget-cli](https://github.com/microsoft/winget-cli), [winget-cli-restsource](https://github.com/microsoft/winget-cli-restsource), and [winget-dsc](https://github.com/microsoft/winget-dsc)) may also be taken into consideration during this review. When a moderator is removed for inactivity, it is not a reflection on the quality of their past contributions, which remain appreciated.
 
 A moderator who has been removed for inactivity and later wishes to resume may be reinstated on request, at the discretion of the core team, without going through the nomination process again.
 


### PR DESCRIPTION
## 📖 Description

Adds a **moderator activity and inactivity policy** to `doc/Moderation.md`, filling a gap noted in #393116: the document explains how moderators are added but never defined any requirement for *retaining* moderator status.

A new **"Maintaining Moderator Status"** subsection under **Information For Moderators → Expectations** documents:

- **Activity bar:** a moderator is active if they reviewed at least ten (10) pull requests covering at least ten (10) different packages in the trailing twelve (12) months.
- **Inactivity review:** the core team periodically reviews moderators below the bar and decides case-by-case (removal is not automatic). Activity in other public Windows Package Manager repositories — winget-cli, winget-cli-restsource, winget-command-not-found, winget-create, winget-dsc, and winget-studio — may also be considered.
- **Reinstatement:** available on request, without re-nomination, at the core team''s discretion.

Documentation-only change. No manifests or policy-bot rules are modified.

Resolves #393116.

Authored with GitHub Copilot assistance.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)
  - Resolves #393116

## 📦 Manifest Checklist

- [x] Checked that there aren''t other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same change
- [ ] This PR only modifies one (1) manifest <!-- N/A — documentation change, no manifest modified -->
- [ ] Validated manifest locally with `winget validate --manifest <path>` <!-- N/A -->
- [ ] Tested manifest locally with `winget install --manifest <path>` <!-- N/A -->
- [ ] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0) <!-- N/A -->

> **Note:** This is a documentation-only change to `doc/Moderation.md`; the manifest checklist items do not apply.