### PR TITLE
New package: Aiden1020.LocalSubs version 0.4.0

### DIFF
--- a/manifests/a/Aiden1020/LocalSubs/0.4.0/Aiden1020.LocalSubs.installer.yaml
+++ b/manifests/a/Aiden1020/LocalSubs/0.4.0/Aiden1020.LocalSubs.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Aiden1020.LocalSubs
+PackageVersion: 0.4.0
+InstallerType: zip
+NestedInstallerType: portable
+Commands:
+- localsubs
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/aiden1020/localsubs/releases/download/v0.4.0/localsubs_windows_amd64.zip
+  InstallerSha256: 903E90FD9ECF83BB52E5428F8C526E8229D6F295C23B4FCE8EFBEF98EBE2EC1F
+  NestedInstallerFiles:
+  - RelativeFilePath: localsubs.exe
+    PortableCommandAlias: localsubs
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/Aiden1020/LocalSubs/0.4.0/Aiden1020.LocalSubs.locale.en-US.yaml
+++ b/manifests/a/Aiden1020/LocalSubs/0.4.0/Aiden1020.LocalSubs.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Aiden1020.LocalSubs
+PackageVersion: 0.4.0
+PackageLocale: en-US
+Publisher: Aiden1020
+PublisherUrl: https://github.com/aiden1020
+PublisherSupportUrl: https://github.com/aiden1020/localsubs/issues
+Author: Tsz-To Wong
+PackageName: LocalSubs
+PackageUrl: https://github.com/aiden1020/localsubs
+License: Apache-2.0
+LicenseUrl: https://github.com/aiden1020/localsubs/blob/v0.4.0/LICENSE
+ShortDescription: Fully local AI subtitle translation for streaming video.
+Description: Translates English streaming subtitles to Traditional Chinese on-device using a local model.
+Tags:
+- ai
+- cli
+- subtitles
+- translation
+ReleaseNotesUrl: https://github.com/aiden1020/localsubs/releases/tag/v0.4.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/Aiden1020/LocalSubs/0.4.0/Aiden1020.LocalSubs.yaml
+++ b/manifests/a/Aiden1020/LocalSubs/0.4.0/Aiden1020.LocalSubs.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Aiden1020.LocalSubs
+PackageVersion: 0.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Adds LocalSubs 0.4.0 as a Windows x64 portable package.

LocalSubs is a fully local AI subtitle translation helper for streaming video.
The WinGet package installs the `localsubs` CLI; users then run
`localsubs setup --backend auto` to download the checksum-verified model and
CPU or NVIDIA CUDA runtime and configure browser Native Messaging.

## Package

- Package identifier: `Aiden1020.LocalSubs`
- Package version: `0.4.0`
- Installer type: ZIP with a nested portable executable
- Release: https://github.com/aiden1020/localsubs/releases/tag/v0.4.0

## Validation

- `winget validate --manifest <manifest-directory>` succeeds without warnings.
- The installer URL points directly to the publisher's GitHub Release asset.
- The manifest SHA-256 matches the published Windows amd64 ZIP checksum:
  `903E90FD9ECF83BB52E5428F8C526E8229D6F295C23B4FCE8EFBEF98EBE2EC1F`.
- The released executable reports `localsubs 0.4.0 api 1`.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/411676)