### PR TITLE
New package: saiviroop.ClipLogger version 1.1.0

### DIFF
--- a/manifests/s/saiviroop/ClipLogger/1.1.0/saiviroop.ClipLogger.installer.yaml
+++ b/manifests/s/saiviroop/ClipLogger/1.1.0/saiviroop.ClipLogger.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: saiviroop.ClipLogger
+PackageVersion: 1.1.0
+InstallerType: inno
+Scope: user
+MinimumOSVersion: 10.0.0.0
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/saiviroop/ClipLogger/releases/download/v1.1.0/ClipLogger-Setup.exe
+    InstallerSha256: 00AB00A64F637DF5CACD7BDC2AF3C6BBD180B5A09903C7F1A3832AC9715F67A1
+    AppsAndFeaturesEntries:
+      - DisplayName: Clip Logger
+        DisplayVersion: 1.1.0
+        Publisher: saiviroop
+        ProductCode: Clip Logger_is1
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/saiviroop/ClipLogger/1.1.0/saiviroop.ClipLogger.locale.en-US.yaml
+++ b/manifests/s/saiviroop/ClipLogger/1.1.0/saiviroop.ClipLogger.locale.en-US.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: saiviroop.ClipLogger
+PackageVersion: 1.1.0
+PackageLocale: en-US
+Publisher: saiviroop
+PublisherUrl: https://github.com/saiviroop
+PublisherSupportUrl: https://github.com/saiviroop/ClipLogger/issues
+PackageName: ClipLogger
+PackageUrl: https://saiviroop.github.io/ClipLogger/
+License: MIT
+LicenseUrl: https://github.com/saiviroop/ClipLogger/blob/master/LICENSE
+Copyright: Copyright (c) 2026 saiviroop
+ShortDescription: Capture selected text to a timestamped log file with one hotkey (Ctrl+Alt+C).
+Description: |-
+  ClipLogger is a free, lightweight Windows tray app for collecting debug context.
+  Select any text - an error, a log line, a stack trace, or a snippet - and press
+  Ctrl+Alt+C to append it to a dated, timestamped .txt log file with the source app
+  it came from. Normal copy and paste are never modified, and it is not a keylogger:
+  it only captures the text you have selected, and only when you press its hotkey.
+  Includes a live, auto-refreshing viewer with search, source tracking, a configurable
+  check-in interval, and optional auto-start on login. Ships as a self-contained
+  installer (no separate .NET install required).
+Moniker: cliplogger
+Tags:
+  - clipboard
+  - logger
+  - log
+  - text-capture
+  - snippets
+  - debugging
+  - developer-tools
+  - productivity
+  - tray
+  - hotkey
+ReleaseNotes: |-
+  1.1.0
+  - Fixed a bug where the periodic check-in prompt could stack endlessly.
+  - Added an embedded application icon for the exe and shortcuts.
+ReleaseNotesUrl: https://github.com/saiviroop/ClipLogger/releases/tag/v1.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/saiviroop/ClipLogger/1.1.0/saiviroop.ClipLogger.yaml
+++ b/manifests/s/saiviroop/ClipLogger/1.1.0/saiviroop.ClipLogger.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: saiviroop.ClipLogger
+PackageVersion: 1.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: saiviroop.ClipLogger version 1.1.0

ClipLogger is a free, open-source (MIT) Windows tray app that captures the
selected text into a timestamped log file with a hotkey (Ctrl+Alt+C).

- Website: https://saiviroop.github.io/ClipLogger/
- Source: https://github.com/saiviroop/ClipLogger

#### Validation
- Manifest validated locally with `winget validate` (passes).
- Installer SHA256 verified against the published GitHub release asset.
- Installer type: Inno Setup, per-user scope, x64; supports silent install.
- Submitted by the package owner/publisher (saiviroop).

#### Checklist
- [x] I have read the Contribution Guidelines and Spec.
- [x] This is a new package.
- [x] Manifest validated locally (`winget validate`).
- [x] Installer URL is a stable, public release asset.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/395382)