### PR TITLE
New version: daruyanagi.XTimelineViewer version 2.0.0

### DIFF
--- a/manifests/d/daruyanagi/XTimelineViewer/2.0.0/daruyanagi.XTimelineViewer.installer.yaml
+++ b/manifests/d/daruyanagi/XTimelineViewer/2.0.0/daruyanagi.XTimelineViewer.installer.yaml
@@ -17,9 +17,9 @@ ReleaseDate: 2026-08-05
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/daruyanagi/XTimelineViewer/releases/download/v2.0.0/XTimelineViewer-v2.0.0-win-x64.zip
-  InstallerSha256: 9E518910605E63A901A43FBC56E5290271E8622D180A1EF5FE60CBF44D42FF0E
+  InstallerSha256: C930D05C3A70A3C8D881AC18E2A6B762B4EEFE56A305F19CADC3180C7650F40B
 - Architecture: arm64
   InstallerUrl: https://github.com/daruyanagi/XTimelineViewer/releases/download/v2.0.0/XTimelineViewer-v2.0.0-win-arm64.zip
-  InstallerSha256: C6D03755081C737FF00CAC7C010C4BF15E731AC3331B6E4F31E9BDF4BD9750FC
+  InstallerSha256: AA1AC0E94E8A9D00FBA54A21995446A046BDCBCEE60186FC61004E0AF56A64B6
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/d/daruyanagi/XTimelineViewer/2.0.0/daruyanagi.XTimelineViewer.installer.yaml
+++ b/manifests/d/daruyanagi/XTimelineViewer/2.0.0/daruyanagi.XTimelineViewer.installer.yaml
@@ -1,0 +1,25 @@
+# Created with WinGet Releaser using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: daruyanagi.XTimelineViewer
+PackageVersion: 2.0.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: xtv.exe
+  PortableCommandAlias: xtv
+- RelativeFilePath: XTimelineViewer.exe
+  PortableCommandAlias: xtimelineviewer
+ReleaseDate: 2026-08-05
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/daruyanagi/XTimelineViewer/releases/download/v2.0.0/XTimelineViewer-v2.0.0-win-x64.zip
+  InstallerSha256: 9E518910605E63A901A43FBC56E5290271E8622D180A1EF5FE60CBF44D42FF0E
+- Architecture: arm64
+  InstallerUrl: https://github.com/daruyanagi/XTimelineViewer/releases/download/v2.0.0/XTimelineViewer-v2.0.0-win-arm64.zip
+  InstallerSha256: C6D03755081C737FF00CAC7C010C4BF15E731AC3331B6E4F31E9BDF4BD9750FC
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/d/daruyanagi/XTimelineViewer/2.0.0/daruyanagi.XTimelineViewer.locale.en-US.yaml
+++ b/manifests/d/daruyanagi/XTimelineViewer/2.0.0/daruyanagi.XTimelineViewer.locale.en-US.yaml
@@ -1,0 +1,64 @@
+# Created with WinGet Releaser using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: daruyanagi.XTimelineViewer
+PackageVersion: 2.0.0
+PackageLocale: en-US
+Publisher: daruyanagi
+PublisherUrl: https://github.com/daruyanagi
+PublisherSupportUrl: https://github.com/daruyanagi/XTimelineViewer/issues
+PackageName: XTimelineViewer
+PackageUrl: https://github.com/daruyanagi/XTimelineViewer
+License: MIT
+LicenseUrl: https://github.com/daruyanagi/XTimelineViewer/blob/HEAD/LICENSE
+ShortDescription: Multi-column X (Twitter) timeline viewer built with WinUI 3 and WebView2
+Description: |-
+  XTimelineViewer lets you view multiple X (Twitter) timelines side by side,
+  similar to TweetDeck / X Pro. Drop X URL shortcuts onto the window to add
+  timelines. Built with WinUI 3 and WebView2, self-contained (no runtime install needed).
+Tags:
+- timeline
+- tweetdeck
+- twitter
+- webview2
+- winui3
+- x
+ReleaseNotes: |-
+  What's Changed
+  - docs(#272): README から Microsoft Store の記述を削除 by @daruyanagi in #273
+  - refactor(#271): 非推奨の AutoActivate 機能を完全削除 by @daruyanagi in #274
+  - chore(#272): Release.ps1・release スキルから Store 手順を削除 by @daruyanagi in #275
+  - docs(#53): README を実態化し CLAUDE.md を追加 by @daruyanagi in #276
+  - ci: PR/main で本体ビルドとテストを自動実行 by @daruyanagi in #277
+  - chore: ルートの画像を docs/ に移動 by @daruyanagi in #278
+  - feat(#261): アプリ表示名を「XTimelineViewer (xTV)」に by @daruyanagi in #279
+  - feat(#261): アプリアイコンを xTV デザインに差し替え by @daruyanagi in #280
+  - feat(#270): xtv.exe にアプリアイコンを埋め込む by @daruyanagi in #282
+  - docs: README の画像パスを docs/ に統一 by @daruyanagi in #283
+  - refactor(#271): 未使用リソースキーと using を除去 by @daruyanagi in #284
+  - feat(#285): 投稿後にプライマリプロフィールへ戻す試験機能 by @daruyanagi in #286
+  - feat(#287): 画像表示中のペインをウィンドウ全体へ一時拡大する試験機能 by @daruyanagi in #288
+  - feat(#289): 動画の全画面ボタンでペインを一時拡大する試験機能 by @daruyanagi in #291
+  - feat(#293): メディアに自前の拡大ボタンを重ね、メディアだけを全画面表示する by @daruyanagi in #294
+  - fix(#295): メディア拡大の画像を高解像度・見切れなしで全画面表示 by @daruyanagi in #296
+  - fix(#297): メディア拡大ボタンの表示欠落と動画二重付与を是正 by @daruyanagi in #298
+  - feat(#299): 動画の現在フレームを画像として保存（試験機能） by @daruyanagi in #300
+  - feat(#301): GIF はフレーム保存を無効化し、GIF(MP4) をダウンロードする by @daruyanagi in #302
+  - feat(#304): メディアDL（画像/動画/GIF）とオーバーレイのボタン配置整理 by @daruyanagi in #305
+  - fix(#297): タイムラインの拡大ボタンを左上へ移動（右端見切れ対策） by @daruyanagi in #306
+  - refactor(#303): メディア拡大まわりの実質デッドコードを整理 by @daruyanagi in #307
+  - feat(#308): 動画は Videos へ保存、DL 進捗トースト＋フォルダーを開くリンク by @daruyanagi in #309
+  - chore(#310): 動画DL に一時診断ログを追加（試験機能の観測用） by @daruyanagi in #311
+  - feat(#312): 試験機能カードの名称更新＋保存先の inline リンク化 by @daruyanagi in #313
+  - feat(#310): 動画DL 失敗トーストに回避策リンクを追加 by @daruyanagi in #314
+  - fix(#317): 検索ダイアログを ESC で閉じられるようにする by @daruyanagi in #318
+  - feat(#315): 直前のリポストを検索（空リプ捕捉・試験機能） by @daruyanagi in #316
+  - feat(#319): 直前のポスト・リポストを検索（🔎 1 ボタンに統合） by @daruyanagi in #320
+  - feat(#281): アプリアイコンを v2 に差し替え（小サイズ最適化・透過素材） by @daruyanagi in #321
+  - feat: 謝辞にアイコン制作者のクレジットを追加、参考ブログを削除 by @daruyanagi in #322
+  - docs: README のアイコンを v2 に差し替え、旧素材を削除 by @daruyanagi in #323
+  - chore: バージョンを 2.0.0 に更新（v2.0.0 リリース） by @daruyanagi in #324
+  Full Changelog: v1.9.0...v2.0.0
+ReleaseNotesUrl: https://github.com/daruyanagi/XTimelineViewer/releases/tag/v2.0.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/d/daruyanagi/XTimelineViewer/2.0.0/daruyanagi.XTimelineViewer.yaml
+++ b/manifests/d/daruyanagi/XTimelineViewer/2.0.0/daruyanagi.XTimelineViewer.yaml
@@ -1,0 +1,8 @@
+# Created with WinGet Releaser using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: daruyanagi.XTimelineViewer
+PackageVersion: 2.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New version: `daruyanagi.XTimelineViewer` version `2.0.0`

Manifests were added manually because the automated `winget-releaser` run could not create a branch on the fork (token permission issue on the publisher side). The structure is identical to the previously published versions of this package.

- **Package**: `daruyanagi.XTimelineViewer`
- **Version**: `2.0.0`
- **Release**: https://github.com/daruyanagi/XTimelineViewer/releases/tag/v2.0.0

Installer URLs and `InstallerSha256` were computed from the published release assets (x64 / arm64) downloaded from that release.

---

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/add?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? — validated with winget v1.29.280 (passed)
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? — not run locally; the same ZIP/portable layout has shipped unchanged since earlier versions of this package
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?