### PR TITLE
New version: Finesssee.Win-CodexBar version 0.43.0

### DIFF
--- a/manifests/f/Finesssee/Win-CodexBar/0.43.0/Finesssee.Win-CodexBar.installer.yaml
+++ b/manifests/f/Finesssee/Win-CodexBar/0.43.0/Finesssee.Win-CodexBar.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Finesssee.Win-CodexBar
+PackageVersion: 0.43.0
+InstallerType: inno
+Scope: user
+UpgradeBehavior: install
+ProductCode: WinCodexBar_is1
+ReleaseDate: 2026-07-17
+AppsAndFeaturesEntries:
+- ProductCode: WinCodexBar_is1
+  DisplayName: CodexBar 0.43.0
+  DisplayVersion: 0.43.0
+  Publisher: CodexBar Contributors
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/nesszer/Win-CodexBar/releases/download/v0.43.0/CodexBar-0.43.0-Setup.exe
+  InstallerSha256: 551B5DF0E0CD3F59C810E98837D7326C83FE88E7009892AB249E840D9FE56ACD
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Finesssee/Win-CodexBar/0.43.0/Finesssee.Win-CodexBar.locale.en-US.yaml
+++ b/manifests/f/Finesssee/Win-CodexBar/0.43.0/Finesssee.Win-CodexBar.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Finesssee.Win-CodexBar
+PackageVersion: 0.43.0
+PackageLocale: en-US
+Publisher: CodexBar Contributors
+PublisherUrl: https://github.com/nesszer
+PublisherSupportUrl: https://github.com/nesszer/Win-CodexBar/issues
+Author: Finesssee
+PackageName: Win-CodexBar
+PackageUrl: https://github.com/nesszer/Win-CodexBar
+License: MIT
+LicenseUrl: https://github.com/nesszer/Win-CodexBar/blob/main/LICENSE
+Copyright: Copyright (c) CodexBar contributors
+ShortDescription: Windows-native menu bar app for OpenAI Codex and Claude Code usage stats.
+Description: Win-CodexBar is a Windows-native desktop app for viewing OpenAI Codex and Claude Code usage stats from a small Tauri shell.
+Moniker: win-codexbar
+Tags:
+- claude-code
+- codex
+- desktop
+- tauri
+- usage
+- windows
+ReleaseNotes: |-
+  Win-CodexBar 0.43.0 adds the sub2api provider, Factory/Droid API-key Auto with web fallback, read-only Kimi Code CLI credential reuse, account-scoped quota notifications, and Claude null five-hour informational placeholders.
+  It also improves cost-scan freshness, refresh generation ownership, FloatBar recovery, localization coverage, and multiple provider parsing fixes.
+ReleaseNotesUrl: https://github.com/nesszer/Win-CodexBar/releases/tag/v0.43.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Finesssee/Win-CodexBar/0.43.0/Finesssee.Win-CodexBar.yaml
+++ b/manifests/f/Finesssee/Win-CodexBar/0.43.0/Finesssee.Win-CodexBar.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Finesssee.Win-CodexBar
+PackageVersion: 0.43.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## New package/version submission

### Package
- Package identifier: `Finesssee.Win-CodexBar`
- Package version: `0.43.0`
- Installer URL: https://github.com/nesszer/Win-CodexBar/releases/download/v0.43.0/CodexBar-0.43.0-Setup.exe
- Installer SHA-256: `551B5DF0E0CD3F59C810E98837D7326C83FE88E7009892AB249E840D9FE56ACD`
- Installer type: Inno Setup (user scope)
- ProductCode: `WinCodexBar_is1` (unchanged)

### Notes
- Routine version update from `0.42.0` → `0.43.0`.
- PackageIdentifier remains `Finesssee.Win-CodexBar` for upgrade continuity.
- Installer and support URLs now point at the canonical GitHub home `nesszer/Win-CodexBar` (repo transfer; `Finesssee/Win-CodexBar` redirects).
- Local `winget validate` succeeded.

### Checklist
- [x] Have you signed the Contributor License Agreement?
- [x] Have you checked that there aren't other open pull requests for the same package update/change?
- [x] This PR only modifies one package
- [x] Have you validated your manifest locally with `winget validate`?

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/403644)