### PR TITLE
New version: ThotTechnologies.Celeborn version 0.3.0

### DIFF
--- a/manifests/t/ThotTechnologies/Celeborn/0.3.0/ThotTechnologies.Celeborn.installer.yaml
+++ b/manifests/t/ThotTechnologies/Celeborn/0.3.0/ThotTechnologies.Celeborn.installer.yaml
@@ -1,0 +1,17 @@
+# winget installer manifest — portable single-exe (no MSI). winget-pkgs accepts zip-nested or bare
+# portable exes but NOT tar.gz (winget-cli #2899), so the release publishes a bare
+# celeborn-<ver>-windows-x86_64.exe asset alongside the tarball (extracted from the verified
+# tarball; its sha256 rides SHA256SUMS). PortableCommandAlias gives users the `celeborn` command
+# regardless of asset filename. Per release: bump PackageVersion + the version in InstallerUrl and
+# paste the exe's sha256. 0.2.1 was submitted as winget-pkgs PR #397921; expect the Defender
+# false-positive dance on each bump (unsigned PyInstaller exe — clear via aka.ms/wdsi, CELE-t463).
+PackageIdentifier: ThotTechnologies.Celeborn
+PackageVersion: 0.3.0
+InstallerType: portable
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/cloud-dancer-labs/celeborn-releases/releases/download/v0.3.0/celeborn-0.3.0-windows-x86_64.exe
+    InstallerSha256: A6C9349812E05863A0A3ED206AA6583DCCF2B87BC3B8E735D5373C703CFA4D4E
+    PortableCommandAlias: celeborn
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/t/ThotTechnologies/Celeborn/0.3.0/ThotTechnologies.Celeborn.locale.en-US.yaml
+++ b/manifests/t/ThotTechnologies/Celeborn/0.3.0/ThotTechnologies.Celeborn.locale.en-US.yaml
@@ -1,0 +1,30 @@
+PackageIdentifier: ThotTechnologies.Celeborn
+PackageVersion: 0.3.0
+PackageLocale: en-US
+Publisher: Thot Technologies LLC
+PublisherUrl: https://github.com/cloud-dancer-labs
+PackageName: Celeborn
+PackageUrl: https://github.com/cloud-dancer-labs/celeborn-code
+# Since 0.3.0 the shipped exe is the compiled client — proprietary (all rights reserved); the
+# license text ships inside every release tarball and on the release page. The BUSL-1.1 license
+# covers the thin installer repo (celeborn-code), not this binary.
+License: Proprietary
+LicenseUrl: https://github.com/cloud-dancer-labs/celeborn-releases/releases/tag/v0.3.0
+Copyright: Copyright (c) 2026 Cloud Dancer (distributed by Thot Technologies LLC)
+ShortDescription: Long-term context substrate for coding agents (CLI).
+Description: >-
+  Celeborn is a context husbandry layer for coding agents — a layered, on-disk memory substrate that
+  keeps an agent's always-loaded context small and bounded, survives compaction, and gets cheaper to
+  resume over time. Works with Claude Code, Codex, and Grok. Every account starts with a 7-day free
+  trial of Celeborn Pro (hosted cross-device sync and the hosted board); your .context/ memory is
+  plain Markdown on your own disk and stays yours either way.
+ReleaseNotesUrl: https://github.com/cloud-dancer-labs/celeborn-releases/releases/tag/v0.3.0
+Tags:
+  - llm
+  - agents
+  - memory
+  - context
+  - claude
+  - cli
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/t/ThotTechnologies/Celeborn/0.3.0/ThotTechnologies.Celeborn.yaml
+++ b/manifests/t/ThotTechnologies/Celeborn/0.3.0/ThotTechnologies.Celeborn.yaml
@@ -1,0 +1,8 @@
+# winget version manifest. Submit the trio (this + installer + locale) to microsoft/winget-pkgs under
+#   manifests/t/ThotTechnologies/Celeborn/<version>/
+# Then users run:  winget install ThotTechnologies.Celeborn
+PackageIdentifier: ThotTechnologies.Celeborn
+PackageVersion: 0.3.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`? (authored on macOS — relying on pipeline validation, same as #397921 which passed)
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Portable single-exe CLI. 0.3.0 moves the download to the dedicated binaries repository
(cloud-dancer-labs/celeborn-releases); the shipped exe is the compiled client and its license
ships with the release. Supersedes #397921 (0.2.1 — closing that one in favor of this).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/403448)