### PR TITLE
New version: M-Igashi.mp3rgui version 2.11.0

### DIFF
--- a/manifests/m/M-Igashi/mp3rgui/2.11.0/M-Igashi.mp3rgui.installer.yaml
+++ b/manifests/m/M-Igashi/mp3rgui/2.11.0/M-Igashi.mp3rgui.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgui
+PackageVersion: 2.11.0
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: mp3rgui.exe
+ReleaseDate: 2026-07-30
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/M-Igashi/mp3rgain/releases/download/v2.11.0/mp3rgui-v2.11.0-windows-x86_64.zip
+    InstallerSha256: 13CFA3ABC35C35C5B933A95ADB5B9A3E685D556CD3A161E450B61DDE036594B2
+  - Architecture: arm64
+    InstallerUrl: https://github.com/M-Igashi/mp3rgain/releases/download/v2.11.0/mp3rgui-v2.11.0-windows-arm64.zip
+    InstallerSha256: CE97CDF46C4AC5F8E83996BEF45A57C3C03139875647E5F6CFD1637D45AD8B3F
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/mp3rgui/2.11.0/M-Igashi.mp3rgui.locale.en-US.yaml
+++ b/manifests/m/M-Igashi/mp3rgui/2.11.0/M-Igashi.mp3rgui.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgui
+PackageVersion: 2.11.0
+PackageLocale: en-US
+Publisher: M-Igashi
+PublisherUrl: https://github.com/M-Igashi
+PublisherSupportUrl: https://github.com/M-Igashi/mp3rgain/issues
+Author: M-Igashi
+PackageName: mp3rgui
+PackageUrl: https://github.com/M-Igashi/mp3rgain
+License: MIT
+LicenseUrl: https://github.com/M-Igashi/mp3rgain/blob/master/LICENSE
+ShortDescription: GUI for lossless MP3 volume adjustment - a modern mp3gain replacement written in Rust
+Description: |-
+  mp3rgui is the graphical interface for mp3rgain, a lossless MP3 volume normalizer.
+  It provides an easy-to-use GUI for adjusting MP3 volume without re-encoding,
+  supporting ReplayGain analysis, AAC/M4A, FLAC, and OGG formats.
+Moniker: mp3rgui
+Tags:
+  - audio
+  - flac
+  - gain
+  - gui
+  - lossless
+  - mp3
+  - music
+  - normalize
+  - ogg
+  - replaygain
+  - rust
+  - volume
+ReleaseNotesUrl: https://github.com/M-Igashi/mp3rgain/releases/tag/v2.11.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/mp3rgui/2.11.0/M-Igashi.mp3rgui.yaml
+++ b/manifests/m/M-Igashi/mp3rgui/2.11.0/M-Igashi.mp3rgui.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgui
+PackageVersion: 2.11.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description
Update M-Igashi.mp3rgui to version 2.11.0.

Release: https://github.com/M-Igashi/mp3rgain/releases/tag/v2.11.0

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? (validated via manifest schema; no Windows machine available)
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/409641)