### PR TITLE
New package: abooodbah.LeanMark version 0.2.0

### DIFF
--- a/manifests/a/abooodbah/LeanMark/0.2.0/abooodbah.LeanMark.installer.yaml
+++ b/manifests/a/abooodbah/LeanMark/0.2.0/abooodbah.LeanMark.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: abooodbah.LeanMark
+PackageVersion: 0.2.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: LeanMark-v0.2.0-windows-x64\LeanMark.exe
+  PortableCommandAlias: leanmark
+ReleaseDate: 2026-08-08
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/abooodbah/leanmark/releases/download/v0.2.0/LeanMark-v0.2.0-windows-x64.zip
+  InstallerSha256: 2D701D4B66A2F9DD636F7244E8506FB1F79FEB3DA6483BEFA53258316B42A68D
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/a/abooodbah/LeanMark/0.2.0/abooodbah.LeanMark.locale.en-US.yaml
+++ b/manifests/a/abooodbah/LeanMark/0.2.0/abooodbah.LeanMark.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: abooodbah.LeanMark
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: Abdulfatah Bahbouh
+PublisherUrl: https://github.com/abooodbah
+PublisherSupportUrl: https://github.com/abooodbah/leanmark/issues
+PackageName: LeanMark
+PackageUrl: https://abooodbah.github.io/leanmark/
+License: MIT
+LicenseUrl: https://github.com/abooodbah/leanmark/blob/main/LICENSE
+ShortDescription: Read-only Markdown viewer with offline Mermaid rendering
+Description: LeanMark is a focused, read-only Markdown viewer. It renders GitHub-flavored Markdown, local images and Mermaid diagrams entirely offline using the system WebView2 runtime rather than a bundled Chromium. Raw HTML is disabled, a strict Content Security Policy is enforced, and remote content is blocked.
+Tags:
+- markdown
+- viewer
+- mermaid
+- offline
+- reader
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/a/abooodbah/LeanMark/0.2.0/abooodbah.LeanMark.yaml
+++ b/manifests/a/abooodbah/LeanMark/0.2.0/abooodbah.LeanMark.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: abooodbah.LeanMark
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Pull request has been manually verified

- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-cli/blob/master/schemas/JSON/manifests/v1.6.0)?

---

MIT-licensed portable Windows utility, published as a zip archive with a sidecar SHA256 file.

**abooodbah.LeanMark 0.2.0** — read-only Markdown viewer. Renders GitHub-flavored Markdown, local images and Mermaid diagrams entirely offline through the system WebView2 runtime rather than a bundled Chromium. Raw HTML is disabled, a strict Content Security Policy is enforced, and remote content and navigation are blocked.

Homepage: https://abooodbah.github.io/leanmark/

**Verification performed**

- `winget validate --manifest` passes (winget v1.29.280, manifest schema 1.6.0).
- SHA256 verified against the published release archive by downloading and hashing it.
- Nested executable path confirmed against the archive contents.

**Not performed:** `winget install --manifest` end-to-end. The application is already installed on this machine from its own installer and I did not want a second portable copy shadowing it on PATH. Happy to run it and report back if a maintainer would like that before merge.

Installer is `zip` with `NestedInstallerType: portable`.

Split out of #415077 following the validator note that a pull request must cover a single application.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/415081)