### PR TITLE
New version: DTHCST.Fregonator version 7.0.0

### DIFF
--- a/manifests/d/DTHCST/Fregonator/7.0.0/DTHCST.Fregonator.installer.yaml
+++ b/manifests/d/DTHCST/Fregonator/7.0.0/DTHCST.Fregonator.installer.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: DTHCST.Fregonator
+PackageVersion: 7.0.0
+InstallerType: inno
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/dthcst/fregonator/releases/download/v7.0/FREGONATOR-7.0-Setup.exe
+  InstallerSha256: 516C1A73A294243BBB681BF436D7E91285E09165DDF5B9CECE19262FB4B89564
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/d/DTHCST/Fregonator/7.0.0/DTHCST.Fregonator.locale.en-US.yaml
+++ b/manifests/d/DTHCST/Fregonator/7.0.0/DTHCST.Fregonator.locale.en-US.yaml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: DTHCST.Fregonator
+PackageVersion: 7.0.0
+PackageLocale: en-US
+Publisher: DTHCST - Costa da Morte
+PublisherUrl: https://dthcst.com
+PublisherSupportUrl: https://github.com/dthcst/fregonator/issues
+Author: Martin Caamano
+PackageName: Fregonator
+PackageUrl: https://fregonator.com
+License: MIT
+LicenseUrl: https://github.com/dthcst/fregonator/blob/main/LICENSE
+ShortDescription: Optimize Windows in 20 seconds with parallel cleanup tasks
+Description: |-
+  Fregonator cleans your Windows PC in 20 seconds with parallel PowerShell tasks.
+  No ads, no Pro version, no telemetry, no registry modifications, no browser data deletion.
+  Grandpa-proof: one button, no account, no commands, nothing to decide. It creates a
+  restore point before touching anything and never touches your photos, passwords or browser.
+  Features include temp file cleanup, recycling bin emptying, DNS flush, SSD TRIM,
+  bloatware removal, DISM/SFC system repair, an ULTRA mode that also updates all your
+  apps with winget, and a real-time progress monitor. 100% open source, 100% free forever.
+  The CCleaner alternative that respects your PC.
+Moniker: fregonator
+Tags:
+- cache
+- ccleaner-alternative
+- clean
+- cleanup
+- disk-space
+- free
+- junk
+- optimize
+- open-source
+- parallel
+- pc-cleaner
+- powershell
+- system
+- temp
+- windows
+ReleaseNotesUrl: https://github.com/dthcst/fregonator/releases/tag/v7.0
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/d/DTHCST/Fregonator/7.0.0/DTHCST.Fregonator.yaml
+++ b/manifests/d/DTHCST/Fregonator/7.0.0/DTHCST.Fregonator.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: DTHCST.Fregonator
+PackageVersion: 7.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
### New version: DTHCST.Fregonator version 7.0.0

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/tools/SandboxTest.md) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 manifest specification](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Adds version 7.0.0 of Fregonator (grandpa-proof rewrite, one-button UI, ULTRA mode). InstallerType inno, SHA256 verified against the published release asset.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/416289)