### PR TITLE
Add: Monodirect.NFCBridge version 2.1.573.0

### DIFF
--- a/manifests/m/Monodirect/NFCBridge/2.1.573.0/Monodirect.NFCBridge.installer.yaml
+++ b/manifests/m/Monodirect/NFCBridge/2.1.573.0/Monodirect.NFCBridge.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Monodirect.NFCBridge
+PackageVersion: 2.1.573.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: nfc-bridge.exe
+    PortableCommandAlias: nfc-bridge
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://api.monocard.me/api/v1/nfc-bridge/download
+    InstallerSha256: fc3a1eb3046cce850027e19265a4e7e8c48f6d30cccc4c3465cb2bd76e53e479
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/Monodirect/NFCBridge/2.1.573.0/Monodirect.NFCBridge.locale.en-US.yaml
+++ b/manifests/m/Monodirect/NFCBridge/2.1.573.0/Monodirect.NFCBridge.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Monodirect.NFCBridge
+PackageVersion: 2.1.573.0
+PackageLocale: en-US
+Publisher: Monodirect
+PublisherUrl: https://monocard.me
+PublisherSupportUrl: https://monocard.me/support
+PrivacyUrl: https://monocard.me/privacy
+PackageName: Monodirect NFC Bridge
+PackageUrl: https://monocard.me
+License: Proprietary
+ShortDescription: NFC reader bridge for the Monodirect web app
+Moniker: nfc-bridge
+Tags:
+  - nfc
+  - nfc-bridge
+  - monodirect
+  - smart-card
+  - contactless
+Documentations:
+  - DocumentLabel: Setup Guide
+    DocumentUrl: https://monocard.me/en/app/admin/nfc-qr
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/Monodirect/NFCBridge/2.1.573.0/Monodirect.NFCBridge.yaml
+++ b/manifests/m/Monodirect/NFCBridge/2.1.573.0/Monodirect.NFCBridge.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Monodirect.NFCBridge
+PackageVersion: 2.1.573.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
New package: Monodirect NFC Bridge

A companion Windows application for the Monodirect web platform that provides NFC card reading/writing via PC/SC.

**Publisher:** Monodirect
**Website:** https://monocard.me
**Installer type:** Portable zip with nested exe
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/407360)