### PR TITLE
Add Live Photo Box CLI version 2.1.1

### DIFF
--- a/manifests/l/LengxiQwQ/LivePhotoBox/2.1.4/LengxiQwQ.LivePhotoBox.installer.yaml
+++ b/manifests/l/LengxiQwQ/LivePhotoBox/2.1.4/LengxiQwQ.LivePhotoBox.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: LengxiQwQ.LivePhotoBox
+PackageVersion: 2.1.4
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: livephotobox.exe
+    PortableCommandAlias: livephotobox
+  - RelativeFilePath: livebox.exe
+    PortableCommandAlias: livebox
+  - RelativeFilePath: lipbox.exe
+    PortableCommandAlias: lipbox
+  - RelativeFilePath: lpb.exe
+    PortableCommandAlias: lpb
+  - RelativeFilePath: lpbx.exe
+    PortableCommandAlias: lpbx
+  - RelativeFilePath: livephoto.exe
+    PortableCommandAlias: livephoto
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/LengxiQwQ/live-photo-box/releases/download/v2.1.4/Live-Photo-Box-v2.1.4-x64-cli.zip
+    InstallerSha256: 232BBFDBCC8FCCC45DE017CD66C67651D4D2CCE58BE0634E6CB9837B3E7500AB
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/l/LengxiQwQ/LivePhotoBox/2.1.4/LengxiQwQ.LivePhotoBox.locale.en-US.yaml
+++ b/manifests/l/LengxiQwQ/LivePhotoBox/2.1.4/LengxiQwQ.LivePhotoBox.locale.en-US.yaml
@@ -1,0 +1,45 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: LengxiQwQ.LivePhotoBox
+PackageVersion: 2.1.4
+PackageLocale: en-US
+Publisher: LengxiQwQ
+PublisherUrl: https://github.com/LengxiQwQ/live-photo-box
+PublisherSupportUrl: https://github.com/LengxiQwQ/live-photo-box/issues
+Author: LengxiQwQ
+PackageName: Live Photo Box CLI
+PackageUrl: https://github.com/LengxiQwQ/live-photo-box
+License: GPL-3.0
+LicenseUrl: https://github.com/LengxiQwQ/live-photo-box/blob/master/LICENSE
+Copyright: Copyright (C) 2026 LengxiQwQ. Licensed under GPL v3.0.
+ShortDescription: Merge images & videos into live photos for smartphone galleries
+Description: >
+  livephotobox is a command-line utility for merging image and video files
+  into live photos compatible with HUAWEI, Samsung, Google, Apple, Xiaomi,
+  and vivo gallery applications. A live photo is a single file containing
+  both a still image and a short video — when viewed in a supported gallery,
+  the video plays automatically.
+Moniker: livephotobox
+Tags:
+  - live-photo
+  - motion-photo
+  - media
+  - photo
+  - video
+  - merge
+  - cli
+  - huawei
+  - samsung
+  - google
+  - apple
+Commands:
+  - livephotobox
+  - livebox
+  - lipbox
+  - lpb
+  - lpbx
+  - livephoto
+ReleaseNotesUrl: https://github.com/LengxiQwQ/live-photo-box/releases/tag/v2.1.4
+ReleaseNotes: >
+  See changelog at https://github.com/LengxiQwQ/live-photo-box/blob/master/changelogs/release-v2.1.4.md
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/l/LengxiQwQ/LivePhotoBox/2.1.4/LengxiQwQ.LivePhotoBox.yaml
+++ b/manifests/l/LengxiQwQ/LivePhotoBox/2.1.4/LengxiQwQ.LivePhotoBox.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: LengxiQwQ.LivePhotoBox
+PackageVersion: 2.1.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## Package: Live Photo Box CLI

**Publisher:** LengxiQwQ
**Version:** 2.1.1
**License:** GPL-3.0

A command-line utility for merging image and video files into live photos compatible with HUAWEI, Samsung, Google, Apple, Xiaomi, and vivo gallery applications.

- 6 portable command aliases: `livephotobox`, `livebox`, `lipbox`, `lpb`, `lpbx`, `livephoto`
- Supports merge operations for all major smartphone live photo protocols
- Self-contained x64 portable package

**Release:** https://github.com/LengxiQwQ/live-photo-box/releases/tag/v2.1.1
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/411313)