### PR TITLE
New package: tinyrack.coder version 0.1.0

### DIFF
--- a/manifests/t/tinyrack/coder/0.1.0/tinyrack.coder.installer.yaml
+++ b/manifests/t/tinyrack/coder/0.1.0/tinyrack.coder.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: tinyrack.coder
+PackageVersion: 0.1.0
+InstallerLocale: en-US
+InstallerType: inno
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/tinyrack-net/coder/releases/download/v0.1.0/Coder-setup-win-x64.exe
+  InstallerSha256: CCC7B0F945F7646548DBFE3F156D02B2C90F29FB588770190F7BB307AE9772AE
+AppsAndFeaturesEntries:
+- ProductCode: '{9F4B3C21-6E58-4A7D-9C1E-0B2D5A8F3E14}_is1'
+  UpgradeCode: '{9F4B3C21-6E58-4A7D-9C1E-0B2D5A8F3E14}'
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-08-04

--- a/manifests/t/tinyrack/coder/0.1.0/tinyrack.coder.locale.en-US.yaml
+++ b/manifests/t/tinyrack/coder/0.1.0/tinyrack.coder.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: tinyrack.coder
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: tinyrack
+PublisherUrl: https://github.com/tinyrack-net
+PublisherSupportUrl: https://github.com/tinyrack-net/coder/issues
+PackageName: Coder
+PackageUrl: https://github.com/tinyrack-net/coder
+License: MIT
+LicenseUrl: https://github.com/tinyrack-net/coder/blob/main/LICENSE
+Copyright: Copyright (c) winetree94
+ShortDescription: Local-first AI coding agent with an always-on daemon
+Description: |-
+  Coder is a local-first AI coding agent. It runs a daemon that owns the
+  workspace, streams turns over JSON-RPC, and keeps working while the window is
+  closed. The desktop application stays resident in the notification area.
+Tags:
+- ai
+- agent
+- coding-assistant
+- developer-tools
+- llm
+ReleaseNotesUrl: https://github.com/tinyrack-net/coder/releases/tag/v0.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/tinyrack/coder/0.1.0/tinyrack.coder.yaml
+++ b/manifests/t/tinyrack/coder/0.1.0/tinyrack.coder.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: tinyrack.coder
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Manifest

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/add?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

---

New package. Coder is a local-first AI coding agent that runs a daemon owning the workspace and stays resident in the notification area.

- Publisher `tinyrack` already ships `tinyrack.dotweave` and `tinyrack.proxer`.
- Installer is Inno Setup, published from the project's release pipeline.
- Installer SHA256 verified against the GitHub release asset.
- All three manifests validated against the official 1.12.0 JSON schemas.

`winget install --manifest` was not run: the maintainer has no Windows host available, so installation is exercised only by the project's own `windows-2025` CI.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/411940)