### PR TITLE
New package: WritingMate.AIDictation version 0.0.5

### DIFF
--- a/manifests/w/WritingMate/AIDictation/0.0.5/WritingMate.AIDictation.installer.yaml
+++ b/manifests/w/WritingMate/AIDictation/0.0.5/WritingMate.AIDictation.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: WritingMate.AIDictation
+PackageVersion: 0.0.5
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: user
+UpgradeBehavior: install
+ReleaseDate: 2026-07-24
+Installers:
+  - Architecture: x64
+    InstallerLocale: en-US
+    InstallerUrl: https://github.com/writingmate/aidictation/releases/download/windows-v0.0.5/AIDictation-Windows-Setup-v0.0.5.exe
+    InstallerSha256: 762A69C6917DF39B13DBB3B2F9C88DEC5DE8A0CADF443CC25376FE359D9252A4
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/w/WritingMate/AIDictation/0.0.5/WritingMate.AIDictation.locale.en-US.yaml
+++ b/manifests/w/WritingMate/AIDictation/0.0.5/WritingMate.AIDictation.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: WritingMate.AIDictation
+PackageVersion: 0.0.5
+PackageLocale: en-US
+Publisher: WritingMate
+PublisherUrl: https://writingmate.ai/
+PrivacyUrl: https://aidictation.com/privacy
+Author: WritingMate
+PackageName: AIDictation
+PackageUrl: https://aidictation.com/
+License: MIT
+LicenseUrl: https://github.com/writingmate/aidictation/blob/main/LICENSE
+ShortDescription: Open-source speech-to-text and dictation app for Windows.
+Description: AIDictation lets you start voice-to-text dictation with a configurable global shortcut and insert the result into supported Windows apps.
+Moniker: aidictation
+Tags:
+  - dictation
+  - speech-recognition
+  - speech-to-text
+  - transcription
+  - voice
+  - voice-typing
+ReleaseNotesUrl: https://github.com/writingmate/aidictation/releases/tag/windows-v0.0.5
+Documentations:
+  - DocumentLabel: Source code
+    DocumentUrl: https://github.com/writingmate/aidictation
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/w/WritingMate/AIDictation/0.0.5/WritingMate.AIDictation.yaml
+++ b/manifests/w/WritingMate/AIDictation/0.0.5/WritingMate.AIDictation.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: WritingMate.AIDictation
+PackageVersion: 0.0.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds the new `WritingMate.AIDictation` package at version `0.0.5` using the official versioned Windows release asset.

Affiliation disclosure: I am affiliated with WritingMate, the publisher of AI Dictation.

AI-assistance disclosure: this submission was prepared with OpenAI Codex assistance. I reviewed the manifest metadata, URLs, hash, and final diff before submission.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (not applicable for this routine new-package submission)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` (WinGet is unavailable on this macOS host)
- [ ] Tested manifest locally with `winget install --manifest <path>` (Windows installation testing was not performed locally)
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

## Validation notes

- Parsed all three YAML files successfully.
- Validated all three documents against Microsoft's official WinGet 1.12 JSON schemas.
- Re-downloaded the installer and confirmed SHA-256 `762A69C6917DF39B13DBB3B2F9C88DEC5DE8A0CADF443CC25376FE359D9252A4`.
- Confirmed every submitted metadata URL returns HTTP 200.
- Ran `git diff --check` successfully.

No local Windows Sandbox or `winget install` result is claimed. Installation, uninstall, upgrade, SmartScreen, and security validation are left to the repository's automated and manual Windows checks.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/411291)