### PR TITLE
New package: JNX03.Flowtake version 1.6.0

### DIFF
--- a/manifests/j/JNX03/Flowtake/1.6.0/JNX03.Flowtake.installer.yaml
+++ b/manifests/j/JNX03/Flowtake/1.6.0/JNX03.Flowtake.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: JNX03.Flowtake
+PackageVersion: 1.6.0
+InstallerLocale: en-US
+InstallerType: wix
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{CEB7F435-02D2-41EF-8B21-28D9E7D3E5CB}'
+ReleaseDate: 2026-07-16
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/JNX03/Flowtake/releases/download/v1.6.0/Flowtake_1.6.0_x64_en-US.msi
+  InstallerSha256: 497FE1454687EE1224FC839C2290A44471041DB7490E72F55EE14464ADD61B8D
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/j/JNX03/Flowtake/1.6.0/JNX03.Flowtake.locale.en-US.yaml
+++ b/manifests/j/JNX03/Flowtake/1.6.0/JNX03.Flowtake.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: JNX03.Flowtake
+PackageVersion: 1.6.0
+PackageLocale: en-US
+Publisher: Jnx03
+PublisherUrl: https://github.com/JNX03
+PublisherSupportUrl: https://github.com/JNX03/Flowtake/issues
+PackageName: Flowtake
+PackageUrl: https://github.com/JNX03/Flowtake
+License: MIT
+LicenseUrl: https://github.com/JNX03/Flowtake/blob/v1.6.0/LICENSE
+PrivacyUrl: https://github.com/JNX03/Flowtake/blob/v1.6.0/README.md#privacy-and-open-source-boundary
+Copyright: Copyright (c) 2025-present Jnx03
+ShortDescription: Local-first screen recorder and timeline editor for polished developer demos.
+Description: >-
+  Record, arrange, and export developer demos locally with editable screen sources,
+  timeline controls, automatic zoom, and local MP4 export.
+Moniker: flowtake
+Tags:
+- developer-tools
+- devrel
+- screen-recorder
+- screencast
+- video-editor
+ReleaseNotesUrl: https://github.com/JNX03/Flowtake/releases/tag/v1.6.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/j/JNX03/Flowtake/1.6.0/JNX03.Flowtake.yaml
+++ b/manifests/j/JNX03/Flowtake/1.6.0/JNX03.Flowtake.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: JNX03.Flowtake
+PackageVersion: 1.6.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds the first WinGet community manifest for Flowtake 1.6.0, a local-first screen recorder and timeline editor for developer demos.

Published installer:
- URL: https://github.com/JNX03/Flowtake/releases/download/v1.6.0/Flowtake_1.6.0_x64_en-US.msi
- SHA-256: 497FE1454687EE1224FC839C2290A44471041DB7490E72F55EE14464ADD61B8D
- Type/scope: WiX MSI, x64, machine

Validation evidence:
- `winget validate --manifest manifests/j/JNX03/Flowtake/1.6.0` passes with WinGet v1.29.280.
- A clean Windows Server 2025 workflow installed this exact local manifest silently, verified WinGet's installer hash, correlated ARP/ProductCode/publisher/version/shortcuts, scanned the published MSI and installed files with Microsoft Defender, launched the exact executable for a bounded 10-second smoke test, and uninstalled it cleanly: https://github.com/JNX03/Flowtake/actions/runs/29504335095
- The v1.6.0 MSI is currently unsigned; the manifest makes no signing claim and pins the exact published asset hash above.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com) — awaiting repository bot status
- [x] Linked to an issue (if applicable)
  - Not applicable: this is a routine single-version manifest submission.

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same manifest submission
- [x] This PR only modifies one manifest: one three-file manifest set for `JNX03.Flowtake` version `1.6.0`
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest installation with `winget install --manifest <path>` on the clean Windows runner linked above
- [x] Manifest conforms to the 1.12 schema
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/403282)