### PR TITLE
New package: DiscoverWorthy.Scratchpad version 0.2.2

### DIFF
--- a/manifests/d/DiscoverWorthy/Scratchpad/0.2.2/DiscoverWorthy.Scratchpad.installer.yaml
+++ b/manifests/d/DiscoverWorthy/Scratchpad/0.2.2/DiscoverWorthy.Scratchpad.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: DiscoverWorthy.Scratchpad
+PackageVersion: 0.2.2
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://dwstprd001.blob.core.windows.net/downloads/DiscoverWorthy-Scratchpad-Setup-0.2.2.exe
+  InstallerSha256: 04EFBA0E7EA0448624D7D0334030551F01F3CE3CBC420FCB0CA6AC7B0917E0FF
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/d/DiscoverWorthy/Scratchpad/0.2.2/DiscoverWorthy.Scratchpad.installer.yaml
+++ b/manifests/d/DiscoverWorthy/Scratchpad/0.2.2/DiscoverWorthy.Scratchpad.installer.yaml
@@ -13,7 +13,7 @@ InstallModes:
 UpgradeBehavior: install
 Installers:
 - Architecture: x64
-  InstallerUrl: https://dwstprd001.blob.core.windows.net/downloads/DiscoverWorthy-Scratchpad-Setup-0.2.2.exe
+  InstallerUrl: https://downloads.discoverworthy.com/scratchpad/DiscoverWorthy-Scratchpad-Setup-0.2.2.exe
   InstallerSha256: 04EFBA0E7EA0448624D7D0334030551F01F3CE3CBC420FCB0CA6AC7B0917E0FF
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/d/DiscoverWorthy/Scratchpad/0.2.2/DiscoverWorthy.Scratchpad.locale.en-US.yaml
+++ b/manifests/d/DiscoverWorthy/Scratchpad/0.2.2/DiscoverWorthy.Scratchpad.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: DiscoverWorthy.Scratchpad
+PackageVersion: 0.2.2
+PackageLocale: en-US
+Publisher: Discover Worthy Pty Ltd
+PublisherUrl: https://discoverworthy.com
+PublisherSupportUrl: https://discoverworthy.com/scratchpad
+PackageName: DiscoverWorthy Scratchpad
+PackageUrl: https://discoverworthy.com/scratchpad
+License: Proprietary
+Copyright: Copyright (c) 2026 Discover Worthy Pty Ltd
+ShortDescription: Quiet meeting capture and a fast daily notebook. Notes are transcribed on your device and flow into your DiscoverWorthy workspace as contacts, tasks, and quotes.
+Moniker: scratchpad
+Tags:
+- meetings
+- notebook
+- notes
+- notetaker
+- productivity
+- transcription
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/d/DiscoverWorthy/Scratchpad/0.2.2/DiscoverWorthy.Scratchpad.yaml
+++ b/manifests/d/DiscoverWorthy/Scratchpad/0.2.2/DiscoverWorthy.Scratchpad.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: DiscoverWorthy.Scratchpad
+PackageVersion: 0.2.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)? (will sign when the CLA bot prompts)
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? (manifest validated; the referenced installer binary itself is signed and verified working via direct install)
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

New package submission for DiscoverWorthy Scratchpad — a meeting-capture and notebook desktop app by Discover Worthy Pty Ltd. Installer is an Authenticode-signed NSIS setup (publisher: Discover Worthy Pty Ltd), hosted on a versioned, immutable URL.