### PR TITLE
Add SciScope.SciScopeTUI version 0.1.2

### DIFF
--- a/manifests/s/SciScope/SciScopeTUI/0.1.2/SciScope.SciScopeTUI.installer.yaml
+++ b/manifests/s/SciScope/SciScopeTUI/0.1.2/SciScope.SciScopeTUI.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: SciScope.SciScopeTUI
+PackageVersion: 0.1.2
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: sciscope-tui.exe
+  PortableCommandAlias: sciscope-tui
+Commands:
+- sciscope-tui
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Timcai06/SciScope/releases/download/v0.1.2/sciscope-tui_windows_amd64.zip
+  InstallerSha256: 877B79B8DAC5F5214B3E6157CCDE8C9D97A69C681A76ADE92F8593EE0B5E9D67
+- Architecture: arm64
+  InstallerUrl: https://github.com/Timcai06/SciScope/releases/download/v0.1.2/sciscope-tui_windows_arm64.zip
+  InstallerSha256: 208F77A1FB3C60C1AE57D1292CAFC714B4A794102F3948055D2BA0F435E88347
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/s/SciScope/SciScopeTUI/0.1.2/SciScope.SciScopeTUI.locale.en-US.yaml
+++ b/manifests/s/SciScope/SciScopeTUI/0.1.2/SciScope.SciScopeTUI.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: SciScope.SciScopeTUI
+PackageVersion: 0.1.2
+PackageLocale: en-US
+Publisher: SciScope
+PublisherUrl: https://github.com/Timcai06
+PublisherSupportUrl: https://github.com/Timcai06/SciScope/issues
+Author: SciScope contributors
+PackageName: SciScope TUI
+PackageUrl: https://github.com/Timcai06/SciScope
+License: Proprietary
+ShortDescription: Terminal client for the SciScope research agent.
+Description: SciScope TUI is a terminal client for a grounded research agent. It can run an offline demo or connect to a SciScope backend through SCISCOPE_BACKEND.
+Moniker: sciscope-tui
+Tags:
+- ai
+- agent
+- research
+- tui
+- literature
+ReleaseNotesUrl: https://github.com/Timcai06/SciScope/releases/tag/v0.1.2
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/s/SciScope/SciScopeTUI/0.1.2/SciScope.SciScopeTUI.yaml
+++ b/manifests/s/SciScope/SciScopeTUI/0.1.2/SciScope.SciScopeTUI.yaml
@@ -1,42 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.singleton.1.10.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
 PackageIdentifier: SciScope.SciScopeTUI
 PackageVersion: 0.1.2
-PackageLocale: en-US
-Publisher: SciScope
-PublisherUrl: https://github.com/Timcai06
-PublisherSupportUrl: https://github.com/Timcai06/SciScope/issues
-Author: SciScope contributors
-PackageName: SciScope TUI
-PackageUrl: https://github.com/Timcai06/SciScope
-License: Proprietary
-ShortDescription: Terminal client for the SciScope research agent.
-Description: SciScope TUI is a terminal client for a grounded research agent. It can run an offline demo or connect to a SciScope backend through SCISCOPE_BACKEND.
-Moniker: sciscope-tui
-Tags:
-  - ai
-  - agent
-  - research
-  - tui
-  - literature
-Commands:
-  - sciscope-tui
-ReleaseNotesUrl: https://github.com/Timcai06/SciScope/releases/tag/v0.1.2
-Installers:
-  - Architecture: x64
-    InstallerType: zip
-    NestedInstallerType: portable
-    NestedInstallerFiles:
-      - RelativeFilePath: sciscope-tui.exe
-        PortableCommandAlias: sciscope-tui
-    InstallerUrl: https://github.com/Timcai06/SciScope/releases/download/v0.1.2/sciscope-tui_windows_amd64.zip
-    InstallerSha256: 877B79B8DAC5F5214B3E6157CCDE8C9D97A69C681A76ADE92F8593EE0B5E9D67
-  - Architecture: arm64
-    InstallerType: zip
-    NestedInstallerType: portable
-    NestedInstallerFiles:
-      - RelativeFilePath: sciscope-tui.exe
-        PortableCommandAlias: sciscope-tui
-    InstallerUrl: https://github.com/Timcai06/SciScope/releases/download/v0.1.2/sciscope-tui_windows_arm64.zip
-    InstallerSha256: 208F77A1FB3C60C1AE57D1292CAFC714B4A794102F3948055D2BA0F435E88347
-ManifestType: singleton
-ManifestVersion: 1.10.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0

--- a/manifests/s/SciScope/SciScopeTUI/0.1.2/SciScope.SciScopeTUI.yaml
+++ b/manifests/s/SciScope/SciScopeTUI/0.1.2/SciScope.SciScopeTUI.yaml
@@ -1,0 +1,42 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.singleton.1.10.0.schema.json
+PackageIdentifier: SciScope.SciScopeTUI
+PackageVersion: 0.1.2
+PackageLocale: en-US
+Publisher: SciScope
+PublisherUrl: https://github.com/Timcai06
+PublisherSupportUrl: https://github.com/Timcai06/SciScope/issues
+Author: SciScope contributors
+PackageName: SciScope TUI
+PackageUrl: https://github.com/Timcai06/SciScope
+License: Proprietary
+ShortDescription: Terminal client for the SciScope research agent.
+Description: SciScope TUI is a terminal client for a grounded research agent. It can run an offline demo or connect to a SciScope backend through SCISCOPE_BACKEND.
+Moniker: sciscope-tui
+Tags:
+  - ai
+  - agent
+  - research
+  - tui
+  - literature
+Commands:
+  - sciscope-tui
+ReleaseNotesUrl: https://github.com/Timcai06/SciScope/releases/tag/v0.1.2
+Installers:
+  - Architecture: x64
+    InstallerType: zip
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: sciscope-tui.exe
+        PortableCommandAlias: sciscope-tui
+    InstallerUrl: https://github.com/Timcai06/SciScope/releases/download/v0.1.2/sciscope-tui_windows_amd64.zip
+    InstallerSha256: 877B79B8DAC5F5214B3E6157CCDE8C9D97A69C681A76ADE92F8593EE0B5E9D67
+  - Architecture: arm64
+    InstallerType: zip
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: sciscope-tui.exe
+        PortableCommandAlias: sciscope-tui
+    InstallerUrl: https://github.com/Timcai06/SciScope/releases/download/v0.1.2/sciscope-tui_windows_arm64.zip
+    InstallerSha256: 208F77A1FB3C60C1AE57D1292CAFC714B4A794102F3948055D2BA0F435E88347
+ManifestType: singleton
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Adds SciScope TUI 0.1.2 as a portable zip package for Windows x64 and arm64.\n\nRelease: https://github.com/Timcai06/SciScope/releases/tag/v0.1.2\n\nThe package installs the Go terminal client only. The backend, PostgreSQL/pgvector service, corpus, and model assets are not included; users can run the offline demo or connect to a hosted SciScope backend via SCISCOPE_BACKEND.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/393345)