### PR TITLE
New version: loreste.mako version 0.1.7

### DIFF
--- a/manifests/l/loreste/mako/0.1.7/loreste.mako.installer.yaml
+++ b/manifests/l/loreste/mako/0.1.7/loreste.mako.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: loreste.mako
+PackageVersion: 0.1.7
+InstallerType: zip
+NestedInstallerType: portable
+ReleaseDate: 2026-07-15
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/loreste/mako/releases/download/v0.1.7/mako-x86_64-pc-windows-msvc.zip
+  InstallerSha256: 085073DD4935934FEE8E91C6084932BA113BB011FA5DF5D7AD1F582B9AA34864
+  NestedInstallerFiles:
+  - RelativeFilePath: mako-x86_64-pc-windows-msvc\bin\mako.exe
+    PortableCommandAlias: mako
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/l/loreste/mako/0.1.7/loreste.mako.locale.en-US.yaml
+++ b/manifests/l/loreste/mako/0.1.7/loreste.mako.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: loreste.mako
+PackageVersion: 0.1.7
+PackageLocale: en-US
+Publisher: loreste
+PublisherUrl: https://github.com/loreste/mako
+PublisherSupportUrl: https://github.com/loreste/mako/issues
+Author: loreste
+PackageName: Mako
+PackageUrl: https://github.com/loreste/mako
+License: MIT
+LicenseUrl: https://github.com/loreste/mako/blob/v0.1.7/LICENSE
+Copyright: Copyright (c) loreste
+ShortDescription: Mako systems/backend language (.mko to native via C)
+Description: |-
+  Mako is a systems and backend language that compiles .mko sources to native
+  code via C. Ships a single CLI binary plus runtime headers and stdlib.
+Moniker: mako
+Tags:
+- backend
+- compiler
+- programming-language
+- systems
+ReleaseNotesUrl: https://github.com/loreste/mako/releases/tag/v0.1.7
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/l/loreste/mako/0.1.7/loreste.mako.yaml
+++ b/manifests/l/loreste/mako/0.1.7/loreste.mako.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Multi-file version manifest (singleton is deprecated in microsoft/winget-pkgs).
+# Submit under: manifests/l/loreste/mako/<version>/
+PackageIdentifier: loreste.mako
+PackageVersion: 0.1.7
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## New package / version

- **Package:** loreste.mako
- **Version:** 0.1.7
- **Publisher:** loreste
- **Installer:** portable zip from GitHub Releases (Windows x64)

## Installer

- URL: https://github.com/loreste/mako/releases/download/v0.1.7/mako-x86_64-pc-windows-msvc.zip
- SHA256: 085073DD4935934FEE8E91C6084932BA113BB011FA5DF5D7AD1F582B9AA34864
- Type: zip / NestedInstallerType portable (`mako.exe`)
- Nested path: `mako-x86_64-pc-windows-msvc\bin\mako.exe`

## Manifest format

Multi-file **ManifestVersion 1.12.0** (not singleton — per Validation Guide):

- `loreste.mako.yaml` (version)
- `loreste.mako.installer.yaml` (installer)
- `loreste.mako.locale.en-US.yaml` (defaultLocale)

## Notes

Release: https://github.com/loreste/mako/releases/tag/v0.1.7

Related earlier PR (0.1.4 multi-file fix): https://github.com/microsoft/winget-pkgs/pull/402823

Checklist:
- [x] Multi-file ManifestVersion 1.12.0
- [x] InstallerSha256 matches release asset
- [x] NestedInstallerFiles path matches zip layout
- [x] PackageIdentifier uses publisher.package form
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/403016)