### PR TITLE
New package: yinjianxxx.AIUsageMonitor version 2.0.0

### DIFF
--- a/manifests/y/yinjianxxx/AIUsageMonitor/2.0.0/yinjianxxx.AIUsageMonitor.installer.yaml
+++ b/manifests/y/yinjianxxx/AIUsageMonitor/2.0.0/yinjianxxx.AIUsageMonitor.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: yinjianxxx.AIUsageMonitor
+PackageVersion: '2.0.0'
+Platform:
+- Windows.Desktop
+InstallerType: zip
+NestedInstallerType: portable
+ReleaseDate: '2026-07-10'
+Installers:
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: ai-usage-monitor.exe
+    PortableCommandAlias: ai-usage-monitor
+  InstallerUrl: https://github.com/yinjianxxx/ai-usage-monitor/releases/download/v2.0.0/ai-usage-monitor-windows-x64.zip
+  InstallerSha256: 2BA4E1AE7A7B08500BD641A55BC49E80631368D86CB09ABDE07C74628991FA74
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/y/yinjianxxx/AIUsageMonitor/2.0.0/yinjianxxx.AIUsageMonitor.locale.en-US.yaml
+++ b/manifests/y/yinjianxxx/AIUsageMonitor/2.0.0/yinjianxxx.AIUsageMonitor.locale.en-US.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: yinjianxxx.AIUsageMonitor
+PackageVersion: '2.0.0'
+PackageLocale: en-US
+Publisher: yinjianxxx
+PublisherUrl: https://github.com/yinjianxxx
+PrivacyUrl: https://github.com/yinjianxxx/ai-usage-monitor/blob/v2.0.0/README.md#privacy-and-network-behaviour
+Author: Craig Constable, yinjianxxx, and contributors
+PackageName: AI Usage Monitor
+PackageUrl: https://github.com/yinjianxxx/ai-usage-monitor
+License: MIT
+LicenseUrl: https://github.com/yinjianxxx/ai-usage-monitor/blob/v2.0.0/LICENSE
+Copyright: Copyright (C) 2025 Craig Constable; modifications Copyright (C) 2026 yinjianxxx
+CopyrightUrl: https://github.com/yinjianxxx/ai-usage-monitor/blob/v2.0.0/LICENSE
+ShortDescription: A stability-focused Windows taskbar and tray usage monitor for Claude Code, Codex, and Antigravity.
+Description: >-
+  A lightweight native Windows taskbar widget and system-tray app for viewing
+  Claude Code, Codex, and Google Antigravity usage windows without opening a
+  provider dashboard. It uses existing authenticated sessions and has no
+  analytics, telemetry, or separate backend service.
+Moniker: ai-usage-monitor
+Tags:
+- antigravity
+- claude-code
+- codex
+- remote-desktop
+- rust
+- system-tray
+- taskbar
+- usage-monitor
+- windows
+ReleaseNotes: First public release of the independent stability-focused community fork.
+ReleaseNotesUrl: https://github.com/yinjianxxx/ai-usage-monitor/releases/tag/v2.0.0
+InstallationNotes: WinGet portable packages do not create a Start menu shortcut. Open a new terminal and run "ai-usage-monitor"; optionally enable "Start with Windows" from the app context menu.
+Documentations:
+- DocumentLabel: README
+  DocumentUrl: https://github.com/yinjianxxx/ai-usage-monitor/blob/v2.0.0/README.md
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/y/yinjianxxx/AIUsageMonitor/2.0.0/yinjianxxx.AIUsageMonitor.locale.zh-CN.yaml
+++ b/manifests/y/yinjianxxx/AIUsageMonitor/2.0.0/yinjianxxx.AIUsageMonitor.locale.zh-CN.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: yinjianxxx.AIUsageMonitor
+PackageVersion: '2.0.0'
+PackageLocale: zh-CN
+Publisher: yinjianxxx
+PackageName: AI Usage Monitor
+License: MIT
+ShortDescription: 面向 Windows 的 Claude Code、Codex 和 Antigravity 用量监视器，提供任务栏组件和托盘图标。
+Description: >-
+  轻量级原生 Windows 任务栏组件与系统托盘应用，无需打开服务商控制台即可查看
+  Claude Code、Codex 和 Google Antigravity 的用量周期。应用复用现有登录会话，
+  不包含分析、遥测或独立后端服务。
+ReleaseNotes: 独立稳定性社区分支的首个公开版本。
+InstallationNotes: WinGet 的 portable 包不会创建开始菜单快捷方式。安装后请在新终端中运行“ai-usage-monitor”；如需开机启动，可在应用右键菜单中启用“Start with Windows”。
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/y/yinjianxxx/AIUsageMonitor/2.0.0/yinjianxxx.AIUsageMonitor.yaml
+++ b/manifests/y/yinjianxxx/AIUsageMonitor/2.0.0/yinjianxxx.AIUsageMonitor.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: yinjianxxx.AIUsageMonitor
+PackageVersion: '2.0.0'
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds the first WinGet manifest for AI Usage Monitor 2.0.0 as an x64 ZIP with a nested portable executable.

The version-specific GitHub Release archive includes the executable, MIT license, third-party notices, dependency license bundle, and README. The manifest exposes `ai-usage-monitor` as the portable command alias.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked issue not required for this routine manifest submission

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for `yinjianxxx.AIUsageMonitor` 2.0.0
- [x] This PR only modifies one manifest
- [x] Validated locally with `winget validate --manifest manifests/y/yinjianxxx/AIUsageMonitor/2.0.0`
- [ ] Local WinGet install was not run because this session cannot enable `LocalManifestFiles` without administrator privileges; the release archive and portable executable were verified independently
- [x] Manifest conforms to the 1.12 schema

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/400395)