### PR TITLE
New version: LibreDB.Studio version 0.9.64

### DIFF
--- a/manifests/l/LibreDB/Studio/0.9.64/LibreDB.Studio.installer.yaml
+++ b/manifests/l/LibreDB/Studio/0.9.64/LibreDB.Studio.installer.yaml
@@ -1,0 +1,27 @@
+# Installer manifest template for the winget community repository
+# (microsoft/winget-pkgs), issue #114. Rendered by
+# scripts/render-windows-packaging.mjs from the release SHA256SUMS.
+#
+# InstallerType zip + NestedInstallerType portable needs winget client 1.5+.
+# The zip is FLAT (scripts/lib/pack-standalone-zip.sh), so RelativeFilePath
+# is stable across releases - `wingetcreate update` carries the
+# NestedInstallerFiles list forward by exact-path match.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: LibreDB.Studio
+PackageVersion: "0.9.64"
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: libredb-studio.exe
+    PortableCommandAlias: libredb-studio
+Commands:
+  - libredb-studio
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/libredb/libredb-studio/releases/download/0.9.64/libredb-studio-standalone-0.9.64-win32-x64.zip
+    InstallerSha256: 1acf4318597a454e52c402e7cf561732bc45b79e1f7251770d77d61d919c5896
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/l/LibreDB/Studio/0.9.64/LibreDB.Studio.locale.en-US.yaml
+++ b/manifests/l/LibreDB/Studio/0.9.64/LibreDB.Studio.locale.en-US.yaml
@@ -1,0 +1,43 @@
+# Default-locale manifest template for the winget community repository
+# (microsoft/winget-pkgs), issue #114. Rendered by
+# scripts/render-windows-packaging.mjs with the release version.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: LibreDB.Studio
+PackageVersion: "0.9.64"
+PackageLocale: en-US
+Publisher: LibreDB
+PublisherUrl: https://libredb.org
+PublisherSupportUrl: https://github.com/libredb/libredb-studio/issues
+PackageName: LibreDB Studio
+PackageUrl: https://github.com/libredb/libredb-studio
+License: MIT
+LicenseUrl: https://github.com/libredb/libredb-studio/blob/main/LICENSE
+Copyright: Copyright (c) 2025 LibreDB
+ShortDescription: Web-based SQL IDE for PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, and Redis with AI query assistance.
+Description: |-
+  LibreDB Studio is an open-source, web-based SQL IDE for cloud-native teams.
+  It connects to PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, and
+  Redis, and ships a Monaco-powered editor with AI query assistance, schema
+  browsing, ER diagrams, charts, and import/export tooling. This package
+  installs the standalone server with a bundled Node.js runtime; run
+  `libredb-studio` and open http://127.0.0.1:3000 - the first run prints
+  generated admin credentials to the terminal (zero-config bootstrap).
+Moniker: libredb-studio
+Tags:
+  - database
+  - db
+  - ide
+  - mongodb
+  - mysql
+  - oracle
+  - postgres
+  - postgresql
+  - redis
+  - sql
+  - sqlite
+ReleaseNotesUrl: https://github.com/libredb/libredb-studio/releases/tag/0.9.64
+Documentations:
+  - DocumentLabel: Distribution & Install Guide
+    DocumentUrl: https://github.com/libredb/libredb-studio/blob/main/docs/DISTRIBUTION.md
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/l/LibreDB/Studio/0.9.64/LibreDB.Studio.yaml
+++ b/manifests/l/LibreDB/Studio/0.9.64/LibreDB.Studio.yaml
@@ -1,0 +1,10 @@
+# Version manifest template for the winget community repository
+# (microsoft/winget-pkgs), issue #114. Rendered by
+# scripts/render-windows-packaging.mjs with the release version; see
+# docs/DISTRIBUTION.md ("Windows") for the first-listing flow.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: LibreDB.Studio
+PackageVersion: "0.9.64"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Updates LibreDB Studio from 0.9.59 to 0.9.64. Publisher submission - I maintain the package ([libredb/libredb-studio](https://github.com/libredb/libredb-studio)).

- The only difference from the merged 0.9.59 manifests is the version and the installer digest: same `zip` InstallerType with the nested portable `libredb-studio.exe`, same flat archive layout, same URL shape.
- `InstallerUrl` is the versioned GitHub release asset and `InstallerSha256` comes from the release's published `SHA256SUMS` (`1acf4318597a454e52c402e7cf561732bc45b79e1f7251770d77d61d919c5896`).
- The manifests are rendered from the in-repo templates (`packaging/winget/`) by the project's release tooling. This one is submitted by hand because 0.9.60-0.9.64 shipped while the first listing was still under review; from the next release on, the project's release CI submits update PRs automatically via wingetcreate.

## Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
- [ ] `winget validate` / `winget install --manifest` run locally - not available on the maintainer's Linux workstation. The manifests are byte-identical to the 0.9.59 set that this repository already validated and merged, apart from the version string and the installer digest.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/411077)