### PR TITLE
MetanoicArmor.I2PChat.TUI version 1.4.0

### DIFF
--- a/manifests/m/MetanoicArmor/I2PChat/TUI/1.4.0/MetanoicArmor.I2PChat.TUI.installer.yaml
+++ b/manifests/m/MetanoicArmor/I2PChat/TUI/1.4.0/MetanoicArmor.I2PChat.TUI.installer.yaml
@@ -1,0 +1,22 @@
+PackageIdentifier: MetanoicArmor.I2PChat.TUI
+PackageVersion: 1.4.0
+InstallerLocale: en-US
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallModes:
+  - interactive
+  - silent
+# TUI winget: *-winget-* zip omits embedded i2pd (SHA from release SHA256SUMS v1.4.0).
+Installers:
+  - Architecture: x64
+    InstallerType: zip
+    InstallerUrl: https://github.com/MetanoicArmor/I2PChat/releases/download/v1.4.0/I2PChat-windows-tui-x64-winget-v1.4.0.zip
+    InstallerSha256: 6b311ccbc27f9f7473c2e1e7f0d36d63379e593cd0d18558d799189bb6c4a484
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: I2PChat/I2PChat-tui.exe
+        PortableCommandAlias: i2pchat-tui
+    ReleaseDate: 2026-08-11
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/MetanoicArmor/I2PChat/TUI/1.4.0/MetanoicArmor.I2PChat.TUI.locale.en-US.yaml
+++ b/manifests/m/MetanoicArmor/I2PChat/TUI/1.4.0/MetanoicArmor.I2PChat.TUI.locale.en-US.yaml
@@ -1,0 +1,27 @@
+PackageIdentifier: MetanoicArmor.I2PChat.TUI
+PackageVersion: 1.4.0
+PackageLocale: en-US
+Publisher: MetanoicArmor
+PublisherUrl: https://github.com/MetanoicArmor
+PackageName: I2PChat TUI
+PackageUrl: https://github.com/MetanoicArmor/I2PChat
+License: AGPL-3.0
+LicenseUrl: https://github.com/MetanoicArmor/I2PChat/blob/main/LICENSE
+Copyright: Copyright (c) MetanoicArmor and contributors
+ShortDescription: Terminal UI (Textual) for I2PChat over I2P SAM
+Description: |-
+  I2PChat TUI is the Textual console client for I2PChat (no PyQt GUI). This winget package uses the
+  *-winget-* release zip without embedded i2pd; use a system i2pd with SAM or the full TUI zip from GitHub Releases
+  for a bundled router.
+Moniker: i2pchat-tui
+Tags:
+  - i2p
+  - chat
+  - p2p
+  - privacy
+  - terminal
+ReleaseNotesUrl: https://github.com/MetanoicArmor/I2PChat/releases/tag/v1.4.0
+ReleaseNotes: |-
+  v1.4.0: Aligns with I2PChat 1.4.0 (protocol-breaking: handshake v4, signed group invites v2, encrypted storage, TOFU safety numbers; not compatible with 1.3.x). Winget *-winget-* zip without embedded i2pd. Full TUI zip with bundled router: I2PChat-windows-tui-x64-v*.zip on GitHub Releases. i2pd: https://github.com/PurpleI2P/i2pd
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/MetanoicArmor/I2PChat/TUI/1.4.0/MetanoicArmor.I2PChat.TUI.yaml
+++ b/manifests/m/MetanoicArmor/I2PChat/TUI/1.4.0/MetanoicArmor.I2PChat.TUI.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: MetanoicArmor.I2PChat.TUI
+PackageVersion: 1.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary
Adds **MetanoicArmor.I2PChat.TUI** **1.4.0** (TUI-only).

Installer: `I2PChat-windows-tui-x64-winget-v1.4.0.zip` from [I2PChat v1.4.0](https://github.com/MetanoicArmor/I2PChat/releases/tag/v1.4.0) (SHA256 from release `SHA256SUMS`).

Separate PR for GUI package as required by winget-pkgs automation.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/415174)