### PR TITLE
New package: LibreDB.Studio version 0.9.59

### DIFF
--- a/manifests/l/LibreDB/Studio/0.9.59/LibreDB.Studio.installer.yaml
+++ b/manifests/l/LibreDB/Studio/0.9.59/LibreDB.Studio.installer.yaml
@@ -1,0 +1,27 @@
+# Installer manifest template for the winget community repository
+# (microsoft/winget-pkgs), issue #114. Rendered by
+# scripts/render-windows-packaging.mjs from the release SHA256SUMS.
+#
+# InstallerType zip + NestedInstallerType portable needs winget client 1.5+.
+# The zip is FLAT (scripts/lib/pack-standalone-zip.sh), so RelativeFilePath
+# is stable across releases - `wingetcreate update` carries the
+# NestedInstallerFiles list forward by exact-path match.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: LibreDB.Studio
+PackageVersion: "0.9.59"
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: libredb-studio.exe
+    PortableCommandAlias: libredb-studio
+Commands:
+  - libredb-studio
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/libredb/libredb-studio/releases/download/0.9.59/libredb-studio-standalone-0.9.59-win32-x64.zip
+    InstallerSha256: aca42e063177c6e6ccb5f71bece4d5bba167ea4fbe1fae8fca40f5ff22db0e13
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/l/LibreDB/Studio/0.9.59/LibreDB.Studio.locale.en-US.yaml
+++ b/manifests/l/LibreDB/Studio/0.9.59/LibreDB.Studio.locale.en-US.yaml
@@ -1,0 +1,43 @@
+# Default-locale manifest template for the winget community repository
+# (microsoft/winget-pkgs), issue #114. Rendered by
+# scripts/render-windows-packaging.mjs with the release version.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: LibreDB.Studio
+PackageVersion: "0.9.59"
+PackageLocale: en-US
+Publisher: LibreDB
+PublisherUrl: https://libredb.org
+PublisherSupportUrl: https://github.com/libredb/libredb-studio/issues
+PackageName: LibreDB Studio
+PackageUrl: https://github.com/libredb/libredb-studio
+License: MIT
+LicenseUrl: https://github.com/libredb/libredb-studio/blob/main/LICENSE
+Copyright: Copyright (c) 2025 LibreDB
+ShortDescription: Web-based SQL IDE for PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, and Redis with AI query assistance.
+Description: |-
+  LibreDB Studio is an open-source, web-based SQL IDE for cloud-native teams.
+  It connects to PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, and
+  Redis, and ships a Monaco-powered editor with AI query assistance, schema
+  browsing, ER diagrams, charts, and import/export tooling. This package
+  installs the standalone server with a bundled Node.js runtime; run
+  `libredb-studio` and open http://127.0.0.1:3000 - the first run prints
+  generated admin credentials to the terminal (zero-config bootstrap).
+Moniker: libredb-studio
+Tags:
+  - database
+  - db
+  - ide
+  - mongodb
+  - mysql
+  - oracle
+  - postgres
+  - postgresql
+  - redis
+  - sql
+  - sqlite
+ReleaseNotesUrl: https://github.com/libredb/libredb-studio/releases/tag/0.9.59
+Documentations:
+  - DocumentLabel: Distribution & Install Guide
+    DocumentUrl: https://github.com/libredb/libredb-studio/blob/main/docs/DISTRIBUTION.md
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/l/LibreDB/Studio/0.9.59/LibreDB.Studio.yaml
+++ b/manifests/l/LibreDB/Studio/0.9.59/LibreDB.Studio.yaml
@@ -1,0 +1,10 @@
+# Version manifest template for the winget community repository
+# (microsoft/winget-pkgs), issue #114. Rendered by
+# scripts/render-windows-packaging.mjs with the release version; see
+# docs/DISTRIBUTION.md ("Windows") for the first-listing flow.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: LibreDB.Studio
+PackageVersion: "0.9.59"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Adds LibreDB Studio - an open-source, web-based SQL IDE for PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, and Redis.

- InstallerType: zip with a nested portable launcher (libredb-studio.exe); the archive bundles a private Node.js runtime, so there is nothing else to install.
- The installer URL is the versioned GitHub release asset; InstallerSha256 matches the release's SHA256SUMS.
- Publisher: LibreDB (https://github.com/libredb/libredb-studio, MIT). This is the first submission for this package; subsequent versions will be submitted automatically by the project's release CI via wingetcreate.

Validated locally: manifests render from the repository's in-repo templates (packaging/winget/) against the published release checksums.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/402985)