### PR TITLE
New package: CorvuxMindware.Portty version 0.1.2

### DIFF
--- a/manifests/c/CorvuxMindware/Portty/0.1.2/CorvuxMindware.Portty.installer.yaml
+++ b/manifests/c/CorvuxMindware/Portty/0.1.2/CorvuxMindware.Portty.installer.yaml
@@ -1,0 +1,18 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: CorvuxMindware.Portty
+PackageVersion: 0.1.2
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: portty-host.exe
+  PortableCommandAlias: portty-host
+- RelativeFilePath: portty.exe
+  PortableCommandAlias: portty
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/mrtechnoo/portty/releases/download/v0.1.2/portty-v0.1.2-x86_64-pc-windows-msvc.zip
+  InstallerSha256: F2E1F7703FFE4FB44C41B185EE23F2102B1866A88B728498A83BADD9B443FFC1
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/CorvuxMindware/Portty/0.1.2/CorvuxMindware.Portty.locale.en-US.yaml
+++ b/manifests/c/CorvuxMindware/Portty/0.1.2/CorvuxMindware.Portty.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: CorvuxMindware.Portty
+PackageVersion: 0.1.2
+PackageLocale: en-US
+Publisher: Corvux Mindware
+PublisherUrl: https://github.com/mrtechnoo
+PublisherSupportUrl: https://github.com/mrtechnoo/portty/issues
+Author: Corvux Mindware
+PackageName: Portty
+PackageUrl: https://github.com/mrtechnoo/portty
+License: Freeware
+LicenseUrl: https://github.com/mrtechnoo/portty/blob/main/LICENSE.txt
+Copyright: Copyright (c) Corvux Mindware Private Limited
+ShortDescription: Securely share a terminal with a paired phone.
+Description: 'Portty securely shares your terminal with a paired phone over an encrypted peer-to-peer link, and lets you approve coding-agent actions from your pocket. It installs two commands: portty (wrap and share a terminal) and portty-host (the paired-device host daemon).'
+Moniker: portty
+Tags:
+- terminal
+- remote
+- cli
+- pairing
+- ssh
+- mobile
+ReleaseNotes: Windows and Linux builds for v0.1.2. Verify your download against the release SHA256SUMS. macOS builds coming shortly.
+ReleaseNotesUrl: https://github.com/mrtechnoo/portty/releases/tag/v0.1.2
+InstallationNotes: Run 'portty share' to wrap your shell and pair a phone. Run 'portty-host status' to check the background host.
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/CorvuxMindware/Portty/0.1.2/CorvuxMindware.Portty.yaml
+++ b/manifests/c/CorvuxMindware/Portty/0.1.2/CorvuxMindware.Portty.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: CorvuxMindware.Portty
+PackageVersion: 0.1.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New package: CorvuxMindware.Portty version 0.1.2

Portty is a small command-line tool that securely shares a terminal with a paired phone. This package installs two portable commands from the official release ZIP: `portty` and `portty-host`.

- Installer: ZIP containing two portable executables (x64)
- Source of binaries: https://github.com/mrtechnoo/portty/releases/tag/v0.1.2
- SHA256 verified against the release `SHA256SUMS`.

This supersedes the earlier 0.1.1 submission (that release was withdrawn).

- [x] I have read the [Contribution guidelines](https://github.com/microsoft/winget-pkgs/blob/master/CONTRIBUTING.md).
- [x] This manifest describes an installer as published by the software's original author/publisher.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/407403)