### PR TITLE
hoijunkim.flip version 0.1.0

### DIFF
--- a/manifests/h/hoijunkim/flip/0.1.0/hoijunkim.flip.installer.yaml
+++ b/manifests/h/hoijunkim/flip/0.1.0/hoijunkim.flip.installer.yaml
@@ -1,0 +1,13 @@
+PackageIdentifier: hoijunkim.flip
+PackageVersion: 0.1.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: flip.exe
+    PortableCommandAlias: flip
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/hoijunkim/flip/releases/download/v0.1.0/flip-v0.1.0-windows-amd64.zip
+    InstallerSha256: 0846E3E7492F013154CED167FD1790D6D78A2F69F81AD7522F819686AB49ABF4
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/h/hoijunkim/flip/0.1.0/hoijunkim.flip.locale.en-US.yaml
+++ b/manifests/h/hoijunkim/flip/0.1.0/hoijunkim.flip.locale.en-US.yaml
@@ -1,0 +1,23 @@
+PackageIdentifier: hoijunkim.flip
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: H.K
+PublisherUrl: https://github.com/hoijunkim
+PublisherSupportUrl: https://github.com/hoijunkim/flip/issues
+PackageName: flip
+PackageUrl: https://github.com/hoijunkim/flip
+License: PolyForm Noncommercial 1.0.0
+LicenseUrl: https://github.com/hoijunkim/flip/blob/main/LICENSE
+ShortDescription: Capture a region of your screen, page by page, into images or a PDF.
+Description: >-
+  flip sends the page-turn key to a window you choose, captures a screen region
+  after each redraw settles, and repeats - then hands you a folder of images or
+  an assembled PDF. Windows, Go + Wails, no cgo.
+Moniker: flip
+Tags:
+  - screenshot
+  - screen-capture
+  - pdf
+  - automation
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/h/hoijunkim/flip/0.1.0/hoijunkim.flip.yaml
+++ b/manifests/h/hoijunkim/flip/0.1.0/hoijunkim.flip.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: hoijunkim.flip
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Pull request has been created with the following:

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)? (signed for #412122, merged 2026-08-11)
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? (not run; the installer archive is byte-identical to the one validated in #412122)
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-cli/blob/master/schemas/JSON/manifests/v1.6.0)?

### Note

This is `hoijun-kim.flip` under a corrected publisher. My GitHub account was renamed from `hoijun-kim` to `hoijunkim`, and a `PackageIdentifier` cannot be edited in place, so the package is submitted again under `hoijunkim.flip`.

Nothing else changed. `InstallerSha256` is the same `0846E3E7...49ABF4` as in #412122 - the same release archive, reachable at the renamed account's URL. The publisher and package URLs point at `github.com/hoijunkim` now.

I will open a separate PR to remove `hoijun-kim.flip` once this one is merged, so the package is never absent from the repository.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/417180)