### PR TITLE
hoijunkim.flip version 0.1.1

### DIFF
--- a/manifests/h/hoijunkim/flip/0.1.1/hoijunkim.flip.installer.yaml
+++ b/manifests/h/hoijunkim/flip/0.1.1/hoijunkim.flip.installer.yaml
@@ -8,6 +8,6 @@ NestedInstallerFiles:
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/hoijunkim/flip/releases/download/v0.1.1/flip-v0.1.1-windows-amd64.zip
-    InstallerSha256: F9A8E9662CD7F936916E43C27B74491C4C650425A546577CAF34445B5995C2A8
+    InstallerSha256: C0A107984036BD15B07AF4F1C3EF5F6DC6BDD875C65925BD996A94717905084F
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/h/hoijunkim/flip/0.1.1/hoijunkim.flip.installer.yaml
+++ b/manifests/h/hoijunkim/flip/0.1.1/hoijunkim.flip.installer.yaml
@@ -1,0 +1,13 @@
+PackageIdentifier: hoijunkim.flip
+PackageVersion: 0.1.1
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: flip.exe
+    PortableCommandAlias: flip
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/hoijunkim/flip/releases/download/v0.1.1/flip-v0.1.1-windows-amd64.zip
+    InstallerSha256: F9A8E9662CD7F936916E43C27B74491C4C650425A546577CAF34445B5995C2A8
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/h/hoijunkim/flip/0.1.1/hoijunkim.flip.locale.en-US.yaml
+++ b/manifests/h/hoijunkim/flip/0.1.1/hoijunkim.flip.locale.en-US.yaml
@@ -1,0 +1,23 @@
+PackageIdentifier: hoijunkim.flip
+PackageVersion: 0.1.1
+PackageLocale: en-US
+Publisher: H.K
+PublisherUrl: https://github.com/hoijunkim
+PublisherSupportUrl: https://github.com/hoijunkim/flip/issues
+PackageName: flip
+PackageUrl: https://github.com/hoijunkim/flip
+License: PolyForm Noncommercial 1.0.0
+LicenseUrl: https://github.com/hoijunkim/flip/blob/main/LICENSE
+ShortDescription: Capture a region of your screen, page by page, into images or a PDF.
+Description: >-
+  flip sends the page-turn key to a window you choose, captures a screen region
+  after each redraw settles, and repeats - then hands you a folder of images or
+  an assembled PDF. Windows, Go + Wails, no cgo.
+Moniker: flip
+Tags:
+  - screenshot
+  - screen-capture
+  - pdf
+  - automation
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/h/hoijunkim/flip/0.1.1/hoijunkim.flip.yaml
+++ b/manifests/h/hoijunkim/flip/0.1.1/hoijunkim.flip.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: hoijunkim.flip
+PackageVersion: 0.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Pull request has been created with the following:

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)? (signed for #412122, merged 2026-08-11)
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change? (#417180 was mine and is closed in favour of this)
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-cli/blob/master/schemas/JSON/manifests/v1.6.0)?

### Note

New publisher for an existing package. My GitHub account was renamed from `hoijun-kim` to `hoijunkim`; a `PackageIdentifier` cannot be edited in place, so flip is submitted again as `hoijunkim.flip`.

This supersedes #417180, which submitted 0.1.0 under the new identifier. flip 0.1.1 has since been released, so that submission would have added an already-superseded version - and it reused the 0.1.0 installer, which is what the Possible-Duplicate label there was detecting. The installer here is a distinct 0.1.1 build (`f9a8e966...95c2a8`), so there is no duplicate to flag.

Once this is merged I will open a separate PR to remove `hoijun-kim.flip`, so the package is never absent from the repository.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/417208)