### PR TITLE
henry-jia.AIQuotaMonitor version 1.2.0

### DIFF
--- a/manifests/h/henry-jia/AIQuotaMonitor/1.2.0/henry-jia.AIQuotaMonitor.installer.yaml
+++ b/manifests/h/henry-jia/AIQuotaMonitor/1.2.0/henry-jia.AIQuotaMonitor.installer.yaml
@@ -1,0 +1,15 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: henry-jia.AIQuotaMonitor
+PackageVersion: 1.2.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: AIQuotaMonitor.exe
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/henry-jia/AIQuotaMonitor/releases/download/v1.2.0/AIQuotaMonitor.zip
+  InstallerSha256: E04EA37BAE77B6D815EFB3E38B8F3A917D5F9E5D4668DC322BF6406D3BABEA43
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/h/henry-jia/AIQuotaMonitor/1.2.0/henry-jia.AIQuotaMonitor.locale.en-US.yaml
+++ b/manifests/h/henry-jia/AIQuotaMonitor/1.2.0/henry-jia.AIQuotaMonitor.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: henry-jia.AIQuotaMonitor
+PackageVersion: 1.2.0
+PackageLocale: en-US
+Publisher: henry-jia
+PackageName: AIQuotaMonitor
+License: MIT
+LicenseUrl: https://github.com/henry-jia/AIQuotaMonitor/blob/main/LICENSE
+ShortDescription: Windows 11 widget that tracks usage quotas across AI subscriptions
+Description: |-
+  AIQuotaMonitor is a free, open-source Windows 11 desktop widget that shows quota usage
+  for multiple AI subscriptions (5-hour / 7-day / 30-day windows) in one translucent
+  always-on-top panel. Most AI vendors expose no quota API, so the app periodically opens
+  each vendor's usage page in an embedded WebView2 (using your existing local login,
+  everything stays on your machine) and extracts the numbers with label-anchored rules.
+  Features: time-pace baseline ticks, reset countdowns, subscription expiry and auto-renew
+  detection, per-service/global pause, dark theme with preset color themes, zh/en UI.
+Tags:
+- ai
+- quota
+- usage-monitor
+- widget
+- wpf
+- desktop
+ReleaseNotesUrl: https://github.com/henry-jia/AIQuotaMonitor/releases/tag/v1.2.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/h/henry-jia/AIQuotaMonitor/1.2.0/henry-jia.AIQuotaMonitor.locale.zh-CN.yaml
+++ b/manifests/h/henry-jia/AIQuotaMonitor/1.2.0/henry-jia.AIQuotaMonitor.locale.zh-CN.yaml
@@ -1,0 +1,16 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
+
+PackageIdentifier: henry-jia.AIQuotaMonitor
+PackageVersion: 1.2.0
+PackageLocale: zh-CN
+Publisher: henry-jia
+PackageName: AIQuotaMonitor
+License: MIT
+ShortDescription: 集中显示多个 AI 套餐配额用量的 Windows 11 桌面小部件
+Tags:
+- ai
+- quota
+- widget
+ManifestType: locale
+ManifestVersion: 1.6.0

--- a/manifests/h/henry-jia/AIQuotaMonitor/1.2.0/henry-jia.AIQuotaMonitor.yaml
+++ b/manifests/h/henry-jia/AIQuotaMonitor/1.2.0/henry-jia.AIQuotaMonitor.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: henry-jia.AIQuotaMonitor
+PackageVersion: 1.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description

AIQuotaMonitor is a free, open-source (MIT) Windows 11 desktop widget that tracks usage quotas across multiple AI subscriptions (5-hour / 7-day / 30-day windows) in one always-on-top translucent panel. Most AI vendors expose no quota API, so the app opens each vendor's own usage page in an embedded WebView2 — reusing the user's existing local login, with all data staying on the machine — and extracts the figures with label-anchored rules. Features: time-pace baseline ticks, reset countdowns, subscription expiry & auto-renew detection, per-service / global pause, dark theme with preset palettes, zh/en UI.

This is a **new package**. Source and the exact build shipped here: https://github.com/henry-jia/AIQuotaMonitor (the installer artifact on GitHub Releases is the same build; its SHA-256 is pinned in the installer manifest). It is distributed as a **portable app in a `.zip`** — no installer executable, no install scripts, no elevation, no services/drivers, no system-wide changes; winget only extracts the archive. The sole runtime dependency is the Microsoft WebView2 Runtime. The app has **no backend, no telemetry, and no auto-updater**. A clause-by-clause note addressing the `Policy-Test-1.2` (Security §1.2) review is posted as a comment below.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com) — signed via PR comment; the `license/cla` check passed
- [ ] Linked to an issue (if applicable) — N/A (no related issue)
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change — the earlier v1.1.0 PR #407617 was closed by me as superseded
- [x] This PR only modifies one (1) manifest — single package identifier `henry-jia.AIQuotaMonitor`
- [x] Validated manifest locally with `winget validate --manifest <path>` — passed locally (and by the Azure validation pipeline)
- [ ] Tested manifest locally with `winget install --manifest <path>` — not run, as it would install the app on this machine; the package is the author's own build and the Azure pipeline validated the installer
- [x] Manifest conforms to the 1.6.0 schema — `ManifestVersion: 1.6.0` (the template's "1.12" was placeholder text)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/407925)
