### PR TITLE
New version: DeltaForge.CLI version 1.2.0

### DIFF
--- a/manifests/d/DeltaForge/CLI/1.2.0/DeltaForge.CLI.installer.yaml
+++ b/manifests/d/DeltaForge/CLI/1.2.0/DeltaForge.CLI.installer.yaml
@@ -1,0 +1,12 @@
+PackageIdentifier: DeltaForge.CLI
+PackageVersion: 1.2.0
+InstallerType: wix
+
+
+
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/deltaforge-org/delta-forge/releases/download/v1.2.0/deltaforge-cli-1.2.0-windows-x64.msi
+  InstallerSha256: 5D83000D84FA5F0768C88453ED3D046FDDFF48E08BBB6437C6DDB20C516178A2
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/d/DeltaForge/CLI/1.2.0/DeltaForge.CLI.locale.en-US.yaml
+++ b/manifests/d/DeltaForge/CLI/1.2.0/DeltaForge.CLI.locale.en-US.yaml
@@ -1,0 +1,27 @@
+PackageIdentifier: DeltaForge.CLI
+PackageVersion: 1.2.0
+PackageLocale: en-US
+Publisher: DeltaForge
+PublisherUrl: https://deltaforge.org
+PublisherSupportUrl: https://deltaforge.org/pages/contact.html
+PackageName: 'DeltaForge CLI'
+Moniker: 'deltaforge-cli'
+PackageUrl: https://deltaforge.org
+License: Proprietary
+LicenseUrl: https://deltaforge.org/pages/terms-of-service.html
+Copyright: 'Copyright (c) 2026 DeltaForge'
+ShortDescription: 'Query Delta Lake and Apache Iceberg in place from your terminal: no warehouse, no cluster, no copy pipeline'
+Tags:
+  - cli
+  - command-line
+  - delta-forge
+  - delta-lake
+  - iceberg
+  - sql
+  - graph
+  - cypher
+  - geospatial
+  - adbc
+  - odbc
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/d/DeltaForge/CLI/1.2.0/DeltaForge.CLI.yaml
+++ b/manifests/d/DeltaForge/CLI/1.2.0/DeltaForge.CLI.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: DeltaForge.CLI
+PackageVersion: 1.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Adds/updates manifests for DeltaForge.CLI 1.2.0.

All artifacts are downloaded from:
https://github.com/deltaforge-org/delta-forge/releases/download/v1.2.0/

Publisher homepage: https://deltaforge.org
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/403168)