### PR TITLE
New version: XxDoomsdayxX.GitPulse version 1.1.0

### DIFF
--- a/manifests/x/XxDoomsdayxX/GitPulse/1.1.0/XxDoomsdayxX.GitPulse.installer.yaml
+++ b/manifests/x/XxDoomsdayxX/GitPulse/1.1.0/XxDoomsdayxX.GitPulse.installer.yaml
@@ -1,0 +1,18 @@
+PackageIdentifier: XxDoomsdayxX.GitPulse
+PackageVersion: 1.1.0
+InstallerType: nullsoft
+InstallModes:
+  - silent
+  - silentWithProgress
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/XxDoomsdayxX/GitPulse/releases/download/v1.1.0/GitPulse-Setup-1.1.0.exe
+    InstallerSha256: A95BE55D509AE0285D3CF403726D836F4AF7E1E3C5206FE775D62EDE130D019A
+    InstallerSwitches:
+      Silent: /S
+      SilentWithProgress: /S
+    ProductCode: '{b137bd44-493a-51bb-b872-fe5fc39866cd}'
+    Scope: user
+    UpgradeBehavior: install
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/x/XxDoomsdayxX/GitPulse/1.1.0/XxDoomsdayxX.GitPulse.locale.en-US.yaml
+++ b/manifests/x/XxDoomsdayxX/GitPulse/1.1.0/XxDoomsdayxX.GitPulse.locale.en-US.yaml
@@ -1,0 +1,27 @@
+PackageIdentifier: XxDoomsdayxX.GitPulse
+PackageVersion: 1.1.0
+PackageLocale: en-US
+Publisher: XxDoomsdayxX
+PublisherUrl: https://github.com/XxDoomsdayxX
+PublisherSupportUrl: https://github.com/XxDoomsdayxX/GitPulse/issues
+PackageName: GitPulse
+PackageUrl: https://github.com/XxDoomsdayxX/GitPulse
+License: MIT
+LicenseUrl: https://github.com/XxDoomsdayxX/GitPulse/blob/main/LICENSE
+ShortDescription: Always-on-top desktop widget that shows your GitHub repo sync status at a glance.
+Description: |-
+  GitPulse sits in the corner of your screen watching a list of GitHub repositories.
+  When new commits land on any of them, its dot turns red and tells you how many
+  commits you are behind. Click Pull and it fast-forwards your local clone, after
+  verifying the folder really is a clone of that repository. When everything is in
+  sync it stays green and silent.
+Tags:
+  - github
+  - git
+  - developer-tools
+  - widget
+  - productivity
+  - electron
+ReleaseNotesUrl: https://github.com/XxDoomsdayxX/GitPulse/releases/tag/v1.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/x/XxDoomsdayxX/GitPulse/1.1.0/XxDoomsdayxX.GitPulse.yaml
+++ b/manifests/x/XxDoomsdayxX/GitPulse/1.1.0/XxDoomsdayxX.GitPulse.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: XxDoomsdayxX.GitPulse
+PackageVersion: 1.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New version: XxDoomsdayxX.GitPulse version 1.1.0

Submitted by the package publisher for their own release.

- [x] Manifests validated locally: `winget validate --manifest <path>` -> "Manifest validation succeeded."
- [x] No other open pull requests for this package.
- [x] Conforms to the 1.6 manifest schema (same shape as the existing 1.0.1 manifests).
- [ ] Local `winget install --manifest <path>` test not yet run - the installer in the URL is the exact artifact published by the release pipeline, SHA256 verified against the uploaded asset.
- [ ] CLA: will be signed via the bot if not already on file.

Release: https://github.com/XxDoomsdayxX/GitPulse/releases/tag/v1.1.0
Changes: multi-repo watchlist, verified fast-forward pulls, desktop notifications, auto-update.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/406176)