### PR TITLE
New package: tsouth89.Ceiling version 1.5.22

### DIFF
--- a/manifests/t/tsouth89/Ceiling/1.5.22/tsouth89.Ceiling.installer.yaml
+++ b/manifests/t/tsouth89/Ceiling/1.5.22/tsouth89.Ceiling.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: tsouth89.Ceiling
+PackageVersion: 1.5.22
+InstallerType: inno
+Scope: user
+UpgradeBehavior: install
+ProductCode: io.github.tsouth89.ceiling_is1
+ReleaseDate: 2026-08-03
+AppsAndFeaturesEntries:
+- ProductCode: io.github.tsouth89.ceiling_is1
+  DisplayName: Ceiling 1.5.22
+  DisplayVersion: 1.5.22
+  Publisher: Brandon South
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/tsouth89/ceiling/releases/download/v1.5.22/Ceiling-1.5.22-Setup.exe
+  InstallerSha256: B5E8B01FE5CA06704F6F87EF3DDD2555B9E044F419119B5E0717463F7E1029F3
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/t/tsouth89/Ceiling/1.5.22/tsouth89.Ceiling.locale.en-US.yaml
+++ b/manifests/t/tsouth89/Ceiling/1.5.22/tsouth89.Ceiling.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: tsouth89.Ceiling
+PackageVersion: 1.5.22
+PackageLocale: en-US
+Publisher: Brandon South
+PublisherUrl: https://github.com/tsouth89
+PublisherSupportUrl: https://github.com/tsouth89/ceiling/issues
+Author: Brandon South
+PackageName: Ceiling
+PackageUrl: https://ceiling.win
+License: MIT
+LicenseUrl: https://github.com/tsouth89/ceiling/blob/v1.5.22/LICENSE
+Copyright: Copyright (c) Ceiling contributors
+ShortDescription: Desktop capacity and quota monitor for coding assistants.
+Description: Ceiling is a local-first Windows app for monitoring provider-reported capacity and quota usage across AI coding platforms.
+Moniker: ceiling
+Tags:
+- claude
+- codex
+- cursor
+- desktop
+- gemini
+- grok
+- usage
+- windows
+ReleaseNotes: Ceiling 1.5.22 fixes a usage-scaling bug where the first 1% of usage read as 100% on OpenCode, Qoder, Chutes, and Sakana. OpenCode Go monthly windows are now labeled Monthly. The Microsoft Store build submits again with normalized installer parameters.
+ReleaseNotesUrl: https://github.com/tsouth89/ceiling/releases/tag/v1.5.22
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/tsouth89/Ceiling/1.5.22/tsouth89.Ceiling.yaml
+++ b/manifests/t/tsouth89/Ceiling/1.5.22/tsouth89.Ceiling.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: tsouth89.Ceiling
+PackageVersion: 1.5.22
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
This adds Ceiling 1.5.22 under the tsouth89.Ceiling package identity.

The installer is Authenticode-signed and timestamped. SHA-256 verified against the GitHub release artifact. winget validate passes.

Supersedes the stale 1.3.2 submission (#404324).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/411757)