### PR TITLE
Add wingetvalidator-prod[bot] identity to policy rules for the Validation GitHub App

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -105,6 +105,7 @@ website
 winget
 wingetbot
 wingetcreate
+wingetvalidator
 workflows
 WSL
 yml

--- a/.github/policies/labelManagement.issueOpened.yml
+++ b/.github/policies/labelManagement.issueOpened.yml
@@ -242,6 +242,9 @@ configuration:
             - not:
                 isActivitySender:
                   user: wingetbot
+            - not:
+                isActivitySender:
+                  user: wingetvalidator-prod[bot]
         then:
           - addLabel:
               label: Author-Not-Authorized

--- a/.github/policies/verifiedDeveloper.yml
+++ b/.github/policies/verifiedDeveloper.yml
@@ -54,14 +54,18 @@ configuration:
                 Template: msftbot/verifiedDeveloper/approved
         triggerOnOwnActions: true
       - description: >-
-          Fallback: When Publisher-Verified is set by wingetbot but
-          Validation-Completed is missing, add it to trigger the merge chain.
+          Fallback: When Publisher-Verified is set by wingetbot or the validation
+          GitHub App but Validation-Completed is missing, add it to trigger the
+          merge chain.
         if:
           - payloadType: Pull_Request
           - labelAdded:
               label: Publisher-Verified
-          - isActivitySender:
-              user: wingetbot
+          - or:
+            - isActivitySender:
+                user: wingetbot
+            - isActivitySender:
+                user: wingetvalidator-prod[bot]
           - not:
               hasLabel:
                 label: Validation-Completed

--- a/.github/policies/wingetbotTriggers.yml
+++ b/.github/policies/wingetbotTriggers.yml
@@ -35,13 +35,16 @@ configuration:
         then:
           - approvePullRequest:
               comment: ""
-      - description: Approve PRs for Validation Waivers when labeled "Validation-Metadata" by wingetbot
+      - description: Approve PRs for Validation Waivers when labeled "Validation-Metadata" by an admin or the validation GitHub App
         if:
           - payloadType: Pull_Request
           - labelAdded:
               label: Validation-Metadata
-          - activitySenderHasPermission:
-              permission: Admin
+          - or:
+            - activitySenderHasPermission:
+                permission: Admin
+            - isActivitySender:
+                user: wingetvalidator-prod[bot]
         then:
           - approvePullRequest:
               comment: ""
@@ -50,14 +53,17 @@ configuration:
       - description: >-
           Merge Validation Waivers when
           * PR is Opened
-          * Created by wingetbot
+          * Created by wingetbot or the validation GitHub App
           * Files modified only contains .validation file
         if:
           - payloadType: Pull_Request
           - isAction:
               action: Opened
-          - isActivitySender:
-              user: wingetbot
+          - or:
+            - isActivitySender:
+                user: wingetbot
+            - isActivitySender:
+                user: wingetvalidator-prod[bot]
           - filesMatchPattern:
                 pattern: ^.*\.validation
           - not:
@@ -73,8 +79,11 @@ configuration:
       - description: Close automatic waiver PRs when "Validation-Merge-Conflict" label is added
         if:
           - payloadType: Pull_Request
-          - isActivitySender:
-              user: wingetbot
+          - or:
+            - isActivitySender:
+                user: wingetbot
+            - isActivitySender:
+                user: wingetvalidator-prod[bot]
           - isOpen
           - labelAdded:
               label: Validation-Merge-Conflict


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
Validation is moving from the `wingetbot` service account to the `wingetvalidator-prod[bot]` GitHub App. 

This PR adds the App identity alongside `wingetbot` in every rule where the two identities are interchangeable. No existing behavior is removed, `wingetbot` continues to satisfy all conditions.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/414911)