### PR TITLE
New version: GNE.DualMonitorTools version 2.12.0.0

### DIFF
--- a/manifests/g/GNE/DualMonitorTools/2.12.0.0/GNE.DualMonitorTools.installer.yaml
+++ b/manifests/g/GNE/DualMonitorTools/2.12.0.0/GNE.DualMonitorTools.installer.yaml
@@ -1,0 +1,16 @@
+# Created with YamlCreate.ps1 v2.4.3 $debug=AUSU.CRLF.7-4-6.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: GNE.DualMonitorTools
+PackageVersion: 2.12.0.0
+InstallerLocale: en-US
+InstallerType: msi
+UpgradeBehavior: install
+ReleaseDate: 2025-08-19
+Installers:
+- Architecture: x86
+  InstallerUrl: https://sourceforge.net/projects/dualmonitortool/files/dualmonitortool/2.12/DualMonitorTools-2.12.msi/download
+  InstallerSha256: 382DB114FCB9A7E64F712D458AE06EEB657C3F998EC3ACA0826407FC80D127DF
+  ProductCode: '{8A998749-7B8A-463D-A06C-8CF6AA580415}'
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/g/GNE/DualMonitorTools/2.12.0.0/GNE.DualMonitorTools.locale.en-US.yaml
+++ b/manifests/g/GNE/DualMonitorTools/2.12.0.0/GNE.DualMonitorTools.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# Created with YamlCreate.ps1 v2.4.3 $debug=AUSU.CRLF.7-4-6.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: GNE.DualMonitorTools
+PackageVersion: 2.12.0.0
+PackageLocale: en-US
+Publisher: GNE
+PublisherUrl: https://dualmonitortool.sourceforge.net/
+PublisherSupportUrl: https://sourceforge.net/projects/dualmonitortool/support
+Author: GNE
+PackageName: Dual Monitor Tools
+PackageUrl: https://dualmonitortool.sourceforge.net/
+License: GNU GPL v3
+ShortDescription: Tools for users with multiple monitors.
+Moniker: dmt
+Tags:
+- monitor
+- screen
+- wallpaper
+ReleaseNotesUrl: https://dualmonitortool.sourceforge.net/history.html
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/g/GNE/DualMonitorTools/2.12.0.0/GNE.DualMonitorTools.yaml
+++ b/manifests/g/GNE/DualMonitorTools/2.12.0.0/GNE.DualMonitorTools.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.4.3 $debug=AUSU.CRLF.7-4-6.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: GNE.DualMonitorTools
+PackageVersion: 2.12.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## Proposed Changes
New version of GNE.DualMonitorTools: 2.12.0.0

- Installer: https://sourceforge.net/projects/dualmonitortool/files/dualmonitortool/2.12/DualMonitorTools-2.12.msi/download
- SHA256: 382DB114FCB9A7E64F712D458AE06EEB657C3F998EC3ACA0826407FC80D127DF (local download of official MSI)
- ProductCode: {8A998749-7B8A-463D-A06C-8CF6AA580415} (from MSI Property table)
- ProductVersion from MSI: 2.12.0.0

Fixes #406890

## Validation
- [x] Downloaded MSI from SourceForge mirror and hashed locally
- [x] Extracted ProductCode/ProductVersion with msitools
- [ ] Windows install validation

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/407680)