### PR TITLE
New package: mangokingTW.HdrScreenshotSyncer version 0.2.1

### DIFF
--- a/manifests/m/mangokingTW/HdrScreenshotSyncer/0.2.1/mangokingTW.HdrScreenshotSyncer.installer.yaml
+++ b/manifests/m/mangokingTW/HdrScreenshotSyncer/0.2.1/mangokingTW.HdrScreenshotSyncer.installer.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: mangokingTW.HdrScreenshotSyncer
+PackageVersion: 0.2.1
+InstallerLocale: en-US
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-08-13
+# One Inno installer adapts to the host architecture, so both point at the same
+# asset and hash.
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/mangokingTW/HdrScreenshotSyncer/releases/download/v0.2.1/HdrScreenshotSyncer-0.2.1-setup.exe
+    InstallerSha256: 2DA35F96A837507970983F1C046AA572755EE77F634F565F98D8F9F28A065E70
+    ProductCode: '{A345CF69-EF8A-4B6D-BF82-25F336A73950}_is1'
+    AppsAndFeaturesEntries:
+      - DisplayName: HdrScreenshotSyncer
+        Publisher: mangokingTW
+        DisplayVersion: 0.2.1
+        ProductCode: '{A345CF69-EF8A-4B6D-BF82-25F336A73950}_is1'
+        InstallerType: inno
+  - Architecture: x86
+    InstallerUrl: https://github.com/mangokingTW/HdrScreenshotSyncer/releases/download/v0.2.1/HdrScreenshotSyncer-0.2.1-setup.exe
+    InstallerSha256: 2DA35F96A837507970983F1C046AA572755EE77F634F565F98D8F9F28A065E70
+    ProductCode: '{A345CF69-EF8A-4B6D-BF82-25F336A73950}_is1'
+    AppsAndFeaturesEntries:
+      - DisplayName: HdrScreenshotSyncer
+        Publisher: mangokingTW
+        DisplayVersion: 0.2.1
+        ProductCode: '{A345CF69-EF8A-4B6D-BF82-25F336A73950}_is1'
+        InstallerType: inno
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/mangokingTW/HdrScreenshotSyncer/0.2.1/mangokingTW.HdrScreenshotSyncer.locale.en-US.yaml
+++ b/manifests/m/mangokingTW/HdrScreenshotSyncer/0.2.1/mangokingTW.HdrScreenshotSyncer.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: mangokingTW.HdrScreenshotSyncer
+PackageVersion: 0.2.1
+PackageLocale: en-US
+Publisher: mangokingTW
+PublisherUrl: https://github.com/mangokingTW
+PublisherSupportUrl: https://github.com/mangokingTW/HdrScreenshotSyncer/issues
+Author: mangokingTW
+PackageName: HdrScreenshotSyncer
+PackageUrl: https://github.com/mangokingTW/HdrScreenshotSyncer
+License: MIT
+LicenseUrl: https://github.com/mangokingTW/HdrScreenshotSyncer/blob/main/LICENSE
+Copyright: Copyright (c) mangokingTW
+ShortDescription: Keeps Snipping Tool's HDR screenshot color corrector in sync with whether the current content is HDR.
+Description: >-
+  HdrScreenshotSyncer is a small tray utility that detects whether the foreground
+  content is actually HDR and sets Snipping Tool's "HDR screenshot color
+  corrector" (IsHDRToneMappingEnabled) to match, so native screenshots come out
+  with the right colors without toggling the setting by hand.
+Moniker: hdrscreenshotsyncer
+Tags:
+  - hdr
+  - screenshot
+  - snipping-tool
+  - tray
+  - windows
+ReleaseNotesUrl: https://github.com/mangokingTW/HdrScreenshotSyncer/releases/tag/v0.2.1
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/mangokingTW/HdrScreenshotSyncer/0.2.1/mangokingTW.HdrScreenshotSyncer.yaml
+++ b/manifests/m/mangokingTW/HdrScreenshotSyncer/0.2.1/mangokingTW.HdrScreenshotSyncer.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: mangokingTW.HdrScreenshotSyncer
+PackageVersion: 0.2.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
- Package: `mangokingTW.HdrScreenshotSyncer`
- Version: `0.2.1`

First published version of this package (earlier 0.1.0/0.2.0 submissions were closed and superseded before merge).

- Installer URL + SHA256 verified against the GitHub release asset `HdrScreenshotSyncer-0.2.1-setup.exe` (SHA256 `2DA35F96A837507970983F1C046AA572755EE77F634F565F98D8F9F28A065E70`, from the release's signed `SHA256SUMS.txt`).
- Single Inno installer for x64/x86; `Scope: user`; no elevation.
- Relying on the winget-pkgs validation pipeline for schema/install checks.

Release notes: https://github.com/mangokingTW/HdrScreenshotSyncer/releases/tag/v0.2.1
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/416646)