### PR TITLE
New package: MentisVision.MDSyntax version 1.2.3

### DIFF
--- a/manifests/m/MentisVision/MDSyntax/1.2.3/MentisVision.MDSyntax.installer.yaml
+++ b/manifests/m/MentisVision/MDSyntax/1.2.3/MentisVision.MDSyntax.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: MentisVision.MDSyntax
+PackageVersion: 1.2.3
+MinimumOSVersion: 10.0.17763.0
+# nullsoft tells winget the silent switches without us stating them. The
+# equivalent /S is exercised on every CI run by windows-smoke.yml, so a change
+# that breaks silent install fails there rather than here.
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-08-10
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Mentis-Vision/MDSyntax-releases/releases/download/v1.2.3/MDSyntax-1.2.3-setup.exe
+    InstallerSha256: 02DEBBA2CF9A0A8B083CE492761532ABA23F3E736BAE2A995EFB39FC8D3035C7
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/MentisVision/MDSyntax/1.2.3/MentisVision.MDSyntax.locale.en-US.yaml
+++ b/manifests/m/MentisVision/MDSyntax/1.2.3/MentisVision.MDSyntax.locale.en-US.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: MentisVision.MDSyntax
+PackageVersion: 1.2.3
+PackageLocale: en-US
+Publisher: Mentis Vision LLC
+PublisherUrl: https://mdsyntax.com
+PublisherSupportUrl: https://mdsyntax.com/support
+PrivacyUrl: https://mdsyntax.com/privacy
+Author: Mentis Vision LLC
+PackageName: MDSyntax
+PackageUrl: https://mdsyntax.com
+License: Proprietary
+LicenseUrl: https://mdsyntax.com/eula
+Copyright: Copyright (c) 2026 Mentis Vision LLC
+ShortDescription: Markdown, code, HTML, SVG and image viewer with live preview and export to PDF, Word and HTML.
+Description: |-
+  MDSyntax opens Markdown, nearly 200 programming and config languages, HTML,
+  SVG, images and exported AI conversation transcripts, and renders them the way
+  they are meant to be read. Live preview, KaTeX math, Mermaid and GraphViz
+  diagrams, and a real editor underneath.
+
+  Export to PDF, Word, HTML or PNG. Reading, editing and plain export are free
+  forever, with no account and no telemetry. Pro is a one-time purchase that
+  adds export templates, batch export, a watched-folder library and version
+  history.
+Moniker: mdsyntax
+Tags:
+  - markdown
+  - editor
+  - viewer
+  - code
+  - pdf
+  - mermaid
+  - latex
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/MentisVision/MDSyntax/1.2.3/MentisVision.MDSyntax.yaml
+++ b/manifests/m/MentisVision/MDSyntax/1.2.3/MentisVision.MDSyntax.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: MentisVision.MDSyntax
+PackageVersion: 1.2.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: MentisVision.MDSyntax version 1.2.3

MDSyntax is a Markdown, code, HTML, SVG and image viewer and editor for
Windows, with live preview, KaTeX math, Mermaid and GraphViz diagrams, and
export to PDF, Word, HTML and PNG.

- **Homepage:** https://mdsyntax.com
- **Installer:** NSIS, per-user, x64
- **Publisher:** Mentis Vision LLC

#### Checklist

- [x] Manifest version 1.6.0
- [x] Installer URL is a versioned release asset that will not be replaced
- [x] `InstallerSha256` verified against the built artifact
- [x] `InstallerType: nullsoft`; silent install is exercised on every CI run of
      the project's own Windows smoke test, which installs with `/S` and then
      reads back the registered URI scheme
- [x] `Scope: user` — the installer is per-user and takes no elevation

The installer is not code-signed. Please let me know if that blocks acceptance
and I will resubmit once a certificate is in place.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/415972)