### PR TITLE
New package: leduftw.monad version 2.0.1

### DIFF
--- a/manifests/l/leduftw/monad/2.0.1/leduftw.monad.installer.yaml
+++ b/manifests/l/leduftw/monad/2.0.1/leduftw.monad.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: leduftw.monad
+PackageVersion: 2.0.1
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: monad.exe
+  PortableCommandAlias: monad
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/leduftw/monad/releases/download/v2.0.1/monad-windows-x64.zip
+  InstallerSha256: D1B202BDA5238E84337B4C08FCCB75F2995D83141B4838FE2179D74E4F6398F8
+- Architecture: arm64
+  InstallerUrl: https://github.com/leduftw/monad/releases/download/v2.0.1/monad-windows-arm64.zip
+  InstallerSha256: 9850DBFA521126F41AC47EA2C6373EEC3D0A49D965A828F7F68677CC53F74F53
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-08-14

--- a/manifests/l/leduftw/monad/2.0.1/leduftw.monad.locale.en-US.yaml
+++ b/manifests/l/leduftw/monad/2.0.1/leduftw.monad.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: leduftw.monad
+PackageVersion: 2.0.1
+PackageLocale: en-US
+Publisher: leduftw
+PublisherUrl: https://github.com/leduftw
+PublisherSupportUrl: https://github.com/leduftw/monad/issues
+PackageName: monad
+PackageUrl: https://github.com/leduftw/monad
+License: MIT
+LicenseUrl: https://github.com/leduftw/monad/blob/v2.0.1/LICENSE
+ShortDescription: Watches what your machine is playing and logs it as a timeline
+Description: Captures system audio, identifies tracks through AudD, and writes a timeline of what played when.
+Moniker: monad
+Tags:
+- audio
+- cli
+- music
+- music-recognition
+- system-audio
+ReleaseNotesUrl: https://github.com/leduftw/monad/releases/tag/v2.0.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/l/leduftw/monad/2.0.1/leduftw.monad.yaml
+++ b/manifests/l/leduftw/monad/2.0.1/leduftw.monad.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: leduftw.monad
+PackageVersion: 2.0.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds the first WinGet manifest for **leduftw.monad 2.0.1**, using the official self-contained x64 and ARM64 portable ZIPs from the immutable GitHub release.

The release archives were built and smoke-tested on native Windows x64 and ARM64 GitHub-hosted runners. Their published SHA-256 hashes and PE architectures were independently verified before submission.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- Linked issue: not applicable

## 📦 Manifest Checklist

- [x] Checked that there are no other open pull requests for this package
- [x] This PR only modifies one manifest set
- [ ] Validated with `winget validate` locally — the submission machine is macOS; the upstream Windows validation pipeline is the native check
- [ ] Installed through a local WinGet manifest — both underlying release archives passed native Windows install and upgrade smoke tests
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/417578)