### PR TITLE
New version: Tropibyte.cshw version 1.0.8.1

### DIFF
--- a/manifests/t/Tropibyte/cshw/1.0.8.1/Tropibyte.cshw.installer.yaml
+++ b/manifests/t/Tropibyte/cshw/1.0.8.1/Tropibyte.cshw.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Tropibyte.cshw
+PackageVersion: 1.0.8.1
+MinimumOSVersion: 10.0.17763.0
+InstallerType: inno
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Commands:
+  - cshw
+FileExtensions:
+  - cshw
+  - csh
+ReleaseDate: 2026-07-26
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/tropibyte/cshw-releases/releases/download/v1.0.8.1/cshw-setup-1.0.8.1.exe
+    InstallerSha256: 7E7B52A3F3487F4D12323B41827376FB84F8FF2A1490B9E84121F105F350AA09
+    ProductCode: '{CFE685C6-DC75-4996-AC4B-7BE4F4D5BCB6}_is1'
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/t/Tropibyte/cshw/1.0.8.1/Tropibyte.cshw.locale.en-US.yaml
+++ b/manifests/t/Tropibyte/cshw/1.0.8.1/Tropibyte.cshw.locale.en-US.yaml
@@ -1,0 +1,75 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Tropibyte.cshw
+PackageVersion: 1.0.8.1
+PackageLocale: en-US
+Publisher: Tropibyte, Inc.
+PublisherUrl: https://www.tropibyte.com
+PublisherSupportUrl: https://www.tropibyte.com/bugs.html
+Author: Tropibyte, Inc.
+PackageName: C Shell for Windows
+PackageUrl: https://www.tropibyte.com/cshw.html
+License: PolyForm Small Business 1.0.0
+LicenseUrl: https://polyformproject.org/licenses/small-business/1.0.0
+Copyright: Copyright (c) 2024-2026 Tropibyte, Inc.
+CopyrightUrl: https://www.tropibyte.com/cshw.html
+ShortDescription: A native Windows command shell with csh/tcsh-flavored syntax, 195+ builtins, real concurrency primitives, arbitrary-precision math, and built-in AI.
+Description: |-
+  cshw is a native Windows command shell with csh/tcsh-flavored syntax. Familiar Unix
+  shell ergonomics meet first-class Win32 access -- no WSL, no Cygwin, no compatibility
+  layer. 195+ builtin commands cover file ops, text processing (grep with PCRE2, sed,
+  awk, sort with -t/-k, head/tail with -f), real concurrency primitives (coroutines,
+  mutex, semaphore, barrier, channel), Win32 calls (rundllproc, winapi, dllimport),
+  and built-in AI (OpenAI, Anthropic, Azure, Ollama, LM Studio). Runs your existing
+  .bat, .cmd, and .ps1 scripts unchanged. The bc/dc commands offer arbitrary-precision
+  arithmetic with an opt-in exact-rational tier (bc -x) including complex numbers and
+  small exact matrices. As of 1.0.8.0, cshw ships a signed server family: the tsrvd
+  supervisor runs out-of-process protocol handlers -- native SMTP, POP3, and IMAP over
+  a shared Maildir, FTP, and a real HTTP/HTTPS/CGI server (http.dll) that speaks
+  HTTP/1.1 and HTTP/2 -- and the new quicsrv worker serves HTTP/3 over QUIC through the
+  same serving core. The fetch client gains native HTTP/2 (--http2) and HTTP/3
+  (--http3) modes that guarantee the protocol. Ships with a 22-chapter user guide.
+Moniker: cshw
+Tags:
+  - shell
+  - csh
+  - tcsh
+  - command-line
+  - cli
+  - terminal
+  - unix
+  - win32
+  - scripting
+  - developer-tools
+PurchaseUrl: https://www.tropibyte.com/cshw.html
+PrivacyUrl: https://www.tropibyte.com
+ReleaseNotes: |-
+  v1.0.8.1 is a correctness and packaging release.
+
+  Fixed: output could cross between concurrently running commands. Command
+  substitution closed the real stdout handle when redirecting, and Windows
+  recycled that handle value for the next capture file -- so a background
+  command's output could land inside an unrelated backtick capture, and a child
+  process could inherit an already-closed handle. Separately, a background
+  command using > took over the shell's own stdout for the duration, so
+  interactive output could vanish. Redirection state is now per-thread.
+
+  New: spawn opens another cshw in a new console window, inheriting the current
+  directory and exported environment (-c/-k payloads, /d, /title, /min, /max,
+  /wait, /here). New -k switch runs a command then stays interactive, matching
+  cmd's /K.
+
+  Fixed: cshw -c "exit 7" returned 0 instead of 7. The start command's
+  documented /min /max /wait /b /d /i switches were silently ignored; all six
+  work now. tokenize reported failure on success.
+
+  Packaging: quicsrv.exe and the bundled nghttp2 / msquic / nghttp3 libraries
+  shipped unsigned in 1.0.8.0 -- everything in this release is signed, and the
+  portable zip now carries the native libraries it was missing, so HTTP/2 and
+  HTTP/3 work for portable and Scoop installs.
+
+  Note: the code-signing certificate changed to correct a malformed publisher
+  name, so Windows treats this as a new publisher and SmartScreen reputation
+  restarts.
+ReleaseNotesUrl: https://github.com/tropibyte/cshw-releases/releases/tag/v1.0.8.1
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/t/Tropibyte/cshw/1.0.8.1/Tropibyte.cshw.yaml
+++ b/manifests/t/Tropibyte/cshw/1.0.8.1/Tropibyte.cshw.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Tropibyte.cshw
+PackageVersion: 1.0.8.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Manifest

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

---

Correctness and packaging release.

- Fixes cross-command output corruption under concurrency (per-thread redirection state).
- Adds `spawn` (new console window) and the `-k` switch (run then stay interactive).
- `cshw -c "exit N"` now propagates the exit code; `start`'s documented /min /max /wait /b /d /i switches now function.
- `quicsrv.exe` and the bundled nghttp2/msquic/nghttp3 libraries shipped unsigned in 1.0.8.0; everything is signed in this release.

Note: the code-signing certificate changed to correct a malformed publisher name (it rendered as `Tropibyte\, Inc.`). The publisher is now `Tropibyte, Inc.` Same organization, same package identifier.

Release: https://github.com/tropibyte/cshw-releases/releases/tag/v1.0.8.1
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/408152)