### PR TITLE
New package: rulssss.CloudCostTree version 0.1.35

### DIFF
--- a/manifests/r/rulssss/CloudCostTree/0.1.35/rulssss.CloudCostTree.installer.yaml
+++ b/manifests/r/rulssss/CloudCostTree/0.1.35/rulssss.CloudCostTree.installer.yaml
@@ -1,0 +1,14 @@
+PackageIdentifier: rulssss.CloudCostTree
+PackageVersion: 0.1.35
+InstallerType: portable
+Commands:
+  - cloudcosttree
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/rulssss/cloudcosttree/releases/download/v0.1.35/cloudcosttree-windows-amd64.exe
+    InstallerSha256: 3225B1AE6FA63CC28770456C3FC50976643327DF19AFF7478AEBCE14A4804676
+  - Architecture: arm64
+    InstallerUrl: https://github.com/rulssss/cloudcosttree/releases/download/v0.1.35/cloudcosttree-windows-arm64.exe
+    InstallerSha256: C1705911D16F2E8DEBE189538535C19651074DFA58B79EA09052F3D9677FA3D8
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/r/rulssss/CloudCostTree/0.1.35/rulssss.CloudCostTree.locale.en-US.yaml
+++ b/manifests/r/rulssss/CloudCostTree/0.1.35/rulssss.CloudCostTree.locale.en-US.yaml
@@ -1,0 +1,10 @@
+PackageIdentifier: rulssss.CloudCostTree
+PackageVersion: 0.1.35
+PackageLocale: en-US
+Publisher: rulssss
+PackageName: CloudCostTree
+License: Proprietary
+ShortDescription: Estimate AWS infrastructure costs in a hierarchical tree before you apply
+PackageUrl: https://cloudcosttree.com
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/r/rulssss/CloudCostTree/0.1.35/rulssss.CloudCostTree.yaml
+++ b/manifests/r/rulssss/CloudCostTree/0.1.35/rulssss.CloudCostTree.yaml
@@ -1,0 +1,8 @@
+# Created with wingetcreate equivalent (hand-authored, no Windows machine
+# available to run wingetcreate.exe itself) following the standard 1.6.0
+# manifest schema.
+PackageIdentifier: rulssss.CloudCostTree
+PackageVersion: 0.1.35
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
CloudCostTree — estimate AWS infrastructure costs in a hierarchical tree before you apply, for Terraform, CloudFormation, Pulumi, Terragrunt, Atmos, and Kubernetes manifest input.

- Homepage: https://cloudcosttree.com
- Source (binary distribution): https://github.com/rulssss/cloudcosttree
- Portable installer type (raw platform binaries, x64/arm64), installer URLs point at GitHub Releases.

## Validation

- [x] Manifest schema authored by hand against the 1.6.0 spec (`ManifestVersion: 1.6.0`)
- [x] Installer URLs verified live and reachable
- [x] `InstallerSha256` computed locally against the exact published release assets (`shasum -a 256`)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/414474)