### PR TITLE
New package: Se7enAI.Ondine version 0.98.19

### DIFF
--- a/manifests/s/Se7enAI/Ondine/0.98.19/Se7enAI.Ondine.installer.yaml
+++ b/manifests/s/Se7enAI/Ondine/0.98.19/Se7enAI.Ondine.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Se7enAI.Ondine
+PackageVersion: 0.98.19
+InstallerLocale: fr-FR
+InstallerType: inno
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/quang101182/ondine-releases/releases/download/v0.98.19/Ondine-Setup-0.98.19.exe
+  InstallerSha256: E7CCABC4F5325DA5A70C8C946BC1142299454233B34ECC517AA6815CCE18E657
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/Se7enAI/Ondine/0.98.19/Se7enAI.Ondine.locale.fr-FR.yaml
+++ b/manifests/s/Se7enAI/Ondine/0.98.19/Se7enAI.Ondine.locale.fr-FR.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Se7enAI.Ondine
+PackageVersion: 0.98.19
+PackageLocale: fr-FR
+Publisher: Se7en AI
+PublisherUrl: https://se7enai.com
+PackageName: Ondine
+PackageUrl: https://se7enai.com
+License: Proprietary
+ShortDescription: Compagne vocale pour Windows - elle parle 6 langues et pilote tes applications a la voix.
+Description: Ondine est une compagne vocale pour Windows. Tu lui parles, elle repond a voix haute en 6 langues (francais, anglais, espagnol, portugais, allemand, italien), pilote tes applications, ouvre de vraies fenetres (YouTube, recherche web, images) et retient notes et rappels. L'application est gratuite et ne demande aucun compte chez nous. Pour reflechir, elle a besoin d'une cle API que tu fournis toi-meme, chez le fournisseur d'IA de ton choix (OpenAI, Anthropic, Google ou Groq) - compte environ 5 dollars une fois, payes directement au fournisseur, sans abonnement. Ondine t'accompagne pas a pas pour la creer au premier lancement.
+Moniker: ondine
+Tags:
+- assistant
+- voice
+- ia
+- windows
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/Se7enAI/Ondine/0.98.19/Se7enAI.Ondine.yaml
+++ b/manifests/s/Se7enAI/Ondine/0.98.19/Se7enAI.Ondine.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Se7enAI.Ondine
+PackageVersion: 0.98.19
+DefaultLocale: fr-FR
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package

- **Package**: `Se7enAI.Ondine`
- **Version**: `0.98.19`
- **Installer**: Inno Setup, user scope, x64
- Manifests validated locally with `winget validate` (Manifest validation succeeded).
- Installer URL is a public GitHub release; the `InstallerSha256` was checked against the file actually served by that URL.

### Note for maintainers

An earlier submission for this package (#404233, version 0.97.1) was **closed by me** on 2026-07-19, on purpose: I had found two blocking defects after opening it, and I did not want that build to reach users through `winget install`. Those defects are fixed, the app has since been through a clean-machine install test, and the download is now open to the public on the vendor site. This is the corrected release.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/add?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-cmd/tree/main/schemas/JSON/manifests/v1.6.0)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/411198)