### PR TITLE
New package: PidgeonHealth.CLI version 0.1.0-beta.2

### DIFF
--- a/manifests/p/PidgeonHealth/CLI/0.1.0-beta.2/PidgeonHealth.CLI.installer.yaml
+++ b/manifests/p/PidgeonHealth/CLI/0.1.0-beta.2/PidgeonHealth.CLI.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: PidgeonHealth.CLI
+PackageVersion: 0.1.0-beta.2
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+Commands:
+  - pidgeon
+ReleaseDate: 2026-07-26
+Installers:
+  - Architecture: x64
+    InstallerType: zip
+    InstallerUrl: https://github.com/PidgeonHealth/pidgeon-cli/releases/download/v0.1.0-beta.2/pidgeon-windows-x64.zip
+    InstallerSha256: 16A0A1A1DD4C24D033C922259F65949DD4D675B89DD24C340F22A40A38BDBCB9
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: pidgeon.exe
+        PortableCommandAlias: pidgeon
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/p/PidgeonHealth/CLI/0.1.0-beta.2/PidgeonHealth.CLI.locale.en-US.yaml
+++ b/manifests/p/PidgeonHealth/CLI/0.1.0-beta.2/PidgeonHealth.CLI.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: PidgeonHealth.CLI
+PackageVersion: 0.1.0-beta.2
+PackageLocale: en-US
+Publisher: Pidgeon Health
+PublisherUrl: https://pidgeon.health
+PublisherSupportUrl: https://github.com/PidgeonHealth/pidgeon-cli/issues
+PackageName: Pidgeon CLI
+PackageUrl: https://github.com/PidgeonHealth/pidgeon-cli
+License: MPL-2.0
+LicenseUrl: https://github.com/PidgeonHealth/pidgeon-cli/blob/main/LICENSE
+ShortDescription: Local-first healthcare interoperability CLI for synthetic test data and conformance work.
+Moniker: pidgeon
+Tags:
+  - healthcare
+  - hl7
+  - fhir
+  - ncpdp
+  - interoperability
+  - synthetic-data
+  - cli
+ReleaseNotesUrl: https://github.com/PidgeonHealth/pidgeon-cli/releases/tag/v0.1.0-beta.2
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/p/PidgeonHealth/CLI/0.1.0-beta.2/PidgeonHealth.CLI.yaml
+++ b/manifests/p/PidgeonHealth/CLI/0.1.0-beta.2/PidgeonHealth.CLI.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: PidgeonHealth.CLI
+PackageVersion: 0.1.0-beta.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds the first WinGet manifest for Pidgeon CLI, version `0.1.0-beta.2`.

The x64 portable ZIP is an immutable asset from the signed GitHub prerelease. A fresh Windows runner verified the exact archive hash, Authenticode signer and timestamp, WinGet 1.12 validation, local-manifest install, the complete installed CLI smoke suite, manifest-based uninstall, and residual cleanup in [qualification run 30216521552](https://github.com/PidgeonHealth/pidgeon/actions/runs/30216521552).

Upstream release: https://github.com/PidgeonHealth/pidgeon-cli/releases/tag/v0.1.0-beta.2

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)
  - Not applicable for this new package submission.

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest with `winget validate --manifest <path>` on a fresh Windows runner
- [x] Tested manifest with `winget install --manifest <path>` on a fresh Windows runner
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/408064)