### PR TITLE
New package: FedeB2160.WinGetStudio version 1.9.0

### DIFF
--- a/manifests/f/FedeB2160/WinGetStudio/1.9.0/FedeB2160.WinGetStudio.installer.yaml
+++ b/manifests/f/FedeB2160/WinGetStudio/1.9.0/FedeB2160.WinGetStudio.installer.yaml
@@ -1,0 +1,15 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: FedeB2160.WinGetStudio
+PackageVersion: 1.9.0
+InstallerLocale: en-US
+InstallerType: portable
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/FedeB2160/WinGetStudio/releases/download/v1.9.0/WinGetStudio.exe
+  InstallerSha256: 684EF281781C39B9E4C6330B323BDAFC787B9A832D18F33645A816D71EF2DE0C
+  ElevationRequirement: elevatesSelf
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-08-04

--- a/manifests/f/FedeB2160/WinGetStudio/1.9.0/FedeB2160.WinGetStudio.locale.en-US.yaml
+++ b/manifests/f/FedeB2160/WinGetStudio/1.9.0/FedeB2160.WinGetStudio.locale.en-US.yaml
@@ -1,0 +1,36 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: FedeB2160.WinGetStudio
+PackageVersion: 1.9.0
+PackageLocale: en-US
+Publisher: FedeB2160
+PublisherUrl: https://github.com/FedeB2160
+PublisherSupportUrl: https://github.com/FedeB2160/WinGetStudio/issues
+PackageName: WinGet Studio
+PackageUrl: https://github.com/FedeB2160/WinGetStudio
+License: MIT
+LicenseUrl: https://github.com/FedeB2160/WinGetStudio/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Federico Borghi
+ShortDescription: 'A desktop front end for winget: update, install, uninstall, pin and export packages.'
+Description: |-
+  A Windows desktop front end for winget. Everything happens in one table with checkboxes:
+  update what has a newer version, install something new by searching as you type, list and
+  uninstall what is already there, pin what must not be touched, and export or import the whole
+  package list to rebuild a machine.
+
+  Light and dark theme, no telemetry, a single executable with nothing to install. Requires
+  administrator rights, which it asks for at startup.
+Moniker: wingetstudio
+Tags:
+- gui
+- package-manager
+- packages
+- winget
+ReleaseNotes: |-
+  Renamed from WinGet Update Tool. Adds an Install tab with search-as-you-type, an Installed
+  tab with a filter and guarded uninstall, package pinning, export and import of the package
+  list, a settings screen, and self-update from GitHub releases.
+ReleaseNotesUrl: https://github.com/FedeB2160/WinGetStudio/releases/tag/v1.9.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/FedeB2160/WinGetStudio/1.9.0/FedeB2160.WinGetStudio.yaml
+++ b/manifests/f/FedeB2160/WinGetStudio/1.9.0/FedeB2160.WinGetStudio.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: FedeB2160.WinGetStudio
+PackageVersion: 1.9.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
New package: **WinGet Studio** — a WPF desktop front end for winget.
Update, install, uninstall, pin and export/import packages from a single
checkbox table.

- Repository: https://github.com/FedeB2160/WinGetStudio
- License: MIT
- Installer: portable, a single signed executable (x86, runs on x64 via WOW64)
- `ElevationRequirement: elevatesSelf` — the exe carries a requireAdministrator
  manifest, so installing needs no privileges while running asks for them
- The executable is Authenticode-signed with a timestamped self-signed
  certificate, so Windows will report an unknown publisher

Validated with `winget validate` and installed locally with
`winget install --manifest` on Windows 11 (winget v1.29.280), schema 1.12.

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/412006)