### PR TITLE
New package: Unity.CLI version 1.0.0.20003

### DIFF
--- a/manifests/u/Unity/CLI/1.0.0.20003/Unity.CLI.installer.yaml
+++ b/manifests/u/Unity/CLI/1.0.0.20003/Unity.CLI.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Unity.CLI
+PackageVersion: 1.0.0.20003
+InstallerLocale: en-US
+InstallerType: msix
+MinimumOSVersion: 10.0.17763.0
+PackageFamilyName: UnityTechnologies.UnityCLI_2vrhnee42bhxm
+Commands:
+- unity
+ReleaseDate: 2026-07-24
+Installers:
+- Architecture: x64
+  InstallerUrl: https://public-cdn.cloud.unity3d.com/hub/prod/cli/1.0.0-beta.3/unity-windows-x64.msix
+  InstallerSha256: 32F22B14F80DB537B480DA6B5B746361220F2DC836EDFA71FB429E7F80D95E66
+  SignatureSha256: 8DAA036D01E8541A383FCC6005F87BD1AB7F669EF01199AF5E76697FF690619F
+- Architecture: arm64
+  InstallerUrl: https://public-cdn.cloud.unity3d.com/hub/prod/cli/1.0.0-beta.3/unity-windows-arm64.msix
+  InstallerSha256: DE761B9CB2A5989B53B62C16F67CD5643D40B60010135FE83710DDBCC11DFD04
+  SignatureSha256: C6DD071B8D3971477666CD0EC4DF6705694377AD6DD5900E842294D15B3B6ADB
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/u/Unity/CLI/1.0.0.20003/Unity.CLI.locale.en-US.yaml
+++ b/manifests/u/Unity/CLI/1.0.0.20003/Unity.CLI.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Unity.CLI
+PackageVersion: 1.0.0.20003
+PackageLocale: en-US
+Publisher: Unity Technologies Inc.
+PublisherUrl: https://unity.com/
+PublisherSupportUrl: https://support.unity.com/
+PrivacyUrl: https://unity.com/legal/privacy-policy
+Author: Unity Technologies Inc.
+PackageName: Unity CLI
+PackageUrl: https://unity.com/unity-hub
+License: Proprietary
+LicenseUrl: https://unity.com/legal/terms-of-service
+Copyright: Copyright © 2026 Unity Technologies Inc.
+CopyrightUrl: https://unity.com/legal/trademarks
+ShortDescription: Command-line interface for installing Unity Editors and creating, opening, and building Unity projects.
+Description: The Unity CLI (invoked as "unity") manages Unity Editor installations and modules, creates and opens projects, runs builds and Editor commands, and manages licenses and cloud sign-in from the terminal. This build reports its version as 1.0.0-beta.3; MSIX package versions encode the prerelease channel in the fourth (revision) field.
+Moniker: unity-cli
+Tags:
+- cli
+- command-line
+- unity
+- unity3d
+ReleaseNotesUrl: https://public-cdn.cloud.unity3d.com/hub/prod/cli/1.0.0-beta.3/CHANGELOG.md
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/u/Unity/CLI/1.0.0.20003/Unity.CLI.locale.en-US.yaml
+++ b/manifests/u/Unity/CLI/1.0.0.20003/Unity.CLI.locale.en-US.yaml
@@ -22,6 +22,17 @@ Tags:
 - command-line
 - unity
 - unity3d
+ReleaseNotes: |-
+  Highlights of 1.0.0-beta.3 (full notes at the release notes URL):
+  - unity run --command executes a registered Editor command headlessly in one invocation.
+  - unity shell gains persistent history, tab completion, session context/defaults, and a framed NDJSON machine protocol for agents.
+  - unity editors running lists running Editor instances and their open projects; unity projects size reports per-folder disk usage.
+  - unity bug can run fully non-interactively via flags; UNITY_NO_CONSENT_PROMPT suppresses the first-run analytics prompt for wrapper scripts.
+  - Install/download progress reports to the terminal taskbar via OSC 9;4; unity upgrade now updates AppImage installs in place.
+  - Crash reporting via Sentry (anonymous, scrubbed; disable with UNITY_NO_CRASH_REPORT) and expanded opt-in usage analytics.
 ReleaseNotesUrl: https://public-cdn.cloud.unity3d.com/hub/prod/cli/1.0.0-beta.3/CHANGELOG.md
+Documentations:
+- DocumentLabel: Unity CLI Manual
+  DocumentUrl: https://docs.unity.com/unity-cli
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0

--- a/manifests/u/Unity/CLI/1.0.0.20003/Unity.CLI.yaml
+++ b/manifests/u/Unity/CLI/1.0.0.20003/Unity.CLI.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Unity.CLI
+PackageVersion: 1.0.0.20003
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package: **Unity.CLI** (`unity`), the command-line interface for Unity — installs Unity Editors and modules, creates/opens/builds Unity projects, and manages licenses from the terminal. Published by Unity Technologies (same publisher as the existing `Unity.UnityHub` package; installers are signed MSIX packages from Unity's official CDN, the same origin as Unity Hub's winget installers).

Version note: `1.0.0.20003` is the MSIX package version of the product release `1.0.0-beta.3` — MSIX `Identity/@Version` cannot carry prerelease tags, so the prerelease channel is encoded in the revision field (release versions strictly increase: later betas < GA). `winget install Unity.CLI` puts the `unity` command on PATH via the package's App Execution Alias.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

Local install test: hash verification, MSIX deployment (x64), App Execution Alias, and `winget uninstall` all verified on Windows 11.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/407542)