### PR TITLE
New version: rulssss.CloudCostTree version 0.1.41

### DIFF
--- a/manifests/r/rulssss/CloudCostTree/0.1.41/rulssss.CloudCostTree.installer.yaml
+++ b/manifests/r/rulssss/CloudCostTree/0.1.41/rulssss.CloudCostTree.installer.yaml
@@ -1,0 +1,14 @@
+PackageIdentifier: rulssss.CloudCostTree
+PackageVersion: 0.1.41
+InstallerType: portable
+Commands:
+  - cloudcosttree
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/rulssss/cloudcosttree/releases/download/v0.1.41/cloudcosttree-windows-amd64.exe
+    InstallerSha256: 1E1795313505F96D0152439E0DA75441E4F0D460F98DDDBDBA772DCFA3162A23
+  - Architecture: arm64
+    InstallerUrl: https://github.com/rulssss/cloudcosttree/releases/download/v0.1.41/cloudcosttree-windows-arm64.exe
+    InstallerSha256: 7C6B8CFF023F7D5F68A30BFBABFDB6E98E7242980C405A308D2CDBF803200845
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/r/rulssss/CloudCostTree/0.1.41/rulssss.CloudCostTree.locale.en-US.yaml
+++ b/manifests/r/rulssss/CloudCostTree/0.1.41/rulssss.CloudCostTree.locale.en-US.yaml
@@ -1,0 +1,10 @@
+PackageIdentifier: rulssss.CloudCostTree
+PackageVersion: 0.1.41
+PackageLocale: en-US
+Publisher: rulssss
+PackageName: CloudCostTree
+License: Proprietary
+ShortDescription: Estimate AWS infrastructure costs in a hierarchical tree before you apply
+PackageUrl: https://cloudcosttree.com
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/r/rulssss/CloudCostTree/0.1.41/rulssss.CloudCostTree.yaml
+++ b/manifests/r/rulssss/CloudCostTree/0.1.41/rulssss.CloudCostTree.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: rulssss.CloudCostTree
+PackageVersion: 0.1.41
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Update to 0.1.41. Installer URLs verified reachable; InstallerSha256 computed locally against the published release assets.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/417405)