### PR TITLE
New package: Bozex.Dictator version 2.2.319

### DIFF
--- a/manifests/b/Bozex/Dictator/2.2.319/Bozex.Dictator.installer.yaml
+++ b/manifests/b/Bozex/Dictator/2.2.319/Bozex.Dictator.installer.yaml
@@ -1,0 +1,19 @@
+PackageIdentifier: Bozex.Dictator
+PackageVersion: 2.2.319
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-08-11
+Installers:
+- Architecture: x64
+  InstallerUrl: https://dictator.my/release/Dictator_2.2.319_x64-setup.exe
+  InstallerSha256: 90248EBD45A6F2ADAECCA3FDDB741C1F9686D9F512C0D6E196B05A28849D4F99
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/b/Bozex/Dictator/2.2.319/Bozex.Dictator.locale.en-US.yaml
+++ b/manifests/b/Bozex/Dictator/2.2.319/Bozex.Dictator.locale.en-US.yaml
@@ -1,0 +1,38 @@
+PackageIdentifier: Bozex.Dictator
+PackageVersion: 2.2.319
+PackageLocale: en-US
+Publisher: Bozex
+PublisherUrl: https://dictator.my/
+PublisherSupportUrl: https://dictator.my/support/
+PrivacyUrl: https://dictator.my/privacy.html
+PackageName: Dictator
+PackageUrl: https://dictator.my/
+License: Proprietary
+LicenseUrl: https://dictator.my/terms.html
+Copyright: Copyright (c) Bozex
+ShortDescription: Speech to text, dictation, live subtitles and offline translation that run on your own machine.
+Description: |-
+  Dictator turns speech into text and dictates into any window — email, documents,
+  chat — without sending audio to the cloud. Recognition runs locally on your GPU,
+  so there are no minute limits and nothing leaves the computer.
+
+  It also reads text aloud in natural voices, shows live captions over any window
+  with translation underneath, translates text on photos and on screen, and
+  translates offline through dictionaries downloaded once.
+
+  Speech recognition covers 100 languages, AI translation 198, offline translation 45.
+Moniker: dictator
+Tags:
+- speech-to-text
+- dictation
+- transcription
+- voice-typing
+- subtitles
+- translation
+- offline
+- tts
+- text-to-speech
+- stt
+ReleaseNotesUrl: https://dictator.my/changelog/
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/b/Bozex/Dictator/2.2.319/Bozex.Dictator.yaml
+++ b/manifests/b/Bozex/Dictator/2.2.319/Bozex.Dictator.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Bozex.Dictator
+PackageVersion: 2.2.319
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Pull request type

- [x] New package

### What does this PR do?

Adds `Bozex.Dictator` version 2.2.319 — a speech-to-text and dictation app for Windows.
Speech recognition runs locally on the user's machine, so there are no minute limits and
no audio is uploaded. It also does text-to-speech, live captions over any window and
offline translation.

- Homepage: https://dictator.my/
- Installer: https://dictator.my/release/Dictator_2.2.319_x64-setup.exe (NSIS, x64)
- Release notes: https://dictator.my/changelog/

Submitted by the publisher. This replaces #415043, which was opened against an older
build before today's release; that PR has been closed.

### Checklist

- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/add?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? — not run: the
      submitting machine already runs this application, and a manifest install would have
      reinstalled it over a working setup. The SHA256 was taken from the file being served.
- [ ] Contributor License Agreement — will sign when the bot asks.

### Note on URL stability

The installer URL points at a fixed version and stays reachable: the publisher's release
process keeps the current and one previous version available, so manifests do not break
on the next release.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/415083)