### PR TITLE
SerZhyAle.DocHtmlTranslate version 26.0718.0252

### DIFF
--- a/manifests/s/SerZhyAle/DocHtmlTranslate/26.0718.0252/SerZhyAle.DocHtmlTranslate.installer.yaml
+++ b/manifests/s/SerZhyAle/DocHtmlTranslate/26.0718.0252/SerZhyAle.DocHtmlTranslate.installer.yaml
@@ -1,0 +1,19 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: SerZhyAle.DocHtmlTranslate
+PackageVersion: 26.0718.0252
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: doc-html-translate.exe
+  PortableCommandAlias: doc-html-translate
+- RelativeFilePath: doc-html-ui.exe
+  PortableCommandAlias: doc-html-ui
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/SerZhyAle/doc-html-translate/releases/download/v26.0718.0252/doc-html-translate-26.0718.0252-windows-x64.zip
+  InstallerSha256: 6866B5A13F2023D0797456B0EC03FBA0155772DC0F1C33E38ED94DE8551372B0
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-07-18

--- a/manifests/s/SerZhyAle/DocHtmlTranslate/26.0718.0252/SerZhyAle.DocHtmlTranslate.locale.en-US.yaml
+++ b/manifests/s/SerZhyAle/DocHtmlTranslate/26.0718.0252/SerZhyAle.DocHtmlTranslate.locale.en-US.yaml
@@ -1,0 +1,52 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: SerZhyAle.DocHtmlTranslate
+PackageVersion: 26.0718.0252
+PackageLocale: en-US
+Publisher: SZA
+PublisherUrl: https://github.com/SerZhyAle
+PublisherSupportUrl: https://github.com/SerZhyAle/doc-html-translate/issues
+Author: Serhii Zhyhunenko
+PackageName: doc-html-translate
+PackageUrl: https://github.com/SerZhyAle/doc-html-translate
+License: MIT
+LicenseUrl: https://github.com/SerZhyAle/doc-html-translate/blob/main/LICENSE
+Copyright: Copyright (c) 2026 SerZhyAle
+ShortDescription: Convert EPUB, PDF, MOBI, AZW3, FB2, RTF, TXT, Markdown, HTML, comic archives (CBZ/CBR/CB7/CBT) and images to clean local HTML with a real table of contents, image-text OCR, and optional Google or Ollama translation.
+Description: |-
+  doc-html-translate is a Windows app that converts documents (EPUB, PDF, MOBI, AZW3, FB2,
+  RTF, TXT, Markdown, HTML), comic archives (CBZ, CBR, CB7, CBT) and standalone images
+  (PNG, JPEG, GIF, WebP, BMP, TIFF) into clean local HTML with generated navigation and a
+  real multi-level table of contents. A built-in reader adds light/sepia/dark/night themes,
+  text size and font controls, and remembers your reading position. It can recognize text
+  inside images (OCR - English bundled, more languages on demand) and optionally translate
+  everything via the Google Cloud Translation API or a local Ollama model. Convert to one
+  long single page or keep chapters with a table of contents. Re-opening an already-converted
+  book is instant. The package ships both the CLI (doc-html-translate) and a small GUI
+  launcher (doc-html-ui). pdftotext is bundled inside the binary; MOBI and AZW3 conversion
+  additionally requires Calibre, and CBR/CB7 comic archives require 7-Zip (non-DRM files only).
+Moniker: doc-html-translate
+Tags:
+- azw3
+- comic
+- ebook
+- epub
+- fb2
+- google-translate
+- html
+- markdown
+- mobi
+- ocr
+- ollama
+- pdf
+- rtf
+- translation
+- txt
+- windows
+ReleaseNotesUrl: https://github.com/SerZhyAle/doc-html-translate/releases/tag/v26.0718.0252
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/SerZhyAle/doc-html-translate/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/SerZhyAle/DocHtmlTranslate/26.0718.0252/SerZhyAle.DocHtmlTranslate.yaml
+++ b/manifests/s/SerZhyAle/DocHtmlTranslate/26.0718.0252/SerZhyAle.DocHtmlTranslate.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: SerZhyAle.DocHtmlTranslate
+PackageVersion: 26.0718.0252
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Update **SerZhyAle.DocHtmlTranslate** to **26.0718.0252**.

- Release: https://github.com/SerZhyAle/doc-html-translate/releases/tag/v26.0718.0252
- Installer URL and SHA256 verified end-to-end via `winget install --manifest` (hash matched, real install succeeded).
- Locale description refreshed to cover the new input formats in this release: comic archives (CBZ/CBR/CB7/CBT) and standalone images.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/404039)