### PR TITLE
Update OneXray installer switches

### DIFF
--- a/manifests/y/YuanDevLLC/OneXray/26.7.1/YuanDevLLC.OneXray.installer.yaml
+++ b/manifests/y/YuanDevLLC/OneXray/26.7.1/YuanDevLLC.OneXray.installer.yaml
@@ -8,8 +8,8 @@ InstallModes:
 - interactive
 - silent
 InstallerSwitches:
-  Silent: /SP- /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
-  SilentWithProgress: /SP- /SILENT /SUPPRESSMSGBOXES /NORESTART
+  Silent: /SP- /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /FORCECLOSEAPPLICATIONS
+  SilentWithProgress: /SP- /SILENT /SUPPRESSMSGBOXES /NORESTART /FORCECLOSEAPPLICATIONS
 UpgradeBehavior: install
 AppsAndFeaturesEntries:
 - DisplayName: OneXray


### PR DESCRIPTION
## Summary

- Add `/FORCECLOSEAPPLICATIONS` to OneXray's Inno installer silent switches.

## Reason

When upgrading OneXray through WinGet, the installer can detect running `OneXray` and `OneXrayCore` processes and fail to close them automatically. In silent mode with suppressed message boxes, Inno Setup defaults to aborting the installation. This switch allows the installer to force-close applications that are using files being updated.

## Validation

- `winget validate manifests\y\YuanDevLLC\OneXray\26.7.1`

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/396696)