### PR TITLE
New version: Teradata.Loom version 1.4.0

### DIFF
--- a/manifests/t/Teradata/Loom/1.4.0/Teradata.Loom.installer.yaml
+++ b/manifests/t/Teradata/Loom/1.4.0/Teradata.Loom.installer.yaml
@@ -1,0 +1,24 @@
+# Created using wingetcreate
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: Teradata.Loom
+PackageVersion: 1.4.0
+InstallerType: zip
+InstallModes:
+- silent
+UpgradeBehavior: install
+ReleaseDate: 2026-02-02
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/teradata-labs/loom/releases/download/v1.4.0/loom-windows-x64.zip
+  # Placeholder - computed during release workflow
+  InstallerSha256: 4EF28B5804496F0D05389DEC0115BE21853FC308B52ED6ADA90384EA3FEB91A5
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: loom-package/loom-windows-amd64.exe
+    PortableCommandAlias: loom
+  - RelativeFilePath: loom-package/looms-windows-amd64.exe
+    PortableCommandAlias: looms
+ManifestType: installer
+ManifestVersion: 1.6.0
+

--- a/manifests/t/Teradata/Loom/1.4.0/Teradata.Loom.locale.en-US.yaml
+++ b/manifests/t/Teradata/Loom/1.4.0/Teradata.Loom.locale.en-US.yaml
@@ -1,0 +1,40 @@
+Description: |-
+    Loom is a Go framework for building autonomous LLM agent threads with natural language agent creation,
+    pattern-guided learning, and multi-agent orchestration. It includes:
+
+    - Natural language agent creation via the weaver meta-agent
+    - Multi-agent orchestration with 6 workflow patterns
+    - 90+ reusable patterns across 16 domains
+    - 8 LLM provider integrations (Anthropic, Bedrock, OpenAI, etc.)
+    - Multi-modal support (vision, document parsing)
+    - Built-in judge evaluation system with DSPy integration
+    - Self-improving agents with pattern proposal capabilities
+    - Real-time streaming and complete observability
+License: Apache-2.0
+LicenseUrl: https://github.com/teradata-labs/loom/blob/main/LICENSE
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0
+Moniker: loom
+PackageIdentifier: Teradata.Loom
+PackageLocale: en-US
+PackageName: Loom
+PackageUrl: https://github.com/teradata-labs/loom
+PackageVersion: 1.4.0
+Publisher: Teradata
+PublisherSupportUrl: https://github.com/teradata-labs/loom/issues
+PublisherUrl: https://github.com/teradata-labs
+ReleaseNotes: See https://github.com/teradata-labs/loom/releases/tag/v1.4.0
+ReleaseNotesUrl: https://github.com/teradata-labs/loom/releases/tag/v1.4.0
+ShortDescription: LLM agent framework with natural language agent creation
+Tags:
+    - ai
+    - llm
+    - agents
+    - anthropic
+    - claude
+    - openai
+    - automation
+    - golang
+    - framework
+    - multi-agent
+    - orchestration

--- a/manifests/t/Teradata/Loom/1.4.0/Teradata.Loom.yaml
+++ b/manifests/t/Teradata/Loom/1.4.0/Teradata.Loom.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: Teradata.Loom
+PackageVersion: 1.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Updates Teradata.Loom to version 1.4.0

## Changes
- Update to v1.4.0
- Update SHA256 hashes for both installers

## Verification
- Release: https://github.com/teradata-labs/loom/releases/tag/v1.4.0
- Binaries verified and hashes calculated from official release

@microsoft-github-policy-service agree
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/416416)