### PR TITLE
New version: Clement.bottom version 0.14.4

### DIFF
--- a/manifests/c/Clement/bottom/0.14.4/Clement.bottom.installer.yaml
+++ b/manifests/c/Clement/bottom/0.14.4/Clement.bottom.installer.yaml
@@ -1,0 +1,39 @@
+# Created with WinGet Releaser using komac v2.14.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: Clement.bottom
+PackageVersion: 0.14.4
+InstallerLocale: en-US
+InstallerType: wix
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-07-09
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles%\bottom'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/ClementTsang/bottom/releases/download/0.14.4/bottom_x86_64_installer.msi
+  InstallerSha256: 3BC333EABD9D788FE40AF1CD322811B8DDDBA4B64D62E3A3489B4C0A0850E845
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+  ProductCode: '{6CC26C51-6AE6-47E4-998E-D329758B88E3}'
+  AppsAndFeaturesEntries:
+  - ProductCode: '{6CC26C51-6AE6-47E4-998E-D329758B88E3}'
+    UpgradeCode: '{3C90C27D-8372-4C82-B03C-020393CB983D}'
+- Architecture: arm64
+  InstallerUrl: https://github.com/ClementTsang/bottom/releases/download/0.14.4/bottom_aarch64_installer.msi
+  InstallerSha256: 997DE2F244FFEE6600073F461CDA2B73EF587A9832C63E0C49D0A52E0C90C08A
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.arm64
+  ProductCode: '{53418DCA-D70C-4B33-B277-4D65A225ED5A}'
+  AppsAndFeaturesEntries:
+  - ProductCode: '{53418DCA-D70C-4B33-B277-4D65A225ED5A}'
+    UpgradeCode: '{3C90C27D-8372-4C82-B03C-020393CB983D}'
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/c/Clement/bottom/0.14.4/Clement.bottom.locale.en-US.yaml
+++ b/manifests/c/Clement/bottom/0.14.4/Clement.bottom.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# Created with WinGet Releaser using komac v2.14.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: Clement.bottom
+PackageVersion: 0.14.4
+PackageLocale: en-US
+Publisher: Clement Tsang
+PublisherUrl: https://github.com/ClementTsang/bottom
+PublisherSupportUrl: https://github.com/ClementTsang/bottom/issues
+Author: Clement Tsang
+PackageName: bottom
+PackageUrl: https://github.com/ClementTsang/bottom
+License: MIT
+LicenseUrl: https://github.com/ClementTsang/bottom/blob/HEAD/LICENSE
+Copyright: Copyright (c) 2019 Clement Tsang
+CopyrightUrl: https://raw.githubusercontent.com/ClementTsang/bottom/master/LICENSE
+ShortDescription: Yet another cross-platform graphical process/system monitor.
+Moniker: bottom
+Tags:
+- monitoring
+- terminal
+- tui
+ReleaseNotes: |-
+  Small release to fix a bug regarding process columns in the config, and the quit hotkey if one was pressing Shift or using Caps Lock on certain platforms.
+  Bug Fixes
+  - #2131: Fix the config not accepting Memory, Memory%, Total Read, and Total Write process column aliases that the config schema advertised (thanks @upuddu).
+  - #2132: Fix 'Q' not working as a quit shortcut.
+  Full Changelog: 0.14.3...0.14.4
+ReleaseNotesUrl: https://github.com/ClementTsang/bottom/releases/tag/0.14.4
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/c/Clement/bottom/0.14.4/Clement.bottom.yaml
+++ b/manifests/c/Clement/bottom/0.14.4/Clement.bottom.yaml
@@ -1,0 +1,8 @@
+# Created with WinGet Releaser using komac v2.14.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: Clement.bottom
+PackageVersion: 0.14.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Summary
- New version: Clement.bottom 0.14.4
- Upstream release: https://github.com/ClementTsang/bottom/releases/tag/0.14.4
- winget currently at 0.14.3; no open PR for 0.14.4 found

## Evidence
- Installers:
  - https://github.com/ClementTsang/bottom/releases/download/0.14.4/bottom_x86_64_installer.msi
  - https://github.com/ClementTsang/bottom/releases/download/0.14.4/bottom_aarch64_installer.msi
- SHA256 x64: `3BC333EABD9D788FE40AF1CD322811B8DDDBA4B64D62E3A3489B4C0A0850E845`
- SHA256 arm64: `997DE2F244FFEE6600073F461CDA2B73EF587A9832C63E0C49D0A52E0C90C08A`
- ProductCode x64: `{6CC26C51-6AE6-47E4-998E-D329758B88E3}`
- ProductCode arm64: `{53418DCA-D70C-4B33-B277-4D65A225ED5A}`
- UpgradeCode unchanged: `{3C90C27D-8372-4C82-B03C-020393CB983D}`

## Test plan
- [ ] WinGet CI validation
- [ ] Installer URL/hash checks
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/402113)