### PR TITLE
New package: MCprotein.rpotato version 0.40.0

### DIFF
--- a/manifests/m/MCprotein/rpotato/0.40.0/MCprotein.rpotato.installer.yaml
+++ b/manifests/m/MCprotein/rpotato/0.40.0/MCprotein.rpotato.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: MCprotein.rpotato
+PackageVersion: 0.40.0
+InstallerType: zip
+NestedInstallerType: portable
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/MCprotein/rolling-potato/releases/download/v0.40.0/rpotato-v0.40.0-x86_64-pc-windows-msvc.zip
+    InstallerSha256: d8427584b462d20411ed921f885fb0caf794e3135e0277b8381122cd3f6d7e7d
+    NestedInstallerFiles:
+      - RelativeFilePath: rpotato.exe
+        PortableCommandAlias: rpotato
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/MCprotein/rpotato/0.40.0/MCprotein.rpotato.locale.en-US.yaml
+++ b/manifests/m/MCprotein/rpotato/0.40.0/MCprotein.rpotato.locale.en-US.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: MCprotein.rpotato
+PackageVersion: 0.40.0
+PackageLocale: en-US
+Publisher: MCprotein
+PackageName: rpotato
+License: Apache-2.0
+ShortDescription: Local coding agents for potato PCs.
+PackageUrl: https://github.com/MCprotein/rolling-potato
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/MCprotein/rpotato/0.40.0/MCprotein.rpotato.yaml
+++ b/manifests/m/MCprotein/rpotato/0.40.0/MCprotein.rpotato.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: MCprotein.rpotato
+PackageVersion: 0.40.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds the first winget manifest for `MCprotein.rpotato` version `0.40.0`. The manifest uses the published Windows x64 portable archive and SHA-256 from the verified GitHub Release asset set.

Release: https://github.com/MCprotein/rolling-potato/releases/tag/v0.40.0
Validation evidence: https://github.com/MCprotein/rolling-potato/actions/runs/29646472454

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (not applicable)

## 📦 Manifest Checklist

- [x] Checked that there are no other open pull requests for `MCprotein.rpotato`
- [x] This PR only modifies one (1) manifest
- [x] Validated the exact manifest artifact with `winget validate --manifest <path>` on Windows
- [x] Tested the exact manifest artifact with `winget install --manifest <path>` and its upgrade/uninstall lifecycle on Windows
- [x] Manifest conforms to the 1.12 schema
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/404237)