### PR TITLE
New package: neyham.AIUsageDashboard version 0.2.0

### DIFF
--- a/manifests/n/neyham/AIUsageDashboard/0.2.0/neyham.AIUsageDashboard.installer.yaml
+++ b/manifests/n/neyham/AIUsageDashboard/0.2.0/neyham.AIUsageDashboard.installer.yaml
@@ -1,0 +1,29 @@
+# Created with WinGet manifest schema 1.12.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: neyham.AIUsageDashboard
+PackageVersion: 0.2.0
+InstallerLocale: en-US
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+UpgradeBehavior: install
+ReleaseDate: 2026-07-12
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/neyham/ai-usage-dashboard/releases/download/v0.2.0/AI-Usage-Dashboard_0.2.0_x64-setup.exe
+    InstallerSha256: 10F79FA6177A4DD77651268E7B69C4C1AF78288761573AAED97E06FA0B3D92C5
+    AppsAndFeaturesEntries:
+      - DisplayName: AI Usage Dashboard
+        DisplayVersion: 0.2.0
+        Publisher: neyha
+        ProductCode: AI Usage Dashboard
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/n/neyham/AIUsageDashboard/0.2.0/neyham.AIUsageDashboard.installer.yaml
+++ b/manifests/n/neyham/AIUsageDashboard/0.2.0/neyham.AIUsageDashboard.installer.yaml
@@ -22,7 +22,6 @@ Installers:
     InstallerSha256: 10F79FA6177A4DD77651268E7B69C4C1AF78288761573AAED97E06FA0B3D92C5
     AppsAndFeaturesEntries:
       - DisplayName: AI Usage Dashboard
-        DisplayVersion: 0.2.0
         Publisher: neyha
         ProductCode: AI Usage Dashboard
 ManifestType: installer

--- a/manifests/n/neyham/AIUsageDashboard/0.2.0/neyham.AIUsageDashboard.locale.en-US.yaml
+++ b/manifests/n/neyham/AIUsageDashboard/0.2.0/neyham.AIUsageDashboard.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# Created with WinGet manifest schema 1.12.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: neyham.AIUsageDashboard
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: neyham
+PublisherUrl: https://github.com/neyham
+PublisherSupportUrl: https://github.com/neyham/ai-usage-dashboard/issues
+Author: neyham
+PackageName: AI Usage Dashboard
+PackageUrl: https://github.com/neyham/ai-usage-dashboard
+License: MIT
+LicenseUrl: https://github.com/neyham/ai-usage-dashboard/blob/v0.2.0/LICENSE
+Copyright: Copyright (c) 2026 neyham
+ShortDescription: Local Windows dashboard for Claude Code and Codex usage limits and DeepSeek API balance.
+Description: |-
+  AI Usage Dashboard is a local-first Windows desktop dashboard and screensaver
+  for viewing Claude Code and Codex usage limits alongside a DeepSeek API
+  balance. Credentials and provider requests stay in the native Rust backend;
+  the renderer receives sanitized usage summaries only. The project has no
+  developer-operated server, analytics, or telemetry.
+Moniker: ai-usage-dashboard
+Tags:
+  - ai
+  - claude
+  - claude-code
+  - codex
+  - dashboard
+  - deepseek
+  - usage
+ReleaseNotesUrl: https://github.com/neyham/ai-usage-dashboard/releases/tag/v0.2.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/n/neyham/AIUsageDashboard/0.2.0/neyham.AIUsageDashboard.yaml
+++ b/manifests/n/neyham/AIUsageDashboard/0.2.0/neyham.AIUsageDashboard.yaml
@@ -1,0 +1,8 @@
+# Created with WinGet manifest schema 1.12.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: neyham.AIUsageDashboard
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Adds AI Usage Dashboard 0.2.0 as a new WinGet package with a per-user x64
Nullsoft installer.

- Project: https://github.com/neyham/ai-usage-dashboard
- Release: https://github.com/neyham/ai-usage-dashboard/releases/tag/v0.2.0
- Package identifier: `neyham.AIUsageDashboard`
- Installer SHA-256: `10F79FA6177A4DD77651268E7B69C4C1AF78288761573AAED97E06FA0B3D92C5`

The manifest passed `winget validate` with WinGet 1.29.280 on Windows 11. The
public installer was downloaded again and its SHA-256 matched the manifest.
Direct silent installation with `/S`, uninstall metadata, application startup,
and a post-install live provider refresh were tested on a Windows 11 Surface.

## Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com) (will complete if requested by the bot)
- [x] Linked to an issue (not applicable; direct publisher submission)

## Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same manifest
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>` (local manifests require an elevated WinGet setting; the same installer was tested directly with its declared silent switch)
- [x] Manifest conforms to the 1.12 schema

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/401282)