### PR TITLE
New package: mangokingTW.HdrScreenshotSyncer version 0.1.0

### DIFF
--- a/manifests/m/mangokingTW/HdrScreenshotSyncer/0.1.0/mangokingTW.HdrScreenshotSyncer.installer.yaml
+++ b/manifests/m/mangokingTW/HdrScreenshotSyncer/0.1.0/mangokingTW.HdrScreenshotSyncer.installer.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: mangokingTW.HdrScreenshotSyncer
+PackageVersion: 0.1.0
+InstallerLocale: en-US
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-08-12
+# One Inno installer adapts to the host architecture, so both point at the same
+# asset and hash.
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/mangokingTW/HdrScreenshotSyncer/releases/download/v0.1.0/HdrScreenshotSyncer-0.1.0-setup.exe
+    InstallerSha256: BE1B5E2890F690BC04A1CCB73E4A70051B9DA02C6C1A01029CA5BB3CBD586360
+    ProductCode: '{A345CF69-EF8A-4B6D-BF82-25F336A73950}_is1'
+    AppsAndFeaturesEntries:
+      - DisplayName: HdrScreenshotSyncer
+        Publisher: mangokingTW
+        DisplayVersion: 0.1.0
+        ProductCode: '{A345CF69-EF8A-4B6D-BF82-25F336A73950}_is1'
+        InstallerType: inno
+  - Architecture: x86
+    InstallerUrl: https://github.com/mangokingTW/HdrScreenshotSyncer/releases/download/v0.1.0/HdrScreenshotSyncer-0.1.0-setup.exe
+    InstallerSha256: BE1B5E2890F690BC04A1CCB73E4A70051B9DA02C6C1A01029CA5BB3CBD586360
+    ProductCode: '{A345CF69-EF8A-4B6D-BF82-25F336A73950}_is1'
+    AppsAndFeaturesEntries:
+      - DisplayName: HdrScreenshotSyncer
+        Publisher: mangokingTW
+        DisplayVersion: 0.1.0
+        ProductCode: '{A345CF69-EF8A-4B6D-BF82-25F336A73950}_is1'
+        InstallerType: inno
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/mangokingTW/HdrScreenshotSyncer/0.1.0/mangokingTW.HdrScreenshotSyncer.locale.en-US.yaml
+++ b/manifests/m/mangokingTW/HdrScreenshotSyncer/0.1.0/mangokingTW.HdrScreenshotSyncer.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: mangokingTW.HdrScreenshotSyncer
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: mangokingTW
+PublisherUrl: https://github.com/mangokingTW
+PublisherSupportUrl: https://github.com/mangokingTW/HdrScreenshotSyncer/issues
+Author: mangokingTW
+PackageName: HdrScreenshotSyncer
+PackageUrl: https://github.com/mangokingTW/HdrScreenshotSyncer
+License: MIT
+LicenseUrl: https://github.com/mangokingTW/HdrScreenshotSyncer/blob/main/LICENSE
+Copyright: Copyright (c) mangokingTW
+ShortDescription: Keeps Snipping Tool's HDR screenshot color corrector in sync with the display's HDR state.
+Description: >-
+  HdrScreenshotSyncer is a small tray utility that detects whether the display is
+  currently in HDR and sets Snipping Tool's "HDR screenshot color corrector"
+  (IsHDRToneMappingEnabled) to match, so native screenshots come out with the
+  right colors without toggling the setting by hand.
+Moniker: hdrscreenshotsyncer
+Tags:
+  - hdr
+  - screenshot
+  - snipping-tool
+  - tray
+  - windows
+ReleaseNotesUrl: https://github.com/mangokingTW/HdrScreenshotSyncer/releases/tag/v0.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/mangokingTW/HdrScreenshotSyncer/0.1.0/mangokingTW.HdrScreenshotSyncer.yaml
+++ b/manifests/m/mangokingTW/HdrScreenshotSyncer/0.1.0/mangokingTW.HdrScreenshotSyncer.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: mangokingTW.HdrScreenshotSyncer
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Pull request has been verified for the following

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you [tested](https://github.com/microsoft/winget-pkgs/blob/master/README.md#test-your-manifest) your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

### Notes

New package. Open-source (MIT) Windows tray utility that keeps Snipping Tool's HDR screenshot color corrector in sync with the display's HDR state. Source, build provenance and OpenSSF Scorecard are public at https://github.com/mangokingTW/HdrScreenshotSyncer.

- Scope: user (per-user Inno install, no elevation required).
- One Inno installer adapts to the host architecture, so x64 and x86 point at the same asset and hash.
- Not code-signed; build provenance is published with every release (`gh attestation verify`).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/416322)