### PR TITLE
New package: ishizakahiroshi.AudioRemote version 0.1.0

### DIFF
--- a/manifests/i/ishizakahiroshi/AudioRemote/ishizakahiroshi.AudioRemote.installer.yaml
+++ b/manifests/i/ishizakahiroshi/AudioRemote/ishizakahiroshi.AudioRemote.installer.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: ishizakahiroshi.AudioRemote
+PackageVersion: 0.1.0
+
+# 22000 is the first Windows 11 build. The server talks to Core Audio through
+# an interface that exists on Windows 10 too, but nothing about this app is
+# tested there and the README says Windows 11 only — so the floor is stated
+# here rather than left for a user to discover.
+MinimumOSVersion: 10.0.22000.0
+
+# The release ships a zip holding one exe, which is what `portable` inside `zip`
+# is for: winget unpacks it into its own package store and puts an `audioremote`
+# alias on PATH. No installer, nothing in Program Files, nothing to uninstall by
+# hand.
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: audioremote.exe
+    PortableCommandAlias: audioremote
+
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/ishizakahiroshi/audioremote/releases/download/v0.1.0/audioremote-win32-x64.zip
+    # Copied from the release's own SHA256SUMS.txt, never recomputed here. Two
+    # places claiming to know the hash is two places that can disagree.
+    InstallerSha256: 45BC534702ECF220ADFEE9BA6818C09AC44F947545276D1B253A2A4B3E2176BD
+
+ReleaseDate: 2026-07-31
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/i/ishizakahiroshi/AudioRemote/ishizakahiroshi.AudioRemote.locale.en-US.yaml
+++ b/manifests/i/ishizakahiroshi/AudioRemote/ishizakahiroshi.AudioRemote.locale.en-US.yaml
@@ -1,0 +1,53 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: ishizakahiroshi.AudioRemote
+PackageVersion: 0.1.0
+PackageLocale: en-US
+
+Publisher: ishizakahiroshi
+PublisherUrl: https://github.com/ishizakahiroshi
+PublisherSupportUrl: https://github.com/ishizakahiroshi/audioremote/issues
+Author: Hiroshi Ishizaka (ishizakahiroshi)
+
+PackageName: AudioRemote
+PackageUrl: https://github.com/ishizakahiroshi/audioremote
+License: MIT
+LicenseUrl: https://github.com/ishizakahiroshi/audioremote/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Hiroshi Ishizaka (ishizakahiroshi)
+CopyrightUrl: https://github.com/ishizakahiroshi/audioremote/blob/main/LICENSE
+
+# Verbatim from `description` in Cargo.toml. One sentence, one source — if the
+# two ever disagree, the crate is the one people can check.
+ShortDescription: Switch your Windows 11 host's default audio output device from any browser on the LAN
+Description: |-
+  AudioRemote runs a small HTTP server on your Windows 11 machine and serves a
+  web page from it, so you can change which device the audio comes out of from
+  any browser on the same network — a phone, a laptop, a VM — without walking
+  over to the host.
+
+  Console, Multimedia and Communications defaults are always switched together,
+  so meeting apps do not keep playing through the device you just left. The
+  guest needs nothing installed: open the share URL once and the token is kept
+  in the browser, so a bookmark is enough from then on.
+
+  Non-loopback clients require a bearer token. The server binds to the LAN by
+  default and can be locked to localhost with `audioremote setup`.
+
+Moniker: audioremote
+Tags:
+  - audio
+  - audio-device
+  - core-audio
+  - endpoint
+  - lan
+  - remote-control
+  - tray
+  - windows
+
+ReleaseNotesUrl: https://github.com/ishizakahiroshi/audioremote/releases/tag/v0.1.0
+Documentations:
+  - DocumentLabel: README
+    DocumentUrl: https://github.com/ishizakahiroshi/audioremote#readme
+
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/i/ishizakahiroshi/AudioRemote/ishizakahiroshi.AudioRemote.yaml
+++ b/manifests/i/ishizakahiroshi/AudioRemote/ishizakahiroshi.AudioRemote.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+# Kept in this repository as the master copy. The manifests that reach users
+# live in microsoft/winget-pkgs, but a package whose only definition sits in
+# somebody else's repo is a package you cannot reproduce — so the originals stay
+# here and are copied out at submission time.
+#
+# Pinned to the released version, not the working one: winget resolves
+# `InstallerUrl` at install time, and a manifest naming a tag that does not
+# exist yet is a broken package. `wingetcreate update` in release.yml bumps
+# these three files at each release.
+
+PackageIdentifier: ishizakahiroshi.AudioRemote
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Description

Adds `ishizakahiroshi.AudioRemote` version `0.1.0` to the Windows Package Manager community repository.

AudioRemote is a Windows 11 portable audio-output switcher. The manifest points to the existing GitHub Release asset and publishes the `audioremote` portable command alias.

## Validation

- `winget validate` passed for all three manifests.
- Installer URL and SHA256 were checked against the existing `v0.1.0` GitHub Release.
- The package is an x64 ZIP with a portable nested installer and no installer-side writes.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/411865)