### PR TITLE
New version: tldr-pages.tlrc version 1.13.1

### DIFF
--- a/manifests/t/tldr-pages/tlrc/1.13.1/tldr-pages.tlrc.installer.yaml
+++ b/manifests/t/tldr-pages/tlrc/1.13.1/tldr-pages.tlrc.installer.yaml
@@ -1,0 +1,21 @@
+# Created with komac v2.12.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: tldr-pages.tlrc
+PackageVersion: 1.13.1
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: tldr.exe
+Commands:
+- tldr.exe
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+ReleaseDate: 2026-05-22
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/tldr-pages/tlrc/releases/download/v1.13.1/tlrc-v1.13.1-x86_64-pc-windows-msvc.zip
+  InstallerSha256: 8B85477C935365008214BE7A5FD319C56855175FF0C4E8CC2D01FA94ACCDD210
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/t/tldr-pages/tlrc/1.13.1/tldr-pages.tlrc.locale.en-US.yaml
+++ b/manifests/t/tldr-pages/tlrc/1.13.1/tldr-pages.tlrc.locale.en-US.yaml
@@ -1,0 +1,36 @@
+# Created with komac v2.12.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: tldr-pages.tlrc
+PackageVersion: 1.13.1
+PackageLocale: en-US
+Publisher: tldr-pages
+PublisherUrl: https://tldr.sh/
+PublisherSupportUrl: https://github.com/tldr-pages/tlrc/issues
+PackageName: tlrc
+PackageUrl: https://github.com/tldr-pages/tlrc
+License: MIT
+LicenseUrl: https://github.com/tldr-pages/tlrc/blob/HEAD/LICENSE
+Copyright: Copyright (c) 2025 tlrc contributors
+ShortDescription: Official tldr client written in Rust.
+Moniker: tldr
+Tags:
+- cheatsheets
+- cli
+- foss
+- guides
+- rust
+- tldr
+ReleaseNotes: |-
+  * updated `rustls-webpki` to fix vulnerabilities (#172)
+  * fix: too many spaces in `--info` output
+
+  Binaries for aarch64 systems are now available on GitHub releases (#173).
+
+  **Full Changelog**: https://github.com/tldr-pages/tlrc/compare/v1.13.0...v1.13.1
+ReleaseNotesUrl: https://github.com/tldr-pages/tlrc/releases/tag/v1.13.1
+Documentations:
+- DocumentLabel: Manpage
+  DocumentUrl: https://tldr.sh/tlrc/
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/t/tldr-pages/tlrc/1.13.1/tldr-pages.tlrc.yaml
+++ b/manifests/t/tldr-pages/tlrc/1.13.1/tldr-pages.tlrc.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.12.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: tldr-pages.tlrc
+PackageVersion: 1.13.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Summary
- Add `tldr-pages.tlrc` 1.13.1 (from 1.12.0)
- Installer hash from official `tlrc-v1.13.1-x86_64-pc-windows-msvc.zip`
- Sibling style from 1.12.0 (x64 zip portable only)

## Validation
- SHA256 verified locally against GitHub release asset
- No open competing PR for 1.13.1

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/402830)