### PR TITLE
Update: jqlang.jq version 1.8.2 (add arm64 installer)

### DIFF
--- a/manifests/j/jqlang/jq/1.8.2/jqlang.jq.installer.yaml
+++ b/manifests/j/jqlang/jq/1.8.2/jqlang.jq.installer.yaml
@@ -14,5 +14,8 @@ Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/jqlang/jq/releases/download/jq-1.8.2/jq-windows-amd64.exe
   InstallerSha256: A6FC67FEDAF9128A3309A1E2EBB8B986AECCF70122EE46D2CB4849E423F0C627
+- Architecture: arm64
+  InstallerUrl: https://github.com/jqlang/jq/releases/download/jq-1.8.2/jq-windows-arm64.exe
+  InstallerSha256: 083B5377392BC57CF27052B6D20A2D927770683BCA844632901FF38B4B7B0AC7
 ManifestType: installer
 ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds the **arm64** installer to the existing `jqlang.jq` **1.8.2** manifest.

jq [1.8.2](https://github.com/jqlang/jq/releases/tag/jq-1.8.2) is the first release to ship an official Windows ARM64 binary (`jq-windows-arm64.exe`), so Windows on ARM users currently get the emulated x64 build instead of the native one. No other fields were changed.

```yaml
- Architecture: arm64
  InstallerUrl: https://github.com/jqlang/jq/releases/download/jq-1.8.2/jq-windows-arm64.exe
  InstallerSha256: 083B5377392BC57CF27052B6D20A2D927770683BCA844632901FF38B4B7B0AC7
```

The hash matches the `sha256sum.txt` published with the release, and the binary is confirmed to be a native ARM64 PE (`PE32+ executable ... ARM64`).

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` (validation succeeded)
- [x] Tested manifest locally with `winget install --manifest <path>` on Windows 11 ARM64 hardware — winget selected the new arm64 installer, hash verified, `jq` alias created and functional (`jq-1.8.2`), and uninstall removed the portable link and package cleanly
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/410434)
