### PR TITLE
New version: mahi160.Photon version 2.0.0-pre.11

### DIFF
--- a/manifests/m/mahi160/Photon/2.0.0-pre.11/mahi160.Photon.installer.yaml
+++ b/manifests/m/mahi160/Photon/2.0.0-pre.11/mahi160.Photon.installer.yaml
@@ -1,0 +1,17 @@
+# Created with the Photon release pipeline (mahi160/photon), not the
+# Windows Package Manager Manifest Creator.
+PackageIdentifier: mahi160.Photon
+PackageVersion: 2.0.0-pre.11
+InstallerType: nullsoft
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: "2026-08-09"
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/mahi160/photon/releases/download/v2.0.0-pre.11/Photon_2.0.0-pre.11_x64-setup.exe
+    InstallerSha256: C80DCC8D0CB79D58304E047595FE5F5D4870BDA81B551BAD91249ACD900635C7
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/m/mahi160/Photon/2.0.0-pre.11/mahi160.Photon.locale.en-US.yaml
+++ b/manifests/m/mahi160/Photon/2.0.0-pre.11/mahi160.Photon.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# Created with the Photon release pipeline (mahi160/photon), not the
+# Windows Package Manager Manifest Creator.
+PackageIdentifier: mahi160.Photon
+PackageVersion: 2.0.0-pre.11
+PackageLocale: en-US
+Publisher: Salauddin Omar Sifat
+PublisherUrl: https://github.com/mahi160
+PublisherSupportUrl: https://github.com/mahi160/photon/issues
+PackageName: Photon
+PackageUrl: https://github.com/mahi160/photon
+License: MIT
+LicenseUrl: https://github.com/mahi160/photon/blob/main/LICENSE.md
+ShortDescription: A calm, minimal desktop media player built exclusively for Jellyfin.
+Description: |-
+  Photon is a calm, minimal desktop media player for Jellyfin. It embeds
+  mpv directly in-process via its render API, GPU-rendered with an
+  automatic CPU fallback, and always plays direct rather than asking the
+  server to transcode. Photon is a player, not a media manager -- no
+  live TV, music, photos, server admin, or casting.
+Moniker: photon
+Tags:
+  - jellyfin
+  - media-player
+  - video-player
+  - mpv
+ReleaseNotesUrl: https://github.com/mahi160/photon/releases/tag/v2.0.0-pre.11
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/m/mahi160/Photon/2.0.0-pre.11/mahi160.Photon.yaml
+++ b/manifests/m/mahi160/Photon/2.0.0-pre.11/mahi160.Photon.yaml
@@ -1,0 +1,7 @@
+# Created with the Photon release pipeline (mahi160/photon), not the
+# Windows Package Manager Manifest Creator.
+PackageIdentifier: mahi160.Photon
+PackageVersion: 2.0.0-pre.11
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Updates mahi160.Photon to version 2.0.0-pre.11.

Release: https://github.com/mahi160/photon/releases/tag/v2.0.0-pre.11
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/414304)