### PR TITLE
New version: OutageDeck.CLI version 0.1.3

### DIFF
--- a/manifests/o/OutageDeck/CLI/0.1.3/OutageDeck.CLI.installer.yaml
+++ b/manifests/o/OutageDeck/CLI/0.1.3/OutageDeck.CLI.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: OutageDeck.CLI
+PackageVersion: 0.1.3
+InstallerType: zip
+NestedInstallerType: portable
+ReleaseDate: 2026-08-12
+Installers:
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: outagedeck.exe
+    PortableCommandAlias: outagedeck
+  InstallerUrl: https://github.com/outagedeck/cli/releases/download/v0.1.3/outagedeck_0.1.3_windows_amd64.zip
+  InstallerSha256: 0F345108CF5104CD93EEEF3F3C14104C01E78312B8A5E512F94243D120AD385A
+- Architecture: arm64
+  NestedInstallerFiles:
+  - RelativeFilePath: outagedeck.exe
+    PortableCommandAlias: outagedeck
+  InstallerUrl: https://github.com/outagedeck/cli/releases/download/v0.1.3/outagedeck_0.1.3_windows_arm64.zip
+  InstallerSha256: 0383E5C7768C0C5C7F0806F0D60115DFFC6C0CAF66C42627AD3D9B0F07A7C39C
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/o/OutageDeck/CLI/0.1.3/OutageDeck.CLI.locale.en-US.yaml
+++ b/manifests/o/OutageDeck/CLI/0.1.3/OutageDeck.CLI.locale.en-US.yaml
@@ -11,10 +11,10 @@ PackageName: OutageDeck CLI
 PackageUrl: https://github.com/outagedeck/cli
 License: MIT
 LicenseUrl: https://github.com/outagedeck/cli/blob/main/LICENSE
-ShortDescription: Check live cloud and SaaS status from your terminal or CI.
+ShortDescription: Check cloud and SaaS status from official feeds in your terminal or CI.
 Description: |-
-  OutageDeck checks the live status of 170+ cloud and SaaS providers using
-  normalized official vendor status feeds. It supports concurrent provider
+  OutageDeck checks status published by cloud and SaaS providers through their
+  official machine-readable status feeds. It supports concurrent provider
   checks, provider search, JSON output, and configurable exit thresholds for
   scripts and CI systems. Public status checks require no account or API key.
 Moniker: outagedeck

--- a/manifests/o/OutageDeck/CLI/0.1.3/OutageDeck.CLI.locale.en-US.yaml
+++ b/manifests/o/OutageDeck/CLI/0.1.3/OutageDeck.CLI.locale.en-US.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: OutageDeck.CLI
+PackageVersion: 0.1.3
+PackageLocale: en-US
+Publisher: OutageDeck
+PublisherUrl: https://outagedeck.com
+PublisherSupportUrl: https://github.com/outagedeck/cli/issues
+Author: OutageDeck
+PackageName: OutageDeck CLI
+PackageUrl: https://github.com/outagedeck/cli
+License: MIT
+LicenseUrl: https://github.com/outagedeck/cli/blob/main/LICENSE
+ShortDescription: Check live cloud and SaaS status from your terminal or CI.
+Description: |-
+  OutageDeck checks the live status of 170+ cloud and SaaS providers using
+  normalized official vendor status feeds. It supports concurrent provider
+  checks, provider search, JSON output, and configurable exit thresholds for
+  scripts and CI systems. Public status checks require no account or API key.
+Moniker: outagedeck
+Tags:
+- cli
+- cloud
+- devops
+- incident-response
+- monitoring
+- outage
+- sre
+- status
+ReleaseNotes: |-
+  Added an alerts command that validates and deduplicates provider names
+  locally, then prints a prefilled email-alert setup link for the selected stack.
+ReleaseNotesUrl: https://github.com/outagedeck/cli/releases/tag/v0.1.3
+Documentations:
+- DocumentLabel: API documentation
+  DocumentUrl: https://outagedeck.com/developers/api
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/o/OutageDeck/CLI/0.1.3/OutageDeck.CLI.yaml
+++ b/manifests/o/OutageDeck/CLI/0.1.3/OutageDeck.CLI.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: OutageDeck.CLI
+PackageVersion: 0.1.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Updates OutageDeck CLI from 0.1.2 to 0.1.3.

Version 0.1.3 adds an `alerts` command. It validates and deduplicates provider names locally, then prints a prefilled email-alert setup link for the selected stack.

## Validation

- downloaded both official Windows release archives again
- both SHA-256 values match the release checksums and submitted manifests
- the x64 archive contains a PE32+ x86-64 `outagedeck.exe`
- the ARM64 archive contains a PE32+ Aarch64 `outagedeck.exe`
- all three manifests parse as YAML and agree on identifier, version, and schema version
- the previous 0.1.2 manifest passed Microsoft's manual validation before merge

A Windows host is not available in this environment, so I have not claimed a local `winget validate` or install test.

## Checklist

- [x] Signed the Contributor License Agreement
- [x] Checked that there are no other open pull requests for OutageDeck.CLI 0.1.3
- [x] This PR only adds one manifest set for one package version
- [ ] Validated locally with `winget validate --manifest <path>` (Windows host unavailable)
- [ ] Tested locally with `winget install --manifest <path>` (Windows host unavailable)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/416514)