### PR TITLE
New package: tungcorn.SpaceLens version 0.1.1

### DIFF
--- a/manifests/t/tungcorn/SpaceLens/0.1.1/tungcorn.SpaceLens.installer.yaml
+++ b/manifests/t/tungcorn/SpaceLens/0.1.1/tungcorn.SpaceLens.installer.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: tungcorn.SpaceLens
+PackageVersion: 0.1.1
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: zip
+NestedInstallerType: portable
+ArchiveBinariesDependOnPath: true
+ReleaseDate: 2026-08-14
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/tungcorn/spacelens/releases/download/v0.1.1/spacelens-v0.1.1-windows-x64.zip
+  InstallerSha256: B4D4CB993BB53E1414C9FC156D9C29A5DCA1B8640AC8D3B1229E5FF5A345793D
+  NestedInstallerFiles:
+  - RelativeFilePath: spacelens.exe
+    PortableCommandAlias: spacelens
+  - RelativeFilePath: spacelens-gui.exe
+    PortableCommandAlias: spacelens-gui
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/t/tungcorn/SpaceLens/0.1.1/tungcorn.SpaceLens.locale.en-US.yaml
+++ b/manifests/t/tungcorn/SpaceLens/0.1.1/tungcorn.SpaceLens.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: tungcorn.SpaceLens
+PackageVersion: 0.1.1
+PackageLocale: en-US
+Publisher: tungcorn
+PublisherUrl: https://github.com/tungcorn
+PublisherSupportUrl: https://github.com/tungcorn/spacelens/issues
+Author: tungcorn
+PackageName: SpaceLens
+PackageUrl: https://github.com/tungcorn/spacelens
+License: MIT
+LicenseUrl: https://github.com/tungcorn/spacelens/blob/v0.1.1/LICENSE
+Copyright: Copyright (c) 2026 tungcorn
+ShortDescription: Fast native C++ storage intelligence and desktop analyzer for Windows.
+Description: SpaceLens is a native Windows desktop analyzer for storage discovery, indexed search, treemap visualization, Cleanup Review, and verified duplicates. This complete package includes spacelens-gui.exe and the read-only spacelens CLI. Recycle Bin maintenance requires explicit human authorization. Do not also install tungcorn.SpaceLens.CLI. Qt 6.8.3 libraries in this package keep their own licenses.
+Moniker: spacelens
+Tags:
+- disk-analyzer
+- disk-usage
+- filesystem
+- storage
+InstallationNotes: Do not install tungcorn.SpaceLens.CLI at the same time. Both packages expose the spacelens command.
+ReleaseNotesUrl: https://github.com/tungcorn/spacelens/releases/tag/v0.1.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/tungcorn/SpaceLens/0.1.1/tungcorn.SpaceLens.yaml
+++ b/manifests/t/tungcorn/SpaceLens/0.1.1/tungcorn.SpaceLens.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: tungcorn.SpaceLens
+PackageVersion: 0.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
This is the complete SpaceLens product for Windows.

- Package identifier: tungcorn.SpaceLens
- Version: 0.1.1
- Installer: published GitHub Release zip
  https://github.com/tungcorn/spacelens/releases/download/v0.1.1/spacelens-v0.1.1-windows-x64.zip
- Nested portable binaries: spacelens-gui.exe (alias spacelens-gui) and spacelens.exe (alias spacelens)
- ArchiveBinariesDependOnPath: true (Qt runtime DLLs live next to the executables)
- Dependency: Microsoft.VCRedist.2015+.x64

This replaces the earlier GUI-only model. The superseded GUI-only PR was closed: https://github.com/microsoft/winget-pkgs/pull/417001

An optional CLI-only package is tracked separately: https://github.com/microsoft/winget-pkgs/pull/417000

Please do not install both packages at the same time. Both expose the `spacelens` command. The complete package already includes the CLI.

Project: https://github.com/tungcorn/spacelens
Release: https://github.com/tungcorn/spacelens/releases/tag/v0.1.1
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/417031)