### PR TITLE
New version: Tropibyte.cshw version 1.0.8.0

### DIFF
--- a/manifests/t/Tropibyte/cshw/1.0.8.0/Tropibyte.cshw.installer.yaml
+++ b/manifests/t/Tropibyte/cshw/1.0.8.0/Tropibyte.cshw.installer.yaml
@@ -1,12 +1,24 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 PackageIdentifier: Tropibyte.cshw
 PackageVersion: 1.0.8.0
-# Inno Setup: winget applies the standard silent switches
-# (/VERYSILENT /SUPPRESSMSGBOXES /NORESTART) automatically for this InstallerType.
+MinimumOSVersion: 10.0.17763.0
 InstallerType: inno
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Commands:
+  - cshw
+FileExtensions:
+  - cshw
+  - csh
+ReleaseDate: 2026-07-23
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/tropibyte/cshw-releases/releases/download/v1.0.8.0/cshw-setup-1.0.8.0.exe
     InstallerSha256: BA3E29E1A1709214D17428E9FBEE624425488170E22FBD8E4EAD162A031A5C24
+    ProductCode: '{CFE685C6-DC75-4996-AC4B-7BE4F4D5BCB6}_is1'
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/t/Tropibyte/cshw/1.0.8.0/Tropibyte.cshw.installer.yaml
+++ b/manifests/t/Tropibyte/cshw/1.0.8.0/Tropibyte.cshw.installer.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Tropibyte.cshw
+PackageVersion: 1.0.8.0
+# Inno Setup: winget applies the standard silent switches
+# (/VERYSILENT /SUPPRESSMSGBOXES /NORESTART) automatically for this InstallerType.
+InstallerType: inno
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/tropibyte/cshw-releases/releases/download/v1.0.8.0/cshw-setup-1.0.8.0.exe
+    InstallerSha256: BA3E29E1A1709214D17428E9FBEE624425488170E22FBD8E4EAD162A031A5C24
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/t/Tropibyte/cshw/1.0.8.0/Tropibyte.cshw.locale.en-US.yaml
+++ b/manifests/t/Tropibyte/cshw/1.0.8.0/Tropibyte.cshw.locale.en-US.yaml
@@ -1,0 +1,56 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Tropibyte.cshw
+PackageVersion: 1.0.8.0
+PackageLocale: en-US
+Publisher: Tropibyte, Inc.
+PublisherUrl: https://www.tropibyte.com
+PublisherSupportUrl: https://www.tropibyte.com/bugs.html
+Author: Tropibyte, Inc.
+PackageName: C Shell for Windows
+PackageUrl: https://www.tropibyte.com/cshw.html
+License: PolyForm Small Business 1.0.0
+LicenseUrl: https://polyformproject.org/licenses/small-business/1.0.0
+Copyright: Copyright (c) 2024-2026 Tropibyte, Inc.
+CopyrightUrl: https://www.tropibyte.com/cshw.html
+ShortDescription: A native Windows command shell with csh/tcsh-flavored syntax, 110+ builtins, real concurrency primitives, arbitrary-precision math, and built-in AI.
+Description: |-
+  cshw is a native Windows command shell with csh/tcsh-flavored syntax. Familiar Unix
+  shell ergonomics meet first-class Win32 access -- no WSL, no Cygwin, no compatibility
+  layer. 110+ builtin commands cover file ops, text processing (grep with PCRE2, sed,
+  awk, sort with -t/-k, head/tail with -f), real concurrency primitives (coroutines,
+  mutex, semaphore, barrier, channel), Win32 calls (rundllproc, winapi, dllimport),
+  and built-in AI (OpenAI, Anthropic, Azure, Ollama, LM Studio). Runs your existing
+  .bat, .cmd, and .ps1 scripts unchanged. The bc/dc commands offer arbitrary-precision
+  arithmetic with an opt-in exact-rational tier (bc -x) including complex numbers and
+  small exact matrices. As of 1.0.8.0, cshw ships a signed server family: the tsrvd
+  supervisor runs out-of-process protocol handlers -- native SMTP, POP3, and IMAP over
+  a shared Maildir, FTP, and a real HTTP/HTTPS/CGI server (http.dll) that speaks
+  HTTP/1.1 and HTTP/2 -- and the new quicsrv worker serves HTTP/3 over QUIC through the
+  same serving core. The fetch client gains native HTTP/2 (--http2) and HTTP/3
+  (--http3) modes that guarantee the protocol. Ships with a 22-chapter user guide.
+Moniker: cshw
+Tags:
+  - shell
+  - csh
+  - tcsh
+  - command-line
+  - cli
+  - terminal
+  - unix
+  - win32
+  - scripting
+  - developer-tools
+PurchaseUrl: https://www.tropibyte.com/cshw.html
+PrivacyUrl: https://www.tropibyte.com
+ReleaseNotes: |-
+  v1.0.8.0: the server family ships. The tsrvd supervisor launches and manages
+  out-of-process protocol handlers -- native SMTP, POP3, and IMAP over a shared
+  Maildir mailstore, FTP, and a real HTTP/HTTPS/CGI server (http.dll) that speaks
+  HTTP/1.1 and HTTP/2 (ALPN + nghttp2). A new quicsrv worker serves HTTP/3 over QUIC
+  (msquic + nghttp3) through the same static + CGI serving core, and the fetch client
+  adds native --http2 and --http3 modes that guarantee the protocol instead of
+  best-effort negotiation. All server binaries are signed and packaged in both the
+  installer and the portable zip. No breaking changes to the shell language.
+ReleaseNotesUrl: https://github.com/tropibyte/cshw-releases/releases/tag/v1.0.8.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/t/Tropibyte/cshw/1.0.8.0/Tropibyte.cshw.yaml
+++ b/manifests/t/Tropibyte/cshw/1.0.8.0/Tropibyte.cshw.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Tropibyte.cshw
+PackageVersion: 1.0.8.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
New version **1.0.8.0** of **Tropibyte.cshw** (C Shell for Windows).

- Installer: signed Inno Setup `.exe`, hosted on the `cshw-releases` mirror.
- `InstallerSha256` verified against the actual published asset (`ba3e29e1…a5c24`, downloaded from the release and hashed).
- Manifests follow schema `1.6.0`, consistent with the existing `1.0.7.0` / `1.0.7.1` entries for this package.

**1.0.8.0 highlights:** ships the signed server family — the `tsrvd` supervisor runs out-of-process SMTP/POP3/IMAP (shared Maildir), FTP, and HTTP/1.1+HTTP/2 (`http.dll`); a new `quicsrv` worker serves HTTP/3 over QUIC; and the `fetch` client gains native `--http2` / `--http3` modes. No breaking changes to the shell language.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/406677)