### PR TITLE
Update HoraceMaxwell.Horosa version 3.6.1 installer hash

### DIFF
--- a/manifests/h/HoraceMaxwell/Horosa/3.6.1/HoraceMaxwell.Horosa.installer.yaml
+++ b/manifests/h/HoraceMaxwell/Horosa/3.6.1/HoraceMaxwell.Horosa.installer.yaml
@@ -16,6 +16,6 @@ ReleaseDate: 2026-08-01
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/Horace-Maxwell/Horosa-Web-App-comprehensively-improved-Windows/releases/download/v3.6.1/Horosa-Setup-3.6.1.exe
-    InstallerSha256: 19EE012091F8C52F07EB274841EAFE29F68C9887566E4AC510B1CBE38548DC1A
+    InstallerSha256: E68D11139560480AB42BE07F6074972E7A4781E3F934BB9DAB9A1FA13903675E
 ManifestType: installer
 ManifestVersion: 1.6.0


### PR DESCRIPTION
The v3.6.1 installer was re-published in place shortly after PR #410859 merged (a user-reported panel crash was fixed on the same version). The manifest therefore pins a stale InstallerSha256 and `winget install` fails verification.

This PR updates only the installer hash (and the release date) to match the currently published asset:

- InstallerSha256: `E68D11139560480AB42BE07F6074972E7A4781E3F934BB9DAB9A1FA13903675E`
- Verified against the published `SHA256SUMS.txt` and the release asset at
  https://github.com/Horace-Maxwell/Horosa-Web-App-comprehensively-improved-Windows/releases/tag/v3.6.1

No other fields changed.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/410967)