### PR TITLE
New version: Coreho.nudl version 0.1.1

### DIFF
--- a/manifests/c/Coreho/nudl/0.1.1/Coreho.nudl.installer.yaml
+++ b/manifests/c/Coreho/nudl/0.1.1/Coreho.nudl.installer.yaml
@@ -1,0 +1,18 @@
+# nudl ships as a PyInstaller --onedir tree (nudl.exe + an _internal folder of
+# dependencies) inside a zip, not a single portable exe. "zip" + NestedInstallerType
+# "portable" is the pattern winget-pkgs uses for that shape: the whole archive is
+# extracted into the install dir, and only the named file is symlinked onto PATH, so
+# nudl.exe keeps _internal beside it.
+PackageIdentifier: Coreho.nudl
+PackageVersion: 0.1.1
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: nudl.exe
+    PortableCommandAlias: nudl
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Coreho/nudl/releases/download/v0.1.1/nudl-0.1.1-win64.zip
+    InstallerSha256: 483022d53020774517532fff2cdad4e34bd3564487cf57b36ba71bf61ef9cf5a
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/c/Coreho/nudl/0.1.1/Coreho.nudl.locale.en-US.yaml
+++ b/manifests/c/Coreho/nudl/0.1.1/Coreho.nudl.locale.en-US.yaml
@@ -1,0 +1,23 @@
+PackageIdentifier: Coreho.nudl
+PackageVersion: 0.1.1
+PackageLocale: en-US
+Publisher: Coreho
+PublisherUrl: https://github.com/Coreho
+PackageName: nudl
+PackageUrl: https://github.com/Coreho/nudl
+License: MIT
+LicenseUrl: https://github.com/Coreho/nudl/blob/master/LICENSE
+ShortDescription: Strips tracking junk off any link you copy — the same real URL, trimmed.
+Description: >-
+  nudl strips tracking parameters off URLs you copy — in Slack, Discord, a terminal, a
+  doc, your browser, anywhere — and hands back the same real link, trimmed. It is not a
+  URL shortener: no alias, no server, no redirect. It makes zero network calls, keeps a
+  local audit log of every change, and can undo any edit within three seconds.
+Tags:
+  - url
+  - privacy
+  - clipboard
+  - tracking
+  - utm
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/c/Coreho/nudl/0.1.1/Coreho.nudl.yaml
+++ b/manifests/c/Coreho/nudl/0.1.1/Coreho.nudl.yaml
@@ -1,0 +1,7 @@
+# Created for winget-pkgs submission (github.com/microsoft/winget-pkgs).
+# Mirrors scoop/nudl.json — bump alongside it on every release.
+PackageIdentifier: Coreho.nudl
+PackageVersion: 0.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
nudl strips tracking parameters off URLs you copy — no network calls, local audit log, undo within three seconds.

- Homepage: https://github.com/Coreho/nudl
- Release: https://github.com/Coreho/nudl/releases/tag/v0.1.1
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/402572)