### PR TITLE
Update willibrandon.dotsider-mcp to 0.24.8

### DIFF
--- a/manifests/w/willibrandon/dotsider-mcp/0.24.8/willibrandon.dotsider-mcp.installer.yaml
+++ b/manifests/w/willibrandon/dotsider-mcp/0.24.8/willibrandon.dotsider-mcp.installer.yaml
@@ -1,0 +1,27 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: willibrandon.dotsider-mcp
+PackageVersion: 0.24.8
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.18362.0
+InstallerType: msi
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/willibrandon/dotsider/releases/download/v0.24.8/dotsider-mcp-win-x64.msi
+  InstallerSha256: 2E118A5D27407C404E75B51E417B2EDDAB3650FF561022BBFB993182CB1A1C2F
+  ProductCode: '{36803762-84EC-41A1-AACD-B7062AF6BC7B}'
+- Architecture: arm64
+  InstallerUrl: https://github.com/willibrandon/dotsider/releases/download/v0.24.8/dotsider-mcp-win-arm64.msi
+  InstallerSha256: 045BAB5BCF3673AB88A1F9395936DE6785637BCF4A06589C81A0F62FEA46E938
+  ProductCode: '{9C6C3F2A-104E-4C70-9C12-FCB3E6765BF0}'
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-08-11

--- a/manifests/w/willibrandon/dotsider-mcp/0.24.8/willibrandon.dotsider-mcp.locale.en-US.yaml
+++ b/manifests/w/willibrandon/dotsider-mcp/0.24.8/willibrandon.dotsider-mcp.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: willibrandon.dotsider-mcp
+PackageVersion: 0.24.8
+PackageLocale: en-US
+Publisher: willibrandon
+PublisherUrl: https://github.com/willibrandon
+PublisherSupportUrl: https://github.com/willibrandon/dotsider/issues
+PackageName: dotsider-mcp
+PackageUrl: https://github.com/willibrandon/dotsider
+License: MIT
+LicenseUrl: https://github.com/willibrandon/dotsider/blob/main/LICENSE
+ShortDescription: MCP server for AI-assisted .NET assembly analysis
+Description: |-
+  dotsider-mcp is a standalone Model Context Protocol server that exposes
+  dotsider's .NET assembly analysis engine to AI coding assistants like
+  Claude Code, VS Code Copilot, and others. It provides 28 tools for
+  assembly analysis, IL disassembly, metadata inspection, dependency graphs,
+  size analysis, string extraction, diffing, and runtime tracing.
+Tags:
+- dotnet
+- assembly
+- mcp
+- ai
+- analysis
+- il
+- metadata
+- devtools
+ReleaseNotesUrl: https://github.com/willibrandon/dotsider/releases/tag/v0.24.8
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/willibrandon/dotsider/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/w/willibrandon/dotsider-mcp/0.24.8/willibrandon.dotsider-mcp.yaml
+++ b/manifests/w/willibrandon/dotsider-mcp/0.24.8/willibrandon.dotsider-mcp.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: willibrandon.dotsider-mcp
+PackageVersion: 0.24.8
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Update dotsider-mcp to version 0.24.8

## Release notes

https://github.com/willibrandon/dotsider/releases/tag/v0.24.8
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/415578)