### PR TITLE
New package: hust-open-atom-club.atomgit-cli version 0.7.0

### DIFF
--- a/manifests/h/hust-open-atom-club/atomgit-cli/0.7.0/hust-open-atom-club.atomgit-cli.installer.yaml
+++ b/manifests/h/hust-open-atom-club/atomgit-cli/0.7.0/hust-open-atom-club.atomgit-cli.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: hust-open-atom-club.atomgit-cli
+PackageVersion: 0.7.0
+InstallerType: zip
+NestedInstallerType: portable
+Commands:
+- ag
+ReleaseDate: 2026-07-28
+Installers:
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: ag.exe
+    PortableCommandAlias: ag
+  InstallerUrl: https://api.atomgit.com/api/v5/repos/hust-open-atom-club/atomgit-cli/releases/v0.7.0/attach_files/ag_windows_amd64_winget.zip/download
+  InstallerSha256: 4C2B252AECCDDCD9B397324974F4FB1888E0790E40D782AE7C45553D5FC2E76F
+- Architecture: arm64
+  NestedInstallerFiles:
+  - RelativeFilePath: ag.exe
+    PortableCommandAlias: ag
+  InstallerUrl: https://api.atomgit.com/api/v5/repos/hust-open-atom-club/atomgit-cli/releases/v0.7.0/attach_files/ag_windows_arm64_winget.zip/download
+  InstallerSha256: 3D695630899CA01970A0B8A143F287F00791C64A4612BF93652E7F0F44077C09
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/h/hust-open-atom-club/atomgit-cli/0.7.0/hust-open-atom-club.atomgit-cli.locale.zh-CN.yaml
+++ b/manifests/h/hust-open-atom-club/atomgit-cli/0.7.0/hust-open-atom-club.atomgit-cli.locale.zh-CN.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: hust-open-atom-club.atomgit-cli
 PackageVersion: 0.7.0
@@ -18,5 +18,5 @@ Tags:
 - command-line
 - git
 - repository
-ManifestType: locale
+ManifestType: defaultLocale
 ManifestVersion: 1.12.0

--- a/manifests/h/hust-open-atom-club/atomgit-cli/0.7.0/hust-open-atom-club.atomgit-cli.locale.zh-CN.yaml
+++ b/manifests/h/hust-open-atom-club/atomgit-cli/0.7.0/hust-open-atom-club.atomgit-cli.locale.zh-CN.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: hust-open-atom-club.atomgit-cli
+PackageVersion: 0.7.0
+PackageLocale: zh-CN
+Publisher: 华中科技大学开放原子开源俱乐部
+PublisherUrl: https://atomgit.com/hust-open-atom-club
+PublisherSupportUrl: https://atomgit.com/hust-open-atom-club/atomgit-cli/issues
+PackageName: AtomGit CLI
+PackageUrl: https://atomgit.com/hust-open-atom-club/atomgit-cli
+License: MulanPSL-2.0
+LicenseUrl: https://atomgit.com/hust-open-atom-club/atomgit-cli/blob/main/LICENSE
+ShortDescription: AtomGit 命令行工具
+Description: AtomGit 命令行工具，用于在终端管理 AtomGit 仓库、Issue、Pull Request、Release 和其他资源。
+Tags:
+- atomgit
+- cli
+- command-line
+- git
+- repository
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/h/hust-open-atom-club/atomgit-cli/0.7.0/hust-open-atom-club.atomgit-cli.yaml
+++ b/manifests/h/hust-open-atom-club/atomgit-cli/0.7.0/hust-open-atom-club.atomgit-cli.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: hust-open-atom-club.atomgit-cli
+PackageVersion: 0.7.0
+DefaultLocale: zh-CN
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Add AtomGit CLI as a portable WinGet package for Windows x64 and ARM64.

- Package identifier: `hust-open-atom-club.atomgit-cli`
- Release: https://atomgit.com/hust-open-atom-club/atomgit-cli/releases/tag/v0.7.0
- Source repository: https://atomgit.com/hust-open-atom-club/atomgit-cli
- Installer archives are platform-specific ZIP files containing `ag.exe`.

## Validation

- YAML parsed successfully with PyYAML.
- Installer archives downloaded from the release attachment API.
- SHA-256 values match `package-managers-checksums.txt`.
- `ag.exe` is present at the archive root for both architectures.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/409870)