### PR TITLE
New package: Overwatchobs.OverwatchHelper version 0.8.9

### DIFF
--- a/manifests/o/Overwatchobs/OverwatchHelper/0.8.9/Overwatchobs.OverwatchHelper.installer.yaml
+++ b/manifests/o/Overwatchobs/OverwatchHelper/0.8.9/Overwatchobs.OverwatchHelper.installer.yaml
@@ -1,0 +1,20 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Overwatchobs.OverwatchHelper
+PackageVersion: 0.8.9
+InstallerType: wix
+Scope: user
+InstallModes:
+  - silent
+  - silentWithProgress
+  - interactive
+InstallerSwitches:
+  Silent: "/qn"
+  SilentWithProgress: "/qb"
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/overwatchobs/helper-releases/releases/download/v0.8.9/overwatch-helper-windows-x86_64-0.8.9.msi
+  InstallerSha256: DB17E00DEE7245A4F1AF7993DF797796C98B125FA444AEB94D22B4E59D2DEE79
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/o/Overwatchobs/OverwatchHelper/0.8.9/Overwatchobs.OverwatchHelper.locale.en-US.yaml
+++ b/manifests/o/Overwatchobs/OverwatchHelper/0.8.9/Overwatchobs.OverwatchHelper.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Overwatchobs.OverwatchHelper
+PackageVersion: 0.8.9
+PackageLocale: en-US
+Publisher: Overwatch Observability LLC
+PublisherUrl: https://www.overwatch-observability.com
+PublisherSupportUrl: https://github.com/overwatchobs/helper-releases/issues
+PackageName: Overwatch Helper
+PackageUrl: https://github.com/overwatchobs/helper-releases
+License: MIT
+LicenseUrl: https://github.com/overwatchobs/helper-releases/blob/main/README.md
+ShortDescription: Local desktop agent for the Overwatch incident-resolution Chrome extension. Registers as a Chrome Native Messaging host and executes allowlisted diagnostic commands on request.
+ReleaseNotesUrl: https://github.com/overwatchobs/helper-releases/releases/tag/v0.8.9
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/o/Overwatchobs/OverwatchHelper/0.8.9/Overwatchobs.OverwatchHelper.locale.en-US.yaml
+++ b/manifests/o/Overwatchobs/OverwatchHelper/0.8.9/Overwatchobs.OverwatchHelper.locale.en-US.yaml
@@ -10,7 +10,7 @@ PublisherSupportUrl: https://github.com/overwatchobs/helper-releases/issues
 PackageName: Overwatch Helper
 PackageUrl: https://github.com/overwatchobs/helper-releases
 License: MIT
-LicenseUrl: https://github.com/overwatchobs/helper-releases/blob/main/README.md
+LicenseUrl: https://github.com/overwatchobs/helper-releases/blob/main/LICENSE
 ShortDescription: Local desktop agent for the Overwatch incident-resolution Chrome extension. Registers as a Chrome Native Messaging host and executes allowlisted diagnostic commands on request.
 ReleaseNotesUrl: https://github.com/overwatchobs/helper-releases/releases/tag/v0.8.9
 ManifestType: defaultLocale

--- a/manifests/o/Overwatchobs/OverwatchHelper/0.8.9/Overwatchobs.OverwatchHelper.yaml
+++ b/manifests/o/Overwatchobs/OverwatchHelper/0.8.9/Overwatchobs.OverwatchHelper.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Overwatchobs.OverwatchHelper
+PackageVersion: 0.8.9
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Manifest
Overwatchobs.OverwatchHelper 0.8.9 — per-user MSI, x64.

This resubmits #395774 (closed as stale) with the **installer moved to GitHub Releases** to resolve the `Validation-Domain` feedback from @stephengillie.

**What changed and why:** the previous submission hosted the installer on `packages.buildkite.com`, and the navigate-from-`PackageUrl`-to-`InstallerUrl` check couldn't be satisfied — that registry's browsable pages are a third-party sign-up form with nothing tying them to us. The installer is now published to a public GitHub releases repo we own, so the chain is directly verifiable:

`PackageUrl` → https://github.com/overwatchobs/helper-releases → [Releases](https://github.com/overwatchobs/helper-releases/releases/tag/v0.8.9) → `InstallerUrl`

`PublisherUrl` remains https://www.overwatch-observability.com, and the repo README identifies the publisher and links back to the product site.

The binary is byte-identical to the one that already passed validation on #395774 (SHA256 `DB17E00D…9D2DEE79`, unchanged) — that run reported `Azure-Pipeline-Passed` with Installation Validation and the AntiMalware/Guardian scans all succeeding.

- [x] Installer is silent (`/qn`) and per-user (`Scope: user`) — installs to `%LocalAppData%\Overwatchobs\OverwatchHelper`, no elevation
- [x] Installer URL is anonymously downloadable and hash-verified
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/410901)