### PR TITLE
New package: NeuralInverse.CLI version 1.0.0-beta

### DIFF
--- a/manifests/n/NeuralInverse/CLI/1.0.0-beta/NeuralInverse.CLI.installer.yaml
+++ b/manifests/n/NeuralInverse/CLI/1.0.0-beta/NeuralInverse.CLI.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: NeuralInverse.CLI
+PackageVersion: 1.0.0-beta
+MinimumOSVersion: 10.0.17763.0
+Installers:
+  - Architecture: x64
+    InstallerType: portable
+    InstallerUrl: https://github.com/NeuralInverse/cli-release/releases/download/v1.0.0-beta/neuralinverse-windows-x64.exe
+    InstallerSha256: EC4FDCD8C8632DF720047D4B8C23A3E920253B7A8BDA32FCAFCE9F327C2B6D9A
+    Commands:
+      - neuralinverse
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/n/NeuralInverse/CLI/1.0.0-beta/NeuralInverse.CLI.locale.en-US.yaml
+++ b/manifests/n/NeuralInverse/CLI/1.0.0-beta/NeuralInverse.CLI.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: NeuralInverse.CLI
+PackageVersion: 1.0.0-beta
+PackageLocale: en-US
+Publisher: Neural Inverse
+PublisherUrl: https://neuralinverse.com
+PackageName: Neural Inverse CLI
+PackageUrl: https://github.com/NeuralInverse/cli-release
+License: Proprietary
+ShortDescription: AI-powered terminal assistant — bring your own LLM
+Description: Neural Inverse CLI is an AI-powered coding assistant that runs in your terminal. Bring your own LLM provider (OpenAI, Anthropic, DeepSeek, Ollama, and more). Features include cross-platform sandbox runtime, OS keychain API key storage, and Neural Inverse Cloud workspace integration.
+Tags:
+  - ai
+  - cli
+  - developer-tools
+  - llm
+  - terminal
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/n/NeuralInverse/CLI/1.0.0-beta/NeuralInverse.CLI.yaml
+++ b/manifests/n/NeuralInverse/CLI/1.0.0-beta/NeuralInverse.CLI.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: NeuralInverse.CLI
+PackageVersion: 1.0.0-beta
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Package Information

- PackageIdentifier: NeuralInverse.CLI
- PackageVersion: 1.0.0-beta
- Publisher: Neural Inverse
- PackageName: Neural Inverse CLI
- License: Proprietary
- InstallerType: portable
- Architecture: x64

### Description

Neural Inverse CLI is an AI-powered terminal assistant that runs in your terminal. Bring your own LLM provider (OpenAI, Anthropic, DeepSeek, Ollama, and more). Features include cross-platform sandbox runtime, OS keychain API key storage, and Neural Inverse Cloud workspace integration.

### URLs

- Homepage: https://neuralinverse.com
- Installer: https://github.com/NeuralInverse/cli-release/releases/download/v1.0.0-beta/neuralinverse-windows-x64.exe
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/415389)