### PR TITLE
Clarify ElevationRequirement documentation and add elevation guidance to validation guide

### DIFF
--- a/doc/ValidationFailureGuide.md
+++ b/doc/ValidationFailureGuide.md
@@ -285,6 +285,7 @@ Function Get-UrlResponse {
 - Incorrect installer type (e.g., `exe` specified for a `nullsoft`, `burn`, or `inno` installer, or `msi` for `wix`) — WinGet handles silent switches automatically for known types, so a wrong type means the wrong switches are used
 - Missing or incorrect silent install switches (`/S`, `/silent`, `/quiet`, etc.)
 - The installer displays a dialog that blocks progress (license agreement, options screen)
+- The installer triggers a UAC prompt that cannot be accepted in the automated test environment — if the installer needs elevation, add `ElevationRequirement: elevationRequired` to the manifest so WinGet handles it
 - A dependency is missing on the test machine
 - The `exe` installer type was specified instead of `portable` for an application that runs without an installer
 
@@ -324,7 +325,30 @@ Function Get-UrlResponse {
 
 **What it means:** A general error occurred during manual validation of the package.
 
-**How to fix:** Check the accompanying PR comment for specific next steps.
+**Common causes:**
+- The installer requires administrator privileges but the manifest does not specify `ElevationRequirement: elevationRequired`. The validation infrastructure runs installers as a standard (non-elevated) user by default. If the installer needs to write to protected locations (e.g., `Program Files`), modify system registry keys (HKLM), or install a Windows service, it will fail without the correct elevation requirement.
+- A dependency is missing on the test machine.
+- The installer encountered an unexpected error during setup.
+
+**How to fix:**
+1. If the validation logs indicate an access-denied or permissions error, add `ElevationRequirement: elevationRequired` to your installer manifest. See the [ElevationRequirement documentation](https://github.com/microsoft/winget-pkgs/blob/master/doc/manifest/schema/1.12.0/installer.md) for guidance on choosing the correct value.
+2. Check the accompanying PR comment for specific next steps.
+
+---
+
+#### `Validation-Shell-Execute`
+
+**What it means:** The installer failed to launch or did not complete during dynamic validation. WinGet was unable to execute the installer successfully via `ShellExecute`.
+
+**Common causes:**
+- The installer requires administrator privileges but the manifest does not specify `ElevationRequirement: elevationRequired`. The validation environment runs as a standard user — if the installer unconditionally needs elevation (e.g., it writes to `Program Files`, modifies HKLM registry keys, or installs a system service), it will fail without this field.
+- The installer binary is corrupted or not a valid executable.
+- The installer depends on a runtime or framework that is not present on the test machine.
+
+**How to fix:**
+1. If the installer needs elevation to complete, add `ElevationRequirement: elevationRequired` to your manifest. Do **not** use `elevatesSelf` unless the installer has its own built-in logic to conditionally request elevation. See the [ElevationRequirement documentation](https://github.com/microsoft/winget-pkgs/blob/master/doc/manifest/schema/1.12.0/installer.md) for details.
+2. Test locally with `winget install --manifest <path>` from a non-elevated terminal to reproduce the issue.
+3. Verify the installer binary is valid and not corrupted.
 
 ---
 
@@ -461,6 +485,8 @@ These labels are applied by [moderators](https://github.com/microsoft/winget-pkg
 | `Validation-Indirect-URL` | URL | ✅ Yes | Remove URL redirection |
 | `Validation-Unattended-Failed` | Install | ✅ Yes | Fix silent install switches |
 | `Validation-Executable-Error` | Install | ⚠️ Maybe | Verify executable is discoverable |
+| `Validation-Installation-Error` | Install | ✅ Yes | Fix installation failure (check elevation) |
+| `Validation-Shell-Execute` | Install | ✅ Yes | Fix installer launch failure (check elevation) |
 | `Validation-Defender-Error` | Install | ⚠️ Maybe | Fix or submit for false positive review |
 | `Validation-Merge-Conflict` | PR | ✅ Yes | Resolve merge conflict |
 | `Validation-MSIX-Dependency` | Dependency | ✅ Yes | Add missing framework dependency |

--- a/doc/manifest/schema/1.12.0/installer.md
+++ b/doc/manifest/schema/1.12.0/installer.md
@@ -632,15 +632,17 @@ This key identifies packages that upgrade themselves. By default, they are exclu
 </details>
 
 <details>
-  <summary><b>ElevationRequirement</b> - Indicator for elevation requirements when installing or upgrading packages.</summary>
+  <summary><b>ElevationRequirement</b> - Indicator for elevation behavior when installing or upgrading packages.</summary>
 
 **Optional Field**
 
-This key represents which scope a package is required to be executed under. Some packages require user level execution while others require administrative level execution.
+This key describes how the installer interacts with elevation (administrator privileges). It tells WinGet whether to request elevation on the user's behalf, whether the installer handles elevation itself, or whether elevation must be avoided entirely.
 
-- elevationRequired - Must be run from a shell that is running in an administrative context (e.g - Admin user using powershell/terminal/cmd with "Run as Administrator")
-- elevationProhibited - Must be run from a shell that is not running in an administrative context
-- elevatesSelf - If called from a non-administrative context, will request elevation. If called from an administrative context, may or may not request elevation.
+- **elevationRequired** — The installer always requires administrator privileges to complete (e.g., it writes to `Program Files`, modifies system registry keys, or installs a Windows service). If WinGet is running in a non-elevated context, it will launch the installer elevated via a UAC prompt.
+- **elevatesSelf** — The installer contains its own logic to determine whether elevation is needed and will request it when necessary. For example, the installer may check whether the current user is a member of the local Administrators group and automatically switch between a per-user and machine-wide installation. WinGet will not elevate the installer itself but will warn the user that a UAC prompt may appear.
+- **elevationProhibited** — The installer must not be run from an elevated (administrator) context. If WinGet is running elevated, the installation will be blocked.
+
+> **Choosing between `elevationRequired` and `elevatesSelf`:** Use `elevationRequired` when the installer unconditionally needs administrator privileges due to what it installs (protected file locations, HKLM registry, system services). Use `elevatesSelf` when the installer has built-in logic that conditionally decides whether elevation is needed based on runtime checks.
 </details>
 
 <details>

--- a/doc/manifest/schema/1.12.0/singleton.md
+++ b/doc/manifest/schema/1.12.0/singleton.md
@@ -691,11 +691,17 @@ ManifestVersion: 1.12.0
 </details>
 
 <details>
-  <summary><b>ElevationRequirement</b> - Indicator for elevation requirements when installing or upgrading packages.</summary>
+  <summary><b>ElevationRequirement</b> - Indicator for elevation behavior when installing or upgrading packages.</summary>
 
   **Optional Field**
 
-  This key represents which scope a package is required to be executed under. Some packages require user level execution while others require administrative level execution.
+  This key describes how the installer interacts with elevation (administrator privileges). It tells WinGet whether to request elevation on the user's behalf, whether the installer handles elevation itself, or whether elevation must be avoided entirely.
+
+  - **elevationRequired** — The installer always requires administrator privileges to complete (e.g., it writes to `Program Files`, modifies system registry keys, or installs a Windows service). If WinGet is running in a non-elevated context, it will launch the installer elevated via a UAC prompt.
+  - **elevatesSelf** — The installer contains its own logic to determine whether elevation is needed and will request it when necessary. For example, the installer may check whether the current user is a member of the local Administrators group and automatically switch between a per-user and machine-wide installation. WinGet will not elevate the installer itself but will warn the user that a UAC prompt may appear.
+  - **elevationProhibited** — The installer must not be run from an elevated (administrator) context. If WinGet is running elevated, the installation will be blocked.
+
+  > **Choosing between `elevationRequired` and `elevatesSelf`:** Use `elevationRequired` when the installer unconditionally needs administrator privileges due to what it installs (protected file locations, HKLM registry, system services). Use `elevatesSelf` when the installer has built-in logic that conditionally decides whether elevation is needed based on runtime checks.
 </details>
 
 <details>


### PR DESCRIPTION
## 📖 Description

Clarifies the `ElevationRequirement` field documentation and adds elevation-related guidance to the Validation Failure Guide. Created with GitHub Copilot assistance.

### Schema documentation changes (`doc/manifest/schema/1.12.0/`)

**`installer.md` and `singleton.md`** — Rewrites the `ElevationRequirement` field descriptions to clearly distinguish intent:

- **`elevationRequired`** — The installer unconditionally needs administrator privileges (writes to `Program Files`, modifies HKLM registry keys, installs a Windows service). WinGet launches the installer elevated via UAC.
- **`elevatesSelf`** — The installer has built-in logic to conditionally determine whether elevation is needed (e.g., checking local admin group membership to switch scope). WinGet warns the user but does not elevate the installer itself.
- **`elevationProhibited`** — Unchanged (must not run elevated).
- Adds a "Choosing between" guidance note to help manifest authors pick the right value.

### Validation Failure Guide changes (`doc/ValidationFailureGuide.md`)

- **New `Validation-Shell-Execute` section** with elevation as a primary troubleshooting step
- **Expanded `Validation-Installation-Error`** with elevation as a common cause and actionable fix guidance
- **Added elevation note** to `Validation-Unattended-Failed` causes (UAC prompts blocking automated tests)
- **Updated quick reference table** with missing `Validation-Installation-Error` and `Validation-Shell-Execute` labels

Resolves https://github.com/microsoft/winget-pkgs/issues/393665

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)
  - Resolves https://github.com/microsoft/winget-pkgs/issues/393665

## 📦 Manifest Checklist

- [ ] ~~Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change~~ N/A — documentation-only change
- [ ] ~~This PR only modifies one (1) manifest~~ N/A — documentation-only change
- [ ] ~~Validated manifest locally with `winget validate --manifest <path>`~~ N/A — documentation-only change
- [ ] ~~Tested manifest locally with `winget install --manifest <path>`~~ N/A — documentation-only change
- [ ] ~~Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)~~ N/A — documentation-only change

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/393666)