### PR TITLE
New version: Nihitdev.yoo version 0.9.0

### DIFF
--- a/manifests/n/Nihitdev/yoo/0.9.0/Nihitdev.yoo.installer.yaml
+++ b/manifests/n/Nihitdev/yoo/0.9.0/Nihitdev.yoo.installer.yaml
@@ -1,0 +1,15 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Nihitdev.yoo
+PackageVersion: 0.9.0
+InstallerType: portable
+Commands:
+- yoo
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/nihitdev/yo-cli/releases/download/v0.9.0/yoo-windows-x86_64.exe
+  InstallerSha256: 018DA0CCA4CB9C69FFFC47511E706E1DAA2C573E71885C532D4DF8238201CF3D
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-08-02

--- a/manifests/n/Nihitdev/yoo/0.9.0/Nihitdev.yoo.locale.en-US.yaml
+++ b/manifests/n/Nihitdev/yoo/0.9.0/Nihitdev.yoo.locale.en-US.yaml
@@ -15,8 +15,10 @@ Tags:
 - cargo
 - cli
 - developer-tools
+- environment
 - git
 - productivity
+- project
 - rust
 - terminal
 ReleaseNotesUrl: https://github.com/nihitdev/yo-cli/releases/tag/v0.9.0

--- a/manifests/n/Nihitdev/yoo/0.9.0/Nihitdev.yoo.locale.en-US.yaml
+++ b/manifests/n/Nihitdev/yoo/0.9.0/Nihitdev.yoo.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Nihitdev.yoo
+PackageVersion: 0.9.0
+PackageLocale: en-US
+Publisher: Nihitdev
+PublisherUrl: https://github.com/nihitdev
+PublisherSupportUrl: https://github.com/nihitdev/yo-cli/issues
+PackageName: yoo
+PackageUrl: https://github.com/nihitdev/yo-cli
+License: GPL-3.0
+ShortDescription: Local CLI for project, Git, and development environment information.
+Tags:
+- cargo
+- cli
+- developer-tools
+- git
+- productivity
+- rust
+- terminal
+ReleaseNotesUrl: https://github.com/nihitdev/yo-cli/releases/tag/v0.9.0
+Documentations:
+- DocumentLabel: Documentation
+  DocumentUrl: https://github.com/nihitdev/yo-cli/blob/main/docs/README.md
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/n/Nihitdev/yoo/0.9.0/Nihitdev.yoo.yaml
+++ b/manifests/n/Nihitdev/yoo/0.9.0/Nihitdev.yoo.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Nihitdev.yoo
+PackageVersion: 0.9.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Updates `Nihitdev.yoo` to version `0.9.0`.

- Release: https://github.com/nihitdev/yo-cli/releases/tag/v0.9.0
- Installer: portable Windows x64 executable
- Validation: `winget validate --manifest manifests/n/Nihitdev/yoo/0.9.0`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/411236)