### PR TITLE
runxhq.runx 0.8.0

### DIFF
--- a/manifests/r/runxhq/runx/0.8.0/runxhq.runx.installer.yaml
+++ b/manifests/r/runxhq/runx/0.8.0/runxhq.runx.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: runxhq.runx
+PackageVersion: 0.8.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: runx-0.8.0-x86_64-pc-windows-msvc\runx.exe
+    PortableCommandAlias: runx
+  - RelativeFilePath: runx-0.8.0-x86_64-pc-windows-msvc\runx-js-worker.exe
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/runxhq/runx/releases/download/cli-v0.8.0/runx-0.8.0-x86_64-pc-windows-msvc.zip
+    InstallerSha256: BD5DF2020E870F3EE1B2F7A34F9D862E49B558ECDB25717A9BE3C7993094C8AB
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/r/runxhq/runx/0.8.0/runxhq.runx.locale.en-US.yaml
+++ b/manifests/r/runxhq/runx/0.8.0/runxhq.runx.locale.en-US.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: runxhq.runx
+PackageVersion: 0.8.0
+PackageLocale: en-US
+PackageName: runx
+Publisher: runxhq
+License: MIT
+ShortDescription: Native governed runtime for agent skills, tools, graphs, and packets.
+PackageUrl: https://github.com/runxhq/runx
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/r/runxhq/runx/0.8.0/runxhq.runx.yaml
+++ b/manifests/r/runxhq/runx/0.8.0/runxhq.runx.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: runxhq.runx
+PackageVersion: 0.8.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Updates runxhq.runx to 0.8.0.

Generated by the runx release workflow from the validated channel manifest.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/408150)