### PR TITLE
New package: ShortArrow.gitreant version 0.1.0

### DIFF
--- a/manifests/s/ShortArrow/gitreant/0.1.0/ShortArrow.gitreant.installer.yaml
+++ b/manifests/s/ShortArrow/gitreant/0.1.0/ShortArrow.gitreant.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ShortArrow.gitreant
+PackageVersion: 0.1.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: gitreant.exe
+  PortableCommandAlias: gitreant
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Git.Git
+ReleaseDate: 2026-07-26
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/ShortArrow/gitreant/releases/download/v0.1.0/gitreant-x86_64-pc-windows-msvc.zip
+  InstallerSha256: 4150B70359FE0F459DE1D2FAA784CB3FDD41A765E6938229A2B7BA50589E8C80
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/ShortArrow/gitreant/0.1.0/ShortArrow.gitreant.locale.en-US.yaml
+++ b/manifests/s/ShortArrow/gitreant/0.1.0/ShortArrow.gitreant.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ShortArrow.gitreant
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: ShortArrow
+PublisherUrl: https://github.com/ShortArrow
+PublisherSupportUrl: https://github.com/ShortArrow/gitreant/issues
+Author: ShortArrow
+PackageName: gitreant
+PackageUrl: https://github.com/ShortArrow/gitreant
+License: MIT OR Apache-2.0
+LicenseUrl: https://github.com/ShortArrow/gitreant/blob/HEAD/LICENSE-MIT
+ShortDescription: Serve git commit graphs of local repositories as a single-page web app
+Description: |-
+  A web app that shows commit graphs of multiple local git repositories side
+  by side in a single-page app. Ships as a single binary with an embedded
+  SPA: branches, merges, tags, stashes, submodule correlation graphs and
+  squash-merge links, rendered locally with no telemetry.
+Moniker: gitreant
+Tags:
+- commit-graph
+- git
+- graph
+- gui
+- repository
+- rust
+- visualization
+ReleaseNotesUrl: https://github.com/ShortArrow/gitreant/releases/tag/v0.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/ShortArrow/gitreant/0.1.0/ShortArrow.gitreant.yaml
+++ b/manifests/s/ShortArrow/gitreant/0.1.0/ShortArrow.gitreant.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ShortArrow.gitreant
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

First submission of **ShortArrow.gitreant** version **0.1.0** — [gitreant](https://github.com/ShortArrow/gitreant) serves commit graphs of local git repositories as a single-page web app, shipped as a single portable binary.

- Portable zip from the GitHub release [v0.1.0](https://github.com/ShortArrow/gitreant/releases/tag/v0.1.0) (SLSA build provenance attested).
- Local install verified: installer hash check passed, the `gitreant` command alias was created, and `gitreant --version` reports 0.1.0.
- Declares `Git.Git` as a dependency (gitreant delegates repository operations to the git CLI).

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)