### PR TITLE
Update: TX230.winproc-tui to 0.8.0

### DIFF
--- a/manifests/t/TX230/winproc-tui/0.8.0/TX230.winproc-tui.installer.yaml
+++ b/manifests/t/TX230/winproc-tui/0.8.0/TX230.winproc-tui.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: TX230.winproc-tui
+PackageVersion: 0.8.0
+InstallerType: zip
+NestedInstallerType: portable
+Commands:
+- winproc-tui
+Installers:
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: winproc-tui.exe
+    PortableCommandAlias: winproc-tui
+  InstallerUrl: https://github.com/TX230/winproc-tui/releases/download/v0.8.0/winproc-tui-0.8.0-windows-x64.zip
+  InstallerSha256: 25B0A1E193A8A1F077F0F1188068BC64EA3DA1DC3E31319C21CACB134451D2D4
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-08-11

--- a/manifests/t/TX230/winproc-tui/0.8.0/TX230.winproc-tui.locale.en-US.yaml
+++ b/manifests/t/TX230/winproc-tui/0.8.0/TX230.winproc-tui.locale.en-US.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: TX230.winproc-tui
+PackageVersion: 0.8.0
+PackageLocale: en-US
+Publisher: TX230
+PublisherUrl: https://github.com/TX230
+PublisherSupportUrl: https://github.com/TX230/winproc-tui/issues
+Author: TX230
+PackageName: winproc-tui
+PackageUrl: https://github.com/TX230/winproc-tui
+License: MIT
+LicenseUrl: https://github.com/TX230/winproc-tui/blob/v0.8.0/LICENSE
+Copyright: Copyright (c) 2026 TX230 (ft)
+ShortDescription: A Windows 11 x64 process monitoring TUI for tracking per-process resource usage over time.
+Description: |-
+  winproc-tui is a terminal process monitor for Windows 11 x64. It shows memory, handles,
+  GUI resources, GPU, and I/O metrics, and provides up to 16 graphs, A/B sample comparison,
+  recording, saved-log review, and tabbed process inspection for executable details,
+  open files, loaded DLLs, and environment variables.
+Moniker: winproc-tui
+Tags:
+- gpu
+- monitoring
+- process
+- ratatui
+- terminal
+- tui
+- windows
+ReleaseNotesUrl: https://github.com/TX230/winproc-tui/releases/tag/v0.8.0
+Documentations:
+- DocumentLabel: README
+  DocumentUrl: https://github.com/TX230/winproc-tui/blob/v0.8.0/README.md
+- DocumentLabel: Japanese README
+  DocumentUrl: https://github.com/TX230/winproc-tui/blob/v0.8.0/README.ja.md
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/TX230/winproc-tui/0.8.0/TX230.winproc-tui.locale.ja-JP.yaml
+++ b/manifests/t/TX230/winproc-tui/0.8.0/TX230.winproc-tui.locale.ja-JP.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: TX230.winproc-tui
+PackageVersion: 0.8.0
+PackageLocale: ja-JP
+Publisher: TX230
+PackageName: winproc-tui
+ShortDescription: Windows 11 x64向けのターミナルプロセス監視TUIです。
+Description: |-
+  winproc-tuiは、Windows 11 x64向けのターミナルプロセスモニターです。
+  メモリ、ハンドル、GUIリソース、GPU、I/Oを表示し、最大16個のグラフ、サンプル間の
+  A/B比較、記録、保存済みログの確認、実行ファイル情報、オープンファイル、ロード済みDLL、
+  環境変数をタブで確認できるプロセス調査機能を備えています。
+Tags:
+- GPU
+- Windows
+- ターミナル
+- プロセス
+- モニタリング
+Documentations:
+- DocumentLabel: 日本語README
+  DocumentUrl: https://github.com/TX230/winproc-tui/blob/v0.8.0/README.ja.md
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/t/TX230/winproc-tui/0.8.0/TX230.winproc-tui.yaml
+++ b/manifests/t/TX230/winproc-tui/0.8.0/TX230.winproc-tui.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: TX230.winproc-tui
+PackageVersion: 0.8.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Updates `TX230.winproc-tui` to the statically linked v0.8.0 release.

The manifest was validated with `winget validate` and tested with the repository's official `Tools/SandboxTest.ps1`. The Windows Sandbox test installed v0.7.0, upgraded to v0.8.0 while preserving `winproc-tui.toml`, and successfully uninstalled the package.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (not applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested install, upgrade, config preservation, and uninstall in Windows Sandbox
- [x] Manifest conforms to the 1.12 schema

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/415633)