### PR TITLE
New version: Materializr.Materializr version 1.6.0

### DIFF
--- a/manifests/m/Materializr/Materializr/1.6.0/Materializr.Materializr.installer.yaml
+++ b/manifests/m/Materializr/Materializr/1.6.0/Materializr.Materializr.installer.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Materializr.Materializr
+PackageVersion: 1.6.0
+InstallerLocale: en-US
+InstallerType: nullsoft
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+ProductCode: Materializr
+ReleaseDate: 2026-08-02
+AppsAndFeaturesEntries:
+- ProductCode: Materializr
+  DisplayVersion: v1.6.0
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles%\Materializr'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/materializr-cad/materializr/releases/download/v1.6.0/Materializr-Setup.exe
+  InstallerSha256: 836E3B3958DD9987857D80AB8AD45B83266FE496EFFC9F902633796ADA17A9BB
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/Materializr/Materializr/1.6.0/Materializr.Materializr.locale.en-US.yaml
+++ b/manifests/m/Materializr/Materializr/1.6.0/Materializr.Materializr.locale.en-US.yaml
@@ -1,0 +1,50 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Materializr.Materializr
+PackageVersion: 1.6.0
+PackageLocale: en-US
+Publisher: Materializr
+PublisherUrl: https://github.com/materializr-cad
+PublisherSupportUrl: https://github.com/materializr-cad/materializr/issues
+Author: Steve Bushwa
+PackageName: Materializr
+PackageUrl: https://github.com/materializr-cad/materializr
+License: GPL-3.0
+LicenseUrl: https://github.com/materializr-cad/materializr/blob/HEAD/LICENSE
+Copyright: Copyright (C) Steve Bushwa
+ShortDescription: Maker 3D CAD — the middle ground between Tinkercad and FreeCAD.
+Description: |-
+  Materializr is open-source 3D CAD for makers — the middle ground between
+  dead-simple tools like Tinkercad and full professional suites like FreeCAD.
+  Sketch on a plane, pull it into a solid (extrude, revolve, loft, sweep),
+  fillet and chamfer, run booleans, cut threads, and edit any step of the
+  history later. Sketches export to SVG and DXF at 1:1 mm for laser cutters and
+  2.5D CNC; it imports STEP, IGES, BREP, STL, SVG and DXF, and exports STEP,
+  STL, IGES, BREP, glTF, OBJ, 3MF, SVG and DXF. Real B-rep solids on the
+  OpenCASCADE kernel.
+Moniker: materializr
+Tags:
+- 3d
+- 3d-printing
+- cad
+- engineering
+- laser
+- modeling
+- opencascade
+- svg
+ReleaseNotes: |-
+  Materializr 1.5.1
+  Added
+  - Sketch dimension tool (D or toolbar): measure or drive line lengths, circle diameters, arc radii, point/line distances, angles and gaps; reference by default, driving when you type a value
+  - Four new thread profiles: trapezoidal (ACME), square, buttress and rounded, plus a fit clearance for 3D-printed bolt+nut pairs
+  - Polygon tool live radius readout
+  Fixed
+  - Parts showing through walls on complex assemblies (depth-tie rendering fix)
+  - Multi-body move/rotate/scale now reloads as an editable history step
+  - Fillets drifting after push/pull edits
+  - Threads cut correctly on unioned bodies and through end chamfers; stepped-rod resize confinement; internal rounded threads keep a smooth bore at any length
+  - Section view no longer stalls on threaded bodies; thread re-cuts are cancellable
+  - Malformed BREP files are rejected instantly instead of hanging the importer
+ReleaseNotesUrl: https://github.com/materializr-cad/materializr/releases/tag/v1.5.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/Materializr/Materializr/1.6.0/Materializr.Materializr.yaml
+++ b/manifests/m/Materializr/Materializr/1.6.0/Materializr.Materializr.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Materializr.Materializr
+PackageVersion: 1.6.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Manifest

Adds `Materializr.Materializr` version 1.6.0.

- Installer: `Materializr-Setup.exe` from the [v1.6.0 release](https://github.com/materializr-cad/materializr/releases/tag/v1.6.0)
- SHA256: `836E3B3958DD9987857D80AB8AD45B83266FE496EFFC9F902633796ADA17A9BB`
- Only the version, URL, hash, ARP DisplayVersion and release date differ from the merged 1.5.0 manifest.

Validated against the 1.12.0 schemas.

## Note

I have an earlier PR open for 1.5.1 (#408147) that stopped on `Validation-Executable-Error`. This supersedes it — happy to close that one either way.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/411696)