### PR TITLE
New package: vadimgrn.usbip-win2 version 0.9.7.8

### DIFF
--- a/manifests/v/vadimgrn/usbip-win2/0.9.7.8/vadimgrn.usbip-win2.installer.yaml
+++ b/manifests/v/vadimgrn/usbip-win2/0.9.7.8/vadimgrn.usbip-win2.installer.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: vadimgrn.usbip-win2
+PackageVersion: 0.9.7.8
+InstallerType: inno
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ProductCode: "{199505b0-b93d-4521-a8c7-897818e0205a}_is1"
+ReleaseDate: 2026-07-04
+ElevationRequirement: elevatesSelf
+AppsAndFeaturesEntries:
+- DisplayName: USBip
+  DisplayVersion: 0.9.7.8
+  Publisher: Vadym Hrynchyshyn
+  ProductCode: "{199505b0-b93d-4521-a8c7-897818e0205a}_is1"
+  InstallerType: inno
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/vadimgrn/usbip-win2/releases/download/v.0.9.7.8/USBip-0.9.7.8-x64.exe
+  InstallerSha256: 44451FE06F4186125C2A5ECD25B099C5560A61A60B1E56F5A0758E77A60AFA44
+- Architecture: arm64
+  InstallerUrl: https://github.com/vadimgrn/usbip-win2/releases/download/v.0.9.7.8/USBip-0.9.7.8-arm64.exe
+  InstallerSha256: 0FDA9D3FC19E31753F57FCF8E3401939C41E259964A960B101F848C89FC19F19
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/v/vadimgrn/usbip-win2/0.9.7.8/vadimgrn.usbip-win2.locale.en-US.yaml
+++ b/manifests/v/vadimgrn/usbip-win2/0.9.7.8/vadimgrn.usbip-win2.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: vadimgrn.usbip-win2
+PackageVersion: 0.9.7.8
+PackageLocale: en-US
+Publisher: Vadym Hrynchyshyn
+PublisherUrl: https://github.com/vadimgrn
+PublisherSupportUrl: https://github.com/vadimgrn/usbip-win2/issues
+Author: Vadym Hrynchyshyn
+PackageName: USBip
+PackageUrl: https://github.com/vadimgrn/usbip-win2
+License: BSD-2-Clause
+LicenseUrl: https://github.com/vadimgrn/usbip-win2/blob/master/LICENSE.txt
+Copyright: Copyright (c) 2021-2026, Vadym Hrynchyshyn
+CopyrightUrl: https://github.com/vadimgrn/usbip-win2/blob/master/LICENSE.txt
+ShortDescription: USB/IP client for Windows
+Description: |-
+  USBip is a USB/IP client for Windows that attaches USB devices shared by a remote USB/IP server over TCP/IP, so they appear as locally connected devices.
+  It is fully compatible with the Linux USB/IP protocol, ships WHLK-certified UDE and filter drivers, uses Winsock Kernel NPI for low latency and high throughput, and includes both a GUI (wusbip) and a command line client (usbip).
+Tags:
+- usb
+- usb-over-ethernet
+- usb-over-ip
+- usb-over-network
+- usbip
+- vhci
+ReleaseNotesUrl: https://github.com/vadimgrn/usbip-win2/releases/tag/v.0.9.7.8
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/vadimgrn/usbip-win2/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/v/vadimgrn/usbip-win2/0.9.7.8/vadimgrn.usbip-win2.yaml
+++ b/manifests/v/vadimgrn/usbip-win2/0.9.7.8/vadimgrn.usbip-win2.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: vadimgrn.usbip-win2
+PackageVersion: 0.9.7.8
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Resolves #391258

Adds a manifest for **USBip** (`vadimgrn.usbip-win2`), a USB/IP client for Windows, requested in #391258. Both the x64 and the Windows 11 ARM64 installers from the upstream GitHub release are included.

### Verification

| Check | Result |
|---|---|
| x64 installer | HTTP 200, `InstallerSha256` `44451FE06F4186125C2A5ECD25B099C5560A61A60B1E56F5A0758E77A60AFA44` |
| arm64 installer | HTTP 200, `InstallerSha256` `0FDA9D3FC19E31753F57FCF8E3401939C41E259964A960B101F848C89FC19F19` |
| `InstallerType` | `inno` — confirmed by the `Inno Setup Setup Data` marker in both binaries |
| `ProductCode` | `{199505b0-b93d-4521-a8c7-897818e0205a}_is1` — derived from `AppGUID` in the upstream [`setup.iss`](https://github.com/vadimgrn/usbip-win2/blob/master/userspace/innosetup/setup.iss) |
| `ArchitecturesAllowed` | `x64compatible` in `setup.iss`, so the arm64 build is accepted on ARM64 Windows |
| Schema validation | All three manifests validate against the v1.12.0 JSON schemas |

Notes for the reviewer:
- The package installs WHLK-certified kernel drivers (UDE + upper filter), so `Scope: machine` and `ElevationRequirement: elevatesSelf` are set. No test-signing or Secure Boot changes are needed — certification was done through the Open Source Codesigning Initiative.
- `setup.iss` sets `AlwaysRestart=yes`; winget's default Inno silent switches include `/NORESTART`, so an unattended install will not reboot the machine on its own.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

> [!NOTE]
> I author on macOS, so I cannot run `winget install` locally. Hashes, reachability, installer type, product code and schema conformance were all verified as shown above; leaving the install test to the validation pipeline.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/414758)