### PR TITLE
Add okamiforge.okami version 0.1.58

### DIFF
--- a/manifests/o/okamiforge/okami/0.1.58/okamiforge.okami.installer.yaml
+++ b/manifests/o/okamiforge/okami/0.1.58/okamiforge.okami.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: okamiforge.okami
+PackageVersion: 0.1.58
+InstallerType: portable
+Commands:
+- okami
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/julia-eileen/okami-releases/releases/download/v0.1.58/okami-windows-x64.exe
+  InstallerSha256: CDBD313022ED96D297DAB522E5135E93D34F6BEA158C6860CC27016A2FF443EA
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/o/okamiforge/okami/0.1.58/okamiforge.okami.locale.en-US.yaml
+++ b/manifests/o/okamiforge/okami/0.1.58/okamiforge.okami.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: okamiforge.okami
+PackageVersion: 0.1.58
+PackageLocale: en-US
+Publisher: okamiforge
+PublisherUrl: https://okamiforge.dev
+PublisherSupportUrl: https://okamiforge.dev
+PackageName: okami
+PackageUrl: https://okamiforge.dev
+License: Proprietary
+ShortDescription: AI coding agent CLI that reads your project before it writes
+Description: Okami is an AI coding agent that reads your project before it writes and works in your own repo. It runs from a self-contained CLI binary with no Node.js or runtime required.
+Moniker: okami
+Tags:
+- ai
+- agent
+- cli
+- coding
+- devtools
+ReleaseNotes: Stability improvements and bug fixes.
+ReleaseNotesUrl: https://github.com/julia-eileen/okami-releases/releases/tag/v0.1.58
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/o/okamiforge/okami/0.1.58/okamiforge.okami.yaml
+++ b/manifests/o/okamiforge/okami/0.1.58/okamiforge.okami.yaml
@@ -1,0 +1,42 @@
+# Winget manifest: https://learn.microsoft.com/en-us/windows/package-manager/package/manifest
+# Portable package — standalone CLI binary, no installer wizard.
+# Submit to: https://github.com/microsoft/winget-pkgs
+# Path in repo: manifests/o/okamiforge/okami/0.1.58/okamiforge.okami.yaml
+
+PackageIdentifier: okamiforge.okami
+PackageVersion: 0.1.58
+PackageLocale: en-US
+Publisher: okamiforge
+PublisherUrl: https://okamiforge.dev
+PublisherSupportUrl: https://okamiforge.dev
+PrivacyUrl: https://okamiforge.dev
+Author: okamiforge
+PackageName: okami
+PackageUrl: https://okamiforge.dev
+License: Proprietary
+LicenseUrl: https://okamiforge.dev
+Copyright: Copyright (c) okamiforge
+ShortDescription: AI coding agent CLI that reads your project before it writes
+Description: Okami is an AI coding agent that reads your project before it writes and works in your own repo. It runs from a small self-contained CLI binary — no Node.js or runtime required.
+Moniker: okami
+Tags:
+  - ai
+  - agent
+  - cli
+  - coding
+  - devtools
+ReleaseNotes: Stability improvements and bug fixes.
+ReleaseNotesUrl: https://github.com/julia-eileen/okami-releases/releases/tag/v0.1.58
+# Installation behavior — portable: winget copies the .exe to
+# %LOCALAPPDATA%\Microsoft\WinGet\Packages\okamiforge.okami and symlinks it
+# onto the user's PATH. No installer wizard, no UAC prompt.
+Installers:
+  - InstallerLocale: en-US
+    Architecture: x64
+    InstallerType: portable
+    InstallerUrl: https://github.com/julia-eileen/okami-releases/releases/download/v0.1.58/okami-windows-x64.exe
+    InstallerSha256: cdbd313022ed96d297dab522e5135e93d34f6bea158c6860cc27016a2ff443ea
+    Commands:
+      - okami
+ManifestType: singleton
+ManifestVersion: 1.6.0

--- a/manifests/o/okamiforge/okami/0.1.58/okamiforge.okami.yaml
+++ b/manifests/o/okamiforge/okami/0.1.58/okamiforge.okami.yaml
@@ -1,42 +1,7 @@
-# Winget manifest: https://learn.microsoft.com/en-us/windows/package-manager/package/manifest
-# Portable package — standalone CLI binary, no installer wizard.
-# Submit to: https://github.com/microsoft/winget-pkgs
-# Path in repo: manifests/o/okamiforge/okami/0.1.58/okamiforge.okami.yaml
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: okamiforge.okami
 PackageVersion: 0.1.58
-PackageLocale: en-US
-Publisher: okamiforge
-PublisherUrl: https://okamiforge.dev
-PublisherSupportUrl: https://okamiforge.dev
-PrivacyUrl: https://okamiforge.dev
-Author: okamiforge
-PackageName: okami
-PackageUrl: https://okamiforge.dev
-License: Proprietary
-LicenseUrl: https://okamiforge.dev
-Copyright: Copyright (c) okamiforge
-ShortDescription: AI coding agent CLI that reads your project before it writes
-Description: Okami is an AI coding agent that reads your project before it writes and works in your own repo. It runs from a small self-contained CLI binary — no Node.js or runtime required.
-Moniker: okami
-Tags:
-  - ai
-  - agent
-  - cli
-  - coding
-  - devtools
-ReleaseNotes: Stability improvements and bug fixes.
-ReleaseNotesUrl: https://github.com/julia-eileen/okami-releases/releases/tag/v0.1.58
-# Installation behavior — portable: winget copies the .exe to
-# %LOCALAPPDATA%\Microsoft\WinGet\Packages\okamiforge.okami and symlinks it
-# onto the user's PATH. No installer wizard, no UAC prompt.
-Installers:
-  - InstallerLocale: en-US
-    Architecture: x64
-    InstallerType: portable
-    InstallerUrl: https://github.com/julia-eileen/okami-releases/releases/download/v0.1.58/okami-windows-x64.exe
-    InstallerSha256: cdbd313022ed96d297dab522e5135e93d34f6bea158c6860cc27016a2ff443ea
-    Commands:
-      - okami
-ManifestType: singleton
-ManifestVersion: 1.6.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Standalone CLI binary for the Okami AI coding agent. No installer wizard —
portable exe that winget places on the user's PATH.

Installer is hosted on GitHub Releases and the SHA256 matches the
published checksum.

Package: okamiforge.okami 0.1.58
Installer: portable (x64)