### PR TITLE
New version: KopioRapido.KopioRapido version 2026.07.06

### DIFF
--- a/manifests/k/KopioRapido/KopioRapido/2026.07.06/KopioRapido.KopioRapido.installer.yaml
+++ b/manifests/k/KopioRapido/KopioRapido/2026.07.06/KopioRapido.KopioRapido.installer.yaml
@@ -1,0 +1,25 @@
+# Winget installer manifest
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: KopioRapido.KopioRapido
+PackageVersion: 2026.07.06
+MinimumOSVersion: 10.0.17763.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: kp.exe
+    PortableCommandAlias: kp
+Commands:
+  - kp
+  - kopiorapido
+Dependencies:
+  PackageDependencies: []
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://releases.kopiorapido.com/2026.07.06/cli/kopiorapido-cli-win-x64-2026.07.06.zip
+    InstallerSha256: f89c1faa7d3dbb59b3603e5795370fa7c83a874c0f626026b81d42001a21b86c
+  - Architecture: arm64
+    InstallerUrl: https://releases.kopiorapido.com/2026.07.06/cli/kopiorapido-cli-win-arm64-2026.07.06.zip
+    InstallerSha256: 99164137c94a1825a1869faceceb0f823574888d3b8431fe6f17c7f933d99a3a
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/k/KopioRapido/KopioRapido/2026.07.06/KopioRapido.KopioRapido.locale.en-US.yaml
+++ b/manifests/k/KopioRapido/KopioRapido/2026.07.06/KopioRapido.KopioRapido.locale.en-US.yaml
@@ -1,0 +1,39 @@
+# Winget locale manifest (en-US)
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: KopioRapido.KopioRapido
+PackageVersion: 2026.07.06
+PackageLocale: en-US
+Publisher: KopioRapido
+PublisherUrl: https://kopiorapido.com
+PublisherSupportUrl: https://kopiorapido.com
+PackageName: KopioRapido CLI
+PackageUrl: https://kopiorapido.com
+License: Shareware
+LicenseUrl: https://kopiorapido.com
+Copyright: Copyright (c) 2026 KopioRapido
+ShortDescription: High-performance file copying CLI with delta sync and intelligent transfer
+Description: |-
+  KopioRapido is a high-performance cross-platform file copying CLI with intelligent transfer optimization.
+
+  Features:
+  - Delta synchronization for efficient updates
+  - Smart compression for network transfers
+  - Multiple operation modes: Copy, Move, Sync, Mirror, BiDirectional Sync
+  - Resumable operations
+  - Real-time progress tracking
+  - JSON output for scripting
+  - Intelligent transfer engine that analyzes storage devices
+  - Adaptive performance monitoring
+Moniker: kp
+Tags:
+  - backup
+  - cli
+  - copy
+  - file-management
+  - rsync
+  - sync
+  - robocopy
+ReleaseNotesUrl: https://kopiorapido.com/changelog
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/k/KopioRapido/KopioRapido/2026.07.06/KopioRapido.KopioRapido.yaml
+++ b/manifests/k/KopioRapido/KopioRapido/2026.07.06/KopioRapido.KopioRapido.yaml
@@ -1,0 +1,8 @@
+# Winget manifest (main version file)
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: KopioRapido.KopioRapido
+PackageVersion: 2026.07.06
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## New version: KopioRapido.KopioRapido version 2026.07.06

### Summary
Update KopioRapido CLI to version 2026.07.06.

### Changes
- Version bump to 2026.07.06
- Updated CLI executable name: kp.exe (alias: kp)
- Delta sync and intelligent transfer improvements
- SQLite migration
- Antivirus interference mitigation

### Artifacts
- **Homepage**: https://kopiorapido.com
- **Download**: https://releases.kopiorapido.com/2026.07.06/cli/
- **Source**: https://github.com/KopioRapido/Source

### Checksums
- **win-x64 SHA256**: f89c1faa7d3dbb59b3603e5795370fa7c83a874c0f626026b81d42001a21b86c
- **win-arm64 SHA256**: 99164137c94a1825a1869faceceb0f823574888d3b8431fe6f17c7f933d99a3a
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/413252)