### PR TITLE
New package: PingRank.PingRank version 0.7.6

### DIFF
--- a/manifests/p/PingRank/PingRank/0.7.6/PingRank.PingRank.installer.yaml
+++ b/manifests/p/PingRank/PingRank/0.7.6/PingRank.PingRank.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: PingRank.PingRank
+PackageVersion: 0.7.6
+InstallerType: wix
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/bpbp-boop/pingrank-cli/releases/download/v0.7.6/pingrank.gg-0.7.6-x64.msi
+    InstallerSha256: B6474E49D68753804E8B224F65A0FF2C8668F6AEFEC7D495F99EDF05A735B13F
+    ProductCode: '{260A93ED-17C2-4143-8168-98B0C656ACE1}'
+    AppsAndFeaturesEntries:
+      - DisplayName: PingRank.gg
+        Publisher: PingRank.gg
+        DisplayVersion: 0.7.6
+        UpgradeCode: '{3D240732-35F5-4C29-AD56-64299C8C934E}'
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/p/PingRank/PingRank/0.7.6/PingRank.PingRank.installer.yaml
+++ b/manifests/p/PingRank/PingRank/0.7.6/PingRank.PingRank.installer.yaml
@@ -17,7 +17,6 @@ Installers:
     AppsAndFeaturesEntries:
       - DisplayName: PingRank.gg
         Publisher: PingRank.gg
-        DisplayVersion: 0.7.6
         UpgradeCode: '{3D240732-35F5-4C29-AD56-64299C8C934E}'
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/p/PingRank/PingRank/0.7.6/PingRank.PingRank.locale.en-US.yaml
+++ b/manifests/p/PingRank/PingRank/0.7.6/PingRank.PingRank.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: PingRank.PingRank
+PackageVersion: 0.7.6
+PackageLocale: en-US
+Publisher: PingRank.gg
+PublisherUrl: https://pingrank.gg
+PublisherSupportUrl: https://github.com/bpbp-boop/pingrank-cli/issues
+PrivacyUrl: https://pingrank.gg/privacy
+PackageName: PingRank.gg
+PackageUrl: https://pingrank.gg
+License: MIT
+LicenseUrl: https://github.com/bpbp-boop/pingrank-cli/blob/master/LICENSE
+ShortDescription: Measures your real ping while you play.
+Description: >-
+  PingRank finds the game you are running, finds the server the game talks
+  to, and times the round trip. Players who share their recordings power the
+  ISP rankings at pingrank.gg.
+Moniker: pingrank
+Tags:
+  - gaming
+  - latency
+  - network
+  - ping
+ReleaseNotesUrl: https://github.com/bpbp-boop/pingrank-cli/releases/tag/v0.7.6
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/p/PingRank/PingRank/0.7.6/PingRank.PingRank.yaml
+++ b/manifests/p/PingRank/PingRank/0.7.6/PingRank.PingRank.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: PingRank.PingRank
+PackageVersion: 0.7.6
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New package: PingRank.PingRank version 0.7.6

First submission for PingRank (https://pingrank.gg). The publisher's GitHub
Actions workflow builds every release from source with build-provenance
attestations: https://github.com/bpbp-boop/pingrank-cli

Manifests are hand-authored against the 1.12.0 schema; the InstallerSha256
and ProductCode were taken from the released MSI. There is no Windows
machine in this publish pipeline, so no local `winget validate` /
`winget install` run — relying on the validation pipeline for those checks.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/405263)