### PR TITLE
New version: shahriyardx.brightctrl version 0.2.5

### DIFF
--- a/manifests/s/shahriyardx/brightctrl/0.2.5/shahriyardx.brightctrl.installer.yaml
+++ b/manifests/s/shahriyardx/brightctrl/0.2.5/shahriyardx.brightctrl.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: shahriyardx.brightctrl
+PackageVersion: 0.2.5
+InstallerType: portable
+Commands:
+  - brightctrl
+ReleaseDate: 2026-08-16
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/shahriyardx/brightctrl/releases/download/v0.2.5/brightctrl.exe
+    InstallerSha256: 8E7AEF7565E35F5801803961ED98191038A9DC64E7FD7BD6A83B89309B8DBC14
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/shahriyardx/brightctrl/0.2.5/shahriyardx.brightctrl.locale.en-US.yaml
+++ b/manifests/s/shahriyardx/brightctrl/0.2.5/shahriyardx.brightctrl.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: shahriyardx.brightctrl
+PackageVersion: 0.2.5
+PackageLocale: en-US
+Publisher: shahriyardx
+PublisherUrl: https://github.com/shahriyardx
+PackageName: brightctrl
+PackageUrl: https://github.com/shahriyardx/brightctrl
+License: MIT
+LicenseUrl: https://github.com/shahriyardx/brightctrl/blob/main/LICENSE
+ShortDescription: Lightweight DDC/CI external monitor brightness controller (TUI + CLI).
+Description: |-
+  brightctrl adjusts the brightness of external monitors over DDC/CI from the
+  terminal — both an interactive TUI and a scriptable CLI. A single native
+  binary with no runtime dependencies. On Windows it uses the Monitor
+  Configuration API.
+Moniker: brightctrl
+Tags:
+  - brightness
+  - ddc
+  - ddc-ci
+  - monitor
+  - cli
+  - tui
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/shahriyardx/brightctrl/0.2.5/shahriyardx.brightctrl.yaml
+++ b/manifests/s/shahriyardx/brightctrl/0.2.5/shahriyardx.brightctrl.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: shahriyardx.brightctrl
+PackageVersion: 0.2.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Pull request has been created with the following manifest

- `manifests/s/shahriyardx/brightctrl/0.2.5`

#### Notes

Upstream release: https://github.com/shahriyardx/brightctrl/releases/tag/v0.2.5

I am the package author. This bumps the existing `shahriyardx.brightctrl` from 0.2.3 to 0.2.5.

- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-cli/blob/master/schemas/JSON/manifests/v1.6.0)?

The manifest is unchanged from the accepted 0.2.3 manifest apart from `PackageVersion`, `InstallerUrl`, `InstallerSha256`, and `ReleaseDate`. The `InstallerSha256` was computed from the published `brightctrl.exe` release asset.