### PR TITLE
New package: ShtilVPN.ShtilVPN version 1.2.8

### DIFF
--- a/manifests/s/ShtilVPN/ShtilVPN/1.2.8/ShtilVPN.ShtilVPN.installer.yaml
+++ b/manifests/s/ShtilVPN/ShtilVPN/1.2.8/ShtilVPN.ShtilVPN.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: ShtilVPN.ShtilVPN
+PackageVersion: 1.2.8
+InstallerType: nullsoft
+UpgradeBehavior: install
+ReleaseDate: 2026-08-06
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/narvinIR/shtil-vpn-desktop/releases/download/desktop-v1.2.8/ShtilVPN_1.2.8_x64-setup.exe
+  InstallerSha256: 1A38158B3C6844A98C686C9F390E5D362F66C739DF5521F33D2BFC059B0E412B
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/s/ShtilVPN/ShtilVPN/1.2.8/ShtilVPN.ShtilVPN.locale.en-US.yaml
+++ b/manifests/s/ShtilVPN/ShtilVPN/1.2.8/ShtilVPN.ShtilVPN.locale.en-US.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: ShtilVPN.ShtilVPN
+PackageVersion: 1.2.8
+PackageLocale: en-US
+Publisher: Shtil VPN
+PublisherUrl: https://sub.ndvsdom54.ru/get
+PublisherSupportUrl: https://t.me/RealityVPNBot_bot
+PackageName: Shtil VPN
+PackageUrl: https://github.com/narvinIR/shtil-vpn-desktop
+License: MIT
+LicenseUrl: https://github.com/narvinIR/shtil-vpn-desktop/blob/main/LICENSE
+Copyright: Copyright (c) 2025 XingGao
+ShortDescription: Personal VPN client for Windows and macOS. Russian sites stay direct.
+Description: |-
+  Shtil is a personal VPN client for the desktop: Windows and macOS (Apple Silicon and Intel). It opens an encrypted VLESS tunnel to your own server and collects nothing about you - no in-app accounts, no logs, no ads, no in-app purchases.
+
+  Features:
+  - Split routing: Russian sites - banks, government services, marketplaces - stay on the direct route instead of going through the tunnel, so they keep full speed and don't treat you as a foreign visitor. The rule list ships inside the app, nothing is downloaded at runtime.
+  - Two modes: the regular one sends your browser and most programs through the tunnel; "all traffic" sends every single program through it.
+  - The key arrives from the bot by a short code: link the computer once, then the key and the subscription date refresh themselves.
+  - A two-hour trial right inside the app - no Telegram account, no payment.
+  - Updates itself: a new version comes from our own address, no store needed.
+  - Five interface languages: Russian, English, German, Spanish, Persian. Light and dark themes, launch at system startup.
+
+  What you need: the app is the entrance to the tunnel; the server itself is not included. You need a subscription link - ours comes from a Telegram bot with a free trial, and any other provider's VLESS link works too.
+
+  Built on the open-source sing-box core.
+Moniker: shtil-vpn
+Tags:
+- network
+- privacy
+- proxy
+- sing-box
+- tunnel
+- vless
+- vpn
+ReleaseNotesUrl: https://github.com/narvinIR/shtil-vpn-desktop/releases/tag/desktop-v1.2.8
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/s/ShtilVPN/ShtilVPN/1.2.8/ShtilVPN.ShtilVPN.locale.en-US.yaml
+++ b/manifests/s/ShtilVPN/ShtilVPN/1.2.8/ShtilVPN.ShtilVPN.locale.en-US.yaml
@@ -6,6 +6,7 @@ PackageLocale: en-US
 Publisher: Shtil VPN
 PublisherUrl: https://sub.ndvsdom54.ru/get
 PublisherSupportUrl: https://t.me/RealityVPNBot_bot
+PrivacyUrl: https://sub.ndvsdom54.ru/privacy
 PackageName: Shtil VPN
 PackageUrl: https://github.com/narvinIR/shtil-vpn-desktop
 License: MIT
@@ -23,6 +24,8 @@ Description: |-
   - Updates itself: a new version comes from our own address, no store needed.
   - Five interface languages: Russian, English, German, Spanish, Persian. Light and dark themes, launch at system startup.
 
+  Free app, paid service: the application itself is free and MIT-licensed - no in-app purchases, no checkout, no ads, no accounts. Our subscription service is sold only in the Telegram bot, outside the app: 30-day access for about US$5-7 per month (499 RUB, or 600 Telegram Stars) after a 7-day free trial. Payments are taken by YooMoney (cards) or Telegram Stars and confirmed in the bot chat, which then issues the subscription link. The app never displays a price and never handles payment data; it also works with a VLESS server you run yourself.
+
   What you need: the app is the entrance to the tunnel; the server itself is not included. You need a subscription link - ours comes from a Telegram bot with a free trial, and any other provider's VLESS link works too.
 
   Built on the open-source sing-box core.
@@ -36,5 +39,6 @@ Tags:
 - vless
 - vpn
 ReleaseNotesUrl: https://github.com/narvinIR/shtil-vpn-desktop/releases/tag/desktop-v1.2.8
+PurchaseUrl: https://t.me/RealityVPNBot_bot
 ManifestType: defaultLocale
 ManifestVersion: 1.10.0

--- a/manifests/s/ShtilVPN/ShtilVPN/1.2.8/ShtilVPN.ShtilVPN.yaml
+++ b/manifests/s/ShtilVPN/ShtilVPN/1.2.8/ShtilVPN.ShtilVPN.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: ShtilVPN.ShtilVPN
+PackageVersion: 1.2.8
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## 📖 Description

New package: **ShtilVPN.ShtilVPN** version **1.2.8** — a personal VPN client (sing-box core, VLESS) for Windows and macOS. Open source: https://github.com/narvinIR/shtil-vpn-desktop

Installer is the NSIS setup from the tagged GitHub release `desktop-v1.2.8`, publicly downloadable, immutable URL.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com) — will sign when the CLA bot asks
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` — no Windows machine available; all three files were validated against the official JSON schemas (`winget-manifest.{version,installer,defaultLocale}.1.10.0.schema.json`), 0 errors
- [ ] Tested manifest locally with `winget install --manifest <path>` — same reason; the installer itself is the file we ship to our users
- [x] Manifest conforms to the 1.10 schema

**Note:** the installer is not code-signed (no publisher certificate), so SmartScreen will warn on first run.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/413219)