### PR TITLE
New package: InferenceHub.InferenceHub version 0.2.18

### DIFF
--- a/manifests/i/InferenceHub/InferenceHub/0.2.18/InferenceHub.InferenceHub.installer.yaml
+++ b/manifests/i/InferenceHub/InferenceHub/0.2.18/InferenceHub.InferenceHub.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: InferenceHub.InferenceHub
+PackageVersion: 0.2.18
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nsis
+Scope: user
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+ReleaseDate: 2026-07-17
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/InferenceHub/inferencehub-desktop/releases/download/v0.2.18/InferenceHub_0.2.18_x64-setup.exe
+  InstallerSha256: 5C6068CF1A9BF8B7C9C253E6CFF301256C0B9873DD17284760E3E7FB728FFC30
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/i/InferenceHub/InferenceHub/0.2.18/InferenceHub.InferenceHub.installer.yaml
+++ b/manifests/i/InferenceHub/InferenceHub/0.2.18/InferenceHub.InferenceHub.installer.yaml
@@ -5,7 +5,7 @@ InstallerLocale: en-US
 Platform:
 - Windows.Desktop
 MinimumOSVersion: 10.0.17763.0
-InstallerType: nsis
+InstallerType: nullsoft
 Scope: user
 InstallModes:
 - interactive

--- a/manifests/i/InferenceHub/InferenceHub/0.2.18/InferenceHub.InferenceHub.locale.en-US.yaml
+++ b/manifests/i/InferenceHub/InferenceHub/0.2.18/InferenceHub.InferenceHub.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: InferenceHub.InferenceHub
+PackageVersion: 0.2.18
+PackageLocale: en-US
+Publisher: InferenceHub
+PublisherUrl: https://inferencehub.tech
+PublisherSupportUrl: https://github.com/InferenceHub/inferencehub-desktop/issues
+PackageName: InferenceHub
+PackageUrl: https://github.com/InferenceHub/inferencehub-desktop
+License: Apache-2.0
+LicenseUrl: https://github.com/InferenceHub/inferencehub-desktop/blob/main/LICENSE
+Copyright: Copyright 2026 InferenceHub
+ShortDescription: Native desktop client for InferenceHub chat — frontier and open-weight models with web search and deep research.
+Description: |-
+  InferenceHub Desktop is a lightweight native client for InferenceHub chat.
+  Sign in once with your InferenceHub account and chat with frontier (Claude)
+  and open-weight models, with web search, deep research, and project-file RAG
+  included. Built with Tauri (no bundled Chromium) and ships no telemetry.
+Moniker: inferencehub
+Tags:
+- ai
+- chat
+- claude
+- desktop
+- llm
+- tauri
+ReleaseNotesUrl: https://github.com/InferenceHub/inferencehub-desktop/releases/tag/v0.2.18
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/i/InferenceHub/InferenceHub/0.2.18/InferenceHub.InferenceHub.yaml
+++ b/manifests/i/InferenceHub/InferenceHub/0.2.18/InferenceHub.InferenceHub.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: InferenceHub.InferenceHub
+PackageVersion: 0.2.18
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)? (will accept via the CLA bot on this PR)
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [ ] Have you [validated your manifest](https://docs.microsoft.com/windows/package-manager/package/manifest?tabs=minschema#validate-your-manifest) locally with `winget validate --manifest <path>`? (authored on macOS — no local winget; relying on the pipeline validation)
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? (the NSIS installer's silent `/S` install is exercised in the project's CI packaging; deferring to the pipeline's sandbox install test)
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

---

New package: **InferenceHub** — a lightweight, open-source (Apache-2.0) Tauri desktop client for InferenceHub chat.

- Source + README: https://github.com/InferenceHub/inferencehub-desktop
- Release: https://github.com/InferenceHub/inferencehub-desktop/releases/tag/v0.2.18
- Installer: NSIS, x64, per-user scope, silent `/S` supported
- Submitted by the publisher (the app's GitHub org and this manifest's publisher are the same project)

Note for moderators: the binary is unsigned (code signing via Azure Artifact Signing is in progress). A Microsoft Defender false-positive review completed today confirmed no detection on these exact files (WDSI submission `70bf0d58-5168-409f-8dde-9d6e841e4fb8`, definitions 1.455.193.0).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/404088)