### PR TITLE
New package: Otakora.Dogu version 0.2.5

### DIFF
--- a/manifests/o/Otakora/Dogu/0.2.5/Otakora.Dogu.installer.yaml
+++ b/manifests/o/Otakora/Dogu/0.2.5/Otakora.Dogu.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Otakora.Dogu
+PackageVersion: 0.2.5
+InstallerType: nullsoft
+InstallModes:
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-07-16
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Otakora/dogu/releases/download/v0.2.5/dogu-windows-x64-0.2.5-setup.exe
+  InstallerSha256: 53EF478047AEF1987F941E6A39209A8EC1DBFA11EAEDCD70F4324A401814707E
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/o/Otakora/Dogu/0.2.5/Otakora.Dogu.locale.en-US.yaml
+++ b/manifests/o/Otakora/Dogu/0.2.5/Otakora.Dogu.locale.en-US.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Otakora.Dogu
+PackageVersion: 0.2.5
+PackageLocale: en-US
+Publisher: Otakora
+PublisherUrl: https://github.com/Otakora
+PackageName: Dogu
+PackageUrl: https://github.com/Otakora/dogu
+License: GPL-2.0-or-later
+LicenseUrl: https://github.com/Otakora/dogu/blob/main/LICENSE
+ShortDescription: A practical desktop file workbench for local files, remotes and queued operations.
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/o/Otakora/Dogu/0.2.5/Otakora.Dogu.yaml
+++ b/manifests/o/Otakora/Dogu/0.2.5/Otakora.Dogu.yaml
@@ -1,0 +1,24 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.singleton.1.12.0.schema.json
+PackageIdentifier: Otakora.Dogu
+PackageVersion: 0.2.5
+PackageLocale: en-US
+Publisher: Otakora
+PublisherUrl: https://github.com/Otakora
+PackageName: Dogu
+PackageUrl: https://github.com/Otakora/dogu
+License: GPL-2.0-or-later
+LicenseUrl: https://github.com/Otakora/dogu/blob/main/LICENSE
+ShortDescription: A practical desktop file workbench for local files, remotes and queued operations.
+InstallerType: nullsoft
+InstallModes:
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-07-16
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Otakora/dogu/releases/download/v0.2.5/dogu-windows-x64-0.2.5-setup.exe
+  InstallerSha256: 53EF478047AEF1987F941E6A39209A8EC1DBFA11EAEDCD70F4324A401814707E
+ManifestType: singleton
+ManifestVersion: 1.12.0
+

--- a/manifests/o/Otakora/Dogu/0.2.5/Otakora.Dogu.yaml
+++ b/manifests/o/Otakora/Dogu/0.2.5/Otakora.Dogu.yaml
@@ -1,24 +1,6 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.singleton.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 PackageIdentifier: Otakora.Dogu
 PackageVersion: 0.2.5
-PackageLocale: en-US
-Publisher: Otakora
-PublisherUrl: https://github.com/Otakora
-PackageName: Dogu
-PackageUrl: https://github.com/Otakora/dogu
-License: GPL-2.0-or-later
-LicenseUrl: https://github.com/Otakora/dogu/blob/main/LICENSE
-ShortDescription: A practical desktop file workbench for local files, remotes and queued operations.
-InstallerType: nullsoft
-InstallModes:
-- silent
-- silentWithProgress
-UpgradeBehavior: install
-ReleaseDate: 2026-07-16
-Installers:
-- Architecture: x64
-  InstallerUrl: https://github.com/Otakora/dogu/releases/download/v0.2.5/dogu-windows-x64-0.2.5-setup.exe
-  InstallerSha256: 53EF478047AEF1987F941E6A39209A8EC1DBFA11EAEDCD70F4324A401814707E
-ManifestType: singleton
+DefaultLocale: en-US
+ManifestType: version
 ManifestVersion: 1.12.0
-


### PR DESCRIPTION
Adds Dogu 0.2.5 to the Windows Package Manager community repository.\n\nInstaller: https://github.com/Otakora/dogu/releases/download/v0.2.5/dogu-windows-x64-0.2.5-setup.exe\nRelease: https://github.com/Otakora/dogu/releases/tag/v0.2.5
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/403272)