### PR TITLE
New version: toevi.WinMD version 1.1.0

### DIFF
--- a/manifests/t/toevi/WinMD/1.1.0/toevi.WinMD.installer.yaml
+++ b/manifests/t/toevi/WinMD/1.1.0/toevi.WinMD.installer.yaml
@@ -1,0 +1,15 @@
+# Created using wingetcreate 1.6.5.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: toevi.WinMD
+PackageVersion: 1.1.0
+MinimumOSVersion: 10.0.19041.0
+InstallerType: inno
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/toevi/WinMD/releases/download/v1.1.0/WinMD-Setup.exe
+  InstallerSha256: 14A6718CB99AFEE7A60EB83833FD631D9D4E576B52EB11359BBD7DC7A6BF85E9
+  AppsAndFeaturesEntries:
+  - Publisher: tmfgroup
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/t/toevi/WinMD/1.1.0/toevi.WinMD.locale.en-US.yaml
+++ b/manifests/t/toevi/WinMD/1.1.0/toevi.WinMD.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# Created using wingetcreate 1.6.5.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: toevi.WinMD
+PackageVersion: 1.1.0
+PackageLocale: en-US
+Publisher: toevi
+PublisherUrl: https://github.com/toevi
+PublisherSupportUrl: https://github.com/toevi/WinMD/issues
+PackageName: WinMD
+PackageUrl: https://github.com/toevi/WinMD
+License: MIT
+LicenseUrl: https://github.com/toevi/WinMD/blob/master/LICENSE
+Copyright: Copyright (c) 2026 Tomek Maselko
+ShortDescription: Lightweight Markdown editor and viewer for Windows
+Description: |-
+  WinMD is a lightweight Markdown editor and viewer for Windows built with WinUI 3 and Windows App SDK.
+  It features a live HTML preview rendered by Markdig with a GitHub-style stylesheet (light and dark theme),
+  a formatting toolbar, PDF export via WebView2, find/replace in both the editor and the rendered preview,
+  undo/redo with keystroke coalescing, and .md file association for opening files from Explorer.
+Moniker: winmd
+Tags:
+- markdown
+- markdown-editor
+- markdown-viewer
+- text-editor
+- winui
+- winui3
+ReleaseNotesUrl: https://github.com/toevi/WinMD/releases/tag/v1.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/t/toevi/WinMD/1.1.0/toevi.WinMD.yaml
+++ b/manifests/t/toevi/WinMD/1.1.0/toevi.WinMD.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.6.5.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: toevi.WinMD
+PackageVersion: 1.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
### New version: toevi.WinMD version 1.1.0

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.9.0)?

Installer: signed (CN=tmfgroup), Inno Setup, x64, from the GitHub release https://github.com/toevi/WinMD/releases/tag/v1.1.0

Changes in 1.1.0 (both were bugs in 1.0.0):
- Share now opens the real Windows share sheet (`DataTransferManager` + `IDataTransferManagerInterop`) instead of just revealing a temp file in Explorer.
- PDF export writes the file directly via a save picker + silent `PrintToPdfAsync`; the system print dialog used to open off-screen in the unpackaged app.

`AppsAndFeaturesEntries` keeps just `Publisher: tmfgroup` (no `DisplayName`), per the review feedback on #389759 â€” the Inno Setup ARP display name is localized, so it cannot be matched reliably.

Note: #389759 (version 1.0.0) is approved and pending merge; this PR adds 1.1.0 in a separate folder and does not touch it.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/405185)