### PR TITLE
New package: napxlexn.AILimits version 0.5.3

### DIFF
--- a/manifests/n/napxlexn/AILimits/0.5.3/napxlexn.AILimits.installer.yaml
+++ b/manifests/n/napxlexn/AILimits/0.5.3/napxlexn.AILimits.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: napxlexn.AILimits
+PackageVersion: 0.5.3
+MinimumOSVersion: 10.0.22000.0
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-07-23
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/napxlexn/ailimits/releases/download/v0.5.3/AiLimits-Setup-0.5.3.exe
+    InstallerSha256: E9C050C0A60B5D855B29ABC2FF0AF4B3ED0528F7913BBE0B464CBBE81B8B5185
+    ProductCode: '{7A1B9C44-5E2D-4F8A-9C3B-AILIMITS0001}_is1'
+    AppsAndFeaturesEntries:
+      - DisplayName: AI Limits
+        Publisher: napxlexn
+        DisplayVersion: 0.5.3
+        ProductCode: '{7A1B9C44-5E2D-4F8A-9C3B-AILIMITS0001}_is1'
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/n/napxlexn/AILimits/0.5.3/napxlexn.AILimits.locale.en-US.yaml
+++ b/manifests/n/napxlexn/AILimits/0.5.3/napxlexn.AILimits.locale.en-US.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: napxlexn.AILimits
+PackageVersion: 0.5.3
+PackageLocale: en-US
+Publisher: napxlexn
+PublisherUrl: https://github.com/napxlexn
+PublisherSupportUrl: https://github.com/napxlexn/ailimits/issues
+PackageName: AI Limits
+PackageUrl: https://github.com/napxlexn/ailimits
+License: GPL-3.0-or-later
+LicenseUrl: https://github.com/napxlexn/ailimits/blob/v0.5.3/LICENSE
+Copyright: Copyright (c) 2026 napxlexn
+ShortDescription: A tiny native Windows 11 overlay showing your AI provider usage limits.
+Description: >-
+  AI Limits is a tiny native Windows 11 floating overlay that shows your AI
+  provider usage limits right on the desktop: Claude, OpenAI Codex, GitHub
+  Copilot, and Google Antigravity. It uses authentication already stored by
+  official CLI tools or credentials explicitly added by the user, does not
+  refresh CLI tokens, and sends no telemetry. It needs no admin rights, ships
+  statically linked with no extra runtime, and has a low idle resource
+  footprint. A taskbar indicator keeps usage visible even when the overlay is
+  hidden.
+Moniker: ailimits
+Tags:
+  - ai
+  - claude
+  - codex
+  - copilot
+  - antigravity
+  - gemini
+  - usage
+  - overlay
+  - widget
+  - monitor
+  - tray
+ReleaseNotesUrl: https://github.com/napxlexn/ailimits/releases/tag/v0.5.3
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/n/napxlexn/AILimits/0.5.3/napxlexn.AILimits.yaml
+++ b/manifests/n/napxlexn/AILimits/0.5.3/napxlexn.AILimits.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: napxlexn.AILimits
+PackageVersion: 0.5.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Adds the first WinGet manifest for AI Limits 0.5.3, using the publisher-hosted x64 per-user Inno Setup installer from the versioned GitHub release.

Local verification:
- `winget validate --manifest manifests/n/napxlexn/AILimits/0.5.3` succeeds with schema 1.12.
- The manifest SHA-256 matches the published GitHub release asset.
- Microsoft `SandboxTest.ps1` installed the manifest successfully in Windows Sandbox; the main executable, auth helper, GPL license, and trademark policy were present.

## Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (not applicable for this new package submission)

## Manifest Checklist

- [x] Checked that there are no other open pull requests for the same manifest
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the 1.12 schema
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/406292)
