### PR TITLE
Fix dependencies of FilesCommunity.Files 4.1.1.0

### DIFF
--- a/manifests/f/FilesCommunity/Files/4.1.1.0/FilesCommunity.Files.installer.yaml
+++ b/manifests/f/FilesCommunity/Files/4.1.1.0/FilesCommunity.Files.installer.yaml
@@ -23,6 +23,8 @@ Dependencies:
   PackageDependencies:
   - PackageIdentifier: Microsoft.VCLibs.Desktop.14
   - PackageIdentifier: Microsoft.WindowsAppRuntime.1.8
+    MinimumVersion: 1.8.7
+  - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.10
 PackageFamilyName: Files_1y0xx7n9077q4
 Capabilities:
 - internetClient

--- a/manifests/f/FilesCommunity/Files/4.1.1.0/FilesCommunity.Files.locale.en-US.yaml
+++ b/manifests/f/FilesCommunity/Files/4.1.1.0/FilesCommunity.Files.locale.en-US.yaml
@@ -9,7 +9,7 @@ PublisherUrl: https://files.community/
 PackageName: Files - Stable
 PackageUrl: https://github.com/files-community/Files
 License: MIT
-LicenseUrl: https://github.com/files-community/Files/blob/main/LICENSE
+LicenseUrl: https://github.com/files-community/Files/blob/v4.1.1/LICENSE
 ShortDescription: A modern file manager that helps users organize their files and folders
 Moniker: files
 ManifestType: defaultLocale


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
<!-- Describe what this PR changes. For manifest submissions, include the package name and version. -->

`Microsoft.WindowsAppRuntime.1.8` version 1.8.7 is required for the package to install, found during Sandbox testing because it has a lower version. 1.8.7 is the minimal version by checking version number in package manifest.

`Microsoft.DotNet.DesktopRuntime.10` is required to run the app, otherwise it requires the user to download and install that manually.

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/405919)