### PR TITLE
New version: ibrahemid.Writ version 0.3.1

### DIFF
--- a/manifests/i/ibrahemid/Writ/0.3.1/ibrahemid.Writ.installer.yaml
+++ b/manifests/i/ibrahemid/Writ/0.3.1/ibrahemid.Writ.installer.yaml
@@ -1,0 +1,25 @@
+# Created with the Writ release packaging workflow.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: ibrahemid.Writ
+PackageVersion: 0.3.1
+MinimumOSVersion: 10.0.17763.0
+InstallerType: wix
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-08-09
+Installers:
+  - Architecture: x64
+    InstallerType: wix
+    InstallerUrl: https://github.com/ibrahemid/writ/releases/download/v0.3.1/Writ_0.3.1_x64_en-US.msi
+    InstallerSha256: 7f59c040e37394fff08a4a00d2081f92812f1ac63fd86e243e1061c37c15f535
+    InstallerSwitches:
+      Silent: /quiet
+      SilentWithProgress: /passive
+    ProductCode: "{F0E802D3-A9B3-4032-A2FE-8415B3F6DF26}"
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/i/ibrahemid/Writ/0.3.1/ibrahemid.Writ.locale.en-US.yaml
+++ b/manifests/i/ibrahemid/Writ/0.3.1/ibrahemid.Writ.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# Created with the Writ release packaging workflow.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: ibrahemid.Writ
+PackageVersion: 0.3.1
+PackageLocale: en-US
+Publisher: ibrahemid
+PublisherUrl: https://github.com/ibrahemid
+PublisherSupportUrl: https://github.com/ibrahemid/writ/issues
+PackageName: Writ
+PackageUrl: https://github.com/ibrahemid/writ
+License: MIT
+LicenseUrl: https://github.com/ibrahemid/writ/blob/main/LICENSE
+Copyright: Copyright (c) 2026 ibrahemid
+ShortDescription: Lightweight, always-ready text editor for developers.
+Description: |-
+  Writ is a hotkey-summoned scratchpad for developers. Press a global shortcut to
+  summon a fast, distraction-free editor with tabs, autosave, and full-text
+  search. Built with Tauri v2 and SolidJS for a tiny footprint and native feel.
+Moniker: writ
+Tags:
+  - scratchpad
+  - editor
+  - productivity
+  - rust
+  - tauri
+ReleaseNotesUrl: https://github.com/ibrahemid/writ/releases/tag/v0.3.1
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/i/ibrahemid/Writ/0.3.1/ibrahemid.Writ.yaml
+++ b/manifests/i/ibrahemid/Writ/0.3.1/ibrahemid.Writ.yaml
@@ -1,0 +1,8 @@
+# Created with the Writ release packaging workflow.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: ibrahemid.Writ
+PackageVersion: 0.3.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Manifests for ibrahemid.Writ 0.3.1 (installer, locale, version). MSI URL and SHA256 match the v0.3.1 release assets.

- [x] Manifests validated against the 1.6.0 schema
- [x] Installer URL points at a versioned release asset
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/414368)