### PR TITLE
Update Morfyuum.AtlayaView version 2.0.36

### DIFF
--- a/manifests/m/Morfyuum/AtlayaView/2.0.36/Morfyuum.AtlayaView.installer.yaml
+++ b/manifests/m/Morfyuum/AtlayaView/2.0.36/Morfyuum.AtlayaView.installer.yaml
@@ -1,0 +1,23 @@
+# Created by tools/Update-WingetManifest.ps1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Morfyuum.AtlayaView
+PackageVersion: 2.0.36
+InstallerType: inno
+Scope: machine
+InstallModes:
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART"
+  SilentWithProgress: "/SILENT /NORESTART"
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Morfyuum/AtlayaView/releases/download/v2.0.36/AtlayaView-Setup-2.0.36-full.exe
+    InstallerSha256: AC7277C3B405132D0991C5930105DF3DDB4F01EDD900753A7958AB81EEA9160D
+    ProductCode: "{38EAC974-2DF5-4D63-A335-ECE4E477537E}_is1"
+    AppsAndFeaturesEntries:
+      - DisplayName: "AtlayaView"
+        Publisher: "Atlaya"
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/Morfyuum/AtlayaView/2.0.36/Morfyuum.AtlayaView.installer.yaml
+++ b/manifests/m/Morfyuum/AtlayaView/2.0.36/Morfyuum.AtlayaView.installer.yaml
@@ -10,7 +10,7 @@ InstallModes:
   - silentWithProgress
 InstallerSwitches:
   Silent: "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART"
-  SilentWithProgress: "/SILENT /NORESTART"
+  SilentWithProgress: "/SILENT /SUPPRESSMSGBOXES /NORESTART"
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/Morfyuum/AtlayaView/releases/download/v2.0.36/AtlayaView-Setup-2.0.36-full.exe

--- a/manifests/m/Morfyuum/AtlayaView/2.0.36/Morfyuum.AtlayaView.locale.en-US.yaml
+++ b/manifests/m/Morfyuum/AtlayaView/2.0.36/Morfyuum.AtlayaView.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# Created by tools/Update-WingetManifest.ps1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Morfyuum.AtlayaView
+PackageVersion: 2.0.36
+PackageLocale: en-US
+Publisher: "Chris Deliga"
+PublisherUrl: https://atlaya.capecter.com
+PublisherSupportUrl: https://github.com/Morfyuum/AtlayaView/issues
+Author: "Chris Deliga"
+PackageName: "AtlayaView"
+PackageUrl: https://atlaya.capecter.com/atlayaview/
+License: "MIT"
+LicenseUrl: https://raw.githubusercontent.com/Morfyuum/AtlayaView/main/LICENSE
+Copyright: "Copyright (c) 2026 Chris Deliga"
+ShortDescription: "Fast local disk space visualization for Windows with cushion treemaps."
+Description: "AtlayaView scans one or more drives and turns used storage into an instantly readable treemap, making large folders and files visible at a glance. It is a local-first Windows desktop application with an optional native Rust renderer and automatic fallback to the managed renderer."
+Moniker: atlayaview
+Tags:
+  - disk-usage
+  - disk-space
+  - treemap
+  - filesystem
+  - storage
+  - visualizer
+  - windows
+ReleaseNotes: "Version 2.0.36 switches AtlayaView from a WinGet portable package to a real Inno Setup installer, registering under Apps and Features with its own Start Menu entry and Program Files folder."
+ReleaseNotesUrl: https://github.com/Morfyuum/AtlayaView/releases/tag/v2.0.36
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/Morfyuum/AtlayaView/2.0.36/Morfyuum.AtlayaView.yaml
+++ b/manifests/m/Morfyuum/AtlayaView/2.0.36/Morfyuum.AtlayaView.yaml
@@ -1,0 +1,8 @@
+# Created by tools/Update-WingetManifest.ps1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Morfyuum.AtlayaView
+PackageVersion: 2.0.36
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Updates Morfyuum.AtlayaView to version 2.0.36 and switches the installer from a portable ZIP (winget portable) to a real Inno Setup installer (InstallerType: inno), so the app now registers under Apps & Features with its own Start Menu entry and Program Files folder.

- InstallerType changed from `zip`/portable to `inno`
- Silent switches: `/VERYSILENT /SUPPRESSMSGBOXES /NORESTART`
- ProductCode added for reliable upgrade/uninstall detection
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/412585)