### PR TITLE
New version: Feci.ParleyDeckCli 1.43.0 and Feci.ParleyDeckSkill 2.7.0

### DIFF
--- a/manifests/f/Feci/ParleyDeckCli/1.43.0/Feci.ParleyDeckCli.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.43.0/Feci.ParleyDeckCli.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.43.0
+InstallerType: portable
+Commands:
+- parley
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.43.0/parley-v1.43.0-windows-x64.exe
+  InstallerSha256: B7FA91D7A81F37342FD0D2285613E3E620E184C3D7E3DCF2DB3EFACF14915EF0
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.43.0/parley-v1.43.0-windows-arm64.exe
+  InstallerSha256: 5FC1380413E0860B0DC818C4C81AC979E6467892A005D3FAA6944DDD42126520
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.43.0/Feci.ParleyDeckCli.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.43.0/Feci.ParleyDeckCli.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.43.0
+PackageLocale: en-US
+Publisher: Feci
+PublisherUrl: https://github.com/feci
+PackageName: Parley Deck CLI
+PackageUrl: https://github.com/feci/parley-deck-cli
+License: Apache-2.0
+LicenseUrl: https://github.com/feci/parley-deck-cli/blob/main/LICENSE
+ShortDescription: CLI that orchestrates Parley Deck multi-agent cooperation workflows.
+Description: "parley orchestrates multi-agent Parley Deck cooperation across local CLI agents: risk-tiered tracks, deliberation rounds, consensus and finalize, implementation with living execution plans, a live TUI, and a human-braked outer loop. v1.43.0 ships the result of a measured investigation into why deliberations became slower. It is not the CLI, where every command runs under a second. Reading the full cooperation protocol costs 3.3x median wall clock per call, the protocol doubled in ten weeks, and across 76 ideas review rounds grew from 1.6 to 5.1 while design rounds stayed flat. Both quadratic context paths were located, and the protocol never required them. NO SPEEDUP SHIPS IN THIS VERSION: the compaction that would deliver it is disabled by a constant, because three review rounds could not show that it never loses a participant objection. This release ships the diagnosis, a strict overlay lock format, and a cross-review prompt that describes its own contents truthfully."
+ReleaseNotesUrl: https://github.com/feci/parley-deck-cli/releases/tag/v1.43.0
+Tags:
+- ai
+- agents
+- automation
+- cli
+- codex
+- consensus
+- loop
+- multi-agent
+- orchestration
+- preflight
+- roster
+- tui
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.43.0/Feci.ParleyDeckCli.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.43.0/Feci.ParleyDeckCli.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.43.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckSkill/2.7.0/Feci.ParleyDeckSkill.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/2.7.0/Feci.ParleyDeckSkill.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 2.7.0
+InstallerType: portable
+Commands:
+- parley-deck-skill
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-skill/releases/download/v2.7.0/parley-deck-skill-v2.7.0-windows-x64.exe
+  InstallerSha256: 6D1049611D0189E3E0EE62FFD550D16822462EA5CF386DD17A2649A799E52268
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-skill/releases/download/v2.7.0/parley-deck-skill-v2.7.0-windows-arm64.exe
+  InstallerSha256: A0133D12457F98EF746978F9D4D2FA6E9991DAE8067379EF8CEE4E73E59B0A6C
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckSkill/2.7.0/Feci.ParleyDeckSkill.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/2.7.0/Feci.ParleyDeckSkill.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 2.7.0
+PackageLocale: en-US
+Publisher: Feci
+PublisherUrl: https://github.com/feci
+PackageName: Parley Deck Skill
+PackageUrl: https://github.com/feci/parley-deck-skill
+License: Apache-2.0
+LicenseUrl: https://github.com/feci/parley-deck-skill/blob/main/LICENSE
+ShortDescription: Installer for the Parley Deck multi-agent cooperation skill.
+Description: "parley-deck-skill installs the vendor-neutral Parley Deck cooperation skill for local CLI agents, plus opt-in companion add-ons. v2.7.0 retires a promissory note in the bundled protocol snapshot. The text previously said a deck would get its own protocol overlay once that shipped. The overlay is now partially implemented in parley-deck-cli 1.43.0, so the protocol states what exists and what does not: the overlay file grammar, the versioned deck lock and composition at the terminal boundary exist and are extend-only, while the roster-annotation identity slot and the removal of prose-matched zone addressing do not. The correction is applied identically to all three copies of the protocol, so they cannot disagree about what is implemented."
+ReleaseNotesUrl: https://github.com/feci/parley-deck-skill/releases/tag/v2.7.0
+Tags:
+- ai
+- agents
+- agy
+- antigravity
+- cli
+- codex
+- claude
+- gemini
+- kimi
+- multi-agent
+- skill
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckSkill/2.7.0/Feci.ParleyDeckSkill.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/2.7.0/Feci.ParleyDeckSkill.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 2.7.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Adds Feci.ParleyDeckCli 1.43.0 and Feci.ParleyDeckSkill 2.7.0.

Portable installers, x64 and arm64, published as GitHub release assets with SHA256 recorded in the installer manifests.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/415407)