### PR TITLE
New package: AuthorityGate.ShellColors version 1.2.2

### DIFF
--- a/manifests/a/AuthorityGate/ShellColors/1.2.2/AuthorityGate.ShellColors.installer.yaml
+++ b/manifests/a/AuthorityGate/ShellColors/1.2.2/AuthorityGate.ShellColors.installer.yaml
@@ -16,6 +16,5 @@ Installers:
     AppsAndFeaturesEntries:
       - DisplayName: AuthorityGate ShellColors
         Publisher: AuthorityGate Inc.
-        DisplayVersion: 1.2.2
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/a/AuthorityGate/ShellColors/1.2.2/AuthorityGate.ShellColors.installer.yaml
+++ b/manifests/a/AuthorityGate/ShellColors/1.2.2/AuthorityGate.ShellColors.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: AuthorityGate.ShellColors
+PackageVersion: 1.2.2
+InstallerType: exe
+Scope: machine
+InstallModes: [interactive, silent, silentWithProgress]
+InstallerSwitches:
+  Silent: /silent
+  SilentWithProgress: /silent
+UpgradeBehavior: install
+ElevationRequirement: elevationRequired
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/AuthorityGate/CMDHelper/releases/download/v1.2.2/AuthorityGate-ShellColors-Setup-1.2.2-x64.exe
+    InstallerSha256: BB589884CF31A2390530840F2EDC5B83050A7083C61048BFEC78F1552A616168
+    AppsAndFeaturesEntries:
+      - DisplayName: AuthorityGate ShellColors
+        Publisher: AuthorityGate Inc.
+        DisplayVersion: 1.2.2
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/AuthorityGate/ShellColors/1.2.2/AuthorityGate.ShellColors.locale.en-US.yaml
+++ b/manifests/a/AuthorityGate/ShellColors/1.2.2/AuthorityGate.ShellColors.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: AuthorityGate.ShellColors
+PackageVersion: 1.2.2
+PackageLocale: en-US
+Publisher: AuthorityGate Inc.
+PackageName: AuthorityGate ShellColors
+PackageUrl: https://download.authoritygate.com
+PublisherUrl: https://authoritygate.com
+PublisherSupportUrl: https://authoritygate.com/contact
+PrivacyUrl: https://authoritygate.com/privacy
+License: MIT
+ShortDescription: Restore separate colors for Windows PowerShell, Administrator, User, and System consoles.
+Description: AuthorityGate ShellColors adds back the separate per-console color identities removed from Windows 11. It provides distinct PowerShell, Administrator, User, and System console colors together with Explorer context-menu and Start Menu integration, signed updates, and free AuthorityGate registration.
+Moniker: shellcolors
+Tags: [authoritygate, cmd, colors, console, powershell, shell, terminal, windows-11]
+ReleaseNotes: Fixes first-run registration so any valid email is recorded directly without requiring an existing website account. Company remains optional, Not now asks again later, and only one registration window can open at a time.
+ReleaseNotesUrl: https://github.com/AuthorityGate/CMDHelper/releases/tag/v1.2.2
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/AuthorityGate/ShellColors/1.2.2/AuthorityGate.ShellColors.yaml
+++ b/manifests/a/AuthorityGate/ShellColors/1.2.2/AuthorityGate.ShellColors.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: AuthorityGate.ShellColors
+PackageVersion: 1.2.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
New AuthorityGate ShellColors package. Version 1.2.2 completes first-run registration inside the application: any valid email is recorded directly, no prior website account is required, Company is optional, Not now asks again later, and duplicate registration windows are prevented. The signed installer passed local /silent installation with exit code 0 and the manifests passed winget validate.\n\nRelease: https://github.com/AuthorityGate/CMDHelper/releases/tag/v1.2.2\n\n@microsoft-github-policy-service agree company="AUTHORITYGATE INC"
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/417696)