### PR TITLE
New version: JairLima.MDWord version 0.1.2

### DIFF
--- a/manifests/j/JairLima/MDWord/0.1.2/JairLima.MDWord.installer.yaml
+++ b/manifests/j/JairLima/MDWord/0.1.2/JairLima.MDWord.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: JairLima.MDWord
+PackageVersion: 0.1.2
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/jairslima/mdword-by-jair-lima/releases/download/v0.1.2/MDWord-0.1.2-Setup.exe
+    InstallerSha256: 4CCD10AF34E7D349C951E8B45F9CC7FE2E781F22AF4C9F1E919D74F74CADF2A5
+    InstallerSwitches:
+      Silent: "/S"
+      SilentWithProgress: "/S"
+FileExtensions:
+  - md
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/j/JairLima/MDWord/0.1.2/JairLima.MDWord.locale.en-US.yaml
+++ b/manifests/j/JairLima/MDWord/0.1.2/JairLima.MDWord.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: JairLima.MDWord
+PackageVersion: 0.1.2
+PackageLocale: en-US
+Publisher: Jair Lima
+PublisherUrl: https://github.com/jairslima
+PublisherSupportUrl: https://github.com/jairslima/mdword-by-jair-lima/issues
+PackageName: MDWord by Jair Lima
+PackageUrl: https://github.com/jairslima/mdword-by-jair-lima
+License: MIT
+LicenseUrl: https://github.com/jairslima/mdword-by-jair-lima/blob/master/LICENSE
+Copyright: Copyright (c) 2026 Jair Lima
+ShortDescription: WYSIWYG Markdown editor with a WordPad-inspired interface
+Description: >-
+  MDWord is a visual Markdown editor built with Electron and a WordPad-style
+  interface. It supports opening, editing, saving, importing and exporting
+  .md files with full WYSIWYG rendering, formatted paste of Markdown content,
+  DOCX/PDF import and export, and scanned PDF OCR. The interface is in
+  Brazilian Portuguese.
+Moniker: mdword
+Tags:
+  - markdown
+  - editor
+  - wysiwyg
+  - writing
+  - docx
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/j/JairLima/MDWord/0.1.2/JairLima.MDWord.yaml
+++ b/manifests/j/JairLima/MDWord/0.1.2/JairLima.MDWord.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: JairLima.MDWord
+PackageVersion: 0.1.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Bumps JairLima.MDWord from 0.1.1 to 0.1.2.

This release fixes an installer bug: the silent-mode (`/S`) NSIS installer previously did not close itself after installation completed (assisted installer, `oneClick: false`), leaving a residual window open indefinitely. Switched to a one-click installer, which now closes automatically after a silent install. This is believed to be the root cause of the `APPINSTALLER_CLI_ERROR_SHELLEXEC_INSTALL_FAILED` / `STATUS_ACCESS_VIOLATION` reported during manual validation of PR #402513 (0.1.1): if the validation VM also runs `/S` and the window never closes, the process may be force-killed, producing a crash-like exit code.

Validated locally:
- `winget validate --manifest` succeeded.
- `winget install --manifest` succeeded (downloaded from the real GitHub release, hash verified, installed cleanly).
- Silent install (`/S`) completes and closes on its own, app launches without crash.

Related: #402513 (still open, for version 0.1.1 — left as-is; this PR supersedes it with a fixed build).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/411082)