### PR TITLE
HoraceMaxwell.Horosa version 3.4.0: correct InstallerSha256 (installer re-released)

### DIFF
--- a/manifests/h/HoraceMaxwell/Horosa/3.4.0/HoraceMaxwell.Horosa.installer.yaml
+++ b/manifests/h/HoraceMaxwell/Horosa/3.4.0/HoraceMaxwell.Horosa.installer.yaml
@@ -12,10 +12,10 @@ InstallModes:
   - silent
   - silentWithProgress
 UpgradeBehavior: install
-ReleaseDate: 2026-07-14
+ReleaseDate: 2026-07-16
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/Horace-Maxwell/Horosa-Web-App-comprehensively-improved-Windows/releases/download/v3.4.0/Horosa-Setup-3.4.0.exe
-    InstallerSha256: A0647EDBB6868C53EDB4210A4FEAC6EC9C050964F0CE1A539D5F6B60F006894E
+    InstallerSha256: B757BFF8FEE366E2FC02D72A1B6215AC9C0D7926CC936D55A58920559F474B04
 ManifestType: installer
 ManifestVersion: 1.6.0


### PR DESCRIPTION
The 3.4.0 installer was re-released at the same version to include installer-side hardening for machines where security software (SmartScreen / third-party AV) blocked the unsigned installer: it now clears the downloaded-file mark on the main executable, suppresses a blocking "cannot access file" system dialog during the first-run warmup step, and shows a clear quarantine-detection prompt if the main executable is locked/quarantined.

Because the binary served at the existing `InstallerUrl` changed, the previously-published manifest's `InstallerSha256` no longer matches the asset. This PR corrects `InstallerSha256` to match the currently-served installer and updates `ReleaseDate` accordingly. No other fields change; `PackageVersion` and `InstallerUrl` are unchanged.

- [x] I verified the `InstallerSha256` matches the SHA256 of the asset currently served at `InstallerUrl` (SHA256SUMS.txt on the release).
- [x] Manifest validated locally.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/403514)