### PR TITLE
New package: fejdraus.CreatioHelper version 1.0.32

### DIFF
--- a/manifests/f/fejdraus/CreatioHelper/1.0.32/fejdraus.CreatioHelper.installer.yaml
+++ b/manifests/f/fejdraus/CreatioHelper/1.0.32/fejdraus.CreatioHelper.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: fejdraus.CreatioHelper
+PackageVersion: 1.0.32
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: CreatioHelper.exe
+    PortableCommandAlias: creatio-helper
+ReleaseDate: 2026-07-24
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/fejdraus/CreatioHelper/releases/download/desktop-v1.0.32/CreatioHelper-Desktop-win-x64-1.0.32.zip
+    InstallerSha256: EE016404101B6AAAFB8E112E0FEB4DD99E1521FB4BC5A924013D0B7B0660E229
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/fejdraus/CreatioHelper/1.0.32/fejdraus.CreatioHelper.locale.en-US.yaml
+++ b/manifests/f/fejdraus/CreatioHelper/1.0.32/fejdraus.CreatioHelper.locale.en-US.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: fejdraus.CreatioHelper
+PackageVersion: 1.0.32
+PackageLocale: en-US
+Publisher: fejdraus
+PublisherUrl: https://github.com/fejdraus
+PublisherSupportUrl: https://github.com/fejdraus/CreatioHelper/issues
+Author: fejdraus
+PackageName: CreatioHelper
+PackageUrl: https://github.com/fejdraus/CreatioHelper
+License: GPL-3.0
+LicenseUrl: https://github.com/fejdraus/CreatioHelper/blob/main/LICENSE
+ShortDescription: Cross-platform tool for automating Terrasoft Creatio deployments
+Description: |-
+  CreatioHelper automates routine operations on Terrasoft Creatio installations through a desktop application, a headless CLI and an agent service.
+
+  It installs and deletes packages, compiles the configuration through WorkspaceConsole, manages IIS sites and application pools, clears the Redis cache, edits ConnectionStrings.config through a form, handles licenses and synchronises changes across multiple Creatio instances over SFTP or Syncthing.
+
+  Compilation is offered in three depths: Compile, Fast Compile for changed schemas only, and a full Compile All. A configuration rollback restores the state that existed before the last package installation.
+Moniker: creatio-helper
+Tags:
+  - creatio
+  - terrasoft
+  - low-code
+  - deployment
+  - devops
+  - automation
+  - iis
+  - redis
+  - dotnet
+ReleaseNotesUrl: https://github.com/fejdraus/CreatioHelper/releases/tag/desktop-v1.0.32
+Documentations:
+  - DocumentLabel: User Guide
+    DocumentUrl: https://github.com/fejdraus/CreatioHelper/blob/main/USER_GUIDE.md
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/fejdraus/CreatioHelper/1.0.32/fejdraus.CreatioHelper.yaml
+++ b/manifests/f/fejdraus/CreatioHelper/1.0.32/fejdraus.CreatioHelper.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: fejdraus.CreatioHelper
+PackageVersion: 1.0.32
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Pull request has been checked for

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

### Notes

New package. CreatioHelper is a cross-platform tool that automates deployment operations for Terrasoft Creatio installations.

- Repository: https://github.com/fejdraus/CreatioHelper
- License: GPL-3.0
- I am the author and maintainer of this package.

The Windows Desktop build is published as a single-file self-contained archive, so the ZIP contains exactly one entry (`CreatioHelper.exe`) at the root. The manifest therefore uses `InstallerType: zip` with `NestedInstallerType: portable` and the command alias `creatio-helper`.

Validated and installed locally on Windows 11 with winget 1.29.280 — hash verified, archive extracted, alias registered.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/407442)