### PR TITLE
Modify: Add zip installer options for CMake 4.4.0

### DIFF
--- a/manifests/k/Kitware/CMake/4.4.0/Kitware.CMake.installer.yaml
+++ b/manifests/k/Kitware/CMake/4.4.0/Kitware.CMake.installer.yaml
@@ -4,15 +4,16 @@
 PackageIdentifier: Kitware.CMake
 PackageVersion: 4.4.0
 InstallerLocale: en-US
-InstallerType: wix
-Scope: machine
-InstallerSwitches:
-  InstallLocation: INSTALL_ROOT="<INSTALLPATH>"
-  Custom: ADD_CMAKE_TO_PATH=System
 UpgradeBehavior: install
 ReleaseDate: 2026-07-09
 Installers:
+# --- MSI (Machine Scope) installer ---
 - Architecture: x86
+  InstallerType: wix
+  Scope: machine
+  InstallerSwitches:
+    InstallLocation: INSTALL_ROOT="<INSTALLPATH>"
+    Custom: ADD_CMAKE_TO_PATH=System
   InstallerUrl: https://github.com/Kitware/CMake/releases/download/v4.4.0/cmake-4.4.0-windows-i386.msi
   InstallerSha256: 786A25282A466C384E45D4D974CCD8D0528CD3CB70F1858BF7510266B095F2BB
   ProductCode: '{8290B40E-B469-415C-9060-4AE4DE263642}'
@@ -21,7 +22,13 @@ Installers:
     UpgradeCode: '{8FFD1D72-B7F1-11E2-8EE5-00238BCA4991}'
   InstallationMetadata:
     DefaultInstallLocation: '%ProgramFiles(x86)%\.\CMake'
+
 - Architecture: x64
+  InstallerType: wix
+  Scope: machine
+  InstallerSwitches:
+    InstallLocation: INSTALL_ROOT="<INSTALLPATH>"
+    Custom: ADD_CMAKE_TO_PATH=System
   InstallerUrl: https://github.com/Kitware/CMake/releases/download/v4.4.0/cmake-4.4.0-windows-x86_64.msi
   InstallerSha256: 82DB53FCB8F38BE541A26093489F39D5ED79B71B53CD121FC32A022A6BF310B1
   ProductCode: '{446F968E-F229-4317-8808-8D4AEF7D800D}'
@@ -30,7 +37,13 @@ Installers:
     UpgradeCode: '{8FFD1D72-B7F1-11E2-8EE5-00238BCA4991}'
   InstallationMetadata:
     DefaultInstallLocation: '%ProgramFiles%\.\CMake'
+
 - Architecture: arm64
+  InstallerType: wix
+  Scope: machine
+  InstallerSwitches:
+    InstallLocation: INSTALL_ROOT="<INSTALLPATH>"
+    Custom: ADD_CMAKE_TO_PATH=System
   InstallerUrl: https://github.com/Kitware/CMake/releases/download/v4.4.0/cmake-4.4.0-windows-arm64.msi
   InstallerSha256: 47996E7E91026C21488AD7170246DD9FA36E45B605BD74927A9915E59795D534
   ProductCode: '{83A74F49-7065-41B9-BC65-0340F3ACC71A}'
@@ -39,5 +52,52 @@ Installers:
     UpgradeCode: '{8FFD1D72-B7F1-11E2-8EE5-00238BCA4991}'
   InstallationMetadata:
     DefaultInstallLocation: '%ProgramFiles%\.\CMake'
+
+# --- ZIP (User Scope / Portable) installer ---
+- Architecture: x86
+  InstallerType: zip
+  InstallerUrl: https://github.com/Kitware/CMake/releases/download/v4.4.0/cmake-4.4.0-windows-i386.zip
+  InstallerSha256: 1B2A35DFD18ADB5EB0CCFE3D3A1E756A198F06981F9CD52DD44735615044D0F7
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: cmake-4.4.0-windows-i386\bin\cmake.exe
+    PortableCommandAlias: cmake
+  - RelativeFilePath: cmake-4.4.0-windows-i386\bin\cmake-gui.exe
+    PortableCommandAlias: cmake-gui
+  - RelativeFilePath: cmake-4.4.0-windows-i386\bin\cpack.exe
+    PortableCommandAlias: cpack
+  - RelativeFilePath: cmake-4.4.0-windows-i386\bin\ctest.exe
+    PortableCommandAlias: ctest
+
+- Architecture: x64
+  InstallerType: zip
+  InstallerUrl: https://github.com/Kitware/CMake/releases/download/v4.4.0/cmake-4.4.0-windows-x86_64.zip
+  InstallerSha256: 156D70EB7625A7B469444DF7D0861D2AF8D5D0A437FCE32C350372B08F5620E8
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: cmake-4.4.0-windows-x86_64\bin\cmake.exe
+    PortableCommandAlias: cmake
+  - RelativeFilePath: cmake-4.4.0-windows-x86_64\bin\cmake-gui.exe
+    PortableCommandAlias: cmake-gui
+  - RelativeFilePath: cmake-4.4.0-windows-x86_64\bin\cpack.exe
+    PortableCommandAlias: cpack
+  - RelativeFilePath: cmake-4.4.0-windows-x86_64\bin\ctest.exe
+    PortableCommandAlias: ctest
+
+- Architecture: arm64
+  InstallerType: zip
+  InstallerUrl: https://github.com/Kitware/CMake/releases/download/v4.4.0/cmake-4.4.0-windows-arm64.zip
+  InstallerSha256: 57437E918B2929BBD25B8D427611120149DF02D4B216872E0F48F361F03D71E5
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: cmake-4.4.0-windows-arm64\bin\cmake.exe
+    PortableCommandAlias: cmake
+  - RelativeFilePath: cmake-4.4.0-windows-arm64\bin\cmake-gui.exe
+    PortableCommandAlias: cmake-gui
+  - RelativeFilePath: cmake-4.4.0-windows-arm64\bin\cpack.exe
+    PortableCommandAlias: cpack
+  - RelativeFilePath: cmake-4.4.0-windows-arm64\bin\ctest.exe
+    PortableCommandAlias: ctest
+
 ManifestType: installer
 ManifestVersion: 1.12.0


### PR DESCRIPTION
Resolves #403447

Updated installer details for CMake version 4.4.0, including new zip installer types for x86, x64, and arm64 architectures.

<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
<!-- Describe what this PR changes. For manifest submissions, include the package name and version. -->

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [ ] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/403617)