### PR TITLE
New package: martsg666.qbPortWeaver version 2.6.1

### DIFF
--- a/manifests/m/martsg666/qbPortWeaver/2.6.1/martsg666.qbPortWeaver.installer.yaml
+++ b/manifests/m/martsg666/qbPortWeaver/2.6.1/martsg666.qbPortWeaver.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: martsg666.qbPortWeaver
+PackageVersion: 2.6.1
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: wix
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-07-16
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/martsg666/qbPortWeaver/releases/download/v2.6.1/qbPortWeaver_2.6.1_Setup.msi
+  InstallerSha256: 3D59D1EECCBE9F8DEFD3274D21595342B7FEEE1AA958ECD1A2ECB099D2C9DAFC
+  ProductCode: '{90473B7C-CB3C-4C54-966E-DBF2D0DC8566}'
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/m/martsg666/qbPortWeaver/2.6.1/martsg666.qbPortWeaver.locale.en-US.yaml
+++ b/manifests/m/martsg666/qbPortWeaver/2.6.1/martsg666.qbPortWeaver.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: martsg666.qbPortWeaver
+PackageVersion: 2.6.1
+PackageLocale: en-US
+Publisher: martsg666
+PublisherUrl: https://github.com/martsg666
+PublisherSupportUrl: https://github.com/martsg666/qbPortWeaver/issues
+PackageName: qbPortWeaver
+PackageUrl: https://github.com/martsg666/qbPortWeaver
+License: Free of use and distribution
+LicenseUrl: https://github.com/martsg666/qbPortWeaver/blob/master/LICENSE
+Copyright: Copyright 2026 martsg666
+ShortDescription: Syncs the listening port of qBittorrent, Transmission, or Deluge with the VPN-assigned port, and imports media files into Plex-compatible library folders
+Description: |-
+  qbPortWeaver is a Windows system tray application that keeps the listening port of qBittorrent, Transmission, or Deluge synchronized with the port assigned by ProtonVPN, PIA, or any NAT-PMP capable VPN gateway.
+  It monitors the VPN's forwarded port on a configurable interval, updates the client automatically when the port changes, verifies the port is reachable, and can recover the VPN connection automatically when port detection fails. A Status panel shows the live sync chain, recent port changes, and session statistics, and a built-in Media Manager can import media files into Plex-compatible library folders.
+Moniker: qbportweaver
+Tags:
+- deluge
+- nat-pmp
+- port-forwarding
+- protonvpn
+- qbittorrent
+- transmission
+- vpn
+ReleaseNotesUrl: https://github.com/martsg666/qbPortWeaver/releases/tag/v2.6.1
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/m/martsg666/qbPortWeaver/2.6.1/martsg666.qbPortWeaver.yaml
+++ b/manifests/m/martsg666/qbPortWeaver/2.6.1/martsg666.qbPortWeaver.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: martsg666.qbPortWeaver
+PackageVersion: 2.6.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
First submission of martsg666.qbPortWeaver (Windows tray application that syncs a BitTorrent client's listening port with the VPN-assigned forwarded port).

- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://learn.microsoft.com/windows/package-manager/package/manifest?tabs=minschema%2Cversion-example)?

Note: the MSI is the same installer distributed on the GitHub release page and via Chocolatey (qbportweaver); it installs silently and registers the listed ProductCode.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/403778)