### PR TITLE
New version: oipoistar.Tinta version 2.3.0

### DIFF
--- a/manifests/o/oipoistar/Tinta/2.3.0/oipoistar.Tinta.installer.yaml
+++ b/manifests/o/oipoistar/Tinta/2.3.0/oipoistar.Tinta.installer.yaml
@@ -1,0 +1,18 @@
+# Created with Claude Code
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: oipoistar.Tinta
+PackageVersion: 2.3.0
+InstallerType: portable
+Commands:
+- tinta
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+ReleaseDate: 2026-07-18
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/oipoistar/tinta/releases/download/v2.3.0/tinta.exe
+  InstallerSha256: 32B3C9AF97394D0D2D7C60CCDFBD4EBAC2DA08C2EB651AD77C8EC8ABF6435051
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/o/oipoistar/Tinta/2.3.0/oipoistar.Tinta.locale.en-US.yaml
+++ b/manifests/o/oipoistar/Tinta/2.3.0/oipoistar.Tinta.locale.en-US.yaml
@@ -1,0 +1,38 @@
+# Created with Claude Code
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: oipoistar.Tinta
+PackageVersion: 2.3.0
+PackageLocale: en-US
+Publisher: oipoistar
+PublisherUrl: https://github.com/oipoistar
+PublisherSupportUrl: https://github.com/oipoistar/tinta/issues
+PackageName: Tinta
+PackageUrl: https://tinta.cc
+License: MIT
+LicenseUrl: https://github.com/oipoistar/tinta/blob/master/LICENSE
+Copyright: Copyright (c) oipoistar
+ShortDescription: Fast, lightweight markdown and Mermaid viewer for Windows
+Description: |-
+  Tinta is a fast, lightweight markdown viewer and reader for Windows,
+  built with Direct2D and DirectWrite for hardware-accelerated rendering.
+  A single native executable under 1 MB that starts in about 200 ms —
+  no Electron, no web engine, no installer. Features native Mermaid
+  flowchart rendering, 10 themes, first-class CJK text layout, internal
+  anchor links, a table of contents, folder browser, full-text search,
+  text selection, zoom, and an edit mode with live preview.
+Moniker: tinta
+Tags:
+- markdown
+- markdown-viewer
+- markdown-reader
+- markdown-editor
+- mermaid
+- viewer
+- reader
+- direct2d
+- lightweight
+- portable
+ReleaseNotesUrl: https://github.com/oipoistar/tinta/releases/tag/v2.3.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/o/oipoistar/Tinta/2.3.0/oipoistar.Tinta.yaml
+++ b/manifests/o/oipoistar/Tinta/2.3.0/oipoistar.Tinta.yaml
@@ -1,0 +1,8 @@
+# Created with Claude Code
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: oipoistar.Tinta
+PackageVersion: 2.3.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Adds oipoistar.Tinta 2.3.0. Manifest validated with winget validate. SHA256 verified against the v2.3.0 release asset. Carries the Microsoft.VCRedist.2015+.x64 dependency added during 2.0.1 review (the 2.3.0 binary predates the static-CRT switch; releases from 2.4 on will drop the dependency).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/405886)