### PR TITLE
New package: RemcoStoeten.Skriuw version 0.16.0

### DIFF
--- a/manifests/r/RemcoStoeten/Skriuw/0.16.0/RemcoStoeten.Skriuw.installer.yaml
+++ b/manifests/r/RemcoStoeten/Skriuw/0.16.0/RemcoStoeten.Skriuw.installer.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: RemcoStoeten.Skriuw
+PackageVersion: 0.16.0
+InstallerType: nullsoft
+UpgradeBehavior: install
+ReleaseDate: 2026-07-06
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/remcostoeten/skriuw/releases/download/desktop-v0.16.0/Skriuw_0.16.0_x64-setup.exe
+  InstallerSha256: 5AEB8C9621F2F39F513FF4054BA5C31989E4D4198AFA9D420E3F35224A87C10E
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/r/RemcoStoeten/Skriuw/0.16.0/RemcoStoeten.Skriuw.locale.en-US.yaml
+++ b/manifests/r/RemcoStoeten/Skriuw/0.16.0/RemcoStoeten.Skriuw.locale.en-US.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: RemcoStoeten.Skriuw
+PackageVersion: 0.16.0
+PackageLocale: en-US
+Publisher: Remco Stoeten
+PublisherUrl: https://github.com/remcostoeten
+PublisherSupportUrl: https://github.com/remcostoeten/skriuw/issues
+Author: Remco Stoeten
+PackageName: Skriuw
+PackageUrl: https://github.com/remcostoeten/skriuw
+License: MIT
+LicenseUrl: https://github.com/remcostoeten/skriuw/blob/daddy/LICENSE
+ShortDescription: A quiet writing workspace for notes, journaling, sharing, and planning
+Moniker: skriuw
+Tags:
+- markdown
+- notes
+- writing
+ReleaseNotesUrl: https://github.com/remcostoeten/skriuw/releases/tag/desktop-v0.16.0
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/r/RemcoStoeten/Skriuw/0.16.0/RemcoStoeten.Skriuw.yaml
+++ b/manifests/r/RemcoStoeten/Skriuw/0.16.0/RemcoStoeten.Skriuw.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: RemcoStoeten.Skriuw
+PackageVersion: 0.16.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## New package submission

- **PackageIdentifier**: RemcoStoeten.Skriuw
- **PackageVersion**: 0.16.0
- **Installer**: NSIS (Tauri), x64
- **Homepage**: https://github.com/remcostoeten/skriuw

First submission of Skriuw, a quiet writing workspace for notes, journaling, sharing, and planning.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`? (authored on Linux — relying on pipeline validation; manifest follows the 1.9.0 schema)
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? (authored on Linux; installer is the official Tauri NSIS build)
- [x] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.9.0)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/398375)