### PR TITLE
New version: toevi.WOLManager version 1.1.2

### DIFF
--- a/manifests/t/toevi/WOLManager/1.1.2/toevi.WOLManager.installer.yaml
+++ b/manifests/t/toevi/WOLManager/1.1.2/toevi.WOLManager.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: toevi.WOLManager
+PackageVersion: 1.1.2
+MinimumOSVersion: 10.0.19041.0
+InstallerType: inno
+ReleaseDate: 2026-07-21
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/toevi/WOLManager/releases/download/v1.1.2/WOLManager-Setup-1.1.2.exe
+  InstallerSha256: 2D06D6D295FB311B59AEDEBDB0F1335029FA4D4D5BB7989D5439E7DBFC01142C
+  AppsAndFeaturesEntries:
+  - Publisher: tmfgroup
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/t/toevi/WOLManager/1.1.2/toevi.WOLManager.locale.en-US.yaml
+++ b/manifests/t/toevi/WOLManager/1.1.2/toevi.WOLManager.locale.en-US.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: toevi.WOLManager
+PackageVersion: 1.1.2
+PackageLocale: en-US
+Publisher: tmfgroup
+PublisherUrl: https://github.com/toevi
+PublisherSupportUrl: https://github.com/toevi/WOLManager/issues
+PackageName: WOL Manager
+PackageUrl: https://github.com/toevi/WOLManager
+License: MIT
+LicenseUrl: https://github.com/toevi/WOLManager/blob/main/LICENSE
+Copyright: Copyright (c) 2025 tmfgroup (Tomek Maselko)
+ShortDescription: Wake-on-LAN and remote power management tool for Windows network administrators.
+Description: |-
+  WOL Manager is a Windows desktop tool for network administrators that combines Wake-on-LAN,
+  remote power control (restart / shutdown), RDP, SSH, network share access, and port scanning
+  in one place. It auto-discovers Windows computers on the LAN, minimizes to the system tray,
+  and polls online/offline status every few seconds.
+Moniker: wolmanager
+Tags:
+- wake-on-lan
+- wol
+- network
+- remote-desktop
+- rdp
+- ssh
+- sysadmin
+- port-scan
+ReleaseNotes: |-
+  - The desktop icon is now created by default during installation
+  - Installer is built in CI, with reproducible build scripts added to the repo
+  - GitHub Actions bumped to current majors
+  - Version unified to 1.1.2 across the app, the installer and Apps & Features
+ReleaseNotesUrl: https://github.com/toevi/WOLManager/releases/tag/v1.1.2
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/toevi/WOLManager/1.1.2/toevi.WOLManager.yaml
+++ b/manifests/t/toevi/WOLManager/1.1.2/toevi.WOLManager.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: toevi.WOLManager
+PackageVersion: 1.1.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Version update for `toevi.WOLManager` (1.1.1 → 1.1.2). I am the package publisher.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

### Notes

- Installer is Authenticode-signed; SHA256 verified against the GitHub release asset.
- `AppsAndFeaturesEntries` is now reduced to just `Publisher`. The 1.1.1 manifest needed
  `DisplayVersion: "1.1"` because that installer wrote `1.1` to ARP while the package version was
  `1.1.1`. The 1.1.2 installer writes `1.1.2` to ARP, matching `PackageVersion`, so the override is
  no longer required.
- Manifest schema moved from 1.9.0 to 1.12.0 for this version.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/413042)