### PR TITLE
New package: jmrplens.gitlab-mcp-server version 2.5.0

### DIFF
--- a/manifests/j/jmrplens/gitlab-mcp-server/2.5.0/jmrplens.gitlab-mcp-server.installer.yaml
+++ b/manifests/j/jmrplens/gitlab-mcp-server/2.5.0/jmrplens.gitlab-mcp-server.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: jmrplens.gitlab-mcp-server
+PackageVersion: 2.5.0
+InstallerType: portable
+Commands:
+- gitlab-mcp-server
+ReleaseDate: 2026-07-07
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/jmrplens/gitlab-mcp-server/releases/download/v2.5.0/gitlab-mcp-server-windows-amd64.exe
+  InstallerSha256: F802F8197535782F1A7357F5DF42117766ADCFF29EC94973D3E9B70389ECB042
+- Architecture: arm64
+  InstallerUrl: https://github.com/jmrplens/gitlab-mcp-server/releases/download/v2.5.0/gitlab-mcp-server-windows-arm64.exe
+  InstallerSha256: 6DA31DA26F9BD95A42B0AFA2C214903342447794A1226F5F77133A18C8FB12A2
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/j/jmrplens/gitlab-mcp-server/2.5.0/jmrplens.gitlab-mcp-server.locale.en-US.yaml
+++ b/manifests/j/jmrplens/gitlab-mcp-server/2.5.0/jmrplens.gitlab-mcp-server.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: jmrplens.gitlab-mcp-server
+PackageVersion: 2.5.0
+PackageLocale: en-US
+Publisher: José M. Requena Plens
+PublisherUrl: https://github.com/jmrplens
+PublisherSupportUrl: https://github.com/jmrplens/gitlab-mcp-server/issues
+PackageName: GitLab MCP Server
+PackageUrl: https://github.com/jmrplens/gitlab-mcp-server
+License: MIT License
+LicenseUrl: https://github.com/jmrplens/gitlab-mcp-server/blob/main/LICENSE
+PrivacyUrl: https://github.com/jmrplens/gitlab-mcp-server/blob/main/PRIVACY.md
+ShortDescription: GitLab MCP server exposing the REST v4 and GraphQL APIs as tools for AI assistants.
+Description: |-
+  A Model Context Protocol (MCP) server that connects AI assistants (Claude, Cursor, VS Code + Copilot, and any MCP client) to GitLab.com or self-managed GitLab instances. Covers the full REST API v4 and GraphQL with automatic edition gating — roughly 850 to 1070 tools depending on the GitLab tier — plus 45 MCP resources, 37 prompts, argument completions, and progress notifications. Single static binary, stdio and HTTP transports, read-only and safe (mutation-preview) modes, and an interactive setup wizard (gitlab-mcp-server --setup) that auto-configures most MCP clients.
+Moniker: gitlab-mcp-server
+Tags:
+- ai
+- claude
+- ci-cd
+- devops
+- gitlab
+- graphql
+- llm
+- mcp
+- model-context-protocol
+- rest-api
+Documentations:
+- DocumentLabel: Documentation
+  DocumentUrl: https://jmrplens.github.io/gitlab-mcp-server/
+ReleaseNotesUrl: https://github.com/jmrplens/gitlab-mcp-server/releases/tag/v2.5.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/j/jmrplens/gitlab-mcp-server/2.5.0/jmrplens.gitlab-mcp-server.yaml
+++ b/manifests/j/jmrplens/gitlab-mcp-server/2.5.0/jmrplens.gitlab-mcp-server.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: jmrplens.gitlab-mcp-server
+PackageVersion: 2.5.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? *(authored on macOS — relying on pipeline validation; YAML validated against the 1.12 schema)*
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? *(authored on macOS — the portable exes are the same assets users download from GitHub Releases)*
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

New portable package: **GitLab MCP Server** — a Model Context Protocol server that connects AI assistants (Claude, Cursor, VS Code + Copilot, any MCP client) to GitLab.com or self-managed GitLab instances. Single static Go binary (x64 + arm64), MIT licensed, checksums pinned to the signed v2.5.0 GitHub release.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/399222)