### PR TITLE
Resolves microsoft/winget-pkgs#404686

### DIFF
--- a/manifests/h/Hugin/Hugin/2025.0.1/Hugin.Hugin.installer.yaml
+++ b/manifests/h/Hugin/Hugin/2025.0.1/Hugin.Hugin.installer.yaml
@@ -11,6 +11,7 @@ ReleaseDate: 2025-12-13
 AppsAndFeaturesEntries:
 - ProductCode: '{34615F17-E222-4439-AAF0-68425FDACBD0}'
   UpgradeCode: '{1B85EFEB-F843-49C6-80D3-A539B035D319}'
+  DisplayVersion: 20.25.0
 InstallationMetadata:
   DefaultInstallLocation: '%ProgramFiles%/Hugin'
 Installers:

--- a/manifests/h/Hugin/Hugin/2025.0.1/Hugin.Hugin.installer.yaml
+++ b/manifests/h/Hugin/Hugin/2025.0.1/Hugin.Hugin.installer.yaml
@@ -12,6 +12,7 @@ AppsAndFeaturesEntries:
 - ProductCode: '{34615F17-E222-4439-AAF0-68425FDACBD0}'
   UpgradeCode: '{1B85EFEB-F843-49C6-80D3-A539B035D319}'
   DisplayVersion: 20.25.0
+  Publisher: Hugin developer team
 InstallationMetadata:
   DefaultInstallLocation: '%ProgramFiles%/Hugin'
 Installers:


### PR DESCRIPTION
Added DisplayVersion (and Publisher) to AppsAndFeaturesEntries.

## 📖 Description
Adds a display version that matches what Hugin actually puts in the registry, since it's different to the version format displayed in Hugin's about box, which appears to be what this winget package uses to identify the version. This was done in the previous version (2024.0.1) but appears to have been missed here. I have also added Publisher, for consistency with that manifest.

## ✅ Checklist
- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)
  - Resolves #404686

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest "winget-pkgs\manifests\h\Hugin\Hugin\2025.0.1"` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest "winget-pkgs\manifests\h\Hugin\Hugin\2025.0.1"`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/405760)