### PR TITLE
New version: Ironship.WordHunter version 1.0.9

### DIFF
--- a/manifests/i/Ironship/WordHunter/1.0.9/Ironship.WordHunter.installer.yaml
+++ b/manifests/i/Ironship/WordHunter/1.0.9/Ironship.WordHunter.installer.yaml
@@ -1,0 +1,30 @@
+# Created with WinGet manifest tools
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Ironship.WordHunter
+PackageVersion: 1.0.9
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+Scope: machine
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+ProductCode: Word Hunter
+ReleaseDate: 2026-08-02
+AppsAndFeaturesEntries:
+- DisplayName: Word Hunter
+  Publisher: wordhunter
+  DisplayVersion: 1.0.9
+  ProductCode: Word Hunter
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles%\Word Hunter'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Ironship/WordHunter/releases/download/WordHunter1.0.9/Word.Hunter.Setup.exe
+  InstallerSha256: F2578A78577F0AC01FA53CAF2626F9899485639C8CF92E0FA761BBB636967E23
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/i/Ironship/WordHunter/1.0.9/Ironship.WordHunter.locale.en-US.yaml
+++ b/manifests/i/Ironship/WordHunter/1.0.9/Ironship.WordHunter.locale.en-US.yaml
@@ -1,0 +1,39 @@
+# Created with WinGet manifest tools
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Ironship.WordHunter
+PackageVersion: 1.0.9
+PackageLocale: en-US
+Publisher: Ironship
+PublisherUrl: https://github.com/Ironship
+PublisherSupportUrl: https://github.com/Ironship/WordHunter/issues
+Author: Ironship
+PackageName: Word Hunter
+PackageUrl: https://github.com/Ironship/WordHunter
+License: AGPL-3.0-or-later
+LicenseUrl: https://github.com/Ironship/WordHunter/blob/WordHunter1.0.9/LICENSE
+ShortDescription: Local-first reader and spaced repetition tool for language learning
+Description: |-
+  Word Hunter is a desktop reader and vocabulary-learning workspace. It can
+  import texts, ebooks, subtitles and PDFs, save words with their context, and
+  review them with flashcards and spaced repetition. Data is stored locally.
+Moniker: wordhunter
+Tags:
+- ebook
+- flashcard
+- language-learning
+- ocr
+- reader
+- spaced-repetition
+- vocabulary
+ReleaseNotes: |-
+  Replaced background folder synchronization with explicit ZIP transfer
+  packages storing words and books as YAML records.
+  Added a 0-100% progress bar to desktop package export.
+  Fixed PC startup when the configured data folder is missing and sped up
+  shutdown.
+  Improved Android TTS, word sheet, PDF import, and startup, and added a
+  Chinese (Simplified) interface.
+ReleaseNotesUrl: https://github.com/Ironship/WordHunter/releases/tag/WordHunter1.0.9
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/i/Ironship/WordHunter/1.0.9/Ironship.WordHunter.yaml
+++ b/manifests/i/Ironship/WordHunter/1.0.9/Ironship.WordHunter.yaml
@@ -1,0 +1,8 @@
+# Created with WinGet manifest tools
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Ironship.WordHunter
+PackageVersion: 1.0.9
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
New version of Ironship.WordHunter (1.0.9).

Verified installer SHA256: f2578a78577f0ac01fa53caf2626f9899485639c8cf92e0fa761bbb636967e23
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/411263)