### PR TITLE
New package: Odikon.DoomScroller version 0.1.43

### DIFF
--- a/manifests/o/Odikon/DoomScroller/0.1.43/Odikon.DoomScroller.installer.yaml
+++ b/manifests/o/Odikon/DoomScroller/0.1.43/Odikon.DoomScroller.installer.yaml
@@ -12,6 +12,7 @@ InstallModes:
 - silent
 - silentWithProgress
 UpgradeBehavior: install
+ReleaseDate: 2026-08-04
 Installers:
 - Architecture: x64
   InstallerUrl: https://d00m.tech/releases/doomscroller/0.1.43/DoomScroller-0.1.43-win-x64.msi

--- a/manifests/o/Odikon/DoomScroller/0.1.43/Odikon.DoomScroller.installer.yaml
+++ b/manifests/o/Odikon/DoomScroller/0.1.43/Odikon.DoomScroller.installer.yaml
@@ -1,0 +1,21 @@
+# Created by the d00m.tech release tooling
+PackageIdentifier: Odikon.DoomScroller
+PackageVersion: 0.1.43
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: msi
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://d00m.tech/releases/doomscroller/0.1.43/DoomScroller-0.1.43-win-x64.msi
+  InstallerSha256: 76AF214C40D5EBE3DF3A9050B07AF949D30B0B0F400F8F229786CE7404C9BE9D
+  ProductCode: '{5DDE6B91-7AEC-4C7D-A87B-4E25C765AC1D}'
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/o/Odikon/DoomScroller/0.1.43/Odikon.DoomScroller.installer.yaml
+++ b/manifests/o/Odikon/DoomScroller/0.1.43/Odikon.DoomScroller.installer.yaml
@@ -12,7 +12,7 @@ InstallModes:
 - silent
 - silentWithProgress
 UpgradeBehavior: install
-ReleaseDate: 2026-08-04
+ReleaseDate: 2026-08-06
 Installers:
 - Architecture: x64
   InstallerUrl: https://d00m.tech/releases/doomscroller/0.1.43/DoomScroller-0.1.43-win-x64.msi

--- a/manifests/o/Odikon/DoomScroller/0.1.43/Odikon.DoomScroller.locale.en-US.yaml
+++ b/manifests/o/Odikon/DoomScroller/0.1.43/Odikon.DoomScroller.locale.en-US.yaml
@@ -1,0 +1,21 @@
+# Created by the d00m.tech release tooling
+PackageIdentifier: Odikon.DoomScroller
+PackageVersion: 0.1.43
+PackageLocale: en-US
+Publisher: Odikon AS
+PublisherUrl: https://www.odikon.no
+PublisherSupportUrl: https://d00m.tech
+PackageName: DoomScroller
+PackageUrl: https://d00m.tech
+License: Proprietary
+Copyright: Copyright Odikon AS
+ShortDescription: Feed reader and internet portal. YouTube subscriptions grouped your way, plus RSS news, discussions, blogs and podcasts in one place, read on your terms.
+Moniker: doomscroller
+Tags:
+- feed
+- news
+- reader
+- rss
+- youtube
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/o/Odikon/DoomScroller/0.1.43/Odikon.DoomScroller.yaml
+++ b/manifests/o/Odikon/DoomScroller/0.1.43/Odikon.DoomScroller.yaml
@@ -1,0 +1,6 @@
+# Created by the d00m.tech release tooling
+PackageIdentifier: Odikon.DoomScroller
+PackageVersion: 0.1.43
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
New package submission for DoomScroller (Odikon AS), a Windows feed reader / internet portal.

- Per-user MSI, Authenticode-signed (Odikon AS via Microsoft Trusted Signing)
- InstallerUrl is a versioned immutable archive path; it will not change or disappear on future releases
- Homepage: https://d00m.tech

- [x] Manifest verified against the artifact (ProductCode extracted from the MSI, SHA256 from the signed checksum file)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/416400)