### PR TITLE
New package: Linus.Orbt version 0.1.9

### DIFF
--- a/manifests/l/Linus/Orbt/0.1.9/Linus.Orbt.installer.yaml
+++ b/manifests/l/Linus/Orbt/0.1.9/Linus.Orbt.installer.yaml
@@ -1,0 +1,14 @@
+PackageIdentifier: Linus.Orbt
+PackageVersion: 0.1.9
+MinimumOSVersion: 10.0.17763.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: orbt.exe
+    PortableCommandAlias: orbt
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/linuszz/orbt/releases/download/v0.1.9/orbt-windows-x86_64.zip
+    InstallerSha256: d464fffb2efbfb5b8f84a62b153da33145d97b02a8e368be58533f6cd6f9c2fc
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/l/Linus/Orbt/0.1.9/Linus.Orbt.locale.en-US.yaml
+++ b/manifests/l/Linus/Orbt/0.1.9/Linus.Orbt.locale.en-US.yaml
@@ -1,0 +1,27 @@
+PackageIdentifier: Linus.Orbt
+PackageVersion: 0.1.9
+PackageLocale: en-US
+Publisher: Linus
+PublisherUrl: https://orbt.sh
+PublisherSupportUrl: https://github.com/linuszz/orbt/issues
+PackageName: Orbt
+PackageUrl: https://github.com/linuszz/orbt
+License: AGPL-3.0-only
+LicenseUrl: https://github.com/linuszz/orbt/blob/main/LICENSE
+ShortDescription: Universal terminal workspace — sessions, panes, and AI agents
+Description: |-
+  Orbt is a terminal multiplexer with a first-class AI agent runtime.
+  Run orbt to start the TUI; sessions persist after detach (Go Dark).
+  Supports SSH remote attach, clipboard sync (Beacon), and embedded
+  AI satellite management.
+Moniker: orbt
+Tags:
+  - terminal
+  - multiplexer
+  - tui
+  - ssh
+  - agent
+  - cli
+ReleaseNotesUrl: https://github.com/linuszz/orbt/releases/tag/v0.1.9
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/l/Linus/Orbt/0.1.9/Linus.Orbt.yaml
+++ b/manifests/l/Linus/Orbt/0.1.9/Linus.Orbt.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Linus.Orbt
+PackageVersion: 0.1.9
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Description

New package submission for **Linus.Orbt** version 0.1.9.

Orbt is a universal terminal workspace — a terminal multiplexer with first-class AI agent runtime. Think tmux, but with embedded Claude Code / Codex / Copilot management, SSH image transfer, and OSC 52 clipboard bridging.

- Homepage: https://orbt.sh
- GitHub: https://github.com/linuszz/orbt
- License: AGPL-3.0-only
- Installer: portable zip (single exe, no installation required)

## Validation

- Package identifier: `Linus.Orbt`
- Architecture: x64
- InstallerType: zip / portable
- SHA256 verified against release asset

## Release

https://github.com/linuszz/orbt/releases/tag/v0.1.9
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/404264)