### PR TITLE
HoraceMaxwell.Horosa version 3.5.0: correct InstallerSha256 (installer re-released)

### DIFF
--- a/manifests/h/HoraceMaxwell/Horosa/3.5.0/HoraceMaxwell.Horosa.installer.yaml
+++ b/manifests/h/HoraceMaxwell/Horosa/3.5.0/HoraceMaxwell.Horosa.installer.yaml
@@ -16,6 +16,6 @@ ReleaseDate: 2026-07-21
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/Horace-Maxwell/Horosa-Web-App-comprehensively-improved-Windows/releases/download/v3.5.0/Horosa-Setup-3.5.0.exe
-    InstallerSha256: 42000224870859B92E71AB81B7A52E830E610F778BDB1E1704E41FC918EA7023
+    InstallerSha256: B95CBE3D415B4D7FBB9AD51896B61A46B45F30D6A25F7FA688F9C426AA20A6B7
 ManifestType: installer
 ManifestVersion: 1.6.0


### PR DESCRIPTION
The 3.5.0 installer was re-released at the same version with performance improvements across all chart and calculation modules (faster chart generation, on-demand loading of long-form reference texts, incremental panel repaint, retained sub-tab state, and background prefetch). Chart results and existing functionality are unchanged.

Because the executable was rebuilt, its SHA256 changed. The manifest merged in #405110 still pins the pre-rebuild hash, so `winget install HoraceMaxwell.Horosa` currently fails hash validation.

This PR updates `InstallerSha256` only — no other field is touched.

| | SHA256 |
| --- | --- |
| Manifest (current) | `42000224870859B92E71AB81B7A52E830E610F778BDB1E1704E41FC918EA7023` |
| Live installer | `B95CBE3D415B4D7FBB9AD51896B61A46B45F30D6A25F7FA688F9C426AA20A6B7` |

Verified against the published `SHA256SUMS.txt` and the release asset itself:
https://github.com/Horace-Maxwell/Horosa-Web-App-comprehensively-improved-Windows/releases/tag/v3.5.0

`ReleaseDate: 2026-07-21` is unchanged and still correct. `InstallerUrl` is unchanged (same URL, same version).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/405415)