### PR TITLE
New package: SuperRadCompany.Microsandbox version 0.6.0

### DIFF
--- a/manifests/s/SuperRadCompany/Microsandbox/0.6.0/SuperRadCompany.Microsandbox.installer.yaml
+++ b/manifests/s/SuperRadCompany/Microsandbox/0.6.0/SuperRadCompany.Microsandbox.installer.yaml
@@ -14,8 +14,14 @@ Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/superradcompany/microsandbox/releases/download/v0.6.0/microsandbox-windows-x86_64.zip
   InstallerSha256: 33EE7A3D986E3008C04B06C1D3E2F00BC4218E2447053324AED449147D1DE653
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
 - Architecture: arm64
   InstallerUrl: https://github.com/superradcompany/microsandbox/releases/download/v0.6.0/microsandbox-windows-aarch64.zip
   InstallerSha256: AE72DAEAB204E8A3CD9DA11D94999B29734F0FB9BFB8507E137048ABA2995A7B
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.arm64
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/s/SuperRadCompany/Microsandbox/0.6.0/SuperRadCompany.Microsandbox.installer.yaml
+++ b/manifests/s/SuperRadCompany/Microsandbox/0.6.0/SuperRadCompany.Microsandbox.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: SuperRadCompany.Microsandbox
+PackageVersion: 0.6.0
+InstallerType: zip
+NestedInstallerType: portable
+Commands:
+- msb
+NestedInstallerFiles:
+- RelativeFilePath: msb.exe
+  PortableCommandAlias: msb
+ArchiveBinariesDependOnPath: true
+ReleaseDate: 2026-06-27
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/superradcompany/microsandbox/releases/download/v0.6.0/microsandbox-windows-x86_64.zip
+  InstallerSha256: 33EE7A3D986E3008C04B06C1D3E2F00BC4218E2447053324AED449147D1DE653
+- Architecture: arm64
+  InstallerUrl: https://github.com/superradcompany/microsandbox/releases/download/v0.6.0/microsandbox-windows-aarch64.zip
+  InstallerSha256: AE72DAEAB204E8A3CD9DA11D94999B29734F0FB9BFB8507E137048ABA2995A7B
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/SuperRadCompany/Microsandbox/0.6.0/SuperRadCompany.Microsandbox.locale.en-US.yaml
+++ b/manifests/s/SuperRadCompany/Microsandbox/0.6.0/SuperRadCompany.Microsandbox.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: SuperRadCompany.Microsandbox
+PackageVersion: 0.6.0
+PackageLocale: en-US
+Publisher: Super Rad Company
+PublisherUrl: https://superrad.company/
+PublisherSupportUrl: https://github.com/superradcompany/microsandbox/issues
+PackageName: Microsandbox
+PackageUrl: https://microsandbox.dev/
+License: Apache-2.0
+LicenseUrl: https://github.com/superradcompany/microsandbox/blob/main/LICENSE
+Copyright: Copyright 2026 Super Rad Company
+ShortDescription: Fast local microVM runtime for running untrusted workloads with hardware isolation.
+Description: Microsandbox runs untrusted workloads inside fast, local microVMs for AI agents, user code, plugins, CI jobs, development environments, scrapers, and automation.
+Moniker: microsandbox
+ReleaseNotesUrl: https://github.com/superradcompany/microsandbox/releases/tag/v0.6.0
+Documentations:
+- DocumentLabel: Documentation
+  DocumentUrl: https://docs.microsandbox.dev
+InstallationNotes: Microsandbox requires Windows Hypervisor Platform to run local microVMs.
+Tags:
+- ai
+- cli
+- containers
+- isolation
+- microvm
+- oci
+- sandbox
+- security
+- vm
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/SuperRadCompany/Microsandbox/0.6.0/SuperRadCompany.Microsandbox.yaml
+++ b/manifests/s/SuperRadCompany/Microsandbox/0.6.0/SuperRadCompany.Microsandbox.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: SuperRadCompany.Microsandbox
+PackageVersion: 0.6.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Adds **SuperRadCompany.Microsandbox** 0.6.0: a fast local microVM runtime for running untrusted workloads with hardware isolation.

Installer: zip + nested portable (`msb.exe`), with `ArchiveBinariesDependOnPath: true` so `msb.exe` loads its adjacent `libkrunfw.dll`.

- [x] `winget validate` passes
- [x] SHA256 verified against the v0.6.0 GitHub release assets (x64 + arm64)
- [x] `msb.exe --version` → `msb 0.6.0` (binary + adjacent DLL load confirmed)

First submission of this package.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/394540)