### PR TITLE
Update: Unity.UnityHub to 3.20.1

### DIFF
--- a/manifests/u/Unity/UnityHub/3.20.1/Unity.UnityHub.installer.yaml
+++ b/manifests/u/Unity/UnityHub/3.20.1/Unity.UnityHub.installer.yaml
@@ -1,0 +1,59 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Unity.UnityHub
+PackageVersion: 3.20.1
+UpgradeBehavior: install
+Protocols:
+- unityhub
+FileExtensions:
+- unityhub
+ReleaseDate: 2026-08-11
+Installers:
+- Architecture: x64
+  InstallerType: nullsoft
+  Scope: machine
+  MinimumOSVersion: 10.0.10240.0
+  InstallerSwitches:
+    Upgrade: --updated
+  ProductCode: Unity Technologies - Hub
+  AppsAndFeaturesEntries:
+  - DisplayName: Unity Hub 3.20.1
+    ProductCode: Unity Technologies - Hub
+  InstallerUrl: https://public-cdn.cloud.unity3d.com/hub/prod/3.20.1/UnityHubSetup-3.20.1-x64.exe
+  InstallerSha256: 58FD1D3DBB9225E4CEA6EFE85DF5BC419C7AD4E0C6737B945937930E95F9A73E
+- Architecture: arm64
+  InstallerType: nullsoft
+  Scope: machine
+  MinimumOSVersion: 10.0.10240.0
+  InstallerSwitches:
+    Upgrade: --updated
+  ProductCode: Unity Technologies - Hub
+  AppsAndFeaturesEntries:
+  - DisplayName: Unity Hub 3.20.1
+    ProductCode: Unity Technologies - Hub
+  InstallerUrl: https://public-cdn.cloud.unity3d.com/hub/prod/3.20.1/UnityHubSetup-3.20.1-arm64.exe
+  InstallerSha256: 6A772B6954A98B34D06EC3E4F4F60EE04E7812AF1E165E21B9EC2068AD4FD116
+- Platform:
+  - Windows.Desktop
+  MinimumOSVersion: 10.0.19043.0
+  Architecture: x64
+  InstallerType: msix
+  InstallerUrl: https://public-cdn.cloud.unity3d.com/hub/prod/3.20.1/UnityHubSetup-3.20.1-x64.msix
+  InstallerSha256: AA2262C61FE5B3617AC54F205669C2612163FA758229FE3AB15565CDF1F67373
+  SignatureSha256: 3D94BBB197FA7B99636F069105DC7A3EC49F9EA6419E83AFB53F2E456D267F17
+  PackageFamilyName: UnityTechnologies.UnityHub_2vrhnee42bhxm
+  RestrictedCapabilities:
+  - runFullTrust
+- Platform:
+  - Windows.Desktop
+  MinimumOSVersion: 10.0.19043.0
+  Architecture: arm64
+  InstallerType: msix
+  InstallerUrl: https://public-cdn.cloud.unity3d.com/hub/prod/3.20.1/UnityHubSetup-3.20.1-arm64.msix
+  InstallerSha256: 24A54EFEFCE5CEA3188D3A7B2C8055BCF8945BAF387F79EE65D54B9816C02A14
+  SignatureSha256: A1C0DFD07DA38E15201E8C7A3BC324ED83495616FEB24F9445778EE2F79D672A
+  PackageFamilyName: UnityTechnologies.UnityHub_2vrhnee42bhxm
+  RestrictedCapabilities:
+  - runFullTrust
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/u/Unity/UnityHub/3.20.1/Unity.UnityHub.locale.en-US.yaml
+++ b/manifests/u/Unity/UnityHub/3.20.1/Unity.UnityHub.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Unity.UnityHub
+PackageVersion: 3.20.1
+PackageLocale: en-US
+Publisher: Unity Technologies Inc.
+PublisherUrl: https://unity.com/
+PublisherSupportUrl: https://support.unity.com/
+PrivacyUrl: https://unity.com/legal/privacy-policy
+Author: Unity Technologies Inc.
+PackageName: Unity Hub
+PackageUrl: https://unity.com/unity-hub
+License: Proprietary
+LicenseUrl: https://unity.com/legal/terms-of-service
+Copyright: Copyright © 2026 Unity Technologies Inc.
+CopyrightUrl: https://unity.com/legal/trademarks
+ShortDescription: Manage multiple installations of the Unity Editor, create new projects, and access your work.
+Description: The Unity Hub is a standalone application that streamlines the way you navigate, download, and manage your Unity projects and installations.
+Tags:
+- unity
+- unity3d
+Documentations:
+- DocumentLabel: Manual
+  DocumentUrl: https://docs.unity3d.com/hub/manual
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/u/Unity/UnityHub/3.20.1/Unity.UnityHub.locale.zh-CN.yaml
+++ b/manifests/u/Unity/UnityHub/3.20.1/Unity.UnityHub.locale.zh-CN.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: Unity.UnityHub
+PackageVersion: 3.20.1
+PackageLocale: zh-CN
+PublisherUrl: https://unity.com/cn
+PrivacyUrl: https://unity.com/cn/legal/privacy-policy
+PackageUrl: https://unity.com/cn/unity-hub
+License: 专有软件
+LicenseUrl: https://unity.com/cn/legal/terms-of-service
+CopyrightUrl: https://unity.com/cn/legal/trademarks
+ShortDescription: 管理 Unity 编辑器的多个安装、创建新项目和访问您的工作
+Description: Unity Hub 是一款独立应用程序，简化 Unity 项目和安装的浏览、下载和管理方式。
+Documentations:
+- DocumentLabel: 手册
+  DocumentUrl: https://docs.unity3d.com/hub/manual
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/u/Unity/UnityHub/3.20.1/Unity.UnityHub.yaml
+++ b/manifests/u/Unity/UnityHub/3.20.1/Unity.UnityHub.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Unity.UnityHub
+PackageVersion: 3.20.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Updates **Unity.UnityHub** to **3.20.1** (GA, released 2026-08-11).

3.20.1 is a patch release; upstream it fixes Editor module installs failing with a checksum mismatch on Linux. There are no Windows packaging or installer-structure changes, so this manifest is structurally identical to 3.20.0 — four installers, with the NSIS `.exe` entries (machine scope, x64 + arm64) listed first to preserve the default install experience, followed by the MSIX packages (x64 + arm64, `PackageFamilyName: UnityTechnologies.UnityHub_2vrhnee42bhxm`, `MinimumOSVersion: 10.0.19043.0`).

All four installers are served from Unity's immutable versioned CDN URLs (`.../hub/prod/3.20.1/...`) and are Authenticode-signed by Unity's EV certificate (`CN=Unity Technologies SF`). The MSIX `Identity` (`Name`, `Publisher`) is unchanged from 3.20.0, so `PackageFamilyName` still applies; `SignatureSha256` values were recomputed from each package's `AppxSignature.p7x`. `ReleaseDate` follows the installers' CDN `Last-Modified` (2026-08-11), consistent with previous versions.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` — authored on macOS, where `winget` is unavailable. Validated instead against the official 1.12.0 JSON schemas (`installer`, `defaultLocale`, `locale`, `version`): all four manifests pass with zero errors. Each `InstallerSha256` was additionally re-derived from the file at its own `InstallerUrl` after verifying every download's byte count against the CDN `Content-Length`, and the x64 installer's SHA-512 was cross-checked against Unity's published `latest.yml` feed.
- [x] Tested manifest locally with `winget install --manifest <path>` — skipped the local install round-trip to avoid replacing the development Hub install on this machine; relying on pipeline installation validation.
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/415206)