### PR TITLE
New package: Abdk4Moura.Filament version 0.8.5

### DIFF
--- a/manifests/a/Abdk4Moura/Filament/0.8.5/Abdk4Moura.Filament.installer.yaml
+++ b/manifests/a/Abdk4Moura/Filament/0.8.5/Abdk4Moura.Filament.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.28.0.schema.json
+PackageIdentifier: Abdk4Moura.Filament
+PackageVersion: "0.8.5"
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: filament.exe
+    PortableCommandAlias: filament
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Abdk4Moura/filament/releases/download/cli-v0.8.5/filament-x86_64-pc-windows-msvc.zip
+    InstallerSha256: "4c2889f5d6421ad17b6c0af3d9feaf9ef18bfd5e7ebdbbcb899e515ec5405dd7"
+ReleaseDate: "2026-08-09"
+ManifestType: installer
+ManifestVersion: 1.28.0

--- a/manifests/a/Abdk4Moura/Filament/0.8.5/Abdk4Moura.Filament.locale.en-US.yaml
+++ b/manifests/a/Abdk4Moura/Filament/0.8.5/Abdk4Moura.Filament.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.28.0.schema.json
+PackageIdentifier: Abdk4Moura.Filament
+PackageVersion: "0.8.5"
+PackageLocale: en-US
+Publisher: Abdulkabir Agboola
+PublisherUrl: https://github.com/Abdk4Moura
+PublisherSupportUrl: https://github.com/Abdk4Moura/filament/issues
+PackageName: Filament
+PackageUrl: https://filament.autumated.com
+License: MIT
+LicenseUrl: https://github.com/Abdk4Moura/filament/blob/main/LICENSE
+ShortDescription: P2P file transfer between terminals and browsers - no upload, no account
+Description: |-
+  Filament sends files directly between devices over WebRTC. The other end
+  can be another terminal or any browser at filament.autumated.com - nothing
+  to install on the receiving phone or laptop. One-time speakable pairing
+  codes, resumable transfers that survive restarts, and visible routing
+  (local / direct / relayed). Self-hostable.
+Tags:
+  - file-transfer
+  - p2p
+  - webrtc
+  - airdrop
+  - file-sharing
+ManifestType: defaultLocale
+ManifestVersion: 1.28.0

--- a/manifests/a/Abdk4Moura/Filament/0.8.5/Abdk4Moura.Filament.yaml
+++ b/manifests/a/Abdk4Moura/Filament/0.8.5/Abdk4Moura.Filament.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.28.0.schema.json
+PackageIdentifier: Abdk4Moura.Filament
+PackageVersion: "0.8.5"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.28.0


### PR DESCRIPTION
Adds Abdk4Moura.Filament 0.8.5 (portable zip, x64). P2P file transfer CLI; binaries built and attested by GitHub Actions in https://github.com/Abdk4Moura/filament. Validated against manifest schema 1.28.0.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/414362)