### PR TITLE
New version: DiegoFagundez.Portify version 0.1.0

### DIFF
--- a/manifests/d/DiegoFagundez/Portify/0.1.0/DiegoFagundez.Portify.installer.yaml
+++ b/manifests/d/DiegoFagundez/Portify/0.1.0/DiegoFagundez.Portify.installer.yaml
@@ -17,6 +17,6 @@ ReleaseDate: "2026-08-07"
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/dfagundez/portify/releases/download/v0.1.0/Portify_0.1.0_x64-setup.exe
-    InstallerSha256: 62D237F00AB5C91443481C00423DFDDB6F9DE6A4E5D2893E0E99A9D88CB3FB5B
+    InstallerSha256: 61511BE101DE6A048B7C276E797843028AE820D5CB4CA2CB1767245A6FC3752D
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/d/DiegoFagundez/Portify/0.1.0/DiegoFagundez.Portify.installer.yaml
+++ b/manifests/d/DiegoFagundez/Portify/0.1.0/DiegoFagundez.Portify.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: DiegoFagundez.Portify
+PackageVersion: 0.1.0
+# WebView2 is the floor here, not Tauri: it ships in Windows 10 1809 and later.
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+# The bundle is built with Tauri's currentUser install mode, so it lands in
+# %LOCALAPPDATA% and never asks for elevation to install.
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+UpgradeBehavior: install
+# Quoted: unquoted, YAML parses this as a date object and the manifest schema
+# wants a string.
+ReleaseDate: "2026-08-07"
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/dfagundez/portify/releases/download/v0.1.0/Portify_0.1.0_x64-setup.exe
+    InstallerSha256: 62D237F00AB5C91443481C00423DFDDB6F9DE6A4E5D2893E0E99A9D88CB3FB5B
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/d/DiegoFagundez/Portify/0.1.0/DiegoFagundez.Portify.locale.en-US.yaml
+++ b/manifests/d/DiegoFagundez/Portify/0.1.0/DiegoFagundez.Portify.locale.en-US.yaml
@@ -1,0 +1,44 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: DiegoFagundez.Portify
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Diego Fagundez
+PublisherUrl: https://github.com/dfagundez
+PublisherSupportUrl: https://github.com/dfagundez/portify/issues
+PackageName: Portify
+PackageUrl: https://github.com/dfagundez/portify
+License: MIT
+LicenseUrl: https://github.com/dfagundez/portify/blob/main/LICENSE
+Copyright: (c) Diego Fagundez
+ShortDescription: See every port in use, and take one back with a click.
+Description: >-
+  Portify replaces the netstat / findstr / taskkill dance with one step. It lists
+  every port in use as one row per port rather than one per socket, shows which
+  process holds each one, and frees a port with a single click or a single
+  command. Before terminating anything it names the other ports the same process
+  is holding, so freeing one port cannot silently take down several.
+
+  It runs from the system tray with a global show/hide hotkey, and ships a
+  companion command line tool. Both are built on one Rust core, so they can never
+  disagree about what a port is or what killing one means.
+Moniker: portify
+Tags:
+  - developer-tools
+  - devops
+  - kill-process
+  - netstat
+  - network
+  - port
+  - ports
+  - process
+  - rust
+  - taskkill
+  - tcp
+  - tray
+  - udp
+ReleaseNotesUrl: https://github.com/dfagundez/portify/releases/tag/v0.1.0
+Documentations:
+  - DocumentLabel: README
+    DocumentUrl: https://github.com/dfagundez/portify#readme
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/d/DiegoFagundez/Portify/0.1.0/DiegoFagundez.Portify.yaml
+++ b/manifests/d/DiegoFagundez/Portify/0.1.0/DiegoFagundez.Portify.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: DiegoFagundez.Portify
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: `DiegoFagundez.Portify` 0.1.0

Portify lists every port in use — one row per port rather than one per socket —
shows which process holds each one, and frees it with a single click or command.
Before terminating anything it names the other ports the same process is
holding, so freeing one port cannot silently take down several.

- Homepage: https://github.com/dfagundez/portify
- Release: https://github.com/dfagundez/portify/releases/tag/v0.1.0
- License: MIT

#### Checklist

- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)? — will sign when the bot asks
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/add? — searched, this is the only one
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`? — **no**, see below
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? — **no**, see below
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

#### What was and was not verified

Being explicit rather than ticking boxes, since two of them are honestly no.

Verified:

- All three manifests validate against the official 1.6.0 JSON schemas
  (`winget-manifest.version`, `.installer`, `.defaultLocale`).
- `PackageIdentifier` and `PackageVersion` agree across the three files.
- The declared `InstallerUrl` resolves, and its SHA-256 matches
  `InstallerSha256` byte for byte against the published release asset.
- The installer itself was installed and used on Windows 11 before release.

**Not** verified: `winget validate` and `winget install --manifest` were not
run. These manifests were authored on Linux, where the winget client does not
exist. I did not want to claim otherwise — the repository CI is a stricter check
than either, and I will act on whatever it reports.

#### Notes

The installer is the Tauri-generated NSIS bundle, built in `currentUser` mode,
so it installs to `%LOCALAPPDATA%` and never requests elevation — hence
`Scope: user`. It supports `/S` for silent installs.

The installer is **not code-signed**; a certificate is tracked in
[dfagundez/portify#4](https://github.com/dfagundez/portify/issues/4).

`MinimumOSVersion` is set by WebView2's floor (Windows 10 1809), not by the
application itself.

The manifests are generated and checked by scripts kept in the project
repository
([packaging/](https://github.com/dfagundez/portify/tree/main/packaging)), so
future version bumps will be mechanical.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/413867)