### PR TITLE
Add Wawtor.Aperio version 0.1.0

### DIFF
--- a/manifests/w/Wawtor/Aperio/0.1.0/Wawtor.Aperio.installer.yaml
+++ b/manifests/w/Wawtor/Aperio/0.1.0/Wawtor.Aperio.installer.yaml
@@ -1,0 +1,17 @@
+PackageIdentifier: Wawtor.Aperio
+PackageVersion: 0.1.0
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/wawtor/aperio/releases/download/v0.1.0/Aperio-v0.1.0-Setup.exe
+    InstallerSha256: a78b700c8f2611c68cf06af33f61a76ba400bed8a0d2bc6115ed8a09d371dc1e
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/w/Wawtor/Aperio/0.1.0/Wawtor.Aperio.locale.en-US.yaml
+++ b/manifests/w/Wawtor/Aperio/0.1.0/Wawtor.Aperio.locale.en-US.yaml
@@ -1,0 +1,23 @@
+PackageIdentifier: Wawtor.Aperio
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Wawtor
+PublisherUrl: https://github.com/wawtor
+PackageName: Aperio
+PackageUrl: https://github.com/wawtor/aperio
+License: Apache-2.0
+LicenseUrl: https://github.com/wawtor/aperio/blob/master/LICENSE
+ShortDescription: Free your AI gimbal webcam from its vendor software.
+Description: >-
+  Aperio is a lightweight background daemon that replaces the vendor companion
+  app for AI motorized-gimbal webcams. It automatically aims the camera at a
+  saved startup position and enables AI tracking whenever an application opens
+  the camera — no vendor software, no telemetry, no background bloat.
+Tags:
+  - webcam
+  - camera
+  - gimbal
+  - emeet
+  - ai-tracking
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/w/Wawtor/Aperio/0.1.0/Wawtor.Aperio.yaml
+++ b/manifests/w/Wawtor/Aperio/0.1.0/Wawtor.Aperio.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Wawtor.Aperio
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Wawtor.Aperio v0.1.0

Aperio is a lightweight background daemon that replaces vendor companion apps for AI motorized-gimbal webcams (EMEET Pixy and compatible). It automatically aims the camera at a saved startup position and enables AI tracking whenever an application opens the camera.

- **Publisher:** Wawtor
- **License:** Apache-2.0
- **Homepage:** https://github.com/wawtor/aperio
- **Installer type:** Inno Setup (x64)
- **Installer URL:** https://github.com/wawtor/aperio/releases/download/v0.1.0/Aperio-v0.1.0-Setup.exe
- **SHA256:** a78b700c8f2611c68cf06af33f61a76ba400bed8a0d2bc6115ed8a09d371dc1e
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/394399)