### PR TITLE
New package: Ruffle.Ruffle version: 0.3.0

### DIFF
--- a/manifests/r/Ruffle/Ruffle/0.3.0.999999/Ruffle.Ruffle.installer.yaml
+++ b/manifests/r/Ruffle/Ruffle/0.3.0.999999/Ruffle.Ruffle.installer.yaml
@@ -1,0 +1,49 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Ruffle.Ruffle
+PackageVersion: 0.3.0.999999
+InstallerLocale: en-US
+InstallerType: zip
+Installers:
+- Architecture: x86
+  NestedInstallerType: wix
+  NestedInstallerFiles:
+  - RelativeFilePath: setup.msi
+  InstallerUrl: https://github.com/ruffle-rs/ruffle/releases/download/v0.3.0/ruffle-0.3.0-windows-x86_32.zip
+  InstallerSha256: DC1DB8348D8DC1698AFB22C88E60D3641FD6A12168A27AA5080E202830A12AB8
+  ProductCode: '{33ACCA2D-4F7F-4C4C-BFAB-FD88146BB5A0}'
+  AppsAndFeaturesEntries:
+  - DisplayName: Ruffle
+    Publisher: Ruffle LLC
+    DisplayVersion: 0.3.0.999999
+    ProductCode: '{33ACCA2D-4F7F-4C4C-BFAB-FD88146BB5A0}'
+    UpgradeCode: '{C6A4BA50-FA08-4B87-9B55-D81A1C730D25}'
+- Architecture: x86
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: ruffle.exe
+  InstallerUrl: https://github.com/ruffle-rs/ruffle/releases/download/v0.3.0/ruffle-0.3.0-windows-x86_32.zip
+  InstallerSha256: DC1DB8348D8DC1698AFB22C88E60D3641FD6A12168A27AA5080E202830A12AB8
+- Architecture: x64
+  NestedInstallerType: wix
+  NestedInstallerFiles:
+  - RelativeFilePath: setup.msi
+  InstallerUrl: https://github.com/ruffle-rs/ruffle/releases/download/v0.3.0/ruffle-0.3.0-windows-x86_64.zip
+  InstallerSha256: 4D3EF46F63BECA337F5608E0B79F2959AD748208CC702E7A7FD2CCC88E06BE59
+  ProductCode: '{DE84F3E4-8E73-450C-AD96-D17C80D3D7C2}'
+  AppsAndFeaturesEntries:
+  - DisplayName: Ruffle
+    Publisher: Ruffle LLC
+    DisplayVersion: 0.3.0.999999
+    ProductCode: '{DE84F3E4-8E73-450C-AD96-D17C80D3D7C2}'
+    UpgradeCode: '{C6A4BA50-FA08-4B87-9B55-D81A1C730D25}'
+- Architecture: x64
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: ruffle.exe
+  InstallerUrl: https://github.com/ruffle-rs/ruffle/releases/download/v0.3.0/ruffle-0.3.0-windows-x86_64.zip
+  InstallerSha256: 4D3EF46F63BECA337F5608E0B79F2959AD748208CC702E7A7FD2CCC88E06BE59
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-06-14

--- a/manifests/r/Ruffle/Ruffle/0.3.0.999999/Ruffle.Ruffle.locale.en-US.yaml
+++ b/manifests/r/Ruffle/Ruffle/0.3.0.999999/Ruffle.Ruffle.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Ruffle.Ruffle
+PackageVersion: 0.3.0.999999
+PackageLocale: en-US
+Publisher: Ruffle
+PublisherUrl: https://github.com/ruffle-rs
+PublisherSupportUrl: https://github.com/ruffle-rs/ruffle/issues
+PackageName: Ruffle
+PackageUrl: https://github.com/ruffle-rs/ruffle
+License: Apache-2.0 + MIT
+LicenseUrl: https://github.com/ruffle-rs/ruffle/blob/HEAD/LICENSE.md
+ShortDescription: A Flash Player emulator written in Rust
+Tags:
+- emulator
+- flash
+- hacktoberfest
+- reimplementation
+- rust
+- swf
+ReleaseNotesUrl: https://github.com/ruffle-rs/ruffle/releases/tag/v0.3.0
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/ruffle-rs/ruffle/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/Ruffle/Ruffle/0.3.0.999999/Ruffle.Ruffle.yaml
+++ b/manifests/r/Ruffle/Ruffle/0.3.0.999999/Ruffle.Ruffle.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Ruffle.Ruffle
+PackageVersion: 0.3.0.999999
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description
This PR adds a release branch of Ruffle.Ruffle. Currently we have only a nightly one.
Yes 6 9s are indeed in the application version in the registry.

## ✅ Checklist
- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/395141)