### PR TITLE
New package: DenisDrobyshev.LookUp version 1.1.0

### DIFF
--- a/manifests/d/DenisDrobyshev/LookUp/1.1.0/DenisDrobyshev.LookUp.installer.yaml
+++ b/manifests/d/DenisDrobyshev/LookUp/1.1.0/DenisDrobyshev.LookUp.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: DenisDrobyshev.LookUp
+PackageVersion: 1.1.0
+InstallerType: portable
+Commands:
+- lookup
+ReleaseDate: 2026-08-14
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/DenisDrobyshev/LookUp/releases/download/v1.1.0/LookUp.exe
+  InstallerSha256: 3936F7D7A21CF018256F49EAC1074B1328D9915AD6E3DC57BA242B435111DD77
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/d/DenisDrobyshev/LookUp/1.1.0/DenisDrobyshev.LookUp.locale.en-US.yaml
+++ b/manifests/d/DenisDrobyshev/LookUp/1.1.0/DenisDrobyshev.LookUp.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: DenisDrobyshev.LookUp
+PackageVersion: 1.1.0
+PackageLocale: en-US
+Publisher: Denis Drobyshev
+PublisherUrl: https://github.com/DenisDrobyshev
+PublisherSupportUrl: https://github.com/DenisDrobyshev/LookUp/issues
+Author: Denis Drobyshev
+PackageName: LookUp
+PackageUrl: https://github.com/DenisDrobyshev/LookUp
+License: MIT
+LicenseUrl: https://github.com/DenisDrobyshev/LookUp/blob/main/LICENSE
+Copyright: Copyright (c) Denis Drobyshev
+ShortDescription: Grab any text on your screen — drag a box, get the recognized text in your clipboard. Local OCR, no cloud.
+Description: |-
+  LookUp is a lightweight Windows tray utility that turns any on-screen text into clipboard
+  text. Press the hotkey (Win+Shift+D), drag a box over anything — a picture, a scanned PDF,
+  a video frame, an app that blocks copying — and the recognized text is copied, ready to
+  paste. Recognition runs locally on the OCR engine built into Windows 10/11: no cloud, no
+  accounts, no API keys. In Auto mode each capture is read in the script of the active
+  keyboard layout, so Latin and Cyrillic text that share glyphs are read correctly.
+Moniker: lookup
+Tags:
+- ocr
+- text-recognition
+- screenshot-to-text
+- screen-capture
+- clipboard
+- productivity
+- windows-ocr
+- tray
+ReleaseNotesUrl: https://github.com/DenisDrobyshev/LookUp/releases/tag/v1.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/d/DenisDrobyshev/LookUp/1.1.0/DenisDrobyshev.LookUp.yaml
+++ b/manifests/d/DenisDrobyshev/LookUp/1.1.0/DenisDrobyshev.LookUp.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: DenisDrobyshev.LookUp
+PackageVersion: 1.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: DenisDrobyshev.LookUp 1.1.0

LookUp is a lightweight open-source (MIT) Windows tray utility that turns any on-screen text into clipboard text using the built-in `Windows.Media.Ocr` engine. Self-contained single exe, distributed as a `portable` package.

- Repository: https://github.com/DenisDrobyshev/LookUp
- Release: https://github.com/DenisDrobyshev/LookUp/releases/tag/v1.1.0

#### Checklist
- [x] New package — no other open PRs for this manifest.
- [x] Manifests conform to schema **1.6.0**.
- [x] `winget validate` passes with no errors or warnings.
- [ ] Local `winget install` not run in this environment; relying on the automated sandbox install.

Note: the binary is not code-signed yet, so automated validation may flag it for manual review (SmartScreen/Defender reputation). Installer type is `portable`; SHA-256 matches the released `SHA256SUMS.txt`.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/417430)