### PR TITLE
New package: MavenImaging.UniversalConverterX version 2.28.0

### DIFF
--- a/manifests/m/MavenImaging/UniversalConverterX/2.28.0/MavenImaging.UniversalConverterX.installer.yaml
+++ b/manifests/m/MavenImaging/UniversalConverterX/2.28.0/MavenImaging.UniversalConverterX.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: MavenImaging.UniversalConverterX
+PackageVersion: 2.28.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: UniversalConverterX.exe
+    PortableCommandAlias: universalconverterx
+  - RelativeFilePath: ucx.exe
+    PortableCommandAlias: ucx
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/SysAdminDoc/UniversalConverterX/releases/download/v2.28.0/UniversalConverterX_2.28.0_portable.zip
+    InstallerSha256: 3A231042234E72863149076C493CCEC159367EA532FC548BBD0B91B4D73C05D3
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/MavenImaging/UniversalConverterX/2.28.0/MavenImaging.UniversalConverterX.locale.en-US.yaml
+++ b/manifests/m/MavenImaging/UniversalConverterX/2.28.0/MavenImaging.UniversalConverterX.locale.en-US.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: MavenImaging.UniversalConverterX
+PackageVersion: 2.28.0
+PackageLocale: en-US
+Publisher: Maven Imaging
+PublisherUrl: https://github.com/SysAdminDoc
+PublisherSupportUrl: https://github.com/SysAdminDoc/UniversalConverterX/issues
+PackageName: UniversalConverter X
+PackageUrl: https://github.com/SysAdminDoc/UniversalConverterX
+License: MIT
+LicenseUrl: https://github.com/SysAdminDoc/UniversalConverterX/blob/main/LICENSE
+ShortDescription: Offline-first Windows file and media conversion workspace.
+Description: Convert media, documents, archives, subtitles, images, and AI-assisted workflows locally with a WinUI desktop app and the ucx command-line interface.
+Tags:
+  - converter
+  - ffmpeg
+  - media
+  - offline
+  - winui
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/MavenImaging/UniversalConverterX/2.28.0/MavenImaging.UniversalConverterX.yaml
+++ b/manifests/m/MavenImaging/UniversalConverterX/2.28.0/MavenImaging.UniversalConverterX.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: MavenImaging.UniversalConverterX
+PackageVersion: 2.28.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Package submission

Adds Universal Converter X 2.28.0 as a portable WinGet package.

- Package identifier: `MavenImaging.UniversalConverterX`
- Package version: `2.28.0`
- Installer type: portable (`x64`)
- Release asset: `UniversalConverterX_2.28.0_portable.zip`
- Portable aliases: `universalconverterx`, `ucx`

## Validation

- `winget validate --manifest installer/winget/manifests/m/MavenImaging/UniversalConverterX/2.28.0` succeeds locally.
- The release asset returns HTTP 200 and its hosted byte length matches the locally validated artifact.
- The manifest SHA-256 matches the published release asset: `3A231042234E72863149076C493CCEC159367EA532FC548BBD0B91B4D73C05D3`.

Release: https://github.com/SysAdminDoc/UniversalConverterX/releases/tag/v2.28.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/403621)