### PR TITLE
New package: epatels.CKImagePDFReducer v2.6.0

### DIFF
--- a/manifests/e/epatels/CKImagePDFReducer/2.6.0/epatels.CKImagePDFReducer.installer.yaml
+++ b/manifests/e/epatels/CKImagePDFReducer/2.6.0/epatels.CKImagePDFReducer.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: epatels.CKImagePDFReducer
+PackageVersion: 2.6.0
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerType: inno
+    Scope: user
+    InstallerUrl: https://github.com/epatels/ck-image-pdf-reducer/releases/download/v2.6.0/CKImagePDFReducerSetup.exe
+    InstallerSha256: 834262E605D3F0979AFD02721FEEBCC57F560CD580C46B353D566EAA7DE7A523
+    InstallerSwitches:
+      Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+      SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/e/epatels/CKImagePDFReducer/2.6.0/epatels.CKImagePDFReducer.locale.en-US.yaml
+++ b/manifests/e/epatels/CKImagePDFReducer/2.6.0/epatels.CKImagePDFReducer.locale.en-US.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: epatels.CKImagePDFReducer
+PackageVersion: 2.6.0
+PackageLocale: en-US
+Publisher: epatels
+PublisherUrl: https://github.com/epatels/ck-image-pdf-reducer
+PackageName: CK Image & PDF Reducer
+PackageUrl: https://github.com/epatels/ck-image-pdf-reducer
+License: Proprietary
+LicenseUrl: https://github.com/epatels/ck-image-pdf-reducer/blob/main/README.md
+ShortDescription: A free, offline, drag-and-drop tool for shrinking images and PDFs — no uploads, no subscriptions.
+Description: |
+  CK Image & PDF Reducer compresses images and PDFs right on your PC. Drag a file in, pick how you want it shrunk, and export — nothing is sent anywhere.
+  
+  - Resize by percentage — scale both dimensions down together
+  - Fix Width / Fix Height — set one dimension, the other auto-scales to preserve aspect ratio
+  - Compress by Quality — reduce JPEG quality to hit a smaller file size
+  - Target File Size — tell it a size limit (e.g. "under 200 KB") and it searches for the best quality/resolution that fits
+  - PDF compression — shrinks PDFs by recompressing embedded images (via Ghostscript, installed separately on first use)
+  - Batch queue — load and process multiple files in one pass
+  - Drag & drop — drop files straight onto the window
+  - Windows right-click menu — optional "Reduce with CK Image & PDF Reducer" entry in Explorer's context menu
+  - HEIC support — reads iPhone-style HEIC images
+Tags:
+  - pdf
+  - image
+  - compress
+  - resize
+  - jpeg
+  - heic
+  - batch
+  - offline
+  - reduce
+  - shrink
+  - ghostscript
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/e/epatels/CKImagePDFReducer/2.6.0/epatels.CKImagePDFReducer.yaml
+++ b/manifests/e/epatels/CKImagePDFReducer/2.6.0/epatels.CKImagePDFReducer.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: epatels.CKImagePDFReducer
+PackageVersion: 2.6.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## New package: epatels.CKImagePDFReducer version 2.6.0

**App name:** CK Image & PDF Reducer  
**Publisher:** epatels  
**License:** Proprietary  
**URL:** https://github.com/epatels/ck-image-pdf-reducer  

This PR was generated automatically by `submit_winget.py`.

### Checklist
- [x] Installer URL is HTTPS
- [x] SHA-256 computed from the actual installer file
- [x] Installer tested locally
- [x] License is Proprietary (freeware, EULA)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/404209)