### PR TITLE
New package: TauriTavern.TauriTavern version 2.2.0

### DIFF
--- a/manifests/t/TauriTavern/TauriTavern/2.2.0/TauriTavern.TauriTavern.installer.yaml
+++ b/manifests/t/TauriTavern/TauriTavern/2.2.0/TauriTavern.TauriTavern.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: TauriTavern.TauriTavern
+PackageVersion: 2.2.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /P
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Darkatse/TauriTavern/releases/download/v2.2.0/TauriTavern-2.2.0-windows-x64-setup.exe
+  InstallerSha256: 3CBF07625DD3DE64E97EFCA9F092FADAC4C25ED6A9909AEB7DE09D31A132CB1A
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/t/TauriTavern/TauriTavern/2.2.0/TauriTavern.TauriTavern.locale.en-US.yaml
+++ b/manifests/t/TauriTavern/TauriTavern/2.2.0/TauriTavern.TauriTavern.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: TauriTavern.TauriTavern
+PackageVersion: 2.2.0
+PackageLocale: en-US
+Publisher: tauritavern
+PublisherUrl: https://tauritavern.github.io
+PublisherSupportUrl: https://github.com/Darkatse/TauriTavern/issues
+Author: TauriTavern Team
+PackageName: TauriTavern
+PackageUrl: https://github.com/Darkatse/TauriTavern
+License: AGPL-3.0-only
+LicenseUrl: https://github.com/Darkatse/TauriTavern/blob/v2.2.0/LICENSE
+ShortDescription: A native SillyTavern client with a Rust backend, built with Tauri.
+Description: TauriTavern ports the SillyTavern frontend to a native application and replaces its Node.js backend with a Rust backend built on Tauri.
+Moniker: tauritavern
+Tags:
+- ai
+- chat
+- sillytavern
+- tauri
+ReleaseDate: 2026-07-30
+ReleaseNotesUrl: https://github.com/Darkatse/TauriTavern/releases/tag/v2.2.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/TauriTavern/TauriTavern/2.2.0/TauriTavern.TauriTavern.locale.zh-CN.yaml
+++ b/manifests/t/TauriTavern/TauriTavern/2.2.0/TauriTavern.TauriTavern.locale.zh-CN.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: TauriTavern.TauriTavern
+PackageVersion: 2.2.0
+PackageLocale: zh-CN
+Publisher: tauritavern
+PackageName: TauriTavern
+License: AGPL-3.0-only
+ShortDescription: 采用 Tauri 和 Rust 重构后端的 SillyTavern 原生客户端。
+Description: TauriTavern 将 SillyTavern 前端移植为原生应用，并以基于 Tauri 的 Rust 后端替代原有 Node.js 后端。
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/t/TauriTavern/TauriTavern/2.2.0/TauriTavern.TauriTavern.yaml
+++ b/manifests/t/TauriTavern/TauriTavern/2.2.0/TauriTavern.TauriTavern.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: TauriTavern.TauriTavern
+PackageVersion: 2.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds the initial WinGet manifest for TauriTavern 2.2.0.

The manifest uses the version-specific x64 NSIS installer published with the official TauriTavern release. It installs for the current user and supports silent and passive installation.
Package metadata is provided in English and Simplified Chinese.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (not applicable for this routine manifest submission)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same manifest
- [x] This PR only modifies one manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the 1.12 schema

The installer URL, SHA256, NSIS format, x64 application architecture, product version, product name, and publisher metadata were checked locally. The manifest upgraded an existing per-user TauriTavern 1.5.0-alpha.2 installation to 2.2.0 in passive mode. A forced silent reinstall of 2.2.0 also completed successfully. Both operations required no interaction, and the installed ARP and binary metadata report version 2.2.0.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/413581)