### PR TITLE
New version: Feci.ParleyDeckSkill version 2.5.1

### DIFF
--- a/manifests/f/Feci/ParleyDeckSkill/2.5.1/Feci.ParleyDeckSkill.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/2.5.1/Feci.ParleyDeckSkill.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 2.5.1
+InstallerType: portable
+Commands:
+- parley-deck-skill
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-skill/releases/download/v2.5.1/parley-deck-skill-v2.5.1-windows-x64.exe
+  InstallerSha256: 18E3145D15CDF2006CD1C0EAAF42C5645962D73299DB667F558899567F4E4708
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-skill/releases/download/v2.5.1/parley-deck-skill-v2.5.1-windows-arm64.exe
+  InstallerSha256: AA4612CFBC9BE0267F7DCC0B251337ED4A64BCC0EE7C1A58826D65AC3E67109B
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckSkill/2.5.1/Feci.ParleyDeckSkill.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/2.5.1/Feci.ParleyDeckSkill.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 2.5.1
+PackageLocale: en-US
+Publisher: Feci
+PublisherUrl: https://github.com/feci
+PackageName: Parley Deck Skill
+PackageUrl: https://github.com/feci/parley-deck-skill
+License: Apache-2.0
+LicenseUrl: https://github.com/feci/parley-deck-skill/blob/main/LICENSE
+ShortDescription: Installer for the Parley Deck multi-agent cooperation skill.
+Description: "parley-deck-skill installs the vendor-neutral Parley Deck cooperation skill for local CLI agents, plus opt-in companion add-ons. v2.5.1 corrects the roster guidance after the multi-agent review of parley-deck-cli 1.41.0. The skill told agents that a deck carrying only the old hand-written roster table keeps working until parley roster sync moves it across; sync moves nothing across, it rebases an existing deck roster onto the user-global values, so on such a deck it correctly reports nothing to do. The real remediation is parley roster migrate, or roster set per member followed by roster render, and neither was named. This version also documents that membership is the committed deck config rather than the layered view, removes the last bootstrap instruction to record roster picks in the generated protocol table, and covers the new verbs, flags and status codes."
+ReleaseNotesUrl: https://github.com/feci/parley-deck-skill/releases/tag/v2.5.1
+Tags:
+- ai
+- agents
+- agy
+- antigravity
+- cli
+- codex
+- claude
+- gemini
+- kimi
+- multi-agent
+- skill
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckSkill/2.5.1/Feci.ParleyDeckSkill.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/2.5.1/Feci.ParleyDeckSkill.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 2.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
New version of Feci.ParleyDeckSkill.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/413352)