### PR TITLE
New package: nikserg.Skim version 1.0.9

### DIFF
--- a/manifests/n/nikserg/Skim/1.0.9/nikserg.Skim.installer.yaml
+++ b/manifests/n/nikserg/Skim/1.0.9/nikserg.Skim.installer.yaml
@@ -1,0 +1,22 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: nikserg.Skim
+PackageVersion: 1.0.9
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ProductCode: Skim
+ReleaseDate: 2026-07-24
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/nikserg/skim/releases/download/v1.0.9/Skim_1.0.9_x64-setup.exe
+  InstallerSha256: 55D723CE70D57BB9B856218092D8AC0D3039C0BFEC41AE3184FA1E05F7DCCD01
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/n/nikserg/Skim/1.0.9/nikserg.Skim.locale.en-US.yaml
+++ b/manifests/n/nikserg/Skim/1.0.9/nikserg.Skim.locale.en-US.yaml
@@ -1,0 +1,38 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: nikserg.Skim
+PackageVersion: 1.0.9
+PackageLocale: en-US
+Publisher: nikserg
+PublisherUrl: https://github.com/nikserg
+PublisherSupportUrl: https://github.com/nikserg/skim/issues
+PackageName: Skim
+PackageUrl: https://skim-tech.com
+License: MIT
+LicenseUrl: https://github.com/nikserg/skim/blob/main/LICENSE
+ShortDescription: A fast, minimalist, AI-native email client for Windows
+Description: |-
+  Skim is a free and open-source email client for Windows with a built-in AI copilot.
+  A Rust core with a native WebView2 UI keeps the installer at a few megabytes and
+  starts instantly, with no bundled browser and no admin rights required.
+  Mail is stored locally in SQLite for offline-first reading, instant full-text
+  search, and optimistic actions that sync in the background. HTML mail is
+  sanitized and rendered in a sandboxed frame, and passwords, OAuth tokens, and
+  the AI key live in Windows Credential Manager. The AI assistant is bring-your-own-key,
+  so there is no subscription and no proxy between you and the provider.
+Moniker: skim
+Tags:
+- ai
+- client
+- e-mail
+- email
+- imap
+- mail
+- minimalist
+- smtp
+ReleaseNotesUrl: https://github.com/nikserg/skim/releases/tag/v1.0.9
+Documentations:
+- DocumentLabel: Readme
+  DocumentUrl: https://github.com/nikserg/skim#readme
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/n/nikserg/Skim/1.0.9/nikserg.Skim.yaml
+++ b/manifests/n/nikserg/Skim/1.0.9/nikserg.Skim.yaml
@@ -1,0 +1,7 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: nikserg.Skim
+PackageVersion: 1.0.9
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New package: nikserg.Skim version 1.0.9

Skim is a free, open-source, minimalist email client for Windows (Rust + Tauri 2). I am the author and maintainer of the package.

- Installer: per-user NSIS (`nullsoft`), no admin rights required
- Homepage: https://skim-tech.com
- Source: https://github.com/nikserg/skim
- Release: https://github.com/nikserg/skim/releases/tag/v1.0.9

- [x] Manifest validated locally with `winget validate --manifest <path>` (schema 1.12.0) - validation succeeded.
- [x] Checked that there is no other open pull request for this package.
- [x] Installed locally with `winget install --manifest <path>` - installer hash verified, install succeeded, and `winget list` correlates the package against its ARP entry (`ProductCode: Skim`) at the right version.
- [x] CLA signed.