### PR TITLE
New package: HaisongHuang.ApineedGlmClaudeCode version 0.3.0

### DIFF
--- a/manifests/h/HaisongHuang/ApineedGlmClaudeCode/0.3.0/HaisongHuang.ApineedGlmClaudeCode.installer.yaml
+++ b/manifests/h/HaisongHuang/ApineedGlmClaudeCode/0.3.0/HaisongHuang.ApineedGlmClaudeCode.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: HaisongHuang.ApineedGlmClaudeCode
+PackageVersion: 0.3.0
+InstallerType: zip
+NestedInstallerType: portable
+Commands:
+  - glm-code
+ReleaseDate: 2026-07-27
+Installers:
+  - Architecture: x64
+    NestedInstallerFiles:
+      - RelativeFilePath: glm-code.exe
+        PortableCommandAlias: glm-code
+    InstallerUrl: https://github.com/haisonghuang/homebrew-tap/releases/download/v0.3.0/apineed-glm-claudecode-v0.3.0-x86_64-pc-windows-msvc.zip
+    InstallerSha256: 62919D34712CEBA96D30C9DBC25B4548282FCF295FEAC94334E76093734BD1AA
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/h/HaisongHuang/ApineedGlmClaudeCode/0.3.0/HaisongHuang.ApineedGlmClaudeCode.locale.en-US.yaml
+++ b/manifests/h/HaisongHuang/ApineedGlmClaudeCode/0.3.0/HaisongHuang.ApineedGlmClaudeCode.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: HaisongHuang.ApineedGlmClaudeCode
+PackageVersion: 0.3.0
+PackageLocale: en-US
+Publisher: Haisong Huang
+PublisherUrl: https://github.com/haisonghuang
+PublisherSupportUrl: https://github.com/haisonghuang/homebrew-tap/issues
+PackageName: apineed-glm-claudecode
+PackageUrl: https://github.com/haisonghuang/homebrew-tap
+License: MIT
+ShortDescription: Minimal Claude Code launcher for API Need
+Description: A minimal command-line launcher that connects Claude Code to API Need through a local protocol-converting proxy.
+Tags:
+  - api
+  - claude-code
+  - cli
+  - developer-tools
+  - glm
+ReleaseNotes: Changes the default model to claude-fable-5 and adds the first Windows x64 release.
+ReleaseNotesUrl: https://github.com/haisonghuang/homebrew-tap/releases/tag/v0.3.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/h/HaisongHuang/ApineedGlmClaudeCode/0.3.0/HaisongHuang.ApineedGlmClaudeCode.yaml
+++ b/manifests/h/HaisongHuang/ApineedGlmClaudeCode/0.3.0/HaisongHuang.ApineedGlmClaudeCode.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: HaisongHuang.ApineedGlmClaudeCode
+PackageVersion: 0.3.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds `HaisongHuang.ApineedGlmClaudeCode` version `0.3.0` as a new Windows x64 portable package.

Release: https://github.com/haisonghuang/homebrew-tap/releases/tag/v0.3.0

The package installs `glm-code.exe` with the `glm-code` command alias. Claude Code is installed separately by the user.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)
  - Not applicable

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

Automated repository checks can validate the manifest and installer hash. Local Windows validation was not run for this submission.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/408372)