### PR TITLE
New package: Octonove.PDFLocal version 1.1.1

### DIFF
--- a/manifests/o/Octonove/PDFLocal/1.1.1/Octonove.PDFLocal.installer.yaml
+++ b/manifests/o/Octonove/PDFLocal/1.1.1/Octonove.PDFLocal.installer.yaml
@@ -1,0 +1,14 @@
+# Created with Claude for Octonove
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: Octonove.PDFLocal
+PackageVersion: 1.1.1
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Octonove/pdflocal/releases/download/v1.1.1/PDFLocal-Setup.exe
+  InstallerSha256: 61E67C006105540AE55BEA9D888AEA018CF9BB96DC0E03F89FE74E3C98F81AB0
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/o/Octonove/PDFLocal/1.1.1/Octonove.PDFLocal.locale.en-US.yaml
+++ b/manifests/o/Octonove/PDFLocal/1.1.1/Octonove.PDFLocal.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: Octonove.PDFLocal
+PackageVersion: 1.1.1
+PackageLocale: en-US
+Publisher: Octonove
+PublisherUrl: https://simplificaconia.com
+PublisherSupportUrl: https://simplificaconia.com/contacto/
+PackageName: PDFLocal
+PackageUrl: https://simplificaconia.com/unir-comprimir-pdf-gratis/
+License: MIT
+Copyright: Copyright (c) Octonove
+ShortDescription: Free PDF toolbox for Windows to merge, split, compress, digitally sign and OCR documents. Nothing is uploaded, 100% local. UI in Spanish.
+Moniker: pdflocal
+Tags:
+- pdf
+- pdf-merger
+- pdf-compressor
+- digital-signature
+- spanish
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/o/Octonove/PDFLocal/1.1.1/Octonove.PDFLocal.yaml
+++ b/manifests/o/Octonove/PDFLocal/1.1.1/Octonove.PDFLocal.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: Octonove.PDFLocal
+PackageVersion: 1.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Adds Octonove.PDFLocal 1.1.1. Free, MIT-licensed Windows app by Octonove (simplificaconia.com). Inno Setup installer hosted on GitHub Releases; SHA256 verified.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/407416)