### PR TITLE
New version: Bozex.Dictator version 2.2.339

### DIFF
--- a/manifests/b/Bozex/Dictator/2.2.339/Bozex.Dictator.installer.yaml
+++ b/manifests/b/Bozex/Dictator/2.2.339/Bozex.Dictator.installer.yaml
@@ -1,0 +1,19 @@
+PackageIdentifier: Bozex.Dictator
+PackageVersion: 2.2.339
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-08-14
+Installers:
+- Architecture: x64
+  InstallerUrl: https://dictator.my/release/Dictator_2.2.339_x64-setup.exe
+  InstallerSha256: DF1684811AF0785947C234F2C194045F5E7F0E7B5D9CD2A316C7F72BBF257D47
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/b/Bozex/Dictator/2.2.339/Bozex.Dictator.locale.en-US.yaml
+++ b/manifests/b/Bozex/Dictator/2.2.339/Bozex.Dictator.locale.en-US.yaml
@@ -1,0 +1,38 @@
+PackageIdentifier: Bozex.Dictator
+PackageVersion: 2.2.339
+PackageLocale: en-US
+Publisher: Bozex
+PublisherUrl: https://dictator.my/
+PublisherSupportUrl: https://dictator.my/support/
+PrivacyUrl: https://dictator.my/privacy.html
+PackageName: Dictator
+PackageUrl: https://dictator.my/
+License: Proprietary
+LicenseUrl: https://dictator.my/terms.html
+Copyright: Copyright (c) Bozex
+ShortDescription: Speech to text, dictation, live subtitles and offline translation that run on your own machine.
+Description: |-
+  Dictator turns speech into text and dictates into any window — email, documents,
+  chat — without sending audio to the cloud. Recognition runs locally on your GPU,
+  so there are no minute limits and nothing leaves the computer.
+
+  It also reads text aloud in natural voices, shows live captions over any window
+  with translation underneath, translates text on photos and on screen, and
+  translates offline through dictionaries downloaded once.
+
+  Speech recognition covers 100 languages, AI translation 198, offline translation 45.
+Moniker: dictator
+Tags:
+- speech-to-text
+- dictation
+- transcription
+- voice-typing
+- subtitles
+- translation
+- offline
+- tts
+- text-to-speech
+- stt
+ReleaseNotesUrl: https://dictator.my/changelog/
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/b/Bozex/Dictator/2.2.339/Bozex.Dictator.yaml
+++ b/manifests/b/Bozex/Dictator/2.2.339/Bozex.Dictator.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Bozex.Dictator
+PackageVersion: 2.2.339
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: `Bozex.Dictator` version `2.2.339`

Dictator is a desktop speech-to-text and dictation app: recognition runs locally
on the user's GPU (whisper.cpp), with live captions, text-to-speech and offline
translation. Windows installer is NSIS, per-user scope.

- Manifest version: 1.6.0
- Installer: `https://dictator.my/release/Dictator_2.2.339_x64-setup.exe` (verified HTTP 200)
- Installer SHA256 taken from the published file itself
- Support URL: https://dictator.my/support/
- Release notes: https://dictator.my/changelog/

The download server keeps the current release plus one previous, so manifests are
refreshed on every publish and always point at a file that exists.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/417545)