### PR TITLE
New version: xmn.BetterTrumpet version 3.2.2

### DIFF
--- a/manifests/x/xmn/BetterTrumpet/3.2.2/xmn.BetterTrumpet.installer.yaml
+++ b/manifests/x/xmn/BetterTrumpet/3.2.2/xmn.BetterTrumpet.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: xmn.BetterTrumpet
+PackageVersion: 3.2.2
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+Installers:
+  - Architecture: x86
+    InstallerUrl: https://github.com/xammen/BetterTrumpet/releases/download/v3.2.2/BetterTrumpet-3.2.2-setup.exe
+    InstallerSha256: 95674AD4FA7D212A003FC2E57B4B9A2F845023DE911C4A2D197BC0CDCD35FD32
+    InstallerSwitches:
+      Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+      SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+ManifestType: installer
+ManifestVersion: 1.10.0
+ReleaseDate: 2026-08-04

--- a/manifests/x/xmn/BetterTrumpet/3.2.2/xmn.BetterTrumpet.locale.en-US.yaml
+++ b/manifests/x/xmn/BetterTrumpet/3.2.2/xmn.BetterTrumpet.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: xmn.BetterTrumpet
+PackageVersion: 3.2.2
+PackageLocale: en-US
+Publisher: xmn
+PublisherUrl: https://github.com/xammen
+PublisherSupportUrl: https://github.com/xammen/BetterTrumpet/issues
+PackageName: BetterTrumpet
+PackageUrl: https://github.com/xammen/BetterTrumpet
+License: MIT
+LicenseUrl: https://github.com/xammen/BetterTrumpet/blob/master/LICENSE
+ShortDescription: A refined fork of EarTrumpet with enhanced volume control and music overlay
+Description: BetterTrumpet is a refined fork of EarTrumpet, the beloved Windows volume mixer. Features include enhanced volume control, a slick music overlay, fully customizable colors, and a cleaner interface.
+Tags:
+  - audio
+  - volume
+  - mixer
+  - sound
+  - music
+  - bettertrumpet
+  - eartrumpet
+  - windows
+ReleaseNotes: Version 3.2.2 fixes default-device changes through the CLI, keeps the flyout and media popup correctly positioned at custom display scales, and preserves acrylic styling when custom window colors are enabled.
+ReleaseNotesUrl: https://github.com/xammen/BetterTrumpet/releases/tag/v3.2.2
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/x/xmn/BetterTrumpet/3.2.2/xmn.BetterTrumpet.yaml
+++ b/manifests/x/xmn/BetterTrumpet/3.2.2/xmn.BetterTrumpet.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: xmn.BetterTrumpet
+PackageVersion: 3.2.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Release 3.2.2

- Updates xmn.BetterTrumpet to version 3.2.2.
- Uses the GitHub setup asset and its SHA256 95674AD4FA7D212A003FC2E57B4B9A2F845023DE911C4A2D197BC0CDCD35FD32.
- Validated locally with winget validate.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/411949)