### PR TITLE
Add 0state.scafld 2.5.2

### DIFF
--- a/manifests/0/0state/scafld/2.5.2/0state.scafld.installer.yaml
+++ b/manifests/0/0state/scafld/2.5.2/0state.scafld.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: 0state.scafld
+PackageVersion: 2.5.2
+InstallerLocale: en-US
+InstallerType: portable
+Commands:
+  - scafld
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/nilstate/scafld/releases/download/v2.5.2/scafld_2.5.2_windows_amd64.exe
+    InstallerSha256: dfd32fd697adc567a36276280a19968a8d242fd7b8ab239cbbf967d71eff03c8
+  - Architecture: arm64
+    InstallerUrl: https://github.com/nilstate/scafld/releases/download/v2.5.2/scafld_2.5.2_windows_arm64.exe
+    InstallerSha256: d433bba680826c9f2d80903d32c1dca8c8e17af9da99299f1d22c3880bd5f17d
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/0/0state/scafld/2.5.2/0state.scafld.locale.en-US.yaml
+++ b/manifests/0/0state/scafld/2.5.2/0state.scafld.locale.en-US.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: 0state.scafld
+PackageVersion: 2.5.2
+PackageLocale: en-US
+Publisher: 0state
+PublisherUrl: https://0state.com
+PackageName: scafld
+License: MIT
+ShortDescription: Deterministic protocol for multi-phase agent work.
+PackageUrl: https://0state.com/scafld
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/0/0state/scafld/2.5.2/0state.scafld.yaml
+++ b/manifests/0/0state/scafld/2.5.2/0state.scafld.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: 0state.scafld
+PackageVersion: 2.5.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Adds the 0state.scafld 2.5.2 portable manifests.\n\nSource release: https://github.com/nilstate/scafld/releases/tag/v2.5.2\n\nThe manifests were staged with nilstate/scafld scripts/prepare-winget-submission.sh 2.5.2, which downloads the published rendered manifests and verifies installer hashes against the release checksums.txt.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/405858)