### PR TITLE
[Tools] Manual Validation - Fix Credential Manager native memory handling

### DIFF
--- a/Tools/ManualValidation/ManualValidationPipeline.cs
+++ b/Tools/ManualValidation/ManualValidationPipeline.cs
@@ -3979,8 +3979,8 @@ bool ConnectionStatus = vm.Scope.IsConnected;
 		//Extend/reference CredWriteW as CredWrite.
 
 		[DllImport("Advapi32.dll", SetLastError = true, EntryPoint = "CredFree", CharSet = CharSet.Unicode)]
-		private static extern bool CredRelease([In] IntPtr credentialPtr);
-		//Extend/reference CredFree as CredWrite.
+		private static extern void CredRelease([In] IntPtr credentialPtr);
+		//Extend/reference CredFree as CredRelease.
 
 		public static Credential GetUserCredential(string target) {
 			CredentialMem credMem;
@@ -3993,9 +3993,8 @@ bool ConnectionStatus = vm.Scope.IsConnected;
 				//Copies data from an unmanaged memory pointer to a managed 8-bit unsigned integer array.
 				//
 				Credential cred = new Credential(credMem.targetName, credMem.userName, Encoding.Unicode.GetString(passwordBytes)); //Make a new Credential object cred.
-				//Original example doesn't include these:
+				//credentialBlob is an interior pointer into credPtr; the release above already frees it.
 				CredRelease(credPtr);
-				CredRelease(credMem.credentialBlob);
 				return cred;
 			} else {
 				throw new Exception("Failed to retrieve credentials");

--- a/Tools/ManualValidation/ManualValidationPipeline.cs
+++ b/Tools/ManualValidation/ManualValidationPipeline.cs
@@ -3986,16 +3986,17 @@ bool ConnectionStatus = vm.Scope.IsConnected;
 			CredentialMem credMem;
 			IntPtr credPtr;
 			if (CredRead(target, 1, 0, out credPtr)) { //If found, returns true and adds to credPtr, else false and error. 
-				credMem = Marshal.PtrToStructure<CredentialMem>(credPtr); 
-				//"Marshals data from an unmanaged block of memory to a newly allocated managed object of the type specified by a generic type parameter."
-				byte[] passwordBytes = new byte[credMem.credentialBlobSize]; //Make a new byte array passwordBytes of size credentialBlobSize.
-				Marshal.Copy(credMem.credentialBlob, passwordBytes, 0, credMem.credentialBlobSize); 
-				//Copies data from an unmanaged memory pointer to a managed 8-bit unsigned integer array.
-				//
-				Credential cred = new Credential(credMem.targetName, credMem.userName, Encoding.Unicode.GetString(passwordBytes)); //Make a new Credential object cred.
-				//credentialBlob is an interior pointer into credPtr; the release above already frees it.
-				CredRelease(credPtr);
-				return cred;
+				try {
+					credMem = Marshal.PtrToStructure<CredentialMem>(credPtr);
+					//"Marshals data from an unmanaged block of memory to a newly allocated managed object of the type specified by a generic type parameter."
+					byte[] passwordBytes = new byte[credMem.credentialBlobSize]; //Make a new byte array passwordBytes of size credentialBlobSize.
+					Marshal.Copy(credMem.credentialBlob, passwordBytes, 0, credMem.credentialBlobSize);
+					//Copies data from an unmanaged memory pointer to a managed 8-bit unsigned integer array.
+					return new Credential(credMem.targetName, credMem.userName, Encoding.Unicode.GetString(passwordBytes)); //Make a new Credential object cred.
+				} finally {
+					//credentialBlob is an interior pointer into credPtr; free the buffer once via CredFree.
+					if (credPtr != IntPtr.Zero) { CredRelease(credPtr); }
+				}
 			} else {
 				throw new Exception("Failed to retrieve credentials");
 			}
@@ -4013,11 +4014,14 @@ bool ConnectionStatus = vm.Scope.IsConnected;
 			userCredential.credentialBlobSize = (int)bpassword.Length;
 			userCredential.credentialBlob = Marshal.StringToCoTaskMemUni(password);
 			//If write fails, emit last error. 
-			if (!CredWrite(ref userCredential, 0)) {
-				throw new System.ComponentModel.Win32Exception(Marshal.GetLastWin32Error());
+			try {
+				if (!CredWrite(ref userCredential, 0)) {
+					throw new System.ComponentModel.Win32Exception(Marshal.GetLastWin32Error());
+				}
+			} finally {
+				//Match StringToCoTaskMemUni allocation with FreeCoTaskMem.
+				Marshal.FreeCoTaskMem(userCredential.credentialBlob);
 			}
-			//Original example doesn't include this. Was going to use FreeCoTaskMem as recommended, but this gave an error. 
-			Marshal.FreeCoTaskMem(userCredential.credentialBlob);
 		}
 
 		[StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]

--- a/Tools/ManualValidation/ManualValidationPipeline.ps1
+++ b/Tools/ManualValidation/ManualValidationPipeline.ps1
@@ -7431,6 +7431,10 @@ namespace CredManager {
 		private static extern bool CredRead(string target, int type, int reservedFlag, out IntPtr credentialPtr);
 		//Extend/reference CredReadW as CredRead.
 
+		[DllImport("Advapi32.dll", SetLastError = true, EntryPoint = "CredFree", CharSet = CharSet.Unicode)]
+		private static extern void CredRelease([In] IntPtr credentialPtr);
+		//Extend/reference CredFree as CredRelease.
+
 		public static Credential GetUserCredential(string target) {
 			CredentialMem credMem;
 			IntPtr credPtr;
@@ -7442,9 +7446,8 @@ namespace CredManager {
 				//Copies data from an unmanaged memory pointer to a managed 8-bit unsigned integer array.
 				//
 				Credential cred = new Credential(credMem.targetName, credMem.userName, Encoding.Unicode.GetString(passwordBytes)); //Make a new Credential object cred.
-				//Original example doesn't include these:
-				Marshal.FreeHGlobal(credPtr);
-				Marshal.FreeHGlobal(credMem.credentialBlob);
+				//credentialBlob is an interior pointer into credPtr; free the buffer once via CredFree.
+				CredRelease(credPtr);
 				return cred;
 			} else {
 				throw new Exception("Failed to retrieve credentials");
@@ -7470,8 +7473,8 @@ namespace CredManager {
 			if (!CredWrite(ref userCredential, 0)) {
 				throw new System.ComponentModel.Win32Exception(Marshal.GetLastWin32Error());
 			}
-			//Original example doesn't include this. Was going to use FreeCoTaskMem as recommended, but this gave an error. 
-			Marshal.FreeHGlobal(userCredential.credentialBlob);
+			//Match StringToCoTaskMemUni allocation with FreeCoTaskMem.
+			Marshal.FreeCoTaskMem(userCredential.credentialBlob);
 		}
 	}
 }

--- a/Tools/ManualValidation/ManualValidationPipeline.ps1
+++ b/Tools/ManualValidation/ManualValidationPipeline.ps1
@@ -7439,16 +7439,17 @@ namespace CredManager {
 			CredentialMem credMem;
 			IntPtr credPtr;
 			if (CredRead(target, 1, 0, out credPtr)) { //If found, returns true and adds to credPtr, else false and error. 
-				credMem = Marshal.PtrToStructure<CredentialMem>(credPtr); 
-				//"Marshals data from an unmanaged block of memory to a newly allocated managed object of the type specified by a generic type parameter."
-				byte[] passwordBytes = new byte[credMem.credentialBlobSize]; //Make a new byte array passwordBytes of size credentialBlobSize.
-				Marshal.Copy(credMem.credentialBlob, passwordBytes, 0, credMem.credentialBlobSize); 
-				//Copies data from an unmanaged memory pointer to a managed 8-bit unsigned integer array.
-				//
-				Credential cred = new Credential(credMem.targetName, credMem.userName, Encoding.Unicode.GetString(passwordBytes)); //Make a new Credential object cred.
-				//credentialBlob is an interior pointer into credPtr; free the buffer once via CredFree.
-				CredRelease(credPtr);
-				return cred;
+				try {
+					credMem = Marshal.PtrToStructure<CredentialMem>(credPtr);
+					//"Marshals data from an unmanaged block of memory to a newly allocated managed object of the type specified by a generic type parameter."
+					byte[] passwordBytes = new byte[credMem.credentialBlobSize]; //Make a new byte array passwordBytes of size credentialBlobSize.
+					Marshal.Copy(credMem.credentialBlob, passwordBytes, 0, credMem.credentialBlobSize);
+					//Copies data from an unmanaged memory pointer to a managed 8-bit unsigned integer array.
+					return new Credential(credMem.targetName, credMem.userName, Encoding.Unicode.GetString(passwordBytes)); //Make a new Credential object cred.
+				} finally {
+					//credentialBlob is an interior pointer into credPtr; free the buffer once via CredFree.
+					if (credPtr != IntPtr.Zero) { CredRelease(credPtr); }
+				}
 			} else {
 				throw new Exception("Failed to retrieve credentials");
 			}
@@ -7470,11 +7471,14 @@ namespace CredManager {
 			userCredential.credentialBlobSize = (int)bpassword.Length;
 			userCredential.credentialBlob = Marshal.StringToCoTaskMemUni(password);
 			//If write fails, emit last error. 
-			if (!CredWrite(ref userCredential, 0)) {
-				throw new System.ComponentModel.Win32Exception(Marshal.GetLastWin32Error());
+			try {
+				if (!CredWrite(ref userCredential, 0)) {
+					throw new System.ComponentModel.Win32Exception(Marshal.GetLastWin32Error());
+				}
+			} finally {
+				//Match StringToCoTaskMemUni allocation with FreeCoTaskMem.
+				Marshal.FreeCoTaskMem(userCredential.credentialBlob);
 			}
-			//Match StringToCoTaskMemUni allocation with FreeCoTaskMem.
-			Marshal.FreeCoTaskMem(userCredential.credentialBlob);
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Two follow-up fixes to the `CredManager.Util` helper added in #396900. Its `CredRead`/`CredWrite` buffers were released with mismatched allocators and only on the success path. This corrects the frees and makes them exception-safe. The same changes are applied to both the PowerShell embedded C# and the `.cs` mirror so the two stay in sync.

## Changes

- **Match allocators to APIs**: release the `CredRead` buffer with the `CredFree` API (via a new `CredRelease` P/Invoke) instead of `Marshal.FreeHGlobal`; remove the duplicate free of `credentialBlob`, which is an interior pointer into that same buffer rather than a separate allocation; free the write blob with `Marshal.FreeCoTaskMem` to match its `StringToCoTaskMemUni` allocation.
- **Correct P/Invoke signature**: declare `CredRelease` as `void` to match the native `CredFree`.
- **Always release once allocated**: wrap both methods in `try/finally` so the buffer is freed on both success and exception paths, and guard the raw `CredFree` call with a non-null check.

## How Validated

- The embedded C# compiles and loads on Windows PowerShell 5.1 and pwsh 7. A standalone round-trip (write, read back, verify the returned values) succeeds, and the not-found path returns cleanly.

## Context

- Follow-up to #396900, which introduced the Credential Manager helper.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/401901)