### PR TITLE
New package: SerZhyAle.StreamsPlayer version 26.0719.0310

### DIFF
--- a/manifests/s/SerZhyAle/StreamsPlayer/26.0719.0310/SerZhyAle.StreamsPlayer.installer.yaml
+++ b/manifests/s/SerZhyAle/StreamsPlayer/26.0719.0310/SerZhyAle.StreamsPlayer.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: SerZhyAle.StreamsPlayer
+PackageVersion: 26.0719.0310
+InstallerType: zip
+NestedInstallerType: portable
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+NestedInstallerFiles:
+- RelativeFilePath: StreamsPlayer.exe
+  PortableCommandAlias: streamsplayer
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/SerZhyAle/StreamsPlayer/releases/download/v26.0719.0310/StreamsPlayer-26.0719.0310-windows-x64.zip
+  InstallerSha256: A8CA42BB78003C9845A6BFA777A9AA173A7C4FDAB0476A0FDA613B38624C3FDC
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/SerZhyAle/StreamsPlayer/26.0719.0310/SerZhyAle.StreamsPlayer.locale.en-US.yaml
+++ b/manifests/s/SerZhyAle/StreamsPlayer/26.0719.0310/SerZhyAle.StreamsPlayer.locale.en-US.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: SerZhyAle.StreamsPlayer
+PackageVersion: 26.0719.0310
+PackageLocale: en-US
+Publisher: SerZhyAle
+PublisherUrl: https://github.com/SerZhyAle
+PublisherSupportUrl: https://github.com/SerZhyAle/StreamsPlayer/issues
+PrivacyUrl: https://serzhyale.github.io/StreamsPlayer/privacy.html
+PackageName: STREAMS Player
+PackageUrl: https://serzhyale.github.io/StreamsPlayer/
+License: MIT
+LicenseUrl: https://github.com/SerZhyAle/StreamsPlayer/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Serhii Zhyhunenko
+Moniker: streamsplayer
+ShortDescription: Browse internet radio and live video in a focused Windows stream catalog.
+Description: STREAMS Player is an English and Russian Windows desktop app for browsing a curated internet radio, live video, and RTSP address catalog. Search, filter, pin, and add streams; choose List or Grid mode with optional live thumbnails; and open video with always-on-top and fullscreen controls. Catalog refresh is explicit, local state stays on the device, and the app has no account, advertising, analytics, or telemetry. Playback compatibility varies by provider, protocol, and codec.
+Tags:
+- radio
+- streaming
+- video
+- rtsp
+- live-tv
+- iptv
+- windows
+ReleaseNotes: |-
+  First public release of STREAMS Player.
+  - Curated internet radio, live video, and RTSP catalog on first launch.
+  - Search, filter by category/language/country/media type, sort, and pin.
+  - Add your own streams; local pins and playback marks are kept on device.
+  - Radio plays in the main window; live video and RTSP open in a focused player.
+  - Optional visual grid with live HTTP(S) video previews (latest 64 frames).
+  - Always-on-top and borderless fullscreen (F11); English/Russian interface.
+  - Explicit catalog refresh only; no account, advertising, analytics, or telemetry.
+  Portable, self-contained x64 build for Windows 10/11.
+ReleaseNotesUrl: https://github.com/SerZhyAle/StreamsPlayer/releases/tag/v26.0719.0310
+ReleaseDate: 2026-07-19
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/SerZhyAle/StreamsPlayer/26.0719.0310/SerZhyAle.StreamsPlayer.locale.ru-RU.yaml
+++ b/manifests/s/SerZhyAle/StreamsPlayer/26.0719.0310/SerZhyAle.StreamsPlayer.locale.ru-RU.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+PackageIdentifier: SerZhyAle.StreamsPlayer
+PackageVersion: 26.0719.0310
+PackageLocale: ru-RU
+Publisher: SerZhyAle
+PublisherUrl: https://github.com/SerZhyAle
+PublisherSupportUrl: https://github.com/SerZhyAle/StreamsPlayer/issues
+PrivacyUrl: https://serzhyale.github.io/StreamsPlayer/privacy.html
+PackageName: Трансляции
+PackageUrl: https://serzhyale.github.io/StreamsPlayer/
+License: MIT
+LicenseUrl: https://github.com/SerZhyAle/StreamsPlayer/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Serhii Zhyhunenko
+ShortDescription: Каталог интернет-радио и live-видео для Windows с русским интерфейсом.
+Description: Трансляции — приложение Windows с русским и английским интерфейсом для просмотра каталога интернет-радио, live-видео и адресов RTSP. Ищите, фильтруйте, закрепляйте и добавляйте потоки; выбирайте список или сетку с отключаемыми живыми миниатюрами; открывайте видео поверх окон или во весь экран. Каталог обновляется только по команде, локальные данные остаются на устройстве, в приложении нет аккаунта, рекламы, аналитики и телеметрии. Совместимость воспроизведения зависит от поставщика, протокола и кодека.
+Tags:
+- радио
+- потоки
+- видео
+- rtsp
+- телевидение
+- iptv
+ReleaseNotes: |-
+  Первый публичный выпуск STREAMS Player.
+  - Готовый каталог интернет-радио, live-видео и RTSP при первом запуске.
+  - Поиск, фильтры по категории/языку/стране/типу медиа, сортировка и закрепление.
+  - Добавление своих потоков; закрепления и отметки воспроизведения хранятся локально.
+  - Радио — в главном окне; live-видео и RTSP — в отдельном окне плеера.
+  - Опциональная визуальная сетка с живыми превью HTTP(S)-видео (последние 64 кадра).
+  - Поверх всех окон и полноэкранный режим (F11); интерфейс EN/RU.
+  - Обновление каталога только по команде; без аккаунта, рекламы, аналитики и телеметрии.
+  Портативная самодостаточная сборка x64 для Windows 10/11.
+ReleaseNotesUrl: https://github.com/SerZhyAle/StreamsPlayer/releases/tag/v26.0719.0310
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/s/SerZhyAle/StreamsPlayer/26.0719.0310/SerZhyAle.StreamsPlayer.yaml
+++ b/manifests/s/SerZhyAle/StreamsPlayer/26.0719.0310/SerZhyAle.StreamsPlayer.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: SerZhyAle.StreamsPlayer
+PackageVersion: 26.0719.0310
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package: `SerZhyAle.StreamsPlayer` version `26.0719.0310`.

STREAMS Player — an independent, open-source (MIT) Windows desktop app for internet radio, live video, and RTSP. Installer is a portable ZIP (nested `StreamsPlayer.exe`, x64), sourced from the project's own GitHub Release `v26.0719.0310`.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable) — N/A, new package

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>` (installer hash verified, portable extracted, alias `streamsplayer` registered)
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)