### PR TITLE
New package: JasonMeng.rolltape version 0.1.0

### DIFF
--- a/manifests/j/JasonMeng/rolltape/0.1.0/JasonMeng.rolltape.installer.yaml
+++ b/manifests/j/JasonMeng/rolltape/0.1.0/JasonMeng.rolltape.installer.yaml
@@ -1,0 +1,15 @@
+PackageIdentifier: JasonMeng.rolltape
+PackageVersion: 0.1.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.19041.0
+InstallerType: portable
+Commands:
+- rolltape
+ReleaseDate: 2026-08-03
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/JasonCZMeng/rolltape/releases/download/v0.1.0/rolltape.0.1.0.exe
+  InstallerSha256: 0591ECBB24C912CDDAFF9342523B4CB13446EB9C24E9548424AC1E12788F9D46
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/j/JasonMeng/rolltape/0.1.0/JasonMeng.rolltape.locale.en-US.yaml
+++ b/manifests/j/JasonMeng/rolltape/0.1.0/JasonMeng.rolltape.locale.en-US.yaml
@@ -1,0 +1,24 @@
+PackageIdentifier: JasonMeng.rolltape
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Jason Meng
+PublisherUrl: https://github.com/JasonCZMeng
+PublisherSupportUrl: https://github.com/JasonCZMeng/rolltape/issues
+PackageName: rolltape
+PackageUrl: https://github.com/JasonCZMeng/rolltape
+License: MIT
+LicenseUrl: https://github.com/JasonCZMeng/rolltape/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Jason Meng
+ShortDescription: Push-to-hold screen clip recorder. Hold a key, tape rolls; release to save an editor-safe MP4.
+Description: rolltape is a push-to-hold screen clip recorder for Windows. Hold a hotkey (F9 by default) and the chosen monitor records with system audio; release the key and an editor-safe constant-60fps H.264 MP4 lands in your clips folder. Quick-tap the hotkey to lock recording hands-free, tap again to stop. The on-screen recording indicator is excluded from the capture itself. Built for gathering source clips for video essays and longer edits.
+Moniker: rolltape
+Tags:
+- clips
+- recorder
+- screen-capture
+- screen-recorder
+- screen-recording
+- video
+ReleaseNotesUrl: https://github.com/JasonCZMeng/rolltape/releases/tag/v0.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/j/JasonMeng/rolltape/0.1.0/JasonMeng.rolltape.yaml
+++ b/manifests/j/JasonMeng/rolltape/0.1.0/JasonMeng.rolltape.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: JasonMeng.rolltape
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
New package submission: **JasonMeng.rolltape** version 0.1.0

rolltape is an open-source (MIT) push-to-hold screen clip recorder for Windows: hold a hotkey and the chosen monitor records with system audio; release to save an editor-safe constant-60fps H.264 MP4. Portable single-exe distribution.

- Homepage: https://github.com/JasonCZMeng/rolltape
- Release: https://github.com/JasonCZMeng/rolltape/releases/tag/v0.1.0
- Installer type: portable (x64), SHA256 matches the published `SHA256SUMS.txt` in the release

Note: the executable is currently unsigned (SmartScreen may warn); checksums are published with the release.

- [x] I have read the [Contributing Guide](https://github.com/microsoft/winget-pkgs/blob/master/CONTRIBUTING.md)
- [x] The manifest targets schema version 1.6.0 and contains the version, installer, and defaultLocale files
- [x] This PR only modifies one manifest (one package version)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/411779)