### PR TITLE
New package: ChaseOS.Studio version 1.0.1

### DIFF
--- a/manifests/c/ChaseOS/Studio/1.0.1/ChaseOS.Studio.installer.yaml
+++ b/manifests/c/ChaseOS/Studio/1.0.1/ChaseOS.Studio.installer.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: ChaseOS.Studio
+PackageVersion: 1.0.1
+InstallerLocale: en-US
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+UpgradeBehavior: install
+ProductCode: "{C36A85E2-8124-4CF8-BB6E-1D0F9B3D5E42}_is1"
+Installers:
+  - Architecture: x64
+    MinimumOSVersion: 10.0.17763.0
+    InstallerUrl: https://downloads.chaseos.ai/releases/studio/windows/20260811-094929-0bff166a/ChaseOS-Studio-Setup-20260811-094929-0bff166a-windows-x64.exe
+    InstallerSha256: 635AA303B39F6F29801257D0E9D54C063BC05D416BE004BC21E3D2E3CF8EC1B4
+    AppsAndFeaturesEntries:
+      - DisplayName: ChaseOS Studio
+        Publisher: ChaseOS
+        DisplayVersion: 1.0.1 (20260811-094929-0bff166a)
+        ProductCode: "{C36A85E2-8124-4CF8-BB6E-1D0F9B3D5E42}_is1"
+        InstallerType: inno
+    ReleaseDate: 2026-08-11
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/ChaseOS/Studio/1.0.1/ChaseOS.Studio.locale.en-US.yaml
+++ b/manifests/c/ChaseOS/Studio/1.0.1/ChaseOS.Studio.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: ChaseOS.Studio
+PackageVersion: 1.0.1
+PackageLocale: en-US
+Publisher: ChaseOS
+PublisherUrl: https://chaseos.ai/
+PublisherSupportUrl: https://chaseos.ai/support
+PrivacyUrl: https://chaseos.ai/privacy
+Author: ChaseOS
+PackageName: ChaseOS Studio
+PackageUrl: https://chaseos.ai/studio
+License: Proprietary
+LicenseUrl: https://chaseos.ai/license
+ShortDescription: A local-first AI workspace for Windows where agents run on your machine behind approval gates.
+Description: >-
+  ChaseOS Studio is a local-first AI workspace for Windows. Project context lives in a
+  private typed graph so it compounds instead of resetting every session. Agents can run
+  unattended on a schedule on your own machine inside declared runtime profiles, while
+  consequential actions stop at approval gates. ChaseOS Core, the underlying engine and
+  contracts, is separately MIT-licensed and public.
+Moniker: chaseos-studio
+Tags:
+  - ai
+  - ai-agents
+  - ai-workspace
+  - automation
+  - knowledge-graph
+  - local-first
+  - privacy
+  - productivity
+  - windows
+ReleaseNotesUrl: https://chaseos.ai/changelog
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/ChaseOS/Studio/1.0.1/ChaseOS.Studio.yaml
+++ b/manifests/c/ChaseOS/Studio/1.0.1/ChaseOS.Studio.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: ChaseOS.Studio
+PackageVersion: 1.0.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## What changed

Adds the first WinGet manifest for ChaseOS Studio 1.0.1.

- Inno Setup 7 installer
- Windows x64, current-user scope
- Windows 10 1809 (build 17763) or later
- Official immutable publisher CDN URL
- SHA-256 pinned to the published release manifest
- Explicit silent and silent-with-progress switches
- Apps & Features identity included for package correlation

## Validation

- `winget validate --manifest manifests/c/ChaseOS/Studio/1.0.1 --disable-interactivity`
- Installer URL returns the expected 452,458,400-byte signed executable.
- The installed package reports publisher `ChaseOS`, version `1.0.1 (20260811-094929-0bff166a)`, and product code `{C36A85E2-8124-4CF8-BB6E-1D0F9B3D5E42}_is1`.

ChaseOS Studio is proprietary/freemium software. The separately published ChaseOS Core is MIT-licensed.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/417178)