### PR TITLE
New package: OneWorks.OneWorks version 0.1.0

### DIFF
--- a/manifests/o/OneWorks/OneWorks/0.1.0/OneWorks.OneWorks.installer.yaml
+++ b/manifests/o/OneWorks/OneWorks/0.1.0/OneWorks.OneWorks.installer.yaml
@@ -4,8 +4,7 @@ PackageVersion: 0.1.0
 Platform:
   - Windows.Desktop
 MinimumOSVersion: 10.0.17763.0
-InstallerType: zip
-NestedInstallerType: portable
+InstallerType: wix
 Commands:
   - oneworks
   - ow
@@ -15,14 +14,9 @@ Dependencies:
     - PackageIdentifier: OpenJS.NodeJS.LTS
 Installers:
   - Architecture: x64
-    InstallerUrl: https://github.com/oneworks-ai/app/releases/download/pkg/oneworks/v0.1.0/oneworks-windows-0.1.0.zip
-    InstallerSha256: 2c6effedd14cb6d818ff1021df6a2f1c12ca0ec2097c84a9df2f9bb2b18214e6
-    NestedInstallerFiles:
-      - RelativeFilePath: oneworks.cmd
-        PortableCommandAlias: oneworks
-      - RelativeFilePath: ow.cmd
-        PortableCommandAlias: ow
-      - RelativeFilePath: owo.cmd
-        PortableCommandAlias: owo
+    Scope: machine
+    InstallerUrl: https://github.com/oneworks-ai/app/releases/download/pkg/oneworks/v0.1.0/oneworks-windows-0.1.0.msi
+    InstallerSha256: 1ce945b9192b253e577001684403a8e57b90092cc76081e5c27dae8e42dabb0b
+    ProductCode: '{CF1DB36D-0298-520C-A31D-B18D58BBF6DA}'
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/o/OneWorks/OneWorks/0.1.0/OneWorks.OneWorks.installer.yaml
+++ b/manifests/o/OneWorks/OneWorks/0.1.0/OneWorks.OneWorks.installer.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: OneWorks.OneWorks
+PackageVersion: 0.1.0
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: zip
+NestedInstallerType: portable
+Commands:
+  - oneworks
+  - ow
+  - owo
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: OpenJS.NodeJS.LTS
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/oneworks-ai/app/releases/download/pkg/oneworks/v0.1.0/oneworks-windows-0.1.0.zip
+    InstallerSha256: 2c6effedd14cb6d818ff1021df6a2f1c12ca0ec2097c84a9df2f9bb2b18214e6
+    NestedInstallerFiles:
+      - RelativeFilePath: oneworks.cmd
+        PortableCommandAlias: oneworks
+      - RelativeFilePath: ow.cmd
+        PortableCommandAlias: ow
+      - RelativeFilePath: owo.cmd
+        PortableCommandAlias: owo
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/o/OneWorks/OneWorks/0.1.0/OneWorks.OneWorks.locale.en-US.yaml
+++ b/manifests/o/OneWorks/OneWorks/0.1.0/OneWorks.OneWorks.locale.en-US.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: OneWorks.OneWorks
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: OneWorks AI
+PublisherUrl: https://github.com/oneworks-ai
+PackageName: OneWorks
+PackageUrl: https://github.com/oneworks-ai/app
+License: MIT
+LicenseUrl: https://github.com/oneworks-ai/app/blob/main/LICENSE
+ShortDescription: AI-assisted development framework CLI.
+Tags:
+  - ai
+  - cli
+  - developer-tools
+  - agent
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/o/OneWorks/OneWorks/0.1.0/OneWorks.OneWorks.yaml
+++ b/manifests/o/OneWorks/OneWorks/0.1.0/OneWorks.OneWorks.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: OneWorks.OneWorks
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Updates the existing `OneWorks.OneWorks` 0.1.0 submission from a portable ZIP to the published x64 per-machine WiX MSI.

- URL: `https://github.com/oneworks-ai/app/releases/download/pkg/oneworks/v0.1.0/oneworks-windows-0.1.0.msi`
- SHA-256: `1ce945b9192b253e577001684403a8e57b90092cc76081e5c27dae8e42dabb0b`
- ProductCode: `{CF1DB36D-0298-520C-A31D-B18D58BBF6DA}`

The MSI checksum/provenance match the published asset and its GitHub attestation verifies. It declares `InstallerType: wix`, x64 architecture, and machine scope; the manifest retains `OpenJS.NodeJS.LTS` and the `oneworks`, `ow`, and `owo` command declarations.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com) (still awaiting bot/account-owner verification)
- [x] No linked issue is required for this existing package submission

## 📦 Manifest Checklist

- [x] This update changes only the installer manifest; the existing PR's version and locale manifests remain unchanged
- [x] Manifest YAML parses and the installer fields match the published MSI identity
- [ ] Validated locally with `winget validate --manifest <path>` (submitter host is macOS; Windows/repository validation remains required)
- [ ] Tested locally with `winget install --manifest <path>` (submitter host is macOS)
- [x] Installer uses the 1.12 `wix` schema type

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/412851)
