### PR TITLE
New version: Feci.ParleyDeckSkill version 1.4.3

### DIFF
--- a/manifests/f/Feci/ParleyDeckSkill/1.4.3/Feci.ParleyDeckSkill.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/1.4.3/Feci.ParleyDeckSkill.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 1.4.3
+InstallerType: portable
+Commands:
+- parley-deck-skill
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-skill/releases/download/v1.4.3/parley-deck-skill-v1.4.3-windows-x64.exe
+  InstallerSha256: 0B897E5BB51D319FDA908E3EF17EFC9E0A95C569C07525D54B92C94DF442FCC8
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-skill/releases/download/v1.4.3/parley-deck-skill-v1.4.3-windows-arm64.exe
+  InstallerSha256: 15E2E6766046AE3FC03C640B0A60A5961AA4F82547B5F025A02E9FD24C5BF801
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckSkill/1.4.3/Feci.ParleyDeckSkill.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/1.4.3/Feci.ParleyDeckSkill.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 1.4.3
+PackageLocale: en-US
+Publisher: Feci
+PublisherUrl: https://github.com/feci
+PackageName: Parley Deck Skill
+PackageUrl: https://github.com/feci/parley-deck-skill
+License: Apache-2.0
+LicenseUrl: https://github.com/feci/parley-deck-skill/blob/main/LICENSE
+ShortDescription: Installer for the Parley Deck multi-agent cooperation skill.
+Description: "Installs the vendor-neutral Parley Deck AI cooperation skill into Codex, Claude Code, Antigravity CLI, legacy Gemini CLI, Hermes, or a custom skill directory. v1.4.3 syncs the bundled fallback protocol to Parley Deck protocol v1.34.0: adds the conditional-rigor track selector (fast, standard, deliberation) with a developer Quickstart, and reorganizes the document into a progressive-disclosure layout (core sections first, reference sections last). Ships two opt-in companion add-on skills installed by default (use --no-addons or --only to choose): parley-worktrees (parallel sessions over one git repo via worktrees) and parley-tracker (vendor-neutral epic/story/subtask authoring readable by business, technical, and AI readers, with a tool-enforced gap-scan)."
+ReleaseNotesUrl: https://github.com/feci/parley-deck-skill/releases/tag/v1.4.3
+Tags:
+- ai
+- agents
+- agy
+- antigravity
+- cli
+- codex
+- claude
+- gemini
+- multi-agent
+- skill
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckSkill/1.4.3/Feci.ParleyDeckSkill.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/1.4.3/Feci.ParleyDeckSkill.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 1.4.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
New version of Feci.ParleyDeckSkill (1.4.3). Portable installer; SHA256 verified against the GitHub release assets.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/397744)