### PR TITLE
New package: Gnit.Bbl version 2.0

### DIFF
--- a/manifests/g/Gnit/Bbl/2.0/Gnit.Bbl.installer.yaml
+++ b/manifests/g/Gnit/Bbl/2.0/Gnit.Bbl.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Gnit.Bbl
+PackageVersion: 2.0
+Installers:
+  - Architecture: x64
+    InstallerType: portable
+    Commands:
+      - bbl
+    InstallerUrl: https://github.com/nehemiaharchives/bbl/releases/download/v2.0/bbl-windows-x64.exe
+    InstallerSha256: 920a7e98bad24e5d19986474bb01df0a52812fc2287328f39b6f0ca1f4b14a8d
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/g/Gnit/Bbl/2.0/Gnit.Bbl.locale.en-US.yaml
+++ b/manifests/g/Gnit/Bbl/2.0/Gnit.Bbl.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Gnit.Bbl
+PackageVersion: 2.0
+PackageLocale: en-US
+Publisher: Gnit
+PublisherUrl: https://github.com/nehemiaharchives
+PackageName: bbl
+PackageUrl: https://github.com/nehemiaharchives/bbl
+License: MIT
+ShortDescription: Read and search Holy Bible in your terminal.
+Description: bbl provides natural language style composable command to read and search bible e.g. "bbl john 3:16", "bbl search Jesus Christ in romans", "bbl install kjv"
+Moniker: bbl
+Tags:
+  - bible
+  - cli
+  - command-line
+  - search
+  - scripture
+ReleaseNotesUrl: https://github.com/nehemiaharchives/bbl/releases/tag/v2.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/g/Gnit/Bbl/2.0/Gnit.Bbl.yaml
+++ b/manifests/g/Gnit/Bbl/2.0/Gnit.Bbl.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Gnit.Bbl
+PackageVersion: 2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Summary
Submitting `Gnit.Bbl` v2.0 - A command line Bible

`bbl` is a command-line tool for reading and searching the Holy Bible from the terminal.

- Source: https://github.com/nehemiaharchives/bbl
- License: Apache 2.0
- Release: https://github.com/nehemiaharchives/bbl/releases/tag/v2.0


## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)
  - N/A

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest C:\Users\joel\code\winget-pkgs\manifests\g\Gnit\Bbl\2.0` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest C:\Users\joel\code\winget-pkgs\manifests\g\Gnit\Bbl\2.0`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/394507)