### PR TITLE
New package: DevMando.MandoCode.Desktop version 0.14.1

### DIFF
--- a/manifests/d/DevMando/MandoCode/Desktop/0.14.1/DevMando.MandoCode.Desktop.installer.yaml
+++ b/manifests/d/DevMando/MandoCode/Desktop/0.14.1/DevMando.MandoCode.Desktop.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: DevMando.MandoCode.Desktop
+PackageVersion: 0.14.1
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.19041.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: MandoCode.Desktop.exe
+  PortableCommandAlias: MandoCodeDesktop
+UpgradeBehavior: install
+ReleaseDate: 2026-07-28
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/DevMando/MandoCode.Desktop/releases/download/v0.14.1/MandoCode.Desktop-v0.14.1-win-x64.zip
+  InstallerSha256: 02EB65AACE3FC7F9CFCB2621B20894A01700AFC4A83FF309BC6377CEA0096855
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/d/DevMando/MandoCode/Desktop/0.14.1/DevMando.MandoCode.Desktop.locale.en-US.yaml
+++ b/manifests/d/DevMando/MandoCode/Desktop/0.14.1/DevMando.MandoCode.Desktop.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: DevMando.MandoCode.Desktop
+PackageVersion: 0.14.1
+PackageLocale: en-US
+Publisher: DevMando
+PublisherUrl: https://github.com/DevMando
+PublisherSupportUrl: https://github.com/DevMando/MandoCode.Desktop/issues
+PackageName: MandoCode Desktop
+PackageUrl: https://github.com/DevMando/MandoCode.Desktop
+License: MIT
+LicenseUrl: https://github.com/DevMando/MandoCode.Desktop/blob/main/LICENSE
+ShortDescription: A Windows desktop home for local AI coding - run models on your own machine through Ollama, with no API keys.
+Description: MandoCode Desktop is a Windows desktop app for local AI coding. Run models on your own hardware through Ollama (or cloud models with an ollama.com subscription), with multi-agent tabs, session persistence, context snapshots, MCP server support, file tagging, diff approvals for every write, and themes. Self-contained - no .NET installation required.
+Moniker: mandocode-desktop
+Tags:
+- ai
+- coding-assistant
+- llm
+- local-llm
+- ollama
+ReleaseNotesUrl: https://github.com/DevMando/MandoCode.Desktop/releases/tag/v0.14.1
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/d/DevMando/MandoCode/Desktop/0.14.1/DevMando.MandoCode.Desktop.yaml
+++ b/manifests/d/DevMando/MandoCode/Desktop/0.14.1/DevMando.MandoCode.Desktop.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: DevMando.MandoCode.Desktop
+PackageVersion: 0.14.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
New package submission: MandoCode Desktop 0.14.1 - a Windows desktop app for local AI coding via Ollama.

- [x] Manifests validated locally with winget validate (Manifest validation succeeded.)
- [x] Installer URL is a GitHub release asset on an immutable tag
- [x] This PR only modifies one manifest (one version of one package)
- [x] I am the publisher of this software
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/409290)