### PR TITLE
Fix installer hash for jar-cart 0.6.0

### DIFF
--- a/manifests/s/Sudhanshu-Ambastha/jar-cart/0.6.0/Sudhanshu-Ambastha.jar-cart.installer.yaml
+++ b/manifests/s/Sudhanshu-Ambastha/jar-cart/0.6.0/Sudhanshu-Ambastha.jar-cart.installer.yaml
@@ -11,7 +11,7 @@ NestedInstallerFiles:
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/Sudhanshu-Ambastha/jar-cart/releases/download/v0.6.0/jar-cart-x86_64-windows.zip
-  InstallerSha256: 67579088E3BDC8C9B8FD43F85CBED1E6875E2F67636C200055F689975642986C
+  InstallerSha256: 1DFE41127028DFEF2713FDAAB694134FCAF1D64DC333ED42EB328A5A17EA849C
 ManifestType: installer
 ManifestVersion: 1.12.0
 ReleaseDate: 2026-07-22


### PR DESCRIPTION
## 📖 Description
Corrected SHA256 hash for jar-cart v0.6.0 installer to match the GitHub release artifact.

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/407895)