### PR TITLE
New package: GreenYogaInc.PDFLiteViewer version 1.0.5

### DIFF
--- a/manifests/g/GreenYogaInc/PDFLiteViewer/1.0.5/GreenYogaInc.PDFLiteViewer.installer.yaml
+++ b/manifests/g/GreenYogaInc/PDFLiteViewer/1.0.5/GreenYogaInc.PDFLiteViewer.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: GreenYogaInc.PDFLiteViewer
+PackageVersion: 1.0.5
+MinimumOSVersion: 10.0.19041.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: PdfLiteViewer.exe
+    PortableCommandAlias: PdfLiteViewer
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/greenyogainc/pdf-lite-viewer/releases/download/v1.0.5/PdfLiteViewer-1.0.5-win-x64.zip
+    InstallerSha256: 280D82069B8DB9F76963C4F3922EF5E0AC1BAB41236CF56F404B1C48E9DFDB1F
+  - Architecture: arm64
+    InstallerUrl: https://github.com/greenyogainc/pdf-lite-viewer/releases/download/v1.0.5/PdfLiteViewer-1.0.5-win-arm64.zip
+    InstallerSha256: 0B4DE4B9876AA043F39C542C0CE6D42901413CBFBFDB825C7AAC9F3E983090AB
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/g/GreenYogaInc/PDFLiteViewer/1.0.5/GreenYogaInc.PDFLiteViewer.locale.en-US.yaml
+++ b/manifests/g/GreenYogaInc/PDFLiteViewer/1.0.5/GreenYogaInc.PDFLiteViewer.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: GreenYogaInc.PDFLiteViewer
+PackageVersion: 1.0.5
+PackageLocale: en-US
+Publisher: Green Yoga Inc
+PublisherUrl: https://github.com/greenyogainc
+PublisherSupportUrl: https://github.com/greenyogainc/pdf-lite-viewer/issues
+PackageName: PDF Lite Viewer
+PackageUrl: https://github.com/greenyogainc/pdf-lite-viewer
+License: MIT
+LicenseUrl: https://github.com/greenyogainc/pdf-lite-viewer/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Green Yoga Inc
+ShortDescription: A free, lightweight PDF viewer for Windows.
+Description: |-
+  Free, minimal, fast PDF viewer. Three viewing modes: facing pages,
+  single page full screen, and continuous scrolling. No bloat.
+Moniker: pdf-lite-viewer
+Tags:
+  - freeware
+  - pdf
+  - pdf-viewer
+  - reader
+  - viewer
+ReleaseNotesUrl: https://github.com/greenyogainc/pdf-lite-viewer/releases/tag/v1.0.5
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/g/GreenYogaInc/PDFLiteViewer/1.0.5/GreenYogaInc.PDFLiteViewer.yaml
+++ b/manifests/g/GreenYogaInc/PDFLiteViewer/1.0.5/GreenYogaInc.PDFLiteViewer.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: GreenYogaInc.PDFLiteViewer
+PackageVersion: 1.0.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/README.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

New package: PDF Lite Viewer 1.0.5 — free, lightweight (MIT) PDF viewer for Windows by Green Yoga Inc. Portable zip installers (x64 + arm64) from the project's GitHub release.

Installer URLs:
- https://github.com/greenyogainc/pdf-lite-viewer/releases/download/v1.0.5/PdfLiteViewer-1.0.5-win-x64.zip
- https://github.com/greenyogainc/pdf-lite-viewer/releases/download/v1.0.5/PdfLiteViewer-1.0.5-win-arm64.zip

Supersedes #405023 (1.0.0).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/407850)