### PR TITLE
New package: jjw1270.MarkDownEditor version 1.2.2

### DIFF
--- a/manifests/j/jjw1270/MarkDownEditor/1.2.2/jjw1270.MarkDownEditor.installer.yaml
+++ b/manifests/j/jjw1270/MarkDownEditor/1.2.2/jjw1270.MarkDownEditor.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: jjw1270.MarkDownEditor
+PackageVersion: 1.2.2
+MinimumOSVersion: 10.0.19041.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: MarkDownEditor.exe
+    PortableCommandAlias: markdowneditor
+UpgradeBehavior: install
+ReleaseDate: 2026-07-27
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/jjw1270/MarkdownEditor/releases/download/v1.2.2/MarkDownEditor-standalone.zip
+    InstallerSha256: 5C8B1BB81B1C7A96E44CFAC7584D032FB4AB856EB6CA3C5FD236EFD6717942F2
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/j/jjw1270/MarkDownEditor/1.2.2/jjw1270.MarkDownEditor.locale.en-US.yaml
+++ b/manifests/j/jjw1270/MarkDownEditor/1.2.2/jjw1270.MarkDownEditor.locale.en-US.yaml
@@ -1,0 +1,48 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: jjw1270.MarkDownEditor
+PackageVersion: 1.2.2
+PackageLocale: en-US
+Publisher: jjw1270
+PublisherUrl: https://github.com/jjw1270
+PublisherSupportUrl: https://github.com/jjw1270/MarkdownEditor/issues
+PackageName: MarkDownEditor
+PackageUrl: https://github.com/jjw1270/MarkdownEditor
+License: MIT
+LicenseUrl: https://github.com/jjw1270/MarkdownEditor/blob/main/LICENSE
+Copyright: Copyright (c) jjw1270
+ShortDescription: A free, portable Markdown viewer and editor for Windows.
+Description: |-
+  MarkDownEditor is a lightweight, portable Markdown viewer and editor for Windows 10 and 11.
+  Set it as the default handler for .md files and double-clicking a document opens it rendered,
+  GitHub-style, in a single tabbed window.
+
+  Features include offline syntax highlighting and mermaid diagrams, a table-of-contents sidebar
+  with scroll-spy, back/forward navigation between linked documents, edit and preview modes with
+  synchronized scrolling, a formatting bar that requires no Markdown knowledge, find and replace,
+  clipboard image pasting, PDF export, auto-reload on external changes, crash recovery, session
+  restore, dark and light themes, and a UI localized into 10 languages.
+
+  Nothing is installed system-wide: settings and cache stay next to the executable. Network access
+  is limited to anonymous update checks and release downloads that the user explicitly starts.
+Moniker: markdowneditor
+Tags:
+  - markdown
+  - markdown-editor
+  - markdown-viewer
+  - markdown-preview
+  - md
+  - editor
+  - viewer
+  - portable
+  - mermaid
+  - dotnet
+  - webview2
+  - text-editor
+  - dark-mode
+  - pdf-export
+ReleaseNotesUrl: https://github.com/jjw1270/MarkdownEditor/releases/tag/v1.2.2
+Documentations:
+  - DocumentLabel: README
+    DocumentUrl: https://github.com/jjw1270/MarkdownEditor#readme
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/j/jjw1270/MarkDownEditor/1.2.2/jjw1270.MarkDownEditor.locale.ko-KR.yaml
+++ b/manifests/j/jjw1270/MarkDownEditor/1.2.2/jjw1270.MarkDownEditor.locale.ko-KR.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+PackageIdentifier: jjw1270.MarkDownEditor
+PackageVersion: 1.2.2
+PackageLocale: ko-KR
+Publisher: jjw1270
+PublisherUrl: https://github.com/jjw1270
+PublisherSupportUrl: https://github.com/jjw1270/MarkdownEditor/issues
+PackageName: MarkDownEditor
+PackageUrl: https://github.com/jjw1270/MarkdownEditor
+License: MIT
+LicenseUrl: https://github.com/jjw1270/MarkdownEditor/blob/main/LICENSE
+ShortDescription: 설치가 필요 없는 가벼운 Windows용 마크다운 뷰어 겸 에디터.
+Description: |-
+  MarkDownEditor는 Windows 10/11용 포터블 마크다운 뷰어 겸 에디터입니다.
+  .md 기본 연결 프로그램으로 지정해두면 탐색기에서 더블클릭하는 것만으로 GitHub 스타일로
+  렌더링된 문서가 한 창의 탭으로 열립니다.
+
+  오프라인 코드 하이라이팅과 mermaid 다이어그램, 목차 사이드바, 문서 간 뒤로/앞으로 이동,
+  편집·미리보기 전환과 스크롤 동기화, 마크다운 문법을 몰라도 쓸 수 있는 서식 바, 찾기/바꾸기,
+  클립보드 이미지 붙여넣기, PDF 내보내기, 외부 변경 자동 반영, 비정상 종료 복구, 세션 복원,
+  다크/라이트 테마, UI 10개 언어를 지원합니다.
+
+  시스템에 설치되는 것은 없습니다. 설정과 캐시는 실행 파일 옆에만 저장됩니다.
+  네트워크는 익명 업데이트 확인과 사용자가 직접 실행한 릴리즈 다운로드에만 사용합니다.
+Tags:
+  - 마크다운
+  - 마크다운에디터
+  - 마크다운뷰어
+  - markdown
+  - markdown-editor
+  - markdown-viewer
+  - md
+  - 에디터
+  - 뷰어
+  - 포터블
+ReleaseNotesUrl: https://github.com/jjw1270/MarkdownEditor/releases/tag/v1.2.2
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/j/jjw1270/MarkDownEditor/1.2.2/jjw1270.MarkDownEditor.yaml
+++ b/manifests/j/jjw1270/MarkDownEditor/1.2.2/jjw1270.MarkDownEditor.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: jjw1270.MarkDownEditor
+PackageVersion: 1.2.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds MarkDownEditor 1.2.2, a portable Markdown viewer and editor for Windows 10 and 11.

The package uses the published standalone ZIP, exposes the `markdowneditor` command alias, and includes English and Korean locale metadata.

Local verification completed:

- `winget validate --manifest manifests/j/jjw1270/MarkDownEditor/1.2.2`
- Release asset SHA-256 matched the installer manifest
- Local manifest install, command alias, GUI/WebView2 startup, and uninstall were tested with WinGet 1.29
- The local client returned `0x8A150060` during archive scanning; the test-only override was used after the matching ZIP passed a separate Microsoft Defender custom scan with no detections

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable) — not applicable

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/408328)