### PR TITLE
Add Laker.EasyPostman version 6.0.11

### DIFF
--- a/manifests/l/Laker/EasyPostman/6.0.11/Laker.EasyPostman.installer.yaml
+++ b/manifests/l/Laker/EasyPostman/6.0.11/Laker.EasyPostman.installer.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: Laker.EasyPostman
+PackageVersion: 6.0.11
+InstallerType: inno
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: /SP- /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+  SilentWithProgress: /SP- /SILENT /SUPPRESSMSGBOXES /NORESTART
+UpgradeBehavior: install
+ProductCode: 8B9C5D6E-7F8A-9B0C-1D2E-3F4A5B6C7D8E_is1
+ReleaseDate: 2026-07-01
+ElevationRequirement: elevatesSelf
+AppsAndFeaturesEntries:
+- ProductCode: 8B9C5D6E-7F8A-9B0C-1D2E-3F4A5B6C7D8E_is1
+  DisplayName: EasyPostman
+  Publisher: Laker
+  DisplayVersion: 6.0.11
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles%\EasyPostman'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/lakernote/EasyPostman/releases/download/v6.0.11/EasyPostman-6.0.11-windows-x64.exe
+  InstallerSha256: EBB81E7F5C98FF7063B5BEB79F34F8AF55EFAB20FBE7294278EC8EF3A0D7B45B
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/l/Laker/EasyPostman/6.0.11/Laker.EasyPostman.locale.en-US.yaml
+++ b/manifests/l/Laker/EasyPostman/6.0.11/Laker.EasyPostman.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: Laker.EasyPostman
+PackageVersion: 6.0.11
+PackageLocale: en-US
+Publisher: Laker
+PublisherUrl: https://github.com/lakernote
+PublisherSupportUrl: https://github.com/lakernote/EasyPostman/issues
+PackageName: EasyPostman
+PackageUrl: https://github.com/lakernote/EasyPostman
+License: Apache-2.0
+LicenseUrl: https://github.com/lakernote/EasyPostman/blob/master/LICENSE
+ShortDescription: An open-source Postman-style API client and JMeter-style load testing desktop app.
+Description: EasyPostman combines a Postman-style API debugging workspace with JMeter-style performance testing in one local-first desktop app.
+Moniker: easypostman
+Tags:
+- api
+- api-client
+- http
+- jmeter
+- postman
+- rest
+- testing
+ReleaseNotesUrl: https://github.com/lakernote/EasyPostman/releases/tag/v6.0.11
+Documentations:
+- DocumentLabel: Documentation
+  DocumentUrl: https://github.com/lakernote/EasyPostman/blob/master/docs/FEATURES.md
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/l/Laker/EasyPostman/6.0.11/Laker.EasyPostman.yaml
+++ b/manifests/l/Laker/EasyPostman/6.0.11/Laker.EasyPostman.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: Laker.EasyPostman
+PackageVersion: 6.0.11
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
### What

Adds the initial WinGet manifest for EasyPostman version 6.0.11.

### Installer

- Installer type: Inno Setup
- Architecture: x64
- Release: https://github.com/lakernote/EasyPostman/releases/tag/v6.0.11
- Installer URL: https://github.com/lakernote/EasyPostman/releases/download/v6.0.11/EasyPostman-6.0.11-windows-x64.exe
- SHA256: EBB81E7F5C98FF7063B5BEB79F34F8AF55EFAB20FBE7294278EC8EF3A0D7B45B

### Notes

The installer is produced by the upstream EasyPostman GitHub Release workflow and supports silent installation with Inno Setup switches.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/396755)