### PR TITLE
New version: Tomclanc.GestureSignV2 version 8.1.9802

### DIFF
--- a/manifests/t/Tomclanc/GestureSignV2/8.1.9802/Tomclanc.GestureSignV2.installer.yaml
+++ b/manifests/t/Tomclanc/GestureSignV2/8.1.9802/Tomclanc.GestureSignV2.installer.yaml
@@ -1,0 +1,24 @@
+# Created using Codex
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: Tomclanc.GestureSignV2
+PackageVersion: 8.1.9802
+InstallerType: wix
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Tomclanc/GestureSignv2/releases/download/v8.1.9802/GestureSign-V2-8.1.9802-x64.msi
+  InstallerSha256: 4C59E34EF4D96D6724C143C13B5C49009261207C0FA33B5BEF1C4944332E3A32
+  ProductCode: '{465DF2E6-01DF-430E-B81F-7203DB0BF248}'
+  AppsAndFeaturesEntries:
+  - DisplayName: GestureSign V2
+    Publisher: TransposonY / WinUI rebuild
+    ProductCode: '{465DF2E6-01DF-430E-B81F-7203DB0BF248}'
+ManifestType: installer
+ManifestVersion: 1.10.0
+ReleaseDate: 2026-07-01

--- a/manifests/t/Tomclanc/GestureSignV2/8.1.9802/Tomclanc.GestureSignV2.locale.en-US.yaml
+++ b/manifests/t/Tomclanc/GestureSignV2/8.1.9802/Tomclanc.GestureSignV2.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# Created using Codex
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: Tomclanc.GestureSignV2
+PackageVersion: 8.1.9802
+PackageLocale: en-US
+Publisher: Tomclanc
+PublisherUrl: https://github.com/Tomclanc
+PublisherSupportUrl: https://github.com/Tomclanc/GestureSignv2/issues
+Author: Tomclanc
+PackageName: GestureSign V2
+PackageUrl: https://github.com/Tomclanc/GestureSignv2
+License: GPL-2.0
+LicenseUrl: https://github.com/Tomclanc/GestureSignv2/blob/main/LICENSE
+Copyright: Copyright (C) 2026 Tomclanc
+ShortDescription: A Windows 11 focused rebuild of GestureSign for touchpad and mouse gestures.
+Description: GestureSign V2 is a Windows 11 focused rebuild of the classic open-source GestureSign project. It supports touchpad gestures, mouse gestures, gesture trails, per-app actions, ignore rules, tray controls, and bundled Kando radial menu quick actions.
+Moniker: gesturesignv2
+Tags:
+- gesture
+- gestures
+- mouse
+- touchpad
+- windows-11
+ReleaseNotesUrl: https://github.com/Tomclanc/GestureSignv2/releases/tag/v8.1.9802
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/t/Tomclanc/GestureSignV2/8.1.9802/Tomclanc.GestureSignV2.yaml
+++ b/manifests/t/Tomclanc/GestureSignV2/8.1.9802/Tomclanc.GestureSignV2.yaml
@@ -1,0 +1,8 @@
+# Created using Codex
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: Tomclanc.GestureSignV2
+PackageVersion: 8.1.9802
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Updates Tomclanc.GestureSignV2 to version 8.1.9802.

Installer: https://github.com/Tomclanc/GestureSignv2/releases/download/v8.1.9802/GestureSign-V2-8.1.9802-x64.msi
SHA256: 4C59E34EF4D96D6724C143C13B5C49009261207C0FA33B5BEF1C4944332E3A32
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/396409)