### PR TITLE
New version: Insecure.Nmap version 7.98

### DIFF
--- a/manifests/i/Insecure/Nmap/7.98/Insecure.Nmap.installer.yaml
+++ b/manifests/i/Insecure/Nmap/7.98/Insecure.Nmap.installer.yaml
@@ -1,0 +1,18 @@
+# Created with YamlCreate.ps1 v2.4.3 $debug=AUSU.CRLF.7-4-6.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: Insecure.Nmap
+PackageVersion: "7.98"
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+Installers:
+- Architecture: x86
+  InstallerUrl: https://nmap.org/dist/nmap-7.98-setup.exe
+  InstallerSha256: 5A52826B45600C34662012CC70F35DF8DDE590B83C14D0F3C7BE04BBB4087D32
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/i/Insecure/Nmap/7.98/Insecure.Nmap.locale.en-US.yaml
+++ b/manifests/i/Insecure/Nmap/7.98/Insecure.Nmap.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# Created with YamlCreate.ps1 v2.4.3 $debug=AUSU.CRLF.7-4-6.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: Insecure.Nmap
+PackageVersion: "7.98"
+PackageLocale: en-US
+Publisher: Nmap Project
+PublisherUrl: https://nmap.org
+# PublisherSupportUrl:
+PrivacyUrl: https://insecure.org/privacy.html
+Author: Nmap Project
+PackageName: Nmap
+PackageUrl: https://nmap.org
+License: Modified GNU GPLv2
+LicenseUrl: https://nmap.org/book/man-legal.html
+# Copyright:
+# CopyrightUrl:
+ShortDescription: Nmap ("Network Mapper") is a free and open source utility for network discovery and security auditing.
+# Description:
+Moniker: nmap
+Tags:
+- network
+- scan
+- security
+# ReleaseNotes:
+# ReleaseNotesUrl:
+# PurchaseUrl:
+# InstallationNotes:
+# Documentations:
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/i/Insecure/Nmap/7.98/Insecure.Nmap.yaml
+++ b/manifests/i/Insecure/Nmap/7.98/Insecure.Nmap.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.4.3 $debug=AUSU.CRLF.7-4-6.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: Insecure.Nmap
+PackageVersion: "7.98"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## Proposed Changes
New version of Insecure.Nmap: 7.98

Installer: https://nmap.org/dist/nmap-7.98-setup.exe
SHA256: 5A52826B45600C34662012CC70F35DF8DDE590B83C14D0F3C7BE04BBB4087D32

Fixes #341747

## Validation
- [x] Downloaded installer and verified SHA256 locally
- [ ] Windows install validation (CI)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/405979)