### PR TITLE
New package: xCompassionate.PageTurn version 1.0.0

### DIFF
--- a/manifests/x/xCompassionate/PageTurn/1.0.0/xCompassionate.PageTurn.installer.yaml
+++ b/manifests/x/xCompassionate/PageTurn/1.0.0/xCompassionate.PageTurn.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: xCompassionate.PageTurn
+PackageVersion: 1.0.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: PageTurn.exe
+  PortableCommandAlias: pageturn
+Scope: user
+UpgradeBehavior: install
+ReleaseDate: 2026-07-25
+FileExtensions:
+- pdf
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/xCompassionate/PageTurn/releases/download/v1.0.0/PageTurn-win.zip
+  InstallerSha256: EEF253991DF8CF5F1FB8834040C8836D132D7DC94A4478CA513FE6A104157A8B
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/x/xCompassionate/PageTurn/1.0.0/xCompassionate.PageTurn.locale.en-US.yaml
+++ b/manifests/x/xCompassionate/PageTurn/1.0.0/xCompassionate.PageTurn.locale.en-US.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: xCompassionate.PageTurn
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: xCompassionate
+PublisherUrl: https://github.com/xCompassionate
+PublisherSupportUrl: https://github.com/xCompassionate/PageTurn/issues
+PackageName: PageTurn
+PackageUrl: https://github.com/xCompassionate/PageTurn
+License: Proprietary
+LicenseUrl: https://github.com/xCompassionate/PageTurn/blob/main/LICENSE
+Copyright: Copyright (c) 2026 xCompassionate
+ShortDescription: Free PDF viewer, signature editor and highlighter that shows documents as a two page book spread.
+Description: |-
+  PageTurn is a free PDF reader that opens documents as a two page spread, the way a book sits open on a desk, with a single page view when you want one big page instead.
+
+  It also handles the parts people normally pay for. Draw a signature with the mouse or type your name in one of four handwriting styles, then drop it on the page along with your initials and an optional signed by block carrying your name, the date and a unique ID. Text boxes let you fill in forms. Saving a filled copy writes a new PDF with everything baked in, leaving the original untouched.
+
+  Reading tools include a four colour highlighter, notes attached to highlights, standalone notes you can reorder, bookmarks with dates, and a side panel that jumps you to any of them. Open several PDFs at once in tabs, and they come back the next time you launch. Six window themes and five page colours, including a night mode built for reading in the dark.
+
+  Everything is stored on your own machine. No account, no cloud, no telemetry, no ads, no paid tier. It is free and it stays free.
+Moniker: pageturn
+Tags:
+- annotation
+- book
+- document
+- ebook
+- fill-and-sign
+- highlighter
+- notes
+- pdf
+- pdf-reader
+- pdf-viewer
+- reader
+- sign
+- signature
+- viewer
+ReleaseNotesUrl: https://github.com/xCompassionate/PageTurn/releases/tag/v1.0.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/x/xCompassionate/PageTurn/1.0.0/xCompassionate.PageTurn.yaml
+++ b/manifests/x/xCompassionate/PageTurn/1.0.0/xCompassionate.PageTurn.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: xCompassionate.PageTurn
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

New package: PageTurn 1.0.0, a free PDF reader with a two page book view, highlighting, notes, bookmarks and signing. Portable app shipped as a zip, so the manifest uses `InstallerType: zip` with `NestedInstallerType: portable` pointing at `PageTurn.exe`.

Publisher and package repository: https://github.com/xCompassionate/PageTurn
Installer: https://github.com/xCompassionate/PageTurn/releases/download/v1.0.0/PageTurn-win.zip

## Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Checked that there aren't other open pull requests for the same manifest
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the 1.12 schema

Note on the two unchecked validation boxes: these manifests were written by hand on Linux, so `winget validate` and `winget install` could not be run locally. The manifest follows the 1.12.0 schema and the installer hash was taken from the published release asset. Happy to fix anything the validation pipeline flags.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/407631)