### PR TITLE
New version: Materializr.Materializr version 1.5.0

### DIFF
--- a/manifests/m/Materializr/Materializr/1.5.0/Materializr.Materializr.installer.yaml
+++ b/manifests/m/Materializr/Materializr/1.5.0/Materializr.Materializr.installer.yaml
@@ -1,25 +1,28 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
 PackageIdentifier: Materializr.Materializr
 PackageVersion: 1.5.0
-# NSIS installer (packaging/windows/installer.nsi) → winget type "nullsoft",
-# which implies the "/S" silent switch. It installs machine-wide to
-# %ProgramFiles%\Materializr and requires elevation (RequestExecutionLevel admin).
+InstallerLocale: en-US
 InstallerType: nullsoft
 Scope: machine
 InstallModes:
-  - interactive
-  - silent
-  - silentWithProgress
+- interactive
+- silent
+- silentWithProgress
 UpgradeBehavior: install
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+ProductCode: Materializr
+ReleaseDate: 2026-07-19
+AppsAndFeaturesEntries:
+- ProductCode: Materializr
+  DisplayVersion: v1.5.0
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles%\Materializr'
 Installers:
-  - Architecture: x64
-    InstallerUrl: https://github.com/materializr-cad/materializr/releases/download/v1.5.0/Materializr-Setup.exe
-    InstallerSha256: 081737A7E4B111FBDF9A7F62B3F6B55A71DD5ECF72B9B5D6E97CBF879D371241
-    # The NSIS script writes these ARP values; the installer tags DisplayVersion
-    # with the tag name (leading "v") via /DAPPVERSION=${github.ref_name}.
-    AppsAndFeaturesEntries:
-      - DisplayName: Materializr
-        Publisher: Materializr
-        DisplayVersion: v1.5.0
+- Architecture: x64
+  InstallerUrl: https://github.com/materializr-cad/materializr/releases/download/v1.5.0/Materializr-Setup.exe
+  InstallerSha256: 081737A7E4B111FBDF9A7F62B3F6B55A71DD5ECF72B9B5D6E97CBF879D371241
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/m/Materializr/Materializr/1.5.0/Materializr.Materializr.installer.yaml
+++ b/manifests/m/Materializr/Materializr/1.5.0/Materializr.Materializr.installer.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Materializr.Materializr
+PackageVersion: 1.5.0
+# NSIS installer (packaging/windows/installer.nsi) → winget type "nullsoft",
+# which implies the "/S" silent switch. It installs machine-wide to
+# %ProgramFiles%\Materializr and requires elevation (RequestExecutionLevel admin).
+InstallerType: nullsoft
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/materializr-cad/materializr/releases/download/v1.5.0/Materializr-Setup.exe
+    InstallerSha256: 081737A7E4B111FBDF9A7F62B3F6B55A71DD5ECF72B9B5D6E97CBF879D371241
+    # The NSIS script writes these ARP values; the installer tags DisplayVersion
+    # with the tag name (leading "v") via /DAPPVERSION=${github.ref_name}.
+    AppsAndFeaturesEntries:
+      - DisplayName: Materializr
+        Publisher: Materializr
+        DisplayVersion: v1.5.0
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/Materializr/Materializr/1.5.0/Materializr.Materializr.locale.en-US.yaml
+++ b/manifests/m/Materializr/Materializr/1.5.0/Materializr.Materializr.locale.en-US.yaml
@@ -1,4 +1,5 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
 PackageIdentifier: Materializr.Materializr
 PackageVersion: 1.5.0
 PackageLocale: en-US
@@ -8,8 +9,8 @@ PublisherSupportUrl: https://github.com/materializr-cad/materializr/issues
 Author: Steve Bushwa
 PackageName: Materializr
 PackageUrl: https://github.com/materializr-cad/materializr
-License: GPL-3.0-or-later
-LicenseUrl: https://github.com/materializr-cad/materializr/blob/main/LICENSE
+License: GPL-3.0
+LicenseUrl: https://github.com/materializr-cad/materializr/blob/HEAD/LICENSE
 Copyright: Copyright (C) Steve Bushwa
 ShortDescription: Maker 3D CAD — the middle ground between Tinkercad and FreeCAD.
 Description: |-
@@ -23,13 +24,25 @@ Description: |-
   OpenCASCADE kernel.
 Moniker: materializr
 Tags:
-  - 3d
-  - 3d-printing
-  - cad
-  - engineering
-  - laser
-  - modeling
-  - opencascade
-  - svg
+- 3d
+- 3d-printing
+- cad
+- engineering
+- laser
+- modeling
+- opencascade
+- svg
+ReleaseNotes: |-
+  Materializr 1.5.0 — the biggest feature release since 1.3.0.
+  Highlights
+  - File exchange: BREP import/export, OBJ and 3MF export, DXF import/export; IGES axis conversion fixed; projects prefer the shorter .mzr extension
+  - Reference images: drop a picture into the viewport and model against it
+  - New modeling ops: Guided Loft, N-section loft, Boundary Fill, and Separate
+  - Chamfer/fillet rebuilt: corner miters and hips, plus a cut-based fallback for blends the native builder refuses; face-lineage topological naming
+  - History: extrude remembers its regions, cascade disables steps that can't follow, hovering a step highlights its geometry
+  - Desktop: Linux HiDPI interface scale, click-drag line tool, movable operation panels
+  Fixed
+  - macOS 26.x startup crash; audit hardening (op validity gates, SVG budgets, settings clamping, transactional load); shell and stepped-hole fixes
+ReleaseNotesUrl: https://github.com/materializr-cad/materializr/releases/tag/v1.5.0
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/m/Materializr/Materializr/1.5.0/Materializr.Materializr.locale.en-US.yaml
+++ b/manifests/m/Materializr/Materializr/1.5.0/Materializr.Materializr.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Materializr.Materializr
+PackageVersion: 1.5.0
+PackageLocale: en-US
+Publisher: Materializr
+PublisherUrl: https://github.com/materializr-cad
+PublisherSupportUrl: https://github.com/materializr-cad/materializr/issues
+Author: Steve Bushwa
+PackageName: Materializr
+PackageUrl: https://github.com/materializr-cad/materializr
+License: GPL-3.0-or-later
+LicenseUrl: https://github.com/materializr-cad/materializr/blob/main/LICENSE
+Copyright: Copyright (C) Steve Bushwa
+ShortDescription: Maker 3D CAD — the middle ground between Tinkercad and FreeCAD.
+Description: |-
+  Materializr is open-source 3D CAD for makers — the middle ground between
+  dead-simple tools like Tinkercad and full professional suites like FreeCAD.
+  Sketch on a plane, pull it into a solid (extrude, revolve, loft, sweep),
+  fillet and chamfer, run booleans, cut threads, and edit any step of the
+  history later. Sketches export to SVG and DXF at 1:1 mm for laser cutters and
+  2.5D CNC; it imports STEP, IGES, BREP, STL, SVG and DXF, and exports STEP,
+  STL, IGES, BREP, glTF, OBJ, 3MF, SVG and DXF. Real B-rep solids on the
+  OpenCASCADE kernel.
+Moniker: materializr
+Tags:
+  - 3d
+  - 3d-printing
+  - cad
+  - engineering
+  - laser
+  - modeling
+  - opencascade
+  - svg
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/Materializr/Materializr/1.5.0/Materializr.Materializr.yaml
+++ b/manifests/m/Materializr/Materializr/1.5.0/Materializr.Materializr.yaml
@@ -1,8 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
-# Version manifest. Submit alongside the installer + locale manifests to
-# microsoft/winget-pkgs under: manifests/m/Materializr/Materializr/1.2.8/
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
 PackageIdentifier: Materializr.Materializr
 PackageVersion: 1.5.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/m/Materializr/Materializr/1.5.0/Materializr.Materializr.yaml
+++ b/manifests/m/Materializr/Materializr/1.5.0/Materializr.Materializr.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# Version manifest. Submit alongside the installer + locale manifests to
+# microsoft/winget-pkgs under: manifests/m/Materializr/Materializr/1.2.8/
+PackageIdentifier: Materializr.Materializr
+PackageVersion: 1.5.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`? *(submitted from Linux — manifests schema-checked against the 1.6.0 JSON schemas; relying on the pipeline's validation)*
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? *(no Windows machine available — the identical NSIS installer layout passed pipeline installation for 1.4.3)*
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Materializr 1.5.0 — https://github.com/materializr-cad/materializr/releases/tag/v1.5.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/404531)