### PR TITLE
Add Dropbox.dbxcli version 3.6.0

### DIFF
--- a/manifests/d/Dropbox/dbxcli/3.6.0/Dropbox.dbxcli.installer.yaml
+++ b/manifests/d/Dropbox/dbxcli/3.6.0/Dropbox.dbxcli.installer.yaml
@@ -1,0 +1,16 @@
+# Created with packaging/winget/render-manifests.sh.
+PackageIdentifier: Dropbox.dbxcli
+PackageVersion: 3.6.0
+InstallerType: zip
+NestedInstallerType: portable
+Commands:
+  - dbxcli
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/dropbox/dbxcli/releases/download/v3.6.0/dbxcli_3.6.0_windows_amd64.zip
+    InstallerSha256: 4A61125752A8B28C401F1D306AE70F36CBAA0DAEDE78FE889513EFCC9B985832
+    NestedInstallerFiles:
+      - RelativeFilePath: dbxcli_3.6.0_windows_amd64/dbxcli.exe
+        PortableCommandAlias: dbxcli
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/d/Dropbox/dbxcli/3.6.0/Dropbox.dbxcli.installer.yaml
+++ b/manifests/d/Dropbox/dbxcli/3.6.0/Dropbox.dbxcli.installer.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
 # Created with packaging/winget/render-manifests.sh.
 PackageIdentifier: Dropbox.dbxcli
 PackageVersion: 3.6.0

--- a/manifests/d/Dropbox/dbxcli/3.6.0/Dropbox.dbxcli.locale.en-US.yaml
+++ b/manifests/d/Dropbox/dbxcli/3.6.0/Dropbox.dbxcli.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# Created with packaging/winget/render-manifests.sh.
+PackageIdentifier: Dropbox.dbxcli
+PackageVersion: 3.6.0
+PackageLocale: en-US
+Publisher: Dropbox
+PublisherUrl: https://www.dropbox.com
+PublisherSupportUrl: https://github.com/dropbox/dbxcli/issues
+PrivacyUrl: https://www.dropbox.com/privacy
+Author: Dropbox
+PackageName: dbxcli
+PackageUrl: https://github.com/dropbox/dbxcli
+License: Apache-2.0
+LicenseUrl: https://github.com/dropbox/dbxcli/blob/v3.6.0/LICENSE
+ShortDescription: Command-line tool for Dropbox users and team admins
+Description: dbxcli is a scriptable Dropbox CLI for files, shared links, teams, and automation workflows.
+Moniker: dbxcli
+Tags:
+  - cli
+  - dropbox
+  - files
+  - storage
+ReleaseNotesUrl: https://github.com/dropbox/dbxcli/releases/tag/v3.6.0
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/d/Dropbox/dbxcli/3.6.0/Dropbox.dbxcli.locale.en-US.yaml
+++ b/manifests/d/Dropbox/dbxcli/3.6.0/Dropbox.dbxcli.locale.en-US.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
 # Created with packaging/winget/render-manifests.sh.
 PackageIdentifier: Dropbox.dbxcli
 PackageVersion: 3.6.0

--- a/manifests/d/Dropbox/dbxcli/3.6.0/Dropbox.dbxcli.yaml
+++ b/manifests/d/Dropbox/dbxcli/3.6.0/Dropbox.dbxcli.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
 # Created with packaging/winget/render-manifests.sh.
 PackageIdentifier: Dropbox.dbxcli
 PackageVersion: 3.6.0

--- a/manifests/d/Dropbox/dbxcli/3.6.0/Dropbox.dbxcli.yaml
+++ b/manifests/d/Dropbox/dbxcli/3.6.0/Dropbox.dbxcli.yaml
@@ -1,0 +1,6 @@
+# Created with packaging/winget/render-manifests.sh.
+PackageIdentifier: Dropbox.dbxcli
+PackageVersion: 3.6.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Validation:
- winget validate .\manifests\d\Dropbox\dbxcli\3.6.0 succeeded with schema-header warnings only.
- winget install --manifest .\manifests\d\Dropbox\dbxcli\3.6.0 succeeded.
- Installer hash verified by winget.
- Archive extracted successfully.
- Portable command alias was added.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/397020)
 
 Project link: https://github.com/dropbox/dbxcli