### PR TITLE
New version: Codedaptive.MOOTx01 version 1.0.24

### DIFF
--- a/manifests/c/Codedaptive/MOOTx01/1.0.24/Codedaptive.MOOTx01.installer.yaml
+++ b/manifests/c/Codedaptive/MOOTx01/1.0.24/Codedaptive.MOOTx01.installer.yaml
@@ -1,0 +1,56 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+#
+# Installer manifest — how winget downloads and runs the setup EXE.
+#
+# InstallerType: inno
+#   The setup EXE is built by Inno Setup (see mootx01-setup.iss). Declaring
+#   `inno` lets winget derive the standard Inno silent switches and the
+#   uninstall/upgrade behavior; we still pin Silent explicitly below.
+#
+# Scope: user
+#   MOOTx01 installs per-user (PrivilegesRequired=lowest in the .iss —
+#   binaries under %APPDATA%\.mootx01\bin, no admin elevation). Winget must
+#   not attempt a machine-wide install.
+#
+# InstallerSwitches.Silent: /VERYSILENT /SUPPRESSMSGBOXES
+#   Winget always installs unattended. /VERYSILENT hides the wizard; the
+#   .iss gates its post-install client-wiring checkbox on `skipifsilent`
+#   and its uninstall MsgBox on `not UninstallSilent`, so a silent install
+#   completes without any modal dialog blocking the winget validation VM.
+#
+# InstallerSha256:
+#   MUST be the SHA-256 of the EXACT asset at InstallerUrl. It cannot be
+#   known until the release build publishes the asset. Fill it from the
+#   published checksum before submitting — see WINGET.md. Left as a
+#   zero placeholder here so a submission that forgets the step fails
+#   loudly at winget validation rather than shipping a wrong hash.
+
+PackageIdentifier: Codedaptive.MOOTx01
+PackageVersion: 1.0.24
+
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES
+UpgradeBehavior: install
+# Correlates the winget package with Inno's Add/Remove Programs entry so
+# `winget upgrade` and `winget uninstall` find the installed build. Inno
+# appends `_is1` to the AppId GUID from mootx01-setup.iss.
+AppsAndFeaturesEntries:
+  - ProductCode: "{E3A7B1C9-4D2F-4E8A-B5C6-1F9D0A2E3B4C}_is1"
+
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/codedaptive/mootx01-ce/releases/download/v1.0.24/mootx01-1.0.24-windows-x86_64-setup.exe
+    InstallerSha256: 762E96D6832C8B5C76C9471BE42BBE10D3387435549988BE537E79AAEC52ACDA
+  - Architecture: arm64
+    InstallerUrl: https://github.com/codedaptive/mootx01-ce/releases/download/v1.0.24/mootx01-1.0.24-windows-arm64-setup.exe
+    InstallerSha256: B6D8285D7FED42F6E077A0281F33B602BE58E9A3782EB88C5969BCDFFAD47C1A
+
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/c/Codedaptive/MOOTx01/1.0.24/Codedaptive.MOOTx01.locale.en-US.yaml
+++ b/manifests/c/Codedaptive/MOOTx01/1.0.24/Codedaptive.MOOTx01.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+#
+# Default-locale manifest — the human-facing metadata winget shows in
+# `winget show Codedaptive.MOOTx01` and the store listing. License and
+# publisher fields must match the LICENSE file and mootx01-setup.iss.
+
+PackageIdentifier: Codedaptive.MOOTx01
+PackageVersion: 1.0.24
+PackageLocale: en-US
+Publisher: Codedaptive LLC
+PublisherUrl: https://github.com/codedaptive/mootx01-ce
+PublisherSupportUrl: https://github.com/codedaptive/mootx01-ce/issues
+PackageName: MOOTx01
+PackageUrl: https://github.com/codedaptive/mootx01-ce
+# SPDX identifier for the Functional Source License 1.1 (Apache-2.0 future
+# grant) that governs this repo — see LICENSE.
+License: FSL-1.1-ALv2
+Copyright: Copyright (c) Codedaptive LLC
+ShortDescription: A persistent, private, on-device memory for your AI clients.
+Description: >-
+  MOOTx01 gives your AI tools a persistent memory that lives on your own
+  machine. It runs as a local background service and connects to AI clients
+  (Claude, Cursor, and others) over the Model Context Protocol, so your
+  assistants can capture, recall, and reason over what you have told them
+  across sessions. All estate data stays local under %LOCALAPPDATA%\MOOTx01;
+  nothing is sent to a cloud.
+Tags:
+  - ai
+  - mcp
+  - memory
+  - llm
+  - productivity
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/c/Codedaptive/MOOTx01/1.0.24/Codedaptive.MOOTx01.yaml
+++ b/manifests/c/Codedaptive/MOOTx01/1.0.24/Codedaptive.MOOTx01.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+#
+# Version manifest — the entry point winget reads first. It names the
+# package and points at the default locale; the installer.yaml and
+# locale.en-US.yaml files in this same directory carry the rest.
+#
+# All three files MUST share the same PackageIdentifier and PackageVersion.
+# When bumping the release, update PackageVersion in all three in lockstep
+# (see WINGET.md).
+
+PackageIdentifier: Codedaptive.MOOTx01
+PackageVersion: 1.0.24
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## New version

- **Package identifier:** Codedaptive.MOOTx01
- **Package version:** 1.0.24
- **Submission type:** Version update (from 1.0.12)

### Changes since 1.0.12
- ADR-026: RAM reduction from 6GB to ~300MB (mmap vectors, disk-resident BM25, string interning)
- Anthropic memory_20250818 tool adapter (governed /memories backend)
- 14 Codex security findings fixed
- ResidencyHint configuration (diskBacked/ramResident)
- Rosetta x86_64 compatibility fix
- Homebrew + winget distribution automation

### URLs
- x86_64: https://github.com/codedaptive/mootx01-ce/releases/download/v1.0.24/mootx01-1.0.24-windows-x86_64-setup.exe
- arm64: https://github.com/codedaptive/mootx01-ce/releases/download/v1.0.24/mootx01-1.0.24-windows-arm64-setup.exe
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/399258)