### PR TITLE
New Package: WritersLogic.WritersProof version 1.5.2.0

### DIFF
--- a/manifests/w/WritersLogic/WritersProof/1.5.2.0/WritersLogic.WritersProof.installer.yaml
+++ b/manifests/w/WritersLogic/WritersProof/1.5.2.0/WritersLogic.WritersProof.installer.yaml
@@ -1,0 +1,11 @@
+PackageIdentifier: WritersLogic.WritersProof
+PackageVersion: 1.5.2.0
+InstallerType: msix
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://updates.writerslogic.com/windows/WritersProof-1.5.2.0-x64.msix
+    InstallerSha256: F64362C53EA260A5717ACA25E991ED1F8BB7686F6BC4799033B59E7DA29E22E2
+    SignatureSha256: F64362C53EA260A5717ACA25E991ED1F8BB7686F6BC4799033B59E7DA29E22E2
+    Scope: user
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/w/WritersLogic/WritersProof/1.5.2.0/WritersLogic.WritersProof.locale.en-US.yaml
+++ b/manifests/w/WritersLogic/WritersProof/1.5.2.0/WritersLogic.WritersProof.locale.en-US.yaml
@@ -1,0 +1,21 @@
+PackageIdentifier: WritersLogic.WritersProof
+PackageVersion: 1.5.2.0
+PackageLocale: en-US
+Publisher: WritersLogic, Inc
+PublisherUrl: https://writerslogic.com
+PublisherSupportUrl: https://writersproof.com/support
+PrivacyUrl: https://writerslogic.com/privacy
+Author: David Condrey
+PackageName: WritersProof
+PackageUrl: https://writersproof.com
+License: Commercial
+ShortDescription: Cryptographic authorship witnessing for writers and creators
+Description: WritersProof captures behavioral evidence (keystrokes, timing, mouse movements) during document creation and packages it into cryptographically signed evidence packets that prove human authorship. Implements the IETF draft-condrey-rats-pop attestation protocol.
+Tags:
+  - authorship
+  - attestation
+  - writing
+  - cryptography
+  - evidence
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/w/WritersLogic/WritersProof/1.5.2.0/WritersLogic.WritersProof.yaml
+++ b/manifests/w/WritersLogic/WritersProof/1.5.2.0/WritersLogic.WritersProof.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: WritersLogic.WritersProof
+PackageVersion: 1.5.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## New Package

**Package:** WritersLogic.WritersProof  
**Version:** 1.5.2.0  
**Installer:** MSIX (x64, sideload)

WritersProof captures behavioral evidence during document creation and packages it into cryptographically signed evidence packets that prove human authorship.

- Homepage: https://writersproof.com
- Publisher: WritersLogic, Inc
- License: Commercial
- Installer SHA256: F64362C53EA260A5717ACA25E991ED1F8BB7686F6BC4799033B59E7DA29E22E2

## Checklist

- [x] I have verified that the URL is valid and the installer is accessible
- [x] I have verified the SHA256 hash matches the downloaded installer
- [x] The package version matches the installer version
- [x] The publisher name matches the signing certificate subject
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/398007)