### PR TITLE
Add version: Concourse.Fly version 8.2.5 - Update version: Concourse.Fly version 8.2.5

### DIFF
--- a/manifests/c/Concourse/Fly/8.2.5/Concourse.Fly.installer.yaml
+++ b/manifests/c/Concourse/Fly/8.2.5/Concourse.Fly.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: Concourse.Fly
+PackageVersion: 8.2.5
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: fly.exe
+ReleaseDate: 2026-06-16
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/concourse/concourse/releases/download/v8.2.5/fly-8.2.5-windows-amd64.zip
+  InstallerSha256: E43D428D9CC449D0C0032D75FD084E3AC6B4E6613137E99135C83405DFD43316
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/Concourse/Fly/8.2.5/Concourse.Fly.locale.en-US.yaml
+++ b/manifests/c/Concourse/Fly/8.2.5/Concourse.Fly.locale.en-US.yaml
@@ -1,0 +1,47 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: Concourse.Fly
+PackageVersion: 8.2.5
+PackageLocale: en-US
+Publisher: Concourse
+PublisherUrl: https://github.com/concourse
+PublisherSupportUrl: https://github.com/concourse/concourse/issues
+PackageName: Concourse Fly
+PackageUrl: https://github.com/concourse/concourse
+License: Apache-2.0
+LicenseUrl: https://github.com/concourse/concourse/blob/HEAD/LICENSE.md
+ShortDescription: Concourse CI/CD manager and controller
+Tags:
+- ci
+- ci-cd
+- concourse
+- continuous-delivery
+- continuous-integration
+- elm
+- go
+- hacktoberfest
+- pipelines
+ReleaseNotes: |-
+  What's Changed
+  🐞 Bug Fixes
+  • fix how resources with check_every：never are handled when scheduling builds by @taylorsilva in #9598
+  • fix streaming volumes with relative symlinks by @taylorsilva in #9601
+  • fix "invalid UTF-8" errors when get steps generate metadata by @kurtmc in #9602
+  📦 Bundled Resource Types
+  • bosh-io-release：v1.3.4
+  • bosh-io-stemcell：v1.5.4
+  • docker-image：v1.13.1
+  • git：v1.22.3
+  • github-release：v1.14.0
+  • hg：v1.5.4
+  • mock：v0.14.5
+  • pool：v1.8.1
+  • registry-image：v1.17.0
+  • s3：v2.5.4
+  • semver：v2.0.1
+  • time：v1.11.3
+  Full Changelog：v8.2.3...v8.2.4
+ReleaseNotesUrl: https://github.com/concourse/concourse/releases/tag/v8.2.4
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/Concourse/Fly/8.2.5/Concourse.Fly.yaml
+++ b/manifests/c/Concourse/Fly/8.2.5/Concourse.Fly.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: Concourse.Fly
+PackageVersion: 8.2.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
<!-- winmatsch:package=Concourse.Fly;version=8.2.5 -->
<!-- winmatsch:operation=Add -->
Add Concourse.Fly version 8.2.5.
Created with winmatsch v0.8.13
Internal validation passed.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/412742)