### PR TITLE
Add agent guidance for issues and PRs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -35,6 +35,15 @@ Additional `<Id>.locale.<tag>.yaml` files provide optional translations.
 - PRs are auto-merged when the `Validation-Completed` label is applied (squash merge)
 - Contributors must sign the Microsoft CLA
 
+## Issues and Pull Requests
+
+- Before filing an issue, search existing open and closed issues for duplicates.
+- Use the GitHub issue forms in `.github/ISSUE_TEMPLATE/`; do not file a blank issue unless a maintainer explicitly asks for one.
+- Use `package_issue.yml` for package behavior problems, `package_request.yml` for new package requests, `update_request.yml` for version update requests, and `feature_request.yml` for repository or process improvements.
+- Do not file WinGet client issues here; use `microsoft/winget-cli` for client behavior.
+- Keep issue bodies concise and evidence-based. Do not paste large speculative patches into issue bodies; open a pull request or link a branch when manifest changes are available.
+- Before opening a pull request, review `CONTRIBUTING.md`, follow the PR template, keep the change to exactly one package, and summarize validation performed.
+
 ## Validation and Testing Commands
 
 Validate a manifest locally:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# Agent instructions
+
+Follow `.github/copilot-instructions.md` for repository-specific development guidance.
+
+## Issues
+
+Before filing a GitHub issue in this repository:
+
+1. Search existing open and closed issues for duplicates.
+2. Use the GitHub issue forms in `.github/ISSUE_TEMPLATE/`; do not file a blank issue unless a maintainer explicitly asks for one.
+3. Use `package_issue.yml` for package behavior problems, `package_request.yml` for new package requests, `update_request.yml` for version update requests, and `feature_request.yml` for repository or process improvements.
+4. Do not file WinGet client issues here; use `microsoft/winget-cli` for client behavior.
+5. Keep issue bodies concise and evidence-based. Do not paste large speculative patches into issue bodies; open a pull request or link a branch when manifest changes are available.
+
+## Pull requests
+
+Before opening a pull request:
+
+1. Review `CONTRIBUTING.md` and follow the repository PR template.
+2. Modify exactly one package per PR.
+3. Validate manifests locally when practical with `winget validate --manifest <path-to-version-folder>`.
+4. Do not recursively scan or search the entire `manifests/` directory; work only in the specific package folder being modified.
+5. Summarize validation performed, or explain why validation was not run.


### PR DESCRIPTION
## 📖 Description
Adds a root AGENTS.md for agent compatibility and mirrors issue/PR guidance in .github/copilot-instructions.md.

This nudges agents to search for duplicates, use the repository issue forms instead of blank issues, route WinGet client issues to microsoft/winget-cli, keep issue bodies concise, and preserve the one-package-per-PR convention.

Related cross-repo context: https://github.com/microsoft/winget-cli/issues/6433

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)
  - Related: https://github.com/microsoft/winget-cli/issues/6433

## 📦 Manifest Checklist

- [x] Not applicable; this PR does not modify manifests.
- [x] Not applicable; this PR only updates agent documentation.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/414220)