### PR TITLE
New package: AlbertDobmeyer.Superclean version 2.1.2

### DIFF
--- a/manifests/a/AlbertDobmeyer/Superclean/2.1.2/AlbertDobmeyer.Superclean.installer.yaml
+++ b/manifests/a/AlbertDobmeyer/Superclean/2.1.2/AlbertDobmeyer.Superclean.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: AlbertDobmeyer.Superclean
+PackageVersion: 2.1.2
+InstallerType: portable
+Commands:
+- superclean
+ReleaseDate: 2026-07-13
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/albertdobmeyer/superclean/releases/download/v2.1.2/superclean-2.1.2-windows-x64.exe
+  InstallerSha256: 08A60CD8C6978E12E2771735B4D141CFCCE17D4C9D9438546C605FABD1B56C2D
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/AlbertDobmeyer/Superclean/2.1.2/AlbertDobmeyer.Superclean.locale.en-US.yaml
+++ b/manifests/a/AlbertDobmeyer/Superclean/2.1.2/AlbertDobmeyer.Superclean.locale.en-US.yaml
@@ -1,0 +1,52 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: AlbertDobmeyer.Superclean
+PackageVersion: 2.1.2
+PackageLocale: en-US
+Publisher: Albert Dobmeyer
+PublisherUrl: https://github.com/albertdobmeyer
+PublisherSupportUrl: https://github.com/albertdobmeyer/superclean/issues
+Author: Albert Dobmeyer
+PackageName: superclean
+PackageUrl: https://github.com/albertdobmeyer/superclean
+License: MIT
+LicenseUrl: https://github.com/albertdobmeyer/superclean/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Albert Dobmeyer
+ShortDescription: A garbage collector for development machines. Reclaims RAM, VRAM, and disk left behind by heavy parallel development, without killing active editors, terminals, or AI tools.
+Description: |-
+  superclean reclaims the RAM, VRAM, and disk that heavy parallel development leaves
+  behind: dev servers orphaned when their parent shell died, models still resident in
+  GPU memory long after the last request, and package caches that grow without a ceiling.
+
+  The difficulty is that the garbage is hard to tell apart from the tools keeping a
+  session alive, since an orphaned dev server and an editor's language server are both,
+  to the operating system, just "node". superclean maintains a fail-closed protected set:
+  it shields editors, terminals, shells, AI coding tools and the Ollama daemon by name,
+  any process whose command line shows it belongs to an agent runtime, every descendant
+  of anything protected, and its own entire ancestor chain. Anything it cannot confidently
+  classify is treated as protected rather than as a target. Kills are re-validated against
+  the process start time immediately before signalling, so a recycled PID is skipped.
+
+  Cleanup escalates through five additive tiers (dust, sweep, scrub, wipe, nuke). Running
+  it with no arguments produces a read-only report and changes nothing; every tier accepts
+  a dry run, and the destructive tier requires typing a confirmation word.
+
+  This portable build is provided for winget. Python users may prefer to install from PyPI
+  with "uvx superclean-cli" or "pipx install superclean-cli".
+Moniker: superclean
+Tags:
+- cleanup
+- cli
+- developer-tools
+- disk-cleanup
+- garbage-collector
+- ollama
+- ram
+- system-maintenance
+- vram
+ReleaseNotesUrl: https://github.com/albertdobmeyer/superclean/releases/tag/v2.1.2
+Documentations:
+- DocumentLabel: Readme
+  DocumentUrl: https://github.com/albertdobmeyer/superclean#readme
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/AlbertDobmeyer/Superclean/2.1.2/AlbertDobmeyer.Superclean.yaml
+++ b/manifests/a/AlbertDobmeyer/Superclean/2.1.2/AlbertDobmeyer.Superclean.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: AlbertDobmeyer.Superclean
+PackageVersion: 2.1.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Package

**AlbertDobmeyer.Superclean 2.1.2** - a garbage collector for development machines.

It reclaims RAM, VRAM, and disk left behind by heavy parallel development (dev servers orphaned when their parent shell died, models still resident in GPU memory, package caches that grow without a ceiling) while maintaining a fail-closed protected set, so it never kills the user's active editors, terminals, shells, or AI tools.

Running it with no arguments produces a read-only report and changes nothing. Cleanup escalates through five additive tiers, every tier supports a dry run, and the destructive tier requires typing a confirmation word.

- Source: https://github.com/albertdobmeyer/superclean
- License: MIT
- I am the author and publisher of this package. This is a new package.

### Validation performed

I want to be precise about what was and was not checked, so a reviewer can calibrate.

**Done:**
- All three manifests validate against the official **1.12.0** JSON schemas (`version`, `installer`, `defaultLocale`).
- `InstallerSha256` verified by downloading the published asset from the `InstallerUrl` and recomputing: matches (`08A60CD8...B56C2D`, 9,213,994 bytes).
- The frozen binary was smoke-tested on Windows from outside its source tree (`--version`, `report`, `protected`, `init`, `sweep --dry-run`), which exercises its bundled data files.
- Windows Defender scan of the binary: no threats.

**Not done, in the interest of not overstating:**
- `winget validate` and `winget install --manifest` were **not** run: the winget client is not present on the machine these manifests were prepared on. Schema validation was performed directly against the published JSON schemas instead.
- If the CLA is not already on file for this account, I will sign it when the bot asks.

### Notes

- `InstallerType: portable`, a single self-contained x64 executable exposing a `superclean` command alias.
- The installer is **built in CI from the tagged commit** ([workflow](https://github.com/albertdobmeyer/superclean/blob/main/.github/workflows/binary.yml)) rather than uploaded from a developer machine, and a `.sha256` is published next to it on the release.
- The project's primary distribution is PyPI (`superclean-cli`, installable via `uvx`/`pipx`); this portable build exists specifically for users who install through winget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/401875)