### PR TITLE
New version: OCBase.OCCT.Personal version 17.0.10.0

### DIFF
--- a/manifests/o/OCBase/OCCT/Personal/17.0.10.0/OCBase.OCCT.Personal.installer.yaml
+++ b/manifests/o/OCBase/OCCT/Personal/17.0.10.0/OCBase.OCCT.Personal.installer.yaml
@@ -1,0 +1,18 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: OCBase.OCCT.Personal
+PackageVersion: 17.0.10.0
+InstallerType: portable
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: uninstallPrevious
+ReleaseDate: 2026-07-17
+Installers:
+- Architecture: x64
+  InstallerUrl: https://dl.ocbase.com/per/stable/OCCT.exe
+  InstallerSha256: B55CE9483A761C03D923BA1D09686D1D3D10A01363B92B60971C433EC48FDAC0
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/o/OCBase/OCCT/Personal/17.0.10.0/OCBase.OCCT.Personal.locale.en-US.yaml
+++ b/manifests/o/OCBase/OCCT/Personal/17.0.10.0/OCBase.OCCT.Personal.locale.en-US.yaml
@@ -1,0 +1,16 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: OCBase.OCCT.Personal
+PackageVersion: 17.0.10.0
+PackageLocale: en-US
+Publisher: OCCT
+PublisherUrl: https://www.ocbase.com/
+PackageName: OCCT
+PackageUrl: https://www.ocbase.com/download
+License: Proprietary
+Copyright: Copyright ©® OCBASE - 2023 until the end of time
+ShortDescription: OCCT is the most popular all-in-one stability check & stress test tool available.
+PurchaseUrl: https://www.ocbase.com/purchase
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/o/OCBase/OCCT/Personal/17.0.10.0/OCBase.OCCT.Personal.yaml
+++ b/manifests/o/OCBase/OCCT/Personal/17.0.10.0/OCBase.OCCT.Personal.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: OCBase.OCCT.Personal
+PackageVersion: 17.0.10.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Description of the new version
Bump **OCBase.OCCT.Personal** to **17.0.10.0** after floating-URL hash mismatch on install.

- InstallerUrl: `https://dl.ocbase.com/per/stable/OCCT.exe` (same floating Personal stable URL as sibling 17.0.9.0)
- InstallerSha256: `B55CE9483A761C03D923BA1D09686D1D3D10A01363B92B60971C433EC48FDAC0` (full download, uppercase)
- InstallerType/portable modes unchanged from sibling

### Validation
- [x] Downloaded installer and computed SHA256 locally
- [x] URL HTTP reachable
- [x] Manifest mirrors sibling structure

Resolves #403646

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/403888)