### PR TITLE
New version: LengxiQwQ.LivePhotoBox version 2.1.5

### DIFF
--- a/manifests/l/LengxiQwQ/LivePhotoBox/2.1.5/LengxiQwQ.LivePhotoBox.installer.yaml
+++ b/manifests/l/LengxiQwQ/LivePhotoBox/2.1.5/LengxiQwQ.LivePhotoBox.installer.yaml
@@ -15,6 +15,6 @@ NestedInstallerFiles:
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/LengxiQwQ/live-photo-box/releases/download/v2.1.5/Live-Photo-Box-v2.1.5-x64-cli.zip
-    InstallerSha256: 9E514C5461838AF539AEFBB726CD06AAA685618D5AECCB43DD5AFAB75A8BF4CE
+    InstallerSha256: 406EBA04EDA1DDF56255B11022FBA1E98A5722A6ABBA64A34125D2BE077716FF
 ManifestType: installer
 ManifestVersion: 1.9.0

--- a/manifests/l/LengxiQwQ/LivePhotoBox/2.1.5/LengxiQwQ.LivePhotoBox.installer.yaml
+++ b/manifests/l/LengxiQwQ/LivePhotoBox/2.1.5/LengxiQwQ.LivePhotoBox.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: LengxiQwQ.LivePhotoBox
+PackageVersion: 2.1.5
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: livephotobox.exe
+    PortableCommandAlias: livephotobox
+  - RelativeFilePath: livebox.exe
+    PortableCommandAlias: livebox
+  - RelativeFilePath: lpb.exe
+    PortableCommandAlias: lpb
+  - RelativeFilePath: livephoto.exe
+    PortableCommandAlias: livephoto
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/LengxiQwQ/live-photo-box/releases/download/v2.1.5/Live-Photo-Box-v2.1.5-x64-cli.zip
+    InstallerSha256: 9E514C5461838AF539AEFBB726CD06AAA685618D5AECCB43DD5AFAB75A8BF4CE
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/l/LengxiQwQ/LivePhotoBox/2.1.5/LengxiQwQ.LivePhotoBox.locale.en-US.yaml
+++ b/manifests/l/LengxiQwQ/LivePhotoBox/2.1.5/LengxiQwQ.LivePhotoBox.locale.en-US.yaml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: LengxiQwQ.LivePhotoBox
+PackageVersion: 2.1.5
+PackageLocale: en-US
+Publisher: LengxiQwQ
+PublisherUrl: https://github.com/LengxiQwQ/live-photo-box
+PublisherSupportUrl: https://github.com/LengxiQwQ/live-photo-box/issues
+Author: LengxiQwQ
+PackageName: Live Photo Box CLI
+PackageUrl: https://github.com/LengxiQwQ/live-photo-box
+License: GPL-3.0
+LicenseUrl: https://github.com/LengxiQwQ/live-photo-box/blob/master/LICENSE
+Copyright: Copyright (C) 2026 LengxiQwQ. Licensed under GPL v3.0.
+ShortDescription: Merge images & videos into live photos for smartphone galleries
+Description: >
+  livephotobox is a command-line utility for merging image and video files
+  into live photos compatible with HUAWEI, Samsung, Google, Apple, Xiaomi,
+  and vivo gallery applications. A live photo is a single file containing
+  both a still image and a short video — when viewed in a supported gallery,
+  the video plays automatically.
+Moniker: livephotobox
+Tags:
+  - live-photo
+  - motion-photo
+  - media
+  - photo
+  - video
+  - merge
+  - cli
+  - huawei
+  - samsung
+  - google
+  - apple
+Commands:
+  - livephotobox
+  - livebox
+  - lpb
+  - livephoto
+ReleaseNotesUrl: https://github.com/LengxiQwQ/live-photo-box/releases/tag/v2.1.5
+ReleaseNotes: >
+  See changelog at https://github.com/LengxiQwQ/live-photo-box/blob/master/changelogs/release-v2.1.5.md
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/l/LengxiQwQ/LivePhotoBox/2.1.5/LengxiQwQ.LivePhotoBox.yaml
+++ b/manifests/l/LengxiQwQ/LivePhotoBox/2.1.5/LengxiQwQ.LivePhotoBox.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: LengxiQwQ.LivePhotoBox
+PackageVersion: 2.1.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
###### Microsoft Reviewers: [Open in Codespaces](https://codespaces.new/microsoft/winget-pkgs?quickstart=1&repo=microsoft/winget-pkgs&ref=add-livephotobox-2.1.5)

:warning: If your PR was created automatically as part of a migration, please disregard this message and continue to modify the manifests directly.

-----
#### Enter the details of the package here.

Name: **Live Photo Box CLI**
Version: **2.1.5**
Publisher: **LengxiQwQ**

#### Enter the URL of the package's official website.
https://github.com/LengxiQwQ/live-photo-box

#### Summary of the package description.
Command-line tool that merges an image and a short video into a single live photo file, playable in HUAWEI, Samsung, Google, Apple, Xiaomi, and vivo gallery apps.

#### If the package has a logo, enter the URL of the logo.
https://raw.githubusercontent.com/LengxiQwQ/live-photo-box/master/LivePhotoBox/Assets/Logo.png

#### If the package's source code is available, enter the URL of the repository.
https://github.com/LengxiQwQ/live-photo-box

#### If the package includes a license, enter the URL of the license.
https://github.com/LengxiQwQ/live-photo-box/blob/master/LICENSE

#### If the package contains a release, enter the URL of the release.
https://github.com/LengxiQwQ/live-photo-box/releases/tag/v2.1.5

#### What is the manifest's most notable change?
Update from 2.1.4 to 2.1.5: reduces the installed command aliases from 6 to 4 (removes `lipbox` and `lpbx`); adds jpegtran support tooling.

#### Additional information
- CLI alias list changed from 6 to 4 in this release: `livephotobox`, `livebox`, `lpb`, `livephoto`.
- Installer SHA256: `9E514C5461838AF539AEFBB726CD06AAA685618D5AECCB43DD5AFAB75A8BF4CE`

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/417285)