### PR TITLE
New package: Createitv.AgcCli version 0.1.0

### DIFF
--- a/manifests/c/Createitv/AgcCli/0.1.0/Createitv.AgcCli.installer.yaml
+++ b/manifests/c/Createitv/AgcCli/0.1.0/Createitv.AgcCli.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Createitv.AgcCli
+PackageVersion: 0.1.0
+InstallerLocale: en-US
+InstallerType: zip
+ReleaseDate: "2026-08-11"
+Installers:
+  - Architecture: x64
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: agc.exe
+        PortableCommandAlias: agc
+    InstallerUrl: https://github.com/Createitv/agc-cli/releases/download/v0.1.0/agc-cli_0.1.0_windows_amd64.zip
+    InstallerSha256: 5F7802E6050FDA8D118D0EBE5A6729774FA317613AD6BFC3D73F59815A29B677
+    UpgradeBehavior: uninstallPrevious
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/Createitv/AgcCli/0.1.0/Createitv.AgcCli.locale.en-US.yaml
+++ b/manifests/c/Createitv/AgcCli/0.1.0/Createitv.AgcCli.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Createitv.AgcCli
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Createitv
+PublisherUrl: https://github.com/Createitv
+PublisherSupportUrl: https://github.com/Createitv/agc-cli/issues/new
+PackageName: agc CLI
+PackageUrl: https://agccli.app/
+License: MIT
+LicenseUrl: https://github.com/Createitv/agc-cli/blob/main/LICENSE
+Copyright: Copyright Createitv
+ShortDescription: AppGallery Connect CLI command center
+Description: agc CLI is a Go command-line tool for AppGallery Connect automation, release dry-runs, profile binding, uploads, reports, local REST workflows, and CI usage.
+Moniker: agc-cli
+Tags:
+  - appgallery-connect
+  - agc
+  - huawei
+  - harmonyos
+  - cli
+  - golang
+ReleaseNotesUrl: https://github.com/Createitv/agc-cli/releases/tag/v0.1.0
+InstallationNotes: Run agc version after install to verify the command is available.
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/Createitv/AgcCli/0.1.0/Createitv.AgcCli.yaml
+++ b/manifests/c/Createitv/AgcCli/0.1.0/Createitv.AgcCli.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Createitv.AgcCli
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Package submission\n\n- Package identifier: Createitv.AgcCli\n- Version: 0.1.0\n- Installer type: zip portable command alias agc\n- Release: https://github.com/Createitv/agc-cli/releases/tag/v0.1.0\n\nThis adds agc CLI, a Go command-line tool for AppGallery Connect automation.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/415361)