### PR TITLE
Add dagaza.Qube version 1.2.5

### DIFF
--- a/manifests/d/dagaza/Qube/1.2.5/dagaza.Qube.installer.yaml
+++ b/manifests/d/dagaza/Qube/1.2.5/dagaza.Qube.installer.yaml
@@ -1,0 +1,12 @@
+PackageIdentifier: dagaza.Qube
+PackageVersion: 1.2.5
+InstallerType: inno
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/dagaza/Qube/releases/download/v1.2.5/Qube-1.2.5-Setup.exe
+    InstallerSha256: 49D593F09E277221739BA05DD32488AC1CA22F57016E9F223982F143A59CAC65
+    InstallerSwitches:
+      Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+      SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/d/dagaza/Qube/1.2.5/dagaza.Qube.locale.en-US.yaml
+++ b/manifests/d/dagaza/Qube/1.2.5/dagaza.Qube.locale.en-US.yaml
@@ -1,0 +1,23 @@
+PackageIdentifier: dagaza.Qube
+PackageVersion: 1.2.5
+PackageLocale: en-US
+Publisher: dagaza
+PublisherUrl: https://github.com/dagaza
+PackageName: Qube
+Moniker: qube
+License: MIT
+LicenseUrl: https://github.com/dagaza/Qube/blob/main/LICENSE
+ShortDescription: Local hardware-accelerated AI desktop assistant (CPU inference build)
+Description: >-
+  Qube is a fully local, privacy-first, voice-to-voice AI desktop assistant. It integrates speech-to-text, text-to-speech, retrieval-augmented generation, and local LLM inference into a native PyQt6 desktop shell. This package is the CPU inference build (works on any PC). For GPU acceleration, also see dagaza.Qube.Vulkan (AMD/Intel) or dagaza.Qube.CUDA (NVIDIA) on WinGet, or download from GitHub Releases.
+PackageUrl: https://github.com/dagaza/Qube
+Tags:
+  - ai
+  - assistant
+  - local
+  - privacy
+  - voice
+  - llm
+  - desktop
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/d/dagaza/Qube/1.2.5/dagaza.Qube.yaml
+++ b/manifests/d/dagaza/Qube/1.2.5/dagaza.Qube.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: dagaza.Qube
+PackageVersion: 1.2.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary
Add WinGet manifest for **dagaza.Qube** **1.2.5** (CPU Windows installer).

## Installer
- **URL:** https://github.com/dagaza/Qube/releases/download/v1.2.5/Qube-1.2.5-Setup.exe
- **SHA256:** `49D593F09E277221739BA05DD32488AC1CA22F57016E9F223982F143A59CAC65`

## Notes
Follow-up PRs will add separate package IDs for GPU builds once published on GitHub Releases:
- `dagaza.Qube.Vulkan` → `Qube-1.2.5-vulkan-Setup.exe`
- `dagaza.Qube.CUDA` → `Qube-1.2.5-cuda-Setup.exe`

## Validation
```powershell
winget validate --manifest manifests/d/dagaza/Qube/1.2.5
```


Made with [Cursor](https://cursor.com)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/408752)