### PR TITLE
New version: SerZhyAle.DocHtmlTranslate version 26.0813.1917

### DIFF
--- a/manifests/s/SerZhyAle/DocHtmlTranslate/26.0813.1917/SerZhyAle.DocHtmlTranslate.installer.yaml
+++ b/manifests/s/SerZhyAle/DocHtmlTranslate/26.0813.1917/SerZhyAle.DocHtmlTranslate.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: SerZhyAle.DocHtmlTranslate
+PackageVersion: "26.0813.1917"
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: doc-html-translate.exe
+  PortableCommandAlias: doc-html-translate
+- RelativeFilePath: doc-html-ui.exe
+  PortableCommandAlias: doc-html-ui
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/SerZhyAle/doc-html-translate/releases/download/v26.0813.1917/doc-html-translate-26.0813.1917-windows-x64.zip
+  InstallerSha256: 3F0877351CB6A2C3B35BB47346AE5B2C65421932FE10D1DF03EF53CA8BD66C33
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-08-13

--- a/manifests/s/SerZhyAle/DocHtmlTranslate/26.0813.1917/SerZhyAle.DocHtmlTranslate.locale.ar-SA.yaml
+++ b/manifests/s/SerZhyAle/DocHtmlTranslate/26.0813.1917/SerZhyAle.DocHtmlTranslate.locale.ar-SA.yaml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: SerZhyAle.DocHtmlTranslate
+PackageVersion: "26.0813.1917"
+PackageLocale: ar-SA
+Publisher: SZA
+PublisherUrl: https://github.com/SerZhyAle
+PublisherSupportUrl: https://github.com/SerZhyAle/doc-html-translate/issues
+Author: Serhii Zhyhunenko
+PackageName: doc-html-translate
+PackageUrl: https://github.com/SerZhyAle/doc-html-translate
+License: MIT
+LicenseUrl: https://github.com/SerZhyAle/doc-html-translate/blob/main/LICENSE
+Copyright: Copyright (c) 2026 SerZhyAle
+ShortDescription: "يحوّل ملفات EPUB وPDF وMOBI وAZW3 وFB2 وRTF وTXT وMarkdown وHTML إلى HTML محلي نظيف، بفهرس حقيقي، واستخراج النص من الصور، وترجمة اختيارية عبر Google أو Ollama."
+Description: |-
+  ‏doc-html-translate تطبيق لنظام Windows يحوّل المستندات (EPUB وPDF وMOBI وAZW3 وFB2 وRTF وTXT
+  وMarkdown وHTML) إلى HTML محلي نظيف مع تنقّل مُولَّد وفهرس حقيقي متعدد المستويات. يضيف القارئ المدمج
+  سمات light وsepia وdark وnight، والتحكم في حجم الخط ونوعه، ويتذكر موضع القراءة. ويستطيع استخراج النص
+  من داخل الصور (التعرف الضوئي - الإنجليزية مضمّنة وبقية اللغات عند الطلب)، وترجمة كل شيء إن أردت عبر
+  Google Cloud Translation API أو نموذج Ollama محلي. الواجهة متاحة بثلاث عشرة لغة. يمكنك الحصول على
+  صفحة واحدة طويلة أو فصول مع فهرس. وإعادة فتح كتاب سبق تحويله فورية. تضم الحزمة واجهة سطر الأوامر
+  (doc-html-translate) وواجهة رسومية صغيرة (doc-html-ui). أداة pdftotext مضمّنة داخل الملف التنفيذي؛
+  أما MOBI وAZW3 فتحتاج إضافة إلى تثبيت Calibre (الملفات الخالية من الحماية الرقمية فقط).
+Tags:
+- azw3
+- cli
+- ebook
+- epub
+- fb2
+- google-translate
+- html
+- markdown
+- mobi
+- ocr
+- ollama
+- pdf
+- rtf
+- translation
+- txt
+- windows
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/s/SerZhyAle/DocHtmlTranslate/26.0813.1917/SerZhyAle.DocHtmlTranslate.locale.bn-BD.yaml
+++ b/manifests/s/SerZhyAle/DocHtmlTranslate/26.0813.1917/SerZhyAle.DocHtmlTranslate.locale.bn-BD.yaml
@@ -1,0 +1,44 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: SerZhyAle.DocHtmlTranslate
+PackageVersion: "26.0813.1917"
+PackageLocale: bn-BD
+Publisher: SZA
+PublisherUrl: https://github.com/SerZhyAle
+PublisherSupportUrl: https://github.com/SerZhyAle/doc-html-translate/issues
+Author: Serhii Zhyhunenko
+PackageName: doc-html-translate
+PackageUrl: https://github.com/SerZhyAle/doc-html-translate
+License: MIT
+LicenseUrl: https://github.com/SerZhyAle/doc-html-translate/blob/main/LICENSE
+Copyright: Copyright (c) 2026 SerZhyAle
+ShortDescription: "EPUB, PDF, MOBI, AZW3, FB2, RTF, TXT, Markdown ও HTML-কে পরিচ্ছন্ন স্থানীয় HTML-এ রূপান্তর করে - সত্যিকারের সূচিপত্র, ছবিতে লেখা শনাক্তকরণ এবং Google বা Ollama দিয়ে ঐচ্ছিক অনুবাদসহ।"
+Description: |-
+  doc-html-translate একটি Windows অ্যাপ্লিকেশন, যা নথি (EPUB, PDF, MOBI, AZW3, FB2, RTF, TXT,
+  Markdown, HTML) পরিচ্ছন্ন স্থানীয় HTML-এ রূপান্তর করে, সঙ্গে তৈরি নেভিগেশন ও সত্যিকারের বহুস্তরের
+  সূচিপত্র। অন্তর্নির্মিত রিডার light/sepia/dark/night থিম, লেখার আকার ও ফন্ট নিয়ন্ত্রণ যোগ করে এবং
+  পাঠ-অবস্থান মনে রাখে। এটি ছবির ভিতরের লেখা শনাক্ত করতে পারে (OCR - ইংরেজি সঙ্গে দেওয়া, বাকি ভাষা
+  চাহিদামতো) এবং চাইলে সব কিছু Google Cloud Translation API বা স্থানীয় Ollama মডেল দিয়ে অনুবাদ করতে
+  পারে। ইন্টারফেস ১৩টি ভাষায় পাওয়া যায়। আপনি একটিমাত্র লম্বা পৃষ্ঠা পেতে পারেন, বা সূচিপত্রসহ
+  অধ্যায়। আগে রূপান্তরিত বই আবার খোলা তাৎক্ষণিক। প্যাকেজে CLI (doc-html-translate) ও একটি ছোট GUI
+  (doc-html-ui) দুটোই আছে। pdftotext বাইনারির ভিতরেই আছে; MOBI ও AZW3-এর জন্য অতিরিক্তভাবে Calibre
+  ইনস্টল থাকা দরকার (কেবল DRM-মুক্ত ফাইল)।
+Tags:
+- azw3
+- cli
+- ebook
+- epub
+- fb2
+- google-translate
+- html
+- markdown
+- mobi
+- ocr
+- ollama
+- pdf
+- rtf
+- translation
+- txt
+- windows
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/s/SerZhyAle/DocHtmlTranslate/26.0813.1917/SerZhyAle.DocHtmlTranslate.locale.de-DE.yaml
+++ b/manifests/s/SerZhyAle/DocHtmlTranslate/26.0813.1917/SerZhyAle.DocHtmlTranslate.locale.de-DE.yaml
@@ -1,0 +1,45 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: SerZhyAle.DocHtmlTranslate
+PackageVersion: "26.0813.1917"
+PackageLocale: de-DE
+Publisher: SZA
+PublisherUrl: https://github.com/SerZhyAle
+PublisherSupportUrl: https://github.com/SerZhyAle/doc-html-translate/issues
+Author: Serhii Zhyhunenko
+PackageName: doc-html-translate
+PackageUrl: https://github.com/SerZhyAle/doc-html-translate
+License: MIT
+LicenseUrl: https://github.com/SerZhyAle/doc-html-translate/blob/main/LICENSE
+Copyright: Copyright (c) 2026 SerZhyAle
+ShortDescription: "Wandelt EPUB, PDF, MOBI, AZW3, FB2, RTF, TXT, Markdown und HTML in sauberes lokales HTML um - mit echtem Inhaltsverzeichnis, Texterkennung in Bildern und optionaler Übersetzung über Google oder Ollama."
+Description: |-
+  doc-html-translate ist eine Windows-Anwendung, die Dokumente (EPUB, PDF, MOBI, AZW3, FB2, RTF, TXT,
+  Markdown, HTML) in sauberes lokales HTML mit erzeugter Navigation und einem echten mehrstufigen
+  Inhaltsverzeichnis umwandelt. Der eingebaute Reader bringt Light-/Sepia-/Dark-/Night-Themes,
+  Schriftgröße und Schriftart mit und merkt sich die Leseposition. Text in Bildern kann erkannt werden
+  (OCR - Englisch ist enthalten, weitere Sprachen auf Wunsch), und auf Wunsch übersetzt die App alles
+  über die Google Cloud Translation API oder ein lokales Ollama-Modell. Die Oberfläche gibt es in 13
+  Sprachen. Wahlweise eine lange Einzelseite oder Kapitel mit Inhaltsverzeichnis. Ein bereits
+  konvertiertes Buch öffnet sich sofort wieder. Das Paket enthält sowohl die CLI (doc-html-translate)
+  als auch eine kleine Oberfläche (doc-html-ui). pdftotext steckt in der Binärdatei; MOBI und AZW3
+  brauchen zusätzlich ein installiertes Calibre (nur Dateien ohne DRM).
+Tags:
+- azw3
+- cli
+- ebook
+- epub
+- fb2
+- google-translate
+- html
+- markdown
+- mobi
+- ocr
+- ollama
+- pdf
+- rtf
+- translation
+- txt
+- windows
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/s/SerZhyAle/DocHtmlTranslate/26.0813.1917/SerZhyAle.DocHtmlTranslate.locale.en-US.yaml
+++ b/manifests/s/SerZhyAle/DocHtmlTranslate/26.0813.1917/SerZhyAle.DocHtmlTranslate.locale.en-US.yaml
@@ -1,0 +1,51 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: SerZhyAle.DocHtmlTranslate
+PackageVersion: "26.0813.1917"
+PackageLocale: en-US
+Publisher: SZA
+PublisherUrl: https://github.com/SerZhyAle
+PublisherSupportUrl: https://github.com/SerZhyAle/doc-html-translate/issues
+Author: Serhii Zhyhunenko
+PackageName: doc-html-translate
+PackageUrl: https://github.com/SerZhyAle/doc-html-translate
+License: MIT
+LicenseUrl: https://github.com/SerZhyAle/doc-html-translate/blob/main/LICENSE
+Copyright: Copyright (c) 2026 SerZhyAle
+ShortDescription: Convert EPUB, PDF, MOBI, AZW3, FB2, RTF, TXT, Markdown and HTML to clean local HTML with a real table of contents, image-text OCR, and optional Google or Ollama translation.
+Description: |-
+  doc-html-translate is a Windows app that converts documents (EPUB, PDF, MOBI, AZW3, FB2,
+  RTF, TXT, Markdown, HTML) into clean local HTML with generated navigation and a real
+  multi-level table of contents. A built-in reader adds light/sepia/dark/night themes, text
+  size and font controls, and remembers your reading position. It can recognize text inside
+  images (OCR - English bundled, more languages on demand) and optionally translate everything
+  via the Google Cloud Translation API or a local Ollama model. The interface is available in 13
+  languages. Convert to one long single page
+  or keep chapters with a table of contents. Re-opening an already-converted book is instant.
+  The package ships both the CLI (doc-html-translate) and a small GUI launcher (doc-html-ui).
+  pdftotext is bundled inside the binary; MOBI and AZW3 conversion additionally requires
+  Calibre to be installed (non-DRM files only).
+Moniker: doc-html-translate
+Tags:
+- azw3
+- cli
+- ebook
+- epub
+- fb2
+- google-translate
+- html
+- markdown
+- mobi
+- ocr
+- ollama
+- pdf
+- rtf
+- translation
+- txt
+- windows
+ReleaseNotesUrl: https://github.com/SerZhyAle/doc-html-translate/releases/tag/v26.0813.1917
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/SerZhyAle/doc-html-translate/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/SerZhyAle/DocHtmlTranslate/26.0813.1917/SerZhyAle.DocHtmlTranslate.locale.es-ES.yaml
+++ b/manifests/s/SerZhyAle/DocHtmlTranslate/26.0813.1917/SerZhyAle.DocHtmlTranslate.locale.es-ES.yaml
@@ -1,0 +1,45 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: SerZhyAle.DocHtmlTranslate
+PackageVersion: "26.0813.1917"
+PackageLocale: es-ES
+Publisher: SZA
+PublisherUrl: https://github.com/SerZhyAle
+PublisherSupportUrl: https://github.com/SerZhyAle/doc-html-translate/issues
+Author: Serhii Zhyhunenko
+PackageName: doc-html-translate
+PackageUrl: https://github.com/SerZhyAle/doc-html-translate
+License: MIT
+LicenseUrl: https://github.com/SerZhyAle/doc-html-translate/blob/main/LICENSE
+Copyright: Copyright (c) 2026 SerZhyAle
+ShortDescription: "Convierte EPUB, PDF, MOBI, AZW3, FB2, RTF, TXT, Markdown y HTML en HTML local limpio, con un índice de verdad, reconocimiento de texto en imágenes y traducción opcional mediante Google u Ollama."
+Description: |-
+  doc-html-translate es una aplicación de Windows que convierte documentos (EPUB, PDF, MOBI, AZW3,
+  FB2, RTF, TXT, Markdown, HTML) en HTML local limpio, con navegación generada y un índice real de
+  varios niveles. El lector integrado añade los temas light/sepia/dark/night, control del tamaño y la
+  familia de letra, y recuerda la posición de lectura. Puede reconocer el texto de las imágenes (OCR -
+  inglés incluido, más idiomas a petición) y, si quieres, traducirlo todo con la API de Google Cloud
+  Translation o un modelo local de Ollama. La interfaz está disponible en 13 idiomas. Puedes obtener
+  una sola página larga o capítulos con índice. Volver a abrir un libro ya convertido es instantáneo.
+  El paquete incluye tanto la CLI (doc-html-translate) como una pequeña interfaz (doc-html-ui).
+  pdftotext va dentro del binario; MOBI y AZW3 necesitan además Calibre instalado (solo archivos sin
+  DRM).
+Tags:
+- azw3
+- cli
+- ebook
+- epub
+- fb2
+- google-translate
+- html
+- markdown
+- mobi
+- ocr
+- ollama
+- pdf
+- rtf
+- translation
+- txt
+- windows
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/s/SerZhyAle/DocHtmlTranslate/26.0813.1917/SerZhyAle.DocHtmlTranslate.locale.fr-FR.yaml
+++ b/manifests/s/SerZhyAle/DocHtmlTranslate/26.0813.1917/SerZhyAle.DocHtmlTranslate.locale.fr-FR.yaml
@@ -1,0 +1,45 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: SerZhyAle.DocHtmlTranslate
+PackageVersion: "26.0813.1917"
+PackageLocale: fr-FR
+Publisher: SZA
+PublisherUrl: https://github.com/SerZhyAle
+PublisherSupportUrl: https://github.com/SerZhyAle/doc-html-translate/issues
+Author: Serhii Zhyhunenko
+PackageName: doc-html-translate
+PackageUrl: https://github.com/SerZhyAle/doc-html-translate
+License: MIT
+LicenseUrl: https://github.com/SerZhyAle/doc-html-translate/blob/main/LICENSE
+Copyright: Copyright (c) 2026 SerZhyAle
+ShortDescription: "Convertit EPUB, PDF, MOBI, AZW3, FB2, RTF, TXT, Markdown et HTML en HTML local propre, avec une vraie table des matières, la reconnaissance du texte dans les images et une traduction facultative via Google ou Ollama."
+Description: |-
+  doc-html-translate est une application Windows qui convertit des documents (EPUB, PDF, MOBI, AZW3,
+  FB2, RTF, TXT, Markdown, HTML) en HTML local propre, avec une navigation générée et une véritable
+  table des matières à plusieurs niveaux. Le lecteur intégré ajoute les thèmes light/sepia/dark/night,
+  le réglage de la taille et de la police, et retient la position de lecture. Il sait reconnaître le
+  texte dans les images (OCR - l'anglais est fourni, les autres langues à la demande) et, si vous le
+  souhaitez, tout traduire via l'API Google Cloud Translation ou un modèle Ollama local. L'interface
+  existe en 13 langues. Vous pouvez obtenir une seule longue page ou des chapitres avec table des
+  matières. Rouvrir un livre déjà converti est instantané. Le paquet contient à la fois la CLI
+  (doc-html-translate) et une petite interface (doc-html-ui). pdftotext est inclus dans le binaire ;
+  MOBI et AZW3 nécessitent en plus Calibre installé (fichiers sans DRM uniquement).
+Tags:
+- azw3
+- cli
+- ebook
+- epub
+- fb2
+- google-translate
+- html
+- markdown
+- mobi
+- ocr
+- ollama
+- pdf
+- rtf
+- translation
+- txt
+- windows
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/s/SerZhyAle/DocHtmlTranslate/26.0813.1917/SerZhyAle.DocHtmlTranslate.locale.hi-IN.yaml
+++ b/manifests/s/SerZhyAle/DocHtmlTranslate/26.0813.1917/SerZhyAle.DocHtmlTranslate.locale.hi-IN.yaml
@@ -1,0 +1,44 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: SerZhyAle.DocHtmlTranslate
+PackageVersion: "26.0813.1917"
+PackageLocale: hi-IN
+Publisher: SZA
+PublisherUrl: https://github.com/SerZhyAle
+PublisherSupportUrl: https://github.com/SerZhyAle/doc-html-translate/issues
+Author: Serhii Zhyhunenko
+PackageName: doc-html-translate
+PackageUrl: https://github.com/SerZhyAle/doc-html-translate
+License: MIT
+LicenseUrl: https://github.com/SerZhyAle/doc-html-translate/blob/main/LICENSE
+Copyright: Copyright (c) 2026 SerZhyAle
+ShortDescription: "EPUB, PDF, MOBI, AZW3, FB2, RTF, TXT, Markdown और HTML को साफ़ स्थानीय HTML में बदलता है - असली विषय-सूची, छवियों में पाठ पहचान और Google या Ollama से वैकल्पिक अनुवाद के साथ।"
+Description: |-
+  doc-html-translate एक Windows एप्लिकेशन है जो दस्तावेज़ों (EPUB, PDF, MOBI, AZW3, FB2, RTF, TXT,
+  Markdown, HTML) को साफ़ स्थानीय HTML में बदलता है, जिसमें बनी हुई नेविगेशन और असली बहुस्तरीय
+  विषय-सूची होती है। अंतर्निहित रीडर light/sepia/dark/night थीम, पाठ का आकार और फ़ॉन्ट नियंत्रण जोड़ता
+  है और पठन-स्थिति याद रखता है। यह छवियों के भीतर का पाठ पहचान सकता है (OCR - अंग्रेज़ी साथ में, बाकी
+  भाषाएँ माँग पर) और चाहें तो सब कुछ Google Cloud Translation API या स्थानीय Ollama मॉडल से अनुवाद कर
+  सकता है। इंटरफ़ेस 13 भाषाओं में उपलब्ध है। आप एक लंबा पृष्ठ पा सकते हैं या विषय-सूची सहित अध्याय।
+  पहले से बदली गई पुस्तक दोबारा खोलना तुरंत होता है। पैकेज में CLI (doc-html-translate) और एक छोटा GUI
+  (doc-html-ui), दोनों हैं। pdftotext बाइनरी के भीतर ही है; MOBI और AZW3 के लिए इसके अलावा Calibre
+  स्थापित होना चाहिए (केवल DRM-रहित फ़ाइलें)।
+Tags:
+- azw3
+- cli
+- ebook
+- epub
+- fb2
+- google-translate
+- html
+- markdown
+- mobi
+- ocr
+- ollama
+- pdf
+- rtf
+- translation
+- txt
+- windows
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/s/SerZhyAle/DocHtmlTranslate/26.0813.1917/SerZhyAle.DocHtmlTranslate.locale.it-IT.yaml
+++ b/manifests/s/SerZhyAle/DocHtmlTranslate/26.0813.1917/SerZhyAle.DocHtmlTranslate.locale.it-IT.yaml
@@ -1,0 +1,45 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: SerZhyAle.DocHtmlTranslate
+PackageVersion: "26.0813.1917"
+PackageLocale: it-IT
+Publisher: SZA
+PublisherUrl: https://github.com/SerZhyAle
+PublisherSupportUrl: https://github.com/SerZhyAle/doc-html-translate/issues
+Author: Serhii Zhyhunenko
+PackageName: doc-html-translate
+PackageUrl: https://github.com/SerZhyAle/doc-html-translate
+License: MIT
+LicenseUrl: https://github.com/SerZhyAle/doc-html-translate/blob/main/LICENSE
+Copyright: Copyright (c) 2026 SerZhyAle
+ShortDescription: "Converte EPUB, PDF, MOBI, AZW3, FB2, RTF, TXT, Markdown e HTML in HTML locale pulito, con un vero indice, riconoscimento del testo nelle immagini e traduzione opzionale tramite Google o Ollama."
+Description: |-
+  doc-html-translate è un'applicazione Windows che converte documenti (EPUB, PDF, MOBI, AZW3, FB2,
+  RTF, TXT, Markdown, HTML) in HTML locale pulito, con navigazione generata e un vero indice a più
+  livelli. Il lettore integrato aggiunge i temi light/sepia/dark/night, il controllo di dimensione e
+  famiglia del carattere e ricorda la posizione di lettura. Può riconoscere il testo dentro le
+  immagini (OCR - inglese incluso, altre lingue su richiesta) e, se vuoi, tradurre tutto tramite
+  Google Cloud Translation API o un modello Ollama locale. L'interfaccia è disponibile in 13 lingue.
+  Puoi ottenere un'unica pagina lunga oppure i capitoli con l'indice. Riaprire un libro già convertito
+  è immediato. Il pacchetto contiene sia la CLI (doc-html-translate) sia una piccola interfaccia
+  (doc-html-ui). pdftotext è incluso nel binario; MOBI e AZW3 richiedono inoltre Calibre installato
+  (solo file senza DRM).
+Tags:
+- azw3
+- cli
+- ebook
+- epub
+- fb2
+- google-translate
+- html
+- markdown
+- mobi
+- ocr
+- ollama
+- pdf
+- rtf
+- translation
+- txt
+- windows
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/s/SerZhyAle/DocHtmlTranslate/26.0813.1917/SerZhyAle.DocHtmlTranslate.locale.pt-BR.yaml
+++ b/manifests/s/SerZhyAle/DocHtmlTranslate/26.0813.1917/SerZhyAle.DocHtmlTranslate.locale.pt-BR.yaml
@@ -1,0 +1,45 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: SerZhyAle.DocHtmlTranslate
+PackageVersion: "26.0813.1917"
+PackageLocale: pt-BR
+Publisher: SZA
+PublisherUrl: https://github.com/SerZhyAle
+PublisherSupportUrl: https://github.com/SerZhyAle/doc-html-translate/issues
+Author: Serhii Zhyhunenko
+PackageName: doc-html-translate
+PackageUrl: https://github.com/SerZhyAle/doc-html-translate
+License: MIT
+LicenseUrl: https://github.com/SerZhyAle/doc-html-translate/blob/main/LICENSE
+Copyright: Copyright (c) 2026 SerZhyAle
+ShortDescription: "Converte EPUB, PDF, MOBI, AZW3, FB2, RTF, TXT, Markdown e HTML em HTML local limpo, com um sumário de verdade, reconhecimento de texto em imagens e tradução opcional via Google ou Ollama."
+Description: |-
+  doc-html-translate é um aplicativo para Windows que converte documentos (EPUB, PDF, MOBI, AZW3, FB2,
+  RTF, TXT, Markdown, HTML) em HTML local limpo, com navegação gerada e um sumário real de vários
+  níveis. O leitor embutido acrescenta os temas light/sepia/dark/night, controle de tamanho e família
+  da fonte, e lembra a posição de leitura. Ele reconhece o texto dentro de imagens (OCR - inglês
+  incluído, outros idiomas sob demanda) e, se você quiser, traduz tudo pela API do Google Cloud
+  Translation ou por um modelo local do Ollama. A interface está disponível em 13 idiomas. Você pode
+  obter uma única página longa ou capítulos com sumário. Reabrir um livro já convertido é instantâneo.
+  O pacote traz tanto a CLI (doc-html-translate) quanto uma pequena interface (doc-html-ui). O
+  pdftotext vem dentro do binário; MOBI e AZW3 exigem ainda o Calibre instalado (apenas arquivos sem
+  DRM).
+Tags:
+- azw3
+- cli
+- ebook
+- epub
+- fb2
+- google-translate
+- html
+- markdown
+- mobi
+- ocr
+- ollama
+- pdf
+- rtf
+- translation
+- txt
+- windows
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/s/SerZhyAle/DocHtmlTranslate/26.0813.1917/SerZhyAle.DocHtmlTranslate.locale.ru-RU.yaml
+++ b/manifests/s/SerZhyAle/DocHtmlTranslate/26.0813.1917/SerZhyAle.DocHtmlTranslate.locale.ru-RU.yaml
@@ -1,0 +1,45 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: SerZhyAle.DocHtmlTranslate
+PackageVersion: "26.0813.1917"
+PackageLocale: ru-RU
+Publisher: SZA
+PublisherUrl: https://github.com/SerZhyAle
+PublisherSupportUrl: https://github.com/SerZhyAle/doc-html-translate/issues
+Author: Serhii Zhyhunenko
+PackageName: doc-html-translate
+PackageUrl: https://github.com/SerZhyAle/doc-html-translate
+License: MIT
+LicenseUrl: https://github.com/SerZhyAle/doc-html-translate/blob/main/LICENSE
+Copyright: Copyright (c) 2026 SerZhyAle
+ShortDescription: "Преобразует EPUB, PDF, MOBI, AZW3, FB2, RTF, TXT, Markdown и HTML в чистый локальный HTML с настоящим оглавлением, распознаванием текста на изображениях и необязательным переводом через Google или Ollama."
+Description: |-
+  doc-html-translate - приложение для Windows, которое превращает документы (EPUB, PDF, MOBI, AZW3,
+  FB2, RTF, TXT, Markdown, HTML) в чистый локальный HTML с созданной навигацией и настоящим
+  многоуровневым оглавлением. Встроенная читалка добавляет темы light/sepia/dark/night, управление
+  размером и гарнитурой шрифта и запоминает место чтения. Приложение умеет распознавать текст на
+  изображениях (OCR - английский в комплекте, остальные языки по запросу) и по желанию переводить всё
+  через Google Cloud Translation API или локальную модель Ollama. Интерфейс доступен на 13 языках.
+  Можно получить одну длинную страницу или главы с оглавлением. Повторное открытие уже
+  сконвертированной книги мгновенно. В пакете есть и CLI (doc-html-translate), и небольшой GUI
+  (doc-html-ui). pdftotext встроен в бинарник; для MOBI и AZW3 дополнительно нужен установленный
+  Calibre (только файлы без DRM).
+Tags:
+- azw3
+- cli
+- ebook
+- epub
+- fb2
+- google-translate
+- html
+- markdown
+- mobi
+- ocr
+- ollama
+- pdf
+- rtf
+- translation
+- txt
+- windows
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/s/SerZhyAle/DocHtmlTranslate/26.0813.1917/SerZhyAle.DocHtmlTranslate.locale.uk-UA.yaml
+++ b/manifests/s/SerZhyAle/DocHtmlTranslate/26.0813.1917/SerZhyAle.DocHtmlTranslate.locale.uk-UA.yaml
@@ -1,0 +1,44 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: SerZhyAle.DocHtmlTranslate
+PackageVersion: "26.0813.1917"
+PackageLocale: uk-UA
+Publisher: SZA
+PublisherUrl: https://github.com/SerZhyAle
+PublisherSupportUrl: https://github.com/SerZhyAle/doc-html-translate/issues
+Author: Serhii Zhyhunenko
+PackageName: doc-html-translate
+PackageUrl: https://github.com/SerZhyAle/doc-html-translate
+License: MIT
+LicenseUrl: https://github.com/SerZhyAle/doc-html-translate/blob/main/LICENSE
+Copyright: Copyright (c) 2026 SerZhyAle
+ShortDescription: "Перетворює EPUB, PDF, MOBI, AZW3, FB2, RTF, TXT, Markdown і HTML на чистий локальний HTML зі справжнім змістом, розпізнаванням тексту на зображеннях і необов'язковим перекладом через Google або Ollama."
+Description: |-
+  doc-html-translate - застосунок для Windows, який перетворює документи (EPUB, PDF, MOBI, AZW3, FB2,
+  RTF, TXT, Markdown, HTML) на чистий локальний HTML зі створеною навігацією та справжнім
+  багаторівневим змістом. Вбудована читалка додає теми light/sepia/dark/night, керування розміром і
+  гарнітурою шрифту та запам'ятовує місце читання. Застосунок уміє розпізнавати текст на зображеннях
+  (OCR - англійська в комплекті, інші мови на вимогу) і за бажанням перекладати все через Google Cloud
+  Translation API або локальну модель Ollama. Інтерфейс доступний 13 мовами. Можна отримати одну довгу
+  сторінку або розділи зі змістом. Повторне відкриття вже сконвертованої книжки миттєве. У пакеті є і
+  CLI (doc-html-translate), і невеликий GUI (doc-html-ui). pdftotext вбудований у бінарник; для MOBI
+  та AZW3 додатково потрібен встановлений Calibre (лише файли без DRM).
+Tags:
+- azw3
+- cli
+- ebook
+- epub
+- fb2
+- google-translate
+- html
+- markdown
+- mobi
+- ocr
+- ollama
+- pdf
+- rtf
+- translation
+- txt
+- windows
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/s/SerZhyAle/DocHtmlTranslate/26.0813.1917/SerZhyAle.DocHtmlTranslate.locale.ur-PK.yaml
+++ b/manifests/s/SerZhyAle/DocHtmlTranslate/26.0813.1917/SerZhyAle.DocHtmlTranslate.locale.ur-PK.yaml
@@ -1,0 +1,44 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: SerZhyAle.DocHtmlTranslate
+PackageVersion: "26.0813.1917"
+PackageLocale: ur-PK
+Publisher: SZA
+PublisherUrl: https://github.com/SerZhyAle
+PublisherSupportUrl: https://github.com/SerZhyAle/doc-html-translate/issues
+Author: Serhii Zhyhunenko
+PackageName: doc-html-translate
+PackageUrl: https://github.com/SerZhyAle/doc-html-translate
+License: MIT
+LicenseUrl: https://github.com/SerZhyAle/doc-html-translate/blob/main/LICENSE
+Copyright: Copyright (c) 2026 SerZhyAle
+ShortDescription: "‏EPUB، PDF، MOBI، AZW3، FB2، RTF، TXT، Markdown اور HTML کو صاف ستھرے مقامی HTML میں بدلتا ہے - اصل فہرست، تصاویر میں متن کی شناخت اور Google یا Ollama کے ذریعے اختیاری ترجمے کے ساتھ۔"
+Description: |-
+  ‏doc-html-translate ونڈوز کی ایک ایپلیکیشن ہے جو دستاویزات (EPUB، PDF، MOBI، AZW3، FB2، RTF، TXT،
+  Markdown، HTML) کو صاف ستھرے مقامی HTML میں بدلتی ہے، ساتھ میں تیار شدہ نیویگیشن اور اصل کثیر سطحی
+  فہرست۔ بلٹ اِن ریڈر light/sepia/dark/night تھیمز، متن کے سائز اور فونٹ کا کنٹرول دیتا ہے اور مقامِ
+  مطالعہ یاد رکھتا ہے۔ یہ تصاویر کے اندر کا متن پہچان سکتی ہے (او سی آر - انگریزی شامل ہے، باقی زبانیں
+  طلب پر) اور چاہیں تو سب کچھ Google Cloud Translation API یا مقامی Ollama ماڈل سے ترجمہ کر سکتی ہے۔
+  انٹرفیس 13 زبانوں میں دستیاب ہے۔ آپ ایک لمبا صفحہ حاصل کر سکتے ہیں یا فہرست کے ساتھ ابواب۔ پہلے سے
+  تبدیل شدہ کتاب دوبارہ کھولنا فوری ہے۔ پیکیج میں CLI (doc-html-translate) اور ایک چھوٹا GUI
+  (doc-html-ui) دونوں شامل ہیں۔ pdftotext بائنری کے اندر ہی ہے؛ MOBI اور AZW3 کے لیے مزید یہ کہ
+  Calibre نصب ہونا چاہیے (صرف DRM سے پاک فائلیں)۔
+Tags:
+- azw3
+- cli
+- ebook
+- epub
+- fb2
+- google-translate
+- html
+- markdown
+- mobi
+- ocr
+- ollama
+- pdf
+- rtf
+- translation
+- txt
+- windows
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/s/SerZhyAle/DocHtmlTranslate/26.0813.1917/SerZhyAle.DocHtmlTranslate.locale.zh-CN.yaml
+++ b/manifests/s/SerZhyAle/DocHtmlTranslate/26.0813.1917/SerZhyAle.DocHtmlTranslate.locale.zh-CN.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: SerZhyAle.DocHtmlTranslate
+PackageVersion: "26.0813.1917"
+PackageLocale: zh-CN
+Publisher: SZA
+PublisherUrl: https://github.com/SerZhyAle
+PublisherSupportUrl: https://github.com/SerZhyAle/doc-html-translate/issues
+Author: Serhii Zhyhunenko
+PackageName: doc-html-translate
+PackageUrl: https://github.com/SerZhyAle/doc-html-translate
+License: MIT
+LicenseUrl: https://github.com/SerZhyAle/doc-html-translate/blob/main/LICENSE
+Copyright: Copyright (c) 2026 SerZhyAle
+ShortDescription: "把 EPUB、PDF、MOBI、AZW3、FB2、RTF、TXT、Markdown 和 HTML 转换为干净的本地 HTML，带真正的目录、图片文字识别，并可选择通过 Google 或 Ollama 翻译。"
+Description: |-
+  doc-html-translate 是一款 Windows 应用，可把文档（EPUB、PDF、MOBI、AZW3、FB2、RTF、TXT、Markdown、HTML）转换为干净的本地
+  HTML，并生成导航和真正的多级目录。内置阅读器提供 light/sepia/dark/night 主题、字号与字体控制，并记住阅读位置。它能识别图片中的文字（OCR -
+  内置英语，其他语言按需下载），也可以选择通过 Google Cloud Translation API 或本地 Ollama 模型翻译全部内容。界面提供 13
+  种语言。你可以得到一个长长的单页，也可以保留带目录的章节。重新打开已转换过的书籍是瞬间完成的。软件包同时包含命令行程序（doc-html-translate）和一个小巧的图形界面（doc-html-ui）。pdftotext
+  已内置于可执行文件中；MOBI 和 AZW3 另需安装 Calibre（仅限无 DRM 的文件）。
+Tags:
+- azw3
+- cli
+- ebook
+- epub
+- fb2
+- google-translate
+- html
+- markdown
+- mobi
+- ocr
+- ollama
+- pdf
+- rtf
+- translation
+- txt
+- windows
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/s/SerZhyAle/DocHtmlTranslate/26.0813.1917/SerZhyAle.DocHtmlTranslate.yaml
+++ b/manifests/s/SerZhyAle/DocHtmlTranslate/26.0813.1917/SerZhyAle.DocHtmlTranslate.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: SerZhyAle.DocHtmlTranslate
+PackageVersion: "26.0813.1917"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New version of an existing package: **SerZhyAle.DocHtmlTranslate 26.0813.1917**

Upstream release: https://github.com/SerZhyAle/doc-html-translate/releases/tag/v26.0813.1917

`doc-html-translate` converts EPUB, PDF, MOBI, AZW3, FB2, RTF, TXT, Markdown, HTML, comic archives and images into clean local HTML with generated navigation and a real multi-level table of contents, so the browser's own page translation can read the result. This version improves the OCR text overlay (the recognized text now covers the lettering it replaces, a plate is no longer allowed to span a whole screenshot, and the OCR language follows the document's writing system when none is given), adds page anchors and an OCR-layer toggle to comics and scans, and updates the PDF engines.

**SHA256 verified end-to-end** with a local `winget install --manifest` against the published release asset before submitting - the download and the hash both check out:

```
Found doc-html-translate [SerZhyAle.DocHtmlTranslate] Version 26.0813.1917
Downloading https://github.com/SerZhyAle/doc-html-translate/releases/download/v26.0813.1917/doc-html-translate-26.0813.1917-windows-x64.zip
Successfully verified installer hash
Successfully installed
```

`winget validate` on the manifest folder: **Manifest validation succeeded.**

Manifests: installer, version and 13 locale files (`en-US`, `ru-RU`, `uk-UA`, `de-DE`, `it-IT`, `es-ES`, `fr-FR`, `pt-BR`, `ar-SA`, `hi-IN`, `bn-BD`, `ur-PK`, `zh-CN`).

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
