### PR TITLE
Add WinGet manifest for AGNTCY.agentbridge version 0.1.1

### DIFF
--- a/manifests/a/AGNTCY/agentbridge/0.1.1/AGNTCY.agentbridge.installer.yaml
+++ b/manifests/a/AGNTCY/agentbridge/0.1.1/AGNTCY.agentbridge.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: AGNTCY.agentbridge
+PackageVersion: 0.1.1
+InstallerType: zip
+NestedInstallerType: portable
+Commands:
+- agentbridge
+ReleaseDate: 2026-07-28
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/agntcy/shadi/releases/download/agntcy-agentbridge-cli-v0.1.1/agentbridge-v0.1.1-x86_64-pc-windows-msvc.zip
+  InstallerSha256: 58E1775416C16C9B40C08B509C5E7E415CD60200C63EB05709A336E88CB77E04
+  NestedInstallerFiles:
+  - RelativeFilePath: agentbridge-v0.1.1-x86_64-pc-windows-msvc\agentbridge.exe
+    PortableCommandAlias: agentbridge
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/AGNTCY/agentbridge/0.1.1/AGNTCY.agentbridge.locale.en-US.yaml
+++ b/manifests/a/AGNTCY/agentbridge/0.1.1/AGNTCY.agentbridge.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: AGNTCY.agentbridge
+PackageVersion: 0.1.1
+PackageLocale: en-US
+Publisher: AGNTCY
+PublisherUrl: https://github.com/agntcy
+PublisherSupportUrl: https://github.com/agntcy/shadi/issues
+Author: AGNTCY Contributors
+PackageName: agentbridge
+PackageUrl: https://github.com/agntcy/shadi
+License: Apache-2.0
+LicenseUrl: https://github.com/agntcy/shadi/blob/agntcy-agentbridge-cli-v0.1.1/LICENSE.md
+ShortDescription: CLI binary for the agentbridge general-purpose agent interconnect.
+Moniker: agentbridge
+Tags:
+- agent
+- cli
+- sandbox
+- security
+- slim
+Documentations:
+- DocumentLabel: Documentation
+  DocumentUrl: https://agntcy.github.io/shadi
+ReleaseNotesUrl: https://github.com/agntcy/shadi/releases/tag/agntcy-agentbridge-cli-v0.1.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/AGNTCY/agentbridge/0.1.1/AGNTCY.agentbridge.yaml
+++ b/manifests/a/AGNTCY/agentbridge/0.1.1/AGNTCY.agentbridge.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: AGNTCY.agentbridge
+PackageVersion: 0.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Add WinGet manifests for AGNTCY.agentbridge 0.1.1.

- publishes the Windows portable ZIP for agentbridge
- points WinGet at the SHADI GitHub release asset and checksum-backed digest
- generated from the SHADI CLI release automation

Upstream release: https://github.com/agntcy/shadi/releases/tag/agntcy-agentbridge-cli-v0.1.1
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/408814)