### PR TITLE
New package: Dirloom.Dirloom version 0.1.0

### DIFF
--- a/manifests/d/Dirloom/Dirloom/0.1.0/Dirloom.Dirloom.installer.yaml
+++ b/manifests/d/Dirloom/Dirloom/0.1.0/Dirloom.Dirloom.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Dirloom.Dirloom
+PackageVersion: 0.1.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: dirloom.exe
+  PortableCommandAlias: dirloom
+Commands:
+- dirloom
+ReleaseDate: 2026-08-11
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/dirloom/dirloom/releases/download/v0.1.0/dirloom_Windows_x86_64.zip
+  InstallerSha256: C72734D8706B335886F0789A89C6F23FFC1781A1B7D59C42D917B9D7A854E8BE
+- Architecture: arm64
+  InstallerUrl: https://github.com/dirloom/dirloom/releases/download/v0.1.0/dirloom_Windows_arm64.zip
+  InstallerSha256: F7AD20348BC60207DBF3935FD6C766180760DB27A00D558B07EC8851B6DC011D
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/d/Dirloom/Dirloom/0.1.0/Dirloom.Dirloom.locale.en-US.yaml
+++ b/manifests/d/Dirloom/Dirloom/0.1.0/Dirloom.Dirloom.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Dirloom.Dirloom
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Dirloom
+PublisherUrl: https://github.com/dirloom
+PublisherSupportUrl: https://github.com/dirloom/dirloom/issues
+PackageName: Dirloom
+PackageUrl: https://github.com/dirloom/dirloom
+License: MIT
+LicenseUrl: https://github.com/dirloom/dirloom/blob/v0.1.0/LICENSE
+Copyright: Copyright (c) 2026 Dirloom contributors
+ShortDescription: A fast, deterministic directory tree CLI.
+Description: Dirloom turns a real directory into a clean, deterministic, filterable, and shareable project structure without telemetry or network access.
+Moniker: dirloom
+Tags:
+- cli
+- developer-tools
+- directory-tree
+- filesystem
+- golang
+ReleaseNotesUrl: https://github.com/dirloom/dirloom/releases/tag/v0.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/d/Dirloom/Dirloom/0.1.0/Dirloom.Dirloom.yaml
+++ b/manifests/d/Dirloom/Dirloom/0.1.0/Dirloom.Dirloom.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Dirloom.Dirloom
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds the initial WinGet manifest for Dirloom 0.1.0, a deterministic,
cross-platform directory tree CLI. The manifest installs the portable Windows
ZIP release on x64 and ARM64 and exposes the `dirloom` command.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (not applicable for this new package submission)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for `Dirloom.Dirloom`
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
  - Local manifest installation is disabled by administrator policy on the test machine. Both release archives and SHA-256 digests were independently verified, and the release CI passes on Windows x64.
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/415669)