### PR TITLE
New package: Duncatzat.Vigils version 0.6.0

### DIFF
--- a/manifests/d/Duncatzat/Vigils/0.6.0/Duncatzat.Vigils.installer.yaml
+++ b/manifests/d/Duncatzat/Vigils/0.6.0/Duncatzat.Vigils.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Duncatzat.Vigils
+PackageVersion: 0.6.0
+InstallerType: nullsoft
+InstallModes:
+  - interactive
+  - silent
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/duncatzat/vigils/releases/download/v0.6.0/Vigils_0.6.0_x64-setup.exe
+    InstallerSha256: 47525194301DAE954A2D11030AA9186CEAFE4750CE950A0F7B72ADAFC28D2FD4
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/d/Duncatzat/Vigils/0.6.0/Duncatzat.Vigils.locale.en-US.yaml
+++ b/manifests/d/Duncatzat/Vigils/0.6.0/Duncatzat.Vigils.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Duncatzat.Vigils
+PackageVersion: 0.6.0
+PackageLocale: en-US
+Publisher: Vigils Authors
+PublisherUrl: https://vigils.ai
+PublisherSupportUrl: https://github.com/duncatzat/vigils/issues
+PackageName: Vigils
+PackageUrl: https://github.com/duncatzat/vigils
+License: Apache-2.0
+LicenseUrl: https://github.com/duncatzat/vigils/blob/main/LICENSE
+ShortDescription: Local-first control plane for AI agents - firewall, redaction, tamper-evident audit
+Description: |-
+  Vigils sits between AI agents (Claude Code, Codex, Cursor, Kimi CLI, ZCode, pi, ...)
+  and the tools they touch. Reversible secret redaction, default-deny firewall,
+  human-in-the-loop approval and a SHA-256 hash-chained audit ledger - entirely local,
+  no cloud, no telemetry. Includes the Aegis desktop command deck with one-click
+  Deploy Guardian.
+Tags:
+  - ai
+  - security
+  - agents
+  - mcp
+  - privacy
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/d/Duncatzat/Vigils/0.6.0/Duncatzat.Vigils.yaml
+++ b/manifests/d/Duncatzat/Vigils/0.6.0/Duncatzat.Vigils.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Duncatzat.Vigils
+PackageVersion: 0.6.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Vigils — local-first control plane for AI agents (firewall, secret redaction, tamper-evident audit). Apache-2.0, NSIS installer, silent install supported. Release: https://github.com/duncatzat/vigils/releases/tag/v0.6.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/403881)