### PR TITLE
New package: ibsorn.gLabels version 3.99.639

### DIFF
--- a/manifests/i/ibsorn/gLabels/3.99.639/ibsorn.gLabels.installer.yaml
+++ b/manifests/i/ibsorn/gLabels/3.99.639/ibsorn.gLabels.installer.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ibsorn.gLabels
+PackageVersion: 3.99.639
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-07-22
+# The installer is built by CPack's NSIS generator, which emits
+# "RequestExecutionLevel admin", so it elevates on its own.
+ElevationRequirement: elevatesSelf
+# CPack writes the uninstall entry to
+#   HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\gLabels 4
+# using CPACK_PACKAGE_INSTALL_REGISTRY_KEY as the subkey name.  DisplayVersion is
+# the upstream snapshot string, which does not match PackageVersion above - that
+# is exactly what this block is for.
+AppsAndFeaturesEntries:
+- DisplayName: gLabels 4 Label Designer
+  DisplayVersion: 3.99-master639
+  Publisher: glabels.org
+  ProductCode: gLabels 4
+  InstallerType: nullsoft
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/ibsorn/glabels-windows/releases/download/win-3.99-master639/gLabels-3.99-master639-win64-setup.exe
+  InstallerSha256: 670B329289E21A468199262591342EDCAE24E0B8770912CCABA9160E8CC4CA3A
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/i/ibsorn/gLabels/3.99.639/ibsorn.gLabels.locale.en-US.yaml
+++ b/manifests/i/ibsorn/gLabels/3.99.639/ibsorn.gLabels.locale.en-US.yaml
@@ -1,0 +1,46 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ibsorn.gLabels
+PackageVersion: 3.99.639
+PackageLocale: en-US
+Publisher: ibsorn
+PublisherUrl: https://github.com/ibsorn/glabels-windows
+PublisherSupportUrl: https://github.com/ibsorn/glabels-windows/issues
+Author: Jaye Evins and the gLabels contributors
+PackageName: gLabels
+PackageUrl: https://github.com/ibsorn/glabels-windows
+License: GPL-3.0-or-later
+LicenseUrl: https://github.com/j-evins/glabels-qt/blob/master/LICENSE
+Copyright: Copyright (C) Jaye Evins and contributors
+ShortDescription: Unofficial Windows build of gLabels 4, a designer for labels, business cards and barcodes.
+Description: |-
+  gLabels is a program for creating labels and business cards. It works with the sheets of
+  peel-off labels and card stock sold in office supply shops, and ships a template database
+  covering more than thirty vendors including Avery, Herma, Zweckform and Dymo. Text, images,
+  lines, shapes and barcodes can be placed on a label, and a document-merge feature fills them
+  from a CSV file or address book so an entire sheet can be personalised at once.
+  Barcode support covers the built-in glbarcode++ symbologies plus zint and libqrencode.
+  A command line renderer, glabels-batch-qt, produces PDFs without opening the interface.
+
+  This package is an unofficial community build of gLabels 4 (glabels-qt), which upstream does
+  not currently distribute for Windows. It is compiled unmodified from upstream sources by a
+  public GitHub Actions workflow and is not endorsed by or affiliated with the gLabels project.
+  Report application bugs upstream and packaging problems to this package's issue tracker.
+Moniker: glabels
+Tags:
+- avery
+- barcode
+- business-cards
+- cd-labels
+- label-designer
+- label-printing
+- labels
+- mail-merge
+- printing
+- qr-code
+ReleaseNotesUrl: https://github.com/ibsorn/glabels-windows/releases/tag/win-3.99-master639
+Documentations:
+- DocumentLabel: Upstream project
+  DocumentUrl: https://github.com/j-evins/glabels-qt
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/i/ibsorn/gLabels/3.99.639/ibsorn.gLabels.yaml
+++ b/manifests/i/ibsorn/gLabels/3.99.639/ibsorn.gLabels.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ibsorn.gLabels
+PackageVersion: 3.99.639
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package: **ibsorn.gLabels** version 3.99.639 — gLabels, a designer for labels, business cards and barcodes with a template database covering 35+ stationery vendors.

gLabels is GPLv3 software by Jaye Evins and contributors. Its Qt version (`glabels-qt`) is cross-platform and builds cleanly on Windows, but the project publishes no Windows binaries. This package therefore points at an **unofficial community build**, and the manifest is explicit about that rather than presenting itself as an upstream release:

- the identifier is namespaced under the person publishing the binaries (`ibsorn.gLabels`), not under the gLabels project;
- `Publisher` is `ibsorn`, with `Author` credited to the gLabels authors;
- the short description and the package description both say it is an unofficial build and point bug reports at the right tracker.

The installer is produced entirely by a public GitHub Actions workflow from unmodified upstream sources: https://github.com/ibsorn/glabels-windows/blob/main/.github/workflows/build-windows.yml

Upstream has been told these builds exist: https://github.com/j-evins/glabels-qt/issues/31#issuecomment-5055774938

### Notes on the manifest

- `PackageVersion` is normalised to `3.99.639` so that versions order correctly. Upstream's snapshot string (`3.99-master639`) is recorded as `AppsAndFeaturesEntries.DisplayVersion`.
- `ProductCode` is `gLabels 4`, the NSIS uninstall registry subkey. This was measured, not assumed: every build installs the packaged installer silently on a clean runner, reads the registry entry back, asserts `DisplayName`, `DisplayVersion` and `Publisher` against what this manifest claims, checks the installed tree, and then uninstalls and confirms the entry is gone. A mismatch fails the build.
- The entry lands in the 32-bit registry view, as it does for any NSIS installer that does not call `SetRegView 64`.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable) — not applicable: there is no existing gLabels issue or package request in this repository to link.

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` (winget v1.29.280, passed)
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> Tested with `winget install --manifest` on Windows 11 (winget v1.29.280). The install
> succeeded and `winget list` reports the ARP entry as
> `ARP\Machine\X86\gLabels 4` at version `3.99-master639` — matching the `ProductCode`,
> `DisplayVersion` and `Scope` this manifest declares, and confirming the 32-bit registry
> view noted above. It resolves to a synthetic ARP identifier rather than `ibsorn.gLabels`
> simply because the package is not in a source yet; that part of the correlation can only
> be exercised once this is merged.
