### PR TITLE
New version: violet2code.MagnifySnap version 1.4.0

### DIFF
--- a/manifests/v/violet2code/MagnifySnap/1.4.0/violet2code.MagnifySnap.installer.yaml
+++ b/manifests/v/violet2code/MagnifySnap/1.4.0/violet2code.MagnifySnap.installer.yaml
@@ -1,0 +1,11 @@
+PackageIdentifier: violet2code.MagnifySnap
+PackageVersion: 1.4.0
+InstallerType: portable
+Commands:
+- magnifysnap
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/violet2code/magnify-snap/releases/download/v1.4.0/MagnifySnap-1.4.0-windows-x64.exe
+  InstallerSha256: DC701B67F4FFE11491AA0DEB103E6AF47EAD89A7121C9EC18FB7A2558943D010
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/v/violet2code/MagnifySnap/1.4.0/violet2code.MagnifySnap.locale.en-US.yaml
+++ b/manifests/v/violet2code/MagnifySnap/1.4.0/violet2code.MagnifySnap.locale.en-US.yaml
@@ -1,0 +1,31 @@
+PackageIdentifier: violet2code.MagnifySnap
+PackageVersion: 1.4.0
+PackageLocale: en-US
+Publisher: violet2code
+PublisherUrl: https://violet2code.github.io/
+PublisherSupportUrl: https://github.com/violet2code/magnify-snap/issues
+PackageName: Magnify.Snap
+PackageUrl: https://violet2code.github.io/
+License: MIT
+LicenseUrl: https://github.com/violet2code/magnify-snap/blob/master/LICENSE
+ShortDescription: Fast screen magnifier that lives in the system tray. One press of the middle mouse button zooms the screen while it stays fully interactive.
+Description: |-
+  Magnify.Snap is a lightweight fullscreen magnifier. Press the middle mouse
+  button (or any custom binding) to zoom the screen to 200% and press again to
+  snap back — the screen stays fully interactive while zoomed. Hold the button
+  to temporarily peek even closer. The view follows the cursor near screen
+  edges. Zoom level, peek level, panning speed and appearance are configurable
+  from the tray settings window.
+Moniker: magnifysnap
+Tags:
+- accessibility
+- magnifier
+- screen-magnifier
+- zoom
+ReleaseNotes: |-
+  Adds a Start menu shortcut so the app can be found and launched after
+  installing it (WinGet's portable installer type creates no shortcuts).
+  The shortcut can be switched off in the settings window.
+ReleaseNotesUrl: https://github.com/violet2code/magnify-snap/releases/tag/v1.4.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/v/violet2code/MagnifySnap/1.4.0/violet2code.MagnifySnap.yaml
+++ b/manifests/v/violet2code/MagnifySnap/1.4.0/violet2code.MagnifySnap.yaml
@@ -1,0 +1,6 @@
+# Created using manual submission
+PackageIdentifier: violet2code.MagnifySnap
+PackageVersion: 1.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Updates Magnify.Snap to 1.4.0.

This release fixes a discoverability problem specific to portable installs: after `winget install magnifysnap` the application had no Start menu entry, desktop icon or shortcut of any kind, so a GUI-only app was effectively unlaunchable for anyone who did not know to type its name. It now registers a Start menu shortcut on first run (switchable off in its settings).

- Homepage: https://violet2code.github.io/
- Release: https://github.com/violet2code/magnify-snap/releases/tag/v1.4.0
- Validated locally with `winget validate`; binary verified clean with a live Windows Defender scan before publishing.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/413723)