### PR TITLE
New package: Cachix.SecretSpec version 0.18.0

### DIFF
--- a/manifests/c/Cachix/SecretSpec/0.18.0/Cachix.SecretSpec.installer.yaml
+++ b/manifests/c/Cachix/SecretSpec/0.18.0/Cachix.SecretSpec.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Cachix.SecretSpec
+PackageVersion: 0.18.0
+InstallerType: zip
+NestedInstallerType: portable
+ReleaseDate: 2026-08-04
+Installers:
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: secretspec.exe
+    PortableCommandAlias: secretspec
+  InstallerUrl: https://github.com/cachix/secretspec/releases/download/v0.18.0/secretspec-x86_64-pc-windows-msvc.zip
+  InstallerSha256: 99EB37FFF1A05796195C457ECD131501024403E8A6CF035695A92263337AEFD2
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/Cachix/SecretSpec/0.18.0/Cachix.SecretSpec.locale.en-US.yaml
+++ b/manifests/c/Cachix/SecretSpec/0.18.0/Cachix.SecretSpec.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Cachix.SecretSpec
+PackageVersion: 0.18.0
+PackageLocale: en-US
+Publisher: Cachix
+PublisherUrl: https://www.cachix.org/
+PublisherSupportUrl: https://github.com/cachix/secretspec/issues
+Author: Domen Kožar
+PackageName: SecretSpec
+PackageUrl: https://secretspec.dev/
+License: Apache-2.0
+LicenseUrl: https://github.com/cachix/secretspec/blob/v0.18.0/LICENSE
+ShortDescription: A declarative interface for every secret provider.
+Description: SecretSpec is a declarative secrets manager for development workflows. It separates secret declarations from storage and resolves them through local keyrings, password managers, cloud secret stores, and other providers.
+Moniker: secretspec
+Tags:
+- cli
+- developer-tools
+- password-manager
+- secrets
+- security
+ReleaseNotesUrl: https://github.com/cachix/secretspec/releases/tag/v0.18.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/Cachix/SecretSpec/0.18.0/Cachix.SecretSpec.yaml
+++ b/manifests/c/Cachix/SecretSpec/0.18.0/Cachix.SecretSpec.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Cachix.SecretSpec
+PackageVersion: 0.18.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds SecretSpec 0.18.0 as the new `Cachix.SecretSpec` package using the
official x64 Windows release ZIP. The archive is installed as a portable
package and exposes `secretspec` on `PATH`.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.com)
- [ ] Linked to an issue (not applicable for this routine manifest submission)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same package
- [x] This PR only modifies one manifest
- [ ] Validated with `winget validate` (WinGet is unavailable in the Linux authoring environment)
- [ ] Tested with `winget install --manifest` (awaiting the repository's Windows validation)
- [x] Manifest conforms to the 1.12 schema

## Additional validation

- All three manifest files pass Microsoft's official 1.12 JSON schemas.
- The release ZIP SHA-256 was independently verified as
  `99EB37FFF1A05796195C457ECD131501024403E8A6CF035695A92263337AEFD2`.
- The archive contains `secretspec.exe` at its root.
- The executable imports only Windows system libraries, so no VC++ runtime
  package dependency is required.

Future releases will be automated by
[cachix/secretspec#297](https://github.com/cachix/secretspec/pull/297) using
`winget-releaser` after this bootstrap package is merged.
