### PR TITLE
New version: farion1231.CC-Switch version 3.18.0

### DIFF
--- a/manifests/f/farion1231/CC-Switch/3.18.0/farion1231.CC-Switch.installer.yaml
+++ b/manifests/f/farion1231/CC-Switch/3.18.0/farion1231.CC-Switch.installer.yaml
@@ -11,18 +11,18 @@ InstallModes:
 - silent
 - silentWithProgress
 UpgradeBehavior: install
+ProductCode: '{8B7305F8-92A3-4423-8408-BD91BB68D870}'
 ReleaseDate: 2026-07-21
+AppsAndFeaturesEntries:
+- Publisher: ccswitch
+  ProductCode: '{8B7305F8-92A3-4423-8408-BD91BB68D870}'
+  UpgradeCode: '{55F90CA4-617A-5350-A7CF-F6F24252866B}'
 InstallationMetadata:
   DefaultInstallLocation: '%LocalAppData%/Programs/CC Switch'
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/farion1231/cc-switch/releases/download/v3.18.0/CC-Switch-v3.18.0-Windows.msi
   InstallerSha256: C4A6EAF763269396F90A81377381E91C8341538B51376912C81BAB73E844612D
-  ProductCode: '{8B7305F8-92A3-4423-8408-BD91BB68D870}'
-  AppsAndFeaturesEntries:
-  - Publisher: ccswitch
-    ProductCode: '{8B7305F8-92A3-4423-8408-BD91BB68D870}'
-    UpgradeCode: '{55F90CA4-617A-5350-A7CF-F6F24252866B}'
 - Architecture: arm64
   InstallerUrl: https://github.com/farion1231/cc-switch/releases/download/v3.18.0/CC-Switch-v3.18.0-Windows-arm64.msi
   InstallerSha256: C8ABD0B39CD6FE0D14637C1D1C66F39B79066AEF3EDF76BB7A5B3B5B57241E09

--- a/manifests/f/farion1231/CC-Switch/3.18.0/farion1231.CC-Switch.installer.yaml
+++ b/manifests/f/farion1231/CC-Switch/3.18.0/farion1231.CC-Switch.installer.yaml
@@ -1,0 +1,35 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: farion1231.CC-Switch
+PackageVersion: 3.18.0
+InstallerLocale: en-US
+InstallerType: wix
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-07-21
+InstallationMetadata:
+  DefaultInstallLocation: '%LocalAppData%/Programs/CC Switch'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/farion1231/cc-switch/releases/download/v3.18.0/CC-Switch-v3.18.0-Windows.msi
+  InstallerSha256: C4A6EAF763269396F90A81377381E91C8341538B51376912C81BAB73E844612D
+  ProductCode: '{8B7305F8-92A3-4423-8408-BD91BB68D870}'
+  AppsAndFeaturesEntries:
+  - Publisher: ccswitch
+    ProductCode: '{8B7305F8-92A3-4423-8408-BD91BB68D870}'
+    UpgradeCode: '{55F90CA4-617A-5350-A7CF-F6F24252866B}'
+- Architecture: arm64
+  InstallerUrl: https://github.com/farion1231/cc-switch/releases/download/v3.18.0/CC-Switch-v3.18.0-Windows-arm64.msi
+  InstallerSha256: C8ABD0B39CD6FE0D14637C1D1C66F39B79066AEF3EDF76BB7A5B3B5B57241E09
+  ProductCode: '{68D572F6-BD4E-43DB-B50C-78260FE45D14}'
+  AppsAndFeaturesEntries:
+  - Publisher: ccswitch
+    ProductCode: '{68D572F6-BD4E-43DB-B50C-78260FE45D14}'
+    UpgradeCode: '{55F90CA4-617A-5350-A7CF-F6F24252866B}'
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/farion1231/CC-Switch/3.18.0/farion1231.CC-Switch.locale.en-US.yaml
+++ b/manifests/f/farion1231/CC-Switch/3.18.0/farion1231.CC-Switch.locale.en-US.yaml
@@ -21,7 +21,6 @@ Tags:
 - desktop-app
 - gemini-cli
 - grok
-- grok-build
 - mcp
 - open-source
 - openclaw
@@ -29,11 +28,9 @@ Tags:
 - provider-management
 - rust
 - skills
-- skills-management
 - tauri
 - typescript
 - wsl-support
-- xai
 ReleaseNotes: |-
   CC Switch v3.18.0
 

--- a/manifests/f/farion1231/CC-Switch/3.18.0/farion1231.CC-Switch.locale.en-US.yaml
+++ b/manifests/f/farion1231/CC-Switch/3.18.0/farion1231.CC-Switch.locale.en-US.yaml
@@ -1,0 +1,53 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: farion1231.CC-Switch
+PackageVersion: 3.18.0
+PackageLocale: en-US
+Publisher: farion1231
+PublisherUrl: https://github.com/farion1231
+PublisherSupportUrl: https://github.com/farion1231/cc-switch/issues
+Author: farion1231
+PackageName: CC Switch
+PackageUrl: https://github.com/farion1231/cc-switch
+License: MIT
+LicenseUrl: https://github.com/farion1231/cc-switch/blob/HEAD/LICENSE
+ShortDescription: A cross-platform desktop All-in-One assistant tool for Claude Code, Codex, OpenCode, OpenClaw, Gemini CLI & Grok Build.
+Moniker: ccswitch
+Tags:
+- ai-tools
+- claude-code
+- codex
+- desktop-app
+- gemini-cli
+- grok
+- grok-build
+- mcp
+- open-source
+- openclaw
+- opencode
+- provider-management
+- rust
+- skills
+- skills-management
+- tauri
+- typescript
+- wsl-support
+- xai
+ReleaseNotes: |-
+  CC Switch v3.18.0
+
+  Highlights
+  - Manage Grok Build (xAI's Grok CLI) as the eighth managed app: provider add/import/one-click switch, bidirectional MCP and Skills sync, proxy takeover, and usage dashboard coverage.
+  - Connect Grok to Claude Code, Claude Desktop, and Codex via xAI account OAuth (device-code, no API key) or an xAI API key (Codex native Responses preset; Claude Code via local routing). Default model: grok-4.5.
+  - Fix Codex usage double-count introduced in v3.17.0; automatic one-time usage rebuild after upgrade, plus a manual "Rebuild Codex Usage" button.
+  - Fix codex 0.144.5+ failing to start due to generated model catalog missing parser-required fields.
+  - Windows: switching providers no longer flashes a console window or freezes the UI for ~2 seconds.
+  - Diagnostic logs persist across restarts (size-rotated) and are fully redacted; UI crashes show a reload card and write details to disk.
+  - Responses↔Chat bridge fixes for multi-turn reasoning, parallel tool-call IDs/order, and null tool schemas rejected by strict upstreams.
+  - Kimi K3 presets and built-in pricing for Codex / Hermes / OpenClaw / OpenCode.
+
+  Release date: 2026-07-21
+ReleaseNotesUrl: https://github.com/farion1231/cc-switch/releases/tag/v3.18.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/farion1231/CC-Switch/3.18.0/farion1231.CC-Switch.locale.en-US.yaml
+++ b/manifests/f/farion1231/CC-Switch/3.18.0/farion1231.CC-Switch.locale.en-US.yaml
@@ -12,22 +12,22 @@ PackageName: CC Switch
 PackageUrl: https://github.com/farion1231/cc-switch
 License: MIT
 LicenseUrl: https://github.com/farion1231/cc-switch/blob/HEAD/LICENSE
-ShortDescription: A cross-platform desktop All-in-One assistant tool for Claude Code, Codex, OpenCode, OpenClaw, Gemini CLI & Grok Build.
+ShortDescription: A cross-platform desktop All-in-One assistant tool for Claude Code, Codex, OpenCode, openclaw & Gemini CLI.
 Moniker: ccswitch
 Tags:
 - ai-tools
 - claude-code
 - codex
 - desktop-app
-- gemini-cli
-- grok
 - mcp
+- minimax
+- omo
 - open-source
-- openclaw
 - opencode
 - provider-management
 - rust
 - skills
+- skills-management
 - tauri
 - typescript
 - wsl-support
@@ -41,7 +41,7 @@ ReleaseNotes: |-
   - Fix codex 0.144.5+ failing to start due to generated model catalog missing parser-required fields.
   - Windows: switching providers no longer flashes a console window or freezes the UI for ~2 seconds.
   - Diagnostic logs persist across restarts (size-rotated) and are fully redacted; UI crashes show a reload card and write details to disk.
-  - Responses↔Chat bridge fixes for multi-turn reasoning, parallel tool-call IDs/order, and null tool schemas rejected by strict upstreams.
+  - Responses-Chat bridge fixes for multi-turn reasoning, parallel tool-call IDs/order, and null tool schemas rejected by strict upstreams.
   - Kimi K3 presets and built-in pricing for Codex / Hermes / OpenClaw / OpenCode.
 
   Release date: 2026-07-21

--- a/manifests/f/farion1231/CC-Switch/3.18.0/farion1231.CC-Switch.yaml
+++ b/manifests/f/farion1231/CC-Switch/3.18.0/farion1231.CC-Switch.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: farion1231.CC-Switch
+PackageVersion: 3.18.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New version of `farion1231.CC-Switch` from **3.16.5** to **3.18.0**.

- Upstream release: https://github.com/farion1231/cc-switch/releases/tag/v3.18.0
- Installers: Windows x64 MSI and Windows arm64 MSI (WiX)
- Package identifier: `farion1231.CC-Switch`

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  - N/A (routine package version update)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/408786)