### PR TITLE
New package: SubstrateSystems.Endstate version 2.18.0

### DIFF
--- a/manifests/s/SubstrateSystems/Endstate/2.18.0/SubstrateSystems.Endstate.installer.yaml
+++ b/manifests/s/SubstrateSystems/Endstate/2.18.0/SubstrateSystems.Endstate.installer.yaml
@@ -1,0 +1,14 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: SubstrateSystems.Endstate
+PackageVersion: 2.18.0
+InstallerLocale: en-US
+InstallerType: wix
+ProductCode: '{86920EDD-3A2A-466C-8CC6-0AB108F2739B}'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Artexis10/endstate-gui/releases/download/gui-v2.18.0/Endstate_2.18.0_x64_en-US.msi
+  InstallerSha256: 82D8DBDC2E43B5030CBC1B14E2BB708030CC8AC3AA9E1499E9E188B348296557
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/SubstrateSystems/Endstate/2.18.0/SubstrateSystems.Endstate.locale.en-US.yaml
+++ b/manifests/s/SubstrateSystems/Endstate/2.18.0/SubstrateSystems.Endstate.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: SubstrateSystems.Endstate
+PackageVersion: 2.18.0
+PackageLocale: en-US
+Publisher: Substrate Systems OÜ
+PublisherUrl: https://substratesystems.io
+PublisherSupportUrl: https://github.com/Artexis10/endstate/issues
+PrivacyUrl: https://substratesystems.io/terms
+Author: Substrate Systems OÜ
+PackageName: Endstate
+PackageUrl: https://substratesystems.io/endstate
+License: Apache-2.0
+LicenseUrl: https://github.com/Artexis10/endstate/blob/main/LICENSE
+ShortDescription: Set up a new Windows PC by reinstalling your apps and restoring your settings from one portable file.
+Description: 'Endstate sets up a new Windows PC in minutes. It scans your current machine for installed apps (via winget) and their settings, saves everything to one portable file you control, then reinstalls the apps and restores your settings on a fresh Windows install. Local-first: no account, no telemetry, and the engine is open source under Apache 2.0.'
+Moniker: endstate
+Tags:
+- winget
+- backup
+- migration
+- provisioning
+- windows
+- setup
+ReleaseNotesUrl: https://github.com/Artexis10/endstate-gui/releases/tag/gui-v2.18.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/SubstrateSystems/Endstate/2.18.0/SubstrateSystems.Endstate.locale.en-US.yaml
+++ b/manifests/s/SubstrateSystems/Endstate/2.18.0/SubstrateSystems.Endstate.locale.en-US.yaml
@@ -4,7 +4,7 @@
 PackageIdentifier: SubstrateSystems.Endstate
 PackageVersion: 2.18.0
 PackageLocale: en-US
-Publisher: Substrate Systems OÜ
+Publisher: substratesystems
 PublisherUrl: https://substratesystems.io
 PublisherSupportUrl: https://github.com/Artexis10/endstate/issues
 PrivacyUrl: https://substratesystems.io/terms

--- a/manifests/s/SubstrateSystems/Endstate/2.18.0/SubstrateSystems.Endstate.yaml
+++ b/manifests/s/SubstrateSystems/Endstate/2.18.0/SubstrateSystems.Endstate.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: SubstrateSystems.Endstate
+PackageVersion: 2.18.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New package
- **PackageIdentifier:** SubstrateSystems.Endstate
- **Version:** 2.18.0
- Free, open-source (Apache-2.0) Windows app: scans your installed apps (via winget) and settings, saves them to one portable file, and reinstalls them on a fresh Windows install.

Manifests generated with wingetcreate 1.12.8.0 and validated locally (validation succeeded). Installer is the MSI from the official GitHub release. The MSI is not Authenticode-signed; a SignPath Foundation application is in progress.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there are no other open pull requests for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 manifest specification](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest)?

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/397416)