### PR TITLE
New package: ProxyKit.ProxyKitCLI 1.0.0

### DIFF
--- a/manifests/p/ProxyKit/ProxyKitCLI/1.0.0/ProxyKit.ProxyKitCLI.installer.yaml
+++ b/manifests/p/ProxyKit/ProxyKitCLI/1.0.0/ProxyKit.ProxyKitCLI.installer.yaml
@@ -1,0 +1,47 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: ProxyKit.ProxyKitCLI
+PackageVersion: 1.0.0
+InstallerLocale: en-US
+MinimumOSVersion: 10.0.17763.0
+Scope: user
+UpgradeBehavior: uninstallPrevious
+ReleaseDate: 2026-07-11
+Installers:
+  - Architecture: x64
+    InstallerType: zip
+    InstallerUrl: https://release.proxykit.net/v1.0.0/cli/windows-amd64/proxykit-cli-1.0.0-windows-amd64.zip
+    InstallerSha256: 23b4b0fbedca9b626e5523e5c888a9974eb575c220bc0112bbe999a4abc2153d
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: bin\proxykit.exe
+        PortableCommandAlias: proxykit
+      - RelativeFilePath: bin\proxy-engine.exe
+        PortableCommandAlias: proxy-engine
+    ArchiveBinariesDependOnPath: true
+    InstallModes:
+      - silent
+    Commands:
+      - proxykit
+    Platform:
+      - Windows.Desktop
+
+  - Architecture: arm64
+    InstallerType: zip
+    InstallerUrl: https://release.proxykit.net/v1.0.0/cli/windows-arm64/proxykit-cli-1.0.0-windows-arm64.zip
+    InstallerSha256: 1436c5342608c10ad730dd8d4af84e1608814c942b3f611b0a0296c985476ed6
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: bin\proxykit.exe
+        PortableCommandAlias: proxykit
+      - RelativeFilePath: bin\proxy-engine.exe
+        PortableCommandAlias: proxy-engine
+    ArchiveBinariesDependOnPath: true
+    InstallModes:
+      - silent
+    Commands:
+      - proxykit
+    Platform:
+      - Windows.Desktop
+
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/p/ProxyKit/ProxyKitCLI/1.0.0/ProxyKit.ProxyKitCLI.locale.en-US.yaml
+++ b/manifests/p/ProxyKit/ProxyKitCLI/1.0.0/ProxyKit.ProxyKitCLI.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: ProxyKit.ProxyKitCLI
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: ProxyKit
+PublisherUrl: https://proxykit.net
+PublisherSupportUrl: https://github.com/AA-Box/ProxyKit-issues/issues
+PackageName: ProxyKit CLI
+PackageUrl: https://proxykit.net
+License: Proprietary
+LicenseUrl: https://proxykit.net/terms#license
+ShortDescription: Standalone ProxyKit CLI and headless MITM proxy engine
+Description: |
+  Command-line companion for ProxyKit. Controls a running proxy engine or launches
+  a bundled headless engine for CI and automation. Separate from ProxyKit.
+Moniker: proxykit
+Tags:
+  - proxy
+  - http
+  - debugging
+  - cli
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/p/ProxyKit/ProxyKitCLI/1.0.0/ProxyKit.ProxyKitCLI.yaml
+++ b/manifests/p/ProxyKit/ProxyKitCLI/1.0.0/ProxyKit.ProxyKitCLI.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: ProxyKit.ProxyKitCLI
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## New package: ProxyKit.ProxyKitCLI

Adds ProxyKit CLI 1.0.0 as a portable ZIP package with `proxykit` and `proxy-engine` command aliases.

Checklist:

- [x] Package identifier: `ProxyKit.ProxyKitCLI`
- [x] Version: `1.0.0`
- [x] Installers hosted on immutable `https://release.proxykit.net/v1.0.0/...` URLs
- [x] x64 and arm64 installer hashes generated from the published `.sha256` sidecars

Validation:

- Verified the Windows x64 and arm64 installer URLs return HTTP 200.
- Ran `git diff --check`.
- Could not run native `winget validate` from this macOS environment.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/401088)