### PR TITLE
New version: SerZhyAle.StreamsPlayer version 26.0723.1040

### DIFF
--- a/manifests/s/SerZhyAle/StreamsPlayer/26.0723.1040/SerZhyAle.StreamsPlayer.installer.yaml
+++ b/manifests/s/SerZhyAle/StreamsPlayer/26.0723.1040/SerZhyAle.StreamsPlayer.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: SerZhyAle.StreamsPlayer
+PackageVersion: 26.0723.1040
+InstallerType: zip
+NestedInstallerType: portable
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+NestedInstallerFiles:
+- RelativeFilePath: StreamsPlayer.exe
+  PortableCommandAlias: streamsplayer
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/SerZhyAle/StreamsPlayer/releases/download/v26.0723.1040/StreamsPlayer-26.0723.1040-windows-x64.zip
+  InstallerSha256: 8E2A1924B2CCE266DD226673B691033B4C919721D34311328015247E0239D066
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/SerZhyAle/StreamsPlayer/26.0723.1040/SerZhyAle.StreamsPlayer.locale.en-US.yaml
+++ b/manifests/s/SerZhyAle/StreamsPlayer/26.0723.1040/SerZhyAle.StreamsPlayer.locale.en-US.yaml
@@ -1,0 +1,42 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: SerZhyAle.StreamsPlayer
+PackageVersion: 26.0723.1040
+PackageLocale: en-US
+Publisher: SerZhyAle
+PublisherUrl: https://github.com/SerZhyAle
+PublisherSupportUrl: https://github.com/SerZhyAle/StreamsPlayer/issues
+PrivacyUrl: https://serzhyale.github.io/StreamsPlayer/privacy.html
+PackageName: STREAMS Player
+PackageUrl: https://serzhyale.github.io/StreamsPlayer/
+License: MIT
+LicenseUrl: https://github.com/SerZhyAle/StreamsPlayer/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Serhii Zhyhunenko
+Moniker: streamsplayer
+ShortDescription: Browse internet radio and live video in a focused Windows stream catalog.
+Description: STREAMS Player is an English and Russian Windows desktop app for browsing a curated internet radio, live video, and RTSP address catalog. Search, filter, pin, and add streams; choose List or Grid mode with optional live thumbnails; and open video with always-on-top and fullscreen controls. Catalog refresh is explicit, local state stays on the device, and the app has no account, advertising, analytics, or telemetry. Playback compatibility varies by provider, protocol, and codec.
+Tags:
+- radio
+- streaming
+- video
+- rtsp
+- live-tv
+- iptv
+- windows
+ReleaseNotes: |-
+  Update with new features and fixes.
+  - Now-playing track titles for radio streams (ICY metadata).
+  - Automatic reconnection when a live stream drops.
+  - Import and export playlists in M3U format.
+  - Stream bitrate and quality details, with a minimum-bitrate filter.
+  - Listening history of recently played channels.
+  - Hide channels you do not want and report broken streams.
+  - Windows System Media Transport Controls and media-key support.
+  - Save the current video frame as a channel icon.
+  - Pinned channels band for quick access.
+  - Selectable video backend (LibVLC or Flyleaf/FFmpeg).
+  - Option to keep the screen awake during playback.
+  - Reorganized, tabbed Settings window.
+ReleaseNotesUrl: https://github.com/SerZhyAle/StreamsPlayer/releases/tag/v26.0723.1040
+ReleaseDate: 2026-07-23
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/SerZhyAle/StreamsPlayer/26.0723.1040/SerZhyAle.StreamsPlayer.locale.ru-RU.yaml
+++ b/manifests/s/SerZhyAle/StreamsPlayer/26.0723.1040/SerZhyAle.StreamsPlayer.locale.ru-RU.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+PackageIdentifier: SerZhyAle.StreamsPlayer
+PackageVersion: 26.0723.1040
+PackageLocale: ru-RU
+Publisher: SerZhyAle
+PublisherUrl: https://github.com/SerZhyAle
+PublisherSupportUrl: https://github.com/SerZhyAle/StreamsPlayer/issues
+PrivacyUrl: https://serzhyale.github.io/StreamsPlayer/privacy.html
+PackageName: Трансляции
+PackageUrl: https://serzhyale.github.io/StreamsPlayer/
+License: MIT
+LicenseUrl: https://github.com/SerZhyAle/StreamsPlayer/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Serhii Zhyhunenko
+ShortDescription: Каталог интернет-радио и live-видео для Windows с русским интерфейсом.
+Description: Трансляции — приложение Windows с русским и английским интерфейсом для просмотра каталога интернет-радио, live-видео и адресов RTSP. Ищите, фильтруйте, закрепляйте и добавляйте потоки; выбирайте список или сетку с отключаемыми живыми миниатюрами; открывайте видео поверх окон или во весь экран. Каталог обновляется только по команде, локальные данные остаются на устройстве, в приложении нет аккаунта, рекламы, аналитики и телеметрии. Совместимость воспроизведения зависит от поставщика, протокола и кодека.
+Tags:
+- радио
+- потоки
+- видео
+- rtsp
+- телевидение
+- iptv
+ReleaseNotes: |-
+  Обновление с новыми возможностями и исправлениями.
+  - Названия текущих треков для радиопотоков (метаданные ICY).
+  - Автоматическое переподключение при обрыве прямого эфира.
+  - Импорт и экспорт плейлистов в формате M3U.
+  - Сведения о битрейте и качестве потока, фильтр по минимальному битрейту.
+  - История недавно воспроизведённых каналов.
+  - Скрытие ненужных каналов и отправка сообщений о нерабочих потоках.
+  - Поддержка системных мультимедийных элементов и медиаклавиш Windows.
+  - Сохранение текущего кадра видео как значка канала.
+  - Панель закреплённых каналов для быстрого доступа.
+  - Выбор видеодвижка (LibVLC или Flyleaf/FFmpeg).
+  - Возможность не давать экрану гаснуть во время воспроизведения.
+  - Переработанное окно настроек с вкладками.
+ReleaseNotesUrl: https://github.com/SerZhyAle/StreamsPlayer/releases/tag/v26.0723.1040
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/s/SerZhyAle/StreamsPlayer/26.0723.1040/SerZhyAle.StreamsPlayer.yaml
+++ b/manifests/s/SerZhyAle/StreamsPlayer/26.0723.1040/SerZhyAle.StreamsPlayer.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: SerZhyAle.StreamsPlayer
+PackageVersion: 26.0723.1040
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Update **SerZhyAle.StreamsPlayer** to **26.0723.1040**.

This update adds now-playing track titles for radio streams (ICY metadata), automatic reconnection when a live stream drops, M3U playlist import/export, stream bitrate and quality details with a minimum-bitrate filter, a listening history of recently played channels, hidden channels with broken-stream reporting, Windows System Media Transport Controls and media-key support, saving the current video frame as a channel icon, a pinned-channels band, a selectable video backend (LibVLC or Flyleaf/FFmpeg), an option to keep the screen awake during playback, and a reorganized, tabbed Settings window.

- Release: https://github.com/SerZhyAle/StreamsPlayer/releases/tag/v26.0723.1040
- Changelog: https://github.com/SerZhyAle/StreamsPlayer/compare/v26.0719.0310...v26.0723.1040

Installer shape is unchanged from the prior accepted version: portable zip (`InstallerType: zip`, `NestedInstallerType: portable`), x64, no declared dependencies, no `Scope`. Only the version, `InstallerUrl`, installer SHA256, `ReleaseNotes`, `ReleaseNotesUrl`, and `ReleaseDate` changed; `ShortDescription`, `Description`, and `PackageName` stay frozen.

## Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)
- [ ] Linked to an issue (if applicable)

## Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)