### PR TITLE
New version: MailFathom.mfctl version 0.5.0

### DIFF
--- a/manifests/m/MailFathom/mfctl/0.5.0/MailFathom.mfctl.installer.yaml
+++ b/manifests/m/MailFathom/mfctl/0.5.0/MailFathom.mfctl.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: MailFathom.mfctl
+PackageVersion: 0.5.0
+InstallerType: portable
+Commands:
+- mfctl
+ReleaseDate: 2026-08-10
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Krzysztof318/MailFathom/releases/download/v0.5.0/mfctl-0.5.0-win-x64.exe
+  InstallerSha256: BE1541800BD283B7E40295B6833B2ABE0139CE8E2DD9DEBD8340B2518F94857A
+- Architecture: arm64
+  InstallerUrl: https://github.com/Krzysztof318/MailFathom/releases/download/v0.5.0/mfctl-0.5.0-win-arm64.exe
+  InstallerSha256: 89E943441AEA73F844B3525F76330B180EA00252F60C36954A01C05EF6422BFC
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/MailFathom/mfctl/0.5.0/MailFathom.mfctl.locale.en-US.yaml
+++ b/manifests/m/MailFathom/mfctl/0.5.0/MailFathom.mfctl.locale.en-US.yaml
@@ -1,0 +1,46 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: MailFathom.mfctl
+PackageVersion: 0.5.0
+PackageLocale: en-US
+Publisher: MailFathom
+PublisherUrl: https://krzysztof318.github.io/MailFathom/
+PublisherSupportUrl: https://github.com/Krzysztof318/MailFathom/issues
+Author: Krzysztof Kasprowicz
+PackageName: MailFathom CLI
+PackageUrl: https://github.com/Krzysztof318/MailFathom
+License: Apache-2.0
+LicenseUrl: https://github.com/Krzysztof318/MailFathom/blob/main/LICENSE
+Copyright: Copyright © 2026 Krzysztof Kasprowicz
+CopyrightUrl: https://github.com/Krzysztof318/MailFathom/blob/main/LICENSE
+ShortDescription: The administrative command-line client for MailFathom, a self-hosted AI-native mail service.
+Description: |-
+  mfctl administers a MailFathom deployment over HTTP. It signs in against the deployment's administrative endpoint,
+  keeps a profile for each deployment you administer, checks that a stored credential still works, and completes the
+  OAuth authorization a mailbox needs — without ever reading the service's configuration, opening its database, or
+  touching its secret store.
+
+  MailFathom itself runs on Linux, as a container or as a native process, and synchronizes IMAP mailboxes into a
+  PostgreSQL database you own, indexes them, and serves them to AI agents over the Model Context Protocol. mfctl is
+  the client you administer such a deployment from, which is why it ships for Windows as well.
+
+  No mfctl binary carries a code signature. Every release publishes a checksum file covering all of them, and the hash
+  in this manifest is the one winget verifies the download against.
+Moniker: mfctl
+Tags:
+- ai
+- cli
+- email
+- imap
+- mail
+- mcp
+- model-context-protocol
+- self-hosted
+ReleaseNotesUrl: https://github.com/Krzysztof318/MailFathom/releases/tag/v0.5.0
+Documentations:
+- DocumentLabel: Administering a deployment
+  DocumentUrl: https://krzysztof318.github.io/MailFathom/operations/admin-endpoint.html
+- DocumentLabel: Installation
+  DocumentUrl: https://krzysztof318.github.io/MailFathom/users/installation.html
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/MailFathom/mfctl/0.5.0/MailFathom.mfctl.yaml
+++ b/manifests/m/MailFathom/mfctl/0.5.0/MailFathom.mfctl.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: MailFathom.mfctl
+PackageVersion: 0.5.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Depends on #414063

MailFathom.mfctl 0.5.0, submitted by the MailFathom release pipeline.

- One package version, as three manifest files at schema 1.12.0.
- A portable installer per released Windows architecture, from version-specific release assets.
- Each `InstallerSha256` is computed from the bytes the release attaches, not from a re-download.

Release: https://github.com/Krzysztof318/MailFathom/releases/tag/v0.5.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/414810)