### PR TITLE
Update: ReplyLayer.CLI to 0.7.13

### DIFF
--- a/manifests/r/ReplyLayer/CLI/0.7.13/ReplyLayer.CLI.installer.yaml
+++ b/manifests/r/ReplyLayer/CLI/0.7.13/ReplyLayer.CLI.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ReplyLayer.CLI
+PackageVersion: 0.7.13
+InstallerType: portable
+Commands:
+- rly
+ReleaseDate: 2026-07-24
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/replylayer/rly/releases/download/cli-v0.7.13/replylayer-0.7.13-windows-x64.exe
+  InstallerSha256: 8d635bb9922fbbf6353480d219593d6c1fd085a03875b1ee76a7e17490cb3bc2
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/r/ReplyLayer/CLI/0.7.13/ReplyLayer.CLI.locale.en-US.yaml
+++ b/manifests/r/ReplyLayer/CLI/0.7.13/ReplyLayer.CLI.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ReplyLayer.CLI
+PackageVersion: 0.7.13
+PackageLocale: en-US
+Publisher: ReplyLayer
+PublisherUrl: https://replylayer.ai
+PublisherSupportUrl: https://replylayer.ai/support
+PrivacyUrl: https://replylayer.ai/legal/privacy
+Author: ReplyLayer
+PackageName: ReplyLayer CLI
+PackageUrl: https://github.com/replylayer/rly
+License: MIT
+LicenseUrl: https://github.com/replylayer/rly/blob/main/LICENSE
+Copyright: Copyright (c) ReplyLayer
+ShortDescription: Command-line interface for ReplyLayer, safe email for AI agents.
+Description: Send, receive, reply to, and security-scan transactional and operational email from the terminal or an agent loop.
+Moniker: rly
+Tags:
+- email
+- ai
+- agent
+- cli
+- replylayer
+- mailbox
+- mcp
+Documentations:
+- DocumentLabel: CLI guide
+  DocumentUrl: https://github.com/replylayer/rly
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/ReplyLayer/CLI/0.7.13/ReplyLayer.CLI.yaml
+++ b/manifests/r/ReplyLayer/CLI/0.7.13/ReplyLayer.CLI.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ReplyLayer.CLI
+PackageVersion: 0.7.13
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description
Update ReplyLayer.CLI to version 0.7.13.

Installer is the signed Windows x64 portable executable from the public release
https://github.com/replylayer/rly/releases/tag/cli-v0.7.13

Verified before submission:
- `InstallerSha256` matches the GPG-signed `SHA256SUMS` published with the release.
- The live installer bytes at `InstallerUrl` hash to that same value.
- Authenticode signature verifies (subject `ReplyLayer LLC`, chaining to
  Microsoft Identity Verification Root CA 2020; timestamp CRL ok).
- All manifest metadata URLs return success.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> The two `winget`-command boxes are deliberately left unchecked: this manifest was
> generated and verified on Linux, so those commands were not run for 0.7.13 and we
> would rather not claim otherwise. The manifest shape is unchanged from the accepted
> 0.7.11 submission (#398192) — only version, installer URL, hash, and release date
> differ.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/407766)