### PR TITLE
New package: epatels.CKPDFUnlocker v8.4.4

### DIFF
--- a/manifests/e/epatels/CKPDFUnlocker/8.4.4/epatels.CKPDFUnlocker.installer.yaml
+++ b/manifests/e/epatels/CKPDFUnlocker/8.4.4/epatels.CKPDFUnlocker.installer.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: epatels.CKPDFUnlocker
+PackageVersion: 8.4.4
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerType: nullsoft
+    Scope: user
+    InstallerUrl: https://github.com/epatels/ck-pdf-unlocker/releases/download/v8.4.4/ck-pdf-unlocker-setup-x64.exe
+    InstallerSha256: 6491CD97EAD0F99F5B1A8E6A1E7DCE52E438AFCAF73031F95D0D98163C3842E6
+    InstallerSwitches:
+      Silent: /S
+      SilentWithProgress: /S
+  - Architecture: x64
+    InstallerType: msi
+    Scope: user
+    InstallerUrl: https://github.com/epatels/ck-pdf-unlocker/releases/download/v8.4.4/ck-pdf-unlocker-setup-x64.msi
+    InstallerSha256: 43A726053C4B0DFF6AFB2C982B20F0EF39656C3A2E222F911834AD0CE45F4428
+    InstallerSwitches:
+      Silent: /quiet
+      SilentWithProgress: /passive
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/e/epatels/CKPDFUnlocker/8.4.4/epatels.CKPDFUnlocker.locale.en-US.yaml
+++ b/manifests/e/epatels/CKPDFUnlocker/8.4.4/epatels.CKPDFUnlocker.locale.en-US.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: epatels.CKPDFUnlocker
+PackageVersion: 8.4.4
+PackageLocale: en-US
+Publisher: epatels
+PublisherUrl: https://github.com/epatels/ck-pdf-unlocker
+PackageName: CK PDF Unlocker
+PackageUrl: https://github.com/epatels/ck-pdf-unlocker
+License: Proprietary
+LicenseUrl: https://github.com/epatels/ck-pdf-unlocker/blob/main/LICENSE
+ShortDescription: Remove passwords and copy/print restrictions from PDF files
+Description: |
+  CK PDF Unlocker removes open-password protection and copy/print restrictions from PDF files. It processes files locally — nothing leaves your device. Supports batch processing, per-file passwords, drag & drop, and dark/light themes.
+Tags:
+  - pdf
+  - password
+  - unlock
+  - decrypt
+  - pikepdf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/e/epatels/CKPDFUnlocker/8.4.4/epatels.CKPDFUnlocker.yaml
+++ b/manifests/e/epatels/CKPDFUnlocker/8.4.4/epatels.CKPDFUnlocker.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: epatels.CKPDFUnlocker
+PackageVersion: 8.4.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## New package: epatels.CKPDFUnlocker version 8.4.4

**App name:** CK PDF Unlocker  
**Publisher:** epatels  
**License:** Proprietary  
**URL:** https://github.com/epatels/ck-pdf-unlocker  

This PR was generated automatically by `submit_winget.py`.

### Checklist
- [x] Installer URL is HTTPS
- [x] SHA-256 computed from the actual installer file
- [x] Installer tested locally
- [x] License is Proprietary (freeware, EULA)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/408200)