### PR TITLE
Update: Add missing dependency for Hanselman.WingetTUI

### DIFF
--- a/manifests/h/Hanselman/WingetTUI/0.13/Hanselman.WingetTUI.installer.yaml
+++ b/manifests/h/Hanselman/WingetTUI/0.13/Hanselman.WingetTUI.installer.yaml
@@ -12,10 +12,16 @@ Installers:
   InstallerSha256: 074b48e15ea48123ffe27b51e256dbc9cff1a094c1496607dfb772c69fddc732
   AppsAndFeaturesEntries:
   - DisplayName: winget-tui (x64)
-# - Architecture: arm64 (Commented out due to https://github.com/microsoft/winget-pkgs/issues/396990)
-#   InstallerUrl: https://github.com/shanselman/winget-tui/releases/download/v0.13.0/winget-tui-arm64.exe
-#   InstallerSha256: c34367d953e381df6593c91f7867d79cdac8114e2b5a78b8e2422ebd5c8dda89
-#   AppsAndFeaturesEntries:
-#   - DisplayName: winget-tui (ARM64)
+  Dependencies:
+    PackageDependencies:
+      - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+- Architecture: arm64
+  InstallerUrl: https://github.com/shanselman/winget-tui/releases/download/v0.13.0/winget-tui-arm64.exe
+  InstallerSha256: c34367d953e381df6593c91f7867d79cdac8114e2b5a78b8e2422ebd5c8dda89
+  AppsAndFeaturesEntries:
+  - DisplayName: winget-tui (ARM64)
+  Dependencies:
+    PackageDependencies:
+      - PackageIdentifier: Microsoft.VCRedist.2015+.arm64
 ManifestType: installer
 ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description
Adds a missing dependency for WingetTUI and uncomments the arm64 installer

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/408496)