### PR TITLE
New package: ArnsteinSkara.AppCenter version 1.0.2

### DIFF
--- a/manifests/a/ArnsteinSkara/AppCenter/1.0.2/ArnsteinSkara.AppCenter.installer.yaml
+++ b/manifests/a/ArnsteinSkara/AppCenter/1.0.2/ArnsteinSkara.AppCenter.installer.yaml
@@ -1,0 +1,22 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# Rendered by deploy.bat - edit the template, not releases\winget\*.
+PackageIdentifier: ArnsteinSkara.AppCenter
+PackageVersion: "1.0.2"
+MinimumOSVersion: 10.0.17763.0
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+# Inno registers itself in Add/Remove as <AppId>_is1 - this is how winget spots
+# an existing install and offers the upgrade.
+ProductCode: "{8F3C1B62-4A7D-4E29-9C6E-1D5B0A7F2E84}_is1"
+ReleaseDate: 2026-08-08
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/RaZiel-no/AppCenter/releases/download/v1.0.2/AppCenter-1.0.2-Setup.exe
+    InstallerSha256: 897537D59CBDB363C18EAAB5483B1AC34D562DAECF05D7FBED70A87B20C8F008
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/a/ArnsteinSkara/AppCenter/1.0.2/ArnsteinSkara.AppCenter.locale.en-US.yaml
+++ b/manifests/a/ArnsteinSkara/AppCenter/1.0.2/ArnsteinSkara.AppCenter.locale.en-US.yaml
@@ -1,0 +1,39 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# Rendered by deploy.bat - edit the template, not releases\winget\*.
+PackageIdentifier: ArnsteinSkara.AppCenter
+PackageVersion: "1.0.2"
+PackageLocale: en-US
+Publisher: Arnstein Skara
+PublisherUrl: https://github.com/RaZiel-no/AppCenter
+PublisherSupportUrl: https://github.com/RaZiel-no/AppCenter/issues
+PackageName: App Center
+PackageUrl: https://github.com/RaZiel-no/AppCenter
+License: GPL-3.0
+LicenseUrl: https://github.com/RaZiel-no/AppCenter/blob/main/LICENSE
+Copyright: Copyright © 2026 Arnstein Skara
+CopyrightUrl: https://github.com/RaZiel-no/AppCenter/blob/main/LICENSE
+ShortDescription: Ubuntu's App Center, rebuilt for Windows on top of winget.
+Description: |-
+  A graphical front-end for the Windows Package Manager, modelled on Ubuntu's
+  App Center. Browse a curated catalogue of 178 apps across Featured,
+  Productivity, Development and Games, search the whole winget repository, and
+  install, update or remove packages from one place.
+
+  Every install, upgrade and uninstall is a real winget command against the
+  local machine, and each one goes through a confirmation dialog first.
+
+  Free software under the GPL-3.0, the same licence Canonical publish Ubuntu's
+  App Center under. It is an independent Windows implementation that shares no
+  code with theirs, and is not affiliated with or endorsed by Canonical.
+Moniker: appcenter
+Tags:
+  - app-store
+  - foss
+  - gui
+  - open-source
+  - package-manager
+  - software-center
+  - winget
+ReleaseNotesUrl: https://github.com/RaZiel-no/AppCenter/releases/tag/v1.0.2
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/a/ArnsteinSkara/AppCenter/1.0.2/ArnsteinSkara.AppCenter.yaml
+++ b/manifests/a/ArnsteinSkara/AppCenter/1.0.2/ArnsteinSkara.AppCenter.yaml
@@ -1,0 +1,7 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# Rendered by deploy.bat - edit the template, not releases\winget\*.
+PackageIdentifier: ArnsteinSkara.AppCenter
+PackageVersion: "1.0.2"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
First submission of **App Center** — a GPL-3.0 open-source winget front-end for Windows (an app-store-style UI over the winget catalogue).

- **PackageIdentifier:** ArnsteinSkara.AppCenter
- **PackageVersion:** 1.0.2
- Inno Setup installer, per-user scope, unsigned (new open-source project); `ProductCode` is pinned for upgrade correlation.
- If the .NET 10 Desktop Runtime is missing, the installer downloads it from `aka.ms` and installs it silently (framework-dependent build keeps the installer at 2.3 MB).
- Not affiliated with Canonical's Ubuntu App Center (which openly inspired it) or Microsoft's retired Visual Studio App Center — the README carries a non-affiliation note, and no package of this name exists in the community repo.

---

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)? (first contribution — will sign when the CLA bot prompts)
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`? (end-to-end: downloaded from the InstallerUrl, hash verified, silent install and uninstall)
- [x] Does your manifest conform to the [1.6 schema](https://learn.microsoft.com/windows/package-manager/package/manifest)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/414192)