### PR TITLE
New package: TransItFoundation.MeetTranscriptions version 2.3.2

### DIFF
--- a/manifests/t/TransItFoundation/MeetTranscriptions/2.3.2/TransItFoundation.MeetTranscriptions.installer.yaml
+++ b/manifests/t/TransItFoundation/MeetTranscriptions/2.3.2/TransItFoundation.MeetTranscriptions.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: TransItFoundation.MeetTranscriptions
+PackageVersion: 2.3.2
+InstallerLocale: en-US
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/daxcoletti/meet-transcriptions/releases/download/v2.3.2/MeetTranscriptions-Setup-2.3.2.exe
+    InstallerSha256: cff949ba2eb29792fcef7c5803f547dd74e08f7badbf7a25059e8b6e4a545307
+    ProductCode: '{7E4B7C1A-2C3D-4F5E-9A8B-6D0E1F2A3B4C}_is1'
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/t/TransItFoundation/MeetTranscriptions/2.3.2/TransItFoundation.MeetTranscriptions.locale.en-US.yaml
+++ b/manifests/t/TransItFoundation/MeetTranscriptions/2.3.2/TransItFoundation.MeetTranscriptions.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: TransItFoundation.MeetTranscriptions
+PackageVersion: 2.3.2
+PackageLocale: en-US
+Publisher: TRANS-IT Foundation
+PublisherUrl: https://github.com/daxcoletti
+PublisherSupportUrl: https://github.com/daxcoletti/meet-transcriptions/issues
+PackageName: Meet Transcriptions
+PackageUrl: https://github.com/daxcoletti/meet-transcriptions
+License: GPL-3.0-or-later
+LicenseUrl: https://github.com/daxcoletti/meet-transcriptions/blob/main/LICENSE
+Copyright: TRANS-IT Foundation
+ShortDescription: Automatic meeting transcription with speaker diarization and AI minutes, rotating free API tiers.
+Description: |-
+  Meet Transcriptions watches a recordings folder and, for every new audio or
+  video file, automatically generates a speaker-diarized transcript (VTT, TXT,
+  JSON) and AI-written meeting minutes in Markdown. It rotates across the free
+  tiers of several transcription APIs (Deepgram, Gladia, AssemblyAI,
+  ElevenLabs, Speechmatics, Groq) to dodge individual quota limits; minutes
+  are generated with Google Gemini or Groq. Lives in the system tray, detects
+  new recordings via native filesystem events, and includes a first-run wizard
+  that checks/downloads ffmpeg and validates the API keys. Bilingual UI
+  (English/Spanish).
+Moniker: meet-transcriptions
+Tags:
+  - transcription
+  - speech-to-text
+  - diarization
+  - meeting-minutes
+  - whisper
+  - meetings
+ReleaseNotesUrl: https://github.com/daxcoletti/meet-transcriptions/releases/tag/v2.3.2
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/t/TransItFoundation/MeetTranscriptions/2.3.2/TransItFoundation.MeetTranscriptions.locale.es-ES.yaml
+++ b/manifests/t/TransItFoundation/MeetTranscriptions/2.3.2/TransItFoundation.MeetTranscriptions.locale.es-ES.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
+PackageIdentifier: TransItFoundation.MeetTranscriptions
+PackageVersion: 2.3.2
+PackageLocale: es-ES
+Publisher: TRANS-IT Foundation
+PackageName: Meet Transcriptions
+PackageUrl: https://github.com/daxcoletti/meet-transcriptions
+License: GPL-3.0-or-later
+ShortDescription: Transcripción automática de reuniones con diarización y minuta con IA, rotando APIs gratuitas.
+Description: |-
+  Meet Transcriptions vigila una carpeta de grabaciones y, por cada audio o
+  video nuevo, genera automáticamente la transcripción con identificación de
+  hablantes (VTT, TXT, JSON) y una minuta en Markdown escrita con IA. Rota
+  entre los planes gratuitos de varios servicios de transcripción (Deepgram,
+  Gladia, AssemblyAI, ElevenLabs, Speechmatics, Groq) para esquivar los
+  límites de cuota; la minuta se genera con Google Gemini o Groq. Vive en la
+  bandeja del sistema, detecta grabaciones nuevas con eventos nativos del
+  sistema de archivos e incluye un asistente de primera ejecución que
+  verifica/descarga ffmpeg y valida las API keys. Interfaz bilingüe
+  (castellano/inglés).
+Tags:
+  - transcripcion
+  - reuniones
+  - minuta
+ManifestType: locale
+ManifestVersion: 1.6.0

--- a/manifests/t/TransItFoundation/MeetTranscriptions/2.3.2/TransItFoundation.MeetTranscriptions.yaml
+++ b/manifests/t/TransItFoundation/MeetTranscriptions/2.3.2/TransItFoundation.MeetTranscriptions.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: TransItFoundation.MeetTranscriptions
+PackageVersion: 2.3.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## New package submission

- **PackageIdentifier:** TransItFoundation.MeetTranscriptions
- **Version:** 2.3.2
- **Homepage:** https://github.com/daxcoletti/meet-transcriptions
- **License:** GPL-3.0-or-later

Meet Transcriptions is an open-source desktop app that watches a recordings folder and automatically generates speaker-diarized transcripts and AI-written meeting minutes, rotating across free transcription API tiers. Inno Setup installer, per-user scope, silent install supported (the installer does not launch the app under /VERYSILENT).

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`? *(authored on Linux — relying on pipeline validation)*
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? *(authored on Linux — relying on pipeline validation)*
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/409997)