### PR TITLE
New package: VaughanWynneJones.VWMUD2026 version 1.0.0

### DIFF
--- a/manifests/v/VaughanWynneJones/VWMUD2026/1.0.0/VaughanWynneJones.VWMUD2026.installer.yaml
+++ b/manifests/v/VaughanWynneJones/VWMUD2026/1.0.0/VaughanWynneJones.VWMUD2026.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: VaughanWynneJones.VWMUD2026
+PackageVersion: 1.0.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: VWMUD2026.exe
+  PortableCommandAlias: vwmud2026
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.8
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Vaughanwj/VWMUD2026/releases/download/v1.0.0/vwmud2026-1.0.0-win-x64.zip
+  InstallerSha256: 1BC7CC043B72D635D857EAE4E2B5AA31E6DEC536A1D7593D01DABF1621C14BED
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/v/VaughanWynneJones/VWMUD2026/1.0.0/VaughanWynneJones.VWMUD2026.locale.en-US.yaml
+++ b/manifests/v/VaughanWynneJones/VWMUD2026/1.0.0/VaughanWynneJones.VWMUD2026.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: VaughanWynneJones.VWMUD2026
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: Vaughan Wynne-Jones
+PublisherUrl: https://github.com/Vaughanwj
+PublisherSupportUrl: https://github.com/Vaughanwj/VWMUD2026/issues
+PackageName: VWMUD Master 2026
+PackageUrl: https://github.com/Vaughanwj/VWMUD2026
+License: GPL-3.0-or-later
+LicenseUrl: https://github.com/Vaughanwj/VWMUD2026/blob/main/LICENSE
+Copyright: Copyright (C) 2026 Vaughan Wynne-Jones
+ShortDescription: A modernized .NET 8 rebuild of the VWMUD MUD client, compatible with classic .mud/.tri profiles and scripts.
+Description: |-
+  VWMUD Master 2026 is a modernized rebuild of VWMUD Master, a MUD (Multi-User
+  Dungeon) client originally written by Vaughan Wynne-Jones from 1994 to 2007.
+  It targets .NET 8 while remaining compatible with the original .mud
+  configuration and .tri trigger file formats and scripting DSL, so existing
+  character profiles and automation scripts keep working unchanged.
+Moniker: vwmud2026
+Tags:
+- mud
+- mud-client
+- telnet
+- multi-user-dungeon
+- terminal
+- game-client
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/v/VaughanWynneJones/VWMUD2026/1.0.0/VaughanWynneJones.VWMUD2026.yaml
+++ b/manifests/v/VaughanWynneJones/VWMUD2026/1.0.0/VaughanWynneJones.VWMUD2026.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: VaughanWynneJones.VWMUD2026
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description
Adds VWMUD Master 2026, a modernized .NET 8 rebuild of the classic VWMUD MUD (Multi-User Dungeon) client, distributed as a portable win-x64 zip with a nested exe.

- Source: https://github.com/Vaughanwj/VWMUD2026
- License: GPL-3.0-or-later

## ✅ Checklist
- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  - Resolves n/a — first submission

## 📦 Manifest Checklist
- [x] Checked that there aren't other open pull requests for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>` — confirmed working: package installed and registered correctly (`winget list` shows it), and the `vwmud2026` portable command alias launches the real app (verified interactively).
- [x] Manifest conforms to the 1.12 schema
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/410110)