### PR TITLE
New version: DaikiSuganuma.WinRemap version 1.0.0

### DIFF
--- a/manifests/d/DaikiSuganuma/WinRemap/1.0.0/DaikiSuganuma.WinRemap.installer.yaml
+++ b/manifests/d/DaikiSuganuma/WinRemap/1.0.0/DaikiSuganuma.WinRemap.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: DaikiSuganuma.WinRemap
+PackageVersion: 1.0.0
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+# Inno Setup's uninstall key is {AppId}_is1 (installer/winremap.iss); this lets
+# winget correlate the install for upgrade and uninstall.
+ProductCode: '{707AFB56-1975-4DF4-8371-B50DD23E3DA1}_is1'
+ReleaseDate: 2026-08-16
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/DaikiSuganuma/winremap/releases/download/v1.0.0/winremap-setup.exe
+    InstallerSha256: A20002CB189A2792B092575A052F2872D69C40D17FA355E3363A76A3A000818E
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/d/DaikiSuganuma/WinRemap/1.0.0/DaikiSuganuma.WinRemap.locale.en-US.yaml
+++ b/manifests/d/DaikiSuganuma/WinRemap/1.0.0/DaikiSuganuma.WinRemap.locale.en-US.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: DaikiSuganuma.WinRemap
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: Daiki Suganuma
+PublisherUrl: https://github.com/DaikiSuganuma
+PublisherSupportUrl: https://github.com/DaikiSuganuma/winremap/issues
+Author: Daiki Suganuma
+PackageName: WinRemap
+PackageUrl: https://github.com/DaikiSuganuma/winremap
+License: MIT
+LicenseUrl: https://github.com/DaikiSuganuma/winremap/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Daiki Suganuma
+CopyrightUrl: https://github.com/DaikiSuganuma/winremap/blob/main/LICENSE
+ShortDescription: A per-application key remapper for Windows, written in Rust.
+Description: |-
+  WinRemap remaps keys only in the applications you choose, declared in one
+  simple TOML file. It uses a low-level keyboard hook written in Rust with no
+  heap allocation or I/O in the callback, so remapping stays responsive and
+  avoids the hook timeouts that affect script-based remappers. Chord and
+  bare-key rules, two-stroke prefixes, macros and optional runtime macro
+  recording are supported. The settings window shows the config in effect and
+  edits it in place, validating as you type and leaving everything you did not
+  touch — comments, ordering, spelling — exactly as it was. WinRemap never logs
+  keystrokes and makes no network requests.
+Moniker: winremap
+Tags:
+  - keyboard
+  - remap
+  - remapper
+  - keymap
+  - productivity
+  - emacs
+  - utility
+  - rust
+ReleaseNotesUrl: https://github.com/DaikiSuganuma/winremap/releases/tag/v1.0.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/d/DaikiSuganuma/WinRemap/1.0.0/DaikiSuganuma.WinRemap.yaml
+++ b/manifests/d/DaikiSuganuma/WinRemap/1.0.0/DaikiSuganuma.WinRemap.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: DaikiSuganuma.WinRemap
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Package: DaikiSuganuma.WinRemap version 1.0.0

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Adds version 1.0.0. I am the publisher of this package.

Release: https://github.com/DaikiSuganuma/winremap/releases/tag/v1.0.0

Changes from 1.0.0 against the existing 0.9.0 manifests are limited to
`PackageVersion` (x3), `ReleaseDate`, `InstallerUrl`, `InstallerSha256` and
`ReleaseNotesUrl`. `ProductCode` is unchanged because the Inno Setup `AppId`
is unchanged.

`InstallerSha256` was taken from the file downloaded from the public release
URL, and matches the `SHA256SUMS` published with the release.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/418315)