### PR TITLE
New version: neyham.AIUsageDashboard version 0.5.0

### DIFF
--- a/manifests/n/neyham/AIUsageDashboard/0.5.0/neyham.AIUsageDashboard.installer.yaml
+++ b/manifests/n/neyham/AIUsageDashboard/0.5.0/neyham.AIUsageDashboard.installer.yaml
@@ -1,0 +1,29 @@
+# Created with WinGet manifest schema 1.12.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: neyham.AIUsageDashboard
+PackageVersion: 0.5.0
+InstallerLocale: en-US
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+UpgradeBehavior: install
+ReleaseDate: 2026-08-02
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/neyham/ai-usage-dashboard/releases/download/v0.5.0/AI-Usage-Dashboard_0.5.0_x64-setup.exe
+    InstallerSha256: 8A0D0D4BA6F54D2DBA491949D46D09A710C3B9BD4646595ACF62F66583B011F5
+    AppsAndFeaturesEntries:
+      - DisplayName: AI Usage Dashboard
+        DisplayVersion: 0.5.0
+        Publisher: neyham
+        ProductCode: AI Usage Dashboard
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/n/neyham/AIUsageDashboard/0.5.0/neyham.AIUsageDashboard.locale.en-US.yaml
+++ b/manifests/n/neyham/AIUsageDashboard/0.5.0/neyham.AIUsageDashboard.locale.en-US.yaml
@@ -1,0 +1,36 @@
+# Created with WinGet manifest schema 1.12.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: neyham.AIUsageDashboard
+PackageVersion: 0.5.0
+PackageLocale: en-US
+Publisher: neyham
+PublisherUrl: https://github.com/neyham
+PublisherSupportUrl: https://github.com/neyham/ai-usage-dashboard/issues
+Author: neyham
+PackageName: AI Usage Dashboard
+PackageUrl: https://github.com/neyham/ai-usage-dashboard
+License: MIT
+LicenseUrl: https://github.com/neyham/ai-usage-dashboard/blob/v0.5.0/LICENSE
+Copyright: Copyright (c) 2026 neyham
+ShortDescription: Local Windows dashboard for Claude Code, Codex, Grok Build, and DeepSeek usage.
+Description: |-
+  AI Usage Dashboard is a local-first Windows desktop dashboard and screensaver
+  for viewing Claude Code, Codex, and Grok Build usage windows alongside a
+  DeepSeek API balance. Display Settings provide a write-only DeepSeek API key
+  field, while credentials and provider requests stay in the native Rust
+  backend; the renderer receives sanitized usage summaries only. The project
+  has no developer-operated server, analytics, or telemetry.
+Moniker: ai-usage-dashboard
+Tags:
+  - ai
+  - claude
+  - claude-code
+  - codex
+  - dashboard
+  - deepseek
+  - grok
+  - usage
+ReleaseNotesUrl: https://github.com/neyham/ai-usage-dashboard/releases/tag/v0.5.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/n/neyham/AIUsageDashboard/0.5.0/neyham.AIUsageDashboard.yaml
+++ b/manifests/n/neyham/AIUsageDashboard/0.5.0/neyham.AIUsageDashboard.yaml
@@ -1,0 +1,8 @@
+# Created with WinGet manifest schema 1.12.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: neyham.AIUsageDashboard
+PackageVersion: 0.5.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

- Update neyham.AIUsageDashboard from 0.4.0 to 0.5.0
- Installer URL points to the published v0.5.0 NSIS asset
- Installer SHA-256 was obtained from the GitHub Release asset digest

## Validation

- Three manifest files use schema 1.12.0
- PackageVersion, ReleaseNotesUrl, installer URL, and DisplayVersion are aligned to 0.5.0
- Windows x64 NSIS installer was built and smoke-tested on native Windows before release

Generated from the project release: https://github.com/neyham/ai-usage-dashboard/releases/tag/v0.5.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/411122)