### PR TITLE
New package: Bavlik.CredScope version 0.2.0

### DIFF
--- a/manifests/b/Bavlik/CredScope/0.2.0/Bavlik.CredScope.installer.yaml
+++ b/manifests/b/Bavlik/CredScope/0.2.0/Bavlik.CredScope.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Bavlik.CredScope
+PackageVersion: 0.2.0
+InstallerType: zip
+NestedInstallerType: portable
+Commands:
+  - credscope
+Installers:
+  - Architecture: x64
+    NestedInstallerFiles:
+      - RelativeFilePath: credscope.exe
+        PortableCommandAlias: credscope
+    InstallerUrl: https://github.com/Bavlik/CredScope/releases/download/v0.2.0/credscope_0.2.0_windows_amd64.zip
+    InstallerSha256: E43C22B4E52C790C04D7B1F02CD87F3CE907CA0688FAA11A5B4493A446A8277C
+  - Architecture: arm64
+    NestedInstallerFiles:
+      - RelativeFilePath: credscope.exe
+        PortableCommandAlias: credscope
+    InstallerUrl: https://github.com/Bavlik/CredScope/releases/download/v0.2.0/credscope_0.2.0_windows_arm64.zip
+    InstallerSha256: 6A394A31E24E3A431E23DDFC070C4822F447513B2E8024075ADA25C4EDE706F7
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/b/Bavlik/CredScope/0.2.0/Bavlik.CredScope.locale.en-US.yaml
+++ b/manifests/b/Bavlik/CredScope/0.2.0/Bavlik.CredScope.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Bavlik.CredScope
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: Abdallah Alotaibi
+PublisherUrl: https://github.com/Bavlik
+PublisherSupportUrl: https://github.com/Bavlik/CredScope/security/advisories/new
+Author: Abdallah Alotaibi
+PackageName: CredScope
+PackageUrl: https://github.com/Bavlik/CredScope
+License: Apache-2.0
+LicenseUrl: https://github.com/Bavlik/CredScope/blob/main/LICENSE
+Copyright: Copyright 2026 Abdallah Alotaibi
+ShortDescription: CredScope is a deterministic, offline-first static credential exposure and reachability analyzer for Docker Compose and GitHub Actions.
+Description: CredScope analyzes Docker Compose and GitHub Actions configuration and imported Gitleaks findings without executing repository content or validating credentials.
+Moniker: credscope
+Tags:
+  - cli
+  - docker-compose
+  - github-actions
+  - security
+  - static-analysis
+InstallationNotes: CredScope v0.2.0 is unsigned. Verify published SHA-256 checksums and do not disable Windows security controls.
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/b/Bavlik/CredScope/0.2.0/Bavlik.CredScope.yaml
+++ b/manifests/b/Bavlik/CredScope/0.2.0/Bavlik.CredScope.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Bavlik.CredScope
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Adds CredScope version 0.2.0.

CredScope is an offline-first CLI for analyzing static credential exposure and reachability context in Docker Compose, GitHub Actions, and imported Gitleaks reports.

## Checklist

- [x] Signed the Contributor License Agreement
- [x] Checked that there are no other open pull requests for the same package
- [x] This PR only modifies one package manifest
- [x] Validated locally with `winget validate --manifest <path>`
- [x] Tested locally with `winget install --manifest <path>`