### PR TITLE
New version: MarcoSumari.IngePresupuestos version 2.9.0

### DIFF
--- a/manifests/m/MarcoSumari/IngePresupuestos/2.9.0/MarcoSumari.IngePresupuestos.installer.yaml
+++ b/manifests/m/MarcoSumari/IngePresupuestos/2.9.0/MarcoSumari.IngePresupuestos.installer.yaml
@@ -1,0 +1,33 @@
+# Created with WinGet Releaser using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: MarcoSumari.IngePresupuestos
+PackageVersion: 2.9.0
+InstallerLocale: es
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: inno
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Custom: /ALLUSERS
+UpgradeBehavior: install
+ProductCode: '{7F0E6389-C972-4472-B7A9-1A14FFD8CF0F}_is1'
+ReleaseDate: 2026-08-08
+AppsAndFeaturesEntries:
+- DisplayName: IngePresupuestos 2.9.0
+  Publisher: Ing. Marco Sumari Tellez
+  ProductCode: '{7F0E6389-C972-4472-B7A9-1A14FFD8CF0F}_is1'
+ElevationRequirement: elevatesSelf
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles%\IngePresupuestos'
+Installers:
+- Architecture: x86
+  InstallerUrl: https://downloads.ingepresupuestos.com/v2.9.0/ingepresupuestos-setup-v2.9.0.exe
+  InstallerSha256: C74EAB4D2FBBDE59340429442598068202A6BCA080A6D23C2F35FB601A58434A
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/MarcoSumari/IngePresupuestos/2.9.0/MarcoSumari.IngePresupuestos.locale.es-PE.yaml
+++ b/manifests/m/MarcoSumari/IngePresupuestos/2.9.0/MarcoSumari.IngePresupuestos.locale.es-PE.yaml
@@ -1,0 +1,48 @@
+# Created with WinGet Releaser using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: MarcoSumari.IngePresupuestos
+PackageVersion: 2.9.0
+PackageLocale: es-PE
+Publisher: Marco Sumari
+PublisherUrl: https://ingepresupuestos.com/
+PublisherSupportUrl: https://ingepresupuestos.com
+PrivacyUrl: https://ingepresupuestos.com/privacidad
+Author: Ing. Marco Sumari
+PackageName: IngePresupuestos
+PackageUrl: https://ingepresupuestos.com/
+License: Proprietary
+LicenseUrl: https://ingepresupuestos.com/licencia
+Copyright: Copyright (c) 2026 Marco Sumari / Sumari SAC
+CopyrightUrl: https://ingepresupuestos.com/licencia
+ShortDescription: Software de presupuestos de obra con ACU, cronograma Gantt valorizado y 13 reportes profesionales.
+Description: |-
+  IngePresupuestos es el software de presupuestos de obra para ingenieros y
+  arquitectos. Elabora presupuestos con Análisis de Costos Unitarios (ACU),
+  cronogramas valorizados (Gantt con ruta crítica y CPM), fórmula polinómica e
+  índices INEI, metrados (incluido acero), y 13 reportes profesionales
+  exportables a PDF, Excel, Word, ODS y ODT. Importa tus presupuestos existentes
+  de S10, PowerCost y Delphin, además de Excel e IFC. Incluye Control de Obra
+  (requerimientos, almacén, cuaderno, valorizaciones y curva S) y un asistente
+  con inteligencia artificial opcional (con tu propia clave). Descarga y uso sin
+  costo: presupuestos, ACU, cronograma, control de obra, importadores y todos
+  los reportes del presupuesto en PDF. La exportación editable (Excel, Word,
+  ODS, ODT, MS Project) y los reportes de Control de Obra se activan con
+  licencia, con 30 días de prueba completa. Tus datos quedan en tu equipo.
+Moniker: ingepresupuestos
+Tags:
+- acu
+- construccion
+- cronograma
+- ingenieria-civil
+- metrados
+- obra
+- presupuestos
+- s10
+ReleaseNotes: |-
+  Iconografía renovada y nuevo modelo de uso: aplicación gratuita en lo esencial
+  (reportes del presupuesto en PDF incluidos); la exportación editable y los
+  reportes de Control de Obra se activan con licencia, con 30 días de prueba.
+ReleaseNotesUrl: https://ingepresupuestos.com/licencia
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/MarcoSumari/IngePresupuestos/2.9.0/MarcoSumari.IngePresupuestos.yaml
+++ b/manifests/m/MarcoSumari/IngePresupuestos/2.9.0/MarcoSumari.IngePresupuestos.yaml
@@ -1,0 +1,8 @@
+# Created with WinGet Releaser using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: MarcoSumari.IngePresupuestos
+PackageVersion: 2.9.0
+DefaultLocale: es-PE
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## New version of an existing package

- PackageIdentifier: MarcoSumari.IngePresupuestos
- PackageVersion: 2.9.0

Notes:
- InstallerUrl moved from GitHub Releases to the publisher's own CDN (downloads.ingepresupuestos.com) — the source repository became private, so previous release-asset URLs are no longer publicly accessible. The publisher domain is already referenced as PackageUrl in prior versions.
- License changed from GPL-3.0 to Proprietary as of 2.9.0 (versions ≤2.8.8 remain GPL). Locale fields updated accordingly.
- SHA256 verified against the published installer.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/413997)