### PR TITLE
New version: eloston.ungoogled-chromium version 150.0.7871.128

### DIFF
--- a/manifests/e/eloston/ungoogled-chromium/150.0.7871.128/eloston.ungoogled-chromium.installer.yaml
+++ b/manifests/e/eloston/ungoogled-chromium/150.0.7871.128/eloston.ungoogled-chromium.installer.yaml
@@ -1,0 +1,98 @@
+# Created with WinGet Releaser using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: eloston.ungoogled-chromium
+PackageVersion: 150.0.7871.128
+InstallerLocale: en-US
+UpgradeBehavior: install
+Protocols:
+- http
+- https
+FileExtensions:
+- crx
+- htm
+- html
+- pdf
+- url
+ReleaseDate: 2026-07-20
+Installers:
+- Architecture: x86
+  InstallerType: exe
+  Scope: user
+  InstallerUrl: https://github.com/ungoogled-software/ungoogled-chromium-windows/releases/download/150.0.7871.128-1.1/ungoogled-chromium_150.0.7871.128-1.1_installer_x86.exe
+  InstallerSha256: 586F7D1F9A229CDEA5DAF972EE214FEF1AA9C8687538731E558BEDE64E826513
+  InstallerSwitches:
+    Silent: /silent /install
+    SilentWithProgress: /silent /install
+- Architecture: x86
+  InstallerType: exe
+  Scope: machine
+  InstallerUrl: https://github.com/ungoogled-software/ungoogled-chromium-windows/releases/download/150.0.7871.128-1.1/ungoogled-chromium_150.0.7871.128-1.1_installer_x86.exe
+  InstallerSha256: 586F7D1F9A229CDEA5DAF972EE214FEF1AA9C8687538731E558BEDE64E826513
+  InstallerSwitches:
+    Silent: /silent /install
+    SilentWithProgress: /silent /install
+    Custom: --system-level
+- Architecture: x86
+  InstallerType: zip
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: ungoogled-chromium_150.0.7871.128-1.1_windows_x86/chrome.exe
+    PortableCommandAlias: chrome
+  InstallerUrl: https://github.com/ungoogled-software/ungoogled-chromium-windows/releases/download/150.0.7871.128-1.1/ungoogled-chromium_150.0.7871.128-1.1_windows_x86.zip
+  InstallerSha256: 87FAE7BB219E60570C650C28C14212CAC35907316AB1E7DE7C26B685203CE965
+  ArchiveBinariesDependOnPath: true
+- Architecture: x64
+  InstallerType: exe
+  Scope: user
+  InstallerUrl: https://github.com/ungoogled-software/ungoogled-chromium-windows/releases/download/150.0.7871.128-1.1/ungoogled-chromium_150.0.7871.128-1.1_installer_x64.exe
+  InstallerSha256: 2D72E911778430D82674C3D0D7B674F90A448EF84DF1ECC5F40CD7951E35744B
+  InstallerSwitches:
+    Silent: /silent /install
+    SilentWithProgress: /silent /install
+- Architecture: x64
+  InstallerType: exe
+  Scope: machine
+  InstallerUrl: https://github.com/ungoogled-software/ungoogled-chromium-windows/releases/download/150.0.7871.128-1.1/ungoogled-chromium_150.0.7871.128-1.1_installer_x64.exe
+  InstallerSha256: 2D72E911778430D82674C3D0D7B674F90A448EF84DF1ECC5F40CD7951E35744B
+  InstallerSwitches:
+    Silent: /silent /install
+    SilentWithProgress: /silent /install
+    Custom: --system-level
+- Architecture: x64
+  InstallerType: zip
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: ungoogled-chromium_150.0.7871.128-1.1_windows_x64/chrome.exe
+    PortableCommandAlias: chrome
+  InstallerUrl: https://github.com/ungoogled-software/ungoogled-chromium-windows/releases/download/150.0.7871.128-1.1/ungoogled-chromium_150.0.7871.128-1.1_windows_x64.zip
+  InstallerSha256: 010291B89489763ADB2CE3BC2AC9A4E77B2045FEAB1B6EF0FBCD4AC334807F9F
+  ArchiveBinariesDependOnPath: true
+- Architecture: arm64
+  InstallerType: exe
+  Scope: user
+  InstallerUrl: https://github.com/ungoogled-software/ungoogled-chromium-windows/releases/download/150.0.7871.128-1.1/ungoogled-chromium_150.0.7871.128-1.1_installer_arm64.exe
+  InstallerSha256: 24C15767FF3C86F764D702B44F896CA304D6F380757CACEC09D1222DB07FABF5
+  InstallerSwitches:
+    Silent: /silent /install
+    SilentWithProgress: /silent /install
+- Architecture: arm64
+  InstallerType: exe
+  Scope: machine
+  InstallerUrl: https://github.com/ungoogled-software/ungoogled-chromium-windows/releases/download/150.0.7871.128-1.1/ungoogled-chromium_150.0.7871.128-1.1_installer_arm64.exe
+  InstallerSha256: 24C15767FF3C86F764D702B44F896CA304D6F380757CACEC09D1222DB07FABF5
+  InstallerSwitches:
+    Silent: /silent /install
+    SilentWithProgress: /silent /install
+    Custom: --system-level
+- Architecture: arm64
+  InstallerType: zip
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: ungoogled-chromium_150.0.7871.128-1.1_windows_arm64/chrome.exe
+    PortableCommandAlias: chrome
+  InstallerUrl: https://github.com/ungoogled-software/ungoogled-chromium-windows/releases/download/150.0.7871.128-1.1/ungoogled-chromium_150.0.7871.128-1.1_windows_arm64.zip
+  InstallerSha256: 79B0BEC5D59088AB806157FFD0DA6354253570E74B1F82C8CFD42C10D2FF940F
+  ArchiveBinariesDependOnPath: true
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/e/eloston/ungoogled-chromium/150.0.7871.128/eloston.ungoogled-chromium.locale.en-US.yaml
+++ b/manifests/e/eloston/ungoogled-chromium/150.0.7871.128/eloston.ungoogled-chromium.locale.en-US.yaml
@@ -1,0 +1,41 @@
+# Created with WinGet Releaser using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: eloston.ungoogled-chromium
+PackageVersion: 150.0.7871.128
+PackageLocale: en-US
+Publisher: ungoogled-chromium Authors
+PublisherUrl: https://ungoogled-software.github.io/
+PublisherSupportUrl: https://github.com/ungoogled-software/ungoogled-chromium-windows/issues
+Author: Eloston
+PackageName: ungoogled-chromium
+PackageUrl: https://github.com/ungoogled-software/ungoogled-chromium-windows/releases
+License: BSD-3-Clause
+LicenseUrl: https://github.com/ungoogled-software/ungoogled-chromium-windows/blob/HEAD/LICENSE
+Copyright: Copyright 2022 The ungoogled-chromium Authors
+CopyrightUrl: https://github.com/ungoogled-software/ungoogled-chromium-windows/blob/master/LICENSE
+ShortDescription: Google Chromium without dependency on Google web services.
+Description: |-
+  ungoogled-chromium is a set of configuration flags, patches, and custom scripts.
+
+  These components altogether strive to accomplish the following
+  * Disable or remove offending services and features that communicate with Google or weaken privacy
+  * Strip binaries from the source tree, and use those provided by the system or build them from source
+  * Add, modify, or disable features that inhibit control and transparency (these changes are minor and do not have significant impacts on the general user experience)
+
+  ungoogled-chromium should not be considered a fork of Chromium.
+  The main reason for this is that a fork is associated with more significant deviations from the Chromium, such as branding, configuration formats, file locations, and other interface changes.
+  ungoogled-chromium will not modify the Chromium browser outside of the project's goals.
+  Since these goals and requirements are not precise, unclear situations are discussed and decided on a case-by-case basis.
+Moniker: ungoogled-chromium
+Tags:
+- browser
+- chromium
+- manifestv2
+- mv2
+- ungoogled
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/ungoogled-software/ungoogled-chromium-windows/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/e/eloston/ungoogled-chromium/150.0.7871.128/eloston.ungoogled-chromium.yaml
+++ b/manifests/e/eloston/ungoogled-chromium/150.0.7871.128/eloston.ungoogled-chromium.yaml
@@ -1,0 +1,8 @@
+# Created with WinGet Releaser using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: eloston.ungoogled-chromium
+PackageVersion: 150.0.7871.128
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Proposed Changes
New version of eloston.ungoogled-chromium: 150.0.7871.128

Source release: https://github.com/ungoogled-software/ungoogled-chromium-windows/releases/tag/150.0.7871.128-1.1

SHA256 values taken from GitHub release asset digests for installer and portable zip assets (x86/x64/arm64).

Addresses #401637 (newer than requested 150.0.7871.114).

## Validation
- [x] Asset digests verified from GitHub Releases API
- [ ] Windows install validation (CI)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/405983)