### PR TITLE
New package: CCGnomes.VaultFlasher version 0.1.0

### DIFF
--- a/manifests/c/CCGnomes/VaultFlasher/0.1.0/CCGnomes.VaultFlasher.installer.yaml
+++ b/manifests/c/CCGnomes/VaultFlasher/0.1.0/CCGnomes.VaultFlasher.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: CCGnomes.VaultFlasher
+PackageVersion: 0.1.0
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Protocols:
+  - vaultflasher
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/markCCGnomes/vault-flasher-releases/releases/download/v0.1.0/VaultFlasher-x64-setup.exe
+    InstallerSha256: F9E76DEEC41552173812BF244AB490E438C14E1E1E9F29571F81627AB81A1263
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/c/CCGnomes/VaultFlasher/0.1.0/CCGnomes.VaultFlasher.locale.en-US.yaml
+++ b/manifests/c/CCGnomes/VaultFlasher/0.1.0/CCGnomes.VaultFlasher.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: CCGnomes.VaultFlasher
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: CCGnomes
+PublisherUrl: https://ccgnomes.com
+PublisherSupportUrl: https://ccgnomes.com/vaultnode/setup/
+PackageName: Vault Flasher
+PackageUrl: https://github.com/markCCGnomes/vault-flasher-releases
+License: Vault Ecosystem License v1.1
+LicenseUrl: https://github.com/markCCGnomes/vault-flasher-releases/blob/main/LICENSE
+Copyright: Copyright (c) 2026 CCGnomes
+ShortDescription: One-click USB flasher for Vault Node images
+Description: >-
+  Vault Flasher downloads the official Vault Node image, verifies its SHA-256
+  against the release's published digest, and writes it to a removable USB
+  drive with a single click — with a read-back verification pass and optional
+  WiFi presetting. It only ever offers removable USB drives (never an internal
+  or system disk) and re-validates the target inside its elevated writer.
+Moniker: vault-flasher
+Tags:
+  - flasher
+  - usb
+  - vault-node
+  - imaging
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/c/CCGnomes/VaultFlasher/0.1.0/CCGnomes.VaultFlasher.yaml
+++ b/manifests/c/CCGnomes/VaultFlasher/0.1.0/CCGnomes.VaultFlasher.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: CCGnomes.VaultFlasher
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

First submission of Vault Flasher — a one-click USB flasher for Vault Node
images by CCGnomes (we are the publisher; the installer is our own build,
hosted on our public releases mirror). `winget validate` passes; the
InstallerUrl downloads anonymously and its SHA-256 matches the manifest.
Local `winget install --manifest` wasn't run (LocalManifestFiles requires an
elevated policy change on the build box), but the exact installer has been
installed and exercised directly.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/406278)