### PR TITLE
Update FabioColor.FadedBalancerDCTL to 1.7.0

### DIFF
--- a/manifests/f/FabioColor/FadedBalancerDCTL/1.7.0/FabioColor.FadedBalancerDCTL.installer.yaml
+++ b/manifests/f/FabioColor/FadedBalancerDCTL/1.7.0/FabioColor.FadedBalancerDCTL.installer.yaml
@@ -1,0 +1,17 @@
+# Created by Codex
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: FabioColor.FadedBalancerDCTL
+PackageVersion: 1.7.0
+InstallerType: inno
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/fabiocolor/Faded-Balancer-DCTL/releases/download/v1.7.0/FadedBalancerDCTL-Setup-1.7.0.exe
+  InstallerSha256: 250E1C04A715EDAFB87194C3B4E1A5E4A65B9F1B368893A9F4FC0C12F8CCDE9E
+  Scope: machine
+  InstallerSwitches:
+    Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+    SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+ManifestType: installer
+ManifestVersion: 1.9.0
+ReleaseDate: 2026-07-11

--- a/manifests/f/FabioColor/FadedBalancerDCTL/1.7.0/FabioColor.FadedBalancerDCTL.locale.en-US.yaml
+++ b/manifests/f/FabioColor/FadedBalancerDCTL/1.7.0/FabioColor.FadedBalancerDCTL.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# Created by Codex
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: FabioColor.FadedBalancerDCTL
+PackageVersion: 1.7.0
+PackageLocale: en-US
+Publisher: Fabio Color
+PublisherUrl: https://github.com/fabiocolor
+PublisherSupportUrl: https://github.com/fabiocolor/Faded-Balancer-DCTL/issues
+PackageName: Faded Balancer DCTL
+PackageUrl: https://github.com/fabiocolor/Faded-Balancer-DCTL
+License: MIT
+LicenseUrl: https://github.com/fabiocolor/Faded-Balancer-DCTL/blob/main/LICENSE
+ShortDescription: DaVinci Resolve DCTL to rebalance faded film scans.
+Description: Faded Balancer DCTL is a DaVinci Resolve DCTL for balancing RGB channels and correcting faded film scans.
+Moniker: fadedbalancerdctl
+Tags:
+- davinci
+- dctl
+- film
+- restoration
+ReleaseNotesUrl: https://github.com/fabiocolor/Faded-Balancer-DCTL/releases/tag/v1.7.0
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/f/FabioColor/FadedBalancerDCTL/1.7.0/FabioColor.FadedBalancerDCTL.yaml
+++ b/manifests/f/FabioColor/FadedBalancerDCTL/1.7.0/FabioColor.FadedBalancerDCTL.yaml
@@ -1,0 +1,8 @@
+# Created by Codex
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: FabioColor.FadedBalancerDCTL
+PackageVersion: 1.7.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Updates FabioColor.FadedBalancerDCTL to the public v1.7.0 release.

- Installer: https://github.com/fabiocolor/Faded-Balancer-DCTL/releases/download/v1.7.0/FadedBalancerDCTL-Setup-1.7.0.exe
- Release notes: https://github.com/fabiocolor/Faded-Balancer-DCTL/releases/tag/v1.7.0
- SHA-256 verified against the published installer asset.

This package installs a DaVinci Resolve DCTL/plugin, so no standalone application executable or About dialog is expected after installation.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/400968)