### PR TITLE
New package: fulsomenko.kanban version 0.8.0

### DIFF
--- a/manifests/f/fulsomenko/kanban/0.8.0/fulsomenko.kanban.installer.yaml
+++ b/manifests/f/fulsomenko/kanban/0.8.0/fulsomenko.kanban.installer.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
 PackageIdentifier: fulsomenko.kanban
 PackageVersion: 0.8.0
 InstallerType: zip

--- a/manifests/f/fulsomenko/kanban/0.8.0/fulsomenko.kanban.installer.yaml
+++ b/manifests/f/fulsomenko/kanban/0.8.0/fulsomenko.kanban.installer.yaml
@@ -1,0 +1,15 @@
+PackageIdentifier: fulsomenko.kanban
+PackageVersion: 0.8.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: kanban.exe
+  PortableCommandAlias: kanban
+- RelativeFilePath: kanban-mcp.exe
+  PortableCommandAlias: kanban-mcp
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/fulsomenko/kanban/releases/download/v0.8.0/kanban-v0.8.0-x86_64-pc-windows-msvc.zip
+  InstallerSha256: C4757A060E75EDD885A94BEFAC739AFF9101D0CA3D0C3627CF74E012BCB39CD0
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/fulsomenko/kanban/0.8.0/fulsomenko.kanban.locale.en-US.yaml
+++ b/manifests/f/fulsomenko/kanban/0.8.0/fulsomenko.kanban.locale.en-US.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
 PackageIdentifier: fulsomenko.kanban
 PackageVersion: 0.8.0
 PackageLocale: en-US

--- a/manifests/f/fulsomenko/kanban/0.8.0/fulsomenko.kanban.locale.en-US.yaml
+++ b/manifests/f/fulsomenko/kanban/0.8.0/fulsomenko.kanban.locale.en-US.yaml
@@ -1,0 +1,21 @@
+PackageIdentifier: fulsomenko.kanban
+PackageVersion: 0.8.0
+PackageLocale: en-US
+Publisher: Fulsomenko
+PublisherUrl: https://github.com/fulsomenko
+PublisherSupportUrl: https://github.com/fulsomenko/kanban/issues
+Author: Max Blomstervall
+PackageName: kanban
+PackageUrl: https://github.com/fulsomenko/kanban
+License: Apache-2.0
+LicenseUrl: https://github.com/fulsomenko/kanban/blob/master/LICENSE.md
+ShortDescription: Terminal-based kanban board inspired by lazygit
+Moniker: kanban
+Tags:
+- kanban
+- tui
+- terminal
+- productivity
+- rust
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/fulsomenko/kanban/0.8.0/fulsomenko.kanban.yaml
+++ b/manifests/f/fulsomenko/kanban/0.8.0/fulsomenko.kanban.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
 PackageIdentifier: fulsomenko.kanban
 PackageVersion: 0.8.0
 DefaultLocale: en-US

--- a/manifests/f/fulsomenko/kanban/0.8.0/fulsomenko.kanban.yaml
+++ b/manifests/f/fulsomenko/kanban/0.8.0/fulsomenko.kanban.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: fulsomenko.kanban
+PackageVersion: 0.8.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New package: `fulsomenko.kanban` version 0.8.0

First submission of kanban, a terminal-based kanban board written in Rust.

- **Installer:** the official Windows release archive `kanban-v0.8.0-x86_64-pc-windows-msvc.zip` from the project's GitHub release.
- **Type:** `zip` with `NestedInstallerType: portable`. The archive ships two binaries, both exposed as portable commands: `kanban.exe` -> `kanban` and `kanban-mcp.exe` -> `kanban-mcp`.
- **SHA256:** `C4757A060E75EDD885A94BEFAC739AFF9101D0CA3D0C3627CF74E012BCB39CD0` (matches the release's `SHA256SUMS` and the GitHub asset digest).

#### Checklist
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] This is a new package (no existing manifests for this identifier).
- [x] Manifests validate against schema 1.12.0 (YAML well-formed; required fields present).
- [ ] `winget install --manifest` tested locally on Windows: not run (submitted from Linux); relying on the automated validation pipeline for installer reachability and SHA verification.

Subsequent versions will be submitted automatically via `winget-releaser` from the upstream release workflow.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/411354)