### PR TITLE
New package: Xcomart.Rulogman version 0.4.0

### DIFF
--- a/manifests/x/Xcomart/Rulogman/0.4.0/Xcomart.Rulogman.installer.yaml
+++ b/manifests/x/Xcomart/Rulogman/0.4.0/Xcomart.Rulogman.installer.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Xcomart.Rulogman
+PackageVersion: 0.4.0
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+# packaging/windows/rulogman.iss sets PrivilegesRequired=lowest, so the installer never
+# elevates and {autopf} resolves per-user: it lands in %LOCALAPPDATA%\Programs\rulogman.
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-08-12
+Installers:
+# The x64 build also runs under emulation on ARM64 Windows, but there is no native
+# arm64 artifact to declare here yet.
+- Architecture: x64
+  InstallerUrl: https://github.com/xcomart/rulogman/releases/download/v0.4.0/rulogman-v0.4.0-x86_64-pc-windows-msvc-setup.exe
+  # SHA256 of the published asset, computed from the download itself:
+  #
+  #   Invoke-WebRequest -Uri <InstallerUrl> -OutFile setup.exe
+  #   (Get-FileHash -Algorithm SHA256 .\setup.exe).Hash
+  #
+  # The winget-pkgs PR pipeline downloads the URL and compares, so a wrong hash
+  # fails validation. `wingetcreate update` computes it by itself for every
+  # release after this first hand-made one.
+  InstallerSha256: F9816A8B274A044F0EE701A337C093F3F1560D5D03870071874971AC99EA4FEB
+  # Inno Setup appends "_is1" to the AppId when it writes its Uninstall registry key,
+  # so this is packaging/windows/rulogman.iss's AppId plus that suffix. It is how winget
+  # recognises an already-installed copy; see packaging/winget/README.md.
+  ProductCode: '{D6066CD8-5F5D-4B13-AB5B-DAD7965FF725}_is1'
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/x/Xcomart/Rulogman/0.4.0/Xcomart.Rulogman.locale.en-US.yaml
+++ b/manifests/x/Xcomart/Rulogman/0.4.0/Xcomart.Rulogman.locale.en-US.yaml
@@ -1,0 +1,54 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Xcomart.Rulogman
+PackageVersion: 0.4.0
+PackageLocale: en-US
+Publisher: Xcomart
+PublisherUrl: https://github.com/xcomart
+PublisherSupportUrl: https://github.com/xcomart/rulogman/issues
+Author: Dennis Park
+PackageName: rulogman
+PackageUrl: https://github.com/xcomart/rulogman
+License: MIT
+LicenseUrl: https://github.com/xcomart/rulogman/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Dennis Park
+ShortDescription: A multi-platform GUI SSH terminal with a files panel, a built-in editor and split panes.
+Description: |-
+  rulogman is a desktop SSH client written in Rust and drawn with gpui, the
+  GPU-accelerated UI framework behind the Zed editor. Connections are saved as
+  profiles — host, user, password or private key — and open in tabs that can be split
+  into panes, each with its own connection and its own scrollback. The terminal itself
+  is alacritty_terminal, so colours, cursor addressing, the alternate screen and
+  full-screen programs such as vim, tmux and htop behave as they do in any other
+  terminal.
+
+  Beside the terminal sits a files panel that browses the session's filesystem over
+  SFTP on a channel of the same connection, with drag-and-drop transfers and a
+  breadcrumb path. Right-clicking a file opens it in a built-in editor tab with line
+  numbers, find and replace, undo and syntax highlighting for seventeen formats, and
+  Ctrl+S writes it back over the connection it came from. Port forwarding rules are
+  saved with the profile and open as soon as the shell is up.
+
+  Not every terminal is remote: local shells are first-class too, with PowerShell, cmd
+  and every installed WSL distribution offered from the start screen. Host keys are
+  checked on the trust-on-first-use convention, and passwords and key passphrases go
+  to the Windows Credential Manager rather than to any configuration file. Themes and
+  terminal colour schemes are picked independently, scheme files use Windows
+  Terminal's format, and the interface is available in eight languages.
+Moniker: rulogman
+Tags:
+- console
+- developer-tools
+- gui
+- port-forwarding
+- rust
+- scp
+- sftp
+- ssh
+- ssh-client
+- terminal
+- terminal-emulator
+- wsl
+ReleaseNotesUrl: https://github.com/xcomart/rulogman/releases/tag/v0.4.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/x/Xcomart/Rulogman/0.4.0/Xcomart.Rulogman.yaml
+++ b/manifests/x/Xcomart/Rulogman/0.4.0/Xcomart.Rulogman.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Xcomart.Rulogman
+PackageVersion: 0.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
First submission of **Xcomart.Rulogman** — [rulogman](https://github.com/xcomart/rulogman), a multi-platform GUI SSH terminal written in Rust, with a files panel, a built-in editor and split panes.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Notes: the installer is Inno Setup, per-user scope (no elevation). It is Authenticode-signed with the project's self-signed release certificate. `winget validate` passes with no warnings; the local `winget install --manifest` check could not be run because `LocalManifestFiles` requires administrator enablement on the build machine.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/416195)