### PR TITLE
MetanoicArmor.I2PChat version 1.4.1

### DIFF
--- a/manifests/m/MetanoicArmor/I2PChat/1.4.1/MetanoicArmor.I2PChat.installer.yaml
+++ b/manifests/m/MetanoicArmor/I2PChat/1.4.1/MetanoicArmor.I2PChat.installer.yaml
@@ -1,0 +1,24 @@
+PackageIdentifier: MetanoicArmor.I2PChat
+PackageVersion: 1.4.1
+InstallerLocale: en-US
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallModes:
+  - interactive
+  - silent
+# GUI winget: *-winget-* zip has no embedded i2pd (SHA from release SHA256SUMS v1.4.1).
+Installers:
+  - Architecture: x64
+    InstallerType: zip
+    InstallerUrl: https://github.com/MetanoicArmor/I2PChat-ng/releases/download/v1.4.1/I2PChat-windows-x64-winget-v1.4.1.zip
+    InstallerSha256: bf7850e3eb5060d2ec2da4e09039589f1a73b7cc10f5948d84b796a283cbdf72
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: I2PChat/I2PChat.exe
+        PortableCommandAlias: i2pchat
+      - RelativeFilePath: I2PChat/I2PChat-tui.exe
+        PortableCommandAlias: i2pchat-tui
+    ReleaseDate: 2026-08-13
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/MetanoicArmor/I2PChat/1.4.1/MetanoicArmor.I2PChat.locale.en-US.yaml
+++ b/manifests/m/MetanoicArmor/I2PChat/1.4.1/MetanoicArmor.I2PChat.locale.en-US.yaml
@@ -1,0 +1,29 @@
+PackageIdentifier: MetanoicArmor.I2PChat
+PackageVersion: 1.4.1
+PackageLocale: en-US
+Publisher: MetanoicArmor
+PublisherUrl: https://github.com/MetanoicArmor
+PackageName: I2PChat
+PackageUrl: https://github.com/MetanoicArmor/I2PChat-ng
+License: AGPL-3.0
+LicenseUrl: https://github.com/MetanoicArmor/I2PChat-ng/blob/main/LICENSE
+Copyright: Copyright (c) MetanoicArmor and contributors
+ShortDescription: Experimental peer-to-peer chat client for the I2P anonymity network
+Description: |-
+  I2PChat is a cross-platform GUI (PyQt6) chat client for the I2P network, with optional
+  console TUI. Binaries are portable (zip); GUI is I2PChat.exe; TUI is I2PChat-tui.exe in the I2PChat folder.
+  This winget package uses the *-winget-* release zip, which omits the embedded i2pd router binary so
+  Microsoft’s installer validation can succeed; use a system i2pd (SAM) or install the full Windows zip from
+  GitHub Releases if you want the bundled router. The full zip includes i2pd (PurpleI2P/i2pd), which some AV
+  vendors label generic “riskware” even though it is legitimate open-source software.
+Moniker: i2pchat
+Tags:
+  - i2p
+  - chat
+  - p2p
+  - privacy
+ReleaseNotesUrl: https://github.com/MetanoicArmor/I2PChat-ng/releases/tag/v1.4.1
+ReleaseNotes: |-
+  v1.4.1: Sealed 1:1 contact metadata and compose drafts at rest; opaque group invite tokens; encrypted groups appear in the sidebar once the identity key is loaded; bundled i2pd 2.61.0. Handshake remains v4 (compatible with 1.4.0; not with 1.3.x). Winget ships the *-winget-* zip without embedded i2pd. Full Windows zip with bundled router: I2PChat-windows-x64-v*.zip on GitHub Releases. i2pd: https://github.com/PurpleI2P/i2pd
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/MetanoicArmor/I2PChat/1.4.1/MetanoicArmor.I2PChat.yaml
+++ b/manifests/m/MetanoicArmor/I2PChat/1.4.1/MetanoicArmor.I2PChat.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: MetanoicArmor.I2PChat
+PackageVersion: 1.4.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary
Adds **MetanoicArmor.I2PChat** **1.4.1** (GUI).

Installer: `I2PChat-windows-x64-winget-v1.4.1.zip` from [I2PChat v1.4.1](https://github.com/MetanoicArmor/I2PChat-ng/releases/tag/v1.4.1) (SHA256 from release `SHA256SUMS`).

The `*-winget-*` zip is built **without** embedded i2pd so Microsoft’s Installers Scan (`binaryValidation` / ESRP) can succeed. Full Windows zip with bundled router remains on GitHub Releases.

Separate PR for TUI package as required by winget-pkgs automation.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/417091)