### PR TITLE
New version: SosomLab.NexaDir.Portable version 0.13.0

### DIFF
--- a/manifests/s/SosomLab/NexaDir/Portable/0.13.0/SosomLab.NexaDir.Portable.installer.yaml
+++ b/manifests/s/SosomLab/NexaDir/Portable/0.13.0/SosomLab.NexaDir.Portable.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: SosomLab.NexaDir.Portable
+PackageVersion: 0.13.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: portable
+Scope: user
+UpgradeBehavior: install
+ReleaseDate: 2026-08-02
+Commands:
+- nexadir
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/SosomLab/nexa-dir2/releases/download/0.13.0/NexaDir-0.13.0-win-x64.exe
+  InstallerSha256: FE67C2839E94C7E8754A6DB4C7C5DDE2CF02BE0AF11F687F8AB8D9E34CD2AE76
+  PortableCommandAlias: nexadir
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/SosomLab/NexaDir/Portable/0.13.0/SosomLab.NexaDir.Portable.locale.en-US.yaml
+++ b/manifests/s/SosomLab/NexaDir/Portable/0.13.0/SosomLab.NexaDir.Portable.locale.en-US.yaml
@@ -1,0 +1,54 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: SosomLab.NexaDir.Portable
+PackageVersion: 0.13.0
+PackageLocale: en-US
+Publisher: SosomLab
+PublisherUrl: https://sosomlab.com
+PublisherSupportUrl: https://github.com/SosomLab/nexa-dir2/issues
+Author: Sangyong Bae
+PackageName: Nexa Dir (Portable)
+PackageUrl: https://sosomlab.com/apps/nexa-dir/
+License: PolyForm Noncommercial License 1.0.0
+LicenseUrl: https://github.com/SosomLab/nexa-dir2/blob/main/LICENSE.md
+Copyright: Copyright (c) 2026 SosomLab
+CopyrightUrl: https://github.com/SosomLab/nexa-dir2/blob/main/LICENSE.md
+ShortDescription: Lightweight, keyboard-first file explorer for Windows — portable single exe.
+Description: |-
+  Nexa Dir is a lightweight file explorer for Windows, built as a single native
+  executable in pure Rust on the Win32 API — no managed runtime, no UI framework,
+  and no external DLLs beyond the OS inbox set.
+
+  This is the portable edition: one executable, no installer. For the installed
+  edition with Start Menu entries and an uninstaller, see SosomLab.NexaDir.
+
+  Highlights:
+  - Single portable exe under 10 MB, with an idle memory footprint under 30 MB.
+  - Dense, dark, keyboard-first UI designed for fast navigation over the mouse.
+  - Cloud storage in the same window: link an existing OneDrive, Google Drive or
+    Dropbox sync folder, or connect an account directly over OAuth to browse,
+    upload and download without syncing anything to disk.
+  - Virtualized tree and list views that stay smooth over 100k+ entries.
+  - Bulk rename with reusable presets and live preview.
+  - Trilingual UI (English, Korean, and Japanese).
+
+  The portable build keeps its settings and session in a data\ folder created next
+  to the executable, so uninstalling this package removes that data along with it.
+
+  Nexa Dir is free for personal and other noncommercial use under the PolyForm
+  Noncommercial License 1.0.0. Commercial use requires a separate paid license.
+Moniker: nexa-dir-portable
+Tags:
+- explorer
+- file-manager
+- files
+- native
+- portable
+- rust
+- win32
+ReleaseNotesUrl: https://github.com/SosomLab/nexa-dir2/releases/tag/0.13.0
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/SosomLab/nexa-dir2/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/SosomLab/NexaDir/Portable/0.13.0/SosomLab.NexaDir.Portable.yaml
+++ b/manifests/s/SosomLab/NexaDir/Portable/0.13.0/SosomLab.NexaDir.Portable.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: SosomLab.NexaDir.Portable
+PackageVersion: 0.13.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Pull request has been validated with

- [x] Validated manifest locally
- [x] Verified installer URL and SHA256 against the published release

### Notes

Version bump for `SosomLab.NexaDir.Portable` (0.12.0 → 0.13.0).

- Installer: <https://github.com/SosomLab/nexa-dir2/releases/download/0.13.0/NexaDir-0.13.0-win-x64.exe>
- SHA256 matches `SHA256SUMS.txt` published with the release.
- Description updated to mention the new cloud storage support.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/410978)