### PR TITLE
Update version: AdGuard.dnsproxy version 0.84.0

### DIFF
--- a/manifests/a/AdGuard/dnsproxy/0.84.0/AdGuard.dnsproxy.installer.yaml
+++ b/manifests/a/AdGuard/dnsproxy/0.84.0/AdGuard.dnsproxy.installer.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: AdGuard.dnsproxy
+PackageVersion: 0.84.0
+InstallerType: zip
+NestedInstallerType: portable
+ReleaseDate: 2026-08-14
+Installers:
+- Architecture: x86
+  NestedInstallerFiles:
+  - RelativeFilePath: windows-386/dnsproxy.exe
+  InstallerUrl: https://github.com/AdguardTeam/dnsproxy/releases/download/v0.84.0/dnsproxy-windows-386-v0.84.0.zip
+  InstallerSha256: 0074E8E0D2DB2AC3B685E388B7DB370C4315F3F29E0D0C63A61B3EDB9B327358
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: windows-amd64/dnsproxy.exe
+  InstallerUrl: https://github.com/AdguardTeam/dnsproxy/releases/download/v0.84.0/dnsproxy-windows-amd64-v0.84.0.zip
+  InstallerSha256: F230A1005E741DD4447E149C957CD78C0D98CED0BA1058C959A4CFC6C1DDDA65
+- Architecture: arm64
+  NestedInstallerFiles:
+  - RelativeFilePath: windows-arm64/dnsproxy.exe
+  InstallerUrl: https://github.com/AdguardTeam/dnsproxy/releases/download/v0.84.0/dnsproxy-windows-arm64-v0.84.0.zip
+  InstallerSha256: 259767A4043AF60D68E1C120B2F5648942DDDF9C267FF62A117085E243526B53
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/AdGuard/dnsproxy/0.84.0/AdGuard.dnsproxy.locale.en-US.yaml
+++ b/manifests/a/AdGuard/dnsproxy/0.84.0/AdGuard.dnsproxy.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: AdGuard.dnsproxy
+PackageVersion: 0.84.0
+PackageLocale: en-US
+Publisher: AdGuard
+PublisherUrl: https://adguard.com/
+PublisherSupportUrl: https://github.com/AdguardTeam/dnsproxy/issues
+PackageName: DNS Proxy
+PackageUrl: https://github.com/AdguardTeam/dnsproxy
+License: Apache-2.0
+LicenseUrl: https://github.com/AdguardTeam/dnsproxy/blob/HEAD/LICENSE
+ShortDescription: Simple DNS proxy with DoH, DoT, DoQ and DNSCrypt support
+Tags:
+- dns
+- dns-over-https
+- dns-over-quic
+- dns-over-tls
+- dnscrypt
+- golang
+- open-source
+- proxy
+ReleaseNotes: |-
+  Fixed
+  • Docker image versioning.
+  • AA flag processing.
+ReleaseNotesUrl: https://github.com/AdguardTeam/dnsproxy/releases/tag/v0.82.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/AdGuard/dnsproxy/0.84.0/AdGuard.dnsproxy.yaml
+++ b/manifests/a/AdGuard/dnsproxy/0.84.0/AdGuard.dnsproxy.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: AdGuard.dnsproxy
+PackageVersion: 0.84.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update AdGuard.dnsproxy to version 0.84.0.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/417400)