### PR TITLE
New package: NamelessSaint.EntraChecks version 1.9.0

### DIFF
--- a/manifests/n/NamelessSaint/EntraChecks/1.9.0/NamelessSaint.EntraChecks.installer.yaml
+++ b/manifests/n/NamelessSaint/EntraChecks/1.9.0/NamelessSaint.EntraChecks.installer.yaml
@@ -1,0 +1,17 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: NamelessSaint.EntraChecks
+PackageVersion: 1.9.0
+InstallerLocale: en-US
+InstallerType: nullsoft
+Scope: user
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/NamelessSaint8/AzurePAM/releases/download/v1.9.0/EntraChecks_1.9.0_x64-setup.exe
+  InstallerSha256: 023A2B6933E0A2F557892442929DA429EB032882FC414FAB1A8C6FF9A25D8845
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/n/NamelessSaint/EntraChecks/1.9.0/NamelessSaint.EntraChecks.locale.en-US.yaml
+++ b/manifests/n/NamelessSaint/EntraChecks/1.9.0/NamelessSaint.EntraChecks.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: NamelessSaint.EntraChecks
+PackageVersion: 1.9.0
+PackageLocale: en-US
+Publisher: NamelessSaint
+PublisherUrl: https://github.com/NamelessSaint8
+PublisherSupportUrl: https://github.com/NamelessSaint8/AzurePAM/issues
+Author: NamelessSaint
+PackageName: EntraChecks
+PackageUrl: https://github.com/NamelessSaint8/AzurePAM
+License: MIT
+LicenseUrl: https://github.com/NamelessSaint8/AzurePAM/blob/main/LICENSE
+Copyright: Copyright (c) NamelessSaint
+ShortDescription: Read-only Microsoft Cloud (Entra/Azure/M365) compliance assessment toolkit.
+Description: EntraChecks runs read-only security and compliance checks across Microsoft 365 and Azure environments, then produces analyst-friendly HTML, CSV, JSON, and Excel reports. Modules cover Conditional Access, MFA, Identity Protection, Intune, Microsoft Secure Score, Defender for Cloud regulatory compliance, Azure Policy, Microsoft Purview Compliance Manager, on-premises Active Directory, hybrid identity correlation, and SOC 2 readiness. The desktop app is a thin Tauri shell over the same PowerShell engine the CLI uses; all checks are read-only and never modify your tenant.
+Moniker: entrachecks
+Tags:
+- security
+- compliance
+- azure
+- entra
+- m365
+- microsoft365
+- soc2
+- audit
+- powershell
+ReleaseNotesUrl: https://github.com/NamelessSaint8/AzurePAM/releases/tag/v1.9.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/n/NamelessSaint/EntraChecks/1.9.0/NamelessSaint.EntraChecks.yaml
+++ b/manifests/n/NamelessSaint/EntraChecks/1.9.0/NamelessSaint.EntraChecks.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: NamelessSaint.EntraChecks
+PackageVersion: 1.9.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New package: `NamelessSaint.EntraChecks` 1.9.0

EntraChecks is a read-only Microsoft Entra ID / Azure / M365 compliance assessment toolkit (MIT, https://github.com/NamelessSaint8/AzurePAM).

This replaces `Stells.EntraChecks`, merged in #412397. I am the author of that package and am republishing under my GitHub handle rather than my legal name. A separate PR removes `manifests/s/Stells/EntraChecks`. 1.8.0 had not reached the source index, so no installed clients should be affected.

- [x] Signed the Contributor License Agreement
- [x] Checked that there aren't other open pull requests for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the 1.12 schema

Installer scope is `user`: the Tauri NSIS bundle uses `installMode: currentUser` and writes its ARP entry under HKCU.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/417239)