### PR TITLE
New version: JairLima.MDWord version 0.1.1

### DIFF
--- a/manifests/j/JairLima/MDWord/0.1.1/JairLima.MDWord.installer.yaml
+++ b/manifests/j/JairLima/MDWord/0.1.1/JairLima.MDWord.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: JairLima.MDWord
+PackageVersion: 0.1.1
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/jairslima/mdword-by-jair-lima/releases/download/v0.1.1/MDWord-0.1.1-Setup.exe
+    InstallerSha256: 26C379942561335516426219366AA04EE9F27B111FECBAD3A022AFE58D258B6E
+    InstallerSwitches:
+      Silent: "/S"
+      SilentWithProgress: "/S"
+FileExtensions:
+  - md
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/j/JairLima/MDWord/0.1.1/JairLima.MDWord.locale.en-US.yaml
+++ b/manifests/j/JairLima/MDWord/0.1.1/JairLima.MDWord.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: JairLima.MDWord
+PackageVersion: 0.1.1
+PackageLocale: en-US
+Publisher: Jair Lima
+PublisherUrl: https://github.com/jairslima
+PublisherSupportUrl: https://github.com/jairslima/mdword-by-jair-lima/issues
+PackageName: MDWord by Jair Lima
+PackageUrl: https://github.com/jairslima/mdword-by-jair-lima
+License: MIT
+LicenseUrl: https://github.com/jairslima/mdword-by-jair-lima/blob/master/LICENSE
+Copyright: Copyright (c) 2026 Jair Lima
+ShortDescription: WYSIWYG Markdown editor with a WordPad-inspired interface
+Description: >-
+  MDWord is a visual Markdown editor built with Electron and a WordPad-style
+  interface. It supports opening, editing, saving, importing and exporting
+  .md files with full WYSIWYG rendering, formatted paste of Markdown content,
+  DOCX/PDF import and export, and scanned PDF OCR. The interface is in
+  Brazilian Portuguese.
+Moniker: mdword
+Tags:
+  - markdown
+  - editor
+  - wysiwyg
+  - writing
+  - docx
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/j/JairLima/MDWord/0.1.1/JairLima.MDWord.yaml
+++ b/manifests/j/JairLima/MDWord/0.1.1/JairLima.MDWord.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: JairLima.MDWord
+PackageVersion: 0.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary

- New package: MDWord by Jair Lima
- Version: 0.1.1
- WYSIWYG Markdown editor (Electron) with a WordPad-inspired interface, formatted Markdown paste, DOCX/PDF import/export, and PDF OCR.
- Installer: NSIS, unattended (`/S`) install verified locally with `winget install --manifest`.
- Source: https://github.com/jairslima/mdword-by-jair-lima
- Release: https://github.com/jairslima/mdword-by-jair-lima/releases/tag/v0.1.1

## Checklist

- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)? (pending automated CLA bot check on this PR)
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

## Notes

Installer is currently unsigned (no Authenticode certificate); Windows SmartScreen may show an "unknown publisher" warning on first run. This does not block installation.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/402513)