### PR TITLE
New package: HTH.TranslationManager version 1.1.0

### DIFF
--- a/manifests/h/HTH/TranslationManager/1.1.0/HTH.TranslationManager.installer.yaml
+++ b/manifests/h/HTH/TranslationManager/1.1.0/HTH.TranslationManager.installer.yaml
@@ -1,0 +1,58 @@
+# Created with winget-manifest scaffold for Nehoray.TranslationManager 1.1.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: HTH.TranslationManager
+PackageVersion: 1.1.0
+InstallerLocale: he-IL
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  # `/SILENT` (not /VERYSILENT) is deliberate. Inno Setup 6.7's
+  # RedirectionGuard handoff (level 2 SL5 → level 3 protected Setup)
+  # fails silently with /VERYSILENT in sandboxed contexts - the
+  # protected temp dir gets created with only `_setup64.tmp` + an
+  # empty `_isetup\` and the install never proceeds, leaving the
+  # install dir half-populated. Same root cause as the failure mode
+  # we hit during the launcher's in-app self-update. /SILENT keeps
+  # the small progress dialog visible, which is what RG's protected
+  # handoff needs to complete; the dialog is dismissed automatically
+  # at the end so the WinGet sandbox sees a clean exit.
+  # /SP- skips the "This will install..." pre-install dialog so the
+  # install still runs without any user clicks.
+  Silent: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  Custom: ""
+UpgradeBehavior: install
+# 0 is implicit; 3010 (success-needs-restart) and 1641 (restart-initiated)
+# are Inno Setup's only documented non-zero success codes. /NORESTART
+# converts 3010→0 in practice but we list them defensively.
+InstallerSuccessCodes:
+  - 1641
+  - 3010
+# Explicit ARP (Apps and Features) entry so WinGet's post-install
+# verification knows exactly which Uninstall registry subkey to look
+# for. Inno writes `<AppId>_is1` under
+# HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\ - the
+# top-level `ProductCode` field is also kept for tooling that reads
+# the older shape.
+AppsAndFeaturesEntries:
+  - DisplayName: Translation Manager
+    DisplayVersion: 1.1.0
+    Publisher: Hebrew Translation Hub
+    ProductCode: '{B0D4F2A7-3CCE-4A1A-9C44-7E1A1B6F0001}_is1'
+    InstallerType: inno
+ProductCode: '{B0D4F2A7-3CCE-4A1A-9C44-7E1A1B6F0001}_is1'
+ReleaseDate: 2026-07-19
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/hebrew-translation-hub/translation-launcher/releases/download/v1.1.0-beta/TranslationManager-Setup-1.1.0.exe
+    InstallerSha256: 5C995099871C4275DFCC3A91278BAC30C6987D9274C07CCB5E8AD8F97C90215A
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/h/HTH/TranslationManager/1.1.0/HTH.TranslationManager.installer.yaml
+++ b/manifests/h/HTH/TranslationManager/1.1.0/HTH.TranslationManager.installer.yaml
@@ -53,6 +53,6 @@ ReleaseDate: 2026-07-19
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/hebrew-translation-hub/translation-launcher/releases/download/v1.1.0-beta/TranslationManager-Setup-1.1.0.exe
-    InstallerSha256: 5C995099871C4275DFCC3A91278BAC30C6987D9274C07CCB5E8AD8F97C90215A
+    InstallerSha256: F8FB523FB58C2029D094AF8A1CD5D188B0E510073408FE7ED695D0A0C5418495
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/h/HTH/TranslationManager/1.1.0/HTH.TranslationManager.locale.en-US.yaml
+++ b/manifests/h/HTH/TranslationManager/1.1.0/HTH.TranslationManager.locale.en-US.yaml
@@ -1,0 +1,39 @@
+# Created with winget-manifest scaffold for Nehoray.TranslationManager 1.1.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: HTH.TranslationManager
+PackageVersion: 1.1.0
+PackageLocale: en-US
+Publisher: Hebrew Translation Hub
+PublisherUrl: https://hebrew-translation-hub.com/
+PublisherSupportUrl: https://hebrew-translation-hub.com/
+Author: Nehoray Cohen
+PackageName: Translation Manager
+PackageUrl: https://hebrew-translation-hub.com/
+License: Proprietary
+LicenseUrl: https://hebrew-translation-hub.com/
+Copyright: Copyright (C) 2026 Nehoray
+CopyrightUrl: https://hebrew-translation-hub.com/
+ShortDescription: Hebrew translation launcher for AAA PC games - installs, manages, and updates community localizations from one app.
+Description: |-
+  Translation Manager is a Hebrew-first Windows launcher that brings community
+  AAA-game translations into one curated catalog. Browse available titles,
+  download the matching translation archive, and apply it to your installed
+  game with one click. The app handles update checks, mod toggling, and
+  per-game purchase / DRM gating, and ships a built-in catalog for popular
+  titles such as Cyberpunk 2077, God of War Ragnarok, Red Dead Redemption,
+  Hogwarts Legacy, and more.
+Moniker: translation-manager
+Tags:
+  - hebrew
+  - translation
+  - localization
+  - gaming
+  - games
+  - launcher
+  - mods
+  - rtl
+ReleaseNotesUrl: https://github.com/hebrew-translation-hub/translation-launcher/releases/tag/v1.1.0-beta
+PurchaseUrl: https://hebrew-translation-hub.com/
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/h/HTH/TranslationManager/1.1.0/HTH.TranslationManager.yaml
+++ b/manifests/h/HTH/TranslationManager/1.1.0/HTH.TranslationManager.yaml
@@ -1,0 +1,8 @@
+# Created with winget-manifest scaffold for Nehoray.TranslationManager 1.1.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: HTH.TranslationManager
+PackageVersion: 1.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package

Adds **HTH.TranslationManager 1.1.0** - a Hebrew game-translation launcher.

The application was previously published as `Nehoray.TranslationManager`. It now ships from an organization account under the brand **Hebrew Translation Hub**, so the identifier was rebranded to match the publisher. Same application, same installer technology (Inno Setup).

The old identifier's manifests are removed in a **separate PR**, since a single pull request may only touch one application.

Note: `AppsAndFeaturesEntries.Publisher` is `Hebrew Translation Hub`, which is what the installer actually writes to Add/Remove Programs (verified on a real install). The old manifests said `Nehoray`, so winget could not match an installed copy.

- `InstallerSha256` verified against the published release asset.
- The installer is unsigned, so the Defender heuristic may flag it as on previous versions of this package; it is a false positive on an Inno Setup build.

---
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
