### PR TITLE
New package: EvilHumphrey.LegendCTL version 2.6.0

### DIFF
--- a/manifests/e/EvilHumphrey/LegendCTL/2.6.0/EvilHumphrey.LegendCTL.installer.yaml
+++ b/manifests/e/EvilHumphrey/LegendCTL/2.6.0/EvilHumphrey.LegendCTL.installer.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: EvilHumphrey.LegendCTL
+PackageVersion: 2.6.0
+InstallerLocale: en-US
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: inno
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART
+UpgradeBehavior: install
+ProductCode: '{ZDUltimateLegend}_is1'
+ReleaseDate: 2026-07-12
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/EvilHumphrey/LegendCTL/releases/download/v2.6.0/ZDUltimateLegend-v2.6.0-Setup.exe
+    InstallerSha256: 5101D9D7DBD3BF27298E752D2F59F8AAED7C6BA7A3322D5C4C386EB9AC1F056F
+    AppsAndFeaturesEntries:
+      - DisplayName: ZD Ultimate Legend Wrapper
+        Publisher: EvilHumphrey
+        ProductCode: '{ZDUltimateLegend}_is1'
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/e/EvilHumphrey/LegendCTL/2.6.0/EvilHumphrey.LegendCTL.locale.en-US.yaml
+++ b/manifests/e/EvilHumphrey/LegendCTL/2.6.0/EvilHumphrey.LegendCTL.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: EvilHumphrey.LegendCTL
+PackageVersion: 2.6.0
+PackageLocale: en-US
+Publisher: EvilHumphrey
+PublisherUrl: https://github.com/EvilHumphrey
+PublisherSupportUrl: https://github.com/EvilHumphrey/LegendCTL/issues
+PackageName: LegendCTL
+PackageUrl: https://github.com/EvilHumphrey/LegendCTL
+License: MIT
+LicenseUrl: https://github.com/EvilHumphrey/LegendCTL/blob/v2.6.0/LICENSE
+Copyright: Copyright (c) 2026 EvilHumphrey
+ShortDescription: Standalone, unofficial Windows configurator for ZD Ultimate Legend controllers. Reads and applies controller settings locally; no official app required.
+Description: >-
+  LegendCTL is a lightweight, local Windows application for reading and applying
+  supported settings on ZD Ultimate Legend controllers directly over USB/HID. It
+  is an independent, standalone tool that does not require the official ZD Gaming
+  app, and it makes no network calls, installs no drivers, and runs no background
+  service. Configure USB polling rate, the button-binding matrix, stick deadzones
+  and sensitivity curves, axis inversion, triggers, per-zone lighting, vibration,
+  and back-paddle bindings, then save them as reusable profiles that persist
+  across sessions. Restore Points and the vendor "Restore to default" path give
+  you a clear way back if a controller ever feels off.
+Moniker: legendctl
+Tags:
+  - configurator
+  - controller
+  - gamepad
+  - xinput
+  - zd
+ReleaseNotesUrl: https://github.com/EvilHumphrey/LegendCTL/releases/tag/v2.6.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/e/EvilHumphrey/LegendCTL/2.6.0/EvilHumphrey.LegendCTL.yaml
+++ b/manifests/e/EvilHumphrey/LegendCTL/2.6.0/EvilHumphrey.LegendCTL.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: EvilHumphrey.LegendCTL
+PackageVersion: 2.6.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New package: EvilHumphrey.LegendCTL version 2.6.0

Current-version submission of **LegendCTL 2.6.0**.

Supersedes #394957 (closed unmerged) — that PR passed validation but lists v2.1.0, now several releases behind. This lands the current version instead.

- Built from the metadata that passed validation in #394957, updated to the **1.12 schema** and current authoring guidance (redundant `DisplayVersion`/`InstallerType` omitted; root-level `ProductCode` added; `LicenseUrl`/`ReleaseNotesUrl` pinned to the `v2.6.0` tag).
- `winget validate` passes.
- `InstallerSha256` matches the hash published in the release's `SHA256SUMS.txt`.
- Installer: Inno Setup, machine scope, silent switches included. Portable ZIP intentionally omitted from this first listing.

---

- [x] Have you signed the [Contributor License Agreement](https://opensource.microsoft.com/cla/)? (accepted 2026-06-30)
- [x] Have you checked that there aren't other open pull requests for the same manifest? (superseded #394957 is now closed)
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? (deferred to the validation pipeline's sandboxed install)
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/402609)