### PR TITLE
New package: blancodagoat.DejaVu version 1.1.0

### DIFF
--- a/manifests/b/blancodagoat/DejaVu/1.1.0/blancodagoat.DejaVu.installer.yaml
+++ b/manifests/b/blancodagoat/DejaVu/1.1.0/blancodagoat.DejaVu.installer.yaml
@@ -1,0 +1,12 @@
+PackageIdentifier: blancodagoat.DejaVu
+PackageVersion: 1.1.0
+MinimumOSVersion: 10.0.19041.0
+InstallerType: portable
+Commands:
+- dejavu
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/blancodagoat/DejaVu/releases/download/v1.1.0/DejaVu.exe
+  InstallerSha256: 723954A2E4603FDAC2C688123DF0659B140A60DA7F61D265EA20F56BDD88AF7E
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/b/blancodagoat/DejaVu/1.1.0/blancodagoat.DejaVu.locale.en-US.yaml
+++ b/manifests/b/blancodagoat/DejaVu/1.1.0/blancodagoat.DejaVu.locale.en-US.yaml
@@ -1,0 +1,18 @@
+PackageIdentifier: blancodagoat.DejaVu
+PackageVersion: 1.1.0
+PackageLocale: en-US
+Publisher: blancodagoat
+PublisherUrl: https://github.com/blancodagoat
+PublisherSupportUrl: https://github.com/blancodagoat/DejaVu/issues
+PackageName: DejaVu
+PackageUrl: https://github.com/blancodagoat/DejaVu
+License: MIT
+LicenseUrl: https://github.com/blancodagoat/DejaVu/blob/main/LICENSE
+ShortDescription: Instant replay with a crash-safe disk buffer where one key saves your last 5 to 25 minutes.
+Moniker: dejavu
+Tags:
+- screen-recorder
+- instant-replay
+- game-clips
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/b/blancodagoat/DejaVu/1.1.0/blancodagoat.DejaVu.yaml
+++ b/manifests/b/blancodagoat/DejaVu/1.1.0/blancodagoat.DejaVu.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: blancodagoat.DejaVu
+PackageVersion: 1.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Adds DejaVu 1.1.0, an open-source (MIT) instant replay tool for Windows, as a portable package. The installer URL is a versioned release asset and the sha256 was computed from the published binary.

https://claude.ai/code/session_017raCgemh1CFLEo5kaZxwFt
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/416362)