### PR TITLE
New package: TheJonaz.Moraine version 0.2.2

### DIFF
--- a/manifests/t/TheJonaz/Moraine/0.2.2/TheJonaz.Moraine.installer.yaml
+++ b/manifests/t/TheJonaz/Moraine/0.2.2/TheJonaz.Moraine.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: TheJonaz.Moraine
+PackageVersion: 0.2.2
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: moraine-windows-x86_64\moraine.exe
+    PortableCommandAlias: moraine
+Commands:
+  - moraine
+ReleaseDate: 2026-07-22
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/TheJonaz/moraine-backup/releases/download/v0.2.2/moraine-windows-x86_64.zip
+    InstallerSha256: D5CBB9A588B446720ACB7B7851AAB6FE7270AE450F4C4F53C86DAB29069EBE91
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/t/TheJonaz/Moraine/0.2.2/TheJonaz.Moraine.locale.en-US.yaml
+++ b/manifests/t/TheJonaz/Moraine/0.2.2/TheJonaz.Moraine.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: TheJonaz.Moraine
+PackageVersion: 0.2.2
+PackageLocale: en-US
+Publisher: Jonaz Thern
+PublisherUrl: https://www.thern.io
+PublisherSupportUrl: https://github.com/TheJonaz/moraine-backup/issues
+Author: Jonaz Thern
+PackageName: Moraine
+PackageUrl: https://moraine.thern.io
+License: MIT
+LicenseUrl: https://github.com/TheJonaz/moraine-backup/blob/main/LICENSE
+Copyright: Copyright (c) Jonaz Thern
+ShortDescription: Snapshot-based backup over SSH/rsync and rclone — command-line client.
+Description: |-
+  Moraine is a small, fast backup client written in Rust. Hard-linked snapshots
+  over SSH make every run look like a complete tree while only changed files take
+  new space; restore anything from any snapshot. It also supports an rclone
+  backend for cloud/object storage and FTP.
+
+  This Windows package ships the `moraine` command-line client. The GTK desktop
+  app is Linux-only.
+Moniker: moraine
+Tags:
+  - backup
+  - snapshot
+  - rsync
+  - rclone
+  - ssh
+  - cli
+  - rust
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/t/TheJonaz/Moraine/0.2.2/TheJonaz.Moraine.yaml
+++ b/manifests/t/TheJonaz/Moraine/0.2.2/TheJonaz.Moraine.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: TheJonaz.Moraine
+PackageVersion: 0.2.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## 📖 Description

New package: **TheJonaz.Moraine** version 0.2.2.

Moraine is a small, fast snapshot backup client written in Rust — hard-linked snapshots over SSH/rsync, plus an rclone backend for cloud/object storage and FTP. This Windows package ships the `moraine` command-line client (portable `moraine.exe` from the official release zip; the GTK desktop app is Linux-only).

Manifests: `manifests/t/TheJonaz/Moraine/0.2.2/` (version + installer + en-US defaultLocale). The installer is the official GitHub release asset and its SHA256 was verified against the file.

**Transparency for reviewers:** these manifests were prepared on Linux, so `winget validate` / `winget install` were **not** run locally — relying on the validation pipeline here. Manifests use schema **1.6.0**. The maintainer (@TheJonaz) will sign the CLA via the bot below.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com) — will sign via the CLA bot below
- [ ] Linked to an issue (if applicable) — N/A (routine new-package submission)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate` — not run (submitted from Linux; relying on the pipeline)
- [ ] Tested manifest locally with `winget install` — not run (submitted from Linux)
- [ ] Manifest conforms to the 1.12 schema — uses schema **1.6.0** (still supported); happy to bump to 1.12 on request

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/407514)