### PR TITLE
New package: tsouth89.CubbyClipboard version 1.2.1

### DIFF
--- a/manifests/t/tsouth89/CubbyClipboard/1.2.1/tsouth89.CubbyClipboard.installer.yaml
+++ b/manifests/t/tsouth89/CubbyClipboard/1.2.1/tsouth89.CubbyClipboard.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: tsouth89.CubbyClipboard
+PackageVersion: 1.2.1
+InstallerType: nullsoft
+Scope: user
+UpgradeBehavior: install
+ReleaseDate: 2026-07-19
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/tsouth89/cubby-clipboard/releases/download/v1.2.1/Cubby.Clipboard_1.2.1_x64-setup.exe
+  InstallerSha256: 382C2848E26B2121F3DB2AA199FC47427E1934C8F255510DDE628D155DBE8855
+- Architecture: arm64
+  InstallerUrl: https://github.com/tsouth89/cubby-clipboard/releases/download/v1.2.1/Cubby.Clipboard_1.2.1_arm64-setup.exe
+  InstallerSha256: 51A3E5801C72C45B1DCAAF4FBF6E3FD33B2A35002410777E632591B9F3201887
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/t/tsouth89/CubbyClipboard/1.2.1/tsouth89.CubbyClipboard.locale.en-US.yaml
+++ b/manifests/t/tsouth89/CubbyClipboard/1.2.1/tsouth89.CubbyClipboard.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: tsouth89.CubbyClipboard
+PackageVersion: 1.2.1
+PackageLocale: en-US
+Publisher: Brandon South
+PublisherUrl: https://github.com/tsouth89
+PublisherSupportUrl: https://github.com/tsouth89/cubby-clipboard/issues
+Author: Brandon South
+PackageName: Cubby Clipboard
+PackageUrl: https://cubbyclipboard.com
+License: GPL-3.0
+LicenseUrl: https://github.com/tsouth89/cubby-clipboard/blob/v1.2.1/LICENSE
+Copyright: Copyright (c) Cubby Clipboard contributors
+ShortDescription: A fast, private clipboard history replacement built for Windows 11.
+Description: Cubby Clipboard is a local-first clipboard history replacement for Windows 11 with persistent encrypted history, instant search, offline OCR for screenshots, rich clipboard formats, and controls for sensitive apps.
+Moniker: cubby
+Tags:
+- clipboard
+- clipboard-history
+- ocr
+- privacy
+- productivity
+- tauri
+- windows
+- windows-11
+ReleaseNotes: |-
+  - Cubby now opens at the top of your history, showing your most recent copy, instead of wherever you had last scrolled.
+  - Lower peak memory use when recognizing text in very large screenshots.
+ReleaseNotesUrl: https://github.com/tsouth89/cubby-clipboard/releases/tag/v1.2.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/tsouth89/CubbyClipboard/1.2.1/tsouth89.CubbyClipboard.yaml
+++ b/manifests/t/tsouth89/CubbyClipboard/1.2.1/tsouth89.CubbyClipboard.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: tsouth89.CubbyClipboard
+PackageVersion: 1.2.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
- [x] I have signed the CLA.
- [x] I have tested the installers successfully.
- [x] I have validated the manifest with `winget validate`.

This adds the current stable Cubby Clipboard package under its own `tsouth89.CubbyClipboard` identity. Both x64 and ARM64 installers were downloaded from the immutable `v1.2.1` release, their SHA-256 hashes match the published release digests, and both have valid timestamped Authenticode signatures.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/405642)