### PR TITLE
New version: dalance.procs version 0.14.12

### DIFF
--- a/manifests/d/dalance/procs/0.14.12/dalance.procs.installer.yaml
+++ b/manifests/d/dalance/procs/0.14.12/dalance.procs.installer.yaml
@@ -1,0 +1,19 @@
+# Created with komac v2.15.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: dalance.procs
+PackageVersion: 0.14.12
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: procs.exe
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+ReleaseDate: 2026-06-25
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/dalance/procs/releases/download/v0.14.12/procs-v0.14.12-x86_64-windows.zip
+  InstallerSha256: 4928C399AE78EE82F99139A5629077B8D90A58599D834584DD4E613CB60C83D0
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/d/dalance/procs/0.14.12/dalance.procs.locale.en-US.yaml
+++ b/manifests/d/dalance/procs/0.14.12/dalance.procs.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# Created with komac v2.15.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: dalance.procs
+PackageVersion: 0.14.12
+PackageLocale: en-US
+Publisher: dalance
+PublisherUrl: https://github.com/dalance
+PublisherSupportUrl: https://github.com/dalance/procs/issues
+Author: dalance
+PackageName: procs
+PackageUrl: https://github.com/dalance/procs
+License: MIT
+LicenseUrl: https://github.com/dalance/procs/blob/HEAD/LICENSE
+ShortDescription: A modern replacement for ps written in Rust.
+Tags:
+- cli
+- process
+- rust
+ReleaseNotes: Changelog
+ReleaseNotesUrl: https://github.com/dalance/procs/releases/tag/v0.14.12
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/dalance/procs/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/d/dalance/procs/0.14.12/dalance.procs.yaml
+++ b/manifests/d/dalance/procs/0.14.12/dalance.procs.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.15.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: dalance.procs
+PackageVersion: 0.14.12
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Checklist for Pull Requests
- [x] Have you signed the Contributor License Agreement?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?

## Validation
- Upstream release: https://github.com/dalance/procs/releases/tag/v0.14.12
- Installer: `https://github.com/dalance/procs/releases/download/v0.14.12/procs-v0.14.12-x86_64-windows.zip`
- InstallerSha256: `4928C399AE78EE82F99139A5629077B8D90A58599D834584DD4E613CB60C83D0`
- Sibling style from 0.14.11 (zip portable + VCRedist.x64)

## Notes
- x64 only, matching existing package shape

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/402893)