### PR TITLE
Add OddBrowser v1.1.0

### DIFF
--- a/manifests/i/OddBrowser/OddBrowser/1.1.0/OddBrowser.yaml
+++ b/manifests/i/OddBrowser/OddBrowser/1.1.0/OddBrowser.yaml
@@ -1,0 +1,22 @@
+# Created using wingetcreate
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: OddBrowser.OddBrowser
+PackageVersion: 1.1.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: portable
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/838288383838383/oddbrowser-releases/releases/download/v1.1.0/OddBrowser.exe
+  InstallerSha256: E2FB275B039C8209E51216EC09EBEB488F2FB21FA72B88E67E18B99958DF176D
+  ProductCode: OddBrowser.OddBrowser
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/l/OddBrowser/OddBrowser/1.1.0/OddBrowser.yaml
+++ b/manifests/l/OddBrowser/OddBrowser/1.1.0/OddBrowser.yaml
@@ -1,0 +1,27 @@
+# Created using wingetcreate
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: OddBrowser.OddBrowser
+PackageVersion: 1.1.0
+PackageLocale: en-US
+Publisher: OddBrowser
+PublisherUrl: https://github.com/838288383838383/oddbrowser-releases
+PackageName: OddBrowser
+PackageUrl: https://github.com/838288383838383/oddbrowser-releases
+License: MIT
+ShortDescription: Independent browser with AI, bookmarks, password manager, cloud sync, Zen mode, TUI, and custom themes. No Chromium. No Firefox.
+Description: >
+  OddBrowser is an independent Win32 C++20 browser built from scratch with DirectWrite and Direct2D.
+  Features include AI chat integration, a bookmarks system, a password manager with AES-256-GCM
+  encryption, cloud sync via GitHub Gists, a Zen mode for distraction-free browsing, a TUI browser,
+  and full Catppuccin Mocha theming.
+Tags:
+- browser
+- ai
+- bookmarks
+- password-manager
+- sync
+- tui
+- theming
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/o/OddBrowser/OddBrowser/1.1.0/OddBrowser.yaml
+++ b/manifests/o/OddBrowser/OddBrowser/1.1.0/OddBrowser.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: OddBrowser.OddBrowser
+PackageVersion: 1.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Adds OddBrowser v1.1.0 to winget.

## New features in v1.1.0
- Bookmarks system with HTML import/export
- Password manager with AES-256-GCM encryption
- Cloud sync via GitHub Gists
- Installer thread safety fixes
- Updater version comparison & asset download fixes

## Manifest details
- Package: OddBrowser.OddBrowser
- Version: 1.1.0
- Architecture: x64
- Installer type: portable
- License: MIT
- Source: https://github.com/838288383838383/oddbrowser-releases
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/394757)