### PR TITLE
New version: zekariasasaminew.pact version 0.3.0

### DIFF
--- a/manifests/z/zekariasasaminew/pact/0.3.0/zekariasasaminew.pact.installer.yaml
+++ b/manifests/z/zekariasasaminew/pact/0.3.0/zekariasasaminew.pact.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: zekariasasaminew.pact
+PackageVersion: 0.3.0
+Platform:
+- Windows.Desktop
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: pact.exe
+ReleaseDate: 2026-07-22
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/zekariasasaminew/pact/releases/download/v0.3.0/pact-x86_64-pc-windows-msvc.zip
+  InstallerSha256: 99D835807E068C4CC3624D8E1FA2DCCF826DE46FC5412FA16488E264F307AD86
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/z/zekariasasaminew/pact/0.3.0/zekariasasaminew.pact.locale.en-US.yaml
+++ b/manifests/z/zekariasasaminew/pact/0.3.0/zekariasasaminew.pact.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: zekariasasaminew.pact
+PackageVersion: 0.3.0
+PackageLocale: en-US
+Publisher: zekariasasaminew
+PublisherUrl: https://github.com/zekariasasaminew
+PublisherSupportUrl: https://github.com/zekariasasaminew/pact/issues
+Author: zekariasasaminew
+PackageName: pact
+PackageUrl: https://github.com/zekariasasaminew/pact
+License: MIT
+LicenseUrl: https://github.com/zekariasasaminew/pact/blob/main/LICENSE
+ShortDescription: Orchestrate multiple AI coding agent CLIs in parallel via git worktrees
+Description: >-
+  pact is a language-agnostic orchestrator for running multiple AI coding
+  agent CLIs (Claude Code, GitHub Copilot CLI, Codex, Gemini CLI) in parallel
+  on the same git repository, without them fighting each other. Each agent
+  gets its own git worktree for real filesystem isolation, conflicts get
+  detected and surfaced instead of discovered the hard way, and merge-all
+  gets every agent's work back onto one branch automatically wherever it
+  safely can.
+Tags:
+- cli
+- git
+- ai
+- agents
+- automation
+- worktree
+- claude
+ReleaseNotesUrl: https://github.com/zekariasasaminew/pact/releases/tag/v0.3.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/z/zekariasasaminew/pact/0.3.0/zekariasasaminew.pact.yaml
+++ b/manifests/z/zekariasasaminew/pact/0.3.0/zekariasasaminew.pact.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: zekariasasaminew.pact
+PackageVersion: 0.3.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Adds a new package: **pact**, a language-agnostic CLI orchestrator for running multiple AI coding agent CLIs (Claude Code, GitHub Copilot CLI, Codex, Gemini CLI) in parallel on the same git repository, using isolated git worktrees, shared dependency caching, and an MCP coordination server.

- Homepage: https://github.com/zekariasasaminew/pact
- Release: https://github.com/zekariasasaminew/pact/releases/tag/v0.3.0
- License: MIT

## Checklist

- [x] I have read and understand the [contributing guide](https://github.com/microsoft/winget-pkgs/blob/master/CONTRIBUTING.md).
- [x] This PR only modifies one (1) manifest.
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12.0 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Note: the last two checkboxes reflect this manifest's actual verification status honestly -- `winget validate`/`winget install` aren't available to run for real in the environment this was authored in (no Windows Package Manager client installed there), so the manifest's correctness was verified by hand against several real, recently-merged manifests in this repo (e.g. `ajeetdsouza/zoxide`'s zip+portable-exe pattern, which pact's own distribution matches closely) and by validating YAML syntax directly, not by an actual `winget validate`/`winget install` run. Happy to address any review feedback.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/407420)