### PR TITLE
New version: ChangemakerStudios.Papercut-SMTP version 7.8.0

### DIFF
--- a/manifests/c/ChangemakerStudios/Papercut-SMTP/7.8.0/ChangemakerStudios.Papercut-SMTP.installer.yaml
+++ b/manifests/c/ChangemakerStudios/Papercut-SMTP/7.8.0/ChangemakerStudios.Papercut-SMTP.installer.yaml
@@ -1,0 +1,27 @@
+PackageIdentifier: ChangemakerStudios.Papercut-SMTP
+PackageVersion: 7.8.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: exe
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: --silent
+  SilentWithProgress: --silent
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/ChangemakerStudios/Papercut-SMTP/releases/download/7.8.0/PapercutSMTP-win-x64-stable-Setup.exe
+  InstallerSha256: BA5737F162F9316143A81E4AFF6965C5FBB2B471895D1B0F41F93949D5AC4BE4
+- Architecture: x86
+  InstallerUrl: https://github.com/ChangemakerStudios/Papercut-SMTP/releases/download/7.8.0/PapercutSMTP-win-x86-stable-Setup.exe
+  InstallerSha256: 11C272D8FD725D7D8ABF628BB68A2EA2C2668FC2445F34CEC9F38903C30122CA
+- Architecture: arm64
+  InstallerUrl: https://github.com/ChangemakerStudios/Papercut-SMTP/releases/download/7.8.0/PapercutSMTP-win-arm64-stable-Setup.exe
+  InstallerSha256: AADB46887C98559A31FEC3DEB7D79540AA2DAA590FB16B9BF178BB2ADDC25C8D
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/c/ChangemakerStudios/Papercut-SMTP/7.8.0/ChangemakerStudios.Papercut-SMTP.installer.yaml
+++ b/manifests/c/ChangemakerStudios/Papercut-SMTP/7.8.0/ChangemakerStudios.Papercut-SMTP.installer.yaml
@@ -13,6 +13,8 @@ InstallerSwitches:
   Silent: --silent
   SilentWithProgress: --silent
 UpgradeBehavior: install
+ProductCode: PapercutSMTP
+ReleaseDate: 2026-08-15
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/ChangemakerStudios/Papercut-SMTP/releases/download/7.8.0/PapercutSMTP-win-x64-stable-Setup.exe

--- a/manifests/c/ChangemakerStudios/Papercut-SMTP/7.8.0/ChangemakerStudios.Papercut-SMTP.locale.en-US.yaml
+++ b/manifests/c/ChangemakerStudios/Papercut-SMTP/7.8.0/ChangemakerStudios.Papercut-SMTP.locale.en-US.yaml
@@ -1,0 +1,42 @@
+PackageIdentifier: ChangemakerStudios.Papercut-SMTP
+PackageVersion: 7.8.0
+PackageLocale: en-US
+Publisher: Changemaker Studios
+PublisherUrl: https://github.com/ChangemakerStudios
+PublisherSupportUrl: https://github.com/ChangemakerStudios/Papercut-SMTP/issues
+Author: Ken Robertson & Jaben Cargman
+PackageName: Papercut SMTP
+PackageUrl: https://github.com/ChangemakerStudios/Papercut-SMTP
+License: Apache-2.0
+LicenseUrl: https://github.com/ChangemakerStudios/Papercut-SMTP/blob/develop/LICENSE
+Copyright: Copyright © 2008 - 2026 Ken Robertson & Jaben Cargman
+ShortDescription: Standalone SMTP server designed for viewing received messages
+Description: >-
+  Papercut SMTP is a 2-in-1 quick email viewer AND built-in SMTP server designed for development.
+
+  It allows developers to safely test email functionality without risk of emails being sent to real recipients.
+
+
+  Features:
+
+  - Desktop WPF application for viewing emails
+
+  - Built-in SMTP server (receive-only)
+
+  - Full email inspection (body, HTML, headers, attachments, raw encoded bits)
+
+  - Support for running as a minimized tray application with notifications
+
+  - WebView2-based HTML email rendering
+Moniker: papercut-smtp
+Tags:
+- smtp
+- email
+- development
+- testing
+- developer-tools
+- mail-server
+ReleaseNotes: https://github.com/ChangemakerStudios/Papercut-SMTP/releases/tag/7.8.0
+ReleaseNotesUrl: https://github.com/ChangemakerStudios/Papercut-SMTP/releases/tag/7.8.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/c/ChangemakerStudios/Papercut-SMTP/7.8.0/ChangemakerStudios.Papercut-SMTP.yaml
+++ b/manifests/c/ChangemakerStudios/Papercut-SMTP/7.8.0/ChangemakerStudios.Papercut-SMTP.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: ChangemakerStudios.Papercut-SMTP
+PackageVersion: 7.8.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
This pull request updates Papercut SMTP to version 7.8.0.

**Release Notes**: https://github.com/ChangemakerStudios/Papercut-SMTP/releases/tag/7.8.0

Automatically generated from the Papercut SMTP release pipeline.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/418212)