### PR TITLE
New package: Hjosugi.AyameDiff version 0.7.8

### DIFF
--- a/manifests/h/Hjosugi/AyameDiff/0.7.8/Hjosugi.AyameDiff.installer.yaml
+++ b/manifests/h/Hjosugi/AyameDiff/0.7.8/Hjosugi.AyameDiff.installer.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Hjosugi.AyameDiff
+PackageVersion: 0.7.8
+InstallerType: zip
+NestedInstallerType: portable
+InstallModes:
+- silent
+UpgradeBehavior: install
+Commands:
+- ayame-diff
+ReleaseDate: 2026-07-11
+Installers:
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: ayame-diff-v0.7.8-windows\ayame-diff.exe
+    PortableCommandAlias: ayame-diff
+  InstallerUrl: https://github.com/hjosugi/ayame-diff/releases/download/v0.7.8/ayame-diff-v0.7.8-windows.zip
+  InstallerSha256: D1E07276B851DE0327BD3723C4A350192C5DD76AA624AF32FAC61C1894CBC2BC
+- Architecture: arm64
+  NestedInstallerFiles:
+  - RelativeFilePath: ayame-diff-v0.7.8-windows\arm64\ayame-diff.exe
+    PortableCommandAlias: ayame-diff
+  InstallerUrl: https://github.com/hjosugi/ayame-diff/releases/download/v0.7.8/ayame-diff-v0.7.8-windows.zip
+  InstallerSha256: D1E07276B851DE0327BD3723C4A350192C5DD76AA624AF32FAC61C1894CBC2BC
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/h/Hjosugi/AyameDiff/0.7.8/Hjosugi.AyameDiff.locale.en-US.yaml
+++ b/manifests/h/Hjosugi/AyameDiff/0.7.8/Hjosugi.AyameDiff.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Hjosugi.AyameDiff
+PackageVersion: 0.7.8
+PackageLocale: en-US
+Publisher: hjosugi
+PublisherUrl: https://github.com/hjosugi
+PublisherSupportUrl: https://github.com/hjosugi/ayame-diff/issues
+Author: hjosugi
+PackageName: ayame-diff
+PackageUrl: https://github.com/hjosugi/ayame-diff
+License: MIT
+LicenseUrl: https://github.com/hjosugi/ayame-diff/blob/v0.7.8/LICENSE
+ShortDescription: Fast CSV, text, folder, and binary diff with a local web GUI
+Description: A native, memory-bounded comparison tool with Japanese encoding support, structured CSV diff, patches, reports, and a bilingual local web GUI.
+Moniker: ayame-diff
+Tags:
+- csv
+- diff
+- folder
+- japanese
+- patch
+- text
+ReleaseNotesUrl: https://github.com/hjosugi/ayame-diff/releases/tag/v0.7.8
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/h/Hjosugi/AyameDiff/0.7.8/Hjosugi.AyameDiff.yaml
+++ b/manifests/h/Hjosugi/AyameDiff/0.7.8/Hjosugi.AyameDiff.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Hjosugi.AyameDiff
+PackageVersion: 0.7.8
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds ayame-diff 0.7.8 as a WinGet ZIP/portable package for x64 and ARM64. The release archive SHA-256 was independently downloaded and verified against the publisher SHA256SUMS.

## ✅ Checklist

- [ ] Signed the Contributor License Agreement (bot verification pending)
- [x] Checked that there are no other open pull requests for Hjosugi.AyameDiff
- [x] This PR only modifies one manifest
- [ ] Validated with `winget validate` on Windows (CI pending)
- [ ] Installed with `winget install --manifest` on Windows (CI pending)
- [x] All three YAML files validate against the official WinGet 1.12 JSON schemas

Upstream project: https://github.com/hjosugi/ayame-diff
Release: https://github.com/hjosugi/ayame-diff/releases/tag/v0.7.8
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/400883)