### PR TITLE
New version: Feci.ParleyDeckCli version 1.39.0

### DIFF
--- a/manifests/f/Feci/ParleyDeckCli/1.39.0/Feci.ParleyDeckCli.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.39.0/Feci.ParleyDeckCli.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.39.0
+InstallerType: portable
+Commands:
+- parley
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.39.0/parley-v1.39.0-windows-x64.exe
+  InstallerSha256: 07323BA1E5C02B4AA78166F51D840E4A3284CDF9AFBD320F80ECE16572931D5B
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.39.0/parley-v1.39.0-windows-arm64.exe
+  InstallerSha256: BBA56E02660AC58583D6FE243AE7CB6C751865D530BBF21368CE14469DE00BD1
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.39.0/Feci.ParleyDeckCli.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.39.0/Feci.ParleyDeckCli.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.39.0
+PackageLocale: en-US
+Publisher: Feci
+PublisherUrl: https://github.com/feci
+PackageName: Parley Deck CLI
+PackageUrl: https://github.com/feci/parley-deck-cli
+License: Apache-2.0
+LicenseUrl: https://github.com/feci/parley-deck-cli/blob/main/LICENSE
+ShortDescription: CLI that orchestrates Parley Deck multi-agent cooperation workflows.
+Description: "parley orchestrates multi-agent Parley Deck cooperation across local CLI agents: risk-tiered tracks (fast, standard, deliberation), deliberation rounds, consensus and finalize, implementation with living execution plans, a live TUI, and a human-braked outer loop. v1.39.0 promotes kimi and opencode from ACP-only catalog entries to full built-in adapters with a declared autonomous-write mode, so parley launches them headlessly (kimi -p, opencode run --auto) instead of requiring a hand-written call, while both keep ACP as an alternative launch mode. It also fixes a defect found in review: a configuration layer could replace an agent launch arguments without touching its declared autonomous-write mode, so parley could report an agent as autonomous while the launched command never passed the flag that enables it. The AUTO signal now fails closed and names the missing arguments, and the agent listing shows the resolved binary and effective launch arguments instead of a built-in label."
+ReleaseNotesUrl: https://github.com/feci/parley-deck-cli/releases/tag/v1.39.0
+Tags:
+- ai
+- agents
+- automation
+- cli
+- codex
+- consensus
+- loop
+- multi-agent
+- orchestration
+- preflight
+- roster
+- tui
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.39.0/Feci.ParleyDeckCli.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.39.0/Feci.ParleyDeckCli.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.39.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Promotes kimi and opencode to full built-in adapters and makes the autonomous-write signal fail closed.

Manifests validated locally; installer SHA256 values verified against the published release assets at https://github.com/feci/parley-deck-cli/releases/tag/v1.39.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/413135)