### PR TITLE
New package: AuthorityGate.RackSight version 1.1.6

### DIFF
--- a/manifests/a/AuthorityGate/RackSight/1.1.6/AuthorityGate.RackSight.installer.yaml
+++ b/manifests/a/AuthorityGate/RackSight/1.1.6/AuthorityGate.RackSight.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: AuthorityGate.RackSight
+PackageVersion: 1.1.6
+InstallerType: nullsoft
+Scope: machine
+InstallModes: [interactive, silent, silentWithProgress]
+UpgradeBehavior: install
+ElevationRequirement: elevationRequired
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/AuthorityGate/RackSight/releases/download/v1.1.6/RackSight-Setup-1.1.6-x64.exe
+    InstallerSha256: 1A00EE1B4608659DE74AD5AAB200DE2BFDCABA9F807F4E4D42988C3D8AF030C3
+    AppsAndFeaturesEntries:
+      - DisplayName: RackSight
+        Publisher: AuthorityGate Inc.
+        DisplayVersion: 1.1.6
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/AuthorityGate/RackSight/1.1.6/AuthorityGate.RackSight.locale.en-US.yaml
+++ b/manifests/a/AuthorityGate/RackSight/1.1.6/AuthorityGate.RackSight.locale.en-US.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: AuthorityGate.RackSight
+PackageVersion: 1.1.6
+PackageLocale: en-US
+Publisher: AuthorityGate Inc.
+PackageName: RackSight Desktop
+License: MIT
+ShortDescription: Desktop rack and server visibility with Redfish monitoring.
+Description: RackSight Desktop provides rack and server visibility, Redfish hardware monitoring, retained telemetry, alerts, and secure credential storage.
+PublisherUrl: https://authoritygate.com
+PublisherSupportUrl: https://authoritygate.com/contact
+PrivacyUrl: https://authoritygate.com/privacy
+PackageUrl: https://download.authoritygate.com
+Tags: [rack, server, redfish, monitoring, datacenter]
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/AuthorityGate/RackSight/1.1.6/AuthorityGate.RackSight.yaml
+++ b/manifests/a/AuthorityGate/RackSight/1.1.6/AuthorityGate.RackSight.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: AuthorityGate.RackSight
+PackageVersion: 1.1.6
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Publisher submission for AuthorityGate.RackSight 1.1.6. The installer is Authenticode-signed by AUTHORITYGATE INC, timestamped, supports unattended installation and upgrade, and the manifest was validated locally with winget validate.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/417511)