### PR TITLE
New package: SimonCrean.Pasiv version 0.4.8

### DIFF
--- a/manifests/s/SimonCrean/Pasiv/0.4.8/SimonCrean.Pasiv.installer.yaml
+++ b/manifests/s/SimonCrean/Pasiv/0.4.8/SimonCrean.Pasiv.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 PackageIdentifier: SimonCrean.Pasiv
 PackageVersion: 0.4.8
 InstallerType: nullsoft
@@ -13,4 +13,4 @@ Installers:
     InstallerUrl: https://github.com/simoncrean/pasiv-releases/releases/download/v0.4.8/Pasiv_0.4.8_x64-setup.exe
     InstallerSha256: DA8A1C7FE6905B7C0AA17D96958F727B8130765D074ADDEC93D78386AD7BA8A8
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/s/SimonCrean/Pasiv/0.4.8/SimonCrean.Pasiv.installer.yaml
+++ b/manifests/s/SimonCrean/Pasiv/0.4.8/SimonCrean.Pasiv.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: SimonCrean.Pasiv
+PackageVersion: 0.4.8
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+UpgradeBehavior: install
+ReleaseDate: 2026-08-03
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/simoncrean/pasiv-releases/releases/download/v0.4.8/Pasiv_0.4.8_x64-setup.exe
+    InstallerSha256: DA8A1C7FE6905B7C0AA17D96958F727B8130765D074ADDEC93D78386AD7BA8A8
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/SimonCrean/Pasiv/0.4.8/SimonCrean.Pasiv.locale.en-US.yaml
+++ b/manifests/s/SimonCrean/Pasiv/0.4.8/SimonCrean.Pasiv.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: SimonCrean.Pasiv
+PackageVersion: 0.4.8
+PackageLocale: en-US
+Publisher: Simon Crean
+PublisherUrl: https://pasiv.network/
+PublisherSupportUrl: https://pasiv.network/support
+PackageName: Pasiv
+PackageUrl: https://pasiv.network/
+License: Proprietary
+Copyright: Copyright (c) 2026 Pasiv
+ShortDescription: One-button non-custodial miner that turns idle CPU/GPU time into crypto
+Description: |-
+  Pasiv turns idle CPU and GPU time into cryptocurrency. It is non-custodial:
+  the mining pool pays your own wallet directly and Pasiv never holds funds or
+  asks for keys. One button starts and stops mining; an optional Auto mode
+  picks whichever supported coin is most profitable for your machine.
+
+  A 4% fee applies only while you are actively mining, to a published address
+  you can audit on the pool (https://pasiv.network/teams).
+Moniker: pasiv
+Tags:
+  - crypto
+  - mining
+  - monero
+  - randomx
+  - xmr
+ReleaseNotesUrl: https://pasiv.network/changelog
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/SimonCrean/Pasiv/0.4.8/SimonCrean.Pasiv.locale.en-US.yaml
+++ b/manifests/s/SimonCrean/Pasiv/0.4.8/SimonCrean.Pasiv.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 PackageIdentifier: SimonCrean.Pasiv
 PackageVersion: 0.4.8
 PackageLocale: en-US
@@ -27,4 +27,4 @@ Tags:
   - xmr
 ReleaseNotesUrl: https://pasiv.network/changelog
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/s/SimonCrean/Pasiv/0.4.8/SimonCrean.Pasiv.yaml
+++ b/manifests/s/SimonCrean/Pasiv/0.4.8/SimonCrean.Pasiv.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: SimonCrean.Pasiv
+PackageVersion: 0.4.8
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0

--- a/manifests/s/SimonCrean/Pasiv/0.4.8/SimonCrean.Pasiv.yaml
+++ b/manifests/s/SimonCrean/Pasiv/0.4.8/SimonCrean.Pasiv.yaml
@@ -1,6 +1,6 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 PackageIdentifier: SimonCrean.Pasiv
 PackageVersion: 0.4.8
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package: **SimonCrean.Pasiv** version **0.4.8**.

Pasiv is a non-custodial desktop miner that turns idle CPU/GPU time into cryptocurrency — the mining pool pays the user's own wallet address directly; the app holds no funds and never asks for keys. Homepage: https://pasiv.network/

Installer is the project's own signed NSIS build, published on the public releases repo (`simoncrean/pasiv-releases`), user-scope, silent-capable.

Note on the category: this is a *user-initiated* miner with a one-button start — it does not mine on install, and nothing runs until the user chooses to start it. The 4% fee address is published and auditable at https://pasiv.network/teams.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` — `Manifest validation succeeded.` (winget v1.29.280, Windows 11)
- [ ] Tested manifest locally with `winget install --manifest <path>` — not run: local-manifest installs require `winget settings --enable LocalManifestFiles` (admin) on the test machine. The installer binary itself was installed and launched successfully from the same URL/build on Windows 11 x64 beforehand, and `InstallerSha256` is taken from that exact artifact.
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/411492)