### PR TITLE
New package: SecureCloudGroup.SmartBrain version 0.8.18

### DIFF
--- a/manifests/s/SecureCloudGroup/SmartBrain/0.8.18/SecureCloudGroup.SmartBrain.installer.yaml
+++ b/manifests/s/SecureCloudGroup/SmartBrain/0.8.18/SecureCloudGroup.SmartBrain.installer.yaml
@@ -1,0 +1,17 @@
+# winget installer manifest. Submitted to microsoft/winget-pkgs; users then run:
+#   winget install SecureCloudGroup.SmartBrain
+# winget marks the verified download as a trusted zone after checking this SHA256, which suppresses
+# the SmartScreen "Windows protected your PC" prompt for an unsigned exe. No code-signing cert needed.
+PackageIdentifier: SecureCloudGroup.SmartBrain
+PackageVersion: 0.8.18
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: SmartBrain.exe
+    PortableCommandAlias: smartbrain
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/SecureCloudGroup/SmartBrain_3000/releases/download/v0.8.18/SmartBrain-windows.zip
+    InstallerSha256: 29DC45FD02AD3F1D7B60E6F4A11F03E0F68D35CDF003C1129E5B9D149F312947
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/SecureCloudGroup/SmartBrain/0.8.18/SecureCloudGroup.SmartBrain.locale.en-US.yaml
+++ b/manifests/s/SecureCloudGroup/SmartBrain/0.8.18/SecureCloudGroup.SmartBrain.locale.en-US.yaml
@@ -1,0 +1,27 @@
+PackageIdentifier: SecureCloudGroup.SmartBrain
+PackageVersion: 0.8.18
+PackageLocale: en-US
+Publisher: The Frels Holdings LLC
+PublisherUrl: https://github.com/SecureCloudGroup
+PublisherSupportUrl: https://github.com/SecureCloudGroup/SmartBrain_3000/issues
+PackageName: SmartBrain
+PackageUrl: https://github.com/SecureCloudGroup/SmartBrain_3000
+License: Elastic-2.0
+Copyright: Copyright (c) 2026 The Frels Holdings LLC
+ShortDescription: Local-first personal AI assistant — your data stays on your machine.
+Description: >-
+  A fully local, single-user AI assistant that runs on your own computer — no Docker needed on
+  64-bit Windows. Your knowledge base, notes, and credentials live in a local database encrypted
+  at rest under a passphrase only you hold. Bring your own API keys, or run fully local models
+  with Ollama.
+Moniker: smartbrain
+Tags:
+  - ai
+  - assistant
+  - chatbot
+  - llm
+  - local
+  - privacy
+  - self-hosted
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/SecureCloudGroup/SmartBrain/0.8.18/SecureCloudGroup.SmartBrain.yaml
+++ b/manifests/s/SecureCloudGroup/SmartBrain/0.8.18/SecureCloudGroup.SmartBrain.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: SecureCloudGroup.SmartBrain
+PackageVersion: 0.8.18
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Submitted from macOS, so no local `winget validate`/`winget install` run — the manifests are the same set previously bot-validated in #401927 with only version, URL, hash, and description updated, and the `InstallerSha256` is verified against the release's published `.sha256` sidecar. Deferring to the pipeline's sandbox validation.

Note: replaces #401927 (version 0.4.0), which went stale while awaiting review — the project has since shipped many releases and 0.4.0 should no longer be published. That PR is now closed in favor of this one at the current version, 0.8.18.

Publisher: this submission is from the SecureCloudGroup org account, the package's publisher.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/412286)