### PR TITLE
Kindel.mcec: correct package metadata (rebrand to MCEC)

### DIFF
--- a/manifests/k/Kindel/mcec/3.0.16/Kindel.mcec.locale.en-US.yaml
+++ b/manifests/k/Kindel/mcec/3.0.16/Kindel.mcec.locale.en-US.yaml
@@ -4,27 +4,33 @@
 PackageIdentifier: Kindel.mcec
 PackageVersion: 3.0.16
 PackageLocale: en-US
-Publisher: Kindel Systems
+Publisher: Kindel, LLC
 PublisherUrl: https://github.com/tig
 PublisherSupportUrl: https://github.com/tig/mcec/issues
-Author: Kindel Systems
-PackageName: MCE Controller
+Author: Kindel, LLC
+PackageName: MCEC (Model Context Environment Controller)
 PackageUrl: https://github.com/tig/mcec
 License: MIT
 LicenseUrl: https://github.com/tig/mcec/blob/HEAD/license.md
-Copyright: Copyright © Kindel Systems, LLC.
-ShortDescription: Control a Windows PC over the network or serial port.
+Copyright: Copyright © Kindel, LLC.
+ShortDescription: Give an AI agent eyes and hands on Windows over MCP; also a network/serial remote control.
 Description: |-
-  MCE Controller lets you control a Windows PC — Windows Media Center and beyond — over
-  the network (TCP/IP) or a serial port. It runs as a server that receives text commands
-  and turns them into keystrokes, mouse actions, launched programs, window activations,
-  and power/shutdown actions, with a configurable command set.
+  MCEC (Model Context Environment Controller) gives an AI agent eyes, hands, and a safe front door on a
+  Windows PC over the Model Context Protocol (MCP): capture a window, read its UI Automation tree, find and
+  wait for controls, launch apps, and drive keyboard, mouse, and window input. It is also the same
+  battle-tested network/serial remote control it has always been, turning text commands into keystrokes,
+  mouse actions, and app launches for home-automation systems such as Control4, Crestron, and iRule. The
+  agent surface is opt-in and off by default.
 Moniker: mcec
 Tags:
+- agent
+- ai
 - automation
-- home-theater
-- htpc
-- media-center
+- computer-use
+- control4
+- crestron
+- home-automation
+- mcp
 - remote-control
 ReleaseNotes: |-
   What's Changed


### PR DESCRIPTION
Metadata-only correction to the existing 3.0.16 manifest (no installer change). Updates the stale pre-3.0 identity: PackageName 'MCE Controller' -> 'MCEC (Model Context Environment Controller)', Publisher/Author/Copyright 'Kindel Systems' -> 'Kindel, LLC', an agent-first ShortDescription/Description that still covers the network/serial remote control, and refreshed Tags. All other fields (installer, hashes, release notes) unchanged.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/397592)