### PR TITLE
New version: 0state.scafld 2.5.5

### DIFF
--- a/manifests/0/0state/scafld/2.5.5/0state.scafld.installer.yaml
+++ b/manifests/0/0state/scafld/2.5.5/0state.scafld.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: 0state.scafld
+PackageVersion: 2.5.5
+InstallerLocale: en-US
+InstallerType: portable
+Commands:
+  - scafld
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/nilstate/scafld/releases/download/v2.5.5/scafld_2.5.5_windows_amd64.exe
+    InstallerSha256: f4f6c6b429b87279c5fe884f2e91d9337fb91b567dba61230f90ba7637bedeae
+  - Architecture: arm64
+    InstallerUrl: https://github.com/nilstate/scafld/releases/download/v2.5.5/scafld_2.5.5_windows_arm64.exe
+    InstallerSha256: 1152c2a4e3356040f105f64332970f0810a6a92c69c0d90863e95f22f4a1c3dc
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/0/0state/scafld/2.5.5/0state.scafld.locale.en-US.yaml
+++ b/manifests/0/0state/scafld/2.5.5/0state.scafld.locale.en-US.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: 0state.scafld
+PackageVersion: 2.5.5
+PackageLocale: en-US
+Publisher: 0state
+PublisherUrl: https://0state.com
+PackageName: scafld
+License: MIT
+ShortDescription: Deterministic protocol for multi-phase agent work.
+PackageUrl: https://0state.com/scafld
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/0/0state/scafld/2.5.5/0state.scafld.yaml
+++ b/manifests/0/0state/scafld/2.5.5/0state.scafld.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: 0state.scafld
+PackageVersion: 2.5.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## Summary

- Adds `0state.scafld` version `2.5.5`.
- Installer URLs point to the public GitHub release `v2.5.5`.
- Installer SHA256 values were generated from the release `checksums.txt` and verified by `scripts/prepare-winget-submission.sh`.

Release: https://github.com/nilstate/scafld/releases/tag/v2.5.5

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/415306)