### PR TITLE
New package: SOVNetwork.SovNode version 1.1.3

### DIFF
--- a/manifests/s/SOVNetwork/SovNode/1.1.3/SOVNetwork.SovNode.installer.yaml
+++ b/manifests/s/SOVNetwork/SovNode/1.1.3/SOVNetwork.SovNode.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: SOVNetwork.SovNode
 PackageVersion: 1.1.3
@@ -12,4 +12,4 @@ Installers:
     InstallerUrl: https://github.com/sov-network/relay-releases/releases/download/v1.1.3/sovnode-windows-x64.zip
     InstallerSha256: 5453D5C1E692F095CB441B0B4639DA88FDBE4B0EF504B1E024F185A787EBC4ED
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/s/SOVNetwork/SovNode/1.1.3/SOVNetwork.SovNode.installer.yaml
+++ b/manifests/s/SOVNetwork/SovNode/1.1.3/SOVNetwork.SovNode.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: SOVNetwork.SovNode
+PackageVersion: 1.1.3
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: SovNode.exe
+    PortableCommandAlias: sovnode
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/sov-network/relay-releases/releases/download/v1.1.3/sovnode-windows-x64.zip
+    InstallerSha256: 5453D5C1E692F095CB441B0B4639DA88FDBE4B0EF504B1E024F185A787EBC4ED
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/SOVNetwork/SovNode/1.1.3/SOVNetwork.SovNode.locale.en-US.yaml
+++ b/manifests/s/SOVNetwork/SovNode/1.1.3/SOVNetwork.SovNode.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: SOVNetwork.SovNode
+PackageVersion: 1.1.3
+PackageLocale: en-US
+Publisher: SOV Network
+PublisherUrl: https://sov-network.github.io
+PublisherSupportUrl: https://sov-network.github.io
+PackageName: SOV Node
+PackageUrl: https://sov-network.github.io
+License: Proprietary
+ShortDescription: A sovereign, proof-of-personhood network wallet and full node.
+Description: |-
+  SOV Node is the desktop wallet and full node for the SOV Network, a
+  self-contained proof-of-personhood mesh. One human, one wallet, verified by
+  biometrics processed on your own device and never sent to a server.
+
+  The desktop build can also run as a full node: turn on the Full Node switch
+  and the machine joins the peer mesh, serves other citizens, and earns the
+  operator payout. It is portable, requires no installation, and writes no
+  registry entries.
+
+  Every release ships a signed manifest and SHA-256 checksums, and is also
+  distributed over BitTorrent and IPFS so no single host can gatekeep it.
+Moniker: sovnode
+Tags:
+  - wallet
+  - p2p
+  - decentralized
+  - node
+  - identity
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/SOVNetwork/SovNode/1.1.3/SOVNetwork.SovNode.locale.en-US.yaml
+++ b/manifests/s/SOVNetwork/SovNode/1.1.3/SOVNetwork.SovNode.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: SOVNetwork.SovNode
 PackageVersion: 1.1.3
@@ -30,4 +30,4 @@ Tags:
   - node
   - identity
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/s/SOVNetwork/SovNode/1.1.3/SOVNetwork.SovNode.yaml
+++ b/manifests/s/SOVNetwork/SovNode/1.1.3/SOVNetwork.SovNode.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: SOVNetwork.SovNode
+PackageVersion: 1.1.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0

--- a/manifests/s/SOVNetwork/SovNode/1.1.3/SOVNetwork.SovNode.yaml
+++ b/manifests/s/SOVNetwork/SovNode/1.1.3/SOVNetwork.SovNode.yaml
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: SOVNetwork.SovNode
 PackageVersion: 1.1.3
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description
New package: SOV Node 1.1.3, the desktop wallet and full node for the SOV Network.

Portable app shipped as a zip. The archive contains a single file, SovNode.exe, matching the declared NestedInstallerFiles RelativeFilePath. No installer, no registry writes. InstallerSha256 was recomputed from the live release asset immediately before submitting and matches.

Project site: https://sov-network.github.io
Release: https://github.com/sov-network/relay-releases/releases/tag/v1.1.3

## Checklist
- [x] Signed the Contributor License Agreement
- [ ] Linked to an issue (if applicable)
## Manifest Checklist
- [x] Checked that there aren't other open pull requests for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with winget validate
- [ ] Tested manifest locally with winget install
- [x] Manifest conforms to the 1.12 schema
Two boxes are deliberately left unchecked: the CLA is not signed yet, and I have not run winget install against the manifest, so I am not attesting to either.- [ ] 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/409844)