### PR TITLE
New package: SubstrateSystems.EndstateCLI version 2.27.2

### DIFF
--- a/manifests/s/SubstrateSystems/EndstateCLI/2.27.2/SubstrateSystems.EndstateCLI.installer.yaml
+++ b/manifests/s/SubstrateSystems/EndstateCLI/2.27.2/SubstrateSystems.EndstateCLI.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: SubstrateSystems.EndstateCLI
+PackageVersion: 2.27.2
+InstallerType: portable
+Commands:
+- endstate
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Artexis10/endstate/releases/download/v2.27.2/endstate.exe
+  InstallerSha256: 3550AE3ECED59BFEEA98FAD25D33D5CA36D49A00254E5FEBFF360FA8B0912732
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/SubstrateSystems/EndstateCLI/2.27.2/SubstrateSystems.EndstateCLI.locale.en-US.yaml
+++ b/manifests/s/SubstrateSystems/EndstateCLI/2.27.2/SubstrateSystems.EndstateCLI.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: SubstrateSystems.EndstateCLI
+PackageVersion: 2.27.2
+PackageLocale: en-US
+Publisher: substratesystems
+PublisherUrl: https://substratesystems.io
+PublisherSupportUrl: https://github.com/Artexis10/endstate/issues
+PrivacyUrl: https://substratesystems.io/terms
+Author: Substrate Systems OÜ
+PackageName: Endstate CLI
+PackageUrl: https://github.com/Artexis10/endstate
+License: Apache-2.0
+LicenseUrl: https://github.com/Artexis10/endstate/blob/main/LICENSE
+ShortDescription: Capture and restore Windows machine state — apps and settings — from the command line.
+Description: 'Endstate CLI is the open-source engine behind Endstate. It scans a Windows machine for installed apps (via winget) and their settings, saves everything to one portable file, and reinstalls apps and restores settings on a fresh install. Scriptable JSON output for automation. Local-first: no account, no telemetry.'
+Moniker: endstate-cli
+Tags:
+- backup
+- cli
+- migration
+- provisioning
+- windows
+- setup
+ReleaseNotesUrl: https://github.com/Artexis10/endstate/releases/tag/v2.27.2
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/SubstrateSystems/EndstateCLI/2.27.2/SubstrateSystems.EndstateCLI.yaml
+++ b/manifests/s/SubstrateSystems/EndstateCLI/2.27.2/SubstrateSystems.EndstateCLI.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: SubstrateSystems.EndstateCLI
+PackageVersion: 2.27.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? (validation passed; install test deferred to pipeline — the installer is the project's own released exe)
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Command-line engine for Endstate (companion to the already-published SubstrateSystems.Endstate GUI package, #397416). Portable single-exe installer from the project's GitHub releases; Apache-2.0, open source.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/405428)