### PR TITLE
New version: RemcoStoeten.Skriuw version 0.26.0

### DIFF
--- a/manifests/r/RemcoStoeten/Skriuw/0.26.0/RemcoStoeten.Skriuw.installer.yaml
+++ b/manifests/r/RemcoStoeten/Skriuw/0.26.0/RemcoStoeten.Skriuw.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: RemcoStoeten.Skriuw
+PackageVersion: 0.26.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-07-28
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/remcostoeten/skriuw/releases/download/v2-v0.26.0/Skriuw_0.26.0_x64-setup.exe
+    InstallerSha256: 4EC0D627724AFAC1720F1E79F58F22A6A0D7060E1AD31EE6282DF796019D8FF1
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/r/RemcoStoeten/Skriuw/0.26.0/RemcoStoeten.Skriuw.locale.en-US.yaml
+++ b/manifests/r/RemcoStoeten/Skriuw/0.26.0/RemcoStoeten.Skriuw.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: RemcoStoeten.Skriuw
+PackageVersion: 0.26.0
+PackageLocale: en-US
+Publisher: Remco Stoeten
+PublisherUrl: https://github.com/remcostoeten
+PublisherSupportUrl: https://github.com/remcostoeten/skriuw/issues
+Author: Remco Stoeten
+PackageName: Skriuw
+PackageUrl: https://skriuw.com
+License: MIT
+LicenseUrl: https://github.com/remcostoeten/skriuw/blob/daddy/LICENSE
+Copyright: Copyright (c) Remco Stoeten
+ShortDescription: Fast, local-first desktop app for notes, journaling, and knowledge work.
+Description: >-
+  Skriuw is a fast, local-first desktop app for notes, journaling, and
+  knowledge work. Version 2 keeps the workspace in local SQLite storage with
+  portable archives and Git-backed history.
+Moniker: skriuw
+Tags:
+  - notes
+  - note-taking
+  - markdown
+  - journal
+  - knowledge-base
+  - local-first
+  - obsidian-alternative
+  - open-source
+  - productivity
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/r/RemcoStoeten/Skriuw/0.26.0/RemcoStoeten.Skriuw.yaml
+++ b/manifests/r/RemcoStoeten/Skriuw/0.26.0/RemcoStoeten.Skriuw.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: RemcoStoeten.Skriuw
+PackageVersion: 0.26.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Publishes Skriuw v2 0.26.0 from the official GitHub release. The installer URL and SHA-256 point to the signed NSIS release asset.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/409217)