### PR TITLE
New package: GerardoFC8.ApostropheForWindows version 0.2.0

### DIFF
--- a/manifests/g/GerardoFC8/ApostropheForWindows/0.2.0/GerardoFC8.ApostropheForWindows.installer.yaml
+++ b/manifests/g/GerardoFC8/ApostropheForWindows/0.2.0/GerardoFC8.ApostropheForWindows.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: GerardoFC8.ApostropheForWindows
+PackageVersion: 0.2.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+Scope: user
+UpgradeBehavior: install
+ReleaseDate: 2026-08-07
+FileExtensions:
+- md
+- markdown
+AppsAndFeaturesEntries:
+- DisplayName: Apostrophe
+  Publisher: gerardofranco
+  ProductCode: Apostrophe
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/GerardoFC8/apostrophe-for-windows/releases/download/v0.2.0/Apostrophe_0.2.0_x64-setup.exe
+  InstallerSha256: 9C2D36A2FCAF1E615594FAE4984C4194CCC35EC91DDFB43D53ABD7FCC8A6A78B
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/g/GerardoFC8/ApostropheForWindows/0.2.0/GerardoFC8.ApostropheForWindows.locale.en-US.yaml
+++ b/manifests/g/GerardoFC8/ApostropheForWindows/0.2.0/GerardoFC8.ApostropheForWindows.locale.en-US.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: GerardoFC8.ApostropheForWindows
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: Gerardo Franco
+PublisherUrl: https://github.com/GerardoFC8
+PublisherSupportUrl: https://github.com/GerardoFC8/apostrophe-for-windows/issues
+PackageName: Apostrophe for Windows
+PackageUrl: https://github.com/GerardoFC8/apostrophe-for-windows
+License: GPL-3.0-or-later
+LicenseUrl: https://github.com/GerardoFC8/apostrophe-for-windows/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Gerardo Franco
+ShortDescription: A native, distraction-free Markdown editor for Windows — a Tauri 2 + Rust port of GNOME's Apostrophe.
+Description: |-
+  Apostrophe for Windows is a native, minimal, distraction-free Markdown editor, ported from
+  GNOME's Apostrophe and built with Tauri 2 and Rust.
+
+  It ships with a live preview, focus and Hemingway writing modes, live Markdown highlighting,
+  spell checking, autosave with crash recovery, and light, dark and sepia themes. The interface
+  is available in English and Spanish.
+
+  Documents can be exported to PDF, HTML, ODT, DOCX, EPUB and LaTeX. The conversion engines
+  (pandoc and typst) are bundled, so nothing else needs to be installed.
+Moniker: apostrophe
+Tags:
+- editor
+- markdown
+- markdown-editor
+- notes
+- pandoc
+- text-editor
+- typst
+- writing
+ReleaseNotesUrl: https://github.com/GerardoFC8/apostrophe-for-windows/releases/tag/v0.2.0
+Documentations:
+- DocumentLabel: README
+  DocumentUrl: https://github.com/GerardoFC8/apostrophe-for-windows/blob/main/README.en.md
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/g/GerardoFC8/ApostropheForWindows/0.2.0/GerardoFC8.ApostropheForWindows.yaml
+++ b/manifests/g/GerardoFC8/ApostropheForWindows/0.2.0/GerardoFC8.ApostropheForWindows.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: GerardoFC8.ApostropheForWindows
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New package: `GerardoFC8.ApostropheForWindows` version `0.2.0`

A native, distraction-free Markdown editor for Windows — a Tauri 2 + Rust port of
GNOME's [Apostrophe](https://gitlab.gnome.org/World/apostrophe), distributed under
GPL-3.0-or-later like the original.

- **Repository:** https://github.com/GerardoFC8/apostrophe-for-windows
- **Release:** https://github.com/GerardoFC8/apostrophe-for-windows/releases/tag/v0.2.0

#### Checklist

- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?

#### Notes

`winget validate` passes. The local `winget install --manifest` check is not ticked because
it requires enabling `LocalManifestFiles` with administrator rights, which was not done; the
installer itself was installed and exercised manually from the published release.

The installer is NSIS (`nullsoft`), installs per-user (no elevation) and supports silent
installation through the standard `/S` switch. The language-selection dialog is skipped in
silent mode by NSIS's own `${Silent}` guard around `MUI_LANGDLL_DISPLAY`.

The installer is not code-signed; this is a free, non-commercial open-source project.
