### PR TITLE
New package: LeftPunch.CrazySmartPDF version 1.1.1

### DIFF
--- a/manifests/l/LeftPunch/CrazySmartPDF/1.1.1/LeftPunch.CrazySmartPDF.installer.yaml
+++ b/manifests/l/LeftPunch/CrazySmartPDF/1.1.1/LeftPunch.CrazySmartPDF.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: LeftPunch.CrazySmartPDF
+PackageVersion: 1.1.1
+InstallerType: exe
+Scope: user
+InstallerSwitches:
+  Silent: --silent
+  SilentWithProgress: --silent
+UpgradeBehavior: install
+ReleaseDate: 2026-07-14
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/GuoweiWu4279/crazysmartpdf-download/releases/download/v1.1.1/CrazySmartPDF-win-Setup.exe
+  InstallerSha256: 1C34B4E4D518F8D1CAC9F38EBAF4EC96AD2B2941DEEDA131276D623B9ADA2CA9
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/l/LeftPunch/CrazySmartPDF/1.1.1/LeftPunch.CrazySmartPDF.locale.en-US.yaml
+++ b/manifests/l/LeftPunch/CrazySmartPDF/1.1.1/LeftPunch.CrazySmartPDF.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: LeftPunch.CrazySmartPDF
+PackageVersion: 1.1.1
+PackageLocale: en-US
+Publisher: LeftPunch.ai
+PublisherUrl: https://leftpunch.ai
+PublisherSupportUrl: https://crazysmartpdf.com/faq
+PrivacyUrl: https://crazysmartpdf.com/privacy
+PackageName: CrazySmartPDF
+PackageUrl: https://crazysmartpdf.com
+License: Proprietary (freemium; one-time $39 Pro unlock)
+LicenseUrl: https://crazysmartpdf.com/pricing
+ShortDescription: Smart Excel-to-PDF converter with whole-folder batch — rows never split across page breaks, wide tables kept readable, output self-checked.
+Description: |-
+  Converts Excel workbooks into print-ready PDFs on Windows. The layout engine re-lays-out
+  each sheet (rows kept whole across page breaks; over-wide tables scaled to a readable floor
+  or sliced across pages), renders each sheet's full data range so a stale print area does not
+  silently drop data (the pre-send review reports data included from beyond a set print area),
+  and self-checks every rendered PDF for blank or clipped pages. The desktop app batch-converts
+  whole folders offline with a live log. Requires Microsoft Excel 2016+.
+Moniker: crazysmartpdf
+Tags:
+- batch
+- converter
+- excel
+- pdf
+- xlsx
+ReleaseNotesUrl: https://github.com/GuoweiWu4279/crazysmartpdf-download/releases/tag/v1.1.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/l/LeftPunch/CrazySmartPDF/1.1.1/LeftPunch.CrazySmartPDF.yaml
+++ b/manifests/l/LeftPunch/CrazySmartPDF/1.1.1/LeftPunch.CrazySmartPDF.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: LeftPunch.CrazySmartPDF
+PackageVersion: 1.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package: **LeftPunch.CrazySmartPDF** version **1.1.1**.

CrazySmartPDF is a Windows Excel-to-PDF converter published by LeftPunch.ai. Installer is the
publisher's own signed Velopack `Setup.exe`, served from a versioned, immutable GitHub Releases URL
that is the same download link the product website points at.

Verification performed before submitting:

- `winget validate --manifest <path>` → **Manifest validation succeeded** (schema 1.12.0, multi-file).
- `InstallerSha256` computed from the published asset actually downloaded from the manifest URL
  (`1C34B4E4D518F8D1CAC9F38EBAF4EC96AD2B2941DEEDA131276D623B9ADA2CA9`).
- Authenticode signature on the installer: **Valid** — `CN=Guowei Wu, O=Guowei Wu`, issued by
  `Microsoft ID Verified CS AOC CA 03`.
- Silent switch: the installer is Velopack Setup 1.2.0, whose `--silent` flag ("hides all dialogs
  and answers yes") is present in the shipped binary; mapped to both `Silent` and `SilentWithProgress`.
- Add/Remove Programs `DisplayName` is `CrazySmartPDF`, matching `PackageName`, so no
  `AppsAndFeaturesEntries` override is needed.
- All manifest URLs (PackageUrl, PublisherUrl, PublisherSupportUrl, PrivacyUrl, LicenseUrl,
  ReleaseNotesUrl, InstallerUrl) return HTTP 200.

Not done locally: `winget install --manifest`. The only machine available already has 1.1.0
installed, and I did not want to mutate it as part of preparing this submission — the validation
pipeline's clean-VM install/uninstall test is the authoritative check. Happy to run it and report
back if a moderator would like that before merge.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com) — leaving unchecked because I have not confirmed a CLA is already on file for this account; will follow the CLA bot's instructions.
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>` — see note above
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/405785)