### PR TITLE
New package: ibrahemid.Writ version 0.1.0

### DIFF
--- a/manifests/i/ibrahemid/Writ/0.1.0/ibrahemid.Writ.installer.yaml
+++ b/manifests/i/ibrahemid/Writ/0.1.0/ibrahemid.Writ.installer.yaml
@@ -1,0 +1,25 @@
+# Created with the Writ release packaging workflow.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: ibrahemid.Writ
+PackageVersion: 0.1.0
+MinimumOSVersion: 10.0.17763.0
+InstallerType: wix
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-07-07
+Installers:
+  - Architecture: x64
+    InstallerType: wix
+    InstallerUrl: https://github.com/ibrahemid/writ/releases/download/v0.1.0/Writ_0.1.0_x64_en-US.msi
+    InstallerSha256: 23aee5190c4cac6c280bd3c7562bf89297f7469d8cc5ac66f6a91c9bc0b788ab
+    InstallerSwitches:
+      Silent: /quiet
+      SilentWithProgress: /passive
+    ProductCode: "{00000000-0000-0000-0000-000000000000}"
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/i/ibrahemid/Writ/0.1.0/ibrahemid.Writ.locale.en-US.yaml
+++ b/manifests/i/ibrahemid/Writ/0.1.0/ibrahemid.Writ.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# Created with the Writ release packaging workflow.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: ibrahemid.Writ
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: ibrahemid
+PublisherUrl: https://github.com/ibrahemid
+PublisherSupportUrl: https://github.com/ibrahemid/writ/issues
+PackageName: Writ
+PackageUrl: https://github.com/ibrahemid/writ
+License: MIT
+LicenseUrl: https://github.com/ibrahemid/writ/blob/main/LICENSE
+Copyright: Copyright (c) 2026 ibrahemid
+ShortDescription: Lightweight, always-ready text editor for developers.
+Description: |-
+  Writ is a hotkey-summoned scratchpad for developers. Press a global shortcut to
+  summon a fast, distraction-free editor with tabs, autosave, and full-text
+  search. Built with Tauri v2 and SolidJS for a tiny footprint and native feel.
+Moniker: writ
+Tags:
+  - scratchpad
+  - editor
+  - productivity
+  - rust
+  - tauri
+ReleaseNotesUrl: https://github.com/ibrahemid/writ/releases/tag/v0.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/i/ibrahemid/Writ/0.1.0/ibrahemid.Writ.yaml
+++ b/manifests/i/ibrahemid/Writ/0.1.0/ibrahemid.Writ.yaml
@@ -1,0 +1,8 @@
+# Created with the Writ release packaging workflow.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: ibrahemid.Writ
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
New package submission for Writ, a lightweight text editor for developers.

- PackageIdentifier: ibrahemid.Writ
- PackageVersion: 0.1.0
- InstallerUrl points at the signed GitHub release asset; InstallerSha256 verified against the release SHA256SUMS.txt.
- Homepage: https://github.com/ibrahemid/writ

Manifests validate against the 1.6 schema.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/399097)