### PR TITLE
New package: nicholaspjm.gobo version 0.2.0

### DIFF
--- a/manifests/n/nicholaspjm/gobo/0.2.0/nicholaspjm.gobo.installer.yaml
+++ b/manifests/n/nicholaspjm/gobo/0.2.0/nicholaspjm.gobo.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: nicholaspjm.gobo
+PackageVersion: 0.2.0
+InstallerType: portable
+Commands:
+  - gobo-connector
+ReleaseDate: 2026-08-14
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/nicholaspjm/gobo-dmx-live-code/releases/download/v0.2.0/gobo-connector-windows.exe
+    InstallerSha256: 5F6B95173B9C922A07B1DE5EF01B460549355C3BCFEAD06C31F531B65E95D2D6
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/n/nicholaspjm/gobo/0.2.0/nicholaspjm.gobo.locale.en-US.yaml
+++ b/manifests/n/nicholaspjm/gobo/0.2.0/nicholaspjm.gobo.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: nicholaspjm.gobo
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: nicholaspjm
+PublisherUrl: https://github.com/nicholaspjm
+PublisherSupportUrl: https://github.com/nicholaspjm/gobo-dmx-live-code/issues
+PackageName: gobo connector
+PackageUrl: https://github.com/nicholaspjm/gobo-dmx-live-code
+License: MIT
+LicenseUrl: https://github.com/nicholaspjm/gobo-dmx-live-code/blob/main/LICENSE
+ShortDescription: Sends DMX from the gobo browser app to Art-Net, sACN or OSC.
+Description: |-
+  gobo is a browser based live coding environment for DMX lighting. A browser
+  cannot open a UDP socket, so it cannot speak Art-Net itself. The connector is
+  the piece that can: run it, open the app, and lighting output works.
+
+  It sets itself to start at login the first time it runs, so this is a one
+  time step. Run it with --uninstall to undo that.
+Tags:
+  - dmx
+  - art-net
+  - sacn
+  - lighting
+  - live-coding
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/n/nicholaspjm/gobo/0.2.0/nicholaspjm.gobo.yaml
+++ b/manifests/n/nicholaspjm/gobo/0.2.0/nicholaspjm.gobo.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: nicholaspjm.gobo
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Package
nicholaspjm.gobo 0.2.0

### Description
gobo is a browser based live coding environment for DMX lighting. A browser cannot open a UDP socket, so it cannot speak Art-Net itself. This package is the connector: the piece that receives from the browser and sends Art-Net, sACN or OSC on the network.

Source: https://github.com/nicholaspjm/gobo-dmx-live-code
Release: https://github.com/nicholaspjm/gobo-dmx-live-code/releases/tag/v0.2.0

### Checklist
- [x] Manifest validates locally (`winget validate --manifest`)
- [x] Installer URL points at a GitHub release asset built by CI
- [x] SHA256 taken from the published asset
- [x] Portable installer, single executable, no installer wrapper
- [x] License is MIT, and the connector itself bundles no third party code beyond `ws` (MIT)

### Notes
The executable is unsigned. It is built in GitHub Actions from the tagged source by `.github/workflows/release.yml`, which also starts the binary and checks it responds before uploading.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/417156)