### PR TITLE
New version: Artsoft.RocksNDiamonds version 4.4.1.3

### DIFF
--- a/manifests/a/Artsoft/RocksNDiamonds/4.4.1.3/Artsoft.RocksNDiamonds.installer.yaml
+++ b/manifests/a/Artsoft/RocksNDiamonds/4.4.1.3/Artsoft.RocksNDiamonds.installer.yaml
@@ -1,0 +1,25 @@
+# Created with YamlCreate.ps1 v2.4.3 $debug=AUSU.CRLF.7-4-6.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Artsoft.RocksNDiamonds
+PackageVersion: 4.4.1.3
+Platform:
+- Windows.Desktop
+InstallerType: inno
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+AppsAndFeaturesEntries:
+- DisplayName: Rocks'n'Diamonds 4.4.1.3
+Installers:
+- Architecture: x86
+  InstallerUrl: https://www.artsoft.org/RELEASES/windows/rocksndiamonds/rocksndiamonds-4.4.1.3-win32-setup.exe
+  InstallerSha256: 30A090CF36CE3DB5C45E24F1D218A9CF8A2E2DD0E0548B1993CFEC1DAB364E91
+- Architecture: x64
+  InstallerUrl: https://www.artsoft.org/RELEASES/windows/rocksndiamonds/rocksndiamonds-4.4.1.3-win64-setup.exe
+  InstallerSha256: 2660AA1A5FBD3FF1C58FED4F0FBCC2E8F6719A585A84CA536B219EF3AC98080B
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/Artsoft/RocksNDiamonds/4.4.1.3/Artsoft.RocksNDiamonds.locale.en-US.yaml
+++ b/manifests/a/Artsoft/RocksNDiamonds/4.4.1.3/Artsoft.RocksNDiamonds.locale.en-US.yaml
@@ -12,9 +12,9 @@ Author: Artsoft Entertainment
 PackageName: Rocks'n'Diamonds
 PackageUrl: https://www.artsoft.org/rocksndiamonds
 License: GPLv2
-LicenseUrl: https://git.artsoft.org/?p=rocksndiamonds.git;a=blob_plain;f=COPYING;hb=HEAD
+LicenseUrl: https://github.com/ArtsoftEntertainment/rocksndiamonds/blob/master/COPYING
 Copyright: Copyright (C) 1989, 1991 Free Software Foundation, Inc.
-CopyrightUrl: https://git.artsoft.org/?p=rocksndiamonds.git;a=blob_plain;f=COPYING;hb=HEAD
+CopyrightUrl: https://github.com/ArtsoftEntertainment/rocksndiamonds/blob/master/COPYING
 ShortDescription: Arcade style game in the tradition of Boulder Dash, Emerald Mine, Supaplex and Sokoban. Featuring classic Amiga style graphics, stereo sounds and MOD music.
 Description: |-
   Arcade style game in the tradition of Boulder Dash, Emerald Mine, Supaplex and Sokoban.

--- a/manifests/a/Artsoft/RocksNDiamonds/4.4.1.3/Artsoft.RocksNDiamonds.locale.en-US.yaml
+++ b/manifests/a/Artsoft/RocksNDiamonds/4.4.1.3/Artsoft.RocksNDiamonds.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# Created with YamlCreate.ps1 v2.4.3 $debug=AUSU.CRLF.7-4-6.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Artsoft.RocksNDiamonds
+PackageVersion: 4.4.1.3
+PackageLocale: en-US
+Publisher: Artsoft Entertainment
+PublisherUrl: https://www.artsoft.org
+PublisherSupportUrl: https://www.artsoft.org/forum
+# PrivacyUrl:
+Author: Artsoft Entertainment
+PackageName: Rocks'n'Diamonds
+PackageUrl: https://www.artsoft.org/rocksndiamonds
+License: GPLv2
+Copyright: Copyright (C) 1989, 1991 Free Software Foundation, Inc.
+ShortDescription: Arcade style game in the tradition of Boulder Dash, Emerald Mine, Supaplex and Sokoban. Featuring classic Amiga style graphics, stereo sounds and MOD music.
+Description: |-
+  Arcade style game in the tradition of Boulder Dash, Emerald Mine, Supaplex and Sokoban.
+  Featuring classic Amiga style graphics, stereo sounds and MOD music.
+Moniker: rocksndiamonds
+Tags:
+- arcade
+- boulder-dash
+- diamonds
+- game
+- rocks
+- sokoban
+- supaplex
+# ReleaseNotes:
+# ReleaseNotesUrl:
+# PurchaseUrl:
+# InstallationNotes:
+# Documentations:
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/Artsoft/RocksNDiamonds/4.4.1.3/Artsoft.RocksNDiamonds.locale.en-US.yaml
+++ b/manifests/a/Artsoft/RocksNDiamonds/4.4.1.3/Artsoft.RocksNDiamonds.locale.en-US.yaml
@@ -12,7 +12,9 @@ Author: Artsoft Entertainment
 PackageName: Rocks'n'Diamonds
 PackageUrl: https://www.artsoft.org/rocksndiamonds
 License: GPLv2
+LicenseUrl: https://git.artsoft.org/?p=rocksndiamonds.git;a=blob_plain;f=COPYING;hb=HEAD
 Copyright: Copyright (C) 1989, 1991 Free Software Foundation, Inc.
+CopyrightUrl: https://git.artsoft.org/?p=rocksndiamonds.git;a=blob_plain;f=COPYING;hb=HEAD
 ShortDescription: Arcade style game in the tradition of Boulder Dash, Emerald Mine, Supaplex and Sokoban. Featuring classic Amiga style graphics, stereo sounds and MOD music.
 Description: |-
   Arcade style game in the tradition of Boulder Dash, Emerald Mine, Supaplex and Sokoban.

--- a/manifests/a/Artsoft/RocksNDiamonds/4.4.1.3/Artsoft.RocksNDiamonds.yaml
+++ b/manifests/a/Artsoft/RocksNDiamonds/4.4.1.3/Artsoft.RocksNDiamonds.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.4.3 $debug=AUSU.CRLF.7-4-6.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Artsoft.RocksNDiamonds
+PackageVersion: 4.4.1.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New version: Artsoft.RocksNDiamonds version 4.4.1.3, requested in #369284.

Both installer SHA256 values (win32 + win64) verified against full local downloads from the vendor URLs.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)
  - Resolves #369284

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

Validation performed on a Linux host (no winget CLI available): all three manifests parse as schema-1.12.0 YAML and both InstallerSha256 values match the live vendor downloads byte-for-byte.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/409519)