### PR TITLE
New package: fileworks.unpacksort version 1.1.0

### DIFF
--- a/manifests/f/fileworks/unpacksort/1.1.0/fileworks.unpacksort.installer.yaml
+++ b/manifests/f/fileworks/unpacksort/1.1.0/fileworks.unpacksort.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: fileworks.unpacksort
+PackageVersion: "1.1.0"
+InstallerType: zip
+NestedInstallerType: portable
+Installers:
+  - Architecture: x64
+    InstallerUrl: "https://github.com/fileworks/unpacksort/releases/download/v1.1.0/unpacksort-1.1.0-windows-x64.zip"
+    InstallerSha256: "9B15AD1AB429C17E9DF153570C6A3F1796F975AB5F71C39DD37D7C8C827B64C2"
+    NestedInstallerFiles:
+      - RelativeFilePath: unpacksort-1.1.0-windows-x64\unpacksort.exe
+        PortableCommandAlias: unpacksort
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/fileworks/unpacksort/1.1.0/fileworks.unpacksort.locale.en-US.yaml
+++ b/manifests/f/fileworks/unpacksort/1.1.0/fileworks.unpacksort.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: fileworks.unpacksort
+PackageVersion: "1.1.0"
+PackageLocale: en-US
+Publisher: fileworks
+PublisherUrl: https://github.com/fileworks
+PackageName: unpacksort
+PackageUrl: https://github.com/fileworks/unpacksort
+License: MIT
+LicenseUrl: https://github.com/fileworks/unpacksort/blob/main/LICENSE
+ShortDescription: Safely recover and organize nested mail and archive content.
+Tags:
+  - archive
+  - cli
+  - email
+  - mbox
+  - recovery
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/fileworks/unpacksort/1.1.0/fileworks.unpacksort.yaml
+++ b/manifests/f/fileworks/unpacksort/1.1.0/fileworks.unpacksort.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: fileworks.unpacksort
+PackageVersion: "1.1.0"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
- [x] I have signed the Contributor License Agreement (CLA), if required by the bot.
- [x] The installer URL is the immutable official fileworks/unpacksort v1.1.0 GitHub Release asset.
- [x] The x64 ZIP SHA-256, nested executable path, package identifier, and portable command alias were verified after publication.
- [x] This pull request contains one package version only.

The portable executable is intentionally unsigned for this initial release; the upstream release documents the expected SmartScreen warning and publishes SHA256SUMS.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/410897)