### PR TITLE
New package: biglexj.ElyTesia version 1.0.1

### DIFF
--- a/manifests/b/biglexj/ElyTesia/1.0.1/biglexj.ElyTesia.installer.yaml
+++ b/manifests/b/biglexj/ElyTesia/1.0.1/biglexj.ElyTesia.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: biglexj.ElyTesia
+PackageVersion: 1.0.1
+InstallerType: wix
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{2690CEBD-2C21-3394-BF27-0415735707F9}'
+ReleaseDate: 2026-07-12
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/biglexj/Ely-Tesia/releases/download/v1.0.1/ElyTesia-Windows-1.0.1.msi
+    InstallerSha256: 9EC88875A8F4355FD779093DAFD9E068B97BB6092137C572C5359DB7DA4EF0C6
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/b/biglexj/ElyTesia/1.0.1/biglexj.ElyTesia.locale.es-PE.yaml
+++ b/manifests/b/biglexj/ElyTesia/1.0.1/biglexj.ElyTesia.locale.es-PE.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: biglexj.ElyTesia
+PackageVersion: 1.0.1
+PackageLocale: es-PE
+Publisher: biglexj
+PublisherUrl: https://github.com/biglexj
+PublisherSupportUrl: https://github.com/biglexj/Ely-Tesia/issues
+Author: biglexj
+PackageName: Ely-Tesia
+PackageUrl: https://github.com/biglexj/Ely-Tesia
+License: MIT
+LicenseUrl: https://github.com/biglexj/Ely-Tesia/blob/main/LICENSE
+Copyright: Copyright (c) 2026 biglexj
+ShortDescription: Visualizador y herramienta de práctica MIDI para Windows y Android.
+Description: |-
+  Ely-Tesia permite visualizar, practicar y grabar canciones MIDI mediante un
+  piano roll animado, teclado interactivo, entrada MIDI física, sintetizador,
+  metrónomo, modo de espera y biblioteca local persistente.
+Moniker: elytesia
+Tags:
+  - midi
+  - music
+  - piano
+  - piano-roll
+  - practice
+  - synthesizer
+ReleaseNotes: |-
+  La versión 1.0.1 mejora la sincronización y los colores de barras, partículas
+  y teclas; corrige el audio virtual de Windows y conserva la biblioteca entre
+  actualizaciones.
+ReleaseNotesUrl: https://github.com/biglexj/Ely-Tesia/releases/tag/v1.0.1
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/b/biglexj/ElyTesia/1.0.1/biglexj.ElyTesia.yaml
+++ b/manifests/b/biglexj/ElyTesia/1.0.1/biglexj.ElyTesia.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: biglexj.ElyTesia
+PackageVersion: 1.0.1
+DefaultLocale: es-PE
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
### New package submission

Adds Ely-Tesia 1.0.1 using the x64 MSI published in the official GitHub Release.

- Package identifier: `biglexj.ElyTesia` 
- Installer type: WiX/MSI
- Scope: User
- License: MIT
- Manifests validated locally with `winget validate`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/401546)