### PR TITLE
New package: TediousCode.FoxSchema.DB2 version 0.1.45

### DIFF
--- a/manifests/t/TediousCode/FoxSchema/DB2/0.1.45/TediousCode.FoxSchema.DB2.installer.yaml
+++ b/manifests/t/TediousCode/FoxSchema/DB2/0.1.45/TediousCode.FoxSchema.DB2.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: TediousCode.FoxSchema.DB2
+PackageVersion: 0.1.45
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: wix
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-07-16
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/tedious-code/foxschema/releases/download/v0.1.45/Fox.Schema.DB2_0.1.45_x64_en-US.msi
+    InstallerSha256: 53D059F11BFD5DAE512309A2AF9682B3DB022DB9E1F4039576CE40B36D028173
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/t/TediousCode/FoxSchema/DB2/0.1.45/TediousCode.FoxSchema.DB2.locale.en-US.yaml
+++ b/manifests/t/TediousCode/FoxSchema/DB2/0.1.45/TediousCode.FoxSchema.DB2.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: TediousCode.FoxSchema.DB2
+PackageVersion: 0.1.45
+PackageLocale: en-US
+Publisher: Tedious Code
+PublisherUrl: https://github.com/tedious-code
+PublisherSupportUrl: https://github.com/tedious-code/foxschema/issues
+Author: huyplb
+PackageName: FoxSchemaDB2
+PackageUrl: https://github.com/tedious-code/foxschema
+License: Apache-2.0
+LicenseUrl: https://github.com/tedious-code/foxschema/blob/main/LICENSE
+Copyright: Copyright (c) Tedious Code
+ShortDescription: Database schema diff and migration tool with IBM Db2 support
+Description: Fox Schema DB2 is the desktop app build that includes IBM Db2 connectivity. Compare a source database schema against a target, generate dialect-native migration SQL, and deploy it. For installs without Db2, use TediousCode.FoxSchema instead.
+Moniker: foxschemadb2
+Tags:
+  - database
+  - schema
+  - migration
+  - sql
+  - diff
+  - db2
+  - ibm
+  - foxschemadb2
+ReleaseNotesUrl: https://github.com/tedious-code/foxschema/releases/tag/v0.1.45
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/t/TediousCode/FoxSchema/DB2/0.1.45/TediousCode.FoxSchema.DB2.yaml
+++ b/manifests/t/TediousCode/FoxSchema/DB2/0.1.45/TediousCode.FoxSchema.DB2.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: TediousCode.FoxSchema.DB2
+PackageVersion: 0.1.45
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Description
New package for **Fox Schema DB2** (desktop MSI with IBM Db2 support).

- Package ID: `TediousCode.FoxSchema.DB2`
- PackageName: `FoxSchemaDB2`
- Moniker: `foxschemadb2` → `winget install foxschemaDb2`
- Installer: WiX MSI from GitHub Releases v0.1.45

Related: standard package PR https://github.com/microsoft/winget-pkgs/pull/403101 (`TediousCode.FoxSchema` / `foxschema`)

## Checklist
- [x] Have you signed the Contributor License Agreement?
- [x] Have you tested this package against the installer?
- [x] Does your submission pass validation?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/403112)