### PR TITLE
New package: DotNaos.Project version 0.3.1

### DIFF
--- a/manifests/d/DotNaos/Project/0.3.1/DotNaos.Project.installer.yaml
+++ b/manifests/d/DotNaos/Project/0.3.1/DotNaos.Project.installer.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: DotNaos.Project
+PackageVersion: '0.3.1'
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{D0B7D247-B537-41B4-9F36-73C61CB16B54}_is1'
+Commands:
+  - project
+  - project-space-connector
+AppsAndFeaturesEntries:
+  - DisplayName: Project
+    DisplayVersion: '0.3.1'
+    Publisher: DotNaos
+    ProductCode: '{D0B7D247-B537-41B4-9F36-73C61CB16B54}_is1'
+InstallationMetadata:
+  DefaultInstallLocation: '%LocalAppData%\Programs\Project Space'
+Installers:
+  - Architecture: x64
+    InstallerUrl: 'https://github.com/DotNaos/project-space/releases/download/v0.3.1/project-space-machine-tools-windows-x64-setup.exe'
+    InstallerSha256: '5CBEE48ACFAC979D763F53BA1B0D51899E01796392857FA11929C3D2E0CE6F54'
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/d/DotNaos/Project/0.3.1/DotNaos.Project.locale.en-US.yaml
+++ b/manifests/d/DotNaos/Project/0.3.1/DotNaos.Project.locale.en-US.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: DotNaos.Project
+PackageVersion: '0.3.1'
+PackageLocale: en-US
+Publisher: DotNaos
+PublisherUrl: https://github.com/DotNaos
+PublisherSupportUrl: https://github.com/DotNaos/project-space/issues
+PackageName: Project
+PackageUrl: https://github.com/DotNaos/project-space
+License: Proprietary
+ShortDescription: Connect a Windows machine to Project Space and manage Project workspaces.
+Description: Project installs the Project CLI and its authenticated machine connector for native Windows x64.
+Tags:
+  - cli
+  - development
+  - project-management
+  - remote-development
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/d/DotNaos/Project/0.3.1/DotNaos.Project.yaml
+++ b/manifests/d/DotNaos/Project/0.3.1/DotNaos.Project.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: DotNaos.Project
+PackageVersion: '0.3.1'
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds the first WinGet community manifest for Project version 0.3.1.

Release: https://github.com/DotNaos/project-space/releases/tag/v0.3.1

Project is a per-user native Windows CLI and authenticated machine connector. The installer does not require administrator access and does not contain an enrollment credential.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)
  - Not applicable; this is a routine first manifest submission.

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for `DotNaos.Project`
- [x] This PR only modifies one manifest
- [x] Validated locally with `winget validate --manifest <path>` using Windows Package Manager v1.29.280
- [ ] Tested end-to-end with `winget install --manifest <path>`
  - WinGet downloaded the public installer and verified its SHA-256. The final launch requested SmartScreen consent on the interactive desktop while the test was driven through headless OpenSSH. The exact downloaded installer was then explicitly unblocked, installed, upgraded, and uninstalled successfully; the upstream installer-validation job can exercise the fully unattended path.
- [x] Manifest conforms to the 1.12 schema

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/400830)