### PR TITLE
New version: SerZhyAle.FastMediaSorter version 26.8.13.2350

### DIFF
--- a/manifests/s/SerZhyAle/FastMediaSorter/26.8.13.2350/SerZhyAle.FastMediaSorter.installer.yaml
+++ b/manifests/s/SerZhyAle/FastMediaSorter/26.8.13.2350/SerZhyAle.FastMediaSorter.installer.yaml
@@ -1,0 +1,16 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: SerZhyAle.FastMediaSorter
+PackageVersion: 26.8.13.2350
+InstallerType: inno
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/SerZhyAle/FastMediaSorter_Lite/releases/download/v26.8.13.2350/FastMediaSorter-26.8.13.2350-windows-x64-setup.exe
+  InstallerSha256: EF277D902DA31562C6D7F44D4AE8563B9810C9449347D71AC66965926735B424
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-08-13

--- a/manifests/s/SerZhyAle/FastMediaSorter/26.8.13.2350/SerZhyAle.FastMediaSorter.locale.en-US.yaml
+++ b/manifests/s/SerZhyAle/FastMediaSorter/26.8.13.2350/SerZhyAle.FastMediaSorter.locale.en-US.yaml
@@ -1,0 +1,62 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: SerZhyAle.FastMediaSorter
+PackageVersion: 26.8.13.2350
+PackageLocale: en-US
+Publisher: SZA
+PublisherUrl: https://github.com/SerZhyAle
+PublisherSupportUrl: https://github.com/SerZhyAle/FastMediaSorter_Lite/issues
+Author: Serhii Zhyhunenko
+PackageName: FastMediaSorter LITE
+PackageUrl: https://github.com/SerZhyAle/FastMediaSorter_Lite
+License: MIT
+LicenseUrl: https://github.com/SerZhyAle/FastMediaSorter_Lite/blob/main/LICENSE
+Copyright: Copyright (c) 2025 SZA
+ShortDescription: Fast Media Sorter for Windows - keyboard-driven viewer and sorter for images and videos, now a modern 64-bit build that needs no .NET Framework.
+Description: |-
+  Fast Media Sorter for Windows (published here as "FastMediaSorter LITE") is a fast, keyboard-driven
+  viewer and sorter for images and video on Windows. Tick folders to browse, then move, copy, rename or
+  delete files with single-key hotkeys - built for photographers and creators who triage large media
+  folders quickly. It handles a wide range of formats, slideshow and random modes, EXIF auto-rotate, an
+  Ambilight-style background fill, and optional on-image OCR translation.
+
+  The main program is now a 64-bit .NET 10 build that carries its own runtime - there is nothing extra
+  to install and no .NET Framework requirement. It replaces the previous version in place and keeps
+  your settings. Video always plays through the built-in VLC engine (H.264/MP4, AVI, MKV, VP9, ZMBV and
+  more), and static and animated WEBP images open on their own, without the Windows "WebP Image
+  Extensions" codec that some editions of Windows lack.
+
+  A 32-bit build with the same feature set ships alongside it for Windows 7/8.1 and 32-bit machines.
+  The installer picks the right one for your PC automatically and points the shortcut and file
+  associations at it, so there is nothing to choose. The 64-bit main program requires Windows 10
+  version 1607 or newer, Windows 11, or Windows Server 2016 or newer.
+
+  The interface is available in 13 languages - English, Russian, Ukrainian, German, Italian,
+  Spanish, French, Portuguese, Arabic, Hindi, Bengali, Urdu and Chinese - and picks the one your
+  Windows display language uses on first run; a button on the toolbar switches it at any time.
+  The bundled Share Manager speaks the same 13 languages and follows the same choice. Only
+  English, Russian and Ukrainian are proofread by the author; the rest are machine translations,
+  and corrections are welcome through the issue tracker. The setup wizard itself stays English.
+Moniker: fastmediasorter
+Tags:
+- file-manager
+- hotkeys
+- images
+- media
+- organizer
+- photos
+- pictures
+- slideshow
+- sorter
+- triage
+- utility
+- videos
+- viewer
+- winforms
+ReleaseNotesUrl: https://github.com/SerZhyAle/FastMediaSorter_Lite/releases/tag/v26.8.13.2350
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/SerZhyAle/FastMediaSorter_Lite/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/SerZhyAle/FastMediaSorter/26.8.13.2350/SerZhyAle.FastMediaSorter.yaml
+++ b/manifests/s/SerZhyAle/FastMediaSorter/26.8.13.2350/SerZhyAle.FastMediaSorter.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: SerZhyAle.FastMediaSorter
+PackageVersion: 26.8.13.2350
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Version update for **SerZhyAle.FastMediaSorter** (Fast Media Sorter for Windows, published as `FastMediaSorter LITE`): `26.8.8.2305` -> `26.8.13.2350`.

Only `PackageVersion`, `InstallerUrl`, `InstallerSha256` and `ReleaseDate` changed. The installer shape is unchanged from the manifest that passed validation previously: the Inno `setup.exe` is referenced directly (`InstallerType: inno`), with **no** `Dependencies`, **no** `Scope` and **no** `NestedInstallerType`.

**What's new in this version** (full text: [CHANGELOG](https://github.com/SerZhyAle/FastMediaSorter_Lite/blob/main/CHANGELOG.md)):

- The OCR translation overlay is markedly more accurate: a speech balloon comes out as one plate instead of several (lines are grouped by the distance between line tops, not by the gap between ink boxes), a heading is no longer glued to the paragraph under it, and a screenshot or form no longer arrives as one plate covering most of the picture.
- A long translation no longer loses its tail in silence: the text shrinks, then the plate grows downwards - bounded by the image edge and by the next plate in the column - and only then is anything trimmed. Text can no longer spill outside its own plate on a short block.
- The translation plate takes its background and text colours from the picture underneath it instead of always being nearly white; the 32-bit program keeps the old light plate.
- Share Manager: a click on the enlarged QR code also saves it as a picture into the Pictures folder and puts it on the clipboard.
- The halo animation around a photo gained three speeds, medium by default (64-bit program).

Links:
- Release: https://github.com/SerZhyAle/FastMediaSorter_Lite/releases/tag/v26.8.13.2350
- Changelog: https://github.com/SerZhyAle/FastMediaSorter_Lite/blob/main/CHANGELOG.md

---

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/add?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?
