### PR TITLE
New package: bullpae.keymander version 0.9.2

### DIFF
--- a/manifests/b/bullpae/keymander/0.9.2/bullpae.keymander.installer.yaml
+++ b/manifests/b/bullpae/keymander/0.9.2/bullpae.keymander.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: bullpae.keymander
+PackageVersion: 0.9.2
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: keymander\kmd.exe
+  PortableCommandAlias: kmd
+- RelativeFilePath: keymander\kmd-desktop.exe
+  PortableCommandAlias: kmd-desktop
+- RelativeFilePath: keymander\kmd-daemon.exe
+  PortableCommandAlias: kmd-daemon
+ReleaseDate: 2026-07-12
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/bullpae/keymander-cli/releases/download/v0.9.2/keymander-portable-x86_64-pc-windows-msvc.zip
+  InstallerSha256: 8F77A700187F9725A62AD5EF105A2B323CD8DAB604F8DCAE9B19F003C69FF53C
+- Architecture: arm64
+  InstallerUrl: https://github.com/bullpae/keymander-cli/releases/download/v0.9.2/keymander-portable-aarch64-pc-windows-msvc.zip
+  InstallerSha256: E79330E784EA19FFDD650BB07D642E47BD61F0B20C0B0FB684ED57ABF45CDBE1
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/b/bullpae/keymander/0.9.2/bullpae.keymander.locale.en-US.yaml
+++ b/manifests/b/bullpae/keymander/0.9.2/bullpae.keymander.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: bullpae.keymander
+PackageVersion: 0.9.2
+PackageLocale: en-US
+Publisher: bullpae
+PublisherUrl: https://github.com/bullpae
+PublisherSupportUrl: https://github.com/bullpae/keymander-cli/issues
+PackageName: keymander
+PackageUrl: https://github.com/bullpae/keymander-cli
+License: MIT
+LicenseUrl: https://github.com/bullpae/keymander-cli/blob/main/LICENSE
+Copyright: Copyright (c) 2026 bullpae
+ShortDescription: Keyboard-driven cross-platform launcher (TUI, desktop, key-remap daemon)
+Description: |-
+  keymander is a CLI-first cross-platform launcher controlled entirely from the keyboard.
+  It ships three binaries: kmd (TUI/CLI launcher), kmd-desktop (GUI launcher window),
+  and kmd-daemon (global hotkey and key-remapping daemon).
+Moniker: keymander
+Tags:
+- cli
+- keyboard
+- launcher
+- productivity
+- terminal
+- tui
+ReleaseNotesUrl: https://github.com/bullpae/keymander-cli/releases/tag/v0.9.2
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/b/bullpae/keymander/0.9.2/bullpae.keymander.yaml
+++ b/manifests/b/bullpae/keymander/0.9.2/bullpae.keymander.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: bullpae.keymander
+PackageVersion: 0.9.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
### New package: bullpae.keymander version 0.9.2

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`? (authored on macOS — relying on the pipeline validation; manifest follows the 1.9.0 schema)
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? (the packaged binaries themselves are tested on Windows 11; manifest install relies on pipeline + moderator validation)
- [x] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.9.0)?

keymander is an open-source (MIT) keyboard-driven cross-platform launcher.
This manifest packages the portable zip release (x64 + arm64) with three
portable executables: `kmd` (TUI/CLI), `kmd-desktop` (GUI launcher), and
`kmd-daemon` (key-remap daemon).

Upstream release: https://github.com/bullpae/keymander-cli/releases/tag/v0.9.2
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/401304)