### PR TITLE
New version: mar1mo-41414.MineScale version 1.2.13

### DIFF
--- a/manifests/m/mar1mo-41414/MineScale/1.2.13/mar1mo-41414.MineScale.installer.yaml
+++ b/manifests/m/mar1mo-41414/MineScale/1.2.13/mar1mo-41414.MineScale.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: mar1mo-41414.MineScale
+PackageVersion: 1.2.13
+InstallerType: portable
+Commands:
+- mc-share-gui
+ReleaseDate: 2026-07-06
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/mar1mo-41414/MineScale/releases/download/v1.2.13/mc-share-gui-windows-x64.exe
+  InstallerSha256: CC9C7E5DC905C0E0CC769BFBE6E46D28AA56F807B3CBEFD9152C7ACEE86BC214
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/mar1mo-41414/MineScale/1.2.13/mar1mo-41414.MineScale.locale.en-US.yaml
+++ b/manifests/m/mar1mo-41414/MineScale/1.2.13/mar1mo-41414.MineScale.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: mar1mo-41414.MineScale
+PackageVersion: 1.2.13
+PackageLocale: en-US
+Publisher: mar1mo-41414
+PublisherUrl: https://github.com/mar1mo-41414
+PublisherSupportUrl: https://github.com/mar1mo-41414/MineScale/issues
+Author: mar1mo-41414
+PackageName: MineScale
+PackageUrl: https://github.com/mar1mo-41414/MineScale
+License: MIT
+LicenseUrl: https://github.com/mar1mo-41414/MineScale/blob/main/LICENSE
+Copyright: Copyright (c) 2025 mar1mo-41414
+ShortDescription: Minecraft Java Edition P2P world sharing - no port forwarding, no accounts.
+Description: |-
+  MineScale lets two players share a Minecraft Java Edition world peer-to-peer
+  over an encrypted QUIC tunnel. No port forwarding, no account registration,
+  no monthly fees. The host runs a LAN world, sends a link, and the joiner's
+  Minecraft client sees it automatically in the multiplayer list.
+Moniker: minescale
+Tags:
+- gaming
+- minecraft
+- multiplayer
+- p2p
+ReleaseNotesUrl: https://github.com/mar1mo-41414/MineScale/releases/tag/v1.2.13
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/mar1mo-41414/MineScale/1.2.13/mar1mo-41414.MineScale.yaml
+++ b/manifests/m/mar1mo-41414/MineScale/1.2.13/mar1mo-41414.MineScale.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: mar1mo-41414.MineScale
+PackageVersion: 1.2.13
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
New version of mar1mo-41414.MineScale: 1.2.13.

Manifests generated via scripts/publish-winget.sh in the project repo — wingetcreate still can't parse this project's portable .exe (single-binary Rust build with embedded VS_VERSION_INFO but no installer wrapper), so the tooling is hand-crafted.

- Repo: https://github.com/mar1mo-41414/MineScale
- Release: https://github.com/mar1mo-41414/MineScale/releases/tag/v1.2.13
- License: MIT

Validation checklist:
- [x] InstallerSha256 matches the released artifact
- [x] InstallerUrl resolves (verified via curl in the script)
- [x] InstallerType: portable (single .exe, no install steps)
- [x] Manifest passes schema 1.12.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/398434)