### PR TITLE
New package: Crabby.ModbusConnect version 0.6.0

### DIFF
--- a/manifests/c/Crabby/ModbusConnect/0.6.0/Crabby.ModbusConnect.installer.yaml
+++ b/manifests/c/Crabby/ModbusConnect/0.6.0/Crabby.ModbusConnect.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Crabby.ModbusConnect
+PackageVersion: 0.6.0
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://modbusconnect.com/downloads/Modbus%20Connect_0.6.0_x64-setup.exe
+    InstallerSha256: 9E86394C39F7337A4491999ED9748710578856C674B3F5ECC8783BF00B8BA24E
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/Crabby/ModbusConnect/0.6.0/Crabby.ModbusConnect.locale.en-US.yaml
+++ b/manifests/c/Crabby/ModbusConnect/0.6.0/Crabby.ModbusConnect.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Crabby.ModbusConnect
+PackageVersion: 0.6.0
+PackageLocale: en-US
+Publisher: Crabby
+PublisherUrl: https://modbusconnect.com
+PublisherSupportUrl: https://modbusconnect.com
+PackageName: Modbus Connect
+PackageUrl: https://modbusconnect.com
+License: Proprietary
+ShortDescription: Modbus TCP Client, Scanner & Logger
+Description: >-
+  Modbus Connect is a Modbus TCP client, network scanner, and data logger for
+  monitoring and logging data from Modbus TCP/IP devices.
+Tags:
+  - modbus
+  - modbus-tcp
+  - plc
+  - industrial
+  - scada
+  - automation
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/Crabby/ModbusConnect/0.6.0/Crabby.ModbusConnect.yaml
+++ b/manifests/c/Crabby/ModbusConnect/0.6.0/Crabby.ModbusConnect.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Crabby.ModbusConnect
+PackageVersion: 0.6.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description
Adds Modbus Connect 0.6.0, a Modbus TCP client, network scanner, and data logger for Windows.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.28 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.28.0)

> **Note:** The installer is unsigned; the publisher has chosen not to purchase a code-signing certificate. Users will see a SmartScreen warning on first run. `InstallerSha256` was computed from the hosted installer at submission time.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/417437)