### PR TITLE
Add yuru7.HackGen version 2.10.0

### DIFF
--- a/manifests/y/yuru7/HackGen/2.10.0/yuru7.HackGen.installer.yaml
+++ b/manifests/y/yuru7/HackGen/2.10.0/yuru7.HackGen.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: yuru7.HackGen
+PackageVersion: 2.10.0
+Installers:
+- Architecture: neutral
+  Scope: machine
+  InstallerType: inno
+  InstallerUrl: https://github.com/dfirr/winget-hackgen/releases/download/v2.10.0/HackGen-2.10.0-Setup.exe
+  InstallerSha256: A1FABFAE036E4688DE76B3FC26CE041338F046C66598EEB57BBFD2F816FFAFED
+  InstallerSwitches:
+    Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+    SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART
+  ProductCode: '{90F8EA35-5CE0-4BBE-81D1-69D1397673F4}_is1'
+  ReleaseDate: 2024-12-29
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/y/yuru7/HackGen/2.10.0/yuru7.HackGen.locale.en-US.yaml
+++ b/manifests/y/yuru7/HackGen/2.10.0/yuru7.HackGen.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: yuru7.HackGen
+PackageVersion: 2.10.0
+PackageLocale: en-US
+Publisher: yuru7
+PublisherUrl: https://github.com/yuru7
+PublisherSupportUrl: https://github.com/yuru7/HackGen/issues
+Author: Yuko OTAWARA
+PackageName: HackGen
+PackageUrl: https://github.com/yuru7/HackGen
+License: SIL Open Font License 1.1
+LicenseUrl: https://raw.githubusercontent.com/yuru7/HackGen/v2.10.0/LICENSE
+Copyright: Copyright (c) 2019, Yuko OTAWARA.
+ShortDescription: A composite programming font based on Hack and GenJyuu-Gothic.
+Description: HackGen is a Japanese programming font that combines Hack with GenJyuu-Gothic and includes monospaced variants for coding and console use.
+Moniker: hackgen
+Tags:
+- font
+- hackgen
+- japanese
+- monospace
+- programming-font
+- typeface
+ReleaseNotes: This release updates the version number for the standard HackGen fonts. Non-Nerd Fonts assets are otherwise unchanged from v2.9.1.
+ReleaseNotesUrl: https://github.com/yuru7/HackGen/releases/tag/v2.10.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/y/yuru7/HackGen/2.10.0/yuru7.HackGen.yaml
+++ b/manifests/y/yuru7/HackGen/2.10.0/yuru7.HackGen.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: yuru7.HackGen
+PackageVersion: 2.10.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Adds HackGen 2.10.0.\n\nHackGen is a Japanese programming font developed by yuru7 and distributed under the SIL Open Font License 1.1. This manifest uses an Inno Setup installer hosted from dfirr/winget-hackgen to install the fonts machine-wide, which makes them visible to Windows Terminal.\n\nValidation performed:\n- winget validate manifests/y/yuru7/HackGen/2.10.0\n- Installer URL and SHA256 verified from GitHub Releases.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/407728)