### PR TITLE
Add version: Vortenia.Overwatch version 2.0.1

### DIFF
--- a/manifests/v/Vortenia/Overwatch/2.0.1/Vortenia.Overwatch.installer.yaml
+++ b/manifests/v/Vortenia/Overwatch/2.0.1/Vortenia.Overwatch.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Vortenia.Overwatch
+PackageVersion: 2.0.1
+InstallerType: portable
+Commands:
+  - overwatch
+ReleaseDate: 2026-07-18
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/vorteniahq/Overwatch/releases/download/v2.0.1/Overwatch.exe
+    InstallerSha256: F9181BE7BEF4667581EA4A2417CD78DFD837BE4358CCF8BC8862E5BD8D7AC4B3
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/v/Vortenia/Overwatch/2.0.1/Vortenia.Overwatch.locale.en-US.yaml
+++ b/manifests/v/Vortenia/Overwatch/2.0.1/Vortenia.Overwatch.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Vortenia.Overwatch
+PackageVersion: 2.0.1
+PackageLocale: en-US
+Publisher: Vortenia
+PublisherUrl: https://vortenia.com
+PublisherSupportUrl: https://github.com/vorteniahq/Overwatch/issues
+PackageName: Overwatch
+PackageUrl: https://vortenia.com/overwatch/
+License: MIT
+LicenseUrl: https://github.com/vorteniahq/Overwatch/blob/master/LICENSE
+ShortDescription: Know who or what touched your Windows PC, and when.
+Description: >-
+  Overwatch is a lightweight Windows tray monitor that records who or what touched
+  your PC and when, then shows it in a plain-English dashboard. It flags logins,
+  wake events, USB devices, and app launches, and can send Telegram alerts when
+  something happens while you are away.
+Moniker: overwatch
+Tags:
+  - monitoring
+  - security
+  - snoop-detection
+  - telegram
+  - tray
+  - windows
+ReleaseNotes: >-
+  Patch release. Fixes a startup crash by storing the events database under
+  %APPDATA%\Overwatch instead of next to the executable, so Overwatch no longer
+  depends on where it is run from. Adds a retry and clearer logging if the
+  database is briefly locked (for example by an antivirus scan).
+ReleaseNotesUrl: https://github.com/vorteniahq/Overwatch/releases/tag/v2.0.1
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/v/Vortenia/Overwatch/2.0.1/Vortenia.Overwatch.yaml
+++ b/manifests/v/Vortenia/Overwatch/2.0.1/Vortenia.Overwatch.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Vortenia.Overwatch
+PackageVersion: 2.0.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Vortenia.Overwatch 2.0.1

Patch release of an existing package (2.0.0 already in repo).

- **InstallerType:** portable (single self-contained exe, unchanged from 2.0.0)
- **InstallerUrl:** https://github.com/vorteniahq/Overwatch/releases/download/v2.0.1/Overwatch.exe (direct GitHub release asset, no redirect)
- **InstallerSha256:** F9181BE7BEF4667581EA4A2417CD78DFD837BE4358CCF8BC8862E5BD8D7AC4B3 (verified against the released binary)
- Manifest schema 1.6.0, three files (version / installer / defaultLocale).

### Checklist
- [x] I have read the [contribution guidelines](https://github.com/microsoft/winget-pkgs/blob/master/CONTRIBUTING.md).
- [x] This is a new version of an existing package; the manifest matches the prior accepted 2.0.0 submission.
- [x] I have verified the installer URL resolves and the SHA256 matches.
- [x] I am the package publisher / authorized to submit (sole owner, CLA signed).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/404347)