### PR TITLE
Update: dixieflatline76.Spice to 2.6.4

### DIFF
--- a/manifests/d/dixieflatline76/Spice/2.6.3/dixieflatline76.Spice.installer.yaml
+++ b/manifests/d/dixieflatline76/Spice/2.6.3/dixieflatline76.Spice.installer.yaml
@@ -1,0 +1,13 @@
+PackageIdentifier: dixieflatline76.Spice
+PackageVersion: 2.6.3
+Installers:
+  - Architecture: x64
+    InstallerType: exe
+    InstallerUrl: https://github.com/dixieflatline76/Spice/releases/download/v2.6.3/Spice-Setup-2.6.3-windows-amd64.exe
+    InstallerSha256: DE0C7E6370BDEEDD0CB7FBE3FEC689E0ACF70E7FCCBA688D56CA47D73B6964BF
+    UpgradeBehavior: install
+    InstallerSwitches:
+      Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+      SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/d/dixieflatline76/Spice/2.6.3/dixieflatline76.Spice.locale.en-US.yaml
+++ b/manifests/d/dixieflatline76/Spice/2.6.3/dixieflatline76.Spice.locale.en-US.yaml
@@ -1,0 +1,16 @@
+PackageIdentifier: dixieflatline76.Spice
+PackageVersion: 2.6.3
+PackageLocale: en-US
+Publisher: dixieflatline76
+PackageName: Spice
+License: PolyForm Noncommercial 1.0.0
+ShortDescription: A highly-concurrent, plugin-driven desktop environment engine.
+Moniker: spice
+Tags:
+  - wallpaper
+  - desktop
+  - customization
+  - go
+  - engine
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/d/dixieflatline76/Spice/2.6.3/dixieflatline76.Spice.yaml
+++ b/manifests/d/dixieflatline76/Spice/2.6.3/dixieflatline76.Spice.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: dixieflatline76.Spice
+PackageVersion: 2.6.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0


### PR DESCRIPTION
## 📖 Description
Updates `dixieflatline76.Spice` to version `2.6.4`. This release includes important stability fixes for the macOS wallpaper daemon (NSWorkspace) and flattens MSIX staged picture paths.

## ✅ Checklist
- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/409791)