### PR TITLE
New version: M-Igashi.mp3rgui version 2.9.6

### DIFF
--- a/manifests/m/M-Igashi/mp3rgui/2.9.6/M-Igashi.mp3rgui.installer.yaml
+++ b/manifests/m/M-Igashi/mp3rgui/2.9.6/M-Igashi.mp3rgui.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgui
+PackageVersion: 2.9.6
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: mp3rgui.exe
+ReleaseDate: 2026-07-10
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/M-Igashi/mp3rgain/releases/download/v2.9.6/mp3rgui-v2.9.6-windows-x86_64.zip
+    InstallerSha256: 00F547C46F85FFC36638F974E80C5DE576EB7FB847B164EDD40DBDC7CD741328
+  - Architecture: arm64
+    InstallerUrl: https://github.com/M-Igashi/mp3rgain/releases/download/v2.9.6/mp3rgui-v2.9.6-windows-arm64.zip
+    InstallerSha256: 41D5FF394A3745908DDCB84E005E6D6EEFA2C6C60FD2F94D23269EF9FBFF2EAD
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/mp3rgui/2.9.6/M-Igashi.mp3rgui.locale.en-US.yaml
+++ b/manifests/m/M-Igashi/mp3rgui/2.9.6/M-Igashi.mp3rgui.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgui
+PackageVersion: 2.9.6
+PackageLocale: en-US
+Publisher: M-Igashi
+PublisherUrl: https://github.com/M-Igashi
+PublisherSupportUrl: https://github.com/M-Igashi/mp3rgain/issues
+Author: M-Igashi
+PackageName: mp3rgui
+PackageUrl: https://github.com/M-Igashi/mp3rgain
+License: MIT
+LicenseUrl: https://github.com/M-Igashi/mp3rgain/blob/master/LICENSE
+ShortDescription: GUI for lossless MP3 volume adjustment - a modern mp3gain replacement written in Rust
+Description: |-
+  mp3rgui is the graphical interface for mp3rgain, a lossless MP3 volume normalizer.
+  It provides an easy-to-use GUI for adjusting MP3 volume without re-encoding,
+  supporting ReplayGain analysis, AAC/M4A, FLAC, and OGG formats.
+Moniker: mp3rgui
+Tags:
+  - audio
+  - flac
+  - gain
+  - gui
+  - lossless
+  - mp3
+  - music
+  - normalize
+  - ogg
+  - replaygain
+  - rust
+  - volume
+ReleaseNotesUrl: https://github.com/M-Igashi/mp3rgain/releases/tag/v2.9.6
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/mp3rgui/2.9.6/M-Igashi.mp3rgui.yaml
+++ b/manifests/m/M-Igashi/mp3rgui/2.9.6/M-Igashi.mp3rgui.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgui
+PackageVersion: 2.9.6
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Automated update for M-Igashi.mp3rgui version 2.9.6.

Release: https://github.com/M-Igashi/mp3rgain/releases/tag/v2.9.6
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/400185)