### PR TITLE
New package: TheAbider.RackStack version 1.122.0

### DIFF
--- a/manifests/t/TheAbider/RackStack/1.122.0/TheAbider.RackStack.installer.yaml
+++ b/manifests/t/TheAbider/RackStack/1.122.0/TheAbider.RackStack.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: TheAbider.RackStack
+PackageVersion: 1.122.0
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 6.1.0.0
+InstallerType: portable
+Commands:
+  - rackstack
+ReleaseDate: 2026-07-17
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/TheAbider/RackStack/releases/download/v1.122.0/RackStack.exe
+    InstallerSha256: A2145966C1878F26F4825CAAAFEA235F54A5B2CF6146C5A59799FEF5803D4808
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/t/TheAbider/RackStack/1.122.0/TheAbider.RackStack.locale.en-US.yaml
+++ b/manifests/t/TheAbider/RackStack/1.122.0/TheAbider.RackStack.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: TheAbider.RackStack
+PackageVersion: 1.122.0
+PackageLocale: en-US
+Publisher: TheAbider
+PublisherUrl: https://github.com/TheAbider
+PublisherSupportUrl: https://github.com/TheAbider/RackStack/issues
+PackageName: RackStack
+PackageUrl: https://github.com/TheAbider/RackStack
+License: MIT
+LicenseUrl: https://github.com/TheAbider/RackStack/blob/master/LICENSE
+Copyright: Copyright (c) 2026 TheAbider
+ShortDescription: PowerShell automation toolkit for configuring Windows Server hosts.
+Description: |-
+  RackStack is a menu-driven PowerShell tool that automates everything between
+  "Windows is installed" and "server is in production." It provides 201 CLI
+  actions and 60+ interactive menus covering networking, Hyper-V, SAN/iSCSI,
+  clustering, VM deployment, cloud onboarding, and batch automation, all with
+  undo, transaction rollback, and audit logging. Built for MSPs, sysadmins,
+  and infrastructure teams who build Windows Servers repeatedly.
+Moniker: rackstack
+Tags:
+  - windows-server
+  - hyper-v
+  - iscsi
+  - clustering
+  - powershell
+  - sysadmin
+  - automation
+  - msp
+ReleaseNotesUrl: https://github.com/TheAbider/RackStack/releases/tag/v1.122.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/t/TheAbider/RackStack/1.122.0/TheAbider.RackStack.yaml
+++ b/manifests/t/TheAbider/RackStack/1.122.0/TheAbider.RackStack.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: TheAbider.RackStack
+PackageVersion: 1.122.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://learn.microsoft.com/windows/package-manager/package/manifest?tabs=minschema%2Cversion-example)?

---

First submission of TheAbider.RackStack, a portable (ps2exe-compiled) PowerShell automation toolkit for configuring Windows Server hosts. Release assets carry SHA-256 hashes, Sigstore cosign signatures, and SLSA build provenance; the InstallerSha256 matches the published release-hashes.txt for v1.122.0.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/403660)