### PR TITLE
New version: EvilHumphrey.LegendCTL version 2.6.2

### DIFF
--- a/manifests/e/EvilHumphrey/LegendCTL/2.6.2/EvilHumphrey.LegendCTL.installer.yaml
+++ b/manifests/e/EvilHumphrey/LegendCTL/2.6.2/EvilHumphrey.LegendCTL.installer.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: EvilHumphrey.LegendCTL
+PackageVersion: 2.6.2
+InstallerLocale: en-US
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: inno
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART
+UpgradeBehavior: install
+ProductCode: '{ZDUltimateLegend}_is1'
+ReleaseDate: 2026-07-20
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/EvilHumphrey/LegendCTL/releases/download/v2.6.2/ZDUltimateLegend-v2.6.2-Setup.exe
+    InstallerSha256: 2CF5F0E198C72D3AC19884021DF0B0E22448A6AD5E627FB0AFC89C5C0C199D96
+    AppsAndFeaturesEntries:
+      - DisplayName: ZD Ultimate Legend Wrapper
+        Publisher: EvilHumphrey
+        ProductCode: '{ZDUltimateLegend}_is1'
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/e/EvilHumphrey/LegendCTL/2.6.2/EvilHumphrey.LegendCTL.locale.en-US.yaml
+++ b/manifests/e/EvilHumphrey/LegendCTL/2.6.2/EvilHumphrey.LegendCTL.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: EvilHumphrey.LegendCTL
+PackageVersion: 2.6.2
+PackageLocale: en-US
+Publisher: EvilHumphrey
+PublisherUrl: https://github.com/EvilHumphrey
+PublisherSupportUrl: https://github.com/EvilHumphrey/LegendCTL/issues
+PackageName: LegendCTL
+PackageUrl: https://github.com/EvilHumphrey/LegendCTL
+License: MIT
+LicenseUrl: https://github.com/EvilHumphrey/LegendCTL/blob/v2.6.2/LICENSE
+Copyright: Copyright (c) 2026 EvilHumphrey
+ShortDescription: Standalone, unofficial Windows configurator for ZD Ultimate Legend controllers. Reads and applies controller settings locally; no official app required.
+Description: >-
+  LegendCTL is a lightweight, local Windows application for reading and applying
+  supported settings on ZD Ultimate Legend controllers directly over USB/HID. It
+  is an independent, standalone tool that does not require the official ZD Gaming
+  app, and it makes no network calls, installs no drivers, and runs no background
+  service. Configure USB polling rate, the button-binding matrix, stick deadzones
+  and sensitivity curves, axis inversion, triggers, per-zone lighting, vibration,
+  and back-paddle bindings, then save them as reusable profiles that persist
+  across sessions. Restore Points and the vendor "Restore to default" path give
+  you a clear way back if a controller ever feels off.
+Moniker: legendctl
+Tags:
+  - configurator
+  - controller
+  - gamepad
+  - xinput
+  - zd
+ReleaseNotesUrl: https://github.com/EvilHumphrey/LegendCTL/releases/tag/v2.6.2
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/e/EvilHumphrey/LegendCTL/2.6.2/EvilHumphrey.LegendCTL.yaml
+++ b/manifests/e/EvilHumphrey/LegendCTL/2.6.2/EvilHumphrey.LegendCTL.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: EvilHumphrey.LegendCTL
+PackageVersion: 2.6.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Version update from the accepted EvilHumphrey.LegendCTL 2.6.0 manifest to the current stable 2.6.2 release. The three schema 1.12.0 manifests preserve the accepted package metadata and change only the eight version-specific fields. The Setup SHA-256 matches both the GitHub release asset digest and its published SHA256SUMS.txt, and winget validate passes.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/411548)