### PR TITLE
Update: Unity.UnityHub to 3.19.5

### DIFF
--- a/manifests/u/Unity/UnityHub/3.19.5/Unity.UnityHub.installer.yaml
+++ b/manifests/u/Unity/UnityHub/3.19.5/Unity.UnityHub.installer.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Unity.UnityHub
+PackageVersion: 3.19.5
+InstallerLocale: en-US
+InstallerType: nullsoft
+Scope: machine
+MinimumOSVersion: 10.0.10240.0
+InstallerSwitches:
+  Upgrade: --updated
+UpgradeBehavior: install
+Protocols:
+- unityhub
+FileExtensions:
+- unityhub
+ProductCode: Unity Technologies - Hub
+ReleaseDate: 2026-07-10
+AppsAndFeaturesEntries:
+- DisplayName: Unity Hub 3.19.5
+  ProductCode: Unity Technologies - Hub
+Installers:
+- Architecture: x64
+  InstallerUrl: https://public-cdn.cloud.unity3d.com/hub/prod/3.19.5/UnityHubSetup-3.19.5-x64.exe
+  InstallerSha256: 06D09EA17E7973FF9889E46B20DDC9B61221B6C3E9E722D69E34B508616F0497
+- Architecture: arm64
+  InstallerUrl: https://public-cdn.cloud.unity3d.com/hub/prod/3.19.5/UnityHubSetup-3.19.5-arm64.exe
+  InstallerSha256: EBC3767C2070CE3AD35E5E1CE4A54E10984D45DC3081A9E6F3241AA9CB238068
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/u/Unity/UnityHub/3.19.5/Unity.UnityHub.locale.en-US.yaml
+++ b/manifests/u/Unity/UnityHub/3.19.5/Unity.UnityHub.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Unity.UnityHub
+PackageVersion: 3.19.5
+PackageLocale: en-US
+Publisher: Unity Technologies Inc.
+PublisherUrl: https://unity.com/
+PublisherSupportUrl: https://support.unity.com/
+PrivacyUrl: https://unity.com/legal/privacy-policy
+Author: Unity Technologies Inc.
+PackageName: Unity Hub
+PackageUrl: https://unity.com/unity-hub
+License: Proprietary
+LicenseUrl: https://unity.com/legal/terms-of-service
+Copyright: Copyright © 2026 Unity Technologies Inc.
+CopyrightUrl: https://unity.com/legal/trademarks
+ShortDescription: Manage multiple installations of the Unity Editor, create new projects, and access your work.
+Description: The Unity Hub is a standalone application that streamlines the way you navigate, download, and manage your Unity projects and installations.
+Tags:
+- unity
+- unity3d
+Documentations:
+- DocumentLabel: Manual
+  DocumentUrl: https://docs.unity3d.com/hub/manual
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/u/Unity/UnityHub/3.19.5/Unity.UnityHub.locale.zh-CN.yaml
+++ b/manifests/u/Unity/UnityHub/3.19.5/Unity.UnityHub.locale.zh-CN.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: Unity.UnityHub
+PackageVersion: 3.19.5
+PackageLocale: zh-CN
+Publisher: Unity Technologies Inc.
+PublisherUrl: https://unity.com/cn
+PublisherSupportUrl: https://support.unity.com/
+PrivacyUrl: https://unity.com/cn/legal/privacy-policy
+Author: Unity Technologies Inc.
+PackageName: Unity Hub
+PackageUrl: https://unity.com/cn/unity-hub
+License: 专有软件
+LicenseUrl: https://unity.com/cn/legal/terms-of-service
+Copyright: Copyright © 2026 Unity Technologies Inc.
+CopyrightUrl: https://unity.com/cn/legal/trademarks
+ShortDescription: 管理 Unity 编辑器的多个安装、创建新项目和访问您的工作
+Description: Unity Hub 是一款独立应用程序，简化 Unity 项目和安装的浏览、下载和管理方式。
+Tags:
+- unity
+- unity3d
+Documentations:
+- DocumentLabel: 手册
+  DocumentUrl: https://docs.unity3d.com/hub/manual
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/u/Unity/UnityHub/3.19.5/Unity.UnityHub.yaml
+++ b/manifests/u/Unity/UnityHub/3.19.5/Unity.UnityHub.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Unity.UnityHub
+PackageVersion: 3.19.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Update **Unity.UnityHub** to **3.19.5** (released 2026-07-10).

- Adds the Windows **arm64** installer alongside x64 — Unity Hub now ships a native arm64 build.
- Uses the immutable versioned download URLs (`…/hub/prod/3.19.5/UnityHubSetup-3.19.5-<arch>.exe`), consistent with the published 3.19.4 manifest.
- Both installers verified: SHA256 computed from the downloaded binaries, and both carry valid Authenticode EV signatures ("Unity Technologies SF").
- The arm64 installer previously passed the full validation pipeline in #398639 (closed as duplicate of the bot's x64-only update).

I'm a developer on the Unity Hub team at Unity Technologies.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` — "Manifest validation succeeded."
- [x] Tested manifest locally with `winget install --manifest <path>` — installed successfully on Windows 11 x64; winget verified the installer hash, and the ARP entry matches the manifest (`Unity Hub 3.19.5` / `Unity Technologies - Hub`). The arm64 installer cannot be executed on this x64 host, but its SHA256 and Authenticode EV signature were verified.
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
