### PR TITLE
New package: pzielinski.pureplayer version 0.1.0

### DIFF
--- a/manifests/p/pzielinski/pureplayer/0.1.0/pzielinski.pureplayer.installer.yaml
+++ b/manifests/p/pzielinski/pureplayer/0.1.0/pzielinski.pureplayer.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: pzielinski.pureplayer
+PackageVersion: 0.1.0
+InstallerLocale: en-US
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-07-20
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/piotrzielinski1994/pureplayer/releases/download/v0.1.0/pureplayer_0.1.0_x64-setup.exe
+    InstallerSha256: 4B147EC90DCAC127946285BCB0A5C8A3A8DB2E168392C92949304D520FD002DB
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/p/pzielinski/pureplayer/0.1.0/pzielinski.pureplayer.locale.en-US.yaml
+++ b/manifests/p/pzielinski/pureplayer/0.1.0/pzielinski.pureplayer.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: pzielinski.pureplayer
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Piotr Zieliński
+PublisherUrl: https://github.com/piotrzielinski1994
+PublisherSupportUrl: https://github.com/piotrzielinski1994/pureplayer/issues
+PackageName: pureplayer
+PackageUrl: https://github.com/piotrzielinski1994/pureplayer
+License: MIT
+LicenseUrl: https://github.com/piotrzielinski1994/pureplayer/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Piotr Zieliński
+ShortDescription: pureplayer - a minimal, keyboard-driven desktop video player
+Description: pureplayer is a minimal, keyboard-driven desktop video player built on Tauri 2 with a React 19 frontend.
+Moniker: pureplayer
+Tags:
+  - video
+  - player
+  - media
+  - keyboard-driven
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/p/pzielinski/pureplayer/0.1.0/pzielinski.pureplayer.yaml
+++ b/manifests/p/pzielinski/pureplayer/0.1.0/pzielinski.pureplayer.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: pzielinski.pureplayer
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: `Pzielinski.PurePlayer` version `0.1.0`

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

#### Notes

pureplayer is a minimal, keyboard-driven desktop video player (Tauri app). First submission of this package. NSIS `x64-setup.exe` installer, supports silent install.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/417550)