### PR TITLE
New package: TediousCode.FoxSchema version 0.1.67

### DIFF
--- a/manifests/t/TediousCode/FoxSchema/0.1.67/TediousCode.FoxSchema.installer.yaml
+++ b/manifests/t/TediousCode/FoxSchema/0.1.67/TediousCode.FoxSchema.installer.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+# InstallerSha256 and InstallerUrl are filled by packaging/winget/fill-installer.sh
+# after the portable zip is published to the GitHub Release.
+PackageIdentifier: TediousCode.FoxSchema
+PackageVersion: 0.1.67
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: foxschema.cmd
+    PortableCommandAlias: foxschema
+  - RelativeFilePath: fox.cmd
+    PortableCommandAlias: fox
+Scope: user
+UpgradeBehavior: install
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: OpenJS.NodeJS.LTS
+      MinimumVersion: 22.5.0
+Commands:
+  - foxschema
+  - fox
+ReleaseDate: 2026-07-24
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/tedious-code/foxschema/releases/download/v0.1.67/foxschema-0.1.67-win-x64.zip
+    InstallerSha256: 5EF33AE64215113E8C209E17074778412BA55DB0E3867E4E59B6D408ADDCE205
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/t/TediousCode/FoxSchema/0.1.67/TediousCode.FoxSchema.locale.en-US.yaml
+++ b/manifests/t/TediousCode/FoxSchema/0.1.67/TediousCode.FoxSchema.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: TediousCode.FoxSchema
+PackageVersion: 0.1.67
+PackageLocale: en-US
+Publisher: Tedious Code
+PublisherUrl: https://github.com/tedious-code
+PublisherSupportUrl: https://github.com/tedious-code/foxschema/issues
+Author: huyplb
+PackageName: Fox Schema
+PackageUrl: https://foxschema.com
+License: Apache-2.0
+LicenseUrl: https://github.com/tedious-code/foxschema/blob/main/LICENSE
+Copyright: Copyright (c) Tedious Code
+ShortDescription: Database schema diff and migration tool (local web UI)
+Description: Fox Schema compares a source database schema against a target, generates dialect-native migration SQL, and can deploy it. This package installs the foxschema CLI, which opens a local web UI in your browser. Requires Node.js 22.5+ (declared as a dependency). One product — includes optional IBM Db2 support where ibm_db is available.
+Moniker: foxschema
+Tags:
+  - database
+  - schema
+  - migration
+  - sql
+  - diff
+  - foxschema
+  - cli
+ReleaseNotesUrl: https://github.com/tedious-code/foxschema/releases/tag/v0.1.67
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/t/TediousCode/FoxSchema/0.1.67/TediousCode.FoxSchema.yaml
+++ b/manifests/t/TediousCode/FoxSchema/0.1.67/TediousCode.FoxSchema.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: TediousCode.FoxSchema
+PackageVersion: 0.1.67
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
One Fox Schema package (CLI portable zip). Depends on OpenJS.NodeJS.LTS. Install: winget install TediousCode.FoxSchema

Made with [Cursor](https://cursor.com)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/407134)