### PR TITLE
New version: Finesssee.Win-CodexBar version 0.46.0

### DIFF
--- a/manifests/f/Finesssee/Win-CodexBar/0.46.0/Finesssee.Win-CodexBar.installer.yaml
+++ b/manifests/f/Finesssee/Win-CodexBar/0.46.0/Finesssee.Win-CodexBar.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Finesssee.Win-CodexBar
+PackageVersion: 0.46.0
+InstallerType: inno
+Scope: user
+UpgradeBehavior: install
+ProductCode: WinCodexBar_is1
+ReleaseDate: 2026-07-30
+AppsAndFeaturesEntries:
+- ProductCode: WinCodexBar_is1
+  DisplayName: CodexBar 0.46.0
+  DisplayVersion: 0.46.0
+  Publisher: CodexBar Contributors
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/nesszer/Win-CodexBar/releases/download/v0.46.0/CodexBar-0.46.0-Setup.exe
+  InstallerSha256: 1ED0E7498EE564DABAB9387B33C01FFA213556B8CA8D920DB52D0EC7CB8F3D83
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Finesssee/Win-CodexBar/0.46.0/Finesssee.Win-CodexBar.locale.en-US.yaml
+++ b/manifests/f/Finesssee/Win-CodexBar/0.46.0/Finesssee.Win-CodexBar.locale.en-US.yaml
@@ -1,0 +1,46 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Finesssee.Win-CodexBar
+PackageVersion: 0.46.0
+PackageLocale: en-US
+Publisher: CodexBar Contributors
+PublisherUrl: https://github.com/nesszer
+PublisherSupportUrl: https://github.com/nesszer/Win-CodexBar/issues
+Author: Finesssee
+PackageName: Win-CodexBar
+PackageUrl: https://github.com/nesszer/Win-CodexBar
+License: MIT
+LicenseUrl: https://github.com/nesszer/Win-CodexBar/blob/main/LICENSE
+Copyright: Copyright (c) CodexBar contributors
+ShortDescription: Windows-native menu bar app for OpenAI Codex and Claude Code usage stats.
+Description: Win-CodexBar is a Windows-native desktop app for viewing OpenAI Codex and Claude Code usage stats from a small Tauri shell.
+Moniker: win-codexbar
+Tags:
+- claude-code
+- codex
+- desktop
+- tauri
+- usage
+- windows
+ReleaseNotes: |-
+  Windows port of upstream CodexBar 0.45.2 to 0.46.0.
+
+  ### Added
+  - Providers: Qwen Cloud and ZoomMate.
+  - Alibaba Token Plan Personal/Solo variants (mainland/international).
+  - Claude prepaid credit balance and Daily Routines visibility setting.
+  - Fractional session-quota estimates on the weekly row.
+  - Codex workspaces indexing foundation and CLI.
+  - CLI config dump redacts secrets by default.
+
+  ### Changed
+  - Incremental Codex local cost scans via disk cache.
+  - Automatic tray metric prefers highest-used/exhausted window.
+  - CLI alias qwen resolves to Qwen Cloud.
+
+  ### Fixed
+  - Claude weekly/model metric ordering and idle session estimates.
+  - Amp, Grok, Chutes, LLMProxy, and Ollama refresh/parse fixes.
+ReleaseNotesUrl: https://github.com/nesszer/Win-CodexBar/releases/tag/v0.46.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Finesssee/Win-CodexBar/0.46.0/Finesssee.Win-CodexBar.yaml
+++ b/manifests/f/Finesssee/Win-CodexBar/0.46.0/Finesssee.Win-CodexBar.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Finesssee.Win-CodexBar
+PackageVersion: 0.46.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description
New version: Finesssee.Win-CodexBar version 0.46.0

Release: https://github.com/nesszer/Win-CodexBar/releases/tag/v0.46.0
Installer: https://github.com/nesszer/Win-CodexBar/releases/download/v0.46.0/CodexBar-0.46.0-Setup.exe
SHA256: 1ed0e7498ee564dabab9387b33c01ffa213556b8ca8d920db52d0ec7cb8f3d83

## Checklist
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] This PR only modifies one package
- [x] Have you validated your manifest locally with `winget validate`?

## Validation
- Verified local Setup.exe SHA256 matches release asset
- `winget validate` succeeded
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/409784)