### PR TITLE
New package: EDILabs.Sagt version 0.9.44

### DIFF
--- a/manifests/e/EDILabs/Sagt/0.9.44/EDILabs.Sagt.installer.yaml
+++ b/manifests/e/EDILabs/Sagt/0.9.44/EDILabs.Sagt.installer.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: EDILabs.Sagt
+PackageVersion: 0.9.44
+InstallerLocale: sv-SE
+Platform:
+  - Windows.Desktop
+# WebView2 följer med Windows 10 från version 1803 (build 17134) enligt Tauris
+# egen dokumentation. Tidigare Windows kräver Evergreen Bootstrapper, vilket
+# installern inte paketerar — därför är 1803 rätt golv och inte en gissning.
+MinimumOSVersion: 10.0.17134.0
+InstallerType: nullsoft
+# tauri.conf.json: bundle.windows.nsis.installMode = "currentUser".
+# Installationen kräver därför ingen förhöjning, vilket också är skälet till att
+# winget-kravet "installs correctly for both administrators and non-administrators"
+# bör vara uppfyllt.
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-08-05
+Installers:
+  # VERSIONERAD URL, inte den stabila `Sagt.ai-setup.exe`.
+  # Den stabila skrivs över vid varje release, vilket hade gjort InstallerSha256
+  # ogiltig utan att någon rörde manifestet — winget kallar det
+  # `Validation-Hash-Verification-Failed` och beskriver det uttryckligen som
+  # vanity-URL-fallet. Den versionerade nyckeln serveras med
+  # `Cache-Control: immutable` och ändras aldrig.
+  - Architecture: x64
+    InstallerUrl: https://downloads.sagt.ai/Sagt.ai-0.9.44-x64-setup.exe
+    InstallerSha256: 2F406071EFDDA53E0F6BB97F1C5EB11669C8CC952817A4FF67F00583FFA6550E
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/e/EDILabs/Sagt/0.9.44/EDILabs.Sagt.locale.en-US.yaml
+++ b/manifests/e/EDILabs/Sagt/0.9.44/EDILabs.Sagt.locale.en-US.yaml
@@ -1,0 +1,46 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: EDILabs.Sagt
+PackageVersion: 0.9.44
+PackageLocale: en-US
+Publisher: EDI Labs AB
+PublisherUrl: https://sagt.ai
+PublisherSupportUrl: https://sagt.ai/kontakt
+PrivacyUrl: https://sagt.ai/integritetspolicy
+Author: EDI Labs AB
+PackageName: Sagt.ai
+PackageUrl: https://sagt.ai
+License: MIT
+LicenseUrl: https://github.com/sagt-ai/sagt-desktop/blob/master/LICENSE
+Copyright: Copyright (c) 2025 EDI Labs AB
+CopyrightUrl: https://github.com/sagt-ai/sagt-desktop/blob/master/LICENSE
+ShortDescription: Swedish speech-to-text that runs locally on your PC
+Description: >-
+  Sagt.ai transcribes Swedish speech to text on Windows. The free tier runs
+  KB-Whisper — the speech model trained by the National Library of Sweden on
+  more than 50,000 hours of Swedish speech — locally on your machine, so audio
+  never leaves the device, it works offline, and no account is required.
+
+  It listens to the computer's own audio, both microphone and system audio, and
+  therefore captures meetings in Teams, Zoom, Skype and Meet without a bot
+  joining the call and without changing anyone's meeting settings.
+
+  A paid tier adds a larger model running on Swedish servers, speaker separation
+  and AI-generated meeting minutes.
+
+  Note: the application interface is in Swedish, and local transcription is
+  optimised for Swedish audio.
+Moniker: sagt
+Tags:
+  - transcription
+  - speech-to-text
+  - swedish
+  - meetings
+  - offline
+  - privacy
+  - whisper
+  - dictation
+# ReleaseNotesUrl utelämnas med flit: versionsanteckningarna ligger i ett privat
+# repo och 404:ar publikt. Se docs/winget/README.md.
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/e/EDILabs/Sagt/0.9.44/EDILabs.Sagt.locale.sv-SE.yaml
+++ b/manifests/e/EDILabs/Sagt/0.9.44/EDILabs.Sagt.locale.sv-SE.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
+
+PackageIdentifier: EDILabs.Sagt
+PackageVersion: 0.9.44
+PackageLocale: sv-SE
+Publisher: EDI Labs AB
+PublisherUrl: https://sagt.ai
+PublisherSupportUrl: https://sagt.ai/kontakt
+PrivacyUrl: https://sagt.ai/integritetspolicy
+Author: EDI Labs AB
+PackageName: Sagt.ai
+PackageUrl: https://sagt.ai
+License: MIT
+LicenseUrl: https://github.com/sagt-ai/sagt-desktop/blob/master/LICENSE
+Copyright: Copyright (c) 2025 EDI Labs AB
+ShortDescription: Svensk tal-till-text som körs lokalt på din dator
+Description: >-
+  Sagt.ai omvandlar svenskt tal till text på Windows. Gratisnivån kör
+  KB-Whisper — Kungliga bibliotekets talmodell, tränad på över 50 000 timmar
+  svenskt tal — lokalt på din dator. Ljudet lämnar aldrig maskinen, det fungerar
+  utan internet och kräver inget konto.
+
+  Appen lyssnar på datorns eget ljud, både mikrofon och systemljud, och fångar
+  därför möten i Teams, Zoom, Skype och Meet utan att någon bot ansluter till
+  samtalet och utan att någon annans mötesinställningar behöver ändras.
+
+  Pro lägger till en större modell på svenska servrar, talarseparering och
+  AI-genererade mötesprotokoll.
+Tags:
+  - transkribering
+  - tal-till-text
+  - svenska
+  - moten
+  - offline
+  - integritet
+  - diktering
+ManifestType: locale
+ManifestVersion: 1.6.0

--- a/manifests/e/EDILabs/Sagt/0.9.44/EDILabs.Sagt.yaml
+++ b/manifests/e/EDILabs/Sagt/0.9.44/EDILabs.Sagt.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: EDILabs.Sagt
+PackageVersion: 0.9.44
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Adds Sagt.ai, a Windows desktop app for Swedish speech-to-text.

The app runs KB-Whisper — the speech model trained by KBLab at the National Library of Sweden — locally on the user's machine. Free tier requires no account and works offline.

- Publisher: EDI Labs AB
- Homepage: https://sagt.ai
- Source (MIT): https://github.com/sagt-ai/sagt-desktop

## Checklist

- [x] Manifest validated with `winget validate` — *Manifest validation succeeded*
- [x] Installer URL points directly at the publisher's own domain (`downloads.sagt.ai`), HTTPS, no redirects
- [x] Versioned, immutable installer URL — the stable `Sagt.ai-setup.exe` is deliberately **not** used, since it is overwritten on each release and would invalidate `InstallerSha256`
- [x] `InstallerSha256` verified against the actual file (173 172 592 bytes)
- [x] Installer is signed (Azure Trusted Signing, `CN=EDI Labs AB`) — signature verified as `Valid`
- [x] Silent install tested: `/S` → exit 0 in 15 s, no interaction required
- [x] Uninstall tested: exit 0, program directory and ARP entry removed
- [x] `Scope: user` — `installMode: currentUser`, so no elevation is needed and it installs for non-administrators

Windows Sandbox was not available for testing (Windows 11 Home), so install and uninstall were verified directly on a clean-state machine instead.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/416274)