### PR TITLE
New package: SharpTS.SharpTS.NativeAOT version 1.0.11-rc.3

### DIFF
--- a/manifests/s/SharpTS/SharpTS/NativeAOT/1.0.11-rc.3/SharpTS.SharpTS.NativeAOT.installer.yaml
+++ b/manifests/s/SharpTS/SharpTS/NativeAOT/1.0.11-rc.3/SharpTS.SharpTS.NativeAOT.installer.yaml
@@ -1,0 +1,22 @@
+# Created with WinGetCreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: SharpTS.SharpTS.NativeAOT
+PackageVersion: 1.0.11-rc.3
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: sharpts.exe
+    PortableCommandAlias: sharpts
+Commands:
+  - sharpts
+ReleaseDate: 2026-08-11
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/nickna/SharpTS/releases/download/v1.0.11-rc.3/sharpts-native-1.0.11-rc.3-win-x64.zip
+    InstallerSha256: 38A26E2076882350AFDCD30F5DFAEA1175069AC0731D872347D3C07268C18A07
+  - Architecture: arm64
+    InstallerUrl: https://github.com/nickna/SharpTS/releases/download/v1.0.11-rc.3/sharpts-native-1.0.11-rc.3-win-arm64.zip
+    InstallerSha256: 0F3D63348B5F858941D7162EBD06084AF93CAC09D4F071604F03B791077099D8
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/SharpTS/SharpTS/NativeAOT/1.0.11-rc.3/SharpTS.SharpTS.NativeAOT.locale.en-US.yaml
+++ b/manifests/s/SharpTS/SharpTS/NativeAOT/1.0.11-rc.3/SharpTS.SharpTS.NativeAOT.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# Created with WinGetCreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: SharpTS.SharpTS.NativeAOT
+PackageVersion: 1.0.11-rc.3
+PackageLocale: en-US
+Publisher: Nick Nassiri
+PublisherUrl: https://github.com/nickna
+PublisherSupportUrl: https://github.com/nickna/SharpTS/issues
+PackageName: SharpTS Native AOT
+PackageUrl: https://github.com/nickna/SharpTS
+License: MIT
+LicenseUrl: https://github.com/nickna/SharpTS/blob/v1.0.11-rc.3/LICENSE
+Copyright: Copyright (c) 2026 Nick Nassiri
+ShortDescription: Native AOT distribution of the SharpTS TypeScript interpreter and compiler
+Description: |-
+  Native AOT distribution of SharpTS with fast startup and no separate .NET installation. It uses
+  a closed, generated .NET interop catalog. External DLL and NuGet references, unrestricted
+  reflection, --verify, --gen-decl, and compiled child_process.fork require the managed package.
+  SharpTS.SharpTS.NativeAOT and SharpTS.SharpTS both expose the sharpts command and must not be
+  installed side by side; uninstall one before switching to the other.
+Tags:
+  - aot
+  - compiler
+  - dotnet
+  - interpreter
+  - native
+  - typescript
+ReleaseNotesUrl: https://github.com/nickna/SharpTS/releases/tag/v1.0.11-rc.3
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/SharpTS/SharpTS/NativeAOT/1.0.11-rc.3/SharpTS.SharpTS.NativeAOT.yaml
+++ b/manifests/s/SharpTS/SharpTS/NativeAOT/1.0.11-rc.3/SharpTS.SharpTS.NativeAOT.yaml
@@ -1,0 +1,8 @@
+# Created with WinGetCreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: SharpTS.SharpTS.NativeAOT
+PackageVersion: 1.0.11-rc.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description
Adds the initial SharpTS.SharpTS.NativeAOT manifest for version 1.0.11-rc.3 from the published SharpTS GitHub release. This is the self-contained Native AOT distribution for x64 and ARM64 Windows.

The managed and Native AOT identities both expose the sharpts command and are intentionally mutually exclusive. The package description documents the Native AOT feature boundaries and switching requirement.

Release: https://github.com/nickna/SharpTS/releases/tag/v1.0.11-rc.3
Tracking issue: https://github.com/nickna/SharpTS/issues/1356

## ✅ Checklist

- [ ] Signed the Contributor License Agreement (awaiting bot confirmation)
- [x] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there are no other open pull requests for the same manifest
- [x] This PR only modifies one manifest
- [x] Validated manifest locally with winget validate --manifest <path>
- [x] Tested manifest locally with winget install --manifest <path>
- [x] Manifest conforms to the 1.12 schema

Local testing covered x64 archive hash verification, install, registration, sharpts --version, interpretation, compilation and compiled output, fresh-terminal command discovery, and uninstall.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/415154)