### PR TITLE
New version: Dmezhnov.KnitCalc version 1.8.64

### DIFF
--- a/manifests/d/Dmezhnov/KnitCalc/1.8.64/Dmezhnov.KnitCalc.installer.yaml
+++ b/manifests/d/Dmezhnov/KnitCalc/1.8.64/Dmezhnov.KnitCalc.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Dmezhnov.KnitCalc
+PackageVersion: 1.8.64
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: inno
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/dmezhnov/knitcalc/releases/download/v1.8.64+87/knitcalc-setup-x64-1.8.64+87.exe
+  InstallerSha256: 70310F4B7513A6905ADA0DCB9951A6F637C7E8C730AA0BA824ABA02432E54E59
+  ProductCode: '{3E2280E5-0275-4912-A2FF-CB4B7F32C007}_is1'
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-06-26

--- a/manifests/d/Dmezhnov/KnitCalc/1.8.64/Dmezhnov.KnitCalc.locale.en-US.yaml
+++ b/manifests/d/Dmezhnov/KnitCalc/1.8.64/Dmezhnov.KnitCalc.locale.en-US.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Dmezhnov.KnitCalc
+PackageVersion: 1.8.64
+PackageLocale: en-US
+Publisher: Dmitry Mezhnov
+PublisherUrl: https://github.com/dmezhnov
+PublisherSupportUrl: https://github.com/dmezhnov/knitcalc/issues
+PackageName: KnitCalc
+PackageUrl: https://github.com/dmezhnov/knitcalc
+License: MIT
+LicenseUrl: https://github.com/dmezhnov/knitcalc/blob/main/LICENSE
+ShortDescription: Knitting calculator
+Description: 'KnitCalc is a knitting calculator: gauge conversion, increases/decreases distribution, yarn estimation and project notes with photos.'
+Tags:
+- knitting
+- calculator
+- craft
+ReleaseNotesUrl: https://github.com/dmezhnov/knitcalc/releases/tag/v1.8.64%2B87
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/d/Dmezhnov/KnitCalc/1.8.64/Dmezhnov.KnitCalc.yaml
+++ b/manifests/d/Dmezhnov/KnitCalc/1.8.64/Dmezhnov.KnitCalc.yaml
@@ -1,0 +1,9 @@
+# Created by hand to switch the installer from the broken zip/portable package
+# to the per-user Inno Setup installer.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Dmezhnov.KnitCalc
+PackageVersion: 1.8.64
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
This switches the KnitCalc installer from the previous zip / portable package to a per-user Inno Setup installer.

**Why:** KnitCalc is a Flutter app whose `knitcalc.exe` depends on adjacent DLLs (`flutter_windows.dll`, plugin DLLs). The portable manifest aliased `knitcalc.exe` via a symlink in `WinGet\Links\`, and launching through that symlink made Windows resolve the DLL search path from the symlink directory (which has no DLLs), so the app failed to start with "flutter_windows.dll was not found". The Inno installer installs the bundle intact under `%LOCALAPPDATA%\Programs\KnitCalc` (per-user, `Scope: user`), so the DLLs resolve and the app launches.

- Installer manifest: `InstallerType: inno`, `Scope: user`, silent switches, `ProductCode` matching the Inno Add/Remove Programs entry.
- Installer SHA256 verified against the released `knitcalc-setup-x64-1.8.64+87.exe` asset.

---
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`? (Authored on Linux; not run locally — manifests mirror the published 1.8.63 set and the v1.12.0 schema, relying on the pipeline validation here.)
- [x] This manifest is a new version of an existing package that installs correctly (the Inno installer was built and the SHA256 verified against the release asset).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/393586)