### PR TITLE
New package: Sparcle.Bolt version 0.1.140

### DIFF
--- a/manifests/s/Sparcle/Bolt/0.1.140/Sparcle.Bolt.installer.yaml
+++ b/manifests/s/Sparcle/Bolt/0.1.140/Sparcle.Bolt.installer.yaml
@@ -1,0 +1,9 @@
+PackageIdentifier: Sparcle.Bolt
+PackageVersion: 0.1.140
+InstallerType: nullsoft
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Sparcle-LLC/sparcle.app/releases/download/v0.1.140/Bolt-Enterprise-0.1.140-x86_64-pc-windows-msvc.exe
+    InstallerSha256: 190366307A204C5A7C1C5C8445E8D3D317336C6993B5076A606941061DBE4B53
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/Sparcle/Bolt/0.1.140/Sparcle.Bolt.installer.yaml
+++ b/manifests/s/Sparcle/Bolt/0.1.140/Sparcle.Bolt.installer.yaml
@@ -3,7 +3,7 @@ PackageVersion: 0.1.140
 InstallerType: nullsoft
 Installers:
   - Architecture: x64
-    InstallerUrl: https://github.com/Sparcle-LLC/sparcle.app/releases/download/v0.1.140/Bolt-Enterprise-0.1.140-x86_64-pc-windows-msvc.exe
+    InstallerUrl: https://github.com/SparcleHQ/sparcle.app/releases/download/v0.1.140/Bolt-Enterprise-0.1.140-x86_64-pc-windows-msvc.exe
     InstallerSha256: 190366307A204C5A7C1C5C8445E8D3D317336C6993B5076A606941061DBE4B53
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/s/Sparcle/Bolt/0.1.140/Sparcle.Bolt.locale.en-US.yaml
+++ b/manifests/s/Sparcle/Bolt/0.1.140/Sparcle.Bolt.locale.en-US.yaml
@@ -1,13 +1,13 @@
 PackageIdentifier: Sparcle.Bolt
 PackageVersion: 0.1.140
 PackageLocale: en-US
-Publisher: Sparcle Inc
+Publisher: Sparcle Inc.
 PublisherUrl: https://sparcle.app/
 PublisherSupportUrl: https://sparcle.app/trust/
 PackageName: Bolt
 PackageUrl: https://sparcle.app/download/
 License: Proprietary
-Copyright: Copyright (c) Sparcle Inc
+Copyright: Copyright (c) Sparcle Inc.
 ShortDescription: Local-first AI workspace with governed data egress
 Description: Bolt is a local-first AI workspace. Email, calendar, files and contacts stay on your machine, and a governed egress boundary controls what any AI model is allowed to see.
 Moniker: bolt

--- a/manifests/s/Sparcle/Bolt/0.1.140/Sparcle.Bolt.locale.en-US.yaml
+++ b/manifests/s/Sparcle/Bolt/0.1.140/Sparcle.Bolt.locale.en-US.yaml
@@ -1,0 +1,20 @@
+PackageIdentifier: Sparcle.Bolt
+PackageVersion: 0.1.140
+PackageLocale: en-US
+Publisher: Sparcle Inc
+PublisherUrl: https://sparcle.app/
+PublisherSupportUrl: https://sparcle.app/trust/
+PackageName: Bolt
+PackageUrl: https://sparcle.app/download/
+License: Proprietary
+Copyright: Copyright (c) Sparcle Inc
+ShortDescription: Local-first AI workspace with governed data egress
+Description: Bolt is a local-first AI workspace. Email, calendar, files and contacts stay on your machine, and a governed egress boundary controls what any AI model is allowed to see.
+Moniker: bolt
+Tags:
+  - ai
+  - productivity
+  - privacy
+  - local-first
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/Sparcle/Bolt/0.1.140/Sparcle.Bolt.yaml
+++ b/manifests/s/Sparcle/Bolt/0.1.140/Sparcle.Bolt.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Sparcle.Bolt
+PackageVersion: 0.1.140
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: Sparcle.Bolt version 0.1.140

Bolt is a local-first AI workspace for macOS, Windows and Linux. Email, calendar, files and contacts stay on the user's machine, and a governed egress boundary controls what any AI model is allowed to see.

- **Publisher:** Sparcle Inc
- **Homepage:** https://sparcle.app/
- **Download page:** https://sparcle.app/download/
- **License:** Proprietary (free download)

#### Checklist

- [x] Manifest validated locally with `winget validate` on Windows 11 — `Manifest validation succeeded.`
- [x] Installer URL is a stable, versioned GitHub release asset
- [x] `InstallerSha256` matches the published artifact
- [x] Publisher-hosted installer; no third-party mirror
- [x] Installer is the vendor's own NSIS package

#### Notes for reviewers

The installer is not yet Authenticode-signed; a code-signing certificate is in procurement. The published artifact is covered by a signed SHA-256 manifest, and the signing key and verification steps are published at https://sparcle.app/trust/verify-download/ if you want to confirm the bytes independently.

The same artifact is clean on VirusTotal (0 detections across 65 engines):
https://www.virustotal.com/gui/file/190366307a204c5a7c1c5c8445e8d3d317336c6993b5076a606941061dbe4b53
