### PR TITLE
New version: CaptainKillSwitch.CaptainKillSwitch version 0.4.0

### DIFF
--- a/manifests/c/CaptainKillSwitch/CaptainKillSwitch/0.4.0/CaptainKillSwitch.CaptainKillSwitch.installer.yaml
+++ b/manifests/c/CaptainKillSwitch/CaptainKillSwitch/0.4.0/CaptainKillSwitch.CaptainKillSwitch.installer.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: CaptainKillSwitch.CaptainKillSwitch
+PackageVersion: 0.4.0
+InstallerLocale: en-US
+InstallerType: wix
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{E35A4D83-8FD2-4FC0-8347-C97E8286EBDC}'
+ReleaseDate: 2026-08-01
+AppsAndFeaturesEntries:
+- Publisher: Captain Kill Switch Team
+  ProductCode: '{E35A4D83-8FD2-4FC0-8347-C97E8286EBDC}'
+  UpgradeCode: '{984FC5FB-4BE0-5465-85FF-3FDCFED283B5}'
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles%/Captain Kill Switch'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/captainkillswitch/downloads/releases/download/v0.4.0/captain-kill-switch-0.4.0-windows-x64.msi
+  InstallerSha256: 7AD647E27D4BFC8BD68539919787D6573FDF9C2FA4115A5E90C7112E876B47B6
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/CaptainKillSwitch/CaptainKillSwitch/0.4.0/CaptainKillSwitch.CaptainKillSwitch.locale.en-US.yaml
+++ b/manifests/c/CaptainKillSwitch/CaptainKillSwitch/0.4.0/CaptainKillSwitch.CaptainKillSwitch.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: CaptainKillSwitch.CaptainKillSwitch
+PackageVersion: 0.4.0
+PackageLocale: en-US
+Publisher: Captain Kill Switch Team
+PublisherUrl: https://captainkillswitch.com/
+PublisherSupportUrl: https://github.com/captainkillswitch/downloads/issues
+Author: Captain Kill Switch Team
+PackageName: Captain Kill Switch
+PackageUrl: https://captainkillswitch.com/
+License: Proprietary (free)
+LicenseUrl: https://captainkillswitch.com/about
+Copyright: Copyright (c) 2026 Captain Kill Switch Team
+ShortDescription: Close every running application in one click from the system tray.
+Description: Captain Kill Switch is a free system-tray utility that closes every running application in one click - a clean close request first, then a firm stop within two seconds. An allowlist model protects Windows system and session processes. Tiny native app, auto-updates, 10 languages. Anonymous usage statistics only; see https://captainkillswitch.com/privacy.
+Moniker: captain-kill-switch
+ReleaseNotes: |-
+  Windows: the app no longer needs the WebView2 runtime at all. The tray is
+  now a native Windows implementation, so machines without (or with a broken)
+  WebView2 runtime start correctly instead of failing silently.
+  - Same tray menu, kill behavior, exclusions and two-second force floor.
+  - Installs upgrade in place; auto-update from 0.3.x works unchanged.
+  - macOS: the installer now correctly states the macOS 10.15 minimum.
+ReleaseNotesUrl: https://github.com/captainkillswitch/downloads/releases/tag/v0.4.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/CaptainKillSwitch/CaptainKillSwitch/0.4.0/CaptainKillSwitch.CaptainKillSwitch.yaml
+++ b/manifests/c/CaptainKillSwitch/CaptainKillSwitch/0.4.0/CaptainKillSwitch.CaptainKillSwitch.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: CaptainKillSwitch.CaptainKillSwitch
+PackageVersion: 0.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
New version of an existing package, based byte-for-byte on the accepted 0.3.3 manifests (PR #410322).

What changed in the app: the Windows build no longer depends on the WebView2 runtime (native tray implementation). Installer is still a WiX MSI, same UpgradeCode, same install location, machine scope — existing installs upgrade in place.

Verified without a Windows machine (no local winget validate/install run, deliberately left unticked):
- InstallerSha256 recomputed locally from the downloaded MSI and cross-checked against the release's SHA256SUMS.txt.
- ProductCode read from the MSI with the same extraction method that reproduces 0.3.3's accepted ProductCode exactly.
- UpgradeCode unchanged from 0.3.3 and verified present in the new MSI.
- AppsAndFeaturesEntries.Publisher updated to match the new MSI's actual Manufacturer property ("Captain Kill Switch Team").
- Manifests otherwise mirror the accepted 0.3.3 set.

- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://learn.microsoft.com/windows/package-manager/package/manifest?tabs=minschema%2Cversion-example)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/410806)