### PR TITLE
New version: Tomclanc.GestureSignV2 version 8.2.15

### DIFF
--- a/manifests/t/Tomclanc/GestureSignV2/8.2.15/Tomclanc.GestureSignV2.installer.yaml
+++ b/manifests/t/Tomclanc/GestureSignV2/8.2.15/Tomclanc.GestureSignV2.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Tomclanc.GestureSignV2
+PackageVersion: 8.2.15
+InstallerType: wix
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{63A3BD9D-F0F4-4D8E-98BB-5210E802A7BE}'
+AppsAndFeaturesEntries:
+- DisplayName: GestureSign V2
+  Publisher: TransposonY / WinUI rebuild
+  ProductCode: '{63A3BD9D-F0F4-4D8E-98BB-5210E802A7BE}'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Tomclanc/GestureSignv2/releases/download/v8.2.15/GestureSign-V2-8.2.15-x64.msi
+  InstallerSha256: 20C4112675E1AF4D3A3F167D78F39F7BDF4FB6A0BC28D8280F1DB2BF166DE47E
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-07-06

--- a/manifests/t/Tomclanc/GestureSignV2/8.2.15/Tomclanc.GestureSignV2.locale.en-US.yaml
+++ b/manifests/t/Tomclanc/GestureSignV2/8.2.15/Tomclanc.GestureSignV2.locale.en-US.yaml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Tomclanc.GestureSignV2
+PackageVersion: 8.2.15
+PackageLocale: en-US
+Publisher: Tomclanc
+PublisherUrl: https://github.com/Tomclanc
+PublisherSupportUrl: https://github.com/Tomclanc/GestureSignv2/issues
+Author: Tomclanc
+PackageName: GestureSign V2
+PackageUrl: https://github.com/Tomclanc/GestureSignv2
+License: GPL-2.0
+LicenseUrl: https://github.com/Tomclanc/GestureSignv2/blob/main/LICENSE
+Copyright: Copyright (C) 2026 Tomclanc
+ShortDescription: A Windows 11 focused rebuild of GestureSign for touchpad and mouse gestures.
+Description: GestureSign V2 is a Windows 11 focused rebuild of the classic open-source GestureSign project. It supports touchpad gestures, mouse gestures, gesture trails, per-app actions, ignore rules, tray controls, and bundled Kando radial menu quick actions.
+Moniker: gesturesignv2
+Tags:
+- gesture
+- gestures
+- mouse
+- touchpad
+- windows-11
+ReleaseNotes: |-
+  Refreshes touchpad edge gesture previews with fuller touchpad thumbnails.
+  Localizes built-in touchpad and touchscreen edge gesture names.
+  Normalizes gesture preview icon sizing.
+  Hides advanced import, export, backup, and restore buttons.
+  Keeps only the main Start Menu shortcut after MSI installation.
+  Fixes a daemon resource binding issue.
+ReleaseNotesUrl: https://github.com/Tomclanc/GestureSignv2/releases/tag/v8.2.15
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/Tomclanc/GestureSignv2/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/Tomclanc/GestureSignV2/8.2.15/Tomclanc.GestureSignV2.locale.zh-CN.yaml
+++ b/manifests/t/Tomclanc/GestureSignV2/8.2.15/Tomclanc.GestureSignV2.locale.zh-CN.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: Tomclanc.GestureSignV2
+PackageVersion: 8.2.15
+PackageLocale: zh-CN
+Publisher: Tomclanc
+PublisherUrl: https://github.com/Tomclanc
+PublisherSupportUrl: https://github.com/Tomclanc/GestureSignv2/issues
+Author: Tomclanc
+PackageName: GestureSign V2
+PackageUrl: https://github.com/Tomclanc/GestureSignv2
+License: GPL-2.0
+LicenseUrl: https://github.com/Tomclanc/GestureSignv2/blob/main/LICENSE
+Copyright: Copyright (C) 2026 Tomclanc
+ShortDescription: 面向 Windows 11 重构的 GestureSign，支持触控板和鼠标手势。
+Description: GestureSign V2 是经典开源项目 GestureSign 的 Windows 11 重构版本，支持触控板手势、鼠标手势、手势轨迹、按应用设置动作、忽略规则、托盘控制，以及内置的 Kando 径向菜单快捷动作。
+Tags:
+- 手势
+- 鼠标
+- 触控板
+- Windows 11
+ReleaseNotes: |-
+  将触控板边缘手势缩略图更新为更完整的触控板样式。
+  为内置触控板和触摸屏边缘手势名称增加多语言适配。
+  统一手势预览图标尺寸。
+  隐藏高级导入、导出、备份和还原按钮。
+  MSI 安装后开始菜单仅保留主程序快捷方式。
+  修复 Daemon 资源绑定错误。
+ReleaseNotesUrl: https://github.com/Tomclanc/GestureSignv2/releases/tag/v8.2.15
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/Tomclanc/GestureSignv2/wiki
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/t/Tomclanc/GestureSignV2/8.2.15/Tomclanc.GestureSignV2.yaml
+++ b/manifests/t/Tomclanc/GestureSignV2/8.2.15/Tomclanc.GestureSignV2.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Tomclanc.GestureSignV2
+PackageVersion: 8.2.15
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Updates Tomclanc.GestureSignV2 to version 8.2.15.

Installer: https://github.com/Tomclanc/GestureSignv2/releases/download/v8.2.15/GestureSign-V2-8.2.15-x64.msi
SHA256: 20C4112675E1AF4D3A3F167D78F39F7BDF4FB6A0BC28D8280F1DB2BF166DE47E

Changes:
- Refreshes touchpad edge gesture previews.
- Adds localized built-in edge gesture display names.
- Normalizes gesture preview icon sizing.
- Hides advanced import/export/backup/restore buttons.
- Keeps only the main Start Menu shortcut after MSI installation.
- Fixes a daemon resource binding issue.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/398647)