### PR TITLE
Update HoraceMaxwell.Horosa version 3.5.1 installer hash

### DIFF
--- a/manifests/h/HoraceMaxwell/Horosa/3.5.1/HoraceMaxwell.Horosa.installer.yaml
+++ b/manifests/h/HoraceMaxwell/Horosa/3.5.1/HoraceMaxwell.Horosa.installer.yaml
@@ -12,10 +12,10 @@ InstallModes:
   - silent
   - silentWithProgress
 UpgradeBehavior: install
-ReleaseDate: 2026-07-22
+ReleaseDate: 2026-07-23
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/Horace-Maxwell/Horosa-Web-App-comprehensively-improved-Windows/releases/download/v3.5.1/Horosa-Setup-3.5.1.exe
-    InstallerSha256: 318DA56EF23ED8AC86FF8814779FBAE7A66EB539563B7742F64D38AF1EB07FA6
+    InstallerSha256: 8E6119288D53025A29F0DC264C5720319FFCAE3E4389EEC88EB3BFFD2AEF7A89
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/h/HoraceMaxwell/Horosa/3.5.1/HoraceMaxwell.Horosa.installer.yaml
+++ b/manifests/h/HoraceMaxwell/Horosa/3.5.1/HoraceMaxwell.Horosa.installer.yaml
@@ -12,10 +12,10 @@ InstallModes:
   - silent
   - silentWithProgress
 UpgradeBehavior: install
-ReleaseDate: 2026-07-23
+ReleaseDate: 2026-07-24
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/Horace-Maxwell/Horosa-Web-App-comprehensively-improved-Windows/releases/download/v3.5.1/Horosa-Setup-3.5.1.exe
-    InstallerSha256: 8E6119288D53025A29F0DC264C5720319FFCAE3E4389EEC88EB3BFFD2AEF7A89
+    InstallerSha256: C2E33DD1E79BF2E5C576DCD326D28301E7249E404DDB23E1670EC85B1E2B20D7
 ManifestType: installer
 ManifestVersion: 1.6.0


### PR DESCRIPTION
The 3.5.1 installer asset was republished at the same URL with a bug-fix build; this updates InstallerSha256 (and ReleaseDate) to match the currently served asset.

Verified against the release's SHA256SUMS.txt:
`8e6119288d53025a29f0dc264c5720319ffcae3e4389eec88eb3bffd2aef7a89  Horosa-Setup-3.5.1.exe`

- [x] Manifests validated locally
- [x] Hash cross-checked with https://github.com/Horace-Maxwell/Horosa-Web-App-comprehensively-improved-Windows/releases/tag/v3.5.1
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/406910)