### PR TITLE
New version: randlee.sc-compose version 1.4.0

### DIFF
--- a/manifests/r/randlee/sc-compose/1.4.0/randlee.sc-compose.installer.yaml
+++ b/manifests/r/randlee/sc-compose/1.4.0/randlee.sc-compose.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: randlee.sc-compose
+PackageVersion: 1.4.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: sc-compose_1.4.0_x86_64-pc-windows-msvc\bin\sc-compose.exe
+  PortableCommandAlias: sc-compose
+ReleaseDate: 2026-08-12
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/randlee/sc-compose/releases/download/v1.4.0/sc-compose_1.4.0_x86_64-pc-windows-msvc.zip
+  InstallerSha256: 961FFBEE86B501B27DA932FDA798440D20632D7E0864669B307282D81766E907
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/r/randlee/sc-compose/1.4.0/randlee.sc-compose.locale.en-US.yaml
+++ b/manifests/r/randlee/sc-compose/1.4.0/randlee.sc-compose.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: randlee.sc-compose
+PackageVersion: 1.4.0
+PackageLocale: en-US
+Publisher: Rand Lee
+PublisherUrl: https://github.com/randlee
+PublisherSupportUrl: https://github.com/randlee/sc-compose/issues
+Author: Rand Lee
+PackageName: sc-compose
+PackageUrl: https://github.com/randlee/sc-compose
+License: MIT
+LicenseUrl: https://github.com/randlee/sc-compose/blob/main/LICENSE
+ShortDescription: Standalone CLI for template composition
+Description: |-
+  sc-compose is a standalone command-line tool for Jinja2-based template
+  composition. It wraps the sc-composer library to provide file and profile
+  rendering modes, frontmatter-driven configuration, and observability hooks
+  — with no external runtime dependencies.
+Moniker: sc-compose
+Tags:
+- cli
+- jinja2
+- rust
+- template
+- template-engine
+ReleaseNotesUrl: https://github.com/randlee/sc-compose/releases/tag/v1.4.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/r/randlee/sc-compose/1.4.0/randlee.sc-compose.yaml
+++ b/manifests/r/randlee/sc-compose/1.4.0/randlee.sc-compose.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: randlee.sc-compose
+PackageVersion: 1.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
New version: `randlee.sc-compose` version **1.4.0**

Update of an existing package, last published at 1.0.1. Structure is unchanged from the
accepted 1.0.1 manifests — same `zip` + `portable` nested installer shape, same publisher
and locale metadata. Only the version, installer URL, SHA256, release date and release
notes URL differ.

- Installer: https://github.com/randlee/sc-compose/releases/download/v1.4.0/sc-compose_1.4.0_x86_64-pc-windows-msvc.zip
- SHA256: `961FFBEE86B501B27DA932FDA798440D20632D7E0864669B307282D81766E907`
- Release: https://github.com/randlee/sc-compose/releases/tag/v1.4.0

**Validation performed — stated precisely, so reviewers know what has and has not been checked:**

- The SHA256 above was computed directly from the release asset downloaded from the exact
  `InstallerUrl` in this manifest (2,556,056 bytes).
- The `RelativeFilePath` was verified against the actual zip contents: the archive's only
  executable is `sc-compose_1.4.0_x86_64-pc-windows-msvc/bin/sc-compose.exe`, matching the
  declared nested path.
- All three manifests were parsed and checked for identifier/version consistency.

I was **not** able to run `winget validate` or `winget install` against these manifests —
this submission was prepared on macOS, where the `winget` client is unavailable. I have
therefore left those checklist items unchecked rather than assert checks I did not perform.
I'd ask reviewers to lean on the automated validation pipeline accordingly, and I'm happy
to act on anything it flags.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/416501)