### PR TITLE
New version: NicholasBohanan.JMLConsole version 1.1.14

### DIFF
--- a/manifests/n/NicholasBohanan/JMLConsole/1.1.14/NicholasBohanan.JMLConsole.installer.yaml
+++ b/manifests/n/NicholasBohanan/JMLConsole/1.1.14/NicholasBohanan.JMLConsole.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: NicholasBohanan.JMLConsole
+PackageVersion: 1.1.14
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-06-25
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/TrickyDanceMoves/jml-agent-fleet/releases/download/v1.1.14/JML.Console.Setup.1.1.14.exe
+    InstallerSha256: 165469B0F27C92C5F15A47744A9EEF5156FA70B5F0AD76445B4EE49CC315A52F
+    AppsAndFeaturesEntries:
+      - DisplayName: JML Console
+        Publisher: Nicholas Bohanan
+        DisplayVersion: 1.1.14
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/n/NicholasBohanan/JMLConsole/1.1.14/NicholasBohanan.JMLConsole.locale.en-US.yaml
+++ b/manifests/n/NicholasBohanan/JMLConsole/1.1.14/NicholasBohanan.JMLConsole.locale.en-US.yaml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: NicholasBohanan.JMLConsole
+PackageVersion: 1.1.14
+PackageLocale: en-US
+Publisher: Nicholas Bohanan
+PublisherUrl: https://github.com/TrickyDanceMoves/jml-agent-fleet
+PublisherSupportUrl: https://github.com/TrickyDanceMoves/jml-agent-fleet/issues
+PackageName: JML Console
+PackageUrl: https://github.com/TrickyDanceMoves/jml-agent-fleet
+License: Proprietary
+LicenseUrl: https://github.com/TrickyDanceMoves/jml-agent-fleet/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Nicholas Bohanan - JML Agent Fleet. All rights reserved.
+ShortDescription: AI-powered identity lifecycle automation for Microsoft Entra ID.
+Description: >-
+  JML Console is the desktop command center for the JML Agent Fleet: eight agents,
+  two AI-backed (Approver, Auditor) and six PowerShell, that automate the full
+  Joiner/Mover/Leaver identity lifecycle on Microsoft Entra ID. Reasoning agents run
+  as first-class Entra Agent IDs and only propose changes; execution runs behind a
+  policy-gated control plane (dual approval, separation of duties, risk scoring) on
+  least-privilege service principals, with a tamper-evident hash-chained audit trail.
+  The AI layer is provider-agnostic (Azure AI Foundry, Azure OpenAI, OpenAI,
+  Anthropic, or local Ollama/LM Studio).
+Moniker: jml-console
+Tags:
+  - entra
+  - identity
+  - iga
+  - lifecycle
+  - automation
+  - microsoft-graph
+  - ai-agents
+  - governance
+ReleaseNotes: Presentation mode now prevents configured tenant identities from reaching AI prompts or rendered agent responses.
+ReleaseNotesUrl: https://github.com/TrickyDanceMoves/jml-agent-fleet/releases/tag/v1.1.14
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/n/NicholasBohanan/JMLConsole/1.1.14/NicholasBohanan.JMLConsole.yaml
+++ b/manifests/n/NicholasBohanan/JMLConsole/1.1.14/NicholasBohanan.JMLConsole.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: NicholasBohanan.JMLConsole
+PackageVersion: 1.1.14
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Pull request

New version of `NicholasBohanan.JMLConsole`: `1.1.14`.

- Installer: GitHub release NSIS executable
- Scope: per-user
- Architecture: x64
- SHA-256: `165469B0F27C92C5F15A47744A9EEF5156FA70B5F0AD76445B4EE49CC315A52F`
- Local validation: `winget validate --manifest packaging\winget\1.1.14` succeeded

This version prevents configured tenant identities from appearing in presentation-mode AI prompts or rendered agent responses.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/394508)