### PR TITLE
New version: Uncaged.Uncaged version 0.2.9

### DIFF
--- a/manifests/u/Uncaged/Uncaged/0.2.9/Uncaged.Uncaged.installer.yaml
+++ b/manifests/u/Uncaged/Uncaged/0.2.9/Uncaged.Uncaged.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Uncaged.Uncaged
+PackageVersion: 0.2.9
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/getuncaged/uncaged/releases/download/v0.2.9/Uncaged-windows-x86_64-setup.exe
+    InstallerSha256: 3C3CA12AE3758D4C519FECDA8819B5DAB77628F252EB2CEADCDF1670C50D27D4
+  - Architecture: arm64
+    InstallerUrl: https://github.com/getuncaged/uncaged/releases/download/v0.2.9/Uncaged-windows-aarch64-setup.exe
+    InstallerSha256: EF108381529CE47A081BE5359821F82E5B25315A55160D43D7EC6EC717B1A54A
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/u/Uncaged/Uncaged/0.2.9/Uncaged.Uncaged.locale.en-US.yaml
+++ b/manifests/u/Uncaged/Uncaged/0.2.9/Uncaged.Uncaged.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Uncaged.Uncaged
+PackageVersion: 0.2.9
+PackageLocale: en-US
+Publisher: Uncaged
+PublisherUrl: https://getuncaged.dev/
+PublisherSupportUrl: https://github.com/getuncaged/uncaged/issues
+PackageName: Uncaged
+PackageUrl: https://getuncaged.dev/
+License: AGPL-3.0-or-later
+LicenseUrl: https://github.com/getuncaged/uncaged/blob/main/LICENSE-AGPL
+Copyright: Uncaged contributors
+ShortDescription: Account-free, bring-your-own-model fork of the Warp terminal.
+Description: |-
+  Uncaged is an account-free, bring-your-own-model fork of the open-source Warp
+  terminal. It ships with no telemetry, autoupdate, crash reporting, or login,
+  and connects only to the model endpoint you configure.
+Moniker: uncaged
+Tags:
+  - terminal
+  - shell
+  - developer-tools
+  - ai
+  - warp
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/u/Uncaged/Uncaged/0.2.9/Uncaged.Uncaged.yaml
+++ b/manifests/u/Uncaged/Uncaged/0.2.9/Uncaged.Uncaged.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Uncaged.Uncaged
+PackageVersion: 0.2.9
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Manifest for Uncaged.Uncaged version 0.2.9

Updates the existing `Uncaged.Uncaged` package from 0.2.4 to 0.2.9.

These manifests are the **published 0.2.4 manifests** with only three things changed: `PackageVersion`, the two `InstallerUrl`s, and the two `InstallerSha256`s. Nothing else was edited.

Installer SHA256s were computed from the actual published release assets (downloaded and hashed):

| Architecture | Installer | Bytes | SHA256 |
|---|---|---|---|
| x64 | `Uncaged-windows-x86_64-setup.exe` | 132,325,335 | `3C3CA12AE3758D4C519FECDA8819B5DAB77628F252EB2CEADCDF1670C50D27D4` |
| arm64 | `Uncaged-windows-aarch64-setup.exe` | 128,103,126 | `EF108381529CE47A081BE5359821F82E5B25315A55160D43D7EC6EC717B1A54A` |

Release: https://github.com/getuncaged/uncaged/releases/tag/v0.2.9

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

**On the two unchecked boxes — being upfront:** this was prepared from macOS, so `winget validate` and `winget install --manifest` were not run. What *was* verified: the SHA256s are from the real published installers, all three files parse as valid YAML, `ManifestVersion` is unchanged at `1.6.0`, and the base manifests are the ones already merged and validated in #400014. Happy to run the local validation and report back if that's preferred before merge.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/411220)