### PR TITLE
Fix Issue #397745: Add Scope: machine to Microsoft.DotNet.DesktopRuntime.10

### DIFF
--- a/manifests/m/Microsoft/DotNet/DesktopRuntime/10/10.0.9/Microsoft.DotNet.DesktopRuntime.10.installer.yaml
+++ b/manifests/m/Microsoft/DotNet/DesktopRuntime/10/10.0.9/Microsoft.DotNet.DesktopRuntime.10.installer.yaml
@@ -4,6 +4,7 @@
 PackageIdentifier: Microsoft.DotNet.DesktopRuntime.10
 PackageVersion: 10.0.9
 MinimumOSVersion: 6.1.7601
+Scope: machine
 InstallerSwitches:
   Silent: /quiet
   SilentWithProgress: /passive


### PR DESCRIPTION
## Summary

- Resolves #397745
- Fixed the root cause
- Updated affected manifest(s)
- No unrelated changes

## Testing

- Manifest validation passed (`winget validate`)
- Repository validation passed
- Local testing completed

## Notes

- Added `Scope: machine` to the `10.0.9` (latest) installer manifest of `Microsoft.DotNet.DesktopRuntime.10`.
- This ensures the package is recognized as machine-wide scope, fixing installer match issues when updating/installing with `--scope machine`.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/397879)