### PR TITLE
New package: NuterraLabs.PickleBrowser version 1.0.1

### DIFF
--- a/manifests/n/NuterraLabs/PickleBrowser/1.0.1/NuterraLabs.PickleBrowser.installer.yaml
+++ b/manifests/n/NuterraLabs/PickleBrowser/1.0.1/NuterraLabs.PickleBrowser.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: NuterraLabs.PickleBrowser
+PackageVersion: 1.0.1
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+ReleaseDate: 2026-08-10
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/ismailntl/pickle-releases/releases/download/v1.0.1/Pickle-Browser-Setup-1.0.1-lite.exe
+  InstallerSha256: 3DF83874D3E24577F5F88C6723ECF0332F838C263982F8B639936E63A6F4F5D1
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/n/NuterraLabs/PickleBrowser/1.0.1/NuterraLabs.PickleBrowser.locale.en-US.yaml
+++ b/manifests/n/NuterraLabs/PickleBrowser/1.0.1/NuterraLabs.PickleBrowser.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: NuterraLabs.PickleBrowser
+PackageVersion: 1.0.1
+PackageLocale: en-US
+Publisher: Nu Terra Labs
+PublisherUrl: https://nuterralabs.com
+PublisherSupportUrl: https://github.com/ismailntl/pickle-releases/issues
+PackageName: Pickle Browser
+PackageUrl: https://github.com/ismailntl/pickle-releases
+License: Proprietary
+Copyright: Copyright (c) 2026 Nu Terra Labs
+ShortDescription: An agent-first browser you use, that an AI can drive while you watch.
+Description: |-
+  Pickle Browser is a desktop browser an AI agent can drive on your behalf. It
+  searches, opens real pages, reads them and reports back with sources, in a
+  window you can watch and take over at any time. Run a model locally for free,
+  or connect Claude, GPT or Gemini. Browsing data stays on your machine.
+Moniker: pickle-browser
+Tags:
+- ai
+- agent
+- automation
+- browser
+- mcp
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/n/NuterraLabs/PickleBrowser/1.0.1/NuterraLabs.PickleBrowser.yaml
+++ b/manifests/n/NuterraLabs/PickleBrowser/1.0.1/NuterraLabs.PickleBrowser.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: NuterraLabs.PickleBrowser
+PackageVersion: 1.0.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package

- **Package**: NuterraLabs.PickleBrowser
- **Version**: 1.0.1
- **Publisher**: Nu Terra Labs

Pickle Browser is a desktop browser an AI agent can drive on your behalf, running locally on the user's machine.

#### Checklist

- [x] Manifest validated locally against the 1.6.0 schema
- [x] `InstallerSha256` computed from the published release asset
- [x] Installer URL is a permanent GitHub release download link
- [x] Silent install supported (NSIS, `/S`)
- [x] `Scope: user` (per-user install, no elevation required)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/415104)