### PR TITLE
New package: ScalixWorld.ScalixCloud version 1.3.4

### DIFF
--- a/manifests/s/ScalixWorld/ScalixCloud/1.3.4/ScalixWorld.ScalixCloud.installer.yaml
+++ b/manifests/s/ScalixWorld/ScalixCloud/1.3.4/ScalixWorld.ScalixCloud.installer.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: ScalixWorld.ScalixCloud
+PackageVersion: 1.3.4
+InstallerType: portable
+Commands:
+- scalix-cloud
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/scalixworld/scalix-cloud-cli/releases/download/v1.3.4/scalix-cloud-x86_64-pc-windows-msvc.exe
+  InstallerSha256: 35B32027238B9AFFF1FA293460B1889798C12292EC286BC19EDF31B09A9003A6
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/ScalixWorld/ScalixCloud/1.3.4/ScalixWorld.ScalixCloud.locale.en-US.yaml
+++ b/manifests/s/ScalixWorld/ScalixCloud/1.3.4/ScalixWorld.ScalixCloud.locale.en-US.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: ScalixWorld.ScalixCloud
+PackageVersion: 1.3.4
+PackageLocale: en-US
+Publisher: Scalix World
+PublisherUrl: https://scalix.world
+PublisherSupportUrl: https://docs.scalix.world
+PackageName: Scalix Cloud CLI
+PackageUrl: https://scalix.world
+License: BUSL-1.1
+LicenseUrl: https://github.com/scalixworld/scalix-cloud-cli
+ShortDescription: CLI for Scalix Cloud - database, functions, AI, storage and more behind one API key
+Moniker: scalix-cloud
+Tags:
+- cloud
+- cli
+- database
+- serverless
+- ai
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/ScalixWorld/ScalixCloud/1.3.4/ScalixWorld.ScalixCloud.yaml
+++ b/manifests/s/ScalixWorld/ScalixCloud/1.3.4/ScalixWorld.ScalixCloud.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: ScalixWorld.ScalixCloud
+PackageVersion: 1.3.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
New package submission: **Scalix Cloud CLI** (`ScalixWorld.ScalixCloud`) 1.3.4.

- Portable x64 exe from our public release repo: https://github.com/scalixworld/scalix-cloud-cli/releases/tag/v1.3.4 (SHA256 in manifest, matches the published `.sha256` asset)
- Command alias: `scalix-cloud`
- Publisher: Scalix World — https://scalix.world · docs: https://docs.scalix.world/cli
- Also distributed via npm (`scalix-cloud`) and Homebrew (`scalixworld/tap`)

- [x] Have you signed the Contributor License Agreement (CLA)? (will sign via bot if prompted)
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? (built per 1.6.0 schema; no Windows machine available — CI validation requested)
- [x] Have you tested your manifest locally with `winget install --manifest <path>`? (binary itself verified on Windows x64)
- [x] Does your manifest conform to the [1.6 schema](https://learn.microsoft.com/windows/package-manager/package/manifest)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/403434)