### PR TITLE
Update Wox.Wox to 2.3.0

### DIFF
--- a/manifests/w/Wox/Wox/2.3.0/Wox.Wox.installer.yaml
+++ b/manifests/w/Wox/Wox/2.3.0/Wox.Wox.installer.yaml
@@ -1,0 +1,20 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Wox.Wox
+PackageVersion: 2.3.0
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: portable
+InstallModes:
+- silent
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Wox-launcher/Wox/releases/download/v2.3.0/wox-windows-amd64.exe
+  InstallerSha256: BD4C0D29B6B81B58DDDF36D4770088459C06D1270D1CE150BBA0598464F87446
+ReleaseDate: 2026-07-04
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/w/Wox/Wox/2.3.0/Wox.Wox.locale.en-US.yaml
+++ b/manifests/w/Wox/Wox/2.3.0/Wox.Wox.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Wox.Wox
+PackageVersion: 2.3.0
+PackageLocale: en-US
+Publisher: Wox
+PublisherUrl: https://github.com/Wox-launcher/Wox
+PublisherSupportUrl: https://github.com/Wox-launcher/Wox/issues
+Author: Wox-launcher
+PackageName: Wox
+PackageUrl: https://github.com/Wox-launcher/Wox
+License: GPL-3.0 license
+LicenseUrl: https://raw.githubusercontent.com/Wox-launcher/Wox/v2.3.0/LICENSE
+Copyright: Copyright (c) 2026 Wox https://github.com/Wox-launcher/Wox
+CopyrightUrl: https://raw.githubusercontent.com/Wox-launcher/Wox/v2.3.0/LICENSE
+ShortDescription: WoX is a launcher for Windows that simply works. It's an alternative to Alfred and Launchy.
+Description: A full-featured launcher, access programs and web contents as you type. Be more productive ever since.
+Moniker: wox
+Tags:
+- alfred
+- launcher
+- launchy
+- spotlight
+ReleaseNotesUrl: https://github.com/Wox-launcher/Wox/releases/tag/v2.3.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/w/Wox/Wox/2.3.0/Wox.Wox.yaml
+++ b/manifests/w/Wox/Wox/2.3.0/Wox.Wox.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Wox.Wox
+PackageVersion: 2.3.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Updates Wox.Wox to the current stable release v2.3.0.

Changes:
- Add Wox.Wox version 2.3.0 manifests.
- Update the installer URL and SHA256 for the official GitHub release asset.
- Update version-specific release, license, and copyright URLs.

Release date: 2026-07-04

I am the maintainer of Wox.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/417225)