### PR TITLE
New package: CCsGlobal.Flitdrop version 0.6.2

### DIFF
--- a/manifests/c/CCsGlobal/Flitdrop/0.6.2/CCsGlobal.Flitdrop.installer.yaml
+++ b/manifests/c/CCsGlobal/Flitdrop/0.6.2/CCsGlobal.Flitdrop.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: CCsGlobal.Flitdrop
+PackageVersion: 0.6.2
+InstallerLocale: en-US
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-07-11
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/MrFrosas/flitdrop/releases/download/v0.6.2/Flitdrop-Setup-0.6.2.exe
+    InstallerSha256: 6EFF2555297F43AE498BBCBA637E0AA78DB1A8566F283DE25F1177D656836C65
+    AppsAndFeaturesEntries:
+      - ProductCode: 13d66c6d-ea8b-5233-a385-4233ab80b29d
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/c/CCsGlobal/Flitdrop/0.6.2/CCsGlobal.Flitdrop.locale.en-US.yaml
+++ b/manifests/c/CCsGlobal/Flitdrop/0.6.2/CCsGlobal.Flitdrop.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: CCsGlobal.Flitdrop
+PackageVersion: 0.6.2
+PackageLocale: en-US
+Publisher: "CC'S GLOBAL"
+PublisherUrl: https://flitdrop.com
+PublisherSupportUrl: https://github.com/MrFrosas/flitdrop/issues
+Author: "CC'S GLOBAL"
+PackageName: Flitdrop
+PackageUrl: https://flitdrop.com
+License: FSL-1.1-ALv2
+LicenseUrl: https://github.com/MrFrosas/flitdrop/blob/main/LICENSE
+Copyright: "Copyright (c) CC'S GLOBAL"
+ShortDescription: Send files, photos and clipboard between your phone and any PC over local Wi-Fi, end-to-end encrypted. Nothing to install on the phone.
+Description: Flitdrop is a free AirDrop alternative for Windows, Mac and Linux. Send photos, videos, files, folders and clipboard between iPhone, Android and your computer over your own Wi-Fi. Scan a QR code once and stay paired, end-to-end encrypted, with nothing to install on the phone.
+Moniker: flitdrop
+Tags:
+  - airdrop
+  - clipboard
+  - cross-platform
+  - file-sharing
+  - file-transfer
+  - nearby-share
+  - qr-code
+  - wifi
+ReleaseNotesUrl: https://github.com/MrFrosas/flitdrop/releases/tag/v0.6.2
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/c/CCsGlobal/Flitdrop/0.6.2/CCsGlobal.Flitdrop.yaml
+++ b/manifests/c/CCsGlobal/Flitdrop/0.6.2/CCsGlobal.Flitdrop.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: CCsGlobal.Flitdrop
+PackageVersion: 0.6.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: CCsGlobal.Flitdrop version 0.6.2

Flitdrop is a free, cross-platform AirDrop alternative: send files, photos, folders and clipboard between a phone and any PC over your own Wi-Fi, end-to-end encrypted, with nothing to install on the phone.

- `InstallerType: nullsoft` (electron-builder NSIS one-click), per-user scope, silent install via `/S`.
- The installer is Authenticode code-signed and RFC-3161 timestamped (Azure Trusted Signing, publisher "CC's Global"), served from the project's official GitHub Releases location.
- Manifests authored against schema 1.6.0; `winget install flitdrop` / `CCsGlobal.Flitdrop`.

Microsoft Store listing for the same app is in certification in parallel.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/401272)