### PR TITLE
Add Microsoft.WindowsBatteryLifeTool version 2.0.18

### DIFF
--- a/manifests/m/Microsoft/WindowsBatteryLifeTool/2.0.18/Microsoft.WindowsBatteryLifeTool.installer.yaml
+++ b/manifests/m/Microsoft/WindowsBatteryLifeTool/2.0.18/Microsoft.WindowsBatteryLifeTool.installer.yaml
@@ -4,17 +4,20 @@ PackageVersion: 2.0.18
 InstallerType: msi
 Scope: machine
 InstallModes:
+- silent
+- silentWithProgress
 - interactive
+ElevationRequirement: elevationRequired
 UpgradeBehavior: install
 ReleaseDate: 2026-07-21
 AppsAndFeaturesEntries:
 - DisplayName: WindowsBatteryLifeTool
   Publisher: Microsoft Corporation
-  ProductCode: '{E83FAB63-BDD3-4E5B-B24E-58286695E4E2}'
+  ProductCode: '{685A77A3-1BB7-4ED2-A56E-BF37C00A6EE0}'
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/microsoft/WebBrowsingPowerRelease/releases/download/v2.0.18/WindowsBatteryLifeTool-2.0.18.msi
-  InstallerSha256: F017C7460D60B35C8630AF89DA498BD4FC76EC26CDF2081CE332167BD183DBE6
-  ProductCode: '{E83FAB63-BDD3-4E5B-B24E-58286695E4E2}'
+  InstallerSha256: 68843172781BD4A8F5FF187DB42416B6C0FE908667365FD65AEF00C2B96EFB7D
+  ProductCode: '{685A77A3-1BB7-4ED2-A56E-BF37C00A6EE0}'
 ManifestType: installer
 ManifestVersion: 1.10.0

--- a/manifests/m/Microsoft/WindowsBatteryLifeTool/2.0.18/Microsoft.WindowsBatteryLifeTool.installer.yaml
+++ b/manifests/m/Microsoft/WindowsBatteryLifeTool/2.0.18/Microsoft.WindowsBatteryLifeTool.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: Microsoft.WindowsBatteryLifeTool
+PackageVersion: 2.0.18
+InstallerType: msi
+Scope: machine
+InstallModes:
+- interactive
+UpgradeBehavior: install
+ReleaseDate: 2026-07-21
+AppsAndFeaturesEntries:
+- DisplayName: WindowsBatteryLifeTool
+  Publisher: Microsoft Corporation
+  ProductCode: '{E83FAB63-BDD3-4E5B-B24E-58286695E4E2}'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/microsoft/WebBrowsingPowerRelease/releases/download/v2.0.18/WindowsBatteryLifeTool-2.0.18.msi
+  InstallerSha256: A880D565BF299420AAE497A6ABF7F06CF89BDBE911E1F6E70A17C74BA5B4DCF1
+  ProductCode: '{E83FAB63-BDD3-4E5B-B24E-58286695E4E2}'
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/m/Microsoft/WindowsBatteryLifeTool/2.0.18/Microsoft.WindowsBatteryLifeTool.installer.yaml
+++ b/manifests/m/Microsoft/WindowsBatteryLifeTool/2.0.18/Microsoft.WindowsBatteryLifeTool.installer.yaml
@@ -14,7 +14,7 @@ AppsAndFeaturesEntries:
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/microsoft/WebBrowsingPowerRelease/releases/download/v2.0.18/WindowsBatteryLifeTool-2.0.18.msi
-  InstallerSha256: A880D565BF299420AAE497A6ABF7F06CF89BDBE911E1F6E70A17C74BA5B4DCF1
+  InstallerSha256: F017C7460D60B35C8630AF89DA498BD4FC76EC26CDF2081CE332167BD183DBE6
   ProductCode: '{E83FAB63-BDD3-4E5B-B24E-58286695E4E2}'
 ManifestType: installer
 ManifestVersion: 1.10.0

--- a/manifests/m/Microsoft/WindowsBatteryLifeTool/2.0.18/Microsoft.WindowsBatteryLifeTool.locale.en-US.yaml
+++ b/manifests/m/Microsoft/WindowsBatteryLifeTool/2.0.18/Microsoft.WindowsBatteryLifeTool.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: Microsoft.WindowsBatteryLifeTool
+PackageVersion: 2.0.18
+PackageLocale: en-US
+Publisher: Microsoft Corporation
+PublisherUrl: https://www.microsoft.com/
+PublisherSupportUrl: https://github.com/microsoft/WebBrowsingPowerRelease/issues
+PrivacyUrl: https://privacy.microsoft.com/privacystatement
+Author: Microsoft Corporation
+PackageName: Windows Battery Life Tool
+PackageUrl: https://github.com/microsoft/WebBrowsingPowerRelease
+License: Microsoft Software License Terms
+Copyright: Copyright (c) Microsoft Corporation
+ShortDescription: Setup utility for the Windows Battery Life Tool Edge Browsing Power deployment package.
+Description: Windows Battery Life Tool installs the Edge Browsing Power deployment package and Getting Started & User Guide for Windows battery life assessments.
+Moniker: windows-battery-life-tool
+Tags:
+- assessment
+- battery
+- battery-life
+- edge
+- power
+ReleaseNotes: Use new EdgeBrowsingPowerV2.0.18 package.
+ReleaseNotesUrl: https://github.com/microsoft/WebBrowsingPowerRelease/releases/tag/v2.0.18
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/m/Microsoft/WindowsBatteryLifeTool/2.0.18/Microsoft.WindowsBatteryLifeTool.yaml
+++ b/manifests/m/Microsoft/WindowsBatteryLifeTool/2.0.18/Microsoft.WindowsBatteryLifeTool.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: Microsoft.WindowsBatteryLifeTool
+PackageVersion: 2.0.18
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Adds the Microsoft.WindowsBatteryLifeTool package manifest for version 2.0.18.

Validation: winget validate --manifest manifests\m\Microsoft\WindowsBatteryLifeTool\2.0.18
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/405832)