### PR TITLE
Update: Japplis.AntCommander.Personal to 6.3

### DIFF
--- a/manifests/j/Japplis/AntCommander/Personal/6.3/Japplis.AntCommander.Personal.installer.yaml
+++ b/manifests/j/Japplis/AntCommander/Personal/6.3/Japplis.AntCommander.Personal.installer.yaml
@@ -1,0 +1,27 @@
+# Created using Apache Ant script from Japplis
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Japplis.AntCommander.Personal
+PackageVersion: 6.3
+Platform:
+- Windows.Desktop
+InstallerType: inno
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+Installers:
+- Architecture: x64
+  Scope: machine
+  InstallerUrl: https://www.antcommander.com/personal/versions/AntCommander-6.3.exe
+  InstallerSha256: abfff6ac1fb46e6c234fd6f024556f7b75c5522c021e211c3f4f7c4438ffa987
+  InstallerSwitches:
+    Custom: /ALLUSERS
+- Architecture: x64
+  Scope: user
+  InstallerUrl: https://www.antcommander.com/personal/versions/AntCommander-6.3.exe
+  InstallerSha256: abfff6ac1fb46e6c234fd6f024556f7b75c5522c021e211c3f4f7c4438ffa987
+  InstallerSwitches:
+    Custom: /CURRENTUSER
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/j/Japplis/AntCommander/Personal/6.3/Japplis.AntCommander.Personal.locale.en-US.yaml
+++ b/manifests/j/Japplis/AntCommander/Personal/6.3/Japplis.AntCommander.Personal.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# Created using Apache Ant script from Japplis
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Japplis.AntCommander.Personal
+PackageVersion: 6.3
+PackageLocale: en-US
+Publisher: Japplis
+PublisherUrl: https://www.japplis.com
+Author: Anthony Goubard
+PackageName: Ant Commander Personal
+PackageUrl: https://www.antcommander.com/personal/
+License: Freeware
+LicenseUrl: https://www.antcommander.com/personal/license.txt
+Copyright: Copyright © 2004 - 2026 Japplis. All rights reserved.
+ShortDescription: Personal file manager with tabs support
+Description: |-
+  Ant Commander Personal - Personal file manager
+  Ant Commander Personal is file manager for basic file operations. It can show multiple directories are the same time, has tabs support, bookmarks, history and a preview for for text and image files.
+ReleaseNotesUrl: https://www.antcommander.com/personal/changes.txt
+Moniker: ant-commander
+Tags: 
+- file-manager
+- file
+- manager
+- management
+- disk
+- explorer
+- finder
+- directory
+- folder
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/j/Japplis/AntCommander/Personal/6.3/Japplis.AntCommander.Personal.yaml
+++ b/manifests/j/Japplis/AntCommander/Personal/6.3/Japplis.AntCommander.Personal.yaml
@@ -1,0 +1,8 @@
+# Created using Apache Ant script from Japplis
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Japplis.AntCommander.Personal
+PackageVersion: 6.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description
Japplis.AntCommander.Personal Version 6.3:
Directory Table:
- Double click on empty space below the table will go to parent directory
Actions:
- Disabled checkbox to move files when creating a new directory and no selected files
- Adding bookmark in file viewer panels should not ask to bookmark selected file
- Fixed apply bookmark attribute when current location is the same as the bookmark
- Fixed bookmarks sharing the same action name
Files:
- Fixed possible "No files-cache implementation set" error
Other:
- Remove homebrew download option as the script no longer passes and very low number of users
- Various small improvements and bug fixes
- Various improvements and bug fixes in the application framework

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable) No

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/414844)