### PR TITLE
Add Ioruba 1.7.1

### DIFF
--- a/manifests/b/BernardoGomes/Ioruba/1.7.1/BernardoGomes.Ioruba.installer.yaml
+++ b/manifests/b/BernardoGomes/Ioruba/1.7.1/BernardoGomes.Ioruba.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: BernardoGomes.Ioruba
+PackageVersion: 1.7.1
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+UpgradeBehavior: install
+ReleaseDate: 2026-08-10
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/bernardopg/ioruba/releases/download/v1.7.1/Ioruba_1.7.1_x64-setup.exe
+    InstallerSha256: C440343DDF55BC2BB148615040D7F32D8C16F516943DD921A29C32EC728387FD
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/b/BernardoGomes/Ioruba/1.7.1/BernardoGomes.Ioruba.locale.en-US.yaml
+++ b/manifests/b/BernardoGomes/Ioruba/1.7.1/BernardoGomes.Ioruba.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: BernardoGomes.Ioruba
+PackageVersion: 1.7.1
+PackageLocale: en-US
+Publisher: Bernardo Gomes
+PublisherUrl: https://github.com/bernardopg
+PackageName: Ioruba
+PackageUrl: https://github.com/bernardopg/ioruba
+License: MIT
+LicenseUrl: https://github.com/bernardopg/ioruba/blob/main/LICENSE
+ShortDescription: Tactile audio mixer for Arduino-based control surfaces
+Description: >-
+  Ioruba turns an Arduino with potentiometers, buttons and encoders into a
+  hardware mixer for your desktop audio, mapping each knob to a sink, source
+  or application.
+Moniker: ioruba
+Tags:
+  - audio
+  - mixer
+  - arduino
+  - volume
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/b/BernardoGomes/Ioruba/1.7.1/BernardoGomes.Ioruba.yaml
+++ b/manifests/b/BernardoGomes/Ioruba/1.7.1/BernardoGomes.Ioruba.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: BernardoGomes.Ioruba
+PackageVersion: 1.7.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Adds the Ioruba 1.7.1 manifests for the signed NSIS installer hosted in the project's GitHub Release. The release URL and SHA256 are generated from the published release assets.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/415149)