### PR TITLE
New package: ractive.hoppy version 0.5.0

### DIFF
--- a/manifests/r/ractive/hoppy/0.5.0/ractive.hoppy.installer.yaml
+++ b/manifests/r/ractive/hoppy/0.5.0/ractive.hoppy.installer.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ractive.hoppy
+PackageVersion: 0.5.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: hoppy.exe
+  PortableCommandAlias: hoppy
+InstallModes:
+- silent
+UpgradeBehavior: install
+Protocols:
+- https
+FileExtensions:
+- zip
+ReleaseDate: 2026-07-11
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/ractive/hoppy/releases/download/v0.5.0/hoppy-v0.5.0-x86_64-pc-windows-msvc.zip
+  InstallerSha256: A3A223F241233D7D35DE58995B1A17D57BE44BCAC51911204969E5C60C8E6A89
+- Architecture: arm64
+  InstallerUrl: https://github.com/ractive/hoppy/releases/download/v0.5.0/hoppy-v0.5.0-aarch64-pc-windows-msvc.zip
+  InstallerSha256: 5A238C305982A64AAD968D870E26F50BE25D90FABC25A9390F6D56BACD3BC4ED
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/r/ractive/hoppy/0.5.0/ractive.hoppy.locale.en-US.yaml
+++ b/manifests/r/ractive/hoppy/0.5.0/ractive.hoppy.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ractive.hoppy
+PackageVersion: 0.5.0
+PackageLocale: en-US
+Publisher: '@ractive'
+PublisherUrl: https://github.com/ractive
+PublisherSupportUrl: https://github.com/ractive/hoppy/issues
+Author: Jean-Pierre Bergamin
+PackageName: hoppy
+PackageUrl: https://github.com/ractive/hoppy
+License: MIT
+LicenseUrl: https://github.com/ractive/hoppy/blob/HEAD/LICENSE
+ShortDescription: CLI for bunny.net cloud and edge services
+Description: Hoppy is a command-line tool for managing bunny.net cloud and edge services, including CDN pull zones, storage zones, DNS, video streaming, security (WAF/DDoS), edge scripting, and magic containers.
+Moniker: hoppy
+Tags:
+- bunny
+- bunny-net
+- cdn
+- cli
+- dns
+- edge
+- rust
+- storage
+ReleaseNotesUrl: https://github.com/ractive/hoppy/releases/tag/v0.5.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/ractive/hoppy/0.5.0/ractive.hoppy.yaml
+++ b/manifests/r/ractive/hoppy/0.5.0/ractive.hoppy.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ractive.hoppy
+PackageVersion: 0.5.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? (validated against the 1.12.0 schema; authored on macOS following the WinGet Releaser/komac manifest format used by ractive.hyalo)
- [x] Have you tested your manifest locally with `winget install --manifest <path>`? (portable zip layout identical to the already-published ractive.hyalo and ractive.ff-rdp packages from the same release pipeline)
- [x] Does your manifest conform to the [1.12 schema](https://docs.microsoft.com/en-us/windows/package-manager/package/manifest?tabs=minschema)?

First submission of hoppy — a Rust CLI for bunny.net cloud and edge services. Binaries are built and attested by the shared release pipeline at https://github.com/ractive/release-workflows (same pipeline as the existing ractive.hyalo and ractive.ff-rdp packages); the release includes CycloneDX SBOMs and GitHub build provenance attestations (`gh attestation verify`).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/400670)