### PR TITLE
Add version: KeeperSecurity.Commander version 18.0.15 - Update version: KeeperSecurity.Commander version 18.0.15

### DIFF
--- a/manifests/k/KeeperSecurity/Commander/18.0.15/KeeperSecurity.Commander.installer.yaml
+++ b/manifests/k/KeeperSecurity/Commander/18.0.15/KeeperSecurity.Commander.installer.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: KeeperSecurity.Commander
+PackageVersion: 18.0.15
+InstallerLocale: en-US
+InstallerType: inno
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Commands:
+- keeper
+ProductCode: "{006266E3-17D6-4166-918C-0B8F4C663D4C}_is1"
+ReleaseDate: 2026-07-17
+AppsAndFeaturesEntries:
+- DisplayName: Keeper Commander 18.0.15
+  ProductCode: "{006266E3-17D6-4166-918C-0B8F4C663D4C}_is1"
+ElevationRequirement: elevatesSelf
+InstallationMetadata:
+  DefaultInstallLocation: "%ProgramFiles%\\Keeper Commander"
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/Keeper-Security/Commander/releases/download/v18.0.15/keeper-commander-windows-v18.0.15.exe
+  InstallerSha256: F9611E9DC9F56271093D069D58B6E8008B614BD9C2B9454873BE1F33B702CD60
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/k/KeeperSecurity/Commander/18.0.15/KeeperSecurity.Commander.locale.en-US.yaml
+++ b/manifests/k/KeeperSecurity/Commander/18.0.15/KeeperSecurity.Commander.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: KeeperSecurity.Commander
+PackageVersion: 18.0.15
+PackageLocale: en-US
+Publisher: Keeper Security, Inc.
+PublisherUrl: https://www.keepersecurity.com/
+PublisherSupportUrl: https://github.com/Keeper-Security/Commander/issues
+PackageName: Keeper Commander
+PackageUrl: https://github.com/Keeper-Security/Commander
+License: MIT
+LicenseUrl: https://github.com/Keeper-Security/Commander/blob/HEAD/LICENSE
+Copyright: Copyright (c) Keeper Security, Inc.
+CopyrightUrl: https://github.com/Keeper-Security/Commander/blob/master/LICENSE
+ShortDescription: Keeper Commander is a python-based CLI and SDK interface to the Keeper Security platform. Provides administrative controls, reporting, import/export and vault management.
+Description: Keeper Commander is a command-line and SDK interface to Keeper® Password Manager. Commander can be used to access and control your Keeper vault, perform administrative functions (such as end-user onboarding and data import/export), launch remote sessions, rotate passwords, eliminate hardcoded passwords and more. Keeper Commander is an open source project with contributions from Keeper's engineering team and partners.
+Moniker: keeper
+Tags:
+- cli
+- password
+- password-manager
+- secrets
+- security-tools
+ReleaseNotes: |-
+  Keeper Commander release v18.0.13
+  New Features
+  • CyberArk → KeeperPAM migration — Added a new pam project cyberark-import command to migrate CyberArk safes, accounts, platforms, and policies into KeeperPAM. See docs/cyberark-pam-import.md for details.
+  Improvements
+  • import --no-shortcuts — Added a --no-shortcuts flag to the import command. When an imported record is identical to an existing vault record, import normally creates a shortcut; with --no-shortcuts it creates a new record instead.
+ReleaseNotesUrl: https://github.com/Keeper-Security/Commander/releases/tag/v18.0.13
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/k/KeeperSecurity/Commander/18.0.15/KeeperSecurity.Commander.yaml
+++ b/manifests/k/KeeperSecurity/Commander/18.0.15/KeeperSecurity.Commander.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: KeeperSecurity.Commander
+PackageVersion: 18.0.15
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
<!-- winmatsch:package=KeeperSecurity.Commander;version=18.0.15 -->
<!-- winmatsch:operation=Add -->
Add KeeperSecurity.Commander version 18.0.15.
Created with winmatsch v0.8.13
Internal validation passed.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/412741)