### PR TITLE
New package: epatels.CKPDFUnlocker v6.5.5

### DIFF
--- a/manifests/e/epatels/CKPDFUnlocker/v6.5.5/epatels.CKPDFUnlocker.installer.yaml
+++ b/manifests/e/epatels/CKPDFUnlocker/v6.5.5/epatels.CKPDFUnlocker.installer.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 PackageIdentifier: epatels.CKPDFUnlocker
-PackageVersion: v6.5.5
+PackageVersion: 6.5.5
 InstallModes:
   - interactive
   - silent
@@ -11,7 +11,7 @@ Installers:
     InstallerType: nullsoft
     Scope: user
     InstallerUrl: https://github.com/epatels/ck-pdf-unlocker/releases/download/v6.5.5/ck-pdf-unlocker-setup-x64.exe
-    InstallerSha256: 0DC0A3D1181CE824FD55269D40E8F331834666891C6FA574C930E2705DDE9A51
+    InstallerSha256: 0dc0a3d1181ce824fd55269d40e8f331834666891c6fa574c930e2705dde9a51
     InstallerSwitches:
       Silent: /S
       SilentWithProgress: /S
@@ -19,6 +19,9 @@ Installers:
     InstallerType: msi
     Scope: user
     InstallerUrl: https://github.com/epatels/ck-pdf-unlocker/releases/download/v6.5.5/ck-pdf-unlocker-setup-x64.msi
-    InstallerSha256: 2AD70577588B7EAFCC089FD462D0C3CC902B8F477359261005FE89114C69B50A
+    InstallerSha256: 2ad70577588b7eafcc089fd462d0c3cc902b8f477359261005fe89114c69b50a
+    InstallerSwitches:
+      Silent: /quiet
+      SilentWithProgress: /quiet /qb
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/e/epatels/CKPDFUnlocker/v6.5.5/epatels.CKPDFUnlocker.installer.yaml
+++ b/manifests/e/epatels/CKPDFUnlocker/v6.5.5/epatels.CKPDFUnlocker.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: epatels.CKPDFUnlocker
+PackageVersion: v6.5.5
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerType: nullsoft
+    Scope: user
+    InstallerUrl: https://github.com/epatels/ck-pdf-unlocker/releases/download/v6.5.5/ck-pdf-unlocker-setup-x64.exe
+    InstallerSha256: 0DC0A3D1181CE824FD55269D40E8F331834666891C6FA574C930E2705DDE9A51
+    InstallerSwitches:
+      Silent: /S
+      SilentWithProgress: /S
+  - Architecture: x64
+    InstallerType: msi
+    Scope: user
+    InstallerUrl: https://github.com/epatels/ck-pdf-unlocker/releases/download/v6.5.5/ck-pdf-unlocker-setup-x64.msi
+    InstallerSha256: 2AD70577588B7EAFCC089FD462D0C3CC902B8F477359261005FE89114C69B50A
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/e/epatels/CKPDFUnlocker/v6.5.5/epatels.CKPDFUnlocker.locale.en-US.yaml
+++ b/manifests/e/epatels/CKPDFUnlocker/v6.5.5/epatels.CKPDFUnlocker.locale.en-US.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: epatels.CKPDFUnlocker
+PackageVersion: v6.5.5
+PackageLocale: en-US
+Publisher: epatels
+PublisherUrl: https://github.com/epatels/ck-pdf-unlocker
+PackageName: CK PDF Unlocker
+PackageUrl: https://github.com/epatels/ck-pdf-unlocker
+License: MIT
+LicenseUrl: https://github.com/epatels/ck-pdf-unlocker/blob/main/LICENSE
+ShortDescription: Remove passwords and copy/print restrictions from PDF files
+Description: |
+  CK PDF Unlocker removes open-password protection and copy/print restrictions from PDF files. It processes files locally — nothing leaves your device. Supports batch processing, per-file passwords, drag & drop, and dark/light themes.
+Tags:
+  - pdf
+  - password
+  - unlock
+  - decrypt
+  - pikepdf
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/e/epatels/CKPDFUnlocker/v6.5.5/epatels.CKPDFUnlocker.yaml
+++ b/manifests/e/epatels/CKPDFUnlocker/v6.5.5/epatels.CKPDFUnlocker.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: epatels.CKPDFUnlocker
+PackageVersion: v6.5.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## New package: epatels.CKPDFUnlocker version v6.5.5

**App name:** CK PDF Unlocker  
**Publisher:** epatels  
**License:** MIT  
**URL:** https://github.com/epatels/ck-pdf-unlocker  

This PR was generated automatically by `submit_winget.py`.

### Checklist
- [x] Installer URL is HTTPS
- [x] SHA-256 computed from the actual installer file
- [x] Installer tested locally
- [x] License is MIT (open-source)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/397263)