### PR TITLE
fix(CharacterArc): add correct arm64 architecture entries for v1.10.1 and v1.10.2

### DIFF
--- a/manifests/u/uu201/CharacterArc/1.10.1/uu201.CharacterArc.installer.yaml
+++ b/manifests/u/uu201/CharacterArc/1.10.1/uu201.CharacterArc.installer.yaml
@@ -1,6 +1,5 @@
 # Created with YamlCreate.ps1 Dumplings Mod
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
-
 PackageIdentifier: uu201.CharacterArc
 PackageVersion: 1.10.1
 InstallerType: nullsoft
@@ -10,13 +9,13 @@ UpgradeBehavior: install
 ProductCode: 49938137-299e-5c61-8d81-5dc02724dce8
 ReleaseDate: 2026-06-21
 Installers:
-- Architecture: x64
+- Architecture: arm64
   Scope: user
   InstallerUrl: https://github.com/uu201/character-arc/releases/download/v1.10.1/CharacterArc-1.10.1-arm64-setup.exe
   InstallerSha256: 414F0C639E77C20050718712E712CB60DB6FD4400515DACAB157F06B57D6186A
   InstallerSwitches:
     Custom: /currentuser
-- Architecture: x64
+- Architecture: arm64
   Scope: machine
   InstallerUrl: https://github.com/uu201/character-arc/releases/download/v1.10.1/CharacterArc-1.10.1-arm64-setup.exe
   InstallerSha256: 414F0C639E77C20050718712E712CB60DB6FD4400515DACAB157F06B57D6186A

--- a/manifests/u/uu201/CharacterArc/1.10.2/uu201.CharacterArc.installer.yaml
+++ b/manifests/u/uu201/CharacterArc/1.10.2/uu201.CharacterArc.installer.yaml
@@ -1,6 +1,5 @@
 # Created with YamlCreate.ps1 Dumplings Mod
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
-
 PackageIdentifier: uu201.CharacterArc
 PackageVersion: 1.10.2
 InstallerType: nullsoft
@@ -10,13 +9,13 @@ UpgradeBehavior: install
 ProductCode: 49938137-299e-5c61-8d81-5dc02724dce8
 ReleaseDate: 2026-06-23
 Installers:
-- Architecture: x64
+- Architecture: arm64
   Scope: user
   InstallerUrl: https://github.com/uu201/character-arc/releases/download/v1.10.2/CharacterArc-1.10.2-arm64-setup.exe
   InstallerSha256: 35DEFAF6A12D8AAF2A19B316451B86FD924ECE4B91E3ECA0E13F809527AD8F04
   InstallerSwitches:
     Custom: /currentuser
-- Architecture: x64
+- Architecture: arm64
   Scope: machine
   InstallerUrl: https://github.com/uu201/character-arc/releases/download/v1.10.2/CharacterArc-1.10.2-arm64-setup.exe
   InstallerSha256: 35DEFAF6A12D8AAF2A19B316451B86FD924ECE4B91E3ECA0E13F809527AD8F04


### PR DESCRIPTION
The existing manifests have x64 entries incorrectly pointing to ARM64 installer URLs. This PR correctly labels them as `Architecture: arm64` with proper installer entries.

Changes:
- v1.10.1: replace mislabeled x64 entries with correct `Architecture: arm64` entries (user + machine scope)
- v1.10.2: replace mislabeled x64 entries with correct `Architecture: arm64` entries (user + machine scope)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/399796)