### PR TITLE
Add WillyGarage.Roost version 0.1.0

### DIFF
--- a/manifests/w/WillyGarage/Roost/0.1.0/WillyGarage.Roost.installer.yaml
+++ b/manifests/w/WillyGarage/Roost/0.1.0/WillyGarage.Roost.installer.yaml
@@ -1,0 +1,12 @@
+# Created for winget-pkgs submission
+PackageIdentifier: WillyGarage.Roost
+PackageVersion: 0.1.0
+InstallerType: portable
+Commands:
+- Roost
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/WillyGarage/roost/releases/download/v0.1.0/Roost.exe
+  InstallerSha256: 0B64A9A5EFDFAC33261C77B38EC1C6D53B1181D10AEDDA656281357C7DB6C4B7
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/w/WillyGarage/Roost/0.1.0/WillyGarage.Roost.locale.en-US.yaml
+++ b/manifests/w/WillyGarage/Roost/0.1.0/WillyGarage.Roost.locale.en-US.yaml
@@ -1,0 +1,18 @@
+# Created for winget-pkgs submission
+PackageIdentifier: WillyGarage.Roost
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: WillyGarage
+PublisherUrl: https://github.com/WillyGarage
+PackageName: Roost
+PackageUrl: https://github.com/WillyGarage/roost
+License: MIT
+LicenseUrl: https://github.com/WillyGarage/roost/blob/main/LICENSE
+ShortDescription: A resident Windows 11 tray utility that moves the active window to another virtual desktop from a type-to-search palette, and creates and names new desktops on the fly.
+Tags:
+- virtual-desktop
+- window-management
+- productivity
+- tray-utility
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/w/WillyGarage/Roost/0.1.0/WillyGarage.Roost.yaml
+++ b/manifests/w/WillyGarage/Roost/0.1.0/WillyGarage.Roost.yaml
@@ -1,0 +1,6 @@
+# Created for winget-pkgs submission
+PackageIdentifier: WillyGarage.Roost
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
New package: Roost, a resident Windows 11 tray utility that moves the active window to another virtual desktop from a type-to-search palette, and creates and names new desktops on the fly.

- Homepage: https://github.com/WillyGarage/roost
- License: MIT
- Installer: single self-contained portable exe (no runtime dependency)

<!-- Automatic Validation Checklist -->
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with winget validate --manifest <path>?
- [ ] Have you tested your manifest locally with winget install --manifest <path>?
- [x] Does your manifest conform to the 1.6 schema?

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/413335)