### PR TITLE
New package: S42yt.FreSH version 26.10.0

### DIFF
--- a/manifests/s/S42yt/FreSH/26.10.0/S42yt.FreSH.installer.yaml
+++ b/manifests/s/S42yt/FreSH/26.10.0/S42yt.FreSH.installer.yaml
@@ -1,0 +1,19 @@
+PackageIdentifier: S42yt.FreSH
+PackageVersion: 26.10.0
+InstallerType: exe
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: /silent /user
+  SilentWithProgress: /silent /user
+UpgradeBehavior: install
+ReleaseDate: 2026-08-15
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/S42yt/FreSH/releases/download/v26.10.0/FreSH-Setup.exe
+    InstallerSha256: 8EB1FE8DBDAF3B36F6E77A50D0E8726018CC740D4513D46CAF42BE575BFBCAE1
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/S42yt/FreSH/26.10.0/S42yt.FreSH.locale.en-US.yaml
+++ b/manifests/s/S42yt/FreSH/26.10.0/S42yt.FreSH.locale.en-US.yaml
@@ -1,0 +1,31 @@
+PackageIdentifier: S42yt.FreSH
+PackageVersion: 26.10.0
+PackageLocale: en-US
+Publisher: Musa Bostanci
+PublisherUrl: https://github.com/S42yt
+PublisherSupportUrl: https://github.com/S42yt/FreSH/issues
+PackageName: FreSH
+PackageUrl: https://github.com/S42yt/FreSH
+License: GPL-3.0-only
+LicenseUrl: https://github.com/S42yt/FreSH/blob/master/LICENSE
+Copyright: Copyright (c) 2025-2026 Musa Bostanci
+ShortDescription: A fast shell for Windows that runs bash scripts unchanged.
+Description: |-
+  FreSH is a shell for Windows written in C with no runtime dependencies. It runs
+  bash scripts unchanged, without WSL, MSYS2 or Git Bash, and ships its own awk,
+  regular expression engine and coreutils so a script behaves the same on every
+  machine. It starts in single digit milliseconds, completes commands, files,
+  variables and flags as you type, and reads its settings from ~/.freshrc.
+Moniker: fresh
+Tags:
+  - shell
+  - bash
+  - zsh
+  - terminal
+  - cli
+ReleaseNotesUrl: https://github.com/S42yt/FreSH/releases/tag/v26.10.0
+Documentations:
+  - DocumentLabel: Documentation
+    DocumentUrl: https://github.com/S42yt/FreSH/tree/master/docs
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/S42yt/FreSH/26.10.0/S42yt.FreSH.yaml
+++ b/manifests/s/S42yt/FreSH/26.10.0/S42yt.FreSH.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: S42yt.FreSH
+PackageVersion: 26.10.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
FreSH is a shell for Windows written in C with no runtime dependencies. It runs
bash scripts unchanged, without WSL, MSYS2 or Git Bash, and ships its own awk,
regular expression engine and unix commands so a script behaves the same on
every machine.

- Homepage: https://github.com/S42yt/FreSH
- Release: https://github.com/S42yt/FreSH/releases/tag/v26.10.0
- License: GPL-3.0-only

### Checks

- [x] `winget validate` passes for all three manifests
- [x] The `InstallerSha256` matches the `SHA256SUMS.txt` published with the release
- [x] Installed with the declared switches, `/silent /user`, on Windows 11 26100, and `FreSH --version` reports 26.10.0 afterwards
- [x] Installs per user, needs no administrator, and uninstalls from Apps & Features
- [x] This is the first submission of this package

### Provenance

Every release is built by GitHub Actions from a tagged commit and carries a
signed build provenance statement, so the installer can be checked against the
source it was built from:

```
gh attestation verify FreSH-Setup.exe --repo S42yt/FreSH
```

A portable package, `S42yt.FreSH.Portable`, is prepared and will follow in a
separate pull request.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/418014)