### PR TITLE
New package: Turin.tmuxw version 0.1.1

### DIFF
--- a/manifests/t/Turin/tmuxw/0.1.1/Turin.tmuxw.installer.yaml
+++ b/manifests/t/Turin/tmuxw/0.1.1/Turin.tmuxw.installer.yaml
@@ -1,0 +1,11 @@
+PackageIdentifier: Turin.tmuxw
+PackageVersion: 0.1.1
+InstallerType: portable
+Commands:
+  - tmux
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/turin-dev/tmux-windows/releases/download/v0.1.1/tmuxw-0.1.1-win-x64.exe
+    InstallerSha256: 245D9E2470F6A8A0A1C9B438464304A04340C9345E595B1649869FB970A5A51F
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/t/Turin/tmuxw/0.1.1/Turin.tmuxw.locale.en-US.yaml
+++ b/manifests/t/Turin/tmuxw/0.1.1/Turin.tmuxw.locale.en-US.yaml
@@ -1,0 +1,26 @@
+PackageIdentifier: Turin.tmuxw
+PackageVersion: 0.1.1
+PackageLocale: en-US
+Publisher: Turin
+PublisherUrl: https://github.com/turin-dev
+PackageName: tmuxw
+PackageUrl: https://github.com/turin-dev/tmux-windows
+License: MIT
+LicenseUrl: https://github.com/turin-dev/tmux-windows/blob/main/LICENSE
+ShortDescription: A native Windows terminal multiplexer (tmux clone) built on ConPTY.
+Description: |-
+  tmuxw is a native Windows terminal multiplexer — a tmux clone built on the
+  Windows ConPTY (Pseudo Console) API with no WSL/Cygwin/MSYS2 dependency. It
+  provides panes, windows (tabs), a client/server model with detach/attach,
+  scrollback with a vi-style copy mode, and a configurable command/key-binding
+  system.
+Moniker: tmuxw
+Tags:
+  - terminal
+  - multiplexer
+  - tmux
+  - conpty
+  - cli
+  - console
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/t/Turin/tmuxw/0.1.1/Turin.tmuxw.yaml
+++ b/manifests/t/Turin/tmuxw/0.1.1/Turin.tmuxw.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Turin.tmuxw
+PackageVersion: 0.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## New package

- **PackageIdentifier:** Turin.tmuxw
- **Version:** 0.1.1

tmuxw is a native Windows terminal multiplexer — a tmux clone built on the Windows ConPTY (Pseudo Console) API with no WSL/Cygwin/MSYS2 dependency. It provides panes, windows (tabs), a client/server model with detach/attach, scrollback with a vi-style copy mode, and a configurable command/key-binding system.

- Installer type: portable (x64), statically linked (no VC++ redistributable required)
- Exposes the `tmux` command
- Upstream project: https://github.com/turin-dev/tmux-windows
- License: MIT

### Checklist
- [x] Manifest validated locally with `winget validate` (succeeded)
- [x] InstallerSha256 matches the published release asset
- [x] InstallerUrl points to a stable GitHub release download
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/399477)