### PR TITLE
New version: pnpm.pnpm version 11.15.1

### DIFF
--- a/manifests/p/pnpm/pnpm/11.15.1/pnpm.pnpm.installer.yaml
+++ b/manifests/p/pnpm/pnpm/11.15.1/pnpm.pnpm.installer.yaml
@@ -1,0 +1,23 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: pnpm.pnpm
+PackageVersion: 11.15.1
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: pnpm.exe
+  PortableCommandAlias: pnpm
+Commands:
+- pnpm
+ReleaseDate: 2026-07-19
+ArchiveBinariesDependOnPath: true
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/pnpm/pnpm/releases/download/v11.15.1/pnpm-win32-x64.zip
+  InstallerSha256: E9179D727211D5556E969FCCFA36F828392892C54728A711C9DA1CC3093F7900
+- Architecture: arm64
+  InstallerUrl: https://github.com/pnpm/pnpm/releases/download/v11.15.1/pnpm-win32-arm64.zip
+  InstallerSha256: F552FB1A974D1E58C5825DF60812FA9C1F78326EEE1D152179225864236E2834
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/p/pnpm/pnpm/11.15.1/pnpm.pnpm.locale.en-US.yaml
+++ b/manifests/p/pnpm/pnpm/11.15.1/pnpm.pnpm.locale.en-US.yaml
@@ -1,0 +1,37 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: pnpm.pnpm
+PackageVersion: 11.15.1
+PackageLocale: en-US
+Publisher: pnpm
+PublisherUrl: https://github.com/pnpm/pnpm
+PublisherSupportUrl: https://github.com/pnpm/pnpm/issues
+Author: pnpm contributors
+PackageName: pnpm
+PackageUrl: https://pnpm.io/
+License: MIT
+LicenseUrl: https://github.com/pnpm/pnpm/blob/HEAD/LICENSE
+Copyright: Copyright (c) Zoltan Kochan and other contributors
+CopyrightUrl: https://github.com/pnpm/pnpm/blob/main/LICENSE
+ShortDescription: Fast, disk space efficient package manager.
+Moniker: pnpm
+Tags:
+- dependency-manager
+- install
+- javascript
+- modules
+- node
+- nodejs
+- npm
+- package-manager
+ReleaseNotes: |-
+  See the GitHub release for v11.15.1 notes.
+ReleaseNotesUrl: https://github.com/pnpm/pnpm/releases/tag/v11.15.1
+Documentations:
+- DocumentLabel: Docs
+  DocumentUrl: https://pnpm.io/motivation
+- DocumentLabel: FAQ
+  DocumentUrl: https://pnpm.io/faq
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/p/pnpm/pnpm/11.15.1/pnpm.pnpm.yaml
+++ b/manifests/p/pnpm/pnpm/11.15.1/pnpm.pnpm.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: pnpm.pnpm
+PackageVersion: 11.15.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Checklist
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] This pull request is not a duplicate.
- [x] Have you validated the package locally to the best of your ability?

### Validation
- PackageIdentifier: `pnpm.pnpm`
- PackageVersion: `11.15.1`
- InstallerType: zip / NestedInstallerType: portable (`pnpm.exe`)
- Architectures: x64 + arm64
- Installer URLs (HTTP 200):
  - https://github.com/pnpm/pnpm/releases/download/v11.15.1/pnpm-win32-x64.zip
  - https://github.com/pnpm/pnpm/releases/download/v11.15.1/pnpm-win32-arm64.zip
- InstallerSha256 (full download, uppercase):
  - x64: `E9179D727211D5556E969FCCFA36F828392892C54728A711C9DA1CC3093F7900`
  - arm64: `F552FB1A974D1E58C5825DF60812FA9C1F78326EEE1D152179225864236E2834`
- ReleaseDate: 2026-07-19 (GitHub release published_at)
- ReleaseNotesUrl: https://github.com/pnpm/pnpm/releases/tag/v11.15.1
- Sibling shape copied from 11.15.0 (ManifestVersion 1.12.0, ArchiveBinariesDependOnPath, PortableCommandAlias)

### Notes
Real version lag: master has 11.15.0; upstream release v11.15.1 exists with Windows zip assets. No competing open PR for this exact version at open time.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/405188)