### PR TITLE
New package: bullpae.keymander version 0.12.0

### DIFF
--- a/manifests/b/bullpae/keymander/0.12.0/bullpae.keymander.installer.yaml
+++ b/manifests/b/bullpae/keymander/0.12.0/bullpae.keymander.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: bullpae.keymander
+PackageVersion: 0.12.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: keymander\kmd.exe
+  PortableCommandAlias: kmd
+- RelativeFilePath: keymander\kmd-desktop.exe
+  PortableCommandAlias: kmd-desktop
+- RelativeFilePath: keymander\kmd-daemon.exe
+  PortableCommandAlias: kmd-daemon
+ReleaseDate: 2026-08-05
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/bullpae/keymander-cli/releases/download/v0.12.0/keymander-portable-x86_64-pc-windows-msvc.zip
+  InstallerSha256: 646F2D8780F9696EB008744720BA4F6AF9A6F340085E8286A282DEF46189EACC
+- Architecture: arm64
+  InstallerUrl: https://github.com/bullpae/keymander-cli/releases/download/v0.12.0/keymander-portable-aarch64-pc-windows-msvc.zip
+  InstallerSha256: A2F7C2C00C79590582A32A6CA0EABBBDBBA55C857F7416C775A9AECF6AAE1307
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/b/bullpae/keymander/0.12.0/bullpae.keymander.locale.en-US.yaml
+++ b/manifests/b/bullpae/keymander/0.12.0/bullpae.keymander.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: bullpae.keymander
+PackageVersion: 0.12.0
+PackageLocale: en-US
+Publisher: bullpae
+PublisherUrl: https://github.com/bullpae
+PublisherSupportUrl: https://github.com/bullpae/keymander-cli/issues
+PackageName: keymander
+PackageUrl: https://github.com/bullpae/keymander-cli
+License: MIT
+LicenseUrl: https://github.com/bullpae/keymander-cli/blob/main/LICENSE
+Copyright: Copyright (c) 2026 bullpae
+ShortDescription: Keyboard-driven cross-platform launcher (TUI, desktop, key-remap daemon)
+Description: |-
+  keymander is a CLI-first cross-platform launcher controlled entirely from the keyboard.
+  It ships three binaries: kmd (TUI/CLI launcher), kmd-desktop (GUI launcher window),
+  and kmd-daemon (global hotkey and key-remapping daemon).
+Moniker: keymander
+Tags:
+- cli
+- keyboard
+- launcher
+- productivity
+- terminal
+- tui
+ReleaseNotesUrl: https://github.com/bullpae/keymander-cli/releases/tag/v0.12.0
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/b/bullpae/keymander/0.12.0/bullpae.keymander.yaml
+++ b/manifests/b/bullpae/keymander/0.12.0/bullpae.keymander.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: bullpae.keymander
+PackageVersion: 0.12.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
### New package: `bullpae.keymander` version 0.12.0

keymander is a keyboard-driven cross-platform launcher (TUI/CLI, desktop GUI, and a key-remapping daemon).

- Homepage: https://github.com/bullpae/keymander-cli
- License: MIT
- Installer: portable zip containing `kmd.exe`, `kmd-desktop.exe`, `kmd-daemon.exe` (x64 + arm64)

#### Checklist

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.9.0)?

Note: this supersedes #401304, which passed validation but was closed before the CLA was signed.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/413755)