### PR TITLE
New version: MarcoSumari.IngePresupuestos version 2.8.4

### DIFF
--- a/manifests/m/MarcoSumari/IngePresupuestos/2.8.4/MarcoSumari.IngePresupuestos.installer.yaml
+++ b/manifests/m/MarcoSumari/IngePresupuestos/2.8.4/MarcoSumari.IngePresupuestos.installer.yaml
@@ -1,0 +1,21 @@
+# Manifiesto de INSTALADOR — winget (schema 1.6.0)
+# Usa el INSTALADOR de Inno Setup (NO el .msix).
+PackageIdentifier: MarcoSumari.IngePresupuestos
+PackageVersion: 2.8.4
+InstallerLocale: es-PE
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: inno          # Inno Setup → winget ya conoce los flags silenciosos
+Scope: machine               # PrivilegesRequired=admin → instala en Program Files
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://downloads.ingepresupuestos.com/v2.8.4/ingepresupuestos-setup-v2.8.4.exe
+    InstallerSha256: C06F9CCE29A9E8501D792C92381E6F1BB883B45454A186EDD21930A87FB2429B
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/MarcoSumari/IngePresupuestos/2.8.4/MarcoSumari.IngePresupuestos.locale.es-PE.yaml
+++ b/manifests/m/MarcoSumari/IngePresupuestos/2.8.4/MarcoSumari.IngePresupuestos.locale.es-PE.yaml
@@ -1,0 +1,44 @@
+# Manifiesto de LOCALE por defecto — winget (schema 1.6.0)
+PackageIdentifier: MarcoSumari.IngePresupuestos
+PackageVersion: 2.8.4
+PackageLocale: es-PE
+Publisher: Marco Sumari
+PublisherUrl: https://ingepresupuestos.com
+PublisherSupportUrl: https://github.com/ingelibre/ingepresupuestos/issues
+PrivacyUrl: https://ingepresupuestos.com/privacidad
+Author: Ing. Marco Sumari
+PackageName: IngePresupuestos
+PackageUrl: https://ingepresupuestos.com
+License: GPL-3.0-or-later
+LicenseUrl: https://github.com/ingelibre/ingepresupuestos/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Marco Sumari / Sumari SAC
+CopyrightUrl: https://github.com/ingelibre/ingepresupuestos/blob/main/LICENSE
+ShortDescription: Software libre de presupuestos de obra con ACU, cronograma Gantt valorizado y 13 reportes profesionales.
+Description: |-
+  IngePresupuestos es el software de presupuestos de obra para ingenieros y
+  arquitectos. Elabora presupuestos con Análisis de Costos Unitarios (ACU),
+  cronogramas valorizados (Gantt con ruta crítica y CPM), fórmula polinómica e
+  índices INEI, metrados (incluido acero), y 13 reportes profesionales
+  exportables a PDF, Excel, Word, ODS y ODT. Importa tus presupuestos existentes
+  de S10, PowerCost y Delphin, además de Excel e IFC. Incluye Control de Obra
+  (requerimientos, almacén, cuaderno, valorizaciones y curva S) y un asistente con
+  inteligencia artificial opcional (con tu propia clave). Software libre y gratuito
+  (GPL-3.0): todas las funciones incluidas. Tus datos quedan en tu equipo.
+Moniker: ingepresupuestos
+ReleaseNotes: |-
+  Corrección en metrados: la planilla de acero ya no se copia a otra partida
+  al cambiar de pestaña. Icono de documento propio para los archivos .db.
+  Licencia GPL-3.0 en el instalador. Software libre y gratuito: todas las
+  funciones incluidas.
+ReleaseNotesUrl: https://github.com/ingelibre/ingepresupuestos/releases/tag/v2.8.4
+Tags:
+  - presupuestos
+  - construccion
+  - acu
+  - cronograma
+  - metrados
+  - s10
+  - ingenieria-civil
+  - obra
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/MarcoSumari/IngePresupuestos/2.8.4/MarcoSumari.IngePresupuestos.yaml
+++ b/manifests/m/MarcoSumari/IngePresupuestos/2.8.4/MarcoSumari.IngePresupuestos.yaml
@@ -1,0 +1,8 @@
+# Manifiesto de VERSIÓN — winget (schema 1.6.0)
+# Destino en el PR a github.com/microsoft/winget-pkgs:
+#   manifests/m/MarcoSumari/IngePresupuestos/2.8.4/
+PackageIdentifier: MarcoSumari.IngePresupuestos
+PackageVersion: 2.8.4
+DefaultLocale: es-PE
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Package
- **PackageIdentifier:** MarcoSumari.IngePresupuestos
- **Version:** 2.8.4
- **Publisher:** Marco Sumari — https://ingepresupuestos.com
- **License:** GPL-3.0-or-later (software libre)
- **InstallerType:** inno (silent flags known by winget)

Software libre de presupuestos de obra (ACU, cronograma Gantt valorizado, metrados, 13 reportes). Instalador de Inno Setup, arquitectura x64.

### Manifest validation
- [x] Manifests follow the 1.6.0 schema and YAML validates.
- [x] `InstallerUrl` is reachable (HTTPS) and `InstallerSha256` matches the file served.
- [x] Metadata (name, publisher, license, description) is accurate.

This is the first submission of this package.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/404994)