### PR TITLE
New package: InteractorOSS.build version 1.0.0

### DIFF
--- a/manifests/i/InteractorOSS/build/1.0.0/InteractorOSS.build.installer.yaml
+++ b/manifests/i/InteractorOSS/build/1.0.0/InteractorOSS.build.installer.yaml
@@ -1,0 +1,14 @@
+PackageIdentifier: InteractorOSS.build
+PackageVersion: "1.0.0"
+InstallerLocale: en-US
+InstallerType: portable
+InstallModes:
+  - interactive
+  - silent
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/InteractorOSS/product-manager/releases/download/cli/v1.0.0/ibuild-windows-x64.exe
+    InstallerSha256: F3DE7DB249AFBF06164E76C73AB61156F536370206F5D3C91B688EFA4C707608
+    PortableCommandAlias: ibuild
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/i/InteractorOSS/build/1.0.0/InteractorOSS.build.locale.en-US.yaml
+++ b/manifests/i/InteractorOSS/build/1.0.0/InteractorOSS.build.locale.en-US.yaml
@@ -1,0 +1,22 @@
+PackageIdentifier: InteractorOSS.build
+PackageVersion: "1.0.0"
+PackageLocale: en-US
+Publisher: InteractorOSS
+PublisherUrl: https://interactor.com
+PackageName: ibuild
+PackageUrl: https://build.interactor.com
+License: AGPL-3.0-or-later
+LicenseUrl: https://github.com/InteractorOSS/product-manager/blob/main/LICENSE
+ShortDescription: Bidirectional sync daemon for Interactor PM tasks/goals
+Description: >
+  ibuild syncs your .build/ folder with Interactor's project management platform.
+  Works in any project regardless of programming language. Reads config from
+  .build/config.json and your personal token from .build/.sync.
+Tags:
+  - tasks
+  - goals
+  - productivity
+  - developer-tools
+  - project-management
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/i/InteractorOSS/build/1.0.0/InteractorOSS.build.yaml
+++ b/manifests/i/InteractorOSS/build/1.0.0/InteractorOSS.build.yaml
@@ -1,0 +1,8 @@
+# WinGet package version manifest for ibuild.
+# Submit to: https://github.com/microsoft/winget-pkgs
+# Path in that repo: manifests/i/InteractorOSS/build/1.0.0/InteractorOSS.build.yaml
+PackageIdentifier: InteractorOSS.build
+PackageVersion: "1.0.0"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Description
Adds the WinGet manifest for `InteractorOSS.build` (ibuild), a bidirectional sync daemon for Interactor PM tasks/goals, version 1.0.0.

- Source: https://github.com/InteractorOSS/product-manager
- License: AGPL-3.0-or-later
- Release asset: https://github.com/InteractorOSS/product-manager/releases/download/cli/v1.0.0/ibuild-windows-x64.exe
- InstallerSha256: F3DE7DB249AFBF06164E76C73AB61156F536370206F5D3C91B688EFA4C707608

## Checklist
- [x] I've verified the manifest structure follows the schema (installer, defaultLocale, version manifests)
- [x] The installer URL and SHA256 have been verified against the published GitHub release asset
- [x] This is a new package submission
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/403165)