### PR TITLE
New package: tungcorn.SpaceLens version 0.1.0

### DIFF
--- a/manifests/t/tungcorn/SpaceLens/0.1.0/tungcorn.SpaceLens.installer.yaml
+++ b/manifests/t/tungcorn/SpaceLens/0.1.0/tungcorn.SpaceLens.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: tungcorn.SpaceLens
+PackageVersion: 0.1.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: zip
+NestedInstallerType: portable
+ArchiveBinariesDependOnPath: true
+ReleaseDate: 2026-08-13
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/tungcorn/spacelens/releases/download/v0.1.0/spacelens-gui-v0.1.0-windows-x64.zip
+  InstallerSha256: 9DA45E0FA9EEDF45AF71A637D971C122FBC093C22650E3BE6EC0874CA7A334C3
+  NestedInstallerFiles:
+  - RelativeFilePath: spacelens-gui.exe
+    PortableCommandAlias: spacelens-gui
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/t/tungcorn/SpaceLens/0.1.0/tungcorn.SpaceLens.locale.en-US.yaml
+++ b/manifests/t/tungcorn/SpaceLens/0.1.0/tungcorn.SpaceLens.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: tungcorn.SpaceLens
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: tungcorn
+PublisherUrl: https://github.com/tungcorn
+PublisherSupportUrl: https://github.com/tungcorn/spacelens/issues
+Author: tungcorn
+PackageName: SpaceLens
+PackageUrl: https://github.com/tungcorn/spacelens
+License: MIT
+LicenseUrl: https://github.com/tungcorn/spacelens/blob/v0.1.0/LICENSE
+Copyright: Copyright (c) 2026 tungcorn
+ShortDescription: Fast native C++ storage intelligence and desktop analyzer for Windows.
+Description: SpaceLens is a native Windows desktop analyzer for storage discovery, indexed search, treemap visualization, Cleanup Review, and verified duplicates. Recycle Bin maintenance requires explicit human authorization. The companion CLI is a separate package and remains read-only. Qt 6.8.3 libraries in this package keep their own licenses.
+Moniker: spacelens
+Tags:
+- disk-analyzer
+- disk-usage
+- filesystem
+- storage
+ReleaseNotesUrl: https://github.com/tungcorn/spacelens/releases/tag/v0.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/tungcorn/SpaceLens/0.1.0/tungcorn.SpaceLens.yaml
+++ b/manifests/t/tungcorn/SpaceLens/0.1.0/tungcorn.SpaceLens.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: tungcorn.SpaceLens
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
This PR adds the SpaceLens desktop GUI 0.1.0.

- PackageIdentifier: tungcorn.SpaceLens
- InstallerType: zip / NestedInstallerType: portable
- Public GitHub Release asset (immutable v0.1.0 URL + SHA-256)
- PortableCommandAlias: spacelens-gui
- ArchiveBinariesDependOnPath: true so the bundled Qt 6.8.3 DLLs/plugins stay resolvable
- Dependency: Microsoft.VCRedist.2015+.x64
- Companion CLI is a separate package (tungcorn.SpaceLens.CLI)

WinGet portable install does not create a Start Menu shortcut. Launch with `spacelens-gui` or from the package folder.

Checklist
- [x] Have you signed the Contributor License Agreement if you haven't already signed it before?
- [ ] Have you linked any related issues or pull requests by using "Resolves **#NNNN**"?
- [x] Have you checked that there isn't already a PR for this change?
- [x] Does your submission pass local validation? (winget validate --manifest <path>)
- [x] Have you tested your manifest locally with winget install --manifest <path>?
- [x] Have you checked that your submission conforms to the 1.12 schema?

Tested locally on Windows 11 x64, user scope. Extracted layout keeps Qt6*.dll and platforms\qwindows.dll. GUI process launched. Uninstall removes package files and does not delete SpaceLens AppData state.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/417001)