### PR TITLE
New version: theesfeld.f00 version 0.10.5

### DIFF
--- a/manifests/t/theesfeld/f00/0.10.5/theesfeld.f00.installer.yaml
+++ b/manifests/t/theesfeld/f00/0.10.5/theesfeld.f00.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: theesfeld.f00
+PackageVersion: 0.10.5
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: f00-x86_64-pc-windows-msvc\f00.exe
+    PortableCommandAlias: f00
+InstallModes:
+  - silent
+UpgradeBehavior: install
+ReleaseDate: 2026-07-17
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/theesfeld/f00/releases/download/v0.10.5/f00-x86_64-pc-windows-msvc.zip
+    InstallerSha256: 8D5BCFBF045DEB8A402E805808113509D05449BFFC785208287E1531AE1701AA
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/t/theesfeld/f00/0.10.5/theesfeld.f00.locale.en-US.yaml
+++ b/manifests/t/theesfeld/f00/0.10.5/theesfeld.f00.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: theesfeld.f00
+PackageVersion: 0.10.5
+PackageLocale: en-US
+Publisher: theesfeld
+PublisherUrl: https://github.com/theesfeld
+PublisherSupportUrl: https://github.com/theesfeld/f00/issues
+Author: theesfeld
+PackageName: f00
+PackageUrl: https://f00.sh
+License: MIT OR Apache-2.0
+LicenseUrl: https://github.com/theesfeld/f00/blob/main/LICENSE-MIT
+Copyright: Copyright (c) theesfeld
+ShortDescription: Modern, friendly directory lister (ls rewrite in Rust)
+Description: |-
+  f00 is a next-generation, cross-platform coreutils ls clone in Rust:
+  modern UX by default, exact GNU behavior under --gnu for scripts,
+  plus tree, JSON, icons, and git status.
+Moniker: f00
+Tags:
+  - cli
+  - coreutils
+  - filesystem
+  - ls
+  - rust
+ReleaseNotesUrl: https://github.com/theesfeld/f00/releases/tag/v0.10.5
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/t/theesfeld/f00/0.10.5/theesfeld.f00.yaml
+++ b/manifests/t/theesfeld/f00/0.10.5/theesfeld.f00.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: theesfeld.f00
+PackageVersion: 0.10.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
# theesfeld.f00 0.10.5

Portable zip installer from GitHub Releases.

- Package: https://f00.sh
- Release: https://github.com/theesfeld/f00/releases/tag/v0.10.5
- Publisher: theesfeld

## Checklist
- [x] Manifests generated from release SHA-256
- [x] Installer is nested portable `f00.exe`

Submitted by automated release packaging for theesfeld/f00.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/403917)