### PR TITLE
Update installer URL: lucuma13.prem-down version 0.1.0

### DIFF
--- a/manifests/l/lucuma13/prem-down/0.1.0/lucuma13.prem-down.installer.yaml
+++ b/manifests/l/lucuma13/prem-down/0.1.0/lucuma13.prem-down.installer.yaml
@@ -17,7 +17,7 @@ FileExtensions:
   - prproj
 Installers:
   - Architecture: x64
-    InstallerUrl: https://github.com/lucuma13/prem-down/releases/download/0.1.0/prem-down_installer_windows.msi
+    InstallerUrl: https://github.com/lucuma13/prem-down/releases/download/v0.1.0/prem-down_installer_windows.msi
     InstallerSha256: f460d4547b10ef2c7a88ae5f1e7e4e2d7431db282fba3c6d1ea576f56dc1ebdf
     ProductCode: "{47994DE9-05BB-4BFF-BBFC-C6B1D10B3F82}"
 ManifestType: installer


### PR DESCRIPTION
The upstream release tag was renamed from `0.1.0` to `v0.1.0`, which moved the GitHub release and 404'd the existing InstallerUrl. This corrects the URL only.

The installer binary is unchanged - the MSI at the new URL is byte-identical, so `InstallerSha256: f460d4547b10ef2c7a88ae5f1e7e4e2d7431db282fba3c6d1ea576f56dc1ebdf` still matches and no other fields are modified.

I am the package publisher.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/411367)