### PR TITLE
New package: AirUSB.Client version 1.1.2

### DIFF
--- a/manifests/a/AirUSB/Client/1.1.2/AirUSB.Client.installer.yaml
+++ b/manifests/a/AirUSB/Client/1.1.2/AirUSB.Client.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: AirUSB.Client
+PackageVersion: 1.1.2
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ElevationRequirement: elevationRequired
+ExpectedReturnCodes:
+- InstallerReturnCode: 3010
+  ReturnResponse: rebootRequiredToFinish
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/M-Abozaid/airusb-releases/releases/download/v1.1.2/UsbAirSetup-1.1.2.exe
+  InstallerSha256: 5498A354C08014A2094D354FA105723246AF79085463277208700695BAFA07C5
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/a/AirUSB/Client/1.1.2/AirUSB.Client.locale.en-US.yaml
+++ b/manifests/a/AirUSB/Client/1.1.2/AirUSB.Client.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: AirUSB.Client
+PackageVersion: 1.1.2
+PackageLocale: en-US
+Publisher: AirUSB
+PublisherUrl: https://airusb.app
+PublisherSupportUrl: https://airusb.app/help
+PackageName: AirUSB Client
+PackageUrl: https://airusb.app
+License: Proprietary
+Copyright: Copyright (c) 2026 AirUSB
+ShortDescription: Windows client for AirUSB wireless print and scan bridges.
+Description: |-
+  Connects Windows to AirUSB wireless print & scan bridges. Auto-discovers
+  bridges on the local network (no manual IP entry), attaches the connected
+  USB printer or scanner over Wi-Fi using USB/IP, reconnects automatically,
+  and updates bridge firmware. Bundles the Microsoft-attestation-signed
+  usbip-win vhci driver; installing requires administrator rights.
+Moniker: airusb
+Tags:
+- airusb
+- print-server
+- printer
+- scanner
+- usbip
+- wireless
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/a/AirUSB/Client/1.1.2/AirUSB.Client.yaml
+++ b/manifests/a/AirUSB/Client/1.1.2/AirUSB.Client.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: AirUSB.Client
+PackageVersion: 1.1.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package submission: AirUSB.Client 1.1.2

Windows client for **AirUSB** wireless print & scan bridges (https://airusb.app) — auto-discovers bridges on the LAN, attaches USB printers/scanners over Wi-Fi via USB/IP, auto-reconnects, and updates bridge firmware.

Resubmission of #404610, which passed validation (`Azure-Pipeline-Passed`, `Validation-Completed`) but was closed pending CLA. CLA being signed on this PR.

- Inno Setup installer, machine scope, elevation required
- Bundles the **Microsoft-attestation-signed usbip-win vhci driver** (same driver family as the existing `dorssel.usbipd-win` package); exit code 3010 declared as rebootRequiredToFinish
- InstallerUrl is a versioned GitHub Releases asset; SHA256 pinned and verified against the live asset
- Publisher: AirUSB (I am the developer/publisher)

- [x] I have read the [Contributing Guidelines](https://github.com/microsoft/winget-pkgs/blob/master/CONTRIBUTING.md)
- [x] This manifest is for a new package
- [x] The installer supports silent install (`/VERYSILENT`, Inno Setup)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/416797)