### PR TITLE
Add WinGet manifest for AGNTCY.shadictl version 0.1.2

### DIFF
--- a/manifests/a/AGNTCY/shadictl/0.1.2/AGNTCY.shadictl.installer.yaml
+++ b/manifests/a/AGNTCY/shadictl/0.1.2/AGNTCY.shadictl.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: AGNTCY.shadictl
+PackageVersion: 0.1.2
+InstallerType: zip
+NestedInstallerType: portable
+Commands:
+- shadictl
+ReleaseDate: 2026-07-27
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/agntcy/shadi/releases/download/agntcy-shadi-cli-v0.1.2/shadictl-v0.1.2-x86_64-pc-windows-msvc.zip
+  InstallerSha256: 234EA3FE46F520460730C1607A17A2831B59D8D72E1050ADB05E207D1ACC49F1
+  NestedInstallerFiles:
+  - RelativeFilePath: shadictl-v0.1.2-x86_64-pc-windows-msvc\shadictl.exe
+    PortableCommandAlias: shadictl
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/AGNTCY/shadictl/0.1.2/AGNTCY.shadictl.locale.en-US.yaml
+++ b/manifests/a/AGNTCY/shadictl/0.1.2/AGNTCY.shadictl.locale.en-US.yaml
@@ -1,27 +1,27 @@
-        # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
-        PackageIdentifier: AGNTCY.shadictl
-        PackageVersion: 0.1.2
-        PackageLocale: en-US
-        Publisher: AGNTCY
-        PublisherUrl: https://github.com/agntcy
-        PublisherSupportUrl: https://github.com/agntcy/shadi/issues
-        Author: AGNTCY Contributors
-        PackageName: shadictl
-        PackageUrl: https://github.com/agntcy/shadi
-        License: Apache-2.0
-        LicenseUrl: https://github.com/agntcy/shadi/blob/agntcy-shadi-cli-v0.1.2/LICENSE.md
-        ShortDescription: Command-line interface for SHADI policy, secrets, memory, and SLIM operations.
-        Moniker: shadictl
-        Tags:
+PackageIdentifier: AGNTCY.shadictl
+PackageVersion: 0.1.2
+PackageLocale: en-US
+Publisher: AGNTCY
+PublisherUrl: https://github.com/agntcy
+PublisherSupportUrl: https://github.com/agntcy/shadi/issues
+Author: AGNTCY Contributors
+PackageName: shadictl
+PackageUrl: https://github.com/agntcy/shadi
+License: Apache-2.0
+LicenseUrl: https://github.com/agntcy/shadi/blob/agntcy-shadi-cli-v0.1.2/LICENSE.md
+ShortDescription: Command-line interface for SHADI policy, secrets, memory, and SLIM operations.
+Moniker: shadictl
+Tags:
 - agent
 - cli
 - sandbox
 - security
 - slim
-        Documentations:
-        - DocumentLabel: Documentation
-          DocumentUrl: https://agntcy.github.io/shadi
-        ReleaseNotesUrl: https://github.com/agntcy/shadi/releases/tag/agntcy-shadi-cli-v0.1.2
-        ManifestType: defaultLocale
-        ManifestVersion: 1.12.0
+Documentations:
+- DocumentLabel: Documentation
+  DocumentUrl: https://agntcy.github.io/shadi
+ReleaseNotesUrl: https://github.com/agntcy/shadi/releases/tag/agntcy-shadi-cli-v0.1.2
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/AGNTCY/shadictl/0.1.2/AGNTCY.shadictl.locale.en-US.yaml
+++ b/manifests/a/AGNTCY/shadictl/0.1.2/AGNTCY.shadictl.locale.en-US.yaml
@@ -1,0 +1,27 @@
+        # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+        PackageIdentifier: AGNTCY.shadictl
+        PackageVersion: 0.1.2
+        PackageLocale: en-US
+        Publisher: AGNTCY
+        PublisherUrl: https://github.com/agntcy
+        PublisherSupportUrl: https://github.com/agntcy/shadi/issues
+        Author: AGNTCY Contributors
+        PackageName: shadictl
+        PackageUrl: https://github.com/agntcy/shadi
+        License: Apache-2.0
+        LicenseUrl: https://github.com/agntcy/shadi/blob/agntcy-shadi-cli-v0.1.2/LICENSE.md
+        ShortDescription: Command-line interface for SHADI policy, secrets, memory, and SLIM operations.
+        Moniker: shadictl
+        Tags:
+- agent
+- cli
+- sandbox
+- security
+- slim
+        Documentations:
+        - DocumentLabel: Documentation
+          DocumentUrl: https://agntcy.github.io/shadi
+        ReleaseNotesUrl: https://github.com/agntcy/shadi/releases/tag/agntcy-shadi-cli-v0.1.2
+        ManifestType: defaultLocale
+        ManifestVersion: 1.12.0

--- a/manifests/a/AGNTCY/shadictl/0.1.2/AGNTCY.shadictl.yaml
+++ b/manifests/a/AGNTCY/shadictl/0.1.2/AGNTCY.shadictl.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: AGNTCY.shadictl
+PackageVersion: 0.1.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Add WinGet manifests for AGNTCY.shadictl 0.1.2.

- publishes the Windows portable ZIP for shadictl
- points WinGet at the SHADI GitHub release asset and checksum-backed digest
- generated from the SHADI CLI release automation

Upstream release: https://github.com/agntcy/shadi/releases/tag/agntcy-shadi-cli-v0.1.2
Refs agntcy/shadi#69
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/408502)