### PR TITLE
New version: Nishal.NekoBeat version 0.3.0

### DIFF
--- a/manifests/n/Nishal/NekoBeat/0.3.0/Nishal.NekoBeat.installer.yaml
+++ b/manifests/n/Nishal/NekoBeat/0.3.0/Nishal.NekoBeat.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Nishal.NekoBeat
+PackageVersion: 0.3.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-08-02
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/nishal21/NekoBeat/releases/download/app-v0.3.0/NekoBeat_0.3.0_x64-setup.exe
+  InstallerSha256: 3AC0EF1CF2108B3C03470452A8400CC32E3F05FD84DBB2E1C12D988577488D07
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/n/Nishal/NekoBeat/0.3.0/Nishal.NekoBeat.locale.en-US.yaml
+++ b/manifests/n/Nishal/NekoBeat/0.3.0/Nishal.NekoBeat.locale.en-US.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Nishal.NekoBeat
+PackageVersion: 0.3.0
+PackageLocale: en-US
+Publisher: Nishal
+PublisherUrl: https://github.com/nishal21
+PublisherSupportUrl: https://github.com/nishal21/NekoBeat/issues
+Author: Nishal
+PackageName: NekoBeat
+PackageUrl: https://github.com/nishal21/NekoBeat
+License: PolyForm Noncommercial 1.0.0
+LicenseUrl: https://github.com/nishal21/NekoBeat/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Nishal
+ShortDescription: A free desktop music aggregator built with Rust, Tauri, and GStreamer
+Description: |-
+  NekoBeat is a native desktop music player that aggregates YouTube, SoundCloud, and Spotify into one interface.
+  Features include a 10-band DSP equalizer, offline caching, synchronized lyrics, PiP miniplayer, Discord Rich Presence, Windows SMTC, and an in-app updater.
+  Windows/Linux/macOS desktop builds are available; this winget package installs the Windows x64 NSIS setup.
+Moniker: nekobeat
+Tags:
+- music
+- music-player
+- youtube
+- soundcloud
+- spotify
+- audio
+- player
+- rust
+- tauri
+- aggregator
+- equalizer
+ReleaseNotes: |-
+  NekoBeat v0.3.0 — Windows/Linux/macOS installers + Android APK.
+  Spotify Android AAR backend, update notifications, library scan fixes.
+  GStreamer runtime bundled in the Windows installer.
+ReleaseNotesUrl: https://github.com/nishal21/NekoBeat/releases/tag/app-v0.3.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/n/Nishal/NekoBeat/0.3.0/Nishal.NekoBeat.yaml
+++ b/manifests/n/Nishal/NekoBeat/0.3.0/Nishal.NekoBeat.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Nishal.NekoBeat
+PackageVersion: 0.3.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description
Update Nishal.NekoBeat from 0.2.0 to 0.3.0.

- Installer: NSIS x64 `NekoBeat_0.3.0_x64-setup.exe`
- URL: https://github.com/nishal21/NekoBeat/releases/download/app-v0.3.0/NekoBeat_0.3.0_x64-setup.exe
- SHA256: `3AC0EF1CF2108B3C03470452A8400CC32E3F05FD84DBB2E1C12D988577488D07`
- Release: https://github.com/nishal21/NekoBeat/releases/tag/app-v0.3.0
- License updated to PolyForm Noncommercial 1.0.0 (matches current repo LICENSE)
- Manifest schema: 1.12.0

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  - N/A

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/411301)