### PR TITLE
New version: Feci.ParleyDeckSkill version 1.5.0

### DIFF
--- a/manifests/f/Feci/ParleyDeckSkill/1.5.0/Feci.ParleyDeckSkill.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/1.5.0/Feci.ParleyDeckSkill.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 1.5.0
+InstallerType: portable
+Commands:
+- parley-deck-skill
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-skill/releases/download/v1.5.0/parley-deck-skill-v1.5.0-windows-x64.exe
+  InstallerSha256: 82988C0CB82F78F7318989CB973CB714846CC884D927065B8029949B255E32D7
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-skill/releases/download/v1.5.0/parley-deck-skill-v1.5.0-windows-arm64.exe
+  InstallerSha256: 5C9369657FE4ECEFC0D51CA8884B5BC9CBA17DBD7D788C2329D6A6289184ED3A
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckSkill/1.5.0/Feci.ParleyDeckSkill.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/1.5.0/Feci.ParleyDeckSkill.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 1.5.0
+PackageLocale: en-US
+Publisher: Feci
+PublisherUrl: https://github.com/feci
+PackageName: Parley Deck Skill
+PackageUrl: https://github.com/feci/parley-deck-skill
+License: Apache-2.0
+LicenseUrl: https://github.com/feci/parley-deck-skill/blob/main/LICENSE
+ShortDescription: Installer for the Parley Deck multi-agent cooperation skill.
+Description: "Installs the vendor-neutral Parley Deck AI cooperation skill into Codex, Claude Code, Antigravity CLI, legacy Gemini CLI, Hermes, Kimi Code, or a custom skill directory. v1.5.0 adds two design add-on skills. parley-design ships the PDS/1.0 protocol as pure markdown with zero runtime dependencies: typed design artifacts, distinctness and coherence gates, ordinal evidence tiers, rule authority classes, waivers and four conformance levels, plus a literate rule registry that is its own single source of truth. parley-design-check is the separable enforcement layer, using Node built-ins only and no network: it reads that registry, refuses to check rules when the registry is absent rather than falling back to a copy, reports what it cannot judge instead of passing it, and models conformance levels as explicit obligation sets. Also ships the earlier opt-in add-ons parley-worktrees and parley-tracker; use --no-addons or --only to choose."
+ReleaseNotesUrl: https://github.com/feci/parley-deck-skill/releases/tag/v1.5.0
+Tags:
+- ai
+- agents
+- agy
+- antigravity
+- cli
+- codex
+- claude
+- gemini
+- kimi
+- multi-agent
+- skill
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckSkill/1.5.0/Feci.ParleyDeckSkill.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/1.5.0/Feci.ParleyDeckSkill.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 1.5.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Adds version 1.5.0 of Feci.ParleyDeckSkill.

This release adds two design add-on skills to the installer payload:

- **parley-design** — the PDS/1.0 design protocol as pure markdown with zero runtime dependencies: typed design artifacts, distinctness and coherence gates, ordinal evidence tiers, rule authority classes, waivers, four conformance levels, and a literate rule registry that is its own single source of truth.
- **parley-design-check** — the separable enforcement layer, Node built-ins only and no network access. It reads that registry, refuses to check rules when the registry is absent rather than falling back to a bundled copy, and reports what it cannot judge instead of passing it.

Both are opt-in add-ons installed by default alongside the existing parley-worktrees and parley-tracker; `--no-addons` or `--only <name>` selects.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/addition?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/409259)