### PR TITLE
Update: FreeCAD.FreeCAD version 1.1.3 release notes

### DIFF
--- a/manifests/f/FreeCAD/FreeCAD/1.1.3/FreeCAD.FreeCAD.locale.en-US.yaml
+++ b/manifests/f/FreeCAD/FreeCAD/1.1.3/FreeCAD.FreeCAD.locale.en-US.yaml
@@ -26,6 +26,9 @@ Tags:
 - cad
 - engineer
 - engineering
+ReleaseNotes: |-
+  FreeCAD 1.1.3 is a maintenance release in the 1.1.x series. It includes security fixes for code-execution and other file-handling vulnerabilities that could be triggered by maliciously crafted FCStd files.
+  This release also fixes repeated update warnings when saving files, addressing a bugfix that was unintentionally omitted from version 1.1.2.
 ReleaseNotesUrl: https://github.com/FreeCAD/FreeCAD/releases/tag/1.1.3
 Documentations:
 - DocumentLabel: Wiki


### PR DESCRIPTION
## 📖 Description

Adds the missing `ReleaseNotes` metadata to the `FreeCAD.FreeCAD` version `1.1.3` default locale manifest.

The text summarizes the official FreeCAD 1.1.3 release information, including the security-related file-handling fixes and the fix for repeated update warnings when saving files.

The original package update was already merged in #407691. This PR only corrects the missing release-notes metadata reported by the validation bot.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com) — status to be confirmed by the CLA bot
- [x] Linked to an issue — not applicable; this is a metadata follow-up to merged PR #407691

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same manifest change
- [x] This PR only modifies one manifest
- [x] Validated locally with `winget validate --manifest manifests/f/FreeCAD/FreeCAD/1.1.3`
- [ ] Tested with `winget install --manifest <path>` — not applicable because installer metadata is unchanged
- [x] Manifest conforms to the 1.12 schema
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/409882)