### PR TITLE
New package: DaivenReyes.LocalDock version 0.1.2

### DIFF
--- a/manifests/d/DaivenReyes/LocalDock/0.1.2/DaivenReyes.LocalDock.installer.yaml
+++ b/manifests/d/DaivenReyes/LocalDock/0.1.2/DaivenReyes.LocalDock.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: DaivenReyes.LocalDock
+PackageVersion: 0.1.2
+InstallerLocale: en-US
+InstallerType: nullsoft
+Scope: user
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+UpgradeBehavior: install
+ReleaseDate: 2026-08-05
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/rdaiven/localdock/releases/download/v0.1.2/LocalDock_0.1.2_x64-setup.exe
+  InstallerSha256: 4C0E4B446033728DEC2CA049C07A40BA29139EADFA58EB3C4594EAC6DED34297
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/d/DaivenReyes/LocalDock/0.1.2/DaivenReyes.LocalDock.locale.en-US.yaml
+++ b/manifests/d/DaivenReyes/LocalDock/0.1.2/DaivenReyes.LocalDock.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: DaivenReyes.LocalDock
+PackageVersion: 0.1.2
+PackageLocale: en-US
+Publisher: Daiven Reyes
+PublisherUrl: https://github.com/rdaiven
+PublisherSupportUrl: https://github.com/rdaiven/localdock/issues
+PackageName: LocalDock
+PackageUrl: https://github.com/rdaiven/localdock
+License: MIT
+LicenseUrl: https://github.com/rdaiven/localdock/blob/master/LICENSE
+Copyright: © 2026 Daiven Reyes
+ShortDescription: Local dev-server control panel
+Description: >-
+  Start, stop, and monitor your local dev servers from one dashboard.
+  LocalDock manages the full process tree for every project, shows live
+  console output, CPU/RAM/uptime, and can group related projects into a
+  stack with one-click start-all/stop-all. It also runs a local MCP server
+  so AI coding assistants can start, stop, and inspect dev servers directly.
+Moniker: localdock
+Tags:
+- developer-tools
+- dev-server
+- process-manager
+- mcp
+- tauri
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/d/DaivenReyes/LocalDock/0.1.2/DaivenReyes.LocalDock.yaml
+++ b/manifests/d/DaivenReyes/LocalDock/0.1.2/DaivenReyes.LocalDock.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: DaivenReyes.LocalDock
+PackageVersion: 0.1.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## 📖 Description
Adds a new package: **LocalDock** (`DaivenReyes.LocalDock`) version 0.1.2 — a Windows desktop dev-server control panel that starts/stops/monitors local dev servers from one dashboard, with process-tree lifecycle management (Windows Job Objects) and a local MCP server so AI coding assistants can manage dev servers directly. Repo: https://github.com/rdaiven/localdock

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>` — blocked in this environment by the `LocalManifestFiles` admin-only setting; the installer this manifest points to (the actual published v0.1.2 GitHub release asset) was smoke-tested manually: silent per-user NSIS install, launches correctly, matches the SHA256 in the manifest.
- [x] Manifest conforms to the 1.10.0 schema
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/412703)