### PR TITLE
New package: Redrum624.Vitrine version 1.24.1

### DIFF
--- a/manifests/r/Redrum624/Vitrine/1.24.1/Redrum624.Vitrine.installer.yaml
+++ b/manifests/r/Redrum624/Vitrine/1.24.1/Redrum624.Vitrine.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Redrum624.Vitrine
+PackageVersion: 1.24.1
+InstallerType: nullsoft
+ReleaseDate: 2026-07-12
+Installers:
+- Architecture: x64
+  Scope: user
+  InstallerUrl: https://github.com/Redrum624/Vitrine/releases/download/v1.24.1/Vitrine.Setup.1.24.1.exe
+  InstallerSha256: BC4868649E0880E24A74053080FBE2E6E979A1E858B105DE1839B0991959E3B3
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/r/Redrum624/Vitrine/1.24.1/Redrum624.Vitrine.locale.en-US.yaml
+++ b/manifests/r/Redrum624/Vitrine/1.24.1/Redrum624.Vitrine.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Redrum624.Vitrine
+PackageVersion: 1.24.1
+PackageLocale: en-US
+Publisher: Redrum624
+PublisherUrl: https://github.com/Redrum624
+PublisherSupportUrl: https://github.com/Redrum624/Vitrine/issues
+PackageName: Vitrine
+PackageUrl: https://github.com/Redrum624/Vitrine
+License: PolyForm-Noncommercial-1.0.0
+LicenseUrl: https://github.com/Redrum624/Vitrine/blob/main/LICENSE
+ShortDescription: Free, non-destructive RAW photo editor for Windows.
+Moniker: vitrine
+Tags:
+- photo
+- photography
+- raw
+- editor
+- image-editing
+ReleaseNotesUrl: https://github.com/Redrum624/Vitrine/releases/tag/v1.24.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/Redrum624/Vitrine/1.24.1/Redrum624.Vitrine.yaml
+++ b/manifests/r/Redrum624/Vitrine/1.24.1/Redrum624.Vitrine.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Redrum624.Vitrine
+PackageVersion: 1.24.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description

Adds a new package: **Vitrine** (`Redrum624.Vitrine`) version 1.24.1 — a free, non-destructive RAW photo editor for Windows, distributed as an NSIS installer. Source: https://github.com/Redrum624/Vitrine, release: https://github.com/Redrum624/Vitrine/releases/tag/v1.24.1.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/401619)