### PR TITLE
Move KDE.Falkon master to KDE.Falkon.Nightly master

### DIFF
--- a/manifests/k/KDE/Falkon/Nightly/master/KDE.Falkon.Nightly.installer.yaml
+++ b/manifests/k/KDE/Falkon/Nightly/master/KDE.Falkon.Nightly.installer.yaml
@@ -15,7 +15,7 @@ FileExtensions:
 ProductCode: Falkon
 Installers:
 - Architecture: x64
-  InstallerUrl: https://cdn.kde.org/ci-builds/network/falkon/master/windows/falkon-master-2717-windows-cl-msvc2022-x86_64.exe
-  InstallerSha256: C128D242E68D31D041657C1F92E95DD8BA031A0018DAF746F8D0C09CABBF5AF5
+  InstallerUrl: https://cdn.kde.org/ci-builds/network/falkon/master/windows/falkon-master-2735-windows-cl-msvc2022-x86_64.exe
+  InstallerSha256: 724325BD84E0E6BE79C637DCE6F6A049B953F258E314549CB0D76E4857880A56
 ManifestType: installer
 ManifestVersion: 1.10.0

--- a/manifests/k/KDE/Falkon/Nightly/master/KDE.Falkon.Nightly.installer.yaml
+++ b/manifests/k/KDE/Falkon/Nightly/master/KDE.Falkon.Nightly.installer.yaml
@@ -1,0 +1,21 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: KDE.Falkon.Nightly
+PackageVersion: master
+InstallerType: nullsoft
+UpgradeBehavior: install
+Protocols:
+- ftp
+- http
+- https
+FileExtensions:
+- htm
+- html
+ProductCode: Falkon
+Installers:
+- Architecture: x64
+  InstallerUrl: https://cdn.kde.org/ci-builds/network/falkon/master/windows/falkon-master-2709-windows-cl-msvc2022-x86_64.exe
+  InstallerSha256: C128D242E68D31D041657C1F92E95DD8BA031A0018DAF746F8D0C09CABBF5AF5
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/k/KDE/Falkon/Nightly/master/KDE.Falkon.Nightly.installer.yaml
+++ b/manifests/k/KDE/Falkon/Nightly/master/KDE.Falkon.Nightly.installer.yaml
@@ -15,7 +15,7 @@ FileExtensions:
 ProductCode: Falkon
 Installers:
 - Architecture: x64
-  InstallerUrl: https://cdn.kde.org/ci-builds/network/falkon/master/windows/falkon-master-2709-windows-cl-msvc2022-x86_64.exe
+  InstallerUrl: https://cdn.kde.org/ci-builds/network/falkon/master/windows/falkon-master-2717-windows-cl-msvc2022-x86_64.exe
   InstallerSha256: C128D242E68D31D041657C1F92E95DD8BA031A0018DAF746F8D0C09CABBF5AF5
 ManifestType: installer
 ManifestVersion: 1.10.0

--- a/manifests/k/KDE/Falkon/Nightly/master/KDE.Falkon.Nightly.locale.en-US.yaml
+++ b/manifests/k/KDE/Falkon/Nightly/master/KDE.Falkon.Nightly.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: KDE.Falkon.Nightly
+PackageVersion: master
+PackageLocale: en-US
+Publisher: KDE e.V.
+PublisherUrl: https://kde.org/
+PrivacyUrl: https://kde.org/privacypolicy/
+Author: KDE e.V.
+PackageName: Falkon
+PackageUrl: https://www.falkon.org/
+License: GPL-3.0-or-later
+Copyright: © 2010-2026 David Rosca, 2020- Juraj Oravec
+ShortDescription: KDE web browser using QtWebEngine.
+Description: Falkon is a very fast Qt web browser. It aims to be a lightweight web browser available through all major platforms. This project has been originally started only for educational purposes. But from its start, Falkon has grown into a feature-rich browser. It has all standard functions you expect from a web browser. It includes bookmarks, history (both also in sidebar) and tabs. Above that, you can manage RSS feeds with an included RSS reader, block ads with a built-in AdBlock plugin, block Flash content with Click2Flash and edit the local CA Certificates database with an SSL manager.
+Tags:
+- browser
+- chromium
+- qtwebengine
+- qupzilla
+- web-browser
+- webbrowser
+- webpage
+ReleaseNotesUrl: https://www.falkon.org/posts/
+Documentations:
+- DocumentLabel: FAQ
+  DocumentUrl: https://www.falkon.org/faq/
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/k/KDE/Falkon/Nightly/master/KDE.Falkon.Nightly.locale.en-US.yaml
+++ b/manifests/k/KDE/Falkon/Nightly/master/KDE.Falkon.Nightly.locale.en-US.yaml
@@ -8,7 +8,7 @@ Publisher: KDE e.V.
 PublisherUrl: https://kde.org/
 PrivacyUrl: https://kde.org/privacypolicy/
 Author: KDE e.V.
-PackageName: Falkon
+PackageName: Falkon (Nightly)
 PackageUrl: https://www.falkon.org/
 License: GPL-3.0-or-later
 Copyright: © 2010-2026 David Rosca, 2020- Juraj Oravec

--- a/manifests/k/KDE/Falkon/Nightly/master/KDE.Falkon.Nightly.locale.zh-CN.yaml
+++ b/manifests/k/KDE/Falkon/Nightly/master/KDE.Falkon.Nightly.locale.zh-CN.yaml
@@ -1,0 +1,23 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.10.0.schema.json
+
+PackageIdentifier: KDE.Falkon.Nightly
+PackageVersion: master
+PackageLocale: zh-CN
+PublisherUrl: https://kde.org/zh-cn/
+ShortDescription: 基于 QtWebEngine 的 KDE 网络浏览器
+Description: |-
+  Falkon 是一款全新的高速 Qt 网页浏览器，旨在成为一个可在所有主流平台上运行的轻量级网络浏览器。该项目最初只是出于教育目的。但 Falkon 从一开始就已成长为一个功能丰富的浏览器。
+  Falkon 拥有网络浏览器的所有标准功能，包括书签、历史记录（也在侧边栏）和标签。此外，您还可以使用内置的 RSS 阅读器管理 RSS 订阅，使用内置的 AdBlock 插件阻止广告，使用 Click2Flash 阻止 Flash 内容，以及使用 SSL 管理器编辑本地 CA 证书数据库。
+Tags:
+- chromium
+- qtwebengine
+- qupzilla
+- 浏览器
+- 网页
+- 网页浏览器
+Documentations:
+- DocumentLabel: 常见问题
+  DocumentUrl: https://www.falkon.org/faq/
+ManifestType: locale
+ManifestVersion: 1.10.0

--- a/manifests/k/KDE/Falkon/Nightly/master/KDE.Falkon.Nightly.yaml
+++ b/manifests/k/KDE/Falkon/Nightly/master/KDE.Falkon.Nightly.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: KDE.Falkon.Nightly
+PackageVersion: master
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
"master" is older than "3.1.0" for WinGet, necesitating moving the package
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/414464)