### PR TITLE
New version: SosomLab.NexaDir version 0.16.0

### DIFF
--- a/manifests/s/SosomLab/NexaDir/0.16.0/SosomLab.NexaDir.installer.yaml
+++ b/manifests/s/SosomLab/NexaDir/0.16.0/SosomLab.NexaDir.installer.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: SosomLab.NexaDir
+PackageVersion: 0.16.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: inno
+UpgradeBehavior: install
+ReleaseDate: 2026-08-11
+Installers:
+# Per-user install (installer default: PrivilegesRequired=lowest, no elevation).
+- Architecture: x64
+  Scope: user
+  InstallerUrl: https://github.com/SosomLab/nexa-dir2/releases/download/0.16.0/NexaDir-Setup-0.16.0.exe
+  InstallerSha256: AD0676E0E1C07E61EF58AE41365FEA0052C4CC0C9D14156591E925C4ABF8097F
+  InstallerSwitches:
+    Custom: /CURRENTUSER
+# Machine-wide install (the installer allows the /ALLUSERS command-line override).
+- Architecture: x64
+  Scope: machine
+  InstallerUrl: https://github.com/SosomLab/nexa-dir2/releases/download/0.16.0/NexaDir-Setup-0.16.0.exe
+  InstallerSha256: AD0676E0E1C07E61EF58AE41365FEA0052C4CC0C9D14156591E925C4ABF8097F
+  InstallerSwitches:
+    Custom: /ALLUSERS
+  ElevationRequirement: elevatesSelf
+AppsAndFeaturesEntries:
+- DisplayName: Nexa Dir
+  Publisher: SosomLab
+  ProductCode: '{7E4B1C9D-3A52-4F8E-9B70-6C2D815FA3E1}_is1'
+  InstallerType: inno
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/SosomLab/NexaDir/0.16.0/SosomLab.NexaDir.locale.en-US.yaml
+++ b/manifests/s/SosomLab/NexaDir/0.16.0/SosomLab.NexaDir.locale.en-US.yaml
@@ -1,0 +1,52 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: SosomLab.NexaDir
+PackageVersion: 0.16.0
+PackageLocale: en-US
+Publisher: SosomLab
+PublisherUrl: https://sosomlab.com
+PublisherSupportUrl: https://github.com/SosomLab/nexa-dir2/issues
+Author: Sangyong Bae
+PackageName: Nexa Dir
+PackageUrl: https://sosomlab.com/apps/nexa-dir/
+License: PolyForm Noncommercial License 1.0.0
+LicenseUrl: https://github.com/SosomLab/nexa-dir2/blob/main/LICENSE.md
+Copyright: Copyright (c) 2026 SosomLab
+CopyrightUrl: https://github.com/SosomLab/nexa-dir2/blob/main/LICENSE.md
+ShortDescription: Lightweight, keyboard-first file explorer for Windows in a single native exe.
+Description: |-
+  Nexa Dir is a lightweight file explorer for Windows, built as a single native
+  executable in pure Rust on the Win32 API — no managed runtime, no UI framework,
+  and no external DLLs beyond the OS inbox set.
+
+  Highlights:
+  - Single portable exe under 10 MB, with an idle memory footprint under 30 MB.
+  - Dense, dark, keyboard-first UI designed for fast navigation over the mouse.
+  - Virtualized tree and list views that stay smooth over 100k+ entries.
+  - Bulk rename with reusable presets and live preview.
+  - Cloud storage in the same window: link an existing OneDrive, Google Drive or
+    Dropbox sync folder, or connect an account directly over OAuth to browse,
+    upload and download without syncing anything to disk.
+  - Trilingual UI (English, Korean, and Japanese).
+
+  Settings and session data live next to the executable under data\, falling back
+  to %LOCALAPPDATA%\NexaDir\data when the install directory is not writable.
+  Uninstalling keeps your data so a reinstall restores your settings.
+
+  Nexa Dir is free for personal and other noncommercial use under the PolyForm
+  Noncommercial License 1.0.0. Commercial use requires a separate paid license.
+Moniker: nexa-dir
+Tags:
+- explorer
+- file-manager
+- files
+- native
+- portable
+- rust
+- win32
+ReleaseNotesUrl: https://github.com/SosomLab/nexa-dir2/releases/tag/0.16.0
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/SosomLab/nexa-dir2/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/SosomLab/NexaDir/0.16.0/SosomLab.NexaDir.yaml
+++ b/manifests/s/SosomLab/NexaDir/0.16.0/SosomLab.NexaDir.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: SosomLab.NexaDir
+PackageVersion: 0.16.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Manifest for `SosomLab.NexaDir` version `0.16.0`

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/add?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? (schema conformance verified by parsing against the 1.12.0 schema; the author develops on a non-Windows host, so CI validation is relied upon)
- [x] Have you tested your manifest locally with `winget install --manifest <path>`? (relies on the pipeline's install/uninstall test)
- [x] Does your manifest conform to the [1.12.0 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

First version update since the package was added at `0.8.1` (#404528). `InstallerSha256` was taken from the release's published `SHA256SUMS.txt` and re-verified against a fresh download of the asset. `AppsAndFeaturesEntries.DisplayVersion` remains omitted per the moderator feedback on that PR.

The description was refreshed to match the current feature set (cloud storage support, and a trilingual UI rather than the dual-language one described at `0.8.1`).

I am the publisher (SosomLab) and the author of this package.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/415215)