### PR TITLE
New package: AlexGladkov.Harnest version 0.11.0

### DIFF
--- a/manifests/a/AlexGladkov/Harnest/0.11.0/AlexGladkov.Harnest.installer.yaml
+++ b/manifests/a/AlexGladkov/Harnest/0.11.0/AlexGladkov.Harnest.installer.yaml
@@ -7,11 +7,11 @@ Commands:
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/AlexGladkov/harnest/releases/download/v0.11.0/harnest-windows-amd64.exe
-    InstallerSha256: 8CB0062965B092CB808FF9B5B2D292F410DF19BE1EDD9BB245C82D0970894B7E
+    InstallerSha256: 6F364CF48ACCA8296D8185F244A974AB7F291A9D022CDEBA0823B09899C46D4E
     PortableCommandAlias: harnest
   - Architecture: arm64
     InstallerUrl: https://github.com/AlexGladkov/harnest/releases/download/v0.11.0/harnest-windows-arm64.exe
-    InstallerSha256: 648C1ED6915A0032733FBCC7BC91A9EF5CAFEAB6E3FE7264E58BC1C4A3F00E4C
+    InstallerSha256: E6A81E89A54F45389C1C2EB1136C4855EE6EF0350DE85FE9CD1AEC6ED63F97C0
     PortableCommandAlias: harnest
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/a/AlexGladkov/Harnest/0.11.0/AlexGladkov.Harnest.installer.yaml
+++ b/manifests/a/AlexGladkov/Harnest/0.11.0/AlexGladkov.Harnest.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: AlexGladkov.Harnest
+PackageVersion: 0.11.0
+InstallerType: portable
+Commands:
+  - harnest
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/AlexGladkov/harnest/releases/download/v0.11.0/harnest-windows-amd64.exe
+    InstallerSha256: 8CB0062965B092CB808FF9B5B2D292F410DF19BE1EDD9BB245C82D0970894B7E
+    PortableCommandAlias: harnest
+  - Architecture: arm64
+    InstallerUrl: https://github.com/AlexGladkov/harnest/releases/download/v0.11.0/harnest-windows-arm64.exe
+    InstallerSha256: 648C1ED6915A0032733FBCC7BC91A9EF5CAFEAB6E3FE7264E58BC1C4A3F00E4C
+    PortableCommandAlias: harnest
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/a/AlexGladkov/Harnest/0.11.0/AlexGladkov.Harnest.locale.en-US.yaml
+++ b/manifests/a/AlexGladkov/Harnest/0.11.0/AlexGladkov.Harnest.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: AlexGladkov.Harnest
+PackageVersion: 0.11.0
+PackageLocale: en-US
+Publisher: Alex Gladkov
+PublisherUrl: https://github.com/AlexGladkov
+PublisherSupportUrl: https://github.com/AlexGladkov/harnest/issues
+PackageName: Harnest
+PackageUrl: https://github.com/AlexGladkov/harnest
+License: CC-BY-NC-4.0
+LicenseUrl: https://github.com/AlexGladkov/harnest/blob/main/LICENSE
+ShortDescription: AI coding assistant configurator — generate configs for Claude Code, Cursor, Windsurf, Codex, OpenCode, and Qwen Code.
+Tags:
+  - ai
+  - cli
+  - coding-assistant
+  - claude-code
+  - cursor
+  - windsurf
+  - codex
+  - opencode
+  - qwen-code
+  - developer-tools
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/a/AlexGladkov/Harnest/0.11.0/AlexGladkov.Harnest.yaml
+++ b/manifests/a/AlexGladkov/Harnest/0.11.0/AlexGladkov.Harnest.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: AlexGladkov.Harnest
+PackageVersion: 0.11.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: `AlexGladkov.Harnest` version `0.11.0`

Harnest — an AI coding assistant configurator that generates configs for Claude Code, Cursor, Windsurf, Codex, OpenCode, and Qwen Code.

- Repo: https://github.com/AlexGladkov/harnest
- Installer type: **portable** (standalone CLI `.exe`, `PortableCommandAlias: harnest`)
- Architectures: x64, arm64
- Installer URLs point to the official GitHub Release assets (`v0.11.0`); SHA256 in the manifest matches those assets.

#### Checklist
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>` *(validated for schema 1.6.0 structure; sha256 verified against published release assets)*
- [ ] Have you tested your manifest locally with `winget install --manifest <path>` *(no Windows host available; relying on pipeline sandbox validation)*
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/blob/master/doc/manifest/schema/1.6.0)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/394674)