### PR TITLE
New package: Programonaut.QuickDeploy version 0.6.3

### DIFF
--- a/manifests/p/Programonaut/QuickDeploy/0.6.3/Programonaut.QuickDeploy.installer.yaml
+++ b/manifests/p/Programonaut/QuickDeploy/0.6.3/Programonaut.QuickDeploy.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Programonaut.QuickDeploy
+PackageVersion: 0.6.3
+InstallerType: portable
+Commands:
+- quickdeploy
+ReleaseDate: "2025-11-19"
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/programonaut/quickdeploy/releases/download/0.6.3/quickdeploy-windows-amd64.exe
+  InstallerSha256: 222CB92F1A4E9EFEBDC67CBD753B4405504869615B5A31EC4A2F70A2FEC1DFA0
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/p/Programonaut/QuickDeploy/0.6.3/Programonaut.QuickDeploy.locale.en-US.yaml
+++ b/manifests/p/Programonaut/QuickDeploy/0.6.3/Programonaut.QuickDeploy.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Programonaut.QuickDeploy
+PackageVersion: 0.6.3
+PackageLocale: en-US
+Publisher: Maximilian Kürschner
+PublisherUrl: https://programonaut.com
+PackageName: QuickDeploy
+PackageUrl: https://quickdeploy.dev/?utm_source=winget&utm_campaign=windows-package
+License: Proprietary
+ShortDescription: A command-line tool for deploying applications to a VPS using Docker.
+Moniker: quickdeploy
+Tags:
+- cli
+- deployment
+- docker
+- vps
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/p/Programonaut/QuickDeploy/0.6.3/Programonaut.QuickDeploy.yaml
+++ b/manifests/p/Programonaut/QuickDeploy/0.6.3/Programonaut.QuickDeploy.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Programonaut.QuickDeploy
+PackageVersion: 0.6.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds QuickDeploy 0.6.3 as a new x64 portable package with the `quickdeploy` command alias.

This is a publisher submission from Programonaut. The installer URL is the stable official GitHub release asset, and its SHA-256 matches the digest published by GitHub Releases.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (not applicable for this package submission)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` (WinGet is unavailable in the Linux authoring environment; all three files were validated directly against the official 1.12 JSON schemas)
- [ ] Tested manifest locally with `winget install --manifest <path>` (Windows/WinGet is unavailable in the authoring environment)
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/412524)