### PR TITLE
New version: Nexaflow.SignalFoundry 0.3.31

### DIFF
--- a/manifests/n/Nexaflow/SignalFoundry/0.3.31/Nexaflow.SignalFoundry.installer.yaml
+++ b/manifests/n/Nexaflow/SignalFoundry/0.3.31/Nexaflow.SignalFoundry.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Nexaflow.SignalFoundry
+PackageVersion: 0.3.31
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+ArchiveBinariesDependOnPath: true
+NestedInstallerFiles:
+- RelativeFilePath: signal-foundry-cli-0.3.31\bin\sf.exe
+  PortableCommandAlias: sf
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/nexaflow-io/signal-foundry-cli-releases/releases/download/cli-v0.3.31/signal-foundry-cli-0.3.31-windows-x64.zip
+  InstallerSha256: 2fc2293d42ecfa54c7f09f1bdb02fe0c3567e25b5f0b92df2bb017781696a0eb
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/n/Nexaflow/SignalFoundry/0.3.31/Nexaflow.SignalFoundry.locale.en-US.yaml
+++ b/manifests/n/Nexaflow/SignalFoundry/0.3.31/Nexaflow.SignalFoundry.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Nexaflow.SignalFoundry
+PackageVersion: 0.3.31
+PackageLocale: en-US
+Publisher: Nexaflow
+PublisherUrl: https://nexaflow.io
+PackageName: Signal Foundry CLI
+PackageUrl: https://signal-foundry.app
+License: Proprietary
+LicenseUrl: https://signal-foundry.app/terms-of-service
+ShortDescription: Agent-first CLI for the Signal Foundry data workspace.
+Moniker: sf
+Tags:
+- cli
+- data-workspace
+- agent
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/n/Nexaflow/SignalFoundry/0.3.31/Nexaflow.SignalFoundry.yaml
+++ b/manifests/n/Nexaflow/SignalFoundry/0.3.31/Nexaflow.SignalFoundry.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Nexaflow.SignalFoundry
+PackageVersion: 0.3.31
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Pull request has been created with [WinGet Automation](https://github.com/microsoft/winget-create)

- PackageIdentifier: `Nexaflow.SignalFoundry`
- PackageVersion: `0.3.31`
- InstallerSha256: `2fc2293d42ecfa54c7f09f1bdb02fe0c3567e25b5f0b92df2bb017781696a0eb`

This supersedes the still-open 0.3.30 submission.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/394841)