### PR TITLE
New version: Xenia.Xenia version 1.0.2844

### DIFF
--- a/manifests/x/Xenia/Xenia/1.0.2844/Xenia.Xenia.installer.yaml
+++ b/manifests/x/Xenia/Xenia/1.0.2844/Xenia.Xenia.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Xenia.Xenia
+PackageVersion: 1.0.2844
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: xenia.exe
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+ReleaseDate: 2026-02-18
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/xenia-project/release-builds-windows/releases/download/v1.0.2844-master/xenia_master.zip
+  InstallerSha256: 6D41AA4BEF26B395B0D48230DC4BE6C43CF6BA0A93F43C0674CA2F7150F846E0
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/x/Xenia/Xenia/1.0.2844/Xenia.Xenia.locale.en-US.yaml
+++ b/manifests/x/Xenia/Xenia/1.0.2844/Xenia.Xenia.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Xenia.Xenia
+PackageVersion: 1.0.2844
+PackageLocale: en-US
+Publisher: Xenia
+PublisherUrl: https://github.com/xenia-project
+PackageName: Xenia
+License: BSD-3-Clause
+ShortDescription: xenia is a BSD licensed open source research project for emulating Xbox 360 games on modern PCs.
+Tags:
+- emulator
+- xbox360
+ReleaseNotes: Windows release build for [GPU/WGF] Bind EDRAM to resolve dumping via ByteAddressBuffer
+ReleaseNotesUrl: https://github.com/xenia-project/release-builds-windows/releases/tag/v1.0.2844-master
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/x/Xenia/Xenia/1.0.2844/Xenia.Xenia.yaml
+++ b/manifests/x/Xenia/Xenia/1.0.2844/Xenia.Xenia.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Xenia.Xenia
+PackageVersion: 1.0.2844
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds `Xenia.Xenia` version **1.0.2844**. The repository currently tops out at 1.0.2817 (released 2024-05-25).

1.0.2844 is the latest build published in `xenia-project/release-builds-windows` (2026-02-18). The archive was downloaded from the version-pinned release URL and the SHA256 in this manifest was computed from that file; `xenia.exe` is present at the archive root, unchanged from the previous version.

Note: the linked issue also asks for `Xenia.Xenia` and `xenia-project.xenia` to be de-duplicated. This PR does not address that — it only adds the requested version to the identifier named in the issue.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)
  - Resolves #411513

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> Not tested with `winget install` locally — Windows Sandbox is not available on the machine used to author this. The manifest is an unchanged copy of the previously merged 1.0.2817 shape (zip / nested portable) with only the version, URL, hash and release date updated.
