### PR TITLE
New package: Moresyl.DSHStudio version 0.1.1

### DIFF
--- a/manifests/m/Moresyl/DSHStudio/0.1.1/Moresyl.DSHStudio.installer.yaml
+++ b/manifests/m/Moresyl/DSHStudio/0.1.1/Moresyl.DSHStudio.installer.yaml
@@ -1,5 +1,5 @@
 # Created with WinGet Manifest Creator v1.12.13.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: Moresyl.DSHStudio
 PackageVersion: 0.1.1
@@ -25,4 +25,4 @@ Installers:
     UpgradeCode: '{5022ECEE-06B6-5FE0-A2E0-7380FBC63B33}'
     InstallerType: wix
 ManifestType: installer
-ManifestVersion: 1.10.0
+ManifestVersion: 1.12.0

--- a/manifests/m/Moresyl/DSHStudio/0.1.1/Moresyl.DSHStudio.installer.yaml
+++ b/manifests/m/Moresyl/DSHStudio/0.1.1/Moresyl.DSHStudio.installer.yaml
@@ -1,0 +1,28 @@
+# Created with WinGet Manifest Creator v1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: Moresyl.DSHStudio
+PackageVersion: 0.1.1
+InstallerLocale: en-US
+InstallerType: wix
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-08-15
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Moresyl/dsh-studio/releases/download/v0.1.1/DSH.Studio_0.1.1_x64_en-US.msi
+  InstallerSha256: 331B8C3E8738A505B797A6161635163909A22E4C467757B5250FA2676FBB6B0F
+  ProductCode: '{786030BD-2233-4C92-B4ED-574FFBC5A992}'
+  AppsAndFeaturesEntries:
+  - DisplayName: DSH Studio
+    Publisher: github
+    DisplayVersion: 0.1.1
+    ProductCode: '{786030BD-2233-4C92-B4ED-574FFBC5A992}'
+    UpgradeCode: '{5022ECEE-06B6-5FE0-A2E0-7380FBC63B33}'
+    InstallerType: wix
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/m/Moresyl/DSHStudio/0.1.1/Moresyl.DSHStudio.locale.en-US.yaml
+++ b/manifests/m/Moresyl/DSHStudio/0.1.1/Moresyl.DSHStudio.locale.en-US.yaml
@@ -1,4 +1,25 @@
 # Created with WinGet Manifest Creator v1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Moresyl.DSHStudio
+PackageVersion: 0.1.1
+PackageLocale: en-US
+Publisher: Moresyl
+PublisherUrl: https://github.com/Moresyl
+PublisherSupportUrl: https://github.com/Moresyl/dsh-studio/issues
+PackageName: DSH Studio
+PackageUrl: https://github.com/Moresyl/dsh-studio
+License: MIT
+LicenseUrl: https://github.com/Moresyl/dsh-studio/blob/main/LICENSE
+ShortDescription: Cross-platform desktop host for installing, configuring, and managing DeepSeek Harness.
+Tags:
+- deepseek
+- developer-tools
+- harness
+ReleaseNotesUrl: https://github.com/Moresyl/dsh-studio/releases/tag/v0.1.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0
+# Created with WinGet Manifest Creator v1.12.13.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
 
 PackageIdentifier: Moresyl.DSHStudio

--- a/manifests/m/Moresyl/DSHStudio/0.1.1/Moresyl.DSHStudio.locale.en-US.yaml
+++ b/manifests/m/Moresyl/DSHStudio/0.1.1/Moresyl.DSHStudio.locale.en-US.yaml
@@ -19,24 +19,3 @@ Tags:
 ReleaseNotesUrl: https://github.com/Moresyl/dsh-studio/releases/tag/v0.1.1
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0
-# Created with WinGet Manifest Creator v1.12.13.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
-
-PackageIdentifier: Moresyl.DSHStudio
-PackageVersion: 0.1.1
-PackageLocale: en-US
-Publisher: Moresyl
-PublisherUrl: https://github.com/Moresyl
-PublisherSupportUrl: https://github.com/Moresyl/dsh-studio/issues
-PackageName: DSH Studio
-PackageUrl: https://github.com/Moresyl/dsh-studio
-License: MIT
-LicenseUrl: https://github.com/Moresyl/dsh-studio/blob/main/LICENSE
-ShortDescription: Cross-platform desktop host for installing, configuring, and managing DeepSeek Harness.
-Tags:
-- deepseek
-- developer-tools
-- harness
-ReleaseNotesUrl: https://github.com/Moresyl/dsh-studio/releases/tag/v0.1.1
-ManifestType: defaultLocale
-ManifestVersion: 1.10.0

--- a/manifests/m/Moresyl/DSHStudio/0.1.1/Moresyl.DSHStudio.locale.en-US.yaml
+++ b/manifests/m/Moresyl/DSHStudio/0.1.1/Moresyl.DSHStudio.locale.en-US.yaml
@@ -1,0 +1,21 @@
+# Created with WinGet Manifest Creator v1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: Moresyl.DSHStudio
+PackageVersion: 0.1.1
+PackageLocale: en-US
+Publisher: Moresyl
+PublisherUrl: https://github.com/Moresyl
+PublisherSupportUrl: https://github.com/Moresyl/dsh-studio/issues
+PackageName: DSH Studio
+PackageUrl: https://github.com/Moresyl/dsh-studio
+License: MIT
+LicenseUrl: https://github.com/Moresyl/dsh-studio/blob/main/LICENSE
+ShortDescription: Cross-platform desktop host for installing, configuring, and managing DeepSeek Harness.
+Tags:
+- deepseek
+- developer-tools
+- harness
+ReleaseNotesUrl: https://github.com/Moresyl/dsh-studio/releases/tag/v0.1.1
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/m/Moresyl/DSHStudio/0.1.1/Moresyl.DSHStudio.yaml
+++ b/manifests/m/Moresyl/DSHStudio/0.1.1/Moresyl.DSHStudio.yaml
@@ -1,0 +1,8 @@
+# Created with WinGet Manifest Creator v1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: Moresyl.DSHStudio
+PackageVersion: 0.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0

--- a/manifests/m/Moresyl/DSHStudio/0.1.1/Moresyl.DSHStudio.yaml
+++ b/manifests/m/Moresyl/DSHStudio/0.1.1/Moresyl.DSHStudio.yaml
@@ -1,8 +1,8 @@
 # Created with WinGet Manifest Creator v1.12.13.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: Moresyl.DSHStudio
 PackageVersion: 0.1.1
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.10.0
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds DSH Studio 0.1.1 as a new WinGet package using its x64 WiX MSI release. The manifest includes the verified installer SHA256, MSI product and upgrade codes, and Apps & Features metadata.

## ✅ Checklist

- [ ] Signed the Contributor License Agreement
- [x] Linked to an issue (not applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same manifest
- [x] This PR only modifies one manifest
- [x] Validated manifest locally with winget validate --manifest <path>
- [x] Tested manifest locally with winget install --manifest <path>
- [x] Manifest conforms to the 1.12 schema

## Local verification

- winget validate completed successfully.
- Full silent installation via winget completed successfully.
- MSI SHA256: 331B8C3E8738A505B797A6161635163909A22E4C467757B5250FA2676FBB6B0F
- Administrative MSI extraction completed silently with exit code 0.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/417785)