### PR TITLE
New package: NixieTechLLC.Lait version 0.4.4

### DIFF
--- a/manifests/n/NixieTechLLC/Lait/0.4.4/NixieTechLLC.Lait.installer.yaml
+++ b/manifests/n/NixieTechLLC/Lait/0.4.4/NixieTechLLC.Lait.installer.yaml
@@ -1,0 +1,13 @@
+PackageIdentifier: NixieTechLLC.Lait
+PackageVersion: 0.4.4
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: lait.exe
+    PortableCommandAlias: lait
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Nixie-Tech-LLC/lait/releases/download/v0.4.4/lait-x86_64-pc-windows-msvc.zip
+    InstallerSha256: DCFDC586AB0227065D83682DD5AFFC8246BD1496970E91B6169A0A258B08CC54
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/n/NixieTechLLC/Lait/0.4.4/NixieTechLLC.Lait.locale.en-US.yaml
+++ b/manifests/n/NixieTechLLC/Lait/0.4.4/NixieTechLLC.Lait.locale.en-US.yaml
@@ -1,0 +1,25 @@
+PackageIdentifier: NixieTechLLC.Lait
+PackageVersion: 0.4.4
+PackageLocale: en-US
+Publisher: Nixie Tech LLC
+PublisherUrl: https://github.com/Nixie-Tech-LLC
+PackageName: lait
+PackageUrl: https://github.com/Nixie-Tech-LLC/lait
+License: MIT OR Apache-2.0
+LicenseUrl: https://github.com/Nixie-Tech-LLC/lait/blob/main/LICENSE-MIT
+ShortDescription: A local-first, peer-to-peer, end-to-end-encrypted issue tracker built on iroh + Loro CRDTs.
+Description: |-
+  lait is a decentralized, offline-first alternative to Linear. Issues are Loro
+  CRDT documents synced peer-to-peer over iroh (QUIC + NAT traversal) with no
+  central server, backed by a durable local git store, with end-to-end
+  encryption gated by a signed membership graph. It exposes CLI, TUI, and MCP
+  (AI-agent) surfaces over one git-backed daemon.
+Tags:
+  - issue-tracker
+  - p2p
+  - crdt
+  - local-first
+  - iroh
+  - cli
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/n/NixieTechLLC/Lait/0.4.4/NixieTechLLC.Lait.yaml
+++ b/manifests/n/NixieTechLLC/Lait/0.4.4/NixieTechLLC.Lait.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: NixieTechLLC.Lait
+PackageVersion: 0.4.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: `NixieTechLLC.Lait` version `0.4.4`

lait — a local-first, peer-to-peer, end-to-end-encrypted issue tracker built on iroh + Loro CRDTs (a decentralized, offline-first alternative to Linear).

- Upstream: https://github.com/Nixie-Tech-LLC/lait
- Installer: portable `x64` zip containing `lait.exe`, from the official GitHub release `v0.4.4`. `InstallerSha256` matches that release asset.

**Note on the checklist (being accurate):** these manifests were generated programmatically and validated for YAML well-formedness and 1.6.0 schema fields; the `InstallerSha256` was taken from the release's published `.sha256`. They were **not** run through `winget validate` / `winget install` in a local Windows sandbox, so I'm relying on this repository's validation pipeline — happy to iterate on any feedback from it.

- [x] This PR only adds one (1) manifest (the `NixieTechLLC.Lait` 0.4.4 package)
- [x] Manifests conform to the 1.6.0 schema (version / installer / defaultLocale)
- [ ] Local `winget validate` / `winget install` testing — not performed (no local Windows sandbox); relying on CI
- [ ] CLA — to be signed by the submitting account if not already
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/401505)