### PR TITLE
New package: pzielinski.puredeck version 0.1.0

### DIFF
--- a/manifests/p/pzielinski/puredeck/0.1.0/pzielinski.puredeck.installer.yaml
+++ b/manifests/p/pzielinski/puredeck/0.1.0/pzielinski.puredeck.installer.yaml
@@ -16,6 +16,6 @@ ReleaseDate: 2026-08-14
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/piotrzielinski1994/puredeck/releases/download/v0.1.0/puredeck_0.1.0_x64-setup.exe
-    InstallerSha256: 6B54DA08049767F8266E6F77E2297A91312EBE2AA90C9FDAA3971C19CB45943D
+    InstallerSha256: 80AE203F5DBAF93ADDD4CA45D7F77E274885E5B8E9D7EF13B94516C087B913BE
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/p/pzielinski/puredeck/0.1.0/pzielinski.puredeck.installer.yaml
+++ b/manifests/p/pzielinski/puredeck/0.1.0/pzielinski.puredeck.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: pzielinski.puredeck
+PackageVersion: 0.1.0
+InstallerLocale: en-US
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-08-14
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/piotrzielinski1994/puredeck/releases/download/v0.1.0/puredeck_0.1.0_x64-setup.exe
+    InstallerSha256: 6B54DA08049767F8266E6F77E2297A91312EBE2AA90C9FDAA3971C19CB45943D
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/p/pzielinski/puredeck/0.1.0/pzielinski.puredeck.locale.en-US.yaml
+++ b/manifests/p/pzielinski/puredeck/0.1.0/pzielinski.puredeck.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: pzielinski.puredeck
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Piotr Zieliński
+PublisherUrl: https://github.com/piotrzielinski1994
+PublisherSupportUrl: https://github.com/piotrzielinski1994/puredeck/issues
+PackageName: puredeck
+PackageUrl: https://github.com/piotrzielinski1994/puredeck
+License: MIT
+LicenseUrl: https://github.com/piotrzielinski1994/puredeck/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Piotr Zieliński
+ShortDescription: puredeck - a keyboard-driven, file-based desktop flashcards app
+Description: puredeck is a keyboard-driven, file-based desktop flashcards app - an open alternative to Anki, built on Tauri 2 with a React 19 frontend.
+Moniker: puredeck
+Tags:
+  - flashcards
+  - anki
+  - spaced-repetition
+  - study
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/p/pzielinski/puredeck/0.1.0/pzielinski.puredeck.yaml
+++ b/manifests/p/pzielinski/puredeck/0.1.0/pzielinski.puredeck.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: pzielinski.puredeck
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: `Pzielinski.PureDeck` version `0.1.0`

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

#### Notes

puredeck is a keyboard-driven, file-based desktop flashcards app - an open alternative to Anki (Tauri app). First submission of this package. NSIS `x64-setup.exe` installer, supports silent install.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/417552)