### PR TITLE
New version: cadwal.BookDB version 2.3.0

### DIFF
--- a/manifests/c/cadwal/BookDB/2.3.0/cadwal.BookDB.installer.yaml
+++ b/manifests/c/cadwal/BookDB/2.3.0/cadwal.BookDB.installer.yaml
@@ -1,0 +1,26 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: cadwal.BookDB
+PackageVersion: 2.3.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: BookDB.Desktop.exe
+  PortableCommandAlias: bookdb
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.DotNet.Runtime.10
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/cadwal/BookDB/releases/download/v2.3.0/BookDB-v2.3.0-win-x64-fdd.zip
+  InstallerSha256: AE4F0B39D0EA634F8E1AF959E028DB20C30070F0113C4B346E20A81E7A0BC1D0
+- Architecture: arm64
+  InstallerUrl: https://github.com/cadwal/BookDB/releases/download/v2.3.0/BookDB-v2.3.0-win-arm64-fdd.zip
+  InstallerSha256: F87CE64CFBE329C093F339EB8A79AAA2615FE3981EC4B6C13B76707269470BC5
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-07-14

--- a/manifests/c/cadwal/BookDB/2.3.0/cadwal.BookDB.locale.en-US.yaml
+++ b/manifests/c/cadwal/BookDB/2.3.0/cadwal.BookDB.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: cadwal.BookDB
+PackageVersion: 2.3.0
+PackageLocale: en-US
+Publisher: cadwal
+PublisherUrl: https://github.com/cadwal
+PublisherSupportUrl: https://github.com/cadwal/BookDB/issues
+PackageName: BookDB
+PackageUrl: https://github.com/cadwal/BookDB
+License: MIT
+ShortDescription: A personal book catalog for Windows
+Description: A book catalog database for personal collections. Can import data from Readerware 4.
+Tags:
+- books
+- catalog
+- library
+ReleaseNotesUrl: https://github.com/cadwal/BookDB/releases/tag/v2.3.0
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/cadwal/BookDB/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/cadwal/BookDB/2.3.0/cadwal.BookDB.yaml
+++ b/manifests/c/cadwal/BookDB/2.3.0/cadwal.BookDB.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: cadwal.BookDB
+PackageVersion: 2.3.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Version bump of **cadwal.BookDB** to **2.3.0** (x64 + arm64 framework-dependent installers), generated with wingetcreate. Release notes: https://github.com/cadwal/BookDB/releases/tag/v2.3.0

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/402465)