### PR TITLE
Update package: DamingWu.VocalCode version 1.0.11

### DIFF
--- a/manifests/d/DamingWu/VocalCode/1.0.11/DamingWu.VocalCode.installer.yaml
+++ b/manifests/d/DamingWu/VocalCode/1.0.11/DamingWu.VocalCode.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: DamingWu.VocalCode
+PackageVersion: 1.0.11
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/wudaming00/vocalcode-docs/releases/download/v1.0.11/VocalCodeSetup-1.0.11.exe
+  InstallerSha256: F23F169411EEF6A9B97B9BCED9B1F15A4FDCDB970BE5D0FF2253A277A3B2A5CB
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/d/DamingWu/VocalCode/1.0.11/DamingWu.VocalCode.locale.en-US.yaml
+++ b/manifests/d/DamingWu/VocalCode/1.0.11/DamingWu.VocalCode.locale.en-US.yaml
@@ -1,0 +1,55 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: DamingWu.VocalCode
+PackageVersion: 1.0.11
+PackageLocale: en-US
+Publisher: Daming Wu
+PublisherUrl: https://vocalcode.app/
+PublisherSupportUrl: https://github.com/wudaming00/vocalcode-docs/issues
+PackageName: VocalCode
+PackageUrl: https://vocalcode.app/
+License: Proprietary
+Copyright: Copyright (c) 2026 Daming Wu
+ShortDescription: Local push-to-talk voice input for AI coding on Windows.
+Description: |-
+  VocalCode is push-to-talk dictation for people who write code with AI coding agents. Hold a
+  configured key or mouse button, speak, and release. VocalCode cleans the recognized text and
+  inserts it into the active field in most desktop apps; a separate binding can send it.
+
+  After the selected model downloads, speech recognition runs on the user's machine and no
+  recognition audio or transcript is uploaded. Initial trial provisioning, model and update
+  downloads, checkout, activation, and periodic paid-licence validation use the internet.
+
+  Parakeet TDT v3 provides English and 24 other European language preferences. Mandarin Chinese
+  uses Paraformer with local punctuation restoration. A replacement dictionary teaches project
+  names and other technical terms.
+
+  VocalCode has a 30-day full trial and a $4.99 one-time launch price, plus applicable tax. There
+  is no subscription.
+Moniker: vocalcode
+Tags:
+- ai-coding
+- developer-tools
+- dictation
+- local-ai
+- offline
+- productivity
+- push-to-talk
+- speech-to-text
+- transcription
+- voice
+- voice-coding
+- voice-input
+- voice-typing
+ReleaseNotes: |-
+  VocalCode 1.0.11 is the current signed production release.
+ReleaseNotesUrl: https://github.com/wudaming00/vocalcode-docs/releases/tag/v1.0.11
+Documentations:
+- DocumentLabel: Documentation
+  DocumentUrl: https://github.com/wudaming00/vocalcode-docs
+- DocumentLabel: FAQ
+  DocumentUrl: https://github.com/wudaming00/vocalcode-docs/blob/main/docs/faq.md
+- DocumentLabel: Privacy Notice
+  DocumentUrl: https://vocalcode.app/privacy/
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/d/DamingWu/VocalCode/1.0.11/DamingWu.VocalCode.yaml
+++ b/manifests/d/DamingWu/VocalCode/1.0.11/DamingWu.VocalCode.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: DamingWu.VocalCode
+PackageVersion: 1.0.11
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Update package: DamingWu.VocalCode version 1.0.11

- Homepage: https://vocalcode.app/
- Public release: https://github.com/wudaming00/vocalcode-docs/releases/tag/v1.0.11
- Versioned installer: https://github.com/wudaming00/vocalcode-docs/releases/download/v1.0.11/VocalCodeSetup-1.0.11.exe
- Installer SHA-256: F23F169411EEF6A9B97B9BCED9B1F15A4FDCDB970BE5D0FF2253A277A3B2A5CB

- [x] winget validate --manifest completed successfully.
- [x] The public installer bytes match the canonical production release evidence.
- [ ] winget install --manifest was not run, so no clean-machine installation claim is made.
- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)

> This checkbox is intentionally left unchecked. @wudaming00 must personally review and sign the CLA; this automation has not accepted it or represented acceptance.

This automation does not accept a CLA or other terms on behalf of the contributor.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/417217)