### PR TITLE
New package: AuthorityGate.ShellColors version 1.2.1

### DIFF
--- a/manifests/a/AuthorityGate/ShellColors/1.2.1/AuthorityGate.ShellColors.installer.yaml
+++ b/manifests/a/AuthorityGate/ShellColors/1.2.1/AuthorityGate.ShellColors.installer.yaml
@@ -12,7 +12,7 @@ ElevationRequirement: elevationRequired
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/AuthorityGate/CMDHelper/releases/download/v1.2.1/AuthorityGate-ShellColors-Setup-1.2.1-x64.exe
-    InstallerSha256: 1905AF7F9C0805511EF2E91DC36A96D203464F9DCFEA0FC7E828199D3BDE7F7
+    InstallerSha256: 1905AF7F9C0805511EF2E91DC36A96D203464F9DCFEA0FC7E828199D3BDDE7F7
     AppsAndFeaturesEntries:
       - DisplayName: AuthorityGate ShellColors
         Publisher: AuthorityGate Inc.

--- a/manifests/a/AuthorityGate/ShellColors/1.2.1/AuthorityGate.ShellColors.installer.yaml
+++ b/manifests/a/AuthorityGate/ShellColors/1.2.1/AuthorityGate.ShellColors.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: AuthorityGate.ShellColors
+PackageVersion: 1.2.1
+InstallerType: exe
+Scope: machine
+InstallModes: [interactive, silent, silentWithProgress]
+InstallerSwitches:
+  Silent: /silent
+  SilentWithProgress: /silent
+UpgradeBehavior: install
+ElevationRequirement: elevationRequired
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/AuthorityGate/CMDHelper/releases/download/v1.2.1/AuthorityGate-ShellColors-Setup-1.2.1-x64.exe
+    InstallerSha256: 1905AF7F9C0805511EF2E91DC36A96D203464F9DCFEA0FC7E828199D3BDE7F7
+    AppsAndFeaturesEntries:
+      - DisplayName: AuthorityGate ShellColors
+        Publisher: AuthorityGate Inc.
+        DisplayVersion: 1.2.1
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/AuthorityGate/ShellColors/1.2.1/AuthorityGate.ShellColors.locale.en-US.yaml
+++ b/manifests/a/AuthorityGate/ShellColors/1.2.1/AuthorityGate.ShellColors.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: AuthorityGate.ShellColors
+PackageVersion: 1.2.1
+PackageLocale: en-US
+Publisher: AuthorityGate Inc.
+PackageName: AuthorityGate ShellColors
+PackageUrl: https://download.authoritygate.com
+PublisherUrl: https://authoritygate.com
+PublisherSupportUrl: https://authoritygate.com/contact
+PrivacyUrl: https://authoritygate.com/privacy
+License: MIT
+ShortDescription: Restore separate colors for Windows PowerShell, Administrator, User, and System consoles.
+Description: AuthorityGate ShellColors adds back the separate per-console color identities removed from Windows 11. It provides distinct PowerShell, Administrator, User, and System console colors together with Explorer context-menu and Start Menu integration, signed updates, and free AuthorityGate registration.
+Moniker: shellcolors
+Tags: [authoritygate, cmd, colors, console, powershell, shell, terminal, windows-11]
+ReleaseNotes: Registration uses a required email and optional company, Not now asks again later, and only one registration window can open at a time. Includes reliable unattended installation and signed updates.
+ReleaseNotesUrl: https://github.com/AuthorityGate/CMDHelper/releases/tag/v1.2.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/AuthorityGate/ShellColors/1.2.1/AuthorityGate.ShellColors.yaml
+++ b/manifests/a/AuthorityGate/ShellColors/1.2.1/AuthorityGate.ShellColors.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: AuthorityGate.ShellColors
+PackageVersion: 1.2.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
New AuthorityGate ShellColors package. Version 1.2.1 collects a required email, keeps Company fully optional, allows Not now to close and ask again later, and prevents stacked registration windows. The installer was locally validated with /silent: exit code 0, expected Apps & Features registration, and Authenticode signatures from AUTHORITYGATE INC.\n\nRelease: https://github.com/AuthorityGate/CMDHelper/releases/tag/v1.2.1\n\n@microsoft-github-policy-service agree company="AUTHORITYGATE INC"
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/417692)