### PR TITLE
New package: StudioCodeAI.LyaStudioCoder version 1.1.2

### DIFF
--- a/manifests/s/StudioCodeAI/LyaStudioCoder/1.1.2/StudioCodeAI.LyaStudioCoder.installer.yaml
+++ b/manifests/s/StudioCodeAI/LyaStudioCoder/1.1.2/StudioCodeAI.LyaStudioCoder.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: StudioCodeAI.LyaStudioCoder
+PackageVersion: 1.1.2
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+Installers:
+  - Architecture: x64
+    InstallerType: nullsoft
+    InstallerUrl: https://github.com/StudioCodeAI/Lya-Studio-Coder/releases/download/v1.1.2/Lya.Studio.Coder_1.1.2_x64-setup.exe
+    InstallerSha256: 2DBC36ADD23FCCFC2FFF1C26A3E3C578632DB64FD3606F82320AFA8F9E571F28
+    InstallerSwitches:
+      Silent: /S
+      SilentWithProgress: /S
+  - Architecture: x64
+    InstallerType: msi
+    InstallerUrl: https://github.com/StudioCodeAI/Lya-Studio-Coder/releases/download/v1.1.2/Lya.Studio.Coder_1.1.2_x64_en-US.msi
+    InstallerSha256: E22410C279650B626A8E2ADC5064C2BCC53432775BDA0F7D595EC41DD193C2B5
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/StudioCodeAI/LyaStudioCoder/1.1.2/StudioCodeAI.LyaStudioCoder.locale.en-US.yaml
+++ b/manifests/s/StudioCodeAI/LyaStudioCoder/1.1.2/StudioCodeAI.LyaStudioCoder.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: StudioCodeAI.LyaStudioCoder
+PackageVersion: 1.1.2
+PackageLocale: en-US
+Publisher: Studio Code AI
+PublisherUrl: https://github.com/StudioCodeAI
+PublisherSupportUrl: https://github.com/StudioCodeAI/Lya-Studio-Coder/issues
+PackageName: Lya Studio Coder
+PackageUrl: https://github.com/StudioCodeAI/Lya-Studio-Coder
+License: Proprietary
+LicenseUrl: https://github.com/StudioCodeAI/Lya-Studio-Coder/blob/main/LICENSE
+ShortDescription: AI-powered IDE with multi-agent orchestration (COSMOS), trilingual interface, and integrated terminal.
+Description: |-
+  Lya Studio Coder is a desktop IDE built with Tauri, React, and Monaco Editor.
+  It features COSMOS multi-agent orchestration with dynamic Star distribution,
+  a trilingual interface (Portuguese, English, Spanish), integrated terminal with
+  CLI quick-launch, ChromaDB-backed memory, n8n workflow automation, and a
+  built-in extension store. Designed for AI-assisted software development with
+  real-time collaboration between multiple AI agents.
+Moniker: lyastudiocoder
+Tags:
+  - ai
+  - ide
+  - coding
+  - developer-tools
+  - multi-agent
+  - orchestration
+  - tauri
+  - react
+  - monaco
+  - terminal
+ReleaseNotesUrl: https://github.com/StudioCodeAI/Lya-Studio-Coder/releases/tag/v1.1.2
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/StudioCodeAI/LyaStudioCoder/1.1.2/StudioCodeAI.LyaStudioCoder.yaml
+++ b/manifests/s/StudioCodeAI/LyaStudioCoder/1.1.2/StudioCodeAI.LyaStudioCoder.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: StudioCodeAI.LyaStudioCoder
+PackageVersion: 1.1.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New Package Submission

- PackageIdentifier: StudioCodeAI.LyaStudioCoder
- PackageVersion: 1.1.2
- PackageName: Lya Studio Coder
- Publisher: Studio Code AI
- License: Proprietary
- InstallerTypes: nullsoft (exe), msi
- ManifestVersion: 1.12.0

Release: https://github.com/StudioCodeAI/Lya-Studio-Coder/releases/tag/v1.1.2

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/400038)