### PR TITLE
New version: Ironship.WordHunter version 1.0.10

### DIFF
--- a/manifests/i/Ironship/WordHunter/1.0.10/Ironship.WordHunter.installer.yaml
+++ b/manifests/i/Ironship/WordHunter/1.0.10/Ironship.WordHunter.installer.yaml
@@ -1,0 +1,30 @@
+# Created with WinGet manifest tools
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Ironship.WordHunter
+PackageVersion: 1.0.10
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+Scope: machine
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+ProductCode: Word Hunter
+ReleaseDate: 2026-08-07
+AppsAndFeaturesEntries:
+- DisplayName: Word Hunter
+  Publisher: wordhunter
+  DisplayVersion: 1.0.10
+  ProductCode: Word Hunter
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles%\Word Hunter'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Ironship/WordHunter/releases/download/WordHunter1.0.10/Word.Hunter.Setup.exe
+  InstallerSha256: 2A0F8B837F6C1B851648E581A8EB8A123A534ACBB994CFE21CF378962AD4EA88
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/i/Ironship/WordHunter/1.0.10/Ironship.WordHunter.locale.en-US.yaml
+++ b/manifests/i/Ironship/WordHunter/1.0.10/Ironship.WordHunter.locale.en-US.yaml
@@ -1,0 +1,36 @@
+# Created with WinGet manifest tools
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Ironship.WordHunter
+PackageVersion: 1.0.8
+PackageLocale: en-US
+Publisher: Ironship
+PublisherUrl: https://github.com/Ironship
+PublisherSupportUrl: https://github.com/Ironship/WordHunter/issues
+Author: Ironship
+PackageName: Word Hunter
+PackageUrl: https://github.com/Ironship/WordHunter
+License: AGPL-3.0-or-later
+LicenseUrl: https://github.com/Ironship/WordHunter/blob/WordHunter1.0.8/LICENSE
+ShortDescription: Local-first reader and spaced repetition tool for language learning
+Description: |-
+  Word Hunter is a desktop reader and vocabulary-learning workspace. It can
+  import texts, ebooks, subtitles and PDFs, save words with their context, and
+  review them with flashcards and spaced repetition. Data is stored locally.
+Moniker: wordhunter
+Tags:
+- ebook
+- flashcard
+- language-learning
+- ocr
+- reader
+- spaced-repetition
+- vocabulary
+ReleaseNotes: |-
+  Made later vocabulary status decisions win reliably across devices.
+  Added a safe deterministic fallback for older vocabulary records.
+  Shortened Android startup and made library loading lighter.
+  Restricted Android cleartext traffic to the local Word Hunter backend.
+ReleaseNotesUrl: https://github.com/Ironship/WordHunter/releases/tag/WordHunter1.0.8
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/i/Ironship/WordHunter/1.0.10/Ironship.WordHunter.locale.en-US.yaml
+++ b/manifests/i/Ironship/WordHunter/1.0.10/Ironship.WordHunter.locale.en-US.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: Ironship.WordHunter
-PackageVersion: 1.0.8
+PackageVersion: 1.0.10
 PackageLocale: en-US
 Publisher: Ironship
 PublisherUrl: https://github.com/Ironship
@@ -11,7 +11,7 @@ Author: Ironship
 PackageName: Word Hunter
 PackageUrl: https://github.com/Ironship/WordHunter
 License: AGPL-3.0-or-later
-LicenseUrl: https://github.com/Ironship/WordHunter/blob/WordHunter1.0.8/LICENSE
+LicenseUrl: https://github.com/Ironship/WordHunter/blob/WordHunter1.0.10/LICENSE
 ShortDescription: Local-first reader and spaced repetition tool for language learning
 Description: |-
   Word Hunter is a desktop reader and vocabulary-learning workspace. It can
@@ -27,10 +27,12 @@ Tags:
 - spaced-repetition
 - vocabulary
 ReleaseNotes: |-
-  Made later vocabulary status decisions win reliably across devices.
-  Added a safe deterministic fallback for older vocabulary records.
-  Shortened Android startup and made library loading lighter.
-  Restricted Android cleartext traffic to the local Word Hunter backend.
-ReleaseNotesUrl: https://github.com/Ironship/WordHunter/releases/tag/WordHunter1.0.8
+  Contextual AI explanations for words and phrases: streamed answers from
+  OpenAI-compatible services, reasoning-effort levels, automatic explanations
+  for new words, optional visual context for scanned pages, a local cache, a
+  translator button, and configurable endpoint, model, and API key. Also
+  improves translation reliability and prevents duplicate durable saves from
+  blocking application shutdown.
+ReleaseNotesUrl: https://github.com/Ironship/WordHunter/releases/tag/WordHunter1.0.10
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0

--- a/manifests/i/Ironship/WordHunter/1.0.10/Ironship.WordHunter.yaml
+++ b/manifests/i/Ironship/WordHunter/1.0.10/Ironship.WordHunter.yaml
@@ -1,0 +1,8 @@
+# Created with WinGet manifest tools
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Ironship.WordHunter
+PackageVersion: 1.0.10
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
New version: Ironship.WordHunter version 1.0.10

- [x] Have you signed the [Contributor License Agreement](https://aka.ms/winget-cla)?
- [x] Have you checked that there are no other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update?
- [x] Have you validated your manifest locally with `winget validate --manifest manifests/i/Ironship/WordHunter/1.0.10/`?
- [x] Have you run `winget install --manifest manifests/i/Ironship/WordHunter/1.0.10/` to verify the installation?

This update is for the stable Word Hunter 1.0.10 release (AI explanations, reasoning-effort levels, auto-trigger).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/413629)