### PR TITLE
Update: ApacheLounge.httpd 2.4.68 patched 2026/06/17

### DIFF
--- a/manifests/a/ApacheLounge/httpd/2.4.68/ApacheLounge.httpd.installer.yaml
+++ b/manifests/a/ApacheLounge/httpd/2.4.68/ApacheLounge.httpd.installer.yaml
@@ -10,18 +10,18 @@ NestedInstallerFiles:
 InstallModes:
 - silent
 UpgradeBehavior: uninstallPrevious
-ReleaseDate: 2026-06-10
+ReleaseDate: 2026-06-17
 ArchiveBinariesDependOnPath: true
 Installers:
 - Architecture: x86
-  InstallerUrl: https://www.apachelounge.com/download/vs18/binaries/httpd-2.4.68-260610-win32-vs18.zip
-  InstallerSha256: FDEB92473F544E61A6BE2A483E9755E9DDBEB64BB6997078774F1053F891D39A
+  InstallerUrl: https://www.apachelounge.com/download/VS18/binaries/httpd-2.4.68-260617-win32-vs18.zip
+  InstallerSha256: 741727E64DC47742AC47953580EC5A8F4E61BD7A3B352B8906A778499915D1BC
   Dependencies:
     PackageDependencies:
     - PackageIdentifier: Microsoft.VCRedist.2015+.x86
 - Architecture: x64
-  InstallerUrl: https://www.apachelounge.com/download/VS18/binaries/httpd-2.4.68-260610-Win64-VS18.zip
-  InstallerSha256: 383A9C68407CB0B8E5FD8725C6F37493483EF94848642BEA09BD1EED76044AE3
+  InstallerUrl: https://www.apachelounge.com/download/VS18/binaries/httpd-2.4.68-260617-Win64-VS18.zip
+  InstallerSha256: EAC38A9F8D21B6BA0817CD1576A3D291CC771AFD3C6A210D120BDEA6F4AA4AEB
   Dependencies:
     PackageDependencies:
     - PackageIdentifier: Microsoft.VCRedist.2015+.x64


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
<!-- Describe what this PR changes. For manifest submissions, include the package name and version. -->
ApacheLounge released HTTPD 2.4.68 on 2026/06/10 and the new package version was added to winget-pkgs. On 2026/06/17 ApacheLounge released an updated installer for 2.4.68 with additional improvements. The original installer URLs were removed and WinGet installs/updates would fail. Updated the manifest to use the current installer URLs and hashes.

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/403876)