### PR TITLE
New version: MarcoSumari.IngePresupuestos version 2.8.0

### DIFF
--- a/manifests/m/MarcoSumari/IngePresupuestos/2.8.0/MarcoSumari.IngePresupuestos.installer.yaml
+++ b/manifests/m/MarcoSumari/IngePresupuestos/2.8.0/MarcoSumari.IngePresupuestos.installer.yaml
@@ -1,0 +1,21 @@
+# Manifiesto de INSTALADOR — winget (schema 1.6.0)
+# Usa el INSTALADOR de Inno Setup (NO el .msix).
+PackageIdentifier: MarcoSumari.IngePresupuestos
+PackageVersion: 2.8.0
+InstallerLocale: es-PE
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: inno          # Inno Setup → winget ya conoce los flags silenciosos
+Scope: machine               # PrivilegesRequired=admin → instala en Program Files
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://downloads.ingepresupuestos.com/v2.8.0/ingepresupuestos-setup-v2.8.0.exe
+    InstallerSha256: D20C397576D9896904130B2F269BEA31CB34547E1F3ACB01CE906E194CF7FE7B
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/MarcoSumari/IngePresupuestos/2.8.0/MarcoSumari.IngePresupuestos.locale.es-PE.yaml
+++ b/manifests/m/MarcoSumari/IngePresupuestos/2.8.0/MarcoSumari.IngePresupuestos.locale.es-PE.yaml
@@ -1,0 +1,42 @@
+# Manifiesto de LOCALE por defecto — winget (schema 1.6.0)
+PackageIdentifier: MarcoSumari.IngePresupuestos
+PackageVersion: 2.8.0
+PackageLocale: es-PE
+Publisher: Marco Sumari
+PublisherUrl: https://ingepresupuestos.com
+PublisherSupportUrl: https://github.com/tuxiasumari/ingepresupuestos/issues
+PrivacyUrl: https://ingepresupuestos.com/privacidad
+Author: Ing. Marco Sumari
+PackageName: IngePresupuestos
+PackageUrl: https://ingepresupuestos.com
+License: GPL-3.0-or-later
+LicenseUrl: https://github.com/tuxiasumari/ingepresupuestos/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Marco Sumari / Sumari SAC
+CopyrightUrl: https://github.com/tuxiasumari/ingepresupuestos/blob/main/LICENSE
+ShortDescription: Software libre de presupuestos de obra con ACU, cronograma Gantt valorizado y 13 reportes profesionales.
+Description: |-
+  IngePresupuestos es el software de presupuestos de obra para ingenieros y
+  arquitectos. Elabora presupuestos con Análisis de Costos Unitarios (ACU),
+  cronogramas valorizados (Gantt con ruta crítica y CPM), fórmula polinómica e
+  índices INEI, metrados (incluido acero), y 13 reportes profesionales
+  exportables a PDF, Excel, Word, ODS y ODT. Importa tus presupuestos existentes
+  de S10, PowerCost y Delphin, además de Excel e IFC. Incluye Control de Obra
+  (requerimientos, almacén, cuaderno, valorizaciones y curva S) y un asistente con
+  inteligencia artificial opcional (con tu propia clave). Software libre y gratuito
+  (GPL-3.0): todas las funciones incluidas. Tus datos quedan en tu equipo.
+Moniker: ingepresupuestos
+ReleaseNotes: |-
+  IngePresupuestos ahora es software libre y gratuito (GPL-3.0): todas las
+  funciones desbloqueadas, incluidos los reportes editables. Mejoras de interfaz.
+ReleaseNotesUrl: https://github.com/tuxiasumari/ingepresupuestos/releases/tag/v2.8.0
+Tags:
+  - presupuestos
+  - construccion
+  - acu
+  - cronograma
+  - metrados
+  - s10
+  - ingenieria-civil
+  - obra
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/MarcoSumari/IngePresupuestos/2.8.0/MarcoSumari.IngePresupuestos.yaml
+++ b/manifests/m/MarcoSumari/IngePresupuestos/2.8.0/MarcoSumari.IngePresupuestos.yaml
@@ -1,0 +1,8 @@
+# Manifiesto de VERSIÓN — winget (schema 1.6.0)
+# Destino en el PR a github.com/microsoft/winget-pkgs:
+#   manifests/m/MarcoSumari/IngePresupuestos/2.8.0/
+PackageIdentifier: MarcoSumari.IngePresupuestos
+PackageVersion: 2.8.0
+DefaultLocale: es-PE
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## New version of an existing package

- **Package**: MarcoSumari.IngePresupuestos
- **Version**: 2.8.0
- **Installer**: Inno Setup (x64), served from https://downloads.ingepresupuestos.com

Now released as free/open-source software (GPL-3.0). Manifests validated locally.

### Checklist
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] This manifest points to an installer over HTTPS with a matching SHA256.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/398682)