### PR TITLE
New package: WinTune.WinTune version 0.2.0

### DIFF
--- a/manifests/w/WinTune/WinTune/0.2.0/WinTune.WinTune.installer.yaml
+++ b/manifests/w/WinTune/WinTune/0.2.0/WinTune.WinTune.installer.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+#
+# Draft installer manifest. Before submitting to winget-pkgs:
+# 1. Publish a GitHub Release with WinTune-<ver>-win-x64.zip (+ arm64).
+# 2. Replace REPLACE_WITH_SHA256_* using the .sha256 sidecars from the release.
+# 3. Bump PackageVersion to match the tag (without leading "v").
+#
+PackageIdentifier: WinTune.WinTune
+PackageVersion: 0.2.0
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: wintune.exe
+    PortableCommandAlias: wintune
+UpgradeBehavior: uninstallPrevious
+Commands:
+  - wintune
+ReleaseDate: 2026-07-26
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Skpow1234/TheWindowsTunning/releases/download/v0.2.0/WinTune-0.2.0-win-x64.zip
+    InstallerSha256: e74ff6dd72018fb46bfb1bf7bcac993604154fadeb4139f6531eaedbec282aff
+  - Architecture: arm64
+    InstallerUrl: https://github.com/Skpow1234/TheWindowsTunning/releases/download/v0.2.0/WinTune-0.2.0-win-arm64.zip
+    InstallerSha256: e66141ea44b340ae6b1fb57e6ea9590f8cf317cdc7112482603413b7431ef8ec
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/w/WinTune/WinTune/0.2.0/WinTune.WinTune.locale.en-US.yaml
+++ b/manifests/w/WinTune/WinTune/0.2.0/WinTune.WinTune.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: WinTune.WinTune
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: WinTune
+PublisherUrl: https://github.com/Skpow1234/TheWindowsTunning
+PublisherSupportUrl: https://github.com/Skpow1234/TheWindowsTunning/issues
+Author: WinTune contributors
+PackageName: WinTune
+PackageUrl: https://github.com/Skpow1234/TheWindowsTunning
+License: MIT
+LicenseUrl: https://github.com/Skpow1234/TheWindowsTunning/blob/main/LICENSE
+Copyright: Copyright (c) WinTune contributors
+ShortDescription: Native Windows performance diagnostics for the terminal
+Description: |-
+  WinTune is a native, CLI-first Windows performance doctor.
+  Measure CPU, memory, disk, processes, startup, services, and power —
+  then explain bottlenecks and apply safe fixes with confirmation.
+  No Electron, no registry cleaner, no scareware.
+Moniker: wintune
+Tags:
+  - windows
+  - performance
+  - diagnostics
+  - cli
+  - terminal
+  - sysadmin
+ReleaseNotesUrl: https://github.com/Skpow1234/TheWindowsTunning/releases
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/w/WinTune/WinTune/0.2.0/WinTune.WinTune.yaml
+++ b/manifests/w/WinTune/WinTune/0.2.0/WinTune.WinTune.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# Draft for microsoft/winget-pkgs. Fill SHA-256 after each GitHub Release.
+PackageIdentifier: WinTune.WinTune
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## 📖 Description

Adds a first winget package for **WinTune** (`WinTune.WinTune`) version **0.2.0**.

WinTune is a native Windows CLI for performance diagnostics (CPU, memory, disk, processes, startup, services, power). This submission installs the portable GitHub Release ZIPs and registers the `wintune` command.

- Package: https://github.com/Skpow1234/TheWindowsTunning
- Release: https://github.com/Skpow1234/TheWindowsTunning/releases/tag/v0.2.0
- Installers: `WinTune-0.2.0-win-x64.zip`, `WinTune-0.2.0-win-arm64.zip` (portable ZIP)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [X] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [X] Tested manifest locally with `winget install --manifest <path>`
- [X] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/407962)