### PR TITLE
New package: Edithatogo.OSFCLI.Go 0.3.2

### DIFF
--- a/manifests/e/Edithatogo/OSFCLI/Go/0.3.2/Edithatogo.OSFCLI.Go.installer.yaml
+++ b/manifests/e/Edithatogo/OSFCLI/Go/0.3.2/Edithatogo.OSFCLI.Go.installer.yaml
@@ -1,0 +1,17 @@
+PackageIdentifier: Edithatogo.OSFCLI.Go
+PackageVersion: 0.3.2
+Installers:
+- Architecture: x64
+  InstallerType: portable
+  InstallerUrl: https://github.com/edithatogo/osf-cli-go/releases/download/v0.3.2/osf-windows-amd64.exe
+  InstallerSha256: FF1B7F07439AF40E8F566231B1D9451DE99C25A08B773CE48D12142C950164BC
+  Commands:
+  - osf
+- Architecture: arm64
+  InstallerType: portable
+  InstallerUrl: https://github.com/edithatogo/osf-cli-go/releases/download/v0.3.2/osf-windows-arm64.exe
+  InstallerSha256: 34D026382FFD17A9C01EE0DEE3B094D14053420A5432DDCFDD6B78FCAF299C80
+  Commands:
+  - osf
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/e/Edithatogo/OSFCLI/Go/0.3.2/Edithatogo.OSFCLI.Go.locale.en-US.yaml
+++ b/manifests/e/Edithatogo/OSFCLI/Go/0.3.2/Edithatogo.OSFCLI.Go.locale.en-US.yaml
@@ -1,0 +1,13 @@
+PackageIdentifier: Edithatogo.OSFCLI.Go
+PackageVersion: 0.3.2
+PackageLocale: en-US
+Publisher: Edithatogo
+PublisherUrl: https://github.com/edithatogo
+PackageName: OSF CLI Go
+PackageUrl: https://github.com/edithatogo/osf-cli-go
+License: Apache-2.0
+LicenseUrl: https://github.com/edithatogo/osf-cli-go/blob/master/LICENSE
+ShortDescription: Command-line client for the Open Science Framework
+Description: OSF CLI Go provides scripted access to Open Science Framework projects, files, registrations, preprints, and MCP workflows.
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/e/Edithatogo/OSFCLI/Go/0.3.2/Edithatogo.OSFCLI.Go.yaml
+++ b/manifests/e/Edithatogo/OSFCLI/Go/0.3.2/Edithatogo.OSFCLI.Go.yaml
@@ -1,10 +1,5 @@
 PackageIdentifier: Edithatogo.OSFCLI.Go
 PackageVersion: 0.3.2
-PackageLocale: en-US
-Publisher: Edithatogo
-PackageName: OSF CLI Go
-License: Apache-2.0
-ShortDescription: Command-line client for the Open Science Framework
-PackageUrl: https://github.com/edithatogo/osf-cli-go
+DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.9.0

--- a/manifests/e/Edithatogo/OSFCLI/Go/0.3.2/Edithatogo.OSFCLI.Go.yaml
+++ b/manifests/e/Edithatogo/OSFCLI/Go/0.3.2/Edithatogo.OSFCLI.Go.yaml
@@ -1,0 +1,10 @@
+PackageIdentifier: Edithatogo.OSFCLI.Go
+PackageVersion: 0.3.2
+PackageLocale: en-US
+Publisher: Edithatogo
+PackageName: OSF CLI Go
+License: Apache-2.0
+ShortDescription: Command-line client for the Open Science Framework
+PackageUrl: https://github.com/edithatogo/osf-cli-go
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## Description
Adds OSF CLI Go, a command-line client for the Open Science Framework.

## Validation
- Release assets are immutable GitHub release binaries.
- SHA-256 values were verified against v0.3.2 release assets.
- Portable installer commands are `osf`.
- Source manifest validation and repository quality checks pass in the upstream project.

Source repository: https://github.com/edithatogo/osf-cli-go
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/401414)