### PR TITLE
New version: Dmezhnov.KnitCalc version 1.8.65

### DIFF
--- a/manifests/d/Dmezhnov/KnitCalc/1.8.65/Dmezhnov.KnitCalc.installer.yaml
+++ b/manifests/d/Dmezhnov/KnitCalc/1.8.65/Dmezhnov.KnitCalc.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Dmezhnov.KnitCalc
+PackageVersion: 1.8.65
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: inno
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/dmezhnov/knitcalc/releases/download/v1.8.65+88/knitcalc-setup-x64-1.8.65+88.exe
+  InstallerSha256: 76A77EB8339A24172557293E3F54EB7F0F3618F1A69DF143AEFBBEE20A88E8BA
+  ProductCode: '{3E2280E5-0275-4912-A2FF-CB4B7F32C007}_is1'
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-06-27

--- a/manifests/d/Dmezhnov/KnitCalc/1.8.65/Dmezhnov.KnitCalc.locale.en-US.yaml
+++ b/manifests/d/Dmezhnov/KnitCalc/1.8.65/Dmezhnov.KnitCalc.locale.en-US.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Dmezhnov.KnitCalc
+PackageVersion: 1.8.65
+PackageLocale: en-US
+Publisher: Dmitry Mezhnov
+PublisherUrl: https://github.com/dmezhnov
+PublisherSupportUrl: https://github.com/dmezhnov/knitcalc/issues
+PackageName: KnitCalc
+PackageUrl: https://github.com/dmezhnov/knitcalc
+License: MIT
+LicenseUrl: https://github.com/dmezhnov/knitcalc/blob/main/LICENSE
+ShortDescription: Knitting calculator
+Description: 'KnitCalc is a knitting calculator: gauge conversion, increases/decreases distribution, yarn estimation and project notes with photos.'
+Tags:
+- knitting
+- calculator
+- craft
+ReleaseNotesUrl: https://github.com/dmezhnov/knitcalc/releases/tag/v1.8.65%2B88
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/d/Dmezhnov/KnitCalc/1.8.65/Dmezhnov.KnitCalc.yaml
+++ b/manifests/d/Dmezhnov/KnitCalc/1.8.65/Dmezhnov.KnitCalc.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Dmezhnov.KnitCalc
+PackageVersion: 1.8.65
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Updates KnitCalc to 1.8.65 and switches the installer from the previous zip / portable package to a per-user Inno Setup installer.

**Why the change from portable to inno:** KnitCalc is a Flutter app whose `knitcalc.exe` depends on adjacent DLLs. The old portable package aliased `knitcalc.exe` via a symlink in `WinGet\Links\`, and launching through that symlink made Windows resolve the DLL search path from the symlink directory (no DLLs there), so the app failed to start. The Inno installer keeps the bundle intact under `%LOCALAPPDATA%\Programs\KnitCalc` (per-user, no admin), so the DLLs resolve. `inno` installers have no nested-installer properties, so the absence of `NestedInstallerType`/`NestedInstallerFiles` vs the previous version is intentional.

**Note vs the earlier 1.8.64 attempt (#393586, closed):** that build crashed in validation with `STATUS_DLL_NOT_FOUND` because the Flutter app needs the Visual C++ runtime, which a clean Windows lacks. 1.8.65 bundles the MSVC runtime (`msvcp140.dll`, `vcruntime140*.dll`, …) next to the exe, so it is fully self-contained.

- Installer SHA256 verified against the released `knitcalc-setup-x64-1.8.65+88.exe` asset.

---
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`? (Authored on Linux; not run locally — manifests follow the v1.12.0 schema and mirror the published set; relying on the pipeline validation here.)
- [x] This manifest is a new version of an existing package; the Inno installer was built and the SHA256 verified against the release asset.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/394202)