### PR TITLE
Add version: Aburousan.Hilbert version 0.2.0

### DIFF
--- a/manifests/a/Aburousan/Hilbert/0.2.0/Aburousan.Hilbert.installer.yaml
+++ b/manifests/a/Aburousan/Hilbert/0.2.0/Aburousan.Hilbert.installer.yaml
@@ -1,16 +1,17 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
 PackageIdentifier: Aburousan.Hilbert
 PackageVersion: 0.2.0
 InstallerLocale: en-US
 InstallerType: nullsoft
 Scope: user
 InstallModes:
-  - silent
-  - silentWithProgress
+- silent
+- silentWithProgress
 UpgradeBehavior: install
 Installers:
-  - Architecture: x64
-    InstallerUrl: https://github.com/aburousan/hilbert-editor/releases/download/tauri-v0.2.0/Hilbert_0.2.0_x64-setup.exe
-    InstallerSha256: FD9821AF7EA6D7B876F251F3A7F24884C975ADAE7F4BF5838FF09EA7A28A27DD
+- Architecture: x64
+  InstallerUrl: https://github.com/aburousan/hilbert-editor/releases/download/tauri-v0.2.0/Hilbert_0.2.0_x64-setup.exe
+  InstallerSha256: FD9821AF7EA6D7B876F251F3A7F24884C975ADAE7F4BF5838FF09EA7A28A27DD
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/a/Aburousan/Hilbert/0.2.0/Aburousan.Hilbert.installer.yaml
+++ b/manifests/a/Aburousan/Hilbert/0.2.0/Aburousan.Hilbert.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Aburousan.Hilbert
+PackageVersion: 0.2.0
+InstallerLocale: en-US
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/aburousan/hilbert-editor/releases/download/tauri-v0.2.0/Hilbert_0.2.0_x64-setup.exe
+    InstallerSha256: FD9821AF7EA6D7B876F251F3A7F24884C975ADAE7F4BF5838FF09EA7A28A27DD
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/Aburousan/Hilbert/0.2.0/Aburousan.Hilbert.locale.en-US.yaml
+++ b/manifests/a/Aburousan/Hilbert/0.2.0/Aburousan.Hilbert.locale.en-US.yaml
@@ -1,4 +1,5 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
 PackageIdentifier: Aburousan.Hilbert
 PackageVersion: 0.2.0
 PackageLocale: en-US
@@ -10,23 +11,18 @@ PackageUrl: https://github.com/aburousan/hilbert-editor
 License: MIT
 LicenseUrl: https://github.com/aburousan/hilbert-editor/blob/main/LICENSE
 ShortDescription: An offline desktop editor for Typst, aimed at maths and physics writing.
-Description: >-
-  Hilbert is a local, offline desktop editor for the Typst typesetting language,
-  built for maths and physics writing. It compiles and previews as you type, and
-  ships with tools for equations, figures, plots, matrices, tables, and data
-  import, along with code intelligence from tinymist. It installs per user and
-  needs no administrator rights.
+Description: Hilbert is a local, offline desktop editor for the Typst typesetting language, built for maths and physics writing. It compiles and previews as you type, and ships with tools for equations, figures, plots, matrices, tables, and data import, along with code intelligence from tinymist. It installs per user and needs no administrator rights.
 Moniker: hilbert
 Tags:
-  - typst
-  - editor
-  - typesetting
-  - latex
-  - markdown
-  - math
-  - physics
-  - science
-  - offline
+- editor
+- latex
+- markdown
+- math
+- offline
+- physics
+- science
+- typesetting
+- typst
 ReleaseNotesUrl: https://github.com/aburousan/hilbert-editor/releases/tag/tauri-v0.2.0
 ManifestType: defaultLocale
-ManifestVersion: 1.12.0
+ManifestVersion: 1.12.0

--- a/manifests/a/Aburousan/Hilbert/0.2.0/Aburousan.Hilbert.locale.en-US.yaml
+++ b/manifests/a/Aburousan/Hilbert/0.2.0/Aburousan.Hilbert.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Aburousan.Hilbert
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: Kazi Abu Rousan
+PublisherUrl: https://github.com/aburousan
+PublisherSupportUrl: https://github.com/aburousan/hilbert-editor/issues
+PackageName: Hilbert
+PackageUrl: https://github.com/aburousan/hilbert-editor
+License: MIT
+LicenseUrl: https://github.com/aburousan/hilbert-editor/blob/main/LICENSE
+ShortDescription: An offline desktop editor for Typst, aimed at maths and physics writing.
+Description: >-
+  Hilbert is a local, offline desktop editor for the Typst typesetting language,
+  built for maths and physics writing. It compiles and previews as you type, and
+  ships with tools for equations, figures, plots, matrices, tables, and data
+  import, along with code intelligence from tinymist. It installs per user and
+  needs no administrator rights.
+Moniker: hilbert
+Tags:
+  - typst
+  - editor
+  - typesetting
+  - latex
+  - markdown
+  - math
+  - physics
+  - science
+  - offline
+ReleaseNotesUrl: https://github.com/aburousan/hilbert-editor/releases/tag/tauri-v0.2.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/Aburousan/Hilbert/0.2.0/Aburousan.Hilbert.yaml
+++ b/manifests/a/Aburousan/Hilbert/0.2.0/Aburousan.Hilbert.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Aburousan.Hilbert
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/manifests/a/Aburousan/Hilbert/0.2.0/Aburousan.Hilbert.yaml
+++ b/manifests/a/Aburousan/Hilbert/0.2.0/Aburousan.Hilbert.yaml
@@ -1,6 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
 PackageIdentifier: Aburousan.Hilbert
 PackageVersion: 0.2.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.12.0
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Pull request type

- [x] New version: an existing package is updated to a new version

### Package

`Aburousan.Hilbert` 0.2.0 — replaces 0.1.10, the last version submitted here.

- Installer: https://github.com/aburousan/hilbert-editor/releases/download/tauri-v0.2.0/Hilbert_0.2.0_x64-setup.exe
- Release notes: https://github.com/aburousan/hilbert-editor/releases/tag/tauri-v0.2.0

### Checklist

- [x] Manifests validate against the 1.12.0 schema
- [x] `InstallerSha256` computed from the published installer
- [x] Installer URL resolves and is a stable release asset
- [x] Only the manifests for this version are added

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/417902)