### PR TITLE
New version: ShortArrow.runex version 0.1.20

### DIFF
--- a/manifests/s/ShortArrow/runex/0.1.20/ShortArrow.runex.installer.yaml
+++ b/manifests/s/ShortArrow/runex/0.1.20/ShortArrow.runex.installer.yaml
@@ -1,0 +1,19 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ShortArrow.runex
+PackageVersion: 0.1.20
+InstallerLocale: en-US
+MinimumOSVersion: 10.0.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: runex.exe
+  PortableCommandAlias: runex
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/ShortArrow/runex/releases/download/v0.1.20/runex-x86_64-pc-windows-msvc.zip
+  InstallerSha256: 39888F33B9684C260CE66482D38A0B28DEFD0927981B3714BF492E7FEA4939B5
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-07-08

--- a/manifests/s/ShortArrow/runex/0.1.20/ShortArrow.runex.locale.en-US.yaml
+++ b/manifests/s/ShortArrow/runex/0.1.20/ShortArrow.runex.locale.en-US.yaml
@@ -1,0 +1,39 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ShortArrow.runex
+PackageVersion: 0.1.20
+PackageLocale: en-US
+Publisher: ShortArrow
+PublisherUrl: https://github.com/ShortArrow
+PublisherSupportUrl: https://github.com/ShortArrow/runex/issues
+Author: ShortArrow
+PackageName: runex
+PackageUrl: https://github.com/ShortArrow/runex
+License: MIT OR Apache-2.0
+LicenseUrl: https://github.com/ShortArrow/runex/blob/main/LICENSE
+Copyright: Copyright (c) 2025 ShortArrow
+ShortDescription: Cross-shell abbreviation engine that expands short tokens into full commands
+Description: |-
+  runex is a cross-shell abbreviation engine that expands short tokens into full commands in real-time.
+
+  - Cross-shell support (bash / zsh / pwsh / cmd / nushell)
+  - Real-time expansion (customizable trigger key)
+  - Single config file shared across shells
+  - Conditional rules (when_command_exists) — recognizes shell cmdlets, aliases, and user-defined functions, not just PATH binaries
+  - Fast and lightweight (Rust core)
+Moniker: runex
+Tags:
+- abbreviation
+- alias
+- bash
+- cli
+- expansion
+- nushell
+- powershell
+- rust
+- shell
+- zsh
+ReleaseNotesUrl: https://github.com/ShortArrow/runex/releases/tag/v0.1.20
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/ShortArrow/runex/0.1.20/ShortArrow.runex.yaml
+++ b/manifests/s/ShortArrow/runex/0.1.20/ShortArrow.runex.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ShortArrow.runex
+PackageVersion: 0.1.20
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description

Update ShortArrow.runex to version 0.1.20. Manifest generated with wingetcreate.

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves https://github.com/ShortArrow/runex/issues/15 (upstream)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>` — installer hash verified successfully, but the install stalls after hash verification on this Defender-active machine (same ML false-positive pattern as previous versions of this package)
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/399500)
