### PR TITLE
New package: AinurNishanov.MeetingNote version 0.3.1

### DIFF
--- a/manifests/a/AinurNishanov/MeetingNote/0.3.1/AinurNishanov.MeetingNote.installer.yaml
+++ b/manifests/a/AinurNishanov/MeetingNote/0.3.1/AinurNishanov.MeetingNote.installer.yaml
@@ -1,0 +1,20 @@
+# Created with WinGetCreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: AinurNishanov.MeetingNote
+PackageVersion: 0.3.1
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-07-22
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/ainishanov/meeting-note/releases/download/v0.3.1/MeetingNoteSetup-v0.3.1.exe
+    InstallerSha256: 449914D9E3FA6E4D1D99ABA02C589CD123288E23D4F362CB2E8ED518F6734210
+    ProductCode: "{1B587C4E-8AB8-4E16-9369-9DB81899AE2D}_is1"
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/AinurNishanov/MeetingNote/0.3.1/AinurNishanov.MeetingNote.locale.en-US.yaml
+++ b/manifests/a/AinurNishanov/MeetingNote/0.3.1/AinurNishanov.MeetingNote.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# Created with WinGetCreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: AinurNishanov.MeetingNote
+PackageVersion: 0.3.1
+PackageLocale: en-US
+Publisher: Ainur Nishanov
+PublisherUrl: https://github.com/ainishanov
+PublisherSupportUrl: https://github.com/ainishanov/meeting-note/issues
+PrivacyUrl: https://ainishanov.github.io/meeting-note/privacy/
+PackageName: Meeting Note
+PackageUrl: https://ainishanov.github.io/meeting-note/
+License: MIT
+LicenseUrl: https://github.com/ainishanov/meeting-note/blob/v0.3.1/LICENSE
+Copyright: Copyright (c) 2026 Meeting Note contributors
+ShortDescription: Turn calls into searchable transcripts, decisions, and action items.
+Description: Meeting Note records Windows call audio, creates a transcript and summary, and keeps a searchable local meeting history.
+Moniker: meeting-note
+Tags:
+  - ai
+  - meeting-notes
+  - transcription
+  - windows
+ReleaseNotesUrl: https://github.com/ainishanov/meeting-note/releases/tag/v0.3.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/AinurNishanov/MeetingNote/0.3.1/AinurNishanov.MeetingNote.locale.ru-RU.yaml
+++ b/manifests/a/AinurNishanov/MeetingNote/0.3.1/AinurNishanov.MeetingNote.locale.ru-RU.yaml
@@ -1,0 +1,17 @@
+# Created with WinGetCreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: AinurNishanov.MeetingNote
+PackageVersion: 0.3.1
+PackageLocale: ru-RU
+Publisher: Айнур Нишанов
+PackageName: Meeting Note
+ShortDescription: Превращает созвоны в расшифровки, решения и задачи с поиском.
+Description: Meeting Note записывает звук созвона в Windows, создаёт расшифровку и итоги и сохраняет локальную историю встреч с поиском.
+Tags:
+  - встречи
+  - искусственный-интеллект
+  - расшифровка
+  - транскрибация
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/a/AinurNishanov/MeetingNote/0.3.1/AinurNishanov.MeetingNote.yaml
+++ b/manifests/a/AinurNishanov/MeetingNote/0.3.1/AinurNishanov.MeetingNote.yaml
@@ -1,0 +1,8 @@
+# Created with WinGetCreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: AinurNishanov.MeetingNote
+PackageVersion: 0.3.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Adds Meeting Note 0.3.1, an open-source Windows desktop app that turns calls into searchable transcripts, decisions, and action items.

## Manifest checklist

- [x] No open PR exists for this package identifier
- [x] `winget validate --manifest packaging\winget\0.3.1` passed
- [x] Published installer URL returns HTTP 200
- [x] Downloaded installer SHA-256 matches the manifest
- [x] Silent install, application launch, and silent uninstall were tested
- [x] Manifest uses the 1.12 schema
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/406163)