### PR TITLE
New package: PowCal.PowCal version 1.7.0

### DIFF
--- a/manifests/p/PowCal/PowCal/1.7.0/PowCal.PowCal.installer.yaml
+++ b/manifests/p/PowCal/PowCal/1.7.0/PowCal.PowCal.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: PowCal.PowCal
+PackageVersion: 1.7.0
+UpgradeBehavior: install
+ReleaseDate: 2026-06-19
+Installers:
+- Architecture: x64
+  InstallerType: exe
+  Scope: user
+  InstallerUrl: https://github.com/thomasbachem/powcal-releases/releases/download/v1.7.0/PowCal-1.7.0-Windows-Setup.exe
+  InstallerSha256: 21415871944FB9879C44F1FE196A3732B5EE33E1BCE248E5841B32FF4F9E04AA
+  InstallModes:
+  - interactive
+  - silent
+  InstallerSwitches:
+    Silent: --silent
+    SilentWithProgress: --silent
+  ProductCode: powcal
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/p/PowCal/PowCal/1.7.0/PowCal.PowCal.locale.en-US.yaml
+++ b/manifests/p/PowCal/PowCal/1.7.0/PowCal.PowCal.locale.en-US.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: PowCal.PowCal
+PackageVersion: 1.7.0
+PackageLocale: en-US
+Publisher: PowCal
+PublisherUrl: https://powcal.com
+PublisherSupportUrl: https://github.com/thomasbachem/powcal-releases/issues
+PackageName: PowCal
+PackageUrl: https://powcal.com
+License: Proprietary
+ShortDescription: A powerful app to customize & extend Google Calendar.
+Moniker: powcal
+Tags:
+- calendar
+- google-calendar
+- productivity
+ReleaseNotesUrl: https://github.com/thomasbachem/powcal-releases/releases/tag/v1.7.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/p/PowCal/PowCal/1.7.0/PowCal.PowCal.yaml
+++ b/manifests/p/PowCal/PowCal/1.7.0/PowCal.PowCal.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: PowCal.PowCal
+PackageVersion: 1.7.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://learn.microsoft.com/en-us/windows/package-manager/package/manifest?tabs=minschema)?

---

First submission for PowCal (https://powcal.com), an Electron-based app extending Google Calendar. Installer is a Squirrel.Windows setup (same framework as GitHub Desktop), hence `--silent` switches and user scope. `InstallerSha256` matches the GitHub release asset digest. Authored on macOS, so local `winget validate`/`install` runs weren't possible – relying on pipeline validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/400382)