### PR TITLE
New package: jungdosa.QuotaDock version 0.7.34

### DIFF
--- a/manifests/j/jungdosa/QuotaDock/0.7.34/jungdosa.QuotaDock.installer.yaml
+++ b/manifests/j/jungdosa/QuotaDock/0.7.34/jungdosa.QuotaDock.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: jungdosa.QuotaDock
+PackageVersion: 0.7.34
+MinimumOSVersion: 10.0.19045.0
+InstallerType: inno
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{A5F3C2E1-9D4B-4A7C-8E6F-1B2C3D4E5F60}_is1'
+ReleaseDate: 2026-08-11
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/jungdosa/QuotaDock/releases/download/v0.7.34/QuotaDock-0.7.34-win-x64-Setup.exe
+  InstallerSha256: D005522E9733261B66DDE64ED04523C801C888887B8BC5C2F79588F6FCFF6135
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/j/jungdosa/QuotaDock/0.7.34/jungdosa.QuotaDock.locale.en-US.yaml
+++ b/manifests/j/jungdosa/QuotaDock/0.7.34/jungdosa.QuotaDock.locale.en-US.yaml
@@ -1,0 +1,45 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: jungdosa.QuotaDock
+PackageVersion: 0.7.34
+PackageLocale: en-US
+Publisher: jungdosa
+PublisherUrl: https://github.com/jungdosa
+PublisherSupportUrl: https://github.com/jungdosa/QuotaDock/issues
+PackageName: QuotaDock
+PackageUrl: https://github.com/jungdosa/QuotaDock
+License: MIT
+LicenseUrl: https://github.com/jungdosa/QuotaDock/blob/main/LICENSE
+Copyright: Copyright (c) jungdosa
+ShortDescription: Desktop widget showing remaining Claude, OpenAI Codex and Google Antigravity usage quota and reset times.
+Description: |-
+  QuotaDock is a small always-on-top Windows widget that shows how much of your
+  Claude Code, OpenAI Codex and Google Antigravity quota is left, and when each
+  limit resets. Every row draws remaining usage above a thin bar counting down
+  to reset, so you can see whether quota is running out faster than the clock.
+
+  It reads the sign-ins you already have rather than asking for anything: the
+  credentials Claude Code stored locally, the official Codex CLI app-server over
+  stdio, and Antigravity's language server on loopback. There is no login screen,
+  no session key to paste, and no browser-cookie extraction. Checking usage never
+  spends quota or credits, and the app sends no telemetry.
+
+  Use one provider or all three; if one fails the others keep working. Twelve
+  display languages, following Windows or chosen in Settings.
+Moniker: quotadock
+Tags:
+- ai
+- antigravity
+- claude
+- claude-code
+- codex
+- desktop-widget
+- gemini
+- monitor
+- openai
+- quota
+- rate-limit
+- system-tray
+- usage
+ReleaseNotesUrl: https://github.com/jungdosa/QuotaDock/releases/tag/v0.7.34
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/j/jungdosa/QuotaDock/0.7.34/jungdosa.QuotaDock.yaml
+++ b/manifests/j/jungdosa/QuotaDock/0.7.34/jungdosa.QuotaDock.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: jungdosa.QuotaDock
+PackageVersion: 0.7.34
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: jungdosa.QuotaDock version 0.7.34

- [x] Manifests validated locally against the 1.6.0 schema
- [x] Installer is Inno Setup, user scope (`PrivilegesRequired=lowest`)
- [x] Silent install verified: `/VERYSILENT /NORESTART` exits 0 and registers
      `{A5F3C2E1-9D4B-4A7C-8E6F-1B2C3D4E5F60}_is1` (checked against the actual registry)
- [x] `InstallerSha256` matches the `SHA256SUMS.txt` published with the release
- [x] I am the publisher of this package

QuotaDock is a Windows desktop widget that shows remaining Claude Code / OpenAI Codex /
Google Antigravity usage quota and reset times. MIT, free, no telemetry.
Homepage: https://jungdosa.github.io/QuotaDock/

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/415139)