### PR TITLE
Add MAINER4IK.XNConnect v1.0.9

### DIFF
--- a/manifests/m/MAINER4IK/XNConnect/1.0.9/MAINER4IK.XNConnect.installer.yaml
+++ b/manifests/m/MAINER4IK/XNConnect/1.0.9/MAINER4IK.XNConnect.installer.yaml
@@ -15,7 +15,7 @@ Commands:
   - xn-connect
 Installers:
   - Architecture: x64
-    InstallerUrl: https://connect.xneon.org/downloads/1.0.9/xn-connect-windows-amd64.exe
+    InstallerUrl: https://github.com/MAINER4IK/xn-connect-cli/releases/download/1.0.9/xn-connect-windows-amd64.exe
     InstallerSha256: 91526F261FA10FF9369DE70A6786773D7780A6357D87D22D47C3DEE7DCB9F799
     InstallerSwitches:
       Custom: ""

--- a/manifests/m/MAINER4IK/XNConnect/1.0.9/MAINER4IK.XNConnect.installer.yaml
+++ b/manifests/m/MAINER4IK/XNConnect/1.0.9/MAINER4IK.XNConnect.installer.yaml
@@ -1,0 +1,23 @@
+# Created using winget-pkgs
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: MAINER4IK.XNConnect
+PackageVersion: 1.0.9
+MinimumOSVersion: 10.0.17763.0
+InstallerType: portable
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Commands:
+  - xn-connect
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://connect.xneon.org/downloads/1.0.9/xn-connect-windows-amd64.exe
+    InstallerSha256: 91526F261FA10FF9369DE70A6786773D7780A6357D87D22D47C3DEE7DCB9F799
+    InstallerSwitches:
+      Custom: ""
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/MAINER4IK/XNConnect/1.0.9/MAINER4IK.XNConnect.locale.en-US.yaml
+++ b/manifests/m/MAINER4IK/XNConnect/1.0.9/MAINER4IK.XNConnect.locale.en-US.yaml
@@ -9,8 +9,11 @@ PublisherUrl: https://connect.xneon.org
 PublisherSupportUrl: https://connect.xneon.org
 PackageName: XN Connect
 PackageUrl: https://connect.xneon.org
-License: Proprietary
-ShortDescription: CLI client for XN Connect — tunnel your game servers to the internet
+License: BSD-3-Clause
+LicenseUrl: https://github.com/MAINER4IK/xn-connect-cli/blob/main/LICENSE
+Copyright: Copyright (c) 2026 MAINER4IK
+CopyrightUrl: https://github.com/MAINER4IK/xn-connect-cli/blob/main/LICENSE
+ShortDescription: CLI client for XN Connect - tunnel your game servers to the internet
 Description: |
   XN Connect is a CLI client for tunneling local game servers (Minecraft, Terraria, Rust, CS2, etc.)
   to the internet via relay nodes. Features a TUI interface with device-code authentication

--- a/manifests/m/MAINER4IK/XNConnect/1.0.9/MAINER4IK.XNConnect.locale.en-US.yaml
+++ b/manifests/m/MAINER4IK/XNConnect/1.0.9/MAINER4IK.XNConnect.locale.en-US.yaml
@@ -5,12 +5,11 @@ PackageIdentifier: MAINER4IK.XNConnect
 PackageVersion: 1.0.9
 PackageLocale: en-US
 Publisher: MAINER4IK
-PublisherUrl: https://github.com/MAINER4IK
-PublisherSupportUrl: https://github.com/MAINER4IK/xn-connect/issues
+PublisherUrl: https://connect.xneon.org
+PublisherSupportUrl: https://connect.xneon.org
 PackageName: XN Connect
-PackageUrl: https://github.com/MAINER4IK/xn-connect
-License: MIT
-LicenseUrl: https://github.com/MAINER4IK/xn-connect/blob/main/LICENSE
+PackageUrl: https://connect.xneon.org
+License: Proprietary
 ShortDescription: CLI client for XN Connect — tunnel your game servers to the internet
 Description: |
   XN Connect is a CLI client for tunneling local game servers (Minecraft, Terraria, Rust, CS2, etc.)

--- a/manifests/m/MAINER4IK/XNConnect/1.0.9/MAINER4IK.XNConnect.locale.en-US.yaml
+++ b/manifests/m/MAINER4IK/XNConnect/1.0.9/MAINER4IK.XNConnect.locale.en-US.yaml
@@ -1,0 +1,38 @@
+# Created using winget-pkgs
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: MAINER4IK.XNConnect
+PackageVersion: 1.0.9
+PackageLocale: en-US
+Publisher: MAINER4IK
+PublisherUrl: https://github.com/MAINER4IK
+PublisherSupportUrl: https://github.com/MAINER4IK/xn-connect/issues
+PackageName: XN Connect
+PackageUrl: https://github.com/MAINER4IK/xn-connect
+License: MIT
+LicenseUrl: https://github.com/MAINER4IK/xn-connect/blob/main/LICENSE
+ShortDescription: CLI client for XN Connect — tunnel your game servers to the internet
+Description: |
+  XN Connect is a CLI client for tunneling local game servers (Minecraft, Terraria, Rust, CS2, etc.)
+  to the internet via relay nodes. Features a TUI interface with device-code authentication
+  and automatic updates.
+
+  Features:
+  - Tunnel local game servers to the internet
+  - Support for Minecraft, Terraria, Rust, CS2, and more
+  - Beautiful TUI (Terminal User Interface)
+  - Device-code authentication via browser
+  - Automatic updates
+  - Multiple relay nodes worldwide
+Tags:
+  - tunnel
+  - gaming
+  - minecraft
+  - rust
+  - cs2
+  - terraria
+  - cli
+  - tui
+  - network
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/MAINER4IK/XNConnect/1.0.9/MAINER4IK.XNConnect.yaml
+++ b/manifests/m/MAINER4IK/XNConnect/1.0.9/MAINER4IK.XNConnect.yaml
@@ -1,0 +1,8 @@
+# Created using winget-pkgs
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: MAINER4IK.XNConnect
+PackageVersion: 1.0.9
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Add XN Connect CLI v1.0.9 to winget.

XN Connect is a CLI client for tunneling local game servers (Minecraft, Terraria, Rust, CS2, etc.) to the internet via relay nodes.

## Manifests
- [x] Version manifest
- [x] Installer manifest
- [x] Locale manifest

## Verification
- [x] Installer URL is valid
- [x] Installer SHA256 matches

## Notes
- Installer type: portable
- Architecture: x64
- Silent install supported
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/411322)