### PR TITLE
Add TaeminGames.Heimdall version 3.5.107

### DIFF
--- a/manifests/t/TaeminGames/Heimdall/3.5.107/taemingames.heimdall.installer.yaml
+++ b/manifests/t/TaeminGames/Heimdall/3.5.107/taemingames.heimdall.installer.yaml
@@ -1,0 +1,19 @@
+# Created using wingetcreate 1.6.5.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: TaeminGames.Heimdall
+PackageVersion: 3.5.107
+InstallerLocale: ko-KR
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: user
+InstallModes:
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/sontaemin80/Heimdall-OS/releases/download/v3.5.107/HEIMDALL_Setup_v3.5.107.exe
+    InstallerSha256: f03bd47154c4a1862c1afab12bb12a2f7fddce2941d591052b6b25114a5c1689
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/t/TaeminGames/Heimdall/3.5.107/taemingames.heimdall.locale.ko-KR.yaml
+++ b/manifests/t/TaeminGames/Heimdall/3.5.107/taemingames.heimdall.locale.ko-KR.yaml
@@ -1,0 +1,16 @@
+# Created using wingetcreate 1.6.5.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
+
+PackageIdentifier: TaeminGames.Heimdall
+PackageVersion: 3.5.107
+PackageLocale: ko-KR
+Publisher: TaeminGames
+PublisherUrl: https://www.taemingames.com
+PublisherSupportUrl: https://github.com/sontaemin80/Heimdall-OS/issues
+Author: sontaemin80
+PackageName: Heimdall OS
+PackageUrl: https://www.taemingames.com
+License: Proprietary
+ShortDescription: Heimdall OS is a powerful agentic AI operating portal.
+ManifestType: locale
+ManifestVersion: 1.6.0

--- a/manifests/t/TaeminGames/Heimdall/3.5.107/taemingames.heimdall.version.yaml
+++ b/manifests/t/TaeminGames/Heimdall/3.5.107/taemingames.heimdall.version.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.6.5.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: TaeminGames.Heimdall
+PackageVersion: 3.5.107
+DefaultLocale: ko-KR
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Hello Microsoft Winget Team, please add Heimdall OS version 3.5.107 Windows installer. This app is built via Inno Setup and supports silent installation.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/417721)