### PR TITLE
Update: EditorConfig-Checker.EditorConfig-Checker to 3.8.0

### DIFF
--- a/manifests/e/EditorConfig-Checker/EditorConfig-Checker/3.8.0/EditorConfig-Checker.EditorConfig-Checker.installer.yaml
+++ b/manifests/e/EditorConfig-Checker/EditorConfig-Checker/3.8.0/EditorConfig-Checker.EditorConfig-Checker.installer.yaml
@@ -17,16 +17,19 @@ Installers:
 - Architecture: x86
   NestedInstallerFiles:
   - RelativeFilePath: bin/ec-windows-386.exe
+    PortableCommandAlias: editorconfig-checker
   InstallerUrl: https://github.com/editorconfig-checker/editorconfig-checker/releases/download/v3.8.0/ec-windows-386.zip
   InstallerSha256: 02043D79BC12AC05CE40B78A55AB7FB9E18BEFA6239A13812C3A4997CE3D487B
 - Architecture: x64
   NestedInstallerFiles:
   - RelativeFilePath: bin/ec-windows-amd64.exe
+    PortableCommandAlias: editorconfig-checker
   InstallerUrl: https://github.com/editorconfig-checker/editorconfig-checker/releases/download/v3.8.0/ec-windows-amd64.zip
   InstallerSha256: 7EC31E1A6A9983AA2A4942CB66DFD35E8B61E76263460413988438AE1426906A
 - Architecture: arm64
   NestedInstallerFiles:
   - RelativeFilePath: bin/ec-windows-arm64.exe
+    PortableCommandAlias: editorconfig-checker
   InstallerUrl: https://github.com/editorconfig-checker/editorconfig-checker/releases/download/v3.8.0/ec-windows-arm64.zip
   InstallerSha256: A05E52BFEC8C2F06AAC736A89706644A75E24AADD066572DB4FC672A80E7C8B9
 ManifestType: installer


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
<!-- Describe what this PR changes. For manifest submissions, include the package name and version. -->

Fixes the existing `EditorConfig-Checker.EditorConfig-Checker` `3.8.0`
manifest so the portable command registered by WinGet matches the intended
CLI name.

### What changed

Added `PortableCommandAlias: editorconfig-checker` for all portable
installers in:

- `manifests/e/EditorConfig-Checker/EditorConfig-Checker/3.8.0/EditorConfig-Checker.EditorConfig-Checker.installer.yaml`

This updates the installed command name from the architecture-specific
binary names:

- `ec-windows-386`
- `ec-windows-amd64`
- `ec-windows-arm64`

to the expected command name:

- `editorconfig-checker`

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/409535)