### PR TITLE
New package: ArcBox.LinkCode version 0.6.1

### DIFF
--- a/manifests/a/ArcBox/LinkCode/0.6.1/ArcBox.LinkCode.installer.yaml
+++ b/manifests/a/ArcBox/LinkCode/0.6.1/ArcBox.LinkCode.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: ArcBox.LinkCode
+PackageVersion: 0.6.1
+InstallerType: nullsoft
+Scope: user
+UpgradeBehavior: install
+Protocols:
+  - linkcode
+ReleaseDate: 2026-07-21
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/arcboxlabs/linkcode/releases/download/v0.6.1/LinkCode-0.6.1-x64.exe
+    InstallerSha256: 4C8FF188DDA0466F7D76F7F8E7E28B2F2690F4CA1122EC5FAEFFB792C8CE1BC5
+  - Architecture: arm64
+    InstallerUrl: https://github.com/arcboxlabs/linkcode/releases/download/v0.6.1/LinkCode-0.6.1-arm64.exe
+    InstallerSha256: 302B6A5643257E5E8FEABE7B49E5BBBDDAA06A24135B48330878C481023248A5
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/a/ArcBox/LinkCode/0.6.1/ArcBox.LinkCode.locale.en-US.yaml
+++ b/manifests/a/ArcBox/LinkCode/0.6.1/ArcBox.LinkCode.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: ArcBox.LinkCode
+PackageVersion: 0.6.1
+PackageLocale: en-US
+Publisher: ArcBox
+PublisherUrl: https://arcbox.dev
+PublisherSupportUrl: https://github.com/arcboxlabs/linkcode/issues
+PrivacyUrl: https://linkcode.ai/privacy
+Author: ArcBox, Inc.
+PackageName: LinkCode
+PackageUrl: https://linkcode.ai
+License: BUSL-1.1
+LicenseUrl: https://github.com/arcboxlabs/linkcode/blob/master/LICENSE
+Copyright: Copyright © 2026 ArcBox, Inc. All rights reserved.
+ShortDescription: Every code agent in the palm of your hand.
+Description: |-
+  LinkCode is one workspace for all your coding agents. A host on your machine
+  takes over Claude Code, Codex, OpenCode, Pi, and Grok Build, normalizes their
+  divergent events into a single contract, and serves the same threads to every
+  client — start an agent at your desk, keep an eye on it from anywhere.
+Moniker: linkcode
+Tags:
+  - agent
+  - ai
+  - claude
+  - codex
+  - developer-tools
+  - electron
+  - opencode
+ReleaseNotesUrl: https://github.com/arcboxlabs/linkcode/releases/tag/v0.6.1
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/a/ArcBox/LinkCode/0.6.1/ArcBox.LinkCode.locale.zh-CN.yaml
+++ b/manifests/a/ArcBox/LinkCode/0.6.1/ArcBox.LinkCode.locale.zh-CN.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.10.0.schema.json
+
+PackageIdentifier: ArcBox.LinkCode
+PackageVersion: 0.6.1
+PackageLocale: zh-CN
+Publisher: ArcBox
+PublisherUrl: https://arcbox.dev
+PublisherSupportUrl: https://github.com/arcboxlabs/linkcode/issues
+PrivacyUrl: https://linkcode.ai/privacy
+Author: ArcBox, Inc.
+PackageName: LinkCode
+PackageUrl: https://linkcode.ai
+License: BUSL-1.1
+LicenseUrl: https://github.com/arcboxlabs/linkcode/blob/master/LICENSE
+Copyright: Copyright © 2026 ArcBox, Inc. All rights reserved.
+ShortDescription: 把每一个代码 Agent 握在掌心。
+Description: |-
+  LinkCode 是统一托管所有编码 Agent 的工作区。本机 host 接管 Claude Code、Codex、
+  OpenCode、Pi 与 Grok Build，把它们各自的事件归一成同一套契约，再把同一条线程
+  送到每一个客户端 —— 在桌前启动 Agent，随时随地继续跟进。
+Tags:
+  - agent
+  - ai
+  - claude
+  - codex
+  - electron
+  - opencode
+  - 开发工具
+ReleaseNotesUrl: https://github.com/arcboxlabs/linkcode/releases/tag/v0.6.1
+ManifestType: locale
+ManifestVersion: 1.10.0

--- a/manifests/a/ArcBox/LinkCode/0.6.1/ArcBox.LinkCode.yaml
+++ b/manifests/a/ArcBox/LinkCode/0.6.1/ArcBox.LinkCode.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: ArcBox.LinkCode
+PackageVersion: 0.6.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
### New package
- PackageIdentifier: `ArcBox.LinkCode`
- PackageVersion: `0.6.1`
- Publisher: ArcBox
- InstallerType: nullsoft (NSIS), per-user
- Architectures: x64 + arm64 (separate installers)
- Installer source: https://github.com/arcboxlabs/linkcode/releases/tag/v0.6.1
- Protocol: `linkcode://`

### Checklist
- [x] Have you signed the Contributor License Agreement?
- [x] Have you checked that there are not other open pull requests for the same package update/change?
- [x] This PR adds a new package (not a version update of an existing one)
- [x] Have you validated your manifest locally during development? (schema 1.10.0)
- [x] Have you tested your manifest locally with winget install --manifest (or equivalent) where possible?
- [x] Does your manifest conform to the 1.10 schema?

### Notes
Signed Windows NSIS installers built by electron-builder; app self-updates via electron-updater after install. Subsequent versions will be submitted automatically from the ArcBox release pipeline once this package exists.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/405860)