### PR TITLE
New version: Framefilter.Keyroost version 0.7.4

### DIFF
--- a/manifests/f/Framefilter/Keyroost/0.7.4/Framefilter.Keyroost.installer.yaml
+++ b/manifests/f/Framefilter/Keyroost/0.7.4/Framefilter.Keyroost.installer.yaml
@@ -1,0 +1,18 @@
+PackageIdentifier: Framefilter.Keyroost
+PackageVersion: "0.7.4"
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: keyroostctl.exe
+    PortableCommandAlias: keyroostctl
+  - RelativeFilePath: keyroost.exe
+    PortableCommandAlias: keyroost
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/framefilter/keyroost/releases/download/v0.7.4/keyroost-v0.7.4-windows-x86_64.zip
+    InstallerSha256: "0B16F9F5E3E35DAA66F145792A98F6E787D4A036A0CFF06B8D24DA4A8BE44766"
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/f/Framefilter/Keyroost/0.7.4/Framefilter.Keyroost.locale.en-US.yaml
+++ b/manifests/f/Framefilter/Keyroost/0.7.4/Framefilter.Keyroost.locale.en-US.yaml
@@ -1,0 +1,16 @@
+PackageIdentifier: Framefilter.Keyroost
+PackageVersion: "0.7.4"
+PackageLocale: en-US
+Publisher: framefilter
+PackageName: keyroost
+License: MIT OR Apache-2.0
+PackageUrl: https://github.com/framefilter/keyroost
+ShortDescription: Program Token2 Molto2 TOTP tokens and manage FIDO2/OATH/OpenPGP/PIV security keys.
+Moniker: keyroost
+Tags:
+  - totp
+  - 2fa
+  - fido2
+  - security-key
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/f/Framefilter/Keyroost/0.7.4/Framefilter.Keyroost.yaml
+++ b/manifests/f/Framefilter/Keyroost/0.7.4/Framefilter.Keyroost.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Framefilter.Keyroost
+PackageVersion: "0.7.4"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Version bump of `Framefilter.Keyroost` from 0.7.3 to 0.7.4.

- Portable zip installer (two nested portables: `keyroostctl.exe`, `keyroost.exe`).
- Manifest is structurally identical to the accepted 0.7.3 manifest; only `PackageVersion`, `InstallerUrl`, and `InstallerSha256` changed.
- `InstallerSha256` matches the published GitHub release asset's `SHA256SUMS`.
- Release: https://github.com/framefilter/keyroost/releases/tag/v0.7.4

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/398942)