### PR TITLE
Revert: Unregister esrp-winget-prod for manifests/m/Microsoft/Gaming/GDK

### DIFF
--- a/manifests/m/Microsoft/Gaming/GDK/.package
+++ b/manifests/m/Microsoft/Gaming/GDK/.package
@@ -1,0 +1,11 @@
+{
+    "schemaVersion": "0.1",
+    "owners":
+    [
+        {
+            "type": "Bot",
+            "login": "esrp-winget-prod[bot]",
+            "id": 273969822
+        }
+    ]
+}


### PR DESCRIPTION
Reverts microsoft/winget-pkgs#387188

Restores the `.package` ownership file for `manifests/m/Microsoft/Gaming/GDK` which registered `esrp-winget-prod[bot]` as the owner.