### PR TITLE
New version: Sanctum.Sanctum version 0.3.3

### DIFF
--- a/manifests/s/Sanctum/Sanctum/0.3.3/Sanctum.Sanctum.installer.yaml
+++ b/manifests/s/Sanctum/Sanctum/0.3.3/Sanctum.Sanctum.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Sanctum.Sanctum
+PackageVersion: 0.3.3
+InstallerType: nullsoft
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/wgravel855-lang/sanctum/releases/download/v0.3.3/Sanctum-Windows-Setup.exe
+    InstallerSha256: 5A7DB42D0A39386B8EAA9B250C9D7084F9B2D4703BD64883E02987AFB4B7E929
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/Sanctum/Sanctum/0.3.3/Sanctum.Sanctum.locale.en-US.yaml
+++ b/manifests/s/Sanctum/Sanctum/0.3.3/Sanctum.Sanctum.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Sanctum.Sanctum
+PackageVersion: 0.3.3
+PackageLocale: en-US
+Publisher: Sanctum
+PublisherUrl: https://github.com/wgravel855-lang/sanctum
+PublisherSupportUrl: https://github.com/wgravel855-lang/sanctum/issues
+Author: Sanctum contributors
+PackageName: Sanctum
+PackageUrl: https://sanctum-renews-projects-f8d0ce91.vercel.app/
+License: GPL-3.0-only
+LicenseUrl: https://github.com/wgravel855-lang/sanctum/blob/main/LICENSE
+ShortDescription: A free, open-source adult-content blocker for Windows.
+Description: >-
+  Sanctum filters adult content across every browser via the DNS and hosts
+  layers, keeps working in the background, and can lock its own settings for a
+  chosen duration. When you hit a blocked site it opens a calm, full-screen
+  pause instead of a wall. You can optionally let a trusted person know if
+  protection is ever weakened, and require their approval to unblock a site.
+  Free, open source, no account, no telemetry.
+Moniker: sanctum
+Tags:
+  - accountability
+  - blocker
+  - content-blocker
+  - dns
+  - parental-controls
+  - productivity
+  - self-control
+  - wellbeing
+ReleaseNotesUrl: https://github.com/wgravel855-lang/sanctum/releases/tag/v0.3.3
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/Sanctum/Sanctum/0.3.3/Sanctum.Sanctum.yaml
+++ b/manifests/s/Sanctum/Sanctum/0.3.3/Sanctum.Sanctum.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Sanctum.Sanctum
+PackageVersion: 0.3.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Manifest

Sanctum.Sanctum version 0.3.3

- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? (passes)
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?
- [x] Have you checked that there aren't other open pull requests for the same manifest? (the earlier 0.1.8 PR #404406 has been closed in favour of this one)
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? **Not performed** — see note below.

### Notes

Sanctum is a free and open-source (GPL-3.0) adult-content blocker for Windows. This is effectively the first add of the package: the earlier submission (#404406, version 0.1.8) never merged and has now been closed, so 0.3.3 supersedes it.

**On the local install test.** I have not run `winget install --manifest` for this version, and I would rather say so than check a box I did not earn. Sanctum installs a LocalSystem Windows service that repoints DNS, so a real install materially changes the machine's network configuration. What I did verify:

- `winget validate --manifest` passes.
- The `InstallerSha256` was confirmed by downloading the published asset from the release URL and hashing it: `5A7DB42D0A39386B8EAA9B250C9D7084F9B2D4703BD64883E02987AFB4B7E929` (match).
- The `InstallerUrl` is a direct versioned release asset (no `/latest/` redirect) and returns HTTP 200.

The installer is the NSIS bundle produced by the project's own build script. Note that the previous submission hit `Validation-Unattended-Failed`; if that recurs here, I suspect the unattended sandbox is unhappy with an installer that registers a LocalSystem service and changes DNS settings, and I would appreciate guidance on the right path for this kind of package.

Release: https://github.com/wgravel855-lang/sanctum/releases/tag/v0.3.3