### PR TITLE
Update: EclipseFoundation.Eclipse.Java to 2026-06

### DIFF
--- a/manifests/e/EclipseFoundation/Eclipse/Java/2026-06/EclipseFoundation.Eclipse.Java.installer.yaml
+++ b/manifests/e/EclipseFoundation/Eclipse/Java/2026-06/EclipseFoundation.Eclipse.Java.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: EclipseFoundation.Eclipse.Java
+PackageVersion: 2026-06
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: eclipse/eclipse.exe
+ArchiveBinariesDependOnPath: true
+Installers:
+- Architecture: x64
+  InstallerUrl: https://download.eclipse.org/technology/epp/downloads/release/2026-06/R/eclipse-java-2026-06-R-win32-x86_64.zip
+  InstallerSha256: AA03A8488B1A4ABC441611E52984269F6DB23969DC5C29C057092FE19C8B83B2
+- Architecture: arm64
+  InstallerUrl: https://download.eclipse.org/technology/epp/downloads/release/2026-06/R/eclipse-java-2026-06-R-win32-aarch64.zip
+  InstallerSha256: 32C555944599959479CAF652651AC0EBE0B2B7197192E0B9BEC1CA2562A50766
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/e/EclipseFoundation/Eclipse/Java/2026-06/EclipseFoundation.Eclipse.Java.locale.en-US.yaml
+++ b/manifests/e/EclipseFoundation/Eclipse/Java/2026-06/EclipseFoundation.Eclipse.Java.locale.en-US.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: EclipseFoundation.Eclipse.Java
+PackageVersion: 2026-06
+PackageLocale: en-US
+Publisher: Eclipse.org Foundation, Inc.
+PackageName: Eclipse IDE for Java Developers
+License: Eclipse Public License 2.0
+ShortDescription: Eclipse IDE for Java Developers
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/e/EclipseFoundation/Eclipse/Java/2026-06/EclipseFoundation.Eclipse.Java.yaml
+++ b/manifests/e/EclipseFoundation/Eclipse/Java/2026-06/EclipseFoundation.Eclipse.Java.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: EclipseFoundation.Eclipse.Java
+PackageVersion: 2026-06
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Updates Eclipse IDE for Java Developers (`EclipseFoundation.Eclipse.Java`) to the 2026-06 release.

Adds direct Eclipse download URLs and SHA-256 hashes for:

- Windows x64
- Windows arm64

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest manifests/e/EclipseFoundation/Eclipse/Java/2026-06`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/410414)

