### PR TITLE
Modify: NitroSoftware.NitroPro version 14.43.7.0

### DIFF
--- a/manifests/n/NitroSoftware/NitroPro/14.43.7.0/NitroSoftware.NitroPro.installer.yaml
+++ b/manifests/n/NitroSoftware/NitroPro/14.43.7.0/NitroSoftware.NitroPro.installer.yaml
@@ -18,6 +18,9 @@ Dependencies:
   - PackageIdentifier: Microsoft.EdgeWebView2Runtime
 ProductCode: '{5354F680-D36C-420A-AE0B-7F531DF1C863}'
 ReleaseDate: 2026-06-09
+AppsAndFeaturesEntries:
+- DisplayName: Nitro PDF Pro
+  UpgradeCode: '{709C6481-3F19-4EDD-A5FF-DDF7F755C563}'
 InstallationMetadata:
   DefaultInstallLocation: '%ProgramFiles%\Nitro\PDF Pro\14'
 Installers:


### PR DESCRIPTION
## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)
  - Resolves #400546

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

## Description

This PR adds the `AppsAndFeaturesEntries` metadata block containing the `UpgradeCode` and `DisplayName` to the retail version of Nitro PDF Pro (`NitroSoftware.NitroPro` version 14.43.7.0).

### Context / Problem
Currently, the subscription-based NLS version of Nitro PDF Pro (`NitroSoftware.NitroPro.NLS` version 26.0.10.0) declares:
```yaml
AppsAndFeaturesEntries:
  - DisplayName: Nitro PDF Pro
    UpgradeCode: '{709C6481-3F19-4EDD-A5FF-DDF7F755C563}'
```
Both of these values also describe a **retail** Nitro PDF Pro 14 installation (which shares the same WiX `UpgradeCode` `{709C6481-3F19-4EDD-A5FF-DDF7F755C563}`). Because the retail `NitroSoftware.NitroPro` manifests did not declare any `AppsAndFeaturesEntries`, winget's correlation resolved retail v14 installs to the `NitroSoftware.NitroPro.NLS` package.
As a result, running `winget upgrade` would incorrectly try to upgrade perpetual-license retail v14 installations to NLS 26.0.10.0, performing an MSI major upgrade that removes the retail perpetual license build and migrates users onto subscription-licensed NLS without consent. It also defeats pins and exclusions targeting `NitroSoftware.NitroPro`.

### Solution
By adding matching `AppsAndFeaturesEntries` with the `UpgradeCode` and `DisplayName` to the retail `NitroSoftware.NitroPro` manifest, winget will see that both packages match this UpgradeCode. Since their versions are disjoint (retail is 14.x and NLS is 26.x), winget will correctly correlate an installed 14.x retail package to `NitroSoftware.NitroPro` instead of `NitroSoftware.NitroPro.NLS`. This resolves the unintended cross-package upgrade path.

Resolves #400546

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/400574)