### PR TITLE
New version: Netpack.XFB version 3.14159265358

### DIFF
--- a/manifests/n/Netpack/XFB/3.14159265358/Netpack.XFB.installer.yaml
+++ b/manifests/n/Netpack/XFB/3.14159265358/Netpack.XFB.installer.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: Netpack.XFB
+PackageVersion: "3.14159265358"
+InstallerType: nullsoft
+Scope: machine
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+ElevationRequirement: elevationRequired
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/netpack/XFB/releases/download/v3.14159265358/XFB-3.14159265358-Setup.exe
+  InstallerSha256: C8D88F38CEFC89FE9948CDD1BBC29AF91CFE96EEBB0F16CA6A35ED0D2BE0B121
+  ProductCode: XFB
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+  AppsAndFeaturesEntries:
+  - DisplayName: XFB (x64) - XFB Radio Automation Software
+    Publisher: Netpack - Online Solutions
+- Architecture: arm64
+  InstallerUrl: https://github.com/netpack/XFB/releases/download/v3.14159265358/XFB-3.14159265358-arm64-Setup.exe
+  InstallerSha256: AB34CBC6F2B2F431860565AD77FCC7C48C338742D4A260A9426CFA836E77BFB5
+  ProductCode: XFB
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.arm64
+  AppsAndFeaturesEntries:
+  - DisplayName: XFB (arm64) - XFB Radio Automation Software
+    Publisher: Netpack - Online Solutions
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/n/Netpack/XFB/3.14159265358/Netpack.XFB.locale.en-US.yaml
+++ b/manifests/n/Netpack/XFB/3.14159265358/Netpack.XFB.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: Netpack.XFB
+PackageVersion: "3.14159265358"
+PackageLocale: en-US
+Publisher: Netpack - Online Solutions
+PublisherUrl: https://netpack.pt/
+PublisherSupportUrl: https://github.com/netpack/XFB/issues
+Author: Frédéric Bogaerts
+PackageName: XFB
+PackageUrl: https://github.com/netpack/XFB
+License: GPL-3.0
+LicenseUrl: https://github.com/netpack/XFB/blob/main/LICENSE
+ShortDescription: Open-source radio automation software
+Description: |-
+  XFB is an open-source radio automation suite for broadcasters. It provides
+  scheduled playlists, jingles and advertising rotation, a live audio FX
+  engine (10-band equalizer, compressor, 432 Hz retune), DJ decks with
+  scratchable jog wheels, an Icecast/Shoutcast streaming client, playlist
+  waveform views with crossfade preparation and volume automation, and
+  comprehensive accessibility support including screen-reader integration
+  and full keyboard navigation.
+Moniker: xfb
+Tags:
+- accessibility
+- audio
+- automation
+- broadcast
+- open-source
+- radio
+ReleaseNotesUrl: https://github.com/netpack/XFB/releases/tag/v3.14159265358
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/n/Netpack/XFB/3.14159265358/Netpack.XFB.yaml
+++ b/manifests/n/Netpack/XFB/3.14159265358/Netpack.XFB.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: Netpack.XFB
+PackageVersion: "3.14159265358"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
### Manifest
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

### Notes
New version of XFB, an open-source radio automation suite, from the same
publisher as the existing `Netpack.XFB` manifests.

The manifests are carried over unchanged from version `3.141592653` with the
version, installer URLs, SHA256 values and release-notes URL updated. Both
installer URLs were confirmed to resolve against the published GitHub release
`v3.14159265358`, and the SHA256 values were computed from the exact assets
uploaded to it.

`winget validate` and `winget install --manifest` were not run for this
revision — the release was prepared on macOS, so those Windows-only checks
could not be performed locally. The manifests are otherwise identical in shape
to the previously merged ones.