### PR TITLE
New package: Bytical.Nerva version 0.1.11

### DIFF
--- a/manifests/b/Bytical/Nerva/0.1.11/Bytical.Nerva.installer.yaml
+++ b/manifests/b/Bytical/Nerva/0.1.11/Bytical.Nerva.installer.yaml
@@ -1,0 +1,21 @@
+# Created using nerva release tooling
+PackageIdentifier: Bytical.Nerva
+PackageVersion: 0.1.11
+InstallerLocale: en-US
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+Scope: user
+UpgradeBehavior: install
+ReleaseDate: "2026-07-15"
+Installers:
+  - Architecture: x64
+    InstallerType: nullsoft
+    InstallerUrl: https://github.com/piyushptiwari1/nerva/releases/download/v0.1.11/Nerva_0.1.11_x64-setup.exe
+    InstallerSha256: A9887EF39EB07B07D784F7957D09D2B9A8D371D6E128D89D500EC2667F8F2F2F
+  - Architecture: x64
+    InstallerType: wix
+    InstallerUrl: https://github.com/piyushptiwari1/nerva/releases/download/v0.1.11/Nerva_0.1.11_x64_en-US.msi
+    InstallerSha256: 48ED4204355E9B905F7D679071F48BE87D7EF890E89C3AB6D7119D3B0BAB6A5A
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/b/Bytical/Nerva/0.1.11/Bytical.Nerva.locale.en-US.yaml
+++ b/manifests/b/Bytical/Nerva/0.1.11/Bytical.Nerva.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# Created using nerva release tooling
+PackageIdentifier: Bytical.Nerva
+PackageVersion: 0.1.11
+PackageLocale: en-US
+Publisher: Bytical Solutions Private Limited
+PublisherUrl: https://bytical.ai
+PublisherSupportUrl: https://github.com/piyushptiwari1/nerva/issues
+Author: Bytical Solutions Private Limited
+PackageName: Nerva
+PackageUrl: https://nerva.bytical.ai
+License: Apache-2.0
+LicenseUrl: https://github.com/piyushptiwari1/nerva/blob/main/LICENSE
+Copyright: © 2026 Bytical Solutions Private Limited
+ShortDescription: The focus workspace that never forgets
+Description: |-
+  Nerva is a native desktop focus workspace built for deep work. Parallel
+  timers that survive sleep and reboot, sticky markdown notes that float
+  above any window, a year-long habit heatmap, and tasks with priority
+  and due times. Offline-first. Telemetry off by default (opt-in only).
+  No account. Apache-2.0.
+Moniker: nerva
+Tags:
+  - productivity
+  - focus
+  - timer
+  - notes
+  - habits
+  - pomodoro
+  - deep-work
+  - offline
+  - markdown
+  - habit-tracker
+ReleaseNotesUrl: https://github.com/piyushptiwari1/nerva/releases/tag/v0.1.11
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/b/Bytical/Nerva/0.1.11/Bytical.Nerva.yaml
+++ b/manifests/b/Bytical/Nerva/0.1.11/Bytical.Nerva.yaml
@@ -1,0 +1,6 @@
+# Created using nerva release tooling
+PackageIdentifier: Bytical.Nerva
+PackageVersion: 0.1.11
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package submission

- **PackageIdentifier**: Bytical.Nerva
- **PackageVersion**: 0.1.11
- Installers: NSIS setup.exe + MSI (x64), signed, from the [v0.1.11 GitHub release](https://github.com/piyushptiwari1/nerva/releases/tag/v0.1.11)

Previous submissions (0.1.0/0.1.1) failed validation on a duplicate ReleaseNotesUrl field and went stale; that is fixed in these manifests.

- [x] Manifests validated against schema 1.6.0
- [x] Installer URLs + SHA256 verified
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/402699)