### PR TITLE
New package: EazyHood.AppCloner version 4.0.0

### DIFF
--- a/manifests/e/EazyHood/AppCloner/4.0.0/EazyHood.AppCloner.installer.yaml
+++ b/manifests/e/EazyHood/AppCloner/4.0.0/EazyHood.AppCloner.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 
 PackageIdentifier: EazyHood.AppCloner
 PackageVersion: 4.0.0
@@ -11,4 +11,4 @@ Installers:
     InstallerUrl: https://github.com/EazyHood/AppCloner/releases/download/v4.0.0/AppCloner.exe
     InstallerSha256: 8720E047E7B4F2B7A73450A59C65A7AC8DF533C76F296940612166507D72951A
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/e/EazyHood/AppCloner/4.0.0/EazyHood.AppCloner.installer.yaml
+++ b/manifests/e/EazyHood/AppCloner/4.0.0/EazyHood.AppCloner.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: EazyHood.AppCloner
+PackageVersion: 4.0.0
+InstallerType: portable
+Commands:
+  - AppCloner
+ReleaseDate: 2026-08-04
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/EazyHood/AppCloner/releases/download/v4.0.0/AppCloner.exe
+    InstallerSha256: 8720E047E7B4F2B7A73450A59C65A7AC8DF533C76F296940612166507D72951A
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/e/EazyHood/AppCloner/4.0.0/EazyHood.AppCloner.locale.en-US.yaml
+++ b/manifests/e/EazyHood/AppCloner/4.0.0/EazyHood.AppCloner.locale.en-US.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: EazyHood.AppCloner
+PackageVersion: 4.0.0
+PackageLocale: en-US
+Publisher: EazyHood
+PublisherUrl: https://github.com/EazyHood
+PublisherSupportUrl: https://github.com/EazyHood/AppCloner/issues
+Author: EazyHood
+PackageName: AppCloner
+PackageUrl: https://github.com/EazyHood/AppCloner
+License: Proprietary
+LicenseUrl: https://github.com/EazyHood/AppCloner/blob/main/LICENSE
+Copyright: Copyright (c) 2026 EazyHood. All rights reserved.
+CopyrightUrl: https://github.com/EazyHood/AppCloner/blob/main/LICENSE
+ShortDescription: Clone Windows apps with independent sessions - run the same app with several accounts at once.
+Description: |-
+  AppCloner runs the same Windows app several times, each clone signed in to a
+  different account: three Chromes, two Discords, two Telegrams. The original app
+  is never copied or modified - each clone is launched with its own data space,
+  using the app's official profile flag when it has one (--user-data-dir,
+  -profile, -workdir) and redirected folders when it does not.
+
+  Free to use, with no paywalls or locked features. Includes light and dark themes
+  and six languages.
+
+  It is a convenience for separating accounts, not a security boundary. Some apps
+  (single global instance, session stored in the registry) need Sandboxie mode or a
+  separate Windows account; AppCloner detects those and says so.
+Moniker: appcloner
+Tags:
+  - clone
+  - multi-account
+  - multi-instance
+  - portable
+  - sessions
+ReleaseNotesUrl: https://github.com/EazyHood/AppCloner/releases/tag/v4.0.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/e/EazyHood/AppCloner/4.0.0/EazyHood.AppCloner.locale.en-US.yaml
+++ b/manifests/e/EazyHood/AppCloner/4.0.0/EazyHood.AppCloner.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 
 PackageIdentifier: EazyHood.AppCloner
 PackageVersion: 4.0.0
@@ -36,4 +36,4 @@ Tags:
   - sessions
 ReleaseNotesUrl: https://github.com/EazyHood/AppCloner/releases/tag/v4.0.0
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0

--- a/manifests/e/EazyHood/AppCloner/4.0.0/EazyHood.AppCloner.yaml
+++ b/manifests/e/EazyHood/AppCloner/4.0.0/EazyHood.AppCloner.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: EazyHood.AppCloner
+PackageVersion: 4.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0

--- a/manifests/e/EazyHood/AppCloner/4.0.0/EazyHood.AppCloner.yaml
+++ b/manifests/e/EazyHood/AppCloner/4.0.0/EazyHood.AppCloner.yaml
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
 
 PackageIdentifier: EazyHood.AppCloner
 PackageVersion: 4.0.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## 📖 Description

New package: **EazyHood.AppCloner** version **4.0.0**.

AppCloner runs the same Windows app several times, each clone signed in to a different account. It is a portable single-file executable, so the manifest uses `InstallerType: portable` with an `AppCloner` command alias.

- Repository: https://github.com/EazyHood/AppCloner
- Release: https://github.com/EazyHood/AppCloner/releases/tag/v4.0.0
- I am the author and owner of this package.

`InstallerSha256` was verified by downloading the asset from the public `InstallerUrl` and hashing it, and it matches the `SHA256SUMS.txt` published alongside the release:

```
8720e047e7b4f2b7a73450a59c65a7ac8df533c76f296940612166507d72951a  AppCloner.exe
```

**One thing worth flagging up front:** the installer is an **unsigned single-file PyInstaller build**. Some antivirus engines report false positives on that packaging format, so if the Defender or SmartScreen validation step fails, that is the likely cause rather than anything in the manifest. The full source is public and the binary is built and smoke-tested by GitHub Actions from the tagged commit ([build log](https://github.com/EazyHood/AppCloner/actions/runs/30878973417)). Happy to provide whatever additional verification helps.

`License` is declared as `Proprietary` rather than an SPDX identifier deliberately: the software is free to download, use and share, but selling it is not permitted, so no OSI licence describes it accurately. The full text is linked in `LicenseUrl`.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
  <!-- Pending: to be signed by the repository owner (@EazyHood) on this PR. -->
- [ ] Linked to an issue (if applicable)
  - Not applicable (new package, no tracking issue).

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` (winget v1.29.280 — "Manifest validation succeeded")
- [ ] Tested manifest locally with `winget install --manifest <path>`
  <!-- Not run: validated and hash-verified only. Say the word if an install test is required before review. -->
- [x] Manifest conforms to the [1.9 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.9.0)
  <!-- The template references 1.12, but doc/manifest/schema/ currently documents up to 1.9.0, so 1.9.0 was used. Glad to bump if 1.12 is expected. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/412285)