### PR TITLE
Add cyhkbl.MaximizeToVirtualDesktop version 1.0.1

### DIFF
--- a/manifests/c/cyhkbl/MaximizeToVirtualDesktop/1.0.1/cyhkbl.MaximizeToVirtualDesktop.installer.yaml
+++ b/manifests/c/cyhkbl/MaximizeToVirtualDesktop/1.0.1/cyhkbl.MaximizeToVirtualDesktop.installer.yaml
@@ -1,0 +1,26 @@
+PackageIdentifier: cyhkbl.MaximizeToVirtualDesktop
+PackageVersion: 1.0.1
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: MaximizeToVirtualDesktop.exe
+    PortableCommandAlias: MaximizeToVirtualDesktop
+Installers:
+  - Architecture: x64
+    InstallerType: zip
+    InstallerUrl: https://github.com/cyhkbl/MaximizeToVirtualDesktop/releases/download/v1.0.1/MaximizeToVirtualDesktop-v1.0.1-win-x64.zip
+    InstallerSha256: 46A535004AA4D9CF08791ED3B903075619FC56A3A4335D607955FC1FD192E32B
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: MaximizeToVirtualDesktop.exe
+        PortableCommandAlias: MaximizeToVirtualDesktop
+  - Architecture: arm64
+    InstallerType: zip
+    InstallerUrl: https://github.com/cyhkbl/MaximizeToVirtualDesktop/releases/download/v1.0.1/MaximizeToVirtualDesktop-v1.0.1-win-arm64.zip
+    InstallerSha256: 9FF63C6082E3B4C270FFF26007CC77D6EC4AC6795FCB836418D851E85BB81989
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: MaximizeToVirtualDesktop.exe
+        PortableCommandAlias: MaximizeToVirtualDesktop
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/c/cyhkbl/MaximizeToVirtualDesktop/1.0.1/cyhkbl.MaximizeToVirtualDesktop.locale.en-US.yaml
+++ b/manifests/c/cyhkbl/MaximizeToVirtualDesktop/1.0.1/cyhkbl.MaximizeToVirtualDesktop.locale.en-US.yaml
@@ -1,0 +1,20 @@
+PackageIdentifier: cyhkbl.MaximizeToVirtualDesktop
+PackageVersion: 1.0.1
+PackageLocale: en-US
+Publisher: cyhkbl
+PublisherUrl: https://github.com/cyhkbl
+PackageName: Maximize to Virtual Desktop
+PackageUrl: https://github.com/cyhkbl/MaximizeToVirtualDesktop
+License: MIT
+LicenseUrl: https://github.com/cyhkbl/MaximizeToVirtualDesktop/blob/master/LICENSE
+ShortDescription: Maximize any window to its own virtual desktop with a single click.
+Description: |-
+  Maximize to Virtual Desktop sends the active window to its own virtual desktop
+  and maximizes it there. Simply click a window's maximize button, or press
+  Ctrl+Alt+Shift+X to toggle the focused window to/from its own virtual desktop.
+Tags:
+  - virtualdesktop
+  - windowmanager
+  - productivity
+ManifestType: locale
+ManifestVersion: 1.6.0

--- a/manifests/c/cyhkbl/MaximizeToVirtualDesktop/1.0.1/cyhkbl.MaximizeToVirtualDesktop.yaml
+++ b/manifests/c/cyhkbl/MaximizeToVirtualDesktop/1.0.1/cyhkbl.MaximizeToVirtualDesktop.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: cyhkbl.MaximizeToVirtualDesktop
+PackageVersion: 1.0.1
+DefaultLocale: en-US
+ManifestType: package
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## New package: Maximize to Virtual Desktop

**Package identifier:** cyhkbl.MaximizeToVirtualDesktop  
**Version:** 1.0.1  
**Publisher:** cyhkbl  

### Description

Maximize to Virtual Desktop sends the active window to its own virtual desktop and maximizes it there. Simply click a window's maximize button, or press Ctrl+Alt+Shift+X to toggle the focused window to/from its own virtual desktop.

### Installer type

- Self-contained zip (portable, no installer)
- NestedInstallerType: portable
- Two architectures: x64 and arm64

### Installer URLs

- x64: https://github.com/cyhkbl/MaximizeToVirtualDesktop/releases/download/v1.0.1/MaximizeToVirtualDesktop-v1.0.1-win-x64.zip
- arm64: https://github.com/cyhkbl/MaximizeToVirtualDesktop/releases/download/v1.0.1/MaximizeToVirtualDesktop-v1.0.1-win-arm64.zip

### License

MIT (fork of shanselman/MaximizeToVirtualDesktop)

### Validation

- Manifest locally validated: winget install --manifest passed on Windows 11 x64
- SHA256 hashes verified against downloaded files
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/415144)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/415144)