### PR TITLE
New package: NinianLemain.ChaosEngineeringRs version 0.2.1

### DIFF
--- a/manifests/n/NinianLemain/ChaosEngineeringRs/0.2.0/NinianLemain.ChaosEngineeringRs.yaml
+++ b/manifests/n/NinianLemain/ChaosEngineeringRs/0.2.0/NinianLemain.ChaosEngineeringRs.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.singleton.1.12.0.schema.json
+PackageIdentifier: NinianLemain.ChaosEngineeringRs
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: Ninian-Lemain
+PublisherUrl: https://github.com/Ninian-Lemain
+PublisherSupportUrl: https://github.com/Ninian-Lemain/chaos-engineering-rs/issues
+PackageName: chaos-engineering-rs
+PackageUrl: https://github.com/Ninian-Lemain/chaos-engineering-rs
+License: MIT OR Apache-2.0
+LicenseUrl: https://github.com/Ninian-Lemain/chaos-engineering-rs/blob/main/LICENSE-MIT
+ShortDescription: Cross-platform chaos engineering CLI with recovery, SLO gates, and protocol packs.
+Moniker: chaos
+Tags:
+  - chaos-engineering
+  - fault-injection
+  - resilience
+  - slo
+  - testing
+InstallerType: zip
+NestedInstallerType: portable
+Commands:
+  - chaos
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Ninian-Lemain/chaos-engineering-rs/releases/download/v0.2.0/chaos-v0.2.0-x86_64-pc-windows-msvc.zip
+    InstallerSha256: dbe1c43779797f969813e156f37f50be407b29c0330f6fc17b75110c9bf8bd8f
+    NestedInstallerFiles:
+      - RelativeFilePath: chaos.exe
+        PortableCommandAlias: chaos
+ManifestType: singleton
+ManifestVersion: 1.12.0

--- a/manifests/n/NinianLemain/ChaosEngineeringRs/0.2.1/NinianLemain.ChaosEngineeringRs.installer.yaml
+++ b/manifests/n/NinianLemain/ChaosEngineeringRs/0.2.1/NinianLemain.ChaosEngineeringRs.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: NinianLemain.ChaosEngineeringRs
+PackageVersion: 0.2.1
+InstallerType: zip
+NestedInstallerType: portable
+Commands:
+  - chaos
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Ninian-Lemain/chaos-engineering-rs/releases/download/v0.2.1/chaos-v0.2.1-x86_64-pc-windows-msvc.zip
+    InstallerSha256: 6162a286a4090f847d3a05e00e2c88e76334101a097760390b50d9cd465d966f
+    NestedInstallerFiles:
+      - RelativeFilePath: chaos.exe
+        PortableCommandAlias: chaos
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/n/NinianLemain/ChaosEngineeringRs/0.2.1/NinianLemain.ChaosEngineeringRs.locale.en-US.yaml
+++ b/manifests/n/NinianLemain/ChaosEngineeringRs/0.2.1/NinianLemain.ChaosEngineeringRs.locale.en-US.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: NinianLemain.ChaosEngineeringRs
+PackageVersion: 0.2.1
+PackageLocale: en-US
+Publisher: Ninian-Lemain
+PublisherUrl: https://github.com/Ninian-Lemain
+PublisherSupportUrl: https://github.com/Ninian-Lemain/chaos-engineering-rs/issues
+PackageName: chaos-engineering-rs
+PackageUrl: https://github.com/Ninian-Lemain/chaos-engineering-rs
+License: MIT OR Apache-2.0
+LicenseUrl: https://github.com/Ninian-Lemain/chaos-engineering-rs/blob/main/LICENSE-MIT
+ShortDescription: Cross-platform chaos engineering CLI with recovery, SLO gates, and protocol packs.
+Moniker: chaos
+Tags:
+  - chaos-engineering
+  - fault-injection
+  - resilience
+  - slo
+  - testing
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/n/NinianLemain/ChaosEngineeringRs/0.2.1/NinianLemain.ChaosEngineeringRs.yaml
+++ b/manifests/n/NinianLemain/ChaosEngineeringRs/0.2.1/NinianLemain.ChaosEngineeringRs.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.singleton.1.12.0.schema.json
 PackageIdentifier: NinianLemain.ChaosEngineeringRs
-PackageVersion: 0.2.0
+PackageVersion: 0.2.1
 PackageLocale: en-US
 Publisher: Ninian-Lemain
 PublisherUrl: https://github.com/Ninian-Lemain
@@ -23,8 +23,8 @@ Commands:
   - chaos
 Installers:
   - Architecture: x64
-    InstallerUrl: https://github.com/Ninian-Lemain/chaos-engineering-rs/releases/download/v0.2.0/chaos-v0.2.0-x86_64-pc-windows-msvc.zip
-    InstallerSha256: dbe1c43779797f969813e156f37f50be407b29c0330f6fc17b75110c9bf8bd8f
+    InstallerUrl: https://github.com/Ninian-Lemain/chaos-engineering-rs/releases/download/v0.2.1/chaos-v0.2.1-x86_64-pc-windows-msvc.zip
+    InstallerSha256: 6162a286a4090f847d3a05e00e2c88e76334101a097760390b50d9cd465d966f
     NestedInstallerFiles:
       - RelativeFilePath: chaos.exe
         PortableCommandAlias: chaos

--- a/manifests/n/NinianLemain/ChaosEngineeringRs/0.2.1/NinianLemain.ChaosEngineeringRs.yaml
+++ b/manifests/n/NinianLemain/ChaosEngineeringRs/0.2.1/NinianLemain.ChaosEngineeringRs.yaml
@@ -1,32 +1,6 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.singleton.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 PackageIdentifier: NinianLemain.ChaosEngineeringRs
 PackageVersion: 0.2.1
-PackageLocale: en-US
-Publisher: Ninian-Lemain
-PublisherUrl: https://github.com/Ninian-Lemain
-PublisherSupportUrl: https://github.com/Ninian-Lemain/chaos-engineering-rs/issues
-PackageName: chaos-engineering-rs
-PackageUrl: https://github.com/Ninian-Lemain/chaos-engineering-rs
-License: MIT OR Apache-2.0
-LicenseUrl: https://github.com/Ninian-Lemain/chaos-engineering-rs/blob/main/LICENSE-MIT
-ShortDescription: Cross-platform chaos engineering CLI with recovery, SLO gates, and protocol packs.
-Moniker: chaos
-Tags:
-  - chaos-engineering
-  - fault-injection
-  - resilience
-  - slo
-  - testing
-InstallerType: zip
-NestedInstallerType: portable
-Commands:
-  - chaos
-Installers:
-  - Architecture: x64
-    InstallerUrl: https://github.com/Ninian-Lemain/chaos-engineering-rs/releases/download/v0.2.1/chaos-v0.2.1-x86_64-pc-windows-msvc.zip
-    InstallerSha256: 6162a286a4090f847d3a05e00e2c88e76334101a097760390b50d9cd465d966f
-    NestedInstallerFiles:
-      - RelativeFilePath: chaos.exe
-        PortableCommandAlias: chaos
-ManifestType: singleton
+DefaultLocale: en-US
+ManifestType: version
 ManifestVersion: 1.12.0


### PR DESCRIPTION
- Package identifier: `NinianLemain.ChaosEngineeringRs` 
- Package version: `0.2.1` 
- Release: https://github.com/Ninian-Lemain/chaos-engineering-rs/releases/tag/v0.2.1 
- Local validation: `winget validate --manifest NinianLemain.ChaosEngineeringRs.yaml` succeeded with WinGet 1.29.280. 

The installer checksum is generated from the published, attested Windows x64 release archive.