### PR TITLE
Update: Correct Installer Type for McAfee.MCPR

### DIFF
--- a/manifests/m/McAfee/MCPR/10.5.374.0/McAfee.MCPR.installer.yaml
+++ b/manifests/m/McAfee/MCPR/10.5.374.0/McAfee.MCPR.installer.yaml
@@ -4,7 +4,7 @@
 PackageIdentifier: McAfee.MCPR
 PackageVersion: 10.5.374.0
 InstallerLocale: en-US
-InstallerType: nullsoft
+InstallerType: portable
 InstallModes:
 - silent
 UpgradeBehavior: install


### PR DESCRIPTION
## 📖 Description
When testing #401175 I saw that the installer did not actually install anything. Instead, it extracted some files and spawned a subprocess for the removal. This indicates the application is a portable app and not an installer. This PR corrects that

<details><summary>Before</summary>
<p>

<img width="1527" height="961" alt="image" src="https://github.com/user-attachments/assets/12982563-b4fc-4704-a6d2-192a976d6871" />

</p>
</details> 

<details><summary>After</summary>
<p>

<img width="1507" height="907" alt="image" src="https://github.com/user-attachments/assets/7e3abdec-8b0f-4153-9772-2f3f92beed40" />


</p>
</details> 


> [!NOTE]
> Policy Test 1.2 originally waived in #290432

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/408494)