### PR TITLE
Code-iX.QTiles version 1.0.1: remove incorrect Scope declaration

### DIFF
--- a/manifests/c/Code-iX/QTiles/1.0.1/Code-iX.QTiles.installer.yaml
+++ b/manifests/c/Code-iX/QTiles/1.0.1/Code-iX.QTiles.installer.yaml
@@ -4,7 +4,6 @@
 PackageIdentifier: Code-iX.QTiles
 PackageVersion: 1.0.1
 InstallerType: wix
-Scope: user
 InstallModes:
 - interactive
 - silent


### PR DESCRIPTION
I am the publisher of this package.

### Problem

`Code-iX.QTiles.installer.yaml` for 1.0.1 declares `Scope: user`, which does not match how the installer actually registers itself, so `winget upgrade Code-iX.QTiles` fails for a large share of users:

```
Es wurde kein anwendbares Upgrade gefunden.  (0x8a15002b)
```

Verbose log:

```
Installer [X64,wix,User,] not applicable: Installer scope does not match currently installed scope: User != Machine
```

### Cause

The MSI is authored `Scope="perUser"` (WiX v4), which produces a UAC-compliant/LUA package with no `ALLUSERS` property. On administrator accounts Windows Installer nevertheless writes the Add/Remove Programs entry to `HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{ProductCode}`, while a standard user account gets it under `HKCU`. winget derives the installed scope from that hive, so the declared `Scope: user` mismatches on every administrator account.

Verified on Windows 10 22H2 with winget 1.29.280: installing 1.0.1 from a non-elevated shell still registers under HKLM, and the MSI log confirms a genuine per-user install (`Running product '{EC7633A9-...}' with user privileges: It's not assigned.`). Forcing the other direction is not possible either — the MSI log reports `MSIINSTALLPERUSER property is not valid for UAC compliant package. Ignoring the MSIINSTALLPERUSER property.`

Since neither `user` nor `machine` is correct for all installs, no fixed value works. Omitting `Scope` disables winget's installed-scope filter and lets upgrades apply in both cases.

### Change

Removes the single line `Scope: user`. Installer URL, SHA256, ProductCode and all other fields are unchanged; the installer binary itself is untouched.

- [x] This PR only modifies manifest metadata for a package I publish.
- [x] Manifest validates with `winget validate`.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/409123)