### PR TITLE
New package: TheBeems.CodexUsageDock version 0.1.0

### DIFF
--- a/manifests/t/TheBeems/CodexUsageDock/0.1.0/TheBeems.CodexUsageDock.installer.yaml
+++ b/manifests/t/TheBeems/CodexUsageDock/0.1.0/TheBeems.CodexUsageDock.installer.yaml
@@ -1,0 +1,18 @@
+# Created with https://github.com/microsoft/winget-create
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: TheBeems.CodexUsageDock
+PackageVersion: 0.1.0
+InstallerType: inno
+Scope: user
+UpgradeBehavior: install
+ProductCode: '{35b848eb-6ef7-4b5d-9f8b-49b5614abb48}_is1'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/TheBeems/CodexUsageDock/releases/download/v0.1.0/CodexUsageDock-0.1.0-x64-setup.exe
+  InstallerSha256: 9580C432DA3DA0574D75BD1602901C63ED31DBF4EB645E1C35DC5FDACAAC19D3
+- Architecture: arm64
+  InstallerUrl: https://github.com/TheBeems/CodexUsageDock/releases/download/v0.1.0/CodexUsageDock-0.1.0-arm64-setup.exe
+  InstallerSha256: 375AA1D97E7316A99B3470396667795644DBCA31E163FFE5C5411CB1148E64C4
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/t/TheBeems/CodexUsageDock/0.1.0/TheBeems.CodexUsageDock.locale.en-US.yaml
+++ b/manifests/t/TheBeems/CodexUsageDock/0.1.0/TheBeems.CodexUsageDock.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# Created with https://github.com/microsoft/winget-create
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: TheBeems.CodexUsageDock
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Mathijs Beemsterboer
+PublisherUrl: https://github.com/TheBeems
+PublisherSupportUrl: https://github.com/TheBeems/CodexUsageDock/issues
+Author: Mathijs Beemsterboer
+PackageName: Codex Usage Dock
+PackageUrl: https://github.com/TheBeems/CodexUsageDock
+License: MIT
+LicenseUrl: https://github.com/TheBeems/CodexUsageDock/blob/v0.1.0/LICENSE
+Copyright: Copyright (c) 2026 Mathijs Beemsterboer
+ShortDescription: Display Codex usage limits and reset times in the PowerToys Command Palette Dock.
+Description: |-
+  Codex Usage Dock is a Windows Command Palette extension that shows the percentage remaining in the rolling five-hour and weekly Codex usage windows, their reset times, and the local Codex connection status. It reads usage from the local Codex app-server and falls back to local session metadata.
+Moniker: codex-usage-dock
+Tags:
+- codex
+- command-palette
+- powertoys
+- windows-commandpalette-extension
+ReleaseNotes: Initial public release with x64 and ARM64 per-user installers.
+ReleaseNotesUrl: https://github.com/TheBeems/CodexUsageDock/releases/tag/v0.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/TheBeems/CodexUsageDock/0.1.0/TheBeems.CodexUsageDock.yaml
+++ b/manifests/t/TheBeems/CodexUsageDock/0.1.0/TheBeems.CodexUsageDock.yaml
@@ -1,0 +1,8 @@
+# Created with https://github.com/microsoft/winget-create
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: TheBeems.CodexUsageDock
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Initial WinGet submission for Codex Usage Dock 0.1.0.\n\n- Adds x64 and ARM64 per-user Inno installers\n- Uses the published GitHub Release SHA-256 hashes\n- Includes the windows-commandpalette-extension tag for Command Palette discovery\n- Validated locally with winget validate\n\nPackage source: https://github.com/TheBeems/CodexUsageDock\nRelease: https://github.com/TheBeems/CodexUsageDock/releases/tag/v0.1.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/401316)