### PR TITLE
New version: Asterline version 0.2.3

### DIFF
--- a/manifests/s/Song0705/Asterline/0.2.3/Song0705.Asterline.installer.yaml
+++ b/manifests/s/Song0705/Asterline/0.2.3/Song0705.Asterline.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Song0705.Asterline
+PackageVersion: 0.2.3
+InstallerType: zip
+NestedInstallerType: portable
+Commands:
+  - asterline
+  - ast
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/song0705/Asterline/releases/download/v0.2.3/asterline-0.2.3-x86_64-pc-windows-msvc.zip
+    InstallerSha256: DE291F095BEEA9FE29B6C69CCB5416165C94400281116A2B3AE32FC8123C5BE1
+    NestedInstallerFiles:
+      - RelativeFilePath: asterline-0.2.3-x86_64-pc-windows-msvc/asterline.exe
+        PortableCommandAlias: asterline
+      - RelativeFilePath: asterline-0.2.3-x86_64-pc-windows-msvc/ast.exe
+        PortableCommandAlias: ast
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/Song0705/Asterline/0.2.3/Song0705.Asterline.locale.en-US.yaml
+++ b/manifests/s/Song0705/Asterline/0.2.3/Song0705.Asterline.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Song0705.Asterline
+PackageVersion: 0.2.3
+PackageLocale: en-US
+Publisher: Asterline contributors
+PublisherUrl: https://github.com/song0705/Asterline
+PublisherSupportUrl: https://github.com/song0705/Asterline/issues
+Author: Asterline contributors
+PackageName: Asterline
+PackageUrl: https://github.com/song0705/Asterline
+License: MIT
+LicenseUrl: https://github.com/song0705/Asterline/blob/main/LICENSE
+Copyright: Copyright (c) Asterline contributors
+ShortDescription: Local-first terminal workspace for coordinating coding agents
+Description: A chat-first terminal workspace for coordinating Codex, Claude, Grok, and Agy coding agents.
+Moniker: asterline
+Tags:
+  - ai
+  - agent
+  - cli
+  - coding
+  - terminal
+ReleaseNotesUrl: https://github.com/song0705/Asterline/releases/tag/v0.2.3
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/Song0705/Asterline/0.2.3/Song0705.Asterline.yaml
+++ b/manifests/s/Song0705/Asterline/0.2.3/Song0705.Asterline.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Song0705.Asterline
+PackageVersion: 0.2.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Adds the initial WinGet manifest for Asterline 0.2.3.

The manifest installs the official x64 portable ZIP and exposes both `asterline` and `ast`. The installer URL is version-pinned and its SHA-256 was independently verified against the release asset.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/417274)