### PR TITLE
New package: mahi160.Photon version 2.0.0-pre.10

### DIFF
--- a/manifests/m/mahi160/Photon/2.0.0-pre.10/mahi160.Photon.installer.yaml
+++ b/manifests/m/mahi160/Photon/2.0.0-pre.10/mahi160.Photon.installer.yaml
@@ -1,0 +1,17 @@
+# Created with the Photon release pipeline (mahi160/photon), not the
+# Windows Package Manager Manifest Creator.
+PackageIdentifier: mahi160.Photon
+PackageVersion: 2.0.0-pre.10
+InstallerType: nullsoft
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: "2026-08-06"
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/mahi160/photon/releases/download/v2.0.0-pre.10/Photon_2.0.0-pre.10_x64-setup.exe
+    InstallerSha256: 695FBDF571EA185A720B6FCB869B1694EA7DE248DD7C4703C0B94236416A27D5
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/m/mahi160/Photon/2.0.0-pre.10/mahi160.Photon.locale.en-US.yaml
+++ b/manifests/m/mahi160/Photon/2.0.0-pre.10/mahi160.Photon.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# Created with the Photon release pipeline (mahi160/photon), not the
+# Windows Package Manager Manifest Creator.
+PackageIdentifier: mahi160.Photon
+PackageVersion: 2.0.0-pre.10
+PackageLocale: en-US
+Publisher: Salauddin Omar Sifat
+PublisherUrl: https://github.com/mahi160
+PublisherSupportUrl: https://github.com/mahi160/photon/issues
+PackageName: Photon
+PackageUrl: https://github.com/mahi160/photon
+License: MIT
+LicenseUrl: https://github.com/mahi160/photon/blob/main/LICENSE.md
+ShortDescription: A calm, minimal desktop media player built exclusively for Jellyfin.
+Description: |-
+  Photon is a calm, minimal desktop media player for Jellyfin. It embeds
+  mpv directly in-process via its render API, GPU-rendered with an
+  automatic CPU fallback, and always plays direct rather than asking the
+  server to transcode. Photon is a player, not a media manager -- no
+  live TV, music, photos, server admin, or casting.
+Moniker: photon
+Tags:
+  - jellyfin
+  - media-player
+  - video-player
+  - mpv
+ReleaseNotesUrl: https://github.com/mahi160/photon/releases/tag/v2.0.0-pre.10
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/m/mahi160/Photon/2.0.0-pre.10/mahi160.Photon.yaml
+++ b/manifests/m/mahi160/Photon/2.0.0-pre.10/mahi160.Photon.yaml
@@ -1,0 +1,7 @@
+# Created with the Photon release pipeline (mahi160/photon), not the
+# Windows Package Manager Manifest Creator.
+PackageIdentifier: mahi160.Photon
+PackageVersion: 2.0.0-pre.10
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
New submission for Photon, a calm, minimal desktop media player for Jellyfin (https://github.com/mahi160/photon).

- Publisher: Salauddin Omar Sifat (mahi160)
- InstallerType: nullsoft (Tauri NSIS bundle, x64)
- Manifests validated against the published v1.10.0 JSON schemas locally before submitting

Photon is still pre-1.0 (`2.0.0-pre.10`) -- Windows builds are tested and playing video on real hardware, per the project's own release notes.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/413211)