### PR TITLE
New package: Morfyuum.AtlayaView.FxDependent version 2.0.36

### DIFF
--- a/manifests/m/Morfyuum/AtlayaView/FxDependent/2.0.36/Morfyuum.AtlayaView.FxDependent.installer.yaml
+++ b/manifests/m/Morfyuum/AtlayaView/FxDependent/2.0.36/Morfyuum.AtlayaView.FxDependent.installer.yaml
@@ -1,0 +1,23 @@
+# Created by tools/Update-WingetManifest.ps1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Morfyuum.AtlayaView.FxDependent
+PackageVersion: 2.0.36
+InstallerType: inno
+Scope: machine
+InstallModes:
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART"
+  SilentWithProgress: "/SILENT /NORESTART"
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Morfyuum/AtlayaView/releases/download/v2.0.36/AtlayaView-Setup-2.0.36-fx.exe
+    InstallerSha256: ABD8B42DCF77DB1F342DF256377D59BF29B9544CA52112F75A0164562CB2B5EF
+    ProductCode: "{D94DF165-53AB-424B-8539-2411D56612E4}_is1"
+    AppsAndFeaturesEntries:
+      - DisplayName: "AtlayaView (ohne .NET-Runtime)"
+        Publisher: "Atlaya"
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/Morfyuum/AtlayaView/FxDependent/2.0.36/Morfyuum.AtlayaView.FxDependent.installer.yaml
+++ b/manifests/m/Morfyuum/AtlayaView/FxDependent/2.0.36/Morfyuum.AtlayaView.FxDependent.installer.yaml
@@ -10,7 +10,7 @@ InstallModes:
   - silentWithProgress
 InstallerSwitches:
   Silent: "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART"
-  SilentWithProgress: "/SILENT /NORESTART"
+  SilentWithProgress: "/SILENT /SUPPRESSMSGBOXES /NORESTART"
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/Morfyuum/AtlayaView/releases/download/v2.0.36/AtlayaView-Setup-2.0.36-fx.exe

--- a/manifests/m/Morfyuum/AtlayaView/FxDependent/2.0.36/Morfyuum.AtlayaView.FxDependent.installer.yaml
+++ b/manifests/m/Morfyuum/AtlayaView/FxDependent/2.0.36/Morfyuum.AtlayaView.FxDependent.installer.yaml
@@ -17,7 +17,6 @@ Installers:
     InstallerSha256: ABD8B42DCF77DB1F342DF256377D59BF29B9544CA52112F75A0164562CB2B5EF
     ProductCode: "{D94DF165-53AB-424B-8539-2411D56612E4}_is1"
     AppsAndFeaturesEntries:
-      - DisplayName: "AtlayaView (ohne .NET-Runtime)"
-        Publisher: "Atlaya"
+      - Publisher: "Atlaya"
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/m/Morfyuum/AtlayaView/FxDependent/2.0.36/Morfyuum.AtlayaView.FxDependent.locale.en-US.yaml
+++ b/manifests/m/Morfyuum/AtlayaView/FxDependent/2.0.36/Morfyuum.AtlayaView.FxDependent.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# Created by tools/Update-WingetManifest.ps1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Morfyuum.AtlayaView.FxDependent
+PackageVersion: 2.0.36
+PackageLocale: en-US
+Publisher: "Chris Deliga"
+PublisherUrl: https://atlaya.capecter.com
+PublisherSupportUrl: https://github.com/Morfyuum/AtlayaView/issues
+Author: "Chris Deliga"
+PackageName: "AtlayaView (Framework-Dependent)"
+PackageUrl: https://atlaya.capecter.com/atlayaview/
+License: "MIT"
+LicenseUrl: https://raw.githubusercontent.com/Morfyuum/AtlayaView/main/LICENSE
+Copyright: "Copyright (c) 2026 Chris Deliga"
+ShortDescription: "Fast local disk space visualization for Windows with cushion treemaps."
+Description: "AtlayaView scans one or more drives and turns used storage into an instantly readable treemap, making large folders and files visible at a glance. It is a local-first Windows desktop application with an optional native Rust renderer and automatic fallback to the managed renderer."
+Moniker: atlayaview
+Tags:
+  - disk-usage
+  - disk-space
+  - treemap
+  - filesystem
+  - storage
+  - visualizer
+  - windows
+ReleaseNotes: "AtlayaView, framework-dependent variant, as a real Inno Setup installer. Requires an installed .NET 9 runtime. Registers under Apps and Features with its own Start Menu entry and Program Files folder, and can be installed side by side with the self-contained AtlayaView package."
+ReleaseNotesUrl: https://github.com/Morfyuum/AtlayaView/releases/tag/v2.0.36
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/Morfyuum/AtlayaView/FxDependent/2.0.36/Morfyuum.AtlayaView.FxDependent.locale.en-US.yaml
+++ b/manifests/m/Morfyuum/AtlayaView/FxDependent/2.0.36/Morfyuum.AtlayaView.FxDependent.locale.en-US.yaml
@@ -15,7 +15,7 @@ LicenseUrl: https://raw.githubusercontent.com/Morfyuum/AtlayaView/main/LICENSE
 Copyright: "Copyright (c) 2026 Chris Deliga"
 ShortDescription: "Fast local disk space visualization for Windows with cushion treemaps."
 Description: "AtlayaView scans one or more drives and turns used storage into an instantly readable treemap, making large folders and files visible at a glance. It is a local-first Windows desktop application with an optional native Rust renderer and automatic fallback to the managed renderer."
-Moniker: atlayaview
+Moniker: atlayaview-fx
 Tags:
   - disk-usage
   - disk-space

--- a/manifests/m/Morfyuum/AtlayaView/FxDependent/2.0.36/Morfyuum.AtlayaView.FxDependent.locale.en-US.yaml
+++ b/manifests/m/Morfyuum/AtlayaView/FxDependent/2.0.36/Morfyuum.AtlayaView.FxDependent.locale.en-US.yaml
@@ -10,7 +10,7 @@ PublisherSupportUrl: https://github.com/Morfyuum/AtlayaView/issues
 Author: "Chris Deliga"
 PackageName: "AtlayaView (Framework-Dependent)"
 PackageUrl: https://atlaya.capecter.com/atlayaview/
-License: "MIT"
+License: "Atlaya Source-Available License (ASAL) v1.0"
 LicenseUrl: https://raw.githubusercontent.com/Morfyuum/AtlayaView/main/LICENSE
 Copyright: "Copyright (c) 2026 Chris Deliga"
 ShortDescription: "Fast local disk space visualization for Windows with cushion treemaps."

--- a/manifests/m/Morfyuum/AtlayaView/FxDependent/2.0.36/Morfyuum.AtlayaView.FxDependent.yaml
+++ b/manifests/m/Morfyuum/AtlayaView/FxDependent/2.0.36/Morfyuum.AtlayaView.FxDependent.yaml
@@ -1,0 +1,8 @@
+# Created by tools/Update-WingetManifest.ps1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Morfyuum.AtlayaView.FxDependent
+PackageVersion: 2.0.36
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Adds a new package Morfyuum.AtlayaView.FxDependent, the framework-dependent variant of AtlayaView (requires an installed .NET 9 runtime, smaller download).

This is a companion package to the existing Morfyuum.AtlayaView (self-contained variant, see PR #412585 for its parallel update to a real installer). Both packages install to separate Program Files folders and can be installed side by side, matching the two download variants already offered on the project's website (https://atlaya.capecter.com/atlayaview/).

- InstallerType: inno
- Silent switches: `/VERYSILENT /SUPPRESSMSGBOXES /NORESTART`
- Same publisher/author/license metadata as Morfyuum.AtlayaView
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/412586)