### PR TITLE
Add ttyd versions 1.7.7 and 1.7.8

### DIFF
--- a/manifests/t/pxuanbach/ttyd/1.7.7/pxuanbach.ttyd.installer.yaml
+++ b/manifests/t/pxuanbach/ttyd/1.7.7/pxuanbach.ttyd.installer.yaml
@@ -1,0 +1,10 @@
+PackageVersion: 1.7.7
+Scope: user
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/pxuanbach/ttyd/releases/download/v1.7.7/ttyd-1.7.7-win-x64.zip
+    InstallerSha256: 09BB25EECD3E2A53B245B99290FE4DA47F1F3D575416F836B392D8F2A43F3D41
+    NestedInstallerType: portable
+    NestedInstallerPath: ttyd.exe
+    InstallerType: zip
+    ProductCode: "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"

--- a/manifests/t/pxuanbach/ttyd/1.7.7/pxuanbach.ttyd.locale.en-US.yaml
+++ b/manifests/t/pxuanbach/ttyd/1.7.7/pxuanbach.ttyd.locale.en-US.yaml
@@ -1,0 +1,20 @@
+PackageVersion: 1.7.7
+PackageLocale: en-US
+Publisher: pxuanbach
+PublisherUrl: https://github.com/pxuanbach
+PackageName: ttyd
+PackageUrl: https://github.com/pxuanbach/ttyd
+License: MIT
+LicenseUrl: https://github.com/pxuanbach/ttyd/blob/main/LICENSE
+ShortDescription: Share your terminal over the web
+Description: |
+  ttyd is a simple, lightweight, and easy-to-use tool that allows you to 
+  share your terminal over the web. Built on top of libwebsockets, it enables 
+  you to access your terminal from anywhere with just a web browser.
+Moniker: ttyd
+Tags:
+  - terminal
+  - tty
+  - ssh
+  - web
+  - remote-access

--- a/manifests/t/pxuanbach/ttyd/1.7.7/pxuanbach.ttyd.yaml
+++ b/manifests/t/pxuanbach/ttyd/1.7.7/pxuanbach.ttyd.yaml
@@ -1,0 +1,20 @@
+Identifier: pxuanbach.ttyd
+Publisher: pxuanbach
+PackageName: ttyd
+PackageVersion: 1.7.7
+License: MIT
+LicenseUrl: https://github.com/pxuanbach/ttyd/blob/main/LICENSE
+Homepage: https://github.com/pxuanbach/ttyd
+Description: Share your terminal over the web
+InstallerType: zip
+ReleaseNotesUrl: https://github.com/pxuanbach/ttyd/releases
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/pxuanbach/ttyd/releases/download/v1.7.7/ttyd-1.7.7-win-x64.zip
+    InstallerSha256: 09BB25EECD3E2A53B245B99290FE4DA47F1F3D575416F836B392D8F2A43F3D41
+    ArchiveSha256: 09BB25EECD3E2A53B245B99290FE4DA47F1F3D575416F836B392D8F2A43F3D41
+    NestedInstallerType: portable
+    NestedInstallerPath: ttyd.exe
+    InstallerType: zip
+    ProductCode: "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"
+Scope: user

--- a/manifests/t/pxuanbach/ttyd/1.7.8/pxuanbach.ttyd.installer.yaml
+++ b/manifests/t/pxuanbach/ttyd/1.7.8/pxuanbach.ttyd.installer.yaml
@@ -1,0 +1,10 @@
+PackageVersion: 1.7.8
+Scope: user
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/pxuanbach/ttyd/releases/download/v1.7.8/ttyd-1.7.8-win-x64.zip
+    InstallerSha256: 11FB0B5D4D7A64907162567077FF1C1730D89B6A0863C111B196A969DC126402
+    NestedInstallerType: portable
+    NestedInstallerPath: ttyd.exe
+    InstallerType: zip
+    ProductCode: "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"

--- a/manifests/t/pxuanbach/ttyd/1.7.8/pxuanbach.ttyd.locale.en-US.yaml
+++ b/manifests/t/pxuanbach/ttyd/1.7.8/pxuanbach.ttyd.locale.en-US.yaml
@@ -1,0 +1,20 @@
+PackageVersion: 1.7.8
+PackageLocale: en-US
+Publisher: pxuanbach
+PublisherUrl: https://github.com/pxuanbach
+PackageName: ttyd
+PackageUrl: https://github.com/pxuanbach/ttyd
+License: MIT
+LicenseUrl: https://github.com/pxuanbach/ttyd/blob/main/LICENSE
+ShortDescription: Share your terminal over the web
+Description: |
+  ttyd is a simple, lightweight, and easy-to-use tool that allows you to 
+  share your terminal over the web. Built on top of libwebsockets, it enables 
+  you to access your terminal from anywhere with just a web browser.
+Moniker: ttyd
+Tags:
+  - terminal
+  - tty
+  - ssh
+  - web
+  - remote-access

--- a/manifests/t/pxuanbach/ttyd/1.7.8/pxuanbach.ttyd.yaml
+++ b/manifests/t/pxuanbach/ttyd/1.7.8/pxuanbach.ttyd.yaml
@@ -1,0 +1,20 @@
+Identifier: pxuanbach.ttyd
+Publisher: pxuanbach
+PackageName: ttyd
+PackageVersion: 1.7.8
+License: MIT
+LicenseUrl: https://github.com/pxuanbach/ttyd/blob/main/LICENSE
+Homepage: https://github.com/pxuanbach/ttyd
+Description: Share your terminal over the web
+InstallerType: zip
+ReleaseNotesUrl: https://github.com/pxuanbach/ttyd/releases
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/pxuanbach/ttyd/releases/download/v1.7.8/ttyd-1.7.8-win-x64.zip
+    InstallerSha256: 11FB0B5D4D7A64907162567077FF1C1730D89B6A0863C111B196A969DC126402
+    ArchiveSha256: 11FB0B5D4D7A64907162567077FF1C1730D89B6A0863C111B196A969DC126402
+    NestedInstallerType: portable
+    NestedInstallerPath: ttyd.exe
+    InstallerType: zip
+    ProductCode: "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"
+Scope: user

--- a/ttyd.installer.yaml
+++ b/ttyd.installer.yaml
@@ -1,0 +1,10 @@
+PackageVersion: 1.7.7
+Scope: user
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/pxuanbach/ttyd/releases/download/v1.7.7/ttyd-1.7.7-win-x64.zip
+    InstallerSha256: D20BB6A44FBC43CA92E5BB79ACB51F6F79A66CF5A55023B71EA0C97955EEAA63
+    NestedInstallerType: portable
+    NestedInstallerPath: ttyd.exe
+    InstallerType: zip
+    ProductCode: "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"

--- a/ttyd.locale.en-US.yaml
+++ b/ttyd.locale.en-US.yaml
@@ -1,0 +1,20 @@
+PackageVersion: 1.7.7
+PackageLocale: en-US
+Publisher: pxuanbach
+PublisherUrl: https://github.com/pxuanbach
+PackageName: ttyd
+PackageUrl: https://github.com/pxuanbach/ttyd
+License: MIT
+LicenseUrl: https://github.com/pxuanbach/ttyd/blob/main/LICENSE
+ShortDescription: Share your terminal over the web
+Description: |
+  ttyd is a simple, lightweight, and easy-to-use tool that allows you to 
+  share your terminal over the web. Built on top of libwebsockets, it enables 
+  you to access your terminal from anywhere with just a web browser.
+Moniker: ttyd
+Tags:
+  - terminal
+  - tty
+  - ssh
+  - web
+  - remote-access

--- a/ttyd.yaml
+++ b/ttyd.yaml
@@ -1,0 +1,20 @@
+Identifier: pxuanbach.ttyd
+Publisher: pxuanbach
+PackageName: ttyd
+PackageVersion: 1.7.7
+License: MIT
+LicenseUrl: https://github.com/pxuanbach/ttyd/blob/main/LICENSE
+Homepage: https://github.com/pxuanbach/ttyd
+Description: Share your terminal over the web
+InstallerType: zip
+ReleaseNotesUrl: https://github.com/pxuanbach/ttyd/releases
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/pxuanbach/ttyd/releases/download/v1.7.7/ttyd-1.7.7-win-x64.zip
+    InstallerSha256: D20BB6A44FBC43CA92E5BB79ACB51F6F79A66CF5A55023B71EA0C97955EEAA63
+    ArchiveSha256: D20BB6A44FBC43CA92E5BB79ACB51F6F79A66CF5A55023B71EA0C97955EEAA63
+    NestedInstallerType: portable
+    NestedInstallerPath: ttyd.exe
+    InstallerType: zip
+    ProductCode: "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"
+Scope: user


### PR DESCRIPTION
## PR Checklist

- [x] I have verified that the manifest files are valid
- [x] I have calculated the SHA256 hash of the installer
- [x] I have read the contributing guidelines

## Manifest Files

This PR adds ttyd versions 1.7.7 and 1.7.8 to the Windows Package Manager repository.

### Package Details
- **Publisher**: pxuanbach
- **Package Name**: ttyd
- **Version**: 1.7.7, 1.7.8
- **License**: MIT
- **Download (v1.7.8)**: https://github.com/pxuanbach/ttyd/releases/download/v1.7.8/ttyd-1.7.8-win-x64.zip
- **SHA256 (v1.7.8)**: 11FB0B5D4D7A64907162567077FF1C1730D89B6A0863C111B196A969DC126402

### Description
ttyd is a simple, lightweight tool that allows you to share your terminal over the web. Built on top of libwebsockets, it enables you to access your terminal from anywhere with just a web browser.

### Files Added
- manifests/t/pxuanbach/ttyd/1.7.7/pxuanbach.ttyd.yaml
- manifests/t/pxuanbach/ttyd/1.7.7/pxuanbach.ttyd.installer.yaml
- manifests/t/pxuanbach/ttyd/1.7.7/pxuanbach.ttyd.locale.en-US.yaml
- manifests/t/pxuanbach/ttyd/1.7.8/pxuanbach.ttyd.yaml
- manifests/t/pxuanbach/ttyd/1.7.8/pxuanbach.ttyd.installer.yaml
- manifests/t/pxuanbach/ttyd/1.7.8/pxuanbach.ttyd.locale.en-US.yaml