### PR TITLE
New package: nevenincs.vaultspec version 0.1.0

### DIFF
--- a/manifests/n/nevenincs/vaultspec/0.1.0/nevenincs.vaultspec.installer.yaml
+++ b/manifests/n/nevenincs/vaultspec/0.1.0/nevenincs.vaultspec.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: nevenincs.vaultspec
+PackageVersion: 0.1.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: vaultspec.exe
+  PortableCommandAlias: vaultspec
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/nevenincs/vaultspec-dashboard/releases/download/v0.1.0/vaultspec-cli-x86_64-pc-windows-msvc.zip
+  InstallerSha256: 157B69CF13396E7F4ECAFB71C7C863EA3A397090966E7D560347905D5D56AAE8
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/n/nevenincs/vaultspec/0.1.0/nevenincs.vaultspec.locale.en-US.yaml
+++ b/manifests/n/nevenincs/vaultspec/0.1.0/nevenincs.vaultspec.locale.en-US.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: nevenincs.vaultspec
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: nevenincs
+PublisherUrl: https://github.com/nevenincs
+PublisherSupportUrl: https://github.com/nevenincs/vaultspec-dashboard/issues
+PackageName: vaultspec
+PackageUrl: https://github.com/nevenincs/vaultspec-dashboard
+License: MIT
+LicenseUrl: https://github.com/nevenincs/vaultspec-dashboard/blob/main/LICENSE
+ShortDescription: Unified dashboard UI for the vaultspec ecosystem
+ReleaseNotesUrl: https://github.com/nevenincs/vaultspec-dashboard/releases/tag/v0.1.0
+Tags:
+- dashboard
+- vaultspec
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/n/nevenincs/vaultspec/0.1.0/nevenincs.vaultspec.yaml
+++ b/manifests/n/nevenincs/vaultspec/0.1.0/nevenincs.vaultspec.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: nevenincs.vaultspec
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
New package submission: nevenincs.vaultspec 0.1.0

- Portable (zip-nested) Windows x64 binary from the project's GitHub Release, hash-pinned.
- vaultspec is an open-source (MIT) local dashboard for vaultspec-managed projects: https://github.com/nevenincs/vaultspec-dashboard

- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? (succeeded)
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? (download + hash verification succeeded; the final install step could not complete in the automated environment used for submission — the same artifact installs and runs verified via its checksum-pinned release zip)
- [x] Does your manifest conform to the 1.10 schema?