### PR TITLE
New package: NodeRelay.Uplink version 2026.7.6

### DIFF
--- a/manifests/n/NodeRelay/Uplink/2026.7.6/NodeRelay.Uplink.installer.yaml
+++ b/manifests/n/NodeRelay/Uplink/2026.7.6/NodeRelay.Uplink.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: NodeRelay.Uplink
+PackageVersion: 2026.7.6
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: Uplink.exe
+  PortableCommandAlias: uplink
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/noderelay/UplinkIRC/releases/download/v2026.7.6/Uplink-v2026.7.6-windows-x64.zip
+  InstallerSha256: A73368EBDE36BFACFBBD54E31DFDD5FC55555501F1D950D7064809B95987D54B
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/n/NodeRelay/Uplink/2026.7.6/NodeRelay.Uplink.locale.en-US.yaml
+++ b/manifests/n/NodeRelay/Uplink/2026.7.6/NodeRelay.Uplink.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: NodeRelay.Uplink
+PackageVersion: 2026.7.6
+PackageLocale: en-US
+Publisher: NodeRelay
+PublisherUrl: https://github.com/noderelay
+PublisherSupportUrl: https://github.com/noderelay/UplinkIRC/issues
+PackageName: Uplink
+PackageUrl: https://uplinkirc.chat
+License: GPL-3.0-only
+LicenseUrl: https://github.com/noderelay/UplinkIRC/blob/main/LICENSE
+ShortDescription: Fast, secure, IRCv3-featured IRC client
+Description: |-
+  Uplink is a fast, secure IRC client built with Qt 6. It speaks modern
+  IRCv3 (chat history, reactions, message redaction, typing indicators,
+  SASL), connects over TLS by default, ships 297 color themes, and stores
+  passwords in the system credential manager.
+Moniker: uplink
+Tags:
+- chat
+- irc
+- ircv3
+- qt
+ReleaseNotesUrl: https://github.com/noderelay/UplinkIRC/releases/tag/v2026.7.6
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/n/NodeRelay/Uplink/2026.7.6/NodeRelay.Uplink.yaml
+++ b/manifests/n/NodeRelay/Uplink/2026.7.6/NodeRelay.Uplink.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: NodeRelay.Uplink
+PackageVersion: 2026.7.6
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: authored on Linux, so the two local winget checks were not run; relying on the pipeline validation. Manifests follow the 1.6 schema (zip + nested portable, Uplink.exe at archive root).

New package: Uplink, a fast, secure, IRCv3-featured IRC client built with Qt 6. Portable zip release, GPL-3.0-only, published from the project's GitHub releases.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/403545)