### PR TITLE
New package: DheiverSantos.Mangaba version 0.1.15

### DIFF
--- a/manifests/d/DheiverSantos/Mangaba/0.1.15/DheiverSantos.Mangaba.installer.yaml
+++ b/manifests/d/DheiverSantos/Mangaba/0.1.15/DheiverSantos.Mangaba.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: DheiverSantos.Mangaba
+PackageVersion: 0.1.15
+InstallerLocale: pt-BR
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/dheiver2/mangaba-openworker/releases/download/v0.1.15/Mangaba_0.1.15_x64-setup.exe
+  InstallerSha256: 3ED596BCCC1B57DE724C7BC678FC2229D5CB45D03EF15FC8F0D8EFC62C055B8A
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/d/DheiverSantos/Mangaba/0.1.15/DheiverSantos.Mangaba.locale.pt-BR.yaml
+++ b/manifests/d/DheiverSantos/Mangaba/0.1.15/DheiverSantos.Mangaba.locale.pt-BR.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: DheiverSantos.Mangaba
+PackageVersion: 0.1.15
+PackageLocale: pt-BR
+Publisher: Dheiver Santos
+PublisherUrl: https://github.com/dheiver2
+PublisherSupportUrl: https://github.com/dheiver2/mangaba-openworker/issues
+PackageName: Mangaba
+PackageUrl: https://github.com/dheiver2/mangaba-openworker
+License: MIT
+LicenseUrl: https://github.com/dheiver2/mangaba-openworker/blob/main/LICENSE
+ShortDescription: Assistente de IA desktop com modelos locais (Mangaba Local) e agentes
+Description: |-
+  Assistente de IA para desktop com suporte a modelos locais rodando na própria
+  máquina (Mangaba Local, motor Ollama), múltiplos provedores de nuvem, agentes
+  com ferramentas (arquivos, shell, web) e automações agendadas.
+Tags:
+- ai
+- assistente
+- llm
+- ollama
+- desktop
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/d/DheiverSantos/Mangaba/0.1.15/DheiverSantos.Mangaba.yaml
+++ b/manifests/d/DheiverSantos/Mangaba/0.1.15/DheiverSantos.Mangaba.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: DheiverSantos.Mangaba
+PackageVersion: 0.1.15
+DefaultLocale: pt-BR
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/README.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

New package: Mangaba — desktop AI assistant with local models (Ollama engine), agents and scheduled automations. Installer is the NSIS user-scope setup published on GitHub Releases.

Note: manifest authored on macOS (cross-compiled app), so local `winget validate/install` was not possible; checked against the 1.6.0 schema by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/409879)