### PR TITLE
New package: JanuaryLabs.Limerence version 0.0.59

### DIFF
--- a/manifests/j/JanuaryLabs/Limerence/0.0.59/JanuaryLabs.Limerence.installer.yaml
+++ b/manifests/j/JanuaryLabs/Limerence/0.0.59/JanuaryLabs.Limerence.installer.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: JanuaryLabs.Limerence
+PackageVersion: 0.0.59
+InstallerType: exe
+Scope: user
+InstallModes:
+- interactive
+- silent
+InstallerSwitches:
+  Silent: --silent
+  SilentWithProgress: --silent
+UpgradeBehavior: install
+ProductCode: limerence
+ReleaseDate: 2026-08-01
+RequireExplicitUpgrade: true
+InstallationMetadata:
+  DefaultInstallLocation: '%LocalAppData%\limerence'
+MinimumOSVersion: 10.0.0.0
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/JanuaryLabs/limerence-desktop-releases/releases/download/v0.0.59/Limerence-Setup.exe
+  InstallerSha256: 52C62A2CEF7D33668D5D1F9DF5D9D02A57C8534F7231C867529D9CD436180806
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/j/JanuaryLabs/Limerence/0.0.59/JanuaryLabs.Limerence.locale.en-US.yaml
+++ b/manifests/j/JanuaryLabs/Limerence/0.0.59/JanuaryLabs.Limerence.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: JanuaryLabs.Limerence
+PackageVersion: 0.0.59
+PackageLocale: en-US
+Publisher: January Labs
+PublisherUrl: https://github.com/JanuaryLabs
+PublisherSupportUrl: https://github.com/JanuaryLabs/limerence-desktop-releases/issues
+PackageName: Limerence
+PackageUrl: https://github.com/JanuaryLabs/limerence-desktop-releases
+License: Proprietary
+Copyright: Copyright (c) 2026 January Labs
+ShortDescription: Ask your databases business questions in plain language.
+Description: |-
+  Limerence turns your databases into a conversational product. Connect your
+  data sources, create AI agents that know your domain terminology and rules,
+  and let anyone on the team ask business questions in plain language and get
+  answers grounded in real data. Self-hosted: runs entirely in your own
+  infrastructure, with the agent sandbox shipped inside the install.
+Moniker: limerence
+Tags:
+- ai
+- database
+- data-analysis
+- postgresql
+- sql
+- sql-server
+- sqlite
+- text-to-sql
+ReleaseNotesUrl: https://github.com/JanuaryLabs/limerence-desktop-releases/releases/tag/v0.0.59
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/j/JanuaryLabs/Limerence/0.0.59/JanuaryLabs.Limerence.yaml
+++ b/manifests/j/JanuaryLabs/Limerence/0.0.59/JanuaryLabs.Limerence.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: JanuaryLabs.Limerence
+PackageVersion: 0.0.59
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
New package submission: Limerence, a self-hosted desktop app that turns your databases into a conversational product (ask business questions in plain language, answers grounded in real data).

- InstallerUrl points at the versioned GitHub release asset; InstallerSha256 computed from the downloaded binary.
- Squirrel.Windows installer: per-user install (no elevation), `--silent` verified in our release CI against this exact Setup.exe.
- `ProductCode: limerence` matches the HKCU uninstall registry key the installer writes.
- `RequireExplicitUpgrade: true` because the app self-updates via Squirrel.
- The installer is currently unsigned (code signing is in progress on our side); SmartScreen behavior is documented in the release notes.

Verification: our release CI (windows-latest) downloads this exact Setup.exe from the release, installs it silently, asserts the installed ProductVersion, and boots the app end-to-end (microVM + health check) before the release is published. SHA256 in the manifest was computed from the downloaded asset.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/411162)