### PR TITLE
New version: Nehoray.TranslationManager version 1.0.2

### DIFF
--- a/manifests/n/Nehoray/TranslationManager/1.0.2/Nehoray.TranslationManager.installer.yaml
+++ b/manifests/n/Nehoray/TranslationManager/1.0.2/Nehoray.TranslationManager.installer.yaml
@@ -1,0 +1,58 @@
+# Created with winget-manifest scaffold for Nehoray.TranslationManager 1.1.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: Nehoray.TranslationManager
+PackageVersion: 1.0.2
+InstallerLocale: he-IL
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  # `/SILENT` (not /VERYSILENT) is deliberate. Inno Setup 6.7's
+  # RedirectionGuard handoff (level 2 SL5 → level 3 protected Setup)
+  # fails silently with /VERYSILENT in sandboxed contexts - the
+  # protected temp dir gets created with only `_setup64.tmp` + an
+  # empty `_isetup\` and the install never proceeds, leaving the
+  # install dir half-populated. Same root cause as the failure mode
+  # we hit during the launcher's in-app self-update. /SILENT keeps
+  # the small progress dialog visible, which is what RG's protected
+  # handoff needs to complete; the dialog is dismissed automatically
+  # at the end so the WinGet sandbox sees a clean exit.
+  # /SP- skips the "This will install..." pre-install dialog so the
+  # install still runs without any user clicks.
+  Silent: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  Custom: ""
+UpgradeBehavior: install
+# 0 is implicit; 3010 (success-needs-restart) and 1641 (restart-initiated)
+# are Inno Setup's only documented non-zero success codes. /NORESTART
+# converts 3010→0 in practice but we list them defensively.
+InstallerSuccessCodes:
+  - 1641
+  - 3010
+# Explicit ARP (Apps and Features) entry so WinGet's post-install
+# verification knows exactly which Uninstall registry subkey to look
+# for. Inno writes `<AppId>_is1` under
+# HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\ - the
+# top-level `ProductCode` field is also kept for tooling that reads
+# the older shape.
+AppsAndFeaturesEntries:
+  - DisplayName: Translation Manager
+    DisplayVersion: 1.0.2
+    Publisher: Nehoray
+    ProductCode: '{B0D4F2A7-3CCE-4A1A-9C44-7E1A1B6F0001}_is1'
+    InstallerType: inno
+ProductCode: '{B0D4F2A7-3CCE-4A1A-9C44-7E1A1B6F0001}_is1'
+ReleaseDate: 2026-07-05
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/nehorayc04/translation-launcher/releases/download/v1.0.2-beta/TranslationManager-Setup-1.0.2.exe
+    InstallerSha256: EB9C741676F3C95DD6AD4292BE671C0546FF76163B7522EEB723F52B63DB452F
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/n/Nehoray/TranslationManager/1.0.2/Nehoray.TranslationManager.locale.en-US.yaml
+++ b/manifests/n/Nehoray/TranslationManager/1.0.2/Nehoray.TranslationManager.locale.en-US.yaml
@@ -1,0 +1,39 @@
+# Created with winget-manifest scaffold for Nehoray.TranslationManager 1.1.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: Nehoray.TranslationManager
+PackageVersion: 1.0.2
+PackageLocale: en-US
+Publisher: Nehoray
+PublisherUrl: https://hebrew-translation-hub.com/
+PublisherSupportUrl: https://hebrew-translation-hub.com/
+Author: Nehoray Cohen
+PackageName: Translation Manager
+PackageUrl: https://hebrew-translation-hub.com/
+License: Proprietary
+LicenseUrl: https://hebrew-translation-hub.com/
+Copyright: Copyright (C) 2026 Nehoray
+CopyrightUrl: https://hebrew-translation-hub.com/
+ShortDescription: Hebrew translation launcher for AAA PC games - installs, manages, and updates community localizations from one app.
+Description: |-
+  Translation Manager is a Hebrew-first Windows launcher that brings community
+  AAA-game translations into one curated catalog. Browse available titles,
+  download the matching translation archive, and apply it to your installed
+  game with one click. The app handles update checks, mod toggling, and
+  per-game purchase / DRM gating, and ships a built-in catalog for popular
+  titles such as Cyberpunk 2077, God of War Ragnarok, Red Dead Redemption,
+  Hogwarts Legacy, and more.
+Moniker: translation-manager
+Tags:
+  - hebrew
+  - translation
+  - localization
+  - gaming
+  - games
+  - launcher
+  - mods
+  - rtl
+ReleaseNotesUrl: https://github.com/nehorayc04/translation-launcher/releases/tag/v1.0.2-beta
+PurchaseUrl: https://hebrew-translation-hub.com/
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/n/Nehoray/TranslationManager/1.0.2/Nehoray.TranslationManager.yaml
+++ b/manifests/n/Nehoray/TranslationManager/1.0.2/Nehoray.TranslationManager.yaml
@@ -1,0 +1,8 @@
+# Created with winget-manifest scaffold for Nehoray.TranslationManager 1.1.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: Nehoray.TranslationManager
+PackageVersion: 1.0.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New version: Nehoray.TranslationManager 1.0.2

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] This PR only modifies one (1) manifest.

Adds version **1.0.2** (beta channel) of Translation Manager. Installer SHA256 verified against the published GitHub release asset (243,310,816 bytes).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/400993)