### PR TITLE
New package: Reaction.Reaction version 0.2.20

### DIFF
--- a/manifests/r/Reaction/Reaction/0.2.20/Reaction.Reaction.installer.yaml
+++ b/manifests/r/Reaction/Reaction/0.2.20/Reaction.Reaction.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Reaction.Reaction
+PackageVersion: 0.2.20
+InstallerLocale: en-US
+InstallerType: nullsoft
+Scope: user
+UpgradeBehavior: install
+ReleaseDate: 2026-08-01
+Installers:
+- Architecture: x64
+  InstallerUrl: https://updates.getreaction.app/Reaction-0.2.20-setup.exe
+  InstallerSha256: 2EA4BE746205A15EFD687445A98B2F0CE5E36D6A42CA58245888788BD461E548
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/r/Reaction/Reaction/0.2.20/Reaction.Reaction.locale.en-US.yaml
+++ b/manifests/r/Reaction/Reaction/0.2.20/Reaction.Reaction.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Reaction.Reaction
+PackageVersion: 0.2.20
+PackageLocale: en-US
+Publisher: Reaction
+PublisherUrl: https://getreaction.app/en
+PublisherSupportUrl: https://getreaction.app/en/support
+PrivacyUrl: https://getreaction.app/en/privacy
+Author: Reaction
+PackageName: Reaction
+PackageUrl: https://getreaction.app/en
+License: Proprietary
+LicenseUrl: https://getreaction.app/en/terms
+Copyright: Copyright (c) 2026 Reaction
+ShortDescription: Anti-idle utility that keeps a machine looking active with human-like mouse and keyboard activity.
+Description: |-
+  Reaction is an anti-idle utility for Windows and Linux. It keeps your machine looking active while you are away from the desk: the cursor travels along smooth human curves with micro-pauses, navigation keys are pressed at an uneven rhythm, pages scroll, and windows are switched in turn - so the screen keeps changing the way it does when a person is working.
+  Where a classic mouse jiggler repeats one movement on a timer, Reaction varies timing, speed and pauses, and switches windows using key combinations written by hand for each application family it recognises - 24 profiles covering 60+ known application names (browsers, editors and IDEs, Office and LibreOffice, PDF viewers). It only acts while the machine is genuinely idle and stops the moment you move the mouse yourself. A hidden mode runs it with no window and no tray icon; global hotkeys pause and restore it.
+  Reaction records nothing - no keystrokes, no screenshots, no files. Commercial license with a 14-day free trial.
+Moniker: reaction
+Tags:
+- anti-idle
+- automation
+- keep-awake
+- mouse-jiggler
+- prevent-sleep
+- productivity
+- utilities
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/Reaction/Reaction/0.2.20/Reaction.Reaction.yaml
+++ b/manifests/r/Reaction/Reaction/0.2.20/Reaction.Reaction.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Reaction.Reaction
+PackageVersion: 0.2.20
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New package: `Reaction.Reaction` version `0.2.20`

Reaction is an anti-idle utility for Windows and Linux: it keeps a machine looking active with
human-like cursor movement, navigation keystrokes and window switching while the machine is idle,
and stops the moment the user touches the mouse.

- Publisher / homepage: https://getreaction.app/en
- Installer: NSIS (electron-builder), x64, per-user scope, silent install via the default `/S`
- Installer URL: https://updates.getreaction.app/Reaction-0.2.20-setup.exe

#### Checklist

- [x] Manifests validate against the 1.12.0 JSON schemas (`version`, `installer`, `defaultLocale`).
- [x] No other open pull request touches this manifest - the package is new; `manifests/r/Reaction/`
      does not exist yet.
- [x] `InstallerSha256` computed from the exact URL in the manifest.
- [ ] `winget validate` / `winget install --manifest` were **not** run: this submission was prepared
      on Linux, so the Windows-only tooling was unavailable. Happy to arrange a local run if that is
      required before merge.

#### Notes for the reviewer

- The installer is **not code-signed** yet (a certificate is in progress), so SmartScreen will warn
  on first run. Flagging it up front rather than letting validation discover it.
- The package is commercial with a 14-day free trial; installation and the trial require no license
  key, so automated validation can install and launch it unattended.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/416435)