### PR TITLE
New package: SANYALnetLabs.DoNotPanicPortfolioViewer version 1.0

### DIFF
--- a/manifests/s/SANYALnetLabs/DoNotPanicPortfolioViewer/1.0/SANYALnetLabs.DoNotPanicPortfolioViewer.installer.yaml
+++ b/manifests/s/SANYALnetLabs/DoNotPanicPortfolioViewer/1.0/SANYALnetLabs.DoNotPanicPortfolioViewer.installer.yaml
@@ -1,0 +1,15 @@
+# Created for the official DO NOT PANIC Portfolio Visualizer 1.0 release.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: SANYALnetLabs.DoNotPanicPortfolioViewer
+PackageVersion: 1.0
+InstallerType: inno
+Scope: machine
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/tuklusan/DO-NOT-PANIC-PORTFOLIO-VISUALIZER/releases/download/v1.0/DoNotPanicPortfolioVisualizerSetup-1.0.exe
+  InstallerSha256: F035C1810903B92B98243D6071975BB99D35981A6208D61E9FFAB1384F6ECD3E
+  ProductCode: '{B0839D4C-1D29-4D9C-95E3-C88E4D8E37E5}_is1'
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/SANYALnetLabs/DoNotPanicPortfolioViewer/1.0/SANYALnetLabs.DoNotPanicPortfolioViewer.installer.yaml
+++ b/manifests/s/SANYALnetLabs/DoNotPanicPortfolioViewer/1.0/SANYALnetLabs.DoNotPanicPortfolioViewer.installer.yaml
@@ -9,7 +9,7 @@ UpgradeBehavior: install
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/tuklusan/DO-NOT-PANIC-PORTFOLIO-VISUALIZER/releases/download/v1.0/DoNotPanicPortfolioVisualizerSetup-1.0.exe
-  InstallerSha256: F035C1810903B92B98243D6071975BB99D35981A6208D61E9FFAB1384F6ECD3E
+  InstallerSha256: BE8C6CBCCD07C1A024D3A12188585FDC6B1BF9A23F8027139FA0A3C0A8737886
   ProductCode: '{B0839D4C-1D29-4D9C-95E3-C88E4D8E37E5}_is1'
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/s/SANYALnetLabs/DoNotPanicPortfolioViewer/1.0/SANYALnetLabs.DoNotPanicPortfolioViewer.locale.en-US.yaml
+++ b/manifests/s/SANYALnetLabs/DoNotPanicPortfolioViewer/1.0/SANYALnetLabs.DoNotPanicPortfolioViewer.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# Created for the official DO NOT PANIC Portfolio Visualizer 1.0 release.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: SANYALnetLabs.DoNotPanicPortfolioViewer
+PackageVersion: 1.0
+PackageLocale: en-US
+Publisher: SANYALnet Labs
+PublisherUrl: https://github.com/tuklusan/DO-NOT-PANIC-PORTFOLIO-VISUALIZER
+PublisherSupportUrl: https://github.com/tuklusan/DO-NOT-PANIC-PORTFOLIO-VISUALIZER/issues
+PackageName: DO NOT PANIC PORTFOLIO VISUALIZER
+PackageUrl: https://github.com/tuklusan/DO-NOT-PANIC-PORTFOLIO-VISUALIZER
+License: SANYALnet Labs Non-Commercial License
+LicenseUrl: https://github.com/tuklusan/DO-NOT-PANIC-PORTFOLIO-VISUALIZER/blob/v1.0/LICENSE
+Copyright: Copyright (c) 2026 Supratim Sanyal of SANYALnet Labs. All rights reserved.
+ShortDescription: A cinematic Windows portfolio and stock-market visualizer with ticker tapes, graph cards, global markets, financial news, and rotating backgrounds.
+Description: DO NOT PANIC Portfolio Visualizer is an artistic, fullscreen-capable Windows financial dashboard featuring configurable stock and ETF ticker tapes, floating graph cards, macro indicators, global market information, RSS or optional AI-styled financial news, and rotating exchange or city backgrounds. Delayed market data is intended for education and entertainment only, not trading, financial planning, portfolio accounting, or dependable financial monitoring.
+Moniker: do-not-panic-portfolio-visualizer
+Tags:
+- dashboard
+- finance
+- financial-news
+- market
+- portfolio
+- stock-market
+- stocks
+- ticker
+ReleaseNotesUrl: https://github.com/tuklusan/DO-NOT-PANIC-PORTFOLIO-VISUALIZER/releases/tag/v1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/SANYALnetLabs/DoNotPanicPortfolioViewer/1.0/SANYALnetLabs.DoNotPanicPortfolioViewer.yaml
+++ b/manifests/s/SANYALnetLabs/DoNotPanicPortfolioViewer/1.0/SANYALnetLabs.DoNotPanicPortfolioViewer.yaml
@@ -1,0 +1,8 @@
+# Created for the official DO NOT PANIC Portfolio Visualizer 1.0 release.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: SANYALnetLabs.DoNotPanicPortfolioViewer
+PackageVersion: 1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Checklist

- [x] Signed the Contributor License Agreement (CLA)
- [x] Checked that there are no other open pull requests for this package version
- [x] This PR modifies one package version only
- [x] Validated locally with `winget validate --manifest <path>`
- [x] Confirmed the official 1.0 installer URL is publicly accessible
- [x] Confirmed the manifest SHA-256 matches the published release checksum

This supersedes the retired beta submission #396674. The 0.9.0-beta7 release asset was intentionally removed; this manifest points to the current non-prerelease 1.0 asset.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/401753)