### PR TITLE
New version: v2fly.v2ray-core version 5.52.0

### DIFF
--- a/manifests/v/v2fly/v2ray-core/5.52.0/v2fly.v2ray-core.installer.yaml
+++ b/manifests/v/v2fly/v2ray-core/5.52.0/v2fly.v2ray-core.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: v2fly.v2ray-core
+PackageVersion: 5.52.0
+InstallerType: zip
+NestedInstallerType: portable
+ReleaseDate: 2026-07-07
+NestedInstallerFiles:
+- RelativeFilePath: v2ray.exe
+  PortableCommandAlias: v2ray
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/v2fly/v2ray-core/releases/download/v5.52.0/v2ray-windows-32.zip
+  InstallerSha256: B992970DCF946380D0FAD62274B84D6B424788C9E2B7049DE6CAE41FB71321C1
+- Architecture: x64
+  InstallerUrl: https://github.com/v2fly/v2ray-core/releases/download/v5.52.0/v2ray-windows-64.zip
+  InstallerSha256: A73B01D1DBFE054B260E37A79CA13B12B6549DBD1827A44F0BCAA113E990CC9D
+- Architecture: arm64
+  InstallerUrl: https://github.com/v2fly/v2ray-core/releases/download/v5.52.0/v2ray-windows-arm64-v8a.zip
+  InstallerSha256: 11092B68FB518CE5136FD84E727BF41FD6BC179EE59283A6660249E83E6237EC
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/v/v2fly/v2ray-core/5.52.0/v2fly.v2ray-core.locale.en-US.yaml
+++ b/manifests/v/v2fly/v2ray-core/5.52.0/v2fly.v2ray-core.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: v2fly.v2ray-core
+PackageVersion: 5.52.0
+PackageLocale: en-US
+Publisher: v2fly
+PublisherUrl: https://www.v2fly.org
+PublisherSupportUrl: https://github.com/v2fly/v2ray-core/issues
+Author: v2fly
+PackageName: v2ray-core
+PackageUrl: https://github.com/v2fly/v2ray-core
+License: MIT
+LicenseUrl: https://github.com/v2fly/v2ray-core/blob/master/LICENSE
+Copyright: Copyright (c) v2fly
+CopyrightUrl: https://github.com/v2fly/v2ray-core/blob/master/LICENSE
+ShortDescription: A platform for building proxies to bypass network restrictions.
+Moniker: v2ray
+Description: Project V is a set of network tools that help you to build your own computer network. It secures your network connections and thus protects your privacy.
+Tags:
+- network
+- proxy
+- vpn
+- v2ray
+ReleaseNotesUrl: https://github.com/v2fly/v2ray-core/releases/tag/v5.52.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/v/v2fly/v2ray-core/5.52.0/v2fly.v2ray-core.yaml
+++ b/manifests/v/v2fly/v2ray-core/5.52.0/v2fly.v2ray-core.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: v2fly.v2ray-core
+PackageVersion: 5.52.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New version: v2fly.v2ray-core version 5.52.0.

Upstream release: https://github.com/v2fly/v2ray-core/releases/tag/v5.52.0 (published 2026-07-07). v5.53.0 exists upstream but is marked as a pre-release, so 5.52.0 is the latest stable version.

## ✅ Checklist

- [x] Signed the Contributor License Agreement

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Manifest conforms to the 1.12 schema
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/414649)