### PR TITLE
New package: net.bloret.launcher version 27.1

### DIFF
--- a/manifests/n/net/bloret/launcher/27.1/net.bloret.launcher.installer.yaml
+++ b/manifests/n/net/bloret/launcher/27.1/net.bloret.launcher.installer.yaml
@@ -1,0 +1,27 @@
+# Created with YamlCreate.ps1 v2.4.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: net.bloret.launcher
+PackageVersion: "27.1"
+InstallerLocale: zh-CN
+InstallerType: inno
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART
+UpgradeBehavior: install
+ReleaseDate: 2026-08-12
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/BloretCrew/Bloret-Launcher/releases/download/27.1/Bloret-Launcher-Setup.exe
+  InstallerSha256: 855E01B00EB5EEB717AD29BFD9B47AED7A899FB9AA315FF7D8469298C4BDC2FE
+  AppsAndFeaturesEntries:
+  - DisplayName: Bloret-Launcher
+    Publisher: Bloret
+    ProductCode: '{A9AFE7D1-89A9-47C5-9E1A-003DB3575EB8}_is1'
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/n/net/bloret/launcher/27.1/net.bloret.launcher.locale.en-US.yaml
+++ b/manifests/n/net/bloret/launcher/27.1/net.bloret.launcher.locale.en-US.yaml
@@ -5,7 +5,7 @@ PackageIdentifier: net.bloret.launcher
 PackageVersion: "27.1"
 PackageLocale: en-US
 Publisher: Bloret
-PublisherUrl: https://bloret.net
+PublisherUrl: https://github.com/BloretCrew
 PublisherSupportUrl: https://github.com/BloretCrew/Bloret-Launcher/issues
 Author: Bloret
 PackageName: Bloret Launcher

--- a/manifests/n/net/bloret/launcher/27.1/net.bloret.launcher.locale.en-US.yaml
+++ b/manifests/n/net/bloret/launcher/27.1/net.bloret.launcher.locale.en-US.yaml
@@ -5,7 +5,7 @@ PackageIdentifier: net.bloret.launcher
 PackageVersion: "27.1"
 PackageLocale: en-US
 Publisher: Bloret
-PublisherUrl: https://github.com/BloretCrew
+PublisherUrl: https://launcher.bloret.net
 PublisherSupportUrl: https://github.com/BloretCrew/Bloret-Launcher/issues
 Author: Bloret
 PackageName: Bloret Launcher

--- a/manifests/n/net/bloret/launcher/27.1/net.bloret.launcher.locale.en-US.yaml
+++ b/manifests/n/net/bloret/launcher/27.1/net.bloret.launcher.locale.en-US.yaml
@@ -1,0 +1,41 @@
+# Created with YamlCreate.ps1 v2.4.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.9.0.schema.json
+
+PackageIdentifier: net.bloret.launcher
+PackageVersion: "27.1"
+PackageLocale: en-US
+Publisher: Bloret
+PublisherUrl: https://bloret.net
+PublisherSupportUrl: https://github.com/BloretCrew/Bloret-Launcher/issues
+Author: Bloret
+PackageName: Bloret Launcher
+PackageUrl: https://launcher.bloret.net
+License: GPL-3.0
+LicenseUrl: https://github.com/BloretCrew/Bloret-Launcher/blob/main/LICENSE
+Copyright: Copyright (c) Bloret
+ShortDescription: Your personal innovative open-source AI Minecraft launcher. Be creative, be simple.
+Description: |-
+  Bloret Launcher is a free and open-source AI-powered Minecraft launcher.
+  It features a plugin system for full customization, remote internationalization,
+  parallel multi-task downloads, Forge / NeoForge, Modrinth modpacks, a built-in
+  resource pack editor, and Blora Agent multi-platform connectivity.
+  Be creative, be simple. Relax, it's Bloret Launcher.
+Tags:
+- ai
+- bloret
+- fabric
+- forge
+- launcher
+- minecraft
+- modrinth
+- neoforge
+- open-source
+- plugin
+ReleaseNotesUrl: https://github.com/BloretCrew/Bloret-Launcher/releases/tag/27.1
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/BloretCrew/Bloret-Launcher/wiki
+- DocumentLabel: Plugin Store
+  DocumentUrl: https://launcher.bloret.net/apps
+ManifestType: locale
+ManifestVersion: 1.9.0

--- a/manifests/n/net/bloret/launcher/27.1/net.bloret.launcher.locale.zh-CN.yaml
+++ b/manifests/n/net/bloret/launcher/27.1/net.bloret.launcher.locale.zh-CN.yaml
@@ -5,7 +5,7 @@ PackageIdentifier: net.bloret.launcher
 PackageVersion: "27.1"
 PackageLocale: zh-CN
 Publisher: Bloret
-PublisherUrl: https://bloret.net
+PublisherUrl: https://github.com/BloretCrew
 PublisherSupportUrl: https://github.com/BloretCrew/Bloret-Launcher/issues
 Author: Bloret
 PackageName: Bloret Launcher

--- a/manifests/n/net/bloret/launcher/27.1/net.bloret.launcher.locale.zh-CN.yaml
+++ b/manifests/n/net/bloret/launcher/27.1/net.bloret.launcher.locale.zh-CN.yaml
@@ -5,7 +5,7 @@ PackageIdentifier: net.bloret.launcher
 PackageVersion: "27.1"
 PackageLocale: zh-CN
 Publisher: Bloret
-PublisherUrl: https://github.com/BloretCrew
+PublisherUrl: https://launcher.bloret.net
 PublisherSupportUrl: https://github.com/BloretCrew/Bloret-Launcher/issues
 Author: Bloret
 PackageName: Bloret Launcher

--- a/manifests/n/net/bloret/launcher/27.1/net.bloret.launcher.locale.zh-CN.yaml
+++ b/manifests/n/net/bloret/launcher/27.1/net.bloret.launcher.locale.zh-CN.yaml
@@ -1,0 +1,50 @@
+# Created with YamlCreate.ps1 v2.4.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: net.bloret.launcher
+PackageVersion: "27.1"
+PackageLocale: zh-CN
+Publisher: Bloret
+PublisherUrl: https://bloret.net
+PublisherSupportUrl: https://github.com/BloretCrew/Bloret-Launcher/issues
+Author: Bloret
+PackageName: Bloret Launcher
+PackageUrl: https://launcher.bloret.net
+License: GPL-3.0
+LicenseUrl: https://github.com/BloretCrew/Bloret-Launcher/blob/main/LICENSE
+Copyright: Copyright (c) Bloret
+ShortDescription: 你的专属创新开源 AI Minecraft 启动器。发挥创意，化繁为简。
+Description: |-
+  Bloret Launcher 是完全免费开源的 AI Minecraft 启动器。
+  隆重推出插件功能，一切均可自定义；支持远程国际化、多任务并行下载安装、
+  Forge / NeoForge、Modrinth 整合包、内置资源包编辑器，以及 Blora Agent 多平台连接。
+  Be creative, be simple. Relax, it's Bloret Launcher.
+Moniker: bloret-launcher
+Tags:
+- ai
+- bloret
+- fabric
+- forge
+- launcher
+- minecraft
+- modrinth
+- neoforge
+- open-source
+- plugin
+ReleaseNotes: |-
+  - 隆重推出插件功能，Bloret Launcher 的一切均可自定义
+  - 可访问 Bloret Launcher 商店寻找或提交插件
+  - 远程国际化功能，数据来源于 tr.bloret.net
+  - 针对 Blora Agent 界面与功能进行了优化
+  - 支持多任务并行下载与安装 Minecraft
+  - 支持将 Blora Agent 连接到微信、飞书、Telegram、Discord、iMessage 等平台
+  - 针对下载设置项、性能与逻辑进行了优化
+  - 新增 FreeBSD 平台支持
+ReleaseNotesUrl: https://github.com/BloretCrew/Bloret-Launcher/releases/tag/27.1
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/BloretCrew/Bloret-Launcher/wiki
+- DocumentLabel: 插件商店
+  DocumentUrl: https://launcher.bloret.net/apps
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/n/net/bloret/launcher/27.1/net.bloret.launcher.yaml
+++ b/manifests/n/net/bloret/launcher/27.1/net.bloret.launcher.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.4.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: net.bloret.launcher
+PackageVersion: "27.1"
+DefaultLocale: zh-CN
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## New package
- Package: **net.bloret.launcher**
- Publisher: **Bloret**
- Version: **27.1**
- Installer: Inno Setup (`Bloret-Launcher-Setup.exe`), user scope
- Download: https://github.com/BloretCrew/Bloret-Launcher/releases/download/27.1/Bloret-Launcher-Setup.exe

## Notes
- This is a **new** package ID (reverse-DNS `net.bloret.launcher`), separate from the older `Bloret.Launcher` / `Bloret.BloretLauncher` entries.
- Manifests include zh-CN (default) and en-US locales with updated 27.1 descriptions (plugin system, remote i18n, Blora Agent, etc.).
- Installer AppId from Inno script: `{A9AFE7D1-89A9-47C5-9E1A-003DB3575EB8}`

## Checklist
- [x] Have you signed the Contributor License Agreement?
- [x] Have you tested the installer locally / verified SHA256 against the GitHub release asset?
- [x] Does this package follow naming / path conventions?

Closes: N/A (new package)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/416656)