### PR TITLE
hoijunkim.gifly version 0.1.1

### DIFF
--- a/manifests/h/hoijunkim/gifly/0.1.1/hoijunkim.gifly.installer.yaml
+++ b/manifests/h/hoijunkim/gifly/0.1.1/hoijunkim.gifly.installer.yaml
@@ -1,0 +1,13 @@
+PackageIdentifier: hoijunkim.gifly
+PackageVersion: 0.1.1
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: gifly.exe
+    PortableCommandAlias: gifly
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/hoijunkim/gifly/releases/download/v0.1.1/gifly-0.1.1-standalone-win64.zip
+    InstallerSha256: 008670B8DC8C280D158FCB94000141E24CC4639E6C9E5CA14AB5402D67838EAC
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/h/hoijunkim/gifly/0.1.1/hoijunkim.gifly.locale.en-US.yaml
+++ b/manifests/h/hoijunkim/gifly/0.1.1/hoijunkim.gifly.locale.en-US.yaml
@@ -1,0 +1,26 @@
+PackageIdentifier: hoijunkim.gifly
+PackageVersion: 0.1.1
+PackageLocale: en-US
+Publisher: H.K
+PublisherUrl: https://github.com/hoijunkim
+PublisherSupportUrl: https://github.com/hoijunkim/gifly/issues
+PackageName: gifly
+PackageUrl: https://github.com/hoijunkim/gifly
+License: PolyForm Noncommercial 1.0.0
+LicenseUrl: https://github.com/hoijunkim/gifly/blob/master/LICENSE
+ShortDescription: Turn a video or a set of images into a GIF, WebP or APNG.
+Description: >-
+  gifly turns a video (trimmed) or a set of images (sequenced) into an optimized
+  GIF, WebP or APNG - with crop/aspect, playback speed, reverse, boomerang,
+  selectable dither, platform presets, a live size estimate, a target-size fit
+  and one-click clipboard copy. Windows, Go + Wails; bundles FFmpeg (LGPL).
+Moniker: gifly
+Tags:
+  - gif
+  - webp
+  - apng
+  - gif-maker
+  - video-to-gif
+  - ffmpeg
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/h/hoijunkim/gifly/0.1.1/hoijunkim.gifly.yaml
+++ b/manifests/h/hoijunkim/gifly/0.1.1/hoijunkim.gifly.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: hoijunkim.gifly
+PackageVersion: 0.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Pull request has been created with the following:

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)? (signed for #412122, merged 2026-08-11)
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-cli/blob/master/schemas/JSON/manifests/v1.6.0)?

### Note

First submission of gifly. It turns a video or a set of images into a GIF, WebP or APNG - Windows only, Go + Wails, cgo-free.

The installer is the standalone build: a single portable `gifly.exe` with FFmpeg embedded, which is why the archive is large (~100 MB). The alternative release asset keeps FFmpeg in a sidecar folder, which does not suit a portable manifest, so the standalone one is what is packaged here.

gifly bundles [FFmpeg](https://ffmpeg.org) under the LGPL-3.0; the license text ships inside the archive under `THIRD-PARTY-LICENSES/`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/417215)