### PR TITLE
New package: cvfile.cv version 0.3.1

### DIFF
--- a/manifests/c/cvfile/cv/0.3.1/cvfile.cv.installer.yaml
+++ b/manifests/c/cvfile/cv/0.3.1/cvfile.cv.installer.yaml
@@ -1,0 +1,27 @@
+PackageIdentifier: cvfile.cv
+PackageVersion: 0.3.1
+MinimumOSVersion: 10.0.17763.0
+InstallerType: zip
+NestedInstallerType: portable
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+NestedInstallerFiles:
+  - RelativeFilePath: cv.exe
+    PortableCommandAlias: cv
+Commands:
+  - cv
+FileExtensions:
+  - cv
+ReleaseDate: 2026-07-02
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/cvfile/cv/releases/download/v0.3.1/cv_0.3.1_windows_x86_64.zip
+    InstallerSha256: 7458f4076f2ff642fa82aa19541faf82462807151b1281cdec0c9d9a54458d39
+  - Architecture: arm64
+    InstallerUrl: https://github.com/cvfile/cv/releases/download/v0.3.1/cv_0.3.1_windows_arm64.zip
+    InstallerSha256: 98f9600a9fddd287fcd28de5548d0b62eec15af813e3f04e3310daa52f5c3a57
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/c/cvfile/cv/0.3.1/cvfile.cv.locale.en-US.yaml
+++ b/manifests/c/cvfile/cv/0.3.1/cvfile.cv.locale.en-US.yaml
@@ -1,0 +1,46 @@
+PackageIdentifier: cvfile.cv
+PackageVersion: 0.3.1
+PackageLocale: en-US
+Publisher: cvfile.org
+PublisherUrl: https://cvfile.org
+PublisherSupportUrl: https://github.com/cvfile/cv/issues
+Author: cvfile contributors
+PackageName: cv
+PackageUrl: https://cvfile.org
+License: Apache-2.0
+LicenseUrl: https://github.com/cvfile/cv/blob/main/LICENSE
+Copyright: Copyright (c) cvfile contributors
+ShortDescription: CLI for the .cv open file format. Extract, inspect, validate, and semantic search across resume files.
+Description: |-
+  The cv command line interface reads and writes files in the .cv open file
+  format. A .cv file is a valid PDF/A-3u document that also carries a clean
+  Markdown copy, an optional HTML copy, and pre computed BGE M3 semantic
+  vectors as PDF Associated Files. One file opens visually in any PDF
+  reader, parses cleanly in any applicant tracking system, embeds on any
+  webpage, and answers semantic queries from any retrieval pipeline.
+
+  The CLI ships the full reader and writer paths: pack a PDF plus text
+  representations into a .cv, extract a payload, inspect XMP metadata,
+  validate against the cv 1.0 specification, and run semantic search over
+  the embedded vectors using the Hugging Face Inference API.
+
+  The full specification, the JavaScript and Python SDKs, the web
+  component, and the LangChain and LlamaIndex integrations live at
+  https://github.com/cvfile/cv.
+Moniker: cv
+Tags:
+  - cv
+  - cvfile
+  - resume
+  - cli
+  - pdf
+  - pdfa
+  - ats
+  - embeddings
+  - semantic
+  - search
+  - rag
+  - ai
+ReleaseNotesUrl: https://github.com/cvfile/cv/releases/tag/v0.3.1
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/c/cvfile/cv/0.3.1/cvfile.cv.yaml
+++ b/manifests/c/cvfile/cv/0.3.1/cvfile.cv.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: cvfile.cv
+PackageVersion: 0.3.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

New package submission for cvfile.cv, the `cv` command line interface for the .cv open resume file format (https://cvfile.org, Apache-2.0).

Portable zip installers for x64 and arm64, published on the project's GitHub releases with SHA-256 checksums taken from the release checksums.txt. Note: manifests were authored from the project's release templates and schema-validated; they have not been run through `winget install --manifest` on a Windows machine, so the unchecked box above is left honest.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/396903)