### PR TITLE
New package: SourceOS.BearBrowser version 150.0.1

### DIFF
--- a/manifests/s/SourceOS/BearBrowser/150.0.1/SourceOS.BearBrowser.installer.yaml
+++ b/manifests/s/SourceOS/BearBrowser/150.0.1/SourceOS.BearBrowser.installer.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: SourceOS.BearBrowser
+PackageVersion: 150.0.1
+InstallerType: nullsoft
+Scope: machine
+UpgradeBehavior: install
+Protocols:
+- http
+- https
+FileExtensions:
+- htm
+- html
+- pdf
+- shtml
+- svg
+- webp
+- xht
+- xhtml
+ReleaseDate: 2026-07-28
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/SourceOS-Linux/BearBrowser/releases/download/v150.0.1/BearBrowser-150.0.1-win64-installer.exe
+  InstallerSha256: AEE5C5639938C6C39937E5220B9DF488EC7C45EE70BBEAA953844BD8D108485F
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/SourceOS/BearBrowser/150.0.1/SourceOS.BearBrowser.locale.en-US.yaml
+++ b/manifests/s/SourceOS/BearBrowser/150.0.1/SourceOS.BearBrowser.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: SourceOS.BearBrowser
+PackageVersion: 150.0.1
+PackageLocale: en-US
+Publisher: SourceOS Linux
+PublisherUrl: https://github.com/SourceOS-Linux
+PublisherSupportUrl: https://github.com/SourceOS-Linux/BearBrowser/issues
+PackageName: BearBrowser
+PackageUrl: https://github.com/SourceOS-Linux/BearBrowser
+License: MPL-2.0
+LicenseUrl: https://github.com/SourceOS-Linux/BearBrowser/blob/main/LICENSE
+Copyright: Copyright (c) 2026 SourceOS Linux
+ShortDescription: Sovereign privacy browser (Firefox 150 fork) with a live network monitor and honeypot
+Description: |-
+  BearBrowser is a sovereign, privacy-first browser — a LibreWolf-mirror fork of Firefox 150 built to be the most private browser you can run.
+  It adds BearNet, a built-in loopback network monitor that shows every host the browser (or the whole machine) is talking to as a live graph and world map, with click-to-block and on-demand OSINT. BearTrap, its honeypot, detects and attributes fingerprinting scripts and blocks canary-token exfiltration. All geolocation is resolved from a local database, so the browser never leaks the addresses it connects to. No telemetry, no Google services, no cloud dependency. This build is unsigned, so SmartScreen may warn on first run.
+Moniker: bearbrowser
+Tags:
+- anti-fingerprinting
+- browser
+- firefox
+- gecko
+- privacy
+- security
+- web-browser
+ReleaseNotesUrl: https://github.com/SourceOS-Linux/BearBrowser/releases/tag/v150.0.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/SourceOS/BearBrowser/150.0.1/SourceOS.BearBrowser.yaml
+++ b/manifests/s/SourceOS/BearBrowser/150.0.1/SourceOS.BearBrowser.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: SourceOS.BearBrowser
+PackageVersion: 150.0.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## New package: SourceOS.BearBrowser 150.0.1

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? *(schema-validated; mirrors the current LibreWolf 1.12.0 manifest structure — same NSIS installer family)*
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? *(no Windows host available to the submitter; the installer sha256 is verified against the published release asset)*
- [x] Does your manifest conform to the [1.12.0 schema](https://github.com/microsoft/winget-cli/blob/master/schemas/JSON/manifests/v1.12.0)?

**BearBrowser** is a sovereign, privacy-first browser — a LibreWolf-mirror fork of Firefox 150 with a built-in network monitor (BearNet) and a fingerprinting honeypot (BearTrap). Source + release: https://github.com/SourceOS-Linux/BearBrowser/releases/tag/v150.0.1

Installer is a machine-scope Nullsoft (NSIS) setup, same installer family as `LibreWolf.LibreWolf`. `InstallerSha256` matches the published `BearBrowser-150.0.1-win64-installer.exe` asset.

> Note: this build is currently **unsigned** (no code-signing certificate yet), so SmartScreen may warn on first run.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/409174)