### PR TITLE
New package: QurioInc.anywhere version 0.1.2

### DIFF
--- a/manifests/q/QurioInc/anywhere/0.1.2/QurioInc.anywhere.installer.yaml
+++ b/manifests/q/QurioInc/anywhere/0.1.2/QurioInc.anywhere.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: QurioInc.anywhere
+PackageVersion: 0.1.2
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+Scope: user
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Qurio-Inc/anywhere-releases/releases/download/v0.1.2/anywhere-windows-setup.exe
+  InstallerSha256: D55FBFD7F0B0D8104C009BB14920C508ED714788D4CE5E88EAD94A4E63B1988F
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/q/QurioInc/anywhere/0.1.2/QurioInc.anywhere.locale.en-US.yaml
+++ b/manifests/q/QurioInc/anywhere/0.1.2/QurioInc.anywhere.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: QurioInc.anywhere
+PackageVersion: 0.1.2
+PackageLocale: en-US
+Publisher: Qurio Inc
+PublisherUrl: https://www.qurio-inc.com/
+PublisherSupportUrl: https://github.com/Qurio-Inc/code_anywhere/issues
+PackageName: anywhere
+PackageUrl: https://anywhere.qurio-inc.com/
+License: MIT
+LicenseUrl: https://github.com/Qurio-Inc/code_anywhere/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Qurio Inc
+ShortDescription: Keep your laptop working with the lid closed - on battery, no external display required.
+Description: |-
+  anywhere keeps long-running work (builds, AI coding sessions, downloads) alive
+  while you are on the move. Pick a duration, close the lid, and jobs keep
+  running on battery; when the timer ends, the original sleep settings are
+  restored automatically. Runs as a system-tray app.
+Moniker: anywhere
+Tags:
+- keep-awake
+- sleep
+- caffeine
+- lid-close
+- battery
+- tray
+ReleaseNotesUrl: https://github.com/Qurio-Inc/anywhere-releases/releases/tag/v0.1.2
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/q/QurioInc/anywhere/0.1.2/QurioInc.anywhere.locale.ja-JP.yaml
+++ b/manifests/q/QurioInc/anywhere/0.1.2/QurioInc.anywhere.locale.ja-JP.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.10.0.schema.json
+PackageIdentifier: QurioInc.anywhere
+PackageVersion: 0.1.2
+PackageLocale: ja-JP
+Publisher: Qurio Inc
+PublisherUrl: https://www.qurio-inc.com/
+PublisherSupportUrl: https://github.com/Qurio-Inc/code_anywhere/issues
+PackageName: anywhere
+PackageUrl: https://anywhere.qurio-inc.com/
+License: MIT
+LicenseUrl: https://github.com/Qurio-Inc/code_anywhere/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Qurio Inc
+ShortDescription: フタを閉じてもスリープさせず、ジョブを走らせ続けるトレイアプリ。
+Description: |-
+  時間を選んでフタを閉じるだけで、ビルドやAIコーディングセッション、
+  ダウンロードなどの処理をバッテリー駆動のまま走らせ続けます。
+  時間が来ると自動でOFFになり、元のスリープ設定に復元されます。
+  タスクトレイ常駐アプリとして動作します。
+ReleaseNotesUrl: https://github.com/Qurio-Inc/anywhere-releases/releases/tag/v0.1.2
+ManifestType: locale
+ManifestVersion: 1.10.0

--- a/manifests/q/QurioInc/anywhere/0.1.2/QurioInc.anywhere.yaml
+++ b/manifests/q/QurioInc/anywhere/0.1.2/QurioInc.anywhere.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: QurioInc.anywhere
+PackageVersion: 0.1.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`? (authored on macOS — relying on the pipeline validation)
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? (authored on macOS — relying on the pipeline validation)
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

New package submission for **anywhere** by Qurio Inc — a free, open-source (MIT) system-tray app that keeps a laptop working with the lid closed (on battery, no external display required), with an auto-off timer that restores the original sleep settings.

- Homepage: https://anywhere.qurio-inc.com/
- Source: https://github.com/Qurio-Inc/code_anywhere
- Release: https://github.com/Qurio-Inc/anywhere-releases/releases/tag/v0.1.2
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/413090)