### PR TITLE
New package: SnipeGroupLimited.Snipe version 140.0.7339.127

### DIFF
--- a/manifests/s/SnipeGroupLimited/Snipe/140.0.7339.127/SnipeGroupLimited.Snipe.installer.yaml
+++ b/manifests/s/SnipeGroupLimited/Snipe/140.0.7339.127/SnipeGroupLimited.Snipe.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: SnipeGroupLimited.Snipe
+PackageVersion: 140.0.7339.127
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/steve12345585/snipe-x64-base/releases/download/v140.0.7339.127/SnipeBrowser-140.0.7339.127-win-x64-setup.exe
+    InstallerSha256: 0A6B59008A3C2824401C5DA5EC76A00C7E3433229C8711FC7C3473A8643F383D
+  - Architecture: x86
+    InstallerUrl: https://github.com/steve12345585/snipe-x64-base/releases/download/v140-32bit/SnipeBrowser-140.0.7339.127-win-x86-setup.exe
+    InstallerSha256: A5576B158912C855137962D7D0A5F7FFF90A615C972E1A4BE53F931D008D2346
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/SnipeGroupLimited/Snipe/140.0.7339.127/SnipeGroupLimited.Snipe.locale.en-US.yaml
+++ b/manifests/s/SnipeGroupLimited/Snipe/140.0.7339.127/SnipeGroupLimited.Snipe.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: SnipeGroupLimited.Snipe
+PackageVersion: 140.0.7339.127
+PackageLocale: en-US
+Publisher: Snipe Group Limited
+PublisherUrl: https://browser.snipeoffice.org/
+PublisherSupportUrl: https://browser.snipeoffice.org/
+PackageName: Snipe
+PackageUrl: https://browser.snipeoffice.org/
+License: Freeware
+Copyright: (c) 2026 Snipe Group Limited
+ShortDescription: A private, de-Googled web browser built on Ungoogled Chromium with zero telemetry.
+Description: |-
+  Snipe is a privacy-first web browser built on Ungoogled Chromium 140, stripped of every Google
+  service that tracks you: no telemetry, no crash reporters, no update daemons, no AI. uBlock Origin
+  is compiled into the core and active from the first page load, Ruffle brings Flash/SWF content back
+  natively, and a local-only password manager keeps credentials off the cloud. It idles around 23 MB
+  of RAM and ships builds from Windows XP through 11. Freeware - no forced updates, no forced accounts.
+Moniker: snipe
+Tags:
+  - browser
+  - privacy
+  - chromium
+  - ungoogled
+  - de-googled
+  - no-telemetry
+  - flash
+  - ublock-origin
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/SnipeGroupLimited/Snipe/140.0.7339.127/SnipeGroupLimited.Snipe.yaml
+++ b/manifests/s/SnipeGroupLimited/Snipe/140.0.7339.127/SnipeGroupLimited.Snipe.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: SnipeGroupLimited.Snipe
+PackageVersion: 140.0.7339.127
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: SnipeGroupLimited.Snipe version 140.0.7339.127

- **Name:** Snipe (Snipe Browser)
- **Publisher:** Snipe Group Limited
- **Homepage:** https://browser.snipeoffice.org/
- **License:** Freeware
- **InstallerType:** inno (silent switches set)

A de-Googled web browser built on Ungoogled Chromium 140. x64 + x86 installers, SHA256 verified against the official GitHub release assets.

---
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)? N/A (no CLA required)
- [x] Manifests validated locally (`winget validate`)
- [x] This is a new package
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/397302)