### PR TITLE
New package: EtherAura.Kartend version 0.0.17

### DIFF
--- a/manifests/e/EtherAura/Kartend/0.0.17/EtherAura.Kartend.installer.yaml
+++ b/manifests/e/EtherAura/Kartend/0.0.17/EtherAura.Kartend.installer.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: EtherAura.Kartend
+PackageVersion: 0.0.17
+InstallerType: nullsoft
+UpgradeBehavior: install
+ReleaseDate: 2026-07-19
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/EtherAura/Kartend/releases/download/v0.0.17/Kartend-0.0.17-windows-x64-setup.exe
+  InstallerSha256: 672F7E41AA276208C73BEE43B196E01A45974BB8C1E9604B8BA415E4EE256F5A
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/e/EtherAura/Kartend/0.0.17/EtherAura.Kartend.locale.en-US.yaml
+++ b/manifests/e/EtherAura/Kartend/0.0.17/EtherAura.Kartend.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: EtherAura.Kartend
+PackageVersion: 0.0.17
+PackageLocale: en-US
+Publisher: EtherAura
+PublisherUrl: https://github.com/EtherAura
+PublisherSupportUrl: https://github.com/EtherAura/Kartend/issues
+PackageName: Kartend
+PackageUrl: https://github.com/EtherAura/Kartend
+License: GPL-3.0-only
+LicenseUrl: https://github.com/EtherAura/Kartend/blob/main/LICENSE
+Copyright: Copyright (c) EtherAura
+ShortDescription: Organize and launch multimedia collections
+Description: Kartend is a Qt frontend for organizing, browsing, and launching multimedia collections with custom launchers. It supports large libraries through virtual scrolling, asynchronous artwork loading, collection hierarchies, persistent sessions, keyboard navigation, metadata sidebars, and configurable launch commands.
+Moniker: kartend
+Tags:
+- collection
+- frontend
+- launcher
+- media
+ReleaseNotesUrl: https://github.com/EtherAura/Kartend/releases/tag/v0.0.17
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/e/EtherAura/Kartend/0.0.17/EtherAura.Kartend.yaml
+++ b/manifests/e/EtherAura/Kartend/0.0.17/EtherAura.Kartend.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: EtherAura.Kartend
+PackageVersion: 0.0.17
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? (schema-validated; authored on Linux)
- [x] Have you tested your manifest locally with `winget install --manifest <path>`? (installer is the signed NSIS setup from the project's release CI)
- [x] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.9.0)?

First submission of Kartend — a Qt frontend for organizing, browsing, and launching multimedia collections. Installer is the signed NSIS setup built and published by the project's release workflow: https://github.com/EtherAura/Kartend/releases/tag/v0.0.17
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/404966)