### PR TITLE
New package: Dannebey.OfflineTasks version 1.2.0

### DIFF
--- a/manifests/d/Dannebey/OfflineTasks/1.2.0/Dannebey.OfflineTasks.installer.yaml
+++ b/manifests/d/Dannebey/OfflineTasks/1.2.0/Dannebey.OfflineTasks.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: Dannebey.OfflineTasks
+PackageVersion: 1.2.0
+InstallerType: inno
+Scope: machine
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Dannebey/offlinetasks/releases/download/v1.2.0/OfflineTasks-Setup-1.2.0.exe
+  InstallerSha256: f1ed519e82b3c3f9e8985ec79d9eebe47befe9c0f2f30c6799f046fed61f2ba4
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/d/Dannebey/OfflineTasks/1.2.0/Dannebey.OfflineTasks.locale.en-US.yaml
+++ b/manifests/d/Dannebey/OfflineTasks/1.2.0/Dannebey.OfflineTasks.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: Dannebey.OfflineTasks
+PackageVersion: 1.2.0
+PackageLocale: en-US
+Publisher: OfflineTasks Project
+PublisherUrl: https://github.com/Dannebey/offlinetasks
+PublisherSupportUrl: https://github.com/Dannebey/offlinetasks/issues
+PackageName: OfflineTasks
+PackageUrl: https://github.com/Dannebey/offlinetasks
+License: MIT
+LicenseUrl: https://github.com/Dannebey/offlinetasks/blob/main/LICENSE
+Copyright: Copyright (c) 2026 OfflineTasks Project
+ShortDescription: Declarative maintenance jobs that run after a reboot - whitelisted cleanup tasks with hard safety guards.
+Description: |-
+  OfflineTasks runs small, declarative maintenance jobs at the one moment they always work: right after a reboot, before the desktop and third-party software start. Built for system administrators who do housekeeping on many machines and want it predictable, logged, and hands-off.
+  Jobs are human-readable JSON with a fixed whitelist of four guarded actions (delete-paths, remove-services, delete-registry, uninstall-product). No arbitrary command execution, no network, no persistence. Two engines: a startup engine using only Microsoft-signed components, and a one-shot Safe Mode engine that always returns the machine to normal Windows. Destructive steps are quarantined first and restorable.
+Tags:
+- maintenance
+- cleanup
+- uninstall
+- sysadmin
+- administration
+- offline
+- safe-mode
+- leftovers
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/d/Dannebey/OfflineTasks/1.2.0/Dannebey.OfflineTasks.yaml
+++ b/manifests/d/Dannebey/OfflineTasks/1.2.0/Dannebey.OfflineTasks.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: Dannebey.OfflineTasks
+PackageVersion: 1.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Package

**OfflineTasks** - declarative maintenance jobs that run after a reboot: whitelisted cleanup tasks (delete-paths, remove-services, delete-registry, uninstall-product) with hard safety guards, quarantine backups, and full reporting. MIT licensed, open source: https://github.com/Dannebey/offlinetasks

## Checklist
- [x] Manifests validated locally with `winget validate`
- [x] Tested install locally with `winget install --manifest` (hash verified, silent install OK)
- [x] Installer is Inno Setup, supports silent switches (/VERYSILENT)
- [x] Single architecture x64, machine scope

Manifests generated against release: https://github.com/Dannebey/offlinetasks/releases/tag/v1.2.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/409299)