### PR TITLE
New version: RedEyeNetworks.Logivore version 1.14.0

### DIFF
--- a/manifests/r/RedEyeNetworks/Logivore/1.14.0/RedEyeNetworks.Logivore.installer.yaml
+++ b/manifests/r/RedEyeNetworks/Logivore/1.14.0/RedEyeNetworks.Logivore.installer.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: RedEyeNetworks.Logivore
+PackageVersion: 1.14.0
+InstallerType: inno
+Scope: machine
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  Custom: /NORESTART
+UpgradeBehavior: install
+Commands:
+- logivore
+Installers:
+- Architecture: x64
+  Scope: user
+  InstallerUrl: https://download.redeyenetworks.com/logivore/releases/1.14.0/logivore-win-x64-setup.exe
+  InstallerSha256: BA3EB0633ADB5C8A20DF9E0F541E416DAC609CCF1283BB6B76B4E1972429CEB7
+- Architecture: x64
+  Scope: machine
+  ElevationRequirement: elevatesSelf
+  InstallerUrl: https://download.redeyenetworks.com/logivore/releases/1.14.0/logivore-win-x64-machine-setup.exe
+  InstallerSha256: 81E35ABE88549A5D62108B13B7BE6AF5FE50B0692B105129EAF81979F09DEC0D
+- Architecture: arm64
+  Scope: user
+  InstallerUrl: https://download.redeyenetworks.com/logivore/releases/1.14.0/logivore-win-arm64-setup.exe
+  InstallerSha256: 3FCF49E506423285A40B0DB17BF894913C4950914AA76B68B54109E56A8D0203
+- Architecture: arm64
+  Scope: machine
+  ElevationRequirement: elevatesSelf
+  InstallerUrl: https://download.redeyenetworks.com/logivore/releases/1.14.0/logivore-win-arm64-machine-setup.exe
+  InstallerSha256: 30A3AF9A689D2DE30E3180604E690B5B7E3EB2E5202E9912930F319DF6C06104
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/r/RedEyeNetworks/Logivore/1.14.0/RedEyeNetworks.Logivore.locale.en-US.yaml
+++ b/manifests/r/RedEyeNetworks/Logivore/1.14.0/RedEyeNetworks.Logivore.locale.en-US.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: RedEyeNetworks.Logivore
+PackageVersion: 1.14.0
+PackageLocale: en-US
+Publisher: RedEye Network Solutions LLC
+PublisherUrl: https://redeyenetworks.com
+PublisherSupportUrl: https://redeyenetworks.com/support
+Author: RedEye Network Solutions LLC
+PackageName: Logivore
+PackageUrl: https://redeyenetworks.com
+License: Proprietary
+Copyright: Copyright 2026 RedEye Network Solutions LLC. All rights reserved.
+ShortDescription: Cross-platform desktop log analyzer with LILA, an AI assistant for log triage
+Description: |-
+  Logivore is a local-first, cross-platform desktop log analyzer for Windows,
+  macOS, and Linux. Parses dozens of log formats (plaintext, syslog, EVTX,
+  PAN-OS TSF, Veeam VBR, GlobalProtect, pcap), correlates events across
+  sources, and surfaces findings via LILA — an AI assistant that runs locally
+  with optional Anthropic Claude or Google Gemini provider integration.
+  Memory-tier-adaptive (Flash / Hybrid / Indexed) so any log size works on
+  any hardware. Trust-gated LLM boundary keeps PII tokenized before it leaves
+  the machine.
+Moniker: logivore
+Tags:
+- log-analysis
+- log-viewer
+- syslog
+- evtx
+- pan-os
+- veeam
+- pcap
+- ai
+- llm
+- claude
+- gemini
+- timeline
+- correlation
+- desktop
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/RedEyeNetworks/Logivore/1.14.0/RedEyeNetworks.Logivore.yaml
+++ b/manifests/r/RedEyeNetworks/Logivore/1.14.0/RedEyeNetworks.Logivore.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: RedEyeNetworks.Logivore
+PackageVersion: 1.14.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Logivore v1.14.0 ships two distinct installers per architecture (user-scope + machine-scope), matching the Microsoft.PowerToys + Notepad++.Notepad++ convention. Each (architecture, scope) tuple maps to a unique Inno Setup EXE with a single, deterministic `PrivilegesRequired` value, so Microsoft's dynamic-scan validation has unambiguous install behavior to verify per installer entry.

Manifest construction is done in Logivore's release.yml as a hand-built heredoc (not `wingetcreate update`) so the 4-entry shape is locked from version 1 — the previous wingetcreate-based flow inherited shape from the latest published manifest, which couldn't grow installer-entry count cleanly.

The same `Logivore.iss` `AppId` is shared across user-scope and machine-scope builds so an existing HKCU install (user-scope) and HKLM install (machine-scope) each match the appropriate manifest installer entry on `winget upgrade`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/405586)