### PR TITLE
New package: damt.Eqho version 0.6.9

### DIFF
--- a/manifests/d/damt/Eqho/0.6.9/damt.Eqho.installer.yaml
+++ b/manifests/d/damt/Eqho/0.6.9/damt.Eqho.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: damt.Eqho
+PackageVersion: 0.6.9
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: user
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/danielmevit/eqho/releases/download/v0.6.9/Eqho-Setup-0.6.9.exe
+  InstallerSha256: B8B69E97639C752F3E290D5039D6F90CC9DD24FB87785B0F11DF7CEA6006F252
+  ProductCode: '{7C21F6E3-9B4A-4D2E-8F0C-5A6B3D91C4E7}_is1'
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/d/damt/Eqho/0.6.9/damt.Eqho.locale.en-US.yaml
+++ b/manifests/d/damt/Eqho/0.6.9/damt.Eqho.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: damt.Eqho
+PackageVersion: 0.6.9
+PackageLocale: en-US
+Publisher: damt.xyz
+PublisherUrl: https://damt.xyz
+PublisherSupportUrl: https://github.com/danielmevit/eqho/issues
+Author: Daniel Mevit
+PackageName: Eqho
+PackageUrl: https://danielmevit.github.io/eqho/
+License: AGPL-3.0
+LicenseUrl: https://github.com/danielmevit/eqho/blob/main/LICENSE
+Copyright: (c) Daniel Mevit
+ShortDescription: Free, offline voice-to-text dictation. Press a hotkey, speak, and your words appear in any app — 100% local, powered by Whisper.
+Description: |-
+  Eqho is an always-on dictation app that lives in your system tray. Press a
+  global hotkey (default Alt+Q), speak naturally, and the transcribed text is
+  typed into whatever application is focused. Speech recognition runs entirely
+  on your machine via OpenAI's Whisper models (faster-whisper/CTranslate2) —
+  no cloud, no account, no API keys. GPU-accelerated on NVIDIA hardware with
+  automatic CPU fallback. Includes a live transcription overlay, searchable
+  local history, custom vocabulary, voice commands, and text replacements.
+Moniker: eqho
+Tags:
+- dictation
+- speech-to-text
+- voice-typing
+- whisper
+- offline
+- privacy
+- accessibility
+- transcription
+ReleaseNotesUrl: https://github.com/danielmevit/eqho/releases/tag/v0.6.9
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/d/damt/Eqho/0.6.9/damt.Eqho.yaml
+++ b/manifests/d/damt/Eqho/0.6.9/damt.Eqho.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: damt.Eqho
+PackageVersion: 0.6.9
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package submission: Eqho 0.6.9

- [x] Manifests validate against the 1.6.0 schema (version / installer / defaultLocale)
- [x] Installer: Inno Setup, per-user scope, x64, SHA256 verified from the GitHub release asset
- [x] This PR only modifies one manifest folder (`manifests/d/damt/Eqho/0.6.9/`)
- [x] Not previously in the repository (new package)

Eqho is a free, open-source (AGPL-3.0), fully offline voice-to-text dictation app for Windows powered by Whisper (faster-whisper/CTranslate2). Homepage: https://danielmevit.github.io/eqho/ · Source: https://github.com/danielmevit/eqho
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/400796)