### PR TITLE
Add version: RivaFarabi.Deckboard version 3.2.0 - Update version: RivaFarabi.Deckboard version 3.2.0

### DIFF
--- a/manifests/r/RivaFarabi/Deckboard/3.2.0/RivaFarabi.Deckboard.installer.yaml
+++ b/manifests/r/RivaFarabi/Deckboard/3.2.0/RivaFarabi.Deckboard.installer.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: RivaFarabi.Deckboard
+PackageVersion: 3.2.0
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+InstallerType: nullsoft
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+ProductCode: "{EA97F60E-66CE-5D9D-8E6A-F64104860C4D}"
+ReleaseDate: 2025-09-26
+AppsAndFeaturesEntries:
+- DisplayName: Deckboard 3.2.0
+  ProductCode: "{EA97F60E-66CE-5D9D-8E6A-F64104860C4D}"
+Installers:
+- Architecture: x86
+  Scope: user
+  InstallerUrl: https://github.com/rivafarabi/deckboard/releases/download/v3.2.0/Deckboard-Setup-3.2.0.exe
+  InstallerSha256: 9CA17A8CB8F61BD6DA4F044F9A8996FCB014852D0F8FD7A5717BEF633868296A
+  InstallerSwitches:
+    Custom: /CURRENTUSER
+- Architecture: x86
+  Scope: machine
+  InstallerUrl: https://github.com/rivafarabi/deckboard/releases/download/v3.2.0/Deckboard-Setup-3.2.0.exe
+  InstallerSha256: 9CA17A8CB8F61BD6DA4F044F9A8996FCB014852D0F8FD7A5717BEF633868296A
+  InstallerSwitches:
+    Custom: /ALLUSERS
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/r/RivaFarabi/Deckboard/3.2.0/RivaFarabi.Deckboard.locale.en-US.yaml
+++ b/manifests/r/RivaFarabi/Deckboard/3.2.0/RivaFarabi.Deckboard.locale.en-US.yaml
@@ -1,0 +1,42 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: RivaFarabi.Deckboard
+PackageVersion: 3.2.0
+PackageLocale: en-US
+Publisher: Riva Farabi
+PublisherUrl: https://github.com/rivafarabi/deckboard
+PublisherSupportUrl: https://github.com/rivafarabi/deckboard/issues
+Author: Riva Farabi
+PackageName: Deckboard
+PackageUrl: https://github.com/rivafarabi/deckboard
+License: Copyright © 2022 Riva Farabi
+Copyright: Copyright © 2022 Riva Farabi
+ShortDescription: Phone as macro shortcut for your computer in the easiest way possible.
+Description: |-
+  Create custom computer macro shortcuts and launch them through your device.
+  No more windows switching to open the folder or website, get Deckboard to simplify them and maximize your productivity!
+  With OBS Studio and Streamlabs OBS supported, bring Deckboard as your personal streaming companion tool!
+  Connect your computer to your device through local WiFi connection by entering IP address or scanning QR code.
+Moniker: deckboard
+Tags:
+- electron
+- macro-recorder
+- macros
+- obs-remote
+- remote-control
+- desktop-shortcuts
+- desktopshortcuts
+- shortcuts-on-desktop
+- streamlabs-obs-remote
+ReleaseNotes: |-
+  Improvements
+  • Add keypress sequence validation on Advance Keypress Editor
+  Bug Fixes
+  • Fix missing keypress on (CTRL, SHIFT, and ALT) Advance Keypress Editor
+  • Fix bug where Advance Keypress Editor's delay time input value cannot be inserted
+  • Fix infinite loading on Linux and Mac's Run Program field
+  • (Linux only) Fix gnome-control-center apps cannot be launched from Deckboard.
+ReleaseNotesUrl: https://github.com/rivafarabi/deckboard/releases/tag/v3.1.4
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/RivaFarabi/Deckboard/3.2.0/RivaFarabi.Deckboard.yaml
+++ b/manifests/r/RivaFarabi/Deckboard/3.2.0/RivaFarabi.Deckboard.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: RivaFarabi.Deckboard
+PackageVersion: 3.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
<!-- winmatsch:package=RivaFarabi.Deckboard;version=3.2.0 -->
<!-- winmatsch:operation=Add -->
Add RivaFarabi.Deckboard version 3.2.0.
Created with winmatsch v0.8.14
Internal validation passed.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/412806)