### PR TITLE
New package: Docker.dmr version 0.1.0

### DIFF
--- a/manifests/d/Docker/dmr/0.1.0/Docker.dmr.installer.yaml
+++ b/manifests/d/Docker/dmr/0.1.0/Docker.dmr.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Docker.dmr
+PackageVersion: 0.1.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: dmr.exe
+  PortableCommandAlias: dmr
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/docker/model-runner/releases/download/dmr-v0.1.0/dmr-windows-amd64.zip
+  InstallerSha256: 7A867617B6EC11EA362A1AE694E119FBACA6FA832CC98330BF2C7450789B3684
+ReleaseDate: 2026-07-07
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/d/Docker/dmr/0.1.0/Docker.dmr.locale.en-US.yaml
+++ b/manifests/d/Docker/dmr/0.1.0/Docker.dmr.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Docker.dmr
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Docker Inc.
+PublisherUrl: https://www.docker.com/
+PublisherSupportUrl: https://github.com/docker/model-runner/issues
+Author: Docker Inc.
+PackageName: dmr
+PackageUrl: https://github.com/docker/model-runner
+License: Apache-2.0
+LicenseUrl: https://github.com/docker/model-runner/blob/HEAD/LICENSE
+Copyright: Copyright (c) Docker Inc.
+ShortDescription: Standalone Docker Model Runner - run local AI models with no Docker Desktop or Engine required.
+Description: >-
+  dmr is the standalone Docker Model Runner: a single binary that bundles
+  both the inference daemon (dmr serve) and the full model management CLI
+  (run, pull, ls, rm, ps, ...) used to talk to it. dmr has no dependency on
+  Docker Desktop or a running Docker Engine.
+Tags:
+- docker
+- ai
+- llm
+- inference
+- model-runner
+- llama-cpp
+ReleaseNotesUrl: https://github.com/docker/model-runner/releases/tag/dmr-v0.1.0
+Documentations:
+- DocumentLabel: README
+  DocumentUrl: https://github.com/docker/model-runner/blob/HEAD/cmd/dmr/README.md
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/d/Docker/dmr/0.1.0/Docker.dmr.yaml
+++ b/manifests/d/Docker/dmr/0.1.0/Docker.dmr.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Docker.dmr
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds the initial manifest for `Docker.dmr`, the standalone Docker
Model Runner (`dmr`) — a single binary bundling both the inference
daemon and full model management CLI, with no dependency on Docker
Desktop or a running Docker Engine
(docker/model-runner#996).

Installer archive: [`dmr-windows-amd64.zip`](https://github.com/docker/model-runner/releases/download/dmr-v0.1.0/dmr-windows-amd64.zip)
from the [`dmr-v0.1.0`](https://github.com/docker/model-runner/releases/tag/dmr-v0.1.0) release.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` — no Windows environment available to run `winget validate`/`winget install`; manifest was instead checked by hand against the published 1.12.0 JSON schemas (required fields, `PackageIdentifier`/SHA256 regexes, enum values for `InstallerType`/`Architecture`) and against the structure of the existing `Docker.Agent` and `Docker.DockerCLI` manifests in this repo.
- [ ] Tested manifest locally with `winget install --manifest <path>` — same limitation as above.
- [x] Manifest conforms to the 1.12 schema (by manual review, see above)

> `<path>`: `manifests/d/Docker/dmr/0.1.0`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/399000)