### PR TITLE
New version: Netpack.XFB version 3.141592653

### DIFF
--- a/manifests/n/Netpack/XFB/3.141592653/Netpack.XFB.installer.yaml
+++ b/manifests/n/Netpack/XFB/3.141592653/Netpack.XFB.installer.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: Netpack.XFB
+PackageVersion: "3.141592653"
+InstallerType: nullsoft
+Scope: machine
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+ElevationRequirement: elevationRequired
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/netpack/XFB/releases/download/v3.141592653/XFB-3.141592653-Setup.exe
+  InstallerSha256: 9E29C3EEC81FE3127FF6471EED412CC9879D5BBA9CC881D34FB81376D814D72A
+  ProductCode: XFB
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+  AppsAndFeaturesEntries:
+  - DisplayName: XFB (x64) - XFB Radio Automation Software
+    Publisher: Netpack - Online Solutions
+- Architecture: arm64
+  InstallerUrl: https://github.com/netpack/XFB/releases/download/v3.141592653/XFB-3.141592653-arm64-Setup.exe
+  InstallerSha256: 329DBE85D3665A0C7400B6A2684B0F6EEF59FE9E12AA7FB122D922C929C1205E
+  ProductCode: XFB
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.arm64
+  AppsAndFeaturesEntries:
+  - DisplayName: XFB (arm64) - XFB Radio Automation Software
+    Publisher: Netpack - Online Solutions
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/n/Netpack/XFB/3.141592653/Netpack.XFB.locale.en-US.yaml
+++ b/manifests/n/Netpack/XFB/3.141592653/Netpack.XFB.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: Netpack.XFB
+PackageVersion: "3.141592653"
+PackageLocale: en-US
+Publisher: Netpack - Online Solutions
+PublisherUrl: https://netpack.pt/
+PublisherSupportUrl: https://github.com/netpack/XFB/issues
+Author: Frédéric Bogaerts
+PackageName: XFB
+PackageUrl: https://github.com/netpack/XFB
+License: GPL-3.0
+LicenseUrl: https://github.com/netpack/XFB/blob/main/LICENSE
+ShortDescription: Open-source radio automation software
+Description: |-
+  XFB is an open-source radio automation suite for broadcasters. It provides
+  scheduled playlists, jingles and advertising rotation, a live audio FX
+  engine (10-band equalizer, compressor, 432 Hz retune), DJ decks with
+  scratchable jog wheels, an Icecast/Shoutcast streaming client, playlist
+  waveform views with crossfade preparation and volume automation, and
+  comprehensive accessibility support including screen-reader integration
+  and full keyboard navigation.
+Moniker: xfb
+Tags:
+- accessibility
+- audio
+- automation
+- broadcast
+- open-source
+- radio
+ReleaseNotesUrl: https://github.com/netpack/XFB/releases/tag/v3.141592653
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/n/Netpack/XFB/3.141592653/Netpack.XFB.yaml
+++ b/manifests/n/Netpack/XFB/3.141592653/Netpack.XFB.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: Netpack.XFB
+PackageVersion: "3.141592653"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Adds version 3.141592653 of Netpack.XFB.

Accessibility release: the screen reader, audio feedback and braille services now initialize, playback and playlist building are fully keyboard driven, and a tutorial for blind users is included.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)? (signed for the previous Netpack.XFB submission, #399379)
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change? (none open for Netpack.XFB)
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`? — not run: prepared on macOS, where the winget client is unavailable. The manifests are a version bump of the merged 3.14159265 manifests, schema 1.10.0.
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? — not run, same reason.
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

InstallerSha256 values were computed from the release assets published at https://github.com/netpack/XFB/releases/tag/v3.141592653:

- x64: `9E29C3EEC81FE3127FF6471EED412CC9879D5BBA9CC881D34FB81376D814D72A`
- arm64: `329DBE85D3665A0C7400B6A2684B0F6EEF59FE9E12AA7FB122D922C929C1205E`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/407569)