### PR TITLE
New package: tldraw.tldraw-offline version 1.11.0

### DIFF
--- a/manifests/t/tldraw/tldraw-offline/1.11.0/tldraw.tldraw-offline.installer.yaml
+++ b/manifests/t/tldraw/tldraw-offline/1.11.0/tldraw.tldraw-offline.installer.yaml
@@ -1,0 +1,15 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: tldraw.tldraw-offline
+PackageVersion: 1.11.0
+InstallerType: nullsoft
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/tldraw/tldraw-offline/releases/download/v1.11.0/tldraw-offline-win-x64.exe
+  InstallerSha256: 5CDF30ED5E8AE1D689601FE3F95E509D1F54761546534AD599249B66779E20FA
+- Architecture: arm64
+  InstallerUrl: https://github.com/tldraw/tldraw-offline/releases/download/v1.11.0/tldraw-offline-win-arm64.exe
+  InstallerSha256: 91C3CA7415E65E2A442C2A29D4A1015A47B6BDD9E948032F187DE1A6B105B818
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/t/tldraw/tldraw-offline/1.11.0/tldraw.tldraw-offline.locale.en-US.yaml
+++ b/manifests/t/tldraw/tldraw-offline/1.11.0/tldraw.tldraw-offline.locale.en-US.yaml
@@ -1,0 +1,15 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: tldraw.tldraw-offline
+PackageVersion: 1.11.0
+PackageLocale: en-US
+Publisher: tldraw.com
+PublisherUrl: https://tldraw.com
+PackageName: tldraw offline
+PackageUrl: https://offline.tldraw.com/
+License: Proprietary
+Copyright: Copyright © 2026 tldraw.com
+ShortDescription: A local whiteboard for you and your agents.
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/tldraw/tldraw-offline/1.11.0/tldraw.tldraw-offline.yaml
+++ b/manifests/t/tldraw/tldraw-offline/1.11.0/tldraw.tldraw-offline.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: tldraw.tldraw-offline
+PackageVersion: 1.11.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description

Adds a new package manifest for [tldraw offline](https://offline.tldraw.com/) [v1.11.0](https://github.com/tldraw/tldraw-offline/releases/tag/v1.11.0).

tldraw offline is a local whiteboard built on tldraw's infinite canvas. This submission adds Windows support for both x64 and arm64 architectures via the official installers published on the project's GitHub releases.

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue
  <!-- Example: Resolves #328283 -->
  - Resolves #404480

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/404479)