### PR TITLE
KopioRapido.KopioRapido 2026.07.04: set PortableCommandAlias to kp

### DIFF
--- a/manifests/k/KopioRapido/KopioRapido/2026.07.04/KopioRapido.KopioRapido.installer.yaml
+++ b/manifests/k/KopioRapido/KopioRapido/2026.07.04/KopioRapido.KopioRapido.installer.yaml
@@ -8,7 +8,7 @@ InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
   - RelativeFilePath: kopiorapido.exe
-    PortableCommandAlias: kopiorapido
+    PortableCommandAlias: kp
 Commands:
   - kp
   - kopiorapido


### PR DESCRIPTION
## Changes

Set `PortableCommandAlias` to `kp` in the installer manifest for version **2026.07.04**.

### Why

The `PortableCommandAlias` determines the symlink name WinGet creates in PATH. It was `kopiorapido`, but the intended primary command is the short alias `kp`. The executable inside the archive is `kopiorapido.exe`; the alias name need not match it.

### Note

The `Commands` list already includes both `kp` and `kopiorapido` for backward compatibility.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/412876)