### PR TITLE
New package: DaikiSuganuma.WinRemap version 0.3.0

### DIFF
--- a/manifests/d/DaikiSuganuma/WinRemap/0.3.0/DaikiSuganuma.WinRemap.installer.yaml
+++ b/manifests/d/DaikiSuganuma/WinRemap/0.3.0/DaikiSuganuma.WinRemap.installer.yaml
@@ -12,6 +12,11 @@ UpgradeBehavior: install
 # winget correlate the install for upgrade and uninstall.
 ProductCode: '{707AFB56-1975-4DF4-8371-B50DD23E3DA1}_is1'
 ReleaseDate: 2026-07-22
+# winremap.exe links vcruntime140.dll dynamically, so a clean machine needs the
+# VC++ redistributable (validation hit STATUS_DLL_NOT_FOUND without it).
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/DaikiSuganuma/winremap/releases/download/v0.3.0/winremap-setup.exe

--- a/manifests/d/DaikiSuganuma/WinRemap/0.3.0/DaikiSuganuma.WinRemap.installer.yaml
+++ b/manifests/d/DaikiSuganuma/WinRemap/0.3.0/DaikiSuganuma.WinRemap.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: DaikiSuganuma.WinRemap
+PackageVersion: 0.3.0
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+# Inno Setup's uninstall key is {AppId}_is1 (installer/winremap.iss); this lets
+# winget correlate the install for upgrade and uninstall.
+ProductCode: '{707AFB56-1975-4DF4-8371-B50DD23E3DA1}_is1'
+ReleaseDate: 2026-07-22
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/DaikiSuganuma/winremap/releases/download/v0.3.0/winremap-setup.exe
+    InstallerSha256: 81BA9DD21634724419E24D68EAE2FD060874FD6D741B3242169E3FA4DBF8CB64
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/d/DaikiSuganuma/WinRemap/0.3.0/DaikiSuganuma.WinRemap.locale.en-US.yaml
+++ b/manifests/d/DaikiSuganuma/WinRemap/0.3.0/DaikiSuganuma.WinRemap.locale.en-US.yaml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: DaikiSuganuma.WinRemap
+PackageVersion: 0.3.0
+PackageLocale: en-US
+Publisher: Daiki Suganuma
+PublisherUrl: https://github.com/DaikiSuganuma
+PublisherSupportUrl: https://github.com/DaikiSuganuma/winremap/issues
+Author: Daiki Suganuma
+PackageName: WinRemap
+PackageUrl: https://github.com/DaikiSuganuma/winremap
+License: MIT
+LicenseUrl: https://github.com/DaikiSuganuma/winremap/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Daiki Suganuma
+CopyrightUrl: https://github.com/DaikiSuganuma/winremap/blob/main/LICENSE
+ShortDescription: A per-application key remapper for Windows, written in Rust.
+Description: |-
+  WinRemap remaps keys only in the applications you choose, declared in one
+  simple TOML file. It uses a low-level keyboard hook written in Rust with no
+  heap allocation or I/O in the callback, so remapping stays responsive and
+  avoids the hook timeouts that affect script-based remappers. Chord and
+  bare-key rules, two-stroke prefixes, macros and optional runtime macro
+  recording are supported. WinRemap never logs keystrokes and makes no network
+  requests.
+Moniker: winremap
+Tags:
+  - keyboard
+  - remap
+  - remapper
+  - keymap
+  - productivity
+  - emacs
+  - utility
+  - rust
+ReleaseNotesUrl: https://github.com/DaikiSuganuma/winremap/releases/tag/v0.3.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/d/DaikiSuganuma/WinRemap/0.3.0/DaikiSuganuma.WinRemap.yaml
+++ b/manifests/d/DaikiSuganuma/WinRemap/0.3.0/DaikiSuganuma.WinRemap.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: DaikiSuganuma.WinRemap
+PackageVersion: 0.3.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: DaikiSuganuma.WinRemap version 0.3.0

WinRemap is a per-application key remapper for Windows, written in Rust (MIT).

- Publisher / repo: https://github.com/DaikiSuganuma/winremap
- Installer: Inno Setup, per-user (no admin), x64
- Release: https://github.com/DaikiSuganuma/winremap/releases/tag/v0.3.0

#### Checklist
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? (passes)
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-cli/blob/master/schemas/JSON/manifests/v1.6.0)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/405731)