### PR TITLE
New version: Feci.ParleyDeckSkill version 1.4.6

### DIFF
--- a/manifests/f/Feci/ParleyDeckSkill/1.4.6/Feci.ParleyDeckSkill.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/1.4.6/Feci.ParleyDeckSkill.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 1.4.6
+InstallerType: portable
+Commands:
+- parley-deck-skill
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-skill/releases/download/v1.4.6/parley-deck-skill-v1.4.6-windows-x64.exe
+  InstallerSha256: 788664B590057B8471B806A0DA4FFEE097532119F1CEF0E4487492778A75188F
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-skill/releases/download/v1.4.6/parley-deck-skill-v1.4.6-windows-arm64.exe
+  InstallerSha256: 62B225DFCC644A79AF9FEDBD6B7811B1F1E5A2AF361A932194DAA0E270035FDC
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckSkill/1.4.6/Feci.ParleyDeckSkill.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/1.4.6/Feci.ParleyDeckSkill.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 1.4.6
+PackageLocale: en-US
+Publisher: Feci
+PublisherUrl: https://github.com/feci
+PackageName: Parley Deck Skill
+PackageUrl: https://github.com/feci/parley-deck-skill
+License: Apache-2.0
+LicenseUrl: https://github.com/feci/parley-deck-skill/blob/main/LICENSE
+ShortDescription: Installer for the Parley Deck multi-agent cooperation skill.
+Description: "Installs the vendor-neutral Parley Deck AI cooperation skill into Codex, Claude Code, Antigravity CLI, legacy Gemini CLI, Hermes, Kimi Code, or a custom skill directory. v1.4.6 adds an Autonomous Execution section (every headless participant runs in its yolo/bypass mode so it can write its own artifact without a blocking prompt, with the per-CLI mapping including Kimi Code's -p) and an Agent display names and roster init section (self-documenting family_model_effort names, parley roster show and parley roster init, and fast as the standard speed on a separate axis from reasoning effort). Ships two opt-in companion add-on skills installed by default (use --no-addons or --only to choose): parley-worktrees (parallel sessions over one git repo via worktrees) and parley-tracker (vendor-neutral epic/story/subtask authoring readable by business, technical, and AI readers, with a tool-enforced gap-scan)."
+ReleaseNotesUrl: https://github.com/feci/parley-deck-skill/releases/tag/v1.4.6
+Tags:
+- ai
+- agents
+- agy
+- antigravity
+- cli
+- codex
+- claude
+- gemini
+- kimi
+- multi-agent
+- skill
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckSkill/1.4.6/Feci.ParleyDeckSkill.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/1.4.6/Feci.ParleyDeckSkill.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 1.4.6
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Manifest for Feci.ParleyDeckSkill 1.4.6

- Portable installer, `parley-deck-skill` command, x64 + arm64.
- InstallerUrls are the GitHub release v1.4.6 assets; SHA256 from the release asset digests (URLs verified 200).

- [x] Contributor License Agreement signed
- [x] This PR only modifies one (1) manifest
- [x] Manifest validated locally

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/404614)