### PR TITLE
New package: JOhnsonKC201.pixelcat version 0.2.0

### DIFF
--- a/manifests/j/JOhnsonKC201/pixelcat/0.2.0/JOhnsonKC201.pixelcat.installer.yaml
+++ b/manifests/j/JOhnsonKC201/pixelcat/0.2.0/JOhnsonKC201.pixelcat.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: JOhnsonKC201.pixelcat
+PackageVersion: 0.2.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/JOhnsonKC201/pixelcat/releases/download/v0.2.0/pixelcat.Setup.0.2.0.exe
+  InstallerSha256: 3B8FF60C694F5003AD471A0D173DCE6E6576AB45CFF27EE91AD4943BC6ED7133
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/j/JOhnsonKC201/pixelcat/0.2.0/JOhnsonKC201.pixelcat.locale.en-US.yaml
+++ b/manifests/j/JOhnsonKC201/pixelcat/0.2.0/JOhnsonKC201.pixelcat.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: JOhnsonKC201.pixelcat
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: JOhnsonKC201
+PublisherUrl: https://github.com/JOhnsonKC201
+PublisherSupportUrl: https://github.com/JOhnsonKC201/pixelcat/issues
+PackageName: pixelcat
+PackageUrl: https://github.com/JOhnsonKC201/pixelcat
+License: MIT
+LicenseUrl: https://github.com/JOhnsonKC201/pixelcat/blob/main/LICENSE
+ShortDescription: A cute pixel cat that lives on your desktop
+Description: |-
+  A from-scratch desktop pet. The cat sits in the corner of your screen, watches your cursor, kneads the keyboard when you type, purrs when you pet it, stretches like mochi when you drag it, and climbs a yarn rope when you scroll. 14 coat patterns plus custom coats, fully procedural sound (synthesized meow, purr, and a lo-fi study-music mode), a pomodoro timer, reminders, mail and calendar nudges, and reactions to AI coding agents. All art, code, and sound are original.
+Moniker: pixelcat
+Tags:
+- cat
+- desktop-pet
+- electron
+- kawaii
+- pixel-art
+- pomodoro
+- virtual-pet
+ReleaseNotesUrl: https://github.com/JOhnsonKC201/pixelcat/releases/tag/v0.2.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/j/JOhnsonKC201/pixelcat/0.2.0/JOhnsonKC201.pixelcat.yaml
+++ b/manifests/j/JOhnsonKC201/pixelcat/0.2.0/JOhnsonKC201.pixelcat.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: JOhnsonKC201.pixelcat
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

New package submission: **JOhnsonKC201.pixelcat** version **0.2.0**.

pixelcat is a free, MIT-licensed desktop pet for Windows (Electron): a pixel-art cat that sits over your desktop, reacts to your cursor, typing, and scrolling, and doubles as a pomodoro/reminder companion. Homepage: https://github.com/JOhnsonKC201/pixelcat

The installer is the official NSIS asset from the project's v0.2.0 GitHub release (per-user scope, unsigned, sha256 pinned in the manifest).

## Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` (validation succeeded)
- [ ] Tested manifest locally with `winget install --manifest <path>` - not run on my dev machine because the app is already running there from source and the packaged build shares its single-instance mutex; the installer itself is the same release asset end users install from GitHub, and I am the package author.
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/407879)