### PR TITLE
New package: toevi.WOLManager version 1.1.1

### DIFF
--- a/manifests/t/toevi/WOLManager/1.1.1/toevi.WOLManager.installer.yaml
+++ b/manifests/t/toevi/WOLManager/1.1.1/toevi.WOLManager.installer.yaml
@@ -9,6 +9,7 @@ Installers:
   InstallerUrl: https://github.com/toevi/WOLManager/releases/download/v1.1.1/WOLManager-Setup-1.1.exe
   InstallerSha256: 22884C6975CDB66733BFC3429D622B935A9FE7E8E0BE264D6907C55881B3A84D
   AppsAndFeaturesEntries:
-  - Publisher: tmfgroup
+  - DisplayVersion: "1.1"
+    Publisher: tmfgroup
 ManifestType: installer
 ManifestVersion: 1.9.0

--- a/manifests/t/toevi/WOLManager/1.1.1/toevi.WOLManager.installer.yaml
+++ b/manifests/t/toevi/WOLManager/1.1.1/toevi.WOLManager.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: toevi.WOLManager
+PackageVersion: 1.1.1
+InstallerType: inno
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/toevi/WOLManager/releases/download/v1.1.1/WOLManager-Setup-1.1.exe
+    InstallerSha256: 22884C6975CDB66733BFC3429D622B935A9FE7E8E0BE264D6907C55881B3A84D
+AppsAndFeaturesEntries:
+  - Publisher: tmfgroup
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/t/toevi/WOLManager/1.1.1/toevi.WOLManager.installer.yaml
+++ b/manifests/t/toevi/WOLManager/1.1.1/toevi.WOLManager.installer.yaml
@@ -1,18 +1,14 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
 PackageIdentifier: toevi.WOLManager
 PackageVersion: 1.1.1
+MinimumOSVersion: 10.0.19041.0
 InstallerType: inno
-Scope: machine
-InstallModes:
-  - interactive
-  - silent
-  - silentWithProgress
-UpgradeBehavior: install
 Installers:
-  - Architecture: x64
-    InstallerUrl: https://github.com/toevi/WOLManager/releases/download/v1.1.1/WOLManager-Setup-1.1.exe
-    InstallerSha256: 22884C6975CDB66733BFC3429D622B935A9FE7E8E0BE264D6907C55881B3A84D
-AppsAndFeaturesEntries:
+- Architecture: x64
+  InstallerUrl: https://github.com/toevi/WOLManager/releases/download/v1.1.1/WOLManager-Setup-1.1.exe
+  InstallerSha256: 22884C6975CDB66733BFC3429D622B935A9FE7E8E0BE264D6907C55881B3A84D
+  AppsAndFeaturesEntries:
   - Publisher: tmfgroup
 ManifestType: installer
 ManifestVersion: 1.9.0

--- a/manifests/t/toevi/WOLManager/1.1.1/toevi.WOLManager.locale.en-US.yaml
+++ b/manifests/t/toevi/WOLManager/1.1.1/toevi.WOLManager.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: toevi.WOLManager
+PackageVersion: 1.1.1
+PackageLocale: en-US
+Publisher: tmfgroup
+PublisherUrl: https://github.com/toevi
+PublisherSupportUrl: https://github.com/toevi/WOLManager/issues
+Author: tmfgroup (Tomek Maselko)
+PackageName: WOL Manager
+PackageUrl: https://github.com/toevi/WOLManager
+License: MIT
+LicenseUrl: https://github.com/toevi/WOLManager/blob/main/LICENSE
+Copyright: Copyright (c) 2025 tmfgroup (Tomek Maselko)
+ShortDescription: Wake-on-LAN and remote power management tool for Windows network administrators.
+Description: >-
+  WOL Manager is a Windows desktop tool for network administrators that combines Wake-on-LAN,
+  remote power control (restart / shutdown), RDP, SSH, network share access, and port scanning
+  in one place. It auto-discovers Windows computers on the LAN, minimizes to the system tray,
+  and polls online/offline status every few seconds.
+Moniker: wolmanager
+Tags:
+  - wake-on-lan
+  - wol
+  - network
+  - remote-desktop
+  - rdp
+  - ssh
+  - sysadmin
+  - port-scan
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/t/toevi/WOLManager/1.1.1/toevi.WOLManager.locale.en-US.yaml
+++ b/manifests/t/toevi/WOLManager/1.1.1/toevi.WOLManager.locale.en-US.yaml
@@ -1,31 +1,32 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
 PackageIdentifier: toevi.WOLManager
 PackageVersion: 1.1.1
 PackageLocale: en-US
 Publisher: tmfgroup
 PublisherUrl: https://github.com/toevi
 PublisherSupportUrl: https://github.com/toevi/WOLManager/issues
-Author: tmfgroup (Tomek Maselko)
 PackageName: WOL Manager
 PackageUrl: https://github.com/toevi/WOLManager
 License: MIT
 LicenseUrl: https://github.com/toevi/WOLManager/blob/main/LICENSE
 Copyright: Copyright (c) 2025 tmfgroup (Tomek Maselko)
 ShortDescription: Wake-on-LAN and remote power management tool for Windows network administrators.
-Description: >-
+Description: |-
   WOL Manager is a Windows desktop tool for network administrators that combines Wake-on-LAN,
   remote power control (restart / shutdown), RDP, SSH, network share access, and port scanning
   in one place. It auto-discovers Windows computers on the LAN, minimizes to the system tray,
   and polls online/offline status every few seconds.
 Moniker: wolmanager
 Tags:
-  - wake-on-lan
-  - wol
-  - network
-  - remote-desktop
-  - rdp
-  - ssh
-  - sysadmin
-  - port-scan
+- wake-on-lan
+- wol
+- network
+- remote-desktop
+- rdp
+- ssh
+- sysadmin
+- port-scan
+ReleaseNotesUrl: https://github.com/toevi/WOLManager/releases/tag/v1.1.1
 ManifestType: defaultLocale
 ManifestVersion: 1.9.0

--- a/manifests/t/toevi/WOLManager/1.1.1/toevi.WOLManager.yaml
+++ b/manifests/t/toevi/WOLManager/1.1.1/toevi.WOLManager.yaml
@@ -1,4 +1,5 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
 PackageIdentifier: toevi.WOLManager
 PackageVersion: 1.1.1
 DefaultLocale: en-US

--- a/manifests/t/toevi/WOLManager/1.1.1/toevi.WOLManager.yaml
+++ b/manifests/t/toevi/WOLManager/1.1.1/toevi.WOLManager.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: toevi.WOLManager
+PackageVersion: 1.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## 📖 Description

New package submission: **toevi.WOLManager** version **1.1.1**.

WOL Manager is a Windows desktop tool for network administrators — Wake-on-LAN,
remote power control (restart/shutdown), RDP, SSH, network share access, and port
scanning in one place.

- Installer: Inno Setup, x64, from the official GitHub release (v1.1.1).
- Code signing: Authenticode-signed `CN=tmfgroup` + DigiCert timestamp — same cert
  as the already-published `toevi.WinMD` package.
- `AppsAndFeaturesEntries`: `Publisher: tmfgroup` and `DisplayVersion: "1.1"`. No
  `DisplayName`, per prior moderator feedback (#389759) — the Inno Setup ARP
  DisplayName is localized. `DisplayVersion` is included because the installer
  writes `1.1` to ARP while the package version is `1.1.1`; this was verified
  locally against the registry entry after `winget install --manifest`, and
  without it winget would keep offering an upgrade for an installed package.
- Structure mirrors the accepted `toevi.WinMD` 1.1.0 manifests.

## ✅ Checklist

- [x] Signed the Contributor License Agreement

## 📦 Manifest Checklist

- [x] Checked there aren't other open PRs for the same manifest
- [x] This PR only modifies one (1) manifest
- [x] Validated locally with `winget validate`
- [x] Tested locally with `winget install`
- [x] Manifest uses schema 1.9.0 (same as accepted toevi.WinMD 1.1.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/405310)