### PR TITLE
hoijunkim.shape version 0.1.2

### DIFF
--- a/manifests/h/hoijunkim/shape/0.1.2/hoijunkim.shape.installer.yaml
+++ b/manifests/h/hoijunkim/shape/0.1.2/hoijunkim.shape.installer.yaml
@@ -1,0 +1,13 @@
+PackageIdentifier: hoijunkim.shape
+PackageVersion: 0.1.2
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: shape-gui.exe
+    PortableCommandAlias: shape
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/hoijunkim/shape/releases/download/v0.1.2/shape-gui_v0.1.2_windows_amd64.zip
+    InstallerSha256: ED4EFBB71C7E7F93DE0B401FDFC36A7C501C2ED56FFC501410119490772B8A1E
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/h/hoijunkim/shape/0.1.2/hoijunkim.shape.locale.en-US.yaml
+++ b/manifests/h/hoijunkim/shape/0.1.2/hoijunkim.shape.locale.en-US.yaml
@@ -1,0 +1,24 @@
+PackageIdentifier: hoijunkim.shape
+PackageVersion: 0.1.2
+PackageLocale: en-US
+Publisher: H.K
+PublisherUrl: https://github.com/hoijunkim
+PublisherSupportUrl: https://github.com/hoijunkim/shape/issues
+PackageName: shape
+PackageUrl: https://github.com/hoijunkim/shape
+License: AGPL-3.0-only
+LicenseUrl: https://github.com/hoijunkim/shape/blob/master/LICENSE
+ShortDescription: Explore any data file by clicking - and read off the jq and SQL your clicks wrote.
+Description: >-
+  Drop in a JSON, NDJSON, CSV, TSV, Parquet or SQLite file and see the real
+  rows. Filter, reshape, edit and export by clicking - and read off the jq and
+  SQL your clicks just wrote, so you leave knowing the query too.
+Moniker: shape
+Tags:
+  - data
+  - jq
+  - sql
+  - csv
+  - parquet
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/h/hoijunkim/shape/0.1.2/hoijunkim.shape.yaml
+++ b/manifests/h/hoijunkim/shape/0.1.2/hoijunkim.shape.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: hoijunkim.shape
+PackageVersion: 0.1.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Pull request has been created with the following:

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)? (signed for #412122, merged 2026-08-11)
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-cli/blob/master/schemas/JSON/manifests/v1.6.0)?

### Note

First submission of shape: drop in a JSON, NDJSON, CSV, TSV, Parquet or SQLite file and explore the real rows - filter, reshape, edit and export, with the equivalent jq and SQL shown for whatever you built. Files larger than memory stream rather than load.

The installer is the portable desktop build (`shape-gui_v0.1.2_windows_amd64.zip`) attached to the v0.1.2 release, built in CI from github.com/hoijunkim/shape.

0.1.2 is submitted rather than the earlier 0.1.1 because shape was relicensed in it, from PolyForm Noncommercial 1.0.0 to AGPL-3.0. Submitting 0.1.1 would put a noncommercial-only package in the repository that is superseded on the day it lands.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/417219)