### PR TITLE
New version: tisun2.OofManager version 1.1.17

### DIFF
--- a/manifests/t/tisun2/OofManager/1.1.17/tisun2.OofManager.installer.yaml
+++ b/manifests/t/tisun2/OofManager/1.1.17/tisun2.OofManager.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: tisun2.OofManager
+PackageVersion: 1.1.17
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART
+UpgradeBehavior: install
+ReleaseDate: 2026-07-03
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/tisun2/OofManager/releases/download/v1.1.17/OofManagerSetup.exe
+    InstallerSha256: E5CACC57B66BA211840626353C2FD4D1BD4081D7A444EDA58F6F64FF849A1552
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/t/tisun2/OofManager/1.1.17/tisun2.OofManager.locale.en-US.yaml
+++ b/manifests/t/tisun2/OofManager/1.1.17/tisun2.OofManager.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: tisun2.OofManager
+PackageVersion: 1.1.17
+PackageLocale: en-US
+Publisher: tisun2
+PublisherUrl: https://github.com/tisun2
+PublisherSupportUrl: https://github.com/tisun2/OofManager/issues
+PackageName: OOF Manager
+PackageUrl: https://github.com/tisun2/OofManager
+License: MIT
+LicenseUrl: https://github.com/tisun2/OofManager/blob/main/LICENSE
+Copyright: Copyright (c) tisun2
+ShortDescription: Manage Microsoft 365 / Exchange Online Out-of-Office (Automatic Reply) settings without opening Outlook.
+Description: |-
+  OOF Manager is a lightweight Windows desktop tool that manages your Microsoft 365 mailbox's
+  Out-of-Office (Automatic Reply) state for you. Sign in once, configure your weekly work hours
+  and reply text, and OOF Manager auto-toggles your OOF on/off at the schedule boundaries.
+  It also pushes the next off-hours window to Exchange as a Scheduled OOF, so the server keeps
+  switching auto-replies even when this app is closed.
+Moniker: oofmanager
+Tags:
+  - exchange
+  - microsoft-365
+  - office-365
+  - out-of-office
+  - oof
+  - outlook
+  - autoreply
+ReleaseNotesUrl: https://github.com/tisun2/OofManager/releases/tag/v1.1.17
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/t/tisun2/OofManager/1.1.17/tisun2.OofManager.yaml
+++ b/manifests/t/tisun2/OofManager/1.1.17/tisun2.OofManager.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: tisun2.OofManager
+PackageVersion: 1.1.17
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
New version: tisun2.OofManager version 1.1.17

Automated manifest update adding version 1.1.17 of **tisun2.OofManager** (OOF Manager).

- Manifests conform to schema 1.10.0 and pass `winget validate`.
- Installer is the Inno Setup EXE published as the GitHub release asset for v1.1.17.
- Installer type (`inno`), scope (`user`), and silent-install switches are unchanged from the previous version.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/396933)