### PR TITLE
New package: dcadolph.vamoose version 0.33.0

### DIFF
--- a/manifests/d/dcadolph/vamoose/0.33.0/dcadolph.vamoose.installer.yaml
+++ b/manifests/d/dcadolph/vamoose/0.33.0/dcadolph.vamoose.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: dcadolph.vamoose
+PackageVersion: 0.33.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: vamoose.exe
+  PortableCommandAlias: vamoose
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/dcadolph/vamoose/releases/download/v0.33.0/vamoose_0.33.0_Windows_x86_64.zip
+  InstallerSha256: 607391AA5CB5A3B3C193761404925038ED6C1A7AB7FB70EB06409978B6C1AD16
+- Architecture: arm64
+  InstallerUrl: https://github.com/dcadolph/vamoose/releases/download/v0.33.0/vamoose_0.33.0_Windows_arm64.zip
+  InstallerSha256: 872A39BA317615681E3368F00DD670AF8FEC6EC4075C0CAA778C0802DBD63161
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/d/dcadolph/vamoose/0.33.0/dcadolph.vamoose.locale.en-US.yaml
+++ b/manifests/d/dcadolph/vamoose/0.33.0/dcadolph.vamoose.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: dcadolph.vamoose
+PackageVersion: 0.33.0
+PackageLocale: en-US
+Publisher: dcadolph
+PublisherUrl: https://github.com/dcadolph
+PublisherSupportUrl: https://github.com/dcadolph/vamoose/issues
+PackageName: vamoose
+PackageUrl: https://vamoose.dev
+License: BUSL-1.1
+LicenseUrl: https://github.com/dcadolph/vamoose/blob/main/LICENSE
+ShortDescription: Calendar workflow engine for time off, approvals, and quick actions
+Description: vamoose books time off as a calendar hold, invites the manager to approve it, and advances the rest of the workflow on their reply. Workflows branch on outcomes, wait, recur on a schedule, notify Slack, email, or webhooks, and file leave in an HR system. Works over Microsoft Graph, Google Calendar, Apple iCloud, or any CalDAV host, and is drivable by AI agents over MCP.
+Moniker: vamoose
+Tags:
+- calendar
+- workflow
+- time-off
+- approvals
+- mcp
+ReleaseNotesUrl: https://github.com/dcadolph/vamoose/releases/tag/v0.33.0
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/d/dcadolph/vamoose/0.33.0/dcadolph.vamoose.yaml
+++ b/manifests/d/dcadolph/vamoose/0.33.0/dcadolph.vamoose.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: dcadolph.vamoose
+PackageVersion: 0.33.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

First submission of vamoose, a calendar workflow engine for time off, approvals, and quick actions. Portable zip installers for x64 and arm64, published from the project's release workflow at https://github.com/dcadolph/vamoose. Local winget validation was not run because this submission was prepared on macOS; the zips contain a single vamoose.exe at the archive root.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/401813)