### PR TITLE
New package: MET.MCAD2026 version 2026.7.8.31

### DIFF
--- a/manifests/m/MET/MCAD2026/2026.7.8.31/MET.MCAD2026.installer.yaml
+++ b/manifests/m/MET/MCAD2026/2026.7.8.31/MET.MCAD2026.installer.yaml
@@ -26,6 +26,6 @@ Installers:
     # Replace this URL with the actual public GitHub Release download link
     # (must be the exact MCAD2026-Setup-2026.exe you publish). See README.
     InstallerUrl: https://github.com/kittech197718/MCAD2026-releases/releases/download/v2026.7.8.31/MCAD2026-Setup-2026.exe
-    InstallerSha256: 36A0770D09A327479411F8414CF7EE81FD1E510E5DA5D13A4438AA0C0286C9CB
+    InstallerSha256: 8A94BA6B0AF3DC5F2F60C79AF999A4F9DED9B86D53469DE692A08E52A6BE124A
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/m/MET/MCAD2026/2026.7.8.31/MET.MCAD2026.installer.yaml
+++ b/manifests/m/MET/MCAD2026/2026.7.8.31/MET.MCAD2026.installer.yaml
@@ -1,0 +1,31 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: MET.MCAD2026
+PackageVersion: 2026.7.8.31
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART
+UpgradeBehavior: install
+ProductCode: '{8E0B2B3A-MCAD-2026-METX-2D0000000001}_is1'
+AppsAndFeaturesEntries:
+  - DisplayName: MCAD2026
+    Publisher: MET Mechatronics Designed Co.,Ltd.
+    DisplayVersion: '2026'
+    ProductCode: '{8E0B2B3A-MCAD-2026-METX-2D0000000001}_is1'
+    InstallerType: inno
+Installers:
+  - Architecture: x64
+    # Replace this URL with the actual public GitHub Release download link
+    # (must be the exact MCAD2026-Setup-2026.exe you publish). See README.
+    InstallerUrl: https://github.com/kittech197718/MCAD2026-releases/releases/download/v2026.7.8.31/MCAD2026-Setup-2026.exe
+    InstallerSha256: 36A0770D09A327479411F8414CF7EE81FD1E510E5DA5D13A4438AA0C0286C9CB
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/MET/MCAD2026/2026.7.8.31/MET.MCAD2026.locale.en-US.yaml
+++ b/manifests/m/MET/MCAD2026/2026.7.8.31/MET.MCAD2026.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: MET.MCAD2026
+PackageVersion: 2026.7.8.31
+PackageLocale: en-US
+Publisher: MET Mechatronics Designed Co.,Ltd.
+PublisherUrl: https://mechdesigned.com
+PublisherSupportUrl: https://mechdesigned.com
+Author: MET Mechatronics Designed Co.,Ltd.
+PackageName: MCAD2026
+PackageUrl: https://mechdesigned.com
+License: Proprietary
+Copyright: Copyright (c) 2026 MET Mechatronics Designed Co.,Ltd.
+ShortDescription: Professional 2D CAD drafting application (DWG/DXF) by MET Mechatronics.
+Description: |-
+  MCAD2026 is a native Windows 2D CAD drafting program for mechanical and
+  electrical design. It opens and edits DWG/DXF drawings, includes AutoCAD-style
+  drawing and modify tools, associative dimensions, layouts and plotting, a
+  wiring-diagram wizard, and an electrical symbol library. The installer bundles
+  the ODA File Converter so DWG files open with no separate install.
+Moniker: mcad2026
+Tags:
+  - cad
+  - 2d-cad
+  - drafting
+  - dwg
+  - dxf
+  - engineering
+  - mechanical
+  - electrical
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/MET/MCAD2026/2026.7.8.31/MET.MCAD2026.locale.en-US.yaml
+++ b/manifests/m/MET/MCAD2026/2026.7.8.31/MET.MCAD2026.locale.en-US.yaml
@@ -3,11 +3,11 @@ PackageIdentifier: MET.MCAD2026
 PackageVersion: 2026.7.8.31
 PackageLocale: en-US
 Publisher: MET Mechatronics Designed Co.,Ltd.
-PublisherUrl: https://mechdesigned.com
-PublisherSupportUrl: https://mechdesigned.com
+PublisherUrl: https://github.com/kittech197718/MCAD2026-releases
+PublisherSupportUrl: https://github.com/kittech197718/MCAD2026-releases/issues
 Author: MET Mechatronics Designed Co.,Ltd.
 PackageName: MCAD2026
-PackageUrl: https://mechdesigned.com
+PackageUrl: https://github.com/kittech197718/MCAD2026-releases
 License: Proprietary
 Copyright: Copyright (c) 2026 MET Mechatronics Designed Co.,Ltd.
 ShortDescription: Professional 2D CAD drafting application (DWG/DXF) by MET Mechatronics.

--- a/manifests/m/MET/MCAD2026/2026.7.8.31/MET.MCAD2026.yaml
+++ b/manifests/m/MET/MCAD2026/2026.7.8.31/MET.MCAD2026.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: MET.MCAD2026
+PackageVersion: 2026.7.8.31
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: MET.MCAD2026 version 2026.7.8.31

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Publisher: MET Mechatronics Designed Co.,Ltd. — a native 2D CAD (DWG/DXF) drafting application. Installer is Inno Setup, Authenticode-signed and timestamped, hosted on a public GitHub Release.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/399738)