### PR TITLE
New version: asciimoo.hister version 0.16.0

### DIFF
--- a/manifests/a/asciimoo/hister/0.16.0/asciimoo.hister.installer.yaml
+++ b/manifests/a/asciimoo/hister/0.16.0/asciimoo.hister.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: asciimoo.hister
+PackageVersion: 0.16.0
+InstallerType: portable
+Commands:
+- hister
+ReleaseDate: 2026-07-01
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/asciimoo/hister/releases/download/v0.16.0/hister_0.16.0_windows_amd64.exe
+  InstallerSha256: e059ff3aeeb5f46aa75620d7823d32fec225f7136187ec87d8c017b3d7847f18
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/asciimoo/hister/0.16.0/asciimoo.hister.locale.en-US.yaml
+++ b/manifests/a/asciimoo/hister/0.16.0/asciimoo.hister.locale.en-US.yaml
@@ -14,6 +14,36 @@ LicenseUrl: https://github.com/asciimoo/hister/blob/master/LICENSE
 ShortDescription: Your own search engine – Full-text search across your files, visited sites and beyond.
 Description: |-
   Hister is a versatile, privacy-focused web search engine designed to index the full content of visited web pages locally. Unlike traditional search engines, it allows you to find specific information within your own browsing history using full-text indexing.
+ReleaseNotes: |-
+  New Features
+  - Public Search Mode: added unauthenticated read-only access to global search and previews while keeping write operations protected.
+  - Documentation Datasets: ships metadata and tooling to import reference documentation (Go, PowerShell, Python, Rust, Node.js, MDN).
+  - StackExchange Extractor: replaced the StackOverflow extractor with a generic StackExchange extractor indexing answers with metadata.
+  - Local File Previews: local Markdown and Org files now render as HTML previews with automatic title extraction and clean syntax.
+  - MCP History & Capabilities: added get_history tool to the MCP endpoint, date filters support, and semantic search capability reporting.
+  - Browser Extension Upgrades: added configurable hotkeys for indexing controls and badge indicators showing if a page is already indexed.
+  - Import & Export Improvements: supports HTML files, multiple input files, compressed JSON, date-range filtering, and directory imports.
+  - Search Sorting & JSON Output: added sorting by newest date, domain, or most visited pages, and a format=json parameter to the search endpoint.
+  - History RSS Feed: the history endpoint and UI now expose an RSS feed for recently indexed documents.
+
+  Enhancements
+  - File indexing startup runs in the background to avoid blocking server start.
+  - Watched directory indexing now uses a proper, non-duplicating queue.
+  - Added CLI indexing flag to explicitly allow sensitive content when requested.
+  - Semantic search concurrency limits and merging of shared and user-specific vector results.
+  - Redesigned history timeline displaying indexed version counts and day-unloaded item indicators.
+  - Refined web UI layout, dark theme, search input, and configurable web title/subtitle branding.
+  - Added type facets and optimized rendering to hide inactive facet categories with single candidates.
+  - Built-in yt-dlp is now pre-installed in the official Docker image.
+
+  Bug Fixes
+  - Fixed Lobsters extraction to match updated HTML structure.
+  - Fixed document label preservation and batch user ID handling.
+  - Fixed text wrapping and layout squeeze on history and search views.
+  - Improved Base URL consistency for CSRF checks and invalid configurations.
+  - Recovered PDF parsing panics and addressed memory issues in PDF dependencies.
+  - Prevented reindexing from stopping entirely when a single document extractor aborts.
+  - Fixed database migration side-effects on UpdatedAt timestamps.
 ReleaseNotesUrl: https://github.com/asciimoo/hister/releases/tag/v0.16.0
 Documentations:
 - DocumentLabel: Documentation

--- a/manifests/a/asciimoo/hister/0.16.0/asciimoo.hister.locale.en-US.yaml
+++ b/manifests/a/asciimoo/hister/0.16.0/asciimoo.hister.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: asciimoo.hister
+PackageVersion: 0.16.0
+PackageLocale: en-US
+Publisher: asciimoo
+PublisherUrl: https://github.com/asciimoo
+PublisherSupportUrl: https://github.com/asciimoo/hister/issues
+Author: Adam Tauber
+PackageName: Hister
+PackageUrl: https://github.com/asciimoo/hister
+License: AGPL-3.0
+LicenseUrl: https://github.com/asciimoo/hister/blob/master/LICENSE
+ShortDescription: Your own search engine – Full-text search across your files, visited sites and beyond.
+Description: |-
+  Hister is a versatile, privacy-focused web search engine designed to index the full content of visited web pages locally. Unlike traditional search engines, it allows you to find specific information within your own browsing history using full-text indexing.
+ReleaseNotesUrl: https://github.com/asciimoo/hister/releases/tag/v0.16.0
+Documentations:
+- DocumentLabel: Documentation
+  DocumentUrl: https://hister.org/docs
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/asciimoo/hister/0.16.0/asciimoo.hister.yaml
+++ b/manifests/a/asciimoo/hister/0.16.0/asciimoo.hister.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: asciimoo.hister
+PackageVersion: 0.16.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Version 0.16.0 of Hister [was released on 1 July](https://github.com/asciimoo/hister/releases/tag/v0.16.0).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/396783)