### PR TITLE
New package: tonythethompson.QuickShellforRun version 0.2.4.0

### DIFF
--- a/manifests/t/tonythethompson/QuickShellforRun/0.2.4.0/tonythethompson.QuickShellforRun.installer.yaml
+++ b/manifests/t/tonythethompson/QuickShellforRun/0.2.4.0/tonythethompson.QuickShellforRun.installer.yaml
@@ -1,0 +1,31 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: tonythethompson.QuickShellforRun
+PackageVersion: 0.2.4.0
+MinimumOSVersion: 10.0.19041.0
+InstallerType: inno
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+AppsAndFeaturesEntries:
+- DisplayName: Quick Shell for Run
+  Publisher: Tony Thompson
+  ProductCode: '{B7D2C4E8-9F1A-4D6B-A2C3-5E8F1D0B7A9C}_is1'
+InstallationMetadata:
+  DefaultInstallLocation: '%LOCALAPPDATA%\Microsoft\PowerToys\PowerToys Run\Plugins\QuickShell'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/tonythethompson/QuickShell/releases/download/v0.2.4.0/QuickShellforRun-Setup-0.2.4.0-x64.exe
+  InstallerSha256: DE2C1D9BF8178487CB691CD59A75E928E112B8D2F1D3F5FCCAEB59C7D054B68B
+- Architecture: arm64
+  InstallerUrl: https://github.com/tonythethompson/QuickShell/releases/download/v0.2.4.0/QuickShellforRun-Setup-0.2.4.0-arm64.exe
+  InstallerSha256: BE3B16510160B284BDD1EED480005B06DB34184FDE3A2DA7E4A307913973ED6D
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-07-29

--- a/manifests/t/tonythethompson/QuickShellforRun/0.2.4.0/tonythethompson.QuickShellforRun.locale.en-US.yaml
+++ b/manifests/t/tonythethompson/QuickShellforRun/0.2.4.0/tonythethompson.QuickShellforRun.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: tonythethompson.QuickShellforRun
+PackageVersion: 0.2.4.0
+PackageLocale: en-US
+Publisher: Tony Thompson
+PublisherUrl: https://github.com/tonythethompson
+PublisherSupportUrl: https://github.com/tonythethompson/QuickShell/issues
+PackageName: Quick Shell for Run
+PackageUrl: https://github.com/tonythethompson/QuickShell
+License: MIT
+LicenseUrl: https://github.com/tonythethompson/QuickShell/blob/master/LICENSE
+ShortDescription: PowerToys Run plugin to open saved workspaces from Quick Shell
+Description: |
+  Quick Shell for Run installs only the PowerToys Run plugin (qs command).
+  Save project folders and launch them in Windows Terminal or other shells
+  without installing the full Command Palette extension.
+
+  Requires PowerToys with Run enabled. Restart PowerToys after install.
+Tags:
+- commandline
+- powershell
+- powertoys
+- powertoys-run
+- quickshell
+- terminal
+- windows-terminal
+ReleaseNotes: |
+  Smaller CmdPal MSIX (~30 MB) and faster loads. Run plugin ships via QuickShellforRun installers.
+ReleaseNotesUrl: https://github.com/tonythethompson/QuickShell/releases/tag/v0.2.4.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/tonythethompson/QuickShellforRun/0.2.4.0/tonythethompson.QuickShellforRun.yaml
+++ b/manifests/t/tonythethompson/QuickShellforRun/0.2.4.0/tonythethompson.QuickShellforRun.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: tonythethompson.QuickShellforRun
+PackageVersion: 0.2.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Initial WinGet package for **Quick Shell for Run** (PowerToys Run plugin only).

- Package: `tonythethompson.QuickShellforRun`
- Version: `0.2.4.0`
- Release: https://github.com/tonythethompson/QuickShell/releases/tag/v0.2.4.0
- Installers: Inno Setup x64 + ARM64 (`QuickShellforRun-Setup-0.2.4.0-*.exe`)

Supersedes https://github.com/microsoft/winget-pkgs/pull/406105 (0.2.3.0, same new package, older version).

## Checklist

- [x] Signed the Contributor License Agreement
- [x] Checked that there aren't other open pull requests for the same manifest (closing #406105)
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>` (pending validation pipeline)
- [x] Manifest conforms to the 1.12 schema


Made with [Cursor](https://cursor.com)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/409537)