### PR TITLE
Fix v2RayTun.Windows ProductCode/UpgradeCode mixup

### DIFF
--- a/manifests/v/v2RayTun/Windows/3.8.12/v2RayTun.Windows.installer.yaml
+++ b/manifests/v/v2RayTun/Windows/3.8.12/v2RayTun.Windows.installer.yaml
@@ -16,7 +16,7 @@ UpgradeBehavior: install
 AppsAndFeaturesEntries:
 - DisplayName: v2RayTun
   Publisher: DATABRIDGES TECHNOLOGIES LTD
-  UpgradeCode: '{4CAA7AAB-7C69-4862-85B4-25E5BA76D312}_is1'
+  ProductCode: '{4CAA7AAB-7C69-4862-85B4-25E5BA76D312}_is1'
 Installers:
 - Architecture: x64
   InstallerUrl: https://storage.v2raytun.com/releases/v2RayTun_Setup_3.8.12.exe


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
<!-- Describe what this PR changes. For manifest submissions, include the package name and version. -->
InnoSetup is not MSI based and therefore does not have an [UpgradeCode](https://learn.microsoft.com/en-us/windows/win32/msi/upgradecode). It does however have a "ProductCode" with `_is1` appended.

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [X] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [ ] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [X] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [X] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/414606)