### PR TITLE
New version: ReTang.SysOverlay version 0.1.41

### DIFF
--- a/manifests/r/ReTang/SysOverlay/0.1.41/ReTang.SysOverlay.installer.yaml
+++ b/manifests/r/ReTang/SysOverlay/0.1.41/ReTang.SysOverlay.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: ReTang.SysOverlay
+PackageVersion: 0.1.41
+Platform:
+  - Windows.Desktop
+InstallerType: nullsoft
+UpgradeBehavior: install
+ReleaseDate: 2026-07-24
+Installers:
+  - Architecture: x64
+    Scope: user
+    InstallerUrl: https://github.com/dsmontero2001/sysoverlay-releases/releases/download/v0.1.41/SysOverlay_0.1.41_x64-setup.exe
+    InstallerSha256: DA754E959D6DCB09029BC8E031694D068664967C792B89793A153953980E27CE
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/r/ReTang/SysOverlay/0.1.41/ReTang.SysOverlay.locale.en-US.yaml
+++ b/manifests/r/ReTang/SysOverlay/0.1.41/ReTang.SysOverlay.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: ReTang.SysOverlay
+PackageVersion: 0.1.41
+PackageLocale: en-US
+Publisher: SysOverlay
+PublisherUrl: https://www.sysoverlay.com
+PublisherSupportUrl: https://www.sysoverlay.com/contact
+PrivacyUrl: https://www.sysoverlay.com/privacy
+Author: ReTang LLC
+PackageName: SysOverlay
+PackageUrl: https://www.sysoverlay.com/download
+License: Proprietary
+LicenseUrl: https://www.sysoverlay.com/terms
+Copyright: Copyright (c) 2026 ReTang LLC
+ShortDescription: Free Windows HUD with PC health monitoring for families and small businesses.
+Description: |
+  SysOverlay is a modern BGInfo alternative for Windows 10 and 11: a live desktop HUD showing hostname, IP, CPU, RAM, disk, uptime, and battery on every PC.
+  The free agent includes signed silent auto-updates. SysOverlay Plus adds a private fleet dashboard with plain-English alerts, in-HUD nudges, and local repair tools — no remote control.
+Moniker: sysoverlay
+Tags:
+  - bginfo
+  - hud
+  - monitoring
+  - utility
+  - windows
+  - desktop-overlay
+Commands:
+  - sysoverlay
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/r/ReTang/SysOverlay/0.1.41/ReTang.SysOverlay.yaml
+++ b/manifests/r/ReTang/SysOverlay/0.1.41/ReTang.SysOverlay.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: ReTang.SysOverlay
+PackageVersion: 0.1.41
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary

Update SysOverlay (ReTang.SysOverlay) from 0.1.39 to 0.1.41.

- Installer: SysOverlay_0.1.41_x64-setup.exe (per-user NSIS)
- Release: https://github.com/dsmontero2001/sysoverlay-releases/releases/tag/v0.1.41

## Validation

winget validate --manifest manifests/r/ReTang/SysOverlay/0.1.41

Made with [Cursor](https://cursor.com)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/407801)