### PR TITLE
New package: JuniorHat78.shot version 0.8.1

### DIFF
--- a/manifests/j/JuniorHat78/shot/0.8.1/JuniorHat78.shot.installer.yaml
+++ b/manifests/j/JuniorHat78/shot/0.8.1/JuniorHat78.shot.installer.yaml
@@ -1,0 +1,17 @@
+PackageIdentifier: JuniorHat78.shot
+PackageVersion: 0.8.1
+MinimumOSVersion: 10.0.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: shot.exe
+    PortableCommandAlias: shot
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/JuniorHat78/shot/releases/download/v0.8.1/shot-v0.8.1-x64.zip
+    InstallerSha256: 0CB4164CBD421E248BA8DDAB08AC0C756A4809C5558AC1838E3EFD4D86E0717A
+  - Architecture: arm64
+    InstallerUrl: https://github.com/JuniorHat78/shot/releases/download/v0.8.1/shot-v0.8.1-arm64.zip
+    InstallerSha256: 3101FB5D88112023CF21A6B18B8047EFCCBBEE17FDF767572B860D811DF628D8
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/j/JuniorHat78/shot/0.8.1/JuniorHat78.shot.locale.en-US.yaml
+++ b/manifests/j/JuniorHat78/shot/0.8.1/JuniorHat78.shot.locale.en-US.yaml
@@ -1,0 +1,26 @@
+PackageIdentifier: JuniorHat78.shot
+PackageVersion: 0.8.1
+PackageLocale: en-US
+Publisher: JuniorHat78
+PublisherUrl: https://github.com/JuniorHat78
+PackageName: shot
+PackageUrl: https://github.com/JuniorHat78/shot
+License: MIT
+LicenseUrl: https://github.com/JuniorHat78/shot/blob/main/LICENSE
+ShortDescription: A frictionless camera app for Windows — one static exe, zero dependencies, zero network.
+Description: |-
+  Opens instantly to a live viewfinder. Space captures WYSIWYG PNG to
+  clipboard and disk, V records H.264 MP4 with mic audio via the hardware
+  encoder, B grades your camera into a report card. Keyboard-first,
+  mouse-complete, self-healing on device loss. No installer, no telemetry,
+  no network access, ever.
+Moniker: shot
+Tags:
+  - camera
+  - webcam
+  - screenshot
+  - video
+  - portable
+ReleaseNotesUrl: https://github.com/JuniorHat78/shot/blob/main/CHANGELOG.md
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/j/JuniorHat78/shot/0.8.1/JuniorHat78.shot.yaml
+++ b/manifests/j/JuniorHat78/shot/0.8.1/JuniorHat78.shot.yaml
@@ -1,0 +1,7 @@
+# Version manifest — submit the three files in this directory to
+# microsoft/winget-pkgs under manifests/j/JuniorHat78/shot/0.8.1/
+PackageIdentifier: JuniorHat78.shot
+PackageVersion: 0.8.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
New package submission: **shot** — a frictionless camera app for Windows (single static exe, portable, MIT).

- Homepage: https://github.com/JuniorHat78/shot
- Release: https://github.com/JuniorHat78/shot/releases/tag/v0.8.1
- InstallerType: zip (nested portable), x64 + arm64
- Sha256s computed from the published release assets.

Notes for reviewers:
- First submission for this package and publisher.
- `winget validate` was not run locally (winget unavailable on the dev machine); relying on pipeline validation.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/403290)