### PR TITLE
New package: blancodagoat.Memento version 1.3.0

### DIFF
--- a/manifests/b/blancodagoat/Memento/1.3.0/blancodagoat.Memento.installer.yaml
+++ b/manifests/b/blancodagoat/Memento/1.3.0/blancodagoat.Memento.installer.yaml
@@ -1,0 +1,12 @@
+PackageIdentifier: blancodagoat.Memento
+PackageVersion: 1.3.0
+MinimumOSVersion: 10.0.19041.0
+InstallerType: portable
+Commands:
+- memento
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/blancodagoat/memento/releases/download/v1.3.0/Memento.exe
+  InstallerSha256: A58A48E0BBA8095040123A410D39FB65E90E74D8D7FB5F516C832DA0302E8A83
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/b/blancodagoat/Memento/1.3.0/blancodagoat.Memento.locale.en-US.yaml
+++ b/manifests/b/blancodagoat/Memento/1.3.0/blancodagoat.Memento.locale.en-US.yaml
@@ -1,0 +1,17 @@
+PackageIdentifier: blancodagoat.Memento
+PackageVersion: 1.3.0
+PackageLocale: en-US
+Publisher: blancodagoat
+PublisherUrl: https://github.com/blancodagoat
+PublisherSupportUrl: https://github.com/blancodagoat/memento/issues
+PackageName: Memento
+PackageUrl: https://github.com/blancodagoat/memento
+License: MIT
+LicenseUrl: https://github.com/blancodagoat/memento/blob/main/LICENSE
+ShortDescription: Minimal tray screenshot tool with region and display capture, PNG plus clipboard, ~8 MB idle.
+Moniker: memento
+Tags:
+- screenshot
+- screen-capture
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/b/blancodagoat/Memento/1.3.0/blancodagoat.Memento.yaml
+++ b/manifests/b/blancodagoat/Memento/1.3.0/blancodagoat.Memento.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: blancodagoat.Memento
+PackageVersion: 1.3.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Adds Memento 1.3.0, an open-source (MIT) tray screenshot tool for Windows, as a portable package. The installer URL is a versioned release asset and the sha256 was computed from the published binary.

https://claude.ai/code/session_017raCgemh1CFLEo5kaZxwFt
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/416361)