### PR TITLE
New package: Microsoft.WindowsSDK.BuildTools version 10.0.28000.2526

### DIFF
--- a/manifests/m/Microsoft/WindowsSDK/10/0/BuildTools/10.0.28000.2526/Microsoft.WindowsSDK.BuildTools.installer.yaml
+++ b/manifests/m/Microsoft/WindowsSDK/10/0/BuildTools/10.0.28000.2526/Microsoft.WindowsSDK.BuildTools.installer.yaml
@@ -1,0 +1,81 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.WindowsSDK.BuildTools
+PackageVersion: 10.0.28000.2526
+ReleaseDate: 2026-07-24
+InstallerType: zip
+NestedInstallerType: portable
+Installers:
+- Architecture: x64
+  InstallerUrl: https://www.nuget.org/api/v2/package/Microsoft.Windows.SDK.BuildTools/10.0.28000.2526
+  InstallerSha256: a09a4c9d68160ced4765137a9a7444ea560ea86c45d6a77093dea58c2f7563a0
+  NestedInstallerFiles:
+  - RelativeFilePath: bin\10.0.28000.0\x64\ComparePackage.exe
+  - RelativeFilePath: bin\10.0.28000.0\x64\DeployUtil.exe
+  - RelativeFilePath: bin\10.0.28000.0\x64\makeappx.exe
+  - RelativeFilePath: bin\10.0.28000.0\x64\makecat.exe
+  - RelativeFilePath: bin\10.0.28000.0\x64\MakeCert.exe
+  - RelativeFilePath: bin\10.0.28000.0\x64\makepri.exe
+  - RelativeFilePath: bin\10.0.28000.0\x64\mc.exe
+  - RelativeFilePath: bin\10.0.28000.0\x64\mdmerge.exe
+  - RelativeFilePath: bin\10.0.28000.0\x64\midl.exe
+  - RelativeFilePath: bin\10.0.28000.0\x64\midlc.exe
+  - RelativeFilePath: bin\10.0.28000.0\x64\midlrt.exe
+  - RelativeFilePath: bin\10.0.28000.0\x64\mt.exe
+  - RelativeFilePath: bin\10.0.28000.0\x64\PackageEditor.exe
+  - RelativeFilePath: bin\10.0.28000.0\x64\rc.exe
+  - RelativeFilePath: bin\10.0.28000.0\x64\signtool.exe
+  - RelativeFilePath: bin\10.0.28000.0\x64\tracewpp.exe
+  - RelativeFilePath: bin\10.0.28000.0\x64\uuidgen.exe
+  - RelativeFilePath: bin\10.0.28000.0\x64\veiid.exe
+  - RelativeFilePath: bin\10.0.28000.0\x64\WinAppDeployCmd.exe
+  - RelativeFilePath: bin\10.0.28000.0\x64\winmdidl.exe
+- Architecture: arm64
+  InstallerUrl: https://www.nuget.org/api/v2/package/Microsoft.Windows.SDK.BuildTools/10.0.28000.2526
+  InstallerSha256: a09a4c9d68160ced4765137a9a7444ea560ea86c45d6a77093dea58c2f7563a0
+  NestedInstallerFiles:
+  - RelativeFilePath: bin\10.0.28000.0\arm64\ComparePackage.exe
+  - RelativeFilePath: bin\10.0.28000.0\arm64\DeployUtil.exe
+  - RelativeFilePath: bin\10.0.28000.0\arm64\makeappx.exe
+  - RelativeFilePath: bin\10.0.28000.0\arm64\makecat.exe
+  - RelativeFilePath: bin\10.0.28000.0\arm64\MakeCert.exe
+  - RelativeFilePath: bin\10.0.28000.0\arm64\makepri.exe
+  - RelativeFilePath: bin\10.0.28000.0\arm64\mc.exe
+  - RelativeFilePath: bin\10.0.28000.0\arm64\mdmerge.exe
+  - RelativeFilePath: bin\10.0.28000.0\arm64\midl.exe
+  - RelativeFilePath: bin\10.0.28000.0\arm64\midlc.exe
+  - RelativeFilePath: bin\10.0.28000.0\arm64\midlrt.exe
+  - RelativeFilePath: bin\10.0.28000.0\arm64\mt.exe
+  - RelativeFilePath: bin\10.0.28000.0\arm64\PackageEditor.exe
+  - RelativeFilePath: bin\10.0.28000.0\arm64\rc.exe
+  - RelativeFilePath: bin\10.0.28000.0\arm64\signtool.exe
+  - RelativeFilePath: bin\10.0.28000.0\arm64\tracewpp.exe
+  - RelativeFilePath: bin\10.0.28000.0\arm64\uuidgen.exe
+  - RelativeFilePath: bin\10.0.28000.0\arm64\veiid.exe
+  - RelativeFilePath: bin\10.0.28000.0\arm64\WinAppDeployCmd.exe
+  - RelativeFilePath: bin\10.0.28000.0\arm64\winmdidl.exe
+- Architecture: x86
+  InstallerUrl: https://www.nuget.org/api/v2/package/Microsoft.Windows.SDK.BuildTools/10.0.28000.2526
+  InstallerSha256: a09a4c9d68160ced4765137a9a7444ea560ea86c45d6a77093dea58c2f7563a0
+  NestedInstallerFiles:
+  - RelativeFilePath: bin\10.0.28000.0\x86\ComparePackage.exe
+  - RelativeFilePath: bin\10.0.28000.0\x86\DeployUtil.exe
+  - RelativeFilePath: bin\10.0.28000.0\x86\makeappx.exe
+  - RelativeFilePath: bin\10.0.28000.0\x86\makecat.exe
+  - RelativeFilePath: bin\10.0.28000.0\x86\MakeCert.exe
+  - RelativeFilePath: bin\10.0.28000.0\x86\makepri.exe
+  - RelativeFilePath: bin\10.0.28000.0\x86\mc.exe
+  - RelativeFilePath: bin\10.0.28000.0\x86\mdmerge.exe
+  - RelativeFilePath: bin\10.0.28000.0\x86\midl.exe
+  - RelativeFilePath: bin\10.0.28000.0\x86\midlc.exe
+  - RelativeFilePath: bin\10.0.28000.0\x86\midlrt.exe
+  - RelativeFilePath: bin\10.0.28000.0\x86\mt.exe
+  - RelativeFilePath: bin\10.0.28000.0\x86\PackageEditor.exe
+  - RelativeFilePath: bin\10.0.28000.0\x86\rc.exe
+  - RelativeFilePath: bin\10.0.28000.0\x86\signtool.exe
+  - RelativeFilePath: bin\10.0.28000.0\x86\tracewpp.exe
+  - RelativeFilePath: bin\10.0.28000.0\x86\uuidgen.exe
+  - RelativeFilePath: bin\10.0.28000.0\x86\WinAppDeployCmd.exe
+  - RelativeFilePath: bin\10.0.28000.0\x86\winmdidl.exe
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/Microsoft/WindowsSDK/10/0/BuildTools/10.0.28000.2526/Microsoft.WindowsSDK.BuildTools.locale.en.yaml
+++ b/manifests/m/Microsoft/WindowsSDK/10/0/BuildTools/10.0.28000.2526/Microsoft.WindowsSDK.BuildTools.locale.en.yaml
@@ -1,0 +1,29 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.WindowsSDK.BuildTools
+PackageVersion: 10.0.28000.2526
+PackageLocale: en
+Publisher: Microsoft
+PackageName: Windows Software Development Kit - Build Tools standalone
+PackageUrl: https://www.nuget.org/packages/Microsoft.Windows.SDK.BuildTools/
+License: Proprietary (Freeware)
+LicenseUrl: https://download.microsoft.com/download/0/F/F/0FF2B061-47DD-4F55-89B6-FD1D8C44F14D/sdk_license.rtf
+ShortDescription: Standalone portable set of command line-based tools from Windows Software Development Kit.
+Tags:
+- Microsoft.Windows.SDK.BuildTools 
+- microsoft-windows-sdk-build-tools
+- microsoftwindowssdkbuildtools
+- windows-software-development-kit
+- windowssoftwaredevelopmentkitbuildtools
+- comparepackage deployutil
+- makeappx makecat
+- makecert makepri
+- mdmerge midl
+- midlc midlrt
+- packageeditor
+- signtool tracewpp
+- uuidgen veiid
+- winappdeploycmd winmdidl
+- requirescmd
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/Microsoft/WindowsSDK/10/0/BuildTools/10.0.28000.2526/Microsoft.WindowsSDK.BuildTools.yaml
+++ b/manifests/m/Microsoft/WindowsSDK/10/0/BuildTools/10.0.28000.2526/Microsoft.WindowsSDK.BuildTools.yaml
@@ -1,0 +1,7 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.WindowsSDK.BuildTools
+PackageVersion: 10.0.28000.2526
+DefaultLocale: en
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
Added the portable versions of many Windows SDK tools.

With this package, users can/could use Windows app development tools like makeappx, makepri, signtool, deployutil, etc., without needing to install the entire Windows SDK installer.

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #400221.

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/409167)