### PR TITLE
New package: Octonove.CajaPDF version 1.1.0

### DIFF
--- a/manifests/o/Octonove/CajaPDF/1.1.0/Octonove.CajaPDF.installer.yaml
+++ b/manifests/o/Octonove/CajaPDF/1.1.0/Octonove.CajaPDF.installer.yaml
@@ -1,0 +1,14 @@
+# Created with Claude for Octonove
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: Octonove.CajaPDF
+PackageVersion: 1.1.0
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Octonove/cajapdf/releases/download/v1.1.0/CajaPDF-Setup.exe
+  InstallerSha256: 0E8DAE4472C780C79E6732E5B4EBFA61EF00CCB888EF9012EE124640E6264534
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/o/Octonove/CajaPDF/1.1.0/Octonove.CajaPDF.locale.en-US.yaml
+++ b/manifests/o/Octonove/CajaPDF/1.1.0/Octonove.CajaPDF.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: Octonove.CajaPDF
+PackageVersion: 1.1.0
+PackageLocale: en-US
+Publisher: Octonove
+PublisherUrl: https://simplificaconia.com
+PublisherSupportUrl: https://simplificaconia.com/contacto/
+PackageName: CajaPDF
+PackageUrl: https://simplificaconia.com/unir-comprimir-pdf-gratis/
+License: MIT
+Copyright: Copyright (c) Octonove
+ShortDescription: Lightweight PDF tool for Windows to merge, split and compress files locally without uploading anything. UI in Spanish.
+Moniker: cajapdf
+Tags:
+- pdf
+- pdf-merger
+- pdf-splitter
+- pdf-compressor
+- spanish
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/o/Octonove/CajaPDF/1.1.0/Octonove.CajaPDF.yaml
+++ b/manifests/o/Octonove/CajaPDF/1.1.0/Octonove.CajaPDF.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: Octonove.CajaPDF
+PackageVersion: 1.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Adds Octonove.CajaPDF 1.1.0. Free, MIT-licensed Windows app by Octonove (simplificaconia.com). Inno Setup installer hosted on GitHub Releases; SHA256 verified.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/407417)