### PR TITLE
New package: iammodev.YAKC version 2.0.0

### DIFF
--- a/manifests/i/iammodev/YAKC/2.0.0/iammodev.YAKC.installer.yaml
+++ b/manifests/i/iammodev/YAKC/2.0.0/iammodev.YAKC.installer.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 PackageIdentifier: iammodev.YAKC
 PackageVersion: 2.0.0
-InstallerType: nsis
+InstallerType: nullsoft
 Scope: user
 InstallModes:
   - silent

--- a/manifests/i/iammodev/YAKC/2.0.0/iammodev.YAKC.installer.yaml
+++ b/manifests/i/iammodev/YAKC/2.0.0/iammodev.YAKC.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: iammodev.YAKC
+PackageVersion: 2.0.0
+InstallerType: nsis
+Scope: user
+InstallModes:
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-07-16
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/iammodev/YAKC/releases/download/v2.0.0/YAKC_2.0.0_x64-setup.exe
+    InstallerSha256: 0757F57DC1138928D589BB77463BE72CFF9744D6E84BA78F34C27AA73F149FA8
+  - Architecture: arm64
+    InstallerUrl: https://github.com/iammodev/YAKC/releases/download/v2.0.0/YAKC_2.0.0_arm64-setup.exe
+    InstallerSha256: B69E28217D58B9801B75FD8E24C769C8F6381658D242DB1B883AF4E0FB970A3E
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/i/iammodev/YAKC/2.0.0/iammodev.YAKC.locale.en-US.yaml
+++ b/manifests/i/iammodev/YAKC/2.0.0/iammodev.YAKC.locale.en-US.yaml
@@ -10,6 +10,7 @@ PackageName: YAKC
 PackageUrl: https://github.com/iammodev/YAKC
 License: MIT
 LicenseUrl: https://github.com/iammodev/YAKC/blob/main/LICENSE
+ReleaseNotesUrl: https://github.com/iammodev/YAKC/releases/tag/v2.0.0
 ShortDescription: Yet Another Key Caster — cross-platform key & mouse click visualizer.
 Description: >-
   YAKC (Yet Another Key Caster) is an open-source, cross-platform key & mouse

--- a/manifests/i/iammodev/YAKC/2.0.0/iammodev.YAKC.locale.en-US.yaml
+++ b/manifests/i/iammodev/YAKC/2.0.0/iammodev.YAKC.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: iammodev.YAKC
+PackageVersion: 2.0.0
+PackageLocale: en-US
+Publisher: Aslan Devecioglu
+PublisherUrl: https://github.com/iammodev
+PublisherSupportUrl: https://github.com/iammodev/YAKC/issues
+Author: Aslan Devecioglu
+PackageName: YAKC
+PackageUrl: https://github.com/iammodev/YAKC
+License: MIT
+LicenseUrl: https://github.com/iammodev/YAKC/blob/main/LICENSE
+ShortDescription: Yet Another Key Caster — cross-platform key & mouse click visualizer.
+Description: >-
+  YAKC (Yet Another Key Caster) is an open-source, cross-platform key & mouse
+  click visualizer for streamers, content creators, teachers and presenters.
+  It displays your keystrokes and mouse clicks as customizable on-screen popups,
+  with any keyboard language supported automatically.
+Moniker: yakc
+Tags:
+  - keycaster
+  - keystroke
+  - keystroke-visualizer
+  - overlay
+  - presentation
+  - screencast
+  - streaming
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/i/iammodev/YAKC/2.0.0/iammodev.YAKC.yaml
+++ b/manifests/i/iammodev/YAKC/2.0.0/iammodev.YAKC.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: iammodev.YAKC
+PackageVersion: 2.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: `iammodev.YAKC` version `2.0.0`

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

> Note: authored on Linux, so `winget validate`/`winget install` were not run locally. The manifests were validated against the 1.6.0 JSON schema, and the installer URLs + SHA256 were verified against the published release. Please let me know if the validation pipeline surfaces anything to adjust.

#### About the package

**YAKC (Yet Another Key Caster)** is an open-source, cross-platform key & mouse click visualizer for streamers, content creators and presenters. This is the initial submission (v2.0.0), a native Rust + Tauri application.

- Repository: https://github.com/iammodev/YAKC
- Release: https://github.com/iammodev/YAKC/releases/tag/v2.0.0
- Installers: NSIS `-setup.exe` for x64 and arm64 (per-user, silent install via `/S`).