### PR TITLE
New version: HP.HPSupportAssistant version 9.54.3.0

### DIFF
--- a/manifests/h/HP/HPSupportAssistant/9.54.3.0/HP.HPSupportAssistant.installer.yaml
+++ b/manifests/h/HP/HPSupportAssistant/9.54.3.0/HP.HPSupportAssistant.installer.yaml
@@ -1,0 +1,15 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: HP.HPSupportAssistant
+PackageVersion: 9.54.3.0
+InstallerType: exe
+InstallerSwitches:
+  Silent: /s
+  SilentWithProgress: /s
+Installers:
+- Architecture: x64
+  InstallerUrl: https://ftp.hp.com/pub/softpaq/sp173501-174000/sp173774.exe
+  InstallerSha256: 4A38BBA43A2FF0E25C55C06E67E34878882C7674D66E3E6FE4E254C49337D75B
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/h/HP/HPSupportAssistant/9.54.3.0/HP.HPSupportAssistant.locale.en-US.yaml
+++ b/manifests/h/HP/HPSupportAssistant/9.54.3.0/HP.HPSupportAssistant.locale.en-US.yaml
@@ -1,0 +1,13 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: HP.HPSupportAssistant
+PackageVersion: 9.54.3.0
+PackageLocale: en-US
+Publisher: HP Inc.
+PackageName: HP Support Assistant
+License: freeware
+Copyright: Copyright (c) 2024 HP Development Company, L.P.
+ShortDescription: HP Support Assistant is a utility that helps HP computer users automatically detect drivers, install updates, troubleshoot issues, and access HP support resources.
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/h/HP/HPSupportAssistant/9.54.3.0/HP.HPSupportAssistant.yaml
+++ b/manifests/h/HP/HPSupportAssistant/9.54.3.0/HP.HPSupportAssistant.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: HP.HPSupportAssistant
+PackageVersion: 9.54.3.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New version: HP.HPSupportAssistant version 9.54.3.0, requested in #408286.

Same manifest content as #409512, moved to the `HP.HPSupportAssistant` identifier to match the existing HP package family (`HP.HPCMSL`, `HP.HPCloudRecoveryTool`, etc.).

Installer SHA256 verified against a full local download (186178552 bytes) of the vendor URL.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)
  - Resolves #408286

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

Validation performed on a Linux host (no winget CLI available): all three manifests parse as schema-1.12.0 YAML and InstallerSha256 matches the live vendor download byte-for-byte.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/411680)