### PR TITLE
New package: RigSmith.Rigsmith version 1.4.0

### DIFF
--- a/manifests/r/RigSmith/Rigsmith/1.4.0/RigSmith.Rigsmith.installer.yaml
+++ b/manifests/r/RigSmith/Rigsmith/1.4.0/RigSmith.Rigsmith.installer.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: RigSmith.Rigsmith
+PackageVersion: 1.4.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: rig.exe
+  PortableCommandAlias: rig
+- RelativeFilePath: changerig.exe
+  PortableCommandAlias: changerig
+- RelativeFilePath: shiprig.exe
+  PortableCommandAlias: shiprig
+- RelativeFilePath: clauderig.exe
+  PortableCommandAlias: clauderig
+Commands:
+- rig
+- changerig
+- shiprig
+- clauderig
+ReleaseDate: 2026-07-16
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/rigsmith/rigsmith/releases/download/v1.4.0/rigsmith_1.4.0_windows_amd64.zip
+  InstallerSha256: 08CA230DD5779C5C333D1B11E9225DBC33C8C77C788488F62413C17EF9590CF0
+- Architecture: arm64
+  InstallerUrl: https://github.com/rigsmith/rigsmith/releases/download/v1.4.0/rigsmith_1.4.0_windows_arm64.zip
+  InstallerSha256: DA7325ED274CB6A7A3F0E62765B4D9C3A5DF9AB70036134B2712B05DB1FF32E1
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/r/RigSmith/Rigsmith/1.4.0/RigSmith.Rigsmith.locale.en-US.yaml
+++ b/manifests/r/RigSmith/Rigsmith/1.4.0/RigSmith.Rigsmith.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: RigSmith.Rigsmith
+PackageVersion: 1.4.0
+PackageLocale: en-US
+Publisher: RigSmith
+PublisherUrl: https://rigsmith.dev/
+PublisherSupportUrl: https://github.com/rigsmith/rigsmith/issues
+Author: John Campion Jr
+PackageName: RigSmith
+PackageUrl: https://rigsmith.dev/
+License: MIT
+LicenseUrl: https://github.com/rigsmith/rigsmith/blob/main/LICENSE
+Copyright: Copyright (c) 2026 John Campion Jr
+ShortDescription: 'The rigsmith toolchain: rig, changerig, shiprig, clauderig'
+Description: The rigsmith toolchain in one package — rig (convention-first dev launcher), changerig (changesets), shiprig (releases/publish), and clauderig (sync Claude Code config). One install drops all four commands on PATH.
+Moniker: rigsmith
+Tags:
+- cli
+- developer-tools
+- dotnet
+- go
+- rust
+ReleaseNotesUrl: https://github.com/rigsmith/rigsmith/releases/tag/v1.4.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/RigSmith/Rigsmith/1.4.0/RigSmith.Rigsmith.yaml
+++ b/manifests/r/RigSmith/Rigsmith/1.4.0/RigSmith.Rigsmith.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: RigSmith.Rigsmith
+PackageVersion: 1.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New package

- **Package**: `RigSmith.Rigsmith` version `1.4.0`
- The RigSmith toolchain bundle — one install drops all four commands (`rig`, `changerig`, `shiprig`, `clauderig`) on PATH from the combined portable zip (nested-installer type `zip` → `portable`, mirroring the existing approved `RigSmith.*` packages).
- Publisher `RigSmith` already publishes `RigSmith.Rig`, `.ChangeRig`, `.ClaudeRig`, `.ShipRig`.

#### Checklist

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] This package does not violate [winget policies](https://aka.ms/winget-policies).
- [x] Manifest conforms to the [1.12.0 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0) and matches the structure of the already-approved `RigSmith.*` packages.
- [x] Not yet validated with `winget validate` / `winget install` locally (authored off-Windows) — relying on the pipeline's automated validation.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/403088)