### PR TITLE
New package: qilang.qi version 2026.07.10-2

### DIFF
--- a/manifests/q/qilang/qi/2026.07.10-2/qilang.qi.installer.yaml
+++ b/manifests/q/qilang/qi/2026.07.10-2/qilang.qi.installer.yaml
@@ -1,0 +1,15 @@
+# winget 安装清单 —— installer（奇语言 qilang）
+# zip 便携包：解压后把 bin/qi.exe 加进 PATH（保留 lib/qi 同级布局供 runtime 查找）
+PackageIdentifier: qilang.qi
+PackageVersion: 2026.07.10-2
+InstallerType: zip
+NestedInstallerType: portable
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/qilang-project/qi/releases/download/2026.07.10-2/qi-2026.07.10-2-windows-x64.zip
+    InstallerSha256: 291AFDD37077ECA53B89AE1E2E8ABABAA0EAAFBCDFC9DC1CD1E658622ADA0E9A
+    NestedInstallerFiles:
+      - RelativeFilePath: bin\qi.exe
+        PortableCommandAlias: qi
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/q/qilang/qi/2026.07.10-2/qilang.qi.locale.zh-CN.yaml
+++ b/manifests/q/qilang/qi/2026.07.10-2/qilang.qi.locale.zh-CN.yaml
@@ -1,0 +1,23 @@
+# winget 安装清单 —— 默认区域信息（奇语言 qilang）
+PackageIdentifier: qilang.qi
+PackageVersion: 2026.07.10-2
+PackageLocale: zh-CN
+Publisher: qilang-project
+PublisherUrl: https://github.com/qilang-project
+PackageName: 奇语言
+PackageUrl: https://github.com/qilang-project/qi
+License: MIT
+ShortDescription: 100% 中文关键字的原生编译语言（LLVM 后端，内置 AI 原语）
+Description: |-
+  奇语言（qilang）是一门 100% 中文关键字的编译型语言，用 LLVM 生成原生机器码。
+  内置结构化输出（询问::<T>）、工具调用、流式对话等 LLM/GenAI 原语，
+  以及 Web 框架、协程并发、ARC 内存管理。编译产物零运行时依赖，可独立分发。
+  注：编译代码时需系统 clang/MSVC 做链接。
+Moniker: qilang
+Tags:
+  - programming-language
+  - chinese
+  - llm
+  - compiler
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/q/qilang/qi/2026.07.10-2/qilang.qi.yaml
+++ b/manifests/q/qilang/qi/2026.07.10-2/qilang.qi.yaml
@@ -1,0 +1,6 @@
+# winget 安装清单 —— version（奇语言 qilang，指向 installer + locale）
+PackageIdentifier: qilang.qi
+PackageVersion: 2026.07.10-2
+DefaultLocale: zh-CN
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## New package: qilang.qi 2026.07.10-2

奇语言 (qilang) — a compiled programming language with 100% Chinese keywords, LLVM backend, built-in LLM/GenAI primitives.

- Publisher: qilang-project
- Homepage: https://github.com/qilang-project/qi
- Installer: portable (zip), x64
- License: MIT

### Manifest validation
- Validated against winget-manifest 1.6.0 schema (installer / defaultLocale / version) — all pass.
- InstallerSha256 verified against the released asset.

### Notes
- Zip portable package; `bin\qi.exe` exposed on PATH via portable alias `qi`.
- The package keeps a `lib\qi\` folder next to `bin\qi.exe`; the compiler locates its static runtime relative to the exe, so the nested layout must be preserved on extract.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/400696)