### PR TITLE
Update HoraceMaxwell.Horosa version 3.7.0 installer hash

### DIFF
--- a/manifests/h/HoraceMaxwell/Horosa/3.7.0/HoraceMaxwell.Horosa.installer.yaml
+++ b/manifests/h/HoraceMaxwell/Horosa/3.7.0/HoraceMaxwell.Horosa.installer.yaml
@@ -16,6 +16,6 @@ ReleaseDate: 2026-08-03
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/Horace-Maxwell/Horosa-Web-App-comprehensively-improved-Windows/releases/download/v3.7.0/Horosa-Setup-3.7.0.exe
-    InstallerSha256: 494BCD820DAC2365198DFF7A9F6730872727826CF8E0CE49EFF71C2AF2F908A2
+    InstallerSha256: BB33E458BBFBE14181E3D344CDC4ABDBF720380CFECE76B5436BB2A7A79FC108
 ManifestType: installer
 ManifestVersion: 1.6.0


### PR DESCRIPTION
The v3.7.0 release assets were republished in place shortly after #411478 merged; the installer SHA256 changed. This updates InstallerSha256 to match the live asset (verified against the published SHA256SUMS.txt).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/411511)