### PR TITLE
New version: Feci.ParleyDeckSkill version 2.0.0

### DIFF
--- a/manifests/f/Feci/ParleyDeckSkill/2.0.0/Feci.ParleyDeckSkill.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/2.0.0/Feci.ParleyDeckSkill.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 2.0.0
+InstallerType: portable
+Commands:
+- parley-deck-skill
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-skill/releases/download/v2.0.0/parley-deck-skill-v2.0.0-windows-x64.exe
+  InstallerSha256: 1DEA328D20323AA84A56EC655FA3A22713BA97AA1E947849B463D9F9EEE71A5B
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-skill/releases/download/v2.0.0/parley-deck-skill-v2.0.0-windows-arm64.exe
+  InstallerSha256: 27A58FCE28CB2DA9BFB2E3D86E81302CD0519D946976EDCCC182C0614089B16D
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckSkill/2.0.0/Feci.ParleyDeckSkill.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/2.0.0/Feci.ParleyDeckSkill.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 2.0.0
+PackageLocale: en-US
+Publisher: Feci
+PublisherUrl: https://github.com/feci
+PackageName: Parley Deck Skill
+PackageUrl: https://github.com/feci/parley-deck-skill
+License: Apache-2.0
+LicenseUrl: https://github.com/feci/parley-deck-skill/blob/main/LICENSE
+ShortDescription: Installer for the Parley Deck multi-agent cooperation skill.
+Description: "Installs the vendor-neutral Parley Deck AI cooperation skill and its four add-on skills into Codex, Claude Code, Antigravity CLI, legacy Gemini CLI, Hermes, Kimi Code, or a custom skill directory. v2.0.0 moves the whole payload under skills/, so the universal installer from vercel-labs/skills discovers and installs all five skills with no flag, and the core skill no longer carries the entire repository into your runtime. BREAKING - the addons/ directory and the root SKILL.md are gone; anything pointing at those paths should point at skills/<name>/ instead. No skill content changed and no command-line flag changed: --no-addons still installs the core skill alone and --only <name> still picks add-ons. The add-ons are parley-design (the PDS/1.0 design protocol as pure markdown), parley-design-check (its separable enforcement layer, Node built-ins only and no network), parley-worktrees and parley-tracker."
+ReleaseNotesUrl: https://github.com/feci/parley-deck-skill/releases/tag/v2.0.0
+Tags:
+- ai
+- agents
+- agy
+- antigravity
+- cli
+- codex
+- claude
+- gemini
+- kimi
+- multi-agent
+- skill
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckSkill/2.0.0/Feci.ParleyDeckSkill.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/2.0.0/Feci.ParleyDeckSkill.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 2.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Portable package update.

- Installer URLs point at the v2.0.0 GitHub release assets (x64 and arm64).
- SHA256 values computed from the exact published assets.
- Description updated: 2.0.0 moves the payload under `skills/`, so the universal installer discovers all five skills without a flag. `addons/` and the root `SKILL.md` are gone — a breaking change for anyone referencing those paths. No skill content and no command-line flag changed.

Manifests validated locally for the unquoted `: ` scalar trap that failed an earlier submission.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/409827)