### PR TITLE
New version: xmn.BetterTrumpet version 3.2.3

### DIFF
--- a/manifests/x/xmn/BetterTrumpet/3.2.3/xmn.BetterTrumpet.installer.yaml
+++ b/manifests/x/xmn/BetterTrumpet/3.2.3/xmn.BetterTrumpet.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: xmn.BetterTrumpet
+PackageVersion: 3.2.3
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+Installers:
+  - Architecture: x86
+    InstallerUrl: https://github.com/xammen/BetterTrumpet/releases/download/v3.2.3/BetterTrumpet-3.2.3-setup.exe
+    InstallerSha256: 1E06CEDDE3BFA04CAD7771CF9E4B2359F91BD26DFC03256FAA9800125FA2A42C
+    InstallerSwitches:
+      Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+      SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+ManifestType: installer
+ManifestVersion: 1.10.0
+ReleaseDate: 2026-08-04

--- a/manifests/x/xmn/BetterTrumpet/3.2.3/xmn.BetterTrumpet.locale.en-US.yaml
+++ b/manifests/x/xmn/BetterTrumpet/3.2.3/xmn.BetterTrumpet.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: xmn.BetterTrumpet
+PackageVersion: 3.2.3
+PackageLocale: en-US
+Publisher: xmn
+PublisherUrl: https://github.com/xammen
+PublisherSupportUrl: https://github.com/xammen/BetterTrumpet/issues
+PackageName: BetterTrumpet
+PackageUrl: https://github.com/xammen/BetterTrumpet
+License: MIT
+LicenseUrl: https://github.com/xammen/BetterTrumpet/blob/master/LICENSE
+ShortDescription: A refined fork of EarTrumpet with enhanced volume control and music overlay
+Description: BetterTrumpet is a refined fork of EarTrumpet, the beloved Windows volume mixer. Features include enhanced volume control, a slick music overlay, fully customizable colors, and a cleaner interface.
+Tags:
+  - audio
+  - volume
+  - mixer
+  - sound
+  - music
+  - bettertrumpet
+  - eartrumpet
+  - windows
+ReleaseNotes: Version 3.2.3 adds folder-based launch volume defaults with deepest-folder matching, explicit app-rule priority, and settings export/import support.
+ReleaseNotesUrl: https://github.com/xammen/BetterTrumpet/releases/tag/v3.2.3
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/x/xmn/BetterTrumpet/3.2.3/xmn.BetterTrumpet.yaml
+++ b/manifests/x/xmn/BetterTrumpet/3.2.3/xmn.BetterTrumpet.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: xmn.BetterTrumpet
+PackageVersion: 3.2.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Summary

- Adds xmn.BetterTrumpet version 3.2.3.
- Uses the public Inno Setup installer from the matching GitHub release with its SHA256.

## Validation

- `winget validate --manifest winget-manifest/manifests/x/xmn/BetterTrumpet/3.2.3`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/411985)