### PR TITLE
Update: Huerte.GitGo to 1.10.3

### DIFF
--- a/manifests/h/Huerte/GitGo/1.10.3/Huerte.GitGo.installer.yaml
+++ b/manifests/h/Huerte/GitGo/1.10.3/Huerte.GitGo.installer.yaml
@@ -4,6 +4,6 @@ InstallerType: portable
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/Huerte/GitGo/releases/download/v1.10.3/gitgo.exe
-    InstallerSha256: 132bde60a9bd6feb1150176537e6b98709d7aa9f29fb633b464875cdc1543b56
+    InstallerSha256: be982a282ad110e351596bb131173d29f6d653d5d8e2147cc86ea1d06b39ad12
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/h/Huerte/GitGo/1.10.3/Huerte.GitGo.installer.yaml
+++ b/manifests/h/Huerte/GitGo/1.10.3/Huerte.GitGo.installer.yaml
@@ -1,0 +1,9 @@
+PackageIdentifier: Huerte.GitGo
+PackageVersion: 1.10.3
+InstallerType: portable
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Huerte/GitGo/releases/download/v1.10.3/gitgo.exe
+    InstallerSha256: 132bde60a9bd6feb1150176537e6b98709d7aa9f29fb633b464875cdc1543b56
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/h/Huerte/GitGo/1.10.3/Huerte.GitGo.locale.en-US.yaml
+++ b/manifests/h/Huerte/GitGo/1.10.3/Huerte.GitGo.locale.en-US.yaml
@@ -1,0 +1,20 @@
+PackageIdentifier: Huerte.GitGo
+PackageVersion: 1.10.3
+PackageLocale: en-US
+Publisher: Huerte
+PublisherUrl: https://github.com/Huerte
+PublisherSupportUrl: https://github.com/Huerte/GitGo/issues
+PackageName: GitGo
+Moniker: gitgo
+PackageUrl: https://github.com/Huerte/GitGo
+License: GPL-3.0-or-later
+LicenseUrl: https://github.com/Huerte/GitGo/blob/main/LICENSE
+ShortDescription: GitGo CLI - Your Fast Git Companion. Simplifies git push, link, stash, and user management.
+Tags:
+  - git
+  - cli
+  - github
+  - development
+ReleaseNotesUrl: https://github.com/Huerte/GitGo/releases/tag/v1.10.3
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/h/Huerte/GitGo/1.10.3/Huerte.GitGo.yaml
+++ b/manifests/h/Huerte/GitGo/1.10.3/Huerte.GitGo.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Huerte.GitGo
+PackageVersion: 1.10.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## 📖 Description
Update GitGo (`Huerte.GitGo`) to version 1.10.3.

This is a critical patch release fixing:
- A display bug where Ctrl+C during a loading command left broken terminal output
- A crash in `gitgo link` and `gitgo init --template` when used with non-GitHub hosts (GitLab, custom servers)

Also adds a `Moniker: gitgo` to the locale manifest for easier discovery.

Full changelog: https://github.com/Huerte/GitGo/blob/main/CHANGELOG.md

## ✅ Checklist
- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)

## 📦 Manifest Checklist
- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.6.0 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/413625)