### PR TITLE
New version: ABowlOfEleven.hopscout version 0.1.1

### DIFF
--- a/manifests/a/ABowlOfEleven/hopscout/0.1.1/ABowlOfEleven.hopscout.installer.yaml
+++ b/manifests/a/ABowlOfEleven/hopscout/0.1.1/ABowlOfEleven.hopscout.installer.yaml
@@ -1,0 +1,26 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ABowlOfEleven.hopscout
+PackageVersion: 0.1.1
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: wix
+Scope: user
+InstallModes:
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{39663AA5-ACCB-421A-9FAB-9489DE51444F}'
+AppsAndFeaturesEntries:
+- UpgradeCode: '{B6E2F0A1-7C43-4D58-9E10-2A6B5C8D4F31}'
+  InstallerType: wix
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/ABowlOfEleven/hopscout/releases/download/v0.1.1/hopscout-0.1.1-x64.msi
+  InstallerSha256: 4009379A1E296B7BFC00ABFF8CAB476BAF48E29BB55C66535488457497B6E491
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-06-26

--- a/manifests/a/ABowlOfEleven/hopscout/0.1.1/ABowlOfEleven.hopscout.locale.en-US.yaml
+++ b/manifests/a/ABowlOfEleven/hopscout/0.1.1/ABowlOfEleven.hopscout.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ABowlOfEleven.hopscout
+PackageVersion: 0.1.1
+PackageLocale: en-US
+Publisher: hopscout contributors
+PublisherUrl: https://github.com/ABowlOfEleven
+PublisherSupportUrl: https://github.com/ABowlOfEleven/hopscout/issues
+PackageName: hopscout
+PackageUrl: https://github.com/ABowlOfEleven/hopscout
+License: MIT
+LicenseUrl: https://github.com/ABowlOfEleven/hopscout/blob/main/LICENSE
+ShortDescription: A modern, MTR-compatible traceroute and network monitor for Windows.
+Description: |-
+  hopscout is a live traceroute and network monitor for Windows with both a
+  terminal UI and a desktop GUI. It supports ICMP (no admin), UDP, and TCP-SYN
+  probing over IPv4 and IPv6, per-flow multipath discovery, path-change alerting,
+  reverse-DNS / ASN / geolocation enrichment, a world map and topology view, and
+  an MTR-compatible command line with report, JSON, and CSV output.
+Moniker: hopscout
+Tags:
+- traceroute
+- mtr
+- networking
+- ping
+- latency
+- cli
+ReleaseNotesUrl: https://github.com/ABowlOfEleven/hopscout/releases/tag/v0.1.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/ABowlOfEleven/hopscout/0.1.1/ABowlOfEleven.hopscout.yaml
+++ b/manifests/a/ABowlOfEleven/hopscout/0.1.1/ABowlOfEleven.hopscout.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ABowlOfEleven.hopscout
+PackageVersion: 0.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Updates **ABowlOfEleven.hopscout** to version 0.1.1.

This release brings the CLI and GUI to feature parity: shared text/JSON/CSV report rendering, the GUI gains IPv4/IPv6 family, payload size, per-probe timeout, first-TTL, no-DNS, and show-IPs controls plus a Location column, inline MPLS labels, and a report Export menu, and the CLI gains a Location column and a dedicated alerts view. Reports now include geolocation (City/Country in CSV, asn/city/country in JSON).

- Installer: per-user WiX v5 MSI (x64), silent install supported
- Publisher matches the installer's registry value (`hopscout contributors`)
- Release notes: https://github.com/ABowlOfEleven/hopscout/releases/tag/v0.1.1

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/393552)
