### PR TITLE
New package: YuanpengLi.MoshWindows version 0.2.0

### DIFF
--- a/manifests/y/YuanpengLi/MoshWindows/0.2.0/YuanpengLi.MoshWindows.installer.yaml
+++ b/manifests/y/YuanpengLi/MoshWindows/0.2.0/YuanpengLi.MoshWindows.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: YuanpengLi.MoshWindows
+PackageVersion: 0.2.0
+MinimumOSVersion: 10.0.17763.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: mosh\mosh.exe
+    PortableCommandAlias: mosh
+  - RelativeFilePath: mosh\mosh-client.exe
+    PortableCommandAlias: mosh-client
+  - RelativeFilePath: mosh\mosh-server.exe
+    PortableCommandAlias: mosh-server
+Commands:
+  - mosh
+  - mosh-client
+  - mosh-server
+ReleaseDate: 2026-07-28
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Yuanpeng-Li/mosh-windows/releases/download/v0.2.0/mosh-windows-x64-v0.2.0.zip
+    InstallerSha256: 2BEFE228BCD7408364474A5C97017F15B82AD2782BE52CDBB53B121657620396
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/y/YuanpengLi/MoshWindows/0.2.0/YuanpengLi.MoshWindows.locale.en-US.yaml
+++ b/manifests/y/YuanpengLi/MoshWindows/0.2.0/YuanpengLi.MoshWindows.locale.en-US.yaml
@@ -1,0 +1,53 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: YuanpengLi.MoshWindows
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: Yuanpeng Li
+PublisherUrl: https://github.com/Yuanpeng-Li
+PublisherSupportUrl: https://github.com/Yuanpeng-Li/mosh-windows/issues
+PackageName: Mosh for Windows
+PackageUrl: https://github.com/Yuanpeng-Li/mosh-windows
+License: GPL-3.0-or-later
+LicenseUrl: https://github.com/Yuanpeng-Li/mosh-windows/blob/windows/COPYING
+Copyright: Copyright 2012 Keith Winstein and the Mosh developers
+CopyrightUrl: https://github.com/Yuanpeng-Li/mosh-windows/blob/windows/COPYING
+ShortDescription: Run `mosh user@host` natively on Windows, without Cygwin or WSL
+Description: |-
+  Mosh is a remote terminal that survives sleep, roaming and packet loss, and
+  echoes typing locally so a high-latency link still feels responsive. It has
+  never had a native Windows build. This is one, built from mosh's own C++
+  source: the terminal emulator, the state-synchronisation protocol and the
+  prediction engine are upstream's, not a reimplementation.
+
+  Both directions work.
+
+  Out: run `mosh user@host` from Windows against any Linux or macOS server.
+  The options are the upstream ones, spelled the same way, so anything you
+  already type works unchanged. The remote host needs nothing from this
+  package -- just mosh from its own package manager, and inbound UDP
+  60000-61000 open.
+
+  In: run `mosh user@windows-box` from anywhere and get a PowerShell session,
+  hosted on a pseudoconsole and surviving the ssh connection closing. That
+  half had not been done before.
+
+  Three programs are installed: mosh (the launcher), mosh-client and
+  mosh-server. It interoperates with stock mosh 1.4.0 in both directions.
+
+  This is an unofficial fork of Mosh, not endorsed by or affiliated with the
+  upstream project.
+
+Moniker: mosh
+Tags:
+  - mosh
+  - ssh
+  - terminal
+  - remote
+  - shell
+  - roaming
+ReleaseNotesUrl: https://github.com/Yuanpeng-Li/mosh-windows/releases/tag/v0.2.0
+Documentations:
+  - DocumentLabel: README
+    DocumentUrl: https://github.com/Yuanpeng-Li/mosh-windows/blob/windows/README.windows.md
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/y/YuanpengLi/MoshWindows/0.2.0/YuanpengLi.MoshWindows.yaml
+++ b/manifests/y/YuanpengLi/MoshWindows/0.2.0/YuanpengLi.MoshWindows.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: YuanpengLi.MoshWindows
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package: **YuanpengLi.MoshWindows** version **0.2.0**.

[Mosh](https://mosh.org) is a remote terminal that survives sleep, roaming and
packet loss. This is a native Windows build of it — no Cygwin, no WSL — built
from mosh's own C++ source, so the terminal emulator, the state-synchronisation
protocol and the prediction engine are upstream's rather than a
reimplementation. It works in both directions: `mosh user@host` out to a
Linux/macOS server, and `mosh user@windows-box` in to a PowerShell session
hosted on a pseudoconsole.

The archive is a portable zip with three executables — `mosh` (the launcher),
`mosh-client` and `mosh-server`. `mosh-server` needs to be on PATH under its own
name because the client asks ssh to run it by that name, which is why all three
get a `PortableCommandAlias`.

Installer URL is the project's own GitHub release:
https://github.com/Yuanpeng-Li/mosh-windows/releases/tag/v0.2.0

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` (winget v1.29.280 — "Manifest validation succeeded.")
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

### On the one unchecked manifest box

`winget install --manifest` was not run: the test machine could not have a
user-scope portable install cleanly removed afterwards, and leaving one behind
would have shadowed the real install. What was verified instead:

- the published archive downloads and its SHA-256 matches the manifest;
- it expands to the exact `mosh\` layout the `NestedInstallerFiles` entries
  name, with all three executables present;
- installing those binaries and running `mosh --local localhost` gives a live
  PowerShell 7.6.3 session at 120x30.

Happy to run the install test and report back if that would help.

### Note on signing

These binaries carry no Authenticode signature. Mosh is a remote shell that
opens a UDP listener and whose server intentionally outlives its ssh session,
so if the static or dynamic scan flags any of that I would appreciate the
detail and will follow up.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/409252)
