### PR TITLE
New package: anyvm-org.anyvm version 0.5.7

### DIFF
--- a/manifests/a/anyvm-org/anyvm/0.5.7/anyvm-org.anyvm.installer.yaml
+++ b/manifests/a/anyvm-org/anyvm/0.5.7/anyvm-org.anyvm.installer.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+# InstallerType: portable means winget drops the exe under
+# %LOCALAPPDATA%\Microsoft\WinGet\Packages\ and puts an alias on PATH.
+# The alias comes from Commands, which is why the asset can keep its
+# platform-qualified file name and the user still just types "anyvm"
+# (same shape as jqlang.jq, whose asset is jq-windows-amd64.exe).
+# PortableCommandAlias does NOT apply here -- it is only read for a
+# portable nested inside a zip.
+
+PackageIdentifier: anyvm-org.anyvm
+PackageVersion: 0.5.7
+InstallerType: portable
+Commands:
+- anyvm
+ReleaseDate: 2026-08-07
+# anyvm drives QEMU but does not bundle it, so winget installs QEMU first --
+# verified end to end on winget v1.29: with QEMU absent it downloads and
+# installs SoftwareFreedomConservancy.QEMU, then anyvm. QEMU lands in
+# %ProgramFiles%\qemu and stays off PATH, which is exactly where anyvm's
+# find_qemu() looks. Same intent as the Homebrew formula's depends_on "qemu".
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: SoftwareFreedomConservancy.QEMU
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/anyvm-org/anyvm/releases/download/v0.5.7/anyvm-windows-x64.exe
+  InstallerSha256: 8F25D3D6A7E3AE523F15FC4A6F096544CA7F384ECC15FCA97F21CFD7D617BE18
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/anyvm-org/anyvm/0.5.7/anyvm-org.anyvm.locale.en-US.yaml
+++ b/manifests/a/anyvm-org/anyvm/0.5.7/anyvm-org.anyvm.locale.en-US.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: anyvm-org.anyvm
+PackageVersion: 0.5.7
+PackageLocale: en-US
+Publisher: anyvm.org
+PublisherUrl: https://anyvm.org
+PublisherSupportUrl: https://github.com/anyvm-org/anyvm/issues
+PackageName: anyvm
+PackageUrl: https://github.com/anyvm-org/anyvm
+License: MIT
+LicenseUrl: https://github.com/anyvm-org/anyvm/blob/main/LICENSE
+ShortDescription: Run any VM anywhere -- bootstrap BSD, Illumos, and Linux guests with QEMU.
+Description: |-
+  anyvm boots a prebuilt BSD, Illumos, Linux, Hurd or Plan 9 guest under QEMU
+  with one command. It downloads the image, configures firmware, ssh, folder
+  sync and port forwarding for that guest on that architecture, then drops you
+  into a shell or runs your command and exits.
+
+  anyvm drives QEMU but does not bundle it, so QEMU is declared as a package
+  dependency and winget installs it first. Pass --skip-dependencies to install
+  anyvm on its own and supply QEMU yourself.
+Moniker: anyvm
+Tags:
+- qemu
+- vm
+- virtual-machine
+- freebsd
+- openbsd
+- netbsd
+- dragonflybsd
+- solaris
+- illumos
+- haiku
+- emulator
+- ci
+ReleaseNotesUrl: https://github.com/anyvm-org/anyvm/releases/tag/v0.5.7
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/anyvm-org/anyvm/0.5.7/anyvm-org.anyvm.yaml
+++ b/manifests/a/anyvm-org/anyvm/0.5.7/anyvm-org.anyvm.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: anyvm-org.anyvm
+PackageVersion: 0.5.7
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Adds anyvm-org.anyvm 0.5.7, a command-line tool that boots prebuilt BSD,
Illumos, Linux, Hurd and Plan 9 guests under QEMU with a single command.

The installer is a portable, self-contained x64 executable published as a
GitHub release asset by the project's own CI:
https://github.com/anyvm-org/anyvm/releases/tag/v0.5.7

anyvm drives QEMU but does not bundle it, so the manifest declares
SoftwareFreedomConservancy.QEMU as a package dependency.

## Checklist

- [x] Signed the Contributor License Agreement
- [ ] Linked to an issue (not applicable)

## Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same
      manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with winget validate --manifest <path>
- [x] Tested manifest locally with winget install --manifest <path>
- [x] Manifest conforms to the 1.12 schema

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/413670)