### PR TITLE
New package: nap6281-hub.ShareSentry version 0.3.1

### DIFF
--- a/manifests/n/nap6281-hub/ShareSentry/0.3.1/nap6281-hub.ShareSentry.installer.yaml
+++ b/manifests/n/nap6281-hub/ShareSentry/0.3.1/nap6281-hub.ShareSentry.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: nap6281-hub.ShareSentry
+PackageVersion: 0.3.1
+InstallerType: portable
+Commands:
+  - sharesentry
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/nap6281-hub/sharesentry/releases/download/v0.3.1/sharesentry-windows-x64.exe
+    InstallerSha256: 5FFC12501F05645386D5C964353DB7210F0740661A7AE77292B1565DD37DA62D
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/n/nap6281-hub/ShareSentry/0.3.1/nap6281-hub.ShareSentry.locale.en-US.yaml
+++ b/manifests/n/nap6281-hub/ShareSentry/0.3.1/nap6281-hub.ShareSentry.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: nap6281-hub.ShareSentry
+PackageVersion: 0.3.1
+PackageLocale: en-US
+Publisher: ShareSentry
+PublisherUrl: https://github.com/nap6281-hub
+PublisherSupportUrl: https://github.com/nap6281-hub/sharesentry/issues
+PackageName: ShareSentry
+PackageUrl: https://github.com/nap6281-hub/sharesentry
+License: MIT
+LicenseUrl: https://github.com/nap6281-hub/sharesentry/blob/main/LICENSE
+ShortDescription: Local document inspector for hidden metadata and review artifacts.
+Description: Scans PDF, DOCX, XLSX, PPTX, and image files locally for metadata, comments, tracked changes, external relationships, attachments, and other pre-share risks without uploading source documents.
+Moniker: sharesentry
+Tags:
+  - document
+  - ediscovery
+  - forensics
+  - metadata
+  - privacy
+  - redaction
+  - security
+ReleaseNotesUrl: https://github.com/nap6281-hub/sharesentry/releases/tag/v0.3.1
+ReleaseDate: 2026-08-07
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/n/nap6281-hub/ShareSentry/0.3.1/nap6281-hub.ShareSentry.yaml
+++ b/manifests/n/nap6281-hub/ShareSentry/0.3.1/nap6281-hub.ShareSentry.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: nap6281-hub.ShareSentry
+PackageVersion: 0.3.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
- [x] I have validated the manifest with winget validate.
- [x] The installer URL is publisher-controlled and versioned.
- [x] The SHA-256 was independently verified against the published release asset.
- [x] The portable executable was smoke-tested with --help.

Adds ShareSentry 0.3.1, an MIT-licensed local document metadata and review-artifact inspector.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/413538)