### PR TITLE
New version: ProxyKit.ProxyKitCLI version 1.0.1

### DIFF
--- a/manifests/p/ProxyKit/ProxyKitCLI/1.0.1/ProxyKit.ProxyKitCLI.installer.yaml
+++ b/manifests/p/ProxyKit/ProxyKitCLI/1.0.1/ProxyKit.ProxyKitCLI.installer.yaml
@@ -1,0 +1,47 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: ProxyKit.ProxyKitCLI
+PackageVersion: 1.0.1
+InstallerLocale: en-US
+MinimumOSVersion: 10.0.17763.0
+Scope: user
+UpgradeBehavior: uninstallPrevious
+ReleaseDate: 2026-08-07
+Installers:
+  - Architecture: x64
+    InstallerType: zip
+    InstallerUrl: https://release.proxykit.net/v1.0.1/cli/windows-amd64/proxykit-cli-1.0.1-windows-amd64.zip
+    InstallerSha256: cb43bbba62a4cbb6ed426580a4bd2807e5d73638b13adf4c43ff0ee3903841d7
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: bin\proxykit.exe
+        PortableCommandAlias: proxykit
+      - RelativeFilePath: bin\proxy-engine.exe
+        PortableCommandAlias: proxy-engine
+    ArchiveBinariesDependOnPath: true
+    InstallModes:
+      - silent
+    Commands:
+      - proxykit
+    Platform:
+      - Windows.Desktop
+
+  - Architecture: arm64
+    InstallerType: zip
+    InstallerUrl: https://release.proxykit.net/v1.0.1/cli/windows-arm64/proxykit-cli-1.0.1-windows-arm64.zip
+    InstallerSha256: e0169c7522528d97df1dc010c05027e304bd70729f84d6b0ab0d34994355102e
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: bin\proxykit.exe
+        PortableCommandAlias: proxykit
+      - RelativeFilePath: bin\proxy-engine.exe
+        PortableCommandAlias: proxy-engine
+    ArchiveBinariesDependOnPath: true
+    InstallModes:
+      - silent
+    Commands:
+      - proxykit
+    Platform:
+      - Windows.Desktop
+
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/p/ProxyKit/ProxyKitCLI/1.0.1/ProxyKit.ProxyKitCLI.locale.en-US.yaml
+++ b/manifests/p/ProxyKit/ProxyKitCLI/1.0.1/ProxyKit.ProxyKitCLI.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: ProxyKit.ProxyKitCLI
+PackageVersion: 1.0.1
+PackageLocale: en-US
+Publisher: ProxyKit
+PublisherUrl: https://proxykit.net
+PublisherSupportUrl: https://github.com/AA-Box/ProxyKit-issues/issues
+PackageName: ProxyKit CLI
+PackageUrl: https://proxykit.net
+License: Proprietary
+LicenseUrl: https://proxykit.net/terms#license
+ShortDescription: Standalone ProxyKit CLI and headless MITM proxy engine
+Description: |
+  Command-line companion for ProxyKit. Controls a running proxy engine or launches
+  a bundled headless engine for CI and automation. Separate from ProxyKit.
+Moniker: proxykit
+Tags:
+  - proxy
+  - http
+  - debugging
+  - cli
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/p/ProxyKit/ProxyKitCLI/1.0.1/ProxyKit.ProxyKitCLI.yaml
+++ b/manifests/p/ProxyKit/ProxyKitCLI/1.0.1/ProxyKit.ProxyKitCLI.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: ProxyKit.ProxyKitCLI
+PackageVersion: 1.0.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New version of **ProxyKit CLI** (`ProxyKit.ProxyKitCLI`): **1.0.1**. Version 1.0.0 is already present; this adds 1.0.1 alongside it and does not modify the existing manifest.

ProxyKit CLI is the standalone command-line companion to ProxyKit — it controls a running proxy engine or launches a bundled headless MITM engine for CI and automation. It is distributed independently of the ProxyKit desktop application.

Delivered, as in 1.0.0, as a zip with a nested portable installer exposing `proxykit` and `proxy-engine` on PATH for both x64 and arm64. No changes to installer type, scope, upgrade behaviour, or package metadata — only the version, URLs, hashes, and release date move.

| Architecture | Installer | SHA256 |
|---|---|---|
| x64 | `proxykit-cli-1.0.1-windows-amd64.zip` | `cb43bbba62a4cbb6ed426580a4bd2807e5d73638b13adf4c43ff0ee3903841d7` |
| arm64 | `proxykit-cli-1.0.1-windows-arm64.zip` | `e0169c7522528d97df1dc010c05027e304bd70729f84d6b0ab0d34994355102e` |

Both hashes come from the `.sha256` sidecars published beside each archive on `release.proxykit.net`. The x64 zip was additionally downloaded in full and hashed directly, confirming the sidecar describes the real bytes rather than only agreeing with itself, and it contains `bin\proxykit.exe` and `bin\proxy-engine.exe` — the exact `RelativeFilePath` entries this manifest declares. Both installer URLs return 200.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)
  <!-- Not applicable: routine version bump, no issue filed. -->

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

<sub>On the two unchecked manifest boxes: the submitter works on macOS and cannot run `winget` locally. In place of `winget validate`, all three files were validated against the published 1.12.0 JSON schemas (`aka.ms/winget-manifest.*.1.12.0.schema.json`) and pass. The sandbox install test has not been run — flagging that honestly rather than ticking the box.</sub>

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/413854)