### PR TITLE
New package: writingdeveloper.Notro version 2.10.2

### DIFF
--- a/manifests/w/writingdeveloper/Notro/2.10.2/writingdeveloper.Notro.installer.yaml
+++ b/manifests/w/writingdeveloper/Notro/2.10.2/writingdeveloper.Notro.installer.yaml
@@ -1,0 +1,17 @@
+PackageIdentifier: writingdeveloper.Notro
+PackageVersion: 2.10.2
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-07-28
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/writingdeveloper/Notro/releases/download/v2.10.2/NotroSetup.exe
+  InstallerSha256: 72A932ED0002607A446C4494B9DDB2B2EABFA99F461CE6FCACE1519AE4C8ECD3
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/w/writingdeveloper/Notro/2.10.2/writingdeveloper.Notro.installer.yaml
+++ b/manifests/w/writingdeveloper/Notro/2.10.2/writingdeveloper.Notro.installer.yaml
@@ -13,5 +13,6 @@ Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/writingdeveloper/Notro/releases/download/v2.10.2/NotroSetup.exe
   InstallerSha256: 72A932ED0002607A446C4494B9DDB2B2EABFA99F461CE6FCACE1519AE4C8ECD3
+  ProductCode: '{5F8A1E2B-3C4D-4E5F-A6B7-C8D9E0F1A2B3}_is1'
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/w/writingdeveloper/Notro/2.10.2/writingdeveloper.Notro.locale.en-US.yaml
+++ b/manifests/w/writingdeveloper/Notro/2.10.2/writingdeveloper.Notro.locale.en-US.yaml
@@ -1,0 +1,28 @@
+PackageIdentifier: writingdeveloper.Notro
+PackageVersion: 2.10.2
+PackageLocale: en-US
+Publisher: writingdeveloper
+PublisherUrl: https://github.com/writingdeveloper
+PublisherSupportUrl: https://github.com/writingdeveloper/Notro/issues
+PackageName: Notro
+PackageUrl: https://github.com/writingdeveloper/Notro
+License: MIT
+LicenseUrl: https://github.com/writingdeveloper/Notro/blob/main/LICENSE
+ShortDescription: Auto-compresses clipboard images for Discord's upload limit and adds an emoji/sticker/GIF picker.
+Description: |-
+  A tiny Windows tray app for Discord free users. It auto-compresses clipboard images that
+  exceed Discord's 10 MB upload limit, compresses oversized video clips with ffmpeg, and
+  ships an emoji / sticker / GIF picker opened with a hotkey. It never modifies the Discord
+  client and never touches your account or token.
+Moniker: notro
+Tags:
+- clipboard
+- compression
+- discord
+- emoji
+- image
+- tray
+- utility
+ReleaseNotesUrl: https://github.com/writingdeveloper/Notro/releases/tag/v2.10.2
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/w/writingdeveloper/Notro/2.10.2/writingdeveloper.Notro.yaml
+++ b/manifests/w/writingdeveloper/Notro/2.10.2/writingdeveloper.Notro.yaml
@@ -1,0 +1,6 @@
+# Created for Notro 2.10.2
+PackageIdentifier: writingdeveloper.Notro
+PackageVersion: 2.10.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package

`writingdeveloper.Notro` version `2.10.2` — a small Windows tray utility that auto-compresses clipboard images and video clips to fit Discord's upload limit, and provides a hotkey emoji/sticker/GIF picker.

- Repository: https://github.com/writingdeveloper/Notro (MIT)
- Release: https://github.com/writingdeveloper/Notro/releases/tag/v2.10.2

### Checklist

- [x] This is a new package; no existing manifests under `manifests/w/writingdeveloper/`, and no other open PR for it.
- [x] Validated locally: `winget validate --manifest` → *Manifest validation succeeded.*
- [x] Manifests conform to schema `1.6.0`.
- [x] `InstallerSha256` was computed from the published release asset and matches the `NotroSetup.exe.sha256` published alongside it.
- [x] Installed from the same artifact on Windows 11 and verified the resulting Apps & Features entry, `ProductCode`, and install location.
- [ ] `winget install --manifest` itself was not run: it requires an administrator to enable `LocalManifestFiles`, which this machine does not have enabled.

### Notes for reviewers

- **`ProductCode` is declared.** Checking the installed entry showed that Inno Setup's default `AppVerName` produces a localized, version-dependent display name (`Notro 버전 2.10.0` on a Korean install), which would not correlate with `PackageName: Notro`. The installer manifest therefore declares the stable Inno uninstall key `{5F8A1E2B-3C4D-4E5F-A6B7-C8D9E0F1A2B3}_is1` as `ProductCode`. The installer has also been changed so future releases register simply as `Notro`.
- **Installer:** Inno Setup, per-user (`PrivilegesRequired=lowest`, installs to `%LOCALAPPDATA%\Programs\Notro`), hence `Scope: user`. Silent switches are the Inno defaults, so no `InstallerSwitches` are declared.
- **Unsigned:** the executable is not code-signed yet (an application to the SignPath Foundation OSS programme is in progress). Each release publishes a SHA-256 next to the installer, and the build is reproducible from source.
- **No bundled ffmpeg:** ffmpeg is not distributed with the package. It is fetched from PyPI to the user's machine on demand, after the user confirms, and verified against the hash PyPI publishes — so no GPL binaries are redistributed here.
- **Privacy:** no telemetry or accounts. The four endpoints the app can contact are documented at https://github.com/writingdeveloper/Notro/blob/main/SECURITY.md
