### PR TITLE
New version: CaptainKillSwitch.CaptainKillSwitch version 0.3.3

### DIFF
--- a/manifests/c/CaptainKillSwitch/CaptainKillSwitch/0.3.3/CaptainKillSwitch.CaptainKillSwitch.installer.yaml
+++ b/manifests/c/CaptainKillSwitch/CaptainKillSwitch/0.3.3/CaptainKillSwitch.CaptainKillSwitch.installer.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: CaptainKillSwitch.CaptainKillSwitch
+PackageVersion: 0.3.3
+InstallerLocale: en-US
+InstallerType: wix
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{9EE7A6C8-C123-4D48-BDED-795827587CEF}'
+ReleaseDate: 2026-07-31
+AppsAndFeaturesEntries:
+- Publisher: captainkillswitch
+  ProductCode: '{9EE7A6C8-C123-4D48-BDED-795827587CEF}'
+  UpgradeCode: '{984FC5FB-4BE0-5465-85FF-3FDCFED283B5}'
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles%/Captain Kill Switch'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/captainkillswitch/downloads/releases/download/v0.3.3/captain-kill-switch-0.3.3-windows-x64.msi
+  InstallerSha256: 6340D5E984F051CDC2FFF7AB73FE63E80B1FF82F6E9D03FC0CFF8C36F329E923
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/CaptainKillSwitch/CaptainKillSwitch/0.3.3/CaptainKillSwitch.CaptainKillSwitch.locale.en-US.yaml
+++ b/manifests/c/CaptainKillSwitch/CaptainKillSwitch/0.3.3/CaptainKillSwitch.CaptainKillSwitch.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: CaptainKillSwitch.CaptainKillSwitch
+PackageVersion: 0.3.3
+PackageLocale: en-US
+Publisher: Captain Kill Switch Team
+PublisherUrl: https://captainkillswitch.com/
+PublisherSupportUrl: https://github.com/captainkillswitch/downloads/issues
+Author: Captain Kill Switch Team
+PackageName: Captain Kill Switch
+PackageUrl: https://captainkillswitch.com/
+License: Proprietary (free)
+LicenseUrl: https://captainkillswitch.com/about
+Copyright: Copyright (c) 2026 Captain Kill Switch Team
+ShortDescription: Close every running application in one click from the system tray.
+Description: Captain Kill Switch is a free system-tray utility that closes every running application in one click - a clean close request first, then a firm stop within two seconds. An allowlist model protects Windows system and session processes. Tiny native app, auto-updates, 10 languages. Anonymous usage statistics only; see https://captainkillswitch.com/privacy.
+Moniker: captain-kill-switch
+ReleaseNotes: |-
+  macOS-only feature release; the Windows build carries the shared changes.
+  - The sweep's one-time "ways to help" note now appears on the tenth sweep of an install, once, and never opens anything by itself.
+  - No change to Windows targeting, exclusions or the two-second force floor.
+ReleaseNotesUrl: https://github.com/captainkillswitch/downloads/releases/tag/v0.3.3
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/CaptainKillSwitch/CaptainKillSwitch/0.3.3/CaptainKillSwitch.CaptainKillSwitch.yaml
+++ b/manifests/c/CaptainKillSwitch/CaptainKillSwitch/0.3.3/CaptainKillSwitch.CaptainKillSwitch.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: CaptainKillSwitch.CaptainKillSwitch
+PackageVersion: 0.3.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### What is this PR for
New version 0.3.3 of `CaptainKillSwitch.CaptainKillSwitch`. Manifests mirror the accepted 0.2.98 set (and my open 0.3.2 PR #410077) with only the per-version fields changed: `PackageVersion`, `ProductCode`, `ReleaseDate`, `InstallerUrl`, `InstallerSha256`, and the release notes. `UpgradeCode` is unchanged, so upgrade detection is preserved.

I am the publisher.

### Verification I actually performed
- **InstallerSha256** — computed locally from the downloaded MSI and matched against `SHA256SUMS.txt` in the release: `6340D5E9…F329E923`.
- **ProductCode** — read out of the MSI's raw bytes. I validated the extraction method first by running it against the 0.2.98 MSI, where it reproduces `{3DEE1E33-9543-4414-87C7-E6811EC6614E}`, the ProductCode already merged in this repo.
- **UpgradeCode** — deliberately carried over from the merged manifest rather than re-derived.

### What I did NOT do
I have no Windows machine, so **`winget validate` and `winget install --manifest` were not run** and I have left those boxes unticked rather than tick them untruthfully. Everything else above was verified by hand.

Supersedes #410077 (0.3.2), which I will close once this passes validation.

---

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] This PR only modifies one (1) manifest
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/410322)