### PR TITLE
New package: Xcomart.Rudbman version 0.1.8

### DIFF
--- a/manifests/x/Xcomart/Rudbman/0.1.8/Xcomart.Rudbman.installer.yaml
+++ b/manifests/x/Xcomart/Rudbman/0.1.8/Xcomart.Rudbman.installer.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Xcomart.Rudbman
+PackageVersion: 0.1.8
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+# packaging/windows/rudbman.iss sets PrivilegesRequired=lowest, so the installer never
+# elevates and {autopf} resolves per-user: it lands in %LOCALAPPDATA%\Programs\rudbman.
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-08-12
+Installers:
+# The x64 build also runs under emulation on ARM64 Windows, but there is no native
+# arm64 artifact to declare here yet.
+- Architecture: x64
+  InstallerUrl: https://github.com/xcomart/rudbman/releases/download/v0.1.8/rudbman-v0.1.8-x86_64-pc-windows-msvc-setup.exe
+  # SHA256 of the published asset, computed from the download itself:
+  #
+  #   Invoke-WebRequest -Uri <InstallerUrl> -OutFile setup.exe
+  #   (Get-FileHash -Algorithm SHA256 .\setup.exe).Hash
+  #
+  # The winget-pkgs PR pipeline downloads the URL and compares, so a wrong hash
+  # fails validation. `wingetcreate update` computes it by itself for every
+  # release after this first hand-made one.
+  InstallerSha256: 5CA78C0DFE36F9E49F4AABE662DB0891DBF8E0A202F2B9AD74E5AAA3B52551E6
+  # Inno Setup appends "_is1" to the AppId when it writes its Uninstall registry key,
+  # so this is packaging/windows/rudbman.iss's AppId plus that suffix. It is how winget
+  # recognises an already-installed copy; see packaging/winget/README.md.
+  ProductCode: '{E09022E1-1203-4A82-A00E-6385C2594DEF}_is1'
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/x/Xcomart/Rudbman/0.1.8/Xcomart.Rudbman.locale.en-US.yaml
+++ b/manifests/x/Xcomart/Rudbman/0.1.8/Xcomart.Rudbman.locale.en-US.yaml
@@ -1,0 +1,55 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Xcomart.Rudbman
+PackageVersion: 0.1.8
+PackageLocale: en-US
+Publisher: Xcomart
+PublisherUrl: https://github.com/xcomart
+PublisherSupportUrl: https://github.com/xcomart/rudbman/issues
+Author: Dennis Soungjin Park
+PackageName: rudbman
+PackageUrl: https://github.com/xcomart/rudbman
+License: MIT
+LicenseUrl: https://github.com/xcomart/rudbman/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Dennis Soungjin Park
+ShortDescription: A multi-platform GUI database workbench that talks to any database with a JDBC driver.
+Description: |-
+  rudbman is a desktop database workbench written in Rust and drawn with gpui, the
+  GPU-accelerated UI framework behind the Zed editor. It reaches a database through
+  that database's own JDBC driver over an embedded JVM bridge, so any product with a
+  JDBC driver is a supported product: drivers come from Maven Central by coordinate or
+  from disk, the driver class is detected from the JAR, and every connection gets an
+  isolated class loader so two vendors' drivers cannot collide.
+
+  Each connection is a tab with its own work area — a schema explorer over catalogs,
+  schemas, tables, views, sequences and routines; a SQL editor with dialect-aware
+  highlighting, statement splitting and cancellation, over a virtualized grid that
+  scrolls a million rows without loading a million rows; ERD diagrams laid out and
+  routed automatically; a visual query builder that turns dragged tables and columns
+  into SQL; and backup of a schema to a replayable .sql script. Connections can run
+  through an SSH tunnel, and secrets live in the Windows credential store rather than
+  on disk.
+
+  No JDK is required — the installer carries a Java runtime built with jlink and
+  rudbman uses the one next to its executable. The interface is available in English,
+  Korean, Japanese, Simplified Chinese, German, Spanish, French and Russian.
+Moniker: rudbman
+Tags:
+- database
+- database-client
+- dba
+- developer-tools
+- erd
+- gui
+- jdbc
+- mysql
+- oracle
+- postgresql
+- query-builder
+- rust
+- sql
+- sql-client
+- workbench
+ReleaseNotesUrl: https://github.com/xcomart/rudbman/releases/tag/v0.1.8
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/x/Xcomart/Rudbman/0.1.8/Xcomart.Rudbman.yaml
+++ b/manifests/x/Xcomart/Rudbman/0.1.8/Xcomart.Rudbman.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Xcomart.Rudbman
+PackageVersion: 0.1.8
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
First submission of **Xcomart.Rudbman** — [rudbman](https://github.com/xcomart/rudbman), a multi-platform GUI database workbench written in Rust that talks to any database with a JDBC driver.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Notes: the installer is Inno Setup, per-user scope (no elevation). It is Authenticode-signed with the project's self-signed release certificate. `winget validate` passes with no warnings; the local `winget install --manifest` check could not be run because `LocalManifestFiles` requires administrator enablement on the build machine.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/416031)