### PR TITLE
New package: STranslate.STranslate version 2.0.9

### DIFF
--- a/manifests/s/STranslate/STranslate/2.0.9/STranslate.STranslate.installer.yaml
+++ b/manifests/s/STranslate/STranslate/2.0.9/STranslate.STranslate.installer.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: STranslate.STranslate
+PackageVersion: 2.0.9
+InstallerLocale: en-US
+InstallerType: exe
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: --silent
+  SilentWithProgress: --silent
+UpgradeBehavior: install
+ReleaseDate: 2026-07-01
+AppsAndFeaturesEntries:
+- DisplayName: STranslate
+  Publisher: STranslate
+  ProductCode: STranslate
+  InstallerType: exe
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/STranslate/STranslate/releases/download/v2.0.9/STranslate-win-Setup.exe
+  InstallerSha256: A28C4F1D5E629FE1DCBAB1641EE51BCB251EFE1E40F30920446FC56EA0B2FAFA
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/STranslate/STranslate/2.0.9/STranslate.STranslate.locale.en-US.yaml
+++ b/manifests/s/STranslate/STranslate/2.0.9/STranslate.STranslate.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: STranslate.STranslate
+PackageVersion: 2.0.9
+PackageLocale: en-US
+Publisher: STranslate
+PublisherUrl: https://github.com/STranslate
+PublisherSupportUrl: https://github.com/STranslate/STranslate/issues
+Author: zggsong
+PackageName: STranslate
+PackageUrl: https://github.com/STranslate/STranslate
+License: MIT
+LicenseUrl: https://github.com/STranslate/STranslate/blob/main/LICENSE
+Copyright: Copyright (c) zggsong
+ShortDescription: A ready-to-go translation and OCR tool for Windows.
+Description: |-
+  STranslate is a ready-to-go translation and OCR tool developed with WPF.
+  It supports multiple translation services, OCR, plugins, and global hotkeys for quick translation.
+Moniker: stranslate
+Tags:
+- ocr
+- translation
+- translator
+- wpf
+ReleaseNotesUrl: https://github.com/STranslate/STranslate/releases/tag/v2.0.9
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/STranslate/STranslate/2.0.9/STranslate.STranslate.locale.zh-CN.yaml
+++ b/manifests/s/STranslate/STranslate/2.0.9/STranslate.STranslate.locale.zh-CN.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: STranslate.STranslate
+PackageVersion: 2.0.9
+PackageLocale: zh-CN
+Publisher: STranslate
+PublisherUrl: https://github.com/STranslate
+PublisherSupportUrl: https://github.com/STranslate/STranslate/issues
+Author: zggsong
+PackageName: STranslate
+PackageUrl: https://github.com/STranslate/STranslate
+License: MIT
+LicenseUrl: https://github.com/STranslate/STranslate/blob/main/LICENSE
+Copyright: Copyright (c) zggsong
+ShortDescription: 一款即用即走的 Windows 翻译与 OCR 工具。
+Description: |-
+  STranslate 是使用 WPF 开发的即用即走翻译、OCR 工具。
+  支持多种翻译服务、OCR、插件以及全局快捷键，方便快速翻译。
+Tags:
+- ocr
+- 翻译
+- 截图翻译
+- wpf
+ReleaseNotesUrl: https://github.com/STranslate/STranslate/releases/tag/v2.0.9
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/s/STranslate/STranslate/2.0.9/STranslate.STranslate.yaml
+++ b/manifests/s/STranslate/STranslate/2.0.9/STranslate.STranslate.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: STranslate.STranslate
+PackageVersion: 2.0.9
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## New package
- Package: STranslate.STranslate
- Version: 2.0.9
- Publisher/Project: https://github.com/STranslate/STranslate
- Installer: official Velopack setup from GitHub Releases (x64, per-user, silent `--silent`)

## Validation
- [x] `winget validate --manifest` succeeded
- [x] Silent install verified: `STranslate-win-Setup.exe --silent`
- [x] Local install verified: `winget install --manifest`
- [x] Install location: `%LocalAppData%\STranslate` (user scope)
- [x] ARP: DisplayName=STranslate, DisplayVersion=2.0.9, Publisher=STranslate

## Notes
Community contribution for the open-source project STranslate (MIT). Not submitted by the original publisher account; package metadata matches the installed application ARP entries.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/405865)