### PR TITLE
New package: OrchisLabs.Gobbler version 0.2.3

### DIFF
--- a/manifests/o/OrchisLabs/Gobbler/0.2.3/OrchisLabs.Gobbler.installer.yaml
+++ b/manifests/o/OrchisLabs/Gobbler/0.2.3/OrchisLabs.Gobbler.installer.yaml
@@ -1,0 +1,19 @@
+# Created with desktop/scripts/update-winget.mjs
+PackageIdentifier: OrchisLabs.Gobbler
+PackageVersion: 0.2.3
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+UpgradeBehavior: install
+ReleaseDate: 2026-08-13
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/OrchisLabs/gobbler-releases/releases/download/desktop-v0.2.3/Gobbler-0.2.3-windows-x64.exe
+  InstallerSha256: B269324EA80724843EF11AFE0FA53DA5D7FBBB301B7688CD49921665BD5CEE43
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/o/OrchisLabs/Gobbler/0.2.3/OrchisLabs.Gobbler.locale.en-US.yaml
+++ b/manifests/o/OrchisLabs/Gobbler/0.2.3/OrchisLabs.Gobbler.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created with desktop/scripts/update-winget.mjs
+PackageIdentifier: OrchisLabs.Gobbler
+PackageVersion: 0.2.3
+PackageLocale: en-US
+Publisher: Orchis Labs
+PublisherUrl: https://gobbler.org
+PackageName: Gobbler
+PackageUrl: https://gobbler.org/apps
+License: Proprietary
+ShortDescription: Focused desktop client for Gobbler with Command-K, global shortcuts, and native notifications.
+Tags:
+- gobbler
+- ai
+- chat
+- desktop
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/o/OrchisLabs/Gobbler/0.2.3/OrchisLabs.Gobbler.yaml
+++ b/manifests/o/OrchisLabs/Gobbler/0.2.3/OrchisLabs.Gobbler.yaml
@@ -1,0 +1,6 @@
+# Created with desktop/scripts/update-winget.mjs
+PackageIdentifier: OrchisLabs.Gobbler
+PackageVersion: 0.2.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Adds OrchisLabs.Gobbler 0.2.3 — the Gobbler desktop client (closed-source preview) by Orchis Labs.

- Installer: NSIS (electron-builder, oneClick=false), user scope, silent via /S
- InstallerUrl: Gobbler-0.2.3-windows-x64.exe from the project's public releases repo (OrchisLabs/gobbler-releases)
- Manifests generated and hashed from the published installer

Checklist:
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? (structure validated by generator; URLs and SHA256 verified against the published release assets)
- [x] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.9.0)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/417081)