### PR TITLE
New version: CyrilPeng.VeneraNext version 1.11.0

### DIFF
--- a/manifests/c/CyrilPeng/VeneraNext/1.11.0/CyrilPeng.VeneraNext.installer.yaml
+++ b/manifests/c/CyrilPeng/VeneraNext/1.11.0/CyrilPeng.VeneraNext.installer.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: CyrilPeng.VeneraNext
+PackageVersion: 1.11.0
+InstallerType: inno
+Scope: machine
+UpgradeBehavior: install
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART
+  Custom: /NORESTART
+AppsAndFeaturesEntries:
+- DisplayName: VeneraNext
+  Publisher: CyrilPeng/venera-next
+  ProductCode: "{C6B7E69A-0FD6-4F2A-AC64-7D1AE8A40FB8}_is1"
+  InstallerType: inno
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/CyrilPeng/venera-next/releases/download/v1.11.0/VeneraNext-1.11.0-windows-installer.exe
+    InstallerSha256: A18A405213CE4AA943F48F58BA96001D338953A70F708AE4707F8BF21C72D770
+    ProductCode: "{C6B7E69A-0FD6-4F2A-AC64-7D1AE8A40FB8}_is1"
+    ReleaseDate: 2026-07-12
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/c/CyrilPeng/VeneraNext/1.11.0/CyrilPeng.VeneraNext.locale.en-US.yaml
+++ b/manifests/c/CyrilPeng/VeneraNext/1.11.0/CyrilPeng.VeneraNext.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: CyrilPeng.VeneraNext
+PackageVersion: 1.11.0
+PackageLocale: en-US
+Publisher: CyrilPeng/venera-next
+PublisherUrl: https://github.com/CyrilPeng/venera-next
+PublisherSupportUrl: https://github.com/CyrilPeng/venera-next/issues
+Author: CyrilPeng
+PackageName: VeneraNext
+PackageUrl: https://github.com/CyrilPeng/venera-next
+License: GPL-3.0
+LicenseUrl: https://github.com/CyrilPeng/venera-next/blob/main/LICENSE
+Copyright: Copyright (C) CyrilPeng
+ShortDescription: A comic app.
+Description: VeneraNext is a free and open-source app for comic reading.
+Moniker: venera-next
+Tags:
+- comic
+- manga
+- reader
+ReleaseNotesUrl: https://github.com/CyrilPeng/venera-next/releases/tag/v1.11.0
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/c/CyrilPeng/VeneraNext/1.11.0/CyrilPeng.VeneraNext.yaml
+++ b/manifests/c/CyrilPeng/VeneraNext/1.11.0/CyrilPeng.VeneraNext.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: CyrilPeng.VeneraNext
+PackageVersion: 1.11.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Adds CyrilPeng.VeneraNext 1.11.0. Generated from the VeneraNext v1.11.0 release workflow artifact; this replaces the initial 1.10.2 submission before merge.