### PR TITLE
New package: MyOTGO.MyOTGO version 1.2.25

### DIFF
--- a/manifests/m/MyOTGO/MyOTGO/1.2.25/MyOTGO.MyOTGO.installer.yaml
+++ b/manifests/m/MyOTGO/MyOTGO/1.2.25/MyOTGO.MyOTGO.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: MyOTGO.MyOTGO
+PackageVersion: 1.2.25
+InstallerLocale: en-US
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: "2026-07-07"
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://myotgo.blob.core.windows.net/downloads/MyOTGO-Setup-Windows-x64-1.2.25.exe
+    InstallerSha256: FB98F23AFD8769A6722E6E8B0575BFBB8AD0E69D68FAC1196D476CD8AFFF6589
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/MyOTGO/MyOTGO/1.2.25/MyOTGO.MyOTGO.installer.yaml
+++ b/manifests/m/MyOTGO/MyOTGO/1.2.25/MyOTGO.MyOTGO.installer.yaml
@@ -12,6 +12,9 @@ InstallModes:
   - silent
   - silentWithProgress
 UpgradeBehavior: install
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
 ReleaseDate: "2026-07-07"
 Installers:
   - Architecture: x64

--- a/manifests/m/MyOTGO/MyOTGO/1.2.25/MyOTGO.MyOTGO.locale.en-US.yaml
+++ b/manifests/m/MyOTGO/MyOTGO/1.2.25/MyOTGO.MyOTGO.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: MyOTGO.MyOTGO
+PackageVersion: 1.2.25
+PackageLocale: en-US
+Publisher: MyOTGO
+PublisherUrl: https://myotgo.com
+PublisherSupportUrl: https://myotgo.com
+Author: MyOTGO
+PackageName: MyOTGO
+PackageUrl: https://myotgo.com
+License: Proprietary
+Copyright: Copyright (c) MyOTGO
+ShortDescription: MyOTGO smart-home and IoT control app for Windows.
+Description: >-
+  MyOTGO is the desktop companion for the MyOTGO smart-home and IoT platform.
+  Control your devices, cameras and automations, chat, and make voice and video
+  calls from your Windows PC.
+Moniker: myotgo
+Tags:
+  - iot
+  - smart-home
+  - home-automation
+  - myotgo
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/MyOTGO/MyOTGO/1.2.25/MyOTGO.MyOTGO.yaml
+++ b/manifests/m/MyOTGO/MyOTGO/1.2.25/MyOTGO.MyOTGO.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: MyOTGO.MyOTGO
+PackageVersion: 1.2.25
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: `MyOTGO.MyOTGO` version `1.2.25`

Adds the MyOTGO Windows desktop app (smart-home / IoT control) so users can install it with `winget install MyOTGO.MyOTGO`.

- Installer: Inno Setup, x64, machine scope, from the publisher's Azure download host (immutable version-pinned URL).
- InstallerSha256 verified against the published binary.
- Manifests validated against the v1.6.0 JSON schema (installer / defaultLocale / version).

#### Checklist
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/add?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? (validated against the published v1.6.0 JSON schema)
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? (submitter is on macOS; relying on CI validation)
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: the installer is currently unsigned; publisher is MyOTGO (https://myotgo.com).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/398836)