### PR TITLE
New package: nebinfra.nebguard version 5.30.1

### DIFF
--- a/manifests/n/nebinfra/nebguard/5.30.1/nebinfra.nebguard.installer.yaml
+++ b/manifests/n/nebinfra/nebguard/5.30.1/nebinfra.nebguard.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: nebinfra.nebguard
+PackageVersion: 5.30.1
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: nebguard.exe
+  PortableCommandAlias: nebguard
+Commands:
+- nebguard
+ReleaseDate: 2026-08-14
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/nebinfra/nebguard-dist/releases/download/v5.30.1/nebguard_5.30.1_windows_amd64.zip
+  InstallerSha256: C8889348EEADABC5360CA972FA0CB608EA43DF45A0C83A8F014F143CCB2B84BE
+- Architecture: arm64
+  InstallerUrl: https://github.com/nebinfra/nebguard-dist/releases/download/v5.30.1/nebguard_5.30.1_windows_arm64.zip
+  InstallerSha256: D307D8A278A70099B6B2D0DDF9E59BF45C14996EFFEFBF2A781F047A01BE17B5
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/n/nebinfra/nebguard/5.30.1/nebinfra.nebguard.locale.en-US.yaml
+++ b/manifests/n/nebinfra/nebguard/5.30.1/nebinfra.nebguard.locale.en-US.yaml
@@ -1,0 +1,42 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: nebinfra.nebguard
+PackageVersion: 5.30.1
+PackageLocale: en-US
+Publisher: Nebinfra Technologies
+PublisherUrl: https://nebinfra.com
+PublisherSupportUrl: https://github.com/nebinfra/nebguard-dist/issues
+Author: Nebinfra Technologies
+PackageName: NebGuard
+PackageUrl: https://docs.nebcore.ai/nebguard
+License: Proprietary
+LicenseUrl: https://github.com/nebinfra/nebguard-dist/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Nebinfra Technologies. All rights reserved.
+CopyrightUrl: https://github.com/nebinfra/nebguard-dist/blob/main/LICENSE
+ShortDescription: Policy-driven guardrails for AI coding agents and autonomous agents.
+Description: NebGuard sits between an AI coding agent and the actions it takes, such as running shell commands, editing files, pushing to git, and applying infrastructure changes. It checks each action against a library of rules at the moments that matter and responds in one of four ways. It allows the action, adds a guiding note, blocks the action before it runs, or injects context that keeps the agent on task. Rules are organized into six domains covering security, development, devops, itsm, ai-governance, and business. The same engine and the same rules run on a developer laptop and inside an agent pod in a cluster, and every decision is recorded so teams get an audit trail for compliance and security review.
+Moniker: nebguard
+Tags:
+- ai-agents
+- ai-governance
+- cli
+- coding-assistant
+- guardrails
+- nebcore
+- policy-engine
+- security
+ReleaseNotes: |-
+  Bug Fixes
+  - help: make all user-visible output public facing
+ReleaseNotesUrl: https://github.com/nebinfra/nebguard-dist/releases/tag/v5.30.1
+Documentations:
+- DocumentLabel: Overview
+  DocumentUrl: https://docs.nebcore.ai/nebguard
+- DocumentLabel: Installation
+  DocumentUrl: https://docs.nebcore.ai/installation
+- DocumentLabel: Setup
+  DocumentUrl: https://docs.nebcore.ai/nebguard/setup
+- DocumentLabel: Concepts
+  DocumentUrl: https://docs.nebcore.ai/nebguard/concepts
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/n/nebinfra/nebguard/5.30.1/nebinfra.nebguard.yaml
+++ b/manifests/n/nebinfra/nebguard/5.30.1/nebinfra.nebguard.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: nebinfra.nebguard
+PackageVersion: 5.30.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package: `nebinfra.nebguard` version 5.30.1.

NebGuard is policy-driven guardrails for AI coding agents. It sits between an agent and the actions it takes (shell commands, file edits, git pushes, infrastructure changes), checks each action against a rule library, and allows, guides, blocks, or injects context.

The installer is the official Windows release archive published by the vendor at
https://github.com/nebinfra/nebguard-dist/releases/tag/v5.30.1, submitted as
`InstallerType: zip` with `NestedInstallerType: portable` because the archive
contains a standalone `nebguard.exe` with no installer. Both x64 and arm64 are included.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/418184)