### PR TITLE
New version: cadwal.BookDB version 3.1.0

### DIFF
--- a/manifests/c/cadwal/BookDB/3.1.0/cadwal.BookDB.installer.yaml
+++ b/manifests/c/cadwal/BookDB/3.1.0/cadwal.BookDB.installer.yaml
@@ -1,0 +1,26 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: cadwal.BookDB
+PackageVersion: 3.1.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: BookDB.Desktop.exe
+  PortableCommandAlias: bookdb
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.DotNet.Runtime.10
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/cadwal/BookDB/releases/download/v3.1.0/BookDB-v3.1.0-win-x64-fdd.zip
+  InstallerSha256: EE981D57A70EF90758C270206B4A9441B9F350F6F45FAA9D7CED5107552B3273
+- Architecture: arm64
+  InstallerUrl: https://github.com/cadwal/BookDB/releases/download/v3.1.0/BookDB-v3.1.0-win-arm64-fdd.zip
+  InstallerSha256: 524AC553FAAFD3D228A33A19C201BEC8D9179CC99D6C747FC61DB88DB26394AB
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-07-22

--- a/manifests/c/cadwal/BookDB/3.1.0/cadwal.BookDB.locale.en-US.yaml
+++ b/manifests/c/cadwal/BookDB/3.1.0/cadwal.BookDB.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: cadwal.BookDB
+PackageVersion: 3.1.0
+PackageLocale: en-US
+Publisher: cadwal
+PublisherUrl: https://github.com/cadwal
+PublisherSupportUrl: https://github.com/cadwal/BookDB/issues
+PackageName: BookDB
+PackageUrl: https://github.com/cadwal/BookDB
+License: MIT
+ShortDescription: A personal book catalog for Windows
+Description: A book catalog database for personal collections. Can import data from Readerware 4.
+Tags:
+- books
+- catalog
+- library
+ReleaseNotesUrl: https://github.com/cadwal/BookDB/releases/tag/v3.1.0
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/cadwal/BookDB/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/cadwal/BookDB/3.1.0/cadwal.BookDB.yaml
+++ b/manifests/c/cadwal/BookDB/3.1.0/cadwal.BookDB.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: cadwal.BookDB
+PackageVersion: 3.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Version bump of **cadwal.BookDB** to **3.1.0** (x64 + arm64 framework-dependent installers), generated with wingetcreate. Release notes: https://github.com/cadwal/BookDB/releases/tag/v3.1.0

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
