### PR TITLE
New package: agent-rt.arc-runner version 0.1.0

### DIFF
--- a/manifests/a/agent-rt/arc-runner/0.1.0/agent-rt.arc-runner.installer.yaml
+++ b/manifests/a/agent-rt/arc-runner/0.1.0/agent-rt.arc-runner.installer.yaml
@@ -1,0 +1,11 @@
+PackageIdentifier: agent-rt.arc-runner
+PackageVersion: 0.1.0
+InstallerType: portable
+Commands:
+  - arc-runner
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/agent-rt/arc/releases/download/v0.1.0/arc-runner.exe
+    InstallerSha256: A7264062AF0A440D55F9BADB019383A366DCDE8CF1A0383907437CA1AC75D964
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/a/agent-rt/arc-runner/0.1.0/agent-rt.arc-runner.locale.en-US.yaml
+++ b/manifests/a/agent-rt/arc-runner/0.1.0/agent-rt.arc-runner.locale.en-US.yaml
@@ -1,0 +1,12 @@
+PackageIdentifier: agent-rt.arc-runner
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: agent-rt
+PublisherUrl: https://github.com/agent-rt
+PackageName: arc runner
+PackageUrl: https://github.com/agent-rt/arc
+License: MIT OR Apache-2.0
+ShortDescription: Windows runner for arc - drive this machine from an AI agent over an encrypted link.
+Moniker: arc-runner
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/a/agent-rt/arc-runner/0.1.0/agent-rt.arc-runner.yaml
+++ b/manifests/a/agent-rt/arc-runner/0.1.0/agent-rt.arc-runner.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: agent-rt.arc-runner
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Adds **agent-rt.arc-runner** 0.1.0 — the Windows runner for [arc](https://github.com/agent-rt/arc), remote control of a machine by an AI agent over an encrypted link. Portable CLI (`arc-runner`). Installer: a standalone x64 `arc-runner.exe` from the project's GitHub release.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/395316)