### PR TITLE
SerZhyAle.DocHtmlTranslate version 26.0702.1530

### DIFF
--- a/manifests/s/SerZhyAle/DocHtmlTranslate/26.0702.1530/SerZhyAle.DocHtmlTranslate.installer.yaml
+++ b/manifests/s/SerZhyAle/DocHtmlTranslate/26.0702.1530/SerZhyAle.DocHtmlTranslate.installer.yaml
@@ -1,0 +1,19 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: SerZhyAle.DocHtmlTranslate
+PackageVersion: 26.0702.1530
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: doc-html-translate.exe
+  PortableCommandAlias: doc-html-translate
+- RelativeFilePath: doc-html-ui.exe
+  PortableCommandAlias: doc-html-ui
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/SerZhyAle/doc-html-translate/releases/download/v26.0702.1530/doc-html-translate-26.0702.1530-windows-x64.zip
+  InstallerSha256: D5A91E985D23A620ADA912B1C9F0E2AB05EB22F6B1EA3DDF6BF9D0302B605D2F
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-07-02

--- a/manifests/s/SerZhyAle/DocHtmlTranslate/26.0702.1530/SerZhyAle.DocHtmlTranslate.locale.en-US.yaml
+++ b/manifests/s/SerZhyAle/DocHtmlTranslate/26.0702.1530/SerZhyAle.DocHtmlTranslate.locale.en-US.yaml
@@ -1,0 +1,51 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: SerZhyAle.DocHtmlTranslate
+PackageVersion: 26.0702.1530
+PackageLocale: en-US
+Publisher: SZA
+PublisherUrl: https://github.com/SerZhyAle
+PublisherSupportUrl: https://github.com/SerZhyAle/doc-html-translate/issues
+Author: Serhii Zhyhunenko
+PackageName: doc-html-translate
+PackageUrl: https://github.com/SerZhyAle/doc-html-translate
+License: MIT
+LicenseUrl: https://github.com/SerZhyAle/doc-html-translate/blob/main/LICENSE
+Copyright: Copyright (c) 2026 SerZhyAle
+ShortDescription: Convert EPUB, PDF, MOBI, AZW3, FB2, RTF, TXT, Markdown and HTML to clean local HTML with a real table of contents, image-text OCR, and optional Google or Ollama translation.
+Description: |-
+  doc-html-translate is a Windows app that converts documents (EPUB, PDF, MOBI, AZW3, FB2,
+  RTF, TXT, Markdown, HTML) into clean local HTML with generated navigation and a real
+  multi-level table of contents. A built-in reader adds light/sepia/dark/night themes, text
+  size and font controls, and remembers your reading position. It can recognize text inside
+  images (OCR - English bundled, more languages on demand) and optionally translate everything
+  via the Google Cloud Translation API or a local Ollama model. Convert to one long single page
+  or keep chapters with a table of contents. Re-opening an already-converted book is instant.
+  The package ships both the CLI (doc-html-translate) and a small GUI launcher (doc-html-ui).
+  pdftotext is bundled inside the binary; MOBI and AZW3 conversion additionally requires
+  Calibre to be installed (non-DRM files only).
+Moniker: doc-html-translate
+Tags:
+- azw3
+- cli
+- ebook
+- epub
+- fb2
+- google-translate
+- html
+- markdown
+- mobi
+- ocr
+- ollama
+- pdf
+- rtf
+- translation
+- txt
+- windows
+ReleaseNotesUrl: https://github.com/SerZhyAle/doc-html-translate/releases/tag/v26.0702.1530
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/SerZhyAle/doc-html-translate/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/SerZhyAle/DocHtmlTranslate/26.0702.1530/SerZhyAle.DocHtmlTranslate.yaml
+++ b/manifests/s/SerZhyAle/DocHtmlTranslate/26.0702.1530/SerZhyAle.DocHtmlTranslate.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: SerZhyAle.DocHtmlTranslate
+PackageVersion: 26.0702.1530
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description
Update **SerZhyAle.DocHtmlTranslate** to version **26.0702.1530**.

The installer now points at the v26.0702.1530 GitHub release zip (SHA256 verified from the release asset). This version adds image-text OCR (Tesseract, with on-demand language packs), a redesigned themed reader (light/sepia/dark/night, text size and font, resume position), and single-page HTML output. The locale manifest ShortDescription/Description were refreshed to match and an `ocr` tag was added.

Release notes: https://github.com/SerZhyAle/doc-html-translate/releases/tag/v26.0702.1530

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>` (installer hash verified, both aliases registered)
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
