### PR TITLE
CoolDesk.CoolDesk version 2.0.9

### DIFF
--- a/manifests/c/CoolDesk/CoolDesk/2.0.9/CoolDesk.CoolDesk.installer.yaml
+++ b/manifests/c/CoolDesk/CoolDesk/2.0.9/CoolDesk.CoolDesk.installer.yaml
@@ -1,0 +1,40 @@
+# Created with WinGet Releaser using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: CoolDesk.CoolDesk
+PackageVersion: 2.0.9
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-08-13
+Installers:
+- Architecture: x64
+  InstallerType: nullsoft
+  Scope: user
+  InstallerUrl: https://github.com/abhayraghuwanshi/cooldesk-extension/releases/download/v2.0.9/CoolDesk_2.0.9_x64-setup.exe
+  InstallerSha256: 98B576640281132C418FF760C3B735258A2EA62277DA6B7B8CABBC08A3643D92
+  ProductCode: CoolDesk
+  AppsAndFeaturesEntries:
+  - Publisher: CN=cool-products
+    ProductCode: CoolDesk
+  InstallationMetadata:
+    DefaultInstallLocation: '%LocalAppData%\CoolDesk'
+- Architecture: x64
+  InstallerType: wix
+  Scope: machine
+  InstallerUrl: https://github.com/abhayraghuwanshi/cooldesk-extension/releases/download/v2.0.9/CoolDesk_2.0.9_x64_en-US.msi
+  InstallerSha256: ED38F431046CEE36194AE0AE09116E0AAA5658DD364C7BE1051D09DB78C6618E
+  ProductCode: '{CAB8ACA6-D899-4C87-83CC-6549E8876085}'
+  AppsAndFeaturesEntries:
+  - Publisher: CN=cool-products
+    ProductCode: '{CAB8ACA6-D899-4C87-83CC-6549E8876085}'
+    UpgradeCode: '{2228EF21-1320-5AB6-89DE-377326D765B8}'
+  InstallationMetadata:
+    DefaultInstallLocation: '%ProgramFiles%/CoolDesk'
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/CoolDesk/CoolDesk/2.0.9/CoolDesk.CoolDesk.locale.en-US.yaml
+++ b/manifests/c/CoolDesk/CoolDesk/2.0.9/CoolDesk.CoolDesk.locale.en-US.yaml
@@ -1,0 +1,41 @@
+# Created with WinGet Releaser using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: CoolDesk.CoolDesk
+PackageVersion: 2.0.9
+PackageLocale: en-US
+Publisher: CoolDesk
+PublisherUrl: https://cool-desk.com/
+PublisherSupportUrl: https://github.com/abhayraghuwanshi/cooldesk-extension/issues
+PrivacyUrl: https://cool-desk.com/privacy-details
+Author: Abhay Raghuwanshi
+PackageName: CoolDesk
+PackageUrl: https://cool-desk.com/
+License: Apache-2.0
+LicenseUrl: https://github.com/abhayraghuwanshi/cooldesk-extension/blob/HEAD/LICENSE
+ShortDescription: AI-powered desktop workspace manager
+Description: CoolDesk is an AI-powered desktop workspace manager that organizes your browser tabs, apps, and workflows. It features a global spotlight search, smart tab grouping, workspace management, and real-time sync across browsers.
+Moniker: cooldesk
+Tags:
+- ai
+- browser
+- productivity
+- tabs
+- workspace
+ReleaseNotes: |-
+  Fixed
+  - Sidebar/bottom-bar dock could get permanently stuck, unreachable from the in-app "back to full window" control.
+  - The docked taskbar bar (and its collapsed edge handle) could render underneath the real macOS Dock or menu bar — invisible and unclickable.
+  - macOS installs showing "CoolDesk is damaged and can't be opened" — the bundled fix script is now impossible to miss (renamed, with a README, in an arranged DMG window).
+  - The Homebrew cask was silently stuck on old versions — the update job now fails loudly instead of no-oping, and the release workflow's gh asset-URL lookup (a long-standing wrong JSON field) is fixed.
+  - AI CLI agents (Claude Code, opencode, Codex) spawned from the spotlight could fail to find a binary that works fine in Terminal, on macOS/Linux.
+  Added
+  - Dock-to-side button in the bottom/top taskbar bar.
+  - Explicit per-layout recovery options in the tray/menu-bar icon: Full Window, Side Dock, Bottom Bar — always reachable regardless of what state the window is stuck in.
+  - Per-column accent color on the Overview dashboard.
+  Changed
+  - Onboarding tour's wallpaper step now works in extension mode too.
+  See the full changelog for details.
+ReleaseNotesUrl: https://github.com/abhayraghuwanshi/cooldesk-extension/releases/tag/v2.0.9
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/CoolDesk/CoolDesk/2.0.9/CoolDesk.CoolDesk.yaml
+++ b/manifests/c/CoolDesk/CoolDesk/2.0.9/CoolDesk.CoolDesk.yaml
@@ -1,0 +1,8 @@
+# Created with WinGet Releaser using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: CoolDesk.CoolDesk
+PackageVersion: 2.0.9
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Adds CoolDesk.CoolDesk version 2.0.9.

Fixed
- Sidebar/bottom-bar dock could get permanently stuck, unreachable from the in-app "back to full window" control.
- The docked taskbar bar (and its collapsed edge handle) could render underneath the real macOS Dock or menu bar — invisible and unclickable.
- macOS installs showing "CoolDesk is damaged and can't be opened" — the bundled fix script is now impossible to miss (renamed, with a README, in an arranged DMG window).
- The Homebrew cask was silently stuck on old versions — the update job now fails loudly instead of no-oping, and the release workflow's gh asset-URL lookup (a long-standing wrong JSON field) is fixed.
- AI CLI agents (Claude Code, opencode, Codex) spawned from the spotlight could fail to find a binary that works fine in Terminal, on macOS/Linux.

Added
- Dock-to-side button in the bottom/top taskbar bar.
- Explicit per-layout recovery options in the tray/menu-bar icon: Full Window, Side Dock, Bottom Bar.
- Per-column accent color on the Overview dashboard.

Changed
- Onboarding tour's wallpaper step now works in extension mode too.

See the [full changelog](https://github.com/abhayraghuwanshi/cooldesk-extension/blob/master/docs/CHANGELOG.md#209--2026-08-14) and [release](https://github.com/abhayraghuwanshi/cooldesk-extension/releases/tag/v2.0.9) for details.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/417432)