### PR TITLE
Add netcraker01.helix-player version 0.1.0

### DIFF
--- a/manifests/n/netcraker01/helix-player/0.1.0/netcraker01.helix-player.installer.yaml
+++ b/manifests/n/netcraker01/helix-player/0.1.0/netcraker01.helix-player.installer.yaml
@@ -1,0 +1,54 @@
+# winget Installer Manifest
+# =============================================================================
+# REPLACE all placeholder values before submission.
+# Build the MSI first, then extract values with:
+#   .\scripts\inspect-msi.ps1 -MsiPath .\Helix_0.1.0_x64_en-US.msi
+#
+# Placeholders to replace:
+#   - REPLACE_WITH_ACTUAL_SHA256_X64  → SHA256 from Get-FileHash or .sha256 file
+#   - REPLACE_WITH_WIX_PRODUCT_CODE    → ProductCode from MSI database (changes per version)
+#   - REPLACE_WITH_WIX_UPGRADE_CODE    → UpgradeCode from MSI database (stable, do NOT change)
+#   - URLs                             → actual GitHub release download URLs
+#
+# The UpgradeCode is pinned in src-tauri/tauri.conf.json (bundle.windows.wix.upgradeCode).
+# It must stay the same across ALL versions — changing it breaks upgrade detection.
+# =============================================================================
+PackageIdentifier: netcraker01.helix-player
+PackageVersion: 0.1.0
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Commands:
+  - helix
+Protocols:
+  - helix
+FileExtensions: []
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Microsoft.EdgeWebView2Runtime
+AppsAndFeaturesEntries:
+  - DisplayName: Helix Player
+    Publisher: netcraker01
+    DisplayVersion: "0.1.0"
+    ProductCode: "{5D94C021-6FA6-4482-B427-2C427D30F3AF}"
+    UpgradeCode: "{E7B2A9F0-3C4D-5E6F-8A1B-2C3D4E5F6A7B}"
+Installers:
+  - Architecture: x64
+    InstallerType: wix
+    InstallerUrl: https://github.com/netcraker01/helix/releases/download/v0.1.0/Helix_0.1.0_x64_en-US.msi
+    InstallerSha256: 2704DCD4695E701ECD87596C7A4FD4AA876488781066FB8106328D1D125FEA28
+    ProductCode: "{5D94C021-6FA6-4482-B427-2C427D30F3AF}"
+  # Uncomment when shipping ARM64 builds:
+  # - Architecture: arm64
+  #   InstallerType: wix
+  #   InstallerUrl: https://github.com/netcraker01/helix/releases/download/v0.1.0/Helix_0.1.0_arm64_en-US.msi
+  #   InstallerSha256: REPLACE_WITH_ACTUAL_SHA256_ARM64
+  #   ProductCode: "{REPLACE_WITH_WIX_PRODUCT_CODE_ARM64}"
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/n/netcraker01/helix-player/0.1.0/netcraker01.helix-player.locale.en-US.yaml
+++ b/manifests/n/netcraker01/helix-player/0.1.0/netcraker01.helix-player.locale.en-US.yaml
@@ -1,0 +1,48 @@
+# winget Default Locale Manifest
+# =============================================================================
+# This is the en-US locale metadata for the winget package.
+# REPLACE placeholder Publisher/URLs with actual values before submission.
+# =============================================================================
+PackageIdentifier: netcraker01.helix-player
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: netcraker01
+PublisherUrl: https://github.com/netcraker01
+PublisherSupportUrl: https://github.com/netcraker01/helix/issues
+Author: netcraker01
+PackageName: Helix Player
+PackageUrl: https://github.com/netcraker01/helix
+License: AGPL-3.0-or-later
+LicenseUrl: https://github.com/netcraker01/helix/blob/main/LICENSE
+Copyright: Copyright (c) 2026 netcraker01
+CopyrightUrl: https://github.com/netcraker01/helix/blob/main/LICENSE
+ShortDescription: Helix Player is a privacy-first music player for streaming, playback, and visualization
+Description: >
+  Helix Player is a privacy-first, open-source desktop music player that streams from
+  YouTube, SoundCloud, and Bandcamp. It features real-time audio visualizations
+  (spectrum analyzer, oscilloscope, Winamp-style effects), a WASM plugin system,
+  and zero tracking or cookies.
+
+  yt-dlp is automatically downloaded on first launch for streaming support.
+  Alternatively, install yt-dlp separately: winget install yt-dlp
+Moniker: helix-player
+Tags:
+  - music
+  - player
+  - streaming
+  - youtube
+  - soundcloud
+  - visualization
+  - privacy
+  - open-source
+  - tauri
+  - rust
+ReleaseNotes: |
+  Initial alpha release of Helix music player.
+  - Stream from YouTube, SoundCloud, Bandcamp
+  - Real-time audio visualizations
+  - Queue management, playlists, favorites
+  - Auto-downloads yt-dlp on first run
+ReleaseNotesUrl: https://github.com/netcraker01/helix/releases/tag/v0.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/n/netcraker01/helix-player/0.1.0/netcraker01.helix-player.version.yaml
+++ b/manifests/n/netcraker01/helix-player/0.1.0/netcraker01.helix-player.version.yaml
@@ -1,0 +1,10 @@
+# winget Manifest Version
+# =============================================================================
+# This file declares the package version for the winget manifest set.
+# Replace the version placeholder with each new release version.
+# =============================================================================
+PackageIdentifier: netcraker01.helix-player
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary
- add winget manifests for Helix Player 0.1.0
- MSI installer hosted on GitHub Releases
- SHA256, ProductCode, and UpgradeCode filled from the built MSI artifact

## Installer
- x64 MSI
- URL: https://github.com/netcraker01/helix/releases/download/v0.1.0/Helix_0.1.0_x64_en-US.msi

## Notes
- Helix Player auto-downloads yt-dlp on first remote use for YouTube / SoundCloud support
- WebView2 runtime dependency is declared in the installer manifest

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/396312)