### PR TITLE
New package: Takeshi.Sumifold version 0.9.0

### DIFF
--- a/manifests/t/Takeshi/Sumifold/0.9.0/Takeshi.Sumifold.installer.yaml
+++ b/manifests/t/Takeshi/Sumifold/0.9.0/Takeshi.Sumifold.installer.yaml
@@ -1,0 +1,23 @@
+# Release Phase 1b — winget installer manifest (Sumifold 0.9.0)
+# 提出先: winget-pkgs の manifests/t/Takeshi/Sumifold/0.9.0/
+# InstallerSha256 は公開済 Sumifold_0.9.0_x64-setup.exe (13,589,977 bytes) の SHA256。
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: Takeshi.Sumifold
+PackageVersion: 0.9.0
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft # NSIS は winget enum では "nullsoft"（"nsis" は無効値）
+Scope: user # currentUser インストール（D6: 管理者不要）
+InstallModes:
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-06-28
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/TakeshiArai-18/Sumifold/releases/download/v0.9.0/Sumifold_0.9.0_x64-setup.exe
+    InstallerSha256: 85A8A55EE8636C7702552EF1292FFE91050605C2D5520999CC77836D7ED1D6F4
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/t/Takeshi/Sumifold/0.9.0/Takeshi.Sumifold.locale.en-US.yaml
+++ b/manifests/t/Takeshi/Sumifold/0.9.0/Takeshi.Sumifold.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# Release Phase 1b — winget default locale manifest: en-US (Sumifold 0.9.0)
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: Takeshi.Sumifold
+PackageVersion: 0.9.0
+PackageLocale: en-US
+Publisher: Takeshi Arai
+PublisherUrl: https://github.com/TakeshiArai-18
+PublisherSupportUrl: https://github.com/TakeshiArai-18/Sumifold/issues
+PackageName: Sumifold
+PackageUrl: https://github.com/TakeshiArai-18/Sumifold
+License: Proprietary
+LicenseUrl: https://github.com/TakeshiArai-18/Sumifold/blob/main/EULA.md
+Copyright: Copyright (c) 2026 Takeshi Arai. All Rights Reserved.
+ShortDescription: A Markdown editor for Windows with rich preview, full-text search, autosave, and crash recovery.
+Description: |-
+  Sumifold is a Markdown editor for Windows featuring rich preview (Mermaid, KaTeX,
+  Shiki syntax highlighting, Graphviz), workspace-wide full-text search, atomic
+  autosave with crash recovery, and a plugin system. This is an unsigned public beta (0.9.0).
+Moniker: sumifold
+Tags:
+  - markdown
+  - editor
+  - mermaid
+  - katex
+  - notes
+ReleaseNotesUrl: https://github.com/TakeshiArai-18/Sumifold/releases/tag/v0.9.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/t/Takeshi/Sumifold/0.9.0/Takeshi.Sumifold.locale.ja-JP.yaml
+++ b/manifests/t/Takeshi/Sumifold/0.9.0/Takeshi.Sumifold.locale.ja-JP.yaml
@@ -1,0 +1,22 @@
+# Release Phase 1b — winget locale manifest: ja-JP (Sumifold 0.9.0)
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
+
+PackageIdentifier: Takeshi.Sumifold
+PackageVersion: 0.9.0
+PackageLocale: ja-JP
+Publisher: Takeshi Arai
+PublisherUrl: https://github.com/TakeshiArai-18
+PublisherSupportUrl: https://github.com/TakeshiArai-18/Sumifold/issues
+PackageName: Sumifold
+PackageUrl: https://github.com/TakeshiArai-18/Sumifold
+License: Proprietary
+LicenseUrl: https://github.com/TakeshiArai-18/Sumifold/blob/main/EULA.md
+Copyright: Copyright (c) 2026 Takeshi Arai. All Rights Reserved.
+ShortDescription: リッチプレビュー・全文検索・自動保存・クラッシュリカバリを備えた Windows 向け Markdown エディタ。
+Description: |-
+  Sumifold は Windows 向けの Markdown エディタです。Mermaid / KaTeX / Shiki / Graphviz による
+  リッチプレビュー、ワークスペース全文検索、原子的な自動保存とクラッシュリカバリ、プラグイン機構を
+  備えます。本リリースは未署名の公開ベータ版（0.9.0）です。
+ReleaseNotesUrl: https://github.com/TakeshiArai-18/Sumifold/releases/tag/v0.9.0
+ManifestType: locale
+ManifestVersion: 1.6.0

--- a/manifests/t/Takeshi/Sumifold/0.9.0/Takeshi.Sumifold.yaml
+++ b/manifests/t/Takeshi/Sumifold/0.9.0/Takeshi.Sumifold.yaml
@@ -1,0 +1,9 @@
+# Release Phase 1b — winget version manifest (Sumifold 0.9.0)
+# 提出先: winget-pkgs の manifests/t/Takeshi/Sumifold/0.9.0/
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: Takeshi.Sumifold
+PackageVersion: 0.9.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
#### New package: `Takeshi.Sumifold` version `0.9.0`

First submission of **Sumifold** — a Windows Markdown editor (CodeMirror 6 editor with rich preview: Mermaid / KaTeX / Shiki / Graphviz, workspace-wide search, atomic autosave & crash recovery, plugin system).

- Publisher: Takeshi Arai
- Installer: NSIS (`nullsoft`), user scope, x64
- Release: https://github.com/TakeshiArai-18/Sumifold/releases/tag/v0.9.0
- Manifest schema `1.6.0` — 4 files (version / installer / locale en-US / locale ja-JP)

#### Validation

- [x] Validated locally with `winget validate --manifest` → **Manifest validation succeeded.**
- `InstallerSha256` is the SHA256 of the published `Sumifold_0.9.0_x64-setup.exe` (13,589,977 bytes).

#### Notes

- This is an **unsigned** public beta (`0.9.0`). The installer is distributed via GitHub Releases and is not code-signed yet (code signing is planned for a later release).
- License: proprietary EULA (linked from the locale manifest).

#### Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/microsoft/winget-pkgs/blob/master/CONTRIBUTING.md).
- [x] This pull request adds a single new package version.
- [x] Manifests validate with the current schema (`1.6.0`).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/394602)