### PR TITLE
New version: nolindnaidoo.pixelcoords version 0.7.7

### DIFF
--- a/manifests/n/nolindnaidoo/pixelcoords/0.7.7/nolindnaidoo.pixelcoords.installer.yaml
+++ b/manifests/n/nolindnaidoo/pixelcoords/0.7.7/nolindnaidoo.pixelcoords.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: nolindnaidoo.pixelcoords
+PackageVersion: 0.7.7
+MinimumOSVersion: 10.0.0.0
+# The release ships a zip holding a single self-contained exe, so this is a
+# portable install: winget extracts it and registers a PATH alias rather
+# than running an installer there isn't one of.
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: pixelcoords-v0.7.7-x86_64-pc-windows-msvc\pixelcoords.exe
+    PortableCommandAlias: pixelcoords
+UpgradeBehavior: uninstallPrevious
+ReleaseDate: 2026-08-05
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/nolindnaidoo/pixelcoords/releases/download/v0.7.7/pixelcoords-v0.7.7-x86_64-pc-windows-msvc.zip
+    InstallerSha256: F9D0CACDA4B864E08C61BFEB4328E527AC285D868E46E2C788F30827FC731429
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/n/nolindnaidoo/pixelcoords/0.7.7/nolindnaidoo.pixelcoords.locale.en-US.yaml
+++ b/manifests/n/nolindnaidoo/pixelcoords/0.7.7/nolindnaidoo.pixelcoords.locale.en-US.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: nolindnaidoo.pixelcoords
+PackageVersion: 0.7.7
+PackageLocale: en-US
+Publisher: nolindnaidoo
+PublisherUrl: https://github.com/nolindnaidoo
+PublisherSupportUrl: https://github.com/nolindnaidoo/pixelcoords/issues
+PackageName: pixelcoords
+PackageUrl: https://pixelcoords.dev
+License: MIT
+LicenseUrl: https://github.com/nolindnaidoo/pixelcoords/blob/main/LICENSE
+Copyright: Copyright (c) nolindnaidoo
+ShortDescription: Freeze your screen, mark regions, get pixel-exact coordinates and crops
+Description: |-
+  pixelcoords freezes your screen so nothing moves while you measure, then
+  lets you mark regions with real shapes - rectangles, ellipses, triangles,
+  N-gons, freehand - rotated, labeled, and placed to the exact pixel with a
+  loupe and arrow-key nudging.
+
+  What you mark becomes data, not a picture: versioned JSON in physical
+  pixels with per-monitor DPI scale, labeled crops, and ready-to-paste
+  click code for your automation stack. It answers where to click, and
+  deliberately stops there - it never moves your mouse.
+Moniker: pixelcoords
+Tags:
+  - screenshot
+  - coordinates
+  - automation
+  - screen-capture
+  - cli
+  - hidpi
+  - multi-monitor
+ReleaseNotesUrl: https://github.com/nolindnaidoo/pixelcoords/releases/tag/v0.7.7
+Documentations:
+  - DocumentLabel: CLI reference
+    DocumentUrl: https://github.com/nolindnaidoo/pixelcoords/blob/main/docs/CLI.md
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/n/nolindnaidoo/pixelcoords/0.7.7/nolindnaidoo.pixelcoords.yaml
+++ b/manifests/n/nolindnaidoo/pixelcoords/0.7.7/nolindnaidoo.pixelcoords.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: nolindnaidoo.pixelcoords
+PackageVersion: 0.7.7
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Freeze your screen, mark regions, get pixel-exact coordinates and crops

- Portable install: the release ships a self-contained exe in a zip, so this uses `InstallerType: zip` with `NestedInstallerType: portable`.
- `InstallerSha256` verified against the published artifact, and the `RelativeFilePath` confirmed present inside the zip.
- MIT licensed. Source: https://github.com/nolindnaidoo/pixelcoords

First submission for this package.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/412722)