### PR TITLE
New version: jefuriiij.PingMeter version 0.4.1

### DIFF
--- a/manifests/j/jefuriiij/PingMeter/0.4.1/jefuriiij.PingMeter.installer.yaml
+++ b/manifests/j/jefuriiij/PingMeter/0.4.1/jefuriiij.PingMeter.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: jefuriiij.PingMeter
+PackageVersion: 0.4.1
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.22000.0
+InstallerType: portable
+Commands:
+- pingmeter
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.10
+ReleaseDate: 2026-08-14
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/jefuriiij/ping-meter/releases/download/v0.4.1/PingMeter.exe
+  InstallerSha256: 248A5D745903127E0041A99C3C23EEB449B0D70EA664CD5DBFE0E9AB586F3C19
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/j/jefuriiij/PingMeter/0.4.1/jefuriiij.PingMeter.locale.en-US.yaml
+++ b/manifests/j/jefuriiij/PingMeter/0.4.1/jefuriiij.PingMeter.locale.en-US.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: jefuriiij.PingMeter
+PackageVersion: 0.4.1
+PackageLocale: en-US
+Publisher: jefuriiij
+PublisherUrl: https://github.com/jefuriiij
+PublisherSupportUrl: https://github.com/jefuriiij/ping-meter/issues
+PackageName: PingMeter
+PackageUrl: https://github.com/jefuriiij/ping-meter
+License: MIT
+LicenseUrl: https://github.com/jefuriiij/ping-meter/blob/main/LICENSE
+Copyright: Copyright (c) 2026 jefuriiij
+ShortDescription: Taskbar-embedded ping monitor with network repair and DNS tools
+Description: |-
+  PingMeter shows your live ping (ms) embedded directly in the Windows 11 taskbar, next
+  to the tray clock — on the primary taskbar, secondary-monitor taskbars, or all of them.
+  It replaces keeping "ping google.com -t" open in a terminal: color-coded latency with
+  configurable thresholds, a sparkline of recent pings, packet-loss percentage, hover
+  stats (min/avg/max/loss and current DNS servers), quick switching between the hosts you
+  save, and a daily log of outages, latency spikes and hourly summaries.
+
+  It also includes optional network tools you start yourself from the settings window:
+  a DNS cache flush, a full connection repair (the standard flush / release / renew /
+  winsock / TCP-IP sequence), and switching the active adapter's IPv4 DNS between
+  automatic, well-known public resolvers, or addresses you type and save. These actions
+  use built-in Windows networking commands and require your approval at a Windows
+  permission prompt; the app itself runs without administrator rights, collects no
+  personal data, and survives Explorer restarts.
+Tags:
+- diagnostics
+- dns
+- latency
+- monitor
+- network
+- ping
+- taskbar
+ReleaseNotesUrl: https://github.com/jefuriiij/ping-meter/releases/tag/v0.4.1
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/j/jefuriiij/PingMeter/0.4.1/jefuriiij.PingMeter.yaml
+++ b/manifests/j/jefuriiij/PingMeter/0.4.1/jefuriiij.PingMeter.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: jefuriiij.PingMeter
+PackageVersion: 0.4.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Version update for **jefuriiij.PingMeter** (0.4.0 → 0.4.1). I'm the package author.

0.4.1 is a settings-window polish release: aligned numeric fields, section headings on each tab, a fix for an `&` rendering bug, and the ability to save named DNS server combinations.

Note on the `Policy-Test-1.2` flag that hit #413979 and #404863: @DandelionSprout tracked it down to the word **"preset"** in the description, which the wordfilter matches on the `eset` substring (the antivirus vendor). Many thanks for finding that. I've reworded this manifest to avoid it — "quick switching between the hosts you save", "addresses you type and save" — and I've also softened the repair-tool wording to "built-in Windows networking commands" while keeping the disclosure accurate.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/README.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/417832)