### PR TITLE
New package: Aero123421.SimpleFlowHarness version 1.1.4

### DIFF
--- a/manifests/a/Aero123421/SimpleFlowHarness/1.1.4/Aero123421.SimpleFlowHarness.installer.yaml
+++ b/manifests/a/Aero123421/SimpleFlowHarness/1.1.4/Aero123421.SimpleFlowHarness.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Aero123421.SimpleFlowHarness
+PackageVersion: 1.1.4
+InstallerType: zip
+NestedInstallerType: portable
+Commands:
+- sfh
+NestedInstallerFiles:
+- RelativeFilePath: sfh.exe
+  PortableCommandAlias: sfh
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Aero123421/SimpleFlowHarness/releases/download/v1.1.4/sfh-windows-x64.zip
+  InstallerSha256: 3200e360791b009534127a0351ca04b309f46394f9cd1e56874fea6cab243816
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/Aero123421/SimpleFlowHarness/1.1.4/Aero123421.SimpleFlowHarness.locale.en-US.yaml
+++ b/manifests/a/Aero123421/SimpleFlowHarness/1.1.4/Aero123421.SimpleFlowHarness.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Aero123421.SimpleFlowHarness
+PackageVersion: 1.1.4
+PackageLocale: en-US
+Publisher: Aero123421
+PublisherUrl: https://github.com/Aero123421
+PublisherSupportUrl: https://github.com/Aero123421/SimpleFlowHarness/issues
+Author: Aero123421
+PackageName: SimpleFlowHarness
+PackageUrl: https://github.com/Aero123421/SimpleFlowHarness
+License: MIT
+LicenseUrl: https://github.com/Aero123421/SimpleFlowHarness/blob/v1.1.4/LICENSE
+ShortDescription: Orchestrate AI CLI agents and ordinary commands with YAML flows.
+Description: >-
+  SimpleFlowHarness (sfh) is a single-binary workflow runner for AI coding CLIs
+  and ordinary commands. It supports routing, retries, parallel fan-out,
+  session continuation, bounded execution, detached runs, and crash recovery.
+Moniker: sfh
+Tags:
+- ai
+- cli
+- workflow
+- orchestration
+- agents
+ReleaseNotesUrl: https://github.com/Aero123421/SimpleFlowHarness/releases/tag/v1.1.4
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/Aero123421/SimpleFlowHarness/1.1.4/Aero123421.SimpleFlowHarness.yaml
+++ b/manifests/a/Aero123421/SimpleFlowHarness/1.1.4/Aero123421.SimpleFlowHarness.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Aero123421.SimpleFlowHarness
+PackageVersion: 1.1.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds SimpleFlowHarness (`sfh`) version 1.1.4 as a new x64 portable ZIP package. The installer is the immutable GitHub Release asset published by the upstream project's fully passing release workflow.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com) — awaiting the CLA bot's confirmation
- [x] Linked to an issue (if applicable) — not applicable for this new package submission

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for `Aero123421.SimpleFlowHarness`
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` — `winget` is not available on the submission host
- [ ] Tested manifest locally with `winget install --manifest <path>` — the portable ZIP was instead downloaded, SHA-256 verified, extracted, and `sfh --version` returned `sfh 1.1.4`
- [x] Manifest conforms to the official 1.12 JSON Schemas; all three files were validated locally against Microsoft's schemas

The manifest directory is `manifests/a/Aero123421/SimpleFlowHarness/1.1.4`. The declared installer SHA-256 is `3200e360791b009534127a0351ca04b309f46394f9cd1e56874fea6cab243816`, matching both the Release sidecar and the downloaded ZIP.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/409826)