### PR TITLE
New package: KiritsuApp.Kiritsu version 0.9.1

### DIFF
--- a/manifests/k/KiritsuApp/Kiritsu/0.9.1/KiritsuApp.Kiritsu.installer.yaml
+++ b/manifests/k/KiritsuApp/Kiritsu/0.9.1/KiritsuApp.Kiritsu.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: KiritsuApp.Kiritsu
+PackageVersion: 0.9.1
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+InstallModes:
+  - interactive
+  - silent
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+UpgradeBehavior: install
+ReleaseDate: 2026-07-29
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/kiritsuapp/kiritsu-releases/releases/download/v0.9.1/Kiritsu_0.9.1_x64-setup.exe
+    InstallerSha256: 5EC65ABE6D10CDC92179CA5FE23D87285D7EC4639B84429BB7E12E49BB442263
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/k/KiritsuApp/Kiritsu/0.9.1/KiritsuApp.Kiritsu.locale.en-US.yaml
+++ b/manifests/k/KiritsuApp/Kiritsu/0.9.1/KiritsuApp.Kiritsu.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: KiritsuApp.Kiritsu
+PackageVersion: 0.9.1
+PackageLocale: en-US
+Publisher: KiritsuApp
+PublisherUrl: https://github.com/kiritsuapp
+PublisherSupportUrl: https://github.com/kiritsuapp/kiritsu-releases/issues
+PackageName: Kiritsu
+PackageUrl: https://github.com/kiritsuapp/kiritsu-releases
+License: MIT
+LicenseUrl: https://github.com/kiritsuapp/kiritsu-releases/blob/main/LICENSE
+ShortDescription: A private, offline-first study companion.
+Description: Model study materials, plan reviews, run focus sessions, and understand progress in a private, offline-first desktop workspace.
+Tags:
+  - education
+  - focus
+  - learning
+  - productivity
+  - study
+ReleaseNotesUrl: https://github.com/kiritsuapp/kiritsu-releases/releases/tag/v0.9.1
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/k/KiritsuApp/Kiritsu/0.9.1/KiritsuApp.Kiritsu.yaml
+++ b/manifests/k/KiritsuApp/Kiritsu/0.9.1/KiritsuApp.Kiritsu.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: KiritsuApp.Kiritsu
+PackageVersion: 0.9.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Initial Kiritsu submission. The manifest was validated successfully with the Windows Package Manager client. Installer assets are hosted in the official public Kiritsu release repository and pinned by SHA-256.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/409561)