### PR TITLE
New version: KeeperSecurity.KeeperSecretsManager version 1.4.0

### DIFF
--- a/manifests/k/KeeperSecurity/KeeperSecretsManager/1.4.0/KeeperSecurity.KeeperSecretsManager.installer.yaml
+++ b/manifests/k/KeeperSecurity/KeeperSecretsManager/1.4.0/KeeperSecurity.KeeperSecretsManager.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: KeeperSecurity.KeeperSecretsManager
+PackageVersion: 1.4.0
+ReleaseDate: 2026-06-17
+InstallerType: inno
+Installers:
+- Architecture: x64
+  ProductCode: '{9ef23836-40d1-11ec-a3d1-bf41427d20f6}'
+  InstallerUrl: https://github.com/Keeper-Security/secrets-manager/releases/download/ksm-cli-1.4.0/keeper-secrets-manager-cli-windows-1.4.0.exe
+  InstallerSha256: A407CCA5C828257A5970D445D0BD01FA69AE99093F18A56FF79CB659D502B048
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/k/KeeperSecurity/KeeperSecretsManager/1.4.0/KeeperSecurity.KeeperSecretsManager.locale.en-US.yaml
+++ b/manifests/k/KeeperSecurity/KeeperSecretsManager/1.4.0/KeeperSecurity.KeeperSecretsManager.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: KeeperSecurity.KeeperSecretsManager
+PackageVersion: 1.4.0
+PackageLocale: en-US
+Publisher: Keeper Security, Inc.
+PackageName: Keeper Secrets Manager
+PackageUrl: https://github.com/Keeper-Security/secrets-manager
+License: MIT
+ShortDescription: A component of the Keeper Enterprise and KeeperPAM platform. KSM provides your DevOps, IT Security and software development teams with a fully cloud-based platform for managing all of your infrastructure secrets and any type of confidential data.
+Tags:
+- keeper-secrets-manager-cli
+- keepersecretsmanagercli
+- ksm-cli
+- ksmcli
+- keeper-enterprise
+- keeperenterprise
+- keeperpam
+- keeper-pam
+- keeper-ksm
+- keeperksm
+- requirescmd
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/k/KeeperSecurity/KeeperSecretsManager/1.4.0/KeeperSecurity.KeeperSecretsManager.yaml
+++ b/manifests/k/KeeperSecurity/KeeperSecretsManager/1.4.0/KeeperSecurity.KeeperSecretsManager.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: KeeperSecurity.KeeperSecretsManager
+PackageVersion: 1.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds version 1.4.0 of the Keeper Secrets Manager CLI (`KeeperSecurity.KeeperSecretsManager`).

This is the first official Keeper-submitted version. The prior v1.3.0 manifest was submitted by a community member (PR #357543) with two issues this corrects:
- Architecture was listed as `x86`; the binary is built with `actions/setup-python architecture: x64` + PyInstaller, making it a native x64 executable.
- `ProductCode` was absent; it is now set to the static `AppId` from the Inno Setup script (`{9ef23836-40d1-11ec-a3d1-bf41427d20f6}`), enabling `winget upgrade` detection.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)