### PR TITLE
New package: thebscolaro.ownlock version 0.3.2

### DIFF
--- a/manifests/t/thebscolaro/ownlock/0.3.2/thebscolaro.ownlock.0.3.2.yaml
+++ b/manifests/t/thebscolaro/ownlock/0.3.2/thebscolaro.ownlock.0.3.2.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: thebscolaro.ownlock
+PackageVersion: 0.3.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0

--- a/manifests/t/thebscolaro/ownlock/0.3.2/thebscolaro.ownlock.installer.0.3.2.yaml
+++ b/manifests/t/thebscolaro/ownlock/0.3.2/thebscolaro.ownlock.installer.0.3.2.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# After Release binaries workflow attaches ownlock-windows-x64.exe to v0.3.2,
+# run: scripts/fill_winget_sha.sh v0.3.2
+# then open a PR to microsoft/winget-pkgs.
+PackageIdentifier: thebscolaro.ownlock
+PackageVersion: 0.3.2
+InstallerLocale: en-US
+InstallerType: portable
+Commands:
+  - ownlock
+ReleaseDate: 2026-07-15
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/thebscolaro/ownlock/releases/download/v0.3.2/ownlock-windows-x64.exe
+    InstallerSha256: 514674A390EB2183834082C8E9E90F9404B75504B7A8304CF39D37AAE38CD851
+    UpgradeBehavior: install
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/t/thebscolaro/ownlock/0.3.2/thebscolaro.ownlock.locale.en-US.0.3.2.yaml
+++ b/manifests/t/thebscolaro/ownlock/0.3.2/thebscolaro.ownlock.locale.en-US.0.3.2.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
+PackageIdentifier: thebscolaro.ownlock
+PackageVersion: 0.3.2
+PackageLocale: en-US
+Publisher: thebscolaro
+PublisherUrl: https://github.com/thebscolaro
+PublisherSupportUrl: https://github.com/thebscolaro/ownlock/issues
+Author: thebscolaro
+PackageName: ownlock
+PackageUrl: https://github.com/thebscolaro/ownlock
+License: MIT
+LicenseUrl: https://github.com/thebscolaro/ownlock/blob/main/LICENSE
+Copyright: Copyright (c) thebscolaro
+ShortDescription: Cross-platform local secret broker for developers and AI agents
+Description: Encrypted local vault, runtime env injection, stdout redaction, and agent hardening (shield/guard). No Docker, no cloud account.
+Moniker: ownlock
+Tags:
+  - secrets
+  - vault
+  - cli
+  - security
+  - ai-agents
+ReleaseNotesUrl: https://github.com/thebscolaro/ownlock/releases/tag/v0.3.2
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Description
Portable CLI package for [ownlock](https://github.com/thebscolaro/ownlock) 0.3.2 (local encrypted secrets vault).

Installer: `ownlock-windows-x64.exe` from https://github.com/thebscolaro/ownlock/releases/tag/v0.3.2

## Checklist
- [x] Manifests validate locally (version / installer / locale)
- [x] InstallerSha256 filled from release asset
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/402801)