### PR TITLE
New version: SeasaltAI.SeaMeetSnapRecorder version 3.4.0

### DIFF
--- a/manifests/s/SeasaltAI/SeaMeetSnapRecorder/3.4.0/SeasaltAI.SeaMeetSnapRecorder.installer.yaml
+++ b/manifests/s/SeasaltAI/SeaMeetSnapRecorder/3.4.0/SeasaltAI.SeaMeetSnapRecorder.installer.yaml
@@ -1,0 +1,12 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: SeasaltAI.SeaMeetSnapRecorder
+PackageVersion: 3.4.0
+InstallerType: nullsoft
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/seameet-ai/SeaMeet-Releases/releases/download/v3.4.0/SeaMeet-AudioScreenRecorder-Windows-x64-Setup-3.4.0.exe
+  InstallerSha256: CF5BBA0904071162D14430CA413E3EAD80A16BB67B676D9737A6F46745A50787
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/SeasaltAI/SeaMeetSnapRecorder/3.4.0/SeasaltAI.SeaMeetSnapRecorder.locale.en-US.yaml
+++ b/manifests/s/SeasaltAI/SeaMeetSnapRecorder/3.4.0/SeasaltAI.SeaMeetSnapRecorder.locale.en-US.yaml
@@ -1,0 +1,16 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: SeasaltAI.SeaMeetSnapRecorder
+PackageVersion: 3.4.0
+PackageLocale: en-US
+Publisher: Seasalt.ai
+PublisherUrl: https://seameet.ai
+PublisherSupportUrl: https://seameet.ai/en/contact/
+PackageName: SeaMeet Snap Recorder
+License: Seameet.ai license
+Copyright: Copyright © 2026 Seasalt.ai
+ShortDescription: 'SeaMeet: record screen and audio, take screenshot and OCR, and transcribe meetings.'
+Moniker: seameet
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/SeasaltAI/SeaMeetSnapRecorder/3.4.0/SeasaltAI.SeaMeetSnapRecorder.yaml
+++ b/manifests/s/SeasaltAI/SeaMeetSnapRecorder/3.4.0/SeasaltAI.SeaMeetSnapRecorder.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: SeasaltAI.SeaMeetSnapRecorder
+PackageVersion: 3.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Updates SeaMeet Snap Recorder (`SeasaltAI.SeaMeetSnapRecorder`) to version `3.4.0`.

Windows x64 installer:
`https://github.com/seameet-ai/SeaMeet-Releases/releases/download/v3.4.0/SeaMeet-AudioScreenRecorder-Windows-x64-Setup-3.4.0.exe`

SHA256:
`CF5BBA0904071162D14430CA413E3EAD80A16BB67B676D9737A6F46745A50787`

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)
  - Not applicable; this is a routine version update.

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/401894)
