### PR TITLE
New package: Codedaptive.MOOTx01 version 1.0.11

### DIFF
--- a/manifests/c/Codedaptive/MOOTx01/1.0.11/Codedaptive.MOOTx01.installer.yaml
+++ b/manifests/c/Codedaptive/MOOTx01/1.0.11/Codedaptive.MOOTx01.installer.yaml
@@ -1,0 +1,56 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+#
+# Installer manifest — how winget downloads and runs the setup EXE.
+#
+# InstallerType: inno
+#   The setup EXE is built by Inno Setup (see mootx01-setup.iss). Declaring
+#   `inno` lets winget derive the standard Inno silent switches and the
+#   uninstall/upgrade behavior; we still pin Silent explicitly below.
+#
+# Scope: user
+#   MOOTx01 installs per-user (PrivilegesRequired=lowest in the .iss —
+#   binaries under %APPDATA%\.mootx01\bin, no admin elevation). Winget must
+#   not attempt a machine-wide install.
+#
+# InstallerSwitches.Silent: /VERYSILENT /SUPPRESSMSGBOXES
+#   Winget always installs unattended. /VERYSILENT hides the wizard; the
+#   .iss gates its post-install client-wiring checkbox on `skipifsilent`
+#   and its uninstall MsgBox on `not UninstallSilent`, so a silent install
+#   completes without any modal dialog blocking the winget validation VM.
+#
+# InstallerSha256:
+#   MUST be the SHA-256 of the EXACT asset at InstallerUrl. It cannot be
+#   known until the release build publishes the asset. Fill it from the
+#   published checksum before submitting — see WINGET.md. Left as a
+#   zero placeholder here so a submission that forgets the step fails
+#   loudly at winget validation rather than shipping a wrong hash.
+
+PackageIdentifier: Codedaptive.MOOTx01
+PackageVersion: 1.0.11
+
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES
+UpgradeBehavior: install
+# Correlates the winget package with Inno's Add/Remove Programs entry so
+# `winget upgrade` and `winget uninstall` find the installed build. Inno
+# appends `_is1` to the AppId GUID from mootx01-setup.iss.
+AppsAndFeaturesEntries:
+  - ProductCode: "{E3A7B1C9-4D2F-4E8A-B5C6-1F9D0A2E3B4C}_is1"
+
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/codedaptive/mootx01-ce/releases/download/v1.0.11/mootx01-1.0.11-windows-x86_64-setup.exe
+    InstallerSha256: 25D0BDCF6E066E49571F463C032B9AB725DE44833610E8F5471BC53688D7BE64
+  - Architecture: arm64
+    InstallerUrl: https://github.com/codedaptive/mootx01-ce/releases/download/v1.0.11/mootx01-1.0.11-windows-arm64-setup.exe
+    InstallerSha256: A0977F40D817C422A746B7A9C44407A9F3D5BA2D1A913C6254D3731197865FD9
+
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/c/Codedaptive/MOOTx01/1.0.11/Codedaptive.MOOTx01.locale.en-US.yaml
+++ b/manifests/c/Codedaptive/MOOTx01/1.0.11/Codedaptive.MOOTx01.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+#
+# Default-locale manifest — the human-facing metadata winget shows in
+# `winget show Codedaptive.MOOTx01` and the store listing. License and
+# publisher fields must match the LICENSE file and mootx01-setup.iss.
+
+PackageIdentifier: Codedaptive.MOOTx01
+PackageVersion: 1.0.11
+PackageLocale: en-US
+Publisher: Codedaptive LLC
+PublisherUrl: https://github.com/codedaptive/mootx01-ce
+PublisherSupportUrl: https://github.com/codedaptive/mootx01-ce/issues
+PackageName: MOOTx01
+PackageUrl: https://github.com/codedaptive/mootx01-ce
+# SPDX identifier for the Functional Source License 1.1 (Apache-2.0 future
+# grant) that governs this repo — see LICENSE.
+License: FSL-1.1-ALv2
+Copyright: Copyright (c) Codedaptive LLC
+ShortDescription: A persistent, private, on-device memory for your AI clients.
+Description: >-
+  MOOTx01 gives your AI tools a persistent memory that lives on your own
+  machine. It runs as a local background service and connects to AI clients
+  (Claude, Cursor, and others) over the Model Context Protocol, so your
+  assistants can capture, recall, and reason over what you have told them
+  across sessions. All estate data stays local under %LOCALAPPDATA%\MOOTx01;
+  nothing is sent to a cloud.
+Tags:
+  - ai
+  - mcp
+  - memory
+  - llm
+  - productivity
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/c/Codedaptive/MOOTx01/1.0.11/Codedaptive.MOOTx01.yaml
+++ b/manifests/c/Codedaptive/MOOTx01/1.0.11/Codedaptive.MOOTx01.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+#
+# Version manifest — the entry point winget reads first. It names the
+# package and points at the default locale; the installer.yaml and
+# locale.en-US.yaml files in this same directory carry the rest.
+#
+# All three files MUST share the same PackageIdentifier and PackageVersion.
+# When bumping the release, update PackageVersion in all three in lockstep
+# (see WINGET.md).
+
+PackageIdentifier: Codedaptive.MOOTx01
+PackageVersion: 1.0.11
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Description
First submission of **MOOTx01** — a persistent, private, on-device memory for AI clients (MCP server). Runs as a local background service; all data stays under %LOCALAPPDATA%\MOOTx01.

- Publisher: Codedaptive LLC
- Installer: Inno Setup, per-user scope (no elevation), x64 + arm64
- Silent install verified with /VERYSILENT /SUPPRESSMSGBOXES (post-install wiring is skipifsilent; uninstall notice gated on UninstallSilent)
- SHA-256s hashed from the published release assets and cross-checked against the release checksums.txt

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/README.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/397412)