### PR TITLE
New package: LeeorNahum.Diffscroll version 1.0.0

### DIFF
--- a/manifests/l/LeeorNahum/Diffscroll/1.0.0/LeeorNahum.Diffscroll.installer.yaml
+++ b/manifests/l/LeeorNahum/Diffscroll/1.0.0/LeeorNahum.Diffscroll.installer.yaml
@@ -1,5 +1,4 @@
-# Created using wingetcreate 1.12.13.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: LeeorNahum.Diffscroll
 PackageVersion: 1.0.0
@@ -14,11 +13,11 @@ InstallModes:
 UpgradeBehavior: install
 Commands:
 - diffscroll
+ReleaseDate: 2026-08-13
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/LeeorNahum/Diffscroll-Releases/releases/download/v1.0.0/Diffscroll-v1.0.0-windows-x86_64-setup.exe
   InstallerSha256: 1B9F0CE2E927ED53D6D4F5992FA9449F183221D39EC7B46645DC94EF2FA653F1
   ProductCode: Diffscroll
 ManifestType: installer
-ManifestVersion: 1.9.0
-ReleaseDate: 2026-08-13
+ManifestVersion: 1.12.0

--- a/manifests/l/LeeorNahum/Diffscroll/1.0.0/LeeorNahum.Diffscroll.installer.yaml
+++ b/manifests/l/LeeorNahum/Diffscroll/1.0.0/LeeorNahum.Diffscroll.installer.yaml
@@ -1,0 +1,24 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: LeeorNahum.Diffscroll
+PackageVersion: 1.0.0
+InstallerLocale: en-US
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Commands:
+- diffscroll
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/LeeorNahum/Diffscroll-Releases/releases/download/v1.0.0/Diffscroll-v1.0.0-windows-x86_64-setup.exe
+  InstallerSha256: 1B9F0CE2E927ED53D6D4F5992FA9449F183221D39EC7B46645DC94EF2FA653F1
+  ProductCode: Diffscroll
+ManifestType: installer
+ManifestVersion: 1.9.0
+ReleaseDate: 2026-08-13

--- a/manifests/l/LeeorNahum/Diffscroll/1.0.0/LeeorNahum.Diffscroll.locale.en-US.yaml
+++ b/manifests/l/LeeorNahum/Diffscroll/1.0.0/LeeorNahum.Diffscroll.locale.en-US.yaml
@@ -1,5 +1,4 @@
-# Created using wingetcreate 1.12.13.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: LeeorNahum.Diffscroll
 PackageVersion: 1.0.0
@@ -28,4 +27,4 @@ ReleaseNotes: |-
   The installer is per-user and needs no administrator elevation. It adds diffscroll to your PATH, registers the Explorer entries, and starts the resident process at sign-in. Uninstall removes only what it installed.
 ReleaseNotesUrl: https://github.com/LeeorNahum/Diffscroll-Releases/releases/tag/v1.0.0
 ManifestType: defaultLocale
-ManifestVersion: 1.9.0
+ManifestVersion: 1.12.0

--- a/manifests/l/LeeorNahum/Diffscroll/1.0.0/LeeorNahum.Diffscroll.locale.en-US.yaml
+++ b/manifests/l/LeeorNahum/Diffscroll/1.0.0/LeeorNahum.Diffscroll.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: LeeorNahum.Diffscroll
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: Leeor Nahum
+PublisherUrl: https://diffscroll.dev
+Author: Leeor Nahum
+PackageName: Diffscroll
+PackageUrl: https://diffscroll.dev
+License: Proprietary
+Copyright: Copyright (c) 2026 Leeor Nahum
+ShortDescription: A directory-scoped live Git diff viewer.
+Description: Point Diffscroll at a folder and every pending Git change renders as one smooth, syntax-highlighted scroll in a real window, submodule content included, read-only. The view stays live, refreshing as you save while holding your reading position. A global hotkey opens the changes you are looking at, and Explorer entries open a selected folder, a folder background, or a selected file's repository.
+Moniker: diffscroll
+Tags:
+- developer-tools
+- diff
+- diff-viewer
+- git
+- version-control
+ReleaseNotes: |-
+  The first public release.
+
+  Shows every pending change in the working tree as one continuous scroll: staged and unstaged, additions, deletions, renames, copies, mode changes, and binary files, each labeled for what it is. Nested repositories are collected recursively, so a submodule's own changed content appears inline. The view refreshes as you save while your reading position holds.
+
+  The installer is per-user and needs no administrator elevation. It adds diffscroll to your PATH, registers the Explorer entries, and starts the resident process at sign-in. Uninstall removes only what it installed.
+ReleaseNotesUrl: https://github.com/LeeorNahum/Diffscroll-Releases/releases/tag/v1.0.0
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/l/LeeorNahum/Diffscroll/1.0.0/LeeorNahum.Diffscroll.yaml
+++ b/manifests/l/LeeorNahum/Diffscroll/1.0.0/LeeorNahum.Diffscroll.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: LeeorNahum.Diffscroll
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0

--- a/manifests/l/LeeorNahum/Diffscroll/1.0.0/LeeorNahum.Diffscroll.yaml
+++ b/manifests/l/LeeorNahum/Diffscroll/1.0.0/LeeorNahum.Diffscroll.yaml
@@ -1,8 +1,7 @@
-# Created using wingetcreate 1.12.13.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: LeeorNahum.Diffscroll
 PackageVersion: 1.0.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.9.0
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package: `LeeorNahum.Diffscroll` version 1.0.0.

Diffscroll is a directory-scoped live Git diff viewer for Windows. Point it at a folder and every pending Git change renders as one syntax-highlighted scroll, submodule content included, read-only.

The installer is a per-user NSIS installer that needs no elevation. It is signed through Azure Artifact Signing and timestamped, and it supports silent install and uninstall.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

## Verification

Tested on Windows 11 26H1 with winget v1.29.280. `winget install --manifest` completed:

```
Found Diffscroll [LeeorNahum.Diffscroll] Version 1.0.0
Downloading https://github.com/LeeorNahum/Diffscroll-Releases/releases/download/v1.0.0/Diffscroll-v1.0.0-windows-x86_64-setup.exe
Successfully verified installer hash
Starting package install...
Successfully installed
```

The installer was separately confirmed against the release it points at:

- Downloaded from its public URL and matched the published SHA-256 `1B9F0CE2E927ED53D6D4F5992FA9449F183221D39EC7B46645DC94EF2FA653F1`.
- Authenticode `Valid`, signed `CN=Leeor Nahum, O=Leeor Nahum, L=Cherry Hill, S=nj, C=US`, timestamped by the Microsoft Public RSA Time Stamping Authority, chaining to `CN=Microsoft Identity Verification Root Certificate Authority 2020`.
- Installed and uninstalled silently with `/S`, the switch set this manifest's `nullsoft` type implies, both exiting 0. After uninstall every file, registry key, shortcut, and the `PATH` entry were gone, with `PATH` restored byte for byte.
- `ProductCode: Diffscroll` matches the real uninstall key at `HKCU\Software\Microsoft\Windows\CurrentVersion\Uninstall\Diffscroll`, and `Commands: diffscroll` matches the launcher the installer places on `PATH`.

Two notes offered rather than glossed over. Post-install, `winget list` reports the package as `ARP\User\X64\Diffscroll`, since it is not yet in a configured source for `ProductCode` correlation to resolve against; the declared `ProductCode` matches the ARP key name exactly, so that should resolve once this merges. And the application is newly signed with no SmartScreen reputation yet, so a reputation prompt currently appears on first run. That is reputation rather than a signature problem, and the release notes say so plainly.

Happy to run anything further that would help.
