### PR TITLE
New package: OpenTypeless.OpenTypeless version 1.1.46

### DIFF
--- a/manifests/o/OpenTypeless/OpenTypeless/1.1.46/OpenTypeless.OpenTypeless.installer.yaml
+++ b/manifests/o/OpenTypeless/OpenTypeless/1.1.46/OpenTypeless.OpenTypeless.installer.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: OpenTypeless.OpenTypeless
+PackageVersion: 1.1.46
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+InstallerType: wix
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Protocols:
+- opentypeless
+ReleaseDate: 2026-06-29
+AppsAndFeaturesEntries:
+- DisplayName: OpenTypeless
+  DisplayVersion: 1.1.46
+  Publisher: opentypeless
+  ProductCode: '{941C0116-CE8D-4B18-AE9A-FFD838A39A93}'
+  UpgradeCode: '{9393620B-8F77-5175-AA68-4DB413BE2C82}'
+ElevationRequirement: elevatesSelf
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/tover0314-w/opentypeless/releases/download/v1.1.46/OpenTypeless_1.1.46_x64_en-US.msi
+  InstallerSha256: C7DA735D9613460AC41EFC42745BD5FE9A38D7C8DFC6845D97C57EA0F5DE4A9D
+  ProductCode: '{941C0116-CE8D-4B18-AE9A-FFD838A39A93}'
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenTypeless/OpenTypeless/1.1.46/OpenTypeless.OpenTypeless.locale.en-US.yaml
+++ b/manifests/o/OpenTypeless/OpenTypeless/1.1.46/OpenTypeless.OpenTypeless.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: OpenTypeless.OpenTypeless
+PackageVersion: 1.1.46
+PackageLocale: en-US
+Publisher: opentypeless
+PublisherUrl: https://www.opentypeless.com/
+PublisherSupportUrl: https://github.com/tover0314-w/opentypeless/issues
+Author: OpenTypeless Contributors
+PackageName: OpenTypeless
+PackageUrl: https://www.opentypeless.com/
+License: MIT
+LicenseUrl: https://github.com/tover0314-w/opentypeless/blob/main/LICENSE
+Copyright: Copyright (c) OpenTypeless Contributors
+ShortDescription: AI voice input, rewriting, and voice Q&A for desktop.
+Description: OpenTypeless lets you press a hotkey, speak naturally, and insert polished text into any app. It supports dictation, selected-text rewriting, translation, and one-shot voice Q&A across macOS, Windows, and Linux.
+Moniker: opentypeless
+Tags:
+- ai
+- byok
+- dictation
+- llm
+- productivity
+- speech-to-text
+- tauri
+- voice-input
+- whisper
+ReleaseNotesUrl: https://github.com/tover0314-w/opentypeless/releases/tag/v1.1.46
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenTypeless/OpenTypeless/1.1.46/OpenTypeless.OpenTypeless.yaml
+++ b/manifests/o/OpenTypeless/OpenTypeless/1.1.46/OpenTypeless.OpenTypeless.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: OpenTypeless.OpenTypeless
+PackageVersion: 1.1.46
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds OpenTypeless version 1.1.46.

OpenTypeless is an AI voice input, rewriting, and voice Q&A desktop app.

Local verification performed on macOS:

- Confirmed no existing `OpenTypeless.OpenTypeless` manifest or open PR.
- Downloaded the MSI from the official GitHub release URL.
- Verified MSI SHA256: `C7DA735D9613460AC41EFC42745BD5FE9A38D7C8DFC6845D97C57EA0F5DE4A9D`.
- Parsed MSI metadata:
  - ProductCode: `{941C0116-CE8D-4B18-AE9A-FFD838A39A93}`
  - UpgradeCode: `{9393620B-8F77-5175-AA68-4DB413BE2C82}`
  - ProductName: `OpenTypeless`
  - ProductVersion: `1.1.46`
  - Manufacturer: `opentypeless`
  - ALLUSERS: `1`
- Verified all YAML files parse successfully.
- Verified `PackageIdentifier`, `PackageVersion`, `ManifestType`, `ManifestVersion`, SHA256, and ProductCode consistency.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)
  - Not applicable.

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.

`winget validate` and `winget install --manifest` were not run locally because this submission was prepared on macOS without the Windows Package Manager client.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/395476)