### PR TITLE
New package: nebinfra.nebcli version 6.17.1

### DIFF
--- a/manifests/n/nebinfra/nebcli/6.17.1/nebinfra.nebcli.installer.yaml
+++ b/manifests/n/nebinfra/nebcli/6.17.1/nebinfra.nebcli.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: nebinfra.nebcli
+PackageVersion: 6.17.1
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: nebcli.exe
+  PortableCommandAlias: nebcli
+Commands:
+- nebcli
+ReleaseDate: 2026-08-14
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/nebinfra/nebcli-dist/releases/download/v6.17.1/nebcli_6.17.1_windows_amd64.zip
+  InstallerSha256: 4F784AA57663D3AB048BD66294844107F2DC4375D9A0BA9A92E7659797E9F376
+- Architecture: arm64
+  InstallerUrl: https://github.com/nebinfra/nebcli-dist/releases/download/v6.17.1/nebcli_6.17.1_windows_arm64.zip
+  InstallerSha256: 1414C8EC8AD2AA75EECCB783628B4FACF724723F8FEA8C6A1DF18683BCAB551C
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/n/nebinfra/nebcli/6.17.1/nebinfra.nebcli.locale.en-US.yaml
+++ b/manifests/n/nebinfra/nebcli/6.17.1/nebinfra.nebcli.locale.en-US.yaml
@@ -1,0 +1,44 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: nebinfra.nebcli
+PackageVersion: 6.17.1
+PackageLocale: en-US
+Publisher: Nebinfra Technologies
+PublisherUrl: https://nebinfra.com
+PublisherSupportUrl: https://github.com/nebinfra/nebcli-dist/issues
+Author: Nebinfra Technologies
+PackageName: NebCLI
+PackageUrl: https://docs.nebcore.ai/nebcli
+License: Proprietary
+LicenseUrl: https://github.com/nebinfra/nebcli-dist/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Nebinfra Technologies. All rights reserved.
+CopyrightUrl: https://github.com/nebinfra/nebcli-dist/blob/main/LICENSE
+ShortDescription: Command-line tool for the NebCore platform that brokers short-lived cloud, cluster, and code-host credentials.
+Description: NebCLI is the single command-line tool for working with the NebCore platform from your terminal. You sign in once, and NebCLI then hands short-lived credentials to the standard tools you already use, including aws, kubectl, helm, and git. It never creates or stores a long-lived secret. When a task needs cloud, cluster, registry, or code-host access, NebCLI requests a short-lived credential, writes it where the matching standard tool already looks, and steps aside. NebCLI also validates Helm charts against platform rules before they merge, sets up and inspects clusters from a written description, and runs a self-check that diagnoses sign-in and connectivity problems.
+Moniker: nebcli
+Tags:
+- aws
+- cli
+- credentials
+- developer-tools
+- devops
+- helm
+- kubernetes
+- nebcore
+ReleaseNotes: |-
+  Bug Fixes
+  - helm: derive appset pin lines from YAML nodes
+  - helm: honor management validation context
+  - help: make all command help output public facing
+ReleaseNotesUrl: https://github.com/nebinfra/nebcli-dist/releases/tag/v6.17.1
+Documentations:
+- DocumentLabel: Overview
+  DocumentUrl: https://docs.nebcore.ai/nebcli
+- DocumentLabel: Installation
+  DocumentUrl: https://docs.nebcore.ai/installation
+- DocumentLabel: Commands
+  DocumentUrl: https://docs.nebcore.ai/nebcli/commands
+- DocumentLabel: Authentication
+  DocumentUrl: https://docs.nebcore.ai/nebcli/authentication
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/n/nebinfra/nebcli/6.17.1/nebinfra.nebcli.yaml
+++ b/manifests/n/nebinfra/nebcli/6.17.1/nebinfra.nebcli.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: nebinfra.nebcli
+PackageVersion: 6.17.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package: `nebinfra.nebcli` version 6.17.1.

NebCLI is the command-line tool for the NebCore platform. It signs a user in once and then brokers short-lived credentials to the standard tools they already use (aws, kubectl, helm, git), validates Helm charts, and bootstraps clusters.

The installer is the official Windows release archive published by the vendor at
https://github.com/nebinfra/nebcli-dist/releases/tag/v6.17.1, submitted as
`InstallerType: zip` with `NestedInstallerType: portable` because the archive
contains a standalone `nebcli.exe` with no installer. Both x64 and arm64 are included.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/418183)