### PR TITLE
New package: hjosugi.Yeet version 0.5.3

### DIFF
--- a/manifests/h/hjosugi/Yeet/0.5.3/hjosugi.Yeet.installer.yaml
+++ b/manifests/h/hjosugi/Yeet/0.5.3/hjosugi.Yeet.installer.yaml
@@ -1,0 +1,14 @@
+PackageIdentifier: hjosugi.Yeet
+PackageVersion: 0.5.3
+InstallerType: inno
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/hjosugi/yeet/releases/download/v0.5.3/yeet-0.5.3-windows-x64-setup.exe
+  InstallerSha256: 5A1189234CE382385E46574C65310101EAEA7BEF890CB3708C45B04A0520CAC6
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/h/hjosugi/Yeet/0.5.3/hjosugi.Yeet.locale.en-US.yaml
+++ b/manifests/h/hjosugi/Yeet/0.5.3/hjosugi.Yeet.locale.en-US.yaml
@@ -1,0 +1,17 @@
+PackageIdentifier: hjosugi.Yeet
+PackageVersion: 0.5.3
+PackageLocale: en-US
+Publisher: hjosugi
+PublisherUrl: https://github.com/hjosugi
+PackageName: Yeet
+PackageUrl: https://github.com/hjosugi/yeet
+License: MIT
+LicenseUrl: https://github.com/hjosugi/yeet/blob/v0.5.3/LICENSE
+ShortDescription: Native Yoink-style drag-and-drop shelf for Wayland and Windows
+Tags:
+- drag-and-drop
+- files
+- utility
+ReleaseNotesUrl: https://github.com/hjosugi/yeet/releases/tag/v0.5.3
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/h/hjosugi/Yeet/0.5.3/hjosugi.Yeet.yaml
+++ b/manifests/h/hjosugi/Yeet/0.5.3/hjosugi.Yeet.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: hjosugi.Yeet
+PackageVersion: 0.5.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Description

Adds Yeet 0.5.3, a native drag-and-drop shelf for Wayland and Windows.

The manifests were generated by the tagged Yeet release workflow. The installer SHA-256 was independently verified against the published v0.5.3 installer before submission.

- Release: https://github.com/hjosugi/yeet/releases/tag/v0.5.3
- Installer type: Inno Setup
- Scope: user
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/405295)