### PR TITLE
New package: Moresyl.MetaClean version 0.1.0

### DIFF
--- a/manifests/m/Moresyl/MetaClean/0.1.0/Moresyl.MetaClean.installer.yaml
+++ b/manifests/m/Moresyl/MetaClean/0.1.0/Moresyl.MetaClean.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Moresyl.MetaClean
+PackageVersion: 0.1.0
+InstallerType: wix
+Scope: machine
+InstallModes:
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-08-15
+Installers:
+- Architecture: x64
+  InstallerLocale: en-US
+  InstallerUrl: https://github.com/Moresyl/metaclean/releases/download/v0.1.0/MetaClean_0.1.0_x64_en-US.msi
+  InstallerSha256: BA016CB1A76BBE93EB7939FA7AD2ABE1EFE9C70BC084D807570892116CDA55D2
+  ProductCode: '{61702295-A96E-4483-8CEA-E04A75B29094}'
+  AppsAndFeaturesEntries:
+  - DisplayName: MetaClean
+    DisplayVersion: 0.1.0
+    Publisher: moresl
+    ProductCode: '{61702295-A96E-4483-8CEA-E04A75B29094}'
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/Moresyl/MetaClean/0.1.0/Moresyl.MetaClean.locale.en-US.yaml
+++ b/manifests/m/Moresyl/MetaClean/0.1.0/Moresyl.MetaClean.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Moresyl.MetaClean
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Moresyl
+PublisherUrl: https://github.com/Moresyl
+PublisherSupportUrl: https://github.com/Moresyl/metaclean/issues
+Author: Moresyl
+PackageName: MetaClean
+PackageUrl: https://github.com/Moresyl/metaclean
+License: MIT
+LicenseUrl: https://github.com/Moresyl/metaclean/blob/master/LICENSE
+Copyright: Copyright (c) Moresyl
+ShortDescription: Remove private metadata from files locally before sharing them.
+Description: MetaClean is a local-first desktop application that inspects and removes private metadata from images, PDFs, Office documents, text, and markup files without uploads, telemetry, or cloud processing.
+Tags:
+- exif
+- metadata
+- office
+- pdf
+- privacy
+- security
+ReleaseNotesUrl: https://github.com/Moresyl/metaclean/releases/tag/v0.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/Moresyl/MetaClean/0.1.0/Moresyl.MetaClean.yaml
+++ b/manifests/m/Moresyl/MetaClean/0.1.0/Moresyl.MetaClean.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Moresyl.MetaClean
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds the first WinGet manifest for MetaClean 0.1.0, an MIT-licensed local-first desktop app for removing private metadata from files. I am the package publisher and project maintainer.

The manifest uses the versioned x64 WiX MSI from the official GitHub release. The SHA-256, ProductCode, version, and ARP publisher were read from that installer.

## ✅ Checklist

- [ ] Signed the Contributor License Agreement (the CLA bot may prompt if this account has not already completed it)
- Linked issue: not applicable for a routine manifest submission

## 📦 Manifest Checklist

- [x] Checked that there are no other open pull requests for Moresyl.MetaClean 0.1.0
- [x] This PR only modifies one package manifest set for one version
- [x] Validated locally with winget validate --manifest manifests/m/Moresyl/MetaClean/0.1.0
- [x] Tested locally with winget install --manifest manifests/m/Moresyl/MetaClean/0.1.0 --force --silent; installation completed successfully
- [x] Manifest conforms to the 1.12 multi-file schema
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/418182)