### PR TITLE
New version: Finesssee.Win-CodexBar version 0.47.0

### DIFF
--- a/manifests/f/Finesssee/Win-CodexBar/0.47.0/Finesssee.Win-CodexBar.installer.yaml
+++ b/manifests/f/Finesssee/Win-CodexBar/0.47.0/Finesssee.Win-CodexBar.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Finesssee.Win-CodexBar
+PackageVersion: 0.47.0
+InstallerType: inno
+Scope: user
+UpgradeBehavior: install
+ProductCode: WinCodexBar_is1
+ReleaseDate: 2026-08-04
+AppsAndFeaturesEntries:
+- ProductCode: WinCodexBar_is1
+  DisplayName: CodexBar 0.47.0
+  DisplayVersion: 0.47.0
+  Publisher: CodexBar Contributors
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/nesszer/Win-CodexBar/releases/download/v0.47.0/CodexBar-0.47.0-Setup.exe
+  InstallerSha256: A86564ACF8CA95BCD8635893003136007863659A6F64617672D3E423857D2C76
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Finesssee/Win-CodexBar/0.47.0/Finesssee.Win-CodexBar.locale.en-US.yaml
+++ b/manifests/f/Finesssee/Win-CodexBar/0.47.0/Finesssee.Win-CodexBar.locale.en-US.yaml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Finesssee.Win-CodexBar
+PackageVersion: 0.47.0
+PackageLocale: en-US
+Publisher: CodexBar Contributors
+PublisherUrl: https://github.com/nesszer
+PublisherSupportUrl: https://github.com/nesszer/Win-CodexBar/issues
+Author: Finesssee
+PackageName: Win-CodexBar
+PackageUrl: https://github.com/nesszer/Win-CodexBar
+License: MIT
+LicenseUrl: https://github.com/nesszer/Win-CodexBar/blob/main/LICENSE
+Copyright: Copyright (c) CodexBar contributors
+ShortDescription: Windows-native menu bar app for OpenAI Codex and Claude Code usage stats.
+Description: Win-CodexBar is a Windows-native desktop app for viewing OpenAI Codex and Claude Code usage stats from a small Tauri shell.
+Moniker: win-codexbar
+Tags:
+- claude-code
+- codex
+- desktop
+- tauri
+- usage
+- windows
+ReleaseNotes: |-
+  Windows port of upstream CodexBar 0.46.0 to 0.47.0.
+
+  ### Added
+  - Providers: Notion AI and xAI usage tracking (upstream 0.47.0).
+  - CLI: `codexbar hooks watch` — continuous provider polling with transition-based hook events.
+  - Low Power Mode setting that floors automatic background refresh to once per 30 minutes.
+  - Per-notification custom sounds and built-in sound set.
+  - Russian localization.
+  - Real-calendar monthly pacing for monthly quota windows.
+
+  ### Fixed
+  - MiniMax Coding Plan web session 500 error; email/Business plan quota now shown.
+  - OpenCode Go rolling 5-hour usage falsely showed exhausted (100%) when the real value was 1%.
+  - FloatBar sizing on High-DPI displays.
+  - Provider fixes for Cursor billing extra usage, Command Code browser session persistence, OpenCode Go WAL reads, and verified z.ai/Kimi/Grok rate windows.
+ReleaseNotesUrl: https://github.com/nesszer/Win-CodexBar/releases/tag/v0.47.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Finesssee/Win-CodexBar/0.47.0/Finesssee.Win-CodexBar.yaml
+++ b/manifests/f/Finesssee/Win-CodexBar/0.47.0/Finesssee.Win-CodexBar.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Finesssee.Win-CodexBar
+PackageVersion: 0.47.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Checklist for Pull Requests

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Is there a linked Issue? No, version bump per upstream release.

## Description

New version of Win-CodexBar: **0.47.0**.

- Release: https://github.com/nesszer/Win-CodexBar/releases/tag/v0.47.0
- Installer: `CodexBar-0.47.0-Setup.exe` (inno, user scope) — same packaging identity as 0.46.0 (PackageIdentifier, InstallerType, Scope, ProductCode, Publisher unchanged).
- `InstallerSha256` recomputed from the published asset: `A86564ACF8CA95BCD8635893003136007863659A6F64617672D3E423857D2C76` (download verified byte-for-byte).
- `winget validate --manifest` passed locally (winget v1.29.280).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/412072)