### PR TITLE
New package: kulkamKakarot.DriveLens version 1.0.0

### DIFF
--- a/manifests/k/kulkamKakarot/DriveLens/1.0.0/kulkamKakarot.DriveLens.installer.yaml
+++ b/manifests/k/kulkamKakarot/DriveLens/1.0.0/kulkamKakarot.DriveLens.installer.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: kulkamKakarot.DriveLens
+PackageVersion: 1.0.0
+InstallerType: nullsoft
+Scope: user
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/kulkamKakarot/drivelens/releases/download/v1.0.0/DriveLens.Setup.1.0.0.exe
+  InstallerSha256: 6CE6DAEE533F7B0078C7917450A5AD3D46181C9A1DE104BBC4244BD22763DD37
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/k/kulkamKakarot/DriveLens/1.0.0/kulkamKakarot.DriveLens.locale.en-US.yaml
+++ b/manifests/k/kulkamKakarot/DriveLens/1.0.0/kulkamKakarot.DriveLens.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: kulkamKakarot.DriveLens
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: kulkamKakarot
+PublisherUrl: https://github.com/kulkamKakarot
+PublisherSupportUrl: https://github.com/kulkamKakarot/drivelens/issues
+PackageName: DriveLens
+PackageUrl: https://github.com/kulkamKakarot/drivelens
+License: MIT
+LicenseUrl: https://github.com/kulkamKakarot/drivelens/blob/main/LICENSE
+ShortDescription: Visual disk-space analyzer for Windows with an interactive treemap and safe Recycle Bin cleanup.
+Description: DriveLens scans any drive or folder and shows exactly what is taking up space in an interactive, color-coded treemap. Browse folders sorted biggest-first, find the 100 largest files on a drive, and clean up safely - deleted items always go to the Recycle Bin, never permanently removed. No network access, no telemetry. Free and open source.
+Moniker: drivelens
+Tags:
+- cleanup
+- disk-analyzer
+- disk-space
+- disk-usage
+- open-source
+- treemap
+ReleaseNotesUrl: https://github.com/kulkamKakarot/drivelens/releases/tag/v1.0.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/k/kulkamKakarot/DriveLens/1.0.0/kulkamKakarot.DriveLens.yaml
+++ b/manifests/k/kulkamKakarot/DriveLens/1.0.0/kulkamKakarot.DriveLens.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: kulkamKakarot.DriveLens
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package submission

- **Package**: kulkamKakarot.DriveLens 1.0.0
- **Description**: Free, open-source visual disk-space analyzer for Windows. Interactive treemap, largest-files view, safe cleanup via Recycle Bin only. No network access, no telemetry.
- **Homepage**: https://github.com/kulkamKakarot/drivelens
- **License**: MIT
- **Installer**: NSIS (electron-builder), x64, user scope

- [x] Manifests validated locally with `winget validate` (validation succeeded)
- [x] `InstallerSha256` computed from the published GitHub release asset
- [x] This package does not already exist in the repository

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/396779)