### PR TITLE
New version: Unity.UnityHub version 3.19.3

### DIFF
--- a/manifests/u/Unity/UnityHub/3.19.3/Unity.UnityHub.installer.yaml
+++ b/manifests/u/Unity/UnityHub/3.19.3/Unity.UnityHub.installer.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Unity.UnityHub
+PackageVersion: 3.19.3
+InstallerLocale: en-US
+InstallerType: nullsoft
+Scope: machine
+InstallerSwitches:
+  Upgrade: --updated
+UpgradeBehavior: install
+Protocols:
+- unityhub
+FileExtensions:
+- unityhub
+ProductCode: Unity Technologies - Hub
+ReleaseDate: 2026-07-02
+AppsAndFeaturesEntries:
+- DisplayName: Unity Hub 3.19.3
+  ProductCode: Unity Technologies - Hub
+Installers:
+- Architecture: x64
+  InstallerUrl: https://public-cdn.cloud.unity3d.com/hub/prod/3.19.3/UnityHubSetup-3.19.3-x64.exe
+  InstallerSha256: A80206BE800BEDF7DD00048E98F94307031B222D038A12038201EE3D3489ED03
+- Architecture: arm64
+  InstallerUrl: https://public-cdn.cloud.unity3d.com/hub/prod/3.19.3/UnityHubSetup-3.19.3-arm64.exe
+  InstallerSha256: F346A76CAF91F44DD58FA31C17BD2E11D369C70F2EF10AC4011ACB9CCE393C73
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/u/Unity/UnityHub/3.19.3/Unity.UnityHub.installer.yaml
+++ b/manifests/u/Unity/UnityHub/3.19.3/Unity.UnityHub.installer.yaml
@@ -22,8 +22,5 @@ Installers:
 - Architecture: x64
   InstallerUrl: https://public-cdn.cloud.unity3d.com/hub/prod/3.19.3/UnityHubSetup-3.19.3-x64.exe
   InstallerSha256: A80206BE800BEDF7DD00048E98F94307031B222D038A12038201EE3D3489ED03
-- Architecture: arm64
-  InstallerUrl: https://public-cdn.cloud.unity3d.com/hub/prod/3.19.3/UnityHubSetup-3.19.3-arm64.exe
-  InstallerSha256: F346A76CAF91F44DD58FA31C17BD2E11D369C70F2EF10AC4011ACB9CCE393C73
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/u/Unity/UnityHub/3.19.3/Unity.UnityHub.installer.yaml
+++ b/manifests/u/Unity/UnityHub/3.19.3/Unity.UnityHub.installer.yaml
@@ -5,6 +5,7 @@ PackageVersion: 3.19.3
 InstallerLocale: en-US
 InstallerType: nullsoft
 Scope: machine
+MinimumOSVersion: 10.0.10240.0
 InstallerSwitches:
   Upgrade: --updated
 UpgradeBehavior: install

--- a/manifests/u/Unity/UnityHub/3.19.3/Unity.UnityHub.locale.en-US.yaml
+++ b/manifests/u/Unity/UnityHub/3.19.3/Unity.UnityHub.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Unity.UnityHub
+PackageVersion: 3.19.3
+PackageLocale: en-US
+Publisher: Unity Technologies Inc.
+PublisherUrl: https://unity.com/
+PublisherSupportUrl: https://support.unity.com/
+PrivacyUrl: https://unity.com/legal/privacy-policy
+Author: Unity Technologies Inc.
+PackageName: Unity Hub
+PackageUrl: https://unity.com/unity-hub
+License: Proprietary
+LicenseUrl: https://unity.com/legal/terms-of-service
+Copyright: Copyright © 2022 Unity Technologies Inc.
+CopyrightUrl: https://unity.com/legal/trademarks
+ShortDescription: Manage multiple installations of the Unity Editor, create new projects, and access your work.
+Description: The Unity Hub is a standalone application that streamlines the way you navigate, download, and manage your Unity projects and installations.
+Tags:
+- unity
+- unity3d
+Documentations:
+- DocumentLabel: Manual
+  DocumentUrl: https://docs.unity3d.com/hub/manual
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/u/Unity/UnityHub/3.19.3/Unity.UnityHub.locale.zh-CN.yaml
+++ b/manifests/u/Unity/UnityHub/3.19.3/Unity.UnityHub.locale.zh-CN.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: Unity.UnityHub
+PackageVersion: 3.19.3
+PackageLocale: zh-CN
+Publisher: Unity Technologies Inc.
+PublisherUrl: https://unity.com/cn
+PublisherSupportUrl: https://support.unity.com/
+PrivacyUrl: https://unity.com/cn/legal/privacy-policy
+Author: Unity Technologies Inc.
+PackageName: Unity Hub
+PackageUrl: https://unity.com/cn/unity-hub
+License: 专有软件
+LicenseUrl: https://unity.com/cn/legal/terms-of-service
+Copyright: Copyright © 2022 Unity Technologies Inc.
+CopyrightUrl: https://unity.com/cn/legal/trademarks
+ShortDescription: 管理 Unity 编辑器的多个安装、创建新项目和访问您的工作
+Description: Unity Hub 是一款独立应用程序，简化 Unity 项目和安装的浏览、下载和管理方式。
+Tags:
+- unity
+- unity3d
+Documentations:
+- DocumentLabel: 手册
+  DocumentUrl: https://docs.unity3d.com/hub/manual
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/u/Unity/UnityHub/3.19.3/Unity.UnityHub.yaml
+++ b/manifests/u/Unity/UnityHub/3.19.3/Unity.UnityHub.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Unity.UnityHub
+PackageVersion: 3.19.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Re-adds **Unity Hub 3.19.3** to winget. This version was previously present but auto-deleted after its `InstallerSha256` stopped matching the rolling `UnityHubSetup-x64.exe` alias (the file at that URL moved on to a newer build). This submission uses Unity's immutable, version-pinned CDN path so the hash stays valid permanently. Architectures: x64. (arm64 omitted — Microsoft Defender flags the 3.19.x arm64 installer during validation; can be re-added if the false-positive is cleared.) `InstallerSha256` verified against a full, byte-count-checked download.

## ✅ Checklist
- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] This PR only modifies one (1) manifest

## 📦 Manifest Checklist
- [x] No other open PRs for this manifest version
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate`
- [x] Tested manifest locally with `winget install`
- [x] Conforms to the 1.12 schema
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/399749)
