### PR TITLE
New version: AurelioAvila.PCTweaker version 0.4.0

### DIFF
--- a/manifests/a/AurelioAvila/PCTweaker/0.4.0/AurelioAvila.PCTweaker.installer.yaml
+++ b/manifests/a/AurelioAvila/PCTweaker/0.4.0/AurelioAvila.PCTweaker.installer.yaml
@@ -1,0 +1,18 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: AurelioAvila.PCTweaker
+PackageVersion: 0.4.0
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerType: nullsoft
+  InstallerUrl: https://github.com/AurelioAvila/pc-tweaker-app/releases/download/v0.4.0/pc-tweaker-app_0.4.0_x64-setup.exe
+  InstallerSha256: 30E1F83E450A3B61DDF349AF136CF0E45109ECC4B1EE98FED8164ACB1749FE33
+  InstallerSwitches:
+    Silent: /S
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/a/AurelioAvila/PCTweaker/0.4.0/AurelioAvila.PCTweaker.locale.en-US.yaml
+++ b/manifests/a/AurelioAvila/PCTweaker/0.4.0/AurelioAvila.PCTweaker.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: AurelioAvila.PCTweaker
+PackageVersion: 0.4.0
+PackageLocale: en-US
+Publisher: Aurelio Avila
+PublisherUrl: https://github.com/AurelioAvila
+PublisherSupportUrl: https://github.com/AurelioAvila/pc-tweaker-app/issues
+PackageName: PC Tweaker
+PackageUrl: https://github.com/AurelioAvila/pc-tweaker-app
+License: Proprietary
+ShortDescription: Desktop app for Windows that applies performance, privacy, gaming and maintenance tweaks with automatic one-click rollback.
+Description: PC Tweaker applies real Windows system tweaks (registry, power plan, network DNS, temp file cleanup) across Performance, Privacy, Gaming and Maintenance categories. Every change saves a snapshot of the previous value before it's applied, so any tweak can be reverted with one click. Includes in-app auto-update.
+Tags:
+- windows
+- performance
+- tweak
+- optimizer
+- gaming
+- privacy
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/a/AurelioAvila/PCTweaker/0.4.0/AurelioAvila.PCTweaker.yaml
+++ b/manifests/a/AurelioAvila/PCTweaker/0.4.0/AurelioAvila.PCTweaker.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: AurelioAvila.PCTweaker
+PackageVersion: 0.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Updates AurelioAvila.PCTweaker to version 0.4.0.

- InstallerUrl points at the v0.4.0 GitHub Release asset
- InstallerSha256 verified independently (sha256sum on the local build artifact) and cross-checked against the GitHub release asset digest — both match
- Manifest structure follows the existing 0.1.0/0.3.0 manifests (single x64 nullsoft installer)
- Note: a PR for the intermediate 0.3.0 (#412399) is still in the moderation queue; this 0.4.0 submission is independent and can be reviewed on its own
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/413778)