### PR TITLE
Update: Unity.UnityHub version 3.19.4 (copyright year)

### DIFF
--- a/manifests/u/Unity/UnityHub/3.19.4/Unity.UnityHub.locale.en-US.yaml
+++ b/manifests/u/Unity/UnityHub/3.19.4/Unity.UnityHub.locale.en-US.yaml
@@ -13,7 +13,7 @@ PackageName: Unity Hub
 PackageUrl: https://unity.com/unity-hub
 License: Proprietary
 LicenseUrl: https://unity.com/legal/terms-of-service
-Copyright: Copyright © 2022 Unity Technologies Inc.
+Copyright: Copyright © 2026 Unity Technologies Inc.
 CopyrightUrl: https://unity.com/legal/trademarks
 ShortDescription: Manage multiple installations of the Unity Editor, create new projects, and access your work.
 Description: The Unity Hub is a standalone application that streamlines the way you navigate, download, and manage your Unity projects and installations.

--- a/manifests/u/Unity/UnityHub/3.19.4/Unity.UnityHub.locale.zh-CN.yaml
+++ b/manifests/u/Unity/UnityHub/3.19.4/Unity.UnityHub.locale.zh-CN.yaml
@@ -13,7 +13,7 @@ PackageName: Unity Hub
 PackageUrl: https://unity.com/cn/unity-hub
 License: 专有软件
 LicenseUrl: https://unity.com/cn/legal/terms-of-service
-Copyright: Copyright © 2022 Unity Technologies Inc.
+Copyright: Copyright © 2026 Unity Technologies Inc.
 CopyrightUrl: https://unity.com/cn/legal/trademarks
 ShortDescription: 管理 Unity 编辑器的多个安装、创建新项目和访问您的工作
 Description: Unity Hub 是一款独立应用程序，简化 Unity 项目和安装的浏览、下载和管理方式。


### PR DESCRIPTION
## 📖 Description

Corrects the `Copyright` field for the currently-published **Unity Hub 3.19.4** (both en-US and zh-CN locales). It read `Copyright © 2022 Unity Technologies Inc.`, but the installer's embedded `LegalCopyright` is `Copyright © 2026 …` — the year was stale. Updated to `Copyright © 2026 Unity Technologies Inc.` (current year from the binary, keeping the legal-entity name used by the manifest's Publisher/Author fields). Fixing the latest version means the corrected value carries forward to future auto-submitted versions.

## ✅ Checklist
- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] This PR only modifies one (1) manifest

## 📦 Manifest Checklist
- [x] No other open PRs for this manifest version
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate`
- [x] Tested manifest locally with `winget install`
- [x] Conforms to the 1.12 schema
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/399758)