### PR TITLE
New version: Feci.ParleyDeckSkill version 2.4.0

### DIFF
--- a/manifests/f/Feci/ParleyDeckSkill/2.4.0/Feci.ParleyDeckSkill.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/2.4.0/Feci.ParleyDeckSkill.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 2.4.0
+InstallerType: portable
+Commands:
+- parley-deck-skill
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-skill/releases/download/v2.4.0/parley-deck-skill-v2.4.0-windows-x64.exe
+  InstallerSha256: F75FE71959C1F7BE9CBC92BB3585F9395322E3913046726B8829616878F21B27
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-skill/releases/download/v2.4.0/parley-deck-skill-v2.4.0-windows-arm64.exe
+  InstallerSha256: 2570D965DE08B4C439BE3B32CFD8A008B0710F1193E3BBAD0C2C99382AC91D2E
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckSkill/2.4.0/Feci.ParleyDeckSkill.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/2.4.0/Feci.ParleyDeckSkill.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 2.4.0
+PackageLocale: en-US
+Publisher: Feci
+PublisherUrl: https://github.com/feci
+PackageName: Parley Deck Skill
+PackageUrl: https://github.com/feci/parley-deck-skill
+License: Apache-2.0
+LicenseUrl: https://github.com/feci/parley-deck-skill/blob/main/LICENSE
+ShortDescription: Installer for the Parley Deck multi-agent cooperation skill.
+Description: "Installs the vendor-neutral Parley Deck AI cooperation skill into Codex, Claude Code, Antigravity CLI, legacy Gemini CLI, Hermes, Kimi Code, or a custom skill directory. v2.4.0 syncs the skill to parley-deck-cli 1.39.0, which changed what decides whether a headless participant can write its own artifact. The launch arguments are the launch; the declared autonomous-write mode is a declaration audited against them, not a second argument list. The skill previously named the declared mode as the source of truth, which pointed readers at a field that launches nothing, so a config override could drop the enabling flag while the agent still reported itself write-capable. This release makes the effective launch argv the source of truth, splits the command-construction guidance into a manual-facilitator branch and a Parley CLI branch that assembles nothing, removes the obsolete separate write-mode argument list from the documented config shape and adds a migration note for configs that still carry it, documents the opencode agent, and adds a version-sync guard so the packaged compatibility metadata can no longer drift silently behind the published package version."
+ReleaseNotesUrl: https://github.com/feci/parley-deck-skill/releases/tag/v2.4.0
+Tags:
+- ai
+- agents
+- agy
+- antigravity
+- cli
+- codex
+- claude
+- gemini
+- kimi
+- multi-agent
+- skill
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckSkill/2.4.0/Feci.ParleyDeckSkill.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/2.4.0/Feci.ParleyDeckSkill.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 2.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Sync of the Parley Deck skill to parley-deck-cli 1.39.0. Portable package, two architectures, SHA256 verified against the published GitHub release assets.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/413239)