### PR TITLE
New version: Rorkai.ASC version 3.7.0

### DIFF
--- a/manifests/r/Rorkai/ASC/3.7.0/Rorkai.ASC.installer.yaml
+++ b/manifests/r/Rorkai/ASC/3.7.0/Rorkai.ASC.installer.yaml
@@ -1,0 +1,12 @@
+# Created with App-Store-Connect-CLI/scripts/generate_winget_manifests.py
+PackageIdentifier: Rorkai.ASC
+PackageVersion: 3.7.0
+InstallerType: portable
+Commands:
+  - asc
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/rorkai/App-Store-Connect-CLI/releases/download/3.7.0/asc_3.7.0_windows_amd64.exe
+    InstallerSha256: 4906415019D43CC282218F26B131FE8F9AF1860C2045B15D983DCACC39F9DFB3
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/r/Rorkai/ASC/3.7.0/Rorkai.ASC.locale.en-US.yaml
+++ b/manifests/r/Rorkai/ASC/3.7.0/Rorkai.ASC.locale.en-US.yaml
@@ -1,0 +1,20 @@
+# Created with App-Store-Connect-CLI/scripts/generate_winget_manifests.py
+PackageIdentifier: Rorkai.ASC
+PackageVersion: 3.7.0
+PackageLocale: en-US
+Publisher: Rorkai
+PackageName: asc
+PackageUrl: https://github.com/rorkai/App-Store-Connect-CLI
+License: MIT
+LicenseUrl: https://github.com/rorkai/App-Store-Connect-CLI/blob/main/LICENSE
+ShortDescription: Fast, scriptable CLI for the App Store Connect API.
+Moniker: asc
+Tags:
+  - app-store-connect
+  - app-store-connect-api
+  - cli
+  - ios
+  - testflight
+ReleaseNotesUrl: https://github.com/rorkai/App-Store-Connect-CLI/releases/tag/3.7.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/r/Rorkai/ASC/3.7.0/Rorkai.ASC.yaml
+++ b/manifests/r/Rorkai/ASC/3.7.0/Rorkai.ASC.yaml
@@ -1,0 +1,6 @@
+# Created with App-Store-Connect-CLI/scripts/generate_winget_manifests.py
+PackageIdentifier: Rorkai.ASC
+PackageVersion: 3.7.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Adds Rorkai.ASC 3.7.0 from https://github.com/rorkai/App-Store-Connect-CLI/releases/tag/3.7.0.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/414453)