### PR TITLE
New version: RobWalsh.BertBrowser version 1.1.1

### DIFF
--- a/manifests/r/RobWalsh/BertBrowser/1.1.1/RobWalsh.BertBrowser.installer.yaml
+++ b/manifests/r/RobWalsh/BertBrowser/1.1.1/RobWalsh.BertBrowser.installer.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: RobWalsh.BertBrowser
+PackageVersion: 1.1.1
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: exe
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: --silent
+  SilentWithProgress: --silent
+UpgradeBehavior: install
+ReleaseDate: 2026-08-10
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/robgwalsh/bertbrowser/releases/download/v1.1.1/BertBrowser-win-Setup.exe
+  InstallerSha256: EADD4EFB80C86B890527CB7533B40CF1F22E16EBAC46611A63DD4DD3CC80BB80
+  AppsAndFeaturesEntries:
+  - DisplayName: BertBrowser
+    Publisher: Rob Walsh
+    ProductCode: BertBrowser
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/r/RobWalsh/BertBrowser/1.1.1/RobWalsh.BertBrowser.locale.en-US.yaml
+++ b/manifests/r/RobWalsh/BertBrowser/1.1.1/RobWalsh.BertBrowser.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: RobWalsh.BertBrowser
+PackageVersion: 1.1.1
+PackageLocale: en-US
+Publisher: Rob Walsh
+PublisherUrl: https://github.com/robgwalsh
+PublisherSupportUrl: https://github.com/robgwalsh/bertbrowser/issues
+PackageName: BertBrowser
+PackageUrl: https://github.com/robgwalsh/bertbrowser
+License: MIT
+LicenseUrl: https://github.com/robgwalsh/bertbrowser/blob/main/LICENSE
+Copyright: Copyright © 2026 Rob Walsh
+ShortDescription: File browser built to my personal preferences
+Description: |-
+  A Windows file browser with whole-PC search built on the NTFS master file table, recursive folder
+  sizes shown the way file sizes are, tabs and split panes, and a fully themed interface.
+  Moves, renames and deletes are undoable, and deleting holds items aside rather than erasing them.
+Tags:
+- explorer
+- file-browser
+- file-manager
+- files
+- search
+ReleaseNotesUrl: https://github.com/robgwalsh/bertbrowser/releases/tag/v1.1.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/RobWalsh/BertBrowser/1.1.1/RobWalsh.BertBrowser.yaml
+++ b/manifests/r/RobWalsh/BertBrowser/1.1.1/RobWalsh.BertBrowser.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: RobWalsh.BertBrowser
+PackageVersion: 1.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New version: `RobWalsh.BertBrowser` version **1.1.1** — https://github.com/robgwalsh/bertbrowser/releases/tag/v1.1.1

I'm the package author. Along with the version bump this corrects the installer metadata carried over
from 1.0.0, which described the [Velopack](https://velopack.io) installer as `portable`:

- `InstallerType: portable` → `exe`, with `Silent: --silent` and `Scope: user` (it installs per-user
  into `%LOCALAPPDATA%`, no elevation).
- Added `AppsAndFeaturesEntries` matching the ARP entry the installer writes, so `winget upgrade`
  can correlate an installed copy.
- Filled in the locale manifest (publisher/package URLs, license URL, description, tags).

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/415114)