### PR TITLE
New package: iodriller.YBM version 0.1.1

### DIFF
--- a/manifests/i/iodriller/YBM/0.1.1/iodriller.YBM.installer.yaml
+++ b/manifests/i/iodriller/YBM/0.1.1/iodriller.YBM.installer.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: iodriller.YBM
+PackageVersion: 0.1.1
+
+# Per-user by design: packaging/windows/ybm.wxs sets Scope="perUser" and
+# installs into %LOCALAPPDATA%, so winget must not try to elevate. YBM's venv,
+# config, and database live beside the program files and have to stay writable
+# by the user the app runs as.
+Scope: user
+InstallerType: msi
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+# No InstallerSwitches: winget drives msiexec itself and already knows the
+# quiet switches for an MSI. Spelling them out only creates a second place for
+# them to be wrong.
+UpgradeBehavior: install
+ReleaseDate: 2026-08-11
+
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/iodriller/YBM/releases/download/v0.1.1/YBM-Setup.msi
+    InstallerSha256: ED578BAF3E12F363CCE4C76EE78ED2C1934C47AAF7995E1772AB6F6B3E1BEDE6
+
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/i/iodriller/YBM/0.1.1/iodriller.YBM.locale.en-US.yaml
+++ b/manifests/i/iodriller/YBM/0.1.1/iodriller.YBM.locale.en-US.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: iodriller.YBM
+PackageVersion: 0.1.1
+PackageLocale: en-US
+Publisher: iodriller
+PublisherUrl: https://github.com/iodriller
+PublisherSupportUrl: https://github.com/iodriller/YBM/issues
+PackageName: YBM
+PackageUrl: https://github.com/iodriller/YBM
+License: MIT
+LicenseUrl: https://github.com/iodriller/YBM/blob/main/LICENSE
+Copyright: Copyright (c) iodriller
+ShortDescription: A local AI agent you can reach from the web, Telegram, and WhatsApp.
+Description: |-
+  YBM runs on your own machine and turns a message into either a direct reply or a
+  traceable task. Tasks can use the tools you enable, including files, terminal
+  commands, Chrome, VS Code, desktop control, scheduled work, MCP servers, and
+  coding agents.
+
+  Every tool call passes through a policy engine before it runs, high-impact
+  capabilities are off by default, and anything risky asks for approval first.
+  Each finished task leaves a receipt naming exactly what it touched.
+
+  Bring your own model: 13 providers are supported, including fully local ones,
+  so nothing has to leave the machine.
+Moniker: ybm
+Tags:
+  - ai
+  - agent
+  - llm
+  - local
+  - automation
+  - self-hosted
+  - telegram
+  - whatsapp
+  - privacy
+ReleaseNotesUrl: https://github.com/iodriller/YBM/releases/tag/v0.1.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/i/iodriller/YBM/0.1.1/iodriller.YBM.yaml
+++ b/manifests/i/iodriller/YBM/0.1.1/iodriller.YBM.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: iodriller.YBM
+PackageVersion: 0.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New package

`iodriller.YBM` version 0.1.1 - YBM, a local AI agent reachable from the web, Telegram, and WhatsApp.

- Homepage: https://github.com/iodriller/YBM
- Installer: https://github.com/iodriller/YBM/releases/download/v0.1.1/YBM-Setup.msi
- License: MIT

### Checklist

- [x] Manifest validated locally with `winget validate` (no errors, no warnings)
- [x] Installer SHA256 taken from the published release asset, not from a build log
- [x] Per-user MSI (`Scope: user`), installs to `%LOCALAPPDATA%\YBM`, no elevation required
- [x] Silent install verified not to launch the application (the post-install launch is gated on `UILevel = 5`, so `/qn` installs stay unattended)
- [x] Uninstall entry registered via ARP

The installer is built in public by a GitHub Actions workflow and carries Sigstore build provenance, verifiable with `gh attestation verify YBM-Setup.msi --repo iodriller/YBM`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/416055)