### PR TITLE
Add MasaKjm.Shelfbox version 0.9.1

### DIFF
--- a/manifests/m/MasaKjm/Shelfbox/0.9.1/MasaKjm.Shelfbox.installer.yaml
+++ b/manifests/m/MasaKjm/Shelfbox/0.9.1/MasaKjm.Shelfbox.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: MasaKjm.Shelfbox
+PackageVersion: 0.9.1
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: shelfbox.exe
+  PortableCommandAlias: shelfbox
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/masa-kjm/shelfbox/releases/download/v0.9.1/shelfbox-v0.9.1-x86_64-pc-windows-msvc.zip
+  InstallerSha256: 6E3D75CB741C8C46A60DEED7D264CED4A147C1BAB582AFD10C34F957F4D835B2
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/m/MasaKjm/Shelfbox/0.9.1/MasaKjm.Shelfbox.locale.en-US.yaml
+++ b/manifests/m/MasaKjm/Shelfbox/0.9.1/MasaKjm.Shelfbox.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: MasaKjm.Shelfbox
+PackageVersion: 0.9.1
+PackageLocale: en-US
+Publisher: masa-kjm
+PublisherUrl: https://github.com/masa-kjm
+PublisherSupportUrl: https://github.com/masa-kjm/shelfbox/issues
+PackageName: Shelfbox
+PackageUrl: https://github.com/masa-kjm/shelfbox
+License: MIT
+LicenseUrl: https://github.com/masa-kjm/shelfbox/blob/v0.9.1/LICENSE
+ShortDescription: Keep local-only files visible in your repository while keeping them out of Git.
+Moniker: shelfbox
+Tags:
+- git
+- cli
+- config
+- local
+ReleaseNotesUrl: https://github.com/masa-kjm/shelfbox/releases/tag/v0.9.1
+Documentations:
+- DocumentLabel: Documentation
+  DocumentUrl: https://github.com/masa-kjm/shelfbox/tree/v0.9.1/docs
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/m/MasaKjm/Shelfbox/0.9.1/MasaKjm.Shelfbox.yaml
+++ b/manifests/m/MasaKjm/Shelfbox/0.9.1/MasaKjm.Shelfbox.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: MasaKjm.Shelfbox
+PackageVersion: 0.9.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Summary

Add the Shelfbox package to winget.

## Validation

- winget validate manifests/m/MasaKjm/Shelfbox/0.9.1
- Tools/SandboxTest.ps1 was attempted, but the repository's sandbox dependency hash check fails due to a known WinGet SandboxTest dependency issue in the script itself.

## Package details

- Package: MasaKjm.Shelfbox
- Version: 0.9.1
- Installer: portable Zip with shelfbox.exe and PortableCommandAlias: shelfbox

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/416370)