### PR TITLE
New package: AlejandroAlvarez.Escriba version 2.2.4

### DIFF
--- a/manifests/a/AlejandroAlvarez/Escriba/2.2.4/AlejandroAlvarez.Escriba.installer.yaml
+++ b/manifests/a/AlejandroAlvarez/Escriba/2.2.4/AlejandroAlvarez.Escriba.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: AlejandroAlvarez.Escriba
+PackageVersion: 2.2.4
+InstallerLocale: en-US
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+UpgradeBehavior: install
+ReleaseDate: 2026-07-30
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/AlejandroAP9/Escriba/releases/download/v2.2.4/Escriba_2.2.4_x64-setup.exe
+    InstallerSha256: 2D09254A4858AD5B6027F131D700D60AEA372B2B94D125D012BBEAD0DA5AD72F
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/a/AlejandroAlvarez/Escriba/2.2.4/AlejandroAlvarez.Escriba.locale.en-US.yaml
+++ b/manifests/a/AlejandroAlvarez/Escriba/2.2.4/AlejandroAlvarez.Escriba.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: AlejandroAlvarez.Escriba
+PackageVersion: 2.2.4
+PackageLocale: en-US
+Publisher: Alejandro Alvarez & Flor Vallejo
+PublisherUrl: https://github.com/AlejandroAP9
+PublisherSupportUrl: https://github.com/AlejandroAP9/Escriba/issues
+PackageName: Escriba
+PackageUrl: https://github.com/AlejandroAP9/Escriba
+License: MIT
+LicenseUrl: https://github.com/AlejandroAP9/Escriba/blob/main/LICENSE
+Copyright: (c) 2026 Alejandro Alvarez & Flor Vallejo. Based on Handy (c) CJ Pais, MIT.
+ShortDescription: Free, local AI voice dictation. Press a shortcut, speak, and your words appear as text in any app. 100% offline by default.
+Description: |-
+  Escriba turns your voice into text using AI that runs entirely on your machine.
+  Local by default: no API keys, no subscription, no cloud. Includes dictation with
+  local Whisper/Parakeet models, AI cleanup and translation, meeting sessions with
+  system audio, a transcription studio with SRT/VTT export, text-to-speech, and an
+  MCP server for AI agents. Interface in Spanish and English. Escriba is a rework
+  of Handy (MIT) built for the Juegos Imperiales 2026 hackathon, where it won
+  first place.
+Moniker: escriba
+Tags:
+  - accessibility
+  - ai
+  - dictation
+  - offline
+  - speech-to-text
+  - transcription
+  - translation
+  - voice
+  - whisper
+ReleaseNotesUrl: https://github.com/AlejandroAP9/Escriba/releases/tag/v2.2.4
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/a/AlejandroAlvarez/Escriba/2.2.4/AlejandroAlvarez.Escriba.locale.es-ES.yaml
+++ b/manifests/a/AlejandroAlvarez/Escriba/2.2.4/AlejandroAlvarez.Escriba.locale.es-ES.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
+PackageIdentifier: AlejandroAlvarez.Escriba
+PackageVersion: 2.2.4
+PackageLocale: es-ES
+Publisher: Alejandro Alvarez & Flor Vallejo
+PublisherUrl: https://github.com/AlejandroAP9
+PublisherSupportUrl: https://github.com/AlejandroAP9/Escriba/issues
+PackageName: Escriba
+PackageUrl: https://github.com/AlejandroAP9/Escriba
+License: MIT
+LicenseUrl: https://github.com/AlejandroAP9/Escriba/blob/main/LICENSE
+Copyright: (c) 2026 Alejandro Alvarez & Flor Vallejo. Basado en Handy (c) CJ Pais, MIT.
+ShortDescription: Dictado por voz con IA local y gratis. Aprietas un atajo, hablas, y tu voz aparece como texto en cualquier app. 100% sin conexion por defecto.
+Description: |-
+  Escriba convierte tu voz en texto con inteligencia artificial corriendo en tu
+  propia maquina. Local por defecto: sin claves de API, sin suscripcion, sin nube.
+  Incluye dictado con modelos locales Whisper/Parakeet, correccion y traduccion
+  con IA, Sesiones con audio del sistema para actas de reuniones, un Estudio de
+  transcripcion con export SRT/VTT, lectura en voz alta, y un servidor MCP para
+  agentes de IA. Interfaz completa en espanol e ingles. Escriba es un rework de
+  Handy (MIT) construido para el hackathon Juegos Imperiales 2026, donde gano el
+  primer lugar.
+Tags:
+  - accesibilidad
+  - dictado
+  - ia
+  - reconocimiento-de-voz
+  - sin-conexion
+  - transcripcion
+  - traduccion
+  - voz
+ReleaseNotesUrl: https://github.com/AlejandroAP9/Escriba/releases/tag/v2.2.4
+ManifestType: locale
+ManifestVersion: 1.6.0

--- a/manifests/a/AlejandroAlvarez/Escriba/2.2.4/AlejandroAlvarez.Escriba.yaml
+++ b/manifests/a/AlejandroAlvarez/Escriba/2.2.4/AlejandroAlvarez.Escriba.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: AlejandroAlvarez.Escriba
+PackageVersion: 2.2.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package submission

- **PackageIdentifier:** AlejandroAlvarez.Escriba
- **PackageVersion:** 2.2.4
- **Installer:** NSIS (x64, per-user), from the official GitHub release: https://github.com/AlejandroAP9/Escriba/releases/tag/v2.2.4
- **SHA256** verified against the release asset.

Escriba is a free, open source (MIT), local-first AI voice dictation app for Windows 10/11. Speech-to-text runs entirely on-device (Whisper/Parakeet); no account or API key required.

-----

- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/README.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?

Note: authored from macOS, so local `winget validate` / `winget install` testing was not possible; relying on the automated validation pipeline. Manifests follow the 1.6.0 schema. Happy to make any changes the moderators request.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/412729)