### PR TITLE
New version: solpbc.Solstone version 0.2.11

### DIFF
--- a/manifests/s/solpbc/Solstone/0.2.11/solpbc.Solstone.installer.yaml
+++ b/manifests/s/solpbc/Solstone/0.2.11/solpbc.Solstone.installer.yaml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: solpbc.Solstone
+PackageVersion: 0.2.11
+MinimumOSVersion: 10.0.18362.0
+Scope: user
+InstallerType: exe
+InstallModes:
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: --silent
+  SilentWithProgress: --silent
+  InstallLocation: --installto "<INSTALLPATH>"
+  Log: --log "<LOGPATH>"
+UpgradeBehavior: install
+ProductCode: Solstone
+ReleaseDate: 2026-07-16
+# The Settings/About UI is a WebView2 surface; the app relies on the OS Evergreen
+# WebView2 runtime (not bundled). Declaring it lets winget resolve the runtime from
+# its own catalog first on the rare machine that lacks it (older Win10/LTSC/Server).
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Microsoft.EdgeWebView2Runtime
+# Correlation for `winget upgrade`: the app registers in Add/Remove Programs under
+# its Velopack --packTitle ("sol"), NOT the pack id ("Solstone"). Every field listed
+# here must match the real ARP entry or winget cannot correlate the installed app,
+# and upgrades go undetected. The 0.2.0 manifest said "Solstone" and could not.
+AppsAndFeaturesEntries:
+  - DisplayName: sol
+    ProductCode: Solstone
+InstallationMetadata:
+  DefaultInstallLocation: '%LocalAppData%\Solstone'
+Installers:
+  # x64: the Setup.exe stub is a 32-bit Velopack shim, but the application it
+  # installs (solstone-windows-app.exe) is PE32+ x86-64. Architecture describes the
+  # app's applicability, not the stub -- tools that sniff the stub guess x86. Do not
+  # let one "correct" this to x86.
+  - Architecture: x64
+    InstallerUrl: https://github.com/solpbc/solstone-windows/releases/download/v0.2.11/solstone-setup-0.2.11.exe
+    InstallerSha256: F3A091451CEF2FB7B441261F800C9886D4EFF995AE1F024A2BACD4E5F2B7012A
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/solpbc/Solstone/0.2.11/solpbc.Solstone.locale.en-US.yaml
+++ b/manifests/s/solpbc/Solstone/0.2.11/solpbc.Solstone.locale.en-US.yaml
@@ -1,0 +1,48 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+#
+# THIS IS THE PUBLISHED COPY. Editing it here is what ships it -- publish-winget.sh
+# renders this file into the winget-pkgs PR. (It did not used to: `komac update`
+# carried the last PUBLISHED version's copy forward and never read this directory,
+# so brand fixes made here sat unpublished for ten releases.)
+#
+# ReleaseNotes/ReleaseNotesUrl are NOT authored here -- publish-winget.sh derives
+# them per release from the CHANGELOG.md section and the release tag.
+
+PackageIdentifier: solpbc.Solstone
+PackageVersion: 0.2.11
+PackageLocale: en-US
+Publisher: sol pbc
+PublisherUrl: https://solpbc.org
+PublisherSupportUrl: https://support.solpbc.org
+PackageName: solstone
+PackageUrl: https://solstone.app
+License: AGPL-3.0-only
+LicenseUrl: https://github.com/solpbc/solstone-windows/blob/main/LICENSE
+Copyright: Copyright (c) 2026 sol pbc
+ShortDescription: sol for Windows, part of solstone — a per-user, non-elevated, tray-resident app that takes in your screen and system audio (plus the microphone when one is present) and keeps it in local, owner-controlled segments for your journal.
+Description: |-
+  solstone is an open-source, privacy-respecting way to collect and gain insight from your own
+  personal data. sol for Windows is a per-user, non-elevated, tray-resident app that takes in what
+  happens on your PC — screen and system audio, plus the microphone when one is present — and keeps
+  it in local, owner-controlled segments for your journal.
+
+  Everything stays yours: there is no analytics, telemetry, tracking, or crash reporting, and
+  nothing phones home. State is always earned — the app never shows 'on' unless it truly is.
+  Updates are delivered by the app itself.
+Moniker: solstone
+Tags:
+  - journal
+  - open-source
+  - personal-data
+  - privacy
+  - self-determination
+  - solstone
+ReleaseNotes: |-
+  Fixed
+
+  - sol no longer re-sends segments your journal has already finished processing. earlier versions kept re-sending them indefinitely, spending bandwidth and CPU on work that was already done. sol removes a local copy only after your journal confirms it holds the segment; without that confirmation, the copy stays on your machine.
+  - sol no longer stalls waiting on large replies from your journal. anything over about a megabyte previously hung until a timeout instead of arriving.
+  - the private link sol uses to reach your journal now rejects malformed or oversized data cleanly instead of letting it disrupt the connection.
+ReleaseNotesUrl: https://github.com/solpbc/solstone-windows/releases/tag/v0.2.11
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/solpbc/Solstone/0.2.11/solpbc.Solstone.yaml
+++ b/manifests/s/solpbc/Solstone/0.2.11/solpbc.Solstone.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: solpbc.Solstone
+PackageVersion: 0.2.11
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Version update for `solpbc.Solstone` to `0.2.11`, published by the package's own author (sol pbc).

Installer: [`solstone-setup-0.2.11.exe`](https://github.com/solpbc/solstone-windows/releases/tag/v0.2.11) — SHA256 verified against the published asset.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/403277)