### PR TITLE
New package: leduftw.dbird version 1.0.1

### DIFF
--- a/manifests/l/leduftw/dbird/1.0.1/leduftw.dbird.installer.yaml
+++ b/manifests/l/leduftw/dbird/1.0.1/leduftw.dbird.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: leduftw.dbird
+PackageVersion: 1.0.1
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: dbird-v1.0.1-x86_64-pc-windows-msvc\dbird.exe
+  PortableCommandAlias: dbird
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/leduftw/dbird/releases/download/v1.0.1/dbird-v1.0.1-x86_64-pc-windows-msvc.zip
+  InstallerSha256: 2F6B26893B1D59AAF1311106AECFDE9C62243364762F1C5FCD8B4C79F0D68988
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/l/leduftw/dbird/1.0.1/leduftw.dbird.installer.yaml
+++ b/manifests/l/leduftw/dbird/1.0.1/leduftw.dbird.installer.yaml
@@ -6,6 +6,9 @@ NestedInstallerType: portable
 NestedInstallerFiles:
 - RelativeFilePath: dbird-v1.0.1-x86_64-pc-windows-msvc\dbird.exe
   PortableCommandAlias: dbird
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.VCRedist.2015+.x64
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/leduftw/dbird/releases/download/v1.0.1/dbird-v1.0.1-x86_64-pc-windows-msvc.zip

--- a/manifests/l/leduftw/dbird/1.0.1/leduftw.dbird.locale.en-US.yaml
+++ b/manifests/l/leduftw/dbird/1.0.1/leduftw.dbird.locale.en-US.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: leduftw.dbird
+PackageVersion: 1.0.1
+PackageLocale: en-US
+Publisher: leduftw
+PublisherUrl: https://github.com/leduftw
+PublisherSupportUrl: https://github.com/leduftw/dbird/issues
+PackageName: dbird
+PackageUrl: https://github.com/leduftw/dbird
+License: MIT
+LicenseUrl: https://github.com/leduftw/dbird/blob/main/LICENSE
+ShortDescription: A fully playable terminal recreation of the classic Flappy Bird game
+ReleaseNotesUrl: https://github.com/leduftw/dbird/releases/tag/v1.0.1
+Moniker: dbird
+Tags:
+- game
+- terminal
+- tui
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/l/leduftw/dbird/1.0.1/leduftw.dbird.yaml
+++ b/manifests/l/leduftw/dbird/1.0.1/leduftw.dbird.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: leduftw.dbird
+PackageVersion: 1.0.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
New package submission for **leduftw.dbird 1.0.1**.

dbird is an open-source (MIT) terminal recreation of the classic Flappy Bird game, written in Rust. The installer is the official portable x64 zip from the project's GitHub release, containing a single console executable (`dbird.exe`, alias `dbird`).

- Package homepage: https://github.com/leduftw/dbird
- Release: https://github.com/leduftw/dbird/releases/tag/v1.0.1
- Manifests written against the 1.9.0 schemas (version, installer, defaultLocale).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/404373)