### PR TITLE
New package: miragecze.Migrato version 0.8.1

### DIFF
--- a/manifests/m/miragecze/Migrato/0.8.1/miragecze.Migrato.installer.yaml
+++ b/manifests/m/miragecze/Migrato/0.8.1/miragecze.Migrato.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: miragecze.Migrato
+PackageVersion: 0.8.1
+InstallerType: portable
+Commands:
+- migrato
+ReleaseDate: 2026-07-10
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/miragecze/migrato/releases/download/v0.8.1/Migrato.exe
+  InstallerSha256: 5F8BF1101EA73FA74DE61E368044200852947B1D2D05004BD57F37933BD71648
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/miragecze/Migrato/0.8.1/miragecze.Migrato.locale.en-US.yaml
+++ b/manifests/m/miragecze/Migrato/0.8.1/miragecze.Migrato.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: miragecze.Migrato
+PackageVersion: 0.8.1
+PackageLocale: en-US
+Publisher: miragecze
+PublisherUrl: https://github.com/miragecze
+PublisherSupportUrl: https://github.com/miragecze/migrato/issues
+PackageName: Migrato
+PackageUrl: https://github.com/miragecze/migrato
+License: MIT
+LicenseUrl: https://github.com/miragecze/migrato/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Migrato contributors
+ShortDescription: Move your files, mail, settings and programs to a new Windows PC over Wi-Fi.
+Description: |-
+  Migrato is an open-source PC migration tool. Run it on both computers on the
+  same network, pair them with a PIN and transfer your data over an encrypted
+  connection: known folders and custom folders, Mozilla Thunderbird and Firefox
+  profiles including passwords, settings of popular apps, installed programs
+  (reinstalled via winget), Wi-Fi networks with passwords, wallpaper and fonts.
+  Transfers verify every file with SHA-256 and resume after interruption.
+  Czech and English UI. No cloud, no telemetry, no Microsoft account required.
+Moniker: migrato
+Tags:
+- migration
+- pc-transfer
+- backup
+- file-transfer
+- wifi
+- lan
+ReleaseNotesUrl: https://github.com/miragecze/migrato/blob/main/CHANGELOG.md
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/miragecze/Migrato/0.8.1/miragecze.Migrato.yaml
+++ b/manifests/m/miragecze/Migrato/0.8.1/miragecze.Migrato.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: miragecze.Migrato
+PackageVersion: 0.8.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package submission

- **Package**: miragecze.Migrato 0.8.1 (portable)
- **Project**: https://github.com/miragecze/migrato — open-source (MIT) PC migration tool: transfers files, Mozilla Thunderbird/Firefox profiles, app settings, installed programs (via winget), Wi-Fi profiles, wallpaper and fonts between two Windows PCs over the local network.

---

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? (authored per 1.6.0 schema; validation pipeline will verify)
- [x] Have you tested your manifest locally with `winget install --manifest <path>`? (portable exe verified from the release asset)
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/400476)