### PR TITLE
New version: 0state.scafld version 2.5.1

### DIFF
--- a/manifests/0/0state/scafld/2.5.1/0state.scafld.installer.yaml
+++ b/manifests/0/0state/scafld/2.5.1/0state.scafld.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: 0state.scafld
+PackageVersion: 2.5.1
+InstallerLocale: en-US
+InstallerType: portable
+Commands:
+  - scafld
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/nilstate/scafld/releases/download/v2.5.1/scafld_2.5.1_windows_amd64.exe
+    InstallerSha256: ba796aafefa0bb2a98fe13583efdf1a04cc05d6d66b14b5afe89b6e351eb9a6c
+  - Architecture: arm64
+    InstallerUrl: https://github.com/nilstate/scafld/releases/download/v2.5.1/scafld_2.5.1_windows_arm64.exe
+    InstallerSha256: 8ec1b728360eb2a9a175902efdccf4059315cc57021ab413fd9795053af1f496
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/0/0state/scafld/2.5.1/0state.scafld.locale.en-US.yaml
+++ b/manifests/0/0state/scafld/2.5.1/0state.scafld.locale.en-US.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: 0state.scafld
+PackageVersion: 2.5.1
+PackageLocale: en-US
+Publisher: 0state
+PublisherUrl: https://0state.com
+PackageName: scafld
+License: MIT
+ShortDescription: Deterministic protocol for multi-phase agent work.
+PackageUrl: https://0state.com/scafld
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/0/0state/scafld/2.5.1/0state.scafld.yaml
+++ b/manifests/0/0state/scafld/2.5.1/0state.scafld.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: 0state.scafld
+PackageVersion: 2.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Updates 0state.scafld to 2.5.1. Manifests were generated from the nilstate/scafld v2.5.1 GitHub release artifact and verified against checksums.txt by scripts/prepare-winget-submission.sh.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/405119)