### PR TITLE
Added ProductCode: Nadeo.TrackManiaUnitedForever version 2.11.26

### DIFF
--- a/manifests/n/Nadeo/TrackManiaUnitedForever/2.11.26/Nadeo.TrackManiaUnitedForever.installer.yaml
+++ b/manifests/n/Nadeo/TrackManiaUnitedForever/2.11.26/Nadeo.TrackManiaUnitedForever.installer.yaml
@@ -1,8 +1,8 @@
-# Created using wingetcreate 1.10.2.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
 
 PackageIdentifier: Nadeo.TrackManiaUnitedForever
 PackageVersion: 2.11.26
+ReleaseDate: 2011-03-29
 InstallerLocale: en-US
 Platform:
 - Windows.Desktop
@@ -17,10 +17,12 @@ Protocols:
 - tmtp
 FileExtensions:
 - gbx
-ReleaseDate: 2011-03-29
 Installers:
 - Architecture: x86
   InstallerUrl: http://files.trackmaniaforever.com/tmunitedforever_setup.exe
   InstallerSha256: F8A4D09C64D65BE271C0346F5B0E41529CB25EB8C605D4602D0F34F27FB1355F
+ProductCode: TmUnitedForever_is1
+AppsAndFeaturesEntries:
+- ProductCode: TmUnitedForever_is1
 ManifestType: installer
 ManifestVersion: 1.10.0


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
Based on how, after I attempted to force-update(/-refresh?) the app client-side through its Winget package, it still showed up as `ARP\Machine\X86\TmUnitedForever_is1` on my PC when running `winget list` afterwards.

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/401603)