### PR TITLE
New package: AndreaBozzo.GitNodes version 0.1.0

### DIFF
--- a/manifests/a/AndreaBozzo/GitNodes/0.1.0/AndreaBozzo.GitNodes.installer.yaml
+++ b/manifests/a/AndreaBozzo/GitNodes/0.1.0/AndreaBozzo.GitNodes.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: AndreaBozzo.GitNodes
+PackageVersion: 0.1.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: gitnodes.exe
+  PortableCommandAlias: gitnodes
+UpgradeBehavior: uninstallPrevious
+Commands:
+- gitnodes
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/AndreaBozzo/gitnodes/releases/download/v0.1.0/gitnodes-x86_64-pc-windows-msvc.zip
+  InstallerSha256: 7d17a49b3c4648a36ffc4887db92994cd5a7796456076ee8181cdaf3d79b1fcf
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/a/AndreaBozzo/GitNodes/0.1.0/AndreaBozzo.GitNodes.locale.en-US.yaml
+++ b/manifests/a/AndreaBozzo/GitNodes/0.1.0/AndreaBozzo.GitNodes.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: AndreaBozzo.GitNodes
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Andrea Bozzo
+PublisherUrl: https://github.com/AndreaBozzo/gitnodes
+PublisherSupportUrl: https://github.com/AndreaBozzo/gitnodes/issues
+PackageName: GitNodes
+PackageUrl: https://github.com/AndreaBozzo/gitnodes
+License: GNU Affero General Public License v3.0 or later
+LicenseUrl: https://github.com/AndreaBozzo/gitnodes/blob/v0.1.0/LICENSE-AGPL
+ShortDescription: A knowledge graph over a Git repository of Markdown files.
+Description: >-
+  GitNodes turns Markdown with YAML frontmatter into a navigable, editable
+  knowledge graph while keeping Git as the source of truth.
+Moniker: gitnodes
+Tags:
+- ai
+- git
+- knowledge-base
+- knowledge-graph
+- markdown
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/a/AndreaBozzo/GitNodes/0.1.0/AndreaBozzo.GitNodes.yaml
+++ b/manifests/a/AndreaBozzo/GitNodes/0.1.0/AndreaBozzo.GitNodes.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: AndreaBozzo.GitNodes
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
### New package: `AndreaBozzo.GitNodes` version `0.1.0`

First submission of GitNodes — a knowledge graph over a Git repository of Markdown files. Turns Markdown with YAML frontmatter into a navigable, editable knowledge graph while keeping Git as the source of truth.

- Publisher/homepage: https://github.com/AndreaBozzo/gitnodes
- Installer: portable `gitnodes.exe` from the official release zip (`gitnodes-x86_64-pc-windows-msvc.zip`), `x64`.
- Manifests validated against schema `1.10.0`; installer SHA256 matches the published release asset.

#### Checklist

- [x] Contributor License Agreement — will be signed via the CLA bot on this PR.
- [x] This is a new package (does not already exist in the repository).
- [x] Manifest follows the [1.10.0 schema](https://github.com/microsoft/winget-cli/tree/master/schemas/JSON/manifests/v1.10.0).
- [x] Installer URL points to the publisher's official release asset with a matching SHA256.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/396497)