### PR TITLE
Finesssee.Win-CodexBar version 0.45.2

### DIFF
--- a/manifests/f/Finesssee/Win-CodexBar/0.45.2/Finesssee.Win-CodexBar.installer.yaml
+++ b/manifests/f/Finesssee/Win-CodexBar/0.45.2/Finesssee.Win-CodexBar.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Finesssee.Win-CodexBar
+PackageVersion: 0.45.2
+InstallerType: inno
+Scope: user
+UpgradeBehavior: install
+ProductCode: WinCodexBar_is1
+ReleaseDate: 2026-07-21
+AppsAndFeaturesEntries:
+- ProductCode: WinCodexBar_is1
+  DisplayName: CodexBar 0.45.2
+  DisplayVersion: 0.45.2
+  Publisher: CodexBar Contributors
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/nesszer/Win-CodexBar/releases/download/v0.45.2/CodexBar-0.45.2-Setup.exe
+  InstallerSha256: D59F308EEC8562644F4F20FC7579D0B7EAE0E2BAC05151C2A2ADA5401900CFEB
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Finesssee/Win-CodexBar/0.45.2/Finesssee.Win-CodexBar.locale.en-US.yaml
+++ b/manifests/f/Finesssee/Win-CodexBar/0.45.2/Finesssee.Win-CodexBar.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Finesssee.Win-CodexBar
+PackageVersion: 0.45.2
+PackageLocale: en-US
+Publisher: CodexBar Contributors
+PublisherUrl: https://github.com/nesszer
+PublisherSupportUrl: https://github.com/nesszer/Win-CodexBar/issues
+Author: Finesssee
+PackageName: Win-CodexBar
+PackageUrl: https://github.com/nesszer/Win-CodexBar
+License: MIT
+LicenseUrl: https://github.com/nesszer/Win-CodexBar/blob/main/LICENSE
+Copyright: Copyright (c) CodexBar contributors
+ShortDescription: Windows-native menu bar app for OpenAI Codex and Claude Code usage stats.
+Description: Win-CodexBar is a Windows-native desktop app for viewing OpenAI Codex and Claude Code usage stats from a small Tauri shell.
+Moniker: win-codexbar
+Tags:
+- claude-code
+- codex
+- desktop
+- tauri
+- usage
+- windows
+ReleaseNotes: |-
+  Win-CodexBar 0.45.2 ports CodexBar 0.43-0.45.2: new providers (ZenMux, ClinePass, LongCat, Neuralwatt, DeepInfra, ai&), OpenRouter multi-key, Doubao arkcli, OpenCode Go local-first, codexbar guard/hooks/serve token-gate, Usage & Spend settings, Adaptive refresh, Cursor token-cost events, and cost/OMP scanner improvements.
+  Claude/OpenCode/Cursor correctness fixes and soft-removal of Kimi K2 and CrossModel are included. macOS-only shell UI polish remains deferred.
+ReleaseNotesUrl: https://github.com/nesszer/Win-CodexBar/releases/tag/v0.45.2
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Finesssee/Win-CodexBar/0.45.2/Finesssee.Win-CodexBar.yaml
+++ b/manifests/f/Finesssee/Win-CodexBar/0.45.2/Finesssee.Win-CodexBar.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Finesssee.Win-CodexBar
+PackageVersion: 0.45.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
New version: Finesssee.Win-CodexBar 0.45.2

Installer: https://github.com/nesszer/Win-CodexBar/releases/download/v0.45.2/CodexBar-0.45.2-Setup.exe
SHA256: D59F308EEC8562644F4F20FC7579D0B7EAE0E2BAC05151C2A2ADA5401900CFEB
Release: https://github.com/nesszer/Win-CodexBar/releases/tag/v0.45.2
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/405133)