### PR TITLE
New package: asanabrial.leteo version 0.1.2

### DIFF
--- a/manifests/a/asanabrial/leteo/0.1.2/asanabrial.leteo.installer.yaml
+++ b/manifests/a/asanabrial/leteo/0.1.2/asanabrial.leteo.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: asanabrial.leteo
+PackageVersion: 0.1.2
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: leteo-v0.1.2-x86_64-pc-windows-msvc\leteo.exe
+  PortableCommandAlias: leteo
+ReleaseDate: 2026-08-12
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/asanabrial/leteo/releases/download/v0.1.2/leteo-v0.1.2-x86_64-pc-windows-msvc.zip
+  InstallerSha256: 5CD91549659F2BFF39BDD5FFB46CDA7C397C7167135EFCFCB9597FF4C8EC50ED
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/a/asanabrial/leteo/0.1.2/asanabrial.leteo.installer.yaml
+++ b/manifests/a/asanabrial/leteo/0.1.2/asanabrial.leteo.installer.yaml
@@ -12,5 +12,8 @@ Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/asanabrial/leteo/releases/download/v0.1.2/leteo-v0.1.2-x86_64-pc-windows-msvc.zip
   InstallerSha256: 5CD91549659F2BFF39BDD5FFB46CDA7C397C7167135EFCFCB9597FF4C8EC50ED
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/a/asanabrial/leteo/0.1.2/asanabrial.leteo.locale.en-US.yaml
+++ b/manifests/a/asanabrial/leteo/0.1.2/asanabrial.leteo.locale.en-US.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: asanabrial.leteo
+PackageVersion: 0.1.2
+PackageLocale: en-US
+Publisher: Alexis Sanabria Lopez
+PublisherUrl: https://github.com/asanabrial
+PublisherSupportUrl: https://github.com/asanabrial/leteo/issues
+Author: Alexis Sanabria Lopez
+PackageName: Leteo
+PackageUrl: https://github.com/asanabrial/leteo
+License: MIT
+LicenseUrl: https://github.com/asanabrial/leteo/blob/main/LICENSE
+Copyright: Copyright (c) Alexis Sanabria Lopez
+ShortDescription: Local-first persistent memory for AI coding agents
+Description: |-
+  Your coding agent forgets everything when the session ends, and most of it when the context
+  is compacted. Leteo is the memory it keeps: decisions, bug fixes, conventions and the
+  discoveries that were expensive to make, stored in a local SQLite database and handed back
+  when they are relevant.
+
+  One binary, no server, no API key. It speaks the Model Context Protocol over stdio and
+  installs lifecycle hooks, so saving and recalling happen without being asked. Nothing leaves
+  the machine unless cloud replication is turned on for a named project.
+Moniker: leteo
+Tags:
+- ai
+- agent
+- cli
+- mcp
+- memory
+- sqlite
+ReleaseNotesUrl: https://github.com/asanabrial/leteo/releases/tag/v0.1.2
+Documentations:
+- DocumentLabel: Specifications
+  DocumentUrl: https://github.com/asanabrial/leteo/tree/main/openspec
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/a/asanabrial/leteo/0.1.2/asanabrial.leteo.yaml
+++ b/manifests/a/asanabrial/leteo/0.1.2/asanabrial.leteo.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: asanabrial.leteo
+PackageVersion: 0.1.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Checklist

- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/add?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

> **Correction.** I ticked the CLA box when opening this and had no basis for it — the agreement had not been signed. It is being signed in the thread below. Apologies for the noise.

### Package

[Leteo](https://github.com/asanabrial/leteo) â€” local-first persistent memory for AI coding agents. One Rust binary over one SQLite database, MIT licensed, no telemetry and no network in normal use.

Already published on [crates.io](https://crates.io/crates/leteo), [npm](https://www.npmjs.com/package/@asanabrial/leteo) and the [MCP Registry](https://registry.modelcontextprotocol.io).

### What was verified

`winget validate --manifest` passes.

Every fact the installer manifest asserts was checked against the published artifact:

| | |
| --- | --- |
| `InstallerSha256` | downloaded the zip and hashed it: `5cd91549659f2bff39bdd5ffb46cda7c397c7167135efcfcb9597ff4c8ec50ed`, which is what the manifest declares and what the release's `SHA256SUMS` publishes |
| `RelativeFilePath` | extracted it: `leteo-v0.1.2-x86_64-pc-windows-msvc/leteo.exe`, the path the manifest names |
| the binary | ran that exact file: `leteo --version` â†’ `leteo 0.1.2` |

### What was not

`winget install --manifest` is unchecked. It needs `LocalManifestFiles` enabled, which requires elevation this machine did not have, so the end-to-end install is untested and I would rather say so than tick the box.

The installer is a zip holding a directory, so it declares `NestedInstallerType: portable` with the relative path above and `leteo` as the command alias.