### PR TITLE
New package: Odikon.RissNotes version 0.1.87

### DIFF
--- a/manifests/o/Odikon/RissNotes/0.1.87/Odikon.RissNotes.installer.yaml
+++ b/manifests/o/Odikon/RissNotes/0.1.87/Odikon.RissNotes.installer.yaml
@@ -1,0 +1,21 @@
+# Created by the riss release tooling
+PackageIdentifier: Odikon.RissNotes
+PackageVersion: 0.1.87
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: msi
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://rissnotes.com/releases/riss/0.1.87/riss-0.1.87-win-x64.msi
+  InstallerSha256: 81E8D4027482F8FF109D063B328C6ADF2446504ED422AB6A2F46DB9C8411766D
+  ProductCode: '{F7460336-25CF-4952-9350-874BE1A6FE8D}'
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/o/Odikon/RissNotes/0.1.87/Odikon.RissNotes.locale.en-US.yaml
+++ b/manifests/o/Odikon/RissNotes/0.1.87/Odikon.RissNotes.locale.en-US.yaml
@@ -7,6 +7,7 @@ PublisherUrl: https://www.odikon.no
 PublisherSupportUrl: https://rissnotes.com
 PackageName: Riss Notes
 PackageUrl: https://rissnotes.com
+Moniker: riss
 License: Proprietary
 LicenseUrl: https://rissnotes.com/license.txt
 Copyright: Copyright Odikon AS

--- a/manifests/o/Odikon/RissNotes/0.1.87/Odikon.RissNotes.locale.en-US.yaml
+++ b/manifests/o/Odikon/RissNotes/0.1.87/Odikon.RissNotes.locale.en-US.yaml
@@ -1,0 +1,21 @@
+# Created by the riss release tooling
+PackageIdentifier: Odikon.RissNotes
+PackageVersion: 0.1.87
+PackageLocale: en-US
+Publisher: Odikon AS
+PublisherUrl: https://www.odikon.no
+PublisherSupportUrl: https://rissnotes.com
+PackageName: Riss Notes
+PackageUrl: https://rissnotes.com
+License: Proprietary
+LicenseUrl: https://rissnotes.com/license.txt
+Copyright: Copyright Odikon AS
+ShortDescription: Text editor built for durable note-taking. The session is the save; untitled documents, unsaved edits, panes and carets all survive restarts.
+Tags:
+- editor
+- notepad
+- notes
+- text
+- writing
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/o/Odikon/RissNotes/0.1.87/Odikon.RissNotes.yaml
+++ b/manifests/o/Odikon/RissNotes/0.1.87/Odikon.RissNotes.yaml
@@ -1,0 +1,6 @@
+# Created by the riss release tooling
+PackageIdentifier: Odikon.RissNotes
+PackageVersion: 0.1.87
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
New package submission for Riss Notes (Odikon AS), a Windows text editor for durable note-taking.

- Per-user MSI, Authenticode-signed (Odikon AS via Microsoft Trusted Signing)
- InstallerUrl is a versioned immutable archive path; it will not change or disappear on future releases
- Homepage: https://rissnotes.com

- [x] I have verified the manifest against the installed MSI (ProductCode extracted from the artifact, SHA256 from the signed checksum file)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/416371)