### PR TITLE
New version: mangokingTW.HdrScreenshotSyncer version 0.2.0

### DIFF
--- a/manifests/m/mangokingTW/HdrScreenshotSyncer/0.2.0/mangokingTW.HdrScreenshotSyncer.installer.yaml
+++ b/manifests/m/mangokingTW/HdrScreenshotSyncer/0.2.0/mangokingTW.HdrScreenshotSyncer.installer.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: mangokingTW.HdrScreenshotSyncer
+PackageVersion: 0.2.0
+InstallerLocale: en-US
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-08-13
+# One Inno installer adapts to the host architecture, so both point at the same
+# asset and hash.
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/mangokingTW/HdrScreenshotSyncer/releases/download/v0.2.0/HdrScreenshotSyncer-0.2.0-setup.exe
+    InstallerSha256: 56DD842CC1328FFF2F370742EFEA2C76E0F72BEEA999C582F0327930E94D608C
+    ProductCode: '{A345CF69-EF8A-4B6D-BF82-25F336A73950}_is1'
+    AppsAndFeaturesEntries:
+      - DisplayName: HdrScreenshotSyncer
+        Publisher: mangokingTW
+        DisplayVersion: 0.2.0
+        ProductCode: '{A345CF69-EF8A-4B6D-BF82-25F336A73950}_is1'
+        InstallerType: inno
+  - Architecture: x86
+    InstallerUrl: https://github.com/mangokingTW/HdrScreenshotSyncer/releases/download/v0.2.0/HdrScreenshotSyncer-0.2.0-setup.exe
+    InstallerSha256: 56DD842CC1328FFF2F370742EFEA2C76E0F72BEEA999C582F0327930E94D608C
+    ProductCode: '{A345CF69-EF8A-4B6D-BF82-25F336A73950}_is1'
+    AppsAndFeaturesEntries:
+      - DisplayName: HdrScreenshotSyncer
+        Publisher: mangokingTW
+        DisplayVersion: 0.2.0
+        ProductCode: '{A345CF69-EF8A-4B6D-BF82-25F336A73950}_is1'
+        InstallerType: inno
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/mangokingTW/HdrScreenshotSyncer/0.2.0/mangokingTW.HdrScreenshotSyncer.locale.en-US.yaml
+++ b/manifests/m/mangokingTW/HdrScreenshotSyncer/0.2.0/mangokingTW.HdrScreenshotSyncer.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: mangokingTW.HdrScreenshotSyncer
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: mangokingTW
+PublisherUrl: https://github.com/mangokingTW
+PublisherSupportUrl: https://github.com/mangokingTW/HdrScreenshotSyncer/issues
+Author: mangokingTW
+PackageName: HdrScreenshotSyncer
+PackageUrl: https://github.com/mangokingTW/HdrScreenshotSyncer
+License: MIT
+LicenseUrl: https://github.com/mangokingTW/HdrScreenshotSyncer/blob/main/LICENSE
+Copyright: Copyright (c) mangokingTW
+ShortDescription: Keeps Snipping Tool's HDR screenshot color corrector in sync with whether the current content is HDR.
+Description: >-
+  HdrScreenshotSyncer is a small tray utility that detects whether the foreground
+  content is actually HDR and sets Snipping Tool's "HDR screenshot color
+  corrector" (IsHDRToneMappingEnabled) to match, so native screenshots come out
+  with the right colors without toggling the setting by hand.
+Moniker: hdrscreenshotsyncer
+Tags:
+  - hdr
+  - screenshot
+  - snipping-tool
+  - tray
+  - windows
+ReleaseNotesUrl: https://github.com/mangokingTW/HdrScreenshotSyncer/releases/tag/v0.2.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/mangokingTW/HdrScreenshotSyncer/0.2.0/mangokingTW.HdrScreenshotSyncer.yaml
+++ b/manifests/m/mangokingTW/HdrScreenshotSyncer/0.2.0/mangokingTW.HdrScreenshotSyncer.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: mangokingTW.HdrScreenshotSyncer
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New version of an existing package

- Package: `mangokingTW.HdrScreenshotSyncer`
- Version: `0.2.0`

Version bump of the existing manifests (same schema/structure as the prior submission).

- Installer URL + SHA256 verified against the GitHub release asset `HdrScreenshotSyncer-0.2.0-setup.exe` (SHA256 `56DD842CC1328FFF2F370742EFEA2C76E0F72BEEA999C582F0327930E94D608C`, from the release's signed `SHA256SUMS.txt`).
- Same Inno installer for x64/x86; `Scope: user`; no elevation.
- Relying on the winget-pkgs validation pipeline for schema/install checks.

0.2.0 adds content-based HDR detection (scans the foreground content instead of the display-level flag). Release: https://github.com/mangokingTW/HdrScreenshotSyncer/releases/tag/v0.2.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/416634)