### PR TITLE
New version: NoFaff.InstallerClean version 2.3.0

### DIFF
--- a/manifests/n/NoFaff/InstallerClean/2.3.0/NoFaff.InstallerClean.installer.yaml
+++ b/manifests/n/NoFaff/InstallerClean/2.3.0/NoFaff.InstallerClean.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: NoFaff.InstallerClean
+PackageVersion: 2.3.0
+InstallerType: inno
+Scope: machine
+ReleaseDate: 2026-07-25
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/no-faff/InstallerClean/releases/download/v2.3.0/InstallerClean-2.3.0-setup.exe
+  InstallerSha256: 459E7F5B1B90022483692F74BD2A4904F633A139BF6B84A430FEB1ABA78FA28F
+  ProductCode: InstallerClean_is1
+  AppsAndFeaturesEntries:
+  - DisplayVersion: 2.3.0
+    ProductCode: InstallerClean_is1
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/n/NoFaff/InstallerClean/2.3.0/NoFaff.InstallerClean.locale.en-GB.yaml
+++ b/manifests/n/NoFaff/InstallerClean/2.3.0/NoFaff.InstallerClean.locale.en-GB.yaml
@@ -1,0 +1,30 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: NoFaff.InstallerClean
+PackageVersion: 2.3.0
+PackageLocale: en-GB
+Publisher: No Faff
+PublisherUrl: https://github.com/no-faff
+PublisherSupportUrl: https://github.com/no-faff/InstallerClean/issues
+Author: No Faff
+PackageName: InstallerClean
+PackageUrl: https://github.com/no-faff/InstallerClean
+License: Apache-2.0
+LicenseUrl: https://github.com/no-faff/InstallerClean/blob/main/LICENSE
+Copyright: Copyright (c) 2026 No Faff
+ShortDescription: Open source tool to safely clean orphaned Windows Installer files and reclaim disk space
+Description: |-
+  InstallerClean safely reclaims disk space by removing orphaned files from C:\Windows\Installer, the hidden folder Windows never cleans up. It queries the Windows Installer API to find installers left behind by uninstalled software and patches replaced by newer ones, then lets you delete them to the Recycle Bin or move them somewhere safe. Free, open source, no telemetry.
+Moniker: installerclean
+Tags:
+- cleanup
+- disk-space
+- installer
+- msi
+- open-source
+- patchcleaner
+- windows-installer
+ReleaseNotesUrl: https://github.com/no-faff/InstallerClean/releases/tag/v2.3.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/n/NoFaff/InstallerClean/2.3.0/NoFaff.InstallerClean.yaml
+++ b/manifests/n/NoFaff/InstallerClean/2.3.0/NoFaff.InstallerClean.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: NoFaff.InstallerClean
+PackageVersion: 2.3.0
+DefaultLocale: en-GB
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New Submission Checklist

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/.github/PULL_REQUEST_TEMPLATE.md#validation) your manifest locally with `winget validate --manifest <path>`?

### Version update

Update NoFaff.InstallerClean from 2.2.0 to 2.3.0.

The manifests are carried forward from the published 2.2.0 ones by our release script, with the version, URL, SHA-256 and release date updated. `winget validate` is not run against them: the release pipeline runs on Linux, where the command does not exist.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/407803)