### PR TITLE
New version: ynjmxn.Gengchou version 2.4.0

### DIFF
--- a/manifests/y/ynjmxn/Gengchou/2.4.0/ynjmxn.Gengchou.installer.yaml
+++ b/manifests/y/ynjmxn/Gengchou/2.4.0/ynjmxn.Gengchou.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ynjmxn.Gengchou
+PackageVersion: '2.4.0'
+Platform:
+- Windows.Desktop
+InstallerType: zip
+NestedInstallerType: portable
+ReleaseDate: '2026-08-01'
+Installers:
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: gengchou.exe
+    PortableCommandAlias: gengchou
+  InstallerUrl: https://github.com/ynjmxn/gengchou/releases/download/v2.4.0/gengchou-windows-x64.zip
+  InstallerSha256: AD49614C24BC7C63303F0DFC61D732A353A53571157242A4D944972050A58F92
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/y/ynjmxn/Gengchou/2.4.0/ynjmxn.Gengchou.locale.en-US.yaml
+++ b/manifests/y/ynjmxn/Gengchou/2.4.0/ynjmxn.Gengchou.locale.en-US.yaml
@@ -1,0 +1,44 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ynjmxn.Gengchou
+PackageVersion: '2.4.0'
+PackageLocale: en-US
+Publisher: ynjmxn
+PublisherUrl: https://github.com/ynjmxn
+PrivacyUrl: https://github.com/ynjmxn/gengchou/blob/v2.4.0/README.md#data--privacy
+Author: Craig Constable, Jianxin Yin, and contributors
+PackageName: Gengchou
+PackageUrl: https://github.com/ynjmxn/gengchou
+License: MIT
+LicenseUrl: https://github.com/ynjmxn/gengchou/blob/v2.4.0/LICENSE
+Copyright: Copyright (C) 2025 Craig Constable; modifications Copyright (C) 2026 Jianxin Yin
+CopyrightUrl: https://github.com/ynjmxn/gengchou/blob/v2.4.0/LICENSE
+ShortDescription: A Windows taskbar and tray AI quota monitor for Claude, Codex, and Antigravity.
+Description: >-
+  Gengchou is a lightweight native Windows taskbar widget and system-tray app
+  for viewing the quota windows reported by Claude, Codex, and Google
+  Antigravity without opening a provider dashboard. On first start it asks once
+  for permission, then detects which providers are signed in on this machine
+  and shows only those. Nothing is read before permission is granted, and
+  access can be revoked per provider at any time. It has no analytics,
+  telemetry, or separate backend service, and it does not store provider
+  tokens.
+Moniker: gengchou
+Tags:
+- antigravity
+- claude-code
+- codex
+- remote-desktop
+- rust
+- system-tray
+- taskbar
+- usage-monitor
+- windows
+ReleaseNotes: Replaces the per-provider first-run prompts with a single permission prompt covering every provider, then detects and shows only the providers signed in on this machine. Existing installations keep their current selection and are never prompted again. Adds a "Not detected" state distinct from "Authentication failed", periodic and on-demand provider detection, and reads Codex and Antigravity credentials from already-running WSL distributions.
+ReleaseNotesUrl: https://github.com/ynjmxn/gengchou/releases/tag/v2.4.0
+InstallationNotes: WinGet portable packages do not create a Start menu shortcut. Open a new terminal and run "gengchou", then answer the one-time permission prompt that covers every provider. Access can be revoked for a single provider later under "Provider access"; optionally enable "Start with Windows" from the app context menu.
+Documentations:
+- DocumentLabel: README
+  DocumentUrl: https://github.com/ynjmxn/gengchou/blob/v2.4.0/README.md
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/y/ynjmxn/Gengchou/2.4.0/ynjmxn.Gengchou.locale.zh-CN.yaml
+++ b/manifests/y/ynjmxn/Gengchou/2.4.0/ynjmxn.Gengchou.locale.zh-CN.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: ynjmxn.Gengchou
+PackageVersion: '2.4.0'
+PackageLocale: zh-CN
+Publisher: ynjmxn
+PackageName: 更筹 Gengchou
+License: MIT
+ShortDescription: 面向 Windows 的 Claude、Codex 和 Antigravity 配额监视器，提供任务栏组件、浮窗和托盘图标。
+Description: >-
+  更筹是轻量级原生 Windows 任务栏组件与系统托盘应用，无需打开服务商控制台
+  即可查看 Claude、Codex 和 Google Antigravity 实际报告的配额窗口。
+  首次启动只请求一次授权，随后探测本机有哪些服务商已登录，并只显示探测到的。
+  未获授权前不读取任何凭据，且可随时按服务商单独撤销。
+  应用不包含分析、遥测或独立后端服务，也不会保存服务商令牌。
+ReleaseNotes: 以一次性授权替代逐个服务商弹窗，授权后自动探测并只显示本机已登录的服务商；从旧版本升级不会再次弹框，现有选择原样保留。新增“未检测到”状态以区别于“认证失败”，支持定期与手动重新探测，并可从已在运行的 WSL 发行版读取 Codex 与 Antigravity 凭据。
+InstallationNotes: WinGet 的 portable 包不会创建开始菜单快捷方式。安装后请在新终端中运行“gengchou”，并回答那一次覆盖全部服务商的授权提示；之后可在“服务商访问权限”菜单中按服务商单独撤销。如需开机启动，可在应用右键菜单中启用“Start with Windows”。
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/y/ynjmxn/Gengchou/2.4.0/ynjmxn.Gengchou.yaml
+++ b/manifests/y/ynjmxn/Gengchou/2.4.0/ynjmxn.Gengchou.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ynjmxn.Gengchou
+PackageVersion: '2.4.0'
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds `ynjmxn.Gengchou` version **2.4.0**. The currently published version is 2.3.4.

Release: https://github.com/ynjmxn/gengchou/releases/tag/v2.4.0

Besides the version, installer URL, SHA-256 and release date, this update also revises the locale manifests. 2.4.0 replaces the per-provider first-run prompts with a single one-time permission prompt followed by provider detection, so the previous `Description` and `InstallationNotes` no longer describe how the package actually behaves. The tag-pinned license, privacy, README and release-notes URLs move from `v2.3.4` to `v2.4.0`.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

`winget install --manifest` was not run, because it requires the administrator-only `LocalManifestFiles` setting on the submitting machine. The inputs it would exercise were verified directly instead: the installer URL was downloaded from the public release, its SHA-256 recomputed and matched against the manifest byte for byte, and the archive confirmed to contain `gengchou.exe` at the declared `RelativeFilePath`.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/410790)