### PR TITLE
New package: Doctordefector.MetrolistDesktop version 2.9.2

### DIFF
--- a/manifests/d/Doctordefector/MetrolistDesktop/2.9.2/Doctordefector.MetrolistDesktop.installer.yaml
+++ b/manifests/d/Doctordefector/MetrolistDesktop/2.9.2/Doctordefector.MetrolistDesktop.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Doctordefector.MetrolistDesktop
+PackageVersion: 2.9.2
+InstallerType: zip
+NestedInstallerType: portable
+MinimumOSVersion: 10.0.0.0
+ReleaseDate: 2026-07-25
+Installers:
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: Metrolist/Metrolist.exe
+    PortableCommandAlias: metrolist
+  InstallerUrl: https://github.com/Doctordefector/Metrolist-Desktop/releases/download/v2.9.2/Metrolist-2.9.2-portable.zip
+  InstallerSha256: 6F1602574424E45080D51EC5A17B4B4AADF264EEC607CAB184B374AEAB52A87C
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/d/Doctordefector/MetrolistDesktop/2.9.2/Doctordefector.MetrolistDesktop.locale.en-US.yaml
+++ b/manifests/d/Doctordefector/MetrolistDesktop/2.9.2/Doctordefector.MetrolistDesktop.locale.en-US.yaml
@@ -1,0 +1,57 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Doctordefector.MetrolistDesktop
+PackageVersion: 2.9.2
+PackageLocale: en-US
+Publisher: Doctordefector
+PublisherUrl: https://github.com/Doctordefector
+PublisherSupportUrl: https://github.com/Doctordefector/Metrolist-Desktop/issues
+Author: Andrei Chapliuk
+PackageName: Metrolist Desktop
+PackageUrl: https://github.com/Doctordefector/Metrolist-Desktop
+License: GPL-3.0-only
+LicenseUrl: https://github.com/Doctordefector/Metrolist-Desktop/blob/main/LICENSE
+Copyright: Copyright (c) Andrei Chapliuk
+ShortDescription: A free, open source YouTube Music client for Windows. Portable, no installer, no ads.
+Description: |-
+  Metrolist Desktop is a native YouTube Music client for Windows 10 and 11, written in
+  Compose Desktop (JVM). It is not a browser wrapper: it talks to the same InnerTube API
+  the mobile app uses, with its own VLC-based player, local database and sync layer.
+
+  Sign in with your own YouTube account and it plays your real library, with two-way sync
+  of liked songs, albums, artists and playlists. Includes synced lyrics from a five-provider
+  chain, a 10-band equalizer, crossfade, sleep timer, playback speed, gapless queue,
+  downloads, listening stats, Discord Rich Presence, Last.fm scrobbling, Listen Together
+  rooms, music recognition and a system tray mini player.
+
+  It ships as a portable package with the VLC playback engine, ffmpeg and its own Java
+  runtime bundled, so there is nothing else to install. Everything it writes - database,
+  credentials, preferences, cache and downloads - stays inside its own folder.
+
+  Metrolist Desktop is the desktop port of the Metrolist Android app and is not affiliated
+  with YouTube, Google or Alphabet.
+Moniker: metrolist-desktop
+Tags:
+- audio-player
+- desktop-client
+- discord-rich-presence
+- lastfm
+- lyrics
+- metrolist
+- music
+- music-player
+- music-streaming
+- no-ads
+- open-source
+- portable
+- youtube
+- youtube-music
+- ytmusic
+ReleaseNotesUrl: https://github.com/Doctordefector/Metrolist-Desktop/releases/tag/v2.9.2
+Documentations:
+- DocumentLabel: Website
+  DocumentUrl: https://doctordefector.github.io/Metrolist-Desktop/
+- DocumentLabel: Troubleshooting
+  DocumentUrl: https://github.com/Doctordefector/Metrolist-Desktop#troubleshooting
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/d/Doctordefector/MetrolistDesktop/2.9.2/Doctordefector.MetrolistDesktop.yaml
+++ b/manifests/d/Doctordefector/MetrolistDesktop/2.9.2/Doctordefector.MetrolistDesktop.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Doctordefector.MetrolistDesktop
+PackageVersion: 2.9.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package: `Doctordefector.MetrolistDesktop` version 2.9.2.

Metrolist Desktop is a free, open source (GPL-3.0) YouTube Music client for Windows 10 and 11,
written in Compose Desktop (JVM). It is not a browser wrapper — it has its own VLC-based player,
local database and sync layer.

Distributed as a portable ZIP with no installer, so this is submitted as
`InstallerType: zip` + `NestedInstallerType: portable`, with `Metrolist/Metrolist.exe` as the
nested portable file.

- Upstream repo: https://github.com/Doctordefector/Metrolist-Desktop
- Release: https://github.com/Doctordefector/Metrolist-Desktop/releases/tag/v2.9.2
- `InstallerSha256` matches the SHA-256 digest GitHub reports for the published release asset.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
      <!-- Will sign via the CLA bot on this PR. -->
- [ ] Linked to an issue (if applicable) — n/a, new package submission

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` — `Manifest validation succeeded.`
- [x] Tested manifest locally with `winget install --manifest <path>` — not run locally; happy to
      run it and report back if a moderator would like that before merge.
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/410566)