### PR TITLE
MetanoicArmor.I2PChat.TUI version 1.4.1

### DIFF
--- a/manifests/m/MetanoicArmor/I2PChat/TUI/1.4.1/MetanoicArmor.I2PChat.TUI.installer.yaml
+++ b/manifests/m/MetanoicArmor/I2PChat/TUI/1.4.1/MetanoicArmor.I2PChat.TUI.installer.yaml
@@ -1,0 +1,22 @@
+PackageIdentifier: MetanoicArmor.I2PChat.TUI
+PackageVersion: 1.4.1
+InstallerLocale: en-US
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallModes:
+  - interactive
+  - silent
+# TUI winget: *-winget-* zip omits embedded i2pd (SHA from release SHA256SUMS v1.4.1).
+Installers:
+  - Architecture: x64
+    InstallerType: zip
+    InstallerUrl: https://github.com/MetanoicArmor/I2PChat-ng/releases/download/v1.4.1/I2PChat-windows-tui-x64-winget-v1.4.1.zip
+    InstallerSha256: d345fc130e1abf3bdd1dafeb844372f791b59dfd4185bb3622fdd2f3bade9c2a
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: I2PChat/I2PChat-tui.exe
+        PortableCommandAlias: i2pchat-tui
+    ReleaseDate: 2026-08-13
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/MetanoicArmor/I2PChat/TUI/1.4.1/MetanoicArmor.I2PChat.TUI.locale.en-US.yaml
+++ b/manifests/m/MetanoicArmor/I2PChat/TUI/1.4.1/MetanoicArmor.I2PChat.TUI.locale.en-US.yaml
@@ -1,0 +1,27 @@
+PackageIdentifier: MetanoicArmor.I2PChat.TUI
+PackageVersion: 1.4.1
+PackageLocale: en-US
+Publisher: MetanoicArmor
+PublisherUrl: https://github.com/MetanoicArmor
+PackageName: I2PChat TUI
+PackageUrl: https://github.com/MetanoicArmor/I2PChat-ng
+License: AGPL-3.0
+LicenseUrl: https://github.com/MetanoicArmor/I2PChat-ng/blob/main/LICENSE
+Copyright: Copyright (c) MetanoicArmor and contributors
+ShortDescription: Terminal UI (Textual) for I2PChat over I2P SAM
+Description: |-
+  I2PChat TUI is the Textual console client for I2PChat (no PyQt GUI). This winget package uses the
+  *-winget-* release zip without embedded i2pd; use a system i2pd with SAM or the full TUI zip from GitHub Releases
+  for a bundled router.
+Moniker: i2pchat-tui
+Tags:
+  - i2p
+  - chat
+  - p2p
+  - privacy
+  - terminal
+ReleaseNotesUrl: https://github.com/MetanoicArmor/I2PChat-ng/releases/tag/v1.4.1
+ReleaseNotes: |-
+  v1.4.1: Aligns with I2PChat 1.4.1 (sealed contacts/drafts, opaque group invites, groups in sidebar on identity load, bundled i2pd 2.61.0; handshake v4, compatible with 1.4.0, not with 1.3.x). Winget *-winget-* zip without embedded i2pd. Full TUI zip with bundled router: I2PChat-windows-tui-x64-v*.zip on GitHub Releases. i2pd: https://github.com/PurpleI2P/i2pd
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/MetanoicArmor/I2PChat/TUI/1.4.1/MetanoicArmor.I2PChat.TUI.yaml
+++ b/manifests/m/MetanoicArmor/I2PChat/TUI/1.4.1/MetanoicArmor.I2PChat.TUI.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: MetanoicArmor.I2PChat.TUI
+PackageVersion: 1.4.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary
Adds **MetanoicArmor.I2PChat.TUI** **1.4.1** (TUI-only).

Installer: `I2PChat-windows-tui-x64-winget-v1.4.1.zip` from [I2PChat v1.4.1](https://github.com/MetanoicArmor/I2PChat-ng/releases/tag/v1.4.1) (SHA256 from release `SHA256SUMS`).

The `*-winget-*` zip omits embedded i2pd for Installers Scan. Full TUI zip with bundled router remains on GitHub Releases.

Separate PR from the GUI package as required by winget-pkgs automation.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/417092)