### PR TITLE
New version: Tomclanc.GestureSignV2 version 16.4.55

### DIFF
--- a/manifests/t/Tomclanc/GestureSignV2/16.4.55/Tomclanc.GestureSignV2.installer.yaml
+++ b/manifests/t/Tomclanc/GestureSignV2/16.4.55/Tomclanc.GestureSignV2.installer.yaml
@@ -1,0 +1,24 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Tomclanc.GestureSignV2
+PackageVersion: 16.4.55
+InstallerType: wix
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{C8AB2E32-A922-4FF4-971B-D4A075D6AA21}'
+AppsAndFeaturesEntries:
+- DisplayName: GestureSign V2
+  Publisher: TransposonY / WinUI rebuild
+  ProductCode: '{C8AB2E32-A922-4FF4-971B-D4A075D6AA21}'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Tomclanc/GestureSignv2/releases/download/v16.4.55/GestureSign-V2-16.4.55-x64.msi
+  InstallerSha256: 2A8FBBFB3F70E5F53186F8F8346731EB4BFD9BB9139C27D189B038B1BA682EF3
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-07-24

--- a/manifests/t/Tomclanc/GestureSignV2/16.4.55/Tomclanc.GestureSignV2.locale.en-US.yaml
+++ b/manifests/t/Tomclanc/GestureSignV2/16.4.55/Tomclanc.GestureSignV2.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Tomclanc.GestureSignV2
+PackageVersion: 16.4.55
+PackageLocale: en-US
+Publisher: Tomclanc
+PublisherUrl: https://github.com/Tomclanc
+PublisherSupportUrl: https://github.com/Tomclanc/GestureSignv2/issues
+Author: Tomclanc
+PackageName: GestureSign V2
+PackageUrl: https://github.com/Tomclanc/GestureSignv2
+License: GPL-2.0
+LicenseUrl: https://github.com/Tomclanc/GestureSignv2/blob/main/LICENSE
+Copyright: Copyright (C) 2026 Tomclanc
+ShortDescription: A Windows 11 focused rebuild of GestureSign for touchpad and mouse gestures.
+Description: GestureSign V2 is a Windows 11 focused rebuild of the classic open-source GestureSign project. It supports touchpad gestures, mouse gestures, gesture trails, per-app actions, ignore rules, tray controls, Smart Close, and bundled Kando radial menu quick actions.
+Moniker: gesturesignv2
+Tags:
+- gesture
+- gestures
+- mouse
+- touchpad
+- windows-11
+ReleaseNotesUrl: https://github.com/Tomclanc/GestureSignv2/releases/tag/v16.4.55
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/Tomclanc/GestureSignv2/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/Tomclanc/GestureSignV2/16.4.55/Tomclanc.GestureSignV2.locale.zh-CN.yaml
+++ b/manifests/t/Tomclanc/GestureSignV2/16.4.55/Tomclanc.GestureSignV2.locale.zh-CN.yaml
@@ -1,0 +1,27 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: Tomclanc.GestureSignV2
+PackageVersion: 16.4.55
+PackageLocale: zh-CN
+Publisher: Tomclanc
+PublisherUrl: https://github.com/Tomclanc
+PublisherSupportUrl: https://github.com/Tomclanc/GestureSignv2/issues
+Author: Tomclanc
+PackageName: GestureSign V2
+PackageUrl: https://github.com/Tomclanc/GestureSignv2
+License: GPL-2.0
+LicenseUrl: https://github.com/Tomclanc/GestureSignv2/blob/main/LICENSE
+Copyright: Copyright (C) 2026 Tomclanc
+ShortDescription: 面向 Windows 11 重构的 GestureSign，支持触控板和鼠标手势。
+Description: GestureSign V2 是经典开源项目 GestureSign 的 Windows 11 重构版本，支持触控板手势、鼠标手势、手势轨迹、按应用设置动作、忽略规则、托盘控制、智能关闭，以及内置的 Kando 径向菜单快捷动作。
+Tags:
+- 手势
+- 鼠标
+- 触控板
+- Windows 11
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/Tomclanc/GestureSignv2/wiki
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/t/Tomclanc/GestureSignV2/16.4.55/Tomclanc.GestureSignV2.yaml
+++ b/manifests/t/Tomclanc/GestureSignV2/16.4.55/Tomclanc.GestureSignV2.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Tomclanc.GestureSignV2
+PackageVersion: 16.4.55
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Updates Tomclanc.GestureSignV2 to version 16.4.55. Manifests were generated and validated with WingetCreate.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/407233)