### PR TITLE
New package: OneEyeAutomation.CSVAuditCleanerLite version 1.0.0

### DIFF
--- a/manifests/o/OneEyeAutomation/CSVAuditCleanerLite/1.0.0/OneEyeAutomation.CSVAuditCleanerLite.installer.yaml
+++ b/manifests/o/OneEyeAutomation/CSVAuditCleanerLite/1.0.0/OneEyeAutomation.CSVAuditCleanerLite.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: OneEyeAutomation.CSVAuditCleanerLite
+PackageVersion: 1.0.0
+InstallerType: zip
+NestedInstallerType: portable
+UpgradeBehavior: install
+Commands:
+- csv-audit-cleaner-lite
+ArchiveBinariesDependOnPath: true
+ReleaseDate: 2026-07-29
+Installers:
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: CSV_Audit_Cleaner_Lite\CSV_Audit_Cleaner_Lite.exe
+    PortableCommandAlias: csv-audit-cleaner-lite
+  InstallerUrl: https://github.com/loved0543-dotcom/csv-audit-cleaner-lite/releases/download/v1.0.0/CSV_Audit_Cleaner_Lite_v1.0.zip
+  InstallerSha256: 00D31280EEBBF4FEC51415B92AE256B36A327852438F93F27AC0D15F0BA26BB1
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/o/OneEyeAutomation/CSVAuditCleanerLite/1.0.0/OneEyeAutomation.CSVAuditCleanerLite.locale.en-US.yaml
+++ b/manifests/o/OneEyeAutomation/CSVAuditCleanerLite/1.0.0/OneEyeAutomation.CSVAuditCleanerLite.locale.en-US.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: OneEyeAutomation.CSVAuditCleanerLite
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: One Eye Automation
+PublisherUrl: https://oneeyeview-automation.vercel.app
+PublisherSupportUrl: https://lovelife717.gumroad.com/l/csv-audit-cleaner
+Author: One Eye Automation
+PackageName: CSV Audit Cleaner Lite
+PackageUrl: https://github.com/loved0543-dotcom/csv-audit-cleaner-lite
+License: Freeware
+LicenseUrl: https://github.com/loved0543-dotcom/csv-audit-cleaner-lite/blob/main/LICENSE.txt
+Copyright: Copyright (c) 2026 One Eye Automation. All rights reserved.
+ShortDescription: Clean CSV whitespace, blank rows, and duplicates locally, with audit reports.
+Description: |-
+  CSV Audit Cleaner Lite is a local-first Windows tool for removing leading and trailing
+  whitespace, fully blank rows, and exact or key-column duplicates. It writes cleaned
+  UTF-8 BOM CSV files without overwriting source files and produces an HTML audit report,
+  JSON summary, and JSONL run log. The Lite edition processes up to 100 data rows per CSV.
+  No cloud upload, telemetry, subscription, or paid API is required.
+Moniker: csv-audit-cleaner-lite
+Tags:
+- audit
+- automation
+- csv
+- data-cleaning
+- deduplication
+- local-first
+- privacy
+ReleaseNotes: |-
+  First public freeware release.
+  Includes CSV whitespace, blank-row, and duplicate cleanup; UTF-8, UTF-8 BOM, and CP949
+  input support; HTML, JSON, and JSONL evidence; and original-safe output.
+ReleaseNotesUrl: https://github.com/loved0543-dotcom/csv-audit-cleaner-lite/releases/tag/v1.0.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/o/OneEyeAutomation/CSVAuditCleanerLite/1.0.0/OneEyeAutomation.CSVAuditCleanerLite.yaml
+++ b/manifests/o/OneEyeAutomation/CSVAuditCleanerLite/1.0.0/OneEyeAutomation.CSVAuditCleanerLite.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: OneEyeAutomation.CSVAuditCleanerLite
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds the first WinGet manifest for CSV Audit Cleaner Lite version 1.0.0.

CSV Audit Cleaner Lite is a local-first Windows CSV cleaner that removes
whitespace, blank rows, and exact or key-column duplicates. It writes cleaned
files without overwriting the originals and produces HTML, JSON, and JSONL
audit evidence. The freeware Lite edition processes up to 100 data rows per
CSV and does not include cloud upload or telemetry.

The installer is the publisher-owned, version-specific GitHub release ZIP. Its
SHA-256 and archive size were independently re-downloaded and matched before
submission.

This is a draft because the host cannot enable `LocalManifestFiles` without
administrator elevation, so the official local `winget install --manifest`
checkbox remains unchecked. As a non-elevated packaging check, the release ZIP
was extracted, its install directory was placed on `PATH`, and the portable
executable was launched from a different working directory. The local UI
returned HTTP 200 and the process shut down normally with exit code 0.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (not applicable for this routine manifest submission)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same manifest
- [x] This PR only modifies one manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the 1.12 schema

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/409643)