### PR TITLE
New version: StruisICT.InLook version 1.1.0

### DIFF
--- a/manifests/s/StruisICT/InLook/1.1.0/StruisICT.InLook.installer.yaml
+++ b/manifests/s/StruisICT/InLook/1.1.0/StruisICT.InLook.installer.yaml
@@ -1,0 +1,30 @@
+# Created with WinGet Releaser using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: StruisICT.InLook
+PackageVersion: 1.1.0
+InstallerLocale: en-US
+InstallerType: wix
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.EdgeWebView2Runtime
+  - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+ProductCode: '{22B298C5-E4C9-4C41-A3ED-BFB9A666CA62}'
+ReleaseDate: 2026-08-04
+AppsAndFeaturesEntries:
+- ProductCode: '{22B298C5-E4C9-4C41-A3ED-BFB9A666CA62}'
+  UpgradeCode: '{8E5A3C2B-1D4F-4E7A-9B6C-7D8E9F0A1B2C}'
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles%\InLook'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/StruisICT/InLook/releases/download/v1.1.0/inlook-1.1.0-x86_64.msi
+  InstallerSha256: 6F3900A5F101F3B5FB6D3729D1D76A03702AE9D28033E641550B76DDBDED8CD4
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/StruisICT/InLook/1.1.0/StruisICT.InLook.locale.en-US.yaml
+++ b/manifests/s/StruisICT/InLook/1.1.0/StruisICT.InLook.locale.en-US.yaml
@@ -1,0 +1,38 @@
+# Created with WinGet Releaser using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: StruisICT.InLook
+PackageVersion: 1.1.0
+PackageLocale: en-US
+Publisher: Struis ICT
+PublisherUrl: https://struisict.com/
+PublisherSupportUrl: https://github.com/StruisICT/InLook/issues
+Author: Struis ICT
+PackageName: InLook
+PackageUrl: https://github.com/StruisICT/InLook
+License: MIT
+LicenseUrl: https://github.com/StruisICT/InLook/blob/HEAD/LICENSE
+Copyright: Copyright (c) 2026 Struis ICT
+ShortDescription: Fast, free .eml email viewer
+Description: |-
+  InLook is a small, fast viewer for .eml email files (the standard RFC 822
+  / MIME format used by Outlook, Thunderbird, and most other mail clients
+  when saving a single message to disk). It renders headers, body (HTML or
+  plain text), and attachments, with embedded HTML sandboxed under a strict
+  Content Security Policy — no remote loads, no tracking pixels. Follows
+  the system light/dark theme, registers as the default .eml handler, and
+  never touches the network. Free Software from Struis ICT.
+Moniker: inlook
+Tags:
+- email
+- eml
+- mail
+- message
+- viewer
+ReleaseNotes: |-
+  1.1.0 (2026-08-03)
+  Features
+  - opt-in technical details panel (+ Linux .msg registration fix) (#79) (7fcb6dc)
+ReleaseNotesUrl: https://github.com/StruisICT/InLook/releases/tag/v1.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/StruisICT/InLook/1.1.0/StruisICT.InLook.yaml
+++ b/manifests/s/StruisICT/InLook/1.1.0/StruisICT.InLook.yaml
@@ -1,0 +1,8 @@
+# Created with WinGet Releaser using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: StruisICT.InLook
+PackageVersion: 1.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New version of an existing package

- **Package:** StruisICT.InLook
- **Version:** 1.1.0
- **Installer:** `inlook-1.1.0-x86_64.msi` from the signed GitHub release [v1.1.0](https://github.com/StruisICT/InLook/releases/tag/v1.1.0)

Manifests generated in the same shape as the accepted 1.0.0 version (schema 1.12.0), with the installer SHA256 and the new MSI ProductCode updated; the UpgradeCode is unchanged.

#### Checklist
- [x] This PR only modifies one (1) package
- [x] Have you validated the manifest locally with `winget validate --manifest <path>`? — validation succeeded
- [x] This package is compliant with the [Windows Package Manager policies](https://learn.microsoft.com/windows/package-manager/package/repository)

Submitted manually because our automated `winget-releaser` run couldn't sync a stale fork; the manifest is otherwise identical in form to prior komac-generated submissions.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/412601)