### PR TITLE
New package: Mibuw.miPDFsignCommunity version 1.0.0

### DIFF
--- a/manifests/m/Mibuw/miPDFsignCommunity/1.0.0/Mibuw.miPDFsignCommunity.installer.yaml
+++ b/manifests/m/Mibuw/miPDFsignCommunity/1.0.0/Mibuw.miPDFsignCommunity.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Mibuw.miPDFsignCommunity
+PackageVersion: 1.0.0
+InstallerType: inno
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{3B528384-34AC-47C4-B477-AA742872F4E3}_is1'
+ReleaseDate: 2026-07-07
+Installers:
+  - Architecture: x86
+    InstallerUrl: https://github.com/Mibuw/miPDFsign-Community/releases/download/v1.0.0/miPDFsignCommunity_Setup_1.0.0.exe
+    InstallerSha256: A0AB7B934C834B77944E7A231BC3720FD747A4DF30435345F0A70E8187E3BEB1
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/Mibuw/miPDFsignCommunity/1.0.0/Mibuw.miPDFsignCommunity.locale.en-US.yaml
+++ b/manifests/m/Mibuw/miPDFsignCommunity/1.0.0/Mibuw.miPDFsignCommunity.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Mibuw.miPDFsignCommunity
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: Wolfgang Mitterbucher
+PublisherUrl: https://www.mitterbucher.com
+PublisherSupportUrl: https://github.com/Mibuw/miPDFsign-Community/issues
+Author: Wolfgang Mitterbucher
+PackageName: miPDFsign Community
+PackageUrl: https://github.com/Mibuw/miPDFsign-Community
+License: AGPL-3.0-only
+LicenseUrl: https://github.com/Mibuw/miPDFsign-Community/blob/main/LICENSE
+Copyright: Copyright (C) Wolfgang Mitterbucher
+ShortDescription: Free AGPL edition of miPDFsign — a tablet signature app that embeds handwritten signatures with biometric data as PAdES into PDFs.
+Description: |-
+  miPDFsign Community is the free, open-source (AGPL-3.0) edition of miPDFsign, a .NET 8 WPF
+  application for signature tablets. It captures handwritten signatures together with biometric
+  pressure data and embeds them as PAdES signatures (Baseline B/T/LT/LTA) into PDF documents,
+  including QES via ID Austria. It uses the iText PDF engine. A commercial edition with
+  additional features is available on request.
+Moniker: mipdfsign-community
+Tags:
+  - pdf
+  - pdf-signing
+  - pades
+  - digital-signature
+  - electronic-signature
+  - biometric-signature
+  - qes
+  - id-austria
+  - signature
+  - tablet
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/Mibuw/miPDFsignCommunity/1.0.0/Mibuw.miPDFsignCommunity.yaml
+++ b/manifests/m/Mibuw/miPDFsignCommunity/1.0.0/Mibuw.miPDFsignCommunity.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Mibuw.miPDFsignCommunity
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package

- **PackageIdentifier:** Mibuw.miPDFsignCommunity
- **Version:** 1.0.0
- **InstallerType:** inno (Inno Setup, signed), machine scope, x86
- **Silent install** supported (`/VERYSILENT /SUPPRESSMSGBOXES /NORESTART`)
- **Homepage:** https://github.com/Mibuw/miPDFsign-Community
- **License:** AGPL-3.0-only

miPDFsign Community is the free, open-source edition of miPDFsign — a .NET 8 / WPF tablet signature app that embeds handwritten signatures with biometric data as PAdES (B/T/LT/LTA) into PDFs, incl. QES via ID Austria.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] This PR only modifies one (1) manifest
- [x] Have you validated your manifest locally with `winget validate`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/398992)