### PR TITLE
New package: LilBuba.K8 version 1.8.0

### DIFF
--- a/manifests/l/LilBuba/K8/1.8.0/LilBuba.K8.installer.yaml
+++ b/manifests/l/LilBuba/K8/1.8.0/LilBuba.K8.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: LilBuba.K8
+PackageVersion: 1.8.0
+InstallerLocale: en-US
+InstallerType: inno
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/jopublic/lilbubba-site/releases/download/v1.8.0/K8_Setup_1.8.0.exe
+  InstallerSha256: DE1113641DC563AAC3D9513056A474066D4C8288D392DDE28F05A09ECEA9DB82
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/l/LilBuba/K8/1.8.0/LilBuba.K8.locale.en-US.yaml
+++ b/manifests/l/LilBuba/K8/1.8.0/LilBuba.K8.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: LilBuba.K8
+PackageVersion: 1.8.0
+PackageLocale: en-US
+Publisher: LilBuba
+PublisherUrl: https://lilbuba.ai
+PublisherSupportUrl: https://lilbuba.ai
+Author: Jo Browning
+PackageName: K8
+PackageUrl: https://lilbuba.ai/k8.html
+License: Proprietary
+LicenseUrl: https://lilbuba.ai/terms.html
+Copyright: Copyright (c) 2026 LilBuba.ai
+ShortDescription: Safe, private, one-time Windows dedupe and cleanup - find duplicate files, photos, media and developer junk, with quarantine-and-restore.
+Description: |-
+  K8 is a family of Windows dedupe and cleanup tools built on one idea: buy it once, run it locally, and it never phones home. It finds duplicate files, photos and media (K8 Bionic), clears regenerable developer junk like node_modules and build artifacts (K8 Cruft), and dedupes video, photo and audio libraries for creators (K8 Media). Everything runs with a quarantine-and-restore safety net, so nothing is ever hard-deleted. 100% local: no account, no cloud, no telemetry. One-time licence, 30-day money-back guarantee. Windows 10 and 11.
+Moniker: k8
+Tags:
+- cleanup
+- disk-space
+- duplicate
+- duplicate-finder
+- privacy
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/l/LilBuba/K8/1.8.0/LilBuba.K8.yaml
+++ b/manifests/l/LilBuba/K8/1.8.0/LilBuba.K8.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: LilBuba.K8
+PackageVersion: 1.8.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Adds **K8** by **LilBuba** — a Windows dedupe & cleanup app (finds duplicate files, photos, media and regenerable developer junk) with a quarantine-and-restore safety net. One-time paid licence, 100% local, from a UK indie developer.

- Installer: Inno Setup, hosted on the publisher's official GitHub Releases.
- Manifest schema 1.6.0; single x64 installer.

- [x] This PR only modifies one (1) manifest.
- [x] I have checked there aren't other open PRs for the same package.
- [x] Validated locally: `winget validate` returned "Manifest validation succeeded."
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/409028)