### PR TITLE
New package: MattJColes.lgtmaybe version 1.4.0

### DIFF
--- a/manifests/m/MattJColes/lgtmaybe/1.4.0/MattJColes.lgtmaybe.installer.yaml
+++ b/manifests/m/MattJColes/lgtmaybe/1.4.0/MattJColes.lgtmaybe.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: MattJColes.lgtmaybe
+PackageVersion: 1.4.0
+InstallerType: portable
+Commands:
+- lgtmaybe
+ReleaseDate: 2026-07-25
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/MattJColes/lgtmaybe/releases/download/lgtmaybe-v1.4.0/lgtmaybe-1.4.0-windows-x86_64.exe
+  InstallerSha256: 6170E7CF0749112DF17D6123B60186CA5FB81696CC7493F4545AB32A795F72D3
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/MattJColes/lgtmaybe/1.4.0/MattJColes.lgtmaybe.locale.en-US.yaml
+++ b/manifests/m/MattJColes/lgtmaybe/1.4.0/MattJColes.lgtmaybe.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: MattJColes.lgtmaybe
+PackageVersion: 1.4.0
+PackageLocale: en-US
+Publisher: Matt Coles
+PublisherUrl: https://github.com/MattJColes
+PublisherSupportUrl: https://github.com/MattJColes/lgtmaybe/issues
+Author: Matt Coles
+PackageName: lgtmaybe
+PackageUrl: https://lgtmaybe.coles.codes/
+License: MIT
+LicenseUrl: https://github.com/MattJColes/lgtmaybe/blob/HEAD/LICENSE
+ShortDescription: Provider-agnostic pull request reviewer for hosted, local, and OpenAI-compatible models.
+Moniker: lgtmaybe
+Tags:
+- ai
+- cli
+- code-review
+- github
+- llm
+- pull-request
+ReleaseNotesUrl: https://github.com/MattJColes/lgtmaybe/releases/tag/lgtmaybe-v1.4.0
+Documentations:
+- DocumentLabel: Documentation
+  DocumentUrl: https://lgtmaybe.coles.codes/
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/MattJColes/lgtmaybe/1.4.0/MattJColes.lgtmaybe.yaml
+++ b/manifests/m/MattJColes/lgtmaybe/1.4.0/MattJColes.lgtmaybe.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: MattJColes.lgtmaybe
+PackageVersion: 1.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Adds the first WinGet manifest for `MattJColes.lgtmaybe` version 1.4.0 as an
x64 portable executable with the `lgtmaybe` command.

## Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable) - not applicable

## Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same manifest
- [x] This PR only modifies one manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the 1.12 schema

Tested locally on Windows with WinGet v1.30.70-preview: the manifest validated,
the installer download and SHA-256 verification succeeded, the portable alias
was registered, `--help`, `config path`, and `help review` passed, and the test
installation uninstalled cleanly.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/407659)