### PR TITLE
New package: Adobe.ExpressPhotos version 6.6.2

### DIFF
--- a/manifests/a/Adobe/ExpressPhotos/6.6.2/Adobe.ExpressPhotos.installer.yaml
+++ b/manifests/a/Adobe/ExpressPhotos/6.6.2/Adobe.ExpressPhotos.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Adobe.ExpressPhotos
+PackageVersion: 6.6.2
+ReleaseDate: 2026-07-14
+Platform:
+- Windows.Universal
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: msix
+PackageFamilyName: AdobeSystemsIncorporated.AdobePhotoshopExpress_mtcwf2zmmt10c
+Installers:
+- Architecture: x64
+  InstallerUrl: https://harmonydl.adobe.com/pub/adobe/harmony/release/windows/x64/PSExpress_Package.msixbundle
+  InstallerSha256: 08E8A92B9CB8524D0161B6A18D691E6DF5A9AEAE43F404B320EE93BF32BDD510
+  SignatureSha256: 198E38597C7C06E47233BB457FEBDD09424C2E872F26187024943AFC72321C1F
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.VCLibs.Desktop.14
+  - PackageIdentifier: Microsoft.WindowsAppRuntime.1.6
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/Adobe/ExpressPhotos/6.6.2/Adobe.ExpressPhotos.locale.en-US.yaml
+++ b/manifests/a/Adobe/ExpressPhotos/6.6.2/Adobe.ExpressPhotos.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Adobe.ExpressPhotos
+PackageVersion: 6.6.2
+PackageLocale: en-US
+Publisher: Adobe Inc.
+PackageName: Adobe Express Photos
+PackageUrl: https://www.adobe.com/express/
+License: Proprietary
+ShortDescription: The quick and easy create-anything app.
+Moniker: adobeexpressphotos
+Tags:
+- adobe-express-photo
+- image-editor
+- imageeditor
+- image-editing
+- imageediting
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/Adobe/ExpressPhotos/6.6.2/Adobe.ExpressPhotos.yaml
+++ b/manifests/a/Adobe/ExpressPhotos/6.6.2/Adobe.ExpressPhotos.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Adobe.ExpressPhotos
+PackageVersion: 6.6.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
Added Adobe Express Photos.

I personally haven't had much use for Adobe editors in almost 15 years, so if the PR starts throwing hash mismatches even just once after initially having successfully passed the pipelines, it'd be relegated to an Issues package request and to winget-extras.

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/411866)