### PR TITLE
New version: Feci.ParleyDeckCli version 1.38.0

### DIFF
--- a/manifests/f/Feci/ParleyDeckCli/1.38.0/Feci.ParleyDeckCli.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.38.0/Feci.ParleyDeckCli.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.38.0
+InstallerType: portable
+Commands:
+- parley
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.38.0/parley-v1.38.0-windows-x64.exe
+  InstallerSha256: 216DE1B08F8C6689D35A1AFCB3FE8029D3D699B5E824287FD2C536829A855560
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.38.0/parley-v1.38.0-windows-arm64.exe
+  InstallerSha256: FFB35CE1E838ED9212D10C1F597E6517614BF4D5E66F04F9F67E9897B757CA1F
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.38.0/Feci.ParleyDeckCli.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.38.0/Feci.ParleyDeckCli.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.38.0
+PackageLocale: en-US
+Publisher: Feci
+PublisherUrl: https://github.com/feci
+PackageName: Parley Deck CLI
+PackageUrl: https://github.com/feci/parley-deck-cli
+License: Apache-2.0
+LicenseUrl: https://github.com/feci/parley-deck-cli/blob/main/LICENSE
+ShortDescription: CLI that orchestrates Parley Deck multi-agent cooperation workflows.
+Description: "parley orchestrates multi-agent Parley Deck cooperation across local CLI agents: risk-tiered tracks (fast, standard, deliberation), deliberation rounds, consensus and finalize, implementation with living execution plans, a live TUI, and a human-braked outer loop. v1.38.0 adds a new protocol section 15, Verification integrity, which defines what makes a verification valid: an owner may not issue a verdict on its own claim, every verdict carries a provenance tag (PRIMARY for a located source or an executed check, SECONDARY for a named participant's verdict, RECALL for memory) and an untagged verdict is treated as RECALL, verdict conflicts are resolved by evidence and never by counting participants, exemption claims require a witness, a facilitator who also drafts must disclose its own position changes, and unanimous judgment-shaped ideas require a steelman of the strongest alternative. It also fixes a contradiction in section 4.0, which listed round-1 independence as an invariant never dropped for speed while section 11.A stated there is no enforcement beyond agent discipline."
+ReleaseNotesUrl: https://github.com/feci/parley-deck-cli/releases/tag/v1.38.0
+Tags:
+- ai
+- agents
+- automation
+- cli
+- codex
+- consensus
+- loop
+- multi-agent
+- orchestration
+- preflight
+- roster
+- tui
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.38.0/Feci.ParleyDeckCli.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.38.0/Feci.ParleyDeckCli.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.38.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Adds protocol section 15 (Verification integrity) to the Parley Deck cooperation protocol.

Manifests validated locally; installer SHA256 values verified against the published release assets at https://github.com/feci/parley-deck-cli/releases/tag/v1.38.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/412421)