### PR TITLE
Update: Unity.UnityHub version 3.19.4

### DIFF
--- a/manifests/u/Unity/UnityHub/3.19.4/Unity.UnityHub.installer.yaml
+++ b/manifests/u/Unity/UnityHub/3.19.4/Unity.UnityHub.installer.yaml
@@ -14,13 +14,13 @@ Protocols:
 FileExtensions:
 - unityhub
 ProductCode: Unity Technologies - Hub
-ReleaseDate: 2026-04-23
+ReleaseDate: 2026-07-07
 AppsAndFeaturesEntries:
-- DisplayName: Unity Hub 3.17.3
+- DisplayName: Unity Hub 3.19.4
   ProductCode: Unity Technologies - Hub
 Installers:
 - Architecture: x64
-  InstallerUrl: https://public-cdn.cloud.unity3d.com/hub/prod/UnityHubSetup-x64.exe
+  InstallerUrl: https://public-cdn.cloud.unity3d.com/hub/prod/3.19.4/UnityHubSetup-3.19.4-x64.exe
   InstallerSha256: F557B40E33BCD7CA6A4CF3119E24AF10805253AD61705F02D28BD3B3FAE38625
 ManifestType: installer
 ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Corrects the existing `Unity.UnityHub` **3.19.4** installer manifest (auto-added by the bot on 2026-07-08) so `InstallerUrl` points at Unity's **immutable, version-pinned** CDN artifact:

`https://public-cdn.cloud.unity3d.com/hub/prod/3.19.4/UnityHubSetup-3.19.4-x64.exe`

instead of the rolling `…/hub/prod/UnityHubSetup-x64.exe` alias, whose bytes are overwritten on every Hub release. The pinned path serves the same bytes today (`InstallerSha256` is unchanged), but stays valid for the life of the manifest — this is the root-cause fix for the recurring hash mismatch in #398600.

Also corrects two stale fields carried over from an older version: `AppsAndFeaturesEntries.DisplayName` (`Unity Hub 3.17.3` → `Unity Hub 3.19.4`) and `ReleaseDate` (`2026-04-23`, which was 3.19.1's date → `2026-07-07`).

Resolves #398600

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue
  - Resolves #398600
- [x] This PR only modifies one (1) manifest

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same manifest version
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate` (author on macOS; validated against the 1.12.0 installer JSON schema instead — the pipeline runs the authoritative check)
- [x] Tested manifest locally with `winget install` (Windows-only; installer URL returns HTTP 200 and SHA256 matches the published artifact)
- [x] Manifest conforms to the 1.12 schema
