### PR TITLE
New version: Yaps.Yaps version 2.3.295

### DIFF
--- a/manifests/y/Yaps/Yaps/2.3.295/Yaps.Yaps.installer.yaml
+++ b/manifests/y/Yaps/Yaps/2.3.295/Yaps.Yaps.installer.yaml
@@ -1,0 +1,23 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Yaps.Yaps
+PackageVersion: 2.3.295
+InstallerLocale: en-US
+InstallerType: nullsoft
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/richawo/yaps-releases/releases/download/v2.3.295/Yaps_2.3.295_x64-setup.exe
+  InstallerSha256: 52761156C9DD4B1AD71259EC754E95B3A9DCEB1F625F37E26A1E18B2F5A4F310
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-08-03

--- a/manifests/y/Yaps/Yaps/2.3.295/Yaps.Yaps.locale.en-US.yaml
+++ b/manifests/y/Yaps/Yaps/2.3.295/Yaps.Yaps.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Yaps.Yaps
+PackageVersion: 2.3.295
+PackageLocale: en-US
+Publisher: yaps
+PublisherUrl: https://www.yaps.ai/
+PublisherSupportUrl: https://www.yaps.ai/support
+PrivacyUrl: https://www.yaps.ai/privacy
+PackageName: Yaps
+PackageUrl: https://www.yaps.ai/download
+License: Proprietary
+LicenseUrl: https://www.yaps.ai/terms
+Copyright: Copyright (c) 2026 Yaps. All rights reserved.
+ShortDescription: Private, offline voice-to-text, text-to-speech, and notes for Windows.
+Description: Yaps is a privacy-first voice productivity app with offline dictation, read-aloud, voice notes, and transcription tools.
+Moniker: yaps
+Tags:
+- dictation
+- notes
+- offline
+- productivity
+- speech-to-text
+- text-to-speech
+- transcription
+- voice
+ReleaseNotesUrl: https://github.com/richawo/yaps-releases/releases/tag/v2.3.295
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/richawo/yaps-releases/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/y/Yaps/Yaps/2.3.295/Yaps.Yaps.yaml
+++ b/manifests/y/Yaps/Yaps/2.3.295/Yaps.Yaps.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Yaps.Yaps
+PackageVersion: 2.3.295
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Updates Yaps.Yaps to version 2.3.295. This supersedes the closed #410884 submission for version 2.3.131.

The manifest preserves the Microsoft.VCRedist.2015+.x64 dependency and uses the immutable GitHub release installer URL and published SHA-256 digest.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/411550)