### PR TITLE
New version: QuotationFactory.QFC version 0.0.1-alpha

### DIFF
--- a/manifests/q/QuotationFactory/QFC/0.0.1-alpha/QuotationFactory.QFC.installer.yaml
+++ b/manifests/q/QuotationFactory/QFC/0.0.1-alpha/QuotationFactory.QFC.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: QuotationFactory.QFC
+PackageVersion: 0.0.1-alpha
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: qfc.exe
+    PortableCommandAlias: qfc
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/quotationfactory/qf_cli/releases/download/v0.0.1-alpha/qfc-win-x64.zip
+    InstallerSha256: 7617358EBFC6BA69ED1B1D245E0B6CB356056F360451A6AF4365FA93DD0C73D8
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/q/QuotationFactory/QFC/0.0.1-alpha/QuotationFactory.QFC.locale.en-US.yaml
+++ b/manifests/q/QuotationFactory/QFC/0.0.1-alpha/QuotationFactory.QFC.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: QuotationFactory.QFC
+PackageVersion: 0.0.1-alpha
+PackageLocale: en-US
+Publisher: Quotation Factory
+PublisherUrl: https://github.com/quotationfactory/qf_cli
+PublisherSupportUrl: https://github.com/quotationfactory/qf_cli/issues
+PackageName: Quotation Factory CLI
+PackageUrl: https://github.com/quotationfactory/qf_cli
+License: Proprietary
+LicenseUrl: https://github.com/quotationfactory/qf_cli
+Copyright: Copyright (c) Quotation Factory
+ShortDescription: CLI for the Quotation Factory / Rhodium24 manufacturing API.
+Description: A self-contained command-line tool for discovering, describing, and calling Quotation Factory / Rhodium24 API endpoints with structured JSON output.
+Moniker: qfc
+Tags:
+  - quotation-factory
+  - qfc
+  - rhodium24
+  - manufacturing
+  - cli
+  - api
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/q/QuotationFactory/QFC/0.0.1-alpha/QuotationFactory.QFC.yaml
+++ b/manifests/q/QuotationFactory/QFC/0.0.1-alpha/QuotationFactory.QFC.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: QuotationFactory.QFC
+PackageVersion: 0.0.1-alpha
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary
- Adds Quotation Factory CLI 0.0.1-alpha.
- Installer URL points to the GitHub release asset for qfc-win-x64.zip.
- Manifest was generated by the Azure DevOps release pipeline after manual approval.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/396961)