### PR TITLE
New version: Framefilter.Keyroost version 0.7.3

### DIFF
--- a/manifests/f/Framefilter/Keyroost/0.7.3/Framefilter.Keyroost.installer.yaml
+++ b/manifests/f/Framefilter/Keyroost/0.7.3/Framefilter.Keyroost.installer.yaml
@@ -1,0 +1,18 @@
+PackageIdentifier: Framefilter.Keyroost
+PackageVersion: "0.7.3"
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: keyroostctl.exe
+    PortableCommandAlias: keyroostctl
+  - RelativeFilePath: keyroost.exe
+    PortableCommandAlias: keyroost
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/framefilter/keyroost/releases/download/v0.7.3/keyroost-v0.7.3-windows-x86_64.zip
+    InstallerSha256: "053C34D52A12A9773D76D507E88AA82959FC4C3BCA98E798100F5D81D95CA4DF"
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/f/Framefilter/Keyroost/0.7.3/Framefilter.Keyroost.locale.en-US.yaml
+++ b/manifests/f/Framefilter/Keyroost/0.7.3/Framefilter.Keyroost.locale.en-US.yaml
@@ -1,0 +1,16 @@
+PackageIdentifier: Framefilter.Keyroost
+PackageVersion: "0.7.3"
+PackageLocale: en-US
+Publisher: framefilter
+PackageName: keyroost
+License: MIT OR Apache-2.0
+PackageUrl: https://github.com/framefilter/keyroost
+ShortDescription: Program Token2 Molto2 TOTP tokens and manage FIDO2/OATH/OpenPGP/PIV security keys.
+Moniker: keyroost
+Tags:
+  - totp
+  - 2fa
+  - fido2
+  - security-key
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/f/Framefilter/Keyroost/0.7.3/Framefilter.Keyroost.yaml
+++ b/manifests/f/Framefilter/Keyroost/0.7.3/Framefilter.Keyroost.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Framefilter.Keyroost
+PackageVersion: "0.7.3"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Version bump of the existing, previously-approved `Framefilter.Keyroost` package (0.6.0 → 0.7.3).

Mirrors the approved 0.6.0 manifest; only the version, installer URL, and SHA256 changed. Installer is the v0.7.3 GitHub release Windows zip:
https://github.com/framefilter/keyroost/releases/download/v0.7.3/keyroost-v0.7.3-windows-x86_64.zip

- Two portable executables (keyroostctl, keyroost) in a zip, per the existing manifest.
- VC++ 2015+ redistributable dependency retained (added at the moderator's request on the bootstrap PR).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/397971)