### PR TITLE
Update: add arm64 installer for Cosine CLI 2.0.25

### DIFF
--- a/manifests/c/Cosine/CLI/2.0.25/Cosine.CLI.installer.yaml
+++ b/manifests/c/Cosine/CLI/2.0.25/Cosine.CLI.installer.yaml
@@ -4,14 +4,21 @@
 PackageIdentifier: Cosine.CLI
 PackageVersion: 2.0.25
 InstallerType: zip
-NestedInstallerType: portable
-NestedInstallerFiles:
-- RelativeFilePath: cos.exe
-  PortableCommandAlias: cos
 Installers:
-- Architecture: x64
-  InstallerUrl: https://github.com/CosineAI/cli/releases/download/2.0.25/cos-windows-amd64.zip
-  InstallerSha256: 69C40BDBDADF414F224BF165403DB55F3DA8B1060F470CB32D31FDC5C6031F47
+  - Architecture: x64
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: cos.exe
+        PortableCommandAlias: cos
+    InstallerUrl: https://github.com/CosineAI/cli/releases/download/2.0.25/cos-windows-amd64.zip
+    InstallerSha256: 69C40BDBDADF414F224BF165403DB55F3DA8B1060F470CB32D31FDC5C6031F47
+  - Architecture: arm64
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: cos.exe
+        PortableCommandAlias: cos
+    InstallerUrl: https://github.com/CosineAI/cli/releases/download/2.0.25/cos-windows-arm64.zip
+    InstallerSha256: 66C6CBF40C1EF5FF659A4F612E04AA378BCFAE7A10B510A8FB11FDC5CC75F444
 ManifestType: installer
 ManifestVersion: 1.12.0
 ReleaseDate: 2026-07-01


### PR DESCRIPTION
## Summary

- Add the Windows arm64 installer entry for Cosine.CLI 2.0.25
- Attach zip portable metadata to each architecture-specific installer entry so the validator can associate `cos.exe` with both x64 and arm64 installers
- Use the published GitHub release asset URL and SHA256 digest for `cos-windows-arm64.zip`

## Verification

- Parsed `manifests/c/Cosine/CLI/2.0.25/Cosine.CLI.installer.yaml` with Ruby YAML
- Confirmed both release ZIPs download successfully and match the manifest SHA256 values
- Confirmed both ZIPs contain top-level `cos.exe`; x64 is PE32+ x86-64 and arm64 is PE32+ Aarch64
- Ran `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check`

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/396936)