### PR TITLE
New package: Aitherium.AitherShell version 1.16.0

### DIFF
--- a/manifests/a/Aitherium/AitherShell/1.16.0/Aitherium.AitherShell.installer.yaml
+++ b/manifests/a/Aitherium/AitherShell/1.16.0/Aitherium.AitherShell.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Aitherium.AitherShell
+PackageVersion: 1.16.0
+InstallerType: portable
+Commands:
+- aither
+ReleaseDate: "2026-08-07"
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Aitherium/aither-adk/releases/download/shell-v1.16.0/aither-shell-win64.exe
+  InstallerSha256: DD000FC290DA8C5A58629973EAF810EC391E04048ADD0DCA7DF56DC765FBBE3F
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/Aitherium/AitherShell/1.16.0/Aitherium.AitherShell.locale.en-US.yaml
+++ b/manifests/a/Aitherium/AitherShell/1.16.0/Aitherium.AitherShell.locale.en-US.yaml
@@ -25,6 +25,6 @@ Tags:
 - cli
 - llm
 - terminal
-ReleaseNotesUrl: https://github.com/Aitherium/AitherOS/releases/tag/shell-cli-v1.16.0
+ReleaseNotesUrl: https://github.com/Aitherium/aither-adk/releases/tag/shell-v1.16.0
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0

--- a/manifests/a/Aitherium/AitherShell/1.16.0/Aitherium.AitherShell.locale.en-US.yaml
+++ b/manifests/a/Aitherium/AitherShell/1.16.0/Aitherium.AitherShell.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Aitherium.AitherShell
+PackageVersion: 1.16.0
+PackageLocale: en-US
+Publisher: Aitherium
+PublisherUrl: https://aitherium.com
+PublisherSupportUrl: https://github.com/Aitherium/aither-adk/issues
+Author: Aitherium
+PackageName: AitherShell
+PackageUrl: https://github.com/Aitherium/aither-adk
+License: BUSL-1.1
+LicenseUrl: https://github.com/Aitherium/aither-adk/blob/main/LICENSE
+Copyright: Copyright (c) Aitherium
+ShortDescription: Interactive terminal for AitherOS — chat with AI agents from your shell
+Description: |-
+  AitherShell is an interactive terminal for AitherOS. Run `aither` for a REPL,
+  or `aither "message"` for a one-shot answer that prints and exits. Agents run
+  on your own hardware, a self-hosted fleet, or a cloud API — the same commands
+  either way.
+Moniker: aither
+Tags:
+- agent
+- ai
+- cli
+- llm
+- terminal
+ReleaseNotesUrl: https://github.com/Aitherium/AitherOS/releases/tag/shell-cli-v1.16.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/Aitherium/AitherShell/1.16.0/Aitherium.AitherShell.yaml
+++ b/manifests/a/Aitherium/AitherShell/1.16.0/Aitherium.AitherShell.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Aitherium.AitherShell
+PackageVersion: 1.16.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New package: `Aitherium.AitherShell` 1.16.0

AitherShell is an interactive terminal for AitherOS — `aither` for a REPL, `aither "message"` for a one-shot answer that prints and exits.

- **Publisher:** Aitherium
- **Installer:** portable (bun-compiled single `.exe`, x64)
- **Command:** `aither`
- **License:** BUSL-1.1

#### Checklist

- [x] Manifests validate against the 1.12.0 schemas (version, installer, defaultLocale) — all three checked with `jsonschema` against `aka.ms/winget-manifest.*.1.12.0.schema.json`
- [x] `InstallerSha256` computed from the actual artifact, downloaded **unauthenticated** (HTTP 200, 101,902,848 bytes, valid PE header) — not copied from a build log
- [x] `InstallerUrl` is a public GitHub release asset requiring no token
- [x] Package identifier matches the folder path `manifests/a/Aitherium/AitherShell/1.16.0`
- [x] Existing package: no (new submission)

Also published as [`@aitherium/shell-cli`](https://www.npmjs.com/package/@aitherium/shell-cli) on npm.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/413832)