### PR TITLE
Fix branch command formatting in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,8 +146,8 @@ cd winget-pkgs
 ```
 Create a new branch for your feature or bug fix:
 ```
- git checkout -b feature-branch
- ```
+git checkout -b feature-branch
+```
 
 Make your changes and commit them:
 ```


### PR DESCRIPTION
## Summary

- remove the extra leading space from the feature branch command
- align the closing code fence with the rest of the Markdown block

## Testing

- `git diff --check`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/404342)