### PR TITLE
Update: axpnet.AeroFTP version 3.3.5 - correct InstallerSha256 for both installers

### DIFF
--- a/manifests/a/axpnet/AeroFTP/3.3.5/axpnet.AeroFTP.installer.yaml
+++ b/manifests/a/axpnet/AeroFTP/3.3.5/axpnet.AeroFTP.installer.yaml
@@ -10,7 +10,7 @@ Installers:
   InstallerType: nullsoft
   Scope: user
   InstallerUrl: https://github.com/axpdev-lab/aeroftp/releases/download/v3.3.5/AeroFTP_3.3.5_x64-setup.exe
-  InstallerSha256: C3941216CE4DE533690174420992E2BF29814A0E3FF4853BA72A8C707E1B2BC4
+  InstallerSha256: 6829A05AB77D415F357E47F1E0D2B442075F08169A7F22AD95D693687478B091
   InstallerSwitches:
     Silent: /S
     SilentWithProgress: /S
@@ -24,7 +24,7 @@ Installers:
   InstallerType: wix
   Scope: machine
   InstallerUrl: https://github.com/axpdev-lab/aeroftp/releases/download/v3.3.5/AeroFTP_3.3.5_x64_en-US.msi
-  InstallerSha256: AD0717257B28B8E8597A4525570ABDD7DF540BD81DB8870A4FA4048782CFAD70
+  InstallerSha256: B9D99D292C6BA14184C5E23C16046B657420217416C8BE6A9416F6115451AE86
   ProductCode: '{C4D55775-FC41-48D7-9764-B995A62B3B6B}'
   AppsAndFeaturesEntries:
   - Publisher: aeroftp


### PR DESCRIPTION
## 📖 Description

Corrects both `InstallerSha256` values in the existing `axpnet.AeroFTP` **3.3.5** manifest. No other field changes; the installer URLs, types, scopes and product codes are untouched.

The two assets behind this version were rebuilt and re-uploaded to the GitHub release on the same day the manifest was cut (2026-04-03), so the published manifest froze the pre-rebuild digests. As a result `winget install axpnet.AeroFTP --version 3.3.5` currently fails the hash check.

| Installer | Manifest (stale) | Correct |
|---|---|---|
| `AeroFTP_3.3.5_x64-setup.exe` | `C3941216…B2BC4` | `6829A05A…78B091` |
| `AeroFTP_3.3.5_x64_en-US.msi` | `AD071725…2CFAD70` | `B9D99D29…451AE86` |

Both new digests were verified two ways: by downloading each asset and hashing it, and against the Sigstore bundle published alongside each asset in the same release (`messageSignature.messageDigest` in `<asset>.sigstore.json`), which attests exactly these digests. I also swept all 81 published `axpnet.AeroFTP` versions against their Sigstore attestations: 150 of 162 installer entries verify clean, the 10 unverifiable ones predate release signing, and 3.3.5 is the only mismatch. This is an isolated, one-off drift on our side, not a pattern.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change — with one caveat, see below
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` — `winget` is Windows-only and this was prepared on Linux. Instead the manifest was validated against the official [1.12 installer JSON schema](https://aka.ms/winget-manifest.installer.1.12.0.schema.json) and checked for duplicate installer identity tuples; both pass.
- [ ] Tested manifest locally with `winget install --manifest <path>` — same reason. The two digests are independently attested by the release's own Sigstore bundles.
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

### On the open bot PR

There is an open automated PR for this same manifest, #405612, and it should be closed in favour of this one. `wingetbot` has proposed this update seven times since 2026-06-09 (#385279, #390233, #393135, #397471, #400593, #402951, #403960, #405612) and every closed attempt was labelled `Error-Hash-Mismatch`. The reason is that the bot's PR only updates the `.exe` digest and leaves the `.msi` one stale, so validation still fails on the second installer and the PR is closed — then the detector fires again on the next sweep. Fixing both digests in one change is what breaks that loop.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/407672)