### PR TITLE
New package: AuthorityGate.RackSightIISServer version 1.1.6

### DIFF
--- a/manifests/a/AuthorityGate/RackSightIISServer/1.1.6/AuthorityGate.RackSightIISServer.installer.yaml
+++ b/manifests/a/AuthorityGate/RackSightIISServer/1.1.6/AuthorityGate.RackSightIISServer.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: AuthorityGate.RackSightIISServer
+PackageVersion: 1.1.6
+InstallerType: exe
+Scope: machine
+InstallModes: [interactive, silent, silentWithProgress]
+InstallerSwitches: { Silent: /silent, SilentWithProgress: /silent }
+UpgradeBehavior: install
+ElevationRequirement: elevationRequired
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/AuthorityGate/RackSight/releases/download/v1.1.6/RackSight-IIS-Server-1.1.6.exe
+    InstallerSha256: BB0EE0C2E8278F714878132D7FED54F32BEA6A9653AD8630D72F8FBF7455AEA8
+    AppsAndFeaturesEntries:
+      - DisplayName: AuthorityGate RackSight IIS Server
+        Publisher: AuthorityGate Inc.
+        DisplayVersion: 1.1.6
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/AuthorityGate/RackSightIISServer/1.1.6/AuthorityGate.RackSightIISServer.locale.en-US.yaml
+++ b/manifests/a/AuthorityGate/RackSightIISServer/1.1.6/AuthorityGate.RackSightIISServer.locale.en-US.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: AuthorityGate.RackSightIISServer
+PackageVersion: 1.1.6
+PackageLocale: en-US
+Publisher: AuthorityGate Inc.
+PackageName: RackSight IIS Server
+License: MIT
+ShortDescription: Multi-user RackSight deployment for Windows Server and IIS.
+Description: RackSight IIS Server installs the complete multi-user RackSight web service and deployment guide for managed Windows Server and IIS environments.
+PublisherUrl: https://authoritygate.com
+PublisherSupportUrl: https://authoritygate.com/contact
+PrivacyUrl: https://authoritygate.com/privacy
+PackageUrl: https://download.authoritygate.com
+Tags: [rack, server, redfish, monitoring, iis]
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/AuthorityGate/RackSightIISServer/1.1.6/AuthorityGate.RackSightIISServer.yaml
+++ b/manifests/a/AuthorityGate/RackSightIISServer/1.1.6/AuthorityGate.RackSightIISServer.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: AuthorityGate.RackSightIISServer
+PackageVersion: 1.1.6
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Publisher submission for AuthorityGate.RackSightIISServer 1.1.6. The installer is Authenticode-signed by AUTHORITYGATE INC, timestamped, supports unattended installation and upgrade, and the manifest was validated locally with winget validate.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/417512)