### PR TITLE
New version: RedEyeNetworks.LogivoreForVeeam version 1.19.0

### DIFF
--- a/manifests/r/RedEyeNetworks/LogivoreForVeeam/1.19.0/RedEyeNetworks.LogivoreForVeeam.installer.yaml
+++ b/manifests/r/RedEyeNetworks/LogivoreForVeeam/1.19.0/RedEyeNetworks.LogivoreForVeeam.installer.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: RedEyeNetworks.LogivoreForVeeam
+PackageVersion: 1.19.0
+InstallerType: inno
+Scope: machine
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  Custom: /NORESTART
+UpgradeBehavior: install
+Commands:
+- logivoreforveeam
+Installers:
+- Architecture: x64
+  Scope: user
+  InstallerUrl: https://download.redeyenetworks.com/logivore-for-veeam/releases/1.19.0/logivore-for-veeam-win-x64-setup.exe
+  InstallerSha256: 0B9E106B628CB1D005B49D91B2A62CBEB579D3F89BD689BC32424D8A85F42783
+- Architecture: x64
+  Scope: machine
+  ElevationRequirement: elevatesSelf
+  InstallerUrl: https://download.redeyenetworks.com/logivore-for-veeam/releases/1.19.0/logivore-for-veeam-win-x64-machine-setup.exe
+  InstallerSha256: 94597DFE99590169FED2CC25F487EB1713CFF66D9611C653CE3997E56C28455F
+- Architecture: arm64
+  Scope: user
+  InstallerUrl: https://download.redeyenetworks.com/logivore-for-veeam/releases/1.19.0/logivore-for-veeam-win-arm64-setup.exe
+  InstallerSha256: 7C8D040349DAB6C2BDDCF386A3A727577A032A23E42CA533AAB18CFC5AAFCE43
+- Architecture: arm64
+  Scope: machine
+  ElevationRequirement: elevatesSelf
+  InstallerUrl: https://download.redeyenetworks.com/logivore-for-veeam/releases/1.19.0/logivore-for-veeam-win-arm64-machine-setup.exe
+  InstallerSha256: 8827010F3F5C2C594F9D59F1FF6DC904E82622590145DE5E95B2F06555C24C1A
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/r/RedEyeNetworks/LogivoreForVeeam/1.19.0/RedEyeNetworks.LogivoreForVeeam.locale.en-US.yaml
+++ b/manifests/r/RedEyeNetworks/LogivoreForVeeam/1.19.0/RedEyeNetworks.LogivoreForVeeam.locale.en-US.yaml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: RedEyeNetworks.LogivoreForVeeam
+PackageVersion: 1.19.0
+PackageLocale: en-US
+Publisher: RedEye Network Solutions LLC
+PublisherUrl: https://redeyenetworks.com
+PublisherSupportUrl: https://redeyenetworks.com/support
+Author: RedEye Network Solutions LLC
+PackageName: Logivore for Veeam
+PackageUrl: https://redeyenetworks.com
+License: Proprietary
+Copyright: Copyright 2026 RedEye Network Solutions LLC. All rights reserved.
+ShortDescription: Logivore plus Advanced Veeam Mode — collects, normalizes, and analyzes Veeam Backup and Replication logs end-to-end
+Description: |-
+  Logivore for Veeam is the Veeam-centric SKU of Logivore. Includes
+  everything in Logivore (cross-platform log analysis, LILA AI
+  assistant, memory-tier-adaptive parsing, local-first trust-gated
+  LLM boundary) plus Microsoft.PowerShell.SDK and a built-in
+  Advanced Veeam Mode that drives the Veeam VBR PowerShell cmdlets
+  to collect job/repository/proxy diagnostics on demand. Targeted
+  at Veeam backup administrators who need to triage failed jobs
+  against backup server, repository, and proxy logs in one
+  timeline.
+Moniker: logivore-for-veeam
+Tags:
+- veeam
+- vbr
+- backup
+- log-analysis
+- log-viewer
+- syslog
+- evtx
+- powershell
+- ai
+- llm
+- claude
+- gemini
+- timeline
+- correlation
+- desktop
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/RedEyeNetworks/LogivoreForVeeam/1.19.0/RedEyeNetworks.LogivoreForVeeam.yaml
+++ b/manifests/r/RedEyeNetworks/LogivoreForVeeam/1.19.0/RedEyeNetworks.LogivoreForVeeam.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: RedEyeNetworks.LogivoreForVeeam
+PackageVersion: 1.19.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Logivore for Veeam v1.19.0 — the Veeam-centric SKU of Logivore, separated from the base package per the v0.11.0 SKU split. Ships as a distinct WinGet package (`RedEyeNetworks.LogivoreForVeeam`) with its own settings folder, credential namespace, install directory, and Argus appcast endpoint so it can coexist with the base `RedEyeNetworks.Logivore` package on the same machine.

Mirror of the base RedEyeNetworks.Logivore 4-installer shape (user + machine × x64 + arm64), each Inno Setup EXE wrapped around a single-file self-contained .NET 9 publish that includes Microsoft.PowerShell.SDK for the Advanced Veeam Mode runspace.

The split was driven by Cortex XDR / CrowdStrike behavioral signatures on the embedded PowerShell SDK + self-extract + auto-launch combo — see the v0.11.0 release notes for the full rationale.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/408020)