### PR TITLE
New package: SouthboundSoftware.Matteshot version 0.14.10

### DIFF
--- a/manifests/s/SouthboundSoftware/Matteshot/0.14.10/SouthboundSoftware.Matteshot.installer.yaml
+++ b/manifests/s/SouthboundSoftware/Matteshot/0.14.10/SouthboundSoftware.Matteshot.installer.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: SouthboundSoftware.Matteshot
+PackageVersion: 0.14.10
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://download.matteshot.app/MatteshotSetup-0.14.10.exe
+  InstallerSha256: C01FC54D29CB8AB5C72467DB96CF464659DEC7838F6CA958991F7065A7238512
+  ProductCode: '{8B1F3C52-9D14-4A6E-B7E0-52A32C1D9F41}_is1'
+  AppsAndFeaturesEntries:
+  - DisplayName: Matteshot
+    Publisher: SouthForge AI
+    DisplayVersion: 0.14.10
+    ProductCode: '{8B1F3C52-9D14-4A6E-B7E0-52A32C1D9F41}_is1'
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/SouthboundSoftware/Matteshot/0.14.10/SouthboundSoftware.Matteshot.locale.en-US.yaml
+++ b/manifests/s/SouthboundSoftware/Matteshot/0.14.10/SouthboundSoftware.Matteshot.locale.en-US.yaml
@@ -28,7 +28,6 @@ Tags:
 - screen-recorder
 - screenshot
 - snipping
-ReleaseNotesUrl: https://github.com/tsouth89/matteshot/releases/tag/v0.14.10
 PurchaseUrl: https://matteshot.app/pricing
 ManifestType: defaultLocale
 ManifestVersion: 1.6.0

--- a/manifests/s/SouthboundSoftware/Matteshot/0.14.10/SouthboundSoftware.Matteshot.locale.en-US.yaml
+++ b/manifests/s/SouthboundSoftware/Matteshot/0.14.10/SouthboundSoftware.Matteshot.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: SouthboundSoftware.Matteshot
+PackageVersion: 0.14.10
+PackageLocale: en-US
+Publisher: Southbound Software
+PublisherUrl: https://matteshot.app
+PublisherSupportUrl: https://matteshot.app
+PrivacyUrl: https://matteshot.app/privacy
+Author: Brandon South
+PackageName: Matteshot
+PackageUrl: https://matteshot.app
+License: Proprietary
+LicenseUrl: https://matteshot.app/terms
+Copyright: Copyright (C) 2026 Southbound Software
+CopyrightUrl: https://matteshot.app/terms
+ShortDescription: Native Windows screenshot and screen recording tool that turns one PrtScn into six polished, ready-to-paste looks.
+Description: |-
+  Press PrtScn and Matteshot instantly turns any window, region, scrolling page, or screen into six polished looks ready to paste. Select and copy only the text you need directly from a screenshot with offline OCR, annotate or redact images, and record, trim, and annotate video. Everything stays local: no uploads, no account, no subscription.
+  Matteshot includes a free 14-day full trial that starts with your first completed capture; after that it is a one-time purchase.
+Moniker: matteshot
+Tags:
+- annotation
+- capture
+- ocr
+- recording
+- redaction
+- screen-capture
+- screen-recorder
+- screenshot
+- snipping
+ReleaseNotesUrl: https://github.com/tsouth89/matteshot/releases/tag/v0.14.10
+PurchaseUrl: https://matteshot.app/pricing
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/SouthboundSoftware/Matteshot/0.14.10/SouthboundSoftware.Matteshot.yaml
+++ b/manifests/s/SouthboundSoftware/Matteshot/0.14.10/SouthboundSoftware.Matteshot.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: SouthboundSoftware.Matteshot
+PackageVersion: 0.14.10
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
- [x] Have you signed the Contributor License Agreement?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the 1.6 schema?

Matteshot is a native Windows screenshot and screen recording tool (Inno Setup, per-user install, code-signed). The installer URL is versioned and permanent; SHA256 verified against the published binary.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/413210)