### PR TITLE
New version: Feci.ParleyDeckCli 1.44.0 and Feci.ParleyDeckSkill 2.8.0

### DIFF
--- a/manifests/f/Feci/ParleyDeckCli/1.44.0/Feci.ParleyDeckCli.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.44.0/Feci.ParleyDeckCli.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.44.0
+InstallerType: portable
+Commands:
+- parley
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.44.0/parley-v1.44.0-windows-x64.exe
+  InstallerSha256: 85013DD73B15417F25F8C1ED4C76B008E278D2966E1CAEC54F588BCB77900E47
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.44.0/parley-v1.44.0-windows-arm64.exe
+  InstallerSha256: FDB347A709894C5068E1DF40E2A08BBEB0C83CC6E0A176A17F829370CEB29B71
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.44.0/Feci.ParleyDeckCli.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.44.0/Feci.ParleyDeckCli.locale.en-US.yaml
@@ -10,7 +10,7 @@ License: Apache-2.0
 LicenseUrl: https://github.com/feci/parley-deck-cli/blob/main/LICENSE
 ShortDescription: CLI that orchestrates Parley Deck multi-agent cooperation workflows.
 Description: "parley orchestrates multi-agent Parley Deck cooperation across local CLI agents. v1.44.0 makes two per-track budget cells real. The protocol table printed 'unbounded' for deliberation fix-up cycles and cross-review rounds while the tool silently applied its own defaults of 3 and 1, so the printed rule and the enforced rule disagreed and the printed one lost. Fix-up is now capped at 5 and cross-review at 3 rounds after round 1, enforced on every code path that opens a round including the consensus-block back-edge, with the protocol text and the enforcement shipping in the same change. A separate off-by-one meant every track allowed one fewer cycle than it printed. Budgets are escalation thresholds and never mark work complete. Eight review-driven fix-up cycles went into this release; two shipped-behaviour defects were caught before it, including a companion skill package whose installer refused its own payload."
-ReleaseNotesUrl: https://github.com/feci/parley-deck-cli/releases/tag/v1.43.1
+ReleaseNotesUrl: https://github.com/feci/parley-deck-cli/releases/tag/v1.44.0
 Tags:
 - ai
 - agents

--- a/manifests/f/Feci/ParleyDeckCli/1.44.0/Feci.ParleyDeckCli.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.44.0/Feci.ParleyDeckCli.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.44.0
+PackageLocale: en-US
+Publisher: Feci
+PublisherUrl: https://github.com/feci
+PackageName: Parley Deck CLI
+PackageUrl: https://github.com/feci/parley-deck-cli
+License: Apache-2.0
+LicenseUrl: https://github.com/feci/parley-deck-cli/blob/main/LICENSE
+ShortDescription: CLI that orchestrates Parley Deck multi-agent cooperation workflows.
+Description: "parley orchestrates multi-agent Parley Deck cooperation across local CLI agents. v1.44.0 makes two per-track budget cells real. The protocol table printed 'unbounded' for deliberation fix-up cycles and cross-review rounds while the tool silently applied its own defaults of 3 and 1, so the printed rule and the enforced rule disagreed and the printed one lost. Fix-up is now capped at 5 and cross-review at 3 rounds after round 1, enforced on every code path that opens a round including the consensus-block back-edge, with the protocol text and the enforcement shipping in the same change. A separate off-by-one meant every track allowed one fewer cycle than it printed. Budgets are escalation thresholds and never mark work complete. Eight review-driven fix-up cycles went into this release; two shipped-behaviour defects were caught before it, including a companion skill package whose installer refused its own payload."
+ReleaseNotesUrl: https://github.com/feci/parley-deck-cli/releases/tag/v1.43.1
+Tags:
+- ai
+- agents
+- automation
+- cli
+- codex
+- consensus
+- loop
+- multi-agent
+- orchestration
+- preflight
+- roster
+- tui
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.44.0/Feci.ParleyDeckCli.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.44.0/Feci.ParleyDeckCli.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.44.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckSkill/2.8.0/Feci.ParleyDeckSkill.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/2.8.0/Feci.ParleyDeckSkill.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 2.8.0
+InstallerType: portable
+Commands:
+- parley-deck-skill
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-skill/releases/download/v2.8.0/parley-deck-skill-v2.8.0-windows-x64.exe
+  InstallerSha256: 7AF28F2FC39270143C3CB586EC941E4743FB5CF606C51108CEE4852A23AB52AD
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-skill/releases/download/v2.8.0/parley-deck-skill-v2.8.0-windows-arm64.exe
+  InstallerSha256: 66F7D4EA595EE1475EA2FA82E8AEBE44A9A60D7BEBAEBAFE75F659A5FD876E1A
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckSkill/2.8.0/Feci.ParleyDeckSkill.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/2.8.0/Feci.ParleyDeckSkill.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 2.8.0
+PackageLocale: en-US
+Publisher: Feci
+PublisherUrl: https://github.com/feci
+PackageName: Parley Deck Skill
+PackageUrl: https://github.com/feci/parley-deck-skill
+License: Apache-2.0
+LicenseUrl: https://github.com/feci/parley-deck-skill/blob/main/LICENSE
+ShortDescription: Installer for the Parley Deck multi-agent cooperation skill.
+Description: "parley-deck-skill installs and syncs the Parley Deck cooperation protocol and its add-on skills across local CLI agents. 2.8.0 updates the bundled protocol snapshot to match parley-deck-cli 1.44.0. Two per-track cells in the rigor table printed 'unbounded' for the deliberation track while the tool applied its own silent defaults; they now read 'cap 5 cycles' for fix-up and 'capped at 3 after round 1' for cross-review, and the CLI enforces both in the same release, so the printed number and the enforced number are the same number. Budgets escalate for human review and never mark work complete, and there is no severity floor."
+ReleaseNotesUrl: https://github.com/feci/parley-deck-skill/releases/tag/v2.5.1
+Tags:
+- ai
+- agents
+- agy
+- antigravity
+- cli
+- codex
+- claude
+- gemini
+- kimi
+- multi-agent
+- skill
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckSkill/2.8.0/Feci.ParleyDeckSkill.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/2.8.0/Feci.ParleyDeckSkill.locale.en-US.yaml
@@ -10,7 +10,7 @@ License: Apache-2.0
 LicenseUrl: https://github.com/feci/parley-deck-skill/blob/main/LICENSE
 ShortDescription: Installer for the Parley Deck multi-agent cooperation skill.
 Description: "parley-deck-skill installs and syncs the Parley Deck cooperation protocol and its add-on skills across local CLI agents. 2.8.0 updates the bundled protocol snapshot to match parley-deck-cli 1.44.0. Two per-track cells in the rigor table printed 'unbounded' for the deliberation track while the tool applied its own silent defaults; they now read 'cap 5 cycles' for fix-up and 'capped at 3 after round 1' for cross-review, and the CLI enforces both in the same release, so the printed number and the enforced number are the same number. Budgets escalate for human review and never mark work complete, and there is no severity floor."
-ReleaseNotesUrl: https://github.com/feci/parley-deck-skill/releases/tag/v2.5.1
+ReleaseNotesUrl: https://github.com/feci/parley-deck-skill/releases/tag/v2.8.0
 Tags:
 - ai
 - agents

--- a/manifests/f/Feci/ParleyDeckSkill/2.8.0/Feci.ParleyDeckSkill.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/2.8.0/Feci.ParleyDeckSkill.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 2.8.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Both packages updated together: the CLI enforces the two per-track budget cells and the skill ships the matching protocol snapshot, so the printed rule and the enforced rule agree.

Installer URLs point at the GitHub release assets for v1.44.0 and v2.8.0; SHA256 values were computed from those uploaded binaries.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/416445)