### PR TITLE
Update: SerZhyAle.StreamsPlayer to 26.0727.0253

### DIFF
--- a/manifests/s/SerZhyAle/StreamsPlayer/26.0727.0253/SerZhyAle.StreamsPlayer.installer.yaml
+++ b/manifests/s/SerZhyAle/StreamsPlayer/26.0727.0253/SerZhyAle.StreamsPlayer.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: SerZhyAle.StreamsPlayer
+PackageVersion: 26.0727.0253
+InstallerType: zip
+NestedInstallerType: portable
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+NestedInstallerFiles:
+- RelativeFilePath: StreamsPlayer.exe
+  PortableCommandAlias: streamsplayer
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/SerZhyAle/StreamsPlayer/releases/download/v26.0727.0253/StreamsPlayer-26.0727.0253-windows-x64.zip
+  InstallerSha256: 42A152DED06A3603DB286A3D9CF864247F90787F87384C5EEB33F72FDEA7FC7B
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/SerZhyAle/StreamsPlayer/26.0727.0253/SerZhyAle.StreamsPlayer.locale.en-US.yaml
+++ b/manifests/s/SerZhyAle/StreamsPlayer/26.0727.0253/SerZhyAle.StreamsPlayer.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: SerZhyAle.StreamsPlayer
+PackageVersion: 26.0727.0253
+PackageLocale: en-US
+Publisher: SerZhyAle
+PublisherUrl: https://github.com/SerZhyAle
+PublisherSupportUrl: https://github.com/SerZhyAle/StreamsPlayer/issues
+PrivacyUrl: https://serzhyale.github.io/StreamsPlayer/privacy.html
+PackageName: STREAMS Player
+PackageUrl: https://serzhyale.github.io/StreamsPlayer/
+License: MIT
+LicenseUrl: https://github.com/SerZhyAle/StreamsPlayer/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Serhii Zhyhunenko
+Moniker: streamsplayer
+ShortDescription: Browse internet radio and live video in a focused Windows stream catalog.
+Description: STREAMS Player is a Windows desktop app for browsing a curated internet radio, live video, and RTSP address catalog, with its interface available in thirteen languages. Search, filter, pin, and add streams; choose List or Grid mode with optional live thumbnails; and open video with always-on-top and fullscreen controls. Catalog refresh is explicit, local state stays on the device, and the app has no account, advertising, analytics, or telemetry. Playback compatibility varies by provider, protocol, and codec.
+Tags:
+- radio
+- streaming
+- video
+- rtsp
+- live-tv
+- iptv
+- windows
+ReleaseNotes: The Ukrainian interface, website, Store listing and package metadata were proofread against their English sources - one consistent term per concept, corrected grammar, and quoted UI labels that match the shipped strings. No functional changes.
+ReleaseNotesUrl: https://github.com/SerZhyAle/StreamsPlayer/releases/tag/v26.0727.0253
+ReleaseDate: 2026-07-27
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/SerZhyAle/StreamsPlayer/26.0727.0253/SerZhyAle.StreamsPlayer.locale.ru-RU.yaml
+++ b/manifests/s/SerZhyAle/StreamsPlayer/26.0727.0253/SerZhyAle.StreamsPlayer.locale.ru-RU.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+PackageIdentifier: SerZhyAle.StreamsPlayer
+PackageVersion: 26.0727.0253
+PackageLocale: ru-RU
+Publisher: SerZhyAle
+PublisherUrl: https://github.com/SerZhyAle
+PublisherSupportUrl: https://github.com/SerZhyAle/StreamsPlayer/issues
+PrivacyUrl: https://serzhyale.github.io/StreamsPlayer/privacy.html
+PackageName: Трансляции
+PackageUrl: https://serzhyale.github.io/StreamsPlayer/
+License: MIT
+LicenseUrl: https://github.com/SerZhyAle/StreamsPlayer/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Serhii Zhyhunenko
+ShortDescription: Каталог интернет-радио и live-видео для Windows с русским интерфейсом.
+Description: Трансляции - приложение Windows для просмотра каталога интернет-радио, live-видео и адресов RTSP; интерфейс доступен на тринадцати языках. Ищите, фильтруйте, закрепляйте и добавляйте потоки; выбирайте список или сетку с отключаемыми живыми миниатюрами; открывайте видео поверх окон или во весь экран. Каталог обновляется только по команде, локальные данные остаются на устройстве, в приложении нет аккаунта, рекламы, аналитики и телеметрии. Совместимость воспроизведения зависит от поставщика, протокола и кодека.
+Tags:
+- радио
+- потоки
+- видео
+- rtsp
+- телевидение
+- iptv
+ReleaseNotes: The Ukrainian interface, website, Store listing and package metadata were proofread against their English sources - one consistent term per concept, corrected grammar, and quoted UI labels that match the shipped strings. No functional changes._RU
+ReleaseNotesUrl: https://github.com/SerZhyAle/StreamsPlayer/releases/tag/v26.0727.0253
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/s/SerZhyAle/StreamsPlayer/26.0727.0253/SerZhyAle.StreamsPlayer.locale.uk-UA.yaml
+++ b/manifests/s/SerZhyAle/StreamsPlayer/26.0727.0253/SerZhyAle.StreamsPlayer.locale.uk-UA.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+PackageIdentifier: SerZhyAle.StreamsPlayer
+PackageVersion: 26.0727.0253
+PackageLocale: uk-UA
+Publisher: SerZhyAle
+PublisherUrl: https://github.com/SerZhyAle
+PublisherSupportUrl: https://github.com/SerZhyAle/StreamsPlayer/issues
+PrivacyUrl: https://serzhyale.github.io/StreamsPlayer/privacy.html
+PackageName: Трансляції
+PackageUrl: https://serzhyale.github.io/StreamsPlayer/
+License: MIT
+LicenseUrl: https://github.com/SerZhyAle/StreamsPlayer/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Serhii Zhyhunenko
+ShortDescription: Каталог інтернет-радіо та live-відео для Windows з українським інтерфейсом.
+Description: Трансляції - застосунок Windows для перегляду каталогу інтернет-радіо, live-відео й адрес RTSP; інтерфейс доступний тринадцятьма мовами. Шукайте, фільтруйте, закріплюйте та додавайте потоки; вибирайте список або сітку з живими мініатюрами, які можна вимкнути; відкривайте відео поверх усіх вікон або на весь екран. Каталог оновлюється лише за командою, локальні дані залишаються на пристрої, у застосунку немає облікового запису, реклами, аналітики й телеметрії. Сумісність відтворення залежить від постачальника, протоколу та кодека.
+Tags:
+- радіо
+- потоки
+- відео
+- rtsp
+- телебачення
+- iptv
+ReleaseNotes: Український інтерфейс, сайт, опис у Store та метадані пакета вичитано за англійськими джерелами - єдина термінологія, виправлена граматика й підписи, що збігаються з інтерфейсом. Функціональних змін немає.
+ReleaseNotesUrl: https://github.com/SerZhyAle/StreamsPlayer/releases/tag/v26.0727.0253
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/s/SerZhyAle/StreamsPlayer/26.0727.0253/SerZhyAle.StreamsPlayer.yaml
+++ b/manifests/s/SerZhyAle/StreamsPlayer/26.0727.0253/SerZhyAle.StreamsPlayer.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: SerZhyAle.StreamsPlayer
+PackageVersion: 26.0727.0253
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Update of the existing package `SerZhyAle.StreamsPlayer` to version 26.0727.0253. Portable ZIP from the project's own GitHub Release; SHA256 recomputed from the downloaded asset and matching the hash published by the release workflow.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

 <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
