### PR TITLE
New package: dOR.OriNotebook version 0.1.1

### DIFF
--- a/manifests/d/dOR/OriNotebook/0.1.1/dOR.OriNotebook.installer.yaml
+++ b/manifests/d/dOR/OriNotebook/0.1.1/dOR.OriNotebook.installer.yaml
@@ -1,0 +1,19 @@
+# Created using Claude Code for dOR
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: dOR.OriNotebook
+PackageVersion: 0.1.1
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-07-17
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/dor-sr/ori-notebook-releases/releases/download/v0.1.1/Ori-Notebook-Setup-x64.exe
+  InstallerSha256: 0E045485476BEEBA74FE8AEEAAC0E606E642DE3E076DFA0C8D919A7F36DF1F0F
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/d/dOR/OriNotebook/0.1.1/dOR.OriNotebook.locale.en-US.yaml
+++ b/manifests/d/dOR/OriNotebook/0.1.1/dOR.OriNotebook.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# Created using Claude Code for dOR
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: dOR.OriNotebook
+PackageVersion: 0.1.1
+PackageLocale: en-US
+Publisher: dOR
+PublisherUrl: https://dorsr.com
+PublisherSupportUrl: https://github.com/dor-sr/ori-notebook-releases/issues
+PackageName: Ori Notebook
+PackageUrl: https://github.com/dor-sr/ori-notebook-releases
+License: Proprietary
+ShortDescription: Local-first notebook. Notes are plain Markdown files on your device, and the built-in agent only proposes edits you review.
+Moniker: ori-notebook
+Tags:
+- markdown
+- notebook
+- notes
+- local-first
+- knowledge-base
+ReleaseNotesUrl: https://github.com/dor-sr/ori-notebook-releases/releases/tag/v0.1.1
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/d/dOR/OriNotebook/0.1.1/dOR.OriNotebook.yaml
+++ b/manifests/d/dOR/OriNotebook/0.1.1/dOR.OriNotebook.yaml
@@ -1,0 +1,8 @@
+# Created using Claude Code for dOR
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: dOR.OriNotebook
+PackageVersion: 0.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
New package submission for Ori Notebook 0.1.1, a local-first Markdown notebook.

- Installer: Tauri-built NSIS (nullsoft), x64, user scope, silent install supported (/S)
- InstallerUrl is a permanent tag-pinned GitHub release asset; SHA256 verified against the download
- Manifests authored by hand against the 1.9.0 schemas (authored on Linux, so local winget validate was not available; relying on pipeline validation)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/403821)