### PR TITLE
New package: Juicedata.JuiceFS version 1.4.1

### DIFF
--- a/manifests/j/Juicedata/JuiceFS/1.4.1/Juicedata.JuiceFS.installer.yaml
+++ b/manifests/j/Juicedata/JuiceFS/1.4.1/Juicedata.JuiceFS.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Juicedata.JuiceFS
+PackageVersion: 1.4.1
+InstallerType: zip
+NestedInstallerType: portable
+Commands:
+- juicefs
+ReleaseDate: 2026-07-30
+Installers:
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: juicefs.exe
+    PortableCommandAlias: juicefs
+  InstallerUrl: https://github.com/juicedata/juicefs/releases/download/v1.4.1/juicefs-1.4.1-windows-amd64.zip
+  InstallerSha256: A79DED34F706586538091E3E9EDC52DFDE62C855599F172B0DCAEFACA0EAB33B
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/j/Juicedata/JuiceFS/1.4.1/Juicedata.JuiceFS.locale.en-US.yaml
+++ b/manifests/j/Juicedata/JuiceFS/1.4.1/Juicedata.JuiceFS.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Juicedata.JuiceFS
+PackageVersion: 1.4.1
+PackageLocale: en-US
+Publisher: Juicedata
+PublisherUrl: https://juicefs.com
+PublisherSupportUrl: https://github.com/juicedata/juicefs/issues
+Author: Juicedata
+PackageName: JuiceFS
+PackageUrl: https://juicefs.com
+License: Apache-2.0
+LicenseUrl: https://github.com/juicedata/juicefs/blob/main/LICENSE
+Copyright: Copyright (c) Juicedata
+ShortDescription: A distributed POSIX file system built on top of Redis and S3.
+Description: JuiceFS is a high-performance POSIX file system released under the Apache License 2.0 and designed for cloud-native environments. Data is persisted in object storage such as Amazon S3, while metadata can be stored in compatible database engines such as Redis, MySQL, and TiKV.
+Moniker: juicefs
+Tags:
+- cli
+- cloud-native
+- filesystem
+- object-storage
+- posix
+- redis
+- s3
+ReleaseNotesUrl: https://github.com/juicedata/juicefs/releases/tag/v1.4.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/j/Juicedata/JuiceFS/1.4.1/Juicedata.JuiceFS.yaml
+++ b/manifests/j/Juicedata/JuiceFS/1.4.1/Juicedata.JuiceFS.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Juicedata.JuiceFS
+PackageVersion: 1.4.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
# New package: Juicedata.JuiceFS version 1.4.1

Adds JuiceFS 1.4.1 to the Windows Package Manager community repository.

JuiceFS is a high-performance POSIX file system released under the Apache License 2.0 and designed for cloud-native environments.

## Installer source

The Windows zip is provided by the official JuiceFS GitHub repository:

```text
https://github.com/juicedata/juicefs/releases/download/v1.4.1/juicefs-1.4.1-windows-amd64.zip
```

The zip is listed on the official v1.4.1 GitHub release and contains the portable `juicefs.exe` binary for x64 Windows.

## Validation

- Installer URL is public and version-specific.
- Installer SHA256 matches the official `checksums.txt`.
- Zip contents were inspected; `juicefs.exe` is at the zip root.
- `winget validate --manifest` completed successfully on Windows Server 2025. The WinGet 1.11 client only reported schema header warnings for the current 1.12 manifest schema.
- Local manifest install, `juicefs version`, and uninstall tests passed on Windows Server 2025.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/411506)