### PR TITLE
New version: SerZhyAle.FastMediaSorter version 26.7.14.1801

### DIFF
--- a/manifests/s/SerZhyAle/FastMediaSorter/26.7.14.1801/SerZhyAle.FastMediaSorter.installer.yaml
+++ b/manifests/s/SerZhyAle/FastMediaSorter/26.7.14.1801/SerZhyAle.FastMediaSorter.installer.yaml
@@ -1,0 +1,16 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: SerZhyAle.FastMediaSorter
+PackageVersion: 26.7.14.1801
+InstallerType: inno
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/SerZhyAle/FastMediaSorter_Lite/releases/download/v26.7.14.1801/FastMediaSorter-26.7.14.1801-windows-x64-setup.exe
+  InstallerSha256: E92AA33ED4509250E7945AC03A16FCE89EB44F8A4288B583C435380776553D8A
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-07-14

--- a/manifests/s/SerZhyAle/FastMediaSorter/26.7.14.1801/SerZhyAle.FastMediaSorter.locale.en-US.yaml
+++ b/manifests/s/SerZhyAle/FastMediaSorter/26.7.14.1801/SerZhyAle.FastMediaSorter.locale.en-US.yaml
@@ -1,0 +1,44 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: SerZhyAle.FastMediaSorter
+PackageVersion: 26.7.14.1801
+PackageLocale: en-US
+Publisher: SZA
+PublisherUrl: https://github.com/SerZhyAle
+PublisherSupportUrl: https://github.com/SerZhyAle/FastMediaSorter_Lite/issues
+Author: Serhii Zhyhunenko
+PackageName: FastMediaSorter LITE
+PackageUrl: https://github.com/SerZhyAle/FastMediaSorter_Lite
+License: MIT
+LicenseUrl: https://github.com/SerZhyAle/FastMediaSorter_Lite/blob/main/LICENSE
+Copyright: Copyright (c) 2025 SZA
+ShortDescription: Lightweight Windows utility for fast sorting of images and videos with hotkeys.
+Description: |-
+  FastMediaSorter LITE is a Windows Forms application for quickly sorting, viewing, and managing
+  image and video files. It supports a wide range of media formats, slideshow and random viewing
+  modes, recent files tracking, and fast move/copy/rename/delete operations bound to hotkeys —
+  designed for photographers and content creators who triage large folders of media efficiently.
+Moniker: fastmediasorter
+Tags:
+- file-manager
+- hotkeys
+- images
+- media
+- organizer
+- photos
+- pictures
+- portable
+- slideshow
+- sorter
+- triage
+- utility
+- videos
+- viewer
+- winforms
+ReleaseNotesUrl: https://github.com/SerZhyAle/FastMediaSorter_Lite/releases/tag/v26.7.14.1801
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/SerZhyAle/FastMediaSorter_Lite/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/SerZhyAle/FastMediaSorter/26.7.14.1801/SerZhyAle.FastMediaSorter.yaml
+++ b/manifests/s/SerZhyAle/FastMediaSorter/26.7.14.1801/SerZhyAle.FastMediaSorter.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: SerZhyAle.FastMediaSorter
+PackageVersion: 26.7.14.1801
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Update **SerZhyAle.FastMediaSorter** to **26.7.14.1801**.

This release moves the Android Folder Share feature into a bundled companion app ("Fast Media Sorter: Share Manager") and adds local SFTP connection statistics. The installer now also lays down the Share Manager exe and the SFTP worker alongside the viewer.

- Release: https://github.com/SerZhyAle/FastMediaSorter_Lite/releases/tag/v26.7.14.1801
- Changelog: https://github.com/SerZhyAle/FastMediaSorter_Lite/blob/main/CHANGELOG.md

Installer shape is unchanged from prior accepted versions: direct Inno `setup.exe` (`InstallerType: inno`), no declared dependencies, no `Scope`. Only the version and installer SHA256 changed.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
