### PR TITLE
New package: ChHsiching.BongoCatTodo version 1.3.1

### DIFF
--- a/manifests/c/ChHsiching/BongoCatTodo/1.3.1/ChHsiching.BongoCatTodo.installer.yaml
+++ b/manifests/c/ChHsiching/BongoCatTodo/1.3.1/ChHsiching.BongoCatTodo.installer.yaml
@@ -1,0 +1,47 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ChHsiching.BongoCatTodo
+PackageVersion: 1.3.1
+InstallerType: nullsoft
+ProductCode: BongoCat Todo
+Installers:
+- Architecture: x86
+  Scope: user
+  InstallerUrl: https://github.com/ChHsiching/bongocat-todo/releases/download/v1.3.1/BongoCat.Todo_1.3.1_x86-setup.exe
+  InstallerSha256: DFC42A1F6060100D502F16D9B2EA66157314C6A00807BC09649A3B2C02A87D59
+  InstallerSwitches:
+    Custom: /CurrentUser
+- Architecture: x86
+  Scope: machine
+  InstallerUrl: https://github.com/ChHsiching/bongocat-todo/releases/download/v1.3.1/BongoCat.Todo_1.3.1_x86-setup.exe
+  InstallerSha256: DFC42A1F6060100D502F16D9B2EA66157314C6A00807BC09649A3B2C02A87D59
+  InstallerSwitches:
+    Custom: /AllUsers
+- Architecture: x64
+  Scope: user
+  InstallerUrl: https://github.com/ChHsiching/bongocat-todo/releases/download/v1.3.1/BongoCat.Todo_1.3.1_x64-setup.exe
+  InstallerSha256: 77B7CF1EFEA2E9A53C82021C3C23331B057B117D39D4FF03A0FFB2D37ED54012
+  InstallerSwitches:
+    Custom: /CurrentUser
+- Architecture: x64
+  Scope: machine
+  InstallerUrl: https://github.com/ChHsiching/bongocat-todo/releases/download/v1.3.1/BongoCat.Todo_1.3.1_x64-setup.exe
+  InstallerSha256: 77B7CF1EFEA2E9A53C82021C3C23331B057B117D39D4FF03A0FFB2D37ED54012
+  InstallerSwitches:
+    Custom: /AllUsers
+- Architecture: arm64
+  Scope: user
+  InstallerUrl: https://github.com/ChHsiching/bongocat-todo/releases/download/v1.3.1/BongoCat.Todo_1.3.1_arm64-setup.exe
+  InstallerSha256: D334A9493BE9253549158E34E1C765AE3D2C436C89A13244E147D1FB2362181C
+  InstallerSwitches:
+    Custom: /CurrentUser
+- Architecture: arm64
+  Scope: machine
+  InstallerUrl: https://github.com/ChHsiching/bongocat-todo/releases/download/v1.3.1/BongoCat.Todo_1.3.1_arm64-setup.exe
+  InstallerSha256: D334A9493BE9253549158E34E1C765AE3D2C436C89A13244E147D1FB2362181C
+  InstallerSwitches:
+    Custom: /AllUsers
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-08-04

--- a/manifests/c/ChHsiching/BongoCatTodo/1.3.1/ChHsiching.BongoCatTodo.locale.en-US.yaml
+++ b/manifests/c/ChHsiching/BongoCatTodo/1.3.1/ChHsiching.BongoCatTodo.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ChHsiching.BongoCatTodo
+PackageVersion: 1.3.1
+PackageLocale: en-US
+Publisher: ChHsiching
+PublisherUrl: https://github.com/ChHsiching
+PublisherSupportUrl: https://github.com/ChHsiching/bongocat-todo/issues
+PackageName: BongoCat Todo
+PackageUrl: https://github.com/ChHsiching/bongocat-todo
+License: MIT
+LicenseUrl: https://github.com/ChHsiching/bongocat-todo/blob/HEAD/LICENSE
+ShortDescription: Desktop pet cat with a todo list and mail notifier
+Description: |-
+  BongoCat Todo is a fork of BongoCat (Tauri 2 + Vue 3 desktop pet) that adds a
+  hand-drawn style todo list module and a mail notification center. Right-click
+  the cat to manage your todos; bind your mailbox to get bubble notifications
+  for new emails — all without leaving your desktop pet.
+Tags:
+- pet
+- todo
+- mail
+- tauri
+- desktop
+ReleaseNotesUrl: https://github.com/ChHsiching/bongocat-todo/releases/tag/v1.3.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/ChHsiching/BongoCatTodo/1.3.1/ChHsiching.BongoCatTodo.locale.zh-CN.yaml
+++ b/manifests/c/ChHsiching/BongoCatTodo/1.3.1/ChHsiching.BongoCatTodo.locale.zh-CN.yaml
@@ -1,0 +1,25 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: ChHsiching.BongoCatTodo
+PackageVersion: 1.3.1
+PackageLocale: zh-CN
+Publisher: ChHsiching
+PublisherUrl: https://github.com/ChHsiching
+PublisherSupportUrl: https://github.com/ChHsiching/bongocat-todo/issues
+PackageName: BongoCat Todo
+PackageUrl: https://github.com/ChHsiching/bongocat-todo
+License: MIT
+LicenseUrl: https://github.com/ChHsiching/bongocat-todo/blob/HEAD/LICENSE
+ShortDescription: 带待办模块和邮件通知中心的桌宠应用
+Description: |-
+  BongoCat Todo 是 BongoCat（Tauri 2 + Vue 3 桌宠）的 fork，新增手绘风格待办模块和邮件通知中心。
+  右键桌宠呼出待办面板，绑定邮箱后新邮件桌宠头顶弹出气泡提醒。
+Tags:
+- 桌宠
+- 待办
+- 邮件
+- tauri
+ReleaseNotesUrl: https://github.com/ChHsiching/bongocat-todo/releases/tag/v1.3.1
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/c/ChHsiching/BongoCatTodo/1.3.1/ChHsiching.BongoCatTodo.yaml
+++ b/manifests/c/ChHsiching/BongoCatTodo/1.3.1/ChHsiching.BongoCatTodo.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ChHsiching.BongoCatTodo
+PackageVersion: 1.3.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package: `ChHsiching.BongoCatTodo` version 1.3.1

BongoCat Todo is a fork of BongoCat (Tauri 2 + Vue 3 desktop pet) that adds a hand-drawn todo list module and a mail notification center. This is the initial submission to winget.

Installer: NSIS, three architectures (x86, x64, arm64), each with per-user and per-machine scope.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)