### PR TITLE
New package: JeromeHerrman.VPinCommander version 0.6.0

### DIFF
--- a/manifests/j/JeromeHerrman/VPinCommander/0.6.0/JeromeHerrman.VPinCommander.installer.yaml
+++ b/manifests/j/JeromeHerrman/VPinCommander/0.6.0/JeromeHerrman.VPinCommander.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: JeromeHerrman.VPinCommander
+PackageVersion: 0.6.0
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: VPinCommander.exe
+  PortableCommandAlias: vpincommander
+UpgradeBehavior: install
+ReleaseDate: 2026-07-15
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/jeromeherrman/VPinCommander/releases/download/v0.6.0/VPinCommander-v0.6.0-win-x64.zip
+  InstallerSha256: 0170AE02C473450776C171A1C6BEA24C651BF2DEE87648EA0C60CB927E630E03
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/j/JeromeHerrman/VPinCommander/0.6.0/JeromeHerrman.VPinCommander.locale.en-US.yaml
+++ b/manifests/j/JeromeHerrman/VPinCommander/0.6.0/JeromeHerrman.VPinCommander.locale.en-US.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: JeromeHerrman.VPinCommander
+PackageVersion: 0.6.0
+PackageLocale: en-US
+Publisher: Jerome Herrman
+PublisherUrl: https://github.com/jeromeherrman
+PublisherSupportUrl: https://github.com/jeromeherrman/VPinCommander/issues
+Author: VPin Commander contributors
+PackageName: VPin Commander
+PackageUrl: https://github.com/jeromeherrman/VPinCommander
+License: MIT
+LicenseUrl: https://github.com/jeromeherrman/VPinCommander/blob/main/LICENSE
+Copyright: Copyright (c) 2026 VPin Commander contributors
+ShortDescription: The most complete open source manager for virtual pinball cabinets.
+Description: |-
+  VPin Commander manages every part of a virtual pinball cabinet: automatic
+  inventory scanning of tables, ROMs, and media; PinUP Popper, PinballX, and
+  PinballY integration; a cabinet health report (missing ROMs, outdated tables,
+  missing PuP-Packs and media, duplicates, DOF and backglass coverage); one-click
+  installation of downloaded content into the proper folders; update tracking
+  against the Virtual Pinball Spreadsheet; Excel export, backup/restore, and
+  optional cloud sync; plus client/server remote management of multiple cabinets
+  with an Android companion app.
+Moniker: vpincommander
+Tags:
+- pinball
+- virtual-pinball
+- vpin
+- visual-pinball
+- vpx
+- pinup-popper
+- pinballx
+- pinbally
+- cabinet
+- arcade
+ReleaseNotesUrl: https://github.com/jeromeherrman/VPinCommander/releases/tag/v0.6.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/j/JeromeHerrman/VPinCommander/0.6.0/JeromeHerrman.VPinCommander.yaml
+++ b/manifests/j/JeromeHerrman/VPinCommander/0.6.0/JeromeHerrman.VPinCommander.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: JeromeHerrman.VPinCommander
+PackageVersion: 0.6.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: JeromeHerrman.VPinCommander version 0.6.0

VPin Commander is an open source (MIT) manager for virtual pinball cabinets:
inventory scanning, PinUP Popper/PinballX/PinballY integration, cabinet health
reports, content installation, and multi-cabinet remote management.

- Repository: https://github.com/jeromeherrman/VPinCommander
- Release: https://github.com/jeromeherrman/VPinCommander/releases/tag/v0.6.0
- Installer: portable self-contained exe inside the release zip
  (`InstallerType: zip` + `NestedInstallerType: portable`)

-----

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)? (will complete via the CLA bot on this PR)
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`? (not yet — relying on pipeline validation; happy to test locally if requested)
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/402765)