### PR TITLE
New package: Yaps.Yaps version 1.3.0

### DIFF
--- a/manifests/y/Yaps/Yaps/1.3.0/Yaps.Yaps.installer.yaml
+++ b/manifests/y/Yaps/Yaps/1.3.0/Yaps.Yaps.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: Yaps.Yaps
+PackageVersion: 1.3.0
+InstallerLocale: en-US
+InstallerType: nullsoft
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: "2026-07-21"
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/richawo/yaps-releases/releases/download/v1.3.0/Yaps_1.3.0_x64-setup.exe
+  InstallerSha256: 862928075351DBE3C7EC9F366BBA28474A9F284B580D3D53BBC3E16B01B8F5B2
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/y/Yaps/Yaps/1.3.0/Yaps.Yaps.installer.yaml
+++ b/manifests/y/Yaps/Yaps/1.3.0/Yaps.Yaps.installer.yaml
@@ -11,6 +11,9 @@ InstallModes:
 - silentWithProgress
 UpgradeBehavior: install
 ReleaseDate: "2026-07-21"
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.VCRedist.2015+.x64
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/richawo/yaps-releases/releases/download/v1.3.0/Yaps_1.3.0_x64-setup.exe

--- a/manifests/y/Yaps/Yaps/1.3.0/Yaps.Yaps.locale.en-US.yaml
+++ b/manifests/y/Yaps/Yaps/1.3.0/Yaps.Yaps.locale.en-US.yaml
@@ -3,7 +3,7 @@
 PackageIdentifier: Yaps.Yaps
 PackageVersion: 1.3.0
 PackageLocale: en-US
-Publisher: Yaps
+Publisher: yaps
 PublisherUrl: https://www.yaps.ai/
 PublisherSupportUrl: https://www.yaps.ai/support
 PrivacyUrl: https://www.yaps.ai/privacy

--- a/manifests/y/Yaps/Yaps/1.3.0/Yaps.Yaps.locale.en-US.yaml
+++ b/manifests/y/Yaps/Yaps/1.3.0/Yaps.Yaps.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: Yaps.Yaps
+PackageVersion: 1.3.0
+PackageLocale: en-US
+Publisher: Yaps
+PublisherUrl: https://www.yaps.ai/
+PublisherSupportUrl: https://www.yaps.ai/support
+PrivacyUrl: https://www.yaps.ai/privacy
+PackageName: Yaps
+PackageUrl: https://www.yaps.ai/download
+License: Proprietary
+LicenseUrl: https://www.yaps.ai/terms
+Copyright: Copyright (c) 2026 Yaps. All rights reserved.
+ShortDescription: Private, offline voice-to-text, text-to-speech, and notes for Windows.
+Description: Yaps is a privacy-first voice productivity app with offline dictation, read-aloud, voice notes, and transcription tools.
+Moniker: yaps
+Tags:
+- dictation
+- notes
+- offline
+- productivity
+- speech-to-text
+- text-to-speech
+- transcription
+- voice
+ReleaseNotesUrl: https://github.com/richawo/yaps-releases/releases/tag/v1.3.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/y/Yaps/Yaps/1.3.0/Yaps.Yaps.yaml
+++ b/manifests/y/Yaps/Yaps/1.3.0/Yaps.Yaps.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: Yaps.Yaps
+PackageVersion: 1.3.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Description

Adds Yaps 1.3.0, a privacy-first voice productivity app for Windows.

The x64 NSIS installer is versioned, Authenticode-signed, and published by the developer from the public `richawo/yaps-releases` repository.

## Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com) (awaiting contributor response)
- [x] Checked that there are no other open pull requests or manifests for Yaps
- [x] This PR modifies one package version only
- [x] Validated all three manifests with `winget validate` 1.29.280 and against the official WinGet 1.6 JSON schemas
- [x] Verified the installer URL, SHA-256, valid Authenticode signature, and all metadata URLs
- [x] Confirmed `DisplayName: Yaps`, `DisplayVersion`, and `Publisher: yaps` against Add/Remove Programs
- [ ] Tested `winget install --manifest` on Windows

Installer SHA-256: `862928075351DBE3C7EC9F366BBA28474A9F284B580D3D53BBC3E16B01B8F5B2`
