### PR TITLE
New version: InferenceHub.InferenceHub version 0.2.19

### DIFF
--- a/manifests/i/InferenceHub/InferenceHub/0.2.19/InferenceHub.InferenceHub.installer.yaml
+++ b/manifests/i/InferenceHub/InferenceHub/0.2.19/InferenceHub.InferenceHub.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: InferenceHub.InferenceHub
+PackageVersion: 0.2.19
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+ReleaseDate: 2026-07-23
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/InferenceHub/inferencehub-desktop/releases/download/v0.2.19/InferenceHub_0.2.19_x64-setup.exe
+  InstallerSha256: EDC08098D6683589D4D079B88CE088EFE7722EC438A3E78AE768B5797A614E59
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/i/InferenceHub/InferenceHub/0.2.19/InferenceHub.InferenceHub.locale.en-US.yaml
+++ b/manifests/i/InferenceHub/InferenceHub/0.2.19/InferenceHub.InferenceHub.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: InferenceHub.InferenceHub
+PackageVersion: 0.2.19
+PackageLocale: en-US
+Publisher: InferenceHub
+PublisherUrl: https://inferencehub.tech
+PublisherSupportUrl: https://github.com/InferenceHub/inferencehub-desktop/issues
+PackageName: InferenceHub
+PackageUrl: https://github.com/InferenceHub/inferencehub-desktop
+License: Apache-2.0
+LicenseUrl: https://github.com/InferenceHub/inferencehub-desktop/blob/main/LICENSE
+Copyright: Copyright 2026 InferenceHub
+ShortDescription: Native desktop client for InferenceHub chat — frontier and open-weight models with web search and deep research.
+Description: |-
+  InferenceHub Desktop is a lightweight native client for InferenceHub chat.
+  Sign in once with your InferenceHub account and chat with frontier (Claude)
+  and open-weight models, with web search, deep research, and project-file RAG
+  included. Built with Tauri (no bundled Chromium) and ships no telemetry.
+Moniker: inferencehub
+Tags:
+- ai
+- chat
+- claude
+- desktop
+- llm
+- tauri
+ReleaseNotesUrl: https://github.com/InferenceHub/inferencehub-desktop/releases/tag/v0.2.19
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/i/InferenceHub/InferenceHub/0.2.19/InferenceHub.InferenceHub.yaml
+++ b/manifests/i/InferenceHub/InferenceHub/0.2.19/InferenceHub.InferenceHub.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: InferenceHub.InferenceHub
+PackageVersion: 0.2.19
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Version update for InferenceHub.InferenceHub: 0.2.18 -> 0.2.19. Same NSIS x64 per-user installer shape as the initial submission (#404088); only version, InstallerUrl, InstallerSha256, ReleaseDate, and ReleaseNotesUrl changed. Sha256 computed from the downloaded release asset.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/README.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: manifest authored on macOS (same as the initial submission), so the two local winget checks are honestly unchecked — relying on pipeline validation. Binary remains unsigned (code signing in progress); Defender FP review for this app completed previously.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/411248)