### PR TITLE
Add Tide.Tide version 0.1.2.0

### DIFF
--- a/manifests/t/Tide/Tide/0.1.2.0/Tide.Tide.installer.yaml
+++ b/manifests/t/Tide/Tide/0.1.2.0/Tide.Tide.installer.yaml
@@ -1,0 +1,20 @@
+PackageIdentifier: Tide.Tide
+PackageVersion: "0.1.2.0"
+InstallerType: nullsoft
+Installers:
+  - Architecture: x64
+    InstallerType: nullsoft
+    Scope: user
+    InstallerUrl: https://github.com/code-with-current/tide/releases/download/v0.1.2-beta/Tide-v0.1.2-beta-x64-Setup.exe
+    InstallerSha256: "01cd1969c088fe3ef509efade6c46bf09f8ab29119096886fdc44a03d0fc1f66"
+    Silent: /S
+    SilentWithProgress: /S
+    ProductCode: com.tide.code
+AppsAndFeaturesEntries:
+  - DisplayName: Tide
+    Publisher: Tide
+    DisplayVersion: "0.1.2-beta"
+    ProductCode: com.tide.code
+    InstallerType: nullsoft
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/t/Tide/Tide/0.1.2.0/Tide.Tide.installer.yaml
+++ b/manifests/t/Tide/Tide/0.1.2.0/Tide.Tide.installer.yaml
@@ -6,7 +6,7 @@ Installers:
     InstallerType: nullsoft
     Scope: user
     InstallerUrl: https://github.com/code-with-current/tide/releases/download/v0.1.2-beta/Tide-v0.1.2-beta-x64-Setup.exe
-    InstallerSha256: "01cd1969c088fe3ef509efade6c46bf09f8ab29119096886fdc44a03d0fc1f66"
+    InstallerSha256: "a235e4ac9019d6ebaba11b3c9dc574990d8721239a48ad42a325dfa5315a9813"
     Silent: /S
     SilentWithProgress: /S
     ProductCode: com.tide.code

--- a/manifests/t/Tide/Tide/0.1.2.0/Tide.Tide.locale.en-US.yaml
+++ b/manifests/t/Tide/Tide/0.1.2.0/Tide.Tide.locale.en-US.yaml
@@ -1,0 +1,24 @@
+PackageIdentifier: Tide.Tide
+PackageVersion: "0.1.2.0"
+PackageLocale: en-US
+Publisher: Tide
+PublisherUrl: https://tide.codes
+PublisherSupportUrl: https://github.com/code-with-current/tide/issues
+PackageName: Tide
+PackageUrl: https://tide.codes
+License: MIT
+LicenseUrl: https://github.com/code-with-current/tide/blob/master/LICENSE
+ShortDescription: Local-first agentic coding companion.
+Description: |-
+  Tide is a local-first agentic coding companion. It indexes your codebase
+  with local ONNX embeddings, gives the AI 20+ real tools, and puts you in
+  control with a permission system. Your code never leaves your machine.
+Tags:
+  - developer-tools
+  - ai
+  - agent
+  - coding
+  - electron
+ReleaseNotesUrl: https://github.com/code-with-current/tide/releases/tag/v0.1.2-beta
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/t/Tide/Tide/0.1.2.0/Tide.Tide.yaml
+++ b/manifests/t/Tide/Tide/0.1.2.0/Tide.Tide.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Tide.Tide
+PackageVersion: "0.1.2.0"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
New package: **Tide.Tide** version 0.1.2.0

- **Package**: Tide — a local-first agentic coding companion
- **Publisher**: Tide
- **Project**: https://tide.codes
- **Source**: https://github.com/code-with-current/tide
- **License**: MIT

Installer: NSIS (per-user, silent `/S`)
Architecture: x64

Pull request generated manually from the release assets at https://github.com/code-with-current/tide/releases/tag/v0.1.2-beta
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/416965)