### PR TITLE
chore: update OpenTubeX.OpenTubeX to 0.31.3

### DIFF
--- a/manifests/o/OpenTubeX/OpenTubeX/0.31.3/OpenTubeX.OpenTubeX.installer.yaml
+++ b/manifests/o/OpenTubeX/OpenTubeX/0.31.3/OpenTubeX.OpenTubeX.installer.yaml
@@ -1,0 +1,45 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: OpenTubeX.OpenTubeX
+PackageVersion: 0.31.3
+InstallerLocale: en-US
+InstallerType: nullsoft
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+Protocols:
+- opentubex
+ProductCode: a38f022d-fec2-5f80-a7fe-620ccf1a2767
+ReleaseDate: 2026-08-14
+AppsAndFeaturesEntries:
+- DisplayName: OpenTubeX 0.31.3
+  ProductCode: a38f022d-fec2-5f80-a7fe-620ccf1a2767
+Installers:
+- Architecture: x64
+  Scope: user
+  InstallerUrl: https://github.com/OpenTubeX/OpenTubeX/releases/download/v0.31.3-beta/opentubex-0.31.3-beta-setup-x64.exe
+  InstallerSha256: 7D8E18D610F3596B40D18C9EED47BC422CDDDB65A98E09DAB351F4075E743A72
+  InstallerSwitches:
+    Custom: /CURRENTUSER
+- Architecture: x64
+  Scope: machine
+  InstallerUrl: https://github.com/OpenTubeX/OpenTubeX/releases/download/v0.31.3-beta/opentubex-0.31.3-beta-setup-x64.exe
+  InstallerSha256: 7D8E18D610F3596B40D18C9EED47BC422CDDDB65A98E09DAB351F4075E743A72
+  InstallerSwitches:
+    Custom: /ALLUSERS
+- Architecture: arm64
+  Scope: user
+  InstallerUrl: https://github.com/OpenTubeX/OpenTubeX/releases/download/v0.31.3-beta/opentubex-0.31.3-beta-setup-arm64.exe
+  InstallerSha256: DC1F6EA3CAFA5605DB5520317413E00B936AAB4262D077BCD90D9125416D0994
+  InstallerSwitches:
+    Custom: /CURRENTUSER
+- Architecture: arm64
+  Scope: machine
+  InstallerUrl: https://github.com/OpenTubeX/OpenTubeX/releases/download/v0.31.3-beta/opentubex-0.31.3-beta-setup-arm64.exe
+  InstallerSha256: DC1F6EA3CAFA5605DB5520317413E00B936AAB4262D077BCD90D9125416D0994
+  InstallerSwitches:
+    Custom: /ALLUSERS
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenTubeX/OpenTubeX/0.31.3/OpenTubeX.OpenTubeX.locale.en-US.yaml
+++ b/manifests/o/OpenTubeX/OpenTubeX/0.31.3/OpenTubeX.OpenTubeX.locale.en-US.yaml
@@ -1,0 +1,41 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: OpenTubeX.OpenTubeX
+PackageVersion: 0.31.3
+PackageLocale: en-US
+Publisher: OpenTubeX contributors
+PublisherUrl: https://github.com/OpenTubeX
+PublisherSupportUrl: https://github.com/OpenTubeX/OpenTubeX/issues
+Author: OpenTubeX contributors
+PackageName: OpenTubeX
+PackageUrl: https://opentubex.org/
+License: AGPL-3.0
+LicenseUrl: https://github.com/OpenTubeX/OpenTubeX/blob/HEAD/LICENSE
+Copyright: Copyleft © 2020-2026
+CopyrightUrl: https://github.com/OpenTubeX/OpenTubeX/blob/HEAD/LICENSE
+ShortDescription: A private YouTube client
+Description: OpenTubeX is a private YouTube client for desktop.
+Moniker: opentubex
+Tags:
+- cross-platform
+- electron
+- privacy
+- private-youtube
+- sponsorblock
+- subscriptions
+- tabbed-browsing
+- tabs
+- video
+- videos
+- youtube
+- youtube-client
+- youtube-player
+ReleaseNotes: |-
+  Fixed bugs
+  - Fixed yt-dlp playback fallback failing for some videos after an IP block is detected (#714, #716)
+  - Fixed repeated Invidious API errors when loading comments whose authors have no avatar (#713, #717)
+  - Fixed live-chat placeholders appearing on videos without chat and repeated errors on videos with no comments (#719)
+ReleaseNotesUrl: https://github.com/OpenTubeX/OpenTubeX/releases/tag/v0.31.3-beta
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenTubeX/OpenTubeX/0.31.3/OpenTubeX.OpenTubeX.yaml
+++ b/manifests/o/OpenTubeX/OpenTubeX/0.31.3/OpenTubeX.OpenTubeX.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: OpenTubeX.OpenTubeX
+PackageVersion: 0.31.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

The winget package is still on OpenTubeX 0.31.0, so users do not receive the fixes released in 0.31.3.

This updates `OpenTubeX.OpenTubeX` to 0.31.3 for the x64 and ARM64 NSIS installers in user and machine scope. The manifest retains the current repository-topic tags and includes the text-only 0.31.3 release notes.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

Validation performed with Komac:

```text
komac submit --dry-run --yes manifests/o/OpenTubeX/OpenTubeX/0.31.3
```

> **Note:** `<path>` is the directory containing the manifest you're submitting.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/417269)