### PR TITLE
New package: S42yt.FreSH.Portable version 26.10.0

### DIFF
--- a/manifests/s/S42yt/FreSH/Portable/26.10.0/S42yt.FreSH.Portable.installer.yaml
+++ b/manifests/s/S42yt/FreSH/Portable/26.10.0/S42yt.FreSH.Portable.installer.yaml
@@ -1,0 +1,13 @@
+PackageIdentifier: S42yt.FreSH.Portable
+PackageVersion: 26.10.0
+InstallerType: portable
+Commands:
+  - FreSH
+UpgradeBehavior: install
+ReleaseDate: 2026-08-15
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/S42yt/FreSH/releases/download/v26.10.0/FreSH.exe
+    InstallerSha256: 527F4CEEF3603C387BB2B34A4B7AF32A2872FEBAB448A8ED4E660AF5C9D67D7D
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/S42yt/FreSH/Portable/26.10.0/S42yt.FreSH.Portable.locale.en-US.yaml
+++ b/manifests/s/S42yt/FreSH/Portable/26.10.0/S42yt.FreSH.Portable.locale.en-US.yaml
@@ -1,0 +1,27 @@
+PackageIdentifier: S42yt.FreSH.Portable
+PackageVersion: 26.10.0
+PackageLocale: en-US
+Publisher: Musa Bostanci
+PublisherUrl: https://github.com/S42yt
+PublisherSupportUrl: https://github.com/S42yt/FreSH/issues
+PackageName: FreSH Portable
+PackageUrl: https://github.com/S42yt/FreSH
+License: GPL-3.0-only
+LicenseUrl: https://github.com/S42yt/FreSH/blob/master/LICENSE
+Copyright: Copyright (c) 2025-2026 Musa Bostanci
+ShortDescription: FreSH as a single executable, with no installer and no registry.
+Description: |-
+  The same shell as S42yt.FreSH, delivered as one executable. Nothing is written
+  to the registry, no Explorer entries are added and no administrator rights are
+  needed. Settings still live in ~/.freshrc.
+Moniker: fresh-portable
+Tags:
+  - shell
+  - bash
+  - zsh
+  - terminal
+  - cli
+  - portable
+ReleaseNotesUrl: https://github.com/S42yt/FreSH/releases/tag/v26.10.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/S42yt/FreSH/Portable/26.10.0/S42yt.FreSH.Portable.yaml
+++ b/manifests/s/S42yt/FreSH/Portable/26.10.0/S42yt.FreSH.Portable.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: S42yt.FreSH.Portable
+PackageVersion: 26.10.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
The same shell as `S42yt.FreSH`, delivered as a single executable. Nothing is
written to the registry, no Explorer entries are added and no administrator
rights are needed, so it suits a machine where an installer is unwelcome.

FreSH is a shell for Windows written in C with no runtime dependencies. It runs
bash scripts unchanged, without WSL, MSYS2 or Git Bash, and ships its own awk,
regular expression engine and unix commands.

- Homepage: https://github.com/S42yt/FreSH
- Release: https://github.com/S42yt/FreSH/releases/tag/v26.10.0
- License: GPL-3.0-only

### Checks

- [x] `winget validate` passes for all three manifests
- [x] The `InstallerSha256` matches the `SHA256SUMS.txt` published with the release
- [x] `InstallerType: portable` with `Commands: [FreSH]`, so the alias is `FreSH`
- [x] The executable from the release runs on Windows 11 26100 and reports 26.10.0
- [x] This is the first submission of this package

The installer package for the same version is
https://github.com/microsoft/winget-pkgs/pull/418014.

### Provenance

Every release is built by GitHub Actions from a tagged commit and carries a
signed build provenance statement, so the executable can be checked against the
source it was built from:

```
gh attestation verify FreSH.exe --repo S42yt/FreSH
```

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/418019)