### PR TITLE
New version: v2matosevic.WinSnipper version 0.5.1

### DIFF
--- a/manifests/v/v2matosevic/WinSnipper/0.5.1/v2matosevic.WinSnipper.installer.yaml
+++ b/manifests/v/v2matosevic/WinSnipper/0.5.1/v2matosevic.WinSnipper.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: v2matosevic.WinSnipper
+PackageVersion: 0.5.1
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: portable
+Commands:
+- winsnipper
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.8
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/v2matosevic/WinSnipper/releases/download/v0.5.1/WinSnipper.exe
+  InstallerSha256: B317D1A10EF8922C888F0446FF7EFC9BA474CB05553FE1EF69D131F5E66B24E9
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/v/v2matosevic/WinSnipper/0.5.1/v2matosevic.WinSnipper.locale.en-US.yaml
+++ b/manifests/v/v2matosevic/WinSnipper/0.5.1/v2matosevic.WinSnipper.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: v2matosevic.WinSnipper
+PackageVersion: 0.5.1
+PackageLocale: en-US
+Publisher: Marko Matošević
+PublisherUrl: https://github.com/v2matosevic
+PublisherSupportUrl: https://github.com/v2matosevic/WinSnipper/issues
+PackageName: WinSnipper
+PackageUrl: https://github.com/v2matosevic/WinSnipper
+License: MIT
+LicenseUrl: https://github.com/v2matosevic/WinSnipper/blob/master/LICENSE
+ShortDescription: Ultra-lightweight Win+Shift+S replacement - snip, floating thumbnail, annotate, paste.
+Description: |-
+  WinSnipper replaces the built-in Windows snip with a faster flow: press the
+  hotkey, drag a region, and the snip is saved, copied to the clipboard, and
+  pinned as a small floating thumbnail. Click the thumbnail to annotate
+  (rectangle, freehand, ellipse, arrow, text, numbered step badges,
+  redact/pixelate, crop) or drag it straight into any app as a file.
+  No confirmation dialogs anywhere - closing the editor saves silently and
+  refreshes the clipboard. Built for fast feedback loops, especially pasting
+  annotated screenshots into AI coding chats.
+Moniker: winsnipper
+Tags:
+- annotation
+- capture
+- ocr
+- productivity
+- screen-capture
+- screenshot
+- snip
+- snipping-tool
+ReleaseNotesUrl: https://github.com/v2matosevic/WinSnipper/releases/tag/v0.5.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/v/v2matosevic/WinSnipper/0.5.1/v2matosevic.WinSnipper.yaml
+++ b/manifests/v/v2matosevic/WinSnipper/0.5.1/v2matosevic.WinSnipper.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: v2matosevic.WinSnipper
+PackageVersion: 0.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New version submission

- **Package**: v2matosevic.WinSnipper **0.5.1** (latest release)
- **Type**: portable (single-file exe, ~0.25 MB), depends on Microsoft.DotNet.DesktopRuntime.8
- **Project**: https://github.com/v2matosevic/WinSnipper — MIT-licensed, open source
- **Installer**: https://github.com/v2matosevic/WinSnipper/releases/download/v0.5.1/WinSnipper.exe

Fresh submission of the current release. Manifests are authored against the
current schema **1.12.0** (the previous PR #386835 used the now-deprecated 1.6.0
and was auto-closed as stale).

- [x] Manifests validate against schema 1.12.0
- [x] License and URLs verified
- [x] Installer SHA256 verified against the published release asset
- [x] This PR only adds one new package version
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/393641)