### PR TITLE
New version: Globulario.Sensei version 1.6.0

### DIFF
--- a/manifests/g/Globulario/Sensei/1.6.0/Globulario.Sensei.installer.yaml
+++ b/manifests/g/Globulario/Sensei/1.6.0/Globulario.Sensei.installer.yaml
@@ -1,0 +1,17 @@
+PackageIdentifier: Globulario.Sensei
+PackageVersion: 1.6.0
+InstallerType: zip
+NestedInstallerType: portable
+# Only user-facing commands go on PATH. awareness-graph.exe and oxigraph.exe stay
+# as siblings in the extracted package dir; `sensei serve` spawns them from there.
+NestedInstallerFiles:
+  - RelativeFilePath: sensei-windows-amd64\bin\sensei.exe
+    PortableCommandAlias: sensei
+  - RelativeFilePath: sensei-windows-amd64\bin\awareness-mcp.exe
+    PortableCommandAlias: awareness-mcp
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/globulario/sensei/releases/download/v1.6.0/sensei-windows-amd64.zip
+    InstallerSha256: 033A5D0B30038DBC45B1E309612A089B45D25A3DA9627483B2D71732125354C5
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/g/Globulario/Sensei/1.6.0/Globulario.Sensei.locale.en-US.yaml
+++ b/manifests/g/Globulario/Sensei/1.6.0/Globulario.Sensei.locale.en-US.yaml
@@ -1,0 +1,27 @@
+PackageIdentifier: Globulario.Sensei
+PackageVersion: 1.6.0
+PackageLocale: en-US
+Publisher: Globulario
+PublisherUrl: https://github.com/globulario
+PublisherSupportUrl: https://github.com/globulario/sensei/issues
+PackageName: Sensei
+PackageUrl: https://github.com/globulario/sensei
+License: AGPL-3.0-only
+LicenseUrl: https://github.com/globulario/sensei/blob/main/LICENSE
+ShortDescription: Architectural memory for AI coding agents — invariants, forbidden fixes, and contracts.
+Description: |-
+  Sensei gives an AI coding agent the architectural knowledge that normally lives
+  only in senior engineers' heads — invariants, failure modes, forbidden fixes,
+  and intent — as a queryable graph the agent consults before it edits and a CI
+  gate enforces after. Local-first: your rules are YAML in your repo, compiled
+  into a local Oxigraph store. No SaaS, no account, no source upload.
+Moniker: sensei
+Tags:
+  - ai
+  - agent
+  - cli
+  - developer-tools
+  - code-review
+  - architecture
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/g/Globulario/Sensei/1.6.0/Globulario.Sensei.yaml
+++ b/manifests/g/Globulario/Sensei/1.6.0/Globulario.Sensei.yaml
@@ -1,0 +1,7 @@
+# winget version manifest. Submit these three files to microsoft/winget-pkgs under
+# manifests/g/Globulario/Sensei/<version>/ to publish `winget install Globulario.Sensei`.
+PackageIdentifier: Globulario.Sensei
+PackageVersion: 1.6.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New version: `Globulario.Sensei` 1.6.0

[Sensei](https://github.com/globulario/sensei) — architectural memory for AI coding agents (invariants, forbidden fixes, contracts). AGPL-3.0-only.

Updates the existing `Globulario.Sensei` manifests from 1.5.0 to the [v1.6.0](https://github.com/globulario/sensei/releases/tag/v1.6.0) release. No change to the installer shape:

- **Installer:** `zip` / `portable`, x64, from the official GitHub release (`sensei-windows-amd64.zip`), SHA256 in the manifest.
- **Commands exposed:** `sensei`, `awareness-mcp`.

#### Validation

Manifests were validated with `winget validate` **and** a real `winget install --manifest` on a `windows-latest` runner, followed by a smoke test: the installed `sensei.exe` reports its version and `sensei serve` comes up on `:10120` (spawning its bundled `oxigraph.exe` / `awareness-graph.exe`). CI: <https://github.com/globulario/sensei/blob/main/.github/workflows/winget-validate.yml>

The referenced `InstallerSha256` was additionally checked against both the release's published `.sha256` sidecar and the GitHub release API digest for the same asset.

---

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/415000)