### PR TITLE
New package: Stipple.VoiceNote version 0.1.13

### DIFF
--- a/manifests/s/Stipple/VoiceNote/0.1.13/Stipple.VoiceNote.installer.yaml
+++ b/manifests/s/Stipple/VoiceNote/0.1.13/Stipple.VoiceNote.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: Stipple.VoiceNote
+PackageVersion: 0.1.13
+InstallerLocale: en-US
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://storage.googleapis.com/voicenote-stipple/downloads/voicenote-0.1.13-windows-x64.exe
+    InstallerSha256: 583107C9191C1F006BB9D38D83F2E4A090D7E2466C0B0ADC5B3EAE8AFCF1E846
+  - Architecture: arm64
+    InstallerUrl: https://storage.googleapis.com/voicenote-stipple/downloads/voicenote-0.1.13-windows-arm64.exe
+    InstallerSha256: 0953DBD4FE6A6700B1722221B1B72869DBEAA4B20359E603DDC989F3C1738679
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/s/Stipple/VoiceNote/0.1.13/Stipple.VoiceNote.locale.en-US.yaml
+++ b/manifests/s/Stipple/VoiceNote/0.1.13/Stipple.VoiceNote.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: Stipple.VoiceNote
+PackageVersion: 0.1.13
+PackageLocale: en-US
+Publisher: Stipple AI
+PublisherUrl: https://voicenote.au
+PublisherSupportUrl: https://voicenote.au/contact
+Author: Stipple AI
+PackageName: VoiceNote
+PackageUrl: https://voicenote.au
+License: Proprietary
+LicenseUrl: https://voicenote.au/terms
+Copyright: Copyright (c) Stipple AI
+ShortDescription: Private, on-device dictation and meeting notes. Your voice never leaves your machine.
+Description: >-
+  VoiceNote is private, on-device dictation and meeting transcription for Windows and Mac.
+  Hold a key and your speech becomes finished text in any app; record meetings with no bot
+  joining the call. Everything runs locally, nothing is uploaded, and it is a one-time purchase.
+Moniker: voicenote
+Tags:
+  - dictation
+  - voice-to-text
+  - speech-to-text
+  - transcription
+  - meeting-notes
+  - productivity
+  - offline
+  - privacy
+ReleaseNotesUrl: https://voicenote.au/changelog
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/s/Stipple/VoiceNote/0.1.13/Stipple.VoiceNote.yaml
+++ b/manifests/s/Stipple/VoiceNote/0.1.13/Stipple.VoiceNote.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: Stipple.VoiceNote
+PackageVersion: 0.1.13
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
### New package: `Stipple.VoiceNote` version `0.1.13`

VoiceNote — private, on-device dictation and meeting transcription for Windows (x64 + native ARM64) and Mac. Everything runs locally; nothing is uploaded.

- **Manifest:** multi-arch, `InstallerType: nullsoft`, `Scope: user`, `InstallModes: [silent, silentWithProgress]`, schema 1.9.0.
- **Validated locally:** `winget validate --manifest` → **succeeded**.
- **Why draft:** I can't run `SandboxTest.ps1` locally (Windows **Home** — no Windows Sandbox), so I'm opening this as a Draft to let the validation pipeline run the sandbox install and report. I'll mark Ready once it's green.
- **Transparency:** the installer is **not yet Authenticode code-signed** — flagging in case that affects SmartScreen / the security scan; part of what I'm hoping the pipeline confirms.

#### Microsoft Reviewers: Open `SearchUI.exe` … n/a — checklist:
- [x] Validated the manifest with `winget validate`.
- [ ] Tested with `winget install --manifest` (blocked: no Windows Sandbox on Home — requesting pipeline validation).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/406308)