### PR TITLE
Add Git.Git dependency: Espressif.EIM-CLI version 0.18.0

### DIFF
--- a/manifests/e/Espressif/EIM-CLI/0.18.0/Espressif.EIM-CLI.installer.yaml
+++ b/manifests/e/Espressif/EIM-CLI/0.18.0/Espressif.EIM-CLI.installer.yaml
@@ -6,6 +6,9 @@ PackageVersion: 0.18.0
 InstallerType: portable
 Commands:
 - eim
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Git.Git
 ReleaseDate: 2026-08-10
 Installers:
 - Architecture: x64


### PR DESCRIPTION
Adds `Git.Git` as a package dependency, since the ESP-IDF Installation Manager CLI requires Git at runtime to clone ESP-IDF repositories.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/415408)