### PR TITLE
New package: Cycl0o0.OpenDeezer version 3.1.4

### DIFF
--- a/manifests/c/Cycl0o0/OpenDeezer/3.1.4/Cycl0o0.OpenDeezer.installer.yaml
+++ b/manifests/c/Cycl0o0/OpenDeezer/3.1.4/Cycl0o0.OpenDeezer.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Cycl0o0.OpenDeezer
+PackageVersion: 3.1.4
+InstallerType: portable
+Commands:
+  - opendeezer
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Cycl0o0/OpenDeezer/releases/download/v3.1.4/opendeezer-tui-windows-amd64.exe
+    InstallerSha256: 57aca3445af9516a9c4be3aee22974e6b18bac64ec714c40ab7eaca3cb5cd4b9
+ReleaseDate: "2026-07-14"
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/Cycl0o0/OpenDeezer/3.1.4/Cycl0o0.OpenDeezer.locale.en-US.yaml
+++ b/manifests/c/Cycl0o0/OpenDeezer/3.1.4/Cycl0o0.OpenDeezer.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Cycl0o0.OpenDeezer
+PackageVersion: 3.1.4
+PackageLocale: en-US
+Publisher: Cycl0o0
+PublisherUrl: https://github.com/Cycl0o0
+PublisherSupportUrl: https://github.com/Cycl0o0/OpenDeezer/issues
+PackageName: OpenDeezer
+PackageUrl: https://github.com/Cycl0o0/OpenDeezer
+License: AGPL-3.0-only
+LicenseUrl: https://github.com/Cycl0o0/OpenDeezer/blob/v3.1.4/LICENSE
+PrivacyUrl: https://github.com/Cycl0o0/OpenDeezer/blob/main/PRIVACY.md
+ShortDescription: Native terminal client for browsing and streaming a Deezer library.
+Description: >-
+  OpenDeezer is an open-source terminal client that browses and streams a
+  Deezer library. It supports favorites, playlists, charts, artists, podcasts,
+  Flow, synchronized lyrics and library management. A Deezer account and access
+  to Deezer's proprietary service are required. OpenDeezer is not affiliated
+  with or endorsed by Deezer.
+ReleaseNotesUrl: https://github.com/Cycl0o0/OpenDeezer/releases/tag/v3.1.4
+Moniker: opendeezer
+Tags:
+  - deezer
+  - music
+  - tui
+  - terminal
+  - streaming
+  - download
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/Cycl0o0/OpenDeezer/3.1.4/Cycl0o0.OpenDeezer.yaml
+++ b/manifests/c/Cycl0o0/OpenDeezer/3.1.4/Cycl0o0.OpenDeezer.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Cycl0o0.OpenDeezer
+PackageVersion: 3.1.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds OpenDeezer 3.1.4 as an x64 portable package. OpenDeezer is an unofficial, open-source terminal client for browsing and streaming a user's Deezer library.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (not applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same manifest
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` (not available on macOS; official 1.12 JSON schema validation passed)
- [ ] Tested manifest locally with `winget install --manifest <path>` (not available on macOS)
- [x] Manifest conforms to the 1.12 schema

The release asset is live and its SHA-256 was independently recomputed as `57aca3445af9516a9c4be3aee22974e6b18bac64ec714c40ab7eaca3cb5cd4b9`.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/402693)