### PR TITLE
New version: Feci.ParleyDeckCli version 1.33.0

### DIFF
--- a/manifests/f/Feci/ParleyDeckCli/1.33.0/Feci.ParleyDeckCli.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.33.0/Feci.ParleyDeckCli.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.33.0
+InstallerType: portable
+Commands:
+- parley
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.33.0/parley-v1.33.0-windows-x64.exe
+  InstallerSha256: 8BED8EFE8F23D3B9B0BFD160752A3D01D6E5BEFCE057824740F179A109541C6C
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.33.0/parley-v1.33.0-windows-arm64.exe
+  InstallerSha256: A842902B3E0392ECA45682E8695473602713BF0B6C7510ECA9C059FCBC9D073E
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.33.0/Feci.ParleyDeckCli.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.33.0/Feci.ParleyDeckCli.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.33.0
+PackageLocale: en-US
+Publisher: Feci
+PublisherUrl: https://github.com/feci
+PackageName: Parley Deck CLI
+PackageUrl: https://github.com/feci/parley-deck-cli
+License: Apache-2.0
+LicenseUrl: https://github.com/feci/parley-deck-cli/blob/main/LICENSE
+ShortDescription: CLI that orchestrates Parley Deck multi-agent cooperation workflows.
+Description: "parley orchestrates multi-agent Parley Deck cooperation: risk-tiered tracks (fast, standard, deliberation) that the driver deterministically enforces, a parley classify command for script-checkable track selection, deliberation rounds across local CLI agents, consensus and finalize, implementation with living execution plans, a live TUI, retrospective optimization, a pre-idea readiness check (parley preflight), a human-braked outer loop (COOPERATION.md section 14 plus the one-shot parley loop tick), and central per-user defaults at ~/.parley/agents.toml."
+ReleaseNotesUrl: https://github.com/feci/parley-deck-cli/releases/tag/v1.33.0
+Tags:
+- ai
+- agents
+- automation
+- cli
+- codex
+- consensus
+- loop
+- multi-agent
+- orchestration
+- preflight
+- tui
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.33.0/Feci.ParleyDeckCli.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.33.0/Feci.ParleyDeckCli.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.33.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Adds Feci.ParleyDeckCli 1.33.0 (portable, x64 + arm64). Upstream release: https://github.com/feci/parley-deck-cli/releases/tag/v1.33.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/397344)