### PR TITLE
Update: Unity.UnityHub to 3.20.0

### DIFF
--- a/manifests/u/Unity/UnityHub/3.20.0/Unity.UnityHub.installer.yaml
+++ b/manifests/u/Unity/UnityHub/3.20.0/Unity.UnityHub.installer.yaml
@@ -1,0 +1,54 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Unity.UnityHub
+PackageVersion: 3.20.0
+InstallerLocale: en-US
+UpgradeBehavior: install
+Protocols:
+- unityhub
+FileExtensions:
+- unityhub
+ReleaseDate: 2026-07-30
+Installers:
+- Architecture: x64
+  InstallerType: nullsoft
+  Scope: machine
+  MinimumOSVersion: 10.0.10240.0
+  InstallerSwitches:
+    Upgrade: --updated
+  ProductCode: Unity Technologies - Hub
+  AppsAndFeaturesEntries:
+  - DisplayName: Unity Hub 3.20.0
+    ProductCode: Unity Technologies - Hub
+  InstallerUrl: https://public-cdn.cloud.unity3d.com/hub/prod/3.20.0/UnityHubSetup-3.20.0-x64.exe
+  InstallerSha256: 9CB7155968AAAD7C8937F1E6DCBFB949B50D230405CA8B77620098B64E1B6DFF
+- Architecture: arm64
+  InstallerType: nullsoft
+  Scope: machine
+  MinimumOSVersion: 10.0.10240.0
+  InstallerSwitches:
+    Upgrade: --updated
+  ProductCode: Unity Technologies - Hub
+  AppsAndFeaturesEntries:
+  - DisplayName: Unity Hub 3.20.0
+    ProductCode: Unity Technologies - Hub
+  InstallerUrl: https://public-cdn.cloud.unity3d.com/hub/prod/3.20.0/UnityHubSetup-3.20.0-arm64.exe
+  InstallerSha256: 33AC1FBD2CE17098E2BAEFB7F7CD15217640BB50AB60FD2CB262FE823E780240
+- Architecture: x64
+  InstallerType: msix
+  Scope: user
+  MinimumOSVersion: 10.0.19043.0
+  PackageFamilyName: UnityTechnologies.UnityHub_2vrhnee42bhxm
+  InstallerUrl: https://public-cdn.cloud.unity3d.com/hub/prod/3.20.0/UnityHubSetup-3.20.0-x64.msix
+  InstallerSha256: 2AFEDE37044F1638D25C60D764AB26F78CF89979FDBC5F59BBE0448FBC451950
+  SignatureSha256: 112DD16AB46B46DB3691338E6326EF50A4894CFE3E3C995C0F32E41E1B97A2E2
+- Architecture: arm64
+  InstallerType: msix
+  Scope: user
+  MinimumOSVersion: 10.0.19043.0
+  PackageFamilyName: UnityTechnologies.UnityHub_2vrhnee42bhxm
+  InstallerUrl: https://public-cdn.cloud.unity3d.com/hub/prod/3.20.0/UnityHubSetup-3.20.0-arm64.msix
+  InstallerSha256: 02280F1926FE33921DA6481583CC4E69D8A842537B272A9B99CE3636126DED0F
+  SignatureSha256: FB06E3A79105AF9BA2257169E179AE3E74B9E8C2C74852233F7D6EE1DA188759
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/u/Unity/UnityHub/3.20.0/Unity.UnityHub.locale.en-US.yaml
+++ b/manifests/u/Unity/UnityHub/3.20.0/Unity.UnityHub.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Unity.UnityHub
+PackageVersion: 3.20.0
+PackageLocale: en-US
+Publisher: Unity Technologies Inc.
+PublisherUrl: https://unity.com/
+PublisherSupportUrl: https://support.unity.com/
+PrivacyUrl: https://unity.com/legal/privacy-policy
+Author: Unity Technologies Inc.
+PackageName: Unity Hub
+PackageUrl: https://unity.com/unity-hub
+License: Proprietary
+LicenseUrl: https://unity.com/legal/terms-of-service
+Copyright: Copyright © 2026 Unity Technologies Inc.
+CopyrightUrl: https://unity.com/legal/trademarks
+ShortDescription: Manage multiple installations of the Unity Editor, create new projects, and access your work.
+Description: The Unity Hub is a standalone application that streamlines the way you navigate, download, and manage your Unity projects and installations.
+Tags:
+- unity
+- unity3d
+Documentations:
+- DocumentLabel: Manual
+  DocumentUrl: https://docs.unity3d.com/hub/manual
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/u/Unity/UnityHub/3.20.0/Unity.UnityHub.locale.zh-CN.yaml
+++ b/manifests/u/Unity/UnityHub/3.20.0/Unity.UnityHub.locale.zh-CN.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: Unity.UnityHub
+PackageVersion: 3.20.0
+PackageLocale: zh-CN
+Publisher: Unity Technologies Inc.
+PublisherUrl: https://unity.com/cn
+PublisherSupportUrl: https://support.unity.com/
+PrivacyUrl: https://unity.com/cn/legal/privacy-policy
+Author: Unity Technologies Inc.
+PackageName: Unity Hub
+PackageUrl: https://unity.com/cn/unity-hub
+License: 专有软件
+LicenseUrl: https://unity.com/cn/legal/terms-of-service
+Copyright: Copyright © 2026 Unity Technologies Inc.
+CopyrightUrl: https://unity.com/cn/legal/trademarks
+ShortDescription: 管理 Unity 编辑器的多个安装、创建新项目和访问您的工作
+Description: Unity Hub 是一款独立应用程序，简化 Unity 项目和安装的浏览、下载和管理方式。
+Tags:
+- unity
+- unity3d
+Documentations:
+- DocumentLabel: 手册
+  DocumentUrl: https://docs.unity3d.com/hub/manual
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/u/Unity/UnityHub/3.20.0/Unity.UnityHub.yaml
+++ b/manifests/u/Unity/UnityHub/3.20.0/Unity.UnityHub.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Unity.UnityHub
+PackageVersion: 3.20.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Updates **Unity.UnityHub** to **3.20.0** (GA, released 2026-07-30).

This release also introduces Unity Hub's new **MSIX** installers, so the manifest now carries four installers: the existing NSIS `.exe` (machine scope, x64 + arm64) plus the new MSIX packages (user scope, x64 + arm64, `PackageFamilyName: UnityTechnologies.UnityHub_2vrhnee42bhxm`). NSIS entries are listed first to preserve the current default install experience. All four installers are served from Unity's immutable versioned CDN URLs and are Authenticode-signed by Unity's EV certificate ("Unity Technologies SF"); `SignatureSha256` values were computed from each package's `AppxSignature.p7x`. The MSIX targets a higher OS floor (10.0.19043.0) than the NSIS installer (10.0.10240.0), reflected per installer.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>` (signatures of all four installers verified locally; skipped the local install round-trip to avoid replacing the development Hub install on this machine — relying on pipeline installation validation)
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/410241)