### PR TITLE
New package: BeamoINT.BeamoFlasher version 0.5.12

### DIFF
--- a/manifests/b/BeamoINT/BeamoFlasher/0.5.12/BeamoINT.BeamoFlasher.installer.yaml
+++ b/manifests/b/BeamoINT/BeamoFlasher/0.5.12/BeamoINT.BeamoFlasher.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: BeamoINT.BeamoFlasher
+PackageVersion: 0.5.12
+Platform:
+  - Windows.Desktop
+InstallerType: nullsoft
+MinimumOSVersion: 10.0.17763.0
+UpgradeBehavior: install
+AppsAndFeaturesEntries:
+  - DisplayName: Beamo Flasher 0.5.12
+    Publisher: BeamoINT
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/BeamoINT/beamo-flasher-releases/releases/download/v0.5.12/Beamo-Flasher-Installer.exe
+    InstallerSha256: 44B435A58FD06D3F9C3E3A2D1D78226AE4F31E2C0B8FE9D50A72647F633F73E4
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/b/BeamoINT/BeamoFlasher/0.5.12/BeamoINT.BeamoFlasher.locale.en-US.yaml
+++ b/manifests/b/BeamoINT/BeamoFlasher/0.5.12/BeamoINT.BeamoFlasher.locale.en-US.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: BeamoINT.BeamoFlasher
+PackageVersion: 0.5.12
+PackageLocale: en-US
+Publisher: BeamoINT
+PublisherUrl: https://github.com/BeamoINT
+PublisherSupportUrl: https://beamo.tech/support
+PackageName: Beamo Flasher
+PackageUrl: https://beamo.tech/flasher-download
+License: MIT
+LicenseUrl: https://github.com/BeamoINT/beamo-flasher-releases/blob/main/LICENSE
+ShortDescription: Desktop application for flashing verified images to SD cards and USB drives.
+Description: Beamo Flasher writes hosted Raspberry Pi images and supported custom images to removable media with verification.
+Tags:
+  - raspberry-pi
+  - sd-card
+  - usb-drive
+  - disk-image
+  - flasher
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/b/BeamoINT/BeamoFlasher/0.5.12/BeamoINT.BeamoFlasher.yaml
+++ b/manifests/b/BeamoINT/BeamoFlasher/0.5.12/BeamoINT.BeamoFlasher.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: BeamoINT.BeamoFlasher
+PackageVersion: 0.5.12
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New package: `BeamoINT.BeamoFlasher` version 0.5.12

Beamo Flasher is a desktop application that writes verified disk images to SD cards and USB drives, with post-write readback verification.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)? (agreed on #403067 as Beamo LLC)
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change? (checked, none)
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

#### On the two unchecked boxes

To be transparent rather than tick them by default: these manifests were prepared on macOS, where `winget` is unavailable, so neither `winget validate` nor `winget install --manifest` was run. Instead all three manifests were validated programmatically against the published 1.12.0 JSON schemas (`winget-manifest.version`, `.installer`, `.defaultLocale`) and all pass. `InstallerSha256` was verified by downloading the release asset over the same public URL and hashing it (matches `SHA256SUMS-windows.txt` in the release). If the validation pipeline would rather I run the real tooling on Windows first, I'm glad to do that and resubmit.

#### Notes

This supersedes #403067, which was closed as stale after repeated `URL-Validation-Error` runs. That failure was caused by `PackageUrl`, `PublisherSupportUrl`, and `LicenseUrl` pointing at a private repository, so the validation pipeline saw HTTP 404 for all three. Every URL in this submission was re-checked anonymously and returns 200:

| Field | URL |
| --- | --- |
| `PackageUrl` | https://beamo.tech/flasher-download |
| `PublisherSupportUrl` | https://beamo.tech/support |
| `LicenseUrl` | https://github.com/BeamoINT/beamo-flasher-releases/blob/main/LICENSE |
| `PublisherUrl` | https://github.com/BeamoINT |
| `InstallerUrl` | https://github.com/BeamoINT/beamo-flasher-releases/releases/download/v0.5.12/Beamo-Flasher-Installer.exe |

The installer is an electron-builder NSIS package (`oneClick: false`), so it accepts `/S` for silent install. `MinimumOSVersion` is 10.0.17763.0 because Electron 39 does not support Windows older than 10 1809.

Please note the installer is not code-signed, so SmartScreen will warn on first launch.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/413597)