### PR TITLE
New version: SerZhyAle.FastMediaSorter version 26.7.23.1127

### DIFF
--- a/manifests/s/SerZhyAle/FastMediaSorter/26.7.23.1127/SerZhyAle.FastMediaSorter.installer.yaml
+++ b/manifests/s/SerZhyAle/FastMediaSorter/26.7.23.1127/SerZhyAle.FastMediaSorter.installer.yaml
@@ -1,0 +1,16 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: SerZhyAle.FastMediaSorter
+PackageVersion: 26.7.23.1127
+InstallerType: inno
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/SerZhyAle/FastMediaSorter_Lite/releases/download/v26.7.23.1127/FastMediaSorter-26.7.23.1127-windows-x64-setup.exe
+  InstallerSha256: 8C058C5501A09E434AD55409D6933948965E37446485BD428214B6E473525AA7
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-07-23

--- a/manifests/s/SerZhyAle/FastMediaSorter/26.7.23.1127/SerZhyAle.FastMediaSorter.locale.en-US.yaml
+++ b/manifests/s/SerZhyAle/FastMediaSorter/26.7.23.1127/SerZhyAle.FastMediaSorter.locale.en-US.yaml
@@ -1,0 +1,44 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: SerZhyAle.FastMediaSorter
+PackageVersion: 26.7.23.1127
+PackageLocale: en-US
+Publisher: SZA
+PublisherUrl: https://github.com/SerZhyAle
+PublisherSupportUrl: https://github.com/SerZhyAle/FastMediaSorter_Lite/issues
+Author: Serhii Zhyhunenko
+PackageName: FastMediaSorter LITE
+PackageUrl: https://github.com/SerZhyAle/FastMediaSorter_Lite
+License: MIT
+LicenseUrl: https://github.com/SerZhyAle/FastMediaSorter_Lite/blob/main/LICENSE
+Copyright: Copyright (c) 2025 SZA
+ShortDescription: Lightweight Windows utility for fast sorting of images and videos with hotkeys.
+Description: |-
+  FastMediaSorter LITE is a Windows Forms application for quickly sorting, viewing, and managing
+  image and video files. It supports a wide range of media formats, slideshow and random viewing
+  modes, recent files tracking, and fast move/copy/rename/delete operations bound to hotkeys —
+  designed for photographers and content creators who triage large folders of media efficiently.
+Moniker: fastmediasorter
+Tags:
+- file-manager
+- hotkeys
+- images
+- media
+- organizer
+- photos
+- pictures
+- portable
+- slideshow
+- sorter
+- triage
+- utility
+- videos
+- viewer
+- winforms
+ReleaseNotesUrl: https://github.com/SerZhyAle/FastMediaSorter_Lite/releases/tag/v26.7.23.1127
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/SerZhyAle/FastMediaSorter_Lite/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/SerZhyAle/FastMediaSorter/26.7.23.1127/SerZhyAle.FastMediaSorter.locale.en-US.yaml
+++ b/manifests/s/SerZhyAle/FastMediaSorter/26.7.23.1127/SerZhyAle.FastMediaSorter.locale.en-US.yaml
@@ -13,12 +13,24 @@ PackageUrl: https://github.com/SerZhyAle/FastMediaSorter_Lite
 License: MIT
 LicenseUrl: https://github.com/SerZhyAle/FastMediaSorter_Lite/blob/main/LICENSE
 Copyright: Copyright (c) 2025 SZA
-ShortDescription: Lightweight Windows utility for fast sorting of images and videos with hotkeys.
+ShortDescription: Fast Media Sorter for Windows - keyboard-driven viewer and sorter for images and videos, now a modern 64-bit build that needs no .NET Framework.
 Description: |-
-  FastMediaSorter LITE is a Windows Forms application for quickly sorting, viewing, and managing
-  image and video files. It supports a wide range of media formats, slideshow and random viewing
-  modes, recent files tracking, and fast move/copy/rename/delete operations bound to hotkeys —
-  designed for photographers and content creators who triage large folders of media efficiently.
+  Fast Media Sorter for Windows (published here as "FastMediaSorter LITE") is a fast, keyboard-driven
+  viewer and sorter for images and video on Windows. Tick folders to browse, then move, copy, rename or
+  delete files with single-key hotkeys - built for photographers and creators who triage large media
+  folders quickly. It handles a wide range of formats, slideshow and random modes, EXIF auto-rotate, an
+  Ambilight-style background fill, and optional on-image OCR translation.
+
+  The main program is now a 64-bit .NET 10 build that carries its own runtime - there is nothing extra
+  to install and no .NET Framework requirement. It replaces the previous version in place and keeps
+  your settings. Video always plays through the built-in VLC engine (H.264/MP4, AVI, MKV, VP9, ZMBV and
+  more), and static and animated WEBP images open on their own, without the Windows "WebP Image
+  Extensions" codec that some editions of Windows lack.
+
+  A 32-bit build with the same feature set ships alongside it for Windows 7/8.1 and 32-bit machines.
+  The installer picks the right one for your PC automatically and points the shortcut and file
+  associations at it, so there is nothing to choose. The 64-bit main program requires Windows 10
+  version 1607 or newer, Windows 11, or Windows Server 2016 or newer.
 Moniker: fastmediasorter
 Tags:
 - file-manager
@@ -28,7 +40,6 @@ Tags:
 - organizer
 - photos
 - pictures
-- portable
 - slideshow
 - sorter
 - triage

--- a/manifests/s/SerZhyAle/FastMediaSorter/26.7.23.1127/SerZhyAle.FastMediaSorter.yaml
+++ b/manifests/s/SerZhyAle/FastMediaSorter/26.7.23.1127/SerZhyAle.FastMediaSorter.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: SerZhyAle.FastMediaSorter
+PackageVersion: 26.7.23.1127
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Update **SerZhyAle.FastMediaSorter** to **26.7.23.1127**.

This release replaces the previous program in place with a new 64-bit .NET 10 mainline (`FastMediaSorter_LITE.exe`, self-contained, no .NET Framework needed) shipped side by side with a lean 32-bit fallback for Windows 7/8.1. Highlights: HEIC/HEIF/AVIF and animated WEBP images open natively, video always plays through the bundled VLC engine, plus zoom-at-cursor, audio/subtitle track picking, "Open URL..", background (non-blocking) file operations, a video control bar, and a raft of fixes across browsing, file operations, slideshow and window-state handling.

- Release: https://github.com/SerZhyAle/FastMediaSorter_Lite/releases/tag/v26.7.23.1127
- Changelog: https://github.com/SerZhyAle/FastMediaSorter_Lite/blob/main/CHANGELOG.md

Installer shape is unchanged from prior accepted versions: direct Inno `setup.exe` (`InstallerType: inno`), no declared dependencies, no `Scope`. Only the version, installer SHA256, and the ShortDescription/Description text (rebrand copy, `PackageName` stays frozen) changed.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
