### PR TITLE
New version: Feci.ParleyDeckSkill version 1.4.5

### DIFF
--- a/manifests/f/Feci/ParleyDeckSkill/1.4.5/Feci.ParleyDeckSkill.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/1.4.5/Feci.ParleyDeckSkill.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 1.4.5
+InstallerType: portable
+Commands:
+- parley-deck-skill
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-skill/releases/download/v1.4.5/parley-deck-skill-v1.4.5-windows-x64.exe
+  InstallerSha256: 08D9B0FF0EDB5F885181C50DF16AFDC2663F02E688EAC07646FD34DE5BB32E23
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-skill/releases/download/v1.4.5/parley-deck-skill-v1.4.5-windows-arm64.exe
+  InstallerSha256: 5AF84DC1D3CFF7FF4D296C4E3B60CFF896BBA3A87DEDCC58499586C85962C2C0
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckSkill/1.4.5/Feci.ParleyDeckSkill.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/1.4.5/Feci.ParleyDeckSkill.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 1.4.5
+PackageLocale: en-US
+Publisher: Feci
+PublisherUrl: https://github.com/feci
+PackageName: Parley Deck Skill
+PackageUrl: https://github.com/feci/parley-deck-skill
+License: Apache-2.0
+LicenseUrl: https://github.com/feci/parley-deck-skill/blob/main/LICENSE
+ShortDescription: Installer for the Parley Deck multi-agent cooperation skill.
+Description: "Installs the vendor-neutral Parley Deck AI cooperation skill into Codex, Claude Code, Antigravity CLI, legacy Gemini CLI, Hermes, Kimi Code, or a custom skill directory. v1.4.5 fixes the Kimi target so the skill installs into Kimi Code's canonical user skills root (~/.kimi-code/skills, or KIMI_CODE_HOME/skills) instead of the legacy kimi-cli tree that Kimi Code does not read at runtime, and keys auto-detection on real Kimi Code evidence rather than the ambiguous kimi command shared with the older kimi-cli. Ships two opt-in companion add-on skills installed by default (use --no-addons or --only to choose): parley-worktrees (parallel sessions over one git repo via worktrees) and parley-tracker (vendor-neutral epic/story/subtask authoring readable by business, technical, and AI readers, with a tool-enforced gap-scan)."
+ReleaseNotesUrl: https://github.com/feci/parley-deck-skill/releases/tag/v1.4.5
+Tags:
+- ai
+- agents
+- agy
+- antigravity
+- cli
+- codex
+- claude
+- gemini
+- kimi
+- multi-agent
+- skill
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckSkill/1.4.5/Feci.ParleyDeckSkill.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/1.4.5/Feci.ParleyDeckSkill.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 1.4.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Manifest for Feci.ParleyDeckSkill 1.4.5

- Portable installer, `parley-deck-skill` command, x64 + arm64.
- InstallerUrls are the signed-off GitHub release assets for v1.4.5; SHA256 taken from the release asset digests.
- Fixes the Kimi Code install target (installs into `~/.kimi-code/skills` rather than the legacy kimi-cli tree).

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] This PR only modifies one (1) manifest
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/404262)