### PR TITLE
New version: atani.transit version 0.3.2

### DIFF
--- a/manifests/a/atani/transit/0.3.2/atani.transit.installer.yaml
+++ b/manifests/a/atani/transit/0.3.2/atani.transit.installer.yaml
@@ -1,0 +1,20 @@
+# Created with WinGet Releaser using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: atani.transit
+PackageVersion: 0.3.2
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: transit.exe
+  PortableCommandAlias: transit
+ReleaseDate: 2026-07-26
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/atani/transit/releases/download/v0.3.2/transit_0.3.2_windows_amd64.zip
+  InstallerSha256: 775650EA833DC42C2091D249CB1D3B92F89A61DDDE435467B9202CDB8B23242D
+- Architecture: arm64
+  InstallerUrl: https://github.com/atani/transit/releases/download/v0.3.2/transit_0.3.2_windows_arm64.zip
+  InstallerSha256: D7AA49CB96C6AA9E26864BB9CB6D2BC79400A113BED2EC8F9E07F6824DBA7882
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/atani/transit/0.3.2/atani.transit.locale.en-US.yaml
+++ b/manifests/a/atani/transit/0.3.2/atani.transit.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# Created with WinGet Releaser using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: atani.transit
+PackageVersion: 0.3.2
+PackageLocale: en-US
+Publisher: Akira Taniwaki
+PublisherUrl: https://github.com/atani
+PublisherSupportUrl: https://github.com/atani/transit/issues
+Author: Akira Taniwaki
+PackageName: Transit
+PackageUrl: https://github.com/atani/transit
+License: MIT
+LicenseUrl: https://github.com/atani/transit/blob/HEAD/LICENSE
+ShortDescription: Japan transit routes and station departures CLI
+Description: transit plans Japan transit routes and shows station departures from the command line, backed by the public Transit API.
+Moniker: transit
+Tags:
+- cli
+- gtfs
+- japan
+- route
+- transit
+ReleaseNotes: |-
+  0.3.2 (2026-07-26)
+  Bug Fixes
+  - 上流 API の変更に追従して駅の解決と表示を改善 (#16) (1ecc10a)
+ReleaseNotesUrl: https://github.com/atani/transit/releases/tag/v0.3.2
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/atani/transit/0.3.2/atani.transit.yaml
+++ b/manifests/a/atani/transit/0.3.2/atani.transit.yaml
@@ -1,0 +1,8 @@
+# Created with WinGet Releaser using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: atani.transit
+PackageVersion: 0.3.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update atani.transit to version 0.3.2

Manifests were generated by the release workflow (WinGet Releaser / komac) from the v0.3.2 release assets.
Verified locally: the installer URLs resolve and the SHA256 values match the downloaded zips.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/407928)