### PR TITLE
New version: Ironship.WordHunter version 1.0.8

### DIFF
--- a/manifests/i/Ironship/WordHunter/1.0.8/Ironship.WordHunter.installer.yaml
+++ b/manifests/i/Ironship/WordHunter/1.0.8/Ironship.WordHunter.installer.yaml
@@ -1,0 +1,30 @@
+# Created with WinGet manifest tools
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Ironship.WordHunter
+PackageVersion: 1.0.8
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+Scope: machine
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+ProductCode: Word Hunter
+ReleaseDate: 2026-07-23
+AppsAndFeaturesEntries:
+- DisplayName: Word Hunter
+  Publisher: wordhunter
+  DisplayVersion: 1.0.8
+  ProductCode: Word Hunter
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles%\Word Hunter'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Ironship/WordHunter/releases/download/WordHunter1.0.8/Word.Hunter.Setup.exe
+  InstallerSha256: 88A7CEFFB161F1D50B19430A3D7CB55E409CC028F921C527DEE09A09014E13DD
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/i/Ironship/WordHunter/1.0.8/Ironship.WordHunter.locale.en-US.yaml
+++ b/manifests/i/Ironship/WordHunter/1.0.8/Ironship.WordHunter.locale.en-US.yaml
@@ -1,0 +1,36 @@
+# Created with WinGet manifest tools
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Ironship.WordHunter
+PackageVersion: 1.0.8
+PackageLocale: en-US
+Publisher: Ironship
+PublisherUrl: https://github.com/Ironship
+PublisherSupportUrl: https://github.com/Ironship/WordHunter/issues
+Author: Ironship
+PackageName: Word Hunter
+PackageUrl: https://github.com/Ironship/WordHunter
+License: AGPL-3.0-or-later
+LicenseUrl: https://github.com/Ironship/WordHunter/blob/WordHunter1.0.8/LICENSE
+ShortDescription: Local-first reader and spaced repetition tool for language learning
+Description: |-
+  Word Hunter is a desktop reader and vocabulary-learning workspace. It can
+  import texts, ebooks, subtitles and PDFs, save words with their context, and
+  review them with flashcards and spaced repetition. Data is stored locally.
+Moniker: wordhunter
+Tags:
+- ebook
+- flashcard
+- language-learning
+- ocr
+- reader
+- spaced-repetition
+- vocabulary
+ReleaseNotes: |-
+  Made later vocabulary status decisions win reliably across devices.
+  Added a safe deterministic fallback for older vocabulary records.
+  Shortened Android startup and made library loading lighter.
+  Restricted Android cleartext traffic to the local Word Hunter backend.
+ReleaseNotesUrl: https://github.com/Ironship/WordHunter/releases/tag/WordHunter1.0.8
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/i/Ironship/WordHunter/1.0.8/Ironship.WordHunter.yaml
+++ b/manifests/i/Ironship/WordHunter/1.0.8/Ironship.WordHunter.yaml
@@ -1,0 +1,8 @@
+# Created with WinGet manifest tools
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Ironship.WordHunter
+PackageVersion: 1.0.8
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Updates Ironship.WordHunter from 1.0.6 to the current stable 1.0.8 release. The installer URL and SHA-256 match the GitHub release asset. Validated locally with winget validate.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/410469)