### PR TITLE
New version: Feci.ParleyDeckSkill version 2.3.0

### DIFF
--- a/manifests/f/Feci/ParleyDeckSkill/2.3.0/Feci.ParleyDeckSkill.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/2.3.0/Feci.ParleyDeckSkill.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 2.3.0
+InstallerType: portable
+Commands:
+- parley-deck-skill
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-skill/releases/download/v2.3.0/parley-deck-skill-v2.3.0-windows-x64.exe
+  InstallerSha256: 113AAE39DBBC73069C144FEE5813256FB0DE86781CA946600E4A3CC924BD700D
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-skill/releases/download/v2.3.0/parley-deck-skill-v2.3.0-windows-arm64.exe
+  InstallerSha256: ED402015C509E482FE2D0DC3E6775A5877DA8DC7DB33EF952D35F2657E409A59
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckSkill/2.3.0/Feci.ParleyDeckSkill.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/2.3.0/Feci.ParleyDeckSkill.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 2.3.0
+PackageLocale: en-US
+Publisher: Feci
+PublisherUrl: https://github.com/feci
+PackageName: Parley Deck Skill
+PackageUrl: https://github.com/feci/parley-deck-skill
+License: Apache-2.0
+LicenseUrl: https://github.com/feci/parley-deck-skill/blob/main/LICENSE
+ShortDescription: Installer for the Parley Deck multi-agent cooperation skill.
+Description: "Installs the vendor-neutral Parley Deck AI cooperation skill into Codex, Claude Code, Antigravity CLI, legacy Gemini CLI, Hermes, Kimi Code, or a custom skill directory. v2.3.0 resyncs the bundled protocol snapshot, the fallback an agent loads when the live project protocol is unavailable, to section 15 Verification integrity, ratified in parley-deck-cli 1.38.0. Section 15 defines what makes a verification valid: a participant may not issue a verdict on a claim it owns, every verdict carries a provenance tag (PRIMARY for a located source or an executed check, SECONDARY for a named participant's verdict, RECALL for memory) and an untagged verdict is treated as RECALL, verdict conflicts are resolved by evidence and never by counting participants, exemption claims require a witness, a facilitator who also drafts must disclose its own position changes, and unanimous judgment-shaped ideas require a steelman of the strongest alternative. The release also carries a fix to a contradiction in section 4.0, which listed round-1 independence as an invariant never dropped for speed while section 11.A stated there is no enforcement beyond agent discipline. Without this resync an offline agent would load a protocol two sections behind the live one."
+ReleaseNotesUrl: https://github.com/feci/parley-deck-skill/releases/tag/v2.3.0
+Tags:
+- ai
+- agents
+- agy
+- antigravity
+- cli
+- codex
+- claude
+- gemini
+- kimi
+- multi-agent
+- skill
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckSkill/2.3.0/Feci.ParleyDeckSkill.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/2.3.0/Feci.ParleyDeckSkill.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 2.3.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Resyncs the bundled Parley Deck protocol snapshot to section 15 (Verification integrity), ratified in parley-deck-cli 1.38.0.

Manifests validated locally; installer SHA256 values verified against the published release assets at https://github.com/feci/parley-deck-skill/releases/tag/v2.3.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/412598)