### PR TITLE
New package: AES256Afro.VideoKidnapper version 1.4.0

### DIFF
--- a/manifests/a/AES256Afro/VideoKidnapper/1.4.0/AES256Afro.VideoKidnapper.installer.yaml
+++ b/manifests/a/AES256Afro/VideoKidnapper/1.4.0/AES256Afro.VideoKidnapper.installer.yaml
@@ -10,7 +10,6 @@ PackageVersion: 1.4.0
 InstallerType: inno
 
 ReleaseDate: 2026-07-02
-ReleaseNotesUrl: https://github.com/AES256Afro/VideoKidnapper/releases/tag/v1.4.0
 
 Installers:
   - Architecture: x64

--- a/manifests/a/AES256Afro/VideoKidnapper/1.4.0/AES256Afro.VideoKidnapper.installer.yaml
+++ b/manifests/a/AES256Afro/VideoKidnapper/1.4.0/AES256Afro.VideoKidnapper.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+#
+# Winget installer manifest. Unlike the 1.2.0 draft (portable exe), this
+# points at the Inno Setup installer: winget drives it silently and gets
+# a real Start Menu entry + Programs & Features uninstall.
+
+PackageIdentifier: AES256Afro.VideoKidnapper
+PackageVersion: 1.4.0
+
+InstallerType: inno
+
+ReleaseDate: 2026-07-02
+ReleaseNotesUrl: https://github.com/AES256Afro/VideoKidnapper/releases/tag/v1.4.0
+
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/AES256Afro/VideoKidnapper/releases/download/v1.4.0/VideoKidnapper-Setup-1.4.0.exe
+    InstallerSha256: 1609AF52D6E9B44C6E50C65E33FA9BBE9A0F54E32DBC2F286B59413DC12045BA
+
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/a/AES256Afro/VideoKidnapper/1.4.0/AES256Afro.VideoKidnapper.locale.en-US.yaml
+++ b/manifests/a/AES256Afro/VideoKidnapper/1.4.0/AES256Afro.VideoKidnapper.locale.en-US.yaml
@@ -1,0 +1,64 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: AES256Afro.VideoKidnapper
+PackageVersion: 1.4.0
+PackageLocale: en-US
+
+Publisher: AES256Afro
+PublisherUrl: https://github.com/AES256Afro
+PublisherSupportUrl: https://github.com/AES256Afro/VideoKidnapper/issues
+
+Author: Christopher Courtney
+PackageName: VideoKidnapper
+PackageUrl: https://videokidnapper.com
+License: Apache-2.0
+LicenseUrl: https://github.com/AES256Afro/VideoKidnapper/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Christopher Courtney
+PrivacyUrl: https://videokidnapper.com/privacy.html
+
+ShortDescription: Dark-themed desktop tool for trimming videos, downloading clips from the open web, and exporting polished GIFs or MP4s with text overlays.
+Description: |-
+  VideoKidnapper is a dark-themed desktop app that trims local video files
+  or downloaded clips from YouTube, Instagram, Bluesky, Twitter/X, Reddit,
+  and Facebook, then exports polished GIFs or MP4s with pixel-accurate text
+  overlays.
+
+  Features include multi-range trimming, undo / redo, a scrubbable
+  thumbnail strip, text outline / shadow / bold / italic and multiline
+  captions, snap-to-guides, auto-captions via Whisper, image overlays,
+  GIF dither / palette / loop tuning, blurred-background aspect fill for
+  Shorts / Reels, color grading, hardware encoding, and a plugin system.
+
+  FFmpeg is a runtime prerequisite — the in-app Setup dialog pulls a
+  portable build on first launch if one isn't already on PATH.
+
+Moniker: videokidnapper
+
+Tags:
+  - video
+  - gif
+  - ffmpeg
+  - trim
+  - clip
+  - yt-dlp
+  - editor
+  - desktop
+
+ReleaseNotes: |-
+  First winget release. Highlights since 1.2.0 — full changelog:
+  https://github.com/AES256Afro/VideoKidnapper/blob/main/CHANGELOG.md
+
+  - Text outline, shadow, bold / italic, and multiline captions with a
+    social-standard "Caption" preset
+  - GIF tuning: dither algorithm, motion-weighted palette, loop count
+  - Blurred-background aspect fill (the Shorts / Reels look)
+  - Cookies-file support and resilient downloads (retry + resume), plus
+    a one-click yt-dlp updater
+  - Drag image overlays anywhere; paste images from the clipboard
+  - New balaclava brand icon on the app, installer, and Start Menu
+  - Security: Pillow floor raised past two advisories
+
+ReleaseNotesUrl: https://github.com/AES256Afro/VideoKidnapper/releases/tag/v1.4.0
+
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/a/AES256Afro/VideoKidnapper/1.4.0/AES256Afro.VideoKidnapper.yaml
+++ b/manifests/a/AES256Afro/VideoKidnapper/1.4.0/AES256Afro.VideoKidnapper.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+#
+# Winget "version" manifest — the stub that ties together the installer
+# + default-locale files. Submitted under:
+#     manifests/a/AES256Afro/VideoKidnapper/1.4.0/
+# in a PR against https://github.com/microsoft/winget-pkgs.
+
+PackageIdentifier: AES256Afro.VideoKidnapper
+PackageVersion: 1.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/README.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

First submission of **AES256Afro.VideoKidnapper** — a free, open-source (Apache-2.0) desktop video trimmer / GIF exporter with text overlays. Uses the Inno Setup installer from the project's GitHub Release (silent install/uninstall, Start Menu entry, Programs & Features registration).

Homepage: https://videokidnapper.com · Source: https://github.com/AES256Afro/VideoKidnapper
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/396922)