### PR TITLE
fix(CharacterArc): correct x64 installer URL for v1.10.2

### DIFF
--- a/manifests/u/uu201/CharacterArc/1.10.2/uu201.CharacterArc.installer.yaml
+++ b/manifests/u/uu201/CharacterArc/1.10.2/uu201.CharacterArc.installer.yaml
@@ -1,6 +1,5 @@
 # Created with YamlCreate.ps1 Dumplings Mod
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
-
 PackageIdentifier: uu201.CharacterArc
 PackageVersion: 1.10.2
 InstallerType: nullsoft
@@ -20,6 +19,18 @@ Installers:
   Scope: machine
   InstallerUrl: https://github.com/uu201/character-arc/releases/download/v1.10.2/CharacterArc-1.10.2-arm64-setup.exe
   InstallerSha256: 35DEFAF6A12D8AAF2A19B316451B86FD924ECE4B91E3ECA0E13F809527AD8F04
+  InstallerSwitches:
+    Custom: /allusers
+- Architecture: x64
+  Scope: user
+  InstallerUrl: https://github.com/uu201/character-arc/releases/download/v1.10.2/CharacterArc-1.10.2-x64-setup.exe
+  InstallerSha256: 399B45E47C6610E14F7DEFAE8D44FCC481EF9A7FCC497135E61EF719BACE7A3A
+  InstallerSwitches:
+    Custom: /currentuser
+- Architecture: x64
+  Scope: machine
+  InstallerUrl: https://github.com/uu201/character-arc/releases/download/v1.10.2/CharacterArc-1.10.2-x64-setup.exe
+  InstallerSha256: 399B45E47C6610E14F7DEFAE8D44FCC481EF9A7FCC497135E61EF719BACE7A3A
   InstallerSwitches:
     Custom: /allusers
 ManifestType: installer

--- a/manifests/u/uu201/CharacterArc/1.10.2/uu201.CharacterArc.installer.yaml
+++ b/manifests/u/uu201/CharacterArc/1.10.2/uu201.CharacterArc.installer.yaml
@@ -9,13 +9,13 @@ UpgradeBehavior: install
 ProductCode: 49938137-299e-5c61-8d81-5dc02724dce8
 ReleaseDate: 2026-06-23
 Installers:
-- Architecture: x64
+- Architecture: arm64
   Scope: user
   InstallerUrl: https://github.com/uu201/character-arc/releases/download/v1.10.2/CharacterArc-1.10.2-arm64-setup.exe
   InstallerSha256: 35DEFAF6A12D8AAF2A19B316451B86FD924ECE4B91E3ECA0E13F809527AD8F04
   InstallerSwitches:
     Custom: /currentuser
-- Architecture: x64
+- Architecture: arm64
   Scope: machine
   InstallerUrl: https://github.com/uu201/character-arc/releases/download/v1.10.2/CharacterArc-1.10.2-arm64-setup.exe
   InstallerSha256: 35DEFAF6A12D8AAF2A19B316451B86FD924ECE4B91E3ECA0E13F809527AD8F04


### PR DESCRIPTION
The v1.10.2 manifest declared `Architecture: x64` but pointed to the ARM64 installer URL and SHA256. This caused x64 users to receive the ARM64 build.

Changes:
- Add correct x64 entries with `Architecture: x64` pointing to `CharacterArc-1.10.2-x64-setup.exe`

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/399795)