### PR TITLE
Add TaeminGames.Heimdall version 3.4.408

### DIFF
--- a/manifests/t/TaeminGames/Heimdall/3.4.408/taemingames.heimdall.installer.yaml
+++ b/manifests/t/TaeminGames/Heimdall/3.4.408/taemingames.heimdall.installer.yaml
@@ -1,0 +1,19 @@
+# Created using wingetcreate 1.6.5.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: TaeminGames.Heimdall
+PackageVersion: 3.4.408
+InstallerLocale: ko-KR
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: user
+InstallModes:
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/sontaemin80/Heimdall-OS/releases/download/v3.4.408/HEIMDALL_Setup_v3.4.408.exe
+    InstallerSha256: de781ead3257be26a65b51149ae503379472562b81ea0d1f663a5a61d52c08c5
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/t/TaeminGames/Heimdall/3.4.408/taemingames.heimdall.locale.ko-KR.yaml
+++ b/manifests/t/TaeminGames/Heimdall/3.4.408/taemingames.heimdall.locale.ko-KR.yaml
@@ -1,0 +1,16 @@
+# Created using wingetcreate 1.6.5.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
+
+PackageIdentifier: TaeminGames.Heimdall
+PackageVersion: 3.4.408
+PackageLocale: ko-KR
+Publisher: TaeminGames
+PublisherUrl: https://www.taemingames.com
+PublisherSupportUrl: https://github.com/sontaemin80/Heimdall-OS/issues
+Author: sontaemin80
+PackageName: Heimdall OS
+PackageUrl: https://www.taemingames.com
+License: Proprietary
+ShortDescription: Heimdall OS is a powerful agentic AI operating portal.
+ManifestType: locale
+ManifestVersion: 1.6.0

--- a/manifests/t/TaeminGames/Heimdall/3.4.408/taemingames.heimdall.version.yaml
+++ b/manifests/t/TaeminGames/Heimdall/3.4.408/taemingames.heimdall.version.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.6.5.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: TaeminGames.Heimdall
+PackageVersion: 3.4.408
+DefaultLocale: ko-KR
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Hello Microsoft Winget Team, please add Heimdall OS version 3.4.408 Windows installer. This app is built via Inno Setup and supports silent installation.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/407285)