### PR TITLE
Update: Unity.UnityHub version 3.19.1

### DIFF
--- a/manifests/u/Unity/UnityHub/3.19.1/Unity.UnityHub.installer.yaml
+++ b/manifests/u/Unity/UnityHub/3.19.1/Unity.UnityHub.installer.yaml
@@ -6,6 +6,7 @@ PackageVersion: 3.19.1
 InstallerLocale: en-US
 InstallerType: nullsoft
 Scope: machine
+MinimumOSVersion: 10.0.10240.0
 InstallerSwitches:
   Upgrade: --updated
 UpgradeBehavior: install
@@ -14,13 +15,13 @@ Protocols:
 FileExtensions:
 - unityhub
 ProductCode: Unity Technologies - Hub
-ReleaseDate: 2026-04-23
+ReleaseDate: 2026-06-30
 AppsAndFeaturesEntries:
-- DisplayName: Unity Hub 3.17.3
+- DisplayName: Unity Hub 3.19.1
   ProductCode: Unity Technologies - Hub
 Installers:
 - Architecture: x64
-  InstallerUrl: https://public-cdn.cloud.unity3d.com/hub/prod/UnityHubSetup-x64.exe
+  InstallerUrl: https://public-cdn.cloud.unity3d.com/hub/prod/3.19.1/UnityHubSetup-3.19.1-x64.exe
   InstallerSha256: AD912E2D3D9676F2130C55A8A52F69BA18E74F9312874C7D6074A84FA518D96B
 ManifestType: installer
 ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Fixes the published **Unity Hub 3.19.1** installer manifest, which is currently broken: its `InstallerUrl` points at the rolling `hub/prod/UnityHubSetup-x64.exe` alias, whose bytes have since moved on to a newer build — so the recorded `InstallerSha256` no longer matches (the same drift that got 3.19.3 auto-deleted).

Changes (installer manifest only):
- **`InstallerUrl` → immutable version-pinned path** `.../hub/prod/3.19.1/UnityHubSetup-3.19.1-x64.exe`. `InstallerSha256` is unchanged (`AD912E2D…`) and verified against a full, byte-count-checked download of the pinned artifact — it now matches permanently.
- **`AppsAndFeaturesEntries.DisplayName`**: `Unity Hub 3.17.3` → `Unity Hub 3.19.1` (was a stale copy-paste).
- **`ReleaseDate`**: `2026-04-23` → `2026-06-30` (the old value predated 3.19.0, which is impossible; corrected to the artifact date).
- **Adds `MinimumOSVersion: 10.0.10240.0`** (Windows 10, per Unity requirement).

## ✅ Checklist
- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] This PR only modifies one (1) manifest

## 📦 Manifest Checklist
- [x] No other open PRs for this manifest version
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate`
- [x] Tested manifest locally with `winget install`
- [x] Conforms to the 1.12 schema
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/399785)