### PR TITLE
New version: RimSort.RimSort version 1.8.0

### DIFF
--- a/manifests/r/RimSort/RimSort/1.8.0/RimSort.RimSort.installer.yaml
+++ b/manifests/r/RimSort/RimSort/1.8.0/RimSort.RimSort.installer.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: RimSort.RimSort
+PackageVersion: 1.8.0
+InstallerType: wix
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-07-03
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/RimSort/RimSort/releases/download/v1.8.0/RimSort-v1.8.0-Windows_x86_64.msi
+    InstallerSha256: 95A1DEEEC3AE91E1A9B7527474E1FF743AA2F97EA21E463C08DA3D38D8A3EBDD
+    ProductCode: "{441502E0-7F03-4743-A982-CC8B70862C1F}"
+    AppsAndFeaturesEntries:
+      - DisplayName: RimSort
+        Publisher: RimSort Team
+        DisplayVersion: 1.8.0.0
+        ProductCode: "{441502E0-7F03-4743-A982-CC8B70862C1F}"
+        UpgradeCode: "{D4F7C3B9-8A5E-4E52-BB9F-3C2D1F7A9E24}"
+        InstallerType: wix
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/r/RimSort/RimSort/1.8.0/RimSort.RimSort.locale.en-US.yaml
+++ b/manifests/r/RimSort/RimSort/1.8.0/RimSort.RimSort.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: RimSort.RimSort
+PackageVersion: 1.8.0
+PackageLocale: en-US
+Publisher: RimSort
+PublisherUrl: https://rimsort.github.io/RimSort/
+PublisherSupportUrl: https://github.com/RimSort/RimSort/issues
+Author: RimSort
+PackageName: RimSort
+PackageUrl: https://github.com/RimSort/RimSort
+License: GPL-3.0
+LicenseUrl: https://github.com/RimSort/RimSort?tab=GPL-3.0-1-ov-file#
+Copyright: 2007 Free Software Foundation, Inc.
+CopyrightUrl: https://fsf.org/
+ShortDescription: RimSort is an open source mod manager for the video game RimWorld. There is support for Linux, Mac, and Windows, built from the ground up to be a reliable, community-managed alternative to RimPy Mod Manager.
+Tags:
+  - mod-manager
+  - mods
+  - rimworld
+  - sorting
+ReleaseNotesUrl: https://github.com/RimSort/RimSort/releases/tag/v1.8.0
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0
+

--- a/manifests/r/RimSort/RimSort/1.8.0/RimSort.RimSort.yaml
+++ b/manifests/r/RimSort/RimSort/1.8.0/RimSort.RimSort.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: RimSort.RimSort
+PackageVersion: 1.8.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0
+


### PR DESCRIPTION
Updates RimSort from 1.0.30 to 1.8.0. Switches installer from zip/portable to the official WiX MSI. Tested via SandboxTest.ps1: hash verified, clean install, automatic ARP test failed but entries were confirmed manually.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/400335)