### PR TITLE
New version: Pane.Pane version 0.4.29

### DIFF
--- a/manifests/p/Pane/Pane/0.4.29/Pane.Pane.installer.yaml
+++ b/manifests/p/Pane/Pane/0.4.29/Pane.Pane.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Pane.Pane
+PackageVersion: 0.4.29
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/ItsJazii/pane/releases/download/v0.4.29/Pane_0.4.29_x64-setup.exe
+  InstallerSha256: C9637C8D1CF569B74995891450EF36C719F185B4F1D9EFA356821AC41F72FD65
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/p/Pane/Pane/0.4.29/Pane.Pane.locale.en-US.yaml
+++ b/manifests/p/Pane/Pane/0.4.29/Pane.Pane.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Pane.Pane
+PackageVersion: 0.4.29
+PackageLocale: en-US
+Publisher: Pane
+PublisherUrl: https://github.com/ItsJazii
+PublisherSupportUrl: https://github.com/ItsJazii/pane/issues
+PackageName: Pane
+PackageUrl: https://github.com/ItsJazii/pane
+License: MIT
+LicenseUrl: https://github.com/ItsJazii/pane/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Jazii
+ShortDescription: All your AI subscription limits in one liquid-glass tray popover.
+Description: |-
+  Pane shows how much of your session and weekly limits each AI tool has left,
+  directly from the Windows system tray. It auto-detects the CLIs and apps you
+  already use (Claude Code, Codex, Cursor, Copilot, Grok and more - 18
+  providers), projects whether you will run out before the reset, computes
+  local spend with live model pricing, and updates itself via signed releases.
+  No telemetry; tokens only ever go to their own vendor's API.
+Moniker: pane
+Tags:
+- ai
+- claude
+- codex
+- copilot
+- cursor
+- grok
+- productivity
+- tray
+- usage
+ReleaseNotesUrl: https://github.com/ItsJazii/pane/releases/tag/v0.4.29
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/p/Pane/Pane/0.4.29/Pane.Pane.yaml
+++ b/manifests/p/Pane/Pane/0.4.29/Pane.Pane.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Pane.Pane
+PackageVersion: 0.4.29
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Update to an existing package

- PackageIdentifier: Pane.Pane (merged in #399096)
- PackageVersion: 0.4.6 → 0.4.29
- InstallerUrl points at the tagged GitHub release built by CI; InstallerSha256 computed from the published asset.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? (Manifest validation succeeded)
- [x] Have you tested your manifest locally with `winget install --manifest <path>`? (the exact CI-built 0.4.29 installer from this URL is what is running on my machine right now, installed and verified)
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/413660)