### PR TITLE
Add Providence.Tuckt version 1.3.3

### DIFF
--- a/manifests/p/Providence/Tuckt/1.3.3/Providence.Tuckt.yaml
+++ b/manifests/p/Providence/Tuckt/1.3.3/Providence.Tuckt.yaml
@@ -1,0 +1,32 @@
+
+PackageIdentifier: Providence.Tuckt
+PackageVersion: 1.3.3
+PackageLocale: en-US
+Publisher: Providence
+PublisherUrl: https://github.com/sohiaburrehman-prog
+PublisherSupportUrl: https://github.com/sohiaburrehman-prog/Tuckt/issues
+PrivacyUrl: https://github.com/sohiaburrehman-prog/Tuckt/blob/master/PRIVACY_POLICY.txt
+Author: Sohiab Rehman
+PackageName: Tuckt
+PackageUrl: https://github.com/sohiaburrehman-prog/Tuckt
+License: Proprietary
+Copyright: Copyright (c) 2026 Sohiab Rehman
+ShortDescription: Clipboard history, notes, and tasks in one local-first tray app
+Description: |
+  Tuckt keeps clipboard history, notes, and tasks in one Windows tray app.
+  Data stays on your PC with DPAPI encryption. No cloud backend required.
+  Optional SafeSync uses your own cloud folder to sync with Mac and iOS.
+Moniker: tuckt
+Tags:
+  - clipboard
+  - clipboard-manager
+  - notes
+  - productivity
+  - tasks
+Installers:
+  - Architecture: x64
+    InstallerType: inno
+    InstallerUrl: https://github.com/sohiaburrehman-prog/Tuckt/releases/download/windows-v1.3.3/Tuckt-1.3.3-Setup.exe
+    InstallerSha256: 70ab41cac9ed1e6d21c7c20432f9d0c08b93266e6a623d5e50f51385f253d872
+ManifestType: singleton
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary
- Add **Providence.Tuckt** 1.3.3 to winget (first submission)
- Inno Setup x64 installer from [Tuckt windows-v1.3.3 release](https://github.com/sohiaburrehman-prog/Tuckt/releases/tag/windows-v1.3.3)
- Source repo and release assets are **public**; installer URL verified anonymously downloadable

## Test plan
- [ ] `winget validate --manifest manifests/p/Providence/Tuckt/1.3.3/Providence.Tuckt.yaml`
- [ ] `winget install --manifest manifests/p/Providence/Tuckt/1.3.3/Providence.Tuckt.yaml`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/395854)