### PR TITLE
New version: Nexaflow.SignalFoundry 0.3.29

### DIFF
--- a/manifests/n/Nexaflow/SignalFoundry/0.3.29/Nexaflow.SignalFoundry.installer.yaml
+++ b/manifests/n/Nexaflow/SignalFoundry/0.3.29/Nexaflow.SignalFoundry.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Nexaflow.SignalFoundry
+PackageVersion: 0.3.29
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+ArchiveBinariesDependOnPath: true
+NestedInstallerFiles:
+- RelativeFilePath: signal-foundry-cli-0.3.29\bin\sf.exe
+  PortableCommandAlias: sf
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/nexaflow-io/signal-foundry-cli-releases/releases/download/cli-v0.3.29/signal-foundry-cli-0.3.29-windows-x64.zip
+  InstallerSha256: f5acc16a48412a1810bfdd91b36b83855f2be834fa2d4d77806261b12a90421a
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/n/Nexaflow/SignalFoundry/0.3.29/Nexaflow.SignalFoundry.locale.en-US.yaml
+++ b/manifests/n/Nexaflow/SignalFoundry/0.3.29/Nexaflow.SignalFoundry.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Nexaflow.SignalFoundry
+PackageVersion: 0.3.29
+PackageLocale: en-US
+Publisher: Nexaflow
+PublisherUrl: https://nexaflow.io
+PackageName: Signal Foundry CLI
+PackageUrl: https://signal-foundry.app
+License: Proprietary
+LicenseUrl: https://signal-foundry.app/terms-of-service
+ShortDescription: Agent-first CLI for the Signal Foundry data workspace.
+Moniker: sf
+Tags:
+- cli
+- data-workspace
+- agent
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/n/Nexaflow/SignalFoundry/0.3.29/Nexaflow.SignalFoundry.yaml
+++ b/manifests/n/Nexaflow/SignalFoundry/0.3.29/Nexaflow.SignalFoundry.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Nexaflow.SignalFoundry
+PackageVersion: 0.3.29
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
- Release: https://github.com/nexaflow-io/signal-foundry-cli-releases/releases/tag/cli-v0.3.29
- Installer: signal-foundry-cli-0.3.29-windows-x64.zip
- Verified checksum against public release artifact and generated manifest.
- Verified archive contains bin/sf.exe, bin/node.exe, and bundled eval corpuses.

This supersedes the previous 0.3.28 submission because 0.3.29 includes an agent-facing JSON help fix.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/394687)