### PR TITLE
New version: NakabaLab.sshm version 1.2.0

### DIFF
--- a/manifests/n/NakabaLab/sshm/1.2.0/NakabaLab.sshm.installer.yaml
+++ b/manifests/n/NakabaLab/sshm/1.2.0/NakabaLab.sshm.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: NakabaLab.sshm
+PackageVersion: 1.2.0
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: sshm.exe
+    PortableCommandAlias: sshm
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/nakaba-lab/ssh-manager-tui/releases/download/v1.2.0/sshm-1.2.0-x86_64-pc-windows-msvc.zip
+    InstallerSha256: 1EDCEE3097547C281CC09B4E007EB4BFE77E292DB74ADC41D63A01AEA7F5E341
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/n/NakabaLab/sshm/1.2.0/NakabaLab.sshm.locale.en-US.yaml
+++ b/manifests/n/NakabaLab/sshm/1.2.0/NakabaLab.sshm.locale.en-US.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: NakabaLab.sshm
+PackageVersion: 1.2.0
+PackageLocale: en-US
+Publisher: nakaba-lab
+PublisherUrl: https://github.com/nakaba-lab/ssh-manager-tui
+Author: nakaba-lab
+PackageName: sshm
+PackageUrl: https://github.com/nakaba-lab/ssh-manager-tui
+License: MIT OR Apache-2.0
+ShortDescription: A TUI SSH host manager for ~/.ssh/config
+Moniker: sshm
+Tags:
+  - ssh
+  - tui
+  - ssh-config
+  - terminal
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/n/NakabaLab/sshm/1.2.0/NakabaLab.sshm.yaml
+++ b/manifests/n/NakabaLab/sshm/1.2.0/NakabaLab.sshm.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: NakabaLab.sshm
+PackageVersion: 1.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Automated version update for NakabaLab.sshm 1.2.0. Manifests validated with `winget validate`. Installer is the GitHub release zip (portable sshm.exe), SHA256 verified against the published `.sha256` sidecar.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/395100)