### PR TITLE
New package: KDE.Cantor version master

### DIFF
--- a/manifests/k/KDE/Cantor/master/KDE.Cantor.installer.yaml
+++ b/manifests/k/KDE/Cantor/master/KDE.Cantor.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: KDE.Cantor
+PackageVersion: master
+InstallerType: nullsoft
+UpgradeBehavior: install
+ProductCode: cantor
+ReleaseDate: 2026-07-26
+Installers:
+- Architecture: x64
+  Scope: user
+  InstallerUrl: https://cdn.kde.org/ci-builds/education/cantor/master/windows/cantor-master-2308-windows-cl-msvc2022-x86_64.exe
+  InstallerSha256: CAE7D856D5345CF878ED98B6D77FCEF9EC899020CA04E6EFBCB67055F4E4B632
+  InstallerSwitches:
+    Custom: /CurrentUser
+- Architecture: x64
+  Scope: machine
+  InstallerUrl: https://cdn.kde.org/ci-builds/education/cantor/master/windows/cantor-master-2308-windows-cl-msvc2022-x86_64.exe
+  InstallerSha256: CAE7D856D5345CF878ED98B6D77FCEF9EC899020CA04E6EFBCB67055F4E4B632
+  InstallerSwitches:
+    Custom: /AllUsers
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/k/KDE/Cantor/master/KDE.Cantor.locale.en-US.yaml
+++ b/manifests/k/KDE/Cantor/master/KDE.Cantor.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: KDE.Cantor
+PackageVersion: master
+PackageLocale: en-US
+Publisher: KDE e.V.
+PublisherUrl: https://kde.org/
+PublisherSupportUrl: https://kde.org/support/
+PrivacyUrl: https://kde.org/privacypolicy/
+Author: KDE e.V.
+PackageName: cantor
+PackageUrl: https://apps.kde.org/cantor/
+License: GPL-2.0-or-later
+LicenseUrl: https://invent.kde.org/education/cantor/-/blob/HEAD/LICENSES/GPL-2.0-or-later.txt
+ShortDescription: KDE Frontend to Mathematical Software
+Description: |-
+  Cantor is a front-end to powerful mathematics and statistics packages. Cantor integrates them into a Jupyter-like graphical user interface using a worksheet metaphor, so you do not have to learn a different interface for every backend you want to use.
+  Cantor supports the Julia, KAlgebra, Lua, Maxima, Octave, Python, Qalculate!, R, Sage and Scilab backends, and provides syntax highlighting, tab completion, plot integration, formula typesetting via LaTeX, and Jupyter notebook import and export.
+Tags:
+- education
+- math
+- mathematics
+- science
+- statistics
+Documentations:
+- DocumentLabel: Handbook
+  DocumentUrl: https://docs.kde.org/?application=cantor
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/k/KDE/Cantor/master/KDE.Cantor.yaml
+++ b/manifests/k/KDE/Cantor/master/KDE.Cantor.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: KDE.Cantor
+PackageVersion: master
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Resolves #400408

Adds a manifest for **KDE.Cantor** (KDE frontend to mathematical software), requested in #400408.

Installer comes from the official KDE CI build CDN, matching the convention already used by the other `KDE.*` nightly manifests in this repo (`KDE.KBreakOut`, `KDE.Akregator`, etc.), including the `/CurrentUser` and `/AllUsers` scope switches.

### Verification

| Check | Result |
|---|---|
| Installer URL | HTTP 200 |
| `InstallerSha256` | `CAE7D856D5345CF878ED98B6D77FCEF9EC899020CA04E6EFBCB67055F4E4B632` — matches the publisher-provided `.exe.sha256` on cdn.kde.org |
| `InstallerType` | `nullsoft` — confirmed by the `Nullsoft Install System` signature in the binary |
| Schema validation | All three manifests validate against the v1.12.0 JSON schemas |

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

> [!NOTE]
> I author on macOS, so I cannot run `winget install` locally. Hash, reachability, installer type and schema conformance were all verified as shown above; leaving the install test to the validation pipeline.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/414756)