### PR TITLE
Update version: tsouth89.Ceiling version 1.5.25

### DIFF
--- a/manifests/t/tsouth89/Ceiling/1.5.25/tsouth89.Ceiling.installer.yaml
+++ b/manifests/t/tsouth89/Ceiling/1.5.25/tsouth89.Ceiling.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: tsouth89.Ceiling
+PackageVersion: 1.5.25
+InstallerType: inno
+Scope: user
+UpgradeBehavior: install
+ProductCode: io.github.tsouth89.ceiling_is1
+ReleaseDate: 2026-08-09
+AppsAndFeaturesEntries:
+- ProductCode: io.github.tsouth89.ceiling_is1
+  DisplayName: Ceiling 1.5.25
+  DisplayVersion: 1.5.25
+  Publisher: Brandon South
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/tsouth89/ceiling/releases/download/v1.5.25/Ceiling-1.5.25-Setup.exe
+  InstallerSha256: 0F549B283DECE1998ED7647DCE9976EEF42A1BB8D12E7F5223AECBB80F9E94A1
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/t/tsouth89/Ceiling/1.5.25/tsouth89.Ceiling.locale.en-US.yaml
+++ b/manifests/t/tsouth89/Ceiling/1.5.25/tsouth89.Ceiling.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: tsouth89.Ceiling
+PackageVersion: 1.5.25
+PackageLocale: en-US
+Publisher: Brandon South
+PublisherUrl: https://github.com/tsouth89
+PublisherSupportUrl: https://github.com/tsouth89/ceiling/issues
+Author: Brandon South
+PackageName: Ceiling
+PackageUrl: https://ceiling.win
+License: MIT
+LicenseUrl: https://github.com/tsouth89/ceiling/blob/v1.5.25/LICENSE
+Copyright: Copyright (c) Ceiling contributors
+ShortDescription: Desktop capacity and quota monitor for coding assistants.
+Description: Ceiling is a local-first Windows app for monitoring provider-reported capacity and quota usage across AI coding platforms.
+Moniker: ceiling
+Tags:
+- claude
+- codex
+- cursor
+- desktop
+- gemini
+- grok
+- usage
+- windows
+ReleaseNotes: Ceiling 1.5.25 keeps Claude's taskbar tile focused on Session and Weekly capacity when model-only caps such as Fable are exhausted. It also prevents unreadable or future-version settings and credential stores from losing unrelated data, restricts plaintext custom Codex endpoints to real loopback hosts, preserves active token-account selection, and fixes reset countdown rounding.
+ReleaseNotesUrl: https://github.com/tsouth89/ceiling/releases/tag/v1.5.25
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/tsouth89/Ceiling/1.5.25/tsouth89.Ceiling.yaml
+++ b/manifests/t/tsouth89/Ceiling/1.5.25/tsouth89.Ceiling.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: tsouth89.Ceiling
+PackageVersion: 1.5.25
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Updates the approved `tsouth89.Ceiling` package from 1.5.22 to 1.5.25.

The public installer URL returns successfully. Its SHA-256 was recomputed independently, its Authenticode signature is valid, and `winget validate` passes for the new manifest folder.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/414311)