### PR TITLE
hoijunkim.fleet version 0.1.1

### DIFF
--- a/manifests/h/hoijunkim/fleet/0.1.1/hoijunkim.fleet.installer.yaml
+++ b/manifests/h/hoijunkim/fleet/0.1.1/hoijunkim.fleet.installer.yaml
@@ -1,0 +1,9 @@
+PackageIdentifier: hoijunkim.fleet
+PackageVersion: 0.1.1
+InstallerType: portable
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/hoijunkim/fleet/releases/download/v0.1.1/fleet.exe
+    InstallerSha256: A22E3097CD0ACEEDB592DF1C335363BF3154D9A6C0ED3FAAD749EB3F364477A7
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/h/hoijunkim/fleet/0.1.1/hoijunkim.fleet.locale.en-US.yaml
+++ b/manifests/h/hoijunkim/fleet/0.1.1/hoijunkim.fleet.locale.en-US.yaml
@@ -1,0 +1,22 @@
+PackageIdentifier: hoijunkim.fleet
+PackageVersion: 0.1.1
+PackageLocale: en-US
+Publisher: H.K
+PublisherUrl: https://github.com/hoijunkim
+PublisherSupportUrl: https://github.com/hoijunkim/fleet/issues
+PackageName: fleet
+PackageUrl: https://github.com/hoijunkim/fleet
+License: PolyForm Noncommercial 1.0.0
+LicenseUrl: https://github.com/hoijunkim/fleet/blob/master/LICENSE
+ShortDescription: See and manage every git repo under your project roots on one board.
+Description: >-
+  fleet shows which repositories are dirty, behind or stale at a glance, then
+  lets you fetch, pull, push, commit, resolve a conflict or open an editor -
+  without walking the directories yourself.
+Moniker: fleet
+Tags:
+  - git
+  - git-gui
+  - developer-tools
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/h/hoijunkim/fleet/0.1.1/hoijunkim.fleet.yaml
+++ b/manifests/h/hoijunkim/fleet/0.1.1/hoijunkim.fleet.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: hoijunkim.fleet
+PackageVersion: 0.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Pull request has been created with the following:

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)? (signed for #412122, merged 2026-08-11)
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-cli/blob/master/schemas/JSON/manifests/v1.6.0)?

### Note

First submission of fleet: a desktop dashboard over every git repository under a set of roots - dirty/behind/stale at a glance, with staging, commit, push, pull, merge, rebase and conflict recovery from the same window.

The installer is the portable `fleet.exe` attached to the v0.1.1 release, built in CI from github.com/hoijunkim/fleet.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/417216)