### PR TITLE
Major fix: Romanitho.Winget-AutoUpdate version 2.12.0

### DIFF
--- a/manifests/r/Romanitho/Winget-AutoUpdate/2.12.0/Romanitho.Winget-AutoUpdate.installer.yaml
+++ b/manifests/r/Romanitho/Winget-AutoUpdate/2.12.0/Romanitho.Winget-AutoUpdate.installer.yaml
@@ -6,6 +6,9 @@ PackageVersion: 2.12.0
 InstallerLocale: en-US
 InstallerType: wix
 Scope: machine
+InstallerSwitches:
+  Silent: /qn UPDATESINTERVAL=Daily UPDATESATLOGON=0
+  SilentWithProgress: /qn UPDATESINTERVAL=Daily UPDATESATLOGON=0
 UpgradeBehavior: install
 ProductCode: '{FB0EB14E-95AC-45D7-A951-432316FFCBD4}'
 ReleaseDate: 2026-05-11

--- a/manifests/r/Romanitho/Winget-AutoUpdate/2.12.0/Romanitho.Winget-AutoUpdate.locale.en-US.yaml
+++ b/manifests/r/Romanitho/Winget-AutoUpdate/2.12.0/Romanitho.Winget-AutoUpdate.locale.en-US.yaml
@@ -12,14 +12,18 @@ PackageName: Winget-AutoUpdate
 PackageUrl: https://github.com/Romanitho/Winget-AutoUpdate
 License: MIT
 LicenseUrl: https://github.com/Romanitho/Winget-AutoUpdate/blob/HEAD/LICENSE
-Copyright: Copyright (c) Romanitho
+Copyright: © Romanitho
 ShortDescription: Daily update apps through winget (with system context) and notify users when updates are available and installed.
 Moniker: WAU
 Tags:
-- Patch
-- WiGUI
+- wingetautoupdate
+- winget-auto-update
+- auto-updater
+- autoupdater
 - updating
-- winget
+- windows-package-manager
+- windowspackagemanager
+- scheduled-update-checks
 ReleaseNotes: |-
   Files
   ─────────────────────┬────────────────────────────────────────────────────────────────┬──────────────────
@@ -31,15 +35,14 @@ ReleaseNotes: |-
   ─────────────────────┴────────────────────────────────────────────────────────────────┴──────────────────
   What's Changed
   - Correct VC++ Redistributable download URL by @KnifMelti in #1142
-  - fix: Correctly pass value of WingetSourceCustom, Fixes #1043 by @Salamek in #1135
+  - fix：Correctly pass value of WingetSourceCustom, Fixes #1043 by @Salamek in #1135
   - Bump peter-evans/create-pull-request from 8.1.0 to 8.1.1 by @dependabot[bot] in #1147
   - Bump actions/github-script from 8 to 9 by @dependabot[bot] in #1148
-  - Sync main to dev : Fix immutableCreate: true on github actions by @Romanitho in #1150
+  - Sync main to dev：Fix immutableCreate：true on github actions by @Romanitho in #1150
   - Update auto-semver-action repository by @Romanitho in #1152
   - Release 2.12.0 by @Romanitho in #1156
   New Contributors
   - @Salamek made their first contribution in #1135
-  Full Changelog: v2.11.0...v2.12.0
 ReleaseNotesUrl: https://github.com/Romanitho/Winget-AutoUpdate/releases/tag/v2.12.0
 Documentations:
 - DocumentLabel: Wiki


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
Unless there's something I've monumentally missed out on, the WAU Winget package currently installs with a configuration that makes Winget Auto-Update fail to actually… well… auto-update.

So I've added additional InstallerSwitches based on the app's Readme to try to make sure that it does.

I also:
* Added 5½ tags.
* Replaced (c) → © for professionality.
* Added anti-`Internal-Error-Dynamic-Scan` measures.

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/401303)