### PR TITLE
New package: BeamoINT.bssh version 0.1.0

### DIFF
--- a/manifests/b/BeamoINT/bssh/0.1.0/BeamoINT.bssh.installer.yaml
+++ b/manifests/b/BeamoINT/bssh/0.1.0/BeamoINT.bssh.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: BeamoINT.bssh
+PackageVersion: 0.1.0
+MinimumOSVersion: 10.0.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: bssh.cmd
+    PortableCommandAlias: bssh
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: OpenJS.NodeJS
+Installers:
+  - Architecture: neutral
+    InstallerUrl: https://github.com/BeamoINT/homebrew-tap/releases/download/bssh-v0.1.0/bssh-0.1.0-windows.zip
+    InstallerSha256: 8017BC6D3A29F9216115A20D165BD3A46204BD25E5FBB5AC3611BD91039E19A6
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/b/BeamoINT/bssh/0.1.0/BeamoINT.bssh.locale.en-US.yaml
+++ b/manifests/b/BeamoINT/bssh/0.1.0/BeamoINT.bssh.locale.en-US.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: BeamoINT.bssh
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: BeamoINT
+PublisherUrl: https://browserssh.com
+PublisherSupportUrl: https://github.com/BeamoINT/browserssh/issues
+PackageName: bssh
+PackageUrl: https://browserssh.com
+License: MIT
+Copyright: Copyright (c) BeamoINT
+ShortDescription: CLI for the Browser SSH agent API and MCP install glue.
+Moniker: bssh
+Tags:
+  - ssh
+  - cli
+  - mcp
+  - agents
+  - browserssh
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/b/BeamoINT/bssh/0.1.0/BeamoINT.bssh.yaml
+++ b/manifests/b/BeamoINT/bssh/0.1.0/BeamoINT.bssh.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: BeamoINT.bssh
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Adds **BeamoINT.bssh** `0.1.0` — the first-party CLI for the Browser SSH agent API and MCP install glue.

- **Installer:** portable, delivered as a `zip` (`NestedInstallerType: portable`) whose `bssh.cmd` launcher runs the self-contained `bssh.mjs` bundle with Node.
- **Dependency:** `OpenJS.NodeJS` (the CLI is a Node script).
- **Source:** https://browserssh.com — installer asset hosted on a public GitHub Release (`BeamoINT/homebrew-tap`, tag `bssh-v0.1.0`), SHA256 pinned.

### Validation
- [x] Manifests validated against the official winget **v1.6.0 JSON schemas** (version / installer / defaultLocale).
- [ ] `winget install --manifest` on Windows — **not run.** These manifests were authored on macOS, so I could not test the install locally. Requesting the CI validation pipeline / reviewers to verify the sandbox install.

Also distributed via Homebrew (`brew install BeamoINT/tap/bssh`) and Scoop (`scoop install beamoint/bssh`).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/404485)