### PR TITLE
New package: Socoliuc.FollowFrame version 0.2.10

### DIFF
--- a/manifests/s/Socoliuc/FollowFrame/0.2.10/Socoliuc.FollowFrame.installer.yaml
+++ b/manifests/s/Socoliuc/FollowFrame/0.2.10/Socoliuc.FollowFrame.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Socoliuc.FollowFrame
+PackageVersion: 0.2.10
+InstallerType: portable
+UpgradeBehavior: install
+Commands:
+  - followframe
+ReleaseDate: 2026-07-25
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://followframe.com/downloads/FollowFrame-Single-Exe-0.2.10-win32-x64.exe
+    InstallerSha256: D180611178152359A78E29E5EE1EF9446AD9065BE403958180B75E498C930988
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/Socoliuc/FollowFrame/0.2.10/Socoliuc.FollowFrame.locale.en-US.yaml
+++ b/manifests/s/Socoliuc/FollowFrame/0.2.10/Socoliuc.FollowFrame.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Socoliuc.FollowFrame
+PackageVersion: 0.2.10
+PackageLocale: en-US
+Publisher: Socoliuc
+PublisherUrl: https://followframe.com/
+PrivacyUrl: https://followframe.com/#privacy
+Author: Socoliuc
+PackageName: FollowFrame
+PackageUrl: https://followframe.com/
+License: Freeware
+Copyright: Copyright (c) 2026 Socoliuc
+ShortDescription: Floating Windows media wall for Instagram content from accounts you follow.
+Description: >-
+  FollowFrame is an independent Windows x64 desktop utility that turns Instagram posts,
+  Reels, photos, videos, and Stories from accounts you follow into a floating 9:16 media wall.
+  It uses a local embedded web session and does not require a Meta app ID.
+Moniker: followframe
+Tags:
+  - desktop
+  - instagram
+  - media-wall
+  - portable
+  - reels
+  - stories
+ReleaseNotes: >-
+  A failed Instagram source-page load now stops a pending refresh immediately and shows the
+  existing retryable capture error instead of waiting for the readiness timeout.
+InstallationNotes: >-
+  On first launch, choose Connect account and sign in inside FollowFrame's source window.
+  The embedded session stays in your Windows user profile.
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/Socoliuc/FollowFrame/0.2.10/Socoliuc.FollowFrame.yaml
+++ b/manifests/s/Socoliuc/FollowFrame/0.2.10/Socoliuc.FollowFrame.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Socoliuc.FollowFrame
+PackageVersion: 0.2.10
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Details

Adds FollowFrame 0.2.10 as a hash-verified x64 portable Windows package.

- Official download: https://followframe.com/downloads/FollowFrame-Single-Exe-0.2.10-win32-x64.exe
- Product page: https://followframe.com/
- Installer SHA-256: `D180611178152359A78E29E5EE1EF9446AD9065BE403958180B75E498C930988`
- Local manifest validation: passed with WinGet 1.29.280

I am the FollowFrame publisher and control the download URL.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/407878)