### PR TITLE
New version: CyberHive.Connect version 3.10.0

### DIFF
--- a/manifests/c/CyberHive/Connect/3.10.0/CyberHive.Connect.installer.yaml
+++ b/manifests/c/CyberHive/Connect/3.10.0/CyberHive.Connect.installer.yaml
@@ -1,0 +1,24 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: CyberHive.Connect
+PackageVersion: 3.10.0
+InstallerLocale: en-US
+InstallerType: inno
+Scope: machine
+InstallerSwitches:
+  Custom: /MANAGED=1
+UpgradeBehavior: install
+ProductCode: '{EA126048-51DD-4E62-A524-9FA0C8F07C24}_is1'
+ReleaseDate: 2026-07-07
+AppsAndFeaturesEntries:
+- ProductCode: '{EA126048-51DD-4E62-A524-9FA0C8F07C24}_is1'
+ElevationRequirement: elevatesSelf
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles%\CyberHive Connect'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://pkgs.cyberhive.com/windows/stable/cyberhive-connect_3.10.0-65526780.exe
+  InstallerSha256: 53F7E0CF5EC198AB2E8E47D4F779BE6480DE8A85DDA5B50E09021FAE681D47FE
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/CyberHive/Connect/3.10.0/CyberHive.Connect.locale.en-US.yaml
+++ b/manifests/c/CyberHive/Connect/3.10.0/CyberHive.Connect.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: CyberHive.Connect
+PackageVersion: 3.10.0
+PackageLocale: en-US
+Publisher: CyberHive
+PublisherUrl: https://www.cyberhive.com/
+PublisherSupportUrl: https://www.cyberhive.com/contact-us/
+PrivacyUrl: https://www.cyberhive.com/privacy-policy/
+Author: CyberHive Ltd.
+PackageName: CyberHive Connect
+PackageUrl: https://www.cyberhive.com/product/cyberhive-connect/
+License: Proprietary
+LicenseUrl: https://www.cyberhive.com/eula/
+Copyright: Copyright © CyberHive Ltd.
+CopyrightUrl: https://www.cyberhive.com/terms-and-conditions/
+ShortDescription: A zero trust software-defined mesh network secured with quantum-safe cryptography
+Description: |-
+  CyberHive Connect provides a Trusted Area Network - a zero trust software-defined mesh network secured with quantum-safe cryptography.
+  Connect features high performance with low latency and fast reconnects. It is simple and scalable, with easy setup and administration.
+Tags:
+- network
+- vpn
+ReleaseNotesUrl: https://docs.cyberhive.com/connect/release-notes/3100
+Documentations:
+- DocumentLabel: Documentation
+  DocumentUrl: https://docs.cyberhive.com/
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/CyberHive/Connect/3.10.0/CyberHive.Connect.locale.en-US.yaml
+++ b/manifests/c/CyberHive/Connect/3.10.0/CyberHive.Connect.locale.en-US.yaml
@@ -22,7 +22,7 @@ Description: |-
 Tags:
 - network
 - vpn
-ReleaseNotesUrl: https://docs.cyberhive.com/connect/release-notes/3100
+ReleaseNotesUrl: https://docs.cyberhive.com/connect/release-notes/#3100
 Documentations:
 - DocumentLabel: Documentation
   DocumentUrl: https://docs.cyberhive.com/

--- a/manifests/c/CyberHive/Connect/3.10.0/CyberHive.Connect.yaml
+++ b/manifests/c/CyberHive/Connect/3.10.0/CyberHive.Connect.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: CyberHive.Connect
+PackageVersion: 3.10.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description
New version of **CyberHive.Connect** to **3.10.0**.

- Cloned sibling manifests from `3.9.3` (inno, machine scope, `/MANAGED=1`, ProductCode preserved).
- Installer URL uses live host `pkgs.cyberhive.com` (issue body had typo host `pgks.cyberhive.com`).
- InstallerSha256 verified by full download of the Windows installer.
- ReleaseDate `2026-07-08` from official release notes (8th July 2026).
- ReleaseNotesUrl updated to `#3100`.

## ✅ Checklist
- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)
  - Resolves #398937

## 📦 Manifest Checklist
- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest structure against sibling 3.9.3 + schema 1.12.0 fields
- [ ] Tested manifest locally with `winget install --manifest <path>` (Linux contributor host; hash/URL verified by full download)
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

## Validation
- Issue: https://github.com/microsoft/winget-pkgs/issues/398937
- Release notes: https://docs.cyberhive.com/connect/release-notes/#3100
- Installer: `https://pkgs.cyberhive.com/windows/stable/cyberhive-connect_3.10.0-65526780.exe`
- InstallerSha256: `53F7E0CF5EC198AB2E8E47D4F779BE6480DE8A85DDA5B50E09021FAE681D47FE` (full download match)
- Size: 117945224 bytes

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/403739)