### PR TITLE
New version: Feci.ParleyDeckCli version 1.43.1

### DIFF
--- a/manifests/f/Feci/ParleyDeckCli/1.43.1/Feci.ParleyDeckCli.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.43.1/Feci.ParleyDeckCli.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.43.1
+InstallerType: portable
+Commands:
+- parley
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.43.1/parley-v1.43.1-windows-x64.exe
+  InstallerSha256: 851D94414125B6203005170FAB793288908880330D25B94095DDA241D4E7FF29
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.43.1/parley-v1.43.1-windows-arm64.exe
+  InstallerSha256: CFB6599AC6A86D20D882658031A51EC85F8D811180CA9F80E61DC8EA9FD2AE3C
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.43.1/Feci.ParleyDeckCli.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.43.1/Feci.ParleyDeckCli.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.43.1
+PackageLocale: en-US
+Publisher: Feci
+PublisherUrl: https://github.com/feci
+PackageName: Parley Deck CLI
+PackageUrl: https://github.com/feci/parley-deck-cli
+License: Apache-2.0
+LicenseUrl: https://github.com/feci/parley-deck-cli/blob/main/LICENSE
+ShortDescription: CLI that orchestrates Parley Deck multi-agent cooperation workflows.
+Description: "parley orchestrates multi-agent Parley Deck cooperation across local CLI agents: risk-tiered tracks, deliberation rounds, consensus and finalize, implementation with living execution plans, a live TUI, and a human-braked outer loop. v1.43.1 removes the dormant context-compaction machinery that 1.43.0 shipped behind a disabled constant. A reviewer objected that unreachable safety code executed by no test gives a later one-line enablement change unjustified confidence, and that objection is adopted here in full. The measured diagnosis of why deliberations became slower is retained in the project deck: reading the full protocol costs 3.3x median wall clock per call, the protocol doubled in ten weeks, and review rounds grew from 1.6 to 5.1 across 76 ideas while design rounds stayed flat. No speedup ships; the work that delivers one is scoped and named."
+ReleaseNotesUrl: https://github.com/feci/parley-deck-cli/releases/tag/v1.43.1
+Tags:
+- ai
+- agents
+- automation
+- cli
+- codex
+- consensus
+- loop
+- multi-agent
+- orchestration
+- preflight
+- roster
+- tui
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.43.1/Feci.ParleyDeckCli.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.43.1/Feci.ParleyDeckCli.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.43.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Portable installers for x64 and arm64, SHA256 recorded in the installer manifest.

Supersedes the ParleyDeckCli 1.43.0 entry in PR #415407; that PR also carries ParleyDeckSkill 2.7.0, which is unaffected.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/415426)