### PR TITLE
New package: GRU953.Studio version 6.0.1

### DIFF
--- a/manifests/g/GRU953/Studio/6.0.1/GRU953.Studio.installer.yaml
+++ b/manifests/g/GRU953/Studio/6.0.1/GRU953.Studio.installer.yaml
@@ -2,16 +2,21 @@ PackageIdentifier: GRU953.Studio
 PackageVersion: 6.0.1
 InstallerType: zip
 NestedInstallerType: portable
-NestedInstallerFiles:
-  - RelativeFilePath: gru953-studio.cmd
-    PortableCommandAlias: gru953-studio
-ArchiveBinariesDependOnPath: true
-Dependencies:
-  PackageDependencies:
-    - PackageIdentifier: OpenJS.NodeJS
 Installers:
   - Architecture: neutral
+    NestedInstallerFiles:
+      - RelativeFilePath: gru953-studio.cmd
+        PortableCommandAlias: gru953-studio
+    # The launcher loads the CLI from src/ beside itself via %~dp0, so it only works
+    # from the folder it was extracted into. With the default, a .cmd invoked through
+    # winget's alias resolves %~dp0 to the alias's directory, where src/ does not
+    # exist — it would install cleanly and then fail to run. Adding the install
+    # location to PATH instead is correct for a script with sibling files.
+    ArchiveBinariesDependOnPath: true
     InstallerUrl: https://github.com/GRU-953/GRU953-Studio/releases/download/v6.0.1/gru953-studio-windows-portable-6.0.1.zip
     InstallerSha256: 5E9EA972E08EB7F831CE6DE6F7FAA34F58178BAE8A17363B873CDAF14BFDFDA7
+    Dependencies:
+      PackageDependencies:
+        - PackageIdentifier: OpenJS.NodeJS
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/g/GRU953/Studio/6.0.1/GRU953.Studio.installer.yaml
+++ b/manifests/g/GRU953/Studio/6.0.1/GRU953.Studio.installer.yaml
@@ -5,6 +5,7 @@ NestedInstallerType: portable
 NestedInstallerFiles:
   - RelativeFilePath: gru953-studio.cmd
     PortableCommandAlias: gru953-studio
+ArchiveBinariesDependOnPath: true
 Dependencies:
   PackageDependencies:
     - PackageIdentifier: OpenJS.NodeJS
@@ -13,4 +14,4 @@ Installers:
     InstallerUrl: https://github.com/GRU-953/GRU953-Studio/releases/download/v6.0.1/gru953-studio-windows-portable-6.0.1.zip
     InstallerSha256: 5E9EA972E08EB7F831CE6DE6F7FAA34F58178BAE8A17363B873CDAF14BFDFDA7
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/g/GRU953/Studio/6.0.1/GRU953.Studio.installer.yaml
+++ b/manifests/g/GRU953/Studio/6.0.1/GRU953.Studio.installer.yaml
@@ -3,15 +3,24 @@ PackageVersion: 6.0.1
 InstallerType: zip
 NestedInstallerType: portable
 Installers:
-  - Architecture: neutral
+  - Architecture: x64
     NestedInstallerFiles:
       - RelativeFilePath: gru953-studio.cmd
         PortableCommandAlias: gru953-studio
     # The launcher loads the CLI from src/ beside itself via %~dp0, so it only works
-    # from the folder it was extracted into. With the default, a .cmd invoked through
+    # from the folder it was extracted into. Without this, a .cmd invoked through
     # winget's alias resolves %~dp0 to the alias's directory, where src/ does not
-    # exist — it would install cleanly and then fail to run. Adding the install
-    # location to PATH instead is correct for a script with sibling files.
+    # exist — it would install cleanly and then fail to run.
+    ArchiveBinariesDependOnPath: true
+    InstallerUrl: https://github.com/GRU-953/GRU953-Studio/releases/download/v6.0.1/gru953-studio-windows-portable-6.0.1.zip
+    InstallerSha256: 5E9EA972E08EB7F831CE6DE6F7FAA34F58178BAE8A17363B873CDAF14BFDFDA7
+    Dependencies:
+      PackageDependencies:
+        - PackageIdentifier: OpenJS.NodeJS
+  - Architecture: arm64
+    NestedInstallerFiles:
+      - RelativeFilePath: gru953-studio.cmd
+        PortableCommandAlias: gru953-studio
     ArchiveBinariesDependOnPath: true
     InstallerUrl: https://github.com/GRU-953/GRU953-Studio/releases/download/v6.0.1/gru953-studio-windows-portable-6.0.1.zip
     InstallerSha256: 5E9EA972E08EB7F831CE6DE6F7FAA34F58178BAE8A17363B873CDAF14BFDFDA7

--- a/manifests/g/GRU953/Studio/6.0.1/GRU953.Studio.installer.yaml
+++ b/manifests/g/GRU953/Studio/6.0.1/GRU953.Studio.installer.yaml
@@ -1,0 +1,16 @@
+PackageIdentifier: GRU953.Studio
+PackageVersion: 6.0.1
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: gru953-studio.cmd
+    PortableCommandAlias: gru953-studio
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: OpenJS.NodeJS
+Installers:
+  - Architecture: neutral
+    InstallerUrl: https://github.com/GRU-953/GRU953-Studio/releases/download/v6.0.1/gru953-studio-windows-portable-6.0.1.zip
+    InstallerSha256: 5E9EA972E08EB7F831CE6DE6F7FAA34F58178BAE8A17363B873CDAF14BFDFDA7
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/g/GRU953/Studio/6.0.1/GRU953.Studio.locale.en-GB.yaml
+++ b/manifests/g/GRU953/Studio/6.0.1/GRU953.Studio.locale.en-GB.yaml
@@ -20,4 +20,4 @@ Tags:
   - claude
   - no-code
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/g/GRU953/Studio/6.0.1/GRU953.Studio.locale.en-GB.yaml
+++ b/manifests/g/GRU953/Studio/6.0.1/GRU953.Studio.locale.en-GB.yaml
@@ -1,0 +1,23 @@
+PackageIdentifier: GRU953.Studio
+PackageVersion: 6.0.1
+PackageLocale: en-GB
+Publisher: Aninda Sundar Howlader
+PublisherUrl: https://github.com/GRU-953
+PackageName: GRU953-Studio
+PackageUrl: https://github.com/GRU-953/GRU953-Studio
+License: PolyForm Noncommercial License 1.0.0
+LicenseUrl: https://github.com/GRU-953/GRU953-Studio/blob/main/LICENSE
+ShortDescription: An AI project lead plus a team of specialist AI developers, for people who do not code.
+Description: >-
+  Describe an app in plain words, answer a few multiple-choice questions, and a
+  team of specialist AI roles designs, builds, tests and privately publishes it
+  to your own GitHub account. Runs inside Claude Code, Claude Desktop, Google
+  Antigravity, VS Code, Cursor and Windsurf. Requires Node.js.
+Moniker: gru953-studio
+Tags:
+  - ai
+  - developer-tools
+  - claude
+  - no-code
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/g/GRU953/Studio/6.0.1/GRU953.Studio.yaml
+++ b/manifests/g/GRU953/Studio/6.0.1/GRU953.Studio.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: GRU953.Studio
+PackageVersion: 6.0.1
+DefaultLocale: en-GB
+ManifestType: version
+ManifestVersion: 1.6.0

--- a/manifests/g/GRU953/Studio/6.0.1/GRU953.Studio.yaml
+++ b/manifests/g/GRU953/Studio/6.0.1/GRU953.Studio.yaml
@@ -2,4 +2,4 @@ PackageIdentifier: GRU953.Studio
 PackageVersion: 6.0.1
 DefaultLocale: en-GB
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New package: `GRU953.Studio` version 6.0.1

- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)? — **not yet; see the correction below**
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/addition?
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`? — **no; see "what was and was not checked" below**
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? — **no; no Windows machine available**
- [x] Does your manifest conform to the [1.12.0 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

**A correction to the first version of this description.** It ticked the CLA and
`winget validate` boxes. Neither was true, and ticking them was wrong of me — the
CLA is unsigned (the repository owner has to sign it personally, and will), and
`winget validate` needs Windows, which I do not have. Both are now unticked and
described accurately. Apologies for the noise in your queue.

#### About the package

GRU953-Studio is an open-source command-line helper that sets up a team of AI
development roles inside AI coding tools (Claude Code, Claude Desktop, VS Code,
Cursor, Windsurf, Google Antigravity). It is aimed at non-technical users.

- Repository: https://github.com/GRU-953/GRU953-Studio
- Release the installer comes from: https://github.com/GRU-953/GRU953-Studio/releases/tag/v6.0.1
- Also distributed on npm as `@gru953/studio-cli` and via a Homebrew tap.

#### Fixed after the first validation run

Your pipeline flagged `Manifest-Validation-Error`, and it was right. These were
written against schema **1.6.0**. The old schema URLs still resolve, so validating
against them passed while the submission failed — checking a manifest against a
version of the spec nobody uses any more is not really validation. Now at
**1.12.0**.

Diffing the two versions then surfaced a field this package genuinely needs:
**`ArchiveBinariesDependOnPath: true`**. The launcher loads the tool from `src/`
beside itself via `%~dp0`, so it only works from the folder it was extracted into.
With the default, a `.cmd` invoked through winget's alias resolves `%~dp0` to the
alias's directory, where `src/` does not exist — so it would have installed
successfully and then failed to run. Adding the install location to `PATH` instead
is the correct behaviour for a script with sibling files. Thank you: I would not
have found that without your check failing.

#### Why portable rather than an installer

The package is a Node.js command-line tool. The archive holds a `.cmd` launcher plus
the tool's source, and `PortableCommandAlias` exposes it as `gru953-studio`. There is
no `.msi` or `.exe` because a signed Windows installer needs a code-signing
certificate with an ongoing cost, hard to justify for a tool npm installs in one
line. If a portable package is not acceptable here, that is a fair call and I would
rather be told than have this linger.

Node.js is declared under `Dependencies.PackageDependencies` (`OpenJS.NodeJS`) rather
than bundled. The launcher also checks for `node` on the PATH itself and prints
installation instructions if it is missing, so it degrades readably even if the
dependency is not honoured.

#### What was and was not checked

Stated plainly, so the gaps are visible rather than implied:

**Checked:**
- All three manifests validated against the official 1.12.0 JSON schemas
  (`aka.ms/winget-manifest.*.1.12.0.schema.json`) — required fields, enums, patterns,
  types and length limits. No problems.
- `InstallerSha256` verified two independent ways: from the release's published
  `SHA256SUMS.txt`, and recomputed from the downloaded asset.
- Archive contents: `gru953-studio.cmd` is at the archive root where
  `RelativeFilePath` expects it, it has CRLF line endings, and it resolves
  `%~dp0src\index.js` correctly.
- The packaged tool runs and exits 0.

**Not checked:** anything requiring Windows — `winget validate`, `winget install`,
and the actual PATH behaviour of `ArchiveBinariesDependOnPath` on a real machine.

If your pipeline finds something those checks could not, please say so and I will fix
it promptly.

Thank you for maintaining this repository.
