### PR TITLE
New package: jefuriiij.PingMeter version 0.2.0

### DIFF
--- a/manifests/j/jefuriiij/PingMeter/0.2.0/jefuriiij.PingMeter.installer.yaml
+++ b/manifests/j/jefuriiij/PingMeter/0.2.0/jefuriiij.PingMeter.installer.yaml
@@ -8,6 +8,9 @@ MinimumOSVersion: 10.0.22000.0
 InstallerType: portable
 Commands:
 - pingmeter
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.8
 ReleaseDate: 2026-07-20
 Installers:
 - Architecture: x64

--- a/manifests/j/jefuriiij/PingMeter/0.2.0/jefuriiij.PingMeter.installer.yaml
+++ b/manifests/j/jefuriiij/PingMeter/0.2.0/jefuriiij.PingMeter.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: jefuriiij.PingMeter
+PackageVersion: 0.2.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.22000.0
+InstallerType: portable
+Commands:
+- pingmeter
+ReleaseDate: 2026-07-20
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/jefuriiij/ping-meter/releases/download/v0.2.0/PingMeter.exe
+  InstallerSha256: 04C33219A8A75349983791FC101A8FBB2179FD5BE4AA6AF8C3AC10590FDF8AF2
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/j/jefuriiij/PingMeter/0.2.0/jefuriiij.PingMeter.locale.en-US.yaml
+++ b/manifests/j/jefuriiij/PingMeter/0.2.0/jefuriiij.PingMeter.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: jefuriiij.PingMeter
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: jefuriiij
+PublisherUrl: https://github.com/jefuriiij
+PublisherSupportUrl: https://github.com/jefuriiij/ping-meter/issues
+PackageName: PingMeter
+PackageUrl: https://github.com/jefuriiij/ping-meter
+License: MIT
+LicenseUrl: https://github.com/jefuriiij/ping-meter/blob/main/LICENSE
+Copyright: Copyright (c) 2026 jefuriiij
+ShortDescription: Taskbar-embedded ping monitor for Windows 11
+Description: |-
+  PingMeter shows your live ping (ms) embedded directly in the Windows 11 taskbar,
+  next to the tray clock — on the primary taskbar, secondary-monitor taskbars, or all
+  of them. It replaces keeping "ping google.com -t" open in a terminal: color-coded
+  latency with configurable thresholds, a sparkline of recent pings, hover stats
+  (min/avg/max/loss), quick switching between preset targets, timeouts shown at a
+  glance, and a daily network event log that records outages, latency spikes, and
+  hourly summaries. Runs without admin rights and survives Explorer restarts.
+Tags:
+- latency
+- monitor
+- network
+- ping
+- taskbar
+ReleaseNotesUrl: https://github.com/jefuriiij/ping-meter/releases/tag/v0.2.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/j/jefuriiij/PingMeter/0.2.0/jefuriiij.PingMeter.yaml
+++ b/manifests/j/jefuriiij/PingMeter/0.2.0/jefuriiij.PingMeter.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: jefuriiij.PingMeter
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
New package submission: **jefuriiij.PingMeter 0.2.0** — a taskbar-embedded ping monitor for Windows 11 (MIT licensed, portable exe). I am the author of the package, submitting from the publisher account.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/README.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`? *(not run — LocalManifestFiles requires elevation on this machine; the exe itself is the file I built and run daily as the author)*
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Notes: `InstallerType: portable` (single exe, no installer). SHA-256 verified against the GitHub release asset. Source: https://github.com/jefuriiij/ping-meter

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/404863)