### PR TITLE
Update OpenTubeX.OpenTubeX to 0.30.1

### DIFF
--- a/manifests/o/OpenTubeX/OpenTubeX/0.30.1/OpenTubeX.OpenTubeX.installer.yaml
+++ b/manifests/o/OpenTubeX/OpenTubeX/0.30.1/OpenTubeX.OpenTubeX.installer.yaml
@@ -1,0 +1,45 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: OpenTubeX.OpenTubeX
+PackageVersion: 0.30.1
+InstallerLocale: en-US
+InstallerType: nullsoft
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+Protocols:
+- opentubex
+ProductCode: a38f022d-fec2-5f80-a7fe-620ccf1a2767
+ReleaseDate: 2026-07-30
+AppsAndFeaturesEntries:
+- DisplayName: OpenTubeX 0.30.1
+  ProductCode: a38f022d-fec2-5f80-a7fe-620ccf1a2767
+Installers:
+- Architecture: x64
+  Scope: user
+  InstallerUrl: https://github.com/OpenTubeX/OpenTubeX/releases/download/v0.30.1-beta/opentubex-0.30.1-beta-setup-x64.exe
+  InstallerSha256: 33688F10E6B0E21BF7FFFE6B4A85002AB637BB87F102CB48285AC96BBC138E5A
+  InstallerSwitches:
+    Custom: /CURRENTUSER
+- Architecture: x64
+  Scope: machine
+  InstallerUrl: https://github.com/OpenTubeX/OpenTubeX/releases/download/v0.30.1-beta/opentubex-0.30.1-beta-setup-x64.exe
+  InstallerSha256: 33688F10E6B0E21BF7FFFE6B4A85002AB637BB87F102CB48285AC96BBC138E5A
+  InstallerSwitches:
+    Custom: /ALLUSERS
+- Architecture: arm64
+  Scope: user
+  InstallerUrl: https://github.com/OpenTubeX/OpenTubeX/releases/download/v0.30.1-beta/opentubex-0.30.1-beta-setup-arm64.exe
+  InstallerSha256: 394ABD72E1688B093CDE23933E96855B33CFF5184FD039215721EBAA56E110FB
+  InstallerSwitches:
+    Custom: /CURRENTUSER
+- Architecture: arm64
+  Scope: machine
+  InstallerUrl: https://github.com/OpenTubeX/OpenTubeX/releases/download/v0.30.1-beta/opentubex-0.30.1-beta-setup-arm64.exe
+  InstallerSha256: 394ABD72E1688B093CDE23933E96855B33CFF5184FD039215721EBAA56E110FB
+  InstallerSwitches:
+    Custom: /ALLUSERS
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenTubeX/OpenTubeX/0.30.1/OpenTubeX.OpenTubeX.locale.en-US.yaml
+++ b/manifests/o/OpenTubeX/OpenTubeX/0.30.1/OpenTubeX.OpenTubeX.locale.en-US.yaml
@@ -1,0 +1,44 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: OpenTubeX.OpenTubeX
+PackageVersion: 0.30.1
+PackageLocale: en-US
+Publisher: OpenTubeX contributors
+PublisherUrl: https://github.com/OpenTubeX
+PublisherSupportUrl: https://github.com/OpenTubeX/OpenTubeX/issues
+Author: OpenTubeX contributors
+PackageName: OpenTubeX
+PackageUrl: https://opentubex.org/
+License: AGPL-3.0
+LicenseUrl: https://github.com/OpenTubeX/OpenTubeX/blob/HEAD/LICENSE
+Copyright: Copyleft © 2020-2026
+CopyrightUrl: https://github.com/OpenTubeX/OpenTubeX/blob/HEAD/LICENSE
+ShortDescription: A private YouTube client
+Description: OpenTubeX is a private YouTube client for desktop.
+Moniker: opentubex
+Tags:
+- freetube
+- freetube-fork
+- privacy
+- subscriptions
+- video
+- videos
+- youtube
+ReleaseNotes: |-
+  More improvements
+  - The thumbnail progress and toast timeout indicator is now wrapped around both rounded corners (#370)
+  - Added an option to use a configurable fixed width for horizontal tabs (#367, #380)
+
+  Fixed bugs
+  - Fixed several Shorts, playlist panel, progress indicator, PiP, history, and layout regressions (#359, #360, #361, #362, #363, #364, #365, #366)
+  - Prevented closed tabs from reappearing after shutdown and made the app window appear sooner on startup (#369)
+  - Hovering a toast now reliably freezes its timeout indicator instead of sometimes letting the line keep draining (#373)
+  - Dragging the thumbnail size slider is smooth again on pages with many videos (#372)
+  - Fixed subscription feed layouts and animations, Shorts controls and watch progress, and menu layering near the tab bar (#374)
+  - Fixed the settings page jumping back to the highlighted section after switching tabs (#371)
+  - Fixed the app header disappearing when opening a modal on a scrolled page (#375)
+  - The animation of the subscription feed tab indicator no longer stutters when the feeds contain a lot of videos (#378)
+ReleaseNotesUrl: https://github.com/OpenTubeX/OpenTubeX/releases/tag/v0.30.1-beta
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenTubeX/OpenTubeX/0.30.1/OpenTubeX.OpenTubeX.yaml
+++ b/manifests/o/OpenTubeX/OpenTubeX/0.30.1/OpenTubeX.OpenTubeX.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: OpenTubeX.OpenTubeX
+PackageVersion: 0.30.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Updates OpenTubeX.OpenTubeX from 0.30.0 to 0.30.1.

This manifest includes the x64 and ARM64 NSIS installers for both user and machine scope. Release notes were converted to text-only YAML and omit the embedded release images.

Validation:
- `komac submit --dry-run --yes manifests/o/OpenTubeX/OpenTubeX/0.30.1`
- `git diff --cached --check`

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/409916)