### PR TITLE
New version: tomoyukioya.FileHistoryClone version 1.1.0

### DIFF
--- a/manifests/t/tomoyukioya/FileHistoryClone/1.1.0/tomoyukioya.FileHistoryClone.installer.yaml
+++ b/manifests/t/tomoyukioya/FileHistoryClone/1.1.0/tomoyukioya.FileHistoryClone.installer.yaml
@@ -1,0 +1,20 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: tomoyukioya.FileHistoryClone
+PackageVersion: 1.1.0
+InstallerType: inno
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+AppsAndFeaturesEntries:
+- ProductCode: '{B9E8B7A6-3C2D-4E1F-9A0B-6D5C4E3F2A1B}_is1'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/tomoyukioya/FileHistoryClone/releases/download/v1.1.0/FileHistoryCloneSetup-1.1.0.exe
+  InstallerSha256: 77E44C055AC1F1A4F6199A7E7C89810B9B9CAAF46F64F12414C56FD51AB4DB86
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-07-24

--- a/manifests/t/tomoyukioya/FileHistoryClone/1.1.0/tomoyukioya.FileHistoryClone.locale.en-US.yaml
+++ b/manifests/t/tomoyukioya/FileHistoryClone/1.1.0/tomoyukioya.FileHistoryClone.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: tomoyukioya.FileHistoryClone
+PackageVersion: 1.1.0
+PackageLocale: en-US
+Publisher: Tomoyuki Ohya
+PublisherUrl: https://github.com/tomoyukioya
+PublisherSupportUrl: https://github.com/tomoyukioya/FileHistoryClone/issues
+PackageName: FileHistoryClone
+PackageUrl: https://github.com/tomoyukioya/FileHistoryClone
+License: MIT
+LicenseUrl: https://github.com/tomoyukioya/FileHistoryClone/blob/main/LICENSE
+ShortDescription: A lightweight, tray-resident Windows "File History"-style continuous versioned backup tool.
+Description: 'FileHistoryClone revives the spirit of Windows File History: it watches the folders you choose and keeps a timestamped copy every time a file changes, stored as plain files you can open in Explorer. Continuous (not scheduled), 100% local, no cloud, no subscription.'
+Moniker: filehistoryclone
+Tags:
+- backup
+- file-history
+- versioning
+- windows
+- dotnet
+ReleaseNotesUrl: https://github.com/tomoyukioya/FileHistoryClone/releases/tag/v1.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/tomoyukioya/FileHistoryClone/1.1.0/tomoyukioya.FileHistoryClone.yaml
+++ b/manifests/t/tomoyukioya/FileHistoryClone/1.1.0/tomoyukioya.FileHistoryClone.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: tomoyukioya.FileHistoryClone
+PackageVersion: 1.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Update tomoyukioya.FileHistoryClone to 1.1.0.

Release notes: https://github.com/tomoyukioya/FileHistoryClone/releases/tag/v1.1.0

The exact installer binary referenced by this manifest (same SHA256) was tested in Windows Sandbox: fresh install, and upgrade from 1.0.0 with user settings preserved.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>` (installer itself tested in Windows Sandbox as noted above)
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
