### PR TITLE
New version: Kindel.mcec version 3.0.5

### DIFF
--- a/manifests/k/Kindel/mcec/3.0.5/Kindel.mcec.installer.yaml
+++ b/manifests/k/Kindel/mcec/3.0.5/Kindel.mcec.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: Kindel.mcec
+PackageVersion: "3.0.5"
+# MCEC ships an NSIS installer (per-machine; requires elevation). winget's
+# "nullsoft" type knows the silent switch is /S.
+InstallerType: nullsoft
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+UpgradeBehavior: install
+ReleaseDate: 2026-07-01
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/tig/mcec/releases/download/v3.0.5/mcec.Setup.exe
+    InstallerSha256: FCA7A1DCBEF6FD0256804462E892AD3D946774C909FFEAACBF965CD820E83A34
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/k/Kindel/mcec/3.0.5/Kindel.mcec.locale.en-US.yaml
+++ b/manifests/k/Kindel/mcec/3.0.5/Kindel.mcec.locale.en-US.yaml
@@ -2,26 +2,32 @@
 PackageIdentifier: Kindel.mcec
 PackageVersion: "3.0.5"
 PackageLocale: en-US
-Publisher: Kindel Systems
+Publisher: Kindel, LLC
 PublisherUrl: https://github.com/tig
 PublisherSupportUrl: https://github.com/tig/mcec/issues
-Author: Kindel Systems
-PackageName: MCE Controller
+Author: Kindel, LLC
+PackageName: MCEC
 PackageUrl: https://github.com/tig/mcec
 License: MIT
-Copyright: Copyright © Kindel Systems, LLC.
-ShortDescription: Control a Windows PC over the network or serial port.
+Copyright: Copyright © Kindel, LLC.
+ShortDescription: See and drive native Windows apps — an MCP server for agent automation.
 Description: |-
-  MCE Controller lets you control a Windows PC — Windows Media Center and beyond — over
-  the network (TCP/IP) or a serial port. It runs as a server that receives text commands
-  and turns them into keystrokes, mouse actions, launched programs, window activations,
-  and power/shutdown actions, with a configurable command set.
+  MCEC (Model Context Environment Controller) lets an AI agent see and drive native Windows
+  applications. It runs a Model Context Protocol (MCP) server so an agent can capture a window,
+  query its UI Automation tree, invoke controls, send keystrokes and mouse input, and record
+  sessions — driving real GUIs, not just APIs. It also keeps MCE Controller's classic command
+  server: control a Windows PC over the network (TCP/IP) or a serial port with a configurable
+  command set.
 Moniker: mcec
+ReleaseNotesUrl: https://github.com/tig/mcec/releases/tag/v3.0.5
 Tags:
-  - media-center
-  - remote-control
+  - mcp
+  - agent
+  - ai
   - automation
-  - home-theater
-  - htpc
+  - ui-automation
+  - windows
+  - remote-control
+  - screenshot
 ManifestType: defaultLocale
 ManifestVersion: 1.10.0

--- a/manifests/k/Kindel/mcec/3.0.5/Kindel.mcec.locale.en-US.yaml
+++ b/manifests/k/Kindel/mcec/3.0.5/Kindel.mcec.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: Kindel.mcec
+PackageVersion: "3.0.5"
+PackageLocale: en-US
+Publisher: Kindel Systems
+PublisherUrl: https://github.com/tig
+PublisherSupportUrl: https://github.com/tig/mcec/issues
+Author: Kindel Systems
+PackageName: MCE Controller
+PackageUrl: https://github.com/tig/mcec
+License: MIT
+Copyright: Copyright © Kindel Systems, LLC.
+ShortDescription: Control a Windows PC over the network or serial port.
+Description: |-
+  MCE Controller lets you control a Windows PC — Windows Media Center and beyond — over
+  the network (TCP/IP) or a serial port. It runs as a server that receives text commands
+  and turns them into keystrokes, mouse actions, launched programs, window activations,
+  and power/shutdown actions, with a configurable command set.
+Moniker: mcec
+Tags:
+  - media-center
+  - remote-control
+  - automation
+  - home-theater
+  - htpc
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/k/Kindel/mcec/3.0.5/Kindel.mcec.yaml
+++ b/manifests/k/Kindel/mcec/3.0.5/Kindel.mcec.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: Kindel.mcec
+PackageVersion: "3.0.5"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
### New version: `Kindel.mcec` version `3.0.5`

Adds the current MCEC release (v3.0.5) to the package. Manifests mirror the initial submission in #394805 (same NSIS `nullsoft` installer, publisher, and metadata), with the version, installer URL, SHA256, and release date updated for v3.0.5.

- InstallerUrl: https://github.com/tig/mcec/releases/download/v3.0.5/mcec.Setup.exe
- InstallerSha256: `FCA7A1DCBEF6FD0256804462E892AD3D946774C909FFEAACBF965CD820E83A34`
- Schema: manifest 1.10.0

Queued behind the initial package PR #394805 (New package: Kindel.mcec).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/396500)