### PR TITLE
New version: Peters.Horizon version 0.2.7

### DIFF
--- a/manifests/p/Peters/Horizon/0.2.7/Peters.Horizon.installer.yaml
+++ b/manifests/p/Peters/Horizon/0.2.7/Peters.Horizon.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: Peters.Horizon
+PackageVersion: 0.2.7
+InstallerType: portable
+Commands:
+- horizon
+ReleaseDate: 2026-08-02
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/peters/horizon/releases/download/v0.2.7/horizon-windows-x64.exe
+  InstallerSha256: 98CF142531FDC4E45C118E69C9E2E0206AFD491E0E8B590348D6D863C549193F
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/p/Peters/Horizon/0.2.7/Peters.Horizon.locale.en-US.yaml
+++ b/manifests/p/Peters/Horizon/0.2.7/Peters.Horizon.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: Peters.Horizon
+PackageVersion: 0.2.7
+PackageLocale: en-US
+Publisher: Peter Rekdal Khan-Sunde
+PublisherUrl: https://github.com/peters
+PublisherSupportUrl: https://github.com/peters/horizon/issues
+PackageName: Horizon
+PackageUrl: https://github.com/peters/horizon
+License: MIT
+LicenseUrl: https://github.com/peters/horizon/blob/v0.2.7/LICENSE
+ShortDescription: GPU-accelerated terminal board on an infinite canvas.
+Description: |-
+  Horizon is a GPU-accelerated terminal board for managing multiple terminal sessions as freely positioned, resizable panels on an infinite canvas.
+  It combines workspaces, panel presets, remote hosts, session persistence, and agent-friendly terminal workflows in one desktop app.
+Tags:
+- terminal
+- workspace
+- developer-tools
+ReleaseNotesUrl: https://github.com/peters/horizon/releases/tag/v0.2.7
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/p/Peters/Horizon/0.2.7/Peters.Horizon.yaml
+++ b/manifests/p/Peters/Horizon/0.2.7/Peters.Horizon.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: Peters.Horizon
+PackageVersion: 0.2.7
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
New stable Horizon release submission for WinGet.

- Package identifier: `Peters.Horizon`
- Version: `0.2.7`
- Installer URL: https://github.com/peters/horizon/releases/download/v0.2.7/horizon-windows-x64.exe
- Installer SHA256: `98cf142531fdc4e45c118e69c9e2e0206afd491e0e8b590348d6d863c549193f`

Generated by the Horizon stable release workflow.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/411251)