### PR TITLE
New package: GitFuse.GitFuse version 0.1.1

### DIFF
--- a/manifests/g/GitFuse/GitFuse/0.1.1/GitFuse.GitFuse.installer.yaml
+++ b/manifests/g/GitFuse/GitFuse/0.1.1/GitFuse.GitFuse.installer.yaml
@@ -1,0 +1,13 @@
+PackageIdentifier: GitFuse.GitFuse
+PackageVersion: 0.1.1
+InstallerLocale: en-US
+MinimumOSVersion: 10.0.0.0
+InstallerType: portable
+Commands:
+  - gitfuse
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/VectorSolus/GitFuse/releases/download/v0.1.1/gitfuse_0.1.1_windows_amd64.zip
+    InstallerSha256: 2cc89bdc01322c851254cf23b92c52d4b6b054207fc27ffef2f7d18962a8c6ca
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/g/GitFuse/GitFuse/0.1.1/GitFuse.GitFuse.installer.yaml
+++ b/manifests/g/GitFuse/GitFuse/0.1.1/GitFuse.GitFuse.installer.yaml
@@ -4,12 +4,14 @@ InstallerLocale: en-US
 MinimumOSVersion: 10.0.0.0
 InstallerType: zip
 NestedInstallerType: portable
-NestedInstallerFiles:
-  - RelativeFilePath: gitfuse.exe
-    PortableCommandAlias: gitfuse
+Commands:
+  - gitfuse
 Installers:
   - Architecture: x64
+    NestedInstallerFiles:
+      - RelativeFilePath: gitfuse.exe
+        PortableCommandAlias: gitfuse
     InstallerUrl: https://github.com/VectorSolus/GitFuse/releases/download/v0.1.1/gitfuse_0.1.1_windows_amd64.zip
-    InstallerSha256: 2cc89bdc01322c851254cf23b92c52d4b6b054207fc27ffef2f7d18962a8c6ca
+    InstallerSha256: 2CC89BDC01322C851254CF23B92C52D4B6B054207FC27FFEF2F7D18962A8C6CA
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/g/GitFuse/GitFuse/0.1.1/GitFuse.GitFuse.installer.yaml
+++ b/manifests/g/GitFuse/GitFuse/0.1.1/GitFuse.GitFuse.installer.yaml
@@ -2,12 +2,14 @@ PackageIdentifier: GitFuse.GitFuse
 PackageVersion: 0.1.1
 InstallerLocale: en-US
 MinimumOSVersion: 10.0.0.0
-InstallerType: portable
-Commands:
-  - gitfuse
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: gitfuse.exe
+    PortableCommandAlias: gitfuse
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/VectorSolus/GitFuse/releases/download/v0.1.1/gitfuse_0.1.1_windows_amd64.zip
     InstallerSha256: 2cc89bdc01322c851254cf23b92c52d4b6b054207fc27ffef2f7d18962a8c6ca
 ManifestType: installer
-ManifestVersion: 1.9.0
+ManifestVersion: 1.12.0

--- a/manifests/g/GitFuse/GitFuse/0.1.1/GitFuse.GitFuse.installer.yaml
+++ b/manifests/g/GitFuse/GitFuse/0.1.1/GitFuse.GitFuse.installer.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 PackageIdentifier: GitFuse.GitFuse
 PackageVersion: 0.1.1
 InstallerLocale: en-US

--- a/manifests/g/GitFuse/GitFuse/0.1.1/GitFuse.GitFuse.locale.en-US.yaml
+++ b/manifests/g/GitFuse/GitFuse/0.1.1/GitFuse.GitFuse.locale.en-US.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 PackageIdentifier: GitFuse.GitFuse
 PackageVersion: 0.1.1
 PackageLocale: en-US

--- a/manifests/g/GitFuse/GitFuse/0.1.1/GitFuse.GitFuse.locale.en-US.yaml
+++ b/manifests/g/GitFuse/GitFuse/0.1.1/GitFuse.GitFuse.locale.en-US.yaml
@@ -14,4 +14,4 @@ Tags:
 PackageUrl: https://gitfuse.dev
 License: AGPL-3.0-only
 ManifestType: defaultLocale
-ManifestVersion: 1.9.0
+ManifestVersion: 1.12.0

--- a/manifests/g/GitFuse/GitFuse/0.1.1/GitFuse.GitFuse.locale.en-US.yaml
+++ b/manifests/g/GitFuse/GitFuse/0.1.1/GitFuse.GitFuse.locale.en-US.yaml
@@ -1,0 +1,17 @@
+PackageIdentifier: GitFuse.GitFuse
+PackageVersion: 0.1.1
+PackageLocale: en-US
+Publisher: GitFuse
+PackageName: GitFuse
+ShortDescription: Sync committed git objects between trusted devices through an encrypted relay.
+Description: GitFuse syncs committed git objects between trusted devices through an encrypted relay.
+Moniker: gitfuse
+Tags:
+  - git
+  - cli
+  - sync
+  - developer-tools
+PackageUrl: https://gitfuse.dev
+License: AGPL-3.0-only
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/g/GitFuse/GitFuse/0.1.1/GitFuse.GitFuse.yaml
+++ b/manifests/g/GitFuse/GitFuse/0.1.1/GitFuse.GitFuse.yaml
@@ -2,4 +2,4 @@ PackageIdentifier: GitFuse.GitFuse
 PackageVersion: 0.1.1
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.9.0
+ManifestVersion: 1.12.0

--- a/manifests/g/GitFuse/GitFuse/0.1.1/GitFuse.GitFuse.yaml
+++ b/manifests/g/GitFuse/GitFuse/0.1.1/GitFuse.GitFuse.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: GitFuse.GitFuse
+PackageVersion: 0.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0

--- a/manifests/g/GitFuse/GitFuse/0.1.1/GitFuse.GitFuse.yaml
+++ b/manifests/g/GitFuse/GitFuse/0.1.1/GitFuse.GitFuse.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 PackageIdentifier: GitFuse.GitFuse
 PackageVersion: 0.1.1
 DefaultLocale: en-US


### PR DESCRIPTION
Adds GitFuse.GitFuse version 0.1.1.

Package identity:
- PackageIdentifier: GitFuse.GitFuse
- PackageName: GitFuse
- Moniker: gitfuse
- Installed command: gitfuse

User-facing install command after approval:
- winget install gitfuse

Exact support/automation command after approval:
- winget install --id GitFuse.GitFuse -e

Release:
- https://github.com/VectorSolus/GitFuse/releases/tag/v0.1.1

Installer:
- https://github.com/VectorSolus/GitFuse/releases/download/v0.1.1/gitfuse_0.1.1_windows_amd64.zip

License:
- AGPL-3.0-only

Architecture:
- x64

Phase61 validation:
- Public release asset HTTP 200
- SHA256 verified
- Homebrew v0.1.1 install/upgrade passed
- Linux installer v0.1.1 passed
- Auth without env override passed
- Sync and restore passed
- Live docs command verification passed
- winget validate skipped locally because this host is macOS
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/412333)