### PR TITLE
New package: crgimenes.kutta version 0.1.11

### DIFF
--- a/manifests/c/crgimenes/kutta/0.1.11/crgimenes.kutta.installer.yaml
+++ b/manifests/c/crgimenes/kutta/0.1.11/crgimenes.kutta.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: crgimenes.kutta
+PackageVersion: 0.1.11
+InstallerType: portable
+Commands:
+- kutta
+ReleaseDate: 2026-08-03
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/crgimenes/kutta/releases/download/v0.1.11/kutta-windows-amd64.exe
+  InstallerSha256: EFEA77603413BFDF9B554C3F811319561ED5C41549B4E7F666D95B88815F87EC
+- Architecture: arm64
+  InstallerUrl: https://github.com/crgimenes/kutta/releases/download/v0.1.11/kutta-windows-arm64.exe
+  InstallerSha256: 06864F76BA8551EF78D3A17F0E84D6A2D5A25B7BA35E7D41F643DD6A948932B8
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/crgimenes/kutta/0.1.11/crgimenes.kutta.locale.en-US.yaml
+++ b/manifests/c/crgimenes/kutta/0.1.11/crgimenes.kutta.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: crgimenes.kutta
+PackageVersion: 0.1.11
+PackageLocale: en-US
+Publisher: Cesar Gimenes
+PublisherUrl: https://crg.eti.br/
+PublisherSupportUrl: https://github.com/crgimenes/kutta/issues
+Author: Cesar Gimenes
+PackageName: kutta
+PackageUrl: https://github.com/crgimenes/kutta
+License: MIT
+LicenseUrl: https://github.com/crgimenes/kutta/blob/HEAD/LICENSE
+Copyright: Copyright (c) 2026 Cesar Gimenes
+ShortDescription: Qualitative 2D wind tunnel with an airfoil editor
+Description: >-
+  kutta streams a 2D flow past an airfoil and draws the speed field, vorticity,
+  smoke streaklines and the lift/drag vectors while you change the angle of
+  attack. It includes a shape editor to draw custom profiles, split a wing into
+  wing + flap, and animate control surfaces with keyframes. Qualitative and
+  educational — it captures the shape of the flow, not calibrated numbers.
+Moniker: kutta
+Tags:
+- aerodynamics
+- airfoil
+- cfd
+- education
+- simulation
+- wind-tunnel
+ReleaseNotesUrl: https://github.com/crgimenes/kutta/releases/tag/v0.1.11
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/crgimenes/kutta/0.1.11/crgimenes.kutta.yaml
+++ b/manifests/c/crgimenes/kutta/0.1.11/crgimenes.kutta.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: crgimenes.kutta
+PackageVersion: 0.1.11
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](https://github.com/microsoft/winget-pkgs/blob/master/CONTRIBUTING.md).
- [x] I have checked that there is no existing PR for this package and version.
- [x] This PR only modifies one manifest (one package version).
- [x] The InstallerSha256 values were computed from the release assets at the InstallerUrl.
- [x] The installers are portable single-file executables published on the project's signed GitHub release v0.1.11.

kutta is a qualitative 2D wind tunnel simulator with an airfoil editor, written in Go.
Homepage: https://github.com/crgimenes/kutta

This supersedes #406312, which was closed by the policy bot after a version bump
landed as several sequential file operations and validation observed the branch
mid-update. This branch is a single commit on top of current master.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/411718)