### PR TITLE
New package: TourneyTek.PokerHawk version 1.12.0

### DIFF
--- a/manifests/t/TourneyTek/PokerHawk/1.12.0/TourneyTek.PokerHawk.installer.yaml
+++ b/manifests/t/TourneyTek/PokerHawk/1.12.0/TourneyTek.PokerHawk.installer.yaml
@@ -6,7 +6,7 @@ InstallerLocale: en-US
 Platform:
 - Windows.Desktop
 MinimumOSVersion: 10.0.0.0
-InstallerType: nsis
+InstallerType: nullsoft
 Scope: user
 InstallModes:
 - interactive

--- a/manifests/t/TourneyTek/PokerHawk/1.12.0/TourneyTek.PokerHawk.installer.yaml
+++ b/manifests/t/TourneyTek/PokerHawk/1.12.0/TourneyTek.PokerHawk.installer.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: TourneyTek.PokerHawk
+PackageVersion: 1.12.0
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: nsis
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+UpgradeBehavior: install
+ReleaseDate: 2026-07-21
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/TourneyTek-Inc/pokerhawk-desktop-releases/releases/download/v1.12.0/PokerHawk.exe
+  InstallerSha256: 7301B10704764D61CD6EA807D439D04B729389592EB147DD39756CE3B2FE6E2D
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/t/TourneyTek/PokerHawk/1.12.0/TourneyTek.PokerHawk.locale.en-US.yaml
+++ b/manifests/t/TourneyTek/PokerHawk/1.12.0/TourneyTek.PokerHawk.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: TourneyTek.PokerHawk
+PackageVersion: 1.12.0
+PackageLocale: en-US
+Publisher: TourneyTek, Inc.
+PublisherUrl: https://www.tourneytek.com
+PublisherSupportUrl: https://www.pokerhawk.io/support
+PackageName: Poker Hawk
+PackageUrl: https://www.pokerhawk.io/download
+License: Proprietary
+LicenseUrl: https://www.pokerhawk.io/legal/eula
+PrivacyUrl: https://www.pokerhawk.io/legal/privacy
+Copyright: Copyright (c) TourneyTek, Inc.
+ShortDescription: Poker tournament tracking and management for hosts and players.
+Description: >-
+  Poker Hawk is a poker tournament host and player companion - run live
+  tournaments with blind timers, table balancing, payouts and ICM, and
+  track your results.
+Moniker: pokerhawk
+Tags:
+- poker
+- tournament
+- poker-tournament
+- card-games
+- blind-timer
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/t/TourneyTek/PokerHawk/1.12.0/TourneyTek.PokerHawk.yaml
+++ b/manifests/t/TourneyTek/PokerHawk/1.12.0/TourneyTek.PokerHawk.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: TourneyTek.PokerHawk
+PackageVersion: 1.12.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package submission

**Poker Hawk** — a poker tournament management app for hosts and players (blind timers, table balancing, payouts/ICM, results tracking).

| | |
|---|---|
| Package | `TourneyTek.PokerHawk` |
| Version | 1.12.0 |
| Publisher | TourneyTek, Inc. |
| Homepage | https://www.pokerhawk.io/download |
| Installer | NSIS (electron-builder), x64, per-user scope, silent switch `/S` |

The installer is served from the project's official GitHub release over a
version-pinned URL (not `latest`), and is Authenticode code-signed via Azure
Trusted Signing — certificate subject `TourneyTek, Inc.`, issuer
`Microsoft ID Verified CS AOC CA 04` — and RFC3161 timestamped.

#### Validation performed

- `InstallerSha256` computed directly from the binary at the pinned `InstallerUrl`
- All metadata URLs (publisher, support, package, license, privacy) verified reachable
- Manifests parse cleanly and are consistent across all three files (schema 1.6.0)

#### Note

These manifests were authored and submitted from macOS, so they have **not**
been run through `winget validate` / a local sandbox install — I'm relying on
the pipeline validation here. Happy to correct anything it flags.

I'm the publisher of this package.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/406042)