### PR TITLE
New package: AuthorityGate.CMDHelp version 1.1.2

### DIFF
--- a/manifests/a/AuthorityGate/CMDHelp/1.1.2/AuthorityGate.CMDHelp.installer.yaml
+++ b/manifests/a/AuthorityGate/CMDHelp/1.1.2/AuthorityGate.CMDHelp.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: AuthorityGate.CMDHelp
+PackageVersion: 1.1.2
+InstallerType: exe
+Scope: machine
+InstallModes: [interactive, silent, silentWithProgress]
+InstallerSwitches:
+  Silent: /silent
+  SilentWithProgress: /silent
+UpgradeBehavior: install
+ElevationRequirement: elevationRequired
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/AuthorityGate/CMDHelper/releases/download/v1.1.2/CMD-Help-Setup-1.1.2-x64.exe
+    InstallerSha256: 8FF899AB3B2010F7A6A6873DBCE5744E6014944FD3A6B2625CD28A3698426A1C
+    AppsAndFeaturesEntries:
+      - DisplayName: AuthorityGate CMD Help
+        Publisher: AuthorityGate Inc.
+        DisplayVersion: 1.1.2
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/AuthorityGate/CMDHelp/1.1.2/AuthorityGate.CMDHelp.locale.en-US.yaml
+++ b/manifests/a/AuthorityGate/CMDHelp/1.1.2/AuthorityGate.CMDHelp.locale.en-US.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: AuthorityGate.CMDHelp
+PackageVersion: 1.1.2
+PackageLocale: en-US
+Publisher: AuthorityGate Inc.
+PackageName: CMD Help
+License: MIT
+ShortDescription: Restore distinct colors for Windows 11 console identities.
+Description: CMD Help restores separate color identities for PowerShell, Administrator, User, and System console windows and adds Explorer and Start Menu integration.
+PublisherUrl: https://authoritygate.com
+PublisherSupportUrl: https://authoritygate.com/contact
+PrivacyUrl: https://authoritygate.com/privacy
+PackageUrl: https://download.authoritygate.com
+Tags: [cmd, console, powershell, terminal, windows-11]
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/AuthorityGate/CMDHelp/1.1.2/AuthorityGate.CMDHelp.yaml
+++ b/manifests/a/AuthorityGate/CMDHelp/1.1.2/AuthorityGate.CMDHelp.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: AuthorityGate.CMDHelp
+PackageVersion: 1.1.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Publisher submission for AuthorityGate.CMDHelp 1.1.2. The installer is Authenticode-signed by AUTHORITYGATE INC, timestamped, supports unattended installation and upgrade, and the manifest was validated locally with winget validate.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/417507)