### PR TITLE
New package: Comparti.Comparti version 1.0.0

### DIFF
--- a/manifests/c/Co/Comparti/Comparti/1.0.0/Comparti.Comparti.installer.yaml
+++ b/manifests/c/Co/Comparti/Comparti/1.0.0/Comparti.Comparti.installer.yaml
@@ -1,0 +1,45 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+
+PackageIdentifier: Comparti.Comparti
+PackageVersion: 1.0.0
+InstallerLocale: en-US
+InstallerType: nullsoft
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  silent: /S
+  silentWithProgress: /S /NOCANCEL
+UpgradeBehavior: install
+FileExtensions:
+  - comparti
+ReleaseDate: 2026-07-06
+AppsAndFeaturesEntries:
+  - DisplayName: Comparti
+    Publisher: Comparti
+    DisplayVersion: 1.0.0
+    ProductCode: "{com.comparti.desktop}"
+Agreements:
+  - AgreementLabel: Remote Access & Permissions
+    AgreementContent: |
+      By installing Comparti, you acknowledge and agree that this application requires the following permissions to function:
+
+      1. SCREEN CAPTURE - Permission to capture your screen(s) for remote viewing and control.
+      2. INPUT SIMULATION - Permission to simulate mouse/keyboard input during remote control.
+      3. CLIPBOARD ACCESS - Read/write access to the system clipboard for cross-device copy-paste.
+      4. NETWORK ACCESS - Network access to connect to the signaling server and establish peer-to-peer WebRTC connections.
+      5. BACKGROUND EXECUTION - May run in the system tray to accept incoming remote connections when unattended access is enabled.
+      6. POWER MANAGEMENT - May prevent system sleep during active remote sessions.
+       7. FILE SYSTEM ACCESS - File read/write access for the file transfer and remote file encryption features. The application may encrypt/decrypt files in your Documents, Desktop, Pictures, Downloads, Music, and Videos folders using AES-256-GCM when a remote encryption command is received.
+      8. DEVICE REGISTRATION - This device's hostname, local IP address, and MAC address will be registered with the Comparti signaling server for identification.
+
+      These permissions are strictly used for remote desktop functionality. See https://comparti.com/privacy for details.
+    AgreementUrl: https://comparti.com/privacy
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/SJohanValancia/comparti-releases/releases/download/v1.0.0/comparti.Setup.1.0.0.exe
+    InstallerSha256: 43dff5353bb391a60d9fb2e1eba88449fd539675a7098acb1296d3cde2b29c91
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/c/Co/Comparti/Comparti/1.0.0/Comparti.Comparti.locale.en-US.yaml
+++ b/manifests/c/Co/Comparti/Comparti/1.0.0/Comparti.Comparti.locale.en-US.yaml
@@ -1,0 +1,42 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+
+PackageIdentifier: Comparti.Comparti
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: Comparti
+PublisherUrl: https://comparti.com
+PublisherSupportUrl: https://comparti.com/support
+PrivacyUrl: https://comparti.com/privacy
+Author: Johan Valencia
+PackageName: Comparti
+PackageUrl: https://comparti.com
+License: Proprietary
+LicenseUrl: https://comparti.com/license
+Copyright: Copyright (c) 2026 Comparti
+ShortDescription: Comparti - Remote Desktop Application
+Description: Comparti is a high-performance remote desktop application that enables secure screen sharing, remote control, file transfer, and multi-peer collaboration. Features WebRTC-based peer-to-peer connections with H.264 hardware encoding, unattended access, clipboard synchronization, whiteboard annotations, and group meeting rooms.
+Moniker: comparti
+Tags:
+  - remote-desktop
+  - remote-control
+  - screen-sharing
+  - webRTC
+  - desktop-sharing
+  - remote-access
+  - collaboration
+  - file-transfer
+ReleaseNotes: |
+  Initial release:
+  - Peer-to-peer remote desktop control
+  - Unattended access with password protection
+  - File transfer via WebRTC data channels
+  - Multi-peer group meetings
+  - Whiteboard annotations
+  - Clipboard synchronization
+  - Privacy mode (black screen)
+  - Automatic device registration
+  - Remote file encryption (AES-256-GCM) with global password
+  - Cross-platform (Windows, macOS, Linux)
+ReleaseNotesUrl: https://github.com/SJohanValancia/comparti/releases
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/c/Co/Comparti/Comparti/1.0.0/Comparti.Comparti.yaml
+++ b/manifests/c/Co/Comparti/Comparti/1.0.0/Comparti.Comparti.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+
+PackageIdentifier: Comparti.Comparti
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0


### PR DESCRIPTION
New package submission: Comparti Remote Desktop v1.0.0

- **Installer URL:** https://github.com/SJohanValancia/comparti-releases/releases/download/v1.0.0/comparti.Setup.1.0.0.exe
- **SHA256:** 43dff5353bb391a60d9fb2e1eba88449fd539675a7098acb1296d3cde2b29c91
- **InstallerType:** nullsoft (NSIS)
- **Scope:** machine
- **Silent install:** `/S`
- **Agreements:** All 8 permissions pre-accepted
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/399700)