### PR TITLE
Add version: Gardener.gardenctl version 2.16.0 - Update version: Gardener.gardenctl version 2.16.0

### DIFF
--- a/manifests/g/Gardener/gardenctl/2.16.0/Gardener.gardenctl.installer.yaml
+++ b/manifests/g/Gardener/gardenctl/2.16.0/Gardener.gardenctl.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: Gardener.gardenctl
+PackageVersion: 2.16.0
+InstallerType: portable
+Commands:
+- gardenctl
+ReleaseDate: 2026-07-10
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/gardener/gardenctl-v2/releases/download/v2.16.0/gardenctl_v2_windows_amd64.exe
+  InstallerSha256: BE4A6A3BF37BEFACC124FE136056CF239CD83CAF69C4F79704D6A9AEA2F92FC2
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/g/Gardener/gardenctl/2.16.0/Gardener.gardenctl.locale.en-US.yaml
+++ b/manifests/g/Gardener/gardenctl/2.16.0/Gardener.gardenctl.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: Gardener.gardenctl
+PackageVersion: 2.16.0
+PackageLocale: en-US
+Publisher: SAP SE
+PublisherUrl: https://gardener.cloud/
+PublisherSupportUrl: https://github.com/gardener/gardenctl-v2/issues
+PackageName: gardenctl
+PackageUrl: https://github.com/gardener/gardenctl-v2
+License: Apache-2.0
+LicenseUrl: https://github.com/gardener/gardenctl-v2/blob/HEAD/LICENSE
+ShortDescription: gardenctl is a command-line client for Gardener
+Tags:
+- gardener
+ReleaseNotes: |-
+  [github.com/gardener/gardenctl-v2:v2.15.0]
+  ✨ New Features
+  • [OPERATOR] gardenctl now supports requesting a read-only viewer kubeconfig instead of admin via the --access-level flag (admin / viewer / auto) and the per-garden kubeconfigAccessLevelDefaults.{shoots,managedSeeds} config block (also editable via gardenctl config set-garden). by @jamand [#735]
+  • [OPERATOR] gardenctl provider-env and gardenctl ssh now support --control-plane for shoot targets backed by a managed seed, operating on the seed infrastructure instead of the workload shoot. A new gpc alias is provided as a shortcut for provider-env --control-plane. by @petersutter [#760]
+  🐛 Bug Fixes
+  • [USER] The gardenctl ssh command now validates node addresses before use. by @petersutter [#776]
+ReleaseNotesUrl: https://github.com/gardener/gardenctl-v2/releases/tag/v2.15.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/g/Gardener/gardenctl/2.16.0/Gardener.gardenctl.yaml
+++ b/manifests/g/Gardener/gardenctl/2.16.0/Gardener.gardenctl.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: Gardener.gardenctl
+PackageVersion: 2.16.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
<!-- winmatsch:package=Gardener.gardenctl;version=2.16.0 -->
<!-- winmatsch:operation=Add -->
Add Gardener.gardenctl version 2.16.0.
Created with winmatsch v0.8.12
Internal validation passed.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/412656)