### PR TITLE
New version: Turin.tmuxw version 0.2.0

### DIFF
--- a/manifests/t/Turin/tmuxw/0.2.0/Turin.tmuxw.installer.yaml
+++ b/manifests/t/Turin/tmuxw/0.2.0/Turin.tmuxw.installer.yaml
@@ -1,11 +1,19 @@
 PackageIdentifier: Turin.tmuxw
 PackageVersion: 0.2.0
-InstallerType: portable
-Commands:
-  - tmux
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
 Installers:
   - Architecture: x64
-    InstallerUrl: https://github.com/turin-dev/tmux-windows/releases/download/v0.2.0/tmuxw-0.2.0-win-x64.exe
-    InstallerSha256: D27EC60331EAC71E4626338BE0305FBB2DF426A200EA501FCB7AB09B8F8E1F11
+    InstallerUrl: https://github.com/turin-dev/tmux-windows/releases/download/v0.2.0/tmuxw-0.2.0-setup.exe
+    InstallerSha256: B7391C883D83A83AA9D10950870C3E6AFB48C87036579CB4BE59146F50C119E9
+    ProductCode: '{5F2A9C31-8B4E-4D6A-9E2F-1C7A3B5D8E04}_is1'
+    AppsAndFeaturesEntries:
+      - Publisher: Turin
+        DisplayVersion: 0.2.0
+        ProductCode: '{5F2A9C31-8B4E-4D6A-9E2F-1C7A3B5D8E04}_is1'
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/t/Turin/tmuxw/0.2.0/Turin.tmuxw.installer.yaml
+++ b/manifests/t/Turin/tmuxw/0.2.0/Turin.tmuxw.installer.yaml
@@ -1,0 +1,11 @@
+PackageIdentifier: Turin.tmuxw
+PackageVersion: 0.2.0
+InstallerType: portable
+Commands:
+  - tmux
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/turin-dev/tmux-windows/releases/download/v0.2.0/tmuxw-0.2.0-win-x64.exe
+    InstallerSha256: D27EC60331EAC71E4626338BE0305FBB2DF426A200EA501FCB7AB09B8F8E1F11
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/t/Turin/tmuxw/0.2.0/Turin.tmuxw.locale.en-US.yaml
+++ b/manifests/t/Turin/tmuxw/0.2.0/Turin.tmuxw.locale.en-US.yaml
@@ -1,0 +1,26 @@
+PackageIdentifier: Turin.tmuxw
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: Turin
+PublisherUrl: https://github.com/turin-dev
+PackageName: tmuxw
+PackageUrl: https://github.com/turin-dev/tmux-windows
+License: MIT
+LicenseUrl: https://github.com/turin-dev/tmux-windows/blob/main/LICENSE
+ShortDescription: A native Windows terminal multiplexer (tmux clone) built on ConPTY.
+Description: |-
+  tmuxw is a native Windows terminal multiplexer — a tmux clone built on the
+  Windows ConPTY (Pseudo Console) API with no WSL/Cygwin/MSYS2 dependency. It
+  provides panes, windows (tabs), a client/server model with detach/attach,
+  scrollback with a vi-style copy mode, and a configurable command/key-binding
+  system.
+Moniker: tmuxw
+Tags:
+  - terminal
+  - multiplexer
+  - tmux
+  - conpty
+  - cli
+  - console
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/t/Turin/tmuxw/0.2.0/Turin.tmuxw.yaml
+++ b/manifests/t/Turin/tmuxw/0.2.0/Turin.tmuxw.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Turin.tmuxw
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## New version

- **PackageIdentifier:** Turin.tmuxw
- **Version:** 0.2.0

tmuxw is a native Windows terminal multiplexer — a tmux clone built on the Windows ConPTY API with no WSL/Cygwin/MSYS2 dependency. 0.2.0 adds the full tmux feature set: pane/window/session management, copy-mode search and visual selection, mouse support, run-shell/if-shell, choose-window, clock-mode, and configurable status formats.

- Installer type: portable (x64), statically linked
- Exposes the `tmux` command
- Upstream: https://github.com/turin-dev/tmux-windows
- License: MIT

### Checklist
- [x] Manifest validated locally with `winget validate`
- [x] InstallerSha256 matches the published release asset
- [x] InstallerUrl points to a stable GitHub release download
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/399798)