### PR TITLE
New package: Sanctum.Sanctum version 0.1.8

### DIFF
--- a/manifests/s/Sanctum/Sanctum/0.1.8/Sanctum.Sanctum.installer.yaml
+++ b/manifests/s/Sanctum/Sanctum/0.1.8/Sanctum.Sanctum.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Sanctum.Sanctum
+PackageVersion: 0.1.8
+InstallerType: nullsoft
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/wgravel855-lang/sanctum/releases/download/v0.1.8/Sanctum-Windows-Setup.exe
+    InstallerSha256: 6CAEFAC340950EB81E3A29FFAF1D64AF4E7FCA12886BE0FF8B1B924CBE68FA48
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/Sanctum/Sanctum/0.1.8/Sanctum.Sanctum.locale.en-US.yaml
+++ b/manifests/s/Sanctum/Sanctum/0.1.8/Sanctum.Sanctum.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Sanctum.Sanctum
+PackageVersion: 0.1.8
+PackageLocale: en-US
+Publisher: Sanctum
+PublisherUrl: https://github.com/wgravel855-lang/sanctum
+PublisherSupportUrl: https://github.com/wgravel855-lang/sanctum/issues
+Author: Sanctum contributors
+PackageName: Sanctum
+PackageUrl: https://sanctum-renews-projects-f8d0ce91.vercel.app/
+License: GPL-3.0-only
+LicenseUrl: https://github.com/wgravel855-lang/sanctum/blob/main/LICENSE
+ShortDescription: A free, open-source adult-content blocker for Windows.
+Description: >-
+  Sanctum filters adult content across every browser via the DNS and hosts
+  layers, keeps working in the background, and can lock its own settings for a
+  chosen duration. When you hit a blocked site it opens a calm, full-screen
+  pause instead of a wall. Free, open source, no account, no telemetry.
+Moniker: sanctum
+Tags:
+  - blocker
+  - content-blocker
+  - dns
+  - parental-controls
+  - productivity
+  - self-control
+  - wellbeing
+ReleaseNotesUrl: https://github.com/wgravel855-lang/sanctum/releases/tag/v0.1.8
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/Sanctum/Sanctum/0.1.8/Sanctum.Sanctum.yaml
+++ b/manifests/s/Sanctum/Sanctum/0.1.8/Sanctum.Sanctum.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Sanctum.Sanctum
+PackageVersion: 0.1.8
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: `Sanctum.Sanctum` version `0.1.8`

Sanctum is a free, open-source, GPLv3 adult-content blocker for Windows. It filters
content at the DNS and hosts layers across every browser, runs as a background
service, and can lock its own settings for a chosen duration. Source and releases:
https://github.com/wgravel855-lang/sanctum

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/tools/SandboxTest.md) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

#### Notes

- The `InstallerUrl` points at the exact versioned GitHub release asset (no redirect) and is pinned to that file's SHA-256.
- Installer is NSIS (`nullsoft`), per-machine scope, and supports interactive and silent modes.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/404406)