### PR TITLE
Add Git.Git dependency: Espressif.eim version 0.18.0

### DIFF
--- a/manifests/e/Espressif/eim/0.18.0/Espressif.eim.installer.yaml
+++ b/manifests/e/Espressif/eim/0.18.0/Espressif.eim.installer.yaml
@@ -13,6 +13,9 @@ AppsAndFeaturesEntries:
   UpgradeCode: '{F76D9627-6E0E-5956-86E2-C847A3D8A984}'
 InstallationMetadata:
   DefaultInstallLocation: '%ProgramFiles%/eim'
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Git.Git
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/espressif/idf-im-ui/releases/download/v0.18.0/eim-gui-windows-x64.msi


### PR DESCRIPTION
Adds `Git.Git` as a package dependency, since the ESP-IDF Installation Manager GUI requires Git at runtime to clone ESP-IDF repositories.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/415409)