### PR TITLE
New package: OlimoffDev.OmenGamingHubUnlocker version 3.2.0.0

### DIFF
--- a/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.2.0.0/OlimoffDev.OmenGamingHubUnlocker.installer.yaml
+++ b/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.2.0.0/OlimoffDev.OmenGamingHubUnlocker.installer.yaml
@@ -1,0 +1,18 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: OlimoffDev.OmenGamingHubUnlocker
+PackageVersion: 3.2.0.0
+InstallerType: portable
+Commands:
+- ogh-unlocker
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker/releases/download/v3.2/OmenGamingHubUnlocker-v3.2-win-x64.exe
+  InstallerSha256: 14D950236EC422B5DCDFEA76D78BEC337130ECC840373CCAA1CDEE0A8EB4BB14
+- Architecture: arm64
+  InstallerUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker/releases/download/v3.2/OmenGamingHubUnlocker-v3.2-win-arm64.exe
+  InstallerSha256: 2298AFA30015344BDB71913298C5CE75DEDD72CCADEFA753E46191AF4AB9FCA9
+ManifestType: installer
+ManifestVersion: 1.10.0
+ReleaseDate: 2026-07-24

--- a/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.2.0.0/OlimoffDev.OmenGamingHubUnlocker.installer.yaml
+++ b/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.2.0.0/OlimoffDev.OmenGamingHubUnlocker.installer.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.12.8.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: OlimoffDev.OmenGamingHubUnlocker
 PackageVersion: 3.2.0.0
@@ -14,5 +14,5 @@ Installers:
   InstallerUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker/releases/download/v3.2/OmenGamingHubUnlocker-v3.2-win-arm64.exe
   InstallerSha256: 2298AFA30015344BDB71913298C5CE75DEDD72CCADEFA753E46191AF4AB9FCA9
 ManifestType: installer
-ManifestVersion: 1.10.0
+ManifestVersion: 1.12.0
 ReleaseDate: 2026-07-24

--- a/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.2.0.0/OlimoffDev.OmenGamingHubUnlocker.installer.yaml
+++ b/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.2.0.0/OlimoffDev.OmenGamingHubUnlocker.installer.yaml
@@ -3,6 +3,7 @@
 
 PackageIdentifier: OlimoffDev.OmenGamingHubUnlocker
 PackageVersion: 3.2.0.0
+MinimumOSVersion: 10.0.19041.0
 InstallerType: portable
 Commands:
 - ogh-unlocker

--- a/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.2.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.en-US.yaml
+++ b/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.2.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.en-US.yaml
@@ -17,14 +17,22 @@ Description: A portable Windows utility for keeping OMEN Gaming Hub installed wh
 InstallationNotes: WinGet removes only the portable executable and command alias. To reverse changes applied by this utility, run Restore original settings before uninstalling the package.
 Moniker: ogh-unlocker
 Tags:
+- disable-omen-gaming-hub
 - firewall
 - gaming
 - hp
+- hp-omen
+- network-blocker
 - omen
+- omen-gaming-hub
+- omen-gaming-hub-unlocker
 - privacy
+- region-lock
 - startup
-- utility
+- vpn
 - windows
+- windows-10
+- windows-11
 ReleaseNotesUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker/releases/tag/v3.2
 Documentations:
 - DocumentLabel: Project documentation

--- a/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.2.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.en-US.yaml
+++ b/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.2.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: OlimoffDev.OmenGamingHubUnlocker
+PackageVersion: 3.2.0.0
+PackageLocale: en-US
+Publisher: Olimoff Dev
+PublisherUrl: https://github.com/Avazbek22
+PublisherSupportUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker/issues
+PackageName: Omen Gaming Hub Unlocker
+PackageUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker
+License: MIT
+LicenseUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker/blob/main/LICENSE
+Copyright: Copyright (c) 2025 Avazbek Olimov
+ShortDescription: Unofficial utility for controlling OMEN Gaming Hub background activity and network access.
+Description: Keeps OMEN Gaming Hub installed while managing its background processes, services, scheduled tasks, startup entries, firewall rules, and known network endpoints. Includes status inspection, dry-run planning, rollback, and AppX reset workflows. This project is not affiliated with or endorsed by HP.
+Moniker: ogh-unlocker
+Tags:
+- firewall
+- gaming
+- hp
+- omen
+- privacy
+- startup
+- utility
+- windows
+ReleaseNotesUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker/releases/tag/v3.2
+Documentations:
+- DocumentLabel: Project documentation
+  DocumentUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker#readme
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.2.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.en-US.yaml
+++ b/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.2.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.en-US.yaml
@@ -14,6 +14,7 @@ LicenseUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker/blob/main/LICENSE
 Copyright: Copyright (c) 2025 Avazbek Olimov
 ShortDescription: Unofficial utility for controlling OMEN Gaming Hub background activity and network access.
 Description: Keeps OMEN Gaming Hub installed while managing its background processes, services, scheduled tasks, startup entries, firewall rules, and known network endpoints. Includes status inspection, dry-run planning, rollback, and AppX reset workflows. This project is not affiliated with or endorsed by HP.
+InstallationNotes: WinGet removes only the portable executable and command alias. To reverse changes applied by this utility, run Restore original settings before uninstalling the package.
 Moniker: ogh-unlocker
 Tags:
 - firewall

--- a/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.2.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.en-US.yaml
+++ b/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.2.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.en-US.yaml
@@ -12,8 +12,8 @@ PackageUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker
 License: MIT
 LicenseUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker/blob/main/LICENSE
 Copyright: Copyright (c) 2025 Avazbek Olimov
-ShortDescription: Unofficial utility for controlling OMEN Gaming Hub background activity and network access.
-Description: Keeps OMEN Gaming Hub installed while managing its background processes, services, scheduled tasks, startup entries, firewall rules, and known network endpoints. Includes status inspection, dry-run planning, rollback, and AppX reset workflows. This project is not affiliated with or endorsed by HP.
+ShortDescription: Manages OMEN Gaming Hub background activity, startup items, and network access on Windows.
+Description: A portable Windows utility for keeping OMEN Gaming Hub installed while controlling its background activity and network access. It can stop OMEN processes, set related services to Manual, disable scheduled tasks and startup entries, block known HP and OMEN network endpoints, inspect the current state, reset the app, and restore the original settings. It may help when OMEN Gaming Hub stops working after an update or displays region-related errors. This project is not affiliated with HP.
 InstallationNotes: WinGet removes only the portable executable and command alias. To reverse changes applied by this utility, run Restore original settings before uninstalling the package.
 Moniker: ogh-unlocker
 Tags:

--- a/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.2.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.en-US.yaml
+++ b/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.2.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.12.8.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: OlimoffDev.OmenGamingHubUnlocker
 PackageVersion: 3.2.0.0
@@ -29,4 +29,4 @@ Documentations:
 - DocumentLabel: Project documentation
   DocumentUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker#readme
 ManifestType: defaultLocale
-ManifestVersion: 1.10.0
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.2.0.0/OlimoffDev.OmenGamingHubUnlocker.yaml
+++ b/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.2.0.0/OlimoffDev.OmenGamingHubUnlocker.yaml
@@ -1,8 +1,8 @@
 # Created using wingetcreate 1.12.8.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: OlimoffDev.OmenGamingHubUnlocker
 PackageVersion: 3.2.0.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.10.0
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.2.0.0/OlimoffDev.OmenGamingHubUnlocker.yaml
+++ b/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.2.0.0/OlimoffDev.OmenGamingHubUnlocker.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: OlimoffDev.OmenGamingHubUnlocker
+PackageVersion: 3.2.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Description

Adds **Omen Gaming Hub Unlocker 3.2.0.0** as a new portable package for x64 and Arm64 Windows systems.

The package is an open-source, unofficial utility that keeps OMEN Gaming Hub installed while letting users inspect and control its background processes, services, scheduled tasks, startup entries, firewall rules, and known network endpoints. It also provides dry-run, rollback, and AppX reset workflows. The project is not affiliated with or endorsed by HP.

Installers are immutable assets from the project's public GitHub release. The manifest exposes the `ogh-unlocker` command alias.

## Validation

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Checked that there are no other open pull requests for this package
- [x] This PR modifies one package manifest
- [x] Validated locally with `winget validate --manifest <path>`
- [x] Tested locally with `winget install --manifest <path>` and `winget uninstall`
- [x] Verified both x64 and Arm64 release URLs and SHA-256 hashes
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

No linked issue is required for this new package submission.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/407904)