### PR TITLE
Update: neyham.AIUsageDashboard version 0.4.0

### DIFF
--- a/manifests/n/neyham/AIUsageDashboard/0.4.0/neyham.AIUsageDashboard.installer.yaml
+++ b/manifests/n/neyham/AIUsageDashboard/0.4.0/neyham.AIUsageDashboard.installer.yaml
@@ -1,0 +1,28 @@
+# Created with WinGet manifest schema 1.12.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: neyham.AIUsageDashboard
+PackageVersion: 0.4.0
+InstallerLocale: en-US
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+UpgradeBehavior: install
+ReleaseDate: 2026-07-31
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/neyham/ai-usage-dashboard/releases/download/v0.4.0/AI-Usage-Dashboard_0.4.0_x64-setup.exe
+    InstallerSha256: 9834FD9E227F477B0E3C24D1E23F8F3B2C395BA83DBBD154623A63EEB760A635
+    AppsAndFeaturesEntries:
+      - DisplayName: AI Usage Dashboard
+        Publisher: neyha
+        ProductCode: AI Usage Dashboard
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/n/neyham/AIUsageDashboard/0.4.0/neyham.AIUsageDashboard.locale.en-US.yaml
+++ b/manifests/n/neyham/AIUsageDashboard/0.4.0/neyham.AIUsageDashboard.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# Created with WinGet manifest schema 1.12.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: neyham.AIUsageDashboard
+PackageVersion: 0.4.0
+PackageLocale: en-US
+Publisher: neyham
+PublisherUrl: https://github.com/neyham
+PublisherSupportUrl: https://github.com/neyham/ai-usage-dashboard/issues
+Author: neyham
+PackageName: AI Usage Dashboard
+PackageUrl: https://github.com/neyham/ai-usage-dashboard
+License: MIT
+LicenseUrl: https://github.com/neyham/ai-usage-dashboard/blob/v0.4.0/LICENSE
+Copyright: Copyright (c) 2026 neyham
+ShortDescription: Local Windows dashboard for Claude Code, Codex, Grok Build, and DeepSeek usage.
+Description: |-
+  AI Usage Dashboard is a local-first Windows desktop dashboard and screensaver
+  for viewing Claude Code, Codex, and Grok Build usage windows alongside a
+  DeepSeek API balance. Credentials and provider requests stay in the native
+  Rust backend; the renderer receives sanitized usage summaries only. The
+  project has no developer-operated server, analytics, or telemetry.
+Moniker: ai-usage-dashboard
+Tags:
+  - ai
+  - claude
+  - claude-code
+  - codex
+  - dashboard
+  - deepseek
+  - grok
+  - usage
+ReleaseNotesUrl: https://github.com/neyham/ai-usage-dashboard/releases/tag/v0.4.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/n/neyham/AIUsageDashboard/0.4.0/neyham.AIUsageDashboard.yaml
+++ b/manifests/n/neyham/AIUsageDashboard/0.4.0/neyham.AIUsageDashboard.yaml
@@ -1,0 +1,8 @@
+# Created with WinGet manifest schema 1.12.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: neyham.AIUsageDashboard
+PackageVersion: 0.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Updates `neyham.AIUsageDashboard` from `0.3.0` to `0.4.0`.

This release adds adaptive usage windows, Codex banked-reset display, optional Grok Build tracking, zero-to-four provider layouts, and aligned Windows/WSL credential discovery for Claude, Codex, and Grok.

- Release: https://github.com/neyham/ai-usage-dashboard/releases/tag/v0.4.0
- Installer: https://github.com/neyham/ai-usage-dashboard/releases/download/v0.4.0/AI-Usage-Dashboard_0.4.0_x64-setup.exe
- Installer SHA-256: `9834FD9E227F477B0E3C24D1E23F8F3B2C395BA83DBBD154623A63EEB760A635`
- The public installer was downloaded again and matched the published checksum file.

## 👩‍❤️‍👨 Validation

- [x] Installer URL is a fixed GitHub Release asset
- [x] Installer SHA-256 verified against published `SHA256SUMS.txt`
- [x] No redundant `DisplayVersion` (matches PackageVersion)
- [x] Installer type remains NSIS (`nullsoft`) for the setup.exe

## Checklist
- [x] Have you signed the Contributor License Agreement?
- [x] This PR targets the default branch

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/410324)