### PR TITLE
New package: Huerte.GitGo version 1.10.1

### DIFF
--- a/manifests/h/Huerte/GitGo/1.10.1/Huerte.GitGo.installer.yaml
+++ b/manifests/h/Huerte/GitGo/1.10.1/Huerte.GitGo.installer.yaml
@@ -1,0 +1,9 @@
+PackageIdentifier: Huerte.GitGo
+PackageVersion: 1.10.1
+InstallerType: portable
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Huerte/GitGo/releases/download/v1.10.1/gitgo.exe
+    InstallerSha256: 4e367dbf9c2c41680232291a6509afa9761c7c453591d194cd51d7c3622c1745
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/h/Huerte/GitGo/1.10.1/Huerte.GitGo.locale.en-US.yaml
+++ b/manifests/h/Huerte/GitGo/1.10.1/Huerte.GitGo.locale.en-US.yaml
@@ -1,0 +1,19 @@
+PackageIdentifier: Huerte.GitGo
+PackageVersion: 1.10.1
+PackageLocale: en-US
+Publisher: Huerte
+PublisherUrl: https://github.com/Huerte
+PublisherSupportUrl: https://github.com/Huerte/GitGo/issues
+PackageName: GitGo
+PackageUrl: https://github.com/Huerte/GitGo
+License: GPL-3.0-or-later
+LicenseUrl: https://github.com/Huerte/GitGo/blob/main/LICENSE
+ShortDescription: GitGo CLI - Your Fast Git Companion. Simplifies git push, link, stash, and user management.
+Tags:
+  - git
+  - cli
+  - github
+  - development
+ReleaseNotesUrl: https://github.com/Huerte/GitGo/releases/tag/v1.10.1
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/h/Huerte/GitGo/1.10.1/Huerte.GitGo.yaml
+++ b/manifests/h/Huerte/GitGo/1.10.1/Huerte.GitGo.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Huerte.GitGo
+PackageVersion: 1.10.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## 📖 Description
Initial submission of GitGo (`Huerte.GitGo`) version 1.10.1 to the Windows Package Manager repository.

GitGo is a fast Git companion CLI tool that simplifies git push, link, stash, user management and more, with a try-and-revert engine that automatically saves and restores your local changes during transitions. It started as a personal itch to scratch and grew from there.

## ✅ Checklist
- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)

## 📦 Manifest Checklist
- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.6.0 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/403630)