### PR TITLE
Update: OpenTubeX.OpenTubeX to 0.30.2

### DIFF
--- a/manifests/o/OpenTubeX/OpenTubeX/0.30.2/OpenTubeX.OpenTubeX.installer.yaml
+++ b/manifests/o/OpenTubeX/OpenTubeX/0.30.2/OpenTubeX.OpenTubeX.installer.yaml
@@ -1,0 +1,45 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: OpenTubeX.OpenTubeX
+PackageVersion: 0.30.2
+InstallerLocale: en-US
+InstallerType: nullsoft
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+Protocols:
+- opentubex
+ProductCode: a38f022d-fec2-5f80-a7fe-620ccf1a2767
+ReleaseDate: 2026-08-02
+AppsAndFeaturesEntries:
+- DisplayName: OpenTubeX 0.30.2
+  ProductCode: a38f022d-fec2-5f80-a7fe-620ccf1a2767
+Installers:
+- Architecture: x64
+  Scope: user
+  InstallerUrl: https://github.com/OpenTubeX/OpenTubeX/releases/download/v0.30.2-beta/opentubex-0.30.2-beta-setup-x64.exe
+  InstallerSha256: A868F8BD0CB3BBB8201546E8595266AF2D4D2D35DA5465E4E53F41D8877F3778
+  InstallerSwitches:
+    Custom: /CURRENTUSER
+- Architecture: x64
+  Scope: machine
+  InstallerUrl: https://github.com/OpenTubeX/OpenTubeX/releases/download/v0.30.2-beta/opentubex-0.30.2-beta-setup-x64.exe
+  InstallerSha256: A868F8BD0CB3BBB8201546E8595266AF2D4D2D35DA5465E4E53F41D8877F3778
+  InstallerSwitches:
+    Custom: /ALLUSERS
+- Architecture: arm64
+  Scope: user
+  InstallerUrl: https://github.com/OpenTubeX/OpenTubeX/releases/download/v0.30.2-beta/opentubex-0.30.2-beta-setup-arm64.exe
+  InstallerSha256: D86E2D9C82E1614EF0A563E6C5D819721CCE4AA8E062A440D0AA59D7A1DE9CB1
+  InstallerSwitches:
+    Custom: /CURRENTUSER
+- Architecture: arm64
+  Scope: machine
+  InstallerUrl: https://github.com/OpenTubeX/OpenTubeX/releases/download/v0.30.2-beta/opentubex-0.30.2-beta-setup-arm64.exe
+  InstallerSha256: D86E2D9C82E1614EF0A563E6C5D819721CCE4AA8E062A440D0AA59D7A1DE9CB1
+  InstallerSwitches:
+    Custom: /ALLUSERS
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenTubeX/OpenTubeX/0.30.2/OpenTubeX.OpenTubeX.locale.en-US.yaml
+++ b/manifests/o/OpenTubeX/OpenTubeX/0.30.2/OpenTubeX.OpenTubeX.locale.en-US.yaml
@@ -1,0 +1,68 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: OpenTubeX.OpenTubeX
+PackageVersion: 0.30.2
+PackageLocale: en-US
+Publisher: OpenTubeX contributors
+PublisherUrl: https://github.com/OpenTubeX
+PublisherSupportUrl: https://github.com/OpenTubeX/OpenTubeX/issues
+Author: OpenTubeX contributors
+PackageName: OpenTubeX
+PackageUrl: https://opentubex.org/
+License: AGPL-3.0
+LicenseUrl: https://github.com/OpenTubeX/OpenTubeX/blob/HEAD/LICENSE
+Copyright: Copyleft © 2020-2026
+CopyrightUrl: https://github.com/OpenTubeX/OpenTubeX/blob/HEAD/LICENSE
+ShortDescription: A private YouTube client
+Description: OpenTubeX is a private YouTube client for desktop.
+Moniker: opentubex
+Tags:
+- cross-platform
+- electron
+- privacy
+- private-youtube
+- sponsorblock
+- subscriptions
+- tabbed-browsing
+- tabs
+- video
+- videos
+- youtube
+- youtube-client
+- youtube-player
+ReleaseNotes: |-
+  Highlights
+  - You can now preview alternative icon packs (Material, Tabler, Phosphor, Lucide, Remix) in Theme Settings while a Font Awesome replacement is being evaluated (#394)
+  - yt-dlp can now be used to get video streams, and the media format selector shows which engine and streaming protocol are in use (#455, #471)
+
+  More improvements
+  - Show subscription feed refresh progress in a persistent notification while browsing outside the Subscriptions page (#386)
+  - Smoothly animate videos into and out of the scroll mini player (#387)
+  - Sync and context-menu search engines are now off by default, and no related requests are made until explicitly enabled (#423, #424)
+  - Show channel details and subscription controls beside Shorts in fullscreen (#451)
+  - Reduced background work while subscription feeds refresh in another app tab (#454)
+
+  Fixed bugs
+  - Fixed changed-setting highlights and individual resets for caption appearance and SponsorBlock category options (#383)
+  - Fixed tab titles, icons, and loading indicators briefly showing incorrect placeholder states (#385)
+  - Playlists containing members-only videos now load correctly, and captions keep their configured size in fullscreen (#399, #412, #429)
+  - Improved video playback reliability by reverting live SABR streaming support and stabilizing SABR error recovery (#422, #426)
+  - Fixed Picture-in-Picture controls resuming the video in the active tab instead of the PiP video (#389, #428)
+  - The tab play indicator is now hidden while a video is buffering (#445)
+  - Fixed end-screen annotation positioning and sizing on non-16:9 videos (#447)
+  - Fixed Shift range selection starting from a tab that had already been deselected (#446)
+  - Fixed seek bar hover thumbnails appearing behind end-screen annotations (#444)
+  - Fixed the fullscreen playlist dock using a native scrollbar instead of the custom overlay scrollbar (#448)
+  - Fixed theater mode doing nothing at intermediate window widths where its button was still visible (#452)
+  - Fixed audio downloads being reported as failed in Flatpak after the media file completed (#400, #442)
+  - Prevented the player from collapsing into a small black area during stream recovery or audio-only playback (#460)
+  - The icon-only chapters button in the player controls now shows whether the chapters overlay is open (#466)
+  - Channel lists with many subscriptions and the Settings page now open without long rendering delays (#458)
+  - Tab previews now show only the page content, use less disk space, and clean up leftover preview files on startup (#469)
+  - Keep custom playlist ordering responsive while videos are pending removal (#461, #462)
+  - Transcript searches now find phrases that span multiple caption lines (#463)
+  - Show a clear notice and remove stale reply controls when advertised comment replies are unavailable (#457)
+ReleaseNotesUrl: https://github.com/OpenTubeX/OpenTubeX/releases/tag/v0.30.2-beta
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenTubeX/OpenTubeX/0.30.2/OpenTubeX.OpenTubeX.yaml
+++ b/manifests/o/OpenTubeX/OpenTubeX/0.30.2/OpenTubeX.OpenTubeX.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: OpenTubeX.OpenTubeX
+PackageVersion: 0.30.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Updates `OpenTubeX.OpenTubeX` from 0.30.1 to 0.30.2.

The manifest includes the x64 and ARM64 NSIS installers for user and machine scope. Its tags now match the current OpenTubeX GitHub repository topics, with the obsolete `freetube` and `freetube-fork` tags removed. Embedded release images were omitted from the text-only release notes.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

Validation performed with Komac:

```text
komac submit --dry-run --yes manifests/o/OpenTubeX/OpenTubeX/0.30.2
```

> **Note:** `<path>` is the directory containing the manifest you're submitting.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/411486)