### PR TITLE
New package: TukaaniProject.XZUtils version 5.8.3

### DIFF
--- a/manifests/t/TukaaniProject/XZUtils/5.8.3/TukaaniProject.XZUtils.installer.yaml
+++ b/manifests/t/TukaaniProject/XZUtils/5.8.3/TukaaniProject.XZUtils.installer.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: TukaaniProject.XZUtils
+PackageVersion: 5.8.3
+ReleaseDate: 2026-03-31
+InstallerType: zip
+NestedInstallerType: portable
+Installers:
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: bin_x86-64\lzmadec.exe
+  - RelativeFilePath: bin_x86-64\lzmainfo.exe
+  - RelativeFilePath: bin_x86-64\xz.exe
+  - RelativeFilePath: bin_x86-64\xzdec.exe
+  InstallerUrl: https://github.com/tukaani-project/xz/releases/download/v5.8.3/xz-5.8.3-windows.zip
+  InstallerSha256: 8D0048EE51177B11EF1613959C2A268C951F4E7F6FB3706E681E00E34BB6D5E3
+  AppsAndFeaturesEntries:
+  - DisplayName: XZ Utils (x64)
+- Architecture: x86
+  NestedInstallerFiles:
+  - RelativeFilePath: bin_i686-sse2\lzmadec.exe
+  - RelativeFilePath: bin_i686-sse2\lzmainfo.exe
+  - RelativeFilePath: bin_i686-sse2\xz.exe
+  - RelativeFilePath: bin_i686-sse2\xzdec.exe
+  InstallerUrl: https://github.com/tukaani-project/xz/releases/download/v5.8.3/xz-5.8.3-windows.zip
+  InstallerSha256: 8D0048EE51177B11EF1613959C2A268C951F4E7F6FB3706E681E00E34BB6D5E3
+  AppsAndFeaturesEntries:
+  - DisplayName: XZ Utils (x86)
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/t/TukaaniProject/XZUtils/5.8.3/TukaaniProject.XZUtils.locale.en-GB.yaml
+++ b/manifests/t/TukaaniProject/XZUtils/5.8.3/TukaaniProject.XZUtils.locale.en-GB.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: TukaaniProject.XZUtils
+PackageVersion: 5.8.3
+PackageLocale: en-GB
+License: Various open-source licences
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/t/TukaaniProject/XZUtils/5.8.3/TukaaniProject.XZUtils.locale.en-US.yaml
+++ b/manifests/t/TukaaniProject/XZUtils/5.8.3/TukaaniProject.XZUtils.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: TukaaniProject.XZUtils
+PackageVersion: 5.8.3
+PackageLocale: en-US
+Publisher: The Tukaani Project
+PackageName: XZ Utils
+PackageUrl: https://tukaani.org/xz/
+License: Various open-source licenses
+LicenseUrl: https://raw.github.com/tukaani-project/xz/refs/heads/master/COPYING
+ShortDescription: A complete C99 implementation of the .xz file format. XZ Utils were originally written for POSIX systems but have been ported to a few non-POSIX systems as well.
+Moniker: xzutils
+Tags:
+- xz-utils
+- xzdec
+- lzmainfo
+- lzmadec
+- c99
+- liblzma.dll
+- requirescmd
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/TukaaniProject/XZUtils/5.8.3/TukaaniProject.XZUtils.yaml
+++ b/manifests/t/TukaaniProject/XZUtils/5.8.3/TukaaniProject.XZUtils.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: TukaaniProject.XZUtils
+PackageVersion: 5.8.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
Added XZ Utils.

I noticed in the Tor logs while running [Nyx for Windows](https://github.com/DandelionSprout/NyxForWindows) on my [server](https://metrics.torproject.org/rs.html#details/5BE0E93B27D10CF81C4B8CF437C818174DA103D9):

`(...) [NOTICE] Tor 0.4.9.9 (git-...) running on Windows 8 [or later] with (...), Liblzma N/A, (...).`

So I websearched `liblzma`, and ZX Utils came up as the most prominent option. ZX Utils turned out to have no effect on that log line, but still.

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/406867)