### PR TITLE
New package: 702studio.KomorebiStarter version 0.2.0

### DIFF
--- a/manifests/7/702studio/KomorebiStarter/0.2.0/702studio.KomorebiStarter.installer.yaml
+++ b/manifests/7/702studio/KomorebiStarter/0.2.0/702studio.KomorebiStarter.installer.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: 702studio.KomorebiStarter
+PackageVersion: 0.2.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.22000.0
+InstallerType: inno
+Scope: user
+InstallModes:
+- silent
+- silentWithProgress
+- interactive
+InstallerSwitches:
+  Custom: /WINGET
+UpgradeBehavior: install
+Commands:
+- wm
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: LGUG2Z.komorebi
+  - PackageIdentifier: LGUG2Z.whkd
+  - PackageIdentifier: LGUG2Z.masir
+AppsAndFeaturesEntries:
+- DisplayName: Komorebi Starter
+  Publisher: 702studio
+  ProductCode: '{5FA3F095-B1A1-4B29-BC3F-AA25DDD5902C}_is1'
+  InstallerType: inno
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/702studio/komorebi-starter/releases/download/v0.2.0/komorebi-starter-setup.exe
+  InstallerSha256: 9C94DA99E4CFF9CF69851772DE6A80C44CA8B5B842EA65830A0C6023F224187A
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/7/702studio/KomorebiStarter/0.2.0/702studio.KomorebiStarter.locale.en-US.yaml
+++ b/manifests/7/702studio/KomorebiStarter/0.2.0/702studio.KomorebiStarter.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: 702studio.KomorebiStarter
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: 702studio
+PublisherUrl: https://github.com/702studio
+PublisherSupportUrl: https://github.com/702studio/komorebi-starter/issues
+Author: 702studio
+PackageName: Komorebi Starter
+PackageUrl: https://github.com/702studio/komorebi-starter
+License: MIT
+LicenseUrl: https://github.com/702studio/komorebi-starter/blob/v0.2.0/LICENSE
+ShortDescription: Agent-friendly komorebi, whkd, masir, and komorebi-bar baseline.
+Description: >-
+  A transactional, keyboard-driven Windows 11 desktop baseline with deterministic
+  configuration, diagnostics, rollback, and a structured command wrapper for agents.
+Moniker: komorebi-starter
+Tags:
+- automation
+- komorebi
+- powershell
+- tiling-window-manager
+- whkd
+- windows-11
+ReleaseNotesUrl: https://github.com/702studio/komorebi-starter/releases/tag/v0.2.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/7/702studio/KomorebiStarter/0.2.0/702studio.KomorebiStarter.yaml
+++ b/manifests/7/702studio/KomorebiStarter/0.2.0/702studio.KomorebiStarter.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: 702studio.KomorebiStarter
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Adds Komorebi Starter 0.2.0 as a new per-user package.

Publisher release: https://github.com/702studio/komorebi-starter/releases/tag/v0.2.0

## Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (not applicable)

## Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same package
- [x] This PR only modifies one manifest
- [x] Validated the manifest locally with `winget validate --manifest <path>`
- [ ] Tested the manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the 1.12 schema

The local install checkbox is intentionally left unchecked because installing this package starts a window manager on the active workstation. The immutable release EXE, SHA-256 linkage, silent installer build, and uninstall integration were validated in the publisher CI; the repository pipeline remains the isolated dynamic install/uninstall authority.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/401521)