### PR TITLE
New package: LuigiElleBalotta.AIUsageNET version 0.4.1

### DIFF
--- a/manifests/l/LuigiElleBalotta/AIUsageNET/0.4.1/LuigiElleBalotta.AIUsageNET.installer.yaml
+++ b/manifests/l/LuigiElleBalotta/AIUsageNET/0.4.1/LuigiElleBalotta.AIUsageNET.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: LuigiElleBalotta.AIUsageNET
+PackageVersion: 0.4.1
+InstallerType: exe
+Scope: user
+UpgradeBehavior: install
+ReleaseDate: 2026-07-22
+InstallerSwitches:
+  Silent: -s
+  SilentWithProgress: -s
+AppsAndFeaturesEntries:
+- DisplayName: AIUsage.NET
+  DisplayVersion: "0.4.1"
+  Publisher: AIUsage.NET
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/LuigiElleBalotta/AIUsage.NET/releases/download/v0.4.1/AIUsage.NET-win-Setup.exe
+  InstallerSha256: 097E31FFCC89421D18032E11B56B8EA192BFE5F55E067E5FA40B1CE034008A58
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/l/LuigiElleBalotta/AIUsageNET/0.4.1/LuigiElleBalotta.AIUsageNET.locale.en-US.yaml
+++ b/manifests/l/LuigiElleBalotta/AIUsageNET/0.4.1/LuigiElleBalotta.AIUsageNET.locale.en-US.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: LuigiElleBalotta.AIUsageNET
+PackageVersion: 0.4.1
+PackageLocale: en-US
+Publisher: LuigiElleBalotta
+PublisherUrl: https://github.com/LuigiElleBalotta
+PublisherSupportUrl: https://github.com/LuigiElleBalotta/AIUsage.NET/issues
+Author: LuigiElleBalotta
+PackageName: AIUsage.NET
+PackageUrl: https://github.com/LuigiElleBalotta/AIUsage.NET
+License: MIT
+LicenseUrl: https://github.com/LuigiElleBalotta/AIUsage.NET/blob/main/LICENSE
+Copyright: Copyright (c) AIUsage.NET contributors
+ShortDescription: Windows system tray app that tracks usage limits and spend for Claude, Codex, Cursor, Copilot, and other AI coding tools.
+Description: >-
+  AIUsage.NET is a free, open source .NET 8 / WPF port of OpenUsage for Windows. It sits in the
+  system tray and shows session and weekly limits, credits, and local spend estimates for AI
+  coding subscriptions (Claude, Codex, Cursor, Copilot, Antigravity, Devin, Grok, OpenCode,
+  OpenRouter, Z.ai), reading credentials already stored on the machine. Includes a local
+  command-line tool and a read-only local HTTP API for scripting and other apps to consume the
+  same usage data.
+Moniker: aiusage
+Tags:
+- ai
+- claude
+- codex
+- cursor
+- copilot
+- dotnet
+- wpf
+- tray
+- usage-tracking
+- open-source
+ReleaseNotesUrl: https://github.com/LuigiElleBalotta/AIUsage.NET/releases/tag/v0.4.1
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/l/LuigiElleBalotta/AIUsageNET/0.4.1/LuigiElleBalotta.AIUsageNET.yaml
+++ b/manifests/l/LuigiElleBalotta/AIUsageNET/0.4.1/LuigiElleBalotta.AIUsageNET.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: LuigiElleBalotta.AIUsageNET
+PackageVersion: 0.4.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
### New package: LuigiElleBalotta.AIUsageNET v0.4.1

AIUsage.NET is a free, open source .NET 8 / WPF Windows tray app that tracks usage limits and
spend for AI coding subscriptions (Claude, Codex, Cursor, Copilot, Antigravity, Devin, Grok,
OpenCode, OpenRouter, Z.ai). It's a Windows port of [OpenUsage](https://github.com/robinebers/openusage).

- Repo: https://github.com/LuigiElleBalotta/AIUsage.NET
- License: MIT
- Installer: Velopack-based `Setup.exe`, silent switch `-s` (verified locally: silent install to a
  custom directory, confirmed registry uninstall entry, then silent uninstall via `Update.exe
  --uninstall`, confirmed the registry entry and install directory were fully removed).
- SHA256 of the installer was verified against the GitHub Release asset digest before submitting.

#### Checklist
- [x] I have read and understand the [contributing guidelines](https://github.com/microsoft/winget-pkgs/blob/master/CONTRIBUTING.md)
- [x] I have run `winget validate --manifest <path>` on this manifest locally
- [x] This PR only modifies one (1) package
- [x] I have verified the installer's silent switch works and installs/uninstalls cleanly

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/405974)