### PR TITLE
New version: Ricardocabral.ajq version 0.0.6

### DIFF
--- a/manifests/r/RicardoCabral/ajq/0.0.6/RicardoCabral.ajq.installer.yaml
+++ b/manifests/r/RicardoCabral/ajq/0.0.6/RicardoCabral.ajq.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: RicardoCabral.ajq
+PackageVersion: 0.0.6
+InstallerType: zip
+NestedInstallerType: portable
+Installers:
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: ajq.exe
+    PortableCommandAlias: ajq
+  InstallerUrl: https://github.com/ricardocabral/ajq/releases/download/v0.0.6/ajq_0.0.6_Windows_x86_64.zip
+  InstallerSha256: E8F7C40560F2C9AA0C30AF83954DE3901CB9BDDC14DDD117C0E2A8860748616F
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/r/RicardoCabral/ajq/0.0.6/RicardoCabral.ajq.locale.en-US.yaml
+++ b/manifests/r/RicardoCabral/ajq/0.0.6/RicardoCabral.ajq.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: RicardoCabral.ajq
+PackageVersion: 0.0.6
+PackageLocale: en-US
+Publisher: Ricardo Cabral
+PublisherUrl: https://github.com/ricardocabral
+PublisherSupportUrl: https://github.com/ricardocabral/ajq/issues
+Author: Ricardo Niederberger Cabral
+PackageName: ajq
+PackageUrl: https://github.com/ricardocabral/ajq
+License: MIT
+LicenseUrl: https://github.com/ricardocabral/ajq/blob/v0.0.6/LICENSE
+ShortDescription: jq-like stream processor for semantic matching and extraction.
+Description: ajq keeps ordinary jq execution deterministic while adding explicit semantic matching and extraction operations.
+Moniker: ajq
+Tags:
+- jq
+- json
+- semantic
+ReleaseNotes: Initial WinGet package release.
+ReleaseNotesUrl: https://github.com/ricardocabral/ajq/releases/tag/v0.0.6
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/RicardoCabral/ajq/0.0.6/RicardoCabral.ajq.yaml
+++ b/manifests/r/RicardoCabral/ajq/0.0.6/RicardoCabral.ajq.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: RicardoCabral.ajq
+PackageVersion: 0.0.6
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## New package

Adds the initial WinGet manifest for `Ricardocabral.ajq` 0.0.6, the immutable release that passed the clean Homebrew smoke workflow.

- Installer URL: https://github.com/ricardocabral/ajq/releases/download/v0.0.6/ajq_0.0.6_Windows_x86_64.zip
- SHA-256: `E8F7C40560F2C9AA0C30AF83954DE3901CB9BDDC14DDD117C0E2A8860748616F`
- The archive SHA-256 is from the upstream `checksums.txt` release asset and was verified locally with the release provenance attestation.