### PR TITLE
New version: Rorkai.ASC version 3.6.0

### DIFF
--- a/manifests/r/Rorkai/ASC/3.6.0/Rorkai.ASC.installer.yaml
+++ b/manifests/r/Rorkai/ASC/3.6.0/Rorkai.ASC.installer.yaml
@@ -1,0 +1,12 @@
+# Created with App-Store-Connect-CLI/scripts/generate_winget_manifests.py
+PackageIdentifier: Rorkai.ASC
+PackageVersion: 3.6.0
+InstallerType: portable
+Commands:
+  - asc
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/rorkai/App-Store-Connect-CLI/releases/download/3.6.0/asc_3.6.0_windows_amd64.exe
+    InstallerSha256: 41F957E82A6CA759DDA11E736A60352DAFC1F9A99178B6B1BD87300FC2F93834
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/r/Rorkai/ASC/3.6.0/Rorkai.ASC.installer.yaml
+++ b/manifests/r/Rorkai/ASC/3.6.0/Rorkai.ASC.installer.yaml
@@ -7,6 +7,6 @@ Commands:
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/rorkai/App-Store-Connect-CLI/releases/download/3.6.0/asc_3.6.0_windows_amd64.exe
-    InstallerSha256: 41F957E82A6CA759DDA11E736A60352DAFC1F9A99178B6B1BD87300FC2F93834
+    InstallerSha256: 0152A9FCC8C74FDBDF1F99380BA7BCEFBE988B9E5841ECAF9BCAFF86FEF0C802
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/r/Rorkai/ASC/3.6.0/Rorkai.ASC.locale.en-US.yaml
+++ b/manifests/r/Rorkai/ASC/3.6.0/Rorkai.ASC.locale.en-US.yaml
@@ -1,0 +1,20 @@
+# Created with App-Store-Connect-CLI/scripts/generate_winget_manifests.py
+PackageIdentifier: Rorkai.ASC
+PackageVersion: 3.6.0
+PackageLocale: en-US
+Publisher: Rorkai
+PackageName: asc
+PackageUrl: https://github.com/rorkai/App-Store-Connect-CLI
+License: MIT
+LicenseUrl: https://github.com/rorkai/App-Store-Connect-CLI/blob/main/LICENSE
+ShortDescription: Fast, scriptable CLI for the App Store Connect API.
+Moniker: asc
+Tags:
+  - app-store-connect
+  - app-store-connect-api
+  - cli
+  - ios
+  - testflight
+ReleaseNotesUrl: https://github.com/rorkai/App-Store-Connect-CLI/releases/tag/3.6.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/r/Rorkai/ASC/3.6.0/Rorkai.ASC.yaml
+++ b/manifests/r/Rorkai/ASC/3.6.0/Rorkai.ASC.yaml
@@ -1,0 +1,6 @@
+# Created with App-Store-Connect-CLI/scripts/generate_winget_manifests.py
+PackageIdentifier: Rorkai.ASC
+PackageVersion: 3.6.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Adds Rorkai.ASC 3.6.0 from https://github.com/rorkai/App-Store-Connect-CLI/releases/tag/3.6.0.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/414041)