### PR TITLE
New package: AsDecided.AsDecided version 0.24.1

### DIFF
--- a/manifests/a/AsDecided/AsDecided/0.24.1/AsDecided.AsDecided.installer.yaml
+++ b/manifests/a/AsDecided/AsDecided/0.24.1/AsDecided.AsDecided.installer.yaml
@@ -1,0 +1,19 @@
+# Created for AsDecided v0.24.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: AsDecided.AsDecided
+PackageVersion: 0.24.1
+InstallerType: zip
+NestedInstallerType: portable
+ReleaseDate: "2026-07-28"
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/asdecided/core/releases/download/v0.24.1/asdecided-x86_64-pc-windows-msvc.zip
+    InstallerSha256: A2C1BFBFFD826080076B57EA4BFF52DB5AFE3E7F1FAD17E54340750E4434FD1F
+    NestedInstallerFiles:
+      - RelativeFilePath: decided.exe
+        PortableCommandAlias: decided
+      - RelativeFilePath: decided-mcp.exe
+        PortableCommandAlias: decided-mcp
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/AsDecided/AsDecided/0.24.1/AsDecided.AsDecided.locale.en-US.yaml
+++ b/manifests/a/AsDecided/AsDecided/0.24.1/AsDecided.AsDecided.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# Created for AsDecided v0.24.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: AsDecided.AsDecided
+PackageVersion: 0.24.1
+PackageLocale: en-US
+Publisher: AsDecided
+PublisherUrl: https://asdecided.com/
+PublisherSupportUrl: https://github.com/asdecided/core/issues
+Author: AsDecided
+PackageName: AsDecided
+PackageUrl: https://github.com/asdecided/core
+License: Apache-2.0
+LicenseUrl: https://github.com/asdecided/core/blob/v0.24.1/LICENSE
+ShortDescription: Engineering decisions your agents can follow.
+Description: >-
+  A local-first decision system that validates, queries, and serves engineering
+  knowledge through the decided CLI and a read-only MCP server.
+Moniker: decided
+Tags:
+  - adr
+  - agent
+  - cli
+  - decisions
+  - developer-tools
+  - mcp
+  - rust
+ReleaseNotesUrl: https://github.com/asdecided/core/releases/tag/v0.24.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/AsDecided/AsDecided/0.24.1/AsDecided.AsDecided.yaml
+++ b/manifests/a/AsDecided/AsDecided/0.24.1/AsDecided.AsDecided.yaml
@@ -1,0 +1,8 @@
+# Created for AsDecided v0.24.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: AsDecided.AsDecided
+PackageVersion: 0.24.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds AsDecided `0.24.1` as a new x64 portable package.

The published ZIP contains two native executables:

- `decided.exe` — the AsDecided CLI
- `decided-mcp.exe` — the read-only MCP server

The installer URL and SHA-256 digest match the public `v0.24.1` GitHub release. The archive was downloaded independently, its digest verified, and both executable paths confirmed.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  - No issue required for this new package submission.

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same manifest
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the 1.12 schema

`winget` is not available on the macOS authoring machine, so Windows-only validation and installation checks are left for the repository pipeline rather than claimed as local evidence.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/409126)