### PR TITLE
New version: loreste.mako version 0.1.4

### DIFF
--- a/manifests/l/loreste/mako/0.1.4/loreste.mako.installer.yaml
+++ b/manifests/l/loreste/mako/0.1.4/loreste.mako.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: loreste.mako
+PackageVersion: 0.1.4
+InstallerType: zip
+NestedInstallerType: portable
+ReleaseDate: 2026-07-15
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/loreste/mako/releases/download/v0.1.4/mako-x86_64-pc-windows-msvc.zip
+  InstallerSha256: FDAB61E654FE1FBCE0222F301CA4802A36E273D465A70ECCAB862BC349F551EF
+  NestedInstallerFiles:
+  - RelativeFilePath: mako-x86_64-pc-windows-msvc\bin\mako.exe
+    PortableCommandAlias: mako
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/l/loreste/mako/0.1.4/loreste.mako.locale.en-US.yaml
+++ b/manifests/l/loreste/mako/0.1.4/loreste.mako.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: loreste.mako
+PackageVersion: 0.1.4
+PackageLocale: en-US
+Publisher: loreste
+PublisherUrl: https://github.com/loreste/mako
+PublisherSupportUrl: https://github.com/loreste/mako/issues
+Author: loreste
+PackageName: Mako
+PackageUrl: https://github.com/loreste/mako
+License: MIT
+LicenseUrl: https://github.com/loreste/mako/blob/v0.1.4/LICENSE
+Copyright: Copyright (c) loreste
+ShortDescription: Mako systems/backend language (.mko to native via C)
+Description: |-
+  Mako is a systems and backend language that compiles .mko sources to native
+  code via C. Ships a single CLI binary plus runtime headers and stdlib.
+Moniker: mako
+Tags:
+- backend
+- compiler
+- programming-language
+- systems
+ReleaseNotesUrl: https://github.com/loreste/mako/releases/tag/v0.1.4
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/l/loreste/mako/0.1.4/loreste.mako.yaml
+++ b/manifests/l/loreste/mako/0.1.4/loreste.mako.yaml
@@ -31,7 +31,8 @@ Installers:
     InstallerSha256: FDAB61E654FE1FBCE0222F301CA4802A36E273D465A70ECCAB862BC349F551EF
     NestedInstallerType: portable
     NestedInstallerFiles:
-      - RelativeFilePath: mako.exe
+      # Zip root folder matches Compress-Archive of the stage directory.
+      - RelativeFilePath: mako-x86_64-pc-windows-msvc\bin\mako.exe
         PortableCommandAlias: mako
 ManifestType: singleton
 ManifestVersion: 1.6.0

--- a/manifests/l/loreste/mako/0.1.4/loreste.mako.yaml
+++ b/manifests/l/loreste/mako/0.1.4/loreste.mako.yaml
@@ -1,38 +1,6 @@
-# Winget singleton manifest for Mako v0.1.4 (filled from release assets).
-# Submit to microsoft/winget-pkgs under manifests/l/loreste/mako/0.1.4/
-# Docs: https://github.com/microsoft/winget-pkgs
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 PackageIdentifier: loreste.mako
 PackageVersion: 0.1.4
-PackageLocale: en-US
-Publisher: loreste
-PublisherUrl: https://github.com/loreste/mako
-PublisherSupportUrl: https://github.com/loreste/mako/issues
-Author: loreste
-PackageName: Mako
-PackageUrl: https://github.com/loreste/mako
-License: MIT
-LicenseUrl: https://github.com/loreste/mako/blob/v0.1.4/LICENSE
-Copyright: Copyright (c) loreste
-ShortDescription: Mako systems/backend language (.mko → native via C)
-Description: >
-  Mako is a systems and backend language that compiles .mko sources to native
-  code via C. Ships a single CLI binary plus runtime headers and stdlib.
-Moniker: mako
-Tags:
-  - compiler
-  - systems
-  - backend
-  - programming-language
-ReleaseNotesUrl: https://github.com/loreste/mako/releases/tag/v0.1.4
-Installers:
-  - Architecture: x64
-    InstallerType: zip
-    InstallerUrl: https://github.com/loreste/mako/releases/download/v0.1.4/mako-x86_64-pc-windows-msvc.zip
-    InstallerSha256: FDAB61E654FE1FBCE0222F301CA4802A36E273D465A70ECCAB862BC349F551EF
-    NestedInstallerType: portable
-    NestedInstallerFiles:
-      # Zip root folder matches Compress-Archive of the stage directory.
-      - RelativeFilePath: mako-x86_64-pc-windows-msvc\bin\mako.exe
-        PortableCommandAlias: mako
-ManifestType: singleton
-ManifestVersion: 1.6.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/manifests/l/loreste/mako/0.1.4/loreste.mako.yaml
+++ b/manifests/l/loreste/mako/0.1.4/loreste.mako.yaml
@@ -1,0 +1,37 @@
+# Winget singleton manifest for Mako v0.1.4 (filled from release assets).
+# Submit to microsoft/winget-pkgs under manifests/l/loreste/mako/0.1.4/
+# Docs: https://github.com/microsoft/winget-pkgs
+PackageIdentifier: loreste.mako
+PackageVersion: 0.1.4
+PackageLocale: en-US
+Publisher: loreste
+PublisherUrl: https://github.com/loreste/mako
+PublisherSupportUrl: https://github.com/loreste/mako/issues
+Author: loreste
+PackageName: Mako
+PackageUrl: https://github.com/loreste/mako
+License: MIT
+LicenseUrl: https://github.com/loreste/mako/blob/v0.1.4/LICENSE
+Copyright: Copyright (c) loreste
+ShortDescription: Mako systems/backend language (.mko → native via C)
+Description: >
+  Mako is a systems and backend language that compiles .mko sources to native
+  code via C. Ships a single CLI binary plus runtime headers and stdlib.
+Moniker: mako
+Tags:
+  - compiler
+  - systems
+  - backend
+  - programming-language
+ReleaseNotesUrl: https://github.com/loreste/mako/releases/tag/v0.1.4
+Installers:
+  - Architecture: x64
+    InstallerType: zip
+    InstallerUrl: https://github.com/loreste/mako/releases/download/v0.1.4/mako-x86_64-pc-windows-msvc.zip
+    InstallerSha256: FDAB61E654FE1FBCE0222F301CA4802A36E273D465A70ECCAB862BC349F551EF
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: mako.exe
+        PortableCommandAlias: mako
+ManifestType: singleton
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## New package / version

- **Package:** loreste.mako
- **Version:** 0.1.4
- **Publisher:** loreste
- **Installer:** portable zip from GitHub Releases (Windows x64)

## Installer

- URL: https://github.com/loreste/mako/releases/download/v0.1.4/mako-x86_64-pc-windows-msvc.zip
- SHA256: FDAB61E654FE1FBCE0222F301CA4802A36E273D465A70ECCAB862BC349F551EF
- Type: zip / portable (`mako.exe`)

## Notes

Mako is a systems/backend language CLI. Release assets and checksums are published at https://github.com/loreste/mako/releases/tag/v0.1.4.

Checklist:
- [x] Manifest version 1.6.0 singleton
- [x] InstallerSha256 matches release asset
- [x] PackageIdentifier uses publisher.package form
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/402823)