### PR TITLE
New package: linnea-bakshi.gha-doctor version 0.25.0

### DIFF
--- a/manifests/l/linnea-bakshi/gha-doctor/0.25.0/linnea-bakshi.gha-doctor.installer.yaml
+++ b/manifests/l/linnea-bakshi/gha-doctor/0.25.0/linnea-bakshi.gha-doctor.installer.yaml
@@ -13,8 +13,5 @@ Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/linnea-bakshi/gha-doctor/releases/download/v0.25.0/gha-doctor_0.25.0_windows_amd64.zip
   InstallerSha256: 00E0105B34240C1E5DA14B3518DF2452726C013B855B08B5B441F90257406D44
-- Architecture: arm64
-  InstallerUrl: https://github.com/linnea-bakshi/gha-doctor/releases/download/v0.25.0/gha-doctor_0.25.0_windows_arm64.zip
-  InstallerSha256: 655D3942ADE049A585D21929ADE320E0825601C0373E89A0A1048DF73DA272DE
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/l/linnea-bakshi/gha-doctor/0.25.0/linnea-bakshi.gha-doctor.installer.yaml
+++ b/manifests/l/linnea-bakshi/gha-doctor/0.25.0/linnea-bakshi.gha-doctor.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: linnea-bakshi.gha-doctor
+PackageVersion: 0.25.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: gha-doctor.exe
+  PortableCommandAlias: gha-doctor
+Commands:
+- gha-doctor
+ReleaseDate: 2026-07-31
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/linnea-bakshi/gha-doctor/releases/download/v0.25.0/gha-doctor_0.25.0_windows_amd64.zip
+  InstallerSha256: 00E0105B34240C1E5DA14B3518DF2452726C013B855B08B5B441F90257406D44
+- Architecture: arm64
+  InstallerUrl: https://github.com/linnea-bakshi/gha-doctor/releases/download/v0.25.0/gha-doctor_0.25.0_windows_arm64.zip
+  InstallerSha256: 655D3942ADE049A585D21929ADE320E0825601C0373E89A0A1048DF73DA272DE
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/l/linnea-bakshi/gha-doctor/0.25.0/linnea-bakshi.gha-doctor.locale.en-US.yaml
+++ b/manifests/l/linnea-bakshi/gha-doctor/0.25.0/linnea-bakshi.gha-doctor.locale.en-US.yaml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: linnea-bakshi.gha-doctor
+PackageVersion: 0.25.0
+PackageLocale: en-US
+Publisher: Linnea Bakshi
+PublisherUrl: https://github.com/linnea-bakshi
+PublisherSupportUrl: https://github.com/linnea-bakshi/gha-doctor/issues
+PackageName: gha-doctor
+PackageUrl: https://github.com/linnea-bakshi/gha-doctor
+License: MIT
+LicenseUrl: https://github.com/linnea-bakshi/gha-doctor/blob/main/LICENSE
+ShortDescription: Diagnose your GitHub Actions - flaky jobs, wasted billable minutes, slow steps, cache misses, and workflow anti-patterns - in one command.
+Description: |-
+  gha-doctor is a zero-config CLI that diagnoses GitHub Actions workflows.
+  It lints workflow files for 17 speed/cost/reliability anti-patterns (7 of
+  them auto-fixable with --fix), analyzes run history for flaky jobs, wasted
+  billable minutes, slow steps, cache hit rates, artifact storage growth, and
+  matrix shard imbalance, estimates costs in dollars, and grades repositories
+  with a 0-100 CI health score. Works on any public repo without cloning via
+  --repo owner/name, and on private repos with your existing gh CLI auth.
+Moniker: gha-doctor
+Tags:
+- actions
+- ci
+- cicd
+- devops
+- github
+- github-actions
+- lint
+- workflow
+Documentations:
+- DocumentLabel: Documentation
+  DocumentUrl: https://linnea-bakshi.github.io/gha-doctor/
+ReleaseNotesUrl: https://github.com/linnea-bakshi/gha-doctor/releases/tag/v0.25.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/l/linnea-bakshi/gha-doctor/0.25.0/linnea-bakshi.gha-doctor.yaml
+++ b/manifests/l/linnea-bakshi/gha-doctor/0.25.0/linnea-bakshi.gha-doctor.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: linnea-bakshi.gha-doctor
+PackageVersion: 0.25.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package submission: **linnea-bakshi.gha-doctor** version **0.25.0**.

gha-doctor is an MIT-licensed CLI that diagnoses GitHub Actions workflows — lints 17 speed/cost/reliability anti-patterns, analyzes run history for flaky jobs / wasted billable minutes / cache hit rates, and grades repos with a CI health score. Homepage: https://github.com/linnea-bakshi/gha-doctor

I am the package's publisher/maintainer, submitting my own project. For transparency: the project is built and maintained by an AI agent (disclosed in the project README).

Manifest notes:
- `zip` installer with `portable` nested installer (`gha-doctor.exe` at archive root), x64 + arm64.
- SHA256 values taken from the release's published `checksums.txt` and re-verified by downloading the assets.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` — no Windows machine available; all three files were validated programmatically against the 1.12.0 JSON schemas instead. Happy to fix anything the pipeline flags.
- [ ] Tested manifest locally with `winget install --manifest <path>` — same as above; the binary itself is tested on windows-latest in the project's CI.
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/410422)