### PR TITLE
New package: SosomLab.nShiftSpace version 0.1.0

### DIFF
--- a/manifests/s/SosomLab/nShiftSpace/0.1.0/SosomLab.nShiftSpace.installer.yaml
+++ b/manifests/s/SosomLab/nShiftSpace/0.1.0/SosomLab.nShiftSpace.installer.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: SosomLab.nShiftSpace
+PackageVersion: 0.1.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: zip
+NestedInstallerType: portable
+UpgradeBehavior: install
+ReleaseDate: 2026-07-03
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/SosomLab/nexa-shortcut/releases/download/v0.1.0/nShiftSpace-x64.zip
+  InstallerSha256: 09143806CF5A2241FF4DC3D91495592E017E14D0ECC47EF41BF2A187C7A3C6E8
+  NestedInstallerFiles:
+  - RelativeFilePath: nShiftSpace-x64.exe
+    PortableCommandAlias: nshiftspace
+- Architecture: x86
+  InstallerUrl: https://github.com/SosomLab/nexa-shortcut/releases/download/v0.1.0/nShiftSpace-x86.zip
+  InstallerSha256: 61F332B3B365ED6163429BC916AA65A20AD7B71E586045F7C219012425D36ACC
+  NestedInstallerFiles:
+  - RelativeFilePath: nShiftSpace-x86.exe
+    PortableCommandAlias: nshiftspace
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/SosomLab/nShiftSpace/0.1.0/SosomLab.nShiftSpace.locale.en-US.yaml
+++ b/manifests/s/SosomLab/nShiftSpace/0.1.0/SosomLab.nShiftSpace.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: SosomLab.nShiftSpace
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: SosomLab
+PublisherUrl: https://sosomlab.com
+PublisherSupportUrl: https://github.com/SosomLab/nexa-shortcut/issues
+PackageName: nShiftSpace
+PackageUrl: https://sosomlab.com/apps/nexa-shortcut/
+License: MIT
+LicenseUrl: https://github.com/SosomLab/nexa-shortcut/blob/main/LICENSE
+Copyright: Copyright (c) 2026 SosomLab
+ShortDescription: Ultra-lightweight Shift+Space Korean/English IME toggle for Windows
+Description: |-
+  nShiftSpace (Nexa ShiftSpace) is an ultra-lightweight Windows tray utility
+  that toggles the Korean/English IME with Shift+Space — the classic Korean
+  keyboard layout behavior. Single 4.5KB executable built with pure Win32 API
+  and no C runtime; zero CPU while idle. To run at login, place a shortcut
+  in shell:startup.
+Moniker: nshiftspace
+Tags:
+- hangul
+- hotkey
+- ime
+- keyboard
+- korean
+- lightweight
+- shift-space
+ReleaseNotesUrl: https://github.com/SosomLab/nexa-shortcut/releases/tag/v0.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/SosomLab/nShiftSpace/0.1.0/SosomLab.nShiftSpace.yaml
+++ b/manifests/s/SosomLab/nShiftSpace/0.1.0/SosomLab.nShiftSpace.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: SosomLab.nShiftSpace
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

> Note: manifests were authored on a non-Windows machine, so local winget validation was not possible — relying on the pipeline validation. SHA256 checksums were computed directly from the release assets.

###

New package submission: **SosomLab.nShiftSpace** 0.1.0 — ultra-lightweight (4.5KB) Shift+Space Korean/English IME toggle tray utility for Windows.

- Portable exe distributed as zip via GitHub Releases: https://github.com/SosomLab/nexa-shortcut/releases/tag/v0.1.0
- Project page: https://sosomlab.com/apps/nexa-shortcut/
- Open source (MIT): https://github.com/SosomLab/nexa-shortcut
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/397365)