### PR TITLE
Add version: errata-ai.Vale version 3.17.0 - Update version: errata-ai.Vale version 3.17.0

### DIFF
--- a/manifests/e/errata-ai/Vale/3.17.0/errata-ai.Vale.installer.yaml
+++ b/manifests/e/errata-ai/Vale/3.17.0/errata-ai.Vale.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: errata-ai.Vale
+PackageVersion: 3.17.0
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: vale.exe
+Commands:
+- vale
+ReleaseDate: 2026-06-12
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/errata-ai/vale/releases/download/v3.17.0/vale_3.17.0_Windows_64-bit.zip
+  InstallerSha256: 7294214B10104BDCBAD027F2A59B0E468F24EDB739EA03BEFCEF6D491BDCF58F
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/e/errata-ai/Vale/3.17.0/errata-ai.Vale.locale.en-US.yaml
+++ b/manifests/e/errata-ai/Vale/3.17.0/errata-ai.Vale.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: errata-ai.Vale
+PackageVersion: 3.17.0
+PackageLocale: en-US
+Publisher: errata.ai
+PublisherUrl: https://vale.sh/
+PublisherSupportUrl: https://github.com/errata-ai/vale/issues
+PackageName: Vale
+PackageUrl: https://vale.sh/
+License: MIT
+LicenseUrl: https://github.com/errata-ai/vale/blob/HEAD/LICENSE
+Copyright: Copyright (c) 2016 Joseph Kato
+CopyrightUrl: https://github.com/errata-ai/vale/blob/v2/LICENSE
+ShortDescription: A syntax-aware linter for prose built with speed and extensibility in mind.
+Moniker: vale
+Tags:
+- linter
+- linting
+- nlp
+- vale
+ReleaseNotes: |-
+  See v3.15.0 for full notes.
+  Changelog
+  • 8c4ed0d chore：support immutable releases
+ReleaseNotesUrl: https://github.com/vale-cli/vale/releases/tag/v3.15.1
+Documentations:
+- DocumentUrl: https://vale.sh/docs/
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/e/errata-ai/Vale/3.17.0/errata-ai.Vale.yaml
+++ b/manifests/e/errata-ai/Vale/3.17.0/errata-ai.Vale.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: errata-ai.Vale
+PackageVersion: 3.17.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
<!-- winmatsch:package=errata-ai.Vale;version=3.17.0 -->
<!-- winmatsch:operation=Add -->
Add errata-ai.Vale version 3.17.0.
Created with winmatsch v0.8.13
Internal validation passed.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/412746)