### PR TITLE
Update: neyham.AIUsageDashboard to 0.3.0

### DIFF
--- a/manifests/n/neyham/AIUsageDashboard/0.3.0/neyham.AIUsageDashboard.installer.yaml
+++ b/manifests/n/neyham/AIUsageDashboard/0.3.0/neyham.AIUsageDashboard.installer.yaml
@@ -1,0 +1,28 @@
+# Created with WinGet manifest schema 1.12.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: neyham.AIUsageDashboard
+PackageVersion: 0.3.0
+InstallerLocale: en-US
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+UpgradeBehavior: install
+ReleaseDate: 2026-07-17
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/neyham/ai-usage-dashboard/releases/download/v0.3.0/AI-Usage-Dashboard_0.3.0_x64-setup.exe
+    InstallerSha256: 02966B966F6563AAC6F0613F186EBD994531A999E2018D631BEFD336294A9424
+    AppsAndFeaturesEntries:
+      - DisplayName: AI Usage Dashboard
+        Publisher: neyha
+        ProductCode: AI Usage Dashboard
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/n/neyham/AIUsageDashboard/0.3.0/neyham.AIUsageDashboard.locale.en-US.yaml
+++ b/manifests/n/neyham/AIUsageDashboard/0.3.0/neyham.AIUsageDashboard.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# Created with WinGet manifest schema 1.12.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: neyham.AIUsageDashboard
+PackageVersion: 0.3.0
+PackageLocale: en-US
+Publisher: neyham
+PublisherUrl: https://github.com/neyham
+PublisherSupportUrl: https://github.com/neyham/ai-usage-dashboard/issues
+Author: neyham
+PackageName: AI Usage Dashboard
+PackageUrl: https://github.com/neyham/ai-usage-dashboard
+License: MIT
+LicenseUrl: https://github.com/neyham/ai-usage-dashboard/blob/v0.3.0/LICENSE
+Copyright: Copyright (c) 2026 neyham
+ShortDescription: Local Windows dashboard for Claude Code and Codex usage limits and DeepSeek API balance.
+Description: |-
+  AI Usage Dashboard is a local-first Windows desktop dashboard and screensaver
+  for viewing Claude Code and Codex usage limits alongside a DeepSeek API
+  balance. Credentials and provider requests stay in the native Rust backend;
+  the renderer receives sanitized usage summaries only. The project has no
+  developer-operated server, analytics, or telemetry.
+Moniker: ai-usage-dashboard
+Tags:
+  - ai
+  - claude
+  - claude-code
+  - codex
+  - dashboard
+  - deepseek
+  - usage
+ReleaseNotesUrl: https://github.com/neyham/ai-usage-dashboard/releases/tag/v0.3.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/n/neyham/AIUsageDashboard/0.3.0/neyham.AIUsageDashboard.yaml
+++ b/manifests/n/neyham/AIUsageDashboard/0.3.0/neyham.AIUsageDashboard.yaml
@@ -1,0 +1,8 @@
+# Created with WinGet manifest schema 1.12.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: neyham.AIUsageDashboard
+PackageVersion: 0.3.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Updates `neyham.AIUsageDashboard` from `0.2.0` to `0.3.0`.

This release adds persistent provider selection, disabled-provider refresh isolation, responsive zero-to-three-panel layouts, and an offline synthetic Judge Demo.

- Release: https://github.com/neyham/ai-usage-dashboard/releases/tag/v0.3.0
- Installer SHA-256: `02966B966F6563AAC6F0613F186EBD994531A999E2018D631BEFD336294A9424`
- The public installer was downloaded again, matched the published checksum file, and reports Windows product version `0.3.0`.
- The manifest passed `winget validate` with WinGet 1.29.280 on Windows 11.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (not applicable)

## 📦 Manifest Checklist

- [x] Checked that there are no other open pull requests for the same manifest update
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>` (the exact v0.3.0 installer was previously installed and tested directly on the Windows 11 Surface; the active installation was not reinstalled)
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/409700)