### PR TITLE
New package: ReTang.SysOverlay version 0.1.36

### DIFF
--- a/manifests/r/ReTang/SysOverlay/0.1.36/ReTang.SysOverlay.installer.yaml
+++ b/manifests/r/ReTang/SysOverlay/0.1.36/ReTang.SysOverlay.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: ReTang.SysOverlay
+PackageVersion: 0.1.36
+Platform:
+  - Windows.Desktop
+InstallerType: nullsoft
+UpgradeBehavior: install
+ReleaseDate: 2026-07-10
+Installers:
+  - Architecture: x64
+    Scope: user
+    InstallerUrl: https://github.com/dsmontero2001/sysoverlay-releases/releases/download/v0.1.36/SysOverlay_0.1.36_x64-setup.exe
+    InstallerSha256: AF03D55F9038E71B2EECDAF1E99ACA74809CD6C59B67020267864FCB323B37F9
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/r/ReTang/SysOverlay/0.1.36/ReTang.SysOverlay.locale.en-US.yaml
+++ b/manifests/r/ReTang/SysOverlay/0.1.36/ReTang.SysOverlay.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: ReTang.SysOverlay
+PackageVersion: 0.1.36
+PackageLocale: en-US
+Publisher: ReTang LLC
+PublisherUrl: https://sysoverlay.com
+PublisherSupportUrl: https://sysoverlay.com/contact
+PrivacyUrl: https://sysoverlay.com/privacy
+Author: ReTang LLC
+PackageName: SysOverlay
+PackageUrl: https://sysoverlay.com/download
+License: Proprietary
+LicenseUrl: https://sysoverlay.com/terms
+Copyright: Copyright (c) 2026 ReTang LLC
+ShortDescription: Free Windows HUD with PC health monitoring for families and small businesses.
+Description: |
+  SysOverlay is a modern BGInfo alternative for Windows 10 and 11: a live desktop HUD showing hostname, IP, CPU, RAM, disk, uptime, and battery on every PC.
+  The free agent includes signed silent auto-updates. SysOverlay Plus adds a private fleet dashboard with plain-English alerts, in-HUD nudges, and local repair tools — no remote control.
+Moniker: sysoverlay
+Tags:
+  - bginfo
+  - hud
+  - monitoring
+  - utility
+  - windows
+  - desktop-overlay
+Commands:
+  - sysoverlay
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/r/ReTang/SysOverlay/0.1.36/ReTang.SysOverlay.yaml
+++ b/manifests/r/ReTang/SysOverlay/0.1.36/ReTang.SysOverlay.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: ReTang.SysOverlay
+PackageVersion: 0.1.36
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## SysOverlay 0.1.36

Free Windows desktop HUD agent (BGInfo alternative) for families and small businesses.

- **Package ID:** ReTang.SysOverlay
- **Installer:** NSIS per-user (
ullsoft, scope user)
- **Download:** GitHub release on dsmontero2001/sysoverlay-releases
- **Validation:** winget validate --manifest manifests/r/ReTang/SysOverlay/0.1.36

Homepage: https://sysoverlay.com/download

Made with [Cursor](https://cursor.com)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/401019)