### PR TITLE
New package: tonythethompson.QuickShellforRaycast version 0.2.1.0

### DIFF
--- a/manifests/t/tonythethompson/QuickShellforRaycast/0.2.1.0/tonythethompson.QuickShellforRaycast.installer.yaml
+++ b/manifests/t/tonythethompson/QuickShellforRaycast/0.2.1.0/tonythethompson.QuickShellforRaycast.installer.yaml
@@ -21,7 +21,7 @@ InstallationMetadata:
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/tonythethompson/QuickShell/releases/download/v0.2.1.0/QuickShellforRaycast-Setup-0.2.1.0-x64.exe
-  InstallerSha256: 591EDF94294BA1E641E34BDE6A1726FDCDE8FB304A5CAA32274C2FABA3211E0A
+  InstallerSha256: 30050147770CC4210276EBFB10C7129FDFA2DB5235C7C59B860AC3EA6936387D
 ManifestType: installer
 ManifestVersion: 1.12.0
 ReleaseDate: 2026-07-07

--- a/manifests/t/tonythethompson/QuickShellforRaycast/0.2.1.0/tonythethompson.QuickShellforRaycast.installer.yaml
+++ b/manifests/t/tonythethompson/QuickShellforRaycast/0.2.1.0/tonythethompson.QuickShellforRaycast.installer.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: tonythethompson.QuickShellforRaycast
+PackageVersion: 0.2.1.0
+MinimumOSVersion: 10.0.19041.0
+InstallerType: inno
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+AppsAndFeaturesEntries:
+- DisplayName: Quick Shell for Raycast
+  Publisher: Tony Thompson
+  ProductCode: '{A4E8B2D1-7C3F-4A9E-B5D1-2F8E6C0A1B3D}_is1'
+InstallationMetadata:
+  DefaultInstallLocation: '%APPDATA%\raycast-x\extensions\quickshell'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/tonythethompson/QuickShell/releases/download/v0.2.1.0/QuickShellforRaycast-Setup-0.2.1.0-x64.exe
+  InstallerSha256: 591EDF94294BA1E641E34BDE6A1726FDCDE8FB304A5CAA32274C2FABA3211E0A
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-07-07

--- a/manifests/t/tonythethompson/QuickShellforRaycast/0.2.1.0/tonythethompson.QuickShellforRaycast.locale.en-US.yaml
+++ b/manifests/t/tonythethompson/QuickShellforRaycast/0.2.1.0/tonythethompson.QuickShellforRaycast.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: tonythethompson.QuickShellforRaycast
+PackageVersion: 0.2.1.0
+PackageLocale: en-US
+Publisher: Tony Thompson
+PublisherUrl: https://github.com/tonythethompson
+PublisherSupportUrl: https://github.com/tonythethompson/QuickShell/issues
+PackageName: Quick Shell for Raycast
+PackageUrl: https://github.com/tonythethompson/QuickShell
+License: MIT
+LicenseUrl: https://github.com/tonythethompson/QuickShell/blob/master/LICENSE
+ShortDescription: Raycast extension to open saved developer workspaces on Windows
+Description: |
+  Quick Shell for Raycast sideloads the QuickShell Raycast extension on Windows.
+  Save project folders, launch terminals, run startup commands, and jump to
+  workspaces with home keywords.
+
+  Requires Raycast for Windows. After install, open Raycast and import or reload
+  the extension if commands do not appear automatically.
+Tags:
+- commandline
+- developer-tools
+- powershell
+- quickshell
+- raycast
+- terminal
+- windows-terminal
+- workspace
+ReleaseNotes: |
+  - Initial WinGet package for the standalone Raycast sideload installer
+  - Copies the extension to the Raycast extensions folder on Windows
+ReleaseNotesUrl: https://github.com/tonythethompson/QuickShell/releases/tag/v0.2.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/tonythethompson/QuickShellforRaycast/0.2.1.0/tonythethompson.QuickShellforRaycast.yaml
+++ b/manifests/t/tonythethompson/QuickShellforRaycast/0.2.1.0/tonythethompson.QuickShellforRaycast.yaml
@@ -1,0 +1,8 @@
+# Created with wingetcreate-style manifests for QuickShellforRaycast
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: tonythethompson.QuickShellforRaycast
+PackageVersion: 0.2.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Quick Shell for Raycast

Standalone Raycast extension sideload installer for Quick Shell (Windows x64).

- Package: `tonythethompson.QuickShellforRaycast`
- Version: 0.2.1.0
- Release: https://github.com/tonythethompson/QuickShell/releases/tag/v0.2.1.0

Draft until manifest SHA256 values are verified against the published release assets.

Made with [Cursor](https://cursor.com)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/398638)