### PR TITLE
New version: Echowire.Echowire version 2026.704.150126

### DIFF
--- a/manifests/e/Echowire/Echowire/2026.704.150126/Echowire.Echowire.installer.yaml
+++ b/manifests/e/Echowire/Echowire/2026.704.150126/Echowire.Echowire.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Echowire.Echowire
+PackageVersion: 2026.704.150126
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-07-06
+Installers:
+- Architecture: x64
+  InstallerUrl: https://echowire.org/api/dl/desktop/stable/win32/x64/2026.704.150126/setup
+  InstallerSha256: 95A012EAEE9DD65792A51BA61B2C76B848224EA0193F6BB7B4475C067654C7AB
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/e/Echowire/Echowire/2026.704.150126/Echowire.Echowire.locale.en-US.yaml
+++ b/manifests/e/Echowire/Echowire/2026.704.150126/Echowire.Echowire.locale.en-US.yaml
@@ -10,7 +10,7 @@ Author: Cameron Proudlock
 PackageName: Echowire
 PackageUrl: https://echowire.org
 License: AGPL-3.0-or-later
-LicenseUrl: https://www.gnu.org/licenses/agpl-3.0.html
+LicenseUrl: https://spdx.org/licenses/AGPL-3.0-or-later.html
 Copyright: Copyright (c) 2026 Echowire Contributors
 ShortDescription: Voice, video, and text chat for groups and friends.
 Description: |-

--- a/manifests/e/Echowire/Echowire/2026.704.150126/Echowire.Echowire.locale.en-US.yaml
+++ b/manifests/e/Echowire/Echowire/2026.704.150126/Echowire.Echowire.locale.en-US.yaml
@@ -10,7 +10,7 @@ Author: Cameron Proudlock
 PackageName: Echowire
 PackageUrl: https://echowire.org
 License: AGPL-3.0-or-later
-LicenseUrl: https://github.com/cproudlock/fluxer/blob/main/LICENCE
+LicenseUrl: https://www.gnu.org/licenses/agpl-3.0.html
 Copyright: Copyright (c) 2026 Echowire Contributors
 ShortDescription: Voice, video, and text chat for groups and friends.
 Description: |-

--- a/manifests/e/Echowire/Echowire/2026.704.150126/Echowire.Echowire.locale.en-US.yaml
+++ b/manifests/e/Echowire/Echowire/2026.704.150126/Echowire.Echowire.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Echowire.Echowire
+PackageVersion: 2026.704.150126
+PackageLocale: en-US
+Publisher: Proudlock Technology
+PublisherUrl: https://echowire.org
+PublisherSupportUrl: https://echowire.org/help
+PrivacyUrl: https://echowire.org/privacy
+Author: Cameron Proudlock
+PackageName: Echowire
+PackageUrl: https://echowire.org
+License: AGPL-3.0-or-later
+LicenseUrl: https://github.com/cproudlock/fluxer/blob/main/LICENCE
+Copyright: Copyright (c) 2026 Echowire Contributors
+ShortDescription: Voice, video, and text chat for groups and friends.
+Description: |-
+  Echowire is a free and open-source voice, video, and text chat application
+  with system-wide push-to-talk, low-latency voice channels, screen sharing,
+  and end-to-end encrypted media. Built on a self-hosted infrastructure with
+  the Fluxer protocol.
+Moniker: echowire
+Tags:
+- chat
+- voice
+- video
+- voip
+- screen-share
+- push-to-talk
+- communication
+- open-source
+ReleaseNotesUrl: https://echowire.org/download
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/e/Echowire/Echowire/2026.704.150126/Echowire.Echowire.yaml
+++ b/manifests/e/Echowire/Echowire/2026.704.150126/Echowire.Echowire.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Echowire.Echowire
+PackageVersion: 2026.704.150126
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Add Echowire 2026.704.150126 to winget-pkgs. Manifests auto-generated by scripts/release/winget-bump.sh from the official release at https://echowire.org/api/dl/desktop/stable/win32/x64/2026.704.150126/setup. SHA256: 95A012EAEE9DD65792A51BA61B2C76B848224EA0193F6BB7B4475C067654C7AB
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/398304)