### PR TITLE
New version: violet2code.MagnifySnap version 1.4.1

### DIFF
--- a/manifests/v/violet2code/MagnifySnap/1.4.1/violet2code.MagnifySnap.installer.yaml
+++ b/manifests/v/violet2code/MagnifySnap/1.4.1/violet2code.MagnifySnap.installer.yaml
@@ -1,0 +1,15 @@
+PackageIdentifier: violet2code.MagnifySnap
+PackageVersion: 1.4.1
+InstallerType: inno
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/violet2code/magnify-snap/releases/download/v1.4.1/MagnifySnap-1.4.1-windows-x64-setup.exe
+  InstallerSha256: CAA52183E31CB0CD74AA95418981BCA0B47A4326F7D1502762CDDDE08B79801A
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/v/violet2code/MagnifySnap/1.4.1/violet2code.MagnifySnap.locale.en-US.yaml
+++ b/manifests/v/violet2code/MagnifySnap/1.4.1/violet2code.MagnifySnap.locale.en-US.yaml
@@ -1,0 +1,33 @@
+PackageIdentifier: violet2code.MagnifySnap
+PackageVersion: 1.4.1
+PackageLocale: en-US
+Publisher: violet2code
+PublisherUrl: https://violet2code.github.io/
+PublisherSupportUrl: https://github.com/violet2code/magnify-snap/issues
+PackageName: Magnify.Snap
+PackageUrl: https://violet2code.github.io/
+License: MIT
+LicenseUrl: https://github.com/violet2code/magnify-snap/blob/master/LICENSE
+ShortDescription: Fast screen magnifier that lives in the system tray. One press of the middle mouse button zooms the screen while it stays fully interactive.
+Description: |-
+  Magnify.Snap is a lightweight fullscreen magnifier. Press the middle mouse
+  button (or any custom binding) to zoom the screen to 200% and press again to
+  snap back — the screen stays fully interactive while zoomed. Hold the button
+  to temporarily peek even closer. The view follows the cursor near screen
+  edges. Zoom level, peek level, panning speed and appearance are configurable
+  from the tray settings window.
+Moniker: magnifysnap
+Tags:
+- accessibility
+- magnifier
+- screen-magnifier
+- zoom
+ReleaseNotes: |-
+  Switches to a proper per-user installer, so the app now appears in the Start
+  menu straight after installation. The previous portable packaging created no
+  shortcuts at all, which left a tray application effectively unlaunchable.
+  Installed copies now update through the installer, keeping the reported
+  version accurate.
+ReleaseNotesUrl: https://github.com/violet2code/magnify-snap/releases/tag/v1.4.1
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/v/violet2code/MagnifySnap/1.4.1/violet2code.MagnifySnap.yaml
+++ b/manifests/v/violet2code/MagnifySnap/1.4.1/violet2code.MagnifySnap.yaml
@@ -1,0 +1,6 @@
+# Created using manual submission
+PackageIdentifier: violet2code.MagnifySnap
+PackageVersion: 1.4.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Updates Magnify.Snap to 1.4.1 and switches the package from `portable` to `inno`.

Reason for the type change: Magnify.Snap is a tray GUI application, and `InstallerType: portable` never creates shortcuts. After installing, users had no Start menu entry, no icon, and (without Developer Mode, where the Links symlink silently fails) no working command alias either — so there was no practical way to launch it.

The new installer is per-user (`PrivilegesRequired=lowest`, installs under %LOCALAPPDATA%\Programs), needs no elevation, creates the Start menu shortcut at install time, and removes everything it created on uninstall. Silent and interactive installs were both verified on Windows 11, as was upgrading over a running instance.

- Homepage: https://violet2code.github.io/
- Release: https://github.com/violet2code/magnify-snap/releases/tag/v1.4.1
- Validated with `winget validate`; both published Windows binaries scanned clean with a live Windows Defender before release.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/413751)