### PR TITLE
New package: Messenger Next version 1.8.0

### DIFF
--- a/manifests/r/Rozsazoltan/MessengerNext/1.8.0/Rozsazoltan.MessengerNext.installer.yaml
+++ b/manifests/r/Rozsazoltan/MessengerNext/1.8.0/Rozsazoltan.MessengerNext.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: Rozsazoltan.MessengerNext
+PackageVersion: 1.8.0
+MinimumOSVersion: 10.0.0.0
+InstallerType: wix
+Scope: machine
+InstallerSwitches:
+  InstallLocation: INSTALLDIR="<INSTALLPATH>"
+UpgradeBehavior: install
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.EdgeWebView2Runtime
+ReleaseDate: 2026-04-20
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/rozsazoltan/messenger/releases/download/v1.8.0/messenger-next.msi
+  InstallerSha256: D70F37E4F94A194A9BC28C5250F201F5B957FC0E6518009D27BA2CFE2AFCF1F9
+  ProductCode: '{406509F9-913B-4B3C-83AD-4BA13813FE9A}'
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/r/Rozsazoltan/MessengerNext/1.8.0/Rozsazoltan.MessengerNext.installer.yaml
+++ b/manifests/r/Rozsazoltan/MessengerNext/1.8.0/Rozsazoltan.MessengerNext.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: Rozsazoltan.MessengerNext
 PackageVersion: 1.8.0
@@ -18,4 +18,4 @@ Installers:
   InstallerSha256: D70F37E4F94A194A9BC28C5250F201F5B957FC0E6518009D27BA2CFE2AFCF1F9
   ProductCode: '{406509F9-913B-4B3C-83AD-4BA13813FE9A}'
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/r/Rozsazoltan/MessengerNext/1.8.0/Rozsazoltan.MessengerNext.locale.en-US.yaml
+++ b/manifests/r/Rozsazoltan/MessengerNext/1.8.0/Rozsazoltan.MessengerNext.locale.en-US.yaml
@@ -3,8 +3,8 @@
 PackageIdentifier: Rozsazoltan.MessengerNext
 PackageVersion: 1.8.0
 PackageLocale: en-US
-Publisher: datarose.net
-PublisherUrl: https://github.com/datarose-net
+Publisher: rozsazoltan
+PublisherUrl: https://github.com/rozsazoltan
 PublisherSupportUrl: https://github.com/rozsazoltan/messenger/issues
 Author: Zoltan Rozsa
 PackageName: Messenger Next

--- a/manifests/r/Rozsazoltan/MessengerNext/1.8.0/Rozsazoltan.MessengerNext.locale.en-US.yaml
+++ b/manifests/r/Rozsazoltan/MessengerNext/1.8.0/Rozsazoltan.MessengerNext.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: Rozsazoltan.MessengerNext
 PackageVersion: 1.8.0
@@ -27,4 +27,4 @@ ReleaseNotes: |-
   - Reduced installer size and fixed several Windows and Linux edge cases.
 ReleaseNotesUrl: https://github.com/rozsazoltan/messenger/releases/tag/v1.8.0
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/r/Rozsazoltan/MessengerNext/1.8.0/Rozsazoltan.MessengerNext.locale.en-US.yaml
+++ b/manifests/r/Rozsazoltan/MessengerNext/1.8.0/Rozsazoltan.MessengerNext.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: Rozsazoltan.MessengerNext
+PackageVersion: 1.8.0
+PackageLocale: en-US
+Publisher: datarose.net
+PublisherUrl: https://github.com/datarose-net
+PublisherSupportUrl: https://github.com/rozsazoltan/messenger/issues
+Author: Zoltan Rozsa
+PackageName: Messenger Next
+PackageUrl: https://github.com/rozsazoltan/messenger
+License: Proprietary
+ShortDescription: A lightweight, distraction-free desktop wrapper for Facebook Messenger.
+Description: >-
+  Messenger Next is an unofficial lightweight desktop wrapper for Facebook
+  Messenger. It provides conversations in a dedicated native window without
+  the Feed, Reels, Marketplace, or other unrelated interface.
+Moniker: messenger-next
+Tags:
+- chat
+- facebook
+- messenger
+- messaging
+ReleaseNotes: |-
+  - Added a preferences panel for desktop behavior and tray settings.
+  - Improved the window and tray lifecycle across supported platforms.
+  - Reduced installer size and fixed several Windows and Linux edge cases.
+ReleaseNotesUrl: https://github.com/rozsazoltan/messenger/releases/tag/v1.8.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/r/Rozsazoltan/MessengerNext/1.8.0/Rozsazoltan.MessengerNext.yaml
+++ b/manifests/r/Rozsazoltan/MessengerNext/1.8.0/Rozsazoltan.MessengerNext.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: Rozsazoltan.MessengerNext
+PackageVersion: 1.8.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0

--- a/manifests/r/Rozsazoltan/MessengerNext/1.8.0/Rozsazoltan.MessengerNext.yaml
+++ b/manifests/r/Rozsazoltan/MessengerNext/1.8.0/Rozsazoltan.MessengerNext.yaml
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: Rozsazoltan.MessengerNext
 PackageVersion: 1.8.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds `Rozsazoltan.MessengerNext` version `1.8.0`.

Messenger Next is an unofficial, lightweight desktop wrapper for Facebook Messenger. It provides conversations in a dedicated native window without the Feed, Reels, Marketplace, or other unrelated interface.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)
  - Not applicable; this is a new package submission.

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** Local validation succeeded. The install test has not been run because it would install the application on the current machine.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/404992)