### PR TITLE
New package: soldforaloss.DevHUD version 0.1.0

### DIFF
--- a/manifests/s/soldforaloss/DevHUD/0.1.0/soldforaloss.DevHUD.installer.yaml
+++ b/manifests/s/soldforaloss/DevHUD/0.1.0/soldforaloss.DevHUD.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: soldforaloss.DevHUD
+PackageVersion: 0.1.0
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/soldforaloss/dev-hud/releases/download/v0.1.0/dev-hud_0.1.0_x64-setup.exe
+  InstallerSha256: E9E140EFFD1E97C4D6AC488AC5A4F177D42BEF39F00DB70823D363F8A1907E12
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/soldforaloss/DevHUD/0.1.0/soldforaloss.DevHUD.locale.en-US.yaml
+++ b/manifests/s/soldforaloss/DevHUD/0.1.0/soldforaloss.DevHUD.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: soldforaloss.DevHUD
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Tommy Rush
+PublisherUrl: https://github.com/soldforaloss
+PublisherSupportUrl: https://github.com/soldforaloss/dev-hud/issues
+PackageName: Dev HUD
+PackageUrl: https://github.com/soldforaloss/dev-hud
+License: MIT
+LicenseUrl: https://github.com/soldforaloss/dev-hud/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Tommy Rush
+ShortDescription: Always-on desktop HUD for your AI dev stack
+Description: |-
+  One glass widget, pinned to your desktop, showing live Claude and Codex rate-limit rings and burn, active AI sessions, your GitHub repos' pulse (CI, PRs, issues, releases), gateway health, and system/hardware telemetry (CPU, RAM, GPU, thermals, disks, network quality, Docker, WSL, Tailscale, and more). Built with Tauri 2 — small, native, no Electron.
+Moniker: dev-hud
+Tags:
+- ai
+- claude
+- codex
+- dashboard
+- desktop-widget
+- developer-tools
+- hud
+- monitoring
+- tauri
+- widget
+ReleaseNotesUrl: https://github.com/soldforaloss/dev-hud/releases/tag/v0.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/soldforaloss/DevHUD/0.1.0/soldforaloss.DevHUD.yaml
+++ b/manifests/s/soldforaloss/DevHUD/0.1.0/soldforaloss.DevHUD.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: soldforaloss.DevHUD
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/README.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? *(LocalManifestFiles policy is disabled on this machine; the referenced NSIS installer is the exact asset published on the GitHub release and installs per-user. Happy to rely on pipeline validation.)*
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

New package: **Dev HUD** — an always-on desktop HUD for AI-assisted development (Claude/Codex usage rings, repo pulse, system/hardware telemetry). Open source (MIT), Tauri 2 NSIS installer, per-user scope.

- Homepage: https://github.com/soldforaloss/dev-hud
- Release: https://github.com/soldforaloss/dev-hud/releases/tag/v0.1.0