### PR TITLE
New package: RemcoStoeten.Skriuw version 0.18.0

### DIFF
--- a/manifests/r/RemcoStoeten/Skriuw/0.18.0/RemcoStoeten.Skriuw.installer.yaml
+++ b/manifests/r/RemcoStoeten/Skriuw/0.18.0/RemcoStoeten.Skriuw.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: RemcoStoeten.Skriuw
+PackageVersion: 0.18.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-07-09
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/remcostoeten/skriuw/releases/download/desktop-v0.18.0/Skriuw_0.18.0_x64-setup.exe
+    InstallerSha256: 520EB8EDEA3841CA7F25B1A4D0F644D33F48CF15FF3BED7FEA6CF18E3C5057AB
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/r/RemcoStoeten/Skriuw/0.18.0/RemcoStoeten.Skriuw.locale.en-US.yaml
+++ b/manifests/r/RemcoStoeten/Skriuw/0.18.0/RemcoStoeten.Skriuw.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: RemcoStoeten.Skriuw
+PackageVersion: 0.18.0
+PackageLocale: en-US
+Publisher: Remco Stoeten
+PublisherUrl: https://github.com/remcostoeten
+PublisherSupportUrl: https://github.com/remcostoeten/skriuw/issues
+Author: Remco Stoeten
+PackageName: Skriuw
+PackageUrl: https://skriuw.com
+License: MIT
+LicenseUrl: https://github.com/remcostoeten/skriuw/blob/daddy/LICENSE
+Copyright: Copyright (c) Remco Stoeten
+ShortDescription: Open source note-taking, journaling, and knowledge base app for web and desktop.
+Description: >-
+  Skriuw is an open source note-taking, journaling, and knowledge base app for
+  web and desktop. It supports Markdown notes, wikilinks, backlinks, tags, a
+  daily journal, and optional bring-your-own-key AI. A calm, fast,
+  privacy-first, self-hostable Notion and Obsidian alternative built with
+  Next.js, PostgreSQL, and Tauri.
+Moniker: skriuw
+Tags:
+  - notes
+  - note-taking
+  - markdown
+  - journal
+  - knowledge-base
+  - wikilinks
+  - obsidian-alternative
+  - notion-alternative
+  - open-source
+  - productivity
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/r/RemcoStoeten/Skriuw/0.18.0/RemcoStoeten.Skriuw.yaml
+++ b/manifests/r/RemcoStoeten/Skriuw/0.18.0/RemcoStoeten.Skriuw.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: RemcoStoeten.Skriuw
+PackageVersion: 0.18.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## New package

- **Package:** RemcoStoeten.Skriuw
- **Version:** 0.18.0
- **Installer:** NSIS (nullsoft), x64, user scope, silent install
- **Source:** https://github.com/remcostoeten/skriuw (MIT)

Initial manifest submission for Skriuw — an open source note-taking, journaling, and knowledge base app for web and desktop. Installer URL points at the signed GitHub release asset; SHA256 verified locally.

### Manifests checklist
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Manifest validated against schema 1.6.0
- [x] Installer URL is a stable release asset
- [x] SHA256 matches the installer
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/400031)