### PR TITLE
Update Relic.Relic 1.0.33 metadata: license is AGPL-3.0

### DIFF
--- a/manifests/r/Relic/Relic/1.0.33/Relic.Relic.locale.en-US.yaml
+++ b/manifests/r/Relic/Relic/1.0.33/Relic.Relic.locale.en-US.yaml
@@ -6,12 +6,13 @@ PackageVersion: 1.0.33
 PackageLocale: en-US
 Publisher: Relic
 PublisherUrl: https://relic.space
-PublisherSupportUrl: https://relic.space
+PublisherSupportUrl: https://github.com/RelicSync/relic/issues
 PrivacyUrl: https://relic.space/legal/privacy
 Author: Jordan Gibbs
 PackageName: Relic
-PackageUrl: https://relic.space
-License: Proprietary
+PackageUrl: https://github.com/RelicSync/relic
+License: AGPL-3.0
+LicenseUrl: https://github.com/RelicSync/relic/blob/main/LICENSE
 Copyright: Copyright (c) Ember Technologies, LLC
 ShortDescription: Clipboard manager with end-to-end encrypted sync, on-device AI search, and secret protection.
 Description: 'Relic captures everything you copy on Windows and makes it searchable with on-device AI: semantic search over your history plus text recognition inside screenshots, with nothing sent to the cloud for analysis. Sync across devices is end-to-end encrypted. Relic detects secrets like passwords and API keys, masks them, respects password manager exclusion formats, and wipes copied secrets from the clipboard after 30 seconds. It also includes encrypted share links, offline QR sharing, a vault for items you want to keep forever, per-app capture blocking, and a command line tool that AI agents can use to read and write your local vault.'
@@ -22,6 +23,7 @@ Tags:
 - e2ee
 - encryption
 - ocr
+- open-source
 - productivity
 - search
 ManifestType: defaultLocale


### PR DESCRIPTION
Metadata-only update for the existing Relic.Relic 1.0.33 manifests (no installer change).

Relic is now open source under AGPL-3.0 at https://github.com/RelicSync/relic. The locale manifest still said `License: Proprietary` from before the change. This PR:

- `License`: Proprietary -> AGPL-3.0, adds `LicenseUrl`
- `PackageUrl` -> the source repository
- `PublisherSupportUrl` -> the repo issue tracker
- adds the `open-source` tag

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/README.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/418203)