### PR TITLE
Update willibrandon.dotsider to 0.24.6

### DIFF
--- a/manifests/w/willibrandon/dotsider/0.24.6/willibrandon.dotsider.installer.yaml
+++ b/manifests/w/willibrandon/dotsider/0.24.6/willibrandon.dotsider.installer.yaml
@@ -1,0 +1,27 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: willibrandon.dotsider
+PackageVersion: 0.24.6
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.18362.0
+InstallerType: msi
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/willibrandon/dotsider/releases/download/v0.24.6/dotsider-win-x64.msi
+  InstallerSha256: 9CEC4EEAA56497E51C8BEE6F89FC07CC91A0D9023C2CA4DB8499FDDB24065A82
+  ProductCode: '{4729F489-8EE9-4931-BAEF-44188141CC0E}'
+- Architecture: arm64
+  InstallerUrl: https://github.com/willibrandon/dotsider/releases/download/v0.24.6/dotsider-win-arm64.msi
+  InstallerSha256: CF9F277B308E49848547629E77A02E558E028A6456F84A9795B3BD8F0C33906E
+  ProductCode: '{2E832CD2-FDF1-4B75-8995-8D6F929A3DF4}'
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-08-11

--- a/manifests/w/willibrandon/dotsider/0.24.6/willibrandon.dotsider.locale.en-US.yaml
+++ b/manifests/w/willibrandon/dotsider/0.24.6/willibrandon.dotsider.locale.en-US.yaml
@@ -1,0 +1,36 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: willibrandon.dotsider
+PackageVersion: 0.24.6
+PackageLocale: en-US
+Publisher: willibrandon
+PublisherUrl: https://github.com/willibrandon
+PublisherSupportUrl: https://github.com/willibrandon/dotsider/issues
+PackageName: dotsider
+PackageUrl: https://github.com/willibrandon/dotsider
+License: MIT
+LicenseUrl: https://github.com/willibrandon/dotsider/blob/main/LICENSE
+ShortDescription: A TUI for analyzing .NET assemblies
+Description: |-
+  dotsider is a terminal UI for analyzing .NET assemblies — structure, metadata,
+  IL disassembly, strings, hex dump, dependency graphs, size maps, and live
+  runtime tracing via EventPipe. It also supports assembly diffing and NuGet
+  package browsing.
+Tags:
+- dotnet
+- assembly
+- tui
+- il
+- metadata
+- pe
+- disassembler
+- cli
+- terminal
+- devtools
+ReleaseNotesUrl: https://github.com/willibrandon/dotsider/releases/tag/v0.24.6
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/willibrandon/dotsider/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/w/willibrandon/dotsider/0.24.6/willibrandon.dotsider.yaml
+++ b/manifests/w/willibrandon/dotsider/0.24.6/willibrandon.dotsider.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: willibrandon.dotsider
+PackageVersion: 0.24.6
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Update dotsider to version 0.24.6

## Release notes

https://github.com/willibrandon/dotsider/releases/tag/v0.24.6
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/415451)