### PR TITLE
New package: AegiosOT.YTile version 0.1.1

### DIFF
--- a/manifests/a/AegiosOT/YTile/0.1.1/AegiosOT.YTile.installer.yaml
+++ b/manifests/a/AegiosOT/YTile/0.1.1/AegiosOT.YTile.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: AegiosOT.YTile
+PackageVersion: 0.1.1
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.19041.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: ytile.exe
+  PortableCommandAlias: ytile
+- RelativeFilePath: ytiled.exe
+  PortableCommandAlias: ytiled
+Commands:
+- ytile
+- ytiled
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/AegiosOT/YTile/releases/download/v0.1.1/ytile-0.1.1-win-x64.zip
+  InstallerSha256: 822109030393331ff83a7d5346b1f0d9711fadf3360f065f5b5fb7af4634da1c
+ReleaseDate: 2026-08-13
+ManifestType: installer
+ManifestVersion: 1.10.0
+

--- a/manifests/a/AegiosOT/YTile/0.1.1/AegiosOT.YTile.locale.en-US.yaml
+++ b/manifests/a/AegiosOT/YTile/0.1.1/AegiosOT.YTile.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: AegiosOT.YTile
+PackageVersion: 0.1.1
+PackageLocale: en-US
+Publisher: AegiosOT
+PublisherUrl: https://github.com/AegiosOT
+PublisherSupportUrl: https://github.com/AegiosOT/YTile/issues
+Author: AegiosOT
+PackageName: YTile
+PackageUrl: https://github.com/AegiosOT/YTile
+License: GPL-3.0
+LicenseUrl: https://github.com/AegiosOT/YTile/blob/main/LICENSE
+ShortDescription: Tiling window manager for Windows
+Description: |-
+  YTile tiles application windows automatically: nine workspaces per monitor
+  hidden by cloaking so alt-tab stays clean, BSP and Columns layouts plus
+  monocle, directional focus and movement that continue onto the adjacent
+  monitor, drag-to-swap, edge resizes that persist into the layout, per-app
+  float/ignore rules, optional taskbar hiding, and a named-pipe NDJSON API
+  for status bars. Ships a daemon (ytiled) and a CLI (ytile); pair with whkd
+  for hotkeys.
+Moniker: ytile
+Tags:
+- tiling
+- tiling-window-manager
+- window-manager
+- productivity
+ReleaseNotesUrl: https://github.com/AegiosOT/YTile/releases/tag/v0.1.1
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0
+

--- a/manifests/a/AegiosOT/YTile/0.1.1/AegiosOT.YTile.yaml
+++ b/manifests/a/AegiosOT/YTile/0.1.1/AegiosOT.YTile.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: AegiosOT.YTile
+PackageVersion: 0.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0
+


### PR DESCRIPTION
## Description

First submission of **AegiosOT.YTile** (YTile, a tiling window manager for Windows), version **0.1.1**.

The manifests are generated by the project's release CI from the exact released archive and are attached as assets on the release itself: https://github.com/AegiosOT/YTile/releases/tag/v0.1.1. The package is a zip with two nested portable binaries (`ytiled.exe`, the daemon, and `ytile.exe`, the CLI).

Note: an earlier submission of this package (#416567, as `JKUSAS.YTile`) was closed by the author — the publisher account was renamed to AegiosOT before anything shipped, so this PR supersedes it under the final identity.

## Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)

## Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [ ] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> The manifests declare `ManifestVersion: 1.10.0` and validate cleanly with winget v1.29.280.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/416687)