### PR TITLE
Update: Genesys.GenesysCloud to 2.53.923.0

### DIFF
--- a/manifests/g/Genesys/GenesysCloud/2.53.923.0/Genesys.GenesysCloud.installer.yaml
+++ b/manifests/g/Genesys/GenesysCloud/2.53.923.0/Genesys.GenesysCloud.installer.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Genesys.GenesysCloud
+PackageVersion: 2.53.923.0
+Scope: machine
+UpgradeBehavior: install
+Protocols:
+- gcvideo
+Installers:
+- Architecture: x64
+  InstallerType: wix
+  InstallerUrl: https://app.mypurecloud.com/directory-windows/build-assets/2.53.923-257/genesys-cloud-windows-2.53.923-x64.msi
+  InstallerSha256: 6129D0038EF441325C486E603C0977D2654891EDE3982963F3C9FF6C754BE079
+  InstallerSwitches:
+    InstallLocation: INSTALLDIR="<INSTALLPATH>"
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+  ProductCode: '{46FE9862-FC06-4E99-9F0B-AB8554F8DAC8}'
+  AppsAndFeaturesEntries:
+  - UpgradeCode: '{A0E8C487-C337-441C-83AF-90364DA4B793}'
+  InstallationMetadata:
+    DefaultInstallLocation: '%ProgramFiles%\Genesys\GenesysCloud'
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/g/Genesys/GenesysCloud/2.53.923.0/Genesys.GenesysCloud.locale.en-US.yaml
+++ b/manifests/g/Genesys/GenesysCloud/2.53.923.0/Genesys.GenesysCloud.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Genesys.GenesysCloud
+PackageVersion: 2.53.923.0
+PackageLocale: en-US
+Publisher: Genesys Inc.
+PublisherUrl: https://www.genesys.com/
+PublisherSupportUrl: https://help.mypurecloud.com/
+PrivacyUrl: https://www.genesys.com/company/legal/privacy-policy
+Author: Genesys Cloud Services, Inc.
+PackageName: GenesysCloud
+PackageUrl: https://help.mypurecloud.com/articles/desktop-app/
+License: Proprietary
+LicenseUrl: https://www.genesys.com/company/legal/terms-of-use
+Copyright: Copyright © 2012-2026 Genesys
+CopyrightUrl: https://www.genesys.com/company/legal/terms-of-use
+ShortDescription: Open Genesys Cloud automatically at startup and run it in the background.
+Description: |-
+  The Genesys Cloud desktop app is available for Windows and Mac:
+  - Use a dedicated application. Run Genesys Cloud as a stand-alone program, and keep it separate from your browser windows and tabs.
+  - Start Genesys Cloud automatically. Automatically open Genesys Cloud when your computer starts up, and avoid missing important communications.
+  - Run in silent mode. Close the window but continue to run in the background, allowing you to continue receiving chats and notifications.
+  - Update automatically. The desktop app notifies you when a newer version is available and prompts you to refresh or install it.
+ReleaseNotes: 32-bit applications running on 64-bit Windows will receive 64-bit updates. Only 64-bit versions are delivered.
+ReleaseNotesUrl: https://help.mypurecloud.com/release-notes-home/genesys-cloud-for-windows-desktop-app-release-notes/
+PurchaseUrl: https://www.genesys.com/pricing
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/g/Genesys/GenesysCloud/2.53.923.0/Genesys.GenesysCloud.yaml
+++ b/manifests/g/Genesys/GenesysCloud/2.53.923.0/Genesys.GenesysCloud.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Genesys.GenesysCloud
+PackageVersion: 2.53.923.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Updates Genesys.GenesysCloud to version 2.53.923.0.

Closes #412593

This release changes the installer architecture from x86 to x64.

## Checklist

- [x] I signed the Contributor License Agreement.
- [x] I linked to an issue.
- [x] I checked that there aren't other open pull requests for the same manifest update.
- [ ] I validated manifests locally with `winget validate`.
- [ ] I tested the manifest locally with `winget install --manifest <path>`.
- [x] Manifest conforms to the schema.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/412649)