### PR TITLE
Ganksoft.Nanopad version 1.2.0 (add missing arm64 installer)

### DIFF
--- a/manifests/g/Ganksoft/Nanopad/1.2.0/Ganksoft.Nanopad.installer.yaml
+++ b/manifests/g/Ganksoft/Nanopad/1.2.0/Ganksoft.Nanopad.installer.yaml
@@ -13,5 +13,8 @@ Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/BrianPeek/Nanopad/releases/download/v1.2.0/Nanopad-1.2.0-x64.zip
   InstallerSha256: CC9191E5A47723838BE1F695F1CBA00932D048EFF60491D34E33E4F22E19E9EE
+- Architecture: arm64
+  InstallerUrl: https://github.com/BrianPeek/Nanopad/releases/download/v1.2.0/Nanopad-1.2.0-arm64.zip
+  InstallerSha256: 2997794978D65F92D0F4A9D0FD6021F39B0BC228422F8438F521BCDF06CE4B00
 ManifestType: installer
 ManifestVersion: 1.12.0


### PR DESCRIPTION
This adds the missing **arm64** installer to the existing `Ganksoft.Nanopad` 1.2.0 manifest.

The 1.2.0 release ships both x64 and arm64 portable zips, but the published manifest only contained the x64 installer, so winget on ARM64 falls back to the x64 package (under emulation). The arm64 installer was dropped because komac `update` reconciles against the previous version's installer set, which has been x64-only since before native ARM64 builds were added.

- Architecture: arm64
- InstallerUrl: https://github.com/BrianPeek/Nanopad/releases/download/v1.2.0/Nanopad-1.2.0-arm64.zip
- InstallerSha256 verified against the released asset.

Validated locally with `winget validate` (succeeded).

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/393356)