### PR TITLE
Revert InstallerSwitches: Romanitho.Winget-AutoUpdate version 2.12.0

### DIFF
--- a/manifests/r/Romanitho/Winget-AutoUpdate/2.12.0/Romanitho.Winget-AutoUpdate.installer.yaml
+++ b/manifests/r/Romanitho/Winget-AutoUpdate/2.12.0/Romanitho.Winget-AutoUpdate.installer.yaml
@@ -6,9 +6,6 @@ PackageVersion: 2.12.0
 InstallerLocale: en-US
 InstallerType: wix
 Scope: machine
-InstallerSwitches:
-  Silent: /qn UPDATESINTERVAL=Daily UPDATESATLOGON=0
-  SilentWithProgress: /qn UPDATESINTERVAL=Daily UPDATESATLOGON=0
 UpgradeBehavior: install
 ProductCode: '{FB0EB14E-95AC-45D7-A951-432316FFCBD4}'
 ReleaseDate: 2026-05-11


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
Turned out the InstallerSwitches I added a couple hours ago were in fact disadvantageous, in an "I acted in good faith but I ultimately bungled it big regardless of circumstances" blunder of mine.

In particular, I learned only 10 minutes ago that Task Scheduler had subfolders. I was prior to that point of the belief that all tasks were in one list.

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves https://github.com/microsoft/winget-pkgs/pull/401303#issuecomment-4950875187.

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.