### PR TITLE
New package: Devlint.GitWand version 3.2.0

### DIFF
--- a/manifests/d/Devlint/GitWand/3.2.0/Devlint.GitWand.installer.yaml
+++ b/manifests/d/Devlint/GitWand/3.2.0/Devlint.GitWand.installer.yaml
@@ -1,4 +1,4 @@
-# Installer manifest — manifests/d/Devlint/GitWand/3.2.0/Devlint.GitWand.installer.yaml
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 PackageIdentifier: Devlint.GitWand
 PackageVersion: 3.2.0
 InstallerLocale: en-US

--- a/manifests/d/Devlint/GitWand/3.2.0/Devlint.GitWand.installer.yaml
+++ b/manifests/d/Devlint/GitWand/3.2.0/Devlint.GitWand.installer.yaml
@@ -1,0 +1,16 @@
+# Installer manifest — manifests/d/Devlint/GitWand/3.2.0/Devlint.GitWand.installer.yaml
+PackageIdentifier: Devlint.GitWand
+PackageVersion: 3.2.0
+InstallerLocale: en-US
+InstallerType: wix
+Scope: machine
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/devlint/GitWand/releases/download/v3.2.0/GitWand_3.2.0_x64_en-US.msi
+    InstallerSha256: 06E53F4BB56040CB86301719F9B7E030A5566C270EA7FA13EAB87A55BBA2CE27
+    ProductCode: "{F1292551-7E19-49B4-8CEB-C36E093143B4}"
+    AppsAndFeaturesEntries:
+      - UpgradeCode: "{657CFCE3-C37E-57E6-8C49-821826D858E4}"
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/d/Devlint/GitWand/3.2.0/Devlint.GitWand.locale.en-US.yaml
+++ b/manifests/d/Devlint/GitWand/3.2.0/Devlint.GitWand.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# Default locale manifest — manifests/d/Devlint/GitWand/3.2.0/Devlint.GitWand.locale.en-US.yaml
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 PackageIdentifier: Devlint.GitWand
 PackageVersion: 3.2.0
 PackageLocale: en-US

--- a/manifests/d/Devlint/GitWand/3.2.0/Devlint.GitWand.locale.en-US.yaml
+++ b/manifests/d/Devlint/GitWand/3.2.0/Devlint.GitWand.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# Default locale manifest — manifests/d/Devlint/GitWand/3.2.0/Devlint.GitWand.locale.en-US.yaml
+PackageIdentifier: Devlint.GitWand
+PackageVersion: 3.2.0
+PackageLocale: en-US
+Publisher: Devlint
+PublisherUrl: https://github.com/devlint
+PublisherSupportUrl: https://github.com/devlint/GitWand/issues
+PackageName: GitWand
+PackageUrl: https://gitwand.devlint.fr/
+License: MIT
+LicenseUrl: https://github.com/devlint/GitWand/blob/main/LICENSE
+ShortDescription: Git client with deterministic merge-conflict auto-resolution
+Description: |-
+  GitWand is a free, open-source native Git client that automatically resolves
+  trivial merge conflicts using 10 deterministic patterns — no guessing, no
+  hallucinations. It covers the full daily Git workflow (changes, history,
+  branches, PR review) and exposes its resolution engine as a CLI, a VS Code
+  extension and an MCP server for AI agents. Built with Tauri 2 + Rust.
+Tags:
+  - git
+  - git-client
+  - merge
+  - merge-conflicts
+  - developer-tools
+  - rust
+  - tauri
+Moniker: gitwand
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/d/Devlint/GitWand/3.2.0/Devlint.GitWand.locale.en-US.yaml
+++ b/manifests/d/Devlint/GitWand/3.2.0/Devlint.GitWand.locale.en-US.yaml
@@ -2,7 +2,7 @@
 PackageIdentifier: Devlint.GitWand
 PackageVersion: 3.2.0
 PackageLocale: en-US
-Publisher: Devlint
+Publisher: gitwand
 PublisherUrl: https://github.com/devlint
 PublisherSupportUrl: https://github.com/devlint/GitWand/issues
 PackageName: GitWand

--- a/manifests/d/Devlint/GitWand/3.2.0/Devlint.GitWand.yaml
+++ b/manifests/d/Devlint/GitWand/3.2.0/Devlint.GitWand.yaml
@@ -1,4 +1,4 @@
-# Version manifest — manifests/d/Devlint/GitWand/3.2.0/Devlint.GitWand.yaml
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 PackageIdentifier: Devlint.GitWand
 PackageVersion: 3.2.0
 DefaultLocale: en-US

--- a/manifests/d/Devlint/GitWand/3.2.0/Devlint.GitWand.yaml
+++ b/manifests/d/Devlint/GitWand/3.2.0/Devlint.GitWand.yaml
@@ -1,0 +1,6 @@
+# Version manifest — manifests/d/Devlint/GitWand/3.2.0/Devlint.GitWand.yaml
+PackageIdentifier: Devlint.GitWand
+PackageVersion: 3.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package: **Devlint.GitWand** version **3.2.0** — GitWand, a free, open-source (MIT) native Git client (Tauri 2 + Rust) with deterministic merge-conflict auto-resolution. Homepage: https://gitwand.devlint.fr/ · Source: https://github.com/devlint/GitWand

The installer is the signed MSI from the official GitHub release. `InstallerSha256` matches the release asset digest reported by the GitHub API, and `ProductCode` / `UpgradeCode` / scope (`ALLUSERS=1` → machine) were extracted directly from the MSI's Property table with msitools.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com) — I'll accept via the CLA bot prompt on this PR (I am the developer of GitWand)
- [ ] Linked to an issue (if applicable) — N/A

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` — no Windows machine available; relying on the validation pipeline (hash and ProductCode were extracted from the MSI itself, see above)
- [ ] Tested manifest locally with `winget install --manifest <path>` — same as above
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/397460)