### PR TITLE
New package: Skynetronics.NetronicsTube version 2.3.0

### DIFF
--- a/manifests/s/Skynetronics/NetronicsTube/2.3.0/Skynetronics.NetronicsTube.installer.yaml
+++ b/manifests/s/Skynetronics/NetronicsTube/2.3.0/Skynetronics.NetronicsTube.installer.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Skynetronics.NetronicsTube
+PackageVersion: 2.3.0
+InstallerLocale: en-US
+InstallerType: inno
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  Upgrade: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+UpgradeBehavior: install
+ReleaseDate: 2026-07-27
+Installers:
+- Architecture: x64
+  InstallerUrl: https://srv.skynetronics.com/netronicstube/releases/NetronicsTube-Setup-2.3.0.exe
+  InstallerSha256: F5556F6E9072EEB8B554C8BF52EA30468ECA9F9D252FAF16F762EADD4A7974C8
+  ProductCode: '{9574F839-89FD-458A-B41C-569383DD2FA9}_is1'
+  AppsAndFeaturesEntries:
+  - DisplayName: NetronicsTube 2.3.0
+    Publisher: skynetronics
+    DisplayVersion: 2.3.0
+    ProductCode: '{9574F839-89FD-458A-B41C-569383DD2FA9}_is1'
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/Skynetronics/NetronicsTube/2.3.0/Skynetronics.NetronicsTube.locale.en-US.yaml
+++ b/manifests/s/Skynetronics/NetronicsTube/2.3.0/Skynetronics.NetronicsTube.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Skynetronics.NetronicsTube
+PackageVersion: 2.3.0
+PackageLocale: en-US
+Publisher: skynetronics
+PublisherUrl: https://skynetronics.com
+PublisherSupportUrl: https://skynetronics.com/projects/netronicstube
+Author: skynetronics
+PackageName: NetronicsTube
+PackageUrl: https://skynetronics.com/projects/netronicstube
+License: Proprietary
+Copyright: Copyright (c) 2026 skynetronics
+ShortDescription: An accessible Windows application for browsing, playing, organizing, and downloading supported YouTube content.
+Description: |-
+  NetronicsTube is an accessible Windows application for browsing, playing,
+  organizing, and downloading supported YouTube content. Its interface is
+  designed for efficient keyboard and screen-reader use while remaining
+  practical for sighted users.
+Moniker: netronicstube
+Tags:
+- accessibility
+- audio
+- downloader
+- media
+- screen-reader
+- video
+- youtube
+ReleaseNotes: |-
+  This update expands playback and search options while improving reliability
+  across longer browsing, playback, and download sessions. See the project
+  changelog for full details.
+ReleaseNotesUrl: https://skynetronics.com/projects/netronicstube
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/Skynetronics/NetronicsTube/2.3.0/Skynetronics.NetronicsTube.yaml
+++ b/manifests/s/Skynetronics/NetronicsTube/2.3.0/Skynetronics.NetronicsTube.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Skynetronics.NetronicsTube
+PackageVersion: 2.3.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds NetronicsTube version 2.3.0 as a new WinGet package.

The public installer was downloaded from the manifest URL and its SHA-256 checksum was verified against the submitted manifest. NetronicsTube is a 64-bit, machine-scope Inno Setup application.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>` (version 2.3.0 is already installed on the validation machine)
- [x] Manifest conforms to the 1.12 schema
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/409203)