### PR TITLE
New package: Devable.Companion version 0.1.0

### DIFF
--- a/manifests/d/Devable/Companion/0.1.0/Devable.Companion.installer.yaml
+++ b/manifests/d/Devable/Companion/0.1.0/Devable.Companion.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Devable.Companion
+PackageVersion: 0.1.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: devable.exe
+  PortableCommandAlias: devable
+ReleaseDate: 2026-08-15
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/devable-dev/devable-companion/releases/download/companion/v0.1.0/devable_0.1.0_windows_amd64.zip
+  InstallerSha256: 5370A7BA14EF279043F57ABC0F5B0D3EAF349ECF888BA0720BD32CE6DF6830F0
+- Architecture: arm64
+  InstallerUrl: https://github.com/devable-dev/devable-companion/releases/download/companion/v0.1.0/devable_0.1.0_windows_arm64.zip
+  InstallerSha256: 2C32D05E86A143F387FFCADA4A9AA18900F5EE892F791B1BAD74274EA910E773
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/d/Devable/Companion/0.1.0/Devable.Companion.locale.en-US.yaml
+++ b/manifests/d/Devable/Companion/0.1.0/Devable.Companion.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Devable.Companion
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Devable
+PublisherUrl: https://github.com/devable-dev
+PublisherSupportUrl: https://github.com/devable-dev/devable-companion/issues
+PackageName: Devable Companion
+PackageUrl: https://github.com/devable-dev/devable-companion
+License: Proprietary
+Copyright: Copyright (c) 2026 Devable
+ShortDescription: CLI and local daemon that runs Devable course environments in Docker
+Description: |-
+  The Devable companion is a single native binary containing a command-line tool and a
+  local daemon. It runs Devable course environments as Docker containers on your own
+  machine, so lesson code executes locally while the Devable web app drives it: starting
+  a lesson's container, syncing your edits, exposing a preview port, and running the
+  lesson's verification tests.
+Moniker: devable
+Tags:
+- cli
+- developer-tools
+- docker
+- education
+- learning
+ReleaseNotesUrl: https://github.com/devable-dev/devable-companion/releases/tag/companion/v0.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/d/Devable/Companion/0.1.0/Devable.Companion.yaml
+++ b/manifests/d/Devable/Companion/0.1.0/Devable.Companion.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Devable.Companion
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Pull request has been created with [manual authoring]

- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

**Note on the unchecked boxes:** The CLA is pending — the repository owner will reply to the CLA bot directly.

 these manifests were authored on macOS, where `winget` is unavailable, so I could not run `winget validate` or `winget install --manifest` before submitting. I would appreciate the validation pipeline's output, and I'll fix anything it flags promptly. What I *was* able to verify is listed below.

---

New package: **Devable.Companion** 0.1.0

A CLI and local daemon that runs [Devable](https://devable.dev) course environments as Docker containers on the learner's own machine.

- Publisher repository: https://github.com/devable-dev/devable-companion
- Release: https://github.com/devable-dev/devable-companion/releases/tag/companion/v0.1.0

What was verified:

- Both `InstallerUrl`s return HTTP 200 anonymously (public GitHub release assets).
- `InstallerSha256` values match the release's `checksums.txt`; I also downloaded the x64 archive and re-hashed it independently to confirm.
- The archive contains `devable.exe` at its root, matching `NestedInstallerFiles.RelativeFilePath`.
- All three manifests parse as valid YAML and follow the 1.12.0 multi-file layout.

Submitted by the package publisher.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/417661)
