### PR TITLE
OleBhartvigsen.FanFolder version 1.2.2

### DIFF
--- a/manifests/o/OleBhartvigsen/FanFolder/1.2.2/OleBhartvigsen.FanFolder.installer.yaml
+++ b/manifests/o/OleBhartvigsen/FanFolder/1.2.2/OleBhartvigsen.FanFolder.installer.yaml
@@ -1,0 +1,33 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: OleBhartvigsen.FanFolder
+PackageVersion: 1.2.2
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: msi
+InstallModes:
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  Scope: user
+  InstallerUrl: https://github.com/olebhartvigsen/FanFolder/releases/download/v1.2.2/FanFolderSetup-x64.msi
+  InstallerSha256: 07927AE287D7A388129E9D5556416F6417A8BFDF29430D204C3610C5B41262A4
+  InstallerSwitches:
+    Silent: /quiet /norestart
+    SilentWithProgress: /passive /norestart
+  ProductCode: ' {CA7D8D62-85B7-4115-9B21-30EF82B8F5AE}'
+- Architecture: arm64
+  Scope: user
+  InstallerUrl: https://github.com/olebhartvigsen/FanFolder/releases/download/v1.2.2/FanFolderSetup-arm64.msi
+  InstallerSha256: E2EFE5B515737D796DAD4CA2EB87415C3B889FE822509FC6861679BC5328DA61
+  InstallerSwitches:
+    Silent: /quiet /norestart
+    SilentWithProgress: /passive /norestart
+  ProductCode: ' {E7CFD0EC-D761-40B3-AB9D-6897AD353ABF}'
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/o/OleBhartvigsen/FanFolder/1.2.2/OleBhartvigsen.FanFolder.locale.en-US.yaml
+++ b/manifests/o/OleBhartvigsen/FanFolder/1.2.2/OleBhartvigsen.FanFolder.locale.en-US.yaml
@@ -1,0 +1,52 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: OleBhartvigsen.FanFolder
+PackageVersion: 1.2.2
+PackageLocale: en-US
+Publisher: Ole Bhartvigsen
+PublisherUrl: https://github.com/olebhartvigsen
+PublisherSupportUrl: https://github.com/olebhartvigsen/FanFolder/issues
+Author: Ole Bhartvigsen
+PackageName: FanFolder
+PackageUrl: https://github.com/olebhartvigsen/FanFolder
+License: Proprietary
+LicenseUrl: https://github.com/olebhartvigsen/FanFolder/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Ole Bulow Hartvigsen
+CopyrightUrl: https://github.com/olebhartvigsen/FanFolder/blob/main/LICENSE
+ShortDescription: Animated fan folder popup for the Windows taskbar.
+Description: |-
+  FanFolder turns any folder into an animated, arc-shaped popup on the Windows
+  taskbar. Click the taskbar icon and the most recently modified items in a
+  configured folder fan out in a smooth animation. Open items, use the full
+  Windows shell context menu (right-click), or drag them into other applications.
+
+  Works with local folders as well as cloud-synced folders such as OneDrive,
+  Dropbox and Google Drive — always showing the latest files.
+
+  Key features:
+  - Multiple animation styles: Fan, Glide, Spring, Fade or None.
+  - Sort by date modified, date created or name, with optional filename regex filter.
+  - Configurable item count, folder path and display options via tray menu or registry.
+  - Full Windows shell context menu and drag-and-drop support.
+  - Per-user MSI install, no admin rights required.
+  - Native x64 and ARM64 builds.
+  - Small footprint and low memory usage.
+Moniker: fanfolder
+Tags:
+- taskbar
+- productivity
+- launcher
+- fan
+- folder
+- utility
+- shell
+- files
+ReleaseNotes: |-
+  Highlights in 1.2.2:
+  - Fixed a blank fan window on machines where the configured folder (or the default recent-documents list) is empty: the fan now shows a "This folder is empty" message instead of an empty frame with a loading spinner.
+  - Removed the unused Microsoft Graph integration and its winhttp / nlohmann_json dependencies, shrinking the build and keeping the app free of runtime network dependencies.
+  - Documentation fixes: corrected the default animation style, the MaxItems range and the default folder path in the README.
+ReleaseNotesUrl: https://github.com/olebhartvigsen/FanFolder/releases/tag/v1.2.2
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/o/OleBhartvigsen/FanFolder/1.2.2/OleBhartvigsen.FanFolder.yaml
+++ b/manifests/o/OleBhartvigsen/FanFolder/1.2.2/OleBhartvigsen.FanFolder.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: OleBhartvigsen.FanFolder
+PackageVersion: 1.2.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## FanFolder 1.2.2

New package version for OleBhartvigsen.FanFolder. Manifests are the ones published alongside the v1.2.2 release and validated locally with `winget validate`.

### Note for the validator

FanFolder lives in the taskbar. To open the fan, single-click its taskbar icon (there's no main window that comes up on its own).

Heads up on one thing you'll likely hit in a clean sandbox: the default source is the Windows recent-documents list, and on a fresh VM that list is empty. When it's empty the fan now shows a small "This folder is empty" item. Earlier versions drew an empty window with a spinner instead, which looked like a hang. That was fixed in 1.2.2, so if you see the "empty" message, that's the app working correctly, not stalling.

Everything installs per-user (`Scope: user`), so no elevation is needed or requested.

### Installer details
- Per-user MSI, x64 and ARM64
- Silent install verified: `/quiet /norestart`
- SHA256 and ProductCode taken from the shipped v1.2.2 MSIs
