### PR TITLE
Update: Tropibyte.cshw to 1.0.8.3

### DIFF
--- a/manifests/t/Tropibyte/cshw/1.0.8.3/Tropibyte.cshw.installer.yaml
+++ b/manifests/t/Tropibyte/cshw/1.0.8.3/Tropibyte.cshw.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 PackageIdentifier: Tropibyte.cshw
 PackageVersion: 1.0.8.3
 MinimumOSVersion: 10.0.17763.0
@@ -21,4 +21,4 @@ Installers:
     InstallerSha256: 2C1FAB3AC16CFA1AB75CB3F4893E1FDAAC20F91C94B4BEF374FF354F09985681
     ProductCode: '{CFE685C6-DC75-4996-AC4B-7BE4F4D5BCB6}_is1'
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/t/Tropibyte/cshw/1.0.8.3/Tropibyte.cshw.installer.yaml
+++ b/manifests/t/Tropibyte/cshw/1.0.8.3/Tropibyte.cshw.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Tropibyte.cshw
+PackageVersion: 1.0.8.3
+MinimumOSVersion: 10.0.17763.0
+InstallerType: inno
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Commands:
+  - cshw
+FileExtensions:
+  - cshw
+  - csh
+ReleaseDate: 2026-07-28
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/tropibyte/cshw-releases/releases/download/v1.0.8.3/cshw-setup-1.0.8.3.exe
+    InstallerSha256: 2C1FAB3AC16CFA1AB75CB3F4893E1FDAAC20F91C94B4BEF374FF354F09985681
+    ProductCode: '{CFE685C6-DC75-4996-AC4B-7BE4F4D5BCB6}_is1'
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/t/Tropibyte/cshw/1.0.8.3/Tropibyte.cshw.locale.en-US.yaml
+++ b/manifests/t/Tropibyte/cshw/1.0.8.3/Tropibyte.cshw.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 PackageIdentifier: Tropibyte.cshw
 PackageVersion: 1.0.8.3
 PackageLocale: en-US
@@ -69,4 +69,4 @@ ReleaseNotes: |-
   unaffected.
 ReleaseNotesUrl: https://github.com/tropibyte/cshw-releases/releases/tag/v1.0.8.3
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/t/Tropibyte/cshw/1.0.8.3/Tropibyte.cshw.locale.en-US.yaml
+++ b/manifests/t/Tropibyte/cshw/1.0.8.3/Tropibyte.cshw.locale.en-US.yaml
@@ -1,0 +1,72 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Tropibyte.cshw
+PackageVersion: 1.0.8.3
+PackageLocale: en-US
+Publisher: Tropibyte, Inc.
+PublisherUrl: https://www.tropibyte.com
+PublisherSupportUrl: https://www.tropibyte.com/bugs.html
+Author: Tropibyte, Inc.
+PackageName: C Shell for Windows
+PackageUrl: https://www.tropibyte.com/cshw.html
+License: PolyForm Small Business 1.0.0
+LicenseUrl: https://polyformproject.org/licenses/small-business/1.0.0
+Copyright: Copyright (c) 2024-2026 Tropibyte, Inc.
+CopyrightUrl: https://www.tropibyte.com/cshw.html
+ShortDescription: A native Windows command shell with csh/tcsh-flavored syntax, 225+ builtins, real concurrency primitives, arbitrary-precision math, and built-in AI.
+Description: |-
+  cshw is a native Windows command shell with csh/tcsh-flavored syntax. Familiar Unix
+  shell ergonomics meet first-class Win32 access -- no WSL, no Cygwin, no compatibility
+  layer. 225+ builtin commands cover file ops, text processing (grep with PCRE2, sed,
+  awk, sort with -t/-k, head/tail with -f), real concurrency primitives (coroutines,
+  mutex, semaphore, barrier, channel), Win32 calls (rundllproc, winapi, dllimport),
+  and built-in AI (OpenAI, Anthropic, Azure, Ollama, LM Studio). Runs your existing
+  .bat, .cmd, and .ps1 scripts unchanged. The bc/dc commands offer arbitrary-precision
+  arithmetic with an opt-in exact-rational tier (bc -x) including complex numbers and
+  small exact matrices. As of 1.0.8.0, cshw ships a signed server family: the tsrvd
+  supervisor runs out-of-process protocol handlers -- native SMTP, POP3, and IMAP over
+  a shared Maildir, FTP, and a real HTTP/HTTPS/CGI server (http.dll) that speaks
+  HTTP/1.1 and HTTP/2 -- and the new quicsrv worker serves HTTP/3 over QUIC through the
+  same serving core. The fetch client gains native HTTP/2 (--http2) and HTTP/3
+  (--http3) modes that guarantee the protocol. Ships with a 22-chapter user guide.
+Moniker: cshw
+Tags:
+  - shell
+  - csh
+  - tcsh
+  - command-line
+  - cli
+  - terminal
+  - unix
+  - win32
+  - scripting
+  - developer-tools
+PurchaseUrl: https://www.tropibyte.com/cshw.html
+PrivacyUrl: https://www.tropibyte.com
+ReleaseNotes: |-
+  **Fixed: a quoted argument starting with `<` or `>` was treated as a redirect.**
+  Upgrade for this one. The redirect parser looked only at the first character of
+  each token and never at the token's type, so a quoted string beginning with an
+  angle bracket was parsed as a redirect operator rather than as data. The lexer
+  had always distinguished the two; the parser simply never asked.
+  
+  It failed in two ways, and the quiet one is the reason this is a same-day
+  release.
+  
+  When the text after `>` was not a legal Windows filename, the open failed and
+  you saw `'echo' failed (errno 22)` with the command's output silently dropped.
+  That is how it was found: `tests/run_all_tests.cshw` prints
+  `echo ">>> Running: $1"` before each suite, and all 81 of those lines were being
+  destroyed, along with the matching `<<< PASSED` / `<<< FAILED` lines.
+  
+  When the text *was* a legal filename there was no error at all. `echo
+  ">notes.txt"` truncated `notes.txt`, consumed the token as a redirect, and left
+  `echo` with no arguments -- so `echo` wrote its own `Echo is ON` status into the
+  file it had just destroyed. A line written to print a string destroyed a file
+  instead, silently. Anything quoting an angle bracket was exposed: markdown
+  blockquotes, `grep "<div>" page.html`, generated HTML or XML.
+  
+  Quoted tokens are now skipped when scanning for redirects. Real redirects are
+  unaffected.
+ReleaseNotesUrl: https://github.com/tropibyte/cshw-releases/releases/tag/v1.0.8.3
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/t/Tropibyte/cshw/1.0.8.3/Tropibyte.cshw.yaml
+++ b/manifests/t/Tropibyte/cshw/1.0.8.3/Tropibyte.cshw.yaml
@@ -1,6 +1,6 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 PackageIdentifier: Tropibyte.cshw
 PackageVersion: 1.0.8.3
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/t/Tropibyte/cshw/1.0.8.3/Tropibyte.cshw.yaml
+++ b/manifests/t/Tropibyte/cshw/1.0.8.3/Tropibyte.cshw.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Tropibyte.cshw
+PackageVersion: 1.0.8.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## 📖 Description

Updates `Tropibyte.cshw` from 1.0.8.1 to **1.0.8.3**. (1.0.8.2 was not submitted; this supersedes it.)

1.0.8.3 fixes a data-loss bug: a quoted argument beginning with `<` or `>` was parsed as a redirect operator rather than as data, so `echo ">notes.txt"` truncated the file instead of printing the string.

The installer is Authenticode-signed by Tropibyte, Inc. Before submitting, the published asset was downloaded from the release URL in the manifest and verified end to end:

- `InstallerSha256` matches the downloaded file (`2C1FAB3A…85681`)
- `Get-AuthenticodeSignature` reports **Valid**, `CN="Tropibyte, Inc.", O=Tropibyte, C=US`

The installer manifest is unchanged from the merged 1.0.8.1 manifest apart from version, hash and release date. The locale manifest additionally corrects the builtin count (195+ → 225+, derived from the shipped man pages) and carries this release's notes. Schema bumped 1.6.0 → 1.12.0.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  - Not applicable

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` — *Manifest validation succeeded*
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> On the one unchecked box: a local `winget install --manifest` was not run, so I have not ticked it. The installer was instead verified by downloading the exact asset the manifest points at and confirming both its SHA-256 and its Authenticode signature, and the same Inno installer configuration has been merged here four times previously (1.0.7.0, 1.0.7.1, 1.0.8.0, 1.0.8.1).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/409037)