### PR TITLE
New version: Feci.ParleyDeckCli version 1.42.0

### DIFF
--- a/manifests/f/Feci/ParleyDeckCli/1.42.0/Feci.ParleyDeckCli.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.42.0/Feci.ParleyDeckCli.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.42.0
+InstallerType: portable
+Commands:
+- parley
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.42.0/parley-v1.42.0-windows-x64.exe
+  InstallerSha256: 35921B874315AD15B634B239813AAFF31850CAD46ED577474FC93ABDCFB83294
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.42.0/parley-v1.42.0-windows-arm64.exe
+  InstallerSha256: 98E45DF5B9C56EF448DC1E897C116CFDFFECA8DBAAE827433E97064E2EBAFBD4
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.42.0/Feci.ParleyDeckCli.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.42.0/Feci.ParleyDeckCli.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.42.0
+PackageLocale: en-US
+Publisher: Feci
+PublisherUrl: https://github.com/feci
+PackageName: Parley Deck CLI
+PackageUrl: https://github.com/feci/parley-deck-cli
+License: Apache-2.0
+LicenseUrl: https://github.com/feci/parley-deck-cli/blob/main/LICENSE
+ShortDescription: CLI that orchestrates Parley Deck multi-agent cooperation workflows.
+Description: "parley orchestrates multi-agent Parley Deck cooperation across local CLI agents: risk-tiered tracks, deliberation rounds, consensus and finalize, implementation with living execution plans, a live TUI, and a human-braked outer loop. v1.42.0 adds a GLOBAL CORE PROTOCOL. Measured across 36 project decks there were eight different protocol versions, because the cooperation protocol was copied into every deck and hand-editable there. The protocol now lives once, in a write-once versioned store under the user config directory, and each deck holds a generated view of it. The new parley protocol command renders that view, checks a deck for hand edits without overwriting them, and publishes a new core version only from an attended terminal session. A deck records the exact core version it uses, and a machine that does not have that version blocks rather than substituting another. Regeneration reports the deck content it will not carry forward, before and during the write."
+ReleaseNotesUrl: https://github.com/feci/parley-deck-cli/releases/tag/v1.42.0
+Tags:
+- ai
+- agents
+- automation
+- cli
+- codex
+- consensus
+- loop
+- multi-agent
+- orchestration
+- preflight
+- roster
+- tui
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.42.0/Feci.ParleyDeckCli.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.42.0/Feci.ParleyDeckCli.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.42.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
New version of Feci.ParleyDeckCli.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/413766)