### PR TITLE
New version: Patchloom.Patchloom version 0.22.0

### DIFF
--- a/manifests/p/Patchloom/Patchloom/0.22.0/Patchloom.Patchloom.installer.yaml
+++ b/manifests/p/Patchloom/Patchloom/0.22.0/Patchloom.Patchloom.installer.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: Patchloom.Patchloom
+PackageVersion: 0.22.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: patchloom.exe
+  PortableCommandAlias: patchloom
+ArchiveBinariesDependOnPath: true
+UpgradeBehavior: install
+ReleaseDate: 2026-07-28
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/patchloom/patchloom/releases/download/patchloom-v0.22.0/patchloom-x86_64-pc-windows-msvc.zip
+  InstallerSha256: 7F8B5BE73C351C348FE7F7D09A163796250AEC0FCD83CBE371CE8BB2481E157A
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+- Architecture: arm64
+  InstallerUrl: https://github.com/patchloom/patchloom/releases/download/patchloom-v0.22.0/patchloom-aarch64-pc-windows-msvc.zip
+  InstallerSha256: 6F1E63401D62647FF6B6FD676E5D8D23D09491AFEE41D788EA4B3E813BAE49AD
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.arm64
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/p/Patchloom/Patchloom/0.22.0/Patchloom.Patchloom.locale.en-US.yaml
+++ b/manifests/p/Patchloom/Patchloom/0.22.0/Patchloom.Patchloom.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: Patchloom.Patchloom
+PackageVersion: 0.22.0
+PackageLocale: en-US
+Publisher: Patchloom
+PublisherUrl: https://github.com/patchloom
+PublisherSupportUrl: https://github.com/patchloom/patchloom/issues
+Author: Patchloom
+PackageName: Patchloom
+PackageUrl: https://github.com/patchloom/patchloom
+License: MIT or Apache-2.0
+LicenseUrl: https://github.com/patchloom/patchloom/blob/main/LICENSE
+Copyright: Copyright (c) Patchloom contributors
+ShortDescription: Structured file editing CLI for AI agents
+Description: |-
+  Patchloom is a single-binary CLI that gives AI coding agents safe, structured
+  file editing: search and replace, unified diffs, parser-backed JSON/YAML/TOML
+  document ops, markdown section editing, AST-aware renames, multi-file
+  transactions, undo, and an MCP server for tool calls.
+Moniker: patchloom
+Tags:
+- cli
+- developer-tools
+- ai
+- mcp
+- rust
+ReleaseNotesUrl: https://github.com/patchloom/patchloom/releases/tag/patchloom-v0.22.0
+Documentations:
+- DocumentLabel: Documentation
+  DocumentUrl: https://patchloom.github.io/patchloom/
+- DocumentLabel: Installation
+  DocumentUrl: https://github.com/patchloom/patchloom/blob/main/docs/getting-started/installation.md
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/p/Patchloom/Patchloom/0.22.0/Patchloom.Patchloom.yaml
+++ b/manifests/p/Patchloom/Patchloom/0.22.0/Patchloom.Patchloom.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: Patchloom.Patchloom
+PackageVersion: 0.22.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Description
New version of [Patchloom.Patchloom](https://github.com/microsoft/winget-pkgs/tree/master/manifests/p/Patchloom/Patchloom) for [patchloom/patchloom](https://github.com/patchloom/patchloom) release `patchloom-v0.22.0`.

Portable zip installers (cargo-dist), same layout as 0.13.0:
- `InstallerType: zip` / `NestedInstallerType: portable`
- `RelativeFilePath: patchloom.exe` (exe at zip root; verified with `unzip -l`)
- x64 + arm64 with VCRedist dependencies
- SHA256 recomputed from live release assets

## Checklist
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)
- [x] This PR only updates one package (Patchloom.Patchloom)
- [x] Manifest paths and PackageIdentifier match existing package
- [x] Installer URLs point at the official GitHub release
- [x] SHA256 hashes verified against downloaded assets
- [x] Nested installer path verified (`patchloom.exe` at archive root)

## Validation notes
```
InstallerSha256 (x64):  7F8B5BE73C351C348FE7F7D09A163796250AEC0FCD83CBE371CE8BB2481E157A
InstallerSha256 (arm64): 6F1E63401D62647FF6B6FD676E5D8D23D09491AFEE41D788EA4B3E813BAE49AD
```

```
unzip -l patchloom-x86_64-pc-windows-msvc.zip
  patchloom.exe   (root)
  CHANGELOG.md, LICENSE, LICENSE-APACHE, README.md
```

Closes nothing in winget-pkgs. Tracks product issue [patchloom/patchloom#960](https://github.com/patchloom/patchloom/issues/960).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/409706)