### PR TITLE
New package: Relay.Relay version 1.0.36

### DIFF
--- a/manifests/r/Relay/Relay/1.0.36/Relay.Relay.installer.yaml
+++ b/manifests/r/Relay/Relay/1.0.36/Relay.Relay.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Relay.Relay
+PackageVersion: 1.0.36
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: RelayDesktop.exe
+    PortableCommandAlias: relay
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://relaykeyboard.com/downloads/v1.0.36/RelayDesktop.zip
+    InstallerSha256: AEA6737AA604074712DBD9C3A75BA3A80B6B4FAE49FCB2503BBF15D354A67CB1
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/r/Relay/Relay/1.0.36/Relay.Relay.locale.en-US.yaml
+++ b/manifests/r/Relay/Relay/1.0.36/Relay.Relay.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Relay.Relay
+PackageVersion: 1.0.36
+PackageLocale: en-US
+Publisher: Relay
+PublisherUrl: https://relaykeyboard.com
+PublisherSupportUrl: https://relaykeyboard.com/support.html
+PrivacyUrl: https://relaykeyboard.com/privacy.html
+PackageName: Relay
+PackageUrl: https://relaykeyboard.com
+License: Proprietary
+LicenseUrl: https://relaykeyboard.com/privacy.html
+ShortDescription: The private keyboard for your life's paperwork. Save your passport, IBAN, licence and documents once, then send any detail in a tap.
+Description: Relay keeps the details people keep asking for (passport number, Emirates ID, IBAN, addresses, documents) in an encrypted vault on your device and inserts them anywhere with a quick-insert shortcut. No account required. Syncs end to end encrypted with the Relay iPhone and Android apps.
+Moniker: relay
+Tags:
+  - keyboard
+  - productivity
+  - privacy
+  - vault
+  - documents
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/r/Relay/Relay/1.0.36/Relay.Relay.yaml
+++ b/manifests/r/Relay/Relay/1.0.36/Relay.Relay.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Relay.Relay
+PackageVersion: 1.0.36
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
New package submission: Relay (Relay.Relay) 1.0.36

- Publisher: Relay (https://relaykeyboard.com)
- Portable single-file WPF app distributed as a zip; nested portable installer with alias `relay`
- Immutable versioned InstallerUrl with SHA-256 pinned
- Homepage / support / privacy URLs included in the locale manifest

Checklist:
- [x] I have read the Contributing Guide
- [x] Manifests validate against schema 1.6.0
- [x] The installer URL is versioned and immutable
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/405315)