### PR TITLE
New version: OpenTubeX.OpenTubeX version 0.29.0

### DIFF
--- a/manifests/o/OpenTubeX/OpenTubeX/0.29.0/OpenTubeX.OpenTubeX.installer.yaml
+++ b/manifests/o/OpenTubeX/OpenTubeX/0.29.0/OpenTubeX.OpenTubeX.installer.yaml
@@ -1,0 +1,45 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: OpenTubeX.OpenTubeX
+PackageVersion: 0.29.0
+InstallerLocale: en-US
+InstallerType: nullsoft
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+Protocols:
+- opentubex
+ProductCode: a38f022d-fec2-5f80-a7fe-620ccf1a2767
+ReleaseDate: 2026-07-21
+AppsAndFeaturesEntries:
+- DisplayName: OpenTubeX 0.29.0
+  ProductCode: a38f022d-fec2-5f80-a7fe-620ccf1a2767
+Installers:
+- Architecture: x64
+  Scope: user
+  InstallerUrl: https://github.com/OpenTubeX/OpenTubeX/releases/download/v0.29.0-beta/opentubex-0.29.0-beta-setup-x64.exe
+  InstallerSha256: 0407722AA1E802870DBDF33AD8C21296C6C2C68388A08BE5721F3856EB31293E
+  InstallerSwitches:
+    Custom: /CURRENTUSER
+- Architecture: x64
+  Scope: machine
+  InstallerUrl: https://github.com/OpenTubeX/OpenTubeX/releases/download/v0.29.0-beta/opentubex-0.29.0-beta-setup-x64.exe
+  InstallerSha256: 0407722AA1E802870DBDF33AD8C21296C6C2C68388A08BE5721F3856EB31293E
+  InstallerSwitches:
+    Custom: /ALLUSERS
+- Architecture: arm64
+  Scope: user
+  InstallerUrl: https://github.com/OpenTubeX/OpenTubeX/releases/download/v0.29.0-beta/opentubex-0.29.0-beta-setup-arm64.exe
+  InstallerSha256: 8CF8D0B10582E49892B968443499188D4879FB1C6C61E6473D58DB9714216B5F
+  InstallerSwitches:
+    Custom: /CURRENTUSER
+- Architecture: arm64
+  Scope: machine
+  InstallerUrl: https://github.com/OpenTubeX/OpenTubeX/releases/download/v0.29.0-beta/opentubex-0.29.0-beta-setup-arm64.exe
+  InstallerSha256: 8CF8D0B10582E49892B968443499188D4879FB1C6C61E6473D58DB9714216B5F
+  InstallerSwitches:
+    Custom: /ALLUSERS
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenTubeX/OpenTubeX/0.29.0/OpenTubeX.OpenTubeX.locale.en-US.yaml
+++ b/manifests/o/OpenTubeX/OpenTubeX/0.29.0/OpenTubeX.OpenTubeX.locale.en-US.yaml
@@ -1,0 +1,66 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: OpenTubeX.OpenTubeX
+PackageVersion: 0.29.0
+PackageLocale: en-US
+Publisher: OpenTubeX contributors
+PublisherUrl: https://github.com/OpenTubeX
+PublisherSupportUrl: https://github.com/OpenTubeX/OpenTubeX/issues
+Author: OpenTubeX contributors
+PackageName: OpenTubeX
+PackageUrl: https://opentubex.org/
+License: AGPL-3.0
+LicenseUrl: https://github.com/OpenTubeX/OpenTubeX/blob/HEAD/LICENSE
+Copyright: Copyleft © 2020-2026
+CopyrightUrl: https://github.com/OpenTubeX/OpenTubeX/blob/HEAD/LICENSE
+ShortDescription: A private YouTube client
+Description: OpenTubeX is a private YouTube client for desktop.
+Moniker: opentubex
+Tags:
+- freetube
+- freetube-fork
+- privacy
+- subscriptions
+- video
+- videos
+- youtube
+ReleaseNotes: |-
+  - Added support for downloading videos via yt-dlp (#37)
+  - The internals of the tab system were reworked. Creating and switching between tabs is a lot smoother now. One downside: Tab previews can no longer be captured of background tabs
+  - New full-screen docks for comments, playlists and chapters
+  - Keyboard shortcuts can now be customized
+  - Experimental fix that allows rewinding live streams/premieres (#163)
+  - Added an option to remember the history across restarts (#135)
+  - The SponsorBlock icon under the player now opens a side panel with the segments, the skip toggle and a new option to whitelist channels
+  - Auto PiP can now be set when minimizing or switching windows
+  - Options for showing indicators of newly fetched content and a separate new feed
+  - Improved comments appearance and now they render nested reply threads
+  - Updated autoplay to show the next video with the countdown on the player
+  - Chapters are now displayed in the sidebar instead of overlapping the video
+  - Added a button to switch between horizontal and vertical tabs
+  - Added a bunch of animations throughout the UI
+  - You can now force disable/enable animations without changing your system settings
+  - Skipping to a SponsorBlock highlight now produces a notification allowing you to undo it (#252)
+  - Premieres are now displayed as premiere instead of just showing the live indicator
+    otx-premiere-metadata
+  - While watching a video you can now make the card that displays the playlist taller/shorter (#256)
+  - Subscriptions auto-refresh timers are now persistent. Example: When you close the app with 5 minutes remaining and open the app again 4 minutes later it's at 1 minute remaining
+  - Added a visual indicator for the auto-refresh
+  - The subscription feed items are now kept visible while refreshing
+  - You can now click on a chatter's handle to open their channel from the live chat
+  - Allow playlist remove actions while playback (#249)
+  - Mark as watched and remove from history are now two separate actions on videos (#222)
+  - Add option to move the profile selector to the channels list (#246)
+  - When a SABR stream encounters a playback error it is now reloaded instead of falling back to legacy formats (max 360p)
+  - Fixed a bug where a SABR reload would keep the current tab's video on the timestamp where it occurred
+  - Improved the reliability of the fast-forward silence feature
+  - Restore the replay icon when the video ended
+  - Tabs with channels that don't have a preview yet now fall back to the avatar
+  - Show when comments are edited
+  - Fixed the position and size of elements in the end screen annotations
+  - Fixed a bug where scrolling one subscription feed affected the scroll position in the other feeds
+  - Fix vertical position of texts and elements with certain Unicode characters (#239)
+ReleaseNotesUrl: https://github.com/OpenTubeX/OpenTubeX/releases/tag/v0.29.0-beta
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenTubeX/OpenTubeX/0.29.0/OpenTubeX.OpenTubeX.yaml
+++ b/manifests/o/OpenTubeX/OpenTubeX/0.29.0/OpenTubeX.OpenTubeX.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: OpenTubeX.OpenTubeX
+PackageVersion: 0.29.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Summary

- Update `OpenTubeX.OpenTubeX` from 0.28.1 to 0.29.0.
- Add x64 and arm64 installer manifests generated with Komac 2.16.0.
- Include cleaned release notes without image placeholder artifacts.

## Impact

Makes OpenTubeX 0.29.0 available to WinGet users on x64 and arm64 systems.

## Validation

- Parsed all generated manifests as YAML.
- Verified installer SHA-256 hashes against the GitHub release assets.
- Confirmed the commit contains only the three 0.29.0 manifest files.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/405271)