### PR TITLE
JDE-Projects.SimpleUNALogViewer version 1.4.1

### DIFF
--- a/manifests/j/JDE-Projects/SimpleUNALogViewer/1.4.1/JDE-Projects.SimpleUNALogViewer.installer.yaml
+++ b/manifests/j/JDE-Projects/SimpleUNALogViewer/1.4.1/JDE-Projects.SimpleUNALogViewer.installer.yaml
@@ -1,0 +1,28 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: JDE-Projects.SimpleUNALogViewer
+PackageVersion: 1.4.1
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+AppsAndFeaturesEntries:
+- DisplayName: Simple UNA Log Viewer version v1.4.1
+  Publisher: JDE Projects
+  DisplayVersion: v1.4.1
+  ProductCode: 0c8c994c-416a-4eca-8c6b-3ac1351afea3_is1
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/JDE-Projects/Simple-UNA-Log-Viewer/releases/download/v1.4.1/SimpleUNALogViewer-v1.4.1-setup.exe
+  InstallerSha256: A226924710CAB0EBB1D221F1A74B3D1D64DF3CA4EC0574FD8CABA627D7FFB313
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-08-12

--- a/manifests/j/JDE-Projects/SimpleUNALogViewer/1.4.1/JDE-Projects.SimpleUNALogViewer.locale.en-US.yaml
+++ b/manifests/j/JDE-Projects/SimpleUNALogViewer/1.4.1/JDE-Projects.SimpleUNALogViewer.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: JDE-Projects.SimpleUNALogViewer
+PackageVersion: 1.4.1
+PackageLocale: en-US
+Publisher: JDE-Projects
+PublisherUrl: https://github.com/JDE-Projects
+PublisherSupportUrl: https://github.com/JDE-Projects/Simple-UNA-Log-Viewer/issues
+PackageName: Simple UNA Log Viewer
+PackageUrl: https://github.com/JDE-Projects/Simple-UNA-Log-Viewer
+License: PolyForm Noncommercial 1.0.0
+LicenseUrl: https://github.com/JDE-Projects/Simple-UNA-Log-Viewer/blob/main/LICENSE
+Copyright: Copyright (c) 2026 JDE-Projects
+ShortDescription: View, filter, and export logs from a UniFi Network Application controller.
+Description: "Simple UNA Log Viewer lets network admins view, filter, and export connection and event logs from a UniFi Network Application controller, with filters the UNA web UI doesn't offer. Filter by site, time range, log type, category, and event; sort results and export everything to CSV. Read-only: it makes no changes to the controller, sites, or device state, and credentials are held in memory only."
+Moniker: simple-una-log-viewer
+Tags:
+- csv-export
+- log-viewer
+- logs
+- network
+- ubiquiti
+- unifi
+ReleaseNotesUrl: https://github.com/JDE-Projects/Simple-UNA-Log-Viewer/releases/tag/v1.4.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/j/JDE-Projects/SimpleUNALogViewer/1.4.1/JDE-Projects.SimpleUNALogViewer.yaml
+++ b/manifests/j/JDE-Projects/SimpleUNALogViewer/1.4.1/JDE-Projects.SimpleUNALogViewer.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: JDE-Projects.SimpleUNALogViewer
+PackageVersion: 1.4.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description
Update JDE-Projects.SimpleUNALogViewer to version 1.4.1.

Release: https://github.com/JDE-Projects/Simple-UNA-Log-Viewer/releases/tag/v1.4.1