### PR TITLE
New package: Octonove.CapturaPro version 1.0.0

### DIFF
--- a/manifests/o/Octonove/CapturaPro/1.0.0/Octonove.CapturaPro.installer.yaml
+++ b/manifests/o/Octonove/CapturaPro/1.0.0/Octonove.CapturaPro.installer.yaml
@@ -1,0 +1,14 @@
+# Created with Claude for Octonove
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: Octonove.CapturaPro
+PackageVersion: 1.0.0
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Octonove/capturapro/releases/download/v1.0.0/CapturaPro-Setup.exe
+  InstallerSha256: 03FE79A67D4DFC2D930123B21E6D9C09CDB6B751FA67AA3A1F0B30ECF1C12502
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/o/Octonove/CapturaPro/1.0.0/Octonove.CapturaPro.locale.en-US.yaml
+++ b/manifests/o/Octonove/CapturaPro/1.0.0/Octonove.CapturaPro.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: Octonove.CapturaPro
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: Octonove
+PublisherUrl: https://simplificaconia.com
+PublisherSupportUrl: https://simplificaconia.com/contacto/
+PackageName: CapturaPro
+PackageUrl: https://simplificaconia.com/grabador-de-pantalla-gratis/
+License: MIT
+Copyright: Copyright (c) Octonove
+ShortDescription: Free screen capture and recording tool for Windows with annotated screenshots, GIF export, system audio recording and no watermark. 100% local, UI in Spanish.
+Moniker: capturapro
+Tags:
+- screen-capture
+- screenshot
+- screen-recorder
+- gif
+- spanish
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/o/Octonove/CapturaPro/1.0.0/Octonove.CapturaPro.yaml
+++ b/manifests/o/Octonove/CapturaPro/1.0.0/Octonove.CapturaPro.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: Octonove.CapturaPro
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Adds Octonove.CapturaPro 1.0.0. Free, MIT-licensed Windows app by Octonove (simplificaconia.com). Inno Setup installer hosted on GitHub Releases; SHA256 verified.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/407414)