### PR TITLE
New version: solpbc.Solstone version 0.2.10

### DIFF
--- a/manifests/s/solpbc/Solstone/0.2.10/solpbc.Solstone.installer.yaml
+++ b/manifests/s/solpbc/Solstone/0.2.10/solpbc.Solstone.installer.yaml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: solpbc.Solstone
+PackageVersion: 0.2.10
+MinimumOSVersion: 10.0.18362.0
+Scope: user
+InstallerType: exe
+InstallModes:
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: --silent
+  SilentWithProgress: --silent
+  InstallLocation: --installto "<INSTALLPATH>"
+  Log: --log "<LOGPATH>"
+UpgradeBehavior: install
+ProductCode: Solstone
+ReleaseDate: 2026-07-08
+# The Settings/About UI is a WebView2 surface; the app relies on the OS Evergreen
+# WebView2 runtime (not bundled). Declaring it lets winget resolve the runtime from
+# its own catalog first on the rare machine that lacks it (older Win10/LTSC/Server).
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Microsoft.EdgeWebView2Runtime
+# Correlation for `winget upgrade`: the app registers in Add/Remove Programs under
+# its Velopack --packTitle ("sol"), NOT the pack id ("Solstone"). Every field listed
+# here must match the real ARP entry or winget cannot correlate the installed app,
+# and upgrades go undetected. The 0.2.0 manifest said "Solstone" and could not.
+AppsAndFeaturesEntries:
+  - DisplayName: sol
+    ProductCode: Solstone
+InstallationMetadata:
+  DefaultInstallLocation: '%LocalAppData%\Solstone'
+Installers:
+  # x64: the Setup.exe stub is a 32-bit Velopack shim, but the application it
+  # installs (solstone-windows-app.exe) is PE32+ x86-64. Architecture describes the
+  # app's applicability, not the stub -- tools that sniff the stub guess x86. Do not
+  # let one "correct" this to x86.
+  - Architecture: x64
+    InstallerUrl: https://github.com/solpbc/solstone-windows/releases/download/v0.2.10/solstone-setup-0.2.10.exe
+    InstallerSha256: 276E7DB783C6E4FC5794A0057E20CFA44763DA94756DD7D17EE692DA309F123E
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/solpbc/Solstone/0.2.10/solpbc.Solstone.locale.en-US.yaml
+++ b/manifests/s/solpbc/Solstone/0.2.10/solpbc.Solstone.locale.en-US.yaml
@@ -1,0 +1,52 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+#
+# THIS IS THE PUBLISHED COPY. Editing it here is what ships it -- publish-winget.sh
+# renders this file into the winget-pkgs PR. (It did not used to: `komac update`
+# carried the last PUBLISHED version's copy forward and never read this directory,
+# so brand fixes made here sat unpublished for ten releases.)
+#
+# ReleaseNotes/ReleaseNotesUrl are NOT authored here -- publish-winget.sh derives
+# them per release from the CHANGELOG.md section and the release tag.
+
+PackageIdentifier: solpbc.Solstone
+PackageVersion: 0.2.10
+PackageLocale: en-US
+Publisher: sol pbc
+PublisherUrl: https://solpbc.org
+PublisherSupportUrl: https://support.solpbc.org
+PackageName: solstone
+PackageUrl: https://solstone.app
+License: AGPL-3.0-only
+LicenseUrl: https://github.com/solpbc/solstone-windows/blob/main/LICENSE
+Copyright: Copyright (c) 2026 sol pbc
+ShortDescription: sol for Windows, part of solstone — a per-user, non-elevated, tray-resident app that takes in your screen and system audio (plus the microphone when one is present) and keeps it in local, owner-controlled segments for your journal.
+Description: |-
+  solstone is an open-source, privacy-respecting way to collect and gain insight from your own
+  personal data. sol for Windows is a per-user, non-elevated, tray-resident app that takes in what
+  happens on your PC — screen and system audio, plus the microphone when one is present — and keeps
+  it in local, owner-controlled segments for your journal.
+
+  Everything stays yours: there is no analytics, telemetry, tracking, or crash reporting, and
+  nothing phones home. State is always earned — the app never shows 'on' unless it truly is.
+  Updates are delivered by the app itself.
+Moniker: solstone
+Tags:
+  - journal
+  - open-source
+  - personal-data
+  - privacy
+  - self-determination
+  - solstone
+ReleaseNotes: |-
+  Fixed
+
+  - sol's Windows taskbar and title bar icon now keeps a cream center behind the
+    mark, so the word stays readable on light, dark, and busy desktop backgrounds.
+  - when something needs attention, sol now gives you a restart action in the tray
+    and on the home pane instead of leaving recovery to a relaunch.
+  - privacy exclusions now show the state sol actually saved. changes wait for the
+    confirmed setting, failed saves roll back visibly, and Microsoft Store apps are
+    labeled as one shared entry.
+ReleaseNotesUrl: https://github.com/solpbc/solstone-windows/releases/tag/v0.2.10
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/solpbc/Solstone/0.2.10/solpbc.Solstone.yaml
+++ b/manifests/s/solpbc/Solstone/0.2.10/solpbc.Solstone.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: solpbc.Solstone
+PackageVersion: 0.2.10
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Version update for `solpbc.Solstone` to `0.2.10`, published by the package's own author (sol pbc).

Update from `0.2.0` (initial package, #392222). Upstream shipped ten releases since; this brings the manifest current.

- **Installer:** [`solstone-setup-0.2.10.exe`](https://github.com/solpbc/solstone-windows/releases/download/v0.2.10/solstone-setup-0.2.10.exe) from the [v0.2.10 release](https://github.com/solpbc/solstone-windows/releases/tag/v0.2.10) — the installer filename became version-stamped after 0.2.0.
- SHA256 computed over the published asset.

A few 0.2.0 fields were incorrect and are corrected in this version:

- **`AppsAndFeaturesEntries.DisplayName`: `Solstone` → `sol`** — the app's actual Add/Remove Programs entry (its Velopack `packTitle`). The old value could not correlate to the installed app, so `winget upgrade` would not detect it.
- **`Dependencies`: adds `Microsoft.EdgeWebView2Runtime`** — the Settings/About UI is a WebView2 surface; the Evergreen runtime is not bundled.
- **`PackageName` / `ShortDescription` / `Description` / `Tags`:** refreshed to the publisher's current product wording.
- **`ManifestVersion`: 1.9.0 → 1.12.0.**

`Architecture` remains `x64` as in 0.2.0: the Setup.exe stub is a 32-bit Velopack shim, but the application it installs (`solstone-windows-app.exe`) is PE32+ x86-64.

(Replaces #401803, which was created with a malformed tree and closed before validation picked it up.)

---
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`? *(authored on Linux — all three manifests validated against the 1.12.0 JSON schemas instead; the pipeline's sandbox validation is the authoritative gate)*
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?
