### PR TITLE
New package: cubezombies.MidnightAthenaeum version 0.10.0

### DIFF
--- a/manifests/c/cubezombies/MidnightAthenaeum/0.10.0/cubezombies.MidnightAthenaeum.installer.yaml
+++ b/manifests/c/cubezombies/MidnightAthenaeum/0.10.0/cubezombies.MidnightAthenaeum.installer.yaml
@@ -6,7 +6,7 @@ InstallerLocale: en-US
 Platform:
   - Windows.Desktop
 MinimumOSVersion: 10.0.17763.0
-InstallerType: nsis
+InstallerType: nullsoft
 Scope: user
 InstallModes:
   - interactive

--- a/manifests/c/cubezombies/MidnightAthenaeum/0.10.0/cubezombies.MidnightAthenaeum.installer.yaml
+++ b/manifests/c/cubezombies/MidnightAthenaeum/0.10.0/cubezombies.MidnightAthenaeum.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: cubezombies.MidnightAthenaeum
+PackageVersion: 0.10.0
+InstallerLocale: en-US
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nsis
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-07-23
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/cubezombies/MidnightAthenaeum/releases/download/v0.10.0/MidnightAthenaeum-Setup-0.10.0.exe
+    InstallerSha256: D950AB4A669B7A5E47D39722F01AAF424A653F64B13045342118D70821A773E4
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/c/cubezombies/MidnightAthenaeum/0.10.0/cubezombies.MidnightAthenaeum.locale.en-US.yaml
+++ b/manifests/c/cubezombies/MidnightAthenaeum/0.10.0/cubezombies.MidnightAthenaeum.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: cubezombies.MidnightAthenaeum
+PackageVersion: 0.10.0
+PackageLocale: en-US
+Publisher: cubezombies
+PublisherUrl: https://github.com/cubezombies
+PublisherSupportUrl: https://github.com/cubezombies/MidnightAthenaeum/issues
+PackageName: Midnight Athenaeum
+PackageUrl: https://github.com/cubezombies/MidnightAthenaeum
+License: MIT
+LicenseUrl: https://github.com/cubezombies/MidnightAthenaeum/blob/main/LICENSE
+Copyright: Copyright (c) 2026 cubezombies
+ShortDescription: A desktop audiobook player for Windows, built with Electron.
+Description: >-
+  Midnight Athenaeum plays local audiobook files with real chapter
+  navigation, per-book resume, per-book playback speed, bookmarks,
+  skip-silence, volume normalization, and a sleep timer. A Continue
+  Listening shelf, library filters, and series grouping keep the book
+  you're on one click away, even in a library of thousands. Entirely
+  offline and local -- no account, no server, no telemetry.
+Tags:
+  - audiobook
+  - audiobooks
+  - m4b
+  - mp3
+  - player
+  - epub
+ReleaseNotesUrl: https://github.com/cubezombies/MidnightAthenaeum/releases/tag/v0.10.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/c/cubezombies/MidnightAthenaeum/0.10.0/cubezombies.MidnightAthenaeum.yaml
+++ b/manifests/c/cubezombies/MidnightAthenaeum/0.10.0/cubezombies.MidnightAthenaeum.yaml
@@ -1,0 +1,8 @@
+# Created with wingetcreate conventions, hand-written for Midnight Athenaeum
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: cubezombies.MidnightAthenaeum
+PackageVersion: 0.10.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary
Adds a new package: **Midnight Athenaeum**, an offline-first desktop audiobook player for Windows (Electron), version 0.10.0.

- Plays local audiobook files (m4b/mp3/etc.) with real chapter navigation, per-book resume, per-book playback speed, bookmarks, skip-silence, volume normalization, sleep timer, and EPUB read-along.
- No account, no server, no telemetry — entirely local/offline.
- Source: https://github.com/cubezombies/MidnightAthenaeum (MIT licensed)
- Installer: NSIS, per-user install, x64.

## Checklist
- [x] Installer URL and SHA256 verified by downloading the actual GitHub release asset and hashing it directly.
- [x] Manifests validated (YAML parses correctly against the 1.6.0 schema field set).
- [x] License/LicenseUrl point to the real MIT LICENSE file in the source repo.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/407058)