### PR TITLE
New version: caomengxuan666.WinuxCmd version 0.12.3

### DIFF
--- a/manifests/c/caomengxuan666/WinuxCmd/0.12.3/caomengxuan666.WinuxCmd.installer.yaml
+++ b/manifests/c/caomengxuan666/WinuxCmd/0.12.3/caomengxuan666.WinuxCmd.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: caomengxuan666.WinuxCmd
+PackageVersion: 0.12.3
+InstallerType: zip
+NestedInstallerType: portable
+Commands:
+- winuxcmd
+ArchiveBinariesDependOnPath: true
+ReleaseDate: 2026-07-21
+Installers:
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: WinuxCmd-0.12.3-win-x64\winuxcmd.exe
+  InstallerUrl: https://github.com/unixwin/WinuxCmd/releases/download/v0.12.3/WinuxCmd-0.12.3-win-x64.zip
+  InstallerSha256: 850A405B20BCE0296F6B07B69C8FFA48B01FB4360B1F80D3ABFD775FBB6F939E
+- Architecture: arm64
+  NestedInstallerFiles:
+  - RelativeFilePath: WinuxCmd-0.12.3-win-arm64\winuxcmd.exe
+  InstallerUrl: https://github.com/unixwin/WinuxCmd/releases/download/v0.12.3/WinuxCmd-0.12.3-win-arm64.zip
+  InstallerSha256: 6D0428BA5484358202A4315D5D525D4489A7C6488E536BFF4AF9F4D98A7D4623
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/caomengxuan666/WinuxCmd/0.12.3/caomengxuan666.WinuxCmd.locale.en-US.yaml
+++ b/manifests/c/caomengxuan666/WinuxCmd/0.12.3/caomengxuan666.WinuxCmd.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: caomengxuan666.WinuxCmd
+PackageVersion: 0.12.3
+PackageLocale: en-US
+Publisher: Cao Mengxuan
+PublisherUrl: https://github.com/caomengxuan666
+PublisherSupportUrl: https://github.com/unixwin/WinuxCmd/issues
+Author: Cao Mengxuan
+PackageName: WinuxCmd
+PackageUrl: https://github.com/unixwin/WinuxCmd
+License: MIT
+LicenseUrl: https://github.com/unixwin/WinuxCmd/blob/HEAD/LICENSE
+Copyright: Copyright (c) 2026 caomengxuan666
+ShortDescription: Linux-style command set for Windows terminals
+Description: |-
+  WinuxCmd provides native Windows implementations of common Linux-style commands for Windows terminals.
+  It includes GNU-style commands such as ls, cat, grep, sed, ps, and lsof, works without WSL, and supports
+  Windows and Linux-style command workflows in PowerShell, Command Prompt, and other shells.
+Tags:
+- command-line
+- coreutils
+- grep
+- linux
+- ls
+- powershell
+- shell
+- terminal
+ReleaseNotesUrl: https://github.com/unixwin/WinuxCmd/releases/tag/v0.12.3
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/caomengxuan666/WinuxCmd/0.12.3/caomengxuan666.WinuxCmd.locale.zh-CN.yaml
+++ b/manifests/c/caomengxuan666/WinuxCmd/0.12.3/caomengxuan666.WinuxCmd.locale.zh-CN.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: caomengxuan666.WinuxCmd
+PackageVersion: 0.12.3
+PackageLocale: zh-CN
+Publisher: 曹梦轩
+Author: 曹梦轩
+PackageName: WinuxCmd
+ShortDescription: 面向 Windows 终端的 Linux 风格命令集
+Description: |-
+  WinuxCmd 为 Windows 终端提供常见 Linux 风格命令的原生实现。
+  它包含 ls、cat、grep、sed、ps、lsof 等 GNU 风格命令，无需 WSL，
+  可在 PowerShell、命令提示符和其他 shell 中支持 Windows 与 Linux 风格命令工作流。
+Tags:
+- linux
+- powershell
+- shell
+- terminal
+- 命令行
+- 终端
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/c/caomengxuan666/WinuxCmd/0.12.3/caomengxuan666.WinuxCmd.yaml
+++ b/manifests/c/caomengxuan666/WinuxCmd/0.12.3/caomengxuan666.WinuxCmd.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: caomengxuan666.WinuxCmd
+PackageVersion: 0.12.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Release source
 https://github.com/unixwin/WinuxCmd/releases/tag/v0.12.3

## Validation
- winget validate manifests/c/caomengxuan666/WinuxCmd/0.12.3


## Notes
Updates the existing portable zip manifest for x64 and arm64 assets.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/405285)