### PR TITLE
Add Wildfoundry.DataplicityCLI version 0.1.4

### DIFF
--- a/manifests/w/Wildfoundry/DataplicityCLI/0.1.4/Wildfoundry.DataplicityCLI.installer.yaml
+++ b/manifests/w/Wildfoundry/DataplicityCLI/0.1.4/Wildfoundry.DataplicityCLI.installer.yaml
@@ -1,0 +1,13 @@
+PackageIdentifier: Wildfoundry.DataplicityCLI
+PackageVersion: 0.1.4
+InstallerType: wix
+InstallerSwitches:
+  Silent: /quiet /norestart
+  SilentWithProgress: /passive /norestart
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/wildfoundry/dataplicity-cli/releases/download/v0.1.4/dataplicity-cli-0.1.4-windows-x64.msi
+  InstallerSha256: B2EA227DADB58B03F8715FA60C1D0AE68088FCBC9C63F3D859B1A582002F6A64
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/w/Wildfoundry/DataplicityCLI/0.1.4/Wildfoundry.DataplicityCLI.locale.en-US.yaml
+++ b/manifests/w/Wildfoundry/DataplicityCLI/0.1.4/Wildfoundry.DataplicityCLI.locale.en-US.yaml
@@ -1,0 +1,21 @@
+PackageIdentifier: Wildfoundry.DataplicityCLI
+PackageVersion: 0.1.4
+PackageLocale: en-US
+Publisher: Dataplicity
+PublisherUrl: https://www.dataplicity.com
+PublisherSupportUrl: https://github.com/wildfoundry/dataplicity-cli/issues
+Author: Dataplicity
+PackageName: Dataplicity CLI
+PackageUrl: https://github.com/wildfoundry/dataplicity-cli
+License: MIT
+LicenseUrl: https://github.com/wildfoundry/dataplicity-cli/blob/main/LICENSE
+ShortDescription: Command line interface for Dataplicity OEM and developer workflows.
+Description: Dataplicity CLI provides authentication, device management, and secure remote access workflows for Dataplicity users.
+Tags:
+- dataplicity
+- cli
+- iot
+- remote-access
+ReleaseNotesUrl: https://github.com/wildfoundry/dataplicity-cli/releases/tag/v0.1.4
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/w/Wildfoundry/DataplicityCLI/0.1.4/Wildfoundry.DataplicityCLI.yaml
+++ b/manifests/w/Wildfoundry/DataplicityCLI/0.1.4/Wildfoundry.DataplicityCLI.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Wildfoundry.DataplicityCLI
+PackageVersion: 0.1.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## Summary
- add initial WinGet manifests for `Wildfoundry.DataplicityCLI`
- publish Windows x64 MSI package from the Dataplicity CLI `v0.1.4` release
- include version, installer, and default locale manifests

## Installer
- URL: https://github.com/wildfoundry/dataplicity-cli/releases/download/v0.1.4/dataplicity-cli-0.1.4-windows-x64.msi
- SHA256: `B2EA227DADB58B03F8715FA60C1D0AE68088FCBC9C63F3D859B1A582002F6A64`

## Notes
This is the initial package submission for `Wildfoundry.DataplicityCLI` to enable automated updates for future releases.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/393479)