### PR TITLE
New version: Tomclanc.GestureSignV2 version 17.2.6

### DIFF
--- a/manifests/t/Tomclanc/GestureSignV2/17.2.6/Tomclanc.GestureSignV2.installer.yaml
+++ b/manifests/t/Tomclanc/GestureSignV2/17.2.6/Tomclanc.GestureSignV2.installer.yaml
@@ -1,0 +1,24 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Tomclanc.GestureSignV2
+PackageVersion: 17.2.6
+InstallerType: wix
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{54C559AA-B36E-41C6-852D-26EE10AE4E68}'
+AppsAndFeaturesEntries:
+- DisplayName: GestureSign V2
+  Publisher: TransposonY / WinUI rebuild
+  ProductCode: '{54C559AA-B36E-41C6-852D-26EE10AE4E68}'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Tomclanc/GestureSignv2/releases/download/v17.2.6/GestureSign-V2-17.2.6-x64.msi
+  InstallerSha256: 4AF511A4752D1BE9225A4EA1E7BA31302C282D4B807865C1C16F47A5CAEE0D7B
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-08-14

--- a/manifests/t/Tomclanc/GestureSignV2/17.2.6/Tomclanc.GestureSignV2.locale.en-US.yaml
+++ b/manifests/t/Tomclanc/GestureSignV2/17.2.6/Tomclanc.GestureSignV2.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Tomclanc.GestureSignV2
+PackageVersion: 17.2.6
+PackageLocale: en-US
+Publisher: Tomclanc
+PublisherUrl: https://github.com/Tomclanc
+PublisherSupportUrl: https://github.com/Tomclanc/GestureSignv2/issues
+Author: Tomclanc
+PackageName: GestureSign V2
+PackageUrl: https://github.com/Tomclanc/GestureSignv2
+License: GPL-2.0
+LicenseUrl: https://github.com/Tomclanc/GestureSignv2/blob/main/LICENSE
+Copyright: Copyright (C) 2026 Tomclanc
+ShortDescription: A Windows 11 focused rebuild of GestureSign for touchpad and mouse gestures.
+Description: GestureSign V2 is a Windows 11 focused rebuild of the classic open-source GestureSign project. It supports touchpad gestures, touchscreen gestures, mouse gestures, gesture trails, per-app actions, ignore rules, tray controls, Smart Close, and bundled Kando radial menu quick actions.
+Moniker: gesturesignv2
+Tags:
+- gesture
+- gestures
+- mouse
+- touchscreen
+- touchpad
+- windows-11
+ReleaseNotes: |-
+  - Fixed an input-state lock on touchpad drivers that omit the final all-contacts-up report. The simulated touchpad release now also resets the raw input source, so touchscreen gestures continue working after a touchpad gesture without restarting the background process.
+ReleaseNotesUrl: https://github.com/Tomclanc/GestureSignv2/releases/tag/v17.2.6
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/Tomclanc/GestureSignv2/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/Tomclanc/GestureSignV2/17.2.6/Tomclanc.GestureSignV2.locale.zh-CN.yaml
+++ b/manifests/t/Tomclanc/GestureSignV2/17.2.6/Tomclanc.GestureSignV2.locale.zh-CN.yaml
@@ -1,0 +1,31 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: Tomclanc.GestureSignV2
+PackageVersion: 17.2.6
+PackageLocale: zh-CN
+Publisher: Tomclanc
+PublisherUrl: https://github.com/Tomclanc
+PublisherSupportUrl: https://github.com/Tomclanc/GestureSignv2/issues
+Author: Tomclanc
+PackageName: GestureSign V2
+PackageUrl: https://github.com/Tomclanc/GestureSignv2
+License: GPL-2.0
+LicenseUrl: https://github.com/Tomclanc/GestureSignv2/blob/main/LICENSE
+Copyright: Copyright (C) 2026 Tomclanc
+ShortDescription: 面向 Windows 11 重构的 GestureSign，支持触控板、触摸屏和鼠标手势。
+Description: GestureSign V2 是经典开源项目 GestureSign 的 Windows 11 重构版本，支持触控板手势、触摸屏手势、鼠标手势、手势轨迹、按应用设置动作、忽略规则、托盘控制、智能关闭，以及内置的 Kando 径向菜单快捷动作。
+Tags:
+- 手势
+- 鼠标
+- 触摸屏
+- 触控板
+- Windows 11
+ReleaseNotes: |-
+  - 修复部分触控板驱动在手势结束时不发送完整抬起报告，导致使用触控板手势后触摸屏手势持续失效、只能重启后台恢复的问题；模拟释放现在会同步复位底层原始输入源。
+ReleaseNotesUrl: https://github.com/Tomclanc/GestureSignv2/releases/tag/v17.2.6
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/Tomclanc/GestureSignv2/wiki
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/t/Tomclanc/GestureSignV2/17.2.6/Tomclanc.GestureSignV2.yaml
+++ b/manifests/t/Tomclanc/GestureSignV2/17.2.6/Tomclanc.GestureSignV2.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Tomclanc.GestureSignV2
+PackageVersion: 17.2.6
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
- Updates Tomclanc.GestureSignV2 to 17.2.6
- Uses the MSI published in the v17.2.6 GitHub release
- Updates the WiX ProductCode, SHA-256, release date, and localized release notes

Local validation: `winget validate` passed.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/417419)