### PR TITLE
New package: maze-mei.DXManager version 1.2.0

### DIFF
--- a/manifests/m/maze-mei/DXManager/1.2.0/maze-mei.DXManager.installer.yaml
+++ b/manifests/m/maze-mei/DXManager/1.2.0/maze-mei.DXManager.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: maze-mei.DXManager
+PackageVersion: 1.2.0
+InstallerType: zip
+NestedInstallerType: portable
+UpgradeBehavior: install
+Commands:
+- dxmanager
+ArchiveBinariesDependOnPath: true
+NestedInstallerFiles:
+- RelativeFilePath: DX Manager\DXManager.exe
+  PortableCommandAlias: dxmanager
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/maze-mei/DX-Manager/releases/download/v1.2.0/DX-Manager-v1.2.0-win-x64.zip
+  InstallerSha256: 43AEE2932CD5E31B362BAB5A06189019F187676E787C1C66C12C3EF379B48014
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/maze-mei/DXManager/1.2.0/maze-mei.DXManager.locale.en-US.yaml
+++ b/manifests/m/maze-mei/DXManager/1.2.0/maze-mei.DXManager.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: maze-mei.DXManager
+PackageVersion: 1.2.0
+PackageLocale: en-US
+Publisher: maze-mei
+PublisherUrl: https://github.com/maze-mei
+PublisherSupportUrl: https://github.com/maze-mei/DX-Manager/issues
+Author: maze
+PackageName: DX Manager
+PackageUrl: https://github.com/maze-mei/DX-Manager
+License: MIT
+LicenseUrl: https://github.com/maze-mei/DX-Manager/blob/v1.2.0/LICENSE
+Copyright: Copyright (c) 2026 maze
+ShortDescription: Manage Samsung DeX virtual displays and scrcpy app windows on Windows.
+Description: DX Manager creates and manages a Samsung DeX virtual display, launches it through scrcpy, and provides up to three separately configured Android app windows over USB or wireless ADB.
+Moniker: dxmanager
+Tags:
+- adb
+- android
+- samsung-dex
+- screen-mirroring
+- scrcpy
+- wireless-adb
+ReleaseNotesUrl: https://github.com/maze-mei/DX-Manager/releases/tag/v1.2.0
+InstallationNotes: DX Manager requires .NET Framework 4.6.2 or later, Android Developer options, and USB debugging. Initial ADB authorization requires a data-capable USB connection.
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/maze-mei/DXManager/1.2.0/maze-mei.DXManager.locale.ko-KR.yaml
+++ b/manifests/m/maze-mei/DXManager/1.2.0/maze-mei.DXManager.locale.ko-KR.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: maze-mei.DXManager
+PackageVersion: 1.2.0
+PackageLocale: ko-KR
+Publisher: maze-mei
+PublisherUrl: https://github.com/maze-mei
+PublisherSupportUrl: https://github.com/maze-mei/DX-Manager/issues
+Author: maze
+PackageName: DX Manager
+PackageUrl: https://github.com/maze-mei/DX-Manager
+License: MIT
+LicenseUrl: https://github.com/maze-mei/DX-Manager/blob/v1.2.0/LICENSE
+Copyright: Copyright (c) 2026 maze
+ShortDescription: Windows에서 Samsung DeX 가상 디스플레이와 scrcpy 앱 창을 관리합니다.
+Description: DX Manager는 Samsung DeX 가상 디스플레이를 생성하고 관리하여 scrcpy로 실행하며, USB 또는 무선 ADB를 통해 서로 다르게 설정한 Android 앱 창을 최대 3개까지 추가로 실행할 수 있습니다.
+Tags:
+- adb
+- android
+- samsung-dex
+- screen-mirroring
+- scrcpy
+- wireless-adb
+ReleaseNotesUrl: https://github.com/maze-mei/DX-Manager/releases/tag/v1.2.0
+InstallationNotes: DX Manager를 사용하려면 .NET Framework 4.6.2 이상, Android 개발자 옵션, USB 디버깅이 필요합니다. 최초 ADB 인증에는 데이터 통신이 가능한 USB 연결이 필요합니다.
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/m/maze-mei/DXManager/1.2.0/maze-mei.DXManager.yaml
+++ b/manifests/m/maze-mei/DXManager/1.2.0/maze-mei.DXManager.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: maze-mei.DXManager
+PackageVersion: 1.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description
Adds DX Manager 1.2.0 as a nested portable ZIP package, including English and Korean metadata.

The release archive was downloaded and its SHA256 was verified. Local manifest validation passes without warnings. A local install reached successful download and hash verification, but WinGet's local-manifest-only archive scan blocked the test; a direct Microsoft Defender scan of the same archive and the current VirusTotal report both show no detections. The repository validation pipeline may perform its independent checks.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (not applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same manifest
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>` (blocked by the local-manifest archive scan described above)
- [x] Manifest conforms to the 1.12 schema