### PR TITLE
New version: Overwatchobs.OverwatchHelper version 0.8.9

### DIFF
--- a/manifests/o/Overwatchobs/OverwatchHelper/0.8.9/Overwatchobs.OverwatchHelper.installer.yaml
+++ b/manifests/o/Overwatchobs/OverwatchHelper/0.8.9/Overwatchobs.OverwatchHelper.installer.yaml
@@ -1,0 +1,20 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Overwatchobs.OverwatchHelper
+PackageVersion: 0.8.9
+InstallerType: wix
+Scope: user
+InstallModes:
+  - silent
+  - silentWithProgress
+  - interactive
+InstallerSwitches:
+  Silent: "/qn"
+  SilentWithProgress: "/qb"
+Installers:
+- Architecture: x64
+  InstallerUrl: https://packages.buildkite.com/overwatchobs/overwatch-files/files/overwatch-helper-windows-x86_64-0.8.9.msi
+  InstallerSha256: DB17E00DEE7245A4F1AF7993DF797796C98B125FA444AEB94D22B4E59D2DEE79
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/o/Overwatchobs/OverwatchHelper/0.8.9/Overwatchobs.OverwatchHelper.locale.en-US.yaml
+++ b/manifests/o/Overwatchobs/OverwatchHelper/0.8.9/Overwatchobs.OverwatchHelper.locale.en-US.yaml
@@ -1,0 +1,14 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Overwatchobs.OverwatchHelper
+PackageVersion: 0.8.9
+PackageLocale: en-US
+Publisher: Overwatch Observability
+PublisherUrl: https://www.overwatch-observability.com
+PackageName: Overwatch Helper
+PackageUrl: https://www.overwatch-observability.com
+License: MIT License
+ShortDescription: Local desktop agent for the Overwatch incident-resolution Chrome extension. Registers as a Chrome Native Messaging host and executes allowlisted diagnostic commands on request.
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/o/Overwatchobs/OverwatchHelper/0.8.9/Overwatchobs.OverwatchHelper.yaml
+++ b/manifests/o/Overwatchobs/OverwatchHelper/0.8.9/Overwatchobs.OverwatchHelper.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Overwatchobs.OverwatchHelper
+PackageVersion: 0.8.9
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Manifest
Overwatchobs.OverwatchHelper 0.8.9 (per-user MSI, x64).

This is a fresh submission replacing #394499, which became wedged after many validation cycles (auto-revalidation stopped firing on that PR). 0.8.9 is the version that fixes the install-validation failure: the MSI now registers the Chrome Native Messaging host **declaratively** (a static manifest JSON plus an HKCU registry pointer written directly by Windows Installer) instead of via a deferred custom action that launched the helper binary during install. That launched process was holding the installer process tree open, which hung the validation install step. The new MSI spawns no process during install, installs silently per-user (no elevation), and has been confirmed to install cleanly via `msiexec /qn` (exit 0).

- [x] Manifest validated locally with `winget validate`
- [x] Installer is silent (`/qn`) and per-user (`Scope: user`)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/395774)