### PR TITLE
New package: tonythethompson.QuickShellforRun version 0.2.1.0

### DIFF
--- a/manifests/t/tonythethompson/QuickShellforRun/0.2.1.0/tonythethompson.QuickShellforRun.installer.yaml
+++ b/manifests/t/tonythethompson/QuickShellforRun/0.2.1.0/tonythethompson.QuickShellforRun.installer.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: tonythethompson.QuickShellforRun
+PackageVersion: 0.2.1.0
+MinimumOSVersion: 10.0.19041.0
+InstallerType: inno
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+AppsAndFeaturesEntries:
+- DisplayName: Quick Shell for Run
+  Publisher: Tony Thompson
+  ProductCode: '{B7D2C4E8-9F1A-4D6B-A2C3-5E8F1D0B7A9C}_is1'
+InstallationMetadata:
+  DefaultInstallLocation: '%LOCALAPPDATA%\Microsoft\PowerToys\PowerToys Run\Plugins\QuickShell'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/tonythethompson/QuickShell/releases/download/v0.2.1.0/QuickShellforRun-Setup-0.2.1.0-x64.exe
+  InstallerSha256: 11D770F917FC58925761DD9CE9E0B3BE389AA0FAA64818670A1FAE591ED40C31
+- Architecture: arm64
+  InstallerUrl: https://github.com/tonythethompson/QuickShell/releases/download/v0.2.1.0/QuickShellforRun-Setup-0.2.1.0-arm64.exe
+  InstallerSha256: 156A832AF634FE7D6E3FDC7D62D8D9E80CA9D27BFDEEE6DE54CA8541B68E47F9
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-07-07

--- a/manifests/t/tonythethompson/QuickShellforRun/0.2.1.0/tonythethompson.QuickShellforRun.installer.yaml
+++ b/manifests/t/tonythethompson/QuickShellforRun/0.2.1.0/tonythethompson.QuickShellforRun.installer.yaml
@@ -21,10 +21,10 @@ InstallationMetadata:
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/tonythethompson/QuickShell/releases/download/v0.2.1.0/QuickShellforRun-Setup-0.2.1.0-x64.exe
-  InstallerSha256: 11D770F917FC58925761DD9CE9E0B3BE389AA0FAA64818670A1FAE591ED40C31
+  InstallerSha256: 6B414F6082ECACDAC1AF3C68854A8642E07A53A0C8E67605AFB7C443B7FD537E
 - Architecture: arm64
   InstallerUrl: https://github.com/tonythethompson/QuickShell/releases/download/v0.2.1.0/QuickShellforRun-Setup-0.2.1.0-arm64.exe
-  InstallerSha256: 156A832AF634FE7D6E3FDC7D62D8D9E80CA9D27BFDEEE6DE54CA8541B68E47F9
+  InstallerSha256: 6A6BE973C9B7557C2A61CC9D7ADD20024DB6638213ECCD24C7EBE3785DDECA6A
 ManifestType: installer
 ManifestVersion: 1.12.0
 ReleaseDate: 2026-07-07

--- a/manifests/t/tonythethompson/QuickShellforRun/0.2.1.0/tonythethompson.QuickShellforRun.locale.en-US.yaml
+++ b/manifests/t/tonythethompson/QuickShellforRun/0.2.1.0/tonythethompson.QuickShellforRun.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: tonythethompson.QuickShellforRun
+PackageVersion: 0.2.1.0
+PackageLocale: en-US
+Publisher: Tony Thompson
+PublisherUrl: https://github.com/tonythethompson
+PublisherSupportUrl: https://github.com/tonythethompson/QuickShell/issues
+PackageName: Quick Shell for Run
+PackageUrl: https://github.com/tonythethompson/QuickShell
+License: MIT
+LicenseUrl: https://github.com/tonythethompson/QuickShell/blob/master/LICENSE
+ShortDescription: PowerToys Run plugin to open saved workspaces from Quick Shell
+Description: |
+  Quick Shell for Run installs only the PowerToys Run plugin (qs command).
+  Save project directories and launch them in Windows Terminal or other shells
+  without installing the full Command Palette extension.
+
+  Requires PowerToys with Run enabled. Restart PowerToys after install.
+Tags:
+- commandline
+- powershell
+- powertoys
+- powertoys-run
+- quickshell
+- terminal
+- windows-terminal
+ReleaseNotes: |
+  - Initial WinGet package for the standalone PowerToys Run installer
+  - Installs the qs plugin to PowerToys Run
+ReleaseNotesUrl: https://github.com/tonythethompson/QuickShell/releases/tag/v0.2.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/tonythethompson/QuickShellforRun/0.2.1.0/tonythethompson.QuickShellforRun.yaml
+++ b/manifests/t/tonythethompson/QuickShellforRun/0.2.1.0/tonythethompson.QuickShellforRun.yaml
@@ -1,0 +1,8 @@
+# Created with wingetcreate-style manifests for QuickShellforRun
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: tonythethompson.QuickShellforRun
+PackageVersion: 0.2.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Quick Shell for Run

Standalone PowerToys Run plugin installer for Quick Shell.

- Package: `tonythethompson.QuickShellforRun`
- Version: 0.2.1.0
- Release: https://github.com/tonythethompson/QuickShell/releases/tag/v0.2.1.0

Draft until GitHub release v0.2.1.0 assets are published and SHA256 values are confirmed.

Made with [Cursor](https://cursor.com)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/398636)