### PR TITLE
New package: shahriyardx.brightctrl version 0.2.3

### DIFF
--- a/manifests/s/shahriyardx/brightctrl/0.2.3/shahriyardx.brightctrl.installer.yaml
+++ b/manifests/s/shahriyardx/brightctrl/0.2.3/shahriyardx.brightctrl.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: shahriyardx.brightctrl
+PackageVersion: 0.2.3
+InstallerType: portable
+Commands:
+  - brightctrl
+ReleaseDate: 2026-06-30
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/shahriyardx/brightctrl/releases/download/v0.2.3/brightctrl.exe
+    InstallerSha256: A80ADDD8AEC584EF8012344DFFE56EC0D10271D0829D39299F57C04D15C69261
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/shahriyardx/brightctrl/0.2.3/shahriyardx.brightctrl.locale.en-US.yaml
+++ b/manifests/s/shahriyardx/brightctrl/0.2.3/shahriyardx.brightctrl.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: shahriyardx.brightctrl
+PackageVersion: 0.2.3
+PackageLocale: en-US
+Publisher: shahriyardx
+PublisherUrl: https://github.com/shahriyardx
+PackageName: brightctrl
+PackageUrl: https://github.com/shahriyardx/brightctrl
+License: MIT
+LicenseUrl: https://github.com/shahriyardx/brightctrl/blob/main/LICENSE
+ShortDescription: Lightweight DDC/CI external monitor brightness controller (TUI + CLI).
+Description: |-
+  brightctrl adjusts the brightness of external monitors over DDC/CI from the
+  terminal — both an interactive TUI and a scriptable CLI. A single native
+  binary with no runtime dependencies. On Windows it uses the Monitor
+  Configuration API.
+Moniker: brightctrl
+Tags:
+  - brightness
+  - ddc
+  - ddc-ci
+  - monitor
+  - cli
+  - tui
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/shahriyardx/brightctrl/0.2.3/shahriyardx.brightctrl.yaml
+++ b/manifests/s/shahriyardx/brightctrl/0.2.3/shahriyardx.brightctrl.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: shahriyardx.brightctrl
+PackageVersion: 0.2.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Package
- **Identifier:** shahriyardx.brightctrl
- **Version:** 0.2.3
- **Type:** portable (single native .exe)

Lightweight DDC/CI external monitor brightness controller (TUI + CLI). On Windows it uses the Monitor Configuration API. Source: https://github.com/shahriyardx/brightctrl

- [x] Have you signed the Contributor License Agreement?
- [x] Have you checked that there aren't other open PRs for the same manifest update/change?
- [x] Manifests validated locally
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/395475)