### PR TITLE
New package: BeeswaxPat.ScribDesktop version 1.10.0

### DIFF
--- a/manifests/b/BeeswaxPat/ScribDesktop/1.10.0/BeeswaxPat.ScribDesktop.installer.yaml
+++ b/manifests/b/BeeswaxPat/ScribDesktop/1.10.0/BeeswaxPat.ScribDesktop.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: BeeswaxPat.ScribDesktop
+PackageVersion: 1.10.0
+InstallerType: zip
+NestedInstallerType: portable
+MinimumOSVersion: 10.0.0.0
+ReleaseDate: 2026-07-25
+Installers:
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: scrib_desktop.exe
+    PortableCommandAlias: scrib-desktop
+  InstallerUrl: https://github.com/beeswaxpat/scrib-desktop/releases/download/v1.10.0/scrib-desktop-v1.10.0-windows-x64.zip
+  InstallerSha256: 94119B4DBD674663B8B5EB423C9E874F05E0AE7558327D4DB7E3C277A6873302
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/b/BeeswaxPat/ScribDesktop/1.10.0/BeeswaxPat.ScribDesktop.locale.en-US.yaml
+++ b/manifests/b/BeeswaxPat/ScribDesktop/1.10.0/BeeswaxPat.ScribDesktop.locale.en-US.yaml
@@ -1,0 +1,58 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: BeeswaxPat.ScribDesktop
+PackageVersion: 1.10.0
+PackageLocale: en-US
+Publisher: Beeswax Pat
+PublisherUrl: https://scrib.blog
+PublisherSupportUrl: https://github.com/beeswaxpat/scrib-desktop/issues
+Author: Beeswax Pat
+PackageName: Scrib Desktop
+PackageUrl: https://github.com/beeswaxpat/scrib-desktop
+License: GPL-3.0
+LicenseUrl: https://github.com/beeswaxpat/scrib-desktop/blob/master/LICENSE
+Copyright: Copyright (C) 2026 Beeswax Pat
+CopyrightUrl: https://github.com/beeswaxpat/scrib-desktop/blob/master/LICENSE
+ShortDescription: A tabbed text editor for Windows with AES-256 file encryption, fully offline
+Description: |-
+  Scrib Desktop is a tabbed text editor for Windows that encrypts files with AES-256. It handles plain text, rich text, and its own encrypted .scrb format, and it runs fully offline: no network code, no telemetry, and no account.
+  Encryption is per file and opt in. Press Ctrl+E on any note to set a password and save it as a .scrb, encrypted with AES-256-CBC and an HMAC-SHA256 integrity check in an encrypt-then-MAC scheme, with the key derived by PBKDF2-SHA256. Tampered files are rejected before decryption. Ctrl+L locks an open encrypted note in place, clearing its decrypted content and password from the editor until the password is re-entered, and an optional idle auto-lock does the same unattended.
+  Other features include multi-tab editing with per-tab colours and session restore, rich text with images and tables stored inside the note, RTF import and export, find and replace across all open tabs, a command palette, and atomic saves so an interrupted write cannot truncate a file.
+  Scrib Desktop is free and open source under the GPL-3.0 license.
+Moniker: scrib-desktop
+Tags:
+- aes-256
+- editor
+- encrypted-notes
+- encryption
+- notepad
+- notes
+- offline
+- open-source
+- portable
+- privacy
+- rich-text
+- text-editor
+ReleaseNotes: |-
+  A correctness and security release. No new features. The .scrb file format and settings schema are unchanged, so existing files open untouched.
+  Save integrity:
+  - Text typed while a save was in progress is no longer discarded. A save now records the content it actually wrote, so a note edited mid-write stays unsaved until the next save persists it.
+  - Saves that change a file's extension (Ctrl+E to encrypt, or the plain and rich text toggle) now ask before replacing an existing file, and decline rather than overwrite when the prompt cannot be shown.
+  - Files changed on disk by another program are no longer overwritten without warning.
+  - Save As refuses a file another tab already has open.
+  Security:
+  - Encrypting an existing file now overwrites the plaintext original before removing it. Recovery is still possible on SSDs, snapshotted volumes and synced folders: see the threat model in README.md.
+  - Locking a tab also clears its undo history, the decoded images held in memory, and the clipboard when it holds text copied from that note.
+  - Changing a password no longer applies the new password when the re-encrypt fails.
+  - Reads are capped at 64 MB, and hostile RTF, table and image payloads are bounded.
+  Test suite grown from 518 to 613.
+ReleaseNotesUrl: https://github.com/beeswaxpat/scrib-desktop/releases/tag/v1.10.0
+Documentations:
+- DocumentLabel: Changelog
+  DocumentUrl: https://github.com/beeswaxpat/scrib-desktop/blob/master/CHANGELOG.md
+- DocumentLabel: Architecture
+  DocumentUrl: https://github.com/beeswaxpat/scrib-desktop/blob/master/ARCHITECTURE.md
+- DocumentLabel: Security policy
+  DocumentUrl: https://github.com/beeswaxpat/scrib-desktop/blob/master/SECURITY.md
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/b/BeeswaxPat/ScribDesktop/1.10.0/BeeswaxPat.ScribDesktop.yaml
+++ b/manifests/b/BeeswaxPat/ScribDesktop/1.10.0/BeeswaxPat.ScribDesktop.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: BeeswaxPat.ScribDesktop
+PackageVersion: 1.10.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package: **BeeswaxPat.ScribDesktop** version **1.10.0**.

Scrib Desktop is a tabbed text editor for Windows with per-file AES-256 encryption, plain and rich text, and no network code. Free and open source under GPL-3.0. Submitted by the package author.

- Repository: https://github.com/beeswaxpat/scrib-desktop
- Release: https://github.com/beeswaxpat/scrib-desktop/releases/tag/v1.10.0

Packaged as `zip` with `NestedInstallerType: portable`. The archive has no wrapper directory, so `RelativeFilePath` is `scrib_desktop.exe` at the archive root.

`Microsoft.VCRedist.2015+.x64` is declared as a package dependency. This is not boilerplate: the archive ships no MSVC runtime DLLs, and `scrib_desktop.exe` imports `msvcp140.dll`, `vcruntime140.dll` and `vcruntime140_1.dll`, so the redistributable is genuinely required.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

### Note on the unchecked box

The CLA has since been agreed to and the `license/cla` check is passing. The remaining unchecked box is left honest rather than ticked:

**`winget install --manifest`:** not run, because it requires `winget settings --enable LocalManifestFiles` from an elevated prompt, which was not available in the environment this was prepared in. Everything that could be checked without it was:

- `winget validate --manifest` returns **Manifest validation succeeded** (winget v1.29.280).
- `InstallerSha256` was verified by downloading the release asset and hashing it, not copied from release metadata: `94119B4DBD674663B8B5EB423C9E874F05E0AE7558327D4DB7E3C277A6873302` (13,657,148 bytes), which also matches the `.sha256` file published alongside the release.
- Archive layout was inspected to confirm `scrib_desktop.exe` sits at the archive root with its sibling DLLs and `data\` directory, so the nested portable path resolves.
- The declared dependency `Microsoft.VCRedist.2015+.x64` was confirmed to exist as a package identifier, and the runtime requirement was confirmed from the binary's import table rather than assumed.

Happy to make any changes a moderator wants.
