### PR TITLE
New version: nolindnaidoo.pixelactions version 0.9.7

### DIFF
--- a/manifests/n/nolindnaidoo/pixelactions/0.9.7/nolindnaidoo.pixelactions.installer.yaml
+++ b/manifests/n/nolindnaidoo/pixelactions/0.9.7/nolindnaidoo.pixelactions.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: nolindnaidoo.pixelactions
+PackageVersion: 0.9.7
+MinimumOSVersion: 10.0.0.0
+# The release ships a zip holding a single self-contained exe, so this is a
+# portable install: winget extracts it and registers a PATH alias rather
+# than running an installer there isn't one of.
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: pixelactions-v0.9.7-x86_64-pc-windows-msvc\pixelactions.exe
+    PortableCommandAlias: pixelactions
+UpgradeBehavior: uninstallPrevious
+ReleaseDate: 2026-08-05
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/nolindnaidoo/pixelactions/releases/download/v0.9.7/pixelactions-v0.9.7-x86_64-pc-windows-msvc.zip
+    InstallerSha256: 409E4122E21A61A7DBF4D99F4D5E6CADEB2F3D9F9B780F93F12B1D2E15BFB438
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/n/nolindnaidoo/pixelactions/0.9.7/nolindnaidoo.pixelactions.locale.en-US.yaml
+++ b/manifests/n/nolindnaidoo/pixelactions/0.9.7/nolindnaidoo.pixelactions.locale.en-US.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: nolindnaidoo.pixelactions
+PackageVersion: 0.9.7
+PackageLocale: en-US
+Publisher: nolindnaidoo
+PublisherUrl: https://github.com/nolindnaidoo
+PublisherSupportUrl: https://github.com/nolindnaidoo/pixelactions/issues
+PackageName: pixelactions
+PackageUrl: https://pixelactions.dev
+License: MIT
+LicenseUrl: https://github.com/nolindnaidoo/pixelactions/blob/main/LICENSE
+Copyright: Copyright (c) nolindnaidoo
+ShortDescription: Perform desktop interactions from pixelcoords sessions, and confirm they landed
+Description: |-
+  pixelactions reads a session a human marked in pixelcoords, resolves the
+  label to a point, performs the interaction, and confirms it landed.
+
+  Actions name regions by label, never by coordinate, so a script survives
+  the window moving. Nothing is injected without --yes. Every step reports
+  whether it executed or was verified, because an OS accepting a click is
+  not the same as the application reacting to one.
+
+  Requires pixelcoords, which it calls for capture-time work.
+Moniker: pixelactions
+Tags:
+  - automation
+  - desktop-automation
+  - rpa
+  - gui-testing
+  - cli
+  - computer-use
+ReleaseNotesUrl: https://github.com/nolindnaidoo/pixelactions/releases/tag/v0.9.7
+Documentations:
+  - DocumentLabel: CLI reference
+    DocumentUrl: https://github.com/nolindnaidoo/pixelactions/blob/main/docs/CLI.md
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/n/nolindnaidoo/pixelactions/0.9.7/nolindnaidoo.pixelactions.yaml
+++ b/manifests/n/nolindnaidoo/pixelactions/0.9.7/nolindnaidoo.pixelactions.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: nolindnaidoo.pixelactions
+PackageVersion: 0.9.7
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
First submission for `nolindnaidoo.pixelactions`.

- **Portable install.** The release ships a self-contained `.exe` inside a zip, so this uses `InstallerType: zip` with `NestedInstallerType: portable` and a PATH alias.
- `InstallerSha256` verified against the published artifact, and the `RelativeFilePath` confirmed present inside that zip.
- MIT licensed — source at https://github.com/nolindnaidoo/pixelactions, release at https://github.com/nolindnaidoo/pixelactions/releases/tag/v0.9.7

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/412724)