### PR TITLE
Add AppsAndFeaturesEntries to Microsoft.SQLServer.2025.Developer 17.0.1000.7

### DIFF
--- a/manifests/m/Microsoft/SQLServer/2025/Developer/17.0.1000.7/Microsoft.SQLServer.2025.Developer.installer.yaml
+++ b/manifests/m/Microsoft/SQLServer/2025/Developer/17.0.1000.7/Microsoft.SQLServer.2025.Developer.installer.yaml
@@ -17,6 +17,11 @@ FileExtensions:
 ExpectedReturnCodes:
 - InstallerReturnCode: 3010
   ReturnResponse: rebootRequiredToFinish
+AppsAndFeaturesEntries:
+- DisplayName: Microsoft SQL Server 2025 (64-bit)
+  Publisher: Microsoft Corporation
+  ProductCode: Microsoft SQL Server SQL2025
+  InstallerType: exe
 Installers:
 - Architecture: x64
   InstallerUrl: https://download.microsoft.com/download/77dc60d3-0139-4dad-83c8-bb52ab22db01/SQL2025-SSEI-StdDev.exe


### PR DESCRIPTION
## Problem

`Microsoft.SQLServer.2025.Developer` never correlates with an installed instance. The SSEI bootstrapper (`SQL2025-SSEI-StdDev.exe`) registers the product in ARP as:

```
HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Microsoft SQL Server SQL2025
  DisplayName = Microsoft SQL Server 2025 (64-bit)
  Publisher   = Microsoft Corporation
```

This doesn't match the manifest `PackageName` (`Microsoft SQL Server 2025 Developer`), and the manifest declares no `AppsAndFeaturesEntries`. Consequences, reproduced on a Windows 11 machine with SQL Server 2025 Developer installed:

- `winget list` shows `ARP\Machine\X64\Microsoft SQL Server SQL2025` with an empty Source column
- `winget list --id Microsoft.SQLServer.2025.Developer` → "No installed package found"
- `winget export` omits it / `winget import` re-installs it on every run (import detects installed state via correlation)
- `winget upgrade` can never see the installed version

## Fix

Add `AppsAndFeaturesEntries` with the exact ARP values above (verified against the live registry of an affected machine; `DisplayVersion` is empty there, hence omitted).

## Checklist

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Is there a linked Issue? **No existing issue found — description above serves as the report.**
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Note: The manifest was not validated locally with `winget validate`; the change is limited to `AppsAndFeaturesEntries` correlation metadata. Happy to adjust if validation flags anything.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/414223)