### PR TITLE
New package: yappologistic.Wineel version 0.1.0

### DIFF
--- a/manifests/y/yappologistic/Wineel/0.1.0/yappologistic.Wineel.yaml
+++ b/manifests/y/yappologistic/Wineel/0.1.0/yappologistic.Wineel.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.singleton.1.6.0.schema.json
+PackageIdentifier: yappologistic.Wineel
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: yappologistic
+PackageName: Wineel
+License: Proprietary
+ShortDescription: Fast native radial application switcher for Windows.
+PackageUrl: https://github.com/yappologistic/Wineel
+InstallerType: inno
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/yappologistic/Wineel/releases/download/v0.1.0/Wineel-0.1.0-win-x64-setup.exe
+    InstallerSha256: E1A25715B987757A47A6BD51331E0B338DAF822BFC6EA64F56FE1F4221F05A38
+ManifestType: singleton
+ManifestVersion: 1.6.0


### PR DESCRIPTION
- [x] The manifest passes local winget validate.
- [x] The installer SHA-256 matches the published GitHub release asset.
- [ ] The repository owner must complete Microsoft’s CLA response.

Package source: https://github.com/yappologistic/Wineel
Release: https://github.com/yappologistic/Wineel/releases/tag/v0.1.0