### PR TITLE
New package: JiaPeng.LanTransfer version 0.2.1

### DIFF
--- a/manifests/j/JiaPeng/LanTransfer/0.2.1/JiaPeng.LanTransfer.installer.yaml
+++ b/manifests/j/JiaPeng/LanTransfer/0.2.1/JiaPeng.LanTransfer.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: JiaPeng.LanTransfer
+PackageVersion: 0.2.1
+InstallerType: zip
+NestedInstallerType: portable
+ArchiveBinariesDependOnPath: true
+Commands:
+- lantransfer
+ReleaseDate: 2026-07-20
+Installers:
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: lantransfer.exe
+    PortableCommandAlias: lantransfer
+  InstallerUrl: https://github.com/hongjiapeng/LanTransfer/releases/download/v0.2.1/lantransfer-v0.2.1-win-x64.zip
+  InstallerSha256: C3760A1C5B18CD19743E0755262692C3DC448578A54500FF9C87B4BD0769E764
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/j/JiaPeng/LanTransfer/0.2.1/JiaPeng.LanTransfer.locale.en-US.yaml
+++ b/manifests/j/JiaPeng/LanTransfer/0.2.1/JiaPeng.LanTransfer.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: JiaPeng.LanTransfer
+PackageVersion: 0.2.1
+PackageLocale: en-US
+Publisher: JiaPeng
+PublisherUrl: https://github.com/hongjiapeng
+PublisherSupportUrl: https://github.com/hongjiapeng/LanTransfer/issues
+PackageName: LanTransfer
+PackageUrl: https://github.com/hongjiapeng/LanTransfer
+License: MIT
+LicenseUrl: https://github.com/hongjiapeng/LanTransfer/blob/main/LICENSE
+ShortDescription: Transfer files and text between devices on the same local network through a browser.
+Description: LanTransfer is a cross-platform local-network file and text transfer tool with a browser-based interface, QR-code connection, and no cloud dependency.
+Moniker: lantransfer
+Tags:
+- file-transfer
+- lan
+- local-network
+- qr-code
+- text-transfer
+ReleaseNotesUrl: https://github.com/hongjiapeng/LanTransfer/releases/tag/v0.2.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/j/JiaPeng/LanTransfer/0.2.1/JiaPeng.LanTransfer.locale.zh-CN.yaml
+++ b/manifests/j/JiaPeng/LanTransfer/0.2.1/JiaPeng.LanTransfer.locale.zh-CN.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: JiaPeng.LanTransfer
+PackageVersion: 0.2.1
+PackageLocale: zh-CN
+Publisher: JiaPeng
+PublisherUrl: https://github.com/hongjiapeng
+PublisherSupportUrl: https://github.com/hongjiapeng/LanTransfer/issues
+PackageName: LanTransfer
+PackageUrl: https://github.com/hongjiapeng/LanTransfer
+License: MIT
+LicenseUrl: https://github.com/hongjiapeng/LanTransfer/blob/main/LICENSE
+ShortDescription: 通过浏览器在同一局域网的设备之间传输文件和文字。
+Description: LanTransfer 是一个跨平台局域网文件和文字传输工具，提供浏览器界面、二维码连接，并且不依赖云服务。
+Tags:
+- 二维码
+- 局域网
+- 文件传输
+- 文字传输
+ReleaseNotesUrl: https://github.com/hongjiapeng/LanTransfer/releases/tag/v0.2.1
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/j/JiaPeng/LanTransfer/0.2.1/JiaPeng.LanTransfer.yaml
+++ b/manifests/j/JiaPeng/LanTransfer/0.2.1/JiaPeng.LanTransfer.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: JiaPeng.LanTransfer
+PackageVersion: 0.2.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds JiaPeng.LanTransfer 0.2.1 as a Windows x64 portable ZIP package.

Release: https://github.com/hongjiapeng/LanTransfer/releases/tag/v0.2.1

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com) (pending the automated CLA check)
- Linked issue: not applicable

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same manifest
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>` (local-manifest installation requires administrator access on the test machine; the published archive was instead smoke-tested for startup, health, text transfer, and file upload)
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/404876)