### PR TITLE
New package: noFAYZ.Zuno version 1.3.0

### DIFF
--- a/manifests/n/noFAYZ/Zuno/1.3.0/noFAYZ.Zuno.installer.yaml
+++ b/manifests/n/noFAYZ/Zuno/1.3.0/noFAYZ.Zuno.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: noFAYZ.Zuno
+PackageVersion: 1.3.0
+InstallerType: nullsoft
+# Tauri's NSIS bundler installs per user by default, which is why the app lands in
+# %LOCALAPPDATA%\Zuno rather than Program Files. Declaring it wrong makes winget look for the
+# install in the wrong place and report the package as missing right after installing it.
+Scope: user
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+ReleaseDate: 2026-08-02
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/noFAYZ/zuno/releases/download/v1.3.0/Zuno_1.3.0_x64-setup.exe
+  InstallerSha256: CE5CC2B8B056ED24A0F5B463C36D4AC84195BDFAFBA1B547F61A2BF1495EA836
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/n/noFAYZ/Zuno/1.3.0/noFAYZ.Zuno.locale.en-US.yaml
+++ b/manifests/n/noFAYZ/Zuno/1.3.0/noFAYZ.Zuno.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: noFAYZ.Zuno
+PackageVersion: 1.3.0
+PackageLocale: en-US
+Publisher: noFAYZ
+PublisherUrl: https://github.com/noFAYZ
+PublisherSupportUrl: https://github.com/noFAYZ/zuno/issues
+PackageName: Zuno
+PackageUrl: https://github.com/noFAYZ/zuno
+License: Apache-2.0
+LicenseUrl: https://github.com/noFAYZ/zuno/blob/main/LICENSE
+ShortDescription: A fast, native-feeling desktop client for YouTube Music
+Description: |-
+  Zuno brings YouTube Music to the desktop as a focused application rather than a browser tab.
+  It plays audio natively, with gapless playback, crossfade and a ten-band equaliser, and keeps
+  synced lyrics, offline downloads, tabs and a mini player close at hand.
+
+  Zuno is an independent, unofficial project. It is not affiliated with, authorized by,
+  sponsored by, or endorsed by YouTube or Google.
+Moniker: zuno
+Tags:
+- audio
+- desktop
+- music
+- music-player
+- player
+- youtube
+- youtube-music
+ReleaseNotesUrl: https://github.com/noFAYZ/zuno/releases/tag/v1.3.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/n/noFAYZ/Zuno/1.3.0/noFAYZ.Zuno.yaml
+++ b/manifests/n/noFAYZ/Zuno/1.3.0/noFAYZ.Zuno.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: noFAYZ.Zuno
+PackageVersion: 1.3.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package: **noFAYZ.Zuno** version **1.3.0** — a desktop client for YouTube Music.

Updated from 1.1.2 to 1.3.0, the current release, since this PR had not merged yet. Also corrected a publisher typo and the license identifier, and added `Scope: user` (the NSIS bundle installs to `%LOCALAPPDATA%`).

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)