### PR TITLE
Add ClickPOS Proxy version 1.0.0

### DIFF
--- a/manifests/c/ClickPOS/ClickPOSProxy/1.0.0/ClickPOS.ClickPOSProxy.installer.yaml
+++ b/manifests/c/ClickPOS/ClickPOSProxy/1.0.0/ClickPOS.ClickPOSProxy.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: ClickPOS.ClickPOSProxy
+PackageVersion: 1.0.0
+InstallerLocale: en-US
+InstallerType: msi
+Scope: machine
+InstallModes:
+  - silent
+  - interactive
+UpgradeBehavior: install
+Installers:
+  - Architecture: x86
+    InstallerUrl: https://github.com/Juszzy/ClickPOS-Proxy/releases/download/v1.0.0/ClickPOS-Proxy-1.0.0.msi
+    InstallerSha256: 801B12FD699E9572FF0FBD89CAB9A90D95DDB91114073ADB89183CAD19A6A6F2
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/c/ClickPOS/ClickPOSProxy/1.0.0/ClickPOS.ClickPOSProxy.installer.yaml
+++ b/manifests/c/ClickPOS/ClickPOSProxy/1.0.0/ClickPOS.ClickPOSProxy.installer.yaml
@@ -11,6 +11,6 @@ UpgradeBehavior: install
 Installers:
   - Architecture: x86
     InstallerUrl: https://github.com/Juszzy/ClickPOS-Proxy/releases/download/v1.0.0/ClickPOS-Proxy-1.0.0.msi
-    InstallerSha256: 801B12FD699E9572FF0FBD89CAB9A90D95DDB91114073ADB89183CAD19A6A6F2
+    InstallerSha256: 77BEEE2FE09DC4046713BCAD7B9C573B7AE01D37ACB068DFAC381F7D911BB9B9
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/c/ClickPOS/ClickPOSProxy/1.0.0/ClickPOS.ClickPOSProxy.locale.en-US.yaml
+++ b/manifests/c/ClickPOS/ClickPOSProxy/1.0.0/ClickPOS.ClickPOSProxy.locale.en-US.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: ClickPOS.ClickPOSProxy
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: ClickPOS Pty Ltd
+PackageName: ClickPOS Proxy
+License: Proprietary
+ShortDescription: Windows service that proxies Epson ePOS print jobs to network printers with auto-discovery and browser dashboard.
+Tags:
+  - epson
+  - epos
+  - receipt
+  - printer
+  - proxy
+  - pos
+ReleaseNotesUrl: https://github.com/Juszzy/ClickPOS-Proxy/releases
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/c/ClickPOS/ClickPOSProxy/1.0.0/ClickPOS.ClickPOSProxy.yaml
+++ b/manifests/c/ClickPOS/ClickPOSProxy/1.0.0/ClickPOS.ClickPOSProxy.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: ClickPOS.ClickPOSProxy
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Adds winget manifest for ClickPOS Proxy 1.0.0 — a Windows service that proxies Epson ePOS print jobs to network printers.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/398366)