### PR TITLE
New package: QUniBone.QUniLatorInstaller version 0.5.0

### DIFF
--- a/manifests/q/QUniBone/QUniLatorInstaller/0.5.0/QUniBone.QUniLatorInstaller.installer.yaml
+++ b/manifests/q/QUniBone/QUniLatorInstaller/0.5.0/QUniBone.QUniLatorInstaller.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: QUniBone.QUniLatorInstaller
+PackageVersion: 0.5.0
+InstallerType: portable
+Commands:
+  - qunilator-installer
+ReleaseDate: 2026-08-08
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/QUniBone/qunilator-installer/releases/download/v0.5.0/qunilator-installer-windows-amd64.exe
+    InstallerSha256: FDBBD385C04559D02FFE628E533A9E85E9E6E0F26B9412814BF875CADADD4DCB
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/q/QUniBone/QUniLatorInstaller/0.5.0/QUniBone.QUniLatorInstaller.locale.en-US.yaml
+++ b/manifests/q/QUniBone/QUniLatorInstaller/0.5.0/QUniBone.QUniLatorInstaller.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: QUniBone.QUniLatorInstaller
+PackageVersion: 0.5.0
+PackageLocale: en-US
+Publisher: QUniBone
+PublisherUrl: https://github.com/QUniBone
+PublisherSupportUrl: https://github.com/QUniBone/qunilator-installer/issues
+Author: Hans Hübner
+PackageName: QUniLator Installer
+PackageUrl: https://github.com/QUniBone/qunilator-installer
+License: BSD-2-Clause
+LicenseUrl: https://github.com/QUniBone/qunilator-installer/blob/main/LICENSE
+Copyright: Copyright (c) 2026, Hans Hübner and the QUniBone contributors
+ShortDescription: Writes a QUniLator image to an SD card and sets the card up before it boots
+Description: |-
+  QUniLator drives a real UNIBUS or QBUS backplane from a BeagleBone Black, so a
+  PDP-11 can boot from emulated disks and tapes. This writes its release image to
+  an SD card: it fetches the release, writes the card, reads back what it wrote,
+  and can settle the operator identity, host name, ssh keys and network address
+  on the card before it has ever booted.
+
+  Writing a raw disk needs administrator rights, which it asks for as it starts.
+Moniker: qunilator-installer
+Tags:
+  - beaglebone
+  - dec
+  - emulator
+  - imaging
+  - pdp-11
+  - sd-card
+  - unibus
+ReleaseNotesUrl: https://github.com/QUniBone/qunilator-installer/releases/tag/v0.5.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/q/QUniBone/QUniLatorInstaller/0.5.0/QUniBone.QUniLatorInstaller.yaml
+++ b/manifests/q/QUniBone/QUniLatorInstaller/0.5.0/QUniBone.QUniLatorInstaller.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: QUniBone.QUniLatorInstaller
+PackageVersion: 0.5.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package: **QUniBone.QUniLatorInstaller version 0.5.0**

QUniLator drives a real UNIBUS or QBUS backplane from a BeagleBone Black so a
PDP-11 can boot from emulated disks and tapes. This package is the tool that
writes its release image to an SD card and sets the card up before it has ever
booted.

A single portable executable, published by the project itself at
https://github.com/QUniBone/qunilator-installer/releases/tag/v0.5.0 — the
`InstallerSha256` here was taken from the `SHA256SUMS` published beside the
binary in that release.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

### On the two unchecked manifest boxes

These manifests were prepared on macOS, so `winget validate` and `winget install`
have not been run against them. What was checked instead: the three files parse,
carry the required fields for their manifest types, agree on identifier and
version, and the installer digest matches the `SHA256SUMS` published with the
release. I will run both commands and report back here.

The binary is not code-signed, so SmartScreen warns on a browser download; it
carries an application manifest requesting administrator rights, which it needs
to write a raw disk.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/414057)