### PR TITLE
New package: Chess.Journal v0.1.33

### DIFF
--- a/manifests/c/Chess.Journal/0.1.33/Chess.Journal.installer.yaml
+++ b/manifests/c/Chess.Journal/0.1.33/Chess.Journal.installer.yaml
@@ -1,0 +1,20 @@
+PackageIdentifier: Chess.Journal
+PackageVersion: 0.1.33
+InstallerLocale: en-US
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+FileExtensions:
+  - pgn
+  - fen
+  - json
+ReleaseDate: 2026-06-30
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/sazardev/chess-journal/releases/download/v0.1.33/Chess.Journal_0.1.33_x64-setup.exe
+    InstallerSha256: 416E12000859C214CA5580AE456EDAF0192047994BAA5C384042FDCC3513F76B
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/c/Chess.Journal/0.1.33/Chess.Journal.locale.en-US.yaml
+++ b/manifests/c/Chess.Journal/0.1.33/Chess.Journal.locale.en-US.yaml
@@ -1,0 +1,58 @@
+PackageIdentifier: Chess.Journal
+PackageVersion: 0.1.33
+PackageLocale: en-US
+Publisher: sazardev
+PublisherUrl: https://github.com/sazardev/chess-journal
+PublisherSupportUrl: https://github.com/sazardev/chess-journal/issues
+Author: sazardev
+PackageName: Chess Journal
+PackageUrl: https://github.com/sazardev/chess-journal
+License: MIT
+LicenseUrl: https://github.com/sazardev/chess-journal/blob/master/LICENSE
+Copyright: Copyright (c) 2026 sazardev
+ShortDescription: Stockfish analysis, local AI commentary, 26K games & 5K puzzles — free desktop chess app.
+Description: |-
+  Your personal chess analysis lab, game library, and study companion.
+
+  Chess Journal is a free, open-source chess app that combines everything serious players need: deep Stockfish engine analysis, on-device AI commentary (no cloud, no API key), a massive built-in game library, and thousands of puzzles.
+
+  Stockfish Engine Analysis
+  - 5 depth presets: Eco, Fast, Balanced, Deep, Max
+  - Eval bar, best line, candidate moves, coherent heatmap
+  - Interactive evaluation graph — click any swing to jump to that move
+  - One-shot whole-game analyzer with quality marks (!! ! ?! ? ??)
+
+  On-Device AI Commentary
+  - Local AI models (Qwen2.5 1.5B or Gemma 3 1B) via llama.cpp
+  - No cloud, no API key, no subscription
+  - Your positions never leave your device
+  - Deterministic templates explain every move even without LLM
+
+  Game Library — 26,000+ Built-in Games
+  - 9,254 classic master games (Morphy to Carlsen, 60+ legends)
+  - 11,336 theory games across 37 categories
+  - 5,037 mate puzzles rated 800–2500
+  - Smart search understands natural language
+
+  Additional Features
+  - Assistive Coach: 6 ELO levels (800–2500)
+  - Opening detection: 515 KB offline ECO database
+  - Chess.com import by username + date range
+  - Board editor with auto castling rights
+  - Import: PGN, FEN, JSON. Export: PGN, FEN, JSON, PNG
+  - Theme system: 7 presets + infinite HSL tuning
+  - Auto-updates: one-click install
+  - Free. Open source. MIT licensed. No ads. No tracking.
+Moniker: chess-journal
+Tags:
+  - chess
+  - chess-analysis
+  - stockfish
+  - chess-study
+  - chess-puzzles
+  - chess-engine
+  - pgn-viewer
+  - pgn-analyzer
+  - offline-chess
+  - open-source
+  - tauri

--- a/manifests/c/Chess.Journal/0.1.33/Chess.Journal.yaml
+++ b/manifests/c/Chess.Journal/0.1.33/Chess.Journal.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Chess.Journal
+PackageVersion: 0.1.33
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Adds Chess Journal v0.1.33 to the Windows Package Manager Community Repository.

Chess Journal is a free, open-source chess app with Stockfish engine analysis, on-device AI commentary (no cloud, no API key), 26,000+ built-in games (9,254 classics + 11,336 theory games + 5,037 puzzles), smart natural-language search, Chess.com import, opening detection, and assistive coaching. All features work offline. MIT licensed.

- Installer type: Nullsoft (NSIS), per-user
- Architecture: x64
- Auto-updater built in