### PR TITLE
New version: Microsoft.WindowsAppRuntime.2 version 2.2.0

### DIFF
--- a/manifests/m/Microsoft/WindowsAppRuntime/2/2.2.0/Microsoft.WindowsAppRuntime.2.installer.yaml
+++ b/manifests/m/Microsoft/WindowsAppRuntime/2/2.2.0/Microsoft.WindowsAppRuntime.2.installer.yaml
@@ -1,0 +1,32 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.WindowsAppRuntime.2
+PackageVersion: 2.2.0
+InstallerType: exe
+InstallModes:
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: --quiet
+  SilentWithProgress: --quiet
+UpgradeBehavior: install
+PackageFamilyName: Microsoft.WindowsAppRuntime.2_8wekyb3d8bbwe
+AppsAndFeaturesEntries:
+- DisplayName: WindowsAppRuntime.2
+  DisplayVersion: 2.2.0.0
+  InstallerType: msix
+ElevationRequirement: elevationRequired
+Installers:
+- Architecture: x86
+  InstallerUrl: https://aka.ms/windowsappsdk/2.2/2.2.0/windowsappruntimeinstall-x86.exe
+  InstallerSha256: D74B2BC3A2A94BC5AD682659E4B26BD2F06DD4FF5E8BC8EE37F1328D215FA297
+- Architecture: x64
+  InstallerUrl: https://aka.ms/windowsappsdk/2.2/2.2.0/windowsappruntimeinstall-x64.exe
+  InstallerSha256: E14ABFEEDD61CCF1E1B9618A9D4E8E5CAD6B6A0BECBACF159A50718D047EB927
+- Architecture: arm64
+  InstallerUrl: https://aka.ms/windowsappsdk/2.2/2.2.0/windowsappruntimeinstall-arm64.exe
+  InstallerSha256: 50377C5B255A2C9ED23B7BDDF67CC48F50BC862F8B38C4B406F49E07D6C7A498
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-06-09

--- a/manifests/m/Microsoft/WindowsAppRuntime/2/2.2.0/Microsoft.WindowsAppRuntime.2.locale.en-US.yaml
+++ b/manifests/m/Microsoft/WindowsAppRuntime/2/2.2.0/Microsoft.WindowsAppRuntime.2.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.WindowsAppRuntime.2
+PackageVersion: 2.2.0
+PackageLocale: en-US
+Publisher: Microsoft Corporation
+PublisherUrl: https://www.microsoft.com/
+PublisherSupportUrl: https://support.microsoft.com/
+PrivacyUrl: https://aka.ms/windowsappsdk-privacy
+Author: Microsoft Corporation
+PackageName: Windows App Runtime 2.0
+PackageUrl: https://learn.microsoft.com/windows/apps/windows-app-sdk/downloads
+License: Proprietary
+LicenseUrl: https://aka.ms/windowsappsdk-license
+Copyright: Copyright(c) Microsoft Corporation. All rights reserved.
+CopyrightUrl: https://www.microsoft.com/legal/intellectualproperty/trademarks
+ShortDescription: The Windows App SDK provides a unified set of APIs and tools that you can use to build modern Windows apps.
+Moniker: windowsappsdk-2
+ReleaseNotesUrl: https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/release-notes/windows-app-sdk-2-0?pivots=stable#version-220
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/Microsoft/WindowsAppRuntime/2/2.2.0/Microsoft.WindowsAppRuntime.2.yaml
+++ b/manifests/m/Microsoft/WindowsAppRuntime/2/2.2.0/Microsoft.WindowsAppRuntime.2.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.WindowsAppRuntime.2
+PackageVersion: 2.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## I suggest using "2" for the PackageIdentifier instead of "2.0".

The PackageFamilyName is `Microsoft.WindowsAppRuntime.2_8wekyb3d8bbwe`—not `2.0` or `2.1`, but simply `2`.

The Windows App SDK 2.0 series maintains compatibility within the 2.x range; for instance, `Microsoft.WindowsAppRuntime.2_2.0.1.0_8wekyb3d8bbwe` is superseded by versions such as `2.1.3.0` or `2.2.0.0`.

Therefore, I propose managing the PackageIdentifier as `2` rather than tracking it separately as `2.0`, `2.1`, or `2.2`.

You might see wingetbot errors like #384273 or #394881 during verification, but the installation itself works.

## Related pull requests
These should be merged simultaneously if possible.

Rename Package ID: Microsoft.WindowsAppRuntime.2 version 2.0.1 #396237
Rename Package ID: Microsoft.WindowsAppRuntime.2 version 2.1.3 #396238
New version: Microsoft.WindowsAppRuntime.2 version 2.2.0 #396239

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/396239)