### PR TITLE
New package: MET.MECHCAD version 2026.6.27

### DIFF
--- a/manifests/m/MET/MECHCAD/2026.6.27/MET.MECHCAD.installer.yaml
+++ b/manifests/m/MET/MECHCAD/2026.6.27/MET.MECHCAD.installer.yaml
@@ -24,6 +24,6 @@ AppsAndFeaturesEntries:
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/kittech197718/MCAD2026-releases/releases/download/mechcad-v2026/MECHCAD-Setup-v2026.exe
-    InstallerSha256: 47262CFDC387BF569004BE896BD41933E72552B54B593AF2C5C98BFDEDC6BA9A
+    InstallerSha256: 79F0D0D786B10D0D9D863279797EE77032F53FFDFF1A2A34CE3DCA41C84EE395
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/m/MET/MECHCAD/2026.6.27/MET.MECHCAD.installer.yaml
+++ b/manifests/m/MET/MECHCAD/2026.6.27/MET.MECHCAD.installer.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: MET.MECHCAD
+PackageVersion: 2026.6.27
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART
+UpgradeBehavior: install
+ProductCode: MECHCAD_is1
+AppsAndFeaturesEntries:
+  - DisplayName: MECHCAD
+    Publisher: MET
+    DisplayVersion: '2026'
+    ProductCode: MECHCAD_is1
+    InstallerType: inno
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/kittech197718/MCAD2026-releases/releases/download/mechcad-v2026/MECHCAD-Setup-v2026.exe
+    InstallerSha256: 47262CFDC387BF569004BE896BD41933E72552B54B593AF2C5C98BFDEDC6BA9A
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/MET/MECHCAD/2026.6.27/MET.MECHCAD.locale.en-US.yaml
+++ b/manifests/m/MET/MECHCAD/2026.6.27/MET.MECHCAD.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: MET.MECHCAD
+PackageVersion: 2026.6.27
+PackageLocale: en-US
+Publisher: MET Mechatronics Designed Co.,Ltd.
+PublisherUrl: https://github.com/kittech197718/MCAD2026-releases
+PublisherSupportUrl: https://github.com/kittech197718/MCAD2026-releases/issues
+Author: MET Mechatronics Designed Co.,Ltd.
+PackageName: MECHCAD
+PackageUrl: https://github.com/kittech197718/MCAD2026-releases
+License: Proprietary
+Copyright: Copyright (c) 2026 MET Mechatronics Designed Co.,Ltd.
+ShortDescription: 3D parametric mechanical CAD application by MET Mechatronics.
+Description: |-
+  MECHCAD is a native Windows 3D parametric mechanical CAD application. It
+  provides sketch-based part modeling, feature history, assemblies with mates,
+  and STEP import/export for mechanical design. Part of the MET CAD suite
+  alongside MCAD2026 (2D drafting).
+Moniker: mechcad
+Tags:
+  - cad
+  - 3d-cad
+  - parametric
+  - mechanical
+  - engineering
+  - modeling
+  - assembly
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/MET/MECHCAD/2026.6.27/MET.MECHCAD.yaml
+++ b/manifests/m/MET/MECHCAD/2026.6.27/MET.MECHCAD.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: MET.MECHCAD
+PackageVersion: 2026.6.27
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: MET.MECHCAD version 2026.6.27

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Publisher: MET Mechatronics Designed Co.,Ltd. — MECHCAD is a 3D parametric mechanical CAD application (companion to MET.MCAD2026). Inno Setup installer, Authenticode-signed and timestamped, hosted on a public GitHub Release.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/400244)