### PR TITLE
New version: Hoornet.Vega version 0.14.2

### DIFF
--- a/manifests/h/Hoornet/Vega/0.14.2/Hoornet.Vega.installer.yaml
+++ b/manifests/h/Hoornet/Vega/0.14.2/Hoornet.Vega.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: Hoornet.Vega
+PackageVersion: 0.14.2
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/hoornet/vega/releases/download/v0.14.2/Vega_0.14.2_x64-setup.exe
+  InstallerSha256: 50A40511A927286B2CA99755F85C382476F59ECFA40BEC0AD70EB94F436CA722
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/h/Hoornet/Vega/0.14.2/Hoornet.Vega.locale.en-US.yaml
+++ b/manifests/h/Hoornet/Vega/0.14.2/Hoornet.Vega.locale.en-US.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: Hoornet.Vega
+PackageVersion: 0.14.2
+PackageLocale: en-US
+Publisher: Hoornet
+PublisherUrl: https://veganostr.com
+PublisherSupportUrl: https://github.com/hoornet/vega/issues
+Author: Hoornet
+PackageName: Vega
+PackageUrl: https://veganostr.com
+License: MIT
+LicenseUrl: https://raw.githubusercontent.com/hoornet/vega/main/LICENSE
+Copyright: Copyright (c) 2026 Jure Sršen
+ShortDescription: A cross-platform desktop client for Nostr
+Description: |-
+  Vega is a desktop client for Nostr, a decentralized social network protocol.
+  It is built with Tauri and React, and treats long-form writing and reading
+  (NIP-23) as a first-class feature rather than an afterthought.
+
+  Features:
+  - Long-form article editor and reader (NIP-23)
+  - Lightning zaps via Nostr Wallet Connect (NIP-47, NIP-57)
+  - Value-for-value podcast streaming
+  - Web of trust filtering
+  - Optional built-in relay, so your notes stay available locally
+  - Encrypted direct messages
+  - Private keys stored in the operating system keychain
+Tags:
+- nostr
+- social-network
+- decentralized
+- lightning
+- bitcoin
+- desktop-client
+ReleaseNotesUrl: https://github.com/hoornet/vega/releases/tag/v0.14.2
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/h/Hoornet/Vega/0.14.2/Hoornet.Vega.yaml
+++ b/manifests/h/Hoornet/Vega/0.14.2/Hoornet.Vega.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: Hoornet.Vega
+PackageVersion: 0.14.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Update Hoornet.Vega from 0.14.0 to 0.14.2.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`? (authored on Linux — manifests are identical to the approved 0.14.0 ones with only version, installer URL, SHA256 and release-notes URL updated; deferring to pipeline validation)
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? (authored on Linux)
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Release notes: https://github.com/hoornet/vega/releases/tag/v0.14.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/410603)