### PR TITLE
New version: Feci.ParleyDeckSkill version 2.2.0

### DIFF
--- a/manifests/f/Feci/ParleyDeckSkill/2.1.0/Feci.ParleyDeckSkill.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/2.1.0/Feci.ParleyDeckSkill.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 2.1.0
+InstallerType: portable
+Commands:
+- parley-deck-skill
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-skill/releases/download/v2.1.0/parley-deck-skill-v2.1.0-windows-x64.exe
+  InstallerSha256: 1318C25150F87A192733C2822C009A2BB58AA43804272D88A8151A50A38A8BB6
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-skill/releases/download/v2.1.0/parley-deck-skill-v2.1.0-windows-arm64.exe
+  InstallerSha256: 13202D156E9D8672D77A2780DC2DF1A3C9CB27A137991E383BB61EEC2B216C7F
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckSkill/2.1.0/Feci.ParleyDeckSkill.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/2.1.0/Feci.ParleyDeckSkill.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 2.1.0
+PackageLocale: en-US
+Publisher: Feci
+PublisherUrl: https://github.com/feci
+PackageName: Parley Deck Skill
+PackageUrl: https://github.com/feci/parley-deck-skill
+License: Apache-2.0
+LicenseUrl: https://github.com/feci/parley-deck-skill/blob/main/LICENSE
+ShortDescription: Installer for the Parley Deck multi-agent cooperation skill.
+Description: "Installs the vendor-neutral Parley Deck AI cooperation skill into Codex, Claude Code, Antigravity CLI, legacy Gemini CLI, Hermes, Kimi Code, or a custom skill directory. v2.1.0 adds parley-bidding, a sixth skill for evidence-backed bidding on software procurements — discovery, qualification, requirements analysis, bid preparation, release freezing, portal staging and submission, with every consequential step held by a human, tender and portal content treated as untrusted evidence rather than instruction, and no handling of passwords, cookies, tokens or MFA codes. It also adds add-on payload integrity: an add-on may ship a manifest listing every file with its SHA-256, so health checks can tell a faithfully copied tree from a damaged one (defect detection, not tamper resistance). Installation and removal are now atomic across the whole fleet — the complete plan is checked before the first write or deletion, and a predictable failure anywhere produces zero writes. Installer mutations are single-writer: do not run two install or uninstall commands at the same time."
+ReleaseNotesUrl: https://github.com/feci/parley-deck-skill/releases/tag/v2.1.0
+Tags:
+- ai
+- agents
+- agy
+- antigravity
+- cli
+- codex
+- claude
+- gemini
+- kimi
+- multi-agent
+- skill
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckSkill/2.1.0/Feci.ParleyDeckSkill.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/2.1.0/Feci.ParleyDeckSkill.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 2.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckSkill/2.2.0/Feci.ParleyDeckSkill.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/2.2.0/Feci.ParleyDeckSkill.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 2.2.0
+InstallerType: portable
+Commands:
+- parley-deck-skill
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-skill/releases/download/v2.2.0/parley-deck-skill-v2.2.0-windows-x64.exe
+  InstallerSha256: 9E385251E892D1508E5FFC5344057E142B4910333D20321E89E36FA8E990332A
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-skill/releases/download/v2.2.0/parley-deck-skill-v2.2.0-windows-arm64.exe
+  InstallerSha256: ACA78034826C6650CEB19B02F810A4392B7D0FEE3FD71A84BFB5447C8A0DAB6D
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckSkill/2.2.0/Feci.ParleyDeckSkill.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/2.2.0/Feci.ParleyDeckSkill.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 2.2.0
+PackageLocale: en-US
+Publisher: Feci
+PublisherUrl: https://github.com/feci
+PackageName: Parley Deck Skill
+PackageUrl: https://github.com/feci/parley-deck-skill
+License: Apache-2.0
+LicenseUrl: https://github.com/feci/parley-deck-skill/blob/main/LICENSE
+ShortDescription: Installer for the Parley Deck multi-agent cooperation skill.
+Description: "Installs the vendor-neutral Parley Deck AI cooperation skill into Codex, Claude Code, Antigravity CLI, legacy Gemini CLI, Hermes, Kimi Code, or a custom skill directory. v2.2.0 gives every packaged skill a byte-exact integrity manifest, so an install placed by any installer can be verified file by file. This closes four defects in 2.1.0. Installing all six skills with a third-party installer reported five of them malformed even when every byte was correct, because only one skill shipped a manifest. A skill installed by this tool and then gutted down to a single file reported healthy, and that verdict survived the upgrade for installs made earlier. The core skill accepted the deletion of files it had itself installed without reporting anything. And health could report a directory as unowned while removal treated it as owned. Note for existing users, doctor will report your add-ons malformed until you re-run install once; force is not needed. Integrity checking here is defect detection, not tamper resistance."
+ReleaseNotesUrl: https://github.com/feci/parley-deck-skill/releases/tag/v2.2.0
+Tags:
+- ai
+- agents
+- agy
+- antigravity
+- cli
+- codex
+- claude
+- gemini
+- kimi
+- multi-agent
+- skill
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckSkill/2.2.0/Feci.ParleyDeckSkill.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/2.2.0/Feci.ParleyDeckSkill.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 2.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Portable CLI. Both installers verified against the published release assets by SHA-256 download.

2.2.0 gives every packaged skill a byte-exact integrity manifest, closing four defects in 2.1.0 — a byte-correct third-party install reported malformed, a gutted install reported healthy, that verdict surviving the upgrade, and health disagreeing with removal about ownership.

Existing users must re-run install once after upgrading; the changelog explains why that is deliberate.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/411947)