### PR TITLE
Add 0state.scafld 2.5.3

### DIFF
--- a/manifests/0/0state/scafld/2.5.3/0state.scafld.installer.yaml
+++ b/manifests/0/0state/scafld/2.5.3/0state.scafld.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: 0state.scafld
+PackageVersion: 2.5.3
+InstallerLocale: en-US
+InstallerType: portable
+Commands:
+  - scafld
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/nilstate/scafld/releases/download/v2.5.3/scafld_2.5.3_windows_amd64.exe
+    InstallerSha256: b2796ab61fe9a1943d43dd25a6b81c7b13b13105b2d01e2d09f9f6cc1450b685
+  - Architecture: arm64
+    InstallerUrl: https://github.com/nilstate/scafld/releases/download/v2.5.3/scafld_2.5.3_windows_arm64.exe
+    InstallerSha256: 9cea1fe0e981e0348f00bce16f7de8315a332644fa0520bb557d2c3d5af9ad81
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/0/0state/scafld/2.5.3/0state.scafld.locale.en-US.yaml
+++ b/manifests/0/0state/scafld/2.5.3/0state.scafld.locale.en-US.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: 0state.scafld
+PackageVersion: 2.5.3
+PackageLocale: en-US
+Publisher: 0state
+PublisherUrl: https://0state.com
+PackageName: scafld
+License: MIT
+ShortDescription: Deterministic protocol for multi-phase agent work.
+PackageUrl: https://0state.com/scafld
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/0/0state/scafld/2.5.3/0state.scafld.yaml
+++ b/manifests/0/0state/scafld/2.5.3/0state.scafld.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: 0state.scafld
+PackageVersion: 2.5.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Updates 0state.scafld to 2.5.3. Manifests were staged with scripts/prepare-winget-submission.sh from the published nilstate/scafld v2.5.3 release artifact and verified against the release checksums.txt.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/410678)