### PR TITLE
Major hotfixes for installers: mikf.gallery-dl vesion 1.32.6

### DIFF
--- a/manifests/m/mikf/gallery-dl/1.32.6/mikf.gallery-dl.installer.yaml
+++ b/manifests/m/mikf/gallery-dl/1.32.6/mikf.gallery-dl.installer.yaml
@@ -1,4 +1,3 @@
-# Created with YamlCreate.ps1 Dumplings Mod
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: mikf.gallery-dl
@@ -7,17 +6,17 @@ Platform:
 - Windows.Desktop
 InstallerType: portable
 ReleaseDate: 2026-07-11
-AppsAndFeaturesEntries:
-- DisplayName: gallery-dl (x64)
 Installers:
 - Architecture: x64
-  InstallerUrl: https://codeberg.org/mikf/gallery-dl/releases/download/v1.32.6/gallery-dl_x86.exe
-  InstallerSha256: F8EED64E9C6AC74F47054D0A3315EEEFB62E960E8DD5D8CBB8339071811EE106
+  InstallerUrl: https://codeberg.org/mikf/gallery-dl/releases/download/v1.32.6/gallery-dl.exe
+  InstallerSha256: a538aa624d7f3d929910093bc952f99ada33f32b2b8a45120caac21bb7b11061
   Commands:
   - gallery-dl
   Dependencies:
     PackageDependencies:
     - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+  AppsAndFeaturesEntries:
+  - DisplayName: gallery-dl (x64)
 - Architecture: x86
   InstallerUrl: https://codeberg.org/mikf/gallery-dl/releases/download/v1.32.6/gallery-dl_x86.exe
   InstallerSha256: F8EED64E9C6AC74F47054D0A3315EEEFB62E960E8DD5D8CBB8339071811EE106
@@ -26,5 +25,7 @@ Installers:
   Dependencies:
     PackageDependencies:
     - PackageIdentifier: Microsoft.VCRedist.2015+.x86
+  AppsAndFeaturesEntries:
+  - DisplayName: gallery-dl (x86)
 ManifestType: installer
 ManifestVersion: 1.12.0


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
* The x64 installer is now x64 and not x86.
* The x86 DisplayName now specifies x86 and not x64

This PR is probably of interest to: @spectershell @spectopo

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [ ] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/404102)