### PR TITLE
New version: ElJoshua08.KeyForge version 0.2.0

### DIFF
--- a/manifests/e/ElJoshua08/KeyForge/0.2.0/ElJoshua08.KeyForge.installer.yaml
+++ b/manifests/e/ElJoshua08/KeyForge/0.2.0/ElJoshua08.KeyForge.installer.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ElJoshua08.KeyForge
+PackageVersion: 0.2.0
+InstallerLocale: en-US
+InstallerType: inno
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Commands:
+- keys
+ProductCode: '{ABC0E6B6-6933-4B98-BC47-065A34D87D1B}_is1'
+ReleaseDate: 2026-08-15
+MinimumOSVersion: 10.0.17763.0
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/ElJoshua08/keyforge/releases/download/v0.2.0/keyforge-0.2.0-setup.exe
+  InstallerSha256: E88DCCCEA832A1AE30B10E1DCD6B94B44BA2F94B004384FD4635E1480C665B8A
+  AppsAndFeaturesEntries:
+  - DisplayName: keyforge
+    DisplayVersion: 0.2.0
+    Publisher: Joshua
+    ProductCode: '{ABC0E6B6-6933-4B98-BC47-065A34D87D1B}_is1'
+    InstallerType: inno
+  InstallationMetadata:
+    DefaultInstallLocation: '%LOCALAPPDATA%\Programs\keyforge'
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/e/ElJoshua08/KeyForge/0.2.0/ElJoshua08.KeyForge.locale.en-US.yaml
+++ b/manifests/e/ElJoshua08/KeyForge/0.2.0/ElJoshua08.KeyForge.locale.en-US.yaml
@@ -1,0 +1,68 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ElJoshua08.KeyForge
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: Joshua
+PublisherUrl: https://github.com/ElJoshua08
+PublisherSupportUrl: https://github.com/ElJoshua08/keyforge/issues
+PackageName: keyforge
+PackageUrl: https://github.com/ElJoshua08/keyforge
+License: MIT
+LicenseUrl: https://github.com/ElJoshua08/keyforge/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Joshua
+CopyrightUrl: https://github.com/ElJoshua08/keyforge/blob/main/LICENSE
+ShortDescription: Generate and manage secrets locally, sealed with Windows DPAPI.
+Description: |-
+  keyforge generates cryptographically strong secrets and keeps them in a
+  DPAPI-sealed local vault you can search. It ships as one binary with no runtime
+  and makes no network calls.
+
+  It generates random strings and API keys over a chosen alphabet, passwords with
+  character-class requirements, EFF diceware passphrases, structured identifiers
+  (UUIDv4, UUIDv7, ULID, nanoid, TOTP seeds), and keypairs (ed25519, RSA, and age
+  identities). Every value is drawn from the operating system CSPRNG by rejection
+  sampling rather than modulo, so no character is more likely than another, and
+  each generator reports the entropy it produced.
+
+  Secrets issued elsewhere can be stored too — paste an API key a provider gave
+  you and keyforge keeps it alongside the ones it made, honest about the fact that
+  it can only estimate the strength of a value it did not generate. Any secret can
+  be rolled: the replacement takes over while the name, creation date, and tags
+  stay put, and the outgoing value is kept so you can finish cutting over before
+  revoking it. An optional per-key interval flags anything overdue.
+
+  Saved secrets live in a vault sealed with Windows DPAPI under your login and are
+  found again with fuzzy search over names, tags, and kinds — never over the secret
+  material itself. Run `keys` with no arguments for the full-screen interface, or
+  use the subcommands for scripting.
+
+  Installs to your user profile and needs no administrator rights.
+Moniker: keyforge
+Tags:
+- api-key
+- cli
+- dpapi
+- generator
+- keygen
+- passphrase
+- password
+- secrets
+- security
+- ssh-key
+- tui
+- vault
+ReleaseNotesUrl: https://github.com/ElJoshua08/keyforge/releases/tag/v0.2.0
+Documentations:
+- DocumentLabel: README
+  DocumentUrl: https://github.com/ElJoshua08/keyforge#readme
+InstallationNotes: |-
+  `keys` is on your PATH if you chose that. Open a NEW terminal — one that was
+  already running keeps the PATH it started with. Run `keys` with no arguments
+  for the interactive interface.
+
+  Your vault lives at %APPDATA%\keyforge\vault.bin and uninstalling never removes
+  it unless you explicitly say so; the uninstaller asks, and defaults to keeping
+  it.
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/e/ElJoshua08/KeyForge/0.2.0/ElJoshua08.KeyForge.yaml
+++ b/manifests/e/ElJoshua08/KeyForge/0.2.0/ElJoshua08.KeyForge.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ElJoshua08.KeyForge
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds **keyforge 0.2.0**, a local secret generator and manager for Windows. It
generates cryptographically strong secrets, stores credentials issued elsewhere,
and keeps them in a vault sealed with Windows DPAPI under the user's login. One
binary, no runtime, no network calls.

- Package: `ElJoshua08.KeyForge` (new — no existing manifests under `manifests/e/ElJoshua08/`)
- Installer: Inno Setup, x64, `Scope: user`, installs to `%LOCALAPPDATA%\Programs\keyforge`
- Source: https://github.com/ElJoshua08/keyforge
- Release: https://github.com/ElJoshua08/keyforge/releases/tag/v0.2.0

The installer requests no elevation (`PrivilegesRequired=lowest`), which is why
`Scope: user` is set explicitly. `ProductCode` was read back from a real
installation's uninstall registry key rather than derived, and `InstallerSha256`
matches the `SHA256SUMS.txt` published with the release.

The binaries are not code-signed; the release page documents the SmartScreen
prompt and publishes SHA-256 checksums for every asset.

Checklist — how each one actually stands

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable) — not applicable, new package submission

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/417840)