### PR TITLE
Update panjie.mods to version 4.0.0

### DIFF
--- a/manifests/p/panjie/mods/4.0.0/panjie.mods.installer.yaml
+++ b/manifests/p/panjie/mods/4.0.0/panjie.mods.installer.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: panjie.mods
+PackageVersion: 4.0.0
+InstallerLocale: en-US
+InstallerType: zip
+ReleaseDate: "2026-08-02"
+Installers:
+- Architecture: x64
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: mods_4.0.0_Windows_x86_64\mods.exe
+    PortableCommandAlias: mods
+  InstallerUrl: https://github.com/panjie/mods/releases/download/v4.0.0/mods_4.0.0_Windows_x86_64.zip
+  InstallerSha256: 7147049701caa4ba781ca482cd2cc4ab2349aa77e15bad293b1b5a89ab906713
+  UpgradeBehavior: uninstallPrevious
+- Architecture: arm64
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: mods_4.0.0_Windows_arm64\mods.exe
+    PortableCommandAlias: mods
+  InstallerUrl: https://github.com/panjie/mods/releases/download/v4.0.0/mods_4.0.0_Windows_arm64.zip
+  InstallerSha256: 6bc5d74959b527de033585ace2486297a9a6818bd6b2a080ee523a7194ff33f9
+  UpgradeBehavior: uninstallPrevious
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/p/panjie/mods/4.0.0/panjie.mods.locale.en-US.yaml
+++ b/manifests/p/panjie/mods/4.0.0/panjie.mods.locale.en-US.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: panjie.mods
+PackageVersion: 4.0.0
+PackageLocale: en-US
+Publisher: panjie
+PublisherUrl: https://github.com/panjie
+PublisherSupportUrl: https://github.com/panjie/mods/issues
+PackageName: mods
+PackageUrl: https://github.com/panjie/mods
+License: MIT
+LicenseUrl: https://github.com/panjie/mods/blob/main/LICENSE
+ShortDescription: AI on the command line
+Moniker: mods
+Tags:
+- ai
+- cli
+- llm
+ReleaseNotesUrl: https://github.com/panjie/mods/releases/tag/v4.0.0
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/p/panjie/mods/4.0.0/panjie.mods.yaml
+++ b/manifests/p/panjie/mods/4.0.0/panjie.mods.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: panjie.mods
+PackageVersion: 4.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Update `panjie.mods` manifest from 3.3.0 to 4.0.0.

Validation performed:

- Confirmed both Windows x64 and ARM64 release assets are available from the official v4.0.0 GitHub Release.
- Independently downloaded both ZIP archives and verified their SHA256 checksums against the manifest.
- Confirmed each archive contains `mods.exe` at the configured nested installer path.
- Parsed all three YAML manifests and ran `git diff --check` successfully.

Release: https://github.com/panjie/mods/releases/tag/v4.0.0

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/411254)