### PR TITLE
New version: M-Igashi.headroom version 2.1.1

### DIFF
--- a/manifests/m/M-Igashi/headroom/2.1.1/M-Igashi.headroom.installer.yaml
+++ b/manifests/m/M-Igashi/headroom/2.1.1/M-Igashi.headroom.installer.yaml
@@ -1,0 +1,19 @@
+# Created with manual update
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.headroom
+PackageVersion: 2.1.1
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: headroom.exe
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Gyan.FFmpeg
+ReleaseDate: 2026-07-03
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/M-Igashi/headroom/releases/download/v2.1.1/headroom-v2.1.1-windows-x86_64.zip
+    InstallerSha256: 0439C628C98B43C8A333DE1B8FE185E0EAF294E37DCEE5000AA38D5A9A078FEF
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/headroom/2.1.1/M-Igashi.headroom.locale.en-US.yaml
+++ b/manifests/m/M-Igashi/headroom/2.1.1/M-Igashi.headroom.locale.en-US.yaml
@@ -1,0 +1,41 @@
+# Created with manual update
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.headroom
+PackageVersion: 2.1.1
+PackageLocale: en-US
+Publisher: M-Igashi
+PublisherUrl: https://github.com/M-Igashi
+PublisherSupportUrl: https://github.com/M-Igashi/headroom/issues
+Author: M-Igashi
+PackageName: headroom
+PackageUrl: https://github.com/M-Igashi/headroom
+License: MIT
+LicenseUrl: https://github.com/M-Igashi/headroom/blob/main/LICENSE
+ShortDescription: Audio loudness analyzer, gain adjustment, and Rekordbox playlist sorter for mastering and DJ workflows
+Description: |-
+  headroom analyzes audio files for loudness (LUFS) and headroom, then applies lossless gain adjustment.
+  It supports MP3, AAC/M4A, FLAC, AIFF, and WAV files.
+  Features include batch processing, ReplayGain analysis, lossless MP3 gain via mp3rgain, lossless AAC/M4A gain adjustment, and a scriptable non-interactive CLI mode for pipelines and CI.
+  v2.0.0 adds the rbsort subcommand, which sorts a Rekordbox collection.xml export by Camelot Key and BPM for harmonic mixing prep — no audio touched, no ffmpeg required.
+Moniker: headroom
+Tags:
+  - aac
+  - audio
+  - cli
+  - dj
+  - ffmpeg
+  - gain
+  - loudness
+  - lufs
+  - mastering
+  - mp3
+  - music
+  - normalize
+  - rekordbox
+  - replaygain
+  - rust
+  - volume
+ReleaseNotesUrl: https://github.com/M-Igashi/headroom/releases/tag/v2.1.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/headroom/2.1.1/M-Igashi.headroom.yaml
+++ b/manifests/m/M-Igashi/headroom/2.1.1/M-Igashi.headroom.yaml
@@ -1,0 +1,8 @@
+# Created with manual update
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.headroom
+PackageVersion: 2.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## New version: M-Igashi.headroom version 2.1.1

### Checklist
- [x] This is a new version of an existing package (2.1.0 → 2.1.1)
- [x] Manifests validated locally (mirrors the accepted 2.1.0 manifest, only version/URL/SHA256/date/release-notes changed)
- [x] InstallerSha256 verified against the official release checksums file
- [x] Installer URL points to the official GitHub release asset

Release: https://github.com/M-Igashi/headroom/releases/tag/v2.1.1
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/397335)