### PR TITLE
New package: dOR.OriNotebook version 0.1.4

### DIFF
--- a/manifests/d/dOR/OriNotebook/0.1.4/dOR.OriNotebook.installer.yaml
+++ b/manifests/d/dOR/OriNotebook/0.1.4/dOR.OriNotebook.installer.yaml
@@ -1,0 +1,19 @@
+# Created using Claude Code for dOR
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: dOR.OriNotebook
+PackageVersion: 0.1.4
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-07-23
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/dor-sr/ori-notebook-releases/releases/download/v0.1.4/Ori-Notebook-Setup-x64.exe
+  InstallerSha256: 2CF30EA0E53EFF82FF59B4C9F982C47A6D8D081769B77AF8FCA87EFBAF6E2C32
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/d/dOR/OriNotebook/0.1.4/dOR.OriNotebook.locale.en-US.yaml
+++ b/manifests/d/dOR/OriNotebook/0.1.4/dOR.OriNotebook.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# Created using Claude Code for dOR
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: dOR.OriNotebook
+PackageVersion: 0.1.4
+PackageLocale: en-US
+Publisher: dOR
+PublisherUrl: https://dorsr.com
+PublisherSupportUrl: https://github.com/dor-sr/ori-notebook-releases/issues
+PackageName: Ori Notebook
+PackageUrl: https://github.com/dor-sr/ori-notebook-releases
+License: Proprietary
+ShortDescription: Local-first notebook. Notes are plain Markdown files on your device, and the built-in agent only proposes edits you review.
+Moniker: ori-notebook
+Tags:
+- markdown
+- notebook
+- notes
+- local-first
+- knowledge-base
+ReleaseNotesUrl: https://github.com/dor-sr/ori-notebook-releases/releases/tag/v0.1.4
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/d/dOR/OriNotebook/0.1.4/dOR.OriNotebook.yaml
+++ b/manifests/d/dOR/OriNotebook/0.1.4/dOR.OriNotebook.yaml
@@ -1,0 +1,8 @@
+# Created using Claude Code for dOR
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: dOR.OriNotebook
+PackageVersion: 0.1.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
### New package: dOR.OriNotebook version 0.1.4

Resubmission of dOR.OriNotebook. The earlier submission (#403821, version 0.1.1) was closed because its source fork was deleted and that release can no longer activate its optional licensed features against the app's current licensing backend. 0.1.4 is the current release.

- [x] I have read the [Contributing Guide](https://github.com/microsoft/winget-pkgs/blob/master/CONTRIBUTING.md).
- [x] The manifest validates locally.
- [x] The installer URL is a stable, versioned GitHub release asset.
- [x] This PR only modifies one manifest (one package version).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/406660)