### PR TITLE
New version: bgreenwell.GitEgo version 0.2.2

### DIFF
--- a/manifests/b/bgreenwell/GitEgo/0.2.2/bgreenwell.GitEgo.installer.yaml
+++ b/manifests/b/bgreenwell/GitEgo/0.2.2/bgreenwell.GitEgo.installer.yaml
@@ -1,0 +1,27 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: bgreenwell.GitEgo
+PackageVersion: 0.2.2
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: git-ego.exe
+  PortableCommandAlias: git-ego
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Commands:
+- git-ego
+ReleaseDate: 2026-07-14
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/bgreenwell/git-ego/releases/download/v0.2.2/git-ego-v0.2.2-windows-x86_64.zip
+  InstallerSha256: 4C722B2A5FA3900CF35900EC1E8494DA12AFA0DD39BA68C5CCED9CE5ECD2D894
+- Architecture: arm64
+  InstallerUrl: https://github.com/bgreenwell/git-ego/releases/download/v0.2.2/git-ego-v0.2.2-windows-arm64.zip
+  InstallerSha256: 967C073692D0789D8D65B3552CBFE17A588D0A2C07F851B7E2DF480EE0FA2456
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/b/bgreenwell/GitEgo/0.2.2/bgreenwell.GitEgo.locale.en-US.yaml
+++ b/manifests/b/bgreenwell/GitEgo/0.2.2/bgreenwell.GitEgo.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: bgreenwell.GitEgo
+PackageVersion: 0.2.2
+PackageLocale: en-US
+Publisher: bgreenwell
+PublisherUrl: https://github.com/bgreenwell
+PublisherSupportUrl: https://github.com/bgreenwell/git-ego/issues
+Author: Brandon Greenwell
+PackageName: git-ego
+PackageUrl: https://github.com/bgreenwell/git-ego
+License: MIT
+LicenseUrl: https://github.com/bgreenwell/git-ego/blob/v0.2.2/LICENSE
+Copyright: Copyright (c) 2025 Brandon Greenwell
+CopyrightUrl: https://github.com/bgreenwell/git-ego/blob/v0.2.2/LICENSE
+ShortDescription: Git identity manager
+Description: Manage multiple Git identities with directory-based profile switching.
+Moniker: git-ego
+ReleaseNotes: 'Full Changelog: v0.2.1...v0.2.2'
+ReleaseNotesUrl: https://github.com/bgreenwell/git-ego/releases/tag/v0.2.2
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/b/bgreenwell/GitEgo/0.2.2/bgreenwell.GitEgo.yaml
+++ b/manifests/b/bgreenwell/GitEgo/0.2.2/bgreenwell.GitEgo.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: bgreenwell.GitEgo
+PackageVersion: 0.2.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Initial manifest submission for git-ego 0.2.2. Includes x64 and ARM64 portable ZIP installers from the upstream GitHub release.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/402222)