### PR TITLE
Update: mbobka.FolderView to 1.0.3

### DIFF
--- a/manifests/m/mbobka/FolderView/1.0.3/mbobka.FolderView.installer.yaml
+++ b/manifests/m/mbobka/FolderView/1.0.3/mbobka.FolderView.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: mbobka.FolderView
 PackageVersion: 1.0.3
@@ -15,4 +15,4 @@ Installers:
   InstallerUrl: https://github.com/mbobka/folderview/releases/download/v1.0.3/FolderView-1.0.3-win-x64.zip
   InstallerSha256: 316B0AB0465897D0A790A76B213E2A6BBB3AB9D1FF188167BB42F3E87C4646CE
 ManifestType: installer
-ManifestVersion: 1.10.0
+ManifestVersion: 1.12.0

--- a/manifests/m/mbobka/FolderView/1.0.3/mbobka.FolderView.installer.yaml
+++ b/manifests/m/mbobka/FolderView/1.0.3/mbobka.FolderView.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: mbobka.FolderView
+PackageVersion: 1.0.3
+InstallerType: zip
+NestedInstallerType: portable
+Commands:
+- fview
+ReleaseDate: 2026-07-16
+Installers:
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: FolderView.exe
+    PortableCommandAlias: fview
+  InstallerUrl: https://github.com/mbobka/folderview/releases/download/v1.0.3/FolderView-1.0.3-win-x64.zip
+  InstallerSha256: 316B0AB0465897D0A790A76B213E2A6BBB3AB9D1FF188167BB42F3E87C4646CE
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/m/mbobka/FolderView/1.0.3/mbobka.FolderView.locale.en-US.yaml
+++ b/manifests/m/mbobka/FolderView/1.0.3/mbobka.FolderView.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: mbobka.FolderView
+PackageVersion: 1.0.3
+PackageLocale: en-US
+Publisher: Vladimir Ivchenkov
+PublisherUrl: https://github.com/mbobka
+PublisherSupportUrl: https://github.com/mbobka/folderview/issues
+Author: Vladimir Ivchenkov
+PackageName: FolderView
+PackageUrl: https://github.com/mbobka/folderview
+License: MIT
+LicenseUrl: https://github.com/mbobka/folderview/blob/master/LICENSE
+Copyright: Copyright (c) 2026 Vladimir Ivchenkov
+ShortDescription: Lightweight image viewer for folders and ZIP archives.
+Description: Lightweight image viewer for folders, ZIP archives, JPEG, PNG, and WebP files.
+Moniker: folderview
+Tags:
+- folder
+- image-viewer
+- jpeg
+- jpg
+- png
+- webp
+- zip
+ReleaseNotesUrl: https://github.com/mbobka/folderview/releases/tag/v1.0.3
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/m/mbobka/FolderView/1.0.3/mbobka.FolderView.locale.en-US.yaml
+++ b/manifests/m/mbobka/FolderView/1.0.3/mbobka.FolderView.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: mbobka.FolderView
 PackageVersion: 1.0.3
@@ -25,4 +25,4 @@ Tags:
 - zip
 ReleaseNotesUrl: https://github.com/mbobka/folderview/releases/tag/v1.0.3
 ManifestType: defaultLocale
-ManifestVersion: 1.10.0
+ManifestVersion: 1.12.0

--- a/manifests/m/mbobka/FolderView/1.0.3/mbobka.FolderView.yaml
+++ b/manifests/m/mbobka/FolderView/1.0.3/mbobka.FolderView.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: mbobka.FolderView
+PackageVersion: 1.0.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0

--- a/manifests/m/mbobka/FolderView/1.0.3/mbobka.FolderView.yaml
+++ b/manifests/m/mbobka/FolderView/1.0.3/mbobka.FolderView.yaml
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: mbobka.FolderView
 PackageVersion: 1.0.3
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.10.0
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Updates `mbobka.FolderView` to version `1.0.3`.

- points the installer manifest to the published `FolderView-1.0.3-win-x64.zip`
- updates the release URL, release date, and SHA256
- removes the obsolete `Microsoft.VCRedist.2015+.x64` dependency because FolderView 1.0.3 is a freestanding C build without MSVC runtime DLL imports
- updates the manifests to schema 1.12.0

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/403238)