### PR TITLE
New version: subhadeeproy3902.pong-ball version 1.0.1

### DIFF
--- a/manifests/s/subhadeeproy3902/pong-ball/1.0.1/subhadeeproy3902.pong-ball.installer.yaml
+++ b/manifests/s/subhadeeproy3902/pong-ball/1.0.1/subhadeeproy3902.pong-ball.installer.yaml
@@ -1,0 +1,18 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: subhadeeproy3902.pong-ball
+PackageVersion: 1.0.1
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: pong-ball.exe
+  PortableCommandAlias: pong-ball
+UpgradeBehavior: uninstallPrevious
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/subhadeeproy3902/pong-ball/releases/download/v1.0.1/pong-ball_windows_amd64.zip
+  InstallerSha256: 4B71BADB479A7832F723B8D7491C0B601863E54B41AA37E86E4AABD70B659B03
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/subhadeeproy3902/pong-ball/1.0.1/subhadeeproy3902.pong-ball.locale.en-US.yaml
+++ b/manifests/s/subhadeeproy3902/pong-ball/1.0.1/subhadeeproy3902.pong-ball.locale.en-US.yaml
@@ -1,0 +1,15 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: subhadeeproy3902.pong-ball
+PackageVersion: 1.0.1
+PackageLocale: en-US
+Publisher: subhadeeproy3902
+PackageName: pong-ball
+PackageUrl: https://pongball.mvp-subha.me
+License: MIT
+ShortDescription: A minimalist physics-based terminal Pong game
+Description: Physics-based Pong for the terminal — sub-stepped collisions, a spring-driven paddle, five themes, three modes, and a persistent score history.
+Moniker: pong-ball
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/subhadeeproy3902/pong-ball/1.0.1/subhadeeproy3902.pong-ball.yaml
+++ b/manifests/s/subhadeeproy3902/pong-ball/1.0.1/subhadeeproy3902.pong-ball.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: subhadeeproy3902.pong-ball
+PackageVersion: 1.0.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## New version: `subhadeeproy3902.pong-ball` version 1.0.1

**pong-ball** — a minimalist, physics-based Pong game for the terminal. Written in Go and shipped as a single static binary with no runtime dependencies.

- Homepage: <https://pongball.mvp-subha.me>
- Source: <https://github.com/subhadeeproy3902/pong-ball>
- Release: <https://github.com/subhadeeproy3902/pong-ball/releases/tag/v1.0.1>

### What's new in 1.0.1

- Replace this with the actual changes from your v1.0.1 release notes.

### Manifest

- `PackageIdentifier`: `subhadeeproy3902.pong-ball`
- `PackageVersion`: `1.0.1`
- Installer: portable `.zip` (`NestedInstallerType: portable`) exposing `pong-ball.exe` with command alias `pong-ball`
- `ManifestVersion`: 1.12.0

### Validation

- [x] Validated locally with `winget validate` -> **Manifest validation succeeded.**
- [x] Tested locally via `winget install --manifest manifests/s/subhadeeproy3902/pong-ball/1.0.1`
- [x] `InstallerSha256` matches the published release asset (`pong-ball_windows_amd64.zip`).
- [x] This is a version update to an existing package (previous version 1.0.0).
- [x] I am the package publisher (self-submission).

The Microsoft validation pipeline will download the installer from the GitHub release and smoke-test installation.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/395809)