### PR TITLE
New package: lpourmoment-dot.ckbpos version 5.0.0

### DIFF
--- a/manifests/l/lpourmoment-dot/ckbpos/5.0.0/lpourmoment-dot.ckbpos.installer.yaml
+++ b/manifests/l/lpourmoment-dot/ckbpos/5.0.0/lpourmoment-dot.ckbpos.installer.yaml
@@ -1,0 +1,21 @@
+# Created using winget-create
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: lpourmoment-dot.ckbpos
+PackageVersion: 5.0.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nsis
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/lpourmoment-dot/CKBPOS/releases/download/v5.0.0/CKBPOS-Setup-5.0.0.exe
+  InstallerSha256: 9BE69A56233FC298079C8BB7A11FDEDE37F9CD9FFBD1CD3A22338662FB95AD1B
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/l/lpourmoment-dot/ckbpos/5.0.0/lpourmoment-dot.ckbpos.locale.pt-BR.yaml
+++ b/manifests/l/lpourmoment-dot/ckbpos/5.0.0/lpourmoment-dot.ckbpos.locale.pt-BR.yaml
@@ -1,0 +1,21 @@
+# Created using winget-create
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: lpourmoment-dot.ckbpos
+PackageVersion: 5.0.0
+PackageLocale: pt-BR
+Publisher: CKB
+PublisherUrl: https://github.com/lpourmoment-dot
+PackageName: CKBPOS
+PackageUrl: https://github.com/lpourmoment-dot/CKBPOS
+License: Proprietary
+ShortDescription: Application Point de Vente Professionnelle
+Description: CKBPOS - Application de point de vente professionnelle avec gestion de stock, comptabilitÃ©, et conformitÃ© fiscale AGT.
+Tags:
+- pos
+- point-of-sale
+- inventory
+- accounting
+- invoice
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/l/lpourmoment-dot/ckbpos/5.0.0/lpourmoment-dot.ckbpos.yaml
+++ b/manifests/l/lpourmoment-dot/ckbpos/5.0.0/lpourmoment-dot.ckbpos.yaml
@@ -1,0 +1,8 @@
+# Created using winget-create
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: lpourmoment-dot.ckbpos
+PackageVersion: 5.0.0
+DefaultLocale: pt-BR
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Add CKBPOS v5.0.0 to WinGet.

- Package: lpourmoment-dot.ckbpos
- Version: 5.0.0
- Installer: NSIS (x64)
- SHA256: 9BE69A56233FC298079C8BB7A11FDEDE37F9CD9FFBD1CD3A22338662FB95AD1B
- URL: https://github.com/lpourmoment-dot/CKBPOS/releases/download/v5.0.0/CKBPOS-Setup-5.0.0.exe

This package has been verified against the GitHub release.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/397447)