### PR TITLE
New version: Feci.ParleyDeckCli version 1.40.0

### DIFF
--- a/manifests/f/Feci/ParleyDeckCli/1.40.0/Feci.ParleyDeckCli.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.40.0/Feci.ParleyDeckCli.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.40.0
+InstallerType: portable
+Commands:
+- parley
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.40.0/parley-v1.40.0-windows-x64.exe
+  InstallerSha256: ADB7153800D71C388537F15DA51B965845B44C61E3F6A55CA2D4BC14A534B6E9
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.40.0/parley-v1.40.0-windows-arm64.exe
+  InstallerSha256: 4ACCBD924B78786C47D2C529AE179EE069EC5FABC3A87E3F114C670624B7944D
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.40.0/Feci.ParleyDeckCli.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.40.0/Feci.ParleyDeckCli.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.40.0
+PackageLocale: en-US
+Publisher: Feci
+PublisherUrl: https://github.com/feci
+PackageName: Parley Deck CLI
+PackageUrl: https://github.com/feci/parley-deck-cli
+License: Apache-2.0
+LicenseUrl: https://github.com/feci/parley-deck-cli/blob/main/LICENSE
+ShortDescription: CLI that orchestrates Parley Deck multi-agent cooperation workflows.
+Description: "Parley Deck CLI orchestrates multi-agent design, implementation and review workflows across local agent CLIs, keeping the cooperation trail in a repository-local parley-deck directory. v1.40.0 standardizes roster operations. parley roster show is now the single answer to what the current agent roster is, printing a frozen versioned column contract in text and JSON. MODEL and EFFORT report what the launch actually passes, or unknown, instead of a configured value the process never receives; a configured model previously changed only the displayed value while the agent launched a different one. Model family and company are derived by the CLI with gateway prefixes peeled first. New commands parley roster set and parley roster sync change one member in one file, or reconcile a project with the machine-wide roster in one direction, previewing by default and never dropping a deliberate pin silently. Runs now record an immutable snapshot of what each agent actually ran."
+ReleaseNotesUrl: https://github.com/feci/parley-deck-cli/releases/tag/v1.40.0
+Tags:
+- ai
+- agents
+- automation
+- cli
+- codex
+- consensus
+- loop
+- multi-agent
+- orchestration
+- preflight
+- roster
+- tui
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.40.0/Feci.ParleyDeckCli.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.40.0/Feci.ParleyDeckCli.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.40.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Standardized roster operations. Portable package, two architectures, SHA256 verified against the published release assets.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/413317)