### PR TITLE
New version: HarjotSinghRana.Reinstate version 0.3.0

### DIFF
--- a/manifests/h/HarjotSinghRana/Reinstate/0.3.0/HarjotSinghRana.Reinstate.installer.yaml
+++ b/manifests/h/HarjotSinghRana/Reinstate/0.3.0/HarjotSinghRana.Reinstate.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: HarjotSinghRana.Reinstate
+PackageVersion: 0.3.0
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: rein.exe
+  PortableCommandAlias: rein
+- RelativeFilePath: reinstate.exe
+  PortableCommandAlias: reinstate
+UpgradeBehavior: install
+Commands:
+- rein
+- reinstate
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/HarjjotSinghh/reinstate/releases/download/v0.3.0/reinstate_0.3.0_windows_amd64.zip
+  InstallerSha256: B2A2C40BD0F8DD571B7DA1FAFB8252C8993C56BB0171AD1F75DE9B8A73F7503A
+ManifestType: installer
+ManifestVersion: 1.10.0
+ReleaseDate: 2026-08-11

--- a/manifests/h/HarjotSinghRana/Reinstate/0.3.0/HarjotSinghRana.Reinstate.locale.en-US.yaml
+++ b/manifests/h/HarjotSinghRana/Reinstate/0.3.0/HarjotSinghRana.Reinstate.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: HarjotSinghRana.Reinstate
+PackageVersion: 0.3.0
+PackageLocale: en-US
+Publisher: Harjot Singh Rana
+PublisherUrl: https://harjot.co
+PublisherSupportUrl: https://github.com/HarjjotSinghh/reinstate/issues
+PackageName: Reinstate
+PackageUrl: https://reinstate.dev
+License: Apache-2.0
+LicenseUrl: https://github.com/HarjjotSinghh/reinstate/blob/v0.3.0/LICENSE
+ShortDescription: Continue supported coding-agent sessions across configured devices.
+Description: Reinstate securely syncs supported coding-agent sessions across configured devices using end-to-end encryption and storage you control.
+Tags:
+- cli
+- claude
+- coding-agent
+- codex
+- encryption
+- session
+- sync
+ReleaseNotesUrl: https://github.com/HarjjotSinghh/reinstate/releases/tag/v0.3.0
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/h/HarjotSinghRana/Reinstate/0.3.0/HarjotSinghRana.Reinstate.yaml
+++ b/manifests/h/HarjotSinghRana/Reinstate/0.3.0/HarjotSinghRana.Reinstate.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: HarjotSinghRana.Reinstate
+PackageVersion: 0.3.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
### Description

New version: `HarjotSinghRana.Reinstate` version 0.3.0.

- Installer: `reinstate_0.3.0_windows_amd64.zip` from https://github.com/HarjjotSinghh/reinstate/releases/tag/v0.3.0
- SHA256 verified against the release `checksums.txt`.
- `InstallerType: zip` with `NestedInstallerType: portable`; the archive contains `rein.exe` and `reinstate.exe`, matching the merged 0.2.0 manifest (#412426).

### Checklist

- [x] Checked that there aren't other open pull requests for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Manifest conforms to the 1.10 schema

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/416529)