### PR TITLE
New package: Tier1Settings.Tier1Timer version 1.1.0

### DIFF
--- a/manifests/t/Tier1Settings/Tier1Timer/1.1.0/Tier1Settings.Tier1Timer.installer.yaml
+++ b/manifests/t/Tier1Settings/Tier1Timer/1.1.0/Tier1Settings.Tier1Timer.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Tier1Settings.Tier1Timer
+PackageVersion: 1.1.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: portable
+Commands:
+- tier1timer
+Installers:
+- Architecture: x64
+  InstallerUrl: https://tier1settings.com/tier1timer/downloads/Tier1Timer-1.1.0.exe
+  InstallerSha256: 01786F1091757F7107380047103D5887953502ACC4A1FAF8743AEC15C67BBADF
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/t/Tier1Settings/Tier1Timer/1.1.0/Tier1Settings.Tier1Timer.locale.en-US.yaml
+++ b/manifests/t/Tier1Settings/Tier1Timer/1.1.0/Tier1Settings.Tier1Timer.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Tier1Settings.Tier1Timer
+PackageVersion: 1.1.0
+PackageLocale: en-US
+Publisher: Tier1Settings
+PublisherUrl: https://tier1settings.com
+PublisherSupportUrl: https://tier1settings.com/contact/
+PackageName: Tier1Timer
+PackageUrl: https://tier1settings.com/tier1timer/
+License: Freeware
+Copyright: Copyright (c) Tier1Settings
+ShortDescription: Set and lock Windows timer resolution to reduce input lag and improve frame pacing in games.
+Description: |-
+  Tier1Timer sets and locks the Windows timer resolution to 0.5 ms (the Windows default is 15.6 ms),
+  reducing input lag and improving frame pacing in games. Auto Mode applies the right timer resolution
+  per game automatically — set it once and forget it. The system timer is always restored to the
+  Windows default on exit or crash. Portable single exe (~1 MB), code-signed via Azure Trusted Signing.
+Moniker: tier1timer
+Tags:
+- fps
+- gaming
+- input-lag
+- latency
+- timer-resolution
+ReleaseNotesUrl: https://tier1settings.com/tier1timer/
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/t/Tier1Settings/Tier1Timer/1.1.0/Tier1Settings.Tier1Timer.yaml
+++ b/manifests/t/Tier1Settings/Tier1Timer/1.1.0/Tier1Settings.Tier1Timer.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Tier1Settings.Tier1Timer
+PackageVersion: 1.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: Tier1Settings.Tier1Timer 1.1.0

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? (validation succeeded)
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Tier1Timer is a free, portable (~1 MB), code-signed (Azure Trusted Signing) Windows tool from tier1settings.com that sets and locks the Windows timer resolution to 0.5 ms to reduce input lag and improve frame pacing in games. The system timer is always restored to the Windows default on exit or crash.

- Publisher/homepage: https://tier1settings.com/tier1timer/
- Installer URL is versioned and immutable; SHA-256 verified against the served file.

I am the publisher of this software (Tier1Settings).