### PR TITLE
New package: XuanyuanLuoxue.XCLI version 0.8.0

### DIFF
--- a/manifests/x/XuanyuanLuoxue/XCLI/0.8.0/XuanyuanLuoxue.XCLI.installer.yaml
+++ b/manifests/x/XuanyuanLuoxue/XCLI/0.8.0/XuanyuanLuoxue.XCLI.installer.yaml
@@ -1,0 +1,14 @@
+# Created by scripts/generate_winget_manifest.py
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: XuanyuanLuoxue.XCLI
+PackageVersion: 0.8.0
+InstallerType: portable
+Commands:
+- x
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/xuanyuanluoxue/x-cli/releases/download/v0.8.0/x-windows-x86_64.exe
+  InstallerSha256: 4E5D7066BC9DE20C47FCA8A655CFE39C9F1D3517B1C3AFF10C675BA81BCE30E7
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/x/XuanyuanLuoxue/XCLI/0.8.0/XuanyuanLuoxue.XCLI.locale.en-US.yaml
+++ b/manifests/x/XuanyuanLuoxue/XCLI/0.8.0/XuanyuanLuoxue.XCLI.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# Created by scripts/generate_winget_manifest.py
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: XuanyuanLuoxue.XCLI
+PackageVersion: 0.8.0
+PackageLocale: en-US
+Publisher: Xavier
+PublisherUrl: https://github.com/xuanyuanluoxue
+PublisherSupportUrl: https://github.com/xuanyuanluoxue/x-cli/issues
+Author: Xavier
+PackageName: x-cli
+PackageUrl: https://github.com/xuanyuanluoxue/x-cli
+License: MIT
+LicenseUrl: https://github.com/xuanyuanluoxue/x-cli/blob/v0.8.0/LICENSE
+Copyright: Copyright (c) 2026 Xavier
+ShortDescription: Local-first CLI for tasks, credentials, diaries, notes, and a Web UI.
+Description: A zero-runtime-dependency personal CLI with local Markdown and JSON storage.
+Moniker: x-cli
+Tags:
+- cli
+- diary
+- local-first
+- notes
+- productivity
+- todo
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/x/XuanyuanLuoxue/XCLI/0.8.0/XuanyuanLuoxue.XCLI.yaml
+++ b/manifests/x/XuanyuanLuoxue/XCLI/0.8.0/XuanyuanLuoxue.XCLI.yaml
@@ -1,0 +1,8 @@
+# Created by scripts/generate_winget_manifest.py
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: XuanyuanLuoxue.XCLI
+PackageVersion: 0.8.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Submits `XuanyuanLuoxue.XCLI` version `0.8.0` as a WinGet 1.12 multi-file manifest set.

- Replaces the previous unsupported singleton submission with version, installer, and defaultLocale manifests.
- Uses the immutable public GitHub Release asset for v0.8.0.
- Installer SHA256: `4E5D7066BC9DE20C47FCA8A655CFE39C9F1D3517B1C3AFF10C675BA81BCE30E7`.
- The release executable was downloaded independently and smoke-tested with `x --version` (`x 0.8.0`).

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (not applicable; this is a new package submission)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest set
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

Local manifest installation was not enabled by the administrator on the test host, so the system's `LocalManifestFiles` security setting was not changed. The manifest passed both local WinGet validation and the release CI validation.