### PR TITLE
New package: Shinnosuke0722.jm version 1.0.2

### DIFF
--- a/manifests/s/Shinnosuke0722/jm/1.0.2/Shinnosuke0722.jm.installer.yaml
+++ b/manifests/s/Shinnosuke0722/jm/1.0.2/Shinnosuke0722.jm.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Shinnosuke0722.jm
+PackageVersion: 1.0.2
+InstallerType: zip
+NestedInstallerType: portable
+Commands:
+  - jm
+ReleaseDate: 2026-08-09
+Installers:
+  - Architecture: x64
+    NestedInstallerFiles:
+      - RelativeFilePath: jm.exe
+        PortableCommandAlias: jm
+    InstallerUrl: https://github.com/Shinnosuke0722/jm/releases/download/v1.0.2/jm-windows-x86_64.zip
+    InstallerSha256: 33c0b72755abb055446cf59e79ae31b0a24a322729cd6415d5282f22a0e9cb7f
+    Dependencies:
+      PackageDependencies:
+        - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/Shinnosuke0722/jm/1.0.2/Shinnosuke0722.jm.locale.en-US.yaml
+++ b/manifests/s/Shinnosuke0722/jm/1.0.2/Shinnosuke0722.jm.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Shinnosuke0722.jm
+PackageVersion: 1.0.2
+PackageLocale: en-US
+Publisher: Shinnosuke0722
+PublisherUrl: https://github.com/Shinnosuke0722
+PublisherSupportUrl: https://github.com/Shinnosuke0722/jm/issues
+Author: lfming0419
+PackageName: jm
+PackageUrl: https://github.com/Shinnosuke0722/jm
+License: MIT OR Apache-2.0
+LicenseUrl: https://github.com/Shinnosuke0722/jm/tree/v1.0.2#license
+ShortDescription: Cross-platform JDK and Java version manager written in Rust
+Moniker: jm
+Tags:
+  - cli
+  - java
+  - jdk
+  - jdk-manager
+  - openjdk
+  - rust
+  - version-manager
+ReleaseNotesUrl: https://github.com/Shinnosuke0722/jm/releases/tag/v1.0.2
+InstallationNotes: >-
+  Enable PowerShell integration by adding "jm shell init powershell |
+  Invoke-Expression" to your PowerShell profile. Update this WinGet-managed
+  installation with "winget upgrade --id Shinnosuke0722.jm --exact"; do not run
+  "jm upgrade".
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/Shinnosuke0722/jm/1.0.2/Shinnosuke0722.jm.yaml
+++ b/manifests/s/Shinnosuke0722/jm/1.0.2/Shinnosuke0722.jm.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Shinnosuke0722.jm
+PackageVersion: 1.0.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds the first WinGet manifest for `jm` 1.0.2, a cross-platform JDK and Java
version manager written in Rust.

The Windows release is a portable x64 ZIP containing `jm.exe`. The manifest
declares the Microsoft Visual C++ 2015-2022 x64 runtime required by the binary.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

Both `winget validate` and
`winget install --manifest <path> --scope user` passed on Windows x64 with
Windows Package Manager v1.29.280. WinGet verified the archive hash, installed
the portable package under user scope, registered `jm` 1.0.2, and after a PATH
refresh `jm --version` returned `jm 1.0.2`.

An additional `winget uninstall --name jm --exact` smoke test removed the
package files and ARP entry. WinGet left the now-invalid archive-binary directory
in the user PATH, matching the open WinGet client bug
[microsoft/winget-cli#6160](https://github.com/microsoft/winget-cli/issues/6160);
the exact stale entry was removed manually. The release archive hash and its
single `jm.exe` payload were also independently verified.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/414637)