### PR TITLE
New version: Glide01.BoxPilot version 1.13.4

### DIFF
--- a/manifests/g/Glide01/BoxPilot/1.13.4/Glide01.BoxPilot.installer.yaml
+++ b/manifests/g/Glide01/BoxPilot/1.13.4/Glide01.BoxPilot.installer.yaml
@@ -1,0 +1,22 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Glide01.BoxPilot
+PackageVersion: 1.13.4
+InstallerLocale: en-US
+InstallerType: wix
+Scope: machine
+UpgradeBehavior: install
+ProductCode: '{880852AD-1720-45D2-A034-44ABDCF0B410}'
+ReleaseDate: 2026-08-05
+AppsAndFeaturesEntries:
+- ProductCode: '{880852AD-1720-45D2-A034-44ABDCF0B410}'
+  UpgradeCode: '{F7A8C9D1-2E3B-4F5A-6B7C-8D9E0F1A2B3C}'
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles%/BoxPilot'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Glide01/BoxPilot/releases/download/v1.13.4/box_pilot_gui-1.13.4-x86_64.msi
+  InstallerSha256: CB204DA42D875F27731CFB298090C04A2CA999C86102881EDD6556A2D2CFCE52
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/g/Glide01/BoxPilot/1.13.4/Glide01.BoxPilot.locale.en-US.yaml
+++ b/manifests/g/Glide01/BoxPilot/1.13.4/Glide01.BoxPilot.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Glide01.BoxPilot
+PackageVersion: 1.13.4
+PackageLocale: en-US
+Publisher: BoxPilot Contributors
+PublisherUrl: https://github.com/Glide01
+PublisherSupportUrl: https://github.com/Glide01/BoxPilot/issues
+PackageName: BoxPilot
+PackageUrl: https://github.com/Glide01/BoxPilot
+License: MIT
+LicenseUrl: https://github.com/Glide01/BoxPilot/blob/HEAD/LICENSE
+ShortDescription: A GUI manager for the sing-box proxy program
+Moniker: boxpilot
+ReleaseNotes: |-
+  BoxPilot v1.13.4 — sing-box 1.13.14 bundled in the MSI.
+  Install via winget: winget install Glide01.BoxPilot
+  BoxPilot is MIT licensed. The bundled sing-box.exe is the official
+  SagerNet/sing-box release binary,
+  distributed under its own GPL-3.0-or-later license.
+ReleaseNotesUrl: https://github.com/Glide01/BoxPilot/releases/tag/v1.13.4
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/g/Glide01/BoxPilot/1.13.4/Glide01.BoxPilot.yaml
+++ b/manifests/g/Glide01/BoxPilot/1.13.4/Glide01.BoxPilot.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Glide01.BoxPilot
+PackageVersion: 1.13.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Manifests generated with [Komac](https://github.com/russellbanks/Komac) v2.16.0 and submitted via the GitHub REST API.

- Installer: Glide01.BoxPilot 1.13.4 (MSI, x64, machine scope)
- UpgradeCode is unchanged from previous versions; ProductCode is regenerated per release by WiX.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/412820)