### PR TITLE
New version: napxlexn.AILimits version 0.6.0

### DIFF
--- a/manifests/n/napxlexn/AILimits/0.6.0/napxlexn.AILimits.installer.yaml
+++ b/manifests/n/napxlexn/AILimits/0.6.0/napxlexn.AILimits.installer.yaml
@@ -16,7 +16,7 @@ Installers:
     # From the v0.6.0 release build's "Installer SHA256" step, cross-checked
     # against the published asset digest
     # (хеш із релізного кроку SHA256, звірений з опублікованим файлом).
-    InstallerSha256: 065A8A96D7EBF04926D124EDCF88D807C352166A3BBC5683471E93C33EB5509C
+    InstallerSha256: 41C580CF879AC9B6F4E7EE94E717F440862A78168DEC14EE8128BAB94E4BAF89
     ProductCode: '{7A1B9C44-5E2D-4F8A-9C3B-AILIMITS0001}_is1'
     AppsAndFeaturesEntries:
       - DisplayName: AI Limits

--- a/manifests/n/napxlexn/AILimits/0.6.0/napxlexn.AILimits.installer.yaml
+++ b/manifests/n/napxlexn/AILimits/0.6.0/napxlexn.AILimits.installer.yaml
@@ -14,8 +14,7 @@ Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/napxlexn/ailimits/releases/download/v0.6.0/AiLimits-Setup-0.6.0.exe
     # From the v0.6.0 release build's "Installer SHA256" step, cross-checked
-    # against the published asset digest
-    # (хеш із релізного кроку SHA256, звірений з опублікованим файлом).
+    # against the published asset digest.
     InstallerSha256: 41C580CF879AC9B6F4E7EE94E717F440862A78168DEC14EE8128BAB94E4BAF89
     ProductCode: '{7A1B9C44-5E2D-4F8A-9C3B-AILIMITS0001}_is1'
     AppsAndFeaturesEntries:

--- a/manifests/n/napxlexn/AILimits/0.6.0/napxlexn.AILimits.installer.yaml
+++ b/manifests/n/napxlexn/AILimits/0.6.0/napxlexn.AILimits.installer.yaml
@@ -21,7 +21,6 @@ Installers:
     AppsAndFeaturesEntries:
       - DisplayName: AI Limits
         Publisher: napxlexn
-        DisplayVersion: 0.6.0
         ProductCode: '{7A1B9C44-5E2D-4F8A-9C3B-AILIMITS0001}_is1'
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/n/napxlexn/AILimits/0.6.0/napxlexn.AILimits.installer.yaml
+++ b/manifests/n/napxlexn/AILimits/0.6.0/napxlexn.AILimits.installer.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: napxlexn.AILimits
+PackageVersion: 0.6.0
+MinimumOSVersion: 10.0.22000.0
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-07-25
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/napxlexn/ailimits/releases/download/v0.6.0/AiLimits-Setup-0.6.0.exe
+    # From the v0.6.0 release build's "Installer SHA256" step, cross-checked
+    # against the published asset digest
+    # (хеш із релізного кроку SHA256, звірений з опублікованим файлом).
+    InstallerSha256: 065A8A96D7EBF04926D124EDCF88D807C352166A3BBC5683471E93C33EB5509C
+    ProductCode: '{7A1B9C44-5E2D-4F8A-9C3B-AILIMITS0001}_is1'
+    AppsAndFeaturesEntries:
+      - DisplayName: AI Limits
+        Publisher: napxlexn
+        DisplayVersion: 0.6.0
+        ProductCode: '{7A1B9C44-5E2D-4F8A-9C3B-AILIMITS0001}_is1'
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/n/napxlexn/AILimits/0.6.0/napxlexn.AILimits.locale.en-US.yaml
+++ b/manifests/n/napxlexn/AILimits/0.6.0/napxlexn.AILimits.locale.en-US.yaml
@@ -15,7 +15,7 @@ Description: >-
   AI Limits is a tiny native Windows 11 floating overlay that shows your AI
   provider usage limits right on the desktop: Claude, OpenAI Codex, GitHub
   Copilot, and Google Antigravity. It uses authentication already stored by
-  official CLI tools or credentials explicitly added by the user, does not
+  official CLI tools or credentials added manually by the user, does not
   refresh CLI tokens, and sends no telemetry. It needs no admin rights, ships
   statically linked with no extra runtime, and has a low idle resource
   footprint. A taskbar indicator keeps usage visible even when the overlay is

--- a/manifests/n/napxlexn/AILimits/0.6.0/napxlexn.AILimits.locale.en-US.yaml
+++ b/manifests/n/napxlexn/AILimits/0.6.0/napxlexn.AILimits.locale.en-US.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: napxlexn.AILimits
+PackageVersion: 0.6.0
+PackageLocale: en-US
+Publisher: napxlexn
+PublisherUrl: https://github.com/napxlexn
+PublisherSupportUrl: https://github.com/napxlexn/ailimits/issues
+PackageName: AI Limits
+PackageUrl: https://github.com/napxlexn/ailimits
+License: GPL-3.0-or-later
+LicenseUrl: https://github.com/napxlexn/ailimits/blob/v0.6.0/LICENSE
+Copyright: Copyright (c) 2026 napxlexn
+ShortDescription: A tiny native Windows 11 overlay showing your AI provider usage limits.
+Description: >-
+  AI Limits is a tiny native Windows 11 floating overlay that shows your AI
+  provider usage limits right on the desktop: Claude, OpenAI Codex, GitHub
+  Copilot, and Google Antigravity. It uses authentication already stored by
+  official CLI tools or credentials explicitly added by the user, does not
+  refresh CLI tokens, and sends no telemetry. It needs no admin rights, ships
+  statically linked with no extra runtime, and has a low idle resource
+  footprint. A taskbar indicator keeps usage visible even when the overlay is
+  hidden.
+Moniker: ailimits
+Tags:
+  - ai
+  - claude
+  - codex
+  - copilot
+  - antigravity
+  - gemini
+  - usage
+  - overlay
+  - widget
+  - monitor
+  - tray
+ReleaseNotesUrl: https://github.com/napxlexn/ailimits/releases/tag/v0.6.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/n/napxlexn/AILimits/0.6.0/napxlexn.AILimits.yaml
+++ b/manifests/n/napxlexn/AILimits/0.6.0/napxlexn.AILimits.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: napxlexn.AILimits
+PackageVersion: 0.6.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New version of an existing package

- **Package**: napxlexn.AILimits
- **Version**: 0.6.0

This adds version 0.6.0 of AI Limits, a native Windows 11 usage-limits overlay for AI CLI subscriptions. The installer is an Inno Setup per-user installer; `InstallerSha256` is taken from the signed GitHub release asset digest and cross-checked against the published file.

#### Manifest checklist
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Manifest schema 1.12.0; version bumped from the prior 0.5.3 submission.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/407754)