### PR TITLE
New version: tsouth89.Ceiling version 1.5.29

### DIFF
--- a/manifests/t/tsouth89/Ceiling/1.5.29/tsouth89.Ceiling.installer.yaml
+++ b/manifests/t/tsouth89/Ceiling/1.5.29/tsouth89.Ceiling.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: tsouth89.Ceiling
+PackageVersion: 1.5.29
+InstallerType: inno
+Scope: user
+UpgradeBehavior: install
+ProductCode: io.github.tsouth89.ceiling_is1
+ReleaseDate: 2026-08-12
+AppsAndFeaturesEntries:
+- ProductCode: io.github.tsouth89.ceiling_is1
+  DisplayName: Ceiling 1.5.29
+  DisplayVersion: 1.5.29
+  Publisher: Brandon South
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/tsouth89/ceiling/releases/download/v1.5.29/Ceiling-1.5.29-Setup.exe
+  InstallerSha256: 9B10380A420889E9E814887D1B1CA16F0D87D95D0ED9E3C5BF502936DE030487
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/t/tsouth89/Ceiling/1.5.29/tsouth89.Ceiling.locale.en-US.yaml
+++ b/manifests/t/tsouth89/Ceiling/1.5.29/tsouth89.Ceiling.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: tsouth89.Ceiling
+PackageVersion: 1.5.29
+PackageLocale: en-US
+Publisher: Brandon South
+PublisherUrl: https://github.com/tsouth89
+PublisherSupportUrl: https://github.com/tsouth89/ceiling/issues
+Author: Brandon South
+PackageName: Ceiling
+PackageUrl: https://ceiling.win
+License: MIT
+LicenseUrl: https://github.com/tsouth89/ceiling/blob/v1.5.29/LICENSE
+Copyright: Copyright (c) Ceiling contributors
+ShortDescription: Desktop capacity and quota monitor for coding assistants.
+Description: Ceiling is a local-first Windows app for monitoring provider-reported capacity and quota usage across AI coding platforms.
+Moniker: ceiling
+Tags:
+- claude
+- codex
+- cursor
+- desktop
+- gemini
+- grok
+- usage
+- windows
+ReleaseNotes: Ceiling 1.5.29 shows Cursor's on-demand spend as money on every surface that displays it, including the taskbar tile, its hover panel, the floating bar, and the Activity schedule, instead of as a percentage of a spend cap. A monthly quota can now raise a pace warning, and settings controls have accessible names that screen readers can reach.
+ReleaseNotesUrl: https://github.com/tsouth89/ceiling/releases/tag/v1.5.29
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/tsouth89/Ceiling/1.5.29/tsouth89.Ceiling.yaml
+++ b/manifests/t/tsouth89/Ceiling/1.5.29/tsouth89.Ceiling.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: tsouth89.Ceiling
+PackageVersion: 1.5.29
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Pull request has been created with [Manual Manifest Authoring]

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/addition?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

---

New version of Ceiling, a local-first Windows capacity and quota monitor for AI coding assistants.

`winget validate` passes. The installer itself has been installed and exercised on Windows 11 from the same published asset, though not via `winget install --manifest`, so that box is left unchecked.

The installer is Authenticode signed and RFC 3161 timestamped, built and published from the immutable `v1.5.29` tag. `InstallerSha256` was verified against the published GitHub asset after download. `ProductCode` and the Inno `AppId` are unchanged from 1.5.25, so upgrade identity is preserved.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/416061)