### PR TITLE
New package: Essenciary.Githical version 0.1.4

### DIFF
--- a/manifests/e/Essenciary/Githical/0.1.4/Essenciary.Githical.installer.yaml
+++ b/manifests/e/Essenciary/Githical/0.1.4/Essenciary.Githical.installer.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Essenciary.Githical
+PackageVersion: 0.1.4
+InstallerType: zip
+NestedInstallerType: portable
+Commands:
+  - githical
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Git.Git
+Installers:
+  - Architecture: x64
+    NestedInstallerFiles:
+      - RelativeFilePath: githical_v0.1.4_windows_amd64\githical.exe
+        PortableCommandAlias: githical
+    InstallerUrl: https://github.com/essenciary/githical/releases/download/v0.1.4/githical_v0.1.4_windows_amd64.zip
+    InstallerSha256: 76363066C3B500CC2CBF3E11BACBE8937ADA0BC4D9E8BAAE0CDE0D2F5D6353FB
+  - Architecture: arm64
+    NestedInstallerFiles:
+      - RelativeFilePath: githical_v0.1.4_windows_arm64\githical.exe
+        PortableCommandAlias: githical
+    InstallerUrl: https://github.com/essenciary/githical/releases/download/v0.1.4/githical_v0.1.4_windows_arm64.zip
+    InstallerSha256: 5415254E8D0DE792B398D13374BB521C911DE64D9D488F8949842D098E053908
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/e/Essenciary/Githical/0.1.4/Essenciary.Githical.installer.yaml
+++ b/manifests/e/Essenciary/Githical/0.1.4/Essenciary.Githical.installer.yaml
@@ -14,12 +14,12 @@ Installers:
       - RelativeFilePath: githical_v0.1.4_windows_amd64\githical.exe
         PortableCommandAlias: githical
     InstallerUrl: https://github.com/essenciary/githical/releases/download/v0.1.4/githical_v0.1.4_windows_amd64.zip
-    InstallerSha256: 76363066C3B500CC2CBF3E11BACBE8937ADA0BC4D9E8BAAE0CDE0D2F5D6353FB
+    InstallerSha256: 898387D08D2BF1A7134338B2661AA3DC3D672C5D55223958A6B8D5B0C28249ED
   - Architecture: arm64
     NestedInstallerFiles:
       - RelativeFilePath: githical_v0.1.4_windows_arm64\githical.exe
         PortableCommandAlias: githical
     InstallerUrl: https://github.com/essenciary/githical/releases/download/v0.1.4/githical_v0.1.4_windows_arm64.zip
-    InstallerSha256: 5415254E8D0DE792B398D13374BB521C911DE64D9D488F8949842D098E053908
+    InstallerSha256: 5439332E35870F707E6B1BA94F5DF77CA3242ECBC244C5B291E3FA25FDCADB8D
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/e/Essenciary/Githical/0.1.4/Essenciary.Githical.locale.en-US.yaml
+++ b/manifests/e/Essenciary/Githical/0.1.4/Essenciary.Githical.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Essenciary.Githical
+PackageVersion: 0.1.4
+PackageLocale: en-US
+Publisher: Essenciary
+PublisherUrl: https://github.com/essenciary
+PublisherSupportUrl: https://github.com/essenciary/githical/issues
+PackageName: Githical
+PackageUrl: https://github.com/essenciary/githical
+License: MIT
+LicenseUrl: https://github.com/essenciary/githical/blob/v0.1.4/LICENSE
+ShortDescription: A clear, focused Git client for the terminal.
+Tags:
+  - git
+  - terminal
+  - tui
+ReleaseNotesUrl: https://github.com/essenciary/githical/releases/tag/v0.1.4
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/e/Essenciary/Githical/0.1.4/Essenciary.Githical.yaml
+++ b/manifests/e/Essenciary/Githical/0.1.4/Essenciary.Githical.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Essenciary.Githical
+PackageVersion: 0.1.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Adds Githical 0.1.4, a terminal Git client, as a portable ZIP package for x64
and arm64 Windows.

Release: https://github.com/essenciary/githical/releases/tag/v0.1.4
Source: https://github.com/essenciary/githical

The manifest declares `Git.Git` as a package dependency. Both Windows binaries
were executed on matching GitHub-hosted Windows runners before the release was
published, and all three manifest files were validated against the official
1.12 JSON schemas.

## Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (not applicable)

## Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same manifest
  update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the 1.12 schema

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/406695)