### PR TITLE
New package: Jacobanil1.SongWeaver version 1.1.0

### DIFF
--- a/manifests/j/Jacobanil1/SongWeaver/1.1.0/Jacobanil1.SongWeaver.installer.yaml
+++ b/manifests/j/Jacobanil1/SongWeaver/1.1.0/Jacobanil1.SongWeaver.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: Jacobanil1.SongWeaver
+PackageVersion: 1.1.0
+InstallerType: portable
+Commands:
+  - SongWeaver
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Jacobanil1/padboard/releases/download/v1.1.0/SongWeaver.exe
+    InstallerSha256: 80F4B2557C1163508790FD2ECCDB9CC8A51E869FA104917DAEEA0805C6D8F9D5
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/j/Jacobanil1/SongWeaver/1.1.0/Jacobanil1.SongWeaver.locale.en-US.yaml
+++ b/manifests/j/Jacobanil1/SongWeaver/1.1.0/Jacobanil1.SongWeaver.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: Jacobanil1.SongWeaver
+PackageVersion: 1.1.0
+PackageLocale: en-US
+Publisher: Jacobanil1
+PublisherUrl: https://github.com/Jacobanil1
+PublisherSupportUrl: https://github.com/Jacobanil1/padboard/issues
+PackageName: SongWeaver
+PackageUrl: https://github.com/Jacobanil1/padboard
+License: MIT
+LicenseUrl: https://github.com/Jacobanil1/padboard/blob/master/LICENSE
+ShortDescription: A 20-100 pad local soundboard for Windows.
+Description: |-
+  SongWeaver is a local soundboard for Windows. Assign audio files from your library
+  to pads and trigger them by click or keyboard, with crossfade between pads, multiple
+  named pad lists/banks, a build-your-own play queue, Play All/Repeat modes, a seek bar,
+  full keyboard control, and support for MP3, WAV, WMA, and M4A.
+Moniker: songweaver
+Tags:
+  - soundboard
+  - audio
+  - music
+  - dj
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/j/Jacobanil1/SongWeaver/1.1.0/Jacobanil1.SongWeaver.yaml
+++ b/manifests/j/Jacobanil1/SongWeaver/1.1.0/Jacobanil1.SongWeaver.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: Jacobanil1.SongWeaver
+PackageVersion: 1.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## New package

- **PackageIdentifier**: Jacobanil1.SongWeaver
- **PackageVersion**: 1.1.0
- **Source**: https://github.com/Jacobanil1/padboard
- **Release**: https://github.com/Jacobanil1/padboard/releases/tag/v1.1.0

SongWeaver is a local soundboard for Windows: assign audio files from your library
to pads and trigger them by click or keyboard, with crossfade, multiple named pad
lists, a build-your-own play queue, Play All/Repeat modes, a seek bar, full keyboard
control, and support for MP3/WAV/WMA/M4A.

(Supersedes #412951 — that submission was for this app's previous name, PadBoard,
before it was rebranded.)

Installer is a portable (unpackaged) x64 executable built with PyInstaller.

- [x] Manifest passes `winget validate`
- [x] Installer URL verified reachable, SHA256 verified against the published release asset
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/417436)