### PR TITLE
New package: SerZhyAle.FastMediaSorter.Server version 26.8.8.2305

### DIFF
--- a/manifests/s/SerZhyAle/FastMediaSorter/Server/26.8.8.2305/SerZhyAle.FastMediaSorter.Server.installer.yaml
+++ b/manifests/s/SerZhyAle/FastMediaSorter/Server/26.8.8.2305/SerZhyAle.FastMediaSorter.Server.installer.yaml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+#
+# The same hard-won rules as the User edition manifest apply here - read
+# docs/specifications/done/SPECIFICATION_WINGET_PUBLISHING.md before editing:
+#   * point at the Inno setup.exe directly (InstallerType: inno). Never at a ZIP.
+#   * NO `Dependencies` (sends winget into a resolution loop -> 0x8A150044).
+#   * NO `NestedInstallerType` (the "inconsistency" note is a non-blocking guide).
+#
+# Two things DIFFER from the User manifest, and both are deliberate:
+#
+#   * `Scope: machine`. The User manifest omits Scope entirely, because declaring
+#     `user` there forced a non-elevated flow that failed. Here the product is a
+#     Windows service, a machine state directory and a firewall rule - it is
+#     machine-scope by construction, and the installer is PrivilegesRequired=admin.
+#     Declaring it makes winget request elevation instead of discovering mid-install
+#     that it needed it.
+#
+#   * `MinimumOSVersion: 10.0.14393`. The User manifest deliberately omits this
+#     because its setup also installs a 32-bit net48 viewer for Windows 7/8.1 and the
+#     declaration would hide the package from exactly those machines. This package
+#     has no such half: the Share Manager is .NET 10 x64 and the whole point is a
+#     service surviving logoff, so the floor is real and stating it keeps the package
+#     off machines where it cannot work.
+#
+# The silent switches are the SAME as the User edition's - but note the Server
+# installer refuses a silent install when a User edition is present unless
+# /MIGRATEFROMUSER is passed, so an unattended migration is never implicit.
+
+PackageIdentifier: SerZhyAle.FastMediaSorter.Server
+PackageVersion: "26.8.8.2305"
+InstallerType: inno
+Scope: machine
+MinimumOSVersion: 10.0.14393
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP- /MIGRATEFROMUSER=yes
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP- /MIGRATEFROMUSER=yes
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/SerZhyAle/FastMediaSorter_Lite/releases/download/v26.8.8.2305/FastMediaSorter-26.8.8.2305-windows-x64-server-setup.exe
+  InstallerSha256: D6E7F910191D6A5D9DF74289D2CEA82835DCD254F2BA363A37B143F95C6168B6
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-08-08

--- a/manifests/s/SerZhyAle/FastMediaSorter/Server/26.8.8.2305/SerZhyAle.FastMediaSorter.Server.locale.en-US.yaml
+++ b/manifests/s/SerZhyAle/FastMediaSorter/Server/26.8.8.2305/SerZhyAle.FastMediaSorter.Server.locale.en-US.yaml
@@ -1,0 +1,66 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: SerZhyAle.FastMediaSorter.Server
+PackageVersion: "26.8.8.2305"
+PackageLocale: en-US
+Publisher: SZA
+PublisherUrl: https://github.com/SerZhyAle
+PublisherSupportUrl: https://github.com/SerZhyAle/FastMediaSorter_Lite/issues
+Author: Serhii Zhyhunenko
+# FROZEN once published: it must keep matching the ARP DisplayName written by
+# FastMediaSorterServer.iss, which is how `winget upgrade` correlates this package.
+# It is deliberately NOT "FastMediaSorter LITE" - that name belongs to the User
+# edition package and sharing it would make the two indistinguishable to winget.
+PackageName: Fast Media Sorter Folder Share Server
+PackageUrl: https://serzhyale.github.io/FastMediaSorter_LITE/server.html
+License: MIT
+LicenseUrl: https://github.com/SerZhyAle/FastMediaSorter_Lite/blob/main/LICENSE
+Copyright: Copyright (c) 2025 SZA
+ShortDescription: Always-on folder sharing to Android over SFTP - a Windows service that starts at boot and serves with nobody signed in. Administrator rights required.
+Description: |-
+  The Server edition of Fast Media Sorter's folder sharing. It publishes the folders you choose to
+  an Android phone over SFTP and keeps them reachable whenever Windows is running - from boot,
+  before anyone logs on, through logoff, and after a crash (the service restarts itself).
+
+  Install this only if the machine's job is to stay available: a dedicated server, a VPS, a
+  NAS-like Windows box, an always-on home server. On an ordinary PC the regular package
+  (SerZhyAle.FastMediaSorter) already shares folders while you are signed in, and needs no
+  administrator rights.
+
+  This is not a different protocol or a second Android app. SFTP, the QR / .fmscfg pairing format
+  and the phone-side reconnect behaviour are identical - only the host differs: the Windows Service
+  Control Manager runs the worker instead of your desktop session. The two editions never run at
+  the same time; installing this one migrates the existing setup and keeps the same host-key
+  fingerprint, so phones already paired do not have to be paired again.
+
+  What the installation does, all of it visible and administrator-approved: registers the
+  FastMediaSorterCompanionSFTP service (delayed automatic start, running as LOCAL SERVICE),
+  creates a machine state directory with a restricted ACL for the host key and credentials, and
+  adds one program-scoped inbound firewall rule for the worker. Nothing is shared until you pick
+  the folders - the service never guesses. Uninstalling stops and deletes the service and removes
+  the firewall rule; your host key is kept unless you delete it yourself.
+
+  Setup requires administrator rights and Windows 10 version 1607 or newer, Windows 11, or
+  Windows Server 2016 or newer. The management console is available in 13 languages.
+Moniker: fastmediasorter-server
+Tags:
+- android
+- backup
+- file-server
+- file-sharing
+- headless
+- lan
+- media
+- server
+- service
+- sftp
+- share
+- windows-service
+ReleaseNotesUrl: https://github.com/SerZhyAle/FastMediaSorter_Lite/releases
+Documentations:
+- DocumentLabel: Server setup guide
+  DocumentUrl: https://serzhyale.github.io/FastMediaSorter_LITE/server.html
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/SerZhyAle/FastMediaSorter_Lite/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/SerZhyAle/FastMediaSorter/Server/26.8.8.2305/SerZhyAle.FastMediaSorter.Server.locale.en-US.yaml
+++ b/manifests/s/SerZhyAle/FastMediaSorter/Server/26.8.8.2305/SerZhyAle.FastMediaSorter.Server.locale.en-US.yaml
@@ -12,7 +12,7 @@ Author: Serhii Zhyhunenko
 # It is deliberately NOT "FastMediaSorter LITE" - that name belongs to the User
 # edition package and sharing it would make the two indistinguishable to winget.
 PackageName: Fast Media Sorter Folder Share Server
-PackageUrl: https://serzhyale.github.io/FastMediaSorter_LITE/server.html
+PackageUrl: https://serzhyale.github.io/FastMediaSorter_Lite/server.html
 License: MIT
 LicenseUrl: https://github.com/SerZhyAle/FastMediaSorter_Lite/blob/main/LICENSE
 Copyright: Copyright (c) 2025 SZA
@@ -59,7 +59,7 @@ Tags:
 ReleaseNotesUrl: https://github.com/SerZhyAle/FastMediaSorter_Lite/releases
 Documentations:
 - DocumentLabel: Server setup guide
-  DocumentUrl: https://serzhyale.github.io/FastMediaSorter_LITE/server.html
+  DocumentUrl: https://serzhyale.github.io/FastMediaSorter_Lite/server.html
 - DocumentLabel: Wiki
   DocumentUrl: https://github.com/SerZhyAle/FastMediaSorter_Lite/wiki
 ManifestType: defaultLocale

--- a/manifests/s/SerZhyAle/FastMediaSorter/Server/26.8.8.2305/SerZhyAle.FastMediaSorter.Server.yaml
+++ b/manifests/s/SerZhyAle/FastMediaSorter/Server/26.8.8.2305/SerZhyAle.FastMediaSorter.Server.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+#
+# SERVER edition manifest set - the always-on Folder Share Server.
+# See docs/specifications/done/SPECIFICATION_SHARE_SYSTEM_SERVICE.md §1.2.
+#
+# This is a SEPARATE winget package from SerZhyAle.FastMediaSorter, on purpose:
+#   * different installer, different AppId, different ARP DisplayName, different
+#     install directory - so `winget upgrade` correlates each edition to its own
+#     product and can never hand a machine the other one;
+#   * a user who types this identifier has made the product choice deliberately.
+#     The existing SerZhyAle.FastMediaSorter package must NEVER start installing a
+#     service silently - its behavior stays user-session/viewer-safe.
+#
+# PackageIdentifier and PackageName are FROZEN once the first version is published.
+# PackageName must keep matching the installed ARP DisplayName written by
+# publishing/installer/FastMediaSorterServer.iss (UninstallDisplayName), which is
+# how winget correlates upgrades.
+#
+# Version/InstallerUrl/InstallerSha256 below are placeholders until the first Server
+# release exists; they are filled by wingetcreate from the published GitHub asset,
+# exactly like the User edition set. Do not hand-edit a SHA.
+
+PackageIdentifier: SerZhyAle.FastMediaSorter.Server
+PackageVersion: "26.8.8.2305"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

**New package: `SerZhyAle.FastMediaSorter.Server`** - "Fast Media Sorter Folder Share Server", version `26.8.8.2305`.

This is the always-on edition of the folder sharing already shipped by the existing package `SerZhyAle.FastMediaSorter`. It publishes user-chosen folders to an Android phone over SFTP from a **Windows service** (`FastMediaSorterCompanionSFTP`, delayed automatic start, running as LOCAL SERVICE), so the folders stay reachable from boot, with nobody signed in, and through a logoff.

**Why a separate package rather than a new version of the existing one:** the two are different products with different installers, different Inno `AppId`s, different ARP display names and different install directories. The existing `SerZhyAle.FastMediaSorter` package is a viewer that runs in the user session and needs no administrator rights - it must never start installing a service. A user who types this identifier has made that choice deliberately.

**Two things differ from the existing package's manifest, both deliberate:**

- `Scope: machine` - the product *is* machine state by construction (a service, a machine data directory with a restricted ACL, one program-scoped inbound firewall rule) and its installer is `PrivilegesRequired=admin`. Declaring the scope makes winget request elevation up front instead of discovering mid-install that it was needed.
- `MinimumOSVersion: 10.0.14393` - the management console is .NET 10 x64 and the whole point is a service that survives logoff, so the floor is real. (The other package deliberately omits this, because its setup also installs a 32-bit viewer for Windows 7/8.1.)

Everything else follows the same rules as the existing package: the Inno `setup.exe` is referenced directly (`InstallerType: inno`), with **no** `Dependencies` and **no** `NestedInstallerType`.

The silent switches include `/MIGRATEFROMUSER=yes`. The installer refuses a silent install when the user-session edition is present unless that switch is passed, so an unattended migration of existing state is never implicit - and the package passes it explicitly.

Links:
- Product page: https://serzhyale.github.io/FastMediaSorter_Lite/server.html
- Release: https://github.com/SerZhyAle/FastMediaSorter_Lite/releases/tag/v26.8.8.2305
- Changelog: https://github.com/SerZhyAle/FastMediaSorter_Lite/blob/main/CHANGELOG.md

---

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/add?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/414217)