### PR TITLE
runxhq.runx 0.6.19

### DIFF
--- a/manifests/r/runxhq/runx/0.6.19/runxhq.runx.installer.yaml
+++ b/manifests/r/runxhq/runx/0.6.19/runxhq.runx.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: runxhq.runx
+PackageVersion: 0.6.19
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: runx-0.6.19-x86_64-pc-windows-msvc\runx.exe
+    PortableCommandAlias: runx
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/runxhq/runx/releases/download/cli-v0.6.19/runx-0.6.19-x86_64-pc-windows-msvc.zip
+    InstallerSha256: F2776547D3B43DC3537E2AA22D8E774D66AAB8D8663CF9F7F4144E68E499C43D
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/r/runxhq/runx/0.6.19/runxhq.runx.locale.en-US.yaml
+++ b/manifests/r/runxhq/runx/0.6.19/runxhq.runx.locale.en-US.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: runxhq.runx
+PackageVersion: 0.6.19
+PackageLocale: en-US
+PackageName: runx
+Publisher: runxhq
+License: MIT
+ShortDescription: Native governed runtime for agent skills, tools, graphs, and packets.
+PackageUrl: https://github.com/runxhq/runx
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/r/runxhq/runx/0.6.19/runxhq.runx.yaml
+++ b/manifests/r/runxhq/runx/0.6.19/runxhq.runx.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: runxhq.runx
+PackageVersion: 0.6.19
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Updates runxhq.runx to 0.6.19.

Generated by the runx release workflow from the validated channel manifest.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/399751)