### PR TITLE
New package: MeVault.MeVaultCLI version 0.1.1

### DIFF
--- a/manifests/m/MeVault/MeVaultCLI/0.1.1/MeVault.MeVaultCLI.installer.yaml
+++ b/manifests/m/MeVault/MeVaultCLI/0.1.1/MeVault.MeVaultCLI.installer.yaml
@@ -6,7 +6,7 @@ MinimumOSVersion: 10.0.17763.0
 InstallerType: portable
 Installers:
   - Architecture: x64
-    InstallerUrl: https://github.com/thecalebyte/mevault/releases/download/v0.1.1/mevault-windows-x64.exe
+    InstallerUrl: https://github.com/thecalebyte/mevault-cli/releases/download/v0.1.1/mevault-windows-x64.exe
     InstallerSha256: e924cc6281fcf8205fb1ca13fb0e6a1d2ab1cfd0b6a758c1647ec41b5bbb4e1c
     InstallerLocale: en-US
 ManifestType: installer

--- a/manifests/m/MeVault/MeVaultCLI/0.1.1/MeVault.MeVaultCLI.installer.yaml
+++ b/manifests/m/MeVault/MeVaultCLI/0.1.1/MeVault.MeVaultCLI.installer.yaml
@@ -1,0 +1,13 @@
+PackageIdentifier: MeVault.MeVaultCLI
+PackageVersion: 0.1.1
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: portable
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/thecalebyte/mevault/releases/download/v0.1.1/mevault-windows-x64.exe
+    InstallerSha256: e924cc6281fcf8205fb1ca13fb0e6a1d2ab1cfd0b6a758c1647ec41b5bbb4e1c
+    InstallerLocale: en-US
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/MeVault/MeVaultCLI/0.1.1/MeVault.MeVaultCLI.locale.en-US.yaml
+++ b/manifests/m/MeVault/MeVaultCLI/0.1.1/MeVault.MeVaultCLI.locale.en-US.yaml
@@ -1,14 +1,14 @@
 PackageIdentifier: MeVault.MeVaultCLI
 PackageVersion: 0.1.1
 PackageLocale: en-US
-Publisher: MeVault
+Publisher: Norvande Ltd
 PublisherUrl: https://github.com/thecalebyte/mevault-cli
 PublisherSupportUrl: https://github.com/thecalebyte/mevault-cli/issues
 PackageName: MeVault CLI
 PackageUrl: https://github.com/thecalebyte/mevault-cli
-License: MIT
+License: Apache-2.0
 LicenseUrl: https://github.com/thecalebyte/mevault-cli/blob/main/LICENSE
-Copyright: Copyright (c) 2026 MeVault
+Copyright: Copyright (c) 2026 Norvande Ltd
 ShortDescription: Local-first secret manager that blocks AI agents from reading developer credentials
 Description: MeVault CLI encrypts secrets with AES-256-GCM and serves them to authorized processes via a local named pipe. AI coding agents (Claude, Copilot, Cursor) are hardcoded as denied.
 Moniker: mevault

--- a/manifests/m/MeVault/MeVaultCLI/0.1.1/MeVault.MeVaultCLI.locale.en-US.yaml
+++ b/manifests/m/MeVault/MeVaultCLI/0.1.1/MeVault.MeVaultCLI.locale.en-US.yaml
@@ -1,0 +1,22 @@
+PackageIdentifier: MeVault.MeVaultCLI
+PackageVersion: 0.1.1
+PackageLocale: en-US
+Publisher: MeVault
+PublisherUrl: https://github.com/thecalebyte/mevault-cli
+PublisherSupportUrl: https://github.com/thecalebyte/mevault-cli/issues
+PackageName: MeVault CLI
+PackageUrl: https://github.com/thecalebyte/mevault-cli
+License: MIT
+LicenseUrl: https://github.com/thecalebyte/mevault-cli/blob/main/LICENSE
+Copyright: Copyright (c) 2026 MeVault
+ShortDescription: Local-first secret manager that blocks AI agents from reading developer credentials
+Description: MeVault CLI encrypts secrets with AES-256-GCM and serves them to authorized processes via a local named pipe. AI coding agents (Claude, Copilot, Cursor) are hardcoded as denied.
+Moniker: mevault
+Tags:
+  - secrets
+  - security
+  - developer-tools
+  - credentials
+  - ai-safety
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/MeVault/MeVaultCLI/0.1.1/MeVault.MeVaultCLI.yaml
+++ b/manifests/m/MeVault/MeVaultCLI/0.1.1/MeVault.MeVaultCLI.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: MeVault.MeVaultCLI
+PackageVersion: 0.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## New package submission

**Package:** MeVault.MeVaultCLI
**Version:** 0.1.1
**Type:** portable (single exe, x64)

### Description
MeVault CLI is a local-first secret manager for developers. It encrypts credentials with AES-256-GCM and serves them to authorized processes via a Windows named pipe. AI coding agents (Claude, Copilot, Cursor, Windsurf) are hardcoded as denied.

### Links
- Publisher URL: https://github.com/thecalebyte/mevault-cli
- Release: https://github.com/thecalebyte/mevault/releases/tag/v0.1.1

### Validation
- Installer SHA256 verified against release artifact
- ManifestVersion 1.6.0
- InstallerType: portable
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/394581)