### PR TITLE
New package: yinjianxxx.Gengchou version 2.2.2

### DIFF
--- a/manifests/y/yinjianxxx/Gengchou/2.2.2/yinjianxxx.Gengchou.installer.yaml
+++ b/manifests/y/yinjianxxx/Gengchou/2.2.2/yinjianxxx.Gengchou.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: yinjianxxx.Gengchou
+PackageVersion: '2.2.2'
+Platform:
+- Windows.Desktop
+InstallerType: zip
+NestedInstallerType: portable
+ReleaseDate: '2026-07-17'
+Installers:
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: gengchou.exe
+    PortableCommandAlias: gengchou
+  InstallerUrl: https://github.com/yinjianxxx/gengchou/releases/download/v2.2.2/gengchou-windows-x64.zip
+  InstallerSha256: CB9E2DB5D97D34B38693D7C8CDE1F7A0AAA9A320C618B14ADE2609C306027A56
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/y/yinjianxxx/Gengchou/2.2.2/yinjianxxx.Gengchou.locale.en-US.yaml
+++ b/manifests/y/yinjianxxx/Gengchou/2.2.2/yinjianxxx.Gengchou.locale.en-US.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: yinjianxxx.Gengchou
+PackageVersion: '2.2.2'
+PackageLocale: en-US
+Publisher: yinjianxxx
+PublisherUrl: https://github.com/yinjianxxx
+PrivacyUrl: https://github.com/yinjianxxx/gengchou/blob/v2.2.2/README.md#data--privacy
+Author: Craig Constable, yinjianxxx, and contributors
+PackageName: Gengchou
+PackageUrl: https://github.com/yinjianxxx/gengchou
+License: MIT
+LicenseUrl: https://github.com/yinjianxxx/gengchou/blob/v2.2.2/LICENSE
+Copyright: Copyright (C) 2025 Craig Constable; modifications Copyright (C) 2026 yinjianxxx
+CopyrightUrl: https://github.com/yinjianxxx/gengchou/blob/v2.2.2/LICENSE
+ShortDescription: A Windows taskbar and tray AI quota monitor for Claude Code, Codex, and Antigravity.
+Description: >-
+  Gengchou is a lightweight native Windows taskbar widget and system-tray app
+  for viewing the quota windows reported by Claude Code, Codex, and Google
+  Antigravity without opening a provider dashboard. It uses existing
+  authenticated sessions and has no analytics, telemetry, or separate backend
+  service.
+Moniker: gengchou
+Tags:
+- antigravity
+- claude-code
+- codex
+- remote-desktop
+- rust
+- system-tray
+- taskbar
+- usage-monitor
+- windows
+ReleaseNotes: Improves concurrent multi-provider refreshes, transient failure handling, authentication warnings, and recovery when a secondary monitor is removed.
+ReleaseNotesUrl: https://github.com/yinjianxxx/gengchou/releases/tag/v2.2.2
+InstallationNotes: WinGet portable packages do not create a Start menu shortcut. Open a new terminal and run "gengchou"; optionally enable "Start with Windows" from the app context menu.
+Documentations:
+- DocumentLabel: README
+  DocumentUrl: https://github.com/yinjianxxx/gengchou/blob/v2.2.2/README.md
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/y/yinjianxxx/Gengchou/2.2.2/yinjianxxx.Gengchou.locale.zh-CN.yaml
+++ b/manifests/y/yinjianxxx/Gengchou/2.2.2/yinjianxxx.Gengchou.locale.zh-CN.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: yinjianxxx.Gengchou
+PackageVersion: '2.2.2'
+PackageLocale: zh-CN
+Publisher: yinjianxxx
+PackageName: 更筹 Gengchou
+License: MIT
+ShortDescription: 面向 Windows 的 Claude Code、Codex 和 Antigravity 配额监视器，提供任务栏组件、浮窗和托盘图标。
+Description: >-
+  更筹是轻量级原生 Windows 任务栏组件与系统托盘应用，无需打开服务商控制台
+  即可查看 Claude Code、Codex 和 Google Antigravity 实际报告的配额窗口。
+  应用复用现有登录会话，不包含分析、遥测或独立后端服务。
+ReleaseNotes: 改进多服务商并发刷新、瞬时失败处理、身份验证警示，以及副屏移除后的界面恢复。
+InstallationNotes: WinGet 的 portable 包不会创建开始菜单快捷方式。安装后请在新终端中运行“gengchou”；如需开机启动，可在应用右键菜单中启用“Start with Windows”。
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/y/yinjianxxx/Gengchou/2.2.2/yinjianxxx.Gengchou.yaml
+++ b/manifests/y/yinjianxxx/Gengchou/2.2.2/yinjianxxx.Gengchou.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: yinjianxxx.Gengchou
+PackageVersion: '2.2.2'
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds the new package `yinjianxxx.Gengchou` version `2.2.2`.

- Uses the official version-specific `gengchou-windows-x64.zip` release asset.
- Installs the nested x64 portable executable `gengchou.exe` with the `gengchou` command alias.
- Includes English (default) and Simplified Chinese locale metadata.
- Uses the final product identity following the withdrawn pre-rename submission #400395; the former package was never published.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (not applicable for this routine manifest submission)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

Local `winget validate` succeeded with WinGet v1.29.280. The published ZIP was downloaded and verified against SHA256 `CB9E2DB5D97D34B38693D7C8CDE1F7A0AAA9A320C618B14ADE2609C306027A56`; it contains `gengchou.exe` at the archive root, and the executable reports product name `Gengchou` and file version `2.2.2`.

The local install checkbox is intentionally left unchecked: this session is not elevated, `LocalManifestFiles` requires administrator enablement, and Windows Sandbox is not available on the test machine. No security setting was changed; the repository validation pipeline can perform the authoritative install test.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/403628)