### PR TITLE
New package: EmanueleMicheletti.Proxelar version 0.5.0

### DIFF
--- a/manifests/e/EmanueleMicheletti/Proxelar/0.5.0/EmanueleMicheletti.Proxelar.installer.yaml
+++ b/manifests/e/EmanueleMicheletti/Proxelar/0.5.0/EmanueleMicheletti.Proxelar.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: EmanueleMicheletti.Proxelar
+PackageVersion: 0.5.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: proxelar.exe
+  PortableCommandAlias: proxelar
+ReleaseDate: 2026-07-25
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/emanuele-em/proxelar/releases/download/v0.5.0/proxelar-v0.5.0-x86_64-pc-windows-msvc.zip
+  InstallerSha256: 821D45776A2D60CCB37AD38010DC537775BA2FC17D13A7B135C6C0D7CEE2A985
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/e/EmanueleMicheletti/Proxelar/0.5.0/EmanueleMicheletti.Proxelar.locale.en-US.yaml
+++ b/manifests/e/EmanueleMicheletti/Proxelar/0.5.0/EmanueleMicheletti.Proxelar.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: EmanueleMicheletti.Proxelar
+PackageVersion: 0.5.0
+PackageLocale: en-US
+Publisher: Emanuele Micheletti
+PublisherUrl: https://micheletti.io
+PublisherSupportUrl: https://github.com/emanuele-em/proxelar/issues
+Author: Emanuele Micheletti
+PackageName: Proxelar
+PackageUrl: https://github.com/emanuele-em/proxelar
+License: MIT
+LicenseUrl: https://github.com/emanuele-em/proxelar/blob/main/LICENSE-MIT
+Copyright: Copyright (c) Emanuele Micheletti
+ShortDescription: Scriptable local traffic workbench for HTTP, HTTPS, and WebSocket debugging
+Description: Proxelar is a single-binary MITM proxy for developers. Capture, inspect, intercept, replay, and rewrite HTTP/HTTPS and WebSocket traffic from a TUI, web GUI, or headless REST API, with Lua scripting, declarative rules, session persistence, and HAR/curl export.
+Moniker: proxelar
+Tags:
+- cli
+- debugging
+- developer-tools
+- http
+- mitm
+- proxy
+- rust
+- tui
+- websocket
+ReleaseNotesUrl: https://github.com/emanuele-em/proxelar/releases/tag/v0.5.0
+Documentations:
+- DocumentLabel: Documentation
+  DocumentUrl: https://proxelar.micheletti.io
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/e/EmanueleMicheletti/Proxelar/0.5.0/EmanueleMicheletti.Proxelar.yaml
+++ b/manifests/e/EmanueleMicheletti/Proxelar/0.5.0/EmanueleMicheletti.Proxelar.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: EmanueleMicheletti.Proxelar
+PackageVersion: 0.5.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
New package submission: [Proxelar](https://github.com/emanuele-em/proxelar), a single-binary, MIT-licensed MITM proxy / traffic debugging tool for developers (TUI, web GUI, Lua scripting). Portable zip installer from the official GitHub release, SHA256 verified against the release's published SHA256SUMS.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`? (authored on macOS; relying on pipeline validation)
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? (authored on macOS; relying on pipeline validation)
- [x] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.9.0)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/409656)