### PR TITLE
Add Volcengine storage CLIs 1.0.0

### DIFF
--- a/manifests/v/Volcengine/TosCli/1.0.0/Volcengine.TosCli.installer.yaml
+++ b/manifests/v/Volcengine/TosCli/1.0.0/Volcengine.TosCli.installer.yaml
@@ -1,0 +1,13 @@
+PackageIdentifier: Volcengine.TosCli
+PackageVersion: 1.0.0
+InstallerType: zip
+NestedInstallerType: portable
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/volcengine/ve-storage-uni-cli/releases/download/v1.0.0/ve-storage-uni-cli-x86_64-pc-windows-msvc.zip
+  InstallerSha256: 14768d45f1a3071efc5824a4da881a9121a8383b9592d4489f24f978f7595b79
+  NestedInstallerFiles:
+  - RelativeFilePath: bin/tos-cli.exe
+    PortableCommandAlias: tos-cli
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/v/Volcengine/TosCli/1.0.0/Volcengine.TosCli.locale.en-US.yaml
+++ b/manifests/v/Volcengine/TosCli/1.0.0/Volcengine.TosCli.locale.en-US.yaml
@@ -1,0 +1,10 @@
+PackageIdentifier: Volcengine.TosCli
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: Volcengine
+PackageName: ByteCloud TOS CLI
+License: Apache-2.0
+ShortDescription: Dedicated ByteCloud TOS command-line interface
+Moniker: tos-cli
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/v/Volcengine/TosCli/1.0.0/Volcengine.TosCli.yaml
+++ b/manifests/v/Volcengine/TosCli/1.0.0/Volcengine.TosCli.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Volcengine.TosCli
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/manifests/v/Volcengine/VeAdriveCli/1.0.0/Volcengine.VeAdriveCli.installer.yaml
+++ b/manifests/v/Volcengine/VeAdriveCli/1.0.0/Volcengine.VeAdriveCli.installer.yaml
@@ -1,0 +1,13 @@
+PackageIdentifier: Volcengine.VeAdriveCli
+PackageVersion: 1.0.0
+InstallerType: zip
+NestedInstallerType: portable
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/volcengine/ve-storage-uni-cli/releases/download/v1.0.0/ve-storage-uni-cli-x86_64-pc-windows-msvc.zip
+  InstallerSha256: 14768d45f1a3071efc5824a4da881a9121a8383b9592d4489f24f978f7595b79
+  NestedInstallerFiles:
+  - RelativeFilePath: bin/ve-adrive-cli.exe
+    PortableCommandAlias: ve-adrive-cli
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/v/Volcengine/VeAdriveCli/1.0.0/Volcengine.VeAdriveCli.locale.en-US.yaml
+++ b/manifests/v/Volcengine/VeAdriveCli/1.0.0/Volcengine.VeAdriveCli.locale.en-US.yaml
@@ -1,0 +1,10 @@
+PackageIdentifier: Volcengine.VeAdriveCli
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: Volcengine
+PackageName: Volcengine ADrive CLI
+License: Apache-2.0
+ShortDescription: Dedicated ADrive command-line interface for Volcengine storage services
+Moniker: ve-adrive-cli
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/v/Volcengine/VeAdriveCli/1.0.0/Volcengine.VeAdriveCli.yaml
+++ b/manifests/v/Volcengine/VeAdriveCli/1.0.0/Volcengine.VeAdriveCli.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Volcengine.VeAdriveCli
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/manifests/v/Volcengine/VeTosCli/1.0.0/Volcengine.VeTosCli.installer.yaml
+++ b/manifests/v/Volcengine/VeTosCli/1.0.0/Volcengine.VeTosCli.installer.yaml
@@ -1,0 +1,13 @@
+PackageIdentifier: Volcengine.VeTosCli
+PackageVersion: 1.0.0
+InstallerType: zip
+NestedInstallerType: portable
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/volcengine/ve-storage-uni-cli/releases/download/v1.0.0/ve-storage-uni-cli-x86_64-pc-windows-msvc.zip
+  InstallerSha256: 14768d45f1a3071efc5824a4da881a9121a8383b9592d4489f24f978f7595b79
+  NestedInstallerFiles:
+  - RelativeFilePath: bin/ve-tos-cli.exe
+    PortableCommandAlias: ve-tos-cli
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/v/Volcengine/VeTosCli/1.0.0/Volcengine.VeTosCli.locale.en-US.yaml
+++ b/manifests/v/Volcengine/VeTosCli/1.0.0/Volcengine.VeTosCli.locale.en-US.yaml
@@ -1,0 +1,10 @@
+PackageIdentifier: Volcengine.VeTosCli
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: Volcengine
+PackageName: Volcengine TOS CLI
+License: Apache-2.0
+ShortDescription: Dedicated TOS command-line interface for Volcengine storage services
+Moniker: ve-tos-cli
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/v/Volcengine/VeTosCli/1.0.0/Volcengine.VeTosCli.yaml
+++ b/manifests/v/Volcengine/VeTosCli/1.0.0/Volcengine.VeTosCli.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Volcengine.VeTosCli
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Adds ve-tos-cli, tos-cli, and ve-adrive-cli 1.0.0.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/394883)