### PR TITLE
New version: DaikiSuganuma.WinRemap version 0.8.0

### DIFF
--- a/manifests/d/DaikiSuganuma/WinRemap/0.8.0/DaikiSuganuma.WinRemap.installer.yaml
+++ b/manifests/d/DaikiSuganuma/WinRemap/0.8.0/DaikiSuganuma.WinRemap.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: DaikiSuganuma.WinRemap
+PackageVersion: 0.8.0
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+# Inno Setup's uninstall key is {AppId}_is1 (installer/winremap.iss); this lets
+# winget correlate the install for upgrade and uninstall.
+ProductCode: '{707AFB56-1975-4DF4-8371-B50DD23E3DA1}_is1'
+ReleaseDate: 2026-08-09
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/DaikiSuganuma/winremap/releases/download/v0.8.0/winremap-setup.exe
+    InstallerSha256: 79F911973AF951F732075DA13A2B0EE0D170A6B2A6B93B2156DF9B5F08678CDF
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/d/DaikiSuganuma/WinRemap/0.8.0/DaikiSuganuma.WinRemap.locale.en-US.yaml
+++ b/manifests/d/DaikiSuganuma/WinRemap/0.8.0/DaikiSuganuma.WinRemap.locale.en-US.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: DaikiSuganuma.WinRemap
+PackageVersion: 0.8.0
+PackageLocale: en-US
+Publisher: Daiki Suganuma
+PublisherUrl: https://github.com/DaikiSuganuma
+PublisherSupportUrl: https://github.com/DaikiSuganuma/winremap/issues
+Author: Daiki Suganuma
+PackageName: WinRemap
+PackageUrl: https://github.com/DaikiSuganuma/winremap
+License: MIT
+LicenseUrl: https://github.com/DaikiSuganuma/winremap/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Daiki Suganuma
+CopyrightUrl: https://github.com/DaikiSuganuma/winremap/blob/main/LICENSE
+ShortDescription: A per-application key remapper for Windows, written in Rust.
+Description: |-
+  WinRemap remaps keys only in the applications you choose, declared in one
+  simple TOML file. It uses a low-level keyboard hook written in Rust with no
+  heap allocation or I/O in the callback, so remapping stays responsive and
+  avoids the hook timeouts that affect script-based remappers. Chord and
+  bare-key rules, two-stroke prefixes, macros and optional runtime macro
+  recording are supported. The settings window shows the config in effect and
+  edits it in place, validating as you type and leaving everything you did not
+  touch — comments, ordering, spelling — exactly as it was. WinRemap never logs
+  keystrokes and makes no network requests.
+Moniker: winremap
+Tags:
+  - keyboard
+  - remap
+  - remapper
+  - keymap
+  - productivity
+  - emacs
+  - utility
+  - rust
+ReleaseNotesUrl: https://github.com/DaikiSuganuma/winremap/releases/tag/v0.8.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/d/DaikiSuganuma/WinRemap/0.8.0/DaikiSuganuma.WinRemap.yaml
+++ b/manifests/d/DaikiSuganuma/WinRemap/0.8.0/DaikiSuganuma.WinRemap.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: DaikiSuganuma.WinRemap
+PackageVersion: 0.8.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Package
`DaikiSuganuma.WinRemap` version `0.8.0`

- Installer: https://github.com/DaikiSuganuma/winremap/releases/download/v0.8.0/winremap-setup.exe
- Release notes: https://github.com/DaikiSuganuma/winremap/releases/tag/v0.8.0

### Checks done before submitting

- `winget validate --manifest` passes.
- The installer was downloaded from the published URL and its SHA256 matches both `InstallerSha256` and the `SHA256SUMS` asset of the release.
- The binary has no non-OS DLL dependencies (the CRT is statically linked), which is what broke an earlier submission of this package.
- `ProductCode` is unchanged: the Inno Setup `AppId` did not change.

This is a version bump of an existing package (0.7.0 was merged in #407875). Only `PackageVersion`, `InstallerUrl`, `InstallerSha256`, `ReleaseDate` and `ReleaseNotesUrl` differ from that manifest.

I am the publisher of this package.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/414253)