### PR TITLE
Zenvara.Zen version 1.0.0

### DIFF
--- a/manifests/z/Zenvara/Zen/1.0.0/Zenvara.Zen.installer.yaml
+++ b/manifests/z/Zenvara/Zen/1.0.0/Zenvara.Zen.installer.yaml
@@ -14,10 +14,10 @@ NestedInstallerFiles:
   - RelativeFilePath: zen.exe
     PortableCommandAlias: zen
 UpgradeBehavior: install
-ReleaseDate: 2026-07-18
+ReleaseDate: 2026-07-21
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/zenvara-platform/cli/releases/download/1.0.0/zen-win-x64.zip
-    InstallerSha256: FEE50C0D5F7134CC9A3B9E7DF5F3E877430D5BB18D77DFCA527F263A79EC4E72
+    InstallerSha256: 067383F27A51F3F49FA8740578DD2CD0B04C45C6066C148EB58042F0518B9133
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/z/Zenvara/Zen/1.0.0/Zenvara.Zen.installer.yaml
+++ b/manifests/z/Zenvara/Zen/1.0.0/Zenvara.Zen.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# Bootstrap manifest for the FIRST winget submission of Zenvara.Zen.
+# After this version is merged into microsoft/winget-pkgs, the winget-releaser
+# action (see the cli repo's .github/workflows/winget.yml) updates url/hash/version
+# for later releases automatically, preserving this zip/nested-portable shape.
+PackageIdentifier: Zenvara.Zen
+PackageVersion: 1.0.0
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: zen.exe
+    PortableCommandAlias: zen
+UpgradeBehavior: install
+ReleaseDate: 2026-07-18
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/zenvara-platform/cli/releases/download/1.0.0/zen-win-x64.zip
+    InstallerSha256: FEE50C0D5F7134CC9A3B9E7DF5F3E877430D5BB18D77DFCA527F263A79EC4E72
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/z/Zenvara/Zen/1.0.0/Zenvara.Zen.locale.en-US.yaml
+++ b/manifests/z/Zenvara/Zen/1.0.0/Zenvara.Zen.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Zenvara.Zen
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: Zenvara
+PublisherUrl: https://zenvara.ai
+PublisherSupportUrl: https://github.com/zenvara-platform/cli/issues
+PackageName: Zenvara CLI
+PackageUrl: https://github.com/zenvara-platform/cli
+License: Proprietary
+LicenseUrl: https://github.com/zenvara-platform/cli/blob/main/LICENSE.md
+Copyright: (c) Zenvara. All rights reserved.
+ShortDescription: Lightweight cross-platform CLI for Zenvara — one native binary to install, run, and operate Zenvara.
+Description: |-
+  zen is the cross-platform command-line tool for Zenvara. It manages the full lifecycle of a
+  Zenvara deployment (install, service/IIS hosting, updates, rollbacks) and transparently forwards
+  flow commands to a local installation or a remote server. It also registers the MCP bridge that
+  connects Claude Code, Gemini, and OpenCode to a running Zenvara. Ships as a single self-contained
+  native executable with no runtime dependencies.
+Tags:
+  - cli
+  - zenvara
+  - mcp
+  - devops
+  - deployment
+ReleaseNotesUrl: https://github.com/zenvara-platform/cli/releases/tag/1.0.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/z/Zenvara/Zen/1.0.0/Zenvara.Zen.yaml
+++ b/manifests/z/Zenvara/Zen/1.0.0/Zenvara.Zen.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Zenvara.Zen
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
New package: Zenvara.Zen 1.0.0. Resubmission from the zenvara-platform org fork (supersedes #404877, which was submitted from a personal fork and hit Error-Installer-Availability during an unrelated CI window on our side; the installer URL is confirmed reachable).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/405182)