### PR TITLE
New version: Feci.ParleyDeckSkill version 2.5.0

### DIFF
--- a/manifests/f/Feci/ParleyDeckSkill/2.5.0/Feci.ParleyDeckSkill.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/2.5.0/Feci.ParleyDeckSkill.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 2.5.0
+InstallerType: portable
+Commands:
+- parley-deck-skill
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-skill/releases/download/v2.5.0/parley-deck-skill-v2.5.0-windows-x64.exe
+  InstallerSha256: 30729C6293C58C6C59AACFDB91C343D8943A5FF3AB2ACC8CD1C1D1C9731064A8
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-skill/releases/download/v2.5.0/parley-deck-skill-v2.5.0-windows-arm64.exe
+  InstallerSha256: 6D7844EAD61D35341F2C6A11F1847D712705CA0449D63964B52E26BBEA1D44DD
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckSkill/2.5.0/Feci.ParleyDeckSkill.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/2.5.0/Feci.ParleyDeckSkill.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 2.5.0
+PackageLocale: en-US
+Publisher: Feci
+PublisherUrl: https://github.com/feci
+PackageName: Parley Deck Skill
+PackageUrl: https://github.com/feci/parley-deck-skill
+License: Apache-2.0
+LicenseUrl: https://github.com/feci/parley-deck-skill/blob/main/LICENSE
+ShortDescription: Installer for the Parley Deck multi-agent cooperation skill.
+Description: "Installs the vendor-neutral Parley Deck AI cooperation skill into Codex, Claude Code, Antigravity CLI, legacy Gemini CLI, Hermes, Kimi Code, OpenCode, or a custom skill directory. v2.5.0 syncs the skill to parley-deck-cli 1.40.0, which standardized roster operations. The skill no longer describes a roster format of its own: it names parley roster show as the single answer to what the current agent roster is, and reproduces that output instead of assembling a table by parsing protocol prose, TOML configuration, or the adapter inventory, which is how one question came to have three different answers. It documents the frozen eleven-column contract and the rule that matters most, that the model and effort columns report what the launch actually passes rather than a configured value the process never receives. It also documents the roster set and roster sync commands with their safety properties, and carries the protocol change in which the roster table becomes a generated, non-authoritative view."
+ReleaseNotesUrl: https://github.com/feci/parley-deck-skill/releases/tag/v2.5.0
+Tags:
+- ai
+- agents
+- agy
+- antigravity
+- cli
+- codex
+- claude
+- gemini
+- kimi
+- multi-agent
+- skill
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckSkill/2.5.0/Feci.ParleyDeckSkill.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/2.5.0/Feci.ParleyDeckSkill.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 2.5.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Sync to parley-deck-cli 1.40.0 roster standardization. Portable package, two architectures, SHA256 verified against the published release assets.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/413318)