### PR TITLE
New package: EvilHumphrey.LegendCTL version 2.1.0

### DIFF
--- a/manifests/e/EvilHumphrey/LegendCTL/2.1.0/EvilHumphrey.LegendCTL.installer.yaml
+++ b/manifests/e/EvilHumphrey/LegendCTL/2.1.0/EvilHumphrey.LegendCTL.installer.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: EvilHumphrey.LegendCTL
+PackageVersion: 2.1.0
+InstallerLocale: en-US
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: inno
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART
+UpgradeBehavior: install
+ReleaseDate: 2026-06-29
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/EvilHumphrey/LegendCTL/releases/download/v2.1.0/ZDUltimateLegend-v2.1.0-Setup.exe
+    InstallerSha256: 198C8FE85A06955973B80A474661D4D661A3F39239F7FCB71C52C98812847669
+    AppsAndFeaturesEntries:
+      - DisplayName: ZD Ultimate Legend Wrapper
+        Publisher: EvilHumphrey
+        DisplayVersion: 2.1.0
+        ProductCode: '{ZDUltimateLegend}_is1'
+        InstallerType: inno
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/e/EvilHumphrey/LegendCTL/2.1.0/EvilHumphrey.LegendCTL.locale.en-US.yaml
+++ b/manifests/e/EvilHumphrey/LegendCTL/2.1.0/EvilHumphrey.LegendCTL.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: EvilHumphrey.LegendCTL
+PackageVersion: 2.1.0
+PackageLocale: en-US
+Publisher: EvilHumphrey
+PublisherUrl: https://github.com/EvilHumphrey
+PublisherSupportUrl: https://github.com/EvilHumphrey/LegendCTL/issues
+PackageName: LegendCTL
+PackageUrl: https://github.com/EvilHumphrey/LegendCTL
+License: MIT
+LicenseUrl: https://github.com/EvilHumphrey/LegendCTL/blob/main/LICENSE
+Copyright: Copyright (c) 2026 EvilHumphrey
+ShortDescription: Standalone, unofficial Windows configurator for ZD Ultimate Legend controllers. Reads and applies controller settings locally; no official app required.
+Description: >-
+  LegendCTL is a lightweight, local Windows application for reading and applying
+  supported settings on ZD Ultimate Legend controllers directly over USB/HID. It
+  is an independent, standalone tool that does not require the official ZD Gaming
+  app, and it makes no network calls, installs no drivers, and runs no background
+  service. Configure USB polling rate, the button-binding matrix, stick deadzones
+  and sensitivity curves, axis inversion, triggers, per-zone lighting, vibration,
+  and back-paddle bindings, then save them as reusable profiles that persist
+  across sessions. Restore Points and the vendor "Restore to default" path give
+  you a clear way back if a controller ever feels off.
+Moniker: legendctl
+Tags:
+  - configurator
+  - controller
+  - gamepad
+  - xinput
+  - zd
+ReleaseNotesUrl: https://github.com/EvilHumphrey/LegendCTL/releases/tag/v2.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/e/EvilHumphrey/LegendCTL/2.1.0/EvilHumphrey.LegendCTL.yaml
+++ b/manifests/e/EvilHumphrey/LegendCTL/2.1.0/EvilHumphrey.LegendCTL.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: EvilHumphrey.LegendCTL
+PackageVersion: 2.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
#### New package: `EvilHumphrey.LegendCTL` version `2.1.0`

LegendCTL is a free, open-source (MIT) **standalone** Windows configurator for ZD Ultimate Legend controllers. It reads and applies supported controller settings locally over USB/HID — no official vendor app required, no drivers, no background service, and no network calls.

- **Repository:** https://github.com/EvilHumphrey/LegendCTL
- **Release:** https://github.com/EvilHumphrey/LegendCTL/releases/tag/v2.1.0
- **Installer:** Inno Setup `ZDUltimateLegend-v2.1.0-Setup.exe`
- **InstallerSha256:** `198C8FE85A06955973B80A474661D4D661A3F39239F7FCB71C52C98812847669` (matches the `SHA256SUMS.txt` published with the release)

#### Checklist
- [x] This is a new package; I confirmed there are no other open PRs for it.
- [x] Manifests validated locally with `winget validate` (succeeded; schema 1.6.0).
- [x] `InstallerSha256` verified against the published release `SHA256SUMS.txt`.
- [x] `InstallerUrl` points at the immutable GitHub release asset.
- [ ] Local `winget install --manifest` test deferred to the automated validation pipeline.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/394957)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/394957)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/394957)