### PR TITLE
New package: AkshayNikhare.RealtimeClipboard version 0.3.0

### DIFF
--- a/manifests/a/AkshayNikhare/RealtimeClipboard/0.3.0/AkshayNikhare.RealtimeClipboard.installer.yaml
+++ b/manifests/a/AkshayNikhare/RealtimeClipboard/0.3.0/AkshayNikhare.RealtimeClipboard.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: AkshayNikhare.RealtimeClipboard
+PackageVersion: 0.3.0
+InstallerType: wix
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+UpgradeBehavior: install
+ReleaseDate: 2026-08-07
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/akshaynikhare/RealtimeClipboard/releases/download/v0.3.0/RealtimeClipboard_0.3.0_x64_en-US.msi
+    InstallerSha256: BD369CC0C19700CB06604EB36E498A504DBA6AB1441485F5A64FF69203CC16A0
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/a/AkshayNikhare/RealtimeClipboard/0.3.0/AkshayNikhare.RealtimeClipboard.installer.yaml
+++ b/manifests/a/AkshayNikhare/RealtimeClipboard/0.3.0/AkshayNikhare.RealtimeClipboard.installer.yaml
@@ -12,5 +12,8 @@ Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/akshaynikhare/RealtimeClipboard/releases/download/v0.3.0/RealtimeClipboard_0.3.0_x64_en-US.msi
     InstallerSha256: BD369CC0C19700CB06604EB36E498A504DBA6AB1441485F5A64FF69203CC16A0
+    AppsAndFeaturesEntries:
+      - Publisher: github
+        ProductCode: '{D04E2FE1-0684-4309-820C-FC6F075C161C}'
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/a/AkshayNikhare/RealtimeClipboard/0.3.0/AkshayNikhare.RealtimeClipboard.locale.en-US.yaml
+++ b/manifests/a/AkshayNikhare/RealtimeClipboard/0.3.0/AkshayNikhare.RealtimeClipboard.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: AkshayNikhare.RealtimeClipboard
+PackageVersion: 0.3.0
+PackageLocale: en-US
+Publisher: Akshay Nikhare
+PublisherUrl: https://github.com/akshaynikhare
+PackageName: RealtimeClipboard
+PackageUrl: https://realtimeclipboard.com/
+License: MIT
+LicenseUrl: https://github.com/akshaynikhare/RealtimeClipboard/blob/main/LICENSE
+ShortDescription: An end-to-end encrypted clipboard shared between your devices
+Description: >-
+  Copy on one machine and paste on another. RealtimeClipboard watches the system
+  clipboard and sends what you copy, encrypted in the browser, to the other
+  devices sharing a five-character key. No account, and nothing is written to
+  disk on any machine or on the relay.
+Tags:
+  - clipboard
+  - clipboard-sync
+  - encryption
+  - productivity
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/a/AkshayNikhare/RealtimeClipboard/0.3.0/AkshayNikhare.RealtimeClipboard.yaml
+++ b/manifests/a/AkshayNikhare/RealtimeClipboard/0.3.0/AkshayNikhare.RealtimeClipboard.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: AkshayNikhare.RealtimeClipboard
+PackageVersion: 0.3.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: `AkshayNikhare.RealtimeClipboard` version 0.3.0

RealtimeClipboard is an end-to-end encrypted clipboard shared between your
devices. Copy on one machine, paste on another. Open source (MIT), no account.

- Homepage: https://realtimeclipboard.com/
- Source: https://github.com/akshaynikhare/RealtimeClipboard
- Installer: the `.msi` from the [v0.3.0 release](https://github.com/akshaynikhare/RealtimeClipboard/releases/tag/v0.3.0), built in public by [this workflow](https://github.com/akshaynikhare/RealtimeClipboard/blob/main/.github/workflows/release.yml)

#### Checklist

- [x] Have you checked that there aren't other open pull requests for the same manifest?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the 1.6 schema?

On the unchecked box, so the reviewer is not guessing: the manifest was validated
with `winget validate` (passed) and the `InstallerSha256` was verified by hashing
the released `.msi` independently, but I have not run `winget install --manifest`
because the machine preparing this submission has no way to answer the elevation
prompt for a per-machine MSI.

#### Note on signing

**The installer is not code-signed.** There is no certificate behind this project
yet, so SmartScreen will warn on it. This is stated plainly on the project's own
[download page](https://realtimeclipboard.com/download/) rather than left for
users to discover, and the release artifacts are reproducible from the public
workflow linked above.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/413661)