### PR TITLE
Add Nirosoftware.SerialFlow version 0.4.0

### DIFF
--- a/manifests/n/Nirosoftware/SerialFlow/0.4.0/Nirosoftware.SerialFlow.installer.yaml
+++ b/manifests/n/Nirosoftware/SerialFlow/0.4.0/Nirosoftware.SerialFlow.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: Nirosoftware.SerialFlow
+PackageVersion: 0.4.0
+InstallerType: portable
+Commands:
+- serialflow
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Nirosoftware/serialflow-releases/releases/download/v0.4.0/serialflow-windows-x64.exe
+  InstallerSha256: 3DA9F1911B138823780381681D122FFC5D996A78F44E8FF6A5C95A824BB051D6
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/n/Nirosoftware/SerialFlow/0.4.0/Nirosoftware.SerialFlow.locale.en-US.yaml
+++ b/manifests/n/Nirosoftware/SerialFlow/0.4.0/Nirosoftware.SerialFlow.locale.en-US.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: Nirosoftware.SerialFlow
+PackageVersion: 0.4.0
+PackageLocale: en-US
+Publisher: Nirosoftware
+PublisherUrl: https://serialflow.app
+PublisherSupportUrl: https://serialflow.app/docs
+PackageName: SerialFlow CLI
+PackageUrl: https://serialflow.app
+License: Proprietary
+ShortDescription: Stream serial data from any machine to the SerialFlow web studio.
+Description: SerialFlow CLI connects local serial devices to SerialFlow for remote streaming and live sessions.
+Tags:
+- serial
+- uart
+- terminal
+- cli
+ReleaseNotesUrl: https://github.com/Nirosoftware/serialflow-releases/releases/tag/v0.4.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/n/Nirosoftware/SerialFlow/0.4.0/Nirosoftware.SerialFlow.yaml
+++ b/manifests/n/Nirosoftware/SerialFlow/0.4.0/Nirosoftware.SerialFlow.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: Nirosoftware.SerialFlow
+PackageVersion: 0.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Automated manifest update for SerialFlow v0.4.0.

- Adds manifests for Nirosoftware.SerialFlow 0.4.0
- Installer URL points to the signed serialflow-windows-x64.exe in Nirosoftware/serialflow-releases
- InstallerSha256 verified against the published release asset and SHA256SUMS.txt
- Manifest installability verified by the release workflow (winget install --manifest / URL+checksum fallback)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/398571)