### PR TITLE
New package: Momocrackcorp.JANUS version 2.2.0

### DIFF
--- a/manifests/m/Momocrackcorp/JANUS/2.2.0/Momocrackcorp.JANUS.installer.yaml
+++ b/manifests/m/Momocrackcorp/JANUS/2.2.0/Momocrackcorp.JANUS.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Momocrackcorp.JANUS
+PackageVersion: 2.2.0
+InstallerType: portable
+Scope: user
+UpgradeBehavior: install
+Commands:
+  - janus
+Installers:
+  - Architecture: neutral
+    InstallerUrl: https://github.com/momocrackcorp/janus-windows/releases/download/v2.2.0/Janus.exe
+    InstallerSha256: 1F995217E73D68D5369DAC644494D307DFF3028EA34E529E5B0D83343895CAC2
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/Momocrackcorp/JANUS/2.2.0/Momocrackcorp.JANUS.locale.es-CL.yaml
+++ b/manifests/m/Momocrackcorp/JANUS/2.2.0/Momocrackcorp.JANUS.locale.es-CL.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Momocrackcorp.JANUS
+PackageVersion: 2.2.0
+PackageLocale: es-CL
+Publisher: momocrackcorp
+PublisherUrl: https://github.com/momocrackcorp
+PublisherSupportUrl: https://github.com/momocrackcorp/janus-windows/issues
+Author: momocrackcorp
+PackageName: JANUS
+PackageUrl: https://github.com/momocrackcorp/janus-windows
+License: Proprietary
+Copyright: Copyright © 2026 momocrackcorp
+ShortDescription: Organiza y migra de forma segura las carpetas personales de Windows.
+Description: >-
+  JANUS facilita la puesta a punto después de una instalación limpia de Windows.
+  Permite asociar Escritorio, Documentos, Descargas, Imágenes, Música y Vídeos
+  con otra unidad o partición, creando respaldos, verificando los archivos y sin
+  borrar automáticamente los originales.
+Moniker: janus
+Tags:
+  - windows
+  - migracion
+  - carpetas
+  - respaldo
+  - seguridad
+  - utilidad
+ReleaseNotesUrl: https://github.com/momocrackcorp/janus-windows/releases/tag/v2.2.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/Momocrackcorp/JANUS/2.2.0/Momocrackcorp.JANUS.yaml
+++ b/manifests/m/Momocrackcorp/JANUS/2.2.0/Momocrackcorp.JANUS.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Momocrackcorp.JANUS
+PackageVersion: 2.2.0
+DefaultLocale: es-CL
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds JANUS 2.2.0 as a portable Windows application. The manifest uses the official versioned GitHub Release asset, the publisher-provided SHA-256 digest, and Spanish (Chile) metadata.

Package source: https://github.com/momocrackcorp/janus-windows

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (not applicable)

## 📦 Manifest Checklist

- [ ] Checked that there aren't other open pull requests for the same package
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with winget validate (WinGet is unavailable in the current environment)
- [ ] Tested manifest locally with winget install (WinGet is unavailable in the current environment)
- [x] Manifest conforms to the 1.12 schema
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/416949)