### PR TITLE
New package: FreedomTerminal.Koegaki version 1.2.1

### DIFF
--- a/manifests/f/FreedomTerminal/Koegaki/1.2.1/FreedomTerminal.Koegaki.installer.yaml
+++ b/manifests/f/FreedomTerminal/Koegaki/1.2.1/FreedomTerminal.Koegaki.installer.yaml
@@ -7,7 +7,7 @@ InstallerSwitches:
   SilentWithProgress: /S
 Installers:
   - Architecture: x64
-    InstallerUrl: https://npdal36mxz3kcwxv.public.blob.vercel-storage.com/Koegaki-1.2.1-setup.exe
+    InstallerUrl: https://koegaki.com/downloads/Koegaki-1.2.1-setup.exe
     InstallerSha256: A826527457A6858B7E882144B6FF9BA631080527A89DA4E451879F5643E7B3C2
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/f/FreedomTerminal/Koegaki/1.2.1/FreedomTerminal.Koegaki.installer.yaml
+++ b/manifests/f/FreedomTerminal/Koegaki/1.2.1/FreedomTerminal.Koegaki.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: FreedomTerminal.Koegaki
+PackageVersion: 1.2.1
+InstallerType: nullsoft
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://npdal36mxz3kcwxv.public.blob.vercel-storage.com/Koegaki-1.2.1-setup.exe
+    InstallerSha256: A826527457A6858B7E882144B6FF9BA631080527A89DA4E451879F5643E7B3C2
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/FreedomTerminal/Koegaki/1.2.1/FreedomTerminal.Koegaki.locale.en-US.yaml
+++ b/manifests/f/FreedomTerminal/Koegaki/1.2.1/FreedomTerminal.Koegaki.locale.en-US.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: FreedomTerminal.Koegaki
+PackageVersion: 1.2.1
+PackageLocale: en-US
+Publisher: Freedom Terminal
+PublisherUrl: https://freedom-terminal.com
+PackageName: Koegaki
+PackageUrl: https://koegaki.com
+License: Proprietary
+Copyright: Copyright Vishut Dhar
+ShortDescription: Private push-to-talk dictation that runs entirely on your machine.
+Description: Koegaki is push-to-talk dictation for Windows. Hold a key, speak, and your words appear wherever you are typing. The speech model runs entirely on-device, so audio and text never leave your machine. No account, no cloud, no subscription. 30-day free trial, then a one-time purchase covers Mac and Windows.
+Moniker: koegaki
+Tags:
+  - dictation
+  - speech-to-text
+  - voice-typing
+  - offline
+  - privacy
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/FreedomTerminal/Koegaki/1.2.1/FreedomTerminal.Koegaki.yaml
+++ b/manifests/f/FreedomTerminal/Koegaki/1.2.1/FreedomTerminal.Koegaki.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: FreedomTerminal.Koegaki
+PackageVersion: 1.2.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

New package: FreedomTerminal.Koegaki version 1.2.1.

Koegaki is push-to-talk dictation for Windows. The speech model runs entirely on-device; audio and text never leave the machine. Publisher site: https://freedom-terminal.com, product site: https://koegaki.com.

Notes for reviewers:
- The installer is not code signed. It is distributed from the vendor's own CDN (Vercel Blob, the URL in the manifest) and the SHA-256 in the manifest was verified against the served bytes.
- Silent install (`/S`, NSIS) verified on Windows 11 before submission, including `winget validate` and a local `winget install --manifest` run.

## Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/415017)