### PR TITLE
New package: AMRSKH.AngkorFetch version 1.1.1

### DIFF
--- a/manifests/a/AMRSKH/AngkorFetch/1.1.1/AngkorFetch.installer.yaml
+++ b/manifests/a/AMRSKH/AngkorFetch/1.1.1/AngkorFetch.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: AMRSKH.AngkorFetch
+PackageVersion: "1.1.1"
+InstallerType: zip
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/AMRSKH/angkorfetch/releases/download/v1.1.1/angkorfetch-windows-x86_64.zip
+    InstallerSha256: 88a37a01bf1629533ef9e32d11b64200069ecf49f1ecd7b3f5f3a127af7d1e6d
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: angkorfetch.exe
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/a/AMRSKH/AngkorFetch/1.1.1/AngkorFetch.locale.en-US.yaml
+++ b/manifests/a/AMRSKH/AngkorFetch/1.1.1/AngkorFetch.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: AMRSKH.AngkorFetch
+PackageVersion: "1.1.1"
+PackageLocale: en-US
+Publisher: AMRSKH
+PublisherUrl: https://github.com/AMRSKH
+PublisherSupportUrl: https://github.com/AMRSKH/angkorfetch/issues
+Author: AMRSKH
+PackageName: AngkorFetch
+PackageUrl: https://github.com/AMRSKH/angkorfetch
+License: MIT
+LicenseUrl: https://github.com/AMRSKH/angkorfetch/blob/main/LICENSE
+ShortDescription: A fast, cross-platform system fetch tool
+Description: AngkorFetch is a fast, cross-platform system-info ("fetch") tool for Windows, Linux, and macOS, written in Rust.
+Moniker: angkorfetch
+Tags:
+  - fetch
+  - system-info
+  - neofetch
+  - rust
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/a/AMRSKH/AngkorFetch/1.1.1/AngkorFetch.yaml
+++ b/manifests/a/AMRSKH/AngkorFetch/1.1.1/AngkorFetch.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: AMRSKH.AngkorFetch
+PackageVersion: "1.1.1"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Validation

- [x] Manifest validated locally: `winget validate --manifest <path>` → `Manifest validation succeeded.`
- [ ] `winget install --manifest <path>` — **not run.** This requires the admin-gated `LocalManifestFiles` setting, which is not enabled in the environment used to prepare this PR. Reported here rather than claimed, so reviewers know what is and is not covered. The evidence below is what was actually verified.
- [x] Conforms to the 1.6.0 schema.

---

New package: **AMRSKH.AngkorFetch** version **1.1.1**

AngkorFetch is a fast, cross-platform system-info ("fetch") tool for Windows, Linux and macOS, written in Rust.

- Repository: https://github.com/AMRSKH/angkorfetch
- Release: https://github.com/AMRSKH/angkorfetch/releases/tag/v1.1.1
- Installer: [`angkorfetch-windows-x86_64.zip`](https://github.com/AMRSKH/angkorfetch/releases/download/v1.1.1/angkorfetch-windows-x86_64.zip) (x64, `zip` with nested `portable`)
- `InstallerSha256`: `88a37a01bf1629533ef9e32d11b64200069ecf49f1ecd7b3f5f3a127af7d1e6d`

### What was verified

- The installer URL returns HTTP 200 and the SHA256 above was computed directly from the downloaded asset, then independently cross-checked against the release's published [`checksums.txt`](https://github.com/AMRSKH/angkorfetch/releases/download/v1.1.1/checksums.txt). Both sources agree.
- The archive contains exactly one entry, `angkorfetch.exe` (425,984 bytes), at the archive root — matching the declared `NestedInstallerFiles` / `RelativeFilePath`.
- The extracted binary runs on Windows x86_64 and reports `AngkorFetch v1.1.1`.

### Supersedes #408161

That earlier submission targeted v1.2.0, a version that was never published as a GitHub release, so its `InstallerUrl` could not resolve and the manifest could never have passed validation. It has been closed in favour of this one. v1.1.1 is the current Latest release. Apologies for the earlier noise.
