### PR TITLE
Add Bytifi.Bytifi 0.1.1

### DIFF
--- a/manifests/b/Bytifi/Bytifi/0.1.1/Bytifi.Bytifi.installer.yaml
+++ b/manifests/b/Bytifi/Bytifi/0.1.1/Bytifi.Bytifi.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Bytifi.Bytifi
+PackageVersion: 0.1.1
+MinimumOSVersion: 10.0.17763.0
+Commands:
+  - bytifi
+Installers:
+  - Architecture: x64
+    InstallerType: portable
+    InstallerUrl: https://github.com/jpwcguy/Bytifi/releases/download/v0.1.1/bytifi.exe
+    InstallerSha256: B9EF8173A452AFB6660AF51C3D29928CFB767407920B48D376C61E02A3A7E020
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/b/Bytifi/Bytifi/0.1.1/Bytifi.Bytifi.locale.en-US.yaml
+++ b/manifests/b/Bytifi/Bytifi/0.1.1/Bytifi.Bytifi.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Bytifi.Bytifi
+PackageVersion: 0.1.1
+PackageLocale: en-US
+Publisher: Bytifi
+PublisherUrl: https://bytifi.com
+PublisherSupportUrl: https://github.com/jpwcguy/Bytifi/issues
+PrivacyUrl: https://bytifi.com/privacy
+PackageName: Bytifi CLI
+PackageUrl: https://github.com/jpwcguy/Bytifi
+License: MIT
+LicenseUrl: https://github.com/jpwcguy/Bytifi/blob/master/package.json
+Copyright: Copyright (c) Bytifi
+ShortDescription: Encrypt and upload files to Bytifi from the terminal
+Description: >-
+  Official Bytifi command-line tool. Encrypts files locally, uploads encrypted
+  bytes to bytifi.com, and prints a share link with the decryption token in
+  the URL fragment.
+Moniker: bytifi
+Tags:
+  - bytifi
+  - cli
+  - encryption
+  - upload
+  - file-sharing
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/b/Bytifi/Bytifi/0.1.1/Bytifi.Bytifi.yaml
+++ b/manifests/b/Bytifi/Bytifi/0.1.1/Bytifi.Bytifi.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Bytifi.Bytifi
+PackageVersion: 0.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds **Bytifi.Bytifi 0.1.1** — the official Bytifi CLI for Windows.

Bytifi encrypts files locally and uploads them to [bytifi.com](https://bytifi.com), then prints a share link with the decryption token in the URL fragment.

- **Publisher:** Bytifi
- **Installer:** portable x64 executable
- **Source:** https://github.com/jpwcguy/Bytifi
- **Release:** https://github.com/jpwcguy/Bytifi/releases/tag/v0.1.1

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  - N/A

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> `manifests/b/Bytifi/Bytifi/0.1.1`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/404433)