### PR TITLE
New package: larrygogo.Meowo version 0.5.14

### DIFF
--- a/manifests/l/larrygogo/Meowo/0.5.14/larrygogo.Meowo.installer.yaml
+++ b/manifests/l/larrygogo/Meowo/0.5.14/larrygogo.Meowo.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: larrygogo.Meowo
+PackageVersion: 0.5.14
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+Scope: user
+UpgradeBehavior: install
+AppsAndFeaturesEntries:
+- DisplayName: Meowo
+  Publisher: larrygogo
+  DisplayVersion: 0.5.14
+  ProductCode: Meowo
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/larrygogo/meowo/releases/download/v0.5.14/Meowo_0.5.14_x64-setup.exe
+  InstallerSha256: 57A3D48119B776BE67E2AE49389D542C624DB0D45C1F2F549EDEDA538E6D1F6A
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/l/larrygogo/Meowo/0.5.14/larrygogo.Meowo.locale.en-US.yaml
+++ b/manifests/l/larrygogo/Meowo/0.5.14/larrygogo.Meowo.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: larrygogo.Meowo
+PackageVersion: 0.5.14
+PackageLocale: en-US
+Publisher: larrygogo
+PublisherUrl: https://meowo.io
+PublisherSupportUrl: https://github.com/larrygogo/meowo/issues
+PackageName: Meowo
+PackageUrl: https://meowo.io
+License: MIT
+LicenseUrl: https://github.com/larrygogo/meowo/blob/main/LICENSE
+ShortDescription: Desktop sticker board for AI coding sessions (Claude Code, Codex, Kimi and more)
+Description: Meowo pins your AI CLI coding sessions to the desktop as sticker cards - see progress, approvals and questions at a glance, jump back to the right terminal or a chat window, and get notified when an agent is waiting for you.
+Tags:
+- ai
+- claude
+- claude-code
+- cli
+- codex
+- developer-tools
+- kanban
+- terminal
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/l/larrygogo/Meowo/0.5.14/larrygogo.Meowo.locale.zh-CN.yaml
+++ b/manifests/l/larrygogo/Meowo/0.5.14/larrygogo.Meowo.locale.zh-CN.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
+PackageIdentifier: larrygogo.Meowo
+PackageVersion: 0.5.14
+PackageLocale: zh-CN
+Publisher: larrygogo
+PackageName: Meowo
+ShortDescription: AI 会话贴纸看板：把 Claude Code 等 AI CLI 会话钉在桌面上
+Description: Meowo 把你的 AI CLI 编程会话以贴纸卡片钉在桌面：一眼看到进度、待审批与提问，一键跳回对应终端或对话窗口，agent 等你时及时提醒。
+ManifestType: locale
+ManifestVersion: 1.6.0

--- a/manifests/l/larrygogo/Meowo/0.5.14/larrygogo.Meowo.yaml
+++ b/manifests/l/larrygogo/Meowo/0.5.14/larrygogo.Meowo.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: larrygogo.Meowo
+PackageVersion: 0.5.14
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there are no other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>` (deferring to the automated pipeline validation — the installer is the same NSIS artifact users install today)?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

First submission for Meowo — a desktop sticker board that pins AI CLI coding sessions (Claude Code, Codex, Kimi, ...) to the desktop. Open source (MIT): https://github.com/larrygogo/meowo
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/417177)