### PR TITLE
New version: LiangWensen.OpenFiles version 3.2026.725

### DIFF
--- a/manifests/l/LiangWensen/OpenFiles/3.2026.725/LiangWensen.OpenFiles.installer.yaml
+++ b/manifests/l/LiangWensen/OpenFiles/3.2026.725/LiangWensen.OpenFiles.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: LiangWensen.OpenFiles
+PackageVersion: 3.2026.725
+InstallerType: nullsoft
+Scope: user
+UpgradeBehavior: install
+Protocols:
+- openfiles
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/pansysoft/openfiles.desktop/releases/download/3.2026.725/OpenFiles.Setup.3.2026.725.exe
+  InstallerSha256: 0A19DC2374E3D3274863536FC1CEEF1DDD3B12B2427799FDDED423A52B685D79
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/l/LiangWensen/OpenFiles/3.2026.725/LiangWensen.OpenFiles.locale.en-US.yaml
+++ b/manifests/l/LiangWensen/OpenFiles/3.2026.725/LiangWensen.OpenFiles.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: LiangWensen.OpenFiles
+PackageVersion: 3.2026.725
+PackageLocale: en-US
+Publisher: Liang Wensen
+PublisherUrl: https://openfiles.pansysoft.app/
+PublisherSupportUrl: https://github.com/pansysoft/openfiles.desktop/issues
+PrivacyUrl: https://openfiles.pansysoft.app/privacy
+Author: Liang Wensen
+PackageName: OpenFiles
+PackageUrl: https://openfiles.pansysoft.app/
+License: Proprietary
+LicenseUrl: https://openfiles.pansysoft.app/terms
+Copyright: Copyright © Liang Wensen
+ShortDescription: AI-native desktop file manager for opening and editing more than 350 file formats.
+Description: OpenFiles brings documents, media, code, archives, Jupyter notebooks, SQLite databases, DWG/DXF CAD drawings, and more into one local desktop file workspace with a file-aware AI assistant.
+Moniker: openfiles
+Tags:
+- ai
+- cad
+- database
+- editor
+- file-manager
+- file-viewer
+- jupyter
+- markdown
+- productivity
+- sqlite
+ReleaseNotesUrl: https://github.com/pansysoft/openfiles.desktop/releases/tag/3.2026.725
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/l/LiangWensen/OpenFiles/3.2026.725/LiangWensen.OpenFiles.yaml
+++ b/manifests/l/LiangWensen/OpenFiles/3.2026.725/LiangWensen.OpenFiles.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: LiangWensen.OpenFiles
+PackageVersion: 3.2026.725
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## New package submission

Adds OpenFiles 3.2026.725 using the publisher-hosted x64 NSIS installer from the public GitHub Release.

- Package website: https://openfiles.pansysoft.app/
- Release: https://github.com/pansysoft/openfiles.desktop/releases/tag/3.2026.725
- Installer SHA256: `0A19DC2374E3D3274863536FC1CEEF1DDD3B12B2427799FDDED423A52B685D79`

## Validation

- Parsed all three YAML manifests
- Validated each manifest against the official Winget 1.10.0 JSON schema
- Verified the installer URL resolves
- `git diff --check`

OpenFiles is proprietary software; the public GitHub repository is its official release and support surface.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/408241)