### PR TITLE
New version: Cingano.wtop version 1.2.0

### DIFF
--- a/manifests/c/Cingano/wtop/1.2.0/Cingano.wtop.installer.yaml
+++ b/manifests/c/Cingano/wtop/1.2.0/Cingano.wtop.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Cingano.wtop
+PackageVersion: 1.2.0
+InstallerType: portable
+Commands:
+  - wtop
+ReleaseDate: 2026-07-04
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/lorenzo-cingano/wtop/releases/download/v1.2.0/wtop.exe
+    InstallerSha256: F7D645C110C6CA7A3B493DA0EB945B1CBB27FC75CD8A0F558A2C6D15935D9130
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/c/Cingano/wtop/1.2.0/Cingano.wtop.locale.en-US.yaml
+++ b/manifests/c/Cingano/wtop/1.2.0/Cingano.wtop.locale.en-US.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Cingano.wtop
+PackageVersion: 1.2.0
+PackageLocale: en-US
+Publisher: Cingano Development
+PublisherUrl: https://github.com/lorenzo-cingano
+PublisherSupportUrl: https://github.com/lorenzo-cingano/wtop/issues
+Author: Cingano Development
+PackageName: wtop
+PackageUrl: https://github.com/lorenzo-cingano/wtop
+License: 0BSD
+LicenseUrl: https://github.com/lorenzo-cingano/wtop/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Cingano Development
+ShortDescription: An htop-style process viewer for Windows
+Description: |-
+  wtop is an htop-style process viewer for Windows, written in pure C using only
+  the Win32 API and the C standard library, with no external dependencies. It
+  shows per-core CPU meters, a memory meter, and a sortable, filterable process
+  table with tree view, process tagging, bulk kill, and full mouse support. A
+  per-process detail view shows environment variables, open files, registry
+  keys and sockets, and the thread list; an I/O tab shows live network and disk
+  throughput.
+Moniker: wtop
+Tags:
+  - htop
+  - top
+  - process
+  - process-viewer
+  - task-manager
+  - system-monitor
+  - monitoring
+  - cli
+  - tui
+  - terminal
+ReleaseNotesUrl: https://github.com/lorenzo-cingano/wtop/releases/tag/v1.2.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/c/Cingano/wtop/1.2.0/Cingano.wtop.yaml
+++ b/manifests/c/Cingano/wtop/1.2.0/Cingano.wtop.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Cingano.wtop
+PackageVersion: 1.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New version: Cingano.wtop 1.2.0

Adds the portable (x64) manifest for wtop 1.2.0, an htop-style process viewer
for Windows.

- Installer asset: https://github.com/lorenzo-cingano/wtop/releases/download/v1.2.0/wtop.exe
- Release notes: https://github.com/lorenzo-cingano/wtop/releases/tag/v1.2.0
- `InstallerSha256` matches the published release asset.
- Manifest validated locally with `winget validate` (passed).

- [x] This PR adds a single new package version.
- [x] Installer URL and `InstallerSha256` verified against the GitHub release asset.
- [x] Manifest schema validated with `winget validate`.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/397936)