### PR TITLE
New package: iLoveVideoEditor.CLI version 1.0.0

### DIFF
--- a/manifests/i/iLoveVideoEditor/CLI/1.0.0/iLoveVideoEditor.CLI.installer.yaml
+++ b/manifests/i/iLoveVideoEditor/CLI/1.0.0/iLoveVideoEditor.CLI.installer.yaml
@@ -1,0 +1,11 @@
+PackageIdentifier: iLoveVideoEditor.CLI
+PackageVersion: 1.0.0
+InstallerType: portable
+Commands:
+  - ilovevideoeditor
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/ilovevideoeditor/cli/releases/download/v1.0.0/ilovevideoeditor-windows-x64.exe
+    InstallerSha256: FBC2ABB9F5273D968E5F072D8D2FD7D54F77FFFCC475072119762FD46C1D515F
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/i/iLoveVideoEditor/CLI/1.0.0/iLoveVideoEditor.CLI.installer.yaml
+++ b/manifests/i/iLoveVideoEditor/CLI/1.0.0/iLoveVideoEditor.CLI.installer.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
 PackageIdentifier: iLoveVideoEditor.CLI
 PackageVersion: 1.0.0
 InstallerType: portable

--- a/manifests/i/iLoveVideoEditor/CLI/1.0.0/iLoveVideoEditor.CLI.locale.en-US.yaml
+++ b/manifests/i/iLoveVideoEditor/CLI/1.0.0/iLoveVideoEditor.CLI.locale.en-US.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
 PackageIdentifier: iLoveVideoEditor.CLI
 PackageVersion: 1.0.0
 PackageLocale: en-US

--- a/manifests/i/iLoveVideoEditor/CLI/1.0.0/iLoveVideoEditor.CLI.locale.en-US.yaml
+++ b/manifests/i/iLoveVideoEditor/CLI/1.0.0/iLoveVideoEditor.CLI.locale.en-US.yaml
@@ -1,0 +1,21 @@
+PackageIdentifier: iLoveVideoEditor.CLI
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: iLoveVideoEditor
+PublisherUrl: https://ilovevideoeditor.com
+PackageName: iLoveVideoEditor CLI
+PackageUrl: https://github.com/ilovevideoeditor/cli
+License: MIT
+LicenseUrl: https://github.com/ilovevideoeditor/cli/blob/main/LICENSE
+Moniker: ilovevideoeditor
+ShortDescription: Render videos from VideoJSON specs in your terminal or CI
+Description: Official CLI for iLoveVideoEditor — queue video renders from VideoJSON specs, check render status, estimate credit cost and list the 249+ public templates. Requires an API key from the iLoveVideoEditor dashboard.
+Tags:
+  - video
+  - video-rendering
+  - video-api
+  - video-generation
+  - cli
+  - ci-cd
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/i/iLoveVideoEditor/CLI/1.0.0/iLoveVideoEditor.CLI.yaml
+++ b/manifests/i/iLoveVideoEditor/CLI/1.0.0/iLoveVideoEditor.CLI.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: iLoveVideoEditor.CLI
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0

--- a/manifests/i/iLoveVideoEditor/CLI/1.0.0/iLoveVideoEditor.CLI.yaml
+++ b/manifests/i/iLoveVideoEditor/CLI/1.0.0/iLoveVideoEditor.CLI.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
 PackageIdentifier: iLoveVideoEditor.CLI
 PackageVersion: 1.0.0
 DefaultLocale: en-US


### PR DESCRIPTION
## Description

New package: **iLoveVideoEditor CLI** — render videos from VideoJSON specs in your terminal or CI.

- Publisher: https://ilovevideoeditor.com
- Package repository: https://github.com/ilovevideoeditor/cli
- Installer: portable x64 executable published on the project's GitHub Releases (compiled from the tagged source with Bun)
- License: MIT

The manifest follows the 1.9.0 schema; `ilovevideoeditor` is exposed as the portable command/moniker so `winget install ilovevideoeditor` resolves.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/402460)