### PR TITLE
Update: TypeWhisper.TypeWhisper to 1.0.7

### DIFF
--- a/manifests/t/TypeWhisper/TypeWhisper/1.0.7/TypeWhisper.TypeWhisper.installer.yaml
+++ b/manifests/t/TypeWhisper/TypeWhisper/1.0.7/TypeWhisper.TypeWhisper.installer.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: TypeWhisper.TypeWhisper
+PackageVersion: 1.0.7
+InstallerType: exe
+InstallModes:
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: --silent
+  SilentWithProgress: --silent
+  InstallLocation: --installto <INSTALLPATH>
+UpgradeBehavior: install
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.10
+ProductCode: TypeWhisper
+AppsAndFeaturesEntries:
+- DisplayName: TypeWhisper
+  Publisher: TypeWhisper
+  ProductCode: TypeWhisper
+  InstallerType: exe
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/TypeWhisper/typewhisper-win/releases/download/v1.0.7/TypeWhisper-win-x64-Setup.exe
+  InstallerSha256: 8320FCEB427FAF2AA94828DBAE86D406558BAD6DF203FBF35E5A3EDF5A38D858
+- Architecture: arm64
+  InstallerUrl: https://github.com/TypeWhisper/typewhisper-win/releases/download/v1.0.7/TypeWhisper-win-arm64-Setup.exe
+  InstallerSha256: F4968AF1B2E23C5B93EB4A3991C053F033C75EDE8C5C63ECB5A0E97D340416A9
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/t/TypeWhisper/TypeWhisper/1.0.7/TypeWhisper.TypeWhisper.locale.en-US.yaml
+++ b/manifests/t/TypeWhisper/TypeWhisper/1.0.7/TypeWhisper.TypeWhisper.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: TypeWhisper.TypeWhisper
+PackageVersion: 1.0.7
+PackageLocale: en-US
+Publisher: TypeWhisper
+PublisherUrl: https://www.typewhisper.com
+PublisherSupportUrl: https://github.com/TypeWhisper/typewhisper-win/issues
+PrivacyUrl: https://github.com/TypeWhisper/typewhisper-win/blob/v1.0.7/docs/PRIVACY.md
+Author: TypeWhisper
+PackageName: TypeWhisper
+PackageUrl: https://github.com/TypeWhisper/typewhisper-win
+License: GPL-3.0-or-later
+LicenseUrl: https://github.com/TypeWhisper/typewhisper-win/blob/v1.0.7/LICENSE
+ShortDescription: Speech-to-text and AI text processing for Windows.
+Description: TypeWhisper for Windows provides system-wide dictation, file transcription, reusable workflows, history, snippets, local and cloud transcription engines, and a plugin marketplace for speech-to-text and AI text processing.
+Moniker: typewhisper
+Tags:
+- ai
+- dictation
+- speech-to-text
+- transcription
+- whisper
+ReleaseNotesUrl: https://github.com/TypeWhisper/typewhisper-win/releases/tag/v1.0.7
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/TypeWhisper/TypeWhisper/1.0.7/TypeWhisper.TypeWhisper.yaml
+++ b/manifests/t/TypeWhisper/TypeWhisper/1.0.7/TypeWhisper.TypeWhisper.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: TypeWhisper.TypeWhisper
+PackageVersion: 1.0.7
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Summary

- add TypeWhisper 1.0.7 manifests for x64 and ARM64
- use the immutable GitHub release installers and verified SHA-256 hashes
- retain the existing silent switches, product code, and .NET Desktop Runtime 10 dependency

## Validation

- `winget validate --manifest manifests/t/TypeWhisper/TypeWhisper/1.0.7`
- `winget show --manifest manifests/t/TypeWhisper/TypeWhisper/1.0.7`
- downloaded both published installers and matched their SHA-256 hashes to the manifests
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/414881)