### PR TITLE
New package: RitvikDayal.FeatherWall version 0.1.0

### DIFF
--- a/manifests/r/RitvikDayal/FeatherWall/0.1.0/RitvikDayal.FeatherWall.installer.yaml
+++ b/manifests/r/RitvikDayal/FeatherWall/0.1.0/RitvikDayal.FeatherWall.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: RitvikDayal.FeatherWall
+PackageVersion: 0.1.0
+MinimumOSVersion: 10.0.17763.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: featherwall.exe
+    PortableCommandAlias: featherwall
+UpgradeBehavior: install
+ReleaseDate: 2026-08-15
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.10
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/RitvikDayal/featherwall/releases/download/v0.1.0/featherwall-v0.1.0-win-x64.zip
+    InstallerSha256: 300F59A28269FC2FC034AD86EE64D6FD320CD17F8C2E7A31C789BCC28844DFD7
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/r/RitvikDayal/FeatherWall/0.1.0/RitvikDayal.FeatherWall.locale.en-US.yaml
+++ b/manifests/r/RitvikDayal/FeatherWall/0.1.0/RitvikDayal.FeatherWall.locale.en-US.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: RitvikDayal.FeatherWall
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Ritvik Dayal
+PublisherUrl: https://github.com/RitvikDayal
+PublisherSupportUrl: https://github.com/RitvikDayal/featherwall/issues
+PackageName: FeatherWall
+PackageUrl: https://github.com/RitvikDayal/featherwall
+License: MIT
+LicenseUrl: https://github.com/RitvikDayal/featherwall/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Ritvik Dayal
+ShortDescription: A featherweight live-wallpaper engine for Windows.
+Description: |-
+  FeatherWall puts any video or image on your Windows desktop and adds a configurable clock
+  widget over it. It runs as a single process built on raw Win32, Direct3D 11 and
+  DirectComposition, with no browser engine, no launcher and no account.
+
+  It supports both desktop topologies, the classic WorkerW layout and the Windows 11 24H2+
+  raised desktop, and pauses playback when a fullscreen app is in front, the session is locked,
+  the connection is remote, or battery saver is on. A still wallpaper costs about 151 MB and
+  0.03 percent CPU, measured on a 2560x1600 display at 150 percent scaling.
+
+  A built-in gallery offers curated public domain and CC0 wallpapers from NASA and Wikimedia
+  Commons, downloaded directly from the source with no API key and no tracking.
+Moniker: featherwall
+Tags:
+  - wallpaper
+  - live-wallpaper
+  - desktop
+  - customization
+  - windows
+  - dotnet
+ReleaseNotesUrl: https://github.com/RitvikDayal/featherwall/releases/tag/v0.1.0
+Documentations:
+  - DocumentLabel: Architecture
+    DocumentUrl: https://github.com/RitvikDayal/featherwall/blob/main/docs/architecture.md
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/r/RitvikDayal/FeatherWall/0.1.0/RitvikDayal.FeatherWall.yaml
+++ b/manifests/r/RitvikDayal/FeatherWall/0.1.0/RitvikDayal.FeatherWall.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: RitvikDayal.FeatherWall
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
New package: **RitvikDayal.FeatherWall** version **0.1.0**

FeatherWall is an open source live-wallpaper engine for Windows 10 and 11. It puts any video or
image on the desktop and adds a configurable clock widget, running as a single process built on
Win32, Direct3D 11 and DirectComposition, with no browser engine and no launcher.

- Repository: https://github.com/RitvikDayal/featherwall
- Release: https://github.com/RitvikDayal/featherwall/releases/tag/v0.1.0
- Licence: MIT

### Packaging notes

The release archive contains a single `featherwall.exe`, so it is packaged as `InstallerType: zip`
with `NestedInstallerType: portable` and a `featherwall` command alias.

The build is framework-dependent, which keeps the download at about 7 MB, so
`Microsoft.DotNet.DesktopRuntime.10` is declared as a package dependency. That identifier was
confirmed present in the winget source (Microsoft .NET Windows Desktop Runtime 10.0, 10.0.11).

### Validation

- `winget validate --manifest <dir>` reports **Manifest validation succeeded**
- Installer SHA-256 verified against the published release asset:
  `300F59A28269FC2FC034AD86EE64D6FD320CD17F8C2E7A31C789BCC28844DFD7`
- Installer URL returns HTTP 200 from the public release
- Searched this repository for existing FeatherWall pull requests and found none

I was not able to run `winget install --manifest` locally, because installing from a local
manifest requires `winget settings --enable LocalManifestFiles` to be turned on by an
administrator, which is not available on the machine this was prepared from. Everything else above
was verified directly rather than assumed.

### Checklist

- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/add?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/417753)