### PR TITLE
New package: RedEyeNetworkSolutions.Hopper version 0.0.19

### DIFF
--- a/manifests/r/RedEyeNetworkSolutions/Hopper/0.0.19/RedEyeNetworkSolutions.Hopper.installer.yaml
+++ b/manifests/r/RedEyeNetworkSolutions/Hopper/0.0.19/RedEyeNetworkSolutions.Hopper.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.28.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: RedEyeNetworkSolutions.Hopper
 PackageVersion: 0.0.19
@@ -28,4 +28,4 @@ Installers:
         InstallerType: nullsoft
 
 ManifestType: installer
-ManifestVersion: 1.28.0
+ManifestVersion: 1.12.0

--- a/manifests/r/RedEyeNetworkSolutions/Hopper/0.0.19/RedEyeNetworkSolutions.Hopper.installer.yaml
+++ b/manifests/r/RedEyeNetworkSolutions/Hopper/0.0.19/RedEyeNetworkSolutions.Hopper.installer.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.28.0.schema.json
+
+PackageIdentifier: RedEyeNetworkSolutions.Hopper
+PackageVersion: 0.0.19
+
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+UpgradeBehavior: install
+ReleaseDate: 2026-07-30
+
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://download.redeyenetworks.com/hopper/releases/0.0.19/Hopper-win-x64-setup.exe
+    InstallerSha256: 286060198AE8FCA437D2AACF79AF006584224DCD44C9ECE89FE2E3FAF8665ADD
+    ProductCode: 5f8109df-e291-54cb-b6dd-560718122a93
+    AppsAndFeaturesEntries:
+      - DisplayName: Hopper 0.0.19
+        DisplayVersion: 0.0.19
+        Publisher: RedEye Network Solutions
+        ProductCode: 5f8109df-e291-54cb-b6dd-560718122a93
+        InstallerType: nullsoft
+
+ManifestType: installer
+ManifestVersion: 1.28.0

--- a/manifests/r/RedEyeNetworkSolutions/Hopper/0.0.19/RedEyeNetworkSolutions.Hopper.locale.en-US.yaml
+++ b/manifests/r/RedEyeNetworkSolutions/Hopper/0.0.19/RedEyeNetworkSolutions.Hopper.locale.en-US.yaml
@@ -1,0 +1,65 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.28.0.schema.json
+
+PackageIdentifier: RedEyeNetworkSolutions.Hopper
+PackageVersion: 0.0.19
+PackageLocale: en-US
+
+# The legal name, matching the Authenticode subject (CN=RedEye Network Solutions LLC) and the
+# sibling Logivore manifest.
+#
+# Deliberately NOT the same string as `AppsAndFeaturesEntries.Publisher` in the installer
+# manifest, which stays "RedEye Network Solutions" because that is verbatim what
+# electron-builder writes to the uninstall registry key. That one is a matcher, not a label —
+# "correcting" it to add LLC would stop WinGet correlating the installed app.
+Publisher: RedEye Network Solutions LLC
+PublisherUrl: https://redeyenetworks.com
+PublisherSupportUrl: https://redeyenetworks.com/support
+Author: RedEye Network Solutions LLC
+
+PackageName: Hopper
+PackageUrl: https://redeyenetworks.com
+Moniker: hopper
+License: Proprietary
+Copyright: Copyright 2026 RedEye Network Solutions LLC. All rights reserved.
+
+ShortDescription: Turn Outlook calendar events into HaloPSA time entries while the meeting is still fresh.
+Description: >-
+  Hopper is a local-first desktop time tracker for MSP engineers, on Windows and macOS. It reads
+  your Outlook calendar over Microsoft Graph and prompts you as each meeting ends, so time reaches
+  HaloPSA inside the five-minute window while the details are still fresh — customer, ticket or
+  project, contract, charge code and note, submitted as a Halo Action. It suggests the customer
+  from the meeting subject, can create a ticket inline when there isn't one yet, records ad-hoc
+  work the calendar never saw, and can sync which meetings you have already handled across your
+  machines. Calendar and customer data stay on the device in an encrypted local SQLite cache
+  (DPAPI on Windows, Keychain on macOS); nothing leaves the machine except the Microsoft Graph and
+  HaloPSA API calls themselves. Bring your own HaloPSA instance and Microsoft Entra app
+  registration — Hopper is a public PKCE client and stores no client secret.
+
+# Printed once installation completes, which is the moment before the setup wizard opens — so the
+# bring-your-own-tenant requirement lands before it can surprise anyone.
+InstallationNotes: >-
+  Hopper needs your own HaloPSA instance and a Microsoft Entra app registration; it is not a
+  hosted service and ships no tenant of its own. On first launch a setup wizard asks for six
+  non-secret values — your Halo resource server, auth server, client ID and loopback redirect URI,
+  plus your Entra tenant ID and client ID — then signs you in to both services and verifies each
+  connection before finishing. Registering the two apps takes a few minutes; both are
+  public/native PKCE clients, so no client secret is created or stored.
+
+Tags:
+  - halopsa
+  - psa
+  - msp
+  - time-tracking
+  - timesheet
+  - billing
+  - outlook
+  - microsoft-365
+  - microsoft-graph
+  - calendar
+  - ticketing
+  - productivity
+  - local-first
+  - desktop
+
+ManifestType: defaultLocale
+ManifestVersion: 1.28.0

--- a/manifests/r/RedEyeNetworkSolutions/Hopper/0.0.19/RedEyeNetworkSolutions.Hopper.locale.en-US.yaml
+++ b/manifests/r/RedEyeNetworkSolutions/Hopper/0.0.19/RedEyeNetworkSolutions.Hopper.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.28.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: RedEyeNetworkSolutions.Hopper
 PackageVersion: 0.0.19
@@ -62,4 +62,4 @@ Tags:
   - desktop
 
 ManifestType: defaultLocale
-ManifestVersion: 1.28.0
+ManifestVersion: 1.12.0

--- a/manifests/r/RedEyeNetworkSolutions/Hopper/0.0.19/RedEyeNetworkSolutions.Hopper.yaml
+++ b/manifests/r/RedEyeNetworkSolutions/Hopper/0.0.19/RedEyeNetworkSolutions.Hopper.yaml
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.28.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: RedEyeNetworkSolutions.Hopper
 PackageVersion: 0.0.19
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.28.0
+ManifestVersion: 1.12.0

--- a/manifests/r/RedEyeNetworkSolutions/Hopper/0.0.19/RedEyeNetworkSolutions.Hopper.yaml
+++ b/manifests/r/RedEyeNetworkSolutions/Hopper/0.0.19/RedEyeNetworkSolutions.Hopper.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.28.0.schema.json
+
+PackageIdentifier: RedEyeNetworkSolutions.Hopper
+PackageVersion: 0.0.19
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.28.0


### PR DESCRIPTION
### New package: RedEyeNetworkSolutions.Hopper 0.0.19

Hopper is a desktop time tracker for MSP engineers: it reads your Outlook calendar over Microsoft Graph and prompts at meeting end to log the time to HaloPSA. Windows and macOS; this manifest covers the Windows x64 build.

I work for RedEye Network Solutions LLC, which develops and signs the application, so this is a first-party submission.

**Publisher and signing**

- The installer is Authenticode-signed as `CN=RedEye Network Solutions LLC` via Azure Trusted Signing. Both the inner application executable and the NSIS installer are signed.
- Publisher and support URLs are live: https://redeyenetworks.com and https://redeyenetworks.com/support

**Installer details**

- NSIS (`nullsoft`), x64, **per-user scope** — the app sets `nsis.perMachine: false`, so its uninstall entry is written to `HKCU`. `Scope: user` is declared accordingly.
- Silent switch `/S`, verified.
- `InstallerUrl` is served from our own CDN, not a code-hosting redirect. The SHA256 was taken from the release artifact and then re-verified against exactly what that URL serves.

**Why `AppsAndFeaturesEntries` is present**

The app is built with electron-builder, which stamps the version into the Add/Remove Programs display name (`Hopper 0.0.19`). That does not equal `PackageName` (`Hopper`), so without an explicit `AppsAndFeaturesEntries` block WinGet installs the package successfully but cannot correlate the installed application afterwards. The `ProductCode` and `DisplayName` values were read from the uninstall registry key of a real installation, and re-confirmed against a fresh install of this exact version.

**Expected post-install behaviour — please read before flagging**

Hopper is a client for the operator's own HaloPSA instance and Microsoft Entra tenant. It is not a hosted service and ships no tenant or credentials of its own. On first launch it opens a setup wizard asking for six non-secret values (HaloPSA resource/auth server URLs and client ID, a loopback redirect URI, and Entra tenant/client IDs), then performs interactive sign-in.

On a validation machine with no HaloPSA or Entra registration, the expected result is: the app installs, launches, and presents that setup wizard. It will not proceed past it without tenant details. That is correct behaviour, not a broken install. `InstallationNotes` in the locale manifest states this, so end users see it immediately after installing.

Both OAuth clients are public/native PKCE — no client secret is created, transmitted, or stored.

**Validation performed locally**

- `winget validate --manifest <path>` — succeeded (client v1.29.280)
- `winget install --manifest <path>` — downloaded from the public `InstallerUrl`, reported "Successfully verified installer hash", installed silently, and launched
- The resulting `HKCU` uninstall entry matches the manifest exactly: key name = `ProductCode`, `DisplayName` = `Hopper 0.0.19`, `DisplayVersion` = `0.0.19`, `Publisher` = `RedEye Network Solutions`
- Manifest schema 1.28.0

Note on the last point: a `--manifest` install cannot demonstrate package correlation, since the package isn't in a configured source yet — `winget list` reports it under a synthetic `ARP\User\X64\…` id. I verified the underlying registry values match `AppsAndFeaturesEntries` instead, which is what correlation will key on once this is in the repo.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/409708)