### PR TITLE
openwhispr: Add version 1.7.3

### DIFF
--- a/manifests/o/OpenWhispr/OpenWhispr/1.7.3/OpenWhispr.OpenWhispr.installer.yaml
+++ b/manifests/o/OpenWhispr/OpenWhispr/1.7.3/OpenWhispr.OpenWhispr.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: OpenWhispr.OpenWhispr
+PackageVersion: 1.7.3
+InstallerType: nullsoft
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  Scope: user
+  InstallerUrl: https://github.com/OpenWhispr/openwhispr/releases/download/v1.7.3/OpenWhispr-Setup-1.7.3.exe
+  InstallerSha256: 256a49099fc6f8ed2b81c7898f8dac704ee7190ccca76cc351508cafcd0a3f55
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenWhispr/OpenWhispr/1.7.3/OpenWhispr.OpenWhispr.installer.yaml
+++ b/manifests/o/OpenWhispr/OpenWhispr/1.7.3/OpenWhispr.OpenWhispr.installer.yaml
@@ -3,11 +3,22 @@
 PackageIdentifier: OpenWhispr.OpenWhispr
 PackageVersion: 1.7.3
 InstallerType: nullsoft
+InstallerSwitches:
+  Upgrade: --updated
 UpgradeBehavior: install
 Installers:
 - Architecture: x64
   Scope: user
   InstallerUrl: https://github.com/OpenWhispr/openwhispr/releases/download/v1.7.3/OpenWhispr-Setup-1.7.3.exe
   InstallerSha256: 256a49099fc6f8ed2b81c7898f8dac704ee7190ccca76cc351508cafcd0a3f55
+  InstallerSwitches:
+    Custom: /currentuser
+- Architecture: x64
+  Scope: machine
+  InstallerUrl: https://github.com/OpenWhispr/openwhispr/releases/download/v1.7.3/OpenWhispr-Setup-1.7.3.exe
+  InstallerSha256: 256a49099fc6f8ed2b81c7898f8dac704ee7190ccca76cc351508cafcd0a3f55
+  InstallerSwitches:
+    Custom: /allusers
+  ElevationRequirement: elevatesSelf
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/o/OpenWhispr/OpenWhispr/1.7.3/OpenWhispr.OpenWhispr.locale.en-US.yaml
+++ b/manifests/o/OpenWhispr/OpenWhispr/1.7.3/OpenWhispr.OpenWhispr.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: OpenWhispr.OpenWhispr
+PackageVersion: 1.7.3
+PackageLocale: en-US
+Publisher: OpenWhispr
+PublisherUrl: https://openwhispr.com
+PublisherSupportUrl: https://github.com/OpenWhispr/openwhispr/issues
+Author: OpenWhispr
+PackageName: OpenWhispr
+PackageUrl: https://github.com/OpenWhispr/openwhispr
+License: MIT
+LicenseUrl: https://github.com/OpenWhispr/openwhispr/blob/v1.7.3/LICENSE
+Copyright: Copyright (c) 2025 OpenWhispr
+ShortDescription: Voice-to-text dictation app with local and cloud models. Privacy-first, open-source alternative to WisprFlow.
+Moniker: openwhispr
+Tags:
+- dictation
+- hotkey
+- privacy
+- speech-recognition
+- speech-to-text
+- transcription
+- tray
+- voice
+- whisper

--- a/manifests/o/OpenWhispr/OpenWhispr/1.7.3/OpenWhispr.OpenWhispr.locale.en-US.yaml
+++ b/manifests/o/OpenWhispr/OpenWhispr/1.7.3/OpenWhispr.OpenWhispr.locale.en-US.yaml
@@ -24,3 +24,6 @@ Tags:
 - tray
 - voice
 - whisper
+
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenWhispr/OpenWhispr/1.7.3/OpenWhispr.OpenWhispr.yaml
+++ b/manifests/o/OpenWhispr/OpenWhispr/1.7.3/OpenWhispr.OpenWhispr.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: OpenWhispr.OpenWhispr
+PackageVersion: 1.7.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Add [OpenWhispr](https://openwhispr.com) v1.7.3 — voice-to-text dictation app with local/cloud models. Privacy-first, open-source alternative to WisprFlow/ Granola.

- **Homepage:** https://openwhispr.com
- **License:** MIT
- **Installer type:** nullsoft (electron-builder NSIS)
- **Architecture:** x64 only

I have read the Contributing Guide and First-Time Contributor Checklist. This is a routine manifest submission (one package version, one PR). No separate issue required.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/395496)