### PR TITLE
New version: ScryerMedia.Weaver version 0.7.4

### DIFF
--- a/manifests/s/ScryerMedia/Weaver/0.7.4/ScryerMedia.Weaver.installer.yaml
+++ b/manifests/s/ScryerMedia/Weaver/0.7.4/ScryerMedia.Weaver.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ScryerMedia.Weaver
+PackageVersion: 0.7.4
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: weaver.exe
+  PortableCommandAlias: weaver
+InstallModes:
+- silent
+UpgradeBehavior: install
+ReleaseDate: 2026-07-16
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/scryer-media/weaver/releases/download/weaver-v0.7.4/weaver-windows-x86_64.zip
+  InstallerSha256: 4B6DC533A3EB9E5BFAC77DABB5A7941541EB6E637355F4468BB0AA1F4C0332DF
+- Architecture: arm64
+  InstallerUrl: https://github.com/scryer-media/weaver/releases/download/weaver-v0.7.4/weaver-windows-arm64.zip
+  InstallerSha256: C79CD1A03DCEF79F65B04651DE1439FD3557F9C29A38EDFF1B171046499C729B
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/ScryerMedia/Weaver/0.7.4/ScryerMedia.Weaver.locale.en-US.yaml
+++ b/manifests/s/ScryerMedia/Weaver/0.7.4/ScryerMedia.Weaver.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ScryerMedia.Weaver
+PackageVersion: 0.7.4
+PackageLocale: en-US
+Publisher: Scryer Media
+PublisherUrl: https://www.scryer.media/
+PublisherSupportUrl: https://github.com/scryer-media/weaver/issues
+Author: Scryer Media
+PackageName: Weaver
+PackageUrl: https://github.com/scryer-media/weaver
+License: GPL-3.0-or-later with UnRAR restriction
+LicenseUrl: https://github.com/scryer-media/weaver/blob/main/LICENSE
+Copyright: Copyright (c) Scryer Media
+ShortDescription: High-performance Usenet binary downloader.
+Description: Weaver is a Usenet binary downloader that handles downloading, decoding, PAR2 verification and repair, and archive extraction.
+Moniker: weaver-usenet
+Tags:
+- downloader
+- media
+- nntp
+- par2
+- usenet
+ReleaseNotesUrl: https://github.com/scryer-media/weaver/releases/tag/weaver-v0.7.4
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/ScryerMedia/Weaver/0.7.4/ScryerMedia.Weaver.yaml
+++ b/manifests/s/ScryerMedia/Weaver/0.7.4/ScryerMedia.Weaver.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ScryerMedia.Weaver
+PackageVersion: 0.7.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## What

Adds Weaver 0.7.4 for x64 and ARM64 Windows as portable ZIP packages.

## Source

- Release: https://github.com/scryer-media/weaver/releases/tag/weaver-v0.7.4
- Release CI: https://github.com/scryer-media/weaver/actions/runs/29459276203
- Manifests generated by the successful `winget-prep` job from the published release artifacts.

## Validation

- Weaver WinGet generator tests passed (4/4).
- Parsed all three generated YAML manifests successfully.
- Verified the x64 and ARM64 SHA-256 values against the downloaded GitHub release assets.
- Verified both Windows ZIP archives contain `weaver.exe` at the archive root.
- Ran `git diff --check` successfully.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/403829)