### PR TITLE
New package: nkiyohara.OWABridge version 0.3.2

### DIFF
--- a/manifests/n/nkiyohara/OWABridge/0.3.2/nkiyohara.OWABridge.installer.yaml
+++ b/manifests/n/nkiyohara/OWABridge/0.3.2/nkiyohara.OWABridge.installer.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: nkiyohara.OWABridge
+PackageVersion: 0.3.2
+InstallerLocale: en-US
+InstallerType: zip
+ReleaseDate: "2026-07-20"
+Installers:
+  - Architecture: arm64
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: owa.exe
+        PortableCommandAlias: owa
+    InstallerUrl: https://github.com/nkiyohara/owa-bridge/releases/download/v0.3.2/owa-bridge_0.3.2_windows_arm64.zip
+    InstallerSha256: 9426bf8569602d5be50cac318f000a3884213dfd3109e1d81998cf5af9e15e04
+    UpgradeBehavior: uninstallPrevious
+  - Architecture: x64
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: owa.exe
+        PortableCommandAlias: owa
+    InstallerUrl: https://github.com/nkiyohara/owa-bridge/releases/download/v0.3.2/owa-bridge_0.3.2_windows_amd64.zip
+    InstallerSha256: 905ca7ad1013b981ef8e098a5d82fa3edc479e378661d012420f414855dc09db
+    UpgradeBehavior: uninstallPrevious
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/n/nkiyohara/OWABridge/0.3.2/nkiyohara.OWABridge.locale.en-US.yaml
+++ b/manifests/n/nkiyohara/OWABridge/0.3.2/nkiyohara.OWABridge.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: nkiyohara.OWABridge
+PackageVersion: 0.3.2
+PackageLocale: en-US
+Publisher: nkiyohara
+PublisherUrl: https://github.com/nkiyohara
+PublisherSupportUrl: https://github.com/nkiyohara/owa-bridge/issues
+PackageName: owa-bridge
+PackageUrl: https://github.com/nkiyohara/owa-bridge
+License: Apache-2.0
+LicenseUrl: https://github.com/nkiyohara/owa-bridge/blob/main/LICENSE
+ShortDescription: Local-first Outlook Web CLI and MCP server
+Description: Manage an authorized Outlook Web mail and calendar session through a guarded CLI or local MCP server without a Microsoft Graph application.
+Moniker: owa-bridge
+Tags:
+  - outlook
+  - email
+  - calendar
+  - cli
+  - mcp
+ReleaseNotesUrl: https://github.com/nkiyohara/owa-bridge/releases/tag/v0.3.2
+InstallationNotes: Run `owa login` interactively, then print client configuration with `owa mcp setup codex` or `owa mcp setup claude-code`.
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/n/nkiyohara/OWABridge/0.3.2/nkiyohara.OWABridge.yaml
+++ b/manifests/n/nkiyohara/OWABridge/0.3.2/nkiyohara.OWABridge.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: nkiyohara.OWABridge
+PackageVersion: 0.3.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds owa-bridge 0.3.2, a local-first Outlook Web mail and calendar CLI and MCP server that does not require a Microsoft Graph application.

The portable x64 and arm64 installers reference the verified v0.3.2 GitHub release archives and their published SHA-256 values.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (not applicable)

## 📦 Manifest Checklist

- [x] Checked that there are no other open pull requests for this package
- [x] This PR only modifies one manifest
- [ ] Validated locally with `winget validate --manifest <path>`
- [ ] Tested locally with `winget install --manifest <path>`
- [x] Manifest conforms to the 1.12 schema

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/404835)