### PR TITLE
New package: Magicianhax.PortsController version 0.1.0

### DIFF
--- a/manifests/m/Magicianhax/PortsController/0.1.0/Magicianhax.PortsController.installer.yaml
+++ b/manifests/m/Magicianhax/PortsController/0.1.0/Magicianhax.PortsController.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Magicianhax.PortsController
+PackageVersion: 0.1.0
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Magicianhax/ports-controller/releases/download/v0.1.0/PortsController_0.1.0_x64-setup.exe
+    InstallerSha256: 576DE8E77947827A2B5E585EB916876EE3A2DCD65573245844E2904DF73677BA
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/Magicianhax/PortsController/0.1.0/Magicianhax.PortsController.locale.en-US.yaml
+++ b/manifests/m/Magicianhax/PortsController/0.1.0/Magicianhax.PortsController.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Magicianhax.PortsController
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Magicianhax
+PublisherUrl: https://github.com/Magicianhax
+PublisherSupportUrl: https://github.com/Magicianhax/ports-controller/issues
+PackageName: Ports Controller
+PackageUrl: https://github.com/Magicianhax/ports-controller
+License: MIT
+LicenseUrl: https://github.com/Magicianhax/ports-controller/blob/main/LICENSE
+ShortDescription: Monitor and control network ports on Windows
+Description: >-
+  A glass, Apple-style Windows desktop app to see every open TCP/UDP port,
+  which process owns it, and kill processes right from the UI. Includes live
+  auto-refresh, search and filters, process details, watched ports with toast
+  notifications, and a system tray with a quick glance of listening ports.
+Tags:
+  - ports
+  - network
+  - netstat
+  - process
+  - developer-tools
+  - tauri
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/Magicianhax/PortsController/0.1.0/Magicianhax.PortsController.yaml
+++ b/manifests/m/Magicianhax/PortsController/0.1.0/Magicianhax.PortsController.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Magicianhax.PortsController
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package submission

- **PackageIdentifier:** Magicianhax.PortsController
- **PackageVersion:** 0.1.0
- **Homepage:** https://github.com/Magicianhax/ports-controller
- **Installer:** NSIS (nullsoft), x64, per-user scope, silent install supported (/S)
- **License:** MIT (open source)

Ports Controller is a Windows desktop app to monitor network ports: live TCP/UDP table with owning processes, one-click kill, process details, watched ports with toast notifications, and a system tray glance. Built with Tauri 2 (Rust + React).

- [x] Manifests validated locally with `winget validate` (validation succeeded)
- [x] Installer URL is a stable GitHub Release asset with matching SHA256
- [x] This PR only adds one manifest (one package version)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/400464)