### PR TITLE
New package: Imperium42.Echophrase version 0.8.0.70

### DIFF
--- a/manifests/i/Imperium42/Echophrase/0.8.0.70/Imperium42.Echophrase.installer.yaml
+++ b/manifests/i/Imperium42/Echophrase/0.8.0.70/Imperium42.Echophrase.installer.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Imperium42.Echophrase
+PackageVersion: 0.8.0.70
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: nsis
+Scope: user
+InstallModes:
+- interactive
+- silent
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+UpgradeBehavior: install
+ReleaseDate: 2026-07-28
+AppsAndFeaturesEntries:
+- DisplayName: Echophrase
+  Publisher: Imperium42
+  DisplayVersion: 0.8.0-beta.70
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/imperium42/echophrase-releases/releases/download/v0.8.0-beta.70/Echophrase_0.8.0-beta.70_x64-setup.exe
+  InstallerSha256: 5E6A61D0232560F327983B1DC456D42C03179C710F43F95067AB80830BF5C09E
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/i/Imperium42/Echophrase/0.8.0.70/Imperium42.Echophrase.installer.yaml
+++ b/manifests/i/Imperium42/Echophrase/0.8.0.70/Imperium42.Echophrase.installer.yaml
@@ -4,7 +4,7 @@ PackageVersion: 0.8.0.70
 Platform:
 - Windows.Desktop
 MinimumOSVersion: 10.0.0.0
-InstallerType: nsis
+InstallerType: nullsoft
 Scope: user
 InstallModes:
 - interactive

--- a/manifests/i/Imperium42/Echophrase/0.8.0.70/Imperium42.Echophrase.locale.en-US.yaml
+++ b/manifests/i/Imperium42/Echophrase/0.8.0.70/Imperium42.Echophrase.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Imperium42.Echophrase
+PackageVersion: 0.8.0.70
+PackageLocale: en-US
+Publisher: Imperium42
+PublisherUrl: https://echophrase.com
+PublisherSupportUrl: https://echophrase.com/contact
+PackageName: Echophrase
+PackageUrl: https://echophrase.com
+License: Proprietary
+LicenseUrl: https://echophrase.com/terms
+PrivacyUrl: https://echophrase.com/privacy
+Copyright: Copyright (c) 2026 Imperium42 LLC
+ShortDescription: Privacy-first, GPU-accelerated speech-to-text dictation that runs 100% offline.
+Description: Echophrase is a privacy-first desktop dictation app. All speech-to-text processing happens locally on your GPU or CPU - your voice never leaves your device. Press a hotkey, speak, and the transcript is pasted at your cursor. Free tier is unlimited, offline, and requires no account.
+Moniker: echophrase
+Tags:
+- dictation
+- offline
+- privacy
+- speech-to-text
+- transcription
+- voice
+- whisper
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/i/Imperium42/Echophrase/0.8.0.70/Imperium42.Echophrase.yaml
+++ b/manifests/i/Imperium42/Echophrase/0.8.0.70/Imperium42.Echophrase.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Imperium42.Echophrase
+PackageVersion: 0.8.0.70
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

New package submission for Echophrase, a privacy-first offline speech-to-text dictation app for Windows by Imperium42 LLC. Installer is an Authenticode-signed (Azure Trusted Signing, Imperium42 OV identity) NSIS per-user installer hosted on the publisher's public releases repository (https://github.com/Imperium42/echophrase-releases). Version 0.8.0.70 maps to the product version 0.8.0-beta.70. Future versions will be submitted automatically from the publisher's CI via wingetcreate.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/408729)

