### PR TITLE
New version: Nexaflow.SignalFoundry 0.3.32

### DIFF
--- a/manifests/n/Nexaflow/SignalFoundry/0.3.32/Nexaflow.SignalFoundry.installer.yaml
+++ b/manifests/n/Nexaflow/SignalFoundry/0.3.32/Nexaflow.SignalFoundry.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Nexaflow.SignalFoundry
+PackageVersion: 0.3.32
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+ArchiveBinariesDependOnPath: true
+NestedInstallerFiles:
+- RelativeFilePath: signal-foundry-cli-0.3.32\bin\sf.exe
+  PortableCommandAlias: sf
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/nexaflow-io/signal-foundry-cli-releases/releases/download/cli-v0.3.32/signal-foundry-cli-0.3.32-windows-x64.zip
+  InstallerSha256: e074c01479c77252ef93ca6413a90242f9b969afd53a298fa3adebb1965ad951
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/n/Nexaflow/SignalFoundry/0.3.32/Nexaflow.SignalFoundry.locale.en-US.yaml
+++ b/manifests/n/Nexaflow/SignalFoundry/0.3.32/Nexaflow.SignalFoundry.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Nexaflow.SignalFoundry
+PackageVersion: 0.3.32
+PackageLocale: en-US
+Publisher: Nexaflow
+PublisherUrl: https://nexaflow.io
+PackageName: Signal Foundry CLI
+PackageUrl: https://signal-foundry.app
+License: Proprietary
+LicenseUrl: https://signal-foundry.app/terms-of-service
+ShortDescription: Agent-first CLI for the Signal Foundry data workspace.
+Moniker: sf
+Tags:
+- cli
+- data-workspace
+- agent
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/n/Nexaflow/SignalFoundry/0.3.32/Nexaflow.SignalFoundry.yaml
+++ b/manifests/n/Nexaflow/SignalFoundry/0.3.32/Nexaflow.SignalFoundry.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Nexaflow.SignalFoundry
+PackageVersion: 0.3.32
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Change
- Add Nexaflow.SignalFoundry 0.3.32.
- Installer points to the public GitHub Release artifact for cli-v0.3.32.

## Validation
- Generated from Signal Foundry CLI release workflow 28357589550.
- Manifest YAML parsed locally.
- Installer SHA256 matches the published signal-foundry-cli-0.3.32-windows-x64.zip release asset.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/394901)