### PR TITLE
New package: rstream.rstream version 1.26.6

### DIFF
--- a/manifests/r/rstream/rstream/1.26.6/rstream.rstream.installer.yaml
+++ b/manifests/r/rstream/rstream/1.26.6/rstream.rstream.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: rstream.rstream
+PackageVersion: 1.26.6
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: bin/rstream.exe
+    PortableCommandAlias: rstream
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://rstream.io/api/packages/cmsfzm8n4001204l55fh4ru1j/download
+    InstallerSha256: 1765ef4678f8e0b803a113df6c5690a39e2aecdf58b451e523efdc8837390202
+  - Architecture: arm64
+    InstallerUrl: https://rstream.io/api/packages/cmsfzmas8001704l524srnjqb/download
+    InstallerSha256: 946766f32a9ea642ddb94ee94e542f4d4174429dce60b8874171cd7d39d69b90
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/r/rstream/rstream/1.26.6/rstream.rstream.installer.yaml
+++ b/manifests/r/rstream/rstream/1.26.6/rstream.rstream.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: rstream.rstream
 PackageVersion: 1.26.6
@@ -15,4 +15,4 @@ Installers:
     InstallerUrl: https://rstream.io/api/packages/cmsfzmas8001704l524srnjqb/download
     InstallerSha256: 946766f32a9ea642ddb94ee94e542f4d4174429dce60b8874171cd7d39d69b90
 ManifestType: installer
-ManifestVersion: 1.10.0
+ManifestVersion: 1.12.0

--- a/manifests/r/rstream/rstream/1.26.6/rstream.rstream.locale.en-US.yaml
+++ b/manifests/r/rstream/rstream/1.26.6/rstream.rstream.locale.en-US.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: rstream.rstream
+PackageVersion: 1.26.6
+PackageLocale: en-US
+Publisher: rstream
+PublisherUrl: https://rstream.io
+PublisherSupportUrl: https://rstream.io/docs
+Author: rstream
+PackageName: rstream
+PackageUrl: https://rstream.io
+License: Apache-2.0
+LicenseUrl: https://github.com/rstreamlabs/rstream-go/blob/main/LICENSE
+ShortDescription: Command-line client for rstream.
+Description: rstream is a developer-first platform for zero-trust networking.
+Moniker: rstream
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/r/rstream/rstream/1.26.6/rstream.rstream.locale.en-US.yaml
+++ b/manifests/r/rstream/rstream/1.26.6/rstream.rstream.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: rstream.rstream
 PackageVersion: 1.26.6
@@ -15,4 +15,4 @@ ShortDescription: Command-line client for rstream.
 Description: rstream is a developer-first platform for zero-trust networking.
 Moniker: rstream
 ManifestType: defaultLocale
-ManifestVersion: 1.10.0
+ManifestVersion: 1.12.0

--- a/manifests/r/rstream/rstream/1.26.6/rstream.rstream.yaml
+++ b/manifests/r/rstream/rstream/1.26.6/rstream.rstream.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: rstream.rstream
+PackageVersion: 1.26.6
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0

--- a/manifests/r/rstream/rstream/1.26.6/rstream.rstream.yaml
+++ b/manifests/r/rstream/rstream/1.26.6/rstream.rstream.yaml
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: rstream.rstream
 PackageVersion: 1.26.6
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.10.0
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds rstream 1.26.6 as a portable ZIP package for Windows x64 and arm64. The manifests reference rstream's existing published archives.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (not applicable for a new package submission)

## 📦 Manifest Checklist

- [x] Checked that there are no other open pull requests for the same manifest
- [x] This PR only modifies one manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` (WinGet is not available on macOS; all three YAML files were validated against the official 1.12 JSON schemas)
- [ ] Tested manifest locally with `winget install --manifest <path>` (WinGet is not available on macOS; both archives were downloaded, their SHA-256 checksums were verified, and `bin/rstream.exe` was confirmed in each archive)
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/412664)