### PR TITLE
New package: tieo.ruscal version 1.2.1

### DIFF
--- a/manifests/t/tieo/ruscal/1.2.1/tieo.ruscal.installer.yaml
+++ b/manifests/t/tieo/ruscal/1.2.1/tieo.ruscal.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: tieo.ruscal
+PackageVersion: 1.2.1
+InstallerType: inno
+Scope: user
+InstallModes:
+  - silent
+  - silentWithProgress
+ReleaseDate: 2026-06-29
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/tieo/ruscal/releases/download/v1.2.1/ruscal-setup.exe
+    InstallerSha256: A6987BC04E4684497EA3AC6EDC266019FBEDF44E17DCC0492380F8EC3C7FBAEE
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/t/tieo/ruscal/1.2.1/tieo.ruscal.locale.en-US.yaml
+++ b/manifests/t/tieo/ruscal/1.2.1/tieo.ruscal.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: tieo.ruscal
+PackageVersion: 1.2.1
+PackageLocale: en-US
+Publisher: tieo
+PublisherUrl: https://github.com/tieo
+PublisherSupportUrl: https://github.com/tieo/ruscal/issues
+Author: tieo
+PackageName: ruscal
+PackageUrl: https://github.com/tieo/ruscal
+License: MIT
+LicenseUrl: https://github.com/tieo/ruscal/blob/master/LICENSE
+Copyright: Copyright (c) 2026 tieo
+CopyrightUrl: https://github.com/tieo/ruscal/blob/master/LICENSE
+ShortDescription: Stops you from forgetting outlook calendar events by clearly showing them in your calendar.
+Description: |-
+  ruscal syncs your local Outlook calendar (read via MAPI) to a Google
+  Calendar of your choice. Events appear in the Google calendar with the
+  organiser surfaced in the description, recurring series expanded, and
+  cancelled occurrences mirrored — so you stop missing meetings on
+  whatever device your Google calendar is on.
+Tags:
+  - calendar
+  - google-calendar
+  - mapi
+  - outlook
+  - sync
+ReleaseNotesUrl: https://github.com/tieo/ruscal/releases/tag/v1.2.1
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/t/tieo/ruscal/1.2.1/tieo.ruscal.yaml
+++ b/manifests/t/tieo/ruscal/1.2.1/tieo.ruscal.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: tieo.ruscal
+PackageVersion: 1.2.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary

Submitting `tieo.ruscal` v1.2.1 — Inno Setup installer, user scope.

- Source: https://github.com/tieo/ruscal
- License: MIT
- Release: https://github.com/tieo/ruscal/releases/tag/v1.2.1
- InstallerSha256 verified against the GitHub release asset.

### Why v1.2.1 instead of v1.2.0

The initial submission (v1.2.0, this PR's first commit) used
`InstallerType: portable` and hung the validation pipeline at
"Installation Validation: Started" — ruscal is a GUI tray app, no
`--version` flag, so the harness's auto-invoke of the registered
command never exited.

v1.2.1 replaces the portable shape with a proper Inno installer:
- User-scope (`PrivilegesRequired=lowest`, no admin prompt)
- Installs to `%LOCALAPPDATA%\Programs\ruscal\`
- Standard Start-menu shortcut + Apps & Features entry
- Inno's silent-install switches (`/SILENT`, `/VERYSILENT`) match the
  `InstallModes` declared in the manifest, so winget's silent default
  works as expected.

## Test plan

- [x] Manifests follow `manifests/t/tieo/ruscal/1.2.1/` layout
- [x] `InstallerType: inno`, `Scope: user`, `InstallModes: [silent, silentWithProgress]`
- [x] SHA256 matches the v1.2.1 release asset
- [ ] Awaiting CI validation
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/394962)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/394962)