### PR TITLE
Update willibrandon.dotsider to 0.18.0

### DIFF
--- a/manifests/w/willibrandon/dotsider/0.18.0/willibrandon.dotsider.installer.yaml
+++ b/manifests/w/willibrandon/dotsider/0.18.0/willibrandon.dotsider.installer.yaml
@@ -1,0 +1,27 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: willibrandon.dotsider
+PackageVersion: 0.18.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.18362.0
+InstallerType: msi
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/willibrandon/dotsider/releases/download/v0.18.0/dotsider-win-x64.msi
+  InstallerSha256: C4FBF6C5E70D1A2E7395F4B48E4E904FD7C5E1BD272D0FCCEBAE1D943FB25307
+  ProductCode: '{5B37AB84-3D6B-4A84-8F45-0E846D14D644}'
+- Architecture: arm64
+  InstallerUrl: https://github.com/willibrandon/dotsider/releases/download/v0.18.0/dotsider-win-arm64.msi
+  InstallerSha256: 6604C6ECB04A60CF87F5A200130FAB2DAA27B5B2EFCF81A4E2A1D208105276FC
+  ProductCode: '{8E7A32D0-76CE-4D99-BE22-E8FFC3F3723E}'
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-07-06

--- a/manifests/w/willibrandon/dotsider/0.18.0/willibrandon.dotsider.locale.en-US.yaml
+++ b/manifests/w/willibrandon/dotsider/0.18.0/willibrandon.dotsider.locale.en-US.yaml
@@ -1,0 +1,36 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: willibrandon.dotsider
+PackageVersion: 0.18.0
+PackageLocale: en-US
+Publisher: willibrandon
+PublisherUrl: https://github.com/willibrandon
+PublisherSupportUrl: https://github.com/willibrandon/dotsider/issues
+PackageName: dotsider
+PackageUrl: https://github.com/willibrandon/dotsider
+License: MIT
+LicenseUrl: https://github.com/willibrandon/dotsider/blob/main/LICENSE
+ShortDescription: A TUI for analyzing .NET assemblies
+Description: |-
+  dotsider is a terminal UI for analyzing .NET assemblies — structure, metadata,
+  IL disassembly, strings, hex dump, dependency graphs, size maps, and live
+  runtime tracing via EventPipe. It also supports assembly diffing and NuGet
+  package browsing.
+Tags:
+- dotnet
+- assembly
+- tui
+- il
+- metadata
+- pe
+- disassembler
+- cli
+- terminal
+- devtools
+ReleaseNotesUrl: https://github.com/willibrandon/dotsider/releases/tag/v0.18.0
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/willibrandon/dotsider/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/w/willibrandon/dotsider/0.18.0/willibrandon.dotsider.yaml
+++ b/manifests/w/willibrandon/dotsider/0.18.0/willibrandon.dotsider.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: willibrandon.dotsider
+PackageVersion: 0.18.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Update dotsider to version 0.18.0

## Release notes

https://github.com/willibrandon/dotsider/releases/tag/v0.18.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/398372)