### PR TITLE
New package: nzbfast.nzbfast version 1.1.1

### DIFF
--- a/manifests/n/nzbfast/nzbfast/1.1.1/nzbfast.nzbfast.installer.yaml
+++ b/manifests/n/nzbfast/nzbfast/1.1.1/nzbfast.nzbfast.installer.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: nzbfast.nzbfast
+PackageVersion: 1.1.1
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+InstallerType: inno
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-08-13
+AppsAndFeaturesEntries:
+- DisplayName: nzbfast
+  Publisher: nzbfast
+  DisplayVersion: 1.1.1
+  ProductCode: '{72B5B673-54D7-46ED-BDDC-C7D3E571D242}_is1'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/nzbfast/nzbfast/releases/download/v1.1.1/nzbfast-1.1.1-windows-x64-setup.exe
+  InstallerSha256: 2435ECE11DEC5996460AAEC66713A792A7A4F94DF72C6A32D7CB400B6F085B85
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/n/nzbfast/nzbfast/1.1.1/nzbfast.nzbfast.locale.en-US.yaml
+++ b/manifests/n/nzbfast/nzbfast/1.1.1/nzbfast.nzbfast.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: nzbfast.nzbfast
+PackageVersion: 1.1.1
+PackageLocale: en-US
+Publisher: nzbfast
+PublisherUrl: https://github.com/nzbfast/nzbfast
+PublisherSupportUrl: https://github.com/nzbfast/nzbfast/issues
+PackageName: nzbfast
+PackageUrl: https://nzbfast.github.io/nzbfast/
+License: GPL-3.0
+LicenseUrl: https://github.com/nzbfast/nzbfast/blob/main/LICENSE
+ShortDescription: The fast Usenet downloader
+Description: |-
+  One self-contained executable: line-rate downloads, one-pass verify and
+  extract, a poster wall, and a built-in indexer. Speaks the SABnzbd and
+  NZBGet APIs, so Sonarr and Radarr connect unmodified.
+Moniker: nzbfast
+Tags:
+- downloader
+- nzb
+- nzbget
+- sabnzbd
+- usenet
+ReleaseNotesUrl: https://github.com/nzbfast/nzbfast/releases/tag/v1.1.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/n/nzbfast/nzbfast/1.1.1/nzbfast.nzbfast.yaml
+++ b/manifests/n/nzbfast/nzbfast/1.1.1/nzbfast.nzbfast.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: nzbfast.nzbfast
+PackageVersion: 1.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package: **nzbfast.nzbfast** version 1.1.1 - a Usenet (NZB) downloader, single self-contained executable with a web dashboard. Maintainer submission.

The installer manifest points at the official Inno Setup installer from the GitHub release, with the SHA256 taken from the release's published SHA256SUMS.txt and re-verified by downloading the asset.

This supersedes #411163, which was opened for the now-outdated version 1.0.13 and is being closed in favour of this one. The manifests are unchanged in shape from that PR (which passed the validation pipeline); only the version, release date, installer URL, SHA256 and release-notes URL differ.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` (authored on a non-Windows machine; validated instead against the published 1.12.0 JSON schemas, and relying on pipeline validation)
- [ ] Tested manifest locally with `winget install --manifest <path>` (same; the installer itself is release-tested, silent install included)
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

Note: the installer is not yet code-signed (signing is in progress, tracked at nzbfast/nzbfast#3).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/417149)