### PR TITLE
New package: Jacobanil1.PadBoard version 1.0.0

### DIFF
--- a/manifests/j/Jacobanil1/PadBoard/1.0.0/Jacobanil1.PadBoard.installer.yaml
+++ b/manifests/j/Jacobanil1/PadBoard/1.0.0/Jacobanil1.PadBoard.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: Jacobanil1.PadBoard
+PackageVersion: 1.0.0
+InstallerType: portable
+Commands:
+  - PadBoard
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Jacobanil1/padboard/releases/download/v1.0.0/PadBoard.exe
+    InstallerSha256: A739A64FD96FB2B59A0F0BE66BE661D7C6A242BFF2CFE12237C269C74FC5F72E
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/j/Jacobanil1/PadBoard/1.0.0/Jacobanil1.PadBoard.locale.en-US.yaml
+++ b/manifests/j/Jacobanil1/PadBoard/1.0.0/Jacobanil1.PadBoard.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: Jacobanil1.PadBoard
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: Jacobanil1
+PublisherUrl: https://github.com/Jacobanil1
+PublisherSupportUrl: https://github.com/Jacobanil1/padboard/issues
+PackageName: PadBoard
+PackageUrl: https://github.com/Jacobanil1/padboard
+License: MIT
+LicenseUrl: https://github.com/Jacobanil1/padboard/blob/master/LICENSE
+ShortDescription: A 20-100 pad local soundboard for Windows.
+Description: |-
+  PadBoard is a local soundboard for Windows. Assign audio files from your library
+  to pads and trigger them by click or keyboard, with crossfade between pads,
+  multiple named pad lists/banks, a seek bar, and support for MP3, WAV, WMA, and M4A.
+Moniker: padboard
+Tags:
+  - soundboard
+  - audio
+  - music
+  - dj
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/j/Jacobanil1/PadBoard/1.0.0/Jacobanil1.PadBoard.yaml
+++ b/manifests/j/Jacobanil1/PadBoard/1.0.0/Jacobanil1.PadBoard.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: Jacobanil1.PadBoard
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## New package

- **PackageIdentifier**: Jacobanil1.PadBoard
- **PackageVersion**: 1.0.0
- **Source**: https://github.com/Jacobanil1/padboard
- **Release**: https://github.com/Jacobanil1/padboard/releases/tag/v1.0.0

PadBoard is a local soundboard for Windows: assign audio files from your library
to pads and trigger them by click or keyboard, with crossfade, multiple named
pad lists, a seek bar, and support for MP3/WAV/WMA/M4A.

Installer is a portable (unpackaged) x64 executable built with PyInstaller.

- [x] Manifest passes `winget validate`
- [x] Installer URL verified reachable, SHA256 verified against the published release asset
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/412951)