### PR TITLE
New package: LinkaiQi.NitTray version 0.1.3

### DIFF
--- a/manifests/l/LinkaiQi/NitTray/0.1.3/LinkaiQi.NitTray.installer.yaml
+++ b/manifests/l/LinkaiQi/NitTray/0.1.3/LinkaiQi.NitTray.installer.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: LinkaiQi.NitTray
+PackageVersion: 0.1.3
+InstallerLocale: en-US
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-07-11
+# ProductCode = Inno Setup AppId + "_is1" (this .iss sets AppId without braces).
+# Lets winget correlate the installed version for upgrade/uninstall.
+AppsAndFeaturesEntries:
+  - ProductCode: F6E903A8-2A56-4159-BB39-397845CF2F68_is1
+    InstallerType: inno
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/LinkaiQi/NitTray/releases/download/v0.1.3/NitTray-installer-x64.exe
+    InstallerSha256: 5EC898B1A9A9A512D8EB9768700F68A4F249FF888344CE4821EA44C257937F52
+  - Architecture: arm64
+    InstallerUrl: https://github.com/LinkaiQi/NitTray/releases/download/v0.1.3/NitTray-installer-arm64.exe
+    InstallerSha256: 98B2D5DD96BE4E5850699571E41E6076DB2C9C1EC6B2056E0DEC6DADA2A8E158
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/l/LinkaiQi/NitTray/0.1.3/LinkaiQi.NitTray.locale.en-US.yaml
+++ b/manifests/l/LinkaiQi/NitTray/0.1.3/LinkaiQi.NitTray.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: LinkaiQi.NitTray
+PackageVersion: 0.1.3
+PackageLocale: en-US
+Publisher: NitTray
+PublisherUrl: https://github.com/LinkaiQi/NitTray
+PublisherSupportUrl: https://github.com/LinkaiQi/NitTray/issues
+PackageName: NitTray
+PackageUrl: https://github.com/LinkaiQi/NitTray
+License: GPL-3.0
+LicenseUrl: https://github.com/LinkaiQi/NitTray/blob/main/LICENSE
+Copyright: Copyright © 2026 NitTray
+ShortDescription: Control Apple Studio Display and Pro Display XDR brightness from Windows.
+Description: >-
+  NitTray is a free, open-source Windows system-tray app that adjusts the brightness of
+  the Apple Studio Display and Pro Display XDR over USB — no Mac required. It lists each
+  connected Apple display with its own brightness slider and runs on Windows 10 and 11
+  (x64 and Arm64).
+Moniker: nittray
+Tags:
+  - apple
+  - brightness
+  - brightness-control
+  - display
+  - monitor
+  - pro-display-xdr
+  - studio-display
+  - system-tray
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/l/LinkaiQi/NitTray/0.1.3/LinkaiQi.NitTray.yaml
+++ b/manifests/l/LinkaiQi/NitTray/0.1.3/LinkaiQi.NitTray.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: LinkaiQi.NitTray
+PackageVersion: 0.1.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package submission: **LinkaiQi.NitTray** version **0.1.3**.

NitTray is a free, open-source Windows system-tray app that adjusts the
brightness of the Apple Studio Display and Pro Display XDR over USB.
Homepage: https://github.com/LinkaiQi/NitTray

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/)
- [x] Linked to an issue (if applicable) — N/A, new package

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the 1.12 schema
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/401365)