### PR TITLE
New version: RodolfoVillaruz.WatchAndCommit version 1.0.5

### DIFF
--- a/manifests/r/RodolfoVillaruz/WatchAndCommit/1.0.5/RodolfoVillaruz.WatchAndCommit.installer.yaml
+++ b/manifests/r/RodolfoVillaruz/WatchAndCommit/1.0.5/RodolfoVillaruz.WatchAndCommit.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: RodolfoVillaruz.WatchAndCommit
+PackageVersion: 1.0.5
+InstallerType: zip
+NestedInstallerType: portable
+ReleaseDate: 2026-07-27
+Installers:
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: wac.exe
+  InstallerUrl: https://github.com/rodolfovillaruz/watch-and-commit/releases/download/v1.0.5/wac-x86_64-pc-windows-msvc.zip
+  InstallerSha256: 4A2584F584209EFD365FAB741248246642CA7176E80644F55230303E3D3C8F20
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/r/RodolfoVillaruz/WatchAndCommit/1.0.5/RodolfoVillaruz.WatchAndCommit.locale.en-US.yaml
+++ b/manifests/r/RodolfoVillaruz/WatchAndCommit/1.0.5/RodolfoVillaruz.WatchAndCommit.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: RodolfoVillaruz.WatchAndCommit
+PackageVersion: 1.0.5
+PackageLocale: en-US
+Publisher: Rodolfo Villaruz
+PublisherUrl: https://github.com/rodolfovillaruz
+PublisherSupportUrl: https://github.com/rodolfovillaruz/watch-and-commit/issues
+Author: Rodolfo Villaruz
+PackageName: watch-and-commit
+PackageUrl: https://github.com/rodolfovillaruz/watch-and-commit
+License: MIT
+LicenseUrl: https://github.com/rodolfovillaruz/watch-and-commit/blob/main/LICENSE
+ShortDescription: A CLI tool that automatically stages and commits file changes using a filesystem watcher
+Tags:
+- cli
+- git
+- automation
+- rust
+- filesystem-watcher
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/r/RodolfoVillaruz/WatchAndCommit/1.0.5/RodolfoVillaruz.WatchAndCommit.yaml
+++ b/manifests/r/RodolfoVillaruz/WatchAndCommit/1.0.5/RodolfoVillaruz.WatchAndCommit.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: RodolfoVillaruz.WatchAndCommit
+PackageVersion: 1.0.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Description

First submission of the `RodolfoVillaruz.WatchAndCommit` package (`wac`), a small Rust CLI that watches a Git working directory and auto-commits changes.

- Repo: https://github.com/rodolfovillaruz/watch-and-commit
- Release: https://github.com/rodolfovillaruz/watch-and-commit/releases/tag/v1.0.5
- License: MIT

Manifests were hand-written against the 1.10.0 schema and checked for valid YAML, but not run through `winget validate`/`winget install` locally (no Windows environment available). Relying on the automated PR validation pipeline to catch any issues — happy to fix anything it flags.

## Checklist

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/408176)