### PR TITLE
New package: Hoornet.Vega version 0.14.0

### DIFF
--- a/manifests/h/Hoornet/Vega/0.14.0/Hoornet.Vega.installer.yaml
+++ b/manifests/h/Hoornet/Vega/0.14.0/Hoornet.Vega.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: Hoornet.Vega
+PackageVersion: 0.14.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/hoornet/vega/releases/download/v0.14.0/Vega_0.14.0_x64-setup.exe
+  InstallerSha256: 11AE06B5FB904175029A5FB6009C0BE190F8AE240699D948C7B6F96DE3F469C3
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/h/Hoornet/Vega/0.14.0/Hoornet.Vega.locale.en-US.yaml
+++ b/manifests/h/Hoornet/Vega/0.14.0/Hoornet.Vega.locale.en-US.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: Hoornet.Vega
+PackageVersion: 0.14.0
+PackageLocale: en-US
+Publisher: Hoornet
+PublisherUrl: https://veganostr.com
+PublisherSupportUrl: https://github.com/hoornet/vega/issues
+Author: Hoornet
+PackageName: Vega
+PackageUrl: https://veganostr.com
+License: MIT
+LicenseUrl: https://raw.githubusercontent.com/hoornet/vega/main/LICENSE
+Copyright: Copyright (c) 2026 Jure Sršen
+ShortDescription: A cross-platform desktop client for Nostr
+Description: |-
+  Vega is a desktop client for Nostr, a decentralized social network protocol.
+  It is built with Tauri and React, and treats long-form writing and reading
+  (NIP-23) as a first-class feature rather than an afterthought.
+
+  Features:
+  - Long-form article editor and reader (NIP-23)
+  - Lightning zaps via Nostr Wallet Connect (NIP-47, NIP-57)
+  - Value-for-value podcast streaming
+  - Web of trust filtering
+  - Optional built-in relay, so your notes stay available locally
+  - Encrypted direct messages
+  - Private keys stored in the operating system keychain
+Tags:
+- nostr
+- social-network
+- decentralized
+- lightning
+- bitcoin
+- desktop-client
+ReleaseNotesUrl: https://github.com/hoornet/vega/releases/tag/v0.14.0
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/h/Hoornet/Vega/0.14.0/Hoornet.Vega.yaml
+++ b/manifests/h/Hoornet/Vega/0.14.0/Hoornet.Vega.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: Hoornet.Vega
+PackageVersion: 0.14.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
### Package
Hoornet.Vega version 0.14.0 — a new package.

Vega is an open-source (MIT) cross-platform desktop client for Nostr, a decentralized social network protocol. Long-form writing and reading (NIP-23) is a first-class feature, alongside Lightning zaps over Nostr Wallet Connect, value-for-value podcast streaming, and web-of-trust filtering.

- Homepage: https://veganostr.com
- Source: https://github.com/hoornet/vega
- Release: https://github.com/hoornet/vega/releases/tag/v0.14.0

### Checklist
- [x] Manifests validate against schema 1.10.0
- [x] Installer URL points at a GitHub release asset
- [x] `InstallerSha256` verified against the published installer
- [x] `InstallerType: nullsoft` (Tauri NSIS; supports silent install)
- [x] I am the package publisher

Note: the installer is not currently code-signed.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/402063)