### PR TITLE
Update: Japplis.AntCommander.Pro to 6.2

### DIFF
--- a/manifests/j/Japplis/AntCommander/Pro/6.2/Japplis.AntCommander.Pro.installer.yaml
+++ b/manifests/j/Japplis/AntCommander/Pro/6.2/Japplis.AntCommander.Pro.installer.yaml
@@ -1,0 +1,27 @@
+# Created using Apache Ant script from Japplis
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Japplis.AntCommander.Pro
+PackageVersion: 6.2
+Platform:
+- Windows.Desktop
+InstallerType: inno
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+Installers:
+- Architecture: x64
+  Scope: machine
+  InstallerUrl: https://www.antcommander.com/versions/AntCommanderPro-6.2.exe
+  InstallerSha256: c5ff485e07f1416a95581e546aa37064afadb811499197dc7b6da40ac3a02760
+  InstallerSwitches:
+    Custom: /ALLUSERS
+- Architecture: x64
+  Scope: user
+  InstallerUrl: https://www.antcommander.com/versions/AntCommanderPro-6.2.exe
+  InstallerSha256: c5ff485e07f1416a95581e546aa37064afadb811499197dc7b6da40ac3a02760
+  InstallerSwitches:
+    Custom: /CURRENTUSER
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/j/Japplis/AntCommander/Pro/6.2/Japplis.AntCommander.Pro.locale.en-US.yaml
+++ b/manifests/j/Japplis/AntCommander/Pro/6.2/Japplis.AntCommander.Pro.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# Created using Apache Ant script from Japplis
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Japplis.AntCommander.Pro
+PackageVersion: 6.2
+PackageLocale: en-US
+Publisher: Japplis
+PublisherUrl: https://www.japplis.com
+Author: Anthony Goubard
+PackageName: Ant Commander Pro
+PackageUrl: https://www.antcommander.com/
+License: Commercial
+LicenseUrl: https://www.antcommander.com/license.txt
+Copyright: Copyright © 2004 - 2026 Japplis. All rights reserved.
+ShortDescription: Powerful file manager for developers
+Description: |-
+  Ant Commander Pro - Professional file manager
+  Ant Commander Pro is a powerful file manager. Several file systems are suported: file, zip, ftp, webdav, etc. Several kinds of panels are available: directory table; directory tree, text editor, image viewer, command line, etc.
+ReleaseNotesUrl: https://www.antcommander.com/changes.txt
+Moniker: ant-commander-pro
+Tags: 
+- file-manager
+- Java
+- file
+- manager
+- management
+- disk
+- sftp
+- explorer
+- finder
+- directory
+- folder
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/j/Japplis/AntCommander/Pro/6.2/Japplis.AntCommander.Pro.yaml
+++ b/manifests/j/Japplis/AntCommander/Pro/6.2/Japplis.AntCommander.Pro.yaml
@@ -1,0 +1,8 @@
+# Created using Apache Ant script from Japplis
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Japplis.AntCommander.Pro
+PackageVersion: 6.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description
Japplis.AntCommander.Pro version 6.2:
Directory Table:
- Fixed filtering files sometimes didn't update the status bar
- Added possibility to remember the sort order and filter when bookmarking a location
Image Viewer:
- Fixed image dimension not showing sometimes in status bar
- Fixed incorrect image rotation sometimes not showing the full image
- Fixed behavior of auto rotate button
- Added possibility to remember the zoom when bookmarking a location
Text Editor:
- Syntax highlight for ini files
- Added possibility to remember the caret position when bookmarking a location
Files:
- Fixed caching icons for special files on not local file systems
- No caching of the directory icons for macOS
- Files with same size and last modified are suggested as skip in file conflict panel
- Replace all and rename all won't affect hidden same file in files conflict panel
- Rename all takes previous renames into account for new name
- Fixed size of single file conflict after first resolution
Actions:
- Added Quick bookmarks (control/meta D)
- Option to use Quick bookmarks window in modal or not modal mode
- Improved copy with renaming
- Better handling when file conflict panel is cancelled (skip)
- Added argument option NavigationFiles=<selection> to define next/previous navigation files
- Various small improvement for Show Top Used Locations
Other:
- Fixed online error creating panels
- Fixed failing opening editor in online demo
- Pro version is now 30 days trial instead of 1 day
- Various small improvements and bug fixes
- Various improvements and bug fixes in the application framework
## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable) No

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/401422)