### PR TITLE
Add version: rejetto.hfs version 3.2.2 - Update version: rejetto.hfs version 3.2.2

### DIFF
--- a/manifests/r/rejetto/hfs/3.2.2/rejetto.hfs.installer.yaml
+++ b/manifests/r/rejetto/hfs/3.2.2/rejetto.hfs.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: rejetto.hfs
+PackageVersion: 3.2.2
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: hfs.exe
+ReleaseDate: 2026-04-24
+ArchiveBinariesDependOnPath: true
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/rejetto/hfs/releases/download/v3.2.2/hfs-windows-x64-3.2.2.zip
+  InstallerSha256: 8C6D4AEF24DF7A7F5BF58BF2BCDE52932AFCD1CC31B50BDC5D2FB8B02D41C514
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/r/rejetto/hfs/3.2.2/rejetto.hfs.locale.en-US.yaml
+++ b/manifests/r/rejetto/hfs/3.2.2/rejetto.hfs.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: rejetto.hfs
+PackageVersion: 3.2.2
+PackageLocale: en-US
+Publisher: rejetto
+PublisherUrl: https://github.com/rejetto
+PublisherSupportUrl: https://github.com/rejetto/hfs/issues
+PackageName: hfs
+PackageUrl: https://github.com/rejetto/hfs
+License: GPL-3.0
+LicenseUrl: https://github.com/rejetto/hfs/blob/HEAD/LICENSE.txt
+ShortDescription: HFS is a web file server to run on your computer. Share folders or even a single file thanks to the virtual file system.
+Tags:
+- file-server
+- file-sharing
+- http-server
+- nodejs
+- typescript
+- web
+ReleaseNotes: |-
+  bug fixes
+  Full Changelog：v3.1.0...v3.1.1
+ReleaseNotesUrl: https://github.com/rejetto/hfs/releases/tag/v3.1.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/rejetto/hfs/3.2.2/rejetto.hfs.yaml
+++ b/manifests/r/rejetto/hfs/3.2.2/rejetto.hfs.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: rejetto.hfs
+PackageVersion: 3.2.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
<!-- winmatsch:package=rejetto.hfs;version=3.2.2 -->
Created with: winmatsch
Operation: Add
Target repository: authenticated-user fork
Manifest path: `manifests/r/rejetto/hfs/3.2.2`
Dry run: False
Skip PR check: False

## Validation
Status: passed
- VLD3007 [Warning]: Portable nested installers should declare a PortableCommandAlias.

## Rules
- No rule executions.
Changes: 0
Reviews: 0

## Changes
- Add: `manifests/r/rejetto/hfs/3.2.2/rejetto.hfs.installer.yaml`
- Add: `manifests/r/rejetto/hfs/3.2.2/rejetto.hfs.locale.en-US.yaml`
- Add: `manifests/r/rejetto/hfs/3.2.2/rejetto.hfs.yaml`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/412568)