### PR TITLE
New version: AbdulazizJHK.ZoomToolkit version 2.1.0

### DIFF
--- a/manifests/a/AbdulazizJHK/ZoomToolkit/2.1.0/AbdulazizJHK.ZoomToolkit.installer.yaml
+++ b/manifests/a/AbdulazizJHK/ZoomToolkit/2.1.0/AbdulazizJHK.ZoomToolkit.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: AbdulazizJHK.ZoomToolkit
+PackageVersion: 2.1.0
+InstallerType: portable
+Commands:
+- zoom-toolkit
+ReleaseDate: 2026-07-14
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/AbdulazizJHK/zoom-toolkit/releases/download/v2.1.0/Zoom.Toolkit.exe
+  InstallerSha256: 48750164D673D8F0C835852A93680E872320EAF38DBAE80233EA767797A8E7A8
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/a/AbdulazizJHK/ZoomToolkit/2.1.0/AbdulazizJHK.ZoomToolkit.locale.en-US.yaml
+++ b/manifests/a/AbdulazizJHK/ZoomToolkit/2.1.0/AbdulazizJHK.ZoomToolkit.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: AbdulazizJHK.ZoomToolkit
+PackageVersion: 2.1.0
+PackageLocale: en-US
+Publisher: AbdulazizJHK
+PublisherUrl: https://github.com/AbdulazizJHK
+PublisherSupportUrl: https://github.com/AbdulazizJHK/zoom-toolkit/issues
+Author: AbdulazizJHK
+PackageName: Zoom Toolkit
+PackageUrl: https://github.com/AbdulazizJHK/zoom-toolkit
+License: MIT
+LicenseUrl: https://github.com/AbdulazizJHK/zoom-toolkit/blob/main/LICENSE
+Copyright: Copyright (c) 2026 AbdulazizJHK
+ShortDescription: Extract, clean, and date-sort audio from Zoom field recorders.
+Description: >-
+  Zoom Toolkit is a bilingual (English / Arabic) desktop app for managing audio
+  recordings from Zoom field recorders. It extracts files from SD-card folder
+  structures into one directory, removes accidental short clips, and organizes
+  recordings into date-based folders. Features Gregorian and Hijri calendars,
+  drag-and-drop, dry-run previews, and a dark "Field Console" interface.
+Moniker: zoom-toolkit
+Tags:
+- arabic
+- audio
+- field-recorder
+- recording
+- utility
+- zoom
+ReleaseNotesUrl: https://github.com/AbdulazizJHK/zoom-toolkit/releases/tag/v2.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/a/AbdulazizJHK/ZoomToolkit/2.1.0/AbdulazizJHK.ZoomToolkit.yaml
+++ b/manifests/a/AbdulazizJHK/ZoomToolkit/2.1.0/AbdulazizJHK.ZoomToolkit.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: AbdulazizJHK.ZoomToolkit
+PackageVersion: 2.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New version: AbdulazizJHK.ZoomToolkit 2.1.0

Update of Zoom Toolkit from 2.0.0 to 2.1.0.

Notable changes in this release:
- Fixes the window resize drift on scaled displays reported by @stephengillie during the 2.0.0 review ([comment](https://github.com/microsoft/winget-pkgs/pull/392296#issuecomment-4972101984)) — the exe now declares PerMonitorV2 DPI awareness in its embedded manifest.
- New custom dark title bar with in-app window controls (native drag, Snap and taskbar behavior preserved).
- Assorted UI/usability improvements (editable path fields, consistent layout, drag-and-drop hints, bilingual).

- Release: https://github.com/AbdulazizJHK/zoom-toolkit/releases/tag/v2.1.0
- Installer type: portable (standalone x64 executable)

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] This manifest was validated locally with `winget validate`.
- [x] I have ensured the manifest matches the installer published in the linked release (SHA256 verified).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/402458)