### PR TITLE
New package: Fluxzero.FluxzeroCLI version 1.4.0

### DIFF
--- a/manifests/f/Fluxzero/FluxzeroCLI/1.4.0/Fluxzero.FluxzeroCLI.installer.yaml
+++ b/manifests/f/Fluxzero/FluxzeroCLI/1.4.0/Fluxzero.FluxzeroCLI.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Fluxzero.FluxzeroCLI
+PackageVersion: 1.4.0
+InstallerType: zip
+NestedInstallerType: portable
+Commands:
+- fz
+ReleaseDate: 2026-07-19
+Installers:
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: fz.exe
+    PortableCommandAlias: fz
+  InstallerUrl: https://github.com/fluxzero-io/fluxzero-cli/releases/download/1.4.0/flux-windows-amd64.zip
+  InstallerSha256: E96EDCF6FA6BCA5716A562537D1675D06CDD7E3D205D4C6A2BB7DCB51ED69F65
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Fluxzero/FluxzeroCLI/1.4.0/Fluxzero.FluxzeroCLI.locale.en-US.yaml
+++ b/manifests/f/Fluxzero/FluxzeroCLI/1.4.0/Fluxzero.FluxzeroCLI.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Fluxzero.FluxzeroCLI
+PackageVersion: 1.4.0
+PackageLocale: en-US
+Publisher: Fluxzero
+PublisherUrl: https://fluxzero.io
+PublisherSupportUrl: https://github.com/fluxzero-io/fluxzero-cli/issues
+Author: Fluxzero
+PackageName: Fluxzero CLI
+PackageUrl: https://github.com/fluxzero-io/fluxzero-cli
+License: EUPL-1.2
+LicenseUrl: https://github.com/fluxzero-io/fluxzero-cli/blob/1.4.0/LICENSE
+Copyright: Copyright Fluxzero contributors
+ShortDescription: Develop, test, and manage Fluxzero applications from the command line.
+Description: The Fluxzero CLI scaffolds projects, manages Fluxzero Cloud resources, and runs local Fluxzero development environments.
+Moniker: fz
+Tags:
+- cli
+- developer-tools
+- fluxzero
+- java
+- kotlin
+ReleaseNotesUrl: https://github.com/fluxzero-io/fluxzero-cli/releases/tag/1.4.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Fluxzero/FluxzeroCLI/1.4.0/Fluxzero.FluxzeroCLI.yaml
+++ b/manifests/f/Fluxzero/FluxzeroCLI/1.4.0/Fluxzero.FluxzeroCLI.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Fluxzero.FluxzeroCLI
+PackageVersion: 1.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Adds Fluxzero CLI 1.4.0 as a portable x64 package from its immutable GitHub release asset.

## Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (not applicable)

## Manifest Checklist

- [x] Checked that there are no other open pull requests for `Fluxzero.FluxzeroCLI`
- [x] This PR only modifies one manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the 1.12 schema

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/404619)