### PR TITLE
New version: Pantelis23.KernRift version v2.8.32

### DIFF
--- a/manifests/p/Pantelis23/KernRift/v2.8.32/Pantelis23.KernRift.installer.yaml
+++ b/manifests/p/Pantelis23/KernRift/v2.8.32/Pantelis23.KernRift.installer.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: Pantelis23.KernRift
+PackageVersion: v2.8.32
+InstallerType: zip
+NestedInstallerType: portable
+FileExtensions:
+- exe
+Commands:
+- krc
+- kr
+ReleaseDate: 2026-07-26
+Installers:
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: krc.exe
+    PortableCommandAlias: krc
+  - RelativeFilePath: kr.exe
+    PortableCommandAlias: kr
+  InstallerUrl: https://github.com/Pantelis23/KernRift/releases/download/v2.8.32/krc-windows-x86_64.zip
+  InstallerSha256: D3603439F26CB00DC76E5F53967FCCBB6CC0DD09FD4C73E027191070D69B4269
+- Architecture: arm64
+  NestedInstallerFiles:
+  - RelativeFilePath: krc.exe
+    PortableCommandAlias: krc
+  - RelativeFilePath: kr.exe
+    PortableCommandAlias: kr
+  InstallerUrl: https://github.com/Pantelis23/KernRift/releases/download/v2.8.32/krc-windows-arm64.zip
+  InstallerSha256: BA3F098FC5165CE7BD1A1632FBD44C76446FFCFDFF026D0D8B7A1447CD5AF4D5
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/p/Pantelis23/KernRift/v2.8.32/Pantelis23.KernRift.locale.en-US.yaml
+++ b/manifests/p/Pantelis23/KernRift/v2.8.32/Pantelis23.KernRift.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: Pantelis23.KernRift
+PackageVersion: v2.8.32
+PackageLocale: en-US
+Publisher: Pantelis Christou
+PublisherUrl: https://github.com/Pantelis23/KernRift
+PublisherSupportUrl: https://github.com/Pantelis23/KernRift/issues
+Author: Pantelis Christou
+PackageName: KernRift
+PackageUrl: https://github.com/Pantelis23/KernRift
+License: MIT
+LicenseUrl: https://github.com/Pantelis23/KernRift/blob/HEAD/LICENSE
+Copyright: Copyright (c) 2025 Pantelis Christou
+ShortDescription: Self-hosted bare-metal systems programming language and compiler
+Description: KernRift is a zero-dependency self-hosted compiler. The package installs two portable command-line tools — krc (the compiler) and kr (the fat-binary runner). It compiles to native x86_64 and ARM64 binaries for Linux, Windows, macOS, and Android. The compiler is written entirely in KernRift itself and produces ELF, PE, Mach-O, and fat binaries.
+Moniker: kernrift
+Tags:
+  - aot
+  - arm64
+  - bare-metal
+  - compiler
+  - cross-compiler
+  - programming-language
+  - self-hosted
+  - systems-programming
+  - x86_64
+ReleaseNotes: 'Full Changelog: https://github.com/Pantelis23/KernRift/releases/tag/v2.8.32'
+ReleaseNotesUrl: https://github.com/Pantelis23/KernRift/releases/tag/v2.8.32
+InstallationNotes: The install directory is added to PATH automatically by winget (portable nested installer). Run 'krc --version' and 'kr --version' to verify.
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/p/Pantelis23/KernRift/v2.8.32/Pantelis23.KernRift.yaml
+++ b/manifests/p/Pantelis23/KernRift/v2.8.32/Pantelis23.KernRift.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: Pantelis23.KernRift
+PackageVersion: v2.8.32
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Adds Pantelis23.KernRift v2.8.32.

A correctness release: v2.8.31 and earlier silently miscompile unsigned variables on the 32-bit backends, where a declared type was not authoritative over the value assigned to it. Also carries a 1.90x performance improvement on Xtensa.

- Both installer URLs verified live (HTTP 200) and both SHA256 hashes verified against the published release assets.
- Manifest shape unchanged from v2.8.31 (zip / nested portable, krc + kr aliases, x64 + arm64).

Full changelog: https://github.com/Heniokhos-Systems/KernRift/releases/tag/v2.8.32
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/408026)