### PR TITLE
New package: ItsJazii.Pane version 0.4.0

### DIFF
--- a/manifests/i/ItsJazii/Pane/0.4.0/ItsJazii.Pane.installer.yaml
+++ b/manifests/i/ItsJazii/Pane/0.4.0/ItsJazii.Pane.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: ItsJazii.Pane
+PackageVersion: 0.4.0
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/ItsJazii/pane/releases/download/v0.4.0/Pane_0.4.0_x64-setup.exe
+  InstallerSha256: 0DAA1D11A3CC8E8C93CBF877447B12924F63CCC09BF6E5546A95654FD9659CC1
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/i/ItsJazii/Pane/0.4.0/ItsJazii.Pane.locale.en-US.yaml
+++ b/manifests/i/ItsJazii/Pane/0.4.0/ItsJazii.Pane.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: ItsJazii.Pane
+PackageVersion: 0.4.0
+PackageLocale: en-US
+Publisher: Jazii
+PublisherUrl: https://github.com/ItsJazii
+PublisherSupportUrl: https://github.com/ItsJazii/pane/issues
+PackageName: Pane
+PackageUrl: https://github.com/ItsJazii/pane
+License: MIT
+LicenseUrl: https://github.com/ItsJazii/pane/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Jazii
+ShortDescription: All your AI subscription limits in one liquid-glass tray popover.
+Description: |-
+  Pane shows how much of your session and weekly limits each AI tool has left,
+  directly from the Windows system tray. It auto-detects the CLIs and apps you
+  already use (Claude Code, Codex, Cursor, Copilot, Grok and more - 18
+  providers), projects whether you will run out before the reset, computes
+  local spend with live model pricing, and updates itself via signed releases.
+  No telemetry; tokens only ever go to their own vendor's API.
+Moniker: pane
+Tags:
+- ai
+- claude
+- codex
+- copilot
+- cursor
+- productivity
+- tray
+- usage
+ReleaseNotesUrl: https://github.com/ItsJazii/pane/releases/tag/v0.4.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/i/ItsJazii/Pane/0.4.0/ItsJazii.Pane.yaml
+++ b/manifests/i/ItsJazii/Pane/0.4.0/ItsJazii.Pane.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: ItsJazii.Pane
+PackageVersion: 0.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

First submission of Pane — an open-source (MIT) Windows system-tray app showing AI subscription usage limits (Claude, Codex, Cursor, Copilot + 14 more providers). NSIS per-user installer from the project's signed GitHub release.

Repo: https://github.com/ItsJazii/pane
Release: https://github.com/ItsJazii/pane/releases/tag/v0.4.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/399095)