### PR TITLE
New version: Feci.ParleyDeckSkill version 1.4.4

### DIFF
--- a/manifests/f/Feci/ParleyDeckSkill/1.4.4/Feci.ParleyDeckSkill.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/1.4.4/Feci.ParleyDeckSkill.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 1.4.4
+InstallerType: portable
+Commands:
+- parley-deck-skill
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-skill/releases/download/v1.4.4/parley-deck-skill-v1.4.4-windows-x64.exe
+  InstallerSha256: 599A7B0C84FBC6926534A1E59ABEF13521132AECBCFACBE24C02A5896DA9875F
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-skill/releases/download/v1.4.4/parley-deck-skill-v1.4.4-windows-arm64.exe
+  InstallerSha256: 49815ACFF264785A25FAECF971563F20B27383105F352CBCAABE9232C3AB4958
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckSkill/1.4.4/Feci.ParleyDeckSkill.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/1.4.4/Feci.ParleyDeckSkill.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 1.4.4
+PackageLocale: en-US
+Publisher: Feci
+PublisherUrl: https://github.com/feci
+PackageName: Parley Deck Skill
+PackageUrl: https://github.com/feci/parley-deck-skill
+License: Apache-2.0
+LicenseUrl: https://github.com/feci/parley-deck-skill/blob/main/LICENSE
+ShortDescription: Installer for the Parley Deck multi-agent cooperation skill.
+Description: "Installs the vendor-neutral Parley Deck AI cooperation skill into Codex, Claude Code, Antigravity CLI, legacy Gemini CLI, Hermes, or a custom skill directory. v1.4.4 syncs the bundled fallback protocol to Parley Deck protocol v1.35.0: adds the LE-4 completion contract (list-form checks with a driver-written validation-evidence ledger and a fail-closed completion veto) and section 13.5 playbooks (advisory parley learn distillation). Ships two opt-in companion add-on skills installed by default (use --no-addons or --only to choose): parley-worktrees (parallel sessions over one git repo via worktrees) and parley-tracker (vendor-neutral epic/story/subtask authoring readable by business, technical, and AI readers, with a tool-enforced gap-scan)."
+ReleaseNotesUrl: https://github.com/feci/parley-deck-skill/releases/tag/v1.4.4
+Tags:
+- ai
+- agents
+- agy
+- antigravity
+- cli
+- codex
+- claude
+- gemini
+- multi-agent
+- skill
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckSkill/1.4.4/Feci.ParleyDeckSkill.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/1.4.4/Feci.ParleyDeckSkill.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 1.4.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
New version of Feci.ParleyDeckSkill (1.4.4). Portable installer; SHA256 verified against the GitHub release assets.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/397947)