### PR TITLE
New package: Bozex.Dictator version 2.2.322

### DIFF
--- a/manifests/b/Bozex/Dictator/2.2.322/Bozex.Dictator.installer.yaml
+++ b/manifests/b/Bozex/Dictator/2.2.322/Bozex.Dictator.installer.yaml
@@ -1,0 +1,19 @@
+PackageIdentifier: Bozex.Dictator
+PackageVersion: 2.2.322
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-08-11
+Installers:
+- Architecture: x64
+  InstallerUrl: https://dictator.my/release/Dictator_2.2.322_x64-setup.exe
+  InstallerSha256: A21AE6F882272E7498254DD7E313EA8D3C9A0A24D10C657D5350B4868F2F9DDB
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/b/Bozex/Dictator/2.2.322/Bozex.Dictator.locale.en-US.yaml
+++ b/manifests/b/Bozex/Dictator/2.2.322/Bozex.Dictator.locale.en-US.yaml
@@ -1,0 +1,38 @@
+PackageIdentifier: Bozex.Dictator
+PackageVersion: 2.2.322
+PackageLocale: en-US
+Publisher: Bozex
+PublisherUrl: https://dictator.my/
+PublisherSupportUrl: https://dictator.my/support/
+PrivacyUrl: https://dictator.my/privacy.html
+PackageName: Dictator
+PackageUrl: https://dictator.my/
+License: Proprietary
+LicenseUrl: https://dictator.my/terms.html
+Copyright: Copyright (c) Bozex
+ShortDescription: Speech to text, dictation, live subtitles and offline translation that run on your own machine.
+Description: |-
+  Dictator turns speech into text and dictates into any window — email, documents,
+  chat — without sending audio to the cloud. Recognition runs locally on your GPU,
+  so there are no minute limits and nothing leaves the computer.
+
+  It also reads text aloud in natural voices, shows live captions over any window
+  with translation underneath, translates text on photos and on screen, and
+  translates offline through dictionaries downloaded once.
+
+  Speech recognition covers 100 languages, AI translation 198, offline translation 45.
+Moniker: dictator
+Tags:
+- speech-to-text
+- dictation
+- transcription
+- voice-typing
+- subtitles
+- translation
+- offline
+- tts
+- text-to-speech
+- stt
+ReleaseNotesUrl: https://dictator.my/changelog/
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/b/Bozex/Dictator/2.2.322/Bozex.Dictator.yaml
+++ b/manifests/b/Bozex/Dictator/2.2.322/Bozex.Dictator.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Bozex.Dictator
+PackageVersion: 2.2.322
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: `Bozex.Dictator` version `2.2.322`

Dictator is a desktop speech-to-text and dictation app: recognition runs locally
on the user's GPU (whisper.cpp), with live captions, text-to-speech and offline
translation. Windows installer is NSIS, per-user scope.

- Manifest version: 1.6.0
- Installer: `https://dictator.my/release/Dictator_2.2.322_x64-setup.exe`
- Support URL: https://dictator.my/support/ (returns 200 — this was the URL
  validation failure in the earlier PR #415043, and it is fixed)
- Release notes: https://dictator.my/changelog/

The previous submission (#415043) referenced 2.2.306, which is no longer
published; it was closed by me in favour of this one against the current
release.

Microsoft Reviewers: [Open in CodeFlow](https://portal.fluentpreview.microsoft.com/api/CodeFlow?pullRequest=https://github.com/microsoft/winget-pkgs/pull/)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/415746)