### PR TITLE
New version: iammodev.YAKC version 2.8.1

### DIFF
--- a/manifests/i/iammodev/YAKC/2.8.1/iammodev.YAKC.installer.yaml
+++ b/manifests/i/iammodev/YAKC/2.8.1/iammodev.YAKC.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: iammodev.YAKC
+PackageVersion: 2.8.1
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-08-13
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/iammodev/YAKC/releases/download/v2.8.1/YAKC_2.8.1_x64-setup.exe
+    InstallerSha256: 582EDAA55FBAED8A848CAEAFD79632D0641F067D6A2085248425387DB26041D7
+  - Architecture: arm64
+    InstallerUrl: https://github.com/iammodev/YAKC/releases/download/v2.8.1/YAKC_2.8.1_arm64-setup.exe
+    InstallerSha256: DEC22984DA87175F48941E7B01509CADEF1460925957D66D617363CFE0F6BF13
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/i/iammodev/YAKC/2.8.1/iammodev.YAKC.locale.en-US.yaml
+++ b/manifests/i/iammodev/YAKC/2.8.1/iammodev.YAKC.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: iammodev.YAKC
+PackageVersion: 2.8.1
+PackageLocale: en-US
+Publisher: Aslan Devecioglu
+PublisherUrl: https://github.com/iammodev
+PublisherSupportUrl: https://github.com/iammodev/YAKC/issues
+Author: Aslan Devecioglu
+PackageName: YAKC
+PackageUrl: https://github.com/iammodev/YAKC
+License: MIT
+LicenseUrl: https://github.com/iammodev/YAKC/blob/main/LICENSE
+ReleaseNotesUrl: https://github.com/iammodev/YAKC/releases/tag/v2.8.1
+ShortDescription: Yet Another Key Caster — cross-platform key & mouse click visualizer.
+Description: >-
+  YAKC (Yet Another Key Caster) is an open-source, cross-platform key & mouse
+  click visualizer for streamers, content creators, teachers and presenters.
+  It displays your keystrokes and mouse clicks as customizable on-screen popups,
+  with any keyboard language supported automatically.
+Moniker: yakc
+Tags:
+  - keycaster
+  - keystroke
+  - keystroke-visualizer
+  - overlay
+  - presentation
+  - screencast
+  - streaming
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/i/iammodev/YAKC/2.8.1/iammodev.YAKC.yaml
+++ b/manifests/i/iammodev/YAKC/2.8.1/iammodev.YAKC.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: iammodev.YAKC
+PackageVersion: 2.8.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Update to YAKC 2.8.1

Adds manifests for **iammodev.YAKC 2.8.1**. The package was previously stuck at 2.0.0; this brings winget in line with the current release.

- [x] Manifests added under `manifests/i/iammodev/YAKC/2.8.1/`
- [x] Installer URLs point to the signed GitHub release assets for v2.8.1
- [x] InstallerSha256 verified against the published `*-setup.exe` (x64 + arm64)

### Microsoft Reviewers
- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)
- [x] This PR only modifies one package
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change? Yes
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/416894)