### PR TITLE
Fix: rullerzhou-afk.clawd-on-desk version 0.14.0 architecture and license

### DIFF
--- a/manifests/r/rullerzhou-afk/clawd-on-desk/0.14.0/rullerzhou-afk.clawd-on-desk.installer.yaml
+++ b/manifests/r/rullerzhou-afk/clawd-on-desk/0.14.0/rullerzhou-afk.clawd-on-desk.installer.yaml
@@ -12,11 +12,23 @@ ReleaseDate: 2026-08-02
 Installers:
 - Architecture: x64
   Scope: user
+  InstallerUrl: https://github.com/rullerzhou-afk/clawd-on-desk/releases/download/v0.14.0/Clawd-on-Desk-Setup-0.14.0-x64.exe
+  InstallerSha256: 3733D49F918D5DCCBDEAF00DAF926938C8BC657F1BEA81CAF6BFB43DE3CB4EFB
+  InstallerSwitches:
+    Custom: /currentuser
+- Architecture: x64
+  Scope: machine
+  InstallerUrl: https://github.com/rullerzhou-afk/clawd-on-desk/releases/download/v0.14.0/Clawd-on-Desk-Setup-0.14.0-x64.exe
+  InstallerSha256: 3733D49F918D5DCCBDEAF00DAF926938C8BC657F1BEA81CAF6BFB43DE3CB4EFB
+  InstallerSwitches:
+    Custom: /allusers
+- Architecture: arm64
+  Scope: user
   InstallerUrl: https://github.com/rullerzhou-afk/clawd-on-desk/releases/download/v0.14.0/Clawd-on-Desk-Setup-0.14.0-arm64.exe
   InstallerSha256: 0E4D6527603A924394697CCB0648B09C146A5C39F8BD725C481D4BBCA0177A42
   InstallerSwitches:
     Custom: /currentuser
-- Architecture: x64
+- Architecture: arm64
   Scope: machine
   InstallerUrl: https://github.com/rullerzhou-afk/clawd-on-desk/releases/download/v0.14.0/Clawd-on-Desk-Setup-0.14.0-arm64.exe
   InstallerSha256: 0E4D6527603A924394697CCB0648B09C146A5C39F8BD725C481D4BBCA0177A42

--- a/manifests/r/rullerzhou-afk/clawd-on-desk/0.14.0/rullerzhou-afk.clawd-on-desk.locale.en-US.yaml
+++ b/manifests/r/rullerzhou-afk/clawd-on-desk/0.14.0/rullerzhou-afk.clawd-on-desk.locale.en-US.yaml
@@ -9,8 +9,8 @@ PublisherUrl: https://github.com/rullerzhou-afk
 PublisherSupportUrl: https://github.com/rullerzhou-afk/clawd-on-desk/issues
 PackageName: Clawd on Desk
 PackageUrl: https://github.com/rullerzhou-afk/clawd-on-desk
-License: MIT
-LicenseUrl: https://github.com/rullerzhou-afk/clawd-on-desk/blob/HEAD/LICENSE
+License: AGPL-3.0-only
+LicenseUrl: https://github.com/rullerzhou-afk/clawd-on-desk/blob/v0.14.0/LICENSE
 Copyright: Copyright (c) 2026 rullerzhou-afk
 ShortDescription: A pixel desktop pet that watches Claude Code, Codex, Cursor & other AI coding agents — so you don't have to.
 Description: |-


### PR DESCRIPTION
## 📖 Description

Corrects the existing `rullerzhou-afk.clawd-on-desk` 0.14.0 manifest:

- maps the x64 user/machine entries to the x64 installer and its verified SHA-256;
- adds arm64 user/machine entries for the arm64 installer;
- preserves the installer's `/currentuser` and `/allusers` scope switches; and
- updates the stale `MIT` license to the release's `AGPL-3.0-only`, with a version-pinned license URL.

The current manifest declares both entries as x64 while both URLs point to the arm64 asset. The package publishes separate x64 and arm64 NSIS installers. GitHub's release API reports these digests:

- x64: `3733D49F918D5DCCBDEAF00DAF926938C8BC657F1BEA81CAF6BFB43DE3CB4EFB`
- arm64: `0E4D6527603A924394697CCB0648B09C146A5C39F8BD725C481D4BBCA0177A42`

A hosted Komac v2.16.0 dry-run reproduced the bad two-x64 shape from the existing manifest while independently resolving the x64 URL/hash and the same NSIS ProductCode: https://github.com/rullerzhou-afk/clawd-on-desk/actions/runs/31549249655

This PR is draft because `winget validate` and `winget install --manifest` require Windows and have not yet been run for this corrected manifest. The YAML and exact architecture/scope/URL/hash contract were validated locally on macOS, and the release x64 installer itself was previously installed and smoke-tested on Windows 11 x64 as part of the upstream release process.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (not applicable for this routine single-version manifest correction)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same manifest change
- [x] This PR only modifies one (1) manifest version
- [ ] Validated manifest locally with `winget validate --manifest <path>` (Windows validation pending)
- [ ] Tested manifest locally with `winget install --manifest <path>` (Windows manifest test pending)
- [x] Manifest uses the existing 1.12 schema and parses as valid YAML

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/416019)