### PR TITLE
Thurbeen.thurbox version 1.1.1

### DIFF
--- a/manifests/t/Thurbeen/thurbox/1.1.1/Thurbeen.thurbox.installer.yaml
+++ b/manifests/t/Thurbeen/thurbox/1.1.1/Thurbeen.thurbox.installer.yaml
@@ -1,0 +1,18 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: Thurbeen.thurbox
+PackageVersion: 1.1.1
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: thurbox.exe
+  PortableCommandAlias: thurbox
+- RelativeFilePath: thurbox-cli.exe
+  PortableCommandAlias: thurbox-cli
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Thurbeen/thurbox/releases/download/v1.1.1/thurbox-v1.1.1-x86_64-pc-windows-msvc.zip
+  InstallerSha256: 73B14023561059C1E7306D71BBAB580BB561F6892CBC08E953B71E45147F2B0D
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/t/Thurbeen/thurbox/1.1.1/Thurbeen.thurbox.locale.en-US.yaml
+++ b/manifests/t/Thurbeen/thurbox/1.1.1/Thurbeen.thurbox.locale.en-US.yaml
@@ -1,0 +1,46 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: Thurbeen.thurbox
+PackageVersion: 1.1.1
+PackageLocale: en-US
+Publisher: LeTuR
+PublisherUrl: https://github.com/Thurbeen
+PublisherSupportUrl: https://github.com/Thurbeen/thurbox/issues
+Author: LeTuR
+PackageName: thurbox
+PackageUrl: https://thurbeen.github.io/thurbox/
+License: MIT
+LicenseUrl: https://github.com/Thurbeen/thurbox/blob/main/LICENSE
+Copyright: Copyright (c) 2026 LeTuR
+CopyrightUrl: https://github.com/Thurbeen/thurbox/blob/main/LICENSE
+ShortDescription: TUI for orchestrating multiple coding-agent CLI sessions in persistent panels.
+Description: |-
+  thurbox is a TUI for orchestrating multiple coding-agent CLI sessions
+  (claude, codex, gemini, opencode, aider, ...) in persistent multiplexer
+  panels. Sessions survive crashes/restarts because the multiplexer keeps the
+  processes alive.
+
+  Windows support is experimental for now — it sees less testing than
+  Linux/macOS, so expect rough edges and please report issues. This package
+  installs the prebuilt x86_64 Windows release binaries (thurbox.exe +
+  thurbox-cli.exe) as portable commands on your PATH.
+
+  Not installed by this package: psmux (the native-Windows tmux clone thurbox
+  drives as its session backend — https://github.com/psmux/psmux) and a
+  coding-agent CLI (claude, codex, gemini, opencode, aider, ...).
+Moniker: thurbox
+Tags:
+- agent
+- aider
+- claude
+- cli
+- coding-agent
+- codex
+- developer-tools
+- orchestrator
+- terminal
+- tui
+ReleaseNotesUrl: https://github.com/Thurbeen/thurbox/releases/tag/v1.1.1
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/t/Thurbeen/thurbox/1.1.1/Thurbeen.thurbox.yaml
+++ b/manifests/t/Thurbeen/thurbox/1.1.1/Thurbeen.thurbox.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: Thurbeen.thurbox
+PackageVersion: 1.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## 📖 Description

New package: `Thurbeen.thurbox` version 1.1.1.

thurbox is a TUI for orchestrating multiple coding-agent CLI sessions (claude, codex, opencode, aider, ...) in persistent multiplexer panels.

The Windows release artifact is a plain `.zip` of portable binaries (`thurbox.exe` + `thurbox-cli.exe` + `LICENSE`), so this is a `zip` installer with `NestedInstallerType: portable` — winget registers PATH aliases `thurbox` and `thurbox-cli`. No MSI, no per-machine installer. Windows x86_64 only; ARM64 runs it under x64 emulation.

Manifests are generated from the canonical copies in my own repo (`packaging/winget/manifests/`) and submitted with `wingetcreate`.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable) — n/a, no related issue

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change — my older duplicate #406345 (1.1.0) is now closed, so this is the only open PR for this manifest
- [x] This PR only modifies one (1) manifest
- [x] Manifest generated and submitted with `wingetcreate`; validated by the Azure validation pipeline (`Azure-Pipeline-Passed` / `Validation-Completed`) and confirmed installable by the manual validation run above
- [ ] Manifest targets `ManifestVersion: 1.6.0` (not 1.12) — accepted by validation; happy to bump it if you'd prefer

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/406494)
