### PR TITLE
New package: JKUSAS.YTile version 0.1.0

### DIFF
--- a/manifests/j/JKUSAS/YTile/0.1.0/JKUSAS.YTile.installer.yaml
+++ b/manifests/j/JKUSAS/YTile/0.1.0/JKUSAS.YTile.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: JKUSAS.YTile
+PackageVersion: 0.1.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.19041.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: ytile.exe
+  PortableCommandAlias: ytile
+- RelativeFilePath: ytiled.exe
+  PortableCommandAlias: ytiled
+Commands:
+- ytile
+- ytiled
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/JKUSAS/YTile/releases/download/v0.1.0/ytile-0.1.0-win-x64.zip
+  InstallerSha256: 01d6ad66b71101286f5cd9a3a6e36aae3c6ac7bea991771879253656b0454e19
+ReleaseDate: 2026-08-12
+ManifestType: installer
+ManifestVersion: 1.10.0
+

--- a/manifests/j/JKUSAS/YTile/0.1.0/JKUSAS.YTile.locale.en-US.yaml
+++ b/manifests/j/JKUSAS/YTile/0.1.0/JKUSAS.YTile.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: JKUSAS.YTile
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: JKUSAS
+PublisherUrl: https://github.com/JKUSAS
+PublisherSupportUrl: https://github.com/JKUSAS/YTile/issues
+Author: JKUSAS
+PackageName: YTile
+PackageUrl: https://github.com/JKUSAS/YTile
+License: GPL-3.0
+LicenseUrl: https://github.com/JKUSAS/YTile/blob/main/LICENSE
+ShortDescription: Tiling window manager for Windows
+Description: |-
+  YTile tiles application windows automatically: nine workspaces per monitor
+  hidden by cloaking so alt-tab stays clean, BSP and Columns layouts plus
+  monocle, directional focus and movement that continue onto the adjacent
+  monitor, drag-to-swap, edge resizes that persist into the layout, per-app
+  float/ignore rules, optional taskbar hiding, and a named-pipe NDJSON API
+  for status bars. Ships a daemon (ytiled) and a CLI (ytile); pair with whkd
+  for hotkeys.
+Moniker: ytile
+Tags:
+- tiling
+- tiling-window-manager
+- window-manager
+- productivity
+ReleaseNotesUrl: https://github.com/JKUSAS/YTile/releases/tag/v0.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0
+

--- a/manifests/j/JKUSAS/YTile/0.1.0/JKUSAS.YTile.yaml
+++ b/manifests/j/JKUSAS/YTile/0.1.0/JKUSAS.YTile.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: JKUSAS.YTile
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0
+


### PR DESCRIPTION
## Description

First submission of **JKUSAS.YTile** (YTile, a tiling window manager for Windows), version **0.1.0**.

The manifests are generated by the project's release CI from the exact released archive and are attached as assets on the release itself: https://github.com/JKUSAS/YTile/releases/tag/v0.1.0. The package is a zip with two nested portable binaries (`ytiled.exe`, the daemon, and `ytile.exe`, the CLI).

## Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)

## Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [ ] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> The manifests declare `ManifestVersion: 1.10.0` and validate cleanly with winget v1.29.280.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/416567)