### PR TITLE
Update: DixieFlatline76.Spice to 2.6.2

### DIFF
--- a/manifests/d/dixieflatline76/Spice/2.6.2/dixieflatline76.Spice.installer.yaml
+++ b/manifests/d/dixieflatline76/Spice/2.6.2/dixieflatline76.Spice.installer.yaml
@@ -1,0 +1,13 @@
+PackageIdentifier: dixieflatline76.Spice
+PackageVersion: 2.6.2
+Installers:
+  - Architecture: x64
+    InstallerType: exe
+    InstallerUrl: https://github.com/dixieflatline76/Spice/releases/download/v2.6.2/Spice-Setup-2.6.2-windows-amd64.exe
+    InstallerSha256: 07A5604AB7C917CA9075DE4D271AA938F5A0E02B2B17FB85F79E4F256ECA1D68
+    UpgradeBehavior: install
+    InstallerSwitches:
+      Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+      SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/d/dixieflatline76/Spice/2.6.2/dixieflatline76.Spice.locale.en-US.yaml
+++ b/manifests/d/dixieflatline76/Spice/2.6.2/dixieflatline76.Spice.locale.en-US.yaml
@@ -1,0 +1,16 @@
+PackageIdentifier: dixieflatline76.Spice
+PackageVersion: 2.6.2
+PackageLocale: en-US
+Publisher: dixieflatline76
+PackageName: Spice
+License: PolyForm Noncommercial 1.0.0
+ShortDescription: A highly-concurrent, plugin-driven desktop environment engine.
+Moniker: spice
+Tags:
+  - wallpaper
+  - desktop
+  - customization
+  - go
+  - engine
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/d/dixieflatline76/Spice/2.6.2/dixieflatline76.Spice.yaml
+++ b/manifests/d/dixieflatline76/Spice/2.6.2/dixieflatline76.Spice.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: dixieflatline76.Spice
+PackageVersion: 2.6.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0


### PR DESCRIPTION
## 📖 Description
Update `DixieFlatline76.Spice` manifest to version `2.6.2`.

Release highlights for v2.6.2:
- Resolved Statens Museum for Kunst (SMK) gallery preview key mismatches.
- Added IIIF image URL scaling fallback (`/max/` recovery) for smaller Getty open-content photographs.
- Audited and updated Getty collection classifications (paintings vs antiquities and vintage photography).
- Includes all major features from v2.6.1 (NPM, Getty, SMK museum expansion, Virtual Museum Framer engine, and offline Salon Preview Galleries).

## ✅ Checklist
- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist
- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/408698)