### PR TITLE
New package: AsDecided.AsDecided version 0.26.2

### DIFF
--- a/manifests/a/AsDecided/AsDecided/0.26.2/AsDecided.AsDecided.installer.yaml
+++ b/manifests/a/AsDecided/AsDecided/0.26.2/AsDecided.AsDecided.installer.yaml
@@ -1,0 +1,19 @@
+# Created for As Decided v0.26.2
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: AsDecided.AsDecided
+PackageVersion: 0.26.2
+InstallerType: zip
+NestedInstallerType: portable
+ReleaseDate: "2026-08-01"
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/asdecided/core/releases/download/v0.26.2/asdecided-x86_64-pc-windows-msvc.zip
+    InstallerSha256: 2F95893AFD7516AFE812112582E5B9B6FB01DEFC08EB1F0A86656527D5362FB1
+    NestedInstallerFiles:
+      - RelativeFilePath: decided.exe
+        PortableCommandAlias: decided
+      - RelativeFilePath: decided-mcp.exe
+        PortableCommandAlias: decided-mcp
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/AsDecided/AsDecided/0.26.2/AsDecided.AsDecided.locale.en-US.yaml
+++ b/manifests/a/AsDecided/AsDecided/0.26.2/AsDecided.AsDecided.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# Created for As Decided v0.26.2
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: AsDecided.AsDecided
+PackageVersion: 0.26.2
+PackageLocale: en-US
+Publisher: AsDecided
+PublisherUrl: https://asdecided.com/
+PublisherSupportUrl: https://github.com/asdecided/core/issues
+Author: AsDecided
+PackageName: AsDecided
+PackageUrl: https://github.com/asdecided/core
+License: Apache-2.0
+LicenseUrl: https://github.com/asdecided/core/blob/v0.26.2/LICENSE
+ShortDescription: Engineering decisions your agents can follow.
+Description: >-
+  A local-first decision system that validates, queries, and serves engineering
+  knowledge through the decided CLI and a read-only MCP server.
+Moniker: decided
+Tags:
+  - adr
+  - agent
+  - cli
+  - decisions
+  - developer-tools
+  - mcp
+  - rust
+ReleaseNotesUrl: https://github.com/asdecided/core/releases/tag/v0.26.2
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/AsDecided/AsDecided/0.26.2/AsDecided.AsDecided.yaml
+++ b/manifests/a/AsDecided/AsDecided/0.26.2/AsDecided.AsDecided.yaml
@@ -1,0 +1,8 @@
+# Created for As Decided v0.26.2
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: AsDecided.AsDecided
+PackageVersion: 0.26.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds the first WinGet manifest for `AsDecided.AsDecided`, using the published v0.26.2 Windows x64 portable archive.

The archive is version-specific and published by the project at `asdecided/core`. Its downloaded SHA-256 matches the GitHub Release digest, and the ZIP contains the two declared root executables: `decided.exe` and `decided-mcp.exe`.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)
  - Not applicable for a routine manifest submission.

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for v0.26.2
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` — prepared on macOS; repository CI is the authoritative WinGet validator
- [ ] Tested manifest locally with `winget install --manifest <path>` — no Windows host was available
- [x] Manifest uses the repository's 1.12 multi-file schema and parses as YAML

Authored under my direction with Codex.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/411175)