### PR TITLE
New package: Kindel.mcec version 2.4.1

### DIFF
--- a/manifests/k/Kindel/mcec/2.4.1/Kindel.mcec.installer.yaml
+++ b/manifests/k/Kindel/mcec/2.4.1/Kindel.mcec.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: Kindel.mcec
+PackageVersion: "2.4.1"
+# MCE Controller ships an NSIS installer (per-machine; requires elevation). winget's
+# "nullsoft" type knows the silent switch is /S.
+InstallerType: nullsoft
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+UpgradeBehavior: install
+ReleaseDate: 2026-06-29
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/tig/mcec/releases/download/v2.4.1/MCEController.Setup.exe
+    InstallerSha256: 393B4066AFF168482038A7C61916B5D526617CFCED73F5D832315B3100338652
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/k/Kindel/mcec/2.4.1/Kindel.mcec.locale.en-US.yaml
+++ b/manifests/k/Kindel/mcec/2.4.1/Kindel.mcec.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: Kindel.mcec
+PackageVersion: "2.4.1"
+PackageLocale: en-US
+Publisher: Kindel Systems
+PublisherUrl: https://github.com/tig
+PublisherSupportUrl: https://github.com/tig/mcec/issues
+Author: Kindel Systems
+PackageName: MCE Controller
+PackageUrl: https://github.com/tig/mcec
+License: MIT
+Copyright: Copyright © Kindel Systems, LLC.
+ShortDescription: Control a Windows PC over the network or serial port.
+Description: |-
+  MCE Controller lets you control a Windows PC — Windows Media Center and beyond — over
+  the network (TCP/IP) or a serial port. It runs as a server that receives text commands
+  and turns them into keystrokes, mouse actions, launched programs, window activations,
+  and power/shutdown actions, with a configurable command set.
+Moniker: mcec
+Tags:
+  - media-center
+  - remote-control
+  - automation
+  - home-theater
+  - htpc
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/k/Kindel/mcec/2.4.1/Kindel.mcec.yaml
+++ b/manifests/k/Kindel/mcec/2.4.1/Kindel.mcec.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: Kindel.mcec
+PackageVersion: "2.4.1"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
### New package: **Kindel.mcec** version **2.4.1**

MCE Controller — control a Windows PC over the network (TCP/IP) or serial port. First submission of this package.

- **Installer:** NSIS (`nullsoft`), per-machine, x64. Silent via `/S`.
- **Authenticode signed** (Azure Trusted Signing): Signer `CN="Kindel, LLC"`, issuer `Microsoft ID Verified CS EOC CA 03`, RFC3161 timestamped — `Get-AuthenticodeSignature` → Valid.
- **InstallerUrl:** https://github.com/tig/mcec/releases/download/v2.4.1/MCEController.Setup.exe
- **InstallerSha256:** `393B4066AFF168482038A7C61916B5D526617CFCED73F5D832315B3100338652`

(Replaces #394798, which was auto-closed after an in-place package rename left files under two package folders. This PR is a clean branch touching only `manifests/k/Kindel/mcec/2.4.1/`.)

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open pull requests for the same manifest?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? (succeeded, no warnings)
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Project: https://github.com/tig/mcec
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/394805)