### PR TITLE
New version: Rorkai.ASC version 2.7.0

### DIFF
--- a/manifests/r/Rorkai/ASC/2.7.0/Rorkai.ASC.installer.yaml
+++ b/manifests/r/Rorkai/ASC/2.7.0/Rorkai.ASC.installer.yaml
@@ -7,6 +7,6 @@ Commands:
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/rorkai/App-Store-Connect-CLI/releases/download/2.7.0/asc_2.7.0_windows_amd64.exe
-    InstallerSha256: A8DB39A1859D8B0172B971D14B87945BDB627895382C8A63856DE9C90A3ACFD8
+    InstallerSha256: 9F5FC00F3F0BF70BC3E3F32F041D0B825D3CEF2C16A221E46C973D738F4A6F35
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/r/Rorkai/ASC/2.7.0/Rorkai.ASC.installer.yaml
+++ b/manifests/r/Rorkai/ASC/2.7.0/Rorkai.ASC.installer.yaml
@@ -1,0 +1,12 @@
+# Created with App-Store-Connect-CLI/scripts/generate_winget_manifests.py
+PackageIdentifier: Rorkai.ASC
+PackageVersion: 2.7.0
+InstallerType: portable
+Commands:
+  - asc
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/rorkai/App-Store-Connect-CLI/releases/download/2.7.0/asc_2.7.0_windows_amd64.exe
+    InstallerSha256: A8DB39A1859D8B0172B971D14B87945BDB627895382C8A63856DE9C90A3ACFD8
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/r/Rorkai/ASC/2.7.0/Rorkai.ASC.locale.en-US.yaml
+++ b/manifests/r/Rorkai/ASC/2.7.0/Rorkai.ASC.locale.en-US.yaml
@@ -1,0 +1,20 @@
+# Created with App-Store-Connect-CLI/scripts/generate_winget_manifests.py
+PackageIdentifier: Rorkai.ASC
+PackageVersion: 2.7.0
+PackageLocale: en-US
+Publisher: Rorkai
+PackageName: asc
+PackageUrl: https://github.com/rorkai/App-Store-Connect-CLI
+License: MIT
+LicenseUrl: https://github.com/rorkai/App-Store-Connect-CLI/blob/main/LICENSE
+ShortDescription: Fast, scriptable CLI for the App Store Connect API.
+Moniker: asc
+Tags:
+  - app-store-connect
+  - app-store-connect-api
+  - cli
+  - ios
+  - testflight
+ReleaseNotesUrl: https://github.com/rorkai/App-Store-Connect-CLI/releases/tag/2.7.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/r/Rorkai/ASC/2.7.0/Rorkai.ASC.yaml
+++ b/manifests/r/Rorkai/ASC/2.7.0/Rorkai.ASC.yaml
@@ -1,0 +1,6 @@
+# Created with App-Store-Connect-CLI/scripts/generate_winget_manifests.py
+PackageIdentifier: Rorkai.ASC
+PackageVersion: 2.7.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Adds Rorkai.ASC 2.7.0 from https://github.com/rorkai/App-Store-Connect-CLI/releases/tag/2.7.0.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/400595)