### PR TITLE
New package: rtcoder.ytrack version 0.1.1

### DIFF
--- a/manifests/r/rtcoder/ytrack/0.1.1/rtcoder.ytrack.installer.yaml
+++ b/manifests/r/rtcoder/ytrack/0.1.1/rtcoder.ytrack.installer.yaml
@@ -1,0 +1,11 @@
+PackageIdentifier: rtcoder.ytrack
+PackageVersion: 0.1.1
+InstallerType: portable
+Commands:
+  - ytrack
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/rtcoder/ytrack/releases/download/v0.1.1/ytrack.exe
+    InstallerSha256: 69EEF5E923E49C67A0A9478A4E51BCE0A91C2F1546885A6451B104E56C26D1A7
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/r/rtcoder/ytrack/0.1.1/rtcoder.ytrack.installer.yaml
+++ b/manifests/r/rtcoder/ytrack/0.1.1/rtcoder.ytrack.installer.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
 PackageIdentifier: rtcoder.ytrack
 PackageVersion: 0.1.1
 InstallerType: portable

--- a/manifests/r/rtcoder/ytrack/0.1.1/rtcoder.ytrack.locale.en-US.yaml
+++ b/manifests/r/rtcoder/ytrack/0.1.1/rtcoder.ytrack.locale.en-US.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
 PackageIdentifier: rtcoder.ytrack
 PackageVersion: 0.1.1
 PackageLocale: en-US

--- a/manifests/r/rtcoder/ytrack/0.1.1/rtcoder.ytrack.locale.en-US.yaml
+++ b/manifests/r/rtcoder/ytrack/0.1.1/rtcoder.ytrack.locale.en-US.yaml
@@ -1,0 +1,19 @@
+PackageIdentifier: rtcoder.ytrack
+PackageVersion: 0.1.1
+PackageLocale: en-US
+Publisher: rtcoder
+PublisherUrl: https://github.com/rtcoder
+PackageName: ytrack
+PackageUrl: https://github.com/rtcoder/ytrack
+License: MIT
+LicenseUrl: https://github.com/rtcoder/ytrack/blob/main/LICENSE
+ShortDescription: YouTrack CLI with global and per-project configuration
+Description: ytrack is a command-line tool for managing YouTrack issues with global and per-project configuration.
+Moniker: ytrack
+Tags:
+  - cli
+  - issue-tracker
+  - youtrack
+ReleaseNotesUrl: https://github.com/rtcoder/ytrack/releases/tag/v0.1.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/rtcoder/ytrack/0.1.1/rtcoder.ytrack.yaml
+++ b/manifests/r/rtcoder/ytrack/0.1.1/rtcoder.ytrack.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: rtcoder.ytrack
+PackageVersion: 0.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/manifests/r/rtcoder/ytrack/0.1.1/rtcoder.ytrack.yaml
+++ b/manifests/r/rtcoder/ytrack/0.1.1/rtcoder.ytrack.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
 PackageIdentifier: rtcoder.ytrack
 PackageVersion: 0.1.1
 DefaultLocale: en-US


### PR DESCRIPTION
### Submission type

New package

### Package identifier

rtcoder.ytrack

### Package version

0.1.1

### Installer

Portable x64 executable from the ytrack v0.1.1 GitHub release.

### Validation performed

- Confirmed the v0.1.1 GitHub release exists and is not a draft or prerelease.
- Confirmed the ytrack.exe release asset exists.
- Matched InstallerSha256 to the release asset digest.
- Parsed all YAML manifest files locally.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/407948)