### PR TITLE
Update oipoistar.Tinta to 2.5.1

### DIFF
--- a/manifests/o/oipoistar/Tinta/2.5.1/oipoistar.Tinta.installer.yaml
+++ b/manifests/o/oipoistar/Tinta/2.5.1/oipoistar.Tinta.installer.yaml
@@ -1,0 +1,15 @@
+# Created with Claude Code
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: oipoistar.Tinta
+PackageVersion: 2.5.1
+InstallerType: portable
+Commands:
+- tinta
+ReleaseDate: 2026-08-09
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/oipoistar/tinta/releases/download/v2.5.1/tinta.exe
+  InstallerSha256: 86DA964EF2A15087F98069F9F0E2848452AC6F3FCF12C80FEFC7046592FD9271
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/o/oipoistar/Tinta/2.5.1/oipoistar.Tinta.locale.en-US.yaml
+++ b/manifests/o/oipoistar/Tinta/2.5.1/oipoistar.Tinta.locale.en-US.yaml
@@ -1,0 +1,38 @@
+# Created with Claude Code
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: oipoistar.Tinta
+PackageVersion: 2.5.1
+PackageLocale: en-US
+Publisher: oipoistar
+PublisherUrl: https://github.com/oipoistar
+PublisherSupportUrl: https://github.com/oipoistar/tinta/issues
+PackageName: Tinta
+PackageUrl: https://tinta.cc
+License: MIT
+LicenseUrl: https://github.com/oipoistar/tinta/blob/master/LICENSE
+Copyright: Copyright (c) oipoistar
+ShortDescription: Fast, lightweight markdown and Mermaid viewer for Windows
+Description: |-
+  Tinta is a fast, lightweight markdown viewer and reader for Windows,
+  built with Direct2D and DirectWrite for hardware-accelerated rendering.
+  A single native executable under 1 MB that starts in about 200 ms —
+  no Electron, no web engine, no installer. Features native Mermaid
+  flowchart rendering, 10 themes, first-class CJK text layout, internal
+  anchor links, a table of contents, folder browser, full-text search,
+  text selection, zoom, and an edit mode with live preview.
+Moniker: tinta
+Tags:
+- markdown
+- markdown-viewer
+- markdown-reader
+- markdown-editor
+- mermaid
+- viewer
+- reader
+- direct2d
+- lightweight
+- portable
+ReleaseNotesUrl: https://github.com/oipoistar/tinta/releases/tag/v2.5.1
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/o/oipoistar/Tinta/2.5.1/oipoistar.Tinta.yaml
+++ b/manifests/o/oipoistar/Tinta/2.5.1/oipoistar.Tinta.yaml
@@ -1,0 +1,8 @@
+# Created with Claude Code
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: oipoistar.Tinta
+PackageVersion: 2.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Update oipoistar.Tinta from 2.5.0 to 2.5.1

Release: https://github.com/oipoistar/tinta/releases/tag/v2.5.1 (context menu, zen mode, clickable task lists, wiki links, folder-wide search, themed window chrome)

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: no `Dependencies` section — the binary statically links the C runtime (since 2.4.0).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/414226)