### PR TITLE
New version: open-policy-agent.opa version 1.18.2

### DIFF
--- a/manifests/o/open-policy-agent/opa/1.18.2/open-policy-agent.opa.installer.yaml
+++ b/manifests/o/open-policy-agent/opa/1.18.2/open-policy-agent.opa.installer.yaml
@@ -1,0 +1,14 @@
+# Created with WinGet automation for open-policy-agent.opa
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: open-policy-agent.opa
+PackageVersion: 1.18.2
+InstallerType: portable
+Commands:
+- opa
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/open-policy-agent/opa/releases/download/v1.18.2/opa_windows_amd64.exe
+  InstallerSha256: B9022224EE660C87CC35CE957C21C352FA57B267D71FB4E1CE779A38E107C9DF
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/o/open-policy-agent/opa/1.18.2/open-policy-agent.opa.locale.en-US.yaml
+++ b/manifests/o/open-policy-agent/opa/1.18.2/open-policy-agent.opa.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created with WinGet automation for open-policy-agent.opa
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: open-policy-agent.opa
+PackageVersion: 1.18.2
+PackageLocale: en-US
+Publisher: Open Policy Agent
+PublisherUrl: https://www.openpolicyagent.org/
+PublisherSupportUrl: https://github.com/open-policy-agent/opa/issues
+PackageName: Open Policy Agent
+PackageUrl: https://www.openpolicyagent.org/
+License: Apache-2.0
+LicenseUrl: https://github.com/open-policy-agent/opa/blob/main/LICENSE
+ShortDescription: Open Policy Agent (OPA) is an open source, general-purpose policy engine that enables unified, context-aware policy enforcement across the entire stack.
+ReleaseNotesUrl: https://github.com/open-policy-agent/opa/releases/tag/v1.18.2
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/o/open-policy-agent/opa/1.18.2/open-policy-agent.opa.yaml
+++ b/manifests/o/open-policy-agent/opa/1.18.2/open-policy-agent.opa.yaml
@@ -1,0 +1,8 @@
+# Created with WinGet automation for open-policy-agent.opa
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: open-policy-agent.opa
+PackageVersion: 1.18.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
### Checklist
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked this isn't a duplicate package submission?
- [x] Have you validated your manifest locally prior to submission?

### Validation
- Package: open-policy-agent.opa
- Version: 1.18.2
- Installer: portable x64 `opa_windows_amd64.exe` (97882112 bytes)
- InstallerSha256: `B9022224EE660C87CC35CE957C21C352FA57B267D71FB4E1CE779A38E107C9DF`
- Source: https://github.com/open-policy-agent/opa/releases/tag/v1.18.2
- ReleaseDate: 2026-07-02
- Notes: master still at 1.7.1; no competing open PR for 1.18.2

### Test plan
- [x] Full-download SHA256 matches upstream `.sha256` asset
- [x] InstallerUrl / ReleaseNotesUrl / LicenseUrl / PublisherUrl HTTP reachable

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/405827)