### PR TITLE
New package: moresl.MetaClean version 0.1.0

### DIFF
--- a/manifests/m/moresl/MetaClean/0.1.0/moresl.MetaClean.installer.yaml
+++ b/manifests/m/moresl/MetaClean/0.1.0/moresl.MetaClean.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: moresl.MetaClean
+PackageVersion: 0.1.0
+InstallerLocale: en-US
+InstallerType: wix
+Scope: machine
+UpgradeBehavior: install
+ReleaseDate: 2026-08-15
+AppsAndFeaturesEntries:
+  - DisplayName: MetaClean
+    Publisher: moresl
+    DisplayVersion: 0.1.0
+    ProductCode: '{61702295-A96E-4483-8CEA-E04A75B29094}'
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Moresyl/metaclean/releases/download/v0.1.0/MetaClean_0.1.0_x64_en-US.msi
+    InstallerSha256: BA016CB1A76BBE93EB7939FA7AD2ABE1EFE9C70BC084D807570892116CDA55D2
+    ProductCode: '{61702295-A96E-4483-8CEA-E04A75B29094}'
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/moresl/MetaClean/0.1.0/moresl.MetaClean.locale.en-US.yaml
+++ b/manifests/m/moresl/MetaClean/0.1.0/moresl.MetaClean.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: moresl.MetaClean
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: moresl
+PublisherUrl: https://github.com/Moresyl
+PublisherSupportUrl: https://github.com/Moresyl/metaclean/issues
+Author: Moresyl
+PackageName: MetaClean
+PackageUrl: https://github.com/Moresyl/metaclean
+License: MIT
+LicenseUrl: https://github.com/Moresyl/metaclean/blob/master/LICENSE
+ShortDescription: Remove metadata from files locally with a cross-platform desktop app.
+Description: MetaClean removes metadata from images, Office documents, PDFs, and text files entirely offline, without uploading files.
+Moniker: metaclean
+Tags:
+  - exif
+  - metadata
+  - offline
+  - office
+  - pdf
+  - privacy
+ReleaseNotesUrl: https://github.com/Moresyl/metaclean/releases/tag/v0.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/moresl/MetaClean/0.1.0/moresl.MetaClean.yaml
+++ b/manifests/m/moresl/MetaClean/0.1.0/moresl.MetaClean.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: moresl.MetaClean
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Adds the initial multi-file WinGet manifest for MetaClean 0.1.0.

Validation performed:
- `winget validate --manifest <path>` succeeded.
- The version-specific GitHub Release MSI was downloaded and its SHA-256 verified.
- MSI ProductCode, publisher, product name, version, and machine scope were read from the published installer.
- Silent installation completed successfully with exit code 0.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/417796)