### PR TITLE
Update: OpenTubeX.OpenTubeX to 0.31.0

### DIFF
--- a/manifests/o/OpenTubeX/OpenTubeX/0.31.0/OpenTubeX.OpenTubeX.installer.yaml
+++ b/manifests/o/OpenTubeX/OpenTubeX/0.31.0/OpenTubeX.OpenTubeX.installer.yaml
@@ -1,0 +1,45 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: OpenTubeX.OpenTubeX
+PackageVersion: 0.31.0
+InstallerLocale: en-US
+InstallerType: nullsoft
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+Protocols:
+- opentubex
+ProductCode: a38f022d-fec2-5f80-a7fe-620ccf1a2767
+ReleaseDate: 2026-08-09
+AppsAndFeaturesEntries:
+- DisplayName: OpenTubeX 0.31.0
+  ProductCode: a38f022d-fec2-5f80-a7fe-620ccf1a2767
+Installers:
+- Architecture: x64
+  Scope: user
+  InstallerUrl: https://github.com/OpenTubeX/OpenTubeX/releases/download/v0.31.0-beta/opentubex-0.31.0-beta-setup-x64.exe
+  InstallerSha256: 6590ACDA56AD5C8DD0ADCE122219A01DA490D5417BF418C74D891FF1AF8CB127
+  InstallerSwitches:
+    Custom: /CURRENTUSER
+- Architecture: x64
+  Scope: machine
+  InstallerUrl: https://github.com/OpenTubeX/OpenTubeX/releases/download/v0.31.0-beta/opentubex-0.31.0-beta-setup-x64.exe
+  InstallerSha256: 6590ACDA56AD5C8DD0ADCE122219A01DA490D5417BF418C74D891FF1AF8CB127
+  InstallerSwitches:
+    Custom: /ALLUSERS
+- Architecture: arm64
+  Scope: user
+  InstallerUrl: https://github.com/OpenTubeX/OpenTubeX/releases/download/v0.31.0-beta/opentubex-0.31.0-beta-setup-arm64.exe
+  InstallerSha256: ABEF61840A8A730A6E4B65F14A64C5B03EA8B38ACC80064DAE7C8B2DB0A30DAC
+  InstallerSwitches:
+    Custom: /CURRENTUSER
+- Architecture: arm64
+  Scope: machine
+  InstallerUrl: https://github.com/OpenTubeX/OpenTubeX/releases/download/v0.31.0-beta/opentubex-0.31.0-beta-setup-arm64.exe
+  InstallerSha256: ABEF61840A8A730A6E4B65F14A64C5B03EA8B38ACC80064DAE7C8B2DB0A30DAC
+  InstallerSwitches:
+    Custom: /ALLUSERS
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenTubeX/OpenTubeX/0.31.0/OpenTubeX.OpenTubeX.locale.en-US.yaml
+++ b/manifests/o/OpenTubeX/OpenTubeX/0.31.0/OpenTubeX.OpenTubeX.locale.en-US.yaml
@@ -1,0 +1,95 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: OpenTubeX.OpenTubeX
+PackageVersion: 0.31.0
+PackageLocale: en-US
+Publisher: OpenTubeX contributors
+PublisherUrl: https://github.com/OpenTubeX
+PublisherSupportUrl: https://github.com/OpenTubeX/OpenTubeX/issues
+Author: OpenTubeX contributors
+PackageName: OpenTubeX
+PackageUrl: https://opentubex.org/
+License: AGPL-3.0
+LicenseUrl: https://github.com/OpenTubeX/OpenTubeX/blob/HEAD/LICENSE
+Copyright: Copyleft © 2020-2026
+CopyrightUrl: https://github.com/OpenTubeX/OpenTubeX/blob/HEAD/LICENSE
+ShortDescription: A private YouTube client
+Description: OpenTubeX is a private YouTube client for desktop.
+Moniker: opentubex
+Tags:
+- cross-platform
+- electron
+- privacy
+- private-youtube
+- sponsorblock
+- subscriptions
+- tabbed-browsing
+- tabs
+- video
+- videos
+- youtube
+- youtube-client
+- youtube-player
+ReleaseNotes: |-
+  Highlights
+  - Upcoming premieres now refresh automatically, comments appear during premieres, and live chat supports improved scrolling, optional timestamps, chat selection, fullscreen docks, and replays (#490)
+  - Settings now opens in a draggable, resizable window with integrated subpages and cross-category search (#555, #570)
+  - Added advanced video and playlist download options plus a page for managing active and completed downloads (#351, #568)
+
+  More improvements
+  - Show managed tool download progress in persistent notifications (#487)
+  - Show translation completion percentages and theme select menus (#420, #482)
+  - Videos about a game now show its box art, title, and release year in the description (#456, #486)
+  - Subscription feed tabs move beside the page title when space permits (#483)
+  - yt-dlp is now the default stream extraction method and can be selected from General settings (#501)
+  - yt-dlp downloads, playback, and managed tool downloads now use the configured proxy (#413, #507)
+  - Show YouTube's paid-promotion disclosure, with an option to disable it (#494)
+  - Added an animation speed control to Theme settings (#491)
+  - Hashtags and handles in video titles and descriptions are now clickable (#485)
+  - Previous and next player buttons are shown only when the playlist has a video to skip to (#481)
+  - Refreshed per-channel playback speed, video quality, subtitle, and volume settings (#536)
+  - Added a setting to disable automatic Shorts looping (#538)
+  - Improved SponsorBlock labels, submission controls, and default skip prompts (#541)
+  - Chapters sidebars and fullscreen docks keep the current chapter centered (#542)
+  - The Ctrl+Tab switcher wraps into multiple rows and shows enabled tab icons (#554)
+  - Show an on-screen indicator when toggling Fast-Forward Through Silence with a keyboard shortcut (#528, #553)
+  - Removed the separator line when using horizontal tabs (#574)
+  - Video tags are shown at the bottom of descriptions, which can now be copied (#558, #573)
+  - Video thumbnails morph into newly opened tabs (#572)
+  - Individual subscription videos can be marked as seen from their overflow menu (#575)
+
+  Fixed bugs
+  - Fixed GitHub-style alerts and collapsible details in the in-app update changelog (#459)
+  - Show release notes for every update skipped since the installed version (#443)
+  - Fixed channel icons disappearing from restored tabs after restarting the app (#493)
+  - Fixed video quality remaining at 360p after switching back from legacy formats (#497)
+  - Show the video thumbnail while switching playback formats (#505)
+  - Fixed fullscreen comments appearing empty after reloading or re-sorting while scrolled down (#499)
+  - Keep the thumbnail and normal player size visible when video stream recovery fails (#508)
+  - Progress notifications no longer cover fullscreen video (#511)
+  - Fixed Picture-in-Picture state after restoring the window with multiple automatic triggers enabled (#492, #496)
+  - Fixed the scroll mini player position after resizing the window (#498)
+  - Comment sections correctly report disabled comments and hide unavailable reply controls (#502)
+  - Avoid running IP block recovery when a changed IP address invalidates streaming URLs (#523)
+  - Improved the update prompt and changelog rendering (#509)
+  - Fixed fullscreen Share and Add to playlist popovers appearing behind SponsorBlock notifications (#510)
+  - Improved Shorts controls, seekbar behavior, tab switching, and loading feedback (#495)
+  - Captions scale with the player and support sizes up to 400% (#527, #532)
+  - Fixed long context menu entries being cut off (#533, #535)
+  - Upcoming premieres cannot be marked as watched before airing (#534)
+  - Videos reload once when the YouTube watch session expires during playback (#540)
+  - Fixed horizontal tab previews being cropped (#549)
+  - Fixed tab bar clipping on macOS and the hamburger remaining visible with bottom navigation (#551)
+  - Channels and suggested videos on Shorts are now links (#556)
+  - Fixed stretched and soft-looking images in community posts (#561)
+  - Improved live chat layout and scrolling, including Super Chat presentation (#559)
+  - Long select options are no longer unnecessarily truncated (#567)
+  - Fixed pinned tab close button alignment in the vertical tab layout (#571)
+  - Fixed the scroll mini player replaying its entrance animation when returning to a tab (#569)
+  - Video information appears immediately while yt-dlp extracts streams (#580)
+  - SponsorBlock hover labels now match overlapping seekbar segments (#581)
+  - Fixed subscribed channels failing to load without a usable thumbnail and blank tabs after failed loads (#578)
+ReleaseNotesUrl: https://github.com/OpenTubeX/OpenTubeX/releases/tag/v0.31.0-beta
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenTubeX/OpenTubeX/0.31.0/OpenTubeX.OpenTubeX.yaml
+++ b/manifests/o/OpenTubeX/OpenTubeX/0.31.0/OpenTubeX.OpenTubeX.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: OpenTubeX.OpenTubeX
+PackageVersion: 0.31.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Updates `OpenTubeX.OpenTubeX` from 0.30.2 to 0.31.0.

The manifest includes the x64 and ARM64 NSIS installers for user and machine scope. Embedded release images were omitted from the text-only release notes.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

Validation performed with Komac:

```text
komac submit --dry-run --yes manifests/o/OpenTubeX/OpenTubeX/0.31.0
```

> **Note:** `<path>` is the directory containing the manifest you're submitting.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/414583)