### PR TITLE
New package: susperia66.ScriptClip version 2.2.1

### DIFF
--- a/manifests/s/susperia66/ScriptClip/2.2.1/susperia66.ScriptClip.yaml
+++ b/manifests/s/susperia66/ScriptClip/2.2.1/susperia66.ScriptClip.yaml
@@ -1,0 +1,36 @@
+# Package manifest for submission to microsoft/winget-pkgs
+
+PackageIdentifier: susperia66.ScriptClip
+PackageVersion: 2.2.1
+PackageLocale: en-US
+Publisher: Craig Bratcher
+PublisherUrl: https://github.com/susperia66
+PublisherSupportUrl: https://github.com/susperia66/script-clip/issues
+PrivacyUrl: https://github.com/susperia66/script-clip
+Author: Craig Bratcher
+PackageName: Script Clip
+PackageUrl: https://github.com/susperia66/script-clip
+License: Proprietary
+Copyright: Copyright (c) 2026 Craig Bratcher. All Rights Reserved.
+ShortDescription: Quick-copy snippet list for Windows
+Description: |
+  Script Clip keeps a list of text snippets on screen. Copy commands, paths, URLs,
+  and phrases with one click or global shortcuts. Includes quick-search, template
+  variables, encrypted backups, scriptclip:// deep links, and smart clipboard prompts.
+Moniker: scriptclip
+Tags:
+  - clipboard
+  - snippets
+  - productivity
+  - text
+ReleaseNotesUrl: https://github.com/susperia66/script-clip/releases/tag/v2.2.1
+Installers:
+  - Architecture: x64
+    InstallerType: exe
+    InstallerUrl: https://github.com/susperia66/script-clip/releases/download/v2.2.1/ScriptClip-Setup-2.2.1.exe
+    InstallerSha256: e58a6a923060977b18b8d1e5f2b462cf68dbd8120d129e67f9db44627573298b
+    InstallerSwitches:
+      Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+      SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+ManifestType: singleton
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Manifest submission

This PR adds **Script Clip** (`susperia66.ScriptClip`) version **2.2.1**.

- Installer: `ScriptClip-Setup-2.2.1.exe` from [script-clip v2.2.1 release](https://github.com/susperia66/script-clip/releases/tag/v2.2.1)
- SHA256 verified against GitHub release API digest

## Test plan

- [ ] `winget validate` on manifest path
- [ ] WinGet PR validation (wingetbot)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/400635)