### PR TITLE
New version: Feci.ParleyDeckCli version 1.36.0

### DIFF
--- a/manifests/f/Feci/ParleyDeckCli/1.36.0/Feci.ParleyDeckCli.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.36.0/Feci.ParleyDeckCli.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.36.0
+InstallerType: portable
+Commands:
+- parley
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.36.0/parley-v1.36.0-windows-x64.exe
+  InstallerSha256: 00EDFD2DB60B6212A9BAC4455AB8ABF50B9D6D8EC6214D70FB2058AAC3DBB60F
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.36.0/parley-v1.36.0-windows-arm64.exe
+  InstallerSha256: 2160312FB142ED253AD4CA77492E3828AF55567DE1BF9C3FDA69F5CCE51697D3
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.36.0/Feci.ParleyDeckCli.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.36.0/Feci.ParleyDeckCli.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.36.0
+PackageLocale: en-US
+Publisher: Feci
+PublisherUrl: https://github.com/feci
+PackageName: Parley Deck CLI
+PackageUrl: https://github.com/feci/parley-deck-cli
+License: Apache-2.0
+LicenseUrl: https://github.com/feci/parley-deck-cli/blob/main/LICENSE
+ShortDescription: CLI that orchestrates Parley Deck multi-agent cooperation workflows.
+Description: "parley orchestrates multi-agent Parley Deck cooperation across local CLI agents: risk-tiered tracks (fast, standard, deliberation), deliberation rounds, consensus and finalize, implementation with living execution plans, a live TUI, and a human-braked outer loop. v1.36.0 adds self-documenting agent display names (family_model_effort, e.g. codex_gpt-5.6-sol_xHigh), fixes the roster-identity vs adapter split with a fail-closed participant resolver so a deck whose roster is claude-1 runs end-to-end, adds parley roster show and parley roster init to view and (re)build the roster and its family mapping, makes autonomous (yolo) write mode first-class per agent, and makes fast the standard speed on a separate axis from reasoning effort (same model and effort, faster output)."
+ReleaseNotesUrl: https://github.com/feci/parley-deck-cli/releases/tag/v1.36.0
+Tags:
+- ai
+- agents
+- automation
+- cli
+- codex
+- consensus
+- loop
+- multi-agent
+- orchestration
+- preflight
+- roster
+- tui
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.36.0/Feci.ParleyDeckCli.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.36.0/Feci.ParleyDeckCli.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.36.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Manifest for Feci.ParleyDeckCli 1.36.0

- Portable installer, `parley` command, x64 + arm64.
- InstallerUrls are the GitHub release v1.36.0 assets; SHA256 from the release asset digests (URLs verified 200).

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] This PR only modifies one (1) manifest
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/404613)