### PR TITLE
New package: Stage5Tools.Translator version 1.16.6

### DIFF
--- a/manifests/s/Stage5Tools/Translator/1.16.6/Stage5Tools.Translator.installer.yaml
+++ b/manifests/s/Stage5Tools/Translator/1.16.6/Stage5Tools.Translator.installer.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 # Created from publisher-owned immutable artifacts by scripts/update-distribution-manifests.mjs
 PackageIdentifier: Stage5Tools.Translator
 PackageVersion: 1.16.6

--- a/manifests/s/Stage5Tools/Translator/1.16.6/Stage5Tools.Translator.installer.yaml
+++ b/manifests/s/Stage5Tools/Translator/1.16.6/Stage5Tools.Translator.installer.yaml
@@ -1,0 +1,30 @@
+# Created from publisher-owned immutable artifacts by scripts/update-distribution-manifests.mjs
+PackageIdentifier: Stage5Tools.Translator
+PackageVersion: 1.16.6
+InstallerType: nullsoft
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+UpgradeBehavior: install
+ElevationRequirement: elevatesSelf
+FileExtensions:
+  - avi
+  - mkv
+  - mov
+  - mp4
+  - webm
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://downloads.stage5.tools/win/1.16.6/Translator-x64.exe
+    InstallerSha256: B7BE49BAD34BE5DE7A0474F13C4F4446EBF282B6A72D244AEB5197BE23A17610
+    AppsAndFeaturesEntries:
+      - DisplayName: Translator
+        Publisher: Mikey Lee
+        InstallerType: nullsoft
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/Stage5Tools/Translator/1.16.6/Stage5Tools.Translator.locale.en-US.yaml
+++ b/manifests/s/Stage5Tools/Translator/1.16.6/Stage5Tools.Translator.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# Created from publisher-owned immutable artifacts by scripts/update-distribution-manifests.mjs
+PackageIdentifier: Stage5Tools.Translator
+PackageVersion: 1.16.6
+PackageLocale: en-US
+Publisher: Mikey Lee
+PublisherUrl: https://stage5.tools/
+PublisherSupportUrl: https://github.com/mikey1384/translator/issues
+PrivacyUrl: https://translator.tools/privacy
+Author: Stage5 Tools LLC
+PackageName: Translator
+PackageUrl: https://translator.tools/
+License: MIT
+LicenseUrl: https://github.com/mikey1384/translator/blob/v1.16.6/LICENSE
+Copyright: Copyright (c) 2025 Mikey Lee
+ShortDescription: Open-source desktop workstation for finding videos, translating and editing subtitles, dubbing, and export.
+Description: Translator keeps video discovery, downloads, transcription, subtitle translation and review, styling, dubbing, and export together in a multi-tab desktop workspace.
+Moniker: translator
+Tags:
+  - captions
+  - dubbing
+  - subtitles
+  - transcription
+  - translation
+  - video
+ReleaseNotesUrl: https://github.com/mikey1384/translator/releases/tag/v1.16.6
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/Stage5Tools/Translator/1.16.6/Stage5Tools.Translator.locale.en-US.yaml
+++ b/manifests/s/Stage5Tools/Translator/1.16.6/Stage5Tools.Translator.locale.en-US.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 # Created from publisher-owned immutable artifacts by scripts/update-distribution-manifests.mjs
 PackageIdentifier: Stage5Tools.Translator
 PackageVersion: 1.16.6

--- a/manifests/s/Stage5Tools/Translator/1.16.6/Stage5Tools.Translator.yaml
+++ b/manifests/s/Stage5Tools/Translator/1.16.6/Stage5Tools.Translator.yaml
@@ -1,0 +1,6 @@
+# Created from publisher-owned immutable artifacts by scripts/update-distribution-manifests.mjs
+PackageIdentifier: Stage5Tools.Translator
+PackageVersion: 1.16.6
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/manifests/s/Stage5Tools/Translator/1.16.6/Stage5Tools.Translator.yaml
+++ b/manifests/s/Stage5Tools/Translator/1.16.6/Stage5Tools.Translator.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 # Created from publisher-owned immutable artifacts by scripts/update-distribution-manifests.mjs
 PackageIdentifier: Stage5Tools.Translator
 PackageVersion: 1.16.6


### PR DESCRIPTION
## 📖 Description

Adds Translator 1.16.6 for Windows x64.

The immutable installer SHA-256 is `B7BE49BAD34BE5DE7A0474F13C4F4446EBF282B6A72D244AEB5197BE23A17610`. The installer is signed by Stage5 Tools LLC. A Windows GitHub Actions lifecycle test passed clean silent install, same-version reinstall, silent uninstall, 1.16.5 install, silent upgrade to 1.16.6, and final silent uninstall: https://github.com/mikey1384/homebrew-translator/actions/runs/31300802539

The three manifests were also parsed and validated against Microsoft's official WinGet 1.12 JSON schemas before submission.

## ✅ Checklist

- [ ] Signed the Contributor License Agreement
- [x] Linked to an issue (if applicable; no issue is required for this new package)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` (official schema validation was completed; WinGet automation will validate this PR)
- [ ] Tested manifest locally with `winget install --manifest <path>` (the exact installer passed the linked clean lifecycle test)
- [x] Manifest conforms to the 1.12 schema

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/414314)