### PR TITLE
New package: ZeroManualWork.Zaviv version 1.119.62

### DIFF
--- a/manifests/z/ZeroManualWork/Zaviv/1.119.62/ZeroManualWork.Zaviv.installer.yaml
+++ b/manifests/z/ZeroManualWork/Zaviv/1.119.62/ZeroManualWork.Zaviv.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: ZeroManualWork.Zaviv
+PackageVersion: 1.119.62
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+InstallModes:
+- interactive
+- silent
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+Installers:
+- Architecture: x64
+  InstallerUrl: https://www.zaviv.ai/api/desktop/downloads/windows?arch=x64&version=1.119.62
+  InstallerSha256: 43DE8208E9BC39E421A6120C11345B6FA6AE16118BC3BF3A82B6FF6AE99FD699
+- Architecture: arm64
+  InstallerUrl: https://www.zaviv.ai/api/desktop/downloads/windows?arch=arm64&version=1.119.62
+  InstallerSha256: 56E695A842544CA7F0C4BB79BC3942B292EC59CD8B3C225BFA3014C80AB7930A
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/z/ZeroManualWork/Zaviv/1.119.62/ZeroManualWork.Zaviv.locale.en-US.yaml
+++ b/manifests/z/ZeroManualWork/Zaviv/1.119.62/ZeroManualWork.Zaviv.locale.en-US.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: ZeroManualWork.Zaviv
+PackageVersion: 1.119.62
+PackageLocale: en-US
+Publisher: ZERO MANUAL WORK LLC
+PublisherUrl: https://www.zaviv.ai
+PublisherSupportUrl: https://www.zaviv.ai
+PackageName: Zaviv
+PackageUrl: https://www.zaviv.ai
+License: Proprietary
+LicenseUrl: https://zaviv.com/legal
+ShortDescription: The agentic IDE - build, run, and supervise coding agents across desktop, web, and mobile.
+Moniker: zaviv
+Tags:
+- ide
+- editor
+- ai
+- agents
+- development
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/z/ZeroManualWork/Zaviv/1.119.62/ZeroManualWork.Zaviv.yaml
+++ b/manifests/z/ZeroManualWork/Zaviv/1.119.62/ZeroManualWork.Zaviv.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: ZeroManualWork.Zaviv
+PackageVersion: 1.119.62
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
New package submission: **ZeroManualWork.Zaviv 1.119.62** (Zaviv, the agentic IDE by ZERO MANUAL WORK LLC).

- NSIS installer, x64 + arm64, Authenticode-signed via Microsoft Trusted Signing (Artifact Signing), publisher CN `ZERO MANUAL WORK LLC`, RFC-3161 timestamped.
- Installer URLs are version-pinned and stable: the route resolves an immutable per-version manifest, so this manifest keeps installing exactly 1.119.62 regardless of later releases. SHA-256 values are taken from the release pipeline's published manifests and match the served binaries.
- Silent install verified in the release pipeline's packaged smoke (silent install, boot, uninstall) on every release.

Checklist (honest state - the manifests were authored on the macOS release machine):

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)? (Will complete the CLA bot flow on this PR if prompted.)
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`? (Authored on macOS; no local winget available. Happy to fix anything the pipeline flags.)
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? (Same; the installer itself is exercised by our packaged smoke on every release.)
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/416442)