### PR TITLE
New version: Nexaflow.SignalFoundry 0.3.28

### DIFF
--- a/manifests/n/Nexaflow/SignalFoundry/0.3.28/Nexaflow.SignalFoundry.installer.yaml
+++ b/manifests/n/Nexaflow/SignalFoundry/0.3.28/Nexaflow.SignalFoundry.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Nexaflow.SignalFoundry
+PackageVersion: 0.3.28
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+ArchiveBinariesDependOnPath: true
+NestedInstallerFiles:
+- RelativeFilePath: signal-foundry-cli-0.3.28\bin\sf.exe
+  PortableCommandAlias: sf
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/nexaflow-io/signal-foundry-cli-releases/releases/download/cli-v0.3.28/signal-foundry-cli-0.3.28-windows-x64.zip
+  InstallerSha256: d1620c2b9ffd862538f2693363d69b4d2c19bb696b444ede8e9153b3b27f1d8f
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/n/Nexaflow/SignalFoundry/0.3.28/Nexaflow.SignalFoundry.locale.en-US.yaml
+++ b/manifests/n/Nexaflow/SignalFoundry/0.3.28/Nexaflow.SignalFoundry.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Nexaflow.SignalFoundry
+PackageVersion: 0.3.28
+PackageLocale: en-US
+Publisher: Nexaflow
+PublisherUrl: https://nexaflow.io
+PackageName: Signal Foundry CLI
+PackageUrl: https://signal-foundry.app
+License: Proprietary
+LicenseUrl: https://signal-foundry.app/terms-of-service
+ShortDescription: Agent-first CLI for the Signal Foundry data workspace.
+Moniker: sf
+Tags:
+- cli
+- data-workspace
+- agent
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/n/Nexaflow/SignalFoundry/0.3.28/Nexaflow.SignalFoundry.yaml
+++ b/manifests/n/Nexaflow/SignalFoundry/0.3.28/Nexaflow.SignalFoundry.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Nexaflow.SignalFoundry
+PackageVersion: 0.3.28
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
- Release: https://github.com/nexaflow-io/signal-foundry-cli-releases/releases/tag/cli-v0.3.28
- Installer: signal-foundry-cli-0.3.28-windows-x64.zip
- Verified checksum against public release artifact and generated manifest.
- Verified archive contains bin/sf.exe, bin/node.exe, and bundled eval corpuses.

This supersedes the previous 0.3.27 submission because 0.3.28 includes a user-facing OAuth recovery hint fix.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/394677)