### PR TITLE
New package: bryramirezp.DictationTool version 0.1.0

### DIFF
--- a/manifests/b/bryramirezp/DictationTool/0.1.0/bryramirezp.DictationTool.installer.yaml
+++ b/manifests/b/bryramirezp/DictationTool/0.1.0/bryramirezp.DictationTool.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: bryramirezp.DictationTool
+PackageVersion: 0.1.0
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-08-15
+AppsAndFeaturesEntries:
+# Only the product code. Inno writes the display name as "Dictation Tool version
+# 0.1.0", and pinning that here would stop winget matching the next release.
+- ProductCode: '{7C1B4E62-9A3D-4F58-B0E7-2D6A5F8C1E90}_is1'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/bryramirezp/dictation-tool/releases/download/v0.1.0/DictationTool-Setup-0.1.0.exe
+  InstallerSha256: 2854B24FAC83EEB883314D1BE4BF609B2B4D1DD88FC8C4734E51618B1FACF145
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/b/bryramirezp/DictationTool/0.1.0/bryramirezp.DictationTool.locale.en-US.yaml
+++ b/manifests/b/bryramirezp/DictationTool/0.1.0/bryramirezp.DictationTool.locale.en-US.yaml
@@ -1,0 +1,51 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: bryramirezp.DictationTool
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: bryramirezp
+PublisherUrl: https://github.com/bryramirezp
+PublisherSupportUrl: https://github.com/bryramirezp/dictation-tool/issues
+Author: Bryan Ramirez
+PackageName: Dictation Tool
+PackageUrl: https://github.com/bryramirezp/dictation-tool
+License: MIT
+LicenseUrl: https://github.com/bryramirezp/dictation-tool/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Bryan Ramirez
+CopyrightUrl: https://github.com/bryramirezp/dictation-tool/blob/main/LICENSE
+ShortDescription: Free offline speech to text for Windows
+Description: |-
+  Push-to-talk dictation for Windows. Hold a key, speak, let go, and your words
+  are typed into whatever application has focus: a browser, a document, a chat,
+  a code editor.
+
+  The speech recognition runs on your own computer using Whisper, so your voice
+  is never uploaded anywhere and the tool keeps working with no internet
+  connection. There is no account and no subscription.
+
+  The microphone is only open while you hold the key. You can dictate in
+  Spanish, English, Portuguese, French, German or Italian, and you pick the
+  language yourself rather than letting it guess, which is both faster and more
+  accurate on short recordings.
+
+  This download runs on the processor. If you have an NVIDIA graphics card,
+  installing from the source code lets it run much faster.
+Moniker: dictation-tool
+Tags:
+- accessibility
+- dictation
+- offline
+- privacy
+- push-to-talk
+- speech-recognition
+- speech-to-text
+- transcription
+- voice
+- voice-typing
+- whisper
+ReleaseNotesUrl: https://github.com/bryramirezp/dictation-tool/releases/tag/v0.1.0
+Documentations:
+- DocumentLabel: Website
+  DocumentUrl: https://bryramirezp.github.io/dictation-tool/
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/b/bryramirezp/DictationTool/0.1.0/bryramirezp.DictationTool.yaml
+++ b/manifests/b/bryramirezp/DictationTool/0.1.0/bryramirezp.DictationTool.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: bryramirezp.DictationTool
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New package: `bryramirezp.DictationTool` version `0.1.0`

Push-to-talk dictation for Windows. Hold a key, speak, let go, and the text is
typed into whatever window has focus. Speech recognition runs locally through
faster-whisper, so it works with no internet connection and nothing is uploaded.

- Homepage: https://bryramirezp.github.io/dictation-tool/
- Source: https://github.com/bryramirezp/dictation-tool
- Release: https://github.com/bryramirezp/dictation-tool/releases/tag/v0.1.0
- License: MIT

I am the author of this package.

#### Checklist

- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/addition?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-cli/blob/master/schemas/JSON/manifests/v1.12.0)?

On the CLA box: being agreed to in a comment below.

On the second unchecked box: `winget validate` passes, but `winget install --manifest`
needs `LocalManifestFiles` enabled, which requires an elevated shell I did not
have on this machine. Instead the released installer itself was installed and
uninstalled silently with the switches winget uses for `InstallerType: inno`
(`/VERYSILENT /SUPPRESSMSGBOXES /NORESTART`). Happy to run the manifest install
and report back if that is required.

#### Notes

Installs per user under `%LOCALAPPDATA%\Programs\DictationTool`, so it needs no
administrator rights; `Scope` is set to `user` accordingly.

`AppsAndFeaturesEntries` carries only the `ProductCode`, read from the registry
after a real install rather than guessed. Inno Setup registers the display name
as "Dictation Tool version 0.1.0", so pinning `DisplayName` would break matching
on the next release.

Verified on Windows 11: silent install creates the Start Menu entry and the
optional startup shortcut, silent uninstall removes the install directory, the
registry entry and that shortcut, and user settings under `%LOCALAPPDATA%` are
left alone. The installer SHA256 matches the release asset as downloaded.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/417700)

