### PR TITLE
New package: lineuae.exerese version 1.2.0

### DIFF
--- a/manifests/l/lineuae/exerese/1.2.0/lineuae.exerese.installer.yaml
+++ b/manifests/l/lineuae/exerese/1.2.0/lineuae.exerese.installer.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: lineuae.exerese
+PackageVersion: 1.2.0
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseNotesUrl: https://github.com/lineuae/exerese/releases/tag/v1.2.0
+Installers:
+  - Architecture: x64
+    InstallerLocale: fr-FR
+    InstallerUrl: https://github.com/lineuae/exerese/releases/download/v1.2.0/exerese_1.2.0_x64-setup.exe
+    InstallerSha256: 8BE5791B64F5F537CF71A91C9A875FBE9A931AA85E9D4DD812DD1F9CD7671C9D
+    AppsAndFeaturesEntries:
+      - DisplayName: exerese
+        Publisher: lineuae
+        DisplayVersion: 1.2.0
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/l/lineuae/exerese/1.2.0/lineuae.exerese.locale.fr-FR.yaml
+++ b/manifests/l/lineuae/exerese/1.2.0/lineuae.exerese.locale.fr-FR.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: lineuae.exerese
+PackageVersion: 1.2.0
+PackageLocale: fr-FR
+Publisher: lineuae
+PublisherUrl: https://github.com/lineuae
+PublisherSupportUrl: https://github.com/lineuae/exerese/issues
+Author: lineuae
+PackageName: exérèse
+PackageUrl: https://github.com/lineuae/exerese
+License: MIT
+LicenseUrl: https://github.com/lineuae/exerese/blob/main/LICENSE
+Copyright: © 2026 lineuae
+CopyrightUrl: https://github.com/lineuae/exerese/blob/main/LICENSE
+ShortDescription: Désinstallation complète sous Windows — retire un programme et ses résidus sans toucher au reste.
+Description: |-
+  exérèse retire un programme Windows en entier : le désinstalleur natif d'abord,
+  puis les résidus qu'il laisse (fichiers, registre, raccourcis, entrées de
+  démarrage, services). Chaque suppression est justifiée par des preuves, passe
+  par la corbeille et reste annulable.
+Moniker: exerese
+Tags:
+  - uninstaller
+  - uninstall
+  - cleanup
+  - residues
+  - windows
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/l/lineuae/exerese/1.2.0/lineuae.exerese.yaml
+++ b/manifests/l/lineuae/exerese/1.2.0/lineuae.exerese.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: lineuae.exerese
+PackageVersion: 1.2.0
+DefaultLocale: fr-FR
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
New package submission for **lineuae.exerese** version **1.2.0**.

exérèse is a complete Windows uninstaller: it runs the program's native uninstaller first, then finds and removes the residues left behind (files, registry, shortcuts, startup entries, services), with evidence for each item and full reversibility (recycle bin, .reg backups, undo). Open-source, MIT.

- Repository: https://github.com/lineuae/exerese
- Release: https://github.com/lineuae/exerese/releases/tag/v1.2.0
- Installer: NSIS (nullsoft), per-user scope, x64. Built by public GitHub Actions CI with a Sigstore build-provenance attestation; each asset ships with its SHA-256.

Manifest schema 1.6.0, default locale fr-FR.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/403636)