### PR TITLE
New package: gistrec.filecast version 1.0.0

### DIFF
--- a/manifests/g/gistrec/filecast/1.0.0/gistrec.filecast.installer.yaml
+++ b/manifests/g/gistrec/filecast/1.0.0/gistrec.filecast.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: gistrec.filecast
+PackageVersion: 1.0.0
+InstallerType: portable
+Commands:
+- filecast
+ReleaseDate: 2026-07-04
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/gistrec/filecast/releases/download/v1.0.0/filecast-windows-x86_64.exe
+  InstallerSha256: D084600EC4E8410FA99BA5B9A39DF837214456B1A62827C8F4135D0EB0114F19
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/g/gistrec/filecast/1.0.0/gistrec.filecast.locale.en-US.yaml
+++ b/manifests/g/gistrec/filecast/1.0.0/gistrec.filecast.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: gistrec.filecast
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: gistrec
+PublisherUrl: https://github.com/gistrec
+PublisherSupportUrl: https://github.com/gistrec/filecast/issues
+Author: gistrec
+PackageName: filecast
+PackageUrl: https://github.com/gistrec/filecast
+License: MIT
+LicenseUrl: https://github.com/gistrec/filecast/blob/master/LICENSE
+ShortDescription: Send a file to every machine on your LAN at once over UDP broadcast/multicast.
+Description: |-
+  filecast is a cross-platform command-line tool that sends a single file to
+  every host on the same LAN at once, using UDP broadcast or IP multicast, with
+  automatic retransmission of dropped packets. One sender reaches any number of
+  receivers in the time of a single transfer. It verifies each file end-to-end
+  with SHA-256, resumes interrupted receives, and needs no server, relay, or
+  internet connection.
+Moniker: filecast
+Tags:
+- broadcast
+- cli
+- file-transfer
+- lan
+- multicast
+- networking
+- udp
+ReleaseNotesUrl: https://github.com/gistrec/filecast/releases/tag/v1.0.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/g/gistrec/filecast/1.0.0/gistrec.filecast.yaml
+++ b/manifests/g/gistrec/filecast/1.0.0/gistrec.filecast.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: gistrec.filecast
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package

- **Package**: `gistrec.filecast`
- **Version**: 1.0.0
- **Installer**: portable, x64 (a single standalone `.exe`)
- **Command alias**: `filecast`

filecast is a cross-platform CLI that sends a single file to every host on the same LAN at once over UDP broadcast or IP multicast, with automatic retransmission of dropped packets, end-to-end SHA-256 verification, and resumable receives. Repo: https://github.com/gistrec/filecast (MIT).

- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [ ] Validated with `winget validate` — **not run**: these manifests were authored on macOS against schema 1.6.0 and validated as YAML only. Please flag any schema nits from the validation pipeline and I will fix them promptly.
- [x] This PR only modifies one (1) manifest.

The installer URL is a permanent GitHub release asset; its SHA-256 matches the release's `checksums.txt`.