### PR TITLE
New version: Feci.ParleyDeckCli version 1.40.1

### DIFF
--- a/manifests/f/Feci/ParleyDeckCli/1.40.1/Feci.ParleyDeckCli.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.40.1/Feci.ParleyDeckCli.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.40.1
+InstallerType: portable
+Commands:
+- parley
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.40.1/parley-v1.40.1-windows-x64.exe
+  InstallerSha256: EE2BE151F4916771477C765450204DBE901FDF165DD2C254FFDBED150A08848E
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.40.1/parley-v1.40.1-windows-arm64.exe
+  InstallerSha256: A7892139C27EF2407F03BF8364CB9712E822F3F72BD2013742BD78EE26411EBC
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.40.1/Feci.ParleyDeckCli.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.40.1/Feci.ParleyDeckCli.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.40.1
+PackageLocale: en-US
+Publisher: Feci
+PublisherUrl: https://github.com/feci
+PackageName: Parley Deck CLI
+PackageUrl: https://github.com/feci/parley-deck-cli
+License: Apache-2.0
+LicenseUrl: https://github.com/feci/parley-deck-cli/blob/main/LICENSE
+ShortDescription: CLI that orchestrates Parley Deck multi-agent cooperation workflows.
+Description: "Parley Deck CLI orchestrates multi-agent design, implementation and review workflows across local agent CLIs. v1.40.1 fixes defects found by the multi-agent review of 1.40.0. The immutable per-run roster snapshot was written but never read, so resuming a run could silently continue it on a different model after configuration changed; continuations now consume the frozen record. Participant selection still read the old protocol table while the roster command read configuration, so the two could disagree about who was in a run; all membership decisions now resolve through one authority. The protocol table is now actually generated, idempotently, preserving values that only the hand-written table carried. Adding or retiring a roster member now requires an explicit second confirmation. Machine-scope writes landed in a path no resolver reads and reported success; they now use the loader own central path. Adds parley roster migrate, a fleet migration tool with per-deck backups, dry-run by default, post-write validation and automatic rollback."
+ReleaseNotesUrl: https://github.com/feci/parley-deck-cli/releases/tag/v1.40.1
+Tags:
+- ai
+- agents
+- automation
+- cli
+- codex
+- consensus
+- loop
+- multi-agent
+- orchestration
+- preflight
+- roster
+- tui
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.40.1/Feci.ParleyDeckCli.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.40.1/Feci.ParleyDeckCli.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.40.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Review fixes for 1.40.0. Portable package, two architectures, SHA256 verified against the published release assets.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/413338)