### PR TITLE
New package: kunobi-ninja.kobe.Unstable version 0.32.0-rc.1

### DIFF
--- a/manifests/k/kunobi-ninja/kobe/Unstable/0.32.0-rc.1/kunobi-ninja.kobe.Unstable.installer.yaml
+++ b/manifests/k/kunobi-ninja/kobe/Unstable/0.32.0-rc.1/kunobi-ninja.kobe.Unstable.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: kunobi-ninja.kobe.Unstable
+PackageVersion: 0.32.0-rc.1
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: portable
+Commands:
+  - kobe
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/kunobi-ninja/kobe/releases/download/v0.32.0-rc.1/kobe-x86_64-pc-windows-msvc.exe
+    InstallerSha256: 98003D5D20B483019B673C02F3113B1AFAF806E3D47E88FACAE4DB2B4C612A32
+  - Architecture: arm64
+    InstallerUrl: https://github.com/kunobi-ninja/kobe/releases/download/v0.32.0-rc.1/kobe-aarch64-pc-windows-msvc.exe
+    InstallerSha256: 1059E171581D8ABAC911CE5CF292F25855810C18B7EEF90478EB919546CA3FE2
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/k/kunobi-ninja/kobe/Unstable/0.32.0-rc.1/kunobi-ninja.kobe.Unstable.locale.en-US.yaml
+++ b/manifests/k/kunobi-ninja/kobe/Unstable/0.32.0-rc.1/kunobi-ninja.kobe.Unstable.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: kunobi-ninja.kobe.Unstable
+PackageVersion: 0.32.0-rc.1
+PackageLocale: en-US
+Publisher: Kunobi Ninja
+PublisherUrl: https://kunobi.com
+PublisherSupportUrl: https://kunobi.com/contact
+Author: Zondax AG
+PackageName: kobe (Unstable)
+PackageUrl: https://github.com/kunobi-ninja/kobe
+License: Apache-2.0
+LicenseUrl: https://github.com/kunobi-ninja/kobe/blob/main/LICENSE
+Copyright: 2026 Zondax AG
+ShortDescription: CLI for the kobe cluster-pool operator — instant CI/dev Kubernetes clusters (unstable channel)
+Description: kobe is a Kubernetes cluster-pool operator for instant CI/dev cluster provisioning (k3k, k3s, k0s, CAPI). This CLI leases and manages clusters from kobe pools. This is the pre-release (RC/beta) channel.
+Moniker: kobe
+Tags:
+  - ci
+  - cli
+  - cluster
+  - devops
+  - k8s
+  - kubernetes
+  - pre-release
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/k/kunobi-ninja/kobe/Unstable/0.32.0-rc.1/kunobi-ninja.kobe.Unstable.yaml
+++ b/manifests/k/kunobi-ninja/kobe/Unstable/0.32.0-rc.1/kunobi-ninja.kobe.Unstable.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: kunobi-ninja.kobe.Unstable
+PackageVersion: 0.32.0-rc.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
### New package

- **PackageIdentifier:** kunobi-ninja.kobe.Unstable
- **PackageVersion:** 0.32.0-rc.1
- InstallerType: portable (signed x64 + arm64 .exe)

kobe CLI — lease and manage instant CI/dev Kubernetes clusters from kobe cluster pools (unstable / pre-release channel). Manifests follow the same shape as kunobi-ninja.kache.Unstable.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there are no other open pull requests for the same manifest?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] This package was created/maintained by me or my organization.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/395782)