### PR TITLE
New package: AionUi.AionUi version 2.1.53

### DIFF
--- a/manifests/a/AionUi/AionUi/2.1.53/AionUi.AionUi.installer.yaml
+++ b/manifests/a/AionUi/AionUi/2.1.53/AionUi.AionUi.installer.yaml
@@ -2,7 +2,7 @@
 PackageIdentifier: AionUi.AionUi
 PackageVersion: 2.1.53
 InstallerLocale: en-US
-InstallerType: nsis
+InstallerType: nullsoft
 UpgradeBehavior: install
 Installers:
 - Architecture: x64

--- a/manifests/a/AionUi/AionUi/2.1.53/AionUi.AionUi.installer.yaml
+++ b/manifests/a/AionUi/AionUi/2.1.53/AionUi.AionUi.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: AionUi.AionUi
+PackageVersion: 2.1.53
+InstallerLocale: en-US
+InstallerType: nsis
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://static.aionui.com/releases/2.1.53/AionUi-2.1.53-win-x64.exe
+  InstallerSha256: BEB4C3C6B0E481425FBD4D07E76596125E7479645619FFC26BEE1F9575B73B8A
+- Architecture: arm64
+  InstallerUrl: https://static.aionui.com/releases/2.1.53/AionUi-2.1.53-win-arm64.exe
+  InstallerSha256: 687C468438A1E53A7EEE6C72F1ABACFCC2EBE18BDF688F16624EC668C701E300
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/AionUi/AionUi/2.1.53/AionUi.AionUi.locale.en-US.yaml
+++ b/manifests/a/AionUi/AionUi/2.1.53/AionUi.AionUi.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: AionUi.AionUi
+PackageVersion: 2.1.53
+PackageLocale: en-US
+Publisher: AionUi
+PublisherUrl: https://www.aionui.com
+PublisherSupportUrl: https://github.com/iOfficeAI/AionUi/issues
+PackageName: AionUi
+PackageUrl: https://www.aionui.com
+License: Apache-2.0
+LicenseUrl: https://github.com/iOfficeAI/AionUi/blob/main/LICENSE
+ShortDescription: Unified GUI for command-line AI agents
+Moniker: aionui
+Tags:
+- agent
+- ai
+- desktop
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/AionUi/AionUi/2.1.53/AionUi.AionUi.yaml
+++ b/manifests/a/AionUi/AionUi/2.1.53/AionUi.AionUi.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: AionUi.AionUi
+PackageVersion: 2.1.53
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package: **AionUi.AionUi** version 2.1.53.

AionUi is a free, open-source (Apache-2.0) desktop GUI that unifies command-line AI agents. Homepage: https://www.aionui.com — the same vendor CDN (`static.aionui.com`) serves the installers and the existing Homebrew cask for macOS.

Installers are NSIS (x64 + arm64); SHA256 hashes computed from the downloaded artifacts.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> Note: no Windows machine was available for local `winget validate` / `winget install`; relying on the pipeline validation. Happy to fix anything it flags.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/415357)