### PR TITLE
New package: WeeNote.WeeNote version 2.9.16

### DIFF
--- a/manifests/w/WeeNote/WeeNote/2.9.16/WeeNote.WeeNote.installer.yaml
+++ b/manifests/w/WeeNote/WeeNote/2.9.16/WeeNote.WeeNote.installer.yaml
@@ -5,7 +5,7 @@ InstallerLocale: ko-KR
 Platform:
   - Windows.Desktop
 MinimumOSVersion: 10.0.0.0
-InstallerType: nsis
+InstallerType: nullsoft
 Scope: user
 InstallModes:
   - silent

--- a/manifests/w/WeeNote/WeeNote/2.9.16/WeeNote.WeeNote.installer.yaml
+++ b/manifests/w/WeeNote/WeeNote/2.9.16/WeeNote.WeeNote.installer.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: WeeNote.WeeNote
+PackageVersion: 2.9.16
+InstallerLocale: ko-KR
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: nsis
+Scope: user
+InstallModes:
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+UpgradeBehavior: install
+ReleaseDate: 2026-07-15
+AppsAndFeaturesEntries:
+  - DisplayName: WeeNote
+    Publisher: Korea Institute of School Counseling
+    DisplayVersion: 2.9.16
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/classbinu/weenote-releases/releases/download/v2.9.16/weenote-2.9.16-setup.exe
+    InstallerSha256: 952C8D0DF9EE9723A4E1EF8335F4B11669161BD8CE8DD7C3D832A300D3CE4912
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/w/WeeNote/WeeNote/2.9.16/WeeNote.WeeNote.installer.yaml
+++ b/manifests/w/WeeNote/WeeNote/2.9.16/WeeNote.WeeNote.installer.yaml
@@ -18,7 +18,6 @@ ReleaseDate: 2026-07-15
 AppsAndFeaturesEntries:
   - DisplayName: WeeNote
     Publisher: Korea Institute of School Counseling
-    DisplayVersion: 2.9.16
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/classbinu/weenote-releases/releases/download/v2.9.16/weenote-2.9.16-setup.exe

--- a/manifests/w/WeeNote/WeeNote/2.9.16/WeeNote.WeeNote.locale.ko-KR.yaml
+++ b/manifests/w/WeeNote/WeeNote/2.9.16/WeeNote.WeeNote.locale.ko-KR.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: WeeNote.WeeNote
+PackageVersion: 2.9.16
+PackageLocale: ko-KR
+Publisher: Korea Institute of School Counseling
+PublisherUrl: https://weenote.kr
+PublisherSupportUrl: https://weenote.kr
+PackageName: WeeNote
+PackageUrl: https://weenote.kr
+License: Proprietary
+CopyrightUrl: https://weenote.kr
+ShortDescription: 학교 전문상담교사를 위한 상담 기록·관리 프로그램
+Description: |-
+  WeeNote(위노트)는 학교 전문상담(교)사를 위한 상담 기록·관리 프로그램입니다.
+  상담일지 작성, 학생·사례 관리, 심리검사, 통계, NEIS 연계 내보내기 등
+  학교 상담 업무 전반을 지원합니다. 모든 데이터는 사용자 PC에 저장됩니다.
+Moniker: weenote
+Tags:
+  - counseling
+  - school
+  - wee
+  - 상담
+  - 상담일지
+  - 위클래스
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/w/WeeNote/WeeNote/2.9.16/WeeNote.WeeNote.yaml
+++ b/manifests/w/WeeNote/WeeNote/2.9.16/WeeNote.WeeNote.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: WeeNote.WeeNote
+PackageVersion: 2.9.16
+DefaultLocale: ko-KR
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
New package submission: **WeeNote** — a counseling record management app for school counselors in South Korea.

- Publisher: Korea Institute of School Counseling (matches the Authenticode certificate CN; "WeeNote" is the product brand)
- Official site: https://weenote.kr
- Installer: NSIS one-click, per-user scope, signed (OV certificate)
- Installer assets are hosted on the public release repo: https://github.com/classbinu/weenote-releases

---

- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Does your manifest conform to the [1.x schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema)?
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`? (authored on macOS — relying on pipeline validation)
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? (authored on macOS — relying on pipeline validation)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/402889)