### PR TITLE
New package: Uotan-Dev.UotanToolboxNT version 3.7.1

### DIFF
--- a/manifests/u/Uotan-Dev/UotanToolboxNT/3.7.1/Uotan-Dev.UotanToolboxNT.installer.yaml
+++ b/manifests/u/Uotan-Dev/UotanToolboxNT/3.7.1/Uotan-Dev.UotanToolboxNT.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Uotan-Dev.UotanToolboxNT
+PackageVersion: 3.7.1
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: UotanToolbox.exe
+  PortableCommandAlias: UotanToolbox
+UpgradeBehavior: install
+ReleaseDate: 2026-07-31
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Uotan-Dev/UotanToolboxNT/releases/download/3.7.1/UotanToolbox_Windows_x64_3.7.1.zip
+  InstallerSha256: 1ABA80DDF90CC14C3C65842E86AE6905AD0A4904760CE8071B8E44EE6389CF34
+- Architecture: arm64
+  InstallerUrl: https://github.com/Uotan-Dev/UotanToolboxNT/releases/download/3.7.1/UotanToolbox_Windows_arm64_3.7.1.zip
+  InstallerSha256: E8286A8B7AFE663184378C768F8F090D3DCC9FE9EF9E5CB362703D764BB3F3A8
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/u/Uotan-Dev/UotanToolboxNT/3.7.1/Uotan-Dev.UotanToolboxNT.locale.en-US.yaml
+++ b/manifests/u/Uotan-Dev/UotanToolboxNT/3.7.1/Uotan-Dev.UotanToolboxNT.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Uotan-Dev.UotanToolboxNT
+PackageVersion: 3.7.1
+PackageLocale: en-US
+Publisher: Uotan-Dev
+PublisherUrl: https://github.com/Uotan-Dev
+PublisherSupportUrl: https://github.com/Uotan-Dev/UotanToolboxNT/issues
+Author: Uotan-Dev
+PackageName: UotanToolboxNT
+PackageUrl: https://toolbox.uotan.cn
+License: GPL-3.0
+LicenseUrl: https://github.com/Uotan-Dev/UotanToolboxNT/blob/master/LICENSE
+ShortDescription: A modern toolbox for Android and OpenHarmony devices
+Description: |-
+  Uotan Toolbox NT is a cross-platform toolbox for working with Android and OpenHarmony devices from the desktop.
+  It bundles the platform tools it needs (adb, fastboot, magiskboot, payload dumper and more) behind a single interface, and covers ADB and fastboot operations, flashing, partition and boot image work, Magisk patching, app management and device information.
+Tags:
+- adb
+- android
+- fastboot
+- flashing
+- magisk
+- openharmony
+- toolbox
+ReleaseNotesUrl: https://github.com/Uotan-Dev/UotanToolboxNT/releases/tag/3.7.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/u/Uotan-Dev/UotanToolboxNT/3.7.1/Uotan-Dev.UotanToolboxNT.locale.zh-CN.yaml
+++ b/manifests/u/Uotan-Dev/UotanToolboxNT/3.7.1/Uotan-Dev.UotanToolboxNT.locale.zh-CN.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: Uotan-Dev.UotanToolboxNT
+PackageVersion: 3.7.1
+PackageLocale: zh-CN
+Publisher: 柚坛
+PublisherUrl: https://github.com/Uotan-Dev
+PublisherSupportUrl: https://github.com/Uotan-Dev/UotanToolboxNT/issues
+PackageName: 柚坛工具箱
+PackageUrl: https://toolbox.uotan.cn
+License: GPL-3.0
+LicenseUrl: https://github.com/Uotan-Dev/UotanToolboxNT/blob/master/LICENSE
+ShortDescription: 现代化 Android & OpenHarmony 工具箱
+Tags:
+- adb
+- android
+- fastboot
+- magisk
+- openharmony
+- 刷机
+- 工具箱
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/u/Uotan-Dev/UotanToolboxNT/3.7.1/Uotan-Dev.UotanToolboxNT.yaml
+++ b/manifests/u/Uotan-Dev/UotanToolboxNT/3.7.1/Uotan-Dev.UotanToolboxNT.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Uotan-Dev.UotanToolboxNT
+PackageVersion: 3.7.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Resolves #414333

Adds a manifest for **Uotan Toolbox NT** (柚坛工具箱), requested in #414333. Both the x64 and arm64 Windows packages from the upstream GitHub release are included, plus a `zh-CN` locale manifest since the app is primarily Chinese-language.

### Verification

| Check | Result |
|---|---|
| x64 archive | HTTP 200, `InstallerSha256` `1ABA80DDF90CC14C3C65842E86AE6905AD0A4904760CE8071B8E44EE6389CF34` |
| arm64 archive | HTTP 200, `InstallerSha256` `E8286A8B7AFE663184378C768F8F090D3DCC9FE9EF9E5CB362703D764BB3F3A8` |
| `NestedInstallerFiles` | `UotanToolbox.exe` confirmed present at the archive root in both archives (listed both zips) |
| Schema validation | All four manifests validate against the v1.12.0 JSON schemas |

Note on the choice of installer: the issue links the `*_Installer_*.exe` asset, but that binary carries no recognizable installer-framework signature (not Inno, Nullsoft, WiX/Burn, Squirrel or Velopack), and the upstream `Build Windows` workflow only produces the `.zip` artifacts — so I could not state its `InstallerType` with confidence. The published `.zip` archives contain the same self-contained build with `UotanToolbox.exe` at the root, so this manifest uses them as `zip` + `NestedInstallerType: portable`. Happy to switch to the `.exe` if a maintainer can confirm what builds it and which silent switch it takes.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

> [!NOTE]
> I author on macOS, so I cannot run `winget install` locally. Hashes, reachability, archive contents and schema conformance were all verified as shown above; leaving the install test to the validation pipeline.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/414760)