### PR TITLE
New version: Helvesec.RMUX version 0.7.0

### DIFF
--- a/manifests/h/Helvesec/RMUX/0.7.0/Helvesec.RMUX.installer.yaml
+++ b/manifests/h/Helvesec/RMUX/0.7.0/Helvesec.RMUX.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: Helvesec.RMUX
+PackageVersion: 0.7.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: rmux-0.7.0-windows-x86_64\rmux.exe
+    PortableCommandAlias: rmux
+ReleaseDate: "2026-06-25"
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Helvesec/rmux/releases/download/v0.7.0/rmux-0.7.0-windows-x86_64.zip
+    InstallerSha256: 962B940EC391A2EC90F99C98379C9AA56828981E3801E97FC719E66A8CF0F32F
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/h/Helvesec/RMUX/0.7.0/Helvesec.RMUX.locale.en-US.yaml
+++ b/manifests/h/Helvesec/RMUX/0.7.0/Helvesec.RMUX.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: Helvesec.RMUX
+PackageVersion: 0.7.0
+PackageLocale: en-US
+Publisher: Helvesec
+PublisherUrl: https://github.com/Helvesec
+PublisherSupportUrl: https://github.com/Helvesec/rmux/issues
+Author: Helvesec
+PackageName: RMUX
+PackageUrl: https://rmux.io
+License: MIT OR Apache-2.0
+ShortDescription: Terminal multiplexer with a tmux-style CLI, daemon runtime, and native Windows support.
+Description: |-
+  RMUX is a terminal multiplexer with a tmux-style command line, daemon-backed persistent sessions, native Windows support, and a Rust SDK for automation.
+Moniker: rmux
+Tags:
+  - cli
+  - multiplexer
+  - rust
+  - terminal
+  - tmux
+ReleaseNotesUrl: https://github.com/Helvesec/rmux/releases/tag/v0.7.0
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/h/Helvesec/RMUX/0.7.0/Helvesec.RMUX.yaml
+++ b/manifests/h/Helvesec/RMUX/0.7.0/Helvesec.RMUX.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: Helvesec.RMUX
+PackageVersion: 0.7.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Generated from the published RMUX v0.7.0 GitHub Release asset and SHA256SUMS.\n\nRelease: https://github.com/Helvesec/rmux/releases/tag/v0.7.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/393121)