### PR TITLE
New package: zuli2021.ZuliProxyBrokerExtended version 1.1.0

### DIFF
--- a/manifests/z/zuli2021/ZuliProxyBrokerExtended/1.1.0/zuli2021.ZuliProxyBrokerExtended.installer.yaml
+++ b/manifests/z/zuli2021/ZuliProxyBrokerExtended/1.1.0/zuli2021.ZuliProxyBrokerExtended.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: zuli2021.ZuliProxyBrokerExtended
+PackageVersion: 1.1.0
+InstallerType: zip
+Commands:
+  - proxybroker
+Installers:
+  - Architecture: x64
+    InstallerType: zip
+    InstallerUrl: https://github.com/zuli2021/zuli-proxybroker-extended/releases/download/v1.1.0/proxybroker-v1.1.0-x86_64-pc-windows-msvc.zip
+    InstallerSha256: 498fe40e8881538fe9ec8b99a9b5e3a07ada163ae965159fd3919c982e2dfd5e
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: proxybroker.exe
+        PortableCommandAlias: proxybroker
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/z/zuli2021/ZuliProxyBrokerExtended/1.1.0/zuli2021.ZuliProxyBrokerExtended.locale.en-US.yaml
+++ b/manifests/z/zuli2021/ZuliProxyBrokerExtended/1.1.0/zuli2021.ZuliProxyBrokerExtended.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: zuli2021.ZuliProxyBrokerExtended
+PackageVersion: 1.1.0
+PackageLocale: en-US
+Publisher: zuli2021
+PublisherUrl: https://github.com/zuli2021/zuli-proxybroker-extended
+PublisherSupportUrl: https://github.com/zuli2021/zuli-proxybroker-extended/issues
+PackageName: Zuli ProxyBroker Extended
+PackageUrl: https://github.com/zuli2021/zuli-proxybroker-extended
+License: Apache-2.0
+LicenseUrl: https://github.com/zuli2021/zuli-proxybroker-extended/blob/v1.1.0/LICENSE
+ShortDescription: Find, validate, and serve rotating public HTTP(S) and SOCKS4/5 proxies.
+Description: >-
+  Zuli ProxyBroker Extended is a Rust CLI and library that discovers public proxies,
+  validates and classifies them by anonymity, and serves a rotating proxy endpoint,
+  with offline DB-IP country lookup. The executable is `proxybroker`.
+Moniker: proxybroker
+Tags:
+  - proxy
+  - socks
+  - http
+  - scraper
+  - checker
+ReleaseNotesUrl: https://github.com/zuli2021/zuli-proxybroker-extended/releases/tag/v1.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/z/zuli2021/ZuliProxyBrokerExtended/1.1.0/zuli2021.ZuliProxyBrokerExtended.yaml
+++ b/manifests/z/zuli2021/ZuliProxyBrokerExtended/1.1.0/zuli2021.ZuliProxyBrokerExtended.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: zuli2021.ZuliProxyBrokerExtended
+PackageVersion: 1.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Adds the Zuli ProxyBroker Extended 1.1.0 package.

- Publisher: zuli2021
- Package: ZuliProxyBrokerExtended
- Version: 1.1.0
- InstallerType: zip (nested portable, alias `proxybroker`)
- License: Apache-2.0

Manifest path: `manifests/z/zuli2021/ZuliProxyBrokerExtended/1.1.0/`

[Zuli ProxyBroker Extended v1.1.0](https://github.com/zuli2021/zuli-proxybroker-extended/releases/tag/v1.1.0)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/414112)