### PR TITLE
Add version: BytecodeAlliance.Wasmtime.Portable version 47.0.3 - Update version: BytecodeAlliance.Wasmtime.Portable version 47.0.3

### DIFF
--- a/manifests/b/BytecodeAlliance/Wasmtime/Portable/47.0.3/BytecodeAlliance.Wasmtime.Portable.installer.yaml
+++ b/manifests/b/BytecodeAlliance/Wasmtime/Portable/47.0.3/BytecodeAlliance.Wasmtime.Portable.installer.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: BytecodeAlliance.Wasmtime.Portable
+PackageVersion: 47.0.3
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: wasmtime-v47.0.3-x86_64-windows/wasmtime-min.exe
+  PortableCommandAlias: wasmtime-min
+- RelativeFilePath: wasmtime-v47.0.3-x86_64-windows/wasmtime.exe
+  PortableCommandAlias: wasmtime
+FileExtensions:
+- wasm
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+ReleaseDate: 2026-07-20
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/bytecodealliance/wasmtime/releases/download/v47.0.3/wasmtime-v47.0.3-x86_64-windows.zip
+  InstallerSha256: 80DDF037820B35A9A53C13519632F52947E848D6BA69A483840B7330110408F3
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/b/BytecodeAlliance/Wasmtime/Portable/47.0.3/BytecodeAlliance.Wasmtime.Portable.locale.en-US.yaml
+++ b/manifests/b/BytecodeAlliance/Wasmtime/Portable/47.0.3/BytecodeAlliance.Wasmtime.Portable.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: BytecodeAlliance.Wasmtime.Portable
+PackageVersion: 47.0.3
+PackageLocale: en-US
+Publisher: Bytecode Alliance
+PublisherUrl: https://bytecodealliance.org/
+PublisherSupportUrl: https://github.com/bytecodealliance/wasmtime/issues
+PackageName: Wasmtime
+PackageUrl: https://wasmtime.dev/
+License: Apache-2.0
+LicenseUrl: https://github.com/bytecodealliance/wasmtime/blob/HEAD/LICENSE
+Copyright: Copyright © 2019-2023 the Bytecode Alliance contributors.
+ShortDescription: A fast and secure runtime for WebAssembly
+Description: Wasmtime is a Bytecode Alliance project that is a standalone wasm-only optimizing runtime for WebAssembly and WASI. It runs WebAssembly code outside of the Web, and can be used both as a command-line utility or as a library embedded in a larger application.
+Tags:
+- aot
+- cranelift
+- jit
+- runtime
+- rust
+- sandbox
+- standalone
+- wasi
+- wasm
+- wasmtime
+- webassembly
+ReleaseNotes: "47.0.0\nReleased 2026-07-20.\nAdded\n• Wasmtime now has the WebAssembly GC proposal enabled by default.\n  #13594\n• Wasmtime now has the WebAssembly exception-handling proposal enabled by\n  default.\n  #13603\n• Cranelift now supports the compact unwind format on Mach-O platforms.\n  #13586\n• Wasmtime now supports bounds-checked unsafe intrinsics which take spectre\n  mitigations into account.\n  #13597\n• The wasmtime::Engine type now supports reflection to determine the value of\n  most Config options that were selected during creation.\n  #13671\n• Support for fibers on unsupported architectures is now supported through an\n  opt-in compile time Cargo feature defining a C API embedders can implement.\n  #13620\n• Embedders can now create an ArrayRef with a memcpy-style constructor.\n  #13716\n• A new Accessor::poll_ready_for_concurrent_call API can be used to detect\n  when backpressure indicates that a function is ready to be invoked.\n  #13683\nChanged\n• Support for wasi-threads and Wasmtime's wasi-common crate have been removed.\n  For more information see the associated RFC in Wasmtime.\n  #13558\n• The call_indirect instruction of final super types has been optimized when\n  the GC proposal is enabled.\n  #13572\n• Cranelift's *_imm builder helpers have been deprecated in favor of\n  *_imm_{s,u} helpers.\n  #13583\n• The wasmtime CLI's syntax supported for --invoke with components now\n  supports fully qualified WIT interface names.\n  #13564\n• Cranelift's stack_{load,store} instructions have been removed.\n  #13580\n• Cranelift's {band,bor,bxor}_not instructions have been removed.\n  #13590\n• Cranelift's global_value instruction has been removed.\n  #13682\n• The wasmtime wizer subcommand now supports specifying the initialization\n  function with WAVE for components.\n  #13582\n• Wasmtime's codegen on aarch64 for the i32x4.relaxed_dot_i8x16_i7x16_add_s\n  wasm instruction now uses a single sdot instruction where possible.\n  #13640\n• Wasmtime's .wasmtime{traps,addrmap} sections in *.cwasm files are now\n  significantly smaller.\n  #13628\n• Wasmtime now supports removing symbols from *.cwasm files and additionally\n  has a documentation page about producing minimally-sized *.cwasm outputs.\n  #13630\n• Wasmtime now suports resources in the named_imports option of bindgen!.\n  #13666\n• Wasmtime now invokes the host's socket_addr_check callback for implicit\n  binds performed in WASIp3.\n  #13677\n• Wasmtime's component-to-component sync-to-sync fused adapters have been\n  optimized.\n  #13695\n• Cranelift now supports RISC-V's Zvbb extension.\n  #13738\nFixed\n• The IPV6_V6ONLY option is now set for UDP sockets.\n  #13596\n• Uncaught wasm exceptions at component boundaries are now turned into traps to\n  prevent components catching exceptions from other components.\n  #13613\n• Addresses being sent do with WASIp3 and UDP are now validated as they are in\n  WASIp2.\n  #13631\n• GC roots on component model fiber stacks are now properly traced.\n  #13693\n• An unaligned load when reading debug state slot values has been fixed.\n  #13791"
+ReleaseNotesUrl: https://github.com/bytecodealliance/wasmtime/releases/tag/v47.0.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/b/BytecodeAlliance/Wasmtime/Portable/47.0.3/BytecodeAlliance.Wasmtime.Portable.yaml
+++ b/manifests/b/BytecodeAlliance/Wasmtime/Portable/47.0.3/BytecodeAlliance.Wasmtime.Portable.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: BytecodeAlliance.Wasmtime.Portable
+PackageVersion: 47.0.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
<!-- winmatsch:package=BytecodeAlliance.Wasmtime.Portable;version=47.0.3 -->
<!-- winmatsch:operation=Add -->
Add BytecodeAlliance.Wasmtime.Portable version 47.0.3.
Created with winmatsch v0.8.13
Internal validation passed.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/412760)