### PR TITLE
New package: ContextEngine.ContextEngine version 0.1.0

### DIFF
--- a/manifests/c/ContextEngine/ContextEngine/0.1.0/ContextEngine.ContextEngine.installer.yaml
+++ b/manifests/c/ContextEngine/ContextEngine/0.1.0/ContextEngine.ContextEngine.installer.yaml
@@ -1,0 +1,19 @@
+PackageIdentifier: ContextEngine.ContextEngine
+PackageVersion: 0.1.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: "10.0.17763.0"
+Installers:
+- Architecture: x64
+  InstallerType: zip
+  InstallerUrl: "https://github.com/context-engine-app/context-engine-mcp/releases/download/v0.1.0/context-engine-x86_64-pc-windows-msvc.zip"
+  InstallerSha256: "b955e0997209062d0d097263c17817a440eb5796c8b2535c652f6c91a2240dfd"
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: context-engine.exe
+    PortableCommandAlias: context-engine
+  Scope: user
+  Commands:
+  - context-engine
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/ContextEngine/ContextEngine/0.1.0/ContextEngine.ContextEngine.installer.yaml
+++ b/manifests/c/ContextEngine/ContextEngine/0.1.0/ContextEngine.ContextEngine.installer.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
 PackageIdentifier: ContextEngine.ContextEngine
 PackageVersion: 0.1.0
 Platform:
@@ -12,7 +14,6 @@ Installers:
   NestedInstallerFiles:
   - RelativeFilePath: context-engine.exe
     PortableCommandAlias: context-engine
-  Scope: user
   Commands:
   - context-engine
 ManifestType: installer

--- a/manifests/c/ContextEngine/ContextEngine/0.1.0/ContextEngine.ContextEngine.locale.en-US.yaml
+++ b/manifests/c/ContextEngine/ContextEngine/0.1.0/ContextEngine.ContextEngine.locale.en-US.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
 PackageIdentifier: ContextEngine.ContextEngine
 PackageVersion: 0.1.0
 PackageLocale: en-US

--- a/manifests/c/ContextEngine/ContextEngine/0.1.0/ContextEngine.ContextEngine.locale.en-US.yaml
+++ b/manifests/c/ContextEngine/ContextEngine/0.1.0/ContextEngine.ContextEngine.locale.en-US.yaml
@@ -1,0 +1,19 @@
+PackageIdentifier: ContextEngine.ContextEngine
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Context Engine App Ltd
+PublisherUrl: "https://context-engine.app"
+PublisherSupportUrl: "https://github.com/context-engine-app/context-engine-mcp/issues"
+PrivacyUrl: "https://context-engine.app/privacy"
+PackageName: Context Engine
+PackageUrl: "https://context-engine.app"
+License: Proprietary
+LicenseUrl: "https://github.com/context-engine-app/context-engine-mcp/releases/download/v0.1.0/LICENSE"
+ShortDescription: "Context Engine command-line interface"
+Description: "Context Engine command-line interface"
+ReleaseNotesUrl: "https://github.com/context-engine-app/context-engine-mcp/releases/tag/v0.1.0"
+Tags:
+- "context-engine"
+- "mcp"
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/ContextEngine/ContextEngine/0.1.0/ContextEngine.ContextEngine.yaml
+++ b/manifests/c/ContextEngine/ContextEngine/0.1.0/ContextEngine.ContextEngine.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
 PackageIdentifier: ContextEngine.ContextEngine
 PackageVersion: 0.1.0
 DefaultLocale: en-US

--- a/manifests/c/ContextEngine/ContextEngine/0.1.0/ContextEngine.ContextEngine.yaml
+++ b/manifests/c/ContextEngine/ContextEngine/0.1.0/ContextEngine.ContextEngine.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: ContextEngine.ContextEngine
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Summary

Adds `ContextEngine.ContextEngine` version `0.1.0` as an x64 portable ZIP package.

The manifests use the immutable publisher release URL and SHA-256, create the `context-engine` command alias, and link to the proprietary license notice shipped with the release.

## Validation

- Validated all three documents against the pinned WinGet 1.12 schemas and semantic checks.
- Verified the immutable Windows archive SHA-256.
- Verified the public license URL returns HTTP 200.

Upstream Windows validation and install testing remain for this pull request's automation.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/410959)