### PR TITLE
New version: RedEyeNetworks.HopMatrix version 1.8.0

### DIFF
--- a/manifests/r/RedEyeNetworks/HopMatrix/1.8.0/RedEyeNetworks.HopMatrix.installer.yaml
+++ b/manifests/r/RedEyeNetworks/HopMatrix/1.8.0/RedEyeNetworks.HopMatrix.installer.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: RedEyeNetworks.HopMatrix
+PackageVersion: 1.8.0
+InstallerType: inno
+Scope: machine
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  Custom: /NORESTART
+UpgradeBehavior: install
+Commands:
+- HopMatrix
+Installers:
+- Architecture: x64
+  Scope: user
+  InstallerUrl: https://download.redeyenetworks.com/hopmatrix/releases/1.8.0/HopMatrix-win-x64-setup.exe
+  InstallerSha256: 29A98BE06ED7E8440C5644F32993DFBFAC44C08612F18E11085C34F48C8F242D
+- Architecture: x64
+  Scope: machine
+  ElevationRequirement: elevatesSelf
+  InstallerUrl: https://download.redeyenetworks.com/hopmatrix/releases/1.8.0/HopMatrix-win-x64-machine-setup.exe
+  InstallerSha256: 9AD9EDC9869C2AADB40AF89658145A5095F1903EFA27FD8962A7C02B2AA5D937
+- Architecture: arm64
+  Scope: user
+  InstallerUrl: https://download.redeyenetworks.com/hopmatrix/releases/1.8.0/HopMatrix-win-arm64-setup.exe
+  InstallerSha256: 42FE4AFEB874DF47A3E90487B0A575CD28201D68585178C6E931F88253C2A7A1
+- Architecture: arm64
+  Scope: machine
+  ElevationRequirement: elevatesSelf
+  InstallerUrl: https://download.redeyenetworks.com/hopmatrix/releases/1.8.0/HopMatrix-win-arm64-machine-setup.exe
+  InstallerSha256: 26F3F4DFD251C3BA9E2C9912644B25478069B29A23EE4306EE77370BA0B8D7E7
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/r/RedEyeNetworks/HopMatrix/1.8.0/RedEyeNetworks.HopMatrix.locale.en-US.yaml
+++ b/manifests/r/RedEyeNetworks/HopMatrix/1.8.0/RedEyeNetworks.HopMatrix.locale.en-US.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: RedEyeNetworks.HopMatrix
+PackageVersion: 1.8.0
+PackageLocale: en-US
+Publisher: RedEye Network Solutions LLC
+PublisherUrl: https://redeyenetworks.com
+PublisherSupportUrl: https://redeyenetworks.com/support
+Author: RedEye Network Solutions LLC
+PackageName: HopMatrix
+PackageUrl: https://redeyenetworks.com
+License: Proprietary
+Copyright: Copyright 2025-2026 RedEye Network Solutions LLC. All rights reserved.
+ShortDescription: Visual multi-path traceroute, network monitoring, and analysis platform
+Description: |-
+  HopMatrix is a portable, single-executable, cross-platform network analysis platform
+  with eight operational modes: Trace, Monitor, iPerf, OUI/MAC Lookup, SNMP, Multicast,
+  L2 Inspector, and Quick Tools. Features continuous multi-path traceroute with real-time
+  topology visualization, 256-endpoint fleet monitoring, iperf3-compatible bandwidth
+  testing, SNMP v1/v2c/v3 discovery, and multicast/CDP/LLDP analysis.
+Moniker: hopmatrix
+Tags:
+- traceroute
+- network
+- monitoring
+- bandwidth
+- iperf
+- snmp
+- multicast
+- network-analysis
+- pathping
+- topology
+- cdp
+- lldp
+- nmap
+- oui
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/RedEyeNetworks/HopMatrix/1.8.0/RedEyeNetworks.HopMatrix.yaml
+++ b/manifests/r/RedEyeNetworks/HopMatrix/1.8.0/RedEyeNetworks.HopMatrix.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: RedEyeNetworks.HopMatrix
+PackageVersion: 1.8.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
HopMatrix v1.8.0 ships two distinct installers per architecture (user-scope + machine-scope), matching the Microsoft.PowerToys + Notepad++.Notepad++ convention. Each (architecture, scope) tuple maps to a unique Inno Setup EXE with a single, deterministic `PrivilegesRequired` value, so Microsoft's dynamic-scan validation has unambiguous install behavior to verify per installer entry.

Manifest construction is now done in HopMatrix's release.yml as a hand-built heredoc (not `wingetcreate update`) so the 4-entry shape is locked from version 1 — the previous wingetcreate-based flow inherited shape from the latest published manifest, which couldn't grow installer-entry count cleanly.

Locally validated with `winget validate --manifest <folder>`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/398840)