### PR TITLE
Fix Betterbird.Betterbird 140.13.0 locales: es-AR -> es-ES, add ru

### DIFF
--- a/manifests/b/Betterbird/Betterbird/140.13.0/Betterbird.Betterbird.locale.es-ES.yaml
+++ b/manifests/b/Betterbird/Betterbird/140.13.0/Betterbird.Betterbird.locale.es-ES.yaml
@@ -3,7 +3,7 @@
 
 PackageIdentifier: Betterbird.Betterbird
 PackageVersion: 140.13.0
-PackageLocale: es-AR
+PackageLocale: es-ES
 ShortDescription: Betterbird es una bifurcación de Mozilla Thunderbird con funciones y correcciones de errores adicionales.
 ManifestType: locale
 ManifestVersion: 1.12.0

--- a/manifests/b/Betterbird/Betterbird/140.13.0/Betterbird.Betterbird.locale.ru.yaml
+++ b/manifests/b/Betterbird/Betterbird/140.13.0/Betterbird.Betterbird.locale.ru.yaml
@@ -1,0 +1,9 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: Betterbird.Betterbird
+PackageVersion: 140.13.0
+PackageLocale: ru
+ShortDescription: Betterbird — это форк Mozilla Thunderbird с дополнительными функциями и исправлениями ошибок.
+ManifestType: locale
+ManifestVersion: 1.12.0


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
Resolves #408061, filed by the Betterbird vendor.

The vendor deprecated the `es-AR` locale (the installer manifest already correctly references `es-ES`) and now ships a `ru` installer (also already present in the installer manifest). This PR:

- Renames `Betterbird.Betterbird.locale.es-AR.yaml` to `Betterbird.Betterbird.locale.es-ES.yaml` (`PackageLocale: es-ES`).
- Adds `Betterbird.Betterbird.locale.ru.yaml`.

`zh-CN` locale metadata is kept, since the vendor notes they may ship a Chinese installer again in the future.

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #408061

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/409475)