### PR TITLE
New package: JairLima.MD2DOCX version 3.5

### DIFF
--- a/manifests/j/JairLima/MD2DOCX/3.5/JairLima.MD2DOCX.installer.yaml
+++ b/manifests/j/JairLima/MD2DOCX/3.5/JairLima.MD2DOCX.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: JairLima.MD2DOCX
+PackageVersion: 3.5
+MinimumOSVersion: 10.0.0.0
+InstallerType: portable
+Commands:
+  - md2docx
+FileExtensions:
+  - md
+  - docx
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/jairslima/md2docx/releases/download/v3.5/md2docx.exe
+    InstallerSha256: F0D4AB44E6617A3900BA2BD79E26453C26E757D96B0C5A570F310D291B5AD028
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/j/JairLima/MD2DOCX/3.5/JairLima.MD2DOCX.locale.en-US.yaml
+++ b/manifests/j/JairLima/MD2DOCX/3.5/JairLima.MD2DOCX.locale.en-US.yaml
@@ -9,7 +9,7 @@ PublisherSupportUrl: https://github.com/jairslima/md2docx/issues
 PackageName: MD to DOCX Converter by Jair Lima
 PackageUrl: https://github.com/jairslima/md2docx
 License: MIT
-LicenseUrl: https://github.com/jairslima/md2docx/blob/main/LICENSE
+LicenseUrl: https://github.com/jairslima/md2docx/blob/master/LICENSE
 ShortDescription: Converts Markdown files to properly formatted Word documents (bidirectional MD<->DOCX, plus PDF->MD), standalone CLI executable.
 Moniker: md2docx
 Tags:

--- a/manifests/j/JairLima/MD2DOCX/3.5/JairLima.MD2DOCX.locale.en-US.yaml
+++ b/manifests/j/JairLima/MD2DOCX/3.5/JairLima.MD2DOCX.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: JairLima.MD2DOCX
+PackageVersion: 3.5
+PackageLocale: en-US
+Publisher: Jair Lima
+PublisherUrl: https://github.com/jairslima
+PublisherSupportUrl: https://github.com/jairslima/md2docx/issues
+PackageName: MD to DOCX Converter by Jair Lima
+PackageUrl: https://github.com/jairslima/md2docx
+License: MIT
+LicenseUrl: https://github.com/jairslima/md2docx/blob/main/LICENSE
+ShortDescription: Converts Markdown files to properly formatted Word documents (bidirectional MD<->DOCX, plus PDF->MD), standalone CLI executable.
+Moniker: md2docx
+Tags:
+  - markdown
+  - docx
+  - word
+  - converter
+  - cli
+  - pdf
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/j/JairLima/MD2DOCX/3.5/JairLima.MD2DOCX.yaml
+++ b/manifests/j/JairLima/MD2DOCX/3.5/JairLima.MD2DOCX.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: JairLima.MD2DOCX
+PackageVersion: 3.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Description

Adds JairLima.MD2DOCX version 3.5 — a standalone CLI executable that converts between Markdown and DOCX (bidirectional), plus PDF -> Markdown.

- Source: https://github.com/jairslima/md2docx
- Release used: https://github.com/jairslima/md2docx/releases/tag/v3.5
- License: MIT
- InstallerType: portable (winget adds it to PATH as `md2docx`)

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/microsoft/winget-pkgs/blob/master/CONTRIBUTING.md).
- [x] This PR only modifies one (1) package
- [x] I have verified this Pull Request is not a duplicate of an already open PR
- [x] I have verified the installer(s) is/are digitally signed, if applicable, and my personal analysis of the URL and the file (including its signature) leads me to believe it is safe
- [x] I have checked that the installer/manifest supports both `x64` and `x86` architectures, if applicable (only x64 build is produced for this tool)
- [x] I have tested the manifest locally with `winget validate --manifest <path>` and `winget install --manifest <path>` (silent install verified working end-to-end)
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs) (confirmed via `license/cla: SUCCESS` check on this PR)
- [x] This PR was created with the [wingetcreate tool](https://github.com/microsoft/winget-create) or a manually created manifest that follows the wiki's [Authoring Manifests best practices guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/manifest/schema/README.md#creating-your-own-manifest)

## Note

Same publisher (JairLima) that has an existing pending PR (#402513, MDWord) currently undergoing a `Validation-Defender-Error` review — that installer is unsigned NSIS. This package is a different, unsigned portable exe, so it's possible (not certain) it hits the same Defender reputation flag; will monitor separately.