### PR TITLE
Fix: sordum.DnsJumper version 2.3 installer hash

### DIFF
--- a/manifests/s/sordum/DnsJumper/2.3/sordum.DnsJumper.installer.yaml
+++ b/manifests/s/sordum/DnsJumper/2.3/sordum.DnsJumper.installer.yaml
@@ -16,7 +16,7 @@ ReleaseDate: 2025-10-08
 Installers:
 - Architecture: x86
   InstallerUrl: https://www.sordum.org/files/download/dns-jumper/DnsJumper.zip
-  InstallerSha256: 4B47FE0818B772B28CE1C6458D47920C08AE159C989ED80763A1954CA3F03D83
+  InstallerSha256: 4533B284F87251E689CE25020DE9108E776A174F9DA98F707E0E1B3C9264C169
 ManifestType: installer
 ManifestVersion: 1.10.0
 


### PR DESCRIPTION
The publisher replaced the archive behind the existing vanity URL, causing WinGet installations to fail with an installer hash mismatch. This updates InstallerSha256 to match the archive currently served by the official Sordum download URL. Manifest validation succeeds with winget validate.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/415119)