### PR TITLE
New package: YuniqueUnic.Callai.CLI version 0.2.1

### DIFF
--- a/manifests/y/YuniqueUnic/Callai.CLI/0.2.1/YuniqueUnic.Callai.CLI.installer.yaml
+++ b/manifests/y/YuniqueUnic/Callai.CLI/0.2.1/YuniqueUnic.Callai.CLI.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: YuniqueUnic.Callai.CLI
+PackageVersion: 0.2.1
+InstallerLocale: en-US
+InstallerType: portable
+Commands:
+  - callai
+UpgradeBehavior: install
+ReleaseDate: 2026-07-12
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/YuniqueUnic/callai/releases/download/v0.2.1/callai-cli-x86_64-pc-windows-msvc.exe
+    InstallerSha256: 0959B4A64FFEFE04DE7D4A1933B0377B66372D8DC637FB207583E7AC1AE1D003
+    # portable renames on install via Commands
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/y/YuniqueUnic/Callai.CLI/0.2.1/YuniqueUnic.Callai.CLI.locale.en-US.yaml
+++ b/manifests/y/YuniqueUnic/Callai.CLI/0.2.1/YuniqueUnic.Callai.CLI.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: YuniqueUnic.Callai.CLI
+PackageVersion: 0.2.1
+PackageLocale: en-US
+Publisher: YuniqueUnic
+PublisherUrl: https://github.com/YuniqueUnic
+PublisherSupportUrl: https://github.com/YuniqueUnic/callai/issues
+Author: unic
+PackageName: callai CLI
+PackageUrl: https://github.com/YuniqueUnic/callai
+License: MIT
+LicenseUrl: https://github.com/YuniqueUnic/callai/blob/main/LICENSE
+Copyright: Copyright (c) 2026 YuniqueUnic
+ShortDescription: Cozy AI window-warming alarm (CLI / daemon)
+Description: |-
+  Headless callai CLI sharing the same domain and data layout as the desktop app.
+  Commands: list, run, daemon, run-once, validate, app.
+Moniker: callai-cli
+Tags:
+  - ai
+  - cli
+  - daemon
+  - scheduler
+ReleaseNotesUrl: https://github.com/YuniqueUnic/callai/releases/tag/v0.2.1
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/y/YuniqueUnic/Callai.CLI/0.2.1/YuniqueUnic.Callai.CLI.yaml
+++ b/manifests/y/YuniqueUnic/Callai.CLI/0.2.1/YuniqueUnic.Callai.CLI.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: YuniqueUnic.Callai.CLI
+PackageVersion: 0.2.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## New package
- **YuniqueUnic.Callai.CLI** `0.2.1` — portable CLI / daemon (x64)

## Publisher
- GitHub: https://github.com/YuniqueUnic/callai
- License: MIT

## Installer
- URL: `https://github.com/YuniqueUnic/callai/releases/download/v0.2.1/callai-cli-x86_64-pc-windows-msvc.exe`
- SHA-256 validated against published release
- InstallerType: portable; Commands: callai

## Notes
- Shares the same domain/data layout as the desktop app.
- Split from multi-package PR #401342 (one application per PR as required by validation).

Please review. Thank you!
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/401367)