### PR TITLE
New package: epatels.CKPDFUnlocker v8.0.0

### DIFF
--- a/manifests/e/epatels/CKPDFUnlocker/8.0.0/epatels.CKPDFUnlocker.installer.yaml
+++ b/manifests/e/epatels/CKPDFUnlocker/8.0.0/epatels.CKPDFUnlocker.installer.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: epatels.CKPDFUnlocker
+PackageVersion: 8.0.0
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerType: nullsoft
+    Scope: user
+    InstallerUrl: https://github.com/epatels/ck-pdf-unlocker/releases/download/v8.0.0/ck-pdf-unlocker-setup-x64.exe
+    InstallerSha256: 504D0E6C8933E9816B5C7B31F206CF434E829554771E67C3E2DA8F78B32BE35A
+    InstallerSwitches:
+      Silent: /S
+      SilentWithProgress: /S
+  - Architecture: x64
+    InstallerType: msi
+    Scope: user
+    InstallerUrl: https://github.com/epatels/ck-pdf-unlocker/releases/download/v8.0.0/ck-pdf-unlocker-setup-x64.msi
+    InstallerSha256: C1589608FDEF6854BAFF0F1C8CB7F76246DECED400492CEF243FDB55D026C2DF
+    InstallerSwitches:
+      Silent: /quiet
+      SilentWithProgress: /passive
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/e/epatels/CKPDFUnlocker/8.0.0/epatels.CKPDFUnlocker.locale.en-US.yaml
+++ b/manifests/e/epatels/CKPDFUnlocker/8.0.0/epatels.CKPDFUnlocker.locale.en-US.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: epatels.CKPDFUnlocker
+PackageVersion: 8.0.0
+PackageLocale: en-US
+Publisher: epatels
+PublisherUrl: https://github.com/epatels/ck-pdf-unlocker
+PackageName: CK PDF Unlocker
+PackageUrl: https://github.com/epatels/ck-pdf-unlocker
+License: Proprietary
+LicenseUrl: https://github.com/epatels/ck-pdf-unlocker/blob/main/LICENSE
+ShortDescription: Remove passwords and copy/print restrictions from PDF files
+Description: |
+  CK PDF Unlocker removes open-password protection and copy/print restrictions from PDF files. It processes files locally — nothing leaves your device. Supports batch processing, per-file passwords, drag & drop, and dark/light themes.
+Tags:
+  - pdf
+  - password
+  - unlock
+  - decrypt
+  - pikepdf
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/e/epatels/CKPDFUnlocker/8.0.0/epatels.CKPDFUnlocker.yaml
+++ b/manifests/e/epatels/CKPDFUnlocker/8.0.0/epatels.CKPDFUnlocker.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: epatels.CKPDFUnlocker
+PackageVersion: 8.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## New package: epatels.CKPDFUnlocker version 8.0.0

**App name:** CK PDF Unlocker  
**Publisher:** epatels  
**License:** Proprietary  
**URL:** https://github.com/epatels/ck-pdf-unlocker  

This PR was generated automatically by `submit_winget.py`.

### Checklist
- [x] Installer URL is HTTPS
- [x] SHA-256 computed from the actual installer file
- [x] Installer tested locally
- [x] License is Proprietary (freeware, EULA)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/404434)