### PR TITLE
New package: AurelioAvila.PromptShield version 0.1.7

### DIFF
--- a/manifests/a/AurelioAvila/PromptShield/0.1.7/AurelioAvila.PromptShield.installer.yaml
+++ b/manifests/a/AurelioAvila/PromptShield/0.1.7/AurelioAvila.PromptShield.installer.yaml
@@ -12,7 +12,7 @@ UpgradeBehavior: install
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/AurelioAvila/promptshield/releases/download/v0.1.7/PromptShield-Setup-0.1.7.exe
-  InstallerSha256: 1D5A23749DF116A144CD173F89245C78A418A9D7E62252CBF0C6FBB749621F21
+  InstallerSha256: EF08AD8C8C770E2BB96F6A0218A06BB78CC56F455C4B9531A398639689FAB8F0
 ManifestType: installer
 ManifestVersion: 1.12.0
 ReleaseDate: 2026-08-13

--- a/manifests/a/AurelioAvila/PromptShield/0.1.7/AurelioAvila.PromptShield.installer.yaml
+++ b/manifests/a/AurelioAvila/PromptShield/0.1.7/AurelioAvila.PromptShield.installer.yaml
@@ -12,7 +12,7 @@ UpgradeBehavior: install
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/AurelioAvila/promptshield/releases/download/v0.1.7/PromptShield-Setup-0.1.7.exe
-  InstallerSha256: EF08AD8C8C770E2BB96F6A0218A06BB78CC56F455C4B9531A398639689FAB8F0
+  InstallerSha256: EA9CD79A4D4054C4C51D70922DE82ED0A134575B1A1B32C2C77586C379290772
 ManifestType: installer
 ManifestVersion: 1.12.0
 ReleaseDate: 2026-08-13

--- a/manifests/a/AurelioAvila/PromptShield/0.1.7/AurelioAvila.PromptShield.installer.yaml
+++ b/manifests/a/AurelioAvila/PromptShield/0.1.7/AurelioAvila.PromptShield.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: AurelioAvila.PromptShield
+PackageVersion: 0.1.7
+InstallerType: nullsoft
+InstallModes:
+- interactive
+- silent
+InstallerSwitches:
+  Silent: /S
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/AurelioAvila/promptshield/releases/download/v0.1.7/PromptShield-Setup-0.1.7.exe
+  InstallerSha256: 0472BE9F72304F047AF1400763B60D3971F701649A27FAEE6436A47F6008589E
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-08-13

--- a/manifests/a/AurelioAvila/PromptShield/0.1.7/AurelioAvila.PromptShield.installer.yaml
+++ b/manifests/a/AurelioAvila/PromptShield/0.1.7/AurelioAvila.PromptShield.installer.yaml
@@ -12,7 +12,7 @@ UpgradeBehavior: install
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/AurelioAvila/promptshield/releases/download/v0.1.7/PromptShield-Setup-0.1.7.exe
-  InstallerSha256: 0472BE9F72304F047AF1400763B60D3971F701649A27FAEE6436A47F6008589E
+  InstallerSha256: 1D5A23749DF116A144CD173F89245C78A418A9D7E62252CBF0C6FBB749621F21
 ManifestType: installer
 ManifestVersion: 1.12.0
 ReleaseDate: 2026-08-13

--- a/manifests/a/AurelioAvila/PromptShield/0.1.7/AurelioAvila.PromptShield.locale.en-US.yaml
+++ b/manifests/a/AurelioAvila/PromptShield/0.1.7/AurelioAvila.PromptShield.locale.en-US.yaml
@@ -8,7 +8,7 @@ PublisherUrl: https://github.com/AurelioAvila
 PublisherSupportUrl: https://github.com/AurelioAvila/promptshield/issues
 PackageName: PromptShield
 PackageUrl: https://github.com/AurelioAvila/promptshield
-License: MIT
+License: Proprietary
 LicenseUrl: https://github.com/AurelioAvila/promptshield/blob/main/LICENSE
 ShortDescription: Catches personal data, secrets and financial details in your prompt before it reaches ChatGPT, Claude or any other AI tool.
 Description: PromptShield scans text for emails, phone numbers, IP addresses, API keys and tokens, private keys, credit card numbers (Luhn-validated), IBANs (checksum-validated), crypto wallet addresses and more, then offers a redacted version safe to paste into an AI chat. The scan runs on request and is never logged or stored. Includes a companion browser extension for ChatGPT, Claude, Gemini, Copilot and Perplexity.

--- a/manifests/a/AurelioAvila/PromptShield/0.1.7/AurelioAvila.PromptShield.locale.en-US.yaml
+++ b/manifests/a/AurelioAvila/PromptShield/0.1.7/AurelioAvila.PromptShield.locale.en-US.yaml
@@ -11,8 +11,9 @@ PackageUrl: https://github.com/AurelioAvila/promptshield
 License: Proprietary
 LicenseUrl: https://github.com/AurelioAvila/promptshield/blob/main/LICENSE
 ShortDescription: Catches personal data, secrets and financial details in your prompt before it reaches ChatGPT, Claude or any other AI tool.
-Description: PromptShield scans text for emails, phone numbers, IP addresses, API keys and tokens, private keys, credit card numbers (Luhn-validated), IBANs (checksum-validated), crypto wallet addresses and more, then offers a redacted version safe to paste into an AI chat. The scan runs on request and is never logged or stored. Includes a companion browser extension for ChatGPT, Claude, Gemini, Copilot and Perplexity.
+Description: PromptShield scans text for emails, phone numbers, IP addresses, API keys and tokens, private keys, credit card numbers (Luhn-validated), IBANs (checksum-validated), crypto wallet addresses and more, then offers a redacted version safe to paste into an AI chat. The scan runs on request and is never logged or stored. Includes a companion browser extension for ChatGPT, Claude, Gemini, Copilot and Perplexity. Free to use; optional paid plans (Personal EUR 7.99/month or EUR 79.90/year; Business EUR 14.99/user/month or EUR 149.90/user/year) add organization policies, API keys and audit history. Subscriptions are billed by Stripe; users must sign in before starting checkout and confirm the purchase on Stripe's own hosted payment page.
 PrivacyUrl: https://promptshield-beta.vercel.app/privacy.html
+PurchaseUrl: https://promptshield-beta.vercel.app/#pricing
 Tags:
 - privacy
 - security

--- a/manifests/a/AurelioAvila/PromptShield/0.1.7/AurelioAvila.PromptShield.locale.en-US.yaml
+++ b/manifests/a/AurelioAvila/PromptShield/0.1.7/AurelioAvila.PromptShield.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: AurelioAvila.PromptShield
+PackageVersion: 0.1.7
+PackageLocale: en-US
+Publisher: Aurelio Avila
+PublisherUrl: https://github.com/AurelioAvila
+PublisherSupportUrl: https://github.com/AurelioAvila/promptshield/issues
+PackageName: PromptShield
+PackageUrl: https://github.com/AurelioAvila/promptshield
+License: MIT
+LicenseUrl: https://github.com/AurelioAvila/promptshield/blob/main/LICENSE
+ShortDescription: Catches personal data, secrets and financial details in your prompt before it reaches ChatGPT, Claude or any other AI tool.
+Description: PromptShield scans text for emails, phone numbers, IP addresses, API keys and tokens, private keys, credit card numbers (Luhn-validated), IBANs (checksum-validated), crypto wallet addresses and more, then offers a redacted version safe to paste into an AI chat. The scan runs on request and is never logged or stored. Includes a companion browser extension for ChatGPT, Claude, Gemini, Copilot and Perplexity.
+PrivacyUrl: https://promptshield-beta.vercel.app/privacy.html
+Tags:
+- privacy
+- security
+- ai
+- chatgpt
+- redaction
+ReleaseNotesUrl: https://github.com/AurelioAvila/promptshield/releases/tag/v0.1.7
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/AurelioAvila/PromptShield/0.1.7/AurelioAvila.PromptShield.yaml
+++ b/manifests/a/AurelioAvila/PromptShield/0.1.7/AurelioAvila.PromptShield.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: AurelioAvila.PromptShield
+PackageVersion: 0.1.7
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

PromptShield is a Windows desktop app that scans prompts for personal data, credentials and financial identifiers before they're sent to an AI chat tool, and offers a redacted version.

- Repo: https://github.com/AurelioAvila/promptshield
- Release: https://github.com/AurelioAvila/promptshield/releases/tag/v0.1.7
- Installer: NSIS, silent switch `/S`

This is a new package identifier (`AurelioAvila.PromptShield`), first submission.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/417245)