### PR TITLE
New package: NotedeckDev.NoteDeck version 1.21.0

### DIFF
--- a/manifests/n/NotedeckDev/NoteDeck/1.21.0/NotedeckDev.NoteDeck.installer.yaml
+++ b/manifests/n/NotedeckDev/NoteDeck/1.21.0/NotedeckDev.NoteDeck.installer.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: NotedeckDev.NoteDeck
+PackageVersion: 1.21.0
+InstallerType: nullsoft
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/notedeck-dev/notedeck/releases/download/v1.21.0/NoteDeck-1.21.0-windows-x64-setup.exe
+    InstallerSha256: 5e18b8377ab7f3da0b9f966e12f720452f9a99ab5f810efc57a9b932888f777c
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/n/NotedeckDev/NoteDeck/1.21.0/NotedeckDev.NoteDeck.locale.en-US.yaml
+++ b/manifests/n/NotedeckDev/NoteDeck/1.21.0/NotedeckDev.NoteDeck.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.9.0.schema.json
+PackageIdentifier: NotedeckDev.NoteDeck
+PackageVersion: 1.21.0
+PackageLocale: en-US
+Publisher: notedeck-dev
+PublisherUrl: https://github.com/notedeck-dev
+PackageName: NoteDeck
+PackageUrl: https://github.com/notedeck-dev/notedeck
+License: AGPL-3.0
+LicenseUrl: https://github.com/notedeck-dev/notedeck/blob/main/LICENSE
+ShortDescription: Misskey Pro — an integrated deck environment (IDE) for Misskey power users
+Description: |-
+  NoteDeck is "Misskey Pro" — an integrated deck environment (IDE)
+  for power users of Misskey and its forks.
+  It offers local full-text search, AI integration, and a localhost API — features a web UI can't provide.
+Tags:
+  - misskey
+  - misskey-pro
+  - fediverse
+  - deck
+  - social-media
+ManifestType: locale
+ManifestVersion: 1.9.0

--- a/manifests/n/NotedeckDev/NoteDeck/1.21.0/NotedeckDev.NoteDeck.locale.ja-JP.yaml
+++ b/manifests/n/NotedeckDev/NoteDeck/1.21.0/NotedeckDev.NoteDeck.locale.ja-JP.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: NotedeckDev.NoteDeck
+PackageVersion: 1.21.0
+PackageLocale: ja-JP
+Publisher: notedeck-dev
+PublisherUrl: https://github.com/notedeck-dev
+PackageName: NoteDeck
+PackageUrl: https://github.com/notedeck-dev/notedeck
+License: AGPL-3.0
+LicenseUrl: https://github.com/notedeck-dev/notedeck/blob/main/LICENSE
+ShortDescription: Misskey Pro — Misskey廃人のための Misskey 統合デッキ環境 (IDE)
+Description: |-
+  NoteDeck は「Misskey Pro」— Misskey とそのフォークに対応した、
+  Misskey廃人のための統合デッキ環境 (IDE) です。
+  ローカル全文検索、AI 統合、localhost API など、Web UI にはない機能を備えています。
+Tags:
+  - misskey
+  - misskey-pro
+  - fediverse
+  - deck
+  - social-media
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/n/NotedeckDev/NoteDeck/1.21.0/NotedeckDev.NoteDeck.yaml
+++ b/manifests/n/NotedeckDev/NoteDeck/1.21.0/NotedeckDev.NoteDeck.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: NotedeckDev.NoteDeck
+PackageVersion: 1.21.0
+DefaultLocale: ja-JP
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
### Package: NotedeckDev.NoteDeck version 1.21.0

This is the first submission of `NotedeckDev.NoteDeck`.

NoteDeck was previously published as `Hitalin.NoteDeck` (versions up to 1.20.1). The project has been
transferred from a personal account to the `notedeck-dev` organization
(https://github.com/notedeck-dev/notedeck), so the package is being re-published under the
organization identifier. A separate PR will follow to deprecate/move the old `Hitalin.NoteDeck`
manifests. Same publisher, same upstream project, same signed release artifacts.

- Upstream release: https://github.com/notedeck-dev/notedeck/releases/tag/v1.21.0
- Installer SHA256 verified against the release's `SHA256SUMS.txt` and recomputed from the
  downloaded artifact.

-----

#### Microsoft Reviewers: [Open in CodeFlow](https://open.vscode.dev/microsoft/winget-pkgs/pull/407740)

- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest against the [1.9.0 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.9.0)?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?

> Note: the manifest could not be validated with `winget validate` / `winget install` locally because
> no Windows machine was available to the submitter. The manifest was authored against the 1.9.0
> schema and the installer hash was verified byte-for-byte against the published release artifact.
> Happy to re-submit if the pipeline validation finds anything.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/407740)