### PR TITLE
New version: Ledgerful.Ledgerful version 0.2.6

### DIFF
--- a/manifests/l/Ledgerful/Ledgerful/0.2.6/Ledgerful.Ledgerful.installer.yaml
+++ b/manifests/l/Ledgerful/Ledgerful/0.2.6/Ledgerful.Ledgerful.installer.yaml
@@ -1,0 +1,19 @@
+# Created with komac (manual recovery after WINGET_TOKEN CreateRef failure on release v0.2.6)
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Ledgerful.Ledgerful
+PackageVersion: 0.2.6
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: ledgerful.exe
+  PortableCommandAlias: ledgerful
+Commands:
+- ledgerful
+ReleaseDate: 2026-08-05
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Ryan-AI-Studios/Ledgerful/releases/download/v0.2.6/ledgerful-x86_64-pc-windows-msvc.zip
+  InstallerSha256: 631A7F0D5DD99BC4B2A11B0E4EB6A80276E5FAEC7C8E118A13862D08A6788978
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/l/Ledgerful/Ledgerful/0.2.6/Ledgerful.Ledgerful.locale.en-US.yaml
+++ b/manifests/l/Ledgerful/Ledgerful/0.2.6/Ledgerful.Ledgerful.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# Created with komac (manual recovery after WINGET_TOKEN CreateRef failure on release v0.2.6)
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Ledgerful.Ledgerful
+PackageVersion: 0.2.6
+PackageLocale: en-US
+Publisher: Ledgerful, LLC
+PublisherUrl: https://github.com/Ryan-AI-Studios/Ledgerful
+PublisherSupportUrl: https://github.com/Ryan-AI-Studios/Ledgerful/issues
+Author: Ledgerful, LLC
+PackageName: Ledgerful
+PackageUrl: https://github.com/Ryan-AI-Studios/Ledgerful
+License: PolyForm Noncommercial 1.0.0
+LicenseUrl: https://github.com/Ryan-AI-Studios/Ledgerful/blob/HEAD/LICENSE
+Copyright: Copyright 2026 Ledgerful, LLC
+CopyrightUrl: https://github.com/Ryan-AI-Studios/Ledgerful/blob/v0.1.9/LICENSE
+ShortDescription: Local-first change intelligence CLI for impact analysis and verification
+Description: |-
+  Ledgerful is a local-first command-line tool for deterministic change intelligence:
+  impact and risk analysis, signed provenance for code changes, verification planning,
+  and local knowledge-graph indexing. The product is source-available under the PolyForm
+  Noncommercial License 1.0.0, with a separate small-entity commercial exception
+  documented in COMMERCIAL-EXCEPTION.md in the source repository.
+Moniker: ledgerful
+Tags:
+- change-intelligence
+- cli
+- developer-tools
+- local-first
+- provenance
+- verification
+ReleaseNotesUrl: https://github.com/Ryan-AI-Studios/Ledgerful/releases/tag/v0.2.6
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/l/Ledgerful/Ledgerful/0.2.6/Ledgerful.Ledgerful.yaml
+++ b/manifests/l/Ledgerful/Ledgerful/0.2.6/Ledgerful.Ledgerful.yaml
@@ -1,0 +1,8 @@
+# Created with komac (manual recovery after WINGET_TOKEN CreateRef failure on release v0.2.6)
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Ledgerful.Ledgerful
+PackageVersion: 0.2.6
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## New version: Ledgerful.Ledgerful 0.2.6

Recovery PR for engine tag **v0.2.6** (winget-releaser CreateRef failed for WINGET_TOKEN).

- Installer: https://github.com/Ryan-AI-Studios/Ledgerful/releases/download/v0.2.6/ledgerful-x86_64-pc-windows-msvc.zip
- SHA256: 631A7F0D5DD99BC4B2A11B0E4EB6A80276E5FAEC7C8E118A13862D08A6788978
- Release: https://github.com/Ryan-AI-Studios/Ledgerful/releases/tag/v0.2.6
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/412736)