### PR TITLE
New package: MSKazemi.YazSes version 2.17.0

### DIFF
--- a/manifests/m/MSKazemi/YazSes/2.17.0/MSKazemi.YazSes.installer.yaml
+++ b/manifests/m/MSKazemi/YazSes/2.17.0/MSKazemi.YazSes.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: MSKazemi.YazSes
+PackageVersion: 2.17.0
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{F3E8B8A4-1B6C-4F24-9BE8-9B7E58E9C4A2}_is1'
+MinimumOSVersion: 10.0.19041.0
+ReleaseDate: 2026-08-09
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/MSKazemi/yazses/releases/download/v2.17.0/YazSes-2.17.0-windows-x64.exe
+    InstallerSha256: ECE08306544AF68F85FCEFDF03B8B997B8C0A6DB897F05E64FE8EDD12F6D1BDF
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/MSKazemi/YazSes/2.17.0/MSKazemi.YazSes.locale.en-US.yaml
+++ b/manifests/m/MSKazemi/YazSes/2.17.0/MSKazemi.YazSes.locale.en-US.yaml
@@ -1,0 +1,49 @@
+PackageIdentifier: MSKazemi.YazSes
+PackageVersion: 2.17.0
+PackageLocale: en-US
+Publisher: MSKazemi
+PublisherUrl: https://github.com/MSKazemi
+PublisherSupportUrl: https://github.com/MSKazemi/yazses/issues
+Author: Mohsen Seyedkazemi Ardebili
+PackageName: YazSes
+PackageUrl: https://mskazemi.com/yazses/
+License: Apache-2.0
+LicenseUrl: https://github.com/MSKazemi/yazses/blob/main/LICENSE
+Copyright: Copyright 2026 Mohsen Seyedkazemi Ardebili
+ShortDescription: Offline voice dictation — hold a key, speak, release. No cloud, no API key, no subscription.
+Description: |-
+  YazSes is a free, open-source, offline voice dictation and speech-to-text
+  tool. Hold a key, speak, release — your words are transcribed on your own CPU
+  and typed into whatever window has focus.
+
+  Everything runs on-device with faster-whisper. There is no cloud service, no
+  API key, no account and no subscription, and no telemetry of any kind. Use it
+  when audio must not be sent to a third party — a confidential meeting, an
+  air-gapped machine, or simply a preference not to rent your own voice.
+
+  It also transcribes recordings (`yazses transcribe talk.m4a`, with optional
+  speaker labels) and can capture a whole meeting into a speaker-labelled
+  transcript with locally generated minutes.
+Moniker: yazses
+Tags:
+  - voice
+  - dictation
+  - voice-typing
+  - speech-to-text
+  - speech-recognition
+  - whisper
+  - transcription
+  - offline
+  - on-device
+  - privacy
+  - accessibility
+  - productivity
+  - open-source
+Documentations:
+  - DocumentLabel: Documentation
+    DocumentUrl: https://mskazemi.com/yazses/
+  - DocumentLabel: Windows install guide
+    DocumentUrl: https://mskazemi.com/yazses/windows-install.html
+ReleaseNotesUrl: https://github.com/MSKazemi/yazses/releases/tag/v2.17.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/MSKazemi/YazSes/2.17.0/MSKazemi.YazSes.yaml
+++ b/manifests/m/MSKazemi/YazSes/2.17.0/MSKazemi.YazSes.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: MSKazemi.YazSes
+PackageVersion: 2.17.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Pull request has been created with the following:

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

---

New package: **MSKazemi.YazSes** 2.17.0 — an open-source (Apache-2.0) offline voice dictation daemon. Hold a key, speak, release, and the text is typed into whatever window has focus. Speech recognition runs locally via faster-whisper; no cloud service or account is involved.

**Manifest details**

| | |
|---|---|
| Installer | Inno Setup, per-user (`DefaultDirName={userpf}`), so `Scope: user` |
| Architecture | x64 |
| `InstallerSha256` | `ECE08306544AF68F85FCEFDF03B8B997B8C0A6DB897F05E64FE8EDD12F6D1BDF` |
| `ProductCode` | `{F3E8B8A4-1B6C-4F24-9BE8-9B7E58E9C4A2}_is1` (Inno AppId + `_is1`) |
| Source | https://github.com/MSKazemi/yazses |

The hash was computed from the published release asset
`YazSes-2.17.0-windows-x64.exe` (99,848,444 bytes) downloaded from the v2.17.0 tag.

**Two things I want to be upfront about:**

1. **The installer is unsigned.** It is built in CI by Inno Setup from the public
   repository, but there is no code-signing certificate yet, so SmartScreen will warn on
   first run. If that is disqualifying for a new package, tell me and I will close this
   until signing is in place.
2. I have **not** been able to run `winget install --manifest` against it myself — I do
   not have a Windows machine to hand, so the install checkbox above is honestly left
   unticked rather than ticked on assumption. The manifest schema validates and the hash
   is verified; the install path itself is what your CI would be confirming.

Happy to adjust scope, installer type, or metadata if the validation pipeline objects.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/415210)