### PR TITLE
Update electerm homepage URL to https://electerm.org

### DIFF
--- a/manifests/e/electerm/electerm/3.15.100/electerm.electerm.locale.en-US.yaml
+++ b/manifests/e/electerm/electerm/3.15.100/electerm.electerm.locale.en-US.yaml
@@ -5,12 +5,12 @@ PackageIdentifier: electerm.electerm
 PackageVersion: 3.15.100
 PackageLocale: en-US
 Publisher: ZHAO Xudong
-PublisherUrl: https://github.com/electerm/electerm
+PublisherUrl: https://electerm.org
 PublisherSupportUrl: https://github.com/electerm/electerm/issues
 PrivacyUrl: https://github.com/electerm/electerm/wiki/privacy-notice
 Author: ZHAO Xudong
 PackageName: electerm
-PackageUrl: https://github.com/electerm/electerm
+PackageUrl: https://electerm.org
 License: MIT
 LicenseUrl: https://github.com/electerm/electerm/blob/HEAD/LICENSE
 Copyright: Copyright (c) 2017~tomorrow electerm, ZHAO Xudong


### PR DESCRIPTION
Update the electerm package's `PublisherUrl` and `PackageUrl` fields from `https://github.com/electerm/electerm` to `https://electerm.org`, which is the new official homepage for the electerm project.

Updated all existing version manifests (20 versions, 3.8.x through 3.15.x).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/398723)