### PR TITLE
New package: narvinIR.ShtilVPN version 1.3.4

### DIFF
--- a/manifests/n/narvinIR/ShtilVPN/1.3.4/narvinIR.ShtilVPN.installer.yaml
+++ b/manifests/n/narvinIR/ShtilVPN/1.3.4/narvinIR.ShtilVPN.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: narvinIR.ShtilVPN
+PackageVersion: 1.3.4
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+Scope: user
+UpgradeBehavior: install
+RequireExplicitUpgrade: true
+ReleaseDate: 2026-08-09
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/narvinIR/shtil-vpn-desktop/releases/download/desktop-v1.3.4/ShtilVPN_1.3.4_x64-setup.exe
+  InstallerSha256: A804DCCCE07785DF080C83963538AEA3A4B77936D36EC51DE8617A95E6AD37F7
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/n/narvinIR/ShtilVPN/1.3.4/narvinIR.ShtilVPN.locale.en-US.yaml
+++ b/manifests/n/narvinIR/ShtilVPN/1.3.4/narvinIR.ShtilVPN.locale.en-US.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: narvinIR.ShtilVPN
+PackageVersion: 1.3.4
+PackageLocale: en-US
+Publisher: narvinIR
+PublisherUrl: https://github.com/narvinIR
+PublisherSupportUrl: https://github.com/narvinIR/shtil-vpn-desktop/issues
+Author: narvinIR
+PackageName: Shtil VPN
+PackageUrl: https://shtil.ndvsdom54.ru
+License: MIT
+LicenseUrl: https://github.com/narvinIR/shtil-vpn-desktop/blob/main/LICENSE
+Copyright: Copyright (c) 2025 XingGao, (c) 2026 Shtil VPN
+ShortDescription: Desktop client on the sing-box core (VLESS + Reality) with split routing and signed over-the-air updates.
+Description: |-
+  Shtil VPN is a Tauri desktop client for Windows and macOS built on the sing-box core.
+  It speaks VLESS + Reality over TCP, raises a system-wide TUN tunnel and splits the route
+  on the device itself, so sites in the user's own country stay on the direct path while the
+  tunnel is up. Routing lists are compiled into the app rather than fetched at runtime, so it
+  starts working even when third-party addresses are unreachable.
+  A subscription key arrives from a Telegram bot by short code, and updates are checked by the
+  app itself and installed only when signed with the publisher's key. Interface in Russian,
+  English, German, Spanish and Persian.
+Moniker: shtil-vpn
+Tags:
+- proxy
+- reality
+- sing-box
+- split-tunneling
+- tauri
+- tun
+- vless
+- vpn
+- vpn-client
+ReleaseNotesUrl: https://github.com/narvinIR/shtil-vpn-desktop/releases/tag/desktop-v1.3.4
+Documentations:
+- DocumentLabel: Guides
+  DocumentUrl: https://shtil.ndvsdom54.ru/en/guides/
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/n/narvinIR/ShtilVPN/1.3.4/narvinIR.ShtilVPN.yaml
+++ b/manifests/n/narvinIR/ShtilVPN/1.3.4/narvinIR.ShtilVPN.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: narvinIR.ShtilVPN
+PackageVersion: 1.3.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Pull Request Checklist

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally against the published schemas (version / installer / defaultLocale 1.12.0)?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? — not run on a Windows host yet: the manifest was validated against the published JSON schemas only. I can run the local install test if that is expected before review.
- [x] Does your manifest conform to the [1.12.0 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

---

New package: **Shtil VPN 1.3.4** — a Tauri desktop client built on the [sing-box](https://github.com/SagerNet/sing-box) core (VLESS + Reality, system-wide TUN), with route splitting done on the device and signed over-the-air updates.

- Homepage: https://shtil.ndvsdom54.ru
- Source: https://github.com/narvinIR/shtil-vpn-desktop (MIT)
- Installer: NSIS, per-user scope, from the tagged GitHub release `desktop-v1.3.4`
- Guides: https://shtil.ndvsdom54.ru/en/guides/

The installer URL points at a version-tagged release asset, so the SHA256 stays stable.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/415443)