### PR TITLE
New version: CudaText.CudaText version 1.235.1.0

### DIFF
--- a/manifests/c/CudaText/CudaText/1.235.1.0/CudaText.CudaText.installer.yaml
+++ b/manifests/c/CudaText/CudaText/1.235.1.0/CudaText.CudaText.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: CudaText.CudaText
+PackageVersion: 1.235.1.0
+InstallerType: zip
+ReleaseDate: 2026-07-19
+ArchiveBinariesDependOnPath: true
+Installers:
+- Architecture: x64
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: cudatext/cudatext.exe
+  InstallerUrl: https://sourceforge.net/projects/cudatext/files/release/1.235.1.0/cudatext-windows-amd64-1.235.1.0.zip/download
+  InstallerSha256: 94B01AA091D4A4C24653470A862648DE1819FD25B2C50410B0C8896E1F0CF113
+- Architecture: x86
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: cudatext/cudatext.exe
+  InstallerUrl: https://sourceforge.net/projects/cudatext/files/release/1.235.1.0/cudatext-windows-i386-1.235.1.0.zip/download
+  InstallerSha256: AFE4B82F171782CBDAF83E16D330895CB469F4D44249BDFE247A2F55479C9079
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/CudaText/CudaText/1.235.1.0/CudaText.CudaText.locale.en-US.yaml
+++ b/manifests/c/CudaText/CudaText/1.235.1.0/CudaText.CudaText.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: CudaText.CudaText
+PackageVersion: 1.235.1.0
+PackageLocale: en-US
+Publisher: CudaText
+PublisherSupportUrl: https://github.com/alexey-t/cudatext/issues
+Author: Alexey T., kvichans, Matthias
+PackageName: CudaText
+PackageUrl: https://sourceforge.net/projects/cudatext/
+License: MPL-2.0
+LicenseUrl: https://github.com/Alexey-T/CudaText/blob/master/LICENSE
+ShortDescription: Cross-platform text editor, written in Free Pascal.
+Description: Open source and cross-platform text editor. Written in Free Pascal, using Lazarus.
+Tags:
+- cross-platform
+- lazarus
+- pascal
+- text-editor
+ReleaseNotesUrl: https://github.com/Alexey-T/CudaText/releases/tag/1.235.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/CudaText/CudaText/1.235.1.0/CudaText.CudaText.yaml
+++ b/manifests/c/CudaText/CudaText/1.235.1.0/CudaText.CudaText.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: CudaText.CudaText
+PackageVersion: 1.235.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds `CudaText.CudaText` version **1.235.1.0**. The repository currently tops out at 1.219.1.0 (released 2024-12-04).

The requested 1.230.2.0 is no longer published on SourceForge, so this submits the current release, 1.235.1.0 (2026-07-19).

Both architectures were downloaded from the version-pinned SourceForge URLs and the SHA256 values in this manifest were computed from those files. The archive layout is unchanged from the previous version — `cudatext/cudatext.exe` is present in both.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)
  - Resolves #317502

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> Not tested with `winget install` locally — Windows Sandbox is not available on the machine used to author this. The manifest is an unchanged copy of the previously merged 1.219.1.0 shape (zip / nested portable) with only the version, URLs, hashes and release date updated.
