### PR TITLE
Update: TypeWhisper.TypeWhisper to 1.0.6

### DIFF
--- a/manifests/t/TypeWhisper/TypeWhisper/1.0.6/TypeWhisper.TypeWhisper.installer.yaml
+++ b/manifests/t/TypeWhisper/TypeWhisper/1.0.6/TypeWhisper.TypeWhisper.installer.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: TypeWhisper.TypeWhisper
+PackageVersion: 1.0.6
+InstallerType: exe
+InstallModes:
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: --silent
+  SilentWithProgress: --silent
+  InstallLocation: --installto <INSTALLPATH>
+UpgradeBehavior: install
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.10
+ProductCode: TypeWhisper
+AppsAndFeaturesEntries:
+- DisplayName: TypeWhisper
+  Publisher: TypeWhisper
+  ProductCode: TypeWhisper
+  InstallerType: exe
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/TypeWhisper/typewhisper-win/releases/download/v1.0.6/TypeWhisper-win-x64-Setup.exe
+  InstallerSha256: 9F4222BB131573645BF9DE7BD22D55B4DBD108F8572026DF56D738EB2C3286EA
+- Architecture: arm64
+  InstallerUrl: https://github.com/TypeWhisper/typewhisper-win/releases/download/v1.0.6/TypeWhisper-win-arm64-Setup.exe
+  InstallerSha256: E09BB4CDD29DB38150F9E7F118B0AB43E8C78C13CE22DFFBF5BE5EC8DEF48497
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/t/TypeWhisper/TypeWhisper/1.0.6/TypeWhisper.TypeWhisper.locale.en-US.yaml
+++ b/manifests/t/TypeWhisper/TypeWhisper/1.0.6/TypeWhisper.TypeWhisper.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: TypeWhisper.TypeWhisper
+PackageVersion: 1.0.6
+PackageLocale: en-US
+Publisher: TypeWhisper
+PublisherUrl: https://www.typewhisper.com
+PublisherSupportUrl: https://github.com/TypeWhisper/typewhisper-win/issues
+PrivacyUrl: https://github.com/TypeWhisper/typewhisper-win/blob/v1.0.6/docs/PRIVACY.md
+Author: TypeWhisper
+PackageName: TypeWhisper
+PackageUrl: https://github.com/TypeWhisper/typewhisper-win
+License: GPL-3.0-or-later
+LicenseUrl: https://github.com/TypeWhisper/typewhisper-win/blob/v1.0.6/LICENSE
+ShortDescription: Speech-to-text and AI text processing for Windows.
+Description: TypeWhisper for Windows provides system-wide dictation, file transcription, reusable workflows, history, snippets, local and cloud transcription engines, and a plugin marketplace for speech-to-text and AI text processing.
+Moniker: typewhisper
+Tags:
+- ai
+- dictation
+- speech-to-text
+- transcription
+- whisper
+ReleaseNotesUrl: https://github.com/TypeWhisper/typewhisper-win/releases/tag/v1.0.6
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/TypeWhisper/TypeWhisper/1.0.6/TypeWhisper.TypeWhisper.yaml
+++ b/manifests/t/TypeWhisper/TypeWhisper/1.0.6/TypeWhisper.TypeWhisper.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: TypeWhisper.TypeWhisper
+PackageVersion: 1.0.6
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Summary

- add TypeWhisper 1.0.6 manifests for x64 and ARM64
- use the immutable GitHub release installers and verified SHA-256 hashes
- retain the existing silent switches, product code, and .NET Desktop Runtime 10 dependency

## Validation

- `winget validate --manifest manifests/t/TypeWhisper/TypeWhisper/1.0.6`
- `winget show --manifest manifests/t/TypeWhisper/TypeWhisper/1.0.6`
- silent x64 installer QA in an isolated installation path, followed by clean removal
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/409147)