### PR TITLE
New package: Octonove.CapturaStudio version 1.4.7

### DIFF
--- a/manifests/o/Octonove/CapturaStudio/1.4.7/Octonove.CapturaStudio.installer.yaml
+++ b/manifests/o/Octonove/CapturaStudio/1.4.7/Octonove.CapturaStudio.installer.yaml
@@ -1,0 +1,14 @@
+# Created with Claude for Octonove
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: Octonove.CapturaStudio
+PackageVersion: 1.4.7
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Octonove/capturastudio/releases/download/v1.4.7/CapturaStudio-Setup.exe
+  InstallerSha256: 8186BFDF388E8612B23007044B0910E8D08271854235EF77ED17D0D9907EA7BD
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/o/Octonove/CapturaStudio/1.4.7/Octonove.CapturaStudio.locale.en-US.yaml
+++ b/manifests/o/Octonove/CapturaStudio/1.4.7/Octonove.CapturaStudio.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: Octonove.CapturaStudio
+PackageVersion: 1.4.7
+PackageLocale: en-US
+Publisher: Octonove
+PublisherUrl: https://simplificaconia.com
+PublisherSupportUrl: https://simplificaconia.com/contacto/
+PackageName: CapturaStudio
+PackageUrl: https://simplificaconia.com/estudio-grabacion-streaming-gratis/
+License: MIT
+Copyright: Copyright (c) Octonove
+ShortDescription: Free recording and streaming studio for Windows with layered scenes, Whisper subtitles, silence trimming and live streaming to Twitch and YouTube. 100% local, UI in Spanish.
+Moniker: capturastudio
+Tags:
+- screen-recorder
+- streaming
+- webcam
+- twitch
+- spanish
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/o/Octonove/CapturaStudio/1.4.7/Octonove.CapturaStudio.yaml
+++ b/manifests/o/Octonove/CapturaStudio/1.4.7/Octonove.CapturaStudio.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: Octonove.CapturaStudio
+PackageVersion: 1.4.7
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Adds Octonove.CapturaStudio 1.4.7. Free, MIT-licensed Windows app by Octonove (simplificaconia.com). Inno Setup installer hosted on GitHub Releases; SHA256 verified.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/407418)