### PR TITLE
New package: andre12230-png.Pecule version 1.23.0

### DIFF
--- a/manifests/a/andre12230-png/Pecule/1.23.0/andre12230-png.Pecule.installer.yaml
+++ b/manifests/a/andre12230-png/Pecule/1.23.0/andre12230-png.Pecule.installer.yaml
@@ -1,0 +1,26 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+# Ou trouver le fichier a installer et comment le poser sur la machine.
+# L'archive publiee est un ZIP qui contient un dossier « Pecule »,
+# lui-meme contenant l'executable : c'est ce que decrivent les deux
+# lignes « NestedInstaller » ci-dessous.
+PackageIdentifier: andre12230-png.Pecule
+PackageVersion: 1.23.0
+InstallerType: zip
+NestedInstallerType: portable
+# INDISPENSABLE ici. Par defaut Winget cree un raccourci vers l'executable
+# dans un dossier a part. Or l'application a besoin de son dossier _internal
+# juste a cote d'elle : lancee depuis le raccourci, elle s'arrete aussitot
+# sur « Failed to load Python DLL » (verifie le 11 aout 2026).
+# Avec ce reglage, Winget ajoute le vrai dossier de l'application au PATH
+# au lieu de creer un raccourci, et tout fonctionne normalement.
+ArchiveBinariesDependOnPath: true
+ReleaseDate: 2026-08-12
+Installers:
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: Pecule/Pecule.exe
+  InstallerUrl: https://github.com/andre12230-png/Pecule/releases/download/v1.23.0/Pecule-1.23.0-win64.zip
+  InstallerSha256: 6F32F5ED8C5811D76A6F38119B02C43C54422B9B9C8B70A7619751276FB1890E
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/andre12230-png/Pecule/1.23.0/andre12230-png.Pecule.locale.en-US.yaml
+++ b/manifests/a/andre12230-png/Pecule/1.23.0/andre12230-png.Pecule.locale.en-US.yaml
@@ -1,0 +1,55 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+# Texte affiche par defaut (anglais). C'est celui que reprennent
+# winstall.app et winget.run. Il precise clairement que l'application
+# elle-meme est en francais, pour ne pas decevoir un anglophone.
+PackageIdentifier: andre12230-png.Pecule
+PackageVersion: 1.23.0
+PackageLocale: en-US
+Publisher: andre12230-png
+PublisherUrl: https://github.com/andre12230-png
+PublisherSupportUrl: https://github.com/andre12230-png/Pecule/issues
+Author: andre12230-png
+PackageName: Pécule
+PackageUrl: https://andre12230-png.github.io/Pecule/
+License: MIT
+LicenseUrl: https://github.com/andre12230-png/Pecule/blob/main/LICENSE
+Copyright: Copyright (c) 2026 andre12230-png
+ShortDescription: |-
+  Free desktop app to track personal bank accounts and budgets on Windows. All data stays on your PC. French-language interface.
+Description: |-
+  Pécule (French for "nest egg") is a free, open source
+  desktop application for tracking personal bank accounts and household budgets
+  on Windows 10 and 11. It stores everything in a local SQLite file: no account
+  to create, no cloud, no connection to your bank.
+
+  Features include reconciliation, recurring transactions, monthly and yearly
+  budget tracking with charts, CSV import of bank statements, QIF import to
+  carry over history from another program (Money, Quicken, GnuCash, HomeBank),
+  and local backups. The app tracks one account per data file.
+
+  Please note: the user interface and the CSV import format are French only.
+Moniker: pecule
+Tags:
+- accounting
+- budget
+- budget-personnel
+- comptabilite
+- comptes-bancaires
+- finance
+- finances-personnelles
+- francais
+- french
+- gestion-budget
+- gestion-de-comptes
+- logiciel-gratuit
+- offline
+- personal-finance
+- privacy
+- sqlite
+ReleaseNotesUrl: https://github.com/andre12230-png/Pecule/releases/tag/v1.23.0
+Documentations:
+- DocumentLabel: Presentation
+  DocumentUrl: https://andre12230-png.github.io/Pecule/
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/andre12230-png/Pecule/1.23.0/andre12230-png.Pecule.locale.en-US.yaml
+++ b/manifests/a/andre12230-png/Pecule/1.23.0/andre12230-png.Pecule.locale.en-US.yaml
@@ -9,6 +9,7 @@ PackageLocale: en-US
 Publisher: andre12230-png
 PublisherUrl: https://github.com/andre12230-png
 PublisherSupportUrl: https://github.com/andre12230-png/Pecule/issues
+PrivacyUrl: https://andre12230-png.github.io/Pecule/confidentialite.html
 Author: andre12230-png
 PackageName: Pécule
 PackageUrl: https://andre12230-png.github.io/Pecule/

--- a/manifests/a/andre12230-png/Pecule/1.23.0/andre12230-png.Pecule.locale.fr-FR.yaml
+++ b/manifests/a/andre12230-png/Pecule/1.23.0/andre12230-png.Pecule.locale.fr-FR.yaml
@@ -1,0 +1,54 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+# Version francaise du texte. C'est elle qui s'affiche pour un utilisateur
+# dont Windows est en francais, et elle apporte les mots-cles francais
+# au referencement des sites qui recopient les manifestes.
+PackageIdentifier: andre12230-png.Pecule
+PackageVersion: 1.23.0
+PackageLocale: fr-FR
+Publisher: andre12230-png
+PublisherUrl: https://github.com/andre12230-png
+PublisherSupportUrl: https://github.com/andre12230-png/Pecule/issues
+Author: andre12230-png
+PackageName: Pécule
+PackageUrl: https://andre12230-png.github.io/Pecule/
+License: MIT
+LicenseUrl: https://github.com/andre12230-png/Pecule/blob/main/LICENSE
+Copyright: Copyright (c) 2026 andre12230-png
+ShortDescription: |-
+  Logiciel gratuit et en francais pour gerer ses comptes bancaires et son budget personnel sous Windows 10 et 11. Donnees 100 % locales.
+Description: |-
+  Pécule est une application de bureau gratuite et libre, entierement
+  en francais, pour suivre ses comptes bancaires et son budget personnel sous
+  Windows 10 et 11. Tout est enregistre dans un simple fichier SQLite sur votre
+  ordinateur : aucun compte a creer, aucun envoi vers un service en ligne,
+  aucune connexion a votre banque.
+
+  Au programme : pointage des operations, operations recurrentes, suivi du
+  budget par mois et par annee avec des graphiques, import des releves
+  bancaires au format CSV, import QIF pour reprendre l'historique d'un autre
+  logiciel (Money, Quicken, GnuCash, HomeBank), et sauvegardes locales.
+  L'application suit un compte par fichier de donnees.
+Tags:
+- budget
+- budget-personnel
+- comptabilite
+- comptabilite-personnelle
+- comptes-bancaires
+- finances-personnelles
+- francais
+- gestion-budget
+- gestion-de-comptes
+- gratuit
+- hors-ligne
+- logiciel-gratuit
+- open-source
+- releves-bancaires
+- sqlite
+- vie-privee
+ReleaseNotesUrl: https://github.com/andre12230-png/Pecule/releases/tag/v1.23.0
+Documentations:
+- DocumentLabel: Page de presentation
+  DocumentUrl: https://andre12230-png.github.io/Pecule/
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/a/andre12230-png/Pecule/1.23.0/andre12230-png.Pecule.locale.fr-FR.yaml
+++ b/manifests/a/andre12230-png/Pecule/1.23.0/andre12230-png.Pecule.locale.fr-FR.yaml
@@ -9,6 +9,7 @@ PackageLocale: fr-FR
 Publisher: andre12230-png
 PublisherUrl: https://github.com/andre12230-png
 PublisherSupportUrl: https://github.com/andre12230-png/Pecule/issues
+PrivacyUrl: https://andre12230-png.github.io/Pecule/confidentialite.html
 Author: andre12230-png
 PackageName: Pécule
 PackageUrl: https://andre12230-png.github.io/Pecule/

--- a/manifests/a/andre12230-png/Pecule/1.23.0/andre12230-png.Pecule.yaml
+++ b/manifests/a/andre12230-png/Pecule/1.23.0/andre12230-png.Pecule.yaml
@@ -1,0 +1,9 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+# Fichier « chapeau » : il ne fait que relier les deux autres manifestes
+# et indiquer quelle langue sert de description par defaut.
+PackageIdentifier: andre12230-png.Pecule
+PackageVersion: 1.23.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Adds **Pécule** 1.23.0, a free and open source (MIT) personal accounts and budget manager for Windows 10/11. The user interface is French only, which the description states explicitly. I am the author of the software.

- Homepage: https://andre12230-png.github.io/Pecule/
- Source: https://github.com/andre12230-png/Pecule
- Release: https://github.com/andre12230-png/Pecule/releases/tag/v1.23.0

The package is a portable ZIP containing a `Pecule` folder with the executable and its `_internal` directory, hence `NestedInstallerType: portable` together with `ArchiveBinariesDependOnPath: true` — without the latter, the app cannot find `_internal` and fails to start.

### Checklist

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.x schema](https://github.com/microsoft/winget-cli/blob/master/schemas/JSON/manifests/v1.12.0)?

### Testing performed

Validated with `winget validate --manifest`, then installed and upgraded end to end on Windows 11 24H2 (x64): `winget install --manifest` of the previous version, followed by `winget upgrade --manifest` to 1.23.0. The upgrade completed and the application's data file, which lives in `%LOCALAPPDATA%\Pecule` and therefore outside the package directory, was byte-for-byte identical afterwards (SHA-256 unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/416272)