### PR TITLE
New version: maze-mei.DXManager version 1.3.0

### DIFF
--- a/manifests/m/maze-mei/DXManager/1.3.0/maze-mei.DXManager.installer.yaml
+++ b/manifests/m/maze-mei/DXManager/1.3.0/maze-mei.DXManager.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: maze-mei.DXManager
+PackageVersion: 1.3.0
+InstallerType: zip
+NestedInstallerType: portable
+UpgradeBehavior: install
+Commands:
+- dxmanager
+ArchiveBinariesDependOnPath: true
+NestedInstallerFiles:
+- RelativeFilePath: DX Manager\DXManager.exe
+  PortableCommandAlias: dxmanager
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/maze-mei/DX-Manager/releases/download/v1.3.0/DX-Manager-v1.3.0-win-x64.zip
+  InstallerSha256: 528F10E22171C4EFCE9865B6810E8CCF02B447D4D45ED4B8B0F56322008B74BA
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/maze-mei/DXManager/1.3.0/maze-mei.DXManager.locale.en-US.yaml
+++ b/manifests/m/maze-mei/DXManager/1.3.0/maze-mei.DXManager.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: maze-mei.DXManager
+PackageVersion: 1.3.0
+PackageLocale: en-US
+Publisher: maze-mei
+PublisherUrl: https://github.com/maze-mei
+PublisherSupportUrl: https://github.com/maze-mei/DX-Manager/issues
+Author: maze
+PackageName: DX Manager
+PackageUrl: https://github.com/maze-mei/DX-Manager
+License: MIT
+LicenseUrl: https://github.com/maze-mei/DX-Manager/blob/v1.3.0/LICENSE
+Copyright: Copyright (c) 2026 maze
+ShortDescription: Manage Samsung DeX virtual displays and scrcpy app windows on Windows.
+Description: DX Manager creates and manages a Samsung DeX virtual display, launches it through scrcpy, and provides up to three separately configured Android app windows over USB or wireless ADB.
+Moniker: dxmanager
+Tags:
+- adb
+- android
+- samsung-dex
+- screen-mirroring
+- scrcpy
+- wireless-adb
+ReleaseNotesUrl: https://github.com/maze-mei/DX-Manager/releases/tag/v1.3.0
+InstallationNotes: DX Manager requires .NET Framework 4.6.2 or later, Android Developer options, and USB debugging. Initial ADB authorization requires a data-capable USB connection.
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/maze-mei/DXManager/1.3.0/maze-mei.DXManager.locale.ko-KR.yaml
+++ b/manifests/m/maze-mei/DXManager/1.3.0/maze-mei.DXManager.locale.ko-KR.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: maze-mei.DXManager
+PackageVersion: 1.3.0
+PackageLocale: ko-KR
+Publisher: maze-mei
+PublisherUrl: https://github.com/maze-mei
+PublisherSupportUrl: https://github.com/maze-mei/DX-Manager/issues
+Author: maze
+PackageName: DX Manager
+PackageUrl: https://github.com/maze-mei/DX-Manager
+License: MIT
+LicenseUrl: https://github.com/maze-mei/DX-Manager/blob/v1.3.0/LICENSE
+Copyright: Copyright (c) 2026 maze
+ShortDescription: Windows에서 Samsung DeX 가상 디스플레이와 scrcpy 앱 창을 관리합니다.
+Description: DX Manager는 Samsung DeX 가상 디스플레이를 생성하고 관리하여 scrcpy로 실행하며, USB 또는 무선 ADB를 통해 서로 다르게 설정한 Android 앱 창을 최대 3개까지 추가로 실행할 수 있습니다.
+Tags:
+- adb
+- android
+- samsung-dex
+- screen-mirroring
+- scrcpy
+- wireless-adb
+ReleaseNotesUrl: https://github.com/maze-mei/DX-Manager/releases/tag/v1.3.0
+InstallationNotes: DX Manager를 사용하려면 .NET Framework 4.6.2 이상, Android 개발자 옵션, USB 디버깅이 필요합니다. 최초 ADB 인증에는 데이터 통신이 가능한 USB 연결이 필요합니다.
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/m/maze-mei/DXManager/1.3.0/maze-mei.DXManager.yaml
+++ b/manifests/m/maze-mei/DXManager/1.3.0/maze-mei.DXManager.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: maze-mei.DXManager
+PackageVersion: 1.3.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Updates maze-mei.DXManager from 1.2.0 to 1.3.0 using the official GitHub release asset. The archive SHA256 and nested portable executable path were verified, and winget validate completed successfully.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/415021)