### PR TITLE
New version: cadwal.BookDB version 2.2.0

### DIFF
--- a/manifests/c/cadwal/BookDB/2.2.0/cadwal.BookDB.installer.yaml
+++ b/manifests/c/cadwal/BookDB/2.2.0/cadwal.BookDB.installer.yaml
@@ -1,0 +1,26 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: cadwal.BookDB
+PackageVersion: 2.2.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: BookDB.Desktop.exe
+  PortableCommandAlias: bookdb
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.DotNet.Runtime.10
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/cadwal/BookDB/releases/download/v2.2.0/BookDB-v2.2.0-win-x64-fdd.zip
+  InstallerSha256: E550784EDB2D7387197E6F0131523A5E5500BCEC3A208C12DC7F2D2739153054
+- Architecture: arm64
+  InstallerUrl: https://github.com/cadwal/BookDB/releases/download/v2.2.0/BookDB-v2.2.0-win-arm64-fdd.zip
+  InstallerSha256: 5FC1A391247AEDA3A04327A82509DF4F3BEA85FA489BFBE5B211DB7C25A63281
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-07-07

--- a/manifests/c/cadwal/BookDB/2.2.0/cadwal.BookDB.locale.en-US.yaml
+++ b/manifests/c/cadwal/BookDB/2.2.0/cadwal.BookDB.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: cadwal.BookDB
+PackageVersion: 2.2.0
+PackageLocale: en-US
+Publisher: cadwal
+PublisherUrl: https://github.com/cadwal
+PublisherSupportUrl: https://github.com/cadwal/BookDB/issues
+PackageName: BookDB
+PackageUrl: https://github.com/cadwal/BookDB
+License: MIT
+ShortDescription: A personal book catalog for Windows
+Description: A book catalog database for personal collections. Can import data from Readerware 4.
+Tags:
+- books
+- catalog
+- library
+ReleaseNotesUrl: https://github.com/cadwal/BookDB/releases/tag/v2.2.0
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/cadwal/BookDB/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/cadwal/BookDB/2.2.0/cadwal.BookDB.yaml
+++ b/manifests/c/cadwal/BookDB/2.2.0/cadwal.BookDB.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: cadwal.BookDB
+PackageVersion: 2.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New version: **cadwal.BookDB 2.2.0** — release notes: https://github.com/cadwal/BookDB/releases/tag/v2.2.0

Supersedes #395675 (version 2.1.0, stuck in validation with `Validation-Installation-Error` despite verified asset hashes) — I will close that PR in favour of this one.

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
