### PR TITLE
New version: Feci.ParleyDeckCli version 1.35.0

### DIFF
--- a/manifests/f/Feci/ParleyDeckCli/1.35.0/Feci.ParleyDeckCli.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.35.0/Feci.ParleyDeckCli.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.35.0
+InstallerType: portable
+Commands:
+- parley
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.35.0/parley-v1.35.0-windows-x64.exe
+  InstallerSha256: E9B54E202F85E6DDBD267BE25CF509E7998E698B8B82FF8F4FA3901D7B3889FB
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.35.0/parley-v1.35.0-windows-arm64.exe
+  InstallerSha256: BCECA805971315F393EEF81E933A28B6EA44A2A570647B76BF47E7C1C1CEC11F
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.35.0/Feci.ParleyDeckCli.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.35.0/Feci.ParleyDeckCli.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.35.0
+PackageLocale: en-US
+Publisher: Feci
+PublisherUrl: https://github.com/feci
+PackageName: Parley Deck CLI
+PackageUrl: https://github.com/feci/parley-deck-cli
+License: Apache-2.0
+LicenseUrl: https://github.com/feci/parley-deck-cli/blob/main/LICENSE
+ShortDescription: CLI that orchestrates Parley Deck multi-agent cooperation workflows.
+Description: "parley orchestrates multi-agent Parley Deck cooperation: risk-tiered tracks (fast, standard, deliberation), deliberation rounds across local CLI agents, consensus and finalize, implementation with living execution plans, and a live TUI. v1.35.0 adds a list-form checks completion contract (the driver runs named criteria, writes a secret-scrubbed evidence table into IMPLEMENTATION.md, and vetoes completion while any criterion fails), named roster presets (parley run --preset plus parley preset list), a consolidated round digest in the TUI Home tab, a $EDITOR composer (/editor and ctrl+e) in the live TUI, and parley learn, which distills a completed idea into an advisory playbook."
+ReleaseNotesUrl: https://github.com/feci/parley-deck-cli/releases/tag/v1.35.0
+Tags:
+- ai
+- agents
+- automation
+- cli
+- codex
+- consensus
+- loop
+- multi-agent
+- orchestration
+- preflight
+- tui
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.35.0/Feci.ParleyDeckCli.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.35.0/Feci.ParleyDeckCli.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.35.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
New version of Feci.ParleyDeckCli (1.35.0). Portable installer; SHA256 verified against the GitHub release assets.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/397946)