### PR TITLE
Update OpenTubeX.OpenTubeX to 0.30.0

### DIFF
--- a/manifests/o/OpenTubeX/OpenTubeX/0.30.0/OpenTubeX.OpenTubeX.installer.yaml
+++ b/manifests/o/OpenTubeX/OpenTubeX/0.30.0/OpenTubeX.OpenTubeX.installer.yaml
@@ -1,0 +1,45 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: OpenTubeX.OpenTubeX
+PackageVersion: 0.30.0
+InstallerLocale: en-US
+InstallerType: nullsoft
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+Protocols:
+- opentubex
+ProductCode: a38f022d-fec2-5f80-a7fe-620ccf1a2767
+ReleaseDate: 2026-07-29
+AppsAndFeaturesEntries:
+- DisplayName: OpenTubeX 0.30.0
+  ProductCode: a38f022d-fec2-5f80-a7fe-620ccf1a2767
+Installers:
+- Architecture: x64
+  Scope: user
+  InstallerUrl: https://github.com/OpenTubeX/OpenTubeX/releases/download/v0.30.0-beta/opentubex-0.30.0-beta-setup-x64.exe
+  InstallerSha256: 9939517E6A9AEF8D42F1EAC130E6A2B2C2011E30019ACB4F7496476A458BAFD7
+  InstallerSwitches:
+    Custom: /CURRENTUSER
+- Architecture: x64
+  Scope: machine
+  InstallerUrl: https://github.com/OpenTubeX/OpenTubeX/releases/download/v0.30.0-beta/opentubex-0.30.0-beta-setup-x64.exe
+  InstallerSha256: 9939517E6A9AEF8D42F1EAC130E6A2B2C2011E30019ACB4F7496476A458BAFD7
+  InstallerSwitches:
+    Custom: /ALLUSERS
+- Architecture: arm64
+  Scope: user
+  InstallerUrl: https://github.com/OpenTubeX/OpenTubeX/releases/download/v0.30.0-beta/opentubex-0.30.0-beta-setup-arm64.exe
+  InstallerSha256: 0D5C687F7654E1CB75AA8C11FD38C5A4ECF4F9F1396B5A5DD835EB6C3A85D36C
+  InstallerSwitches:
+    Custom: /CURRENTUSER
+- Architecture: arm64
+  Scope: machine
+  InstallerUrl: https://github.com/OpenTubeX/OpenTubeX/releases/download/v0.30.0-beta/opentubex-0.30.0-beta-setup-arm64.exe
+  InstallerSha256: 0D5C687F7654E1CB75AA8C11FD38C5A4ECF4F9F1396B5A5DD835EB6C3A85D36C
+  InstallerSwitches:
+    Custom: /ALLUSERS
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenTubeX/OpenTubeX/0.30.0/OpenTubeX.OpenTubeX.locale.en-US.yaml
+++ b/manifests/o/OpenTubeX/OpenTubeX/0.30.0/OpenTubeX.OpenTubeX.locale.en-US.yaml
@@ -1,0 +1,51 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: OpenTubeX.OpenTubeX
+PackageVersion: 0.30.0
+PackageLocale: en-US
+Publisher: OpenTubeX contributors
+PublisherUrl: https://github.com/OpenTubeX
+PublisherSupportUrl: https://github.com/OpenTubeX/OpenTubeX/issues
+Author: OpenTubeX contributors
+PackageName: OpenTubeX
+PackageUrl: https://opentubex.org/
+License: AGPL-3.0
+LicenseUrl: https://github.com/OpenTubeX/OpenTubeX/blob/HEAD/LICENSE
+Copyright: Copyleft © 2020-2026
+CopyrightUrl: https://github.com/OpenTubeX/OpenTubeX/blob/HEAD/LICENSE
+ShortDescription: A private YouTube client
+Description: OpenTubeX is a private YouTube client for desktop.
+Moniker: opentubex
+Tags:
+- freetube
+- freetube-fork
+- privacy
+- subscriptions
+- video
+- videos
+- youtube
+ReleaseNotes: |-
+  Highlights
+  - Added support for end-to-end encrypted synchronization of subscriptions, playlists, history, channel playback speeds, profiles, tabs and settings
+  - Added a YouTube-style Shorts display and player that can be disabled in the theme settings (#344)
+  - Added a simple watch queue with a side panel on the watch page (#272, #275)
+  - The full-screen docks can now be resized and rearranged (#279)
+  - Updated the Add to playlist button to open an inline popover
+  - The subscription feed refresh can now be canceled and shows new videos instantly while still loading the rest (#293, #300)
+  - The New subscriptions feed now separates Videos, Shorts and Live content into dedicated sections (#347)
+  - Added predefined options for downloading videos as .mp4 files, and audio downloads now always embed metadata
+  - You can now multi-select tabs using Ctrl or Shift (#288, #308)
+  - Added an option to restore all previously open tabs on startup
+  - Tabs now display icons by default, which can be disabled in settings
+  - Toast notifications have a new appearance with icons, optional timeout indicators and video thumbnails (#294, #302, #303, #342)
+  - Performance improvements for startup, scrolling, long feeds, subscription refreshes, ambient mode and tab state updates (#315)
+  - Added display and submission support for SponsorBlock full-video labels and mute segments (#350, #357)
+  - Added a web search option with search engine customization to the right-click menu when selecting text (#340)
+  - Added clearer grouping to the single-column video action menu (#317)
+  - Fixed SABR recovery getting stuck in backoff loops or permanently dropping playback to 360p after repeated failures (#310, #325)
+  - Fixed comments not loading automatically in full-screen or background tabs (#305, #307, #330)
+  - Fixed subscription New-feed entries disappearing (#287, #323)
+ReleaseNotesUrl: https://github.com/OpenTubeX/OpenTubeX/releases/tag/v0.30.0-beta
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenTubeX/OpenTubeX/0.30.0/OpenTubeX.OpenTubeX.yaml
+++ b/manifests/o/OpenTubeX/OpenTubeX/0.30.0/OpenTubeX.OpenTubeX.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: OpenTubeX.OpenTubeX
+PackageVersion: 0.30.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Summary

- Updates OpenTubeX.OpenTubeX to 0.30.0
- Uses the v0.30.0-beta setup assets for x64 and arm64
- Keeps release notes text-only for winget validation

## Validation

- /home/nico/Downloads/komac-2.16.0-x86_64-unknown-linux-gnu/komac submit manifests/o/OpenTubeX/OpenTubeX/0.30.0 --dry-run -y

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/409559)