### PR TITLE
Update: JiaPeng.LanTransfer to 0.4.0

### DIFF
--- a/manifests/j/JiaPeng/LanTransfer/0.4.0/JiaPeng.LanTransfer.installer.yaml
+++ b/manifests/j/JiaPeng/LanTransfer/0.4.0/JiaPeng.LanTransfer.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: 'JiaPeng.LanTransfer'
+PackageVersion: '0.4.0'
+InstallerType: 'inno'
+InstallModes:
+- 'silent'
+- 'silentWithProgress'
+InstallerSwitches:
+  Silent: '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART'
+  SilentWithProgress: '/SILENT /SUPPRESSMSGBOXES /NORESTART'
+ReleaseDate: '2026-08-09'
+Installers:
+- Architecture: 'x64'
+  InstallerUrl: 'https://github.com/hongjiapeng/LanTransfer/releases/download/v0.4.0/LanTransfer-0.4.0-win-x64-Setup.exe'
+  InstallerSha256: EE7F5714A46AFAA8546DFC5B8776C8E5EAC6FC1D7389FE2BF832A5A84251D52B
+ManifestType: installer
+ManifestVersion: '1.12.0'

--- a/manifests/j/JiaPeng/LanTransfer/0.4.0/JiaPeng.LanTransfer.locale.en-US.yaml
+++ b/manifests/j/JiaPeng/LanTransfer/0.4.0/JiaPeng.LanTransfer.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: 'JiaPeng.LanTransfer'
+PackageVersion: '0.4.0'
+PackageLocale: 'en-US'
+Publisher: 'JiaPeng'
+PublisherUrl: 'https://github.com/hongjiapeng'
+PublisherSupportUrl: 'https://github.com/hongjiapeng/LanTransfer/issues'
+PackageName: 'LanTransfer'
+PackageUrl: 'https://github.com/hongjiapeng/LanTransfer'
+License: 'MIT'
+LicenseUrl: 'https://github.com/hongjiapeng/LanTransfer/blob/main/LICENSE'
+ShortDescription: 'Transfer files and text between devices on the same local network through a browser.'
+Description: 'LanTransfer is a cross-platform local-network file and text transfer tool with a browser-based interface, QR-code connection, and no cloud dependency.'
+Moniker: 'lantransfer'
+Tags:
+- 'file-transfer'
+- 'lan'
+- 'local-network'
+- 'qr-code'
+- 'text-transfer'
+ReleaseNotesUrl: 'https://github.com/hongjiapeng/LanTransfer/releases/tag/v0.4.0'
+ManifestType: defaultLocale
+ManifestVersion: '1.12.0'

--- a/manifests/j/JiaPeng/LanTransfer/0.4.0/JiaPeng.LanTransfer.locale.zh-CN.yaml
+++ b/manifests/j/JiaPeng/LanTransfer/0.4.0/JiaPeng.LanTransfer.locale.zh-CN.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: 'JiaPeng.LanTransfer'
+PackageVersion: '0.4.0'
+PackageLocale: 'zh-CN'
+Publisher: 'JiaPeng'
+PublisherUrl: 'https://github.com/hongjiapeng'
+PublisherSupportUrl: 'https://github.com/hongjiapeng/LanTransfer/issues'
+PackageName: 'LanTransfer'
+PackageUrl: 'https://github.com/hongjiapeng/LanTransfer'
+License: 'MIT'
+LicenseUrl: 'https://github.com/hongjiapeng/LanTransfer/blob/main/LICENSE'
+ShortDescription: '通过浏览器在同一局域网的设备之间传输文件和文字。'
+Description: 'LanTransfer 是一个跨平台局域网文件和文字传输工具，提供浏览器界面、二维码连接，并且不依赖云服务。'
+Tags:
+- '二维码'
+- '局域网'
+- '文件传输'
+- '文字传输'
+ReleaseNotesUrl: 'https://github.com/hongjiapeng/LanTransfer/releases/tag/v0.4.0'
+ManifestType: locale
+ManifestVersion: '1.12.0'

--- a/manifests/j/JiaPeng/LanTransfer/0.4.0/JiaPeng.LanTransfer.yaml
+++ b/manifests/j/JiaPeng/LanTransfer/0.4.0/JiaPeng.LanTransfer.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: 'JiaPeng.LanTransfer'
+PackageVersion: '0.4.0'
+DefaultLocale: 'en-US'
+ManifestType: version
+ManifestVersion: '1.12.0'


### PR DESCRIPTION
## Description

Updates `JiaPeng.LanTransfer` to version `0.4.0`.

- Uses the public Inno Setup installer from the GitHub Release.
- Updates the installer URL, SHA256, release date, and release notes URL.
- Preserves the existing English and Simplified Chinese locale metadata.

## Validation

- `winget validate --manifest manifests/j/JiaPeng/LanTransfer/0.4.0` passed locally.
- The release asset is public and immutable; SHA256: `EE7F5714A46AFAA8546DFC5B8776C8E5EAC6FC1D7389FE2BF832A5A84251D52B`.
- The GitHub Release workflow completed successfully, including the Windows installer job.
- Full local silent installation was not completed because an existing LanTransfer instance was running; Inno Setup safely reported that condition instead of closing the user's application.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/414276)