### PR TITLE
SerZhyAle.DocHtmlTranslate version 26.0715.2158

### DIFF
--- a/manifests/s/SerZhyAle/DocHtmlTranslate/26.0715.2158/SerZhyAle.DocHtmlTranslate.installer.yaml
+++ b/manifests/s/SerZhyAle/DocHtmlTranslate/26.0715.2158/SerZhyAle.DocHtmlTranslate.installer.yaml
@@ -1,0 +1,19 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: SerZhyAle.DocHtmlTranslate
+PackageVersion: 26.0715.2158
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: doc-html-translate.exe
+  PortableCommandAlias: doc-html-translate
+- RelativeFilePath: doc-html-ui.exe
+  PortableCommandAlias: doc-html-ui
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/SerZhyAle/doc-html-translate/releases/download/v26.0715.2158/doc-html-translate-26.0715.2158-windows-x64.zip
+  InstallerSha256: 85071541367BB13AD6BAA3AA89EACC3E5EFF227040184D11CE99A461014C53D1
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-07-15

--- a/manifests/s/SerZhyAle/DocHtmlTranslate/26.0715.2158/SerZhyAle.DocHtmlTranslate.locale.en-US.yaml
+++ b/manifests/s/SerZhyAle/DocHtmlTranslate/26.0715.2158/SerZhyAle.DocHtmlTranslate.locale.en-US.yaml
@@ -1,0 +1,51 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: SerZhyAle.DocHtmlTranslate
+PackageVersion: 26.0715.2158
+PackageLocale: en-US
+Publisher: SZA
+PublisherUrl: https://github.com/SerZhyAle
+PublisherSupportUrl: https://github.com/SerZhyAle/doc-html-translate/issues
+Author: Serhii Zhyhunenko
+PackageName: doc-html-translate
+PackageUrl: https://github.com/SerZhyAle/doc-html-translate
+License: MIT
+LicenseUrl: https://github.com/SerZhyAle/doc-html-translate/blob/main/LICENSE
+Copyright: Copyright (c) 2026 SerZhyAle
+ShortDescription: Convert EPUB, PDF, MOBI, AZW3, FB2, RTF, TXT, Markdown and HTML to clean local HTML with a real table of contents, image-text OCR, and optional Google or Ollama translation.
+Description: |-
+  doc-html-translate is a Windows app that converts documents (EPUB, PDF, MOBI, AZW3, FB2,
+  RTF, TXT, Markdown, HTML) into clean local HTML with generated navigation and a real
+  multi-level table of contents. A built-in reader adds light/sepia/dark/night themes, text
+  size and font controls, and remembers your reading position. It can recognize text inside
+  images (OCR - English bundled, more languages on demand) and optionally translate everything
+  via the Google Cloud Translation API or a local Ollama model. Convert to one long single page
+  or keep chapters with a table of contents. Re-opening an already-converted book is instant.
+  The package ships both the CLI (doc-html-translate) and a small GUI launcher (doc-html-ui).
+  pdftotext is bundled inside the binary; MOBI and AZW3 conversion additionally requires
+  Calibre to be installed (non-DRM files only).
+Moniker: doc-html-translate
+Tags:
+- azw3
+- cli
+- ebook
+- epub
+- fb2
+- google-translate
+- html
+- markdown
+- mobi
+- ocr
+- ollama
+- pdf
+- rtf
+- translation
+- txt
+- windows
+ReleaseNotesUrl: https://github.com/SerZhyAle/doc-html-translate/releases/tag/v26.0715.2158
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/SerZhyAle/doc-html-translate/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/SerZhyAle/DocHtmlTranslate/26.0715.2158/SerZhyAle.DocHtmlTranslate.yaml
+++ b/manifests/s/SerZhyAle/DocHtmlTranslate/26.0715.2158/SerZhyAle.DocHtmlTranslate.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: SerZhyAle.DocHtmlTranslate
+PackageVersion: 26.0715.2158
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Update: `SerZhyAle.DocHtmlTranslate` to **26.0715.2158**.

Upstream release: https://github.com/SerZhyAle/doc-html-translate/releases/tag/v26.0715.2158
SHA256 verified via local `winget install --manifest` (installer hash confirmed, package installs and uninstalls cleanly).

**What's new in this version:**
- File-type association is now opt-in, off by default. The app adds a non-destructive "Convert to HTML" right-click entry and an "Open with" entry, but no longer becomes the default handler unless you ask (CLI `-register`, GUI toggle, or first-run prompt). New `-unregister` releases the default while keeping the right-click and "Open with" entries.
- The winget package still installs the portable build (unchanged).

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
