### PR TITLE
New package: ClaudioAbierto.RapidoFS version 0.2.0

### DIFF
--- a/manifests/c/ClaudioAbierto/RapidoFS/0.2.0/ClaudioAbierto.RapidoFS.installer.yaml
+++ b/manifests/c/ClaudioAbierto/RapidoFS/0.2.0/ClaudioAbierto.RapidoFS.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ClaudioAbierto.RapidoFS
+PackageVersion: 0.2.0
+InstallerType: zip
+NestedInstallerType: portable
+Commands:
+  - rao
+ReleaseDate: 2026-08-08
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/elclaudioabierto/rapido-fs/releases/download/v0.2.0/rao-windows-x64.zip
+    InstallerSha256: 1179FCEBE73246B3A429ACFD6EC0B6A4496C37935EEE9ED319096E6DDE60A59B
+    NestedInstallerFiles:
+      - RelativeFilePath: rao.exe
+        PortableCommandAlias: rao
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/ClaudioAbierto/RapidoFS/0.2.0/ClaudioAbierto.RapidoFS.locale.en-US.yaml
+++ b/manifests/c/ClaudioAbierto/RapidoFS/0.2.0/ClaudioAbierto.RapidoFS.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ClaudioAbierto.RapidoFS
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: Claudio Abierto
+PublisherUrl: https://github.com/elclaudioabierto
+PublisherSupportUrl: https://github.com/elclaudioabierto/rapido-fs/issues
+Author: Claudio Abierto
+PackageName: rapido-fs
+PackageUrl: https://github.com/elclaudioabierto/rapido-fs
+License: MIT
+LicenseUrl: https://github.com/elclaudioabierto/rapido-fs/blob/v0.2.0/LICENSE
+ShortDescription: Fast, non-destructive filesystem inventory and search.
+Description: >-
+  rapido-fs provides the rao command for ranking folders and files by size,
+  searching filesystem metadata, and exporting reports without modifying the
+  scanned tree.
+Moniker: rao
+Tags:
+  - cli
+  - disk-usage
+  - filesystem
+  - search
+ReleaseNotesUrl: https://github.com/elclaudioabierto/rapido-fs/releases/tag/v0.2.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/ClaudioAbierto/RapidoFS/0.2.0/ClaudioAbierto.RapidoFS.yaml
+++ b/manifests/c/ClaudioAbierto/RapidoFS/0.2.0/ClaudioAbierto.RapidoFS.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ClaudioAbierto.RapidoFS
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Adds rapido-fs 0.2.0 as a portable x64 Windows package from the official GitHub Release. The archive hash and manifest were validated locally with WinGet 1.29.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/414078)