### PR TITLE
Add getreu.tpnote version 1.26.2

### DIFF
--- a/manifests/g/getreu/tpnote/1.26.2/getreu.tpnote.installer.yaml
+++ b/manifests/g/getreu/tpnote/1.26.2/getreu.tpnote.installer.yaml
@@ -1,0 +1,10 @@
+PackageIdentifier: getreu.tpnote
+PackageVersion: 1.26.2
+MinimumOSVersion: 10.0.0.0
+InstallerType: msi
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://blog.getreu.net/projects/tp-note/_downloads/package/x86_64-pc-windows-gnu/tpnote-1.26.2-x86_64.msi
+    InstallerSha256: 86d060245f48713d920b465dc562a48fbe7c0f9dd9d167cb894f41cd6bad03e0
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/g/getreu/tpnote/1.26.2/getreu.tpnote.locale.en-US.yaml
+++ b/manifests/g/getreu/tpnote/1.26.2/getreu.tpnote.locale.en-US.yaml
@@ -1,0 +1,11 @@
+PackageIdentifier: getreu.tpnote
+PackageVersion: 1.26.2
+PackageLocale: en-US
+Publisher: Jens Getreu
+PackageName: Tp-Note
+ShortDescription: Fast note-taking with templates and filename analysis
+Description: Tp-Note is a note-taking tool and a template system that facilitates personal knowledge management.
+License: MIT
+PackageUrl: https://blog.getreu.net/projects/tp-note/
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/g/getreu/tpnote/1.26.2/getreu.tpnote.yaml
+++ b/manifests/g/getreu/tpnote/1.26.2/getreu.tpnote.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: getreu.tpnote
+PackageVersion: 1.26.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0


### PR DESCRIPTION
## 📖 Description
Update Tp-Note (getreu.tpnote) from version 1.25.20 to 1.26.2.

Tp-Note is a note-taking tool and template system for personal knowledge management.
MSI installer for x64 Windows, hosted at blog.getreu.net.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  - N/A

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` (requires Windows — validated structurally against 1.5.0 schema)
- [ ] Tested manifest locally with `winget install --manifest <path>` (requires Windows)
- [ ] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0) — manifest uses 1.5.0 schema, consistent with the previously accepted 1.25.20 submission
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/394298)