### PR TITLE
New version: RedCactus.BubbleBeta version 4.62.1

### DIFF
--- a/manifests/r/RedCactus/BubbleBeta/4.62.1/RedCactus.BubbleBeta.installer.yaml
+++ b/manifests/r/RedCactus/BubbleBeta/4.62.1/RedCactus.BubbleBeta.installer.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: RedCactus.BubbleBeta
+PackageVersion: 4.62.1
+InstallerLocale: en-US
+InstallerType: msi
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+ProductCode: '{2FBD6A3B-9174-485E-BFA0-A1E050181EA8}'
+ReleaseDate: 2026-04-21
+AppsAndFeaturesEntries:
+- DisplayName: Bubble
+  Publisher: Red Cactus B.V.
+  ProductCode: '{2FBD6A3B-9174-485E-BFA0-A1E050181EA8}'
+  UpgradeCode: '{56FC8793-125F-40DC-8864-EC6FCADC95D4}'
+InstallationMetadata:
+  DefaultInstallLocation: APPDIR:.
+Installers:
+- Architecture: x64
+  InstallerUrl: https://api.eu.redcactus.cloud/v1/public/software/download/494342c8-f3e9-491d-b6f2-4654c8ac8cbd
+  InstallerSha256: 3CA7120BC930F3DA5876323B68E2E157859AD344FFB67F8D700AA53C9A54F23E
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/r/RedCactus/BubbleBeta/4.62.1/RedCactus.BubbleBeta.locale.en-US.yaml
+++ b/manifests/r/RedCactus/BubbleBeta/4.62.1/RedCactus.BubbleBeta.locale.en-US.yaml
@@ -1,0 +1,18 @@
+# Created with komac v2.14.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: RedCactus.BubbleBeta
+PackageVersion: 4.62.1
+PackageLocale: en-US
+Publisher: Red Cactus BV
+PublisherUrl: https://www.redcactus.cloud/
+PublisherSupportUrl: https://www.redcactus.cloud/en/contact
+Author: Red Cactus BV
+PackageName: Bubble Beta
+PackageUrl: https://www.redcactus.cloud/en/bubble-applications
+License: Proprietary (Red Cactus Terms of Use)
+LicenseUrl: https://www.redcactus.cloud/terms-of-use-bubble365-teams-app
+Copyright: © Red Cactus BV
+ShortDescription: Bubble Beta is a CRM and telephony integration tool by Red Cactus, offering real-time communication without data synchronization.
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/RedCactus/BubbleBeta/4.62.1/RedCactus.BubbleBeta.yaml
+++ b/manifests/r/RedCactus/BubbleBeta/4.62.1/RedCactus.BubbleBeta.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: RedCactus.BubbleBeta
+PackageVersion: 4.62.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New version: RedCactus.BubbleBeta version 4.62.1, requested in #366852.

Installer SHA256 verified against a full local download of the MSI from the vendor URL.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)
  - Resolves #366852

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

Validation performed on a Linux host (no winget CLI available): all three manifests parse as schema-1.12.0 YAML, ProductCode/UpgradeCode shape checked, and InstallerSha256 matches the live vendor download byte-for-byte.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/409490)