### PR TITLE
New package: AMCF.AZERTYGlobal version 1.1.0.0

### DIFF
--- a/manifests/a/AMCF/AZERTYGlobal/1.1.0.0/AMCF.AZERTYGlobal.installer.yaml
+++ b/manifests/a/AMCF/AZERTYGlobal/1.1.0.0/AMCF.AZERTYGlobal.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: AMCF.AZERTYGlobal
+PackageVersion: 1.1.0.0
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: msix
+Scope: user
+InstallModes:
+  - silent
+UpgradeBehavior: install
+PackageFamilyName: AZERTYGlobal.AZERTYGlobal_yh4wjq6y8vthy
+Installers:
+  - Architecture: neutral
+    InstallerUrl: https://download.azerty.global/AZERTY_Global_1.1.0.msixbundle
+    InstallerSha256: 79A9C9C80CE9441272961DA20CEC3206307D26CD9BBF23AB57F9D7BE8BF6530E
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/AMCF/AZERTYGlobal/1.1.0.0/AMCF.AZERTYGlobal.locale.en-US.yaml
+++ b/manifests/a/AMCF/AZERTYGlobal/1.1.0.0/AMCF.AZERTYGlobal.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: AMCF.AZERTYGlobal
+PackageVersion: 1.1.0.0
+PackageLocale: en-US
+Publisher: Association pour la Modernisation du Clavier Français
+PublisherUrl: https://azerty.global/en/
+PublisherSupportUrl: https://github.com/AZERTYGlobal/app/issues
+PackageName: AZERTY Global
+PackageUrl: https://azerty.global/en/
+License: EUPL-1.2
+LicenseUrl: https://github.com/AZERTYGlobal/app/blob/main/LICENCE
+Copyright: © 2017-2026 Antoine Olivier
+ShortDescription: An improved French AZERTY keyboard layout that preserves your existing habits.
+Description: A corrected AZERTY layout that preserves 99% of existing habits and makes accented uppercase letters, programming symbols, and foreign-language characters easy to type.
+Tags:
+  - azerty
+  - french
+  - keyboard
+  - keyboard-layout
+  - productivity
+ReleaseNotes: 'Added fully local usage statistics, improved error messages, and a complete English interface with a language selector.'
+ReleaseDate: 2026-07-23
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/a/AMCF/AZERTYGlobal/1.1.0.0/AMCF.AZERTYGlobal.locale.fr-FR.yaml
+++ b/manifests/a/AMCF/AZERTYGlobal/1.1.0.0/AMCF.AZERTYGlobal.locale.fr-FR.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: AMCF.AZERTYGlobal
+PackageVersion: 1.1.0.0
+PackageLocale: fr-FR
+Publisher: Association pour la Modernisation du Clavier Français
+PublisherUrl: https://azerty.global/
+PublisherSupportUrl: https://github.com/AZERTYGlobal/app/issues
+PackageName: AZERTY Global
+PackageUrl: https://azerty.global/
+License: EUPL-1.2
+LicenseUrl: https://github.com/AZERTYGlobal/app/blob/main/LICENCE
+Copyright: © 2017-2026 Antoine Olivier
+Moniker: azertyglobal
+ShortDescription: Une disposition AZERTY française améliorée, sans changer vos habitudes.
+Description: L'AZERTY corrigé qui conserve 99 % des habitudes existantes et facilite les majuscules accentuées, les symboles de programmation et les langues étrangères.
+Tags:
+  - azerty
+  - clavier
+  - français
+  - keyboard
+  - keyboard-layout
+  - productivité
+ReleaseNotes: 'Ajout des statistiques d''utilisation entièrement locales, amélioration des messages d''erreur et traduction complète de l''interface en anglais avec sélecteur de langue.'
+ReleaseDate: 2026-07-23
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/AMCF/AZERTYGlobal/1.1.0.0/AMCF.AZERTYGlobal.yaml
+++ b/manifests/a/AMCF/AZERTYGlobal/1.1.0.0/AMCF.AZERTYGlobal.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: AMCF.AZERTYGlobal
+PackageVersion: 1.1.0.0
+DefaultLocale: fr-FR
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package: **AMCF.AZERTYGlobal** version **1.1.0.0** — AZERTY Global, an improved French AZERTY keyboard layout published by the Association pour la Modernisation du Clavier Français (azerty.global).

MSIX bundle, user scope, EUPL-1.2. Four manifests on schema 1.12.0: version, installer, `fr-FR` (defaultLocale) and `en-US`.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)
  - N/A — first submission of this package, no related issue.

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

### Notes for moderators

- `PackageFamilyName` is `AZERTYGlobal.AZERTYGlobal_yh4wjq6y8vthy`; the `PackageIdentifier` uses the `AMCF` prefix because the publisher of record is the Association pour la Modernisation du Clavier Français, the non-profit that owns the project (RNA W632015664).
- Installer URL is served from the project's own domain and is publicly reachable: `https://download.azerty.global/AZERTY_Global_1.1.0.msixbundle` (12.9 MB).