### PR TITLE
New package: JOhnsonKC201.pixelpets version 0.3.0

### DIFF
--- a/manifests/j/JOhnsonKC201/pixelpets/0.3.0/JOhnsonKC201.pixelpets.installer.yaml
+++ b/manifests/j/JOhnsonKC201/pixelpets/0.3.0/JOhnsonKC201.pixelpets.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: JOhnsonKC201.pixelpets
+PackageVersion: 0.3.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/JOhnsonKC201/pixelpets/releases/download/v0.3.0/pixelpets.Setup.0.3.0.exe
+  InstallerSha256: A2EE491A0D927E276044E15648EF9281F1A731C38B29D014EC423A5A0B59EC23
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/j/JOhnsonKC201/pixelpets/0.3.0/JOhnsonKC201.pixelpets.locale.en-US.yaml
+++ b/manifests/j/JOhnsonKC201/pixelpets/0.3.0/JOhnsonKC201.pixelpets.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: JOhnsonKC201.pixelpets
+PackageVersion: 0.3.0
+PackageLocale: en-US
+Publisher: JOhnsonKC201
+PublisherUrl: https://github.com/JOhnsonKC201
+PublisherSupportUrl: https://github.com/JOhnsonKC201/pixelpets/issues
+PackageName: pixelpets
+PackageUrl: https://github.com/JOhnsonKC201/pixelpets
+License: MIT
+LicenseUrl: https://github.com/JOhnsonKC201/pixelpets/blob/main/LICENSE
+ShortDescription: A pixel cat or dog that lives on your desktop
+Description: |-
+  A desktop pet built from scratch: nearly every sprite, animation and sound is original and procedural. It sits at the edge of your screen, watches your cursor, kneads the keyboard when you type, purrs when you pet it, and stretches like mochi when you drag it. Prefer a dog? Switch species from the tray and you get a real one: 14 breeds, a wagging tail that reads your pet's mood, a play bow instead of a hunting crouch, and a tennis ball it will actually chase down and bring back. Also included: 14 cat coats plus custom coats, fully synthesized sound (meow, purr, bark, pant, and a lo-fi study-music mode), a pomodoro timer, reminders, mail and calendar nudges, and reactions to AI coding agents.
+Moniker: pixelpets
+Tags:
+- cat
+- desktop-pet
+- dog
+- electron
+- kawaii
+- pixel-art
+- pomodoro
+- virtual-pet
+ReleaseNotesUrl: https://github.com/JOhnsonKC201/pixelpets/releases/tag/v0.3.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/j/JOhnsonKC201/pixelpets/0.3.0/JOhnsonKC201.pixelpets.yaml
+++ b/manifests/j/JOhnsonKC201/pixelpets/0.3.0/JOhnsonKC201.pixelpets.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: JOhnsonKC201.pixelpets
+PackageVersion: 0.3.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
New package: `JOhnsonKC201.pixelpets` version 0.3.0.

This replaces #407879, which I closed rather than patched. That one submitted the same app under the old identifier `JOhnsonKC201.pixelcat`. I renamed the project to pixelpets after adding a second species, so landing a permanent `PackageIdentifier` of `pixelcat` would have meant publishing a second package and deprecating the first one days later. This submits 0.3.0 under the name the project is keeping.

One note that may be useful to whoever owns the policy pipeline. #407879 was held at `Policy-Test-2.7` as "Algo Speak - Potential adult content". The description contained no standalone flagged word. The trigger was the substring `corn` inside the word **corner**, from "the cat sits in the corner of your screen". That suggests substring rather than whole-word matching, which would equally flag acorn, cornea, scorn, popcorn and cornerstone. The description here is worded so it does not hit that path.

- Installer: https://github.com/JOhnsonKC201/pixelpets/releases/download/v0.3.0/pixelpets.Setup.0.3.0.exe
- Release notes: https://github.com/JOhnsonKC201/pixelpets/releases/tag/v0.3.0
- Source: https://github.com/JOhnsonKC201/pixelpets (MIT, open source, all art, code and sound original)

---

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open pull requests for the same manifest?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? (`Manifest validation succeeded.`)
- [x] Does your manifest conform to the [1.12.0 schema](https://github.com/microsoft/winget-cli/blob/master/schemas/JSON/manifests/v1.12.0)?

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/411781)