### PR TITLE
New package: YuniqueUnic.Callai version 0.2.1

### DIFF
--- a/manifests/y/YuniqueUnic/Callai/0.2.1/YuniqueUnic.Callai.installer.yaml
+++ b/manifests/y/YuniqueUnic/Callai/0.2.1/YuniqueUnic.Callai.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: YuniqueUnic.Callai
+PackageVersion: 0.2.1
+InstallerLocale: en-US
+InstallerType: wix
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-07-12
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/YuniqueUnic/callai/releases/download/v0.2.1/callai_0.2.1_x64_en-US.msi
+    InstallerSha256: 29E3997BD04DFD69BB5FAC292658CEA70734498D5D1B9973AD969518E645F8B0
+    ProductCode: '{4A6DF148-AF4E-4BB8-A827-EE109307954A}'
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/y/YuniqueUnic/Callai/0.2.1/YuniqueUnic.Callai.locale.en-US.yaml
+++ b/manifests/y/YuniqueUnic/Callai/0.2.1/YuniqueUnic.Callai.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: YuniqueUnic.Callai
+PackageVersion: 0.2.1
+PackageLocale: en-US
+Publisher: YuniqueUnic
+PublisherUrl: https://github.com/YuniqueUnic
+PublisherSupportUrl: https://github.com/YuniqueUnic/callai/issues
+Author: unic
+PackageName: callai
+PackageUrl: https://github.com/YuniqueUnic/callai
+License: MIT
+LicenseUrl: https://github.com/YuniqueUnic/callai/blob/main/LICENSE
+Copyright: Copyright (c) 2026 YuniqueUnic
+ShortDescription: Cozy AI window-warming alarm (desktop)
+Description: |-
+  callai is a cozy desktop + CLI alarm that schedules lightweight tasks
+  to keep AI rolling usage windows warm during your work hours.
+  Built with Tauri 2 + animal-island-ui.
+Moniker: callai
+Tags:
+  - ai
+  - alarm
+  - tauri
+  - scheduler
+  - productivity
+ReleaseNotesUrl: https://github.com/YuniqueUnic/callai/releases/tag/v0.2.1
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/y/YuniqueUnic/Callai/0.2.1/YuniqueUnic.Callai.yaml
+++ b/manifests/y/YuniqueUnic/Callai/0.2.1/YuniqueUnic.Callai.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: YuniqueUnic.Callai
+PackageVersion: 0.2.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## New package
- **YuniqueUnic.Callai** `0.2.1` — desktop GUI (WiX MSI, x64)

## Publisher
- GitHub: https://github.com/YuniqueUnic/callai
- License: MIT

## Installer
- URL: `https://github.com/YuniqueUnic/callai/releases/download/v0.2.1/callai_0.2.1_x64_en-US.msi`
- SHA-256 validated against published release

## Notes
- Desktop installers are not EV code-signed yet; SmartScreen may warn (documented in package description / project README).
- Split from multi-package PR #401342 (one application per PR as required by validation).

Please review. Thank you!
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/401366)