### PR TITLE
New package: Sidhaarthaa.ZenWin version 0.1.1

### DIFF
--- a/manifests/s/Sidhaarthaa/ZenWin/0.1.1/Sidhaarthaa.ZenWin.installer.yaml
+++ b/manifests/s/Sidhaarthaa/ZenWin/0.1.1/Sidhaarthaa.ZenWin.installer.yaml
@@ -1,0 +1,18 @@
+# Created for the Windows Package Manager Community Repository
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: Sidhaarthaa.ZenWin
+PackageVersion: 0.1.1
+InstallerType: inno
+Scope: user
+UpgradeBehavior: install
+ReleaseDate: 2026-06-30
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/sidhaarthaa/zen-win/releases/download/v0.1.1/ZenWin-x64-setup.exe
+  InstallerSha256: 353E6DEC399753A00B764DC8DAFF1AA589A9D716BB9AF6BB42220B27804EC1E2
+- Architecture: arm64
+  InstallerUrl: https://github.com/sidhaarthaa/zen-win/releases/download/v0.1.1/ZenWin-arm64-setup.exe
+  InstallerSha256: 093DE9290519DDC9812CED38EC1AD5B853D5B46DF6FB34E00F5494130A95AD8B
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/s/Sidhaarthaa/ZenWin/0.1.1/Sidhaarthaa.ZenWin.locale.en-US.yaml
+++ b/manifests/s/Sidhaarthaa/ZenWin/0.1.1/Sidhaarthaa.ZenWin.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# Created for the Windows Package Manager Community Repository
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: Sidhaarthaa.ZenWin
+PackageVersion: 0.1.1
+PackageLocale: en-US
+Publisher: ZenWin
+PublisherUrl: https://github.com/sidhaarthaa
+PublisherSupportUrl: https://github.com/sidhaarthaa/zen-win/issues
+Author: sidhaarthaa
+PackageName: ZenWin
+PackageUrl: https://github.com/sidhaarthaa/zen-win
+License: MIT
+LicenseUrl: https://github.com/sidhaarthaa/zen-win/blob/master/LICENSE
+Copyright: Copyright (c) 2026 ZenWin contributors
+ShortDescription: Universal Zen Mode for Windows applications
+Description: ZenWin applies a distraction-reducing Zen Mode to the currently focused Windows desktop application.
+Tags:
+- focus
+- productivity
+- windows
+- zen
+ReleaseNotesUrl: https://github.com/sidhaarthaa/zen-win/releases/tag/v0.1.1
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/s/Sidhaarthaa/ZenWin/0.1.1/Sidhaarthaa.ZenWin.yaml
+++ b/manifests/s/Sidhaarthaa/ZenWin/0.1.1/Sidhaarthaa.ZenWin.yaml
@@ -1,0 +1,8 @@
+# Created for the Windows Package Manager Community Repository
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: Sidhaarthaa.ZenWin
+PackageVersion: 0.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
### Package submission

Adds `Sidhaarthaa.ZenWin` version `0.1.1` for x64 and ARM64 Windows.

- Uses publisher-hosted Inno Setup executables from the immutable GitHub release.
- Supports silent per-user installation and uninstall.
- Both SHA-256 hashes match the published assets.
- Manifests pass `winget validate` with Windows Package Manager v1.28.240.
- The x64 installer passed silent install, runtime responsiveness, and silent uninstall testing.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/395440)