### PR TITLE
New version: CaptainKillSwitch.CaptainKillSwitch version 0.4.1

### DIFF
--- a/manifests/c/CaptainKillSwitch/CaptainKillSwitch/0.4.1/CaptainKillSwitch.CaptainKillSwitch.installer.yaml
+++ b/manifests/c/CaptainKillSwitch/CaptainKillSwitch/0.4.1/CaptainKillSwitch.CaptainKillSwitch.installer.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: CaptainKillSwitch.CaptainKillSwitch
+PackageVersion: 0.4.1
+InstallerLocale: en-US
+InstallerType: wix
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{9FDA3A80-1E27-42DB-B6ED-7FE23749B28A}'
+ReleaseDate: 2026-08-09
+AppsAndFeaturesEntries:
+- Publisher: Captain Kill Switch Team
+  ProductCode: '{9FDA3A80-1E27-42DB-B6ED-7FE23749B28A}'
+  UpgradeCode: '{984FC5FB-4BE0-5465-85FF-3FDCFED283B5}'
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles%/Captain Kill Switch'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/captainkillswitch/downloads/releases/download/v0.4.1/captain-kill-switch-0.4.1-windows-x64.msi
+  InstallerSha256: BF96ABC1364D0BE7346D7D8C68D0EB4F50AB24B5308E2943DD98093F8FB13935
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/CaptainKillSwitch/CaptainKillSwitch/0.4.1/CaptainKillSwitch.CaptainKillSwitch.locale.en-US.yaml
+++ b/manifests/c/CaptainKillSwitch/CaptainKillSwitch/0.4.1/CaptainKillSwitch.CaptainKillSwitch.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: CaptainKillSwitch.CaptainKillSwitch
+PackageVersion: 0.4.1
+PackageLocale: en-US
+Publisher: Captain Kill Switch Team
+PublisherUrl: https://captainkillswitch.com/
+PublisherSupportUrl: https://github.com/captainkillswitch/downloads/issues
+Author: Captain Kill Switch Team
+PackageName: Captain Kill Switch
+PackageUrl: https://captainkillswitch.com/
+License: Proprietary (free)
+LicenseUrl: https://captainkillswitch.com/about
+Copyright: Copyright (c) 2026 Captain Kill Switch Team
+ShortDescription: Close every running application in one click from the system tray.
+Description: Captain Kill Switch is a free system-tray utility that closes every running application in one click - a clean close request first, then a firm stop within two seconds. An allowlist model protects Windows system and session processes. Tiny native app, auto-updates, 10 languages. Anonymous usage statistics only; see https://captainkillswitch.com/privacy.
+Moniker: captain-kill-switch
+ReleaseNotes: |-
+  Windows: the app no longer needs the WebView2 runtime at all. The tray is
+  now a native Windows implementation, so machines without (or with a broken)
+  WebView2 runtime start correctly instead of failing silently.
+  - Same tray menu, kill behavior, exclusions and two-second force floor.
+  - Installs upgrade in place; auto-update from 0.3.x works unchanged.
+  - macOS: the installer now correctly states the macOS 10.15 minimum.
+ReleaseNotesUrl: https://github.com/captainkillswitch/downloads/releases/tag/v0.4.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/CaptainKillSwitch/CaptainKillSwitch/0.4.1/CaptainKillSwitch.CaptainKillSwitch.yaml
+++ b/manifests/c/CaptainKillSwitch/CaptainKillSwitch/0.4.1/CaptainKillSwitch.CaptainKillSwitch.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: CaptainKillSwitch.CaptainKillSwitch
+PackageVersion: 0.4.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
0.4.1 supersedes the stuck 0.4.0 submission (#410806) and specifically fixes the failure its validation found.

**Root cause of #410806's `Validation-Executable-Error`** (thanks @stephengillie for the exit code): the 0.4.0 exe dynamically imported `VCRUNTIME140.dll`, so it died with STATUS_DLL_NOT_FOUND on any machine without the VC++ redistributable. 0.4.1 links the CRT statically (`+crt-static`) — the exe now has no VC runtime imports, verified in CI by reading the PE import table.

Verified for this submission (no Windows machine available, so `winget validate`/`winget install` were not run locally and are deliberately left unticked):
- InstallerSha256 computed independently from the downloaded MSI and cross-checked against the release's `SHA256SUMS.txt`
- ProductCode read from the new MSI with the method that reproduces 0.4.0's accepted ProductCode; UpgradeCode unchanged
- Manifests mirror the accepted 0.3.3 / submitted 0.4.0 structure

---

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/414316)