### PR TITLE
KlowdfurrRad.TrayAuth version 1.0.0

### DIFF
--- a/manifests/k/KlowdfurrRad/TrayAuth/1.0.0/KlowdfurrRad.TrayAuth.installer.yaml
+++ b/manifests/k/KlowdfurrRad/TrayAuth/1.0.0/KlowdfurrRad.TrayAuth.installer.yaml
@@ -21,7 +21,6 @@ Installers:
   AppsAndFeaturesEntries:
   - DisplayName: TrayAuth
     Publisher: KlowdfurrRad
-    DisplayVersion: 1.0.0
     ProductCode: '{8F3C1A64-2D57-4E9B-9A21-6B0E7C5D4F18}_is1'
     InstallerType: inno
 ManifestType: installer

--- a/manifests/k/KlowdfurrRad/TrayAuth/1.0.0/KlowdfurrRad.TrayAuth.installer.yaml
+++ b/manifests/k/KlowdfurrRad/TrayAuth/1.0.0/KlowdfurrRad.TrayAuth.installer.yaml
@@ -1,0 +1,29 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: KlowdfurrRad.TrayAuth
+PackageVersion: 1.0.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: inno
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/KlowdfurrRad/TrayAuth/releases/download/v1.0.0/TrayAuth-Setup-1.0.0.exe
+  InstallerSha256: 8B1CB1487258F0BD3D9E061A6D85B7A9659F9529D12888B6A31FA7EF36D7D83A
+  ProductCode: '{8F3C1A64-2D57-4E9B-9A21-6B0E7C5D4F18}_is1'
+  AppsAndFeaturesEntries:
+  - DisplayName: TrayAuth
+    Publisher: KlowdfurrRad
+    DisplayVersion: 1.0.0
+    ProductCode: '{8F3C1A64-2D57-4E9B-9A21-6B0E7C5D4F18}_is1'
+    InstallerType: inno
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-07-28

--- a/manifests/k/KlowdfurrRad/TrayAuth/1.0.0/KlowdfurrRad.TrayAuth.locale.en-US.yaml
+++ b/manifests/k/KlowdfurrRad/TrayAuth/1.0.0/KlowdfurrRad.TrayAuth.locale.en-US.yaml
@@ -11,9 +11,9 @@ Author: Raadhes Chandaluru
 PackageName: TrayAuth
 PackageUrl: https://github.com/KlowdfurrRad/TrayAuth
 License: MIT
-LicenseUrl: https://github.com/KlowdfurrRad/TrayAuth/blob/main/LICENSE
+LicenseUrl: https://github.com/KlowdfurrRad/TrayAuth/blob/v1.0.0/LICENSE
 Copyright: Copyright (c) 2026 Raadhes Chandaluru
-CopyrightUrl: https://github.com/KlowdfurrRad/TrayAuth/blob/main/LICENSE
+CopyrightUrl: https://github.com/KlowdfurrRad/TrayAuth/blob/v1.0.0/LICENSE
 ShortDescription: Authenticator codes in the Windows tray, in a panel that slides out of the taskbar.
 Description: |-
   TrayAuth keeps your two-factor authentication codes one click away. Click the tray icon and a

--- a/manifests/k/KlowdfurrRad/TrayAuth/1.0.0/KlowdfurrRad.TrayAuth.locale.en-US.yaml
+++ b/manifests/k/KlowdfurrRad/TrayAuth/1.0.0/KlowdfurrRad.TrayAuth.locale.en-US.yaml
@@ -1,0 +1,57 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: KlowdfurrRad.TrayAuth
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: KlowdfurrRad
+PublisherUrl: https://github.com/KlowdfurrRad
+PublisherSupportUrl: https://github.com/KlowdfurrRad/TrayAuth/issues
+Author: Raadhes Chandaluru
+PackageName: TrayAuth
+PackageUrl: https://github.com/KlowdfurrRad/TrayAuth
+License: MIT
+LicenseUrl: https://github.com/KlowdfurrRad/TrayAuth/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Raadhes Chandaluru
+CopyrightUrl: https://github.com/KlowdfurrRad/TrayAuth/blob/main/LICENSE
+ShortDescription: Authenticator codes in the Windows tray, in a panel that slides out of the taskbar.
+Description: |-
+  TrayAuth keeps your two-factor authentication codes one click away. Click the tray icon and a
+  panel slides out of the taskbar showing live TOTP codes; click a code to copy it, and the
+  clipboard clears itself twenty seconds later.
+
+  Accounts are added by typing the base32 setup key a site shows next to its QR image. The add
+  dialog previews the code your key produces, so you can check it against the site before saving.
+
+  Accounts are stored in %APPDATA%\TrayAuth, encrypted with Windows DPAPI and readable only by
+  your Windows account. TrayAuth makes no network calls of any kind, and there is no account to
+  create and nothing to sync. Because a DPAPI vault is bound to the Windows profile that wrote
+  it, TrayAuth can export every account to a JSON file plus a scannable QR image, so a backup can
+  be restored here or added to a phone.
+
+  Codes are generated per RFC 4226 and RFC 6238 and verified against the published RFC test
+  vectors for SHA1, SHA256 and SHA512, so they agree with any other authenticator app. Six, seven
+  and eight digit codes and custom periods are supported.
+Moniker: trayauth
+Tags:
+- 2fa
+- authenticator
+- mfa
+- one-time-password
+- otp
+- rfc6238
+- security
+- system-tray
+- totp
+- two-factor
+ReleaseNotes: |-
+  First release.
+
+  - Tray panel that slides out of whichever edge the taskbar is docked to
+  - Click to copy, with the clipboard cleared after 20 seconds
+  - Global Ctrl+Alt+A hotkey
+  - Vault encrypted at rest with Windows DPAPI
+  - Export and import accounts, including scannable QR images
+ReleaseNotesUrl: https://github.com/KlowdfurrRad/TrayAuth/releases/tag/v1.0.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/k/KlowdfurrRad/TrayAuth/1.0.0/KlowdfurrRad.TrayAuth.yaml
+++ b/manifests/k/KlowdfurrRad/TrayAuth/1.0.0/KlowdfurrRad.TrayAuth.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: KlowdfurrRad.TrayAuth
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package: **KlowdfurrRad.TrayAuth** version 1.0.0.

TrayAuth is an open-source (MIT) TOTP authenticator for the Windows notification area. Clicking the tray icon slides a panel out of the taskbar showing live two-factor codes; accounts are added by typing the base32 setup key. Codes follow RFC 4226/6238 and are verified against the published RFC 6238 test vectors. The vault is encrypted at rest with Windows DPAPI, and the app makes no network calls.

- Source: https://github.com/KlowdfurrRad/TrayAuth
- Release: https://github.com/KlowdfurrRad/TrayAuth/releases/tag/v1.0.0

**Installer notes**

- Inno Setup, **per-user** (`PrivilegesRequired=lowest`), so it installs without elevation and no UAC prompt — hence `Scope: user` in the installer manifest.
- No `InstallerSwitches` block: `InstallerType: inno` lets the client apply the correct silent switches itself.
- `ProductCode` and `AppsAndFeaturesEntries` match the Add/Remove Programs entry the installer writes (`TrayAuth` / `KlowdfurrRad` / `1.0.0`), verified with `winget list`:
  `TrayAuth   ARP\User\X64\{8F3C1A64-2D57-4E9B-9A21-6B0E7C5D4F18}_is1   1.0.0`
- Self-contained .NET 8 build, so the installer carries no runtime dependency.
- Uninstall removes the program and its registry entries; the user's encrypted vault in `%APPDATA%\TrayAuth` is intentionally left in place unless the user opts to delete it, since it cannot be recovered.

**Testing performed**

`winget install --manifest` was run against these manifests on Windows 11 24H2 (x64): the installer downloaded from the release URL, the hash verified, and the silent install completed with no prompts. Install, upgrade-detection and uninstall were each exercised. Windows Sandbox is unavailable on Windows 11 Home, so `SandboxTest.ps1` could not be run locally.

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/408883)
