### PR TITLE
Update metadata: BrightBlock.Hyprlayer version 1.5.8

### DIFF
--- a/manifests/b/BrightBlock/Hyprlayer/1.5.8/BrightBlock.Hyprlayer.locale.en-US.yaml
+++ b/manifests/b/BrightBlock/Hyprlayer/1.5.8/BrightBlock.Hyprlayer.locale.en-US.yaml
@@ -7,7 +7,7 @@ PackageLocale: en-US
 Publisher: BrightBlock
 PublisherUrl: https://github.com/BrightBlock
 PublisherSupportUrl: https://github.com/BrightBlock/hyprlayer-cli/issues
-PackageName: Hyprlayer
+PackageName: Hyprlayer CLI
 PackageUrl: https://github.com/BrightBlock/hyprlayer-cli
 License: MIT
 LicenseUrl: https://github.com/BrightBlock/hyprlayer-cli/blob/HEAD/LICENSE


### PR DESCRIPTION
## 📖 Description

Metadata-only update for `BrightBlock.Hyprlayer` 1.5.8: rename `PackageName` from `Hyprlayer` to `Hyprlayer CLI`.

We (BrightBlock) also ship a desktop app whose Apps & Features entry is `Hyprlayer` / `BrightBlock` (not distributed via winget). winget correlates that ARP entry with this portable CLI package, so on any machine with the desktop app installed, `winget install BrightBlock.Hyprlayer` converts to an upgrade and fails with "the install technology is different from the current version installed", and `winget upgrade --all` repeatedly attempts that impossible upgrade. Qualifying the CLI's name (the `GitHub CLI` / GitHub Desktop pattern) breaks the false correlation. The package identifier is unchanged, and future releases published via WinGet Releaser will carry the new name forward.

Verified on a machine exhibiting the collision: with this manifest, `winget list` shows the desktop app and the CLI as distinct entries and the CLI installs cleanly.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/396897)