### PR TITLE
New version: jefuriiij.PingMeter version 0.4.0

### DIFF
--- a/manifests/j/jefuriiij/PingMeter/0.4.0/jefuriiij.PingMeter.installer.yaml
+++ b/manifests/j/jefuriiij/PingMeter/0.4.0/jefuriiij.PingMeter.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: jefuriiij.PingMeter
+PackageVersion: 0.4.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.22000.0
+InstallerType: portable
+Commands:
+- pingmeter
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.10
+ReleaseDate: 2026-08-08
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/jefuriiij/ping-meter/releases/download/v0.4.0/PingMeter.exe
+  InstallerSha256: A2D17EC0C0F0C56E5B61E198D0075B9C24C31FC43681C12FE3A6BEE33DAF1E16
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/j/jefuriiij/PingMeter/0.4.0/jefuriiij.PingMeter.locale.en-US.yaml
+++ b/manifests/j/jefuriiij/PingMeter/0.4.0/jefuriiij.PingMeter.locale.en-US.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: jefuriiij.PingMeter
+PackageVersion: 0.4.0
+PackageLocale: en-US
+Publisher: jefuriiij
+PublisherUrl: https://github.com/jefuriiij
+PublisherSupportUrl: https://github.com/jefuriiij/ping-meter/issues
+PackageName: PingMeter
+PackageUrl: https://github.com/jefuriiij/ping-meter
+License: MIT
+LicenseUrl: https://github.com/jefuriiij/ping-meter/blob/main/LICENSE
+Copyright: Copyright (c) 2026 jefuriiij
+ShortDescription: Taskbar-embedded ping monitor with network repair and DNS tools
+Description: |-
+  PingMeter shows your live ping (ms) embedded directly in the Windows 11 taskbar, next
+  to the tray clock — on the primary taskbar, secondary-monitor taskbars, or all of them.
+  It replaces keeping "ping google.com -t" open in a terminal: color-coded latency with
+  configurable thresholds, a sparkline of recent pings, packet-loss percentage, hover
+  stats (min/avg/max/loss and current DNS servers), quick switching between preset
+  targets, and a daily log of outages, latency spikes and hourly summaries.
+
+  It also includes optional network tools you start yourself from the settings window:
+  a DNS cache flush, a full connection repair (the standard flush DNS / release / renew
+  / winsock reset / TCP-IP reset sequence), and switching the active adapter's IPv4 DNS
+  between automatic, well-known public resolvers, or addresses you type. These actions
+  run Windows' own ipconfig and netsh commands and require your approval at a Windows
+  permission prompt; the app itself runs without administrator rights, collects no
+  personal data, and survives Explorer restarts.
+Tags:
+- diagnostics
+- dns
+- latency
+- monitor
+- network
+- ping
+- taskbar
+ReleaseNotesUrl: https://github.com/jefuriiij/ping-meter/releases/tag/v0.4.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/j/jefuriiij/PingMeter/0.4.0/jefuriiij.PingMeter.yaml
+++ b/manifests/j/jefuriiij/PingMeter/0.4.0/jefuriiij.PingMeter.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: jefuriiij.PingMeter
+PackageVersion: 0.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Version update for **jefuriiij.PingMeter** (0.2.0 → 0.4.0). I'm the package author.

Notes for validation:

- **Fixed the issue found during manual validation of #404863** — thanks @stephengillie. The Settings window is now resizable (`FormBorderStyle.Sizable` + maximize box, 460×300 minimum) and clamps itself to the monitor's work area on show, so it can no longer extend past the bottom of a small VM screen; its pages scroll and the OK/Apply/Cancel strip is docked to the form, so every control stays reachable at any window height.
- **Dependency changed to `Microsoft.DotNet.DesktopRuntime.10`** (was `.8`) — the app was retargeted to .NET 10.
- **Description expanded** to cover functionality added since 0.2.0: packet-loss display, DNS info in the hover tooltip, and the optional network tools (DNS cache flush, the standard connection-repair sequence, and IPv4 DNS switching). Those actions run Windows' own `ipconfig`/`netsh` only when the user clicks them and approves the Windows permission prompt; the app itself runs unelevated and downloads/executes no remote code.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/README.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/413979)