### PR TITLE
New package: atani.transit version 0.3.1

### DIFF
--- a/manifests/a/atani/transit/0.3.1/atani.transit.installer.yaml
+++ b/manifests/a/atani/transit/0.3.1/atani.transit.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: atani.transit
+PackageVersion: 0.3.1
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: transit.exe
+    PortableCommandAlias: transit
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/atani/transit/releases/download/v0.3.1/transit_0.3.1_windows_amd64.zip
+    InstallerSha256: D39E45ABF9B0BBC74ED758C6642FF22AB40CC0FDE3D595070A73F10AC3E7C0FC
+  - Architecture: arm64
+    InstallerUrl: https://github.com/atani/transit/releases/download/v0.3.1/transit_0.3.1_windows_arm64.zip
+    InstallerSha256: B8F383F5A9C5A89B789FEC169E2F5F8A3241CD3D928D0583559161AF86FDEF0B
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/a/atani/transit/0.3.1/atani.transit.locale.en-US.yaml
+++ b/manifests/a/atani/transit/0.3.1/atani.transit.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: atani.transit
+PackageVersion: 0.3.1
+PackageLocale: en-US
+Publisher: Akira Taniwaki
+PublisherUrl: https://github.com/atani
+PublisherSupportUrl: https://github.com/atani/transit/issues
+Author: Akira Taniwaki
+PackageName: Transit
+PackageUrl: https://github.com/atani/transit
+License: MIT
+LicenseUrl: https://github.com/atani/transit/blob/main/LICENSE
+ShortDescription: Japan transit routes and station departures CLI
+Description: transit plans Japan transit routes and shows station departures from the command line, backed by the public Transit API.
+Moniker: transit
+Tags:
+  - cli
+  - gtfs
+  - japan
+  - route
+  - transit
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/a/atani/transit/0.3.1/atani.transit.yaml
+++ b/manifests/a/atani/transit/0.3.1/atani.transit.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: atani.transit
+PackageVersion: 0.3.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
New package: atani.transit version 0.3.1

transit is a Japan transit routes and station departures CLI (MIT licensed).
Homepage: https://github.com/atani/transit

Manifests were generated by the release workflow from the v0.3.1 release assets.
Verified locally: installer URLs return HTTP 200 and the SHA256 values match the downloaded zips.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/397024)