### PR TITLE
New version: RedEyeNetworks.Logivore version 1.27.0

### DIFF
--- a/manifests/r/RedEyeNetworks/Logivore/1.27.0/RedEyeNetworks.Logivore.installer.yaml
+++ b/manifests/r/RedEyeNetworks/Logivore/1.27.0/RedEyeNetworks.Logivore.installer.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: RedEyeNetworks.Logivore
+PackageVersion: 1.27.0
+InstallerType: inno
+Scope: machine
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  Custom: /NORESTART
+UpgradeBehavior: install
+Commands:
+- logivore
+Installers:
+- Architecture: x64
+  Scope: user
+  InstallerUrl: https://download.redeyenetworks.com/logivore/releases/1.27.0/logivore-win-x64-setup.exe
+  InstallerSha256: 8DBDC19F8EBA4FEC653558B778F830AB9679BF29D632F3EA41A76CD3A1BDE132
+- Architecture: x64
+  Scope: machine
+  ElevationRequirement: elevatesSelf
+  InstallerUrl: https://download.redeyenetworks.com/logivore/releases/1.27.0/logivore-win-x64-machine-setup.exe
+  InstallerSha256: 62AFA0ACE58E571D5E6F1A1319485B94C48D38F7C56264CE7CFC75BDA7A9A179
+- Architecture: arm64
+  Scope: user
+  InstallerUrl: https://download.redeyenetworks.com/logivore/releases/1.27.0/logivore-win-arm64-setup.exe
+  InstallerSha256: 115B8D32709F40AC1F57A7BFC7AA9529D8FF73E74718407147D9158A8C93976C
+- Architecture: arm64
+  Scope: machine
+  ElevationRequirement: elevatesSelf
+  InstallerUrl: https://download.redeyenetworks.com/logivore/releases/1.27.0/logivore-win-arm64-machine-setup.exe
+  InstallerSha256: BE6505822347F74A37C24D39B5C9EC81ECB5809CCA4BA955004DEC6D0A534A4C
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/r/RedEyeNetworks/Logivore/1.27.0/RedEyeNetworks.Logivore.locale.en-US.yaml
+++ b/manifests/r/RedEyeNetworks/Logivore/1.27.0/RedEyeNetworks.Logivore.locale.en-US.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: RedEyeNetworks.Logivore
+PackageVersion: 1.27.0
+PackageLocale: en-US
+Publisher: RedEye Network Solutions LLC
+PublisherUrl: https://redeyenetworks.com
+PublisherSupportUrl: https://redeyenetworks.com/support
+Author: RedEye Network Solutions LLC
+PackageName: Logivore
+PackageUrl: https://redeyenetworks.com
+License: Proprietary
+Copyright: Copyright 2026 RedEye Network Solutions LLC. All rights reserved.
+ShortDescription: Cross-platform desktop log analyzer with LILA, an AI assistant for log triage
+Description: |-
+  Logivore is a local-first, cross-platform desktop log analyzer for Windows,
+  macOS, and Linux. Parses dozens of log formats (plaintext, syslog, EVTX,
+  PAN-OS TSF, Veeam VBR, GlobalProtect, pcap), correlates events across
+  sources, and surfaces findings via LILA — an AI assistant that runs locally
+  with optional Anthropic Claude or Google Gemini provider integration.
+  Memory-tier-adaptive (Flash / Hybrid / Indexed) so any log size works on
+  any hardware. Trust-gated LLM boundary keeps PII tokenized before it leaves
+  the machine.
+Moniker: logivore
+Tags:
+- log-analysis
+- log-viewer
+- syslog
+- evtx
+- pan-os
+- veeam
+- pcap
+- ai
+- llm
+- claude
+- gemini
+- timeline
+- correlation
+- desktop
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/RedEyeNetworks/Logivore/1.27.0/RedEyeNetworks.Logivore.yaml
+++ b/manifests/r/RedEyeNetworks/Logivore/1.27.0/RedEyeNetworks.Logivore.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: RedEyeNetworks.Logivore
+PackageVersion: 1.27.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Logivore v1.27.0 ships two distinct installers per architecture (user-scope + machine-scope), matching the Microsoft.PowerToys + Notepad++.Notepad++ convention. Each (architecture, scope) tuple maps to a unique Inno Setup EXE with a single, deterministic `PrivilegesRequired` value, so Microsoft's dynamic-scan validation has unambiguous install behavior to verify per installer entry.

Manifest construction is done in Logivore's release.yml as a hand-built heredoc (not `wingetcreate update`) so the 4-entry shape is locked from version 1 — the previous wingetcreate-based flow inherited shape from the latest published manifest, which couldn't grow installer-entry count cleanly.

The same `Logivore.iss` `AppId` is shared across user-scope and machine-scope builds so an existing HKCU install (user-scope) and HKLM install (machine-scope) each match the appropriate manifest installer entry on `winget upgrade`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/414243)