### PR TITLE
New version: Netpack.XFB version 3.1419

### DIFF
--- a/manifests/n/Netpack/XFB/3.1419/Netpack.XFB.installer.yaml
+++ b/manifests/n/Netpack/XFB/3.1419/Netpack.XFB.installer.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: Netpack.XFB
+PackageVersion: "3.1419"
+InstallerType: nullsoft
+Scope: machine
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+ElevationRequirement: elevationRequired
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/netpack/XFB/releases/download/v3.1419/XFB-3.1419-Setup.exe
+  InstallerSha256: D6FE553A03E8D1D0FD7A611935720630BDF0CA46840DE8AB3AE252FA1719327B
+  ProductCode: XFB
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+  AppsAndFeaturesEntries:
+  - DisplayName: XFB (x64) - XFB Radio Automation Software
+    Publisher: Netpack - Online Solutions
+- Architecture: arm64
+  InstallerUrl: https://github.com/netpack/XFB/releases/download/v3.1419/XFB-3.1419-arm64-Setup.exe
+  InstallerSha256: C94643D4ED87DC311E438D37F9E1ACC7A0E2CCDBE45EFAA9099E8760EEA57ECD
+  ProductCode: XFB
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.arm64
+  AppsAndFeaturesEntries:
+  - DisplayName: XFB (arm64) - XFB Radio Automation Software
+    Publisher: Netpack - Online Solutions
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/n/Netpack/XFB/3.1419/Netpack.XFB.locale.en-US.yaml
+++ b/manifests/n/Netpack/XFB/3.1419/Netpack.XFB.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: Netpack.XFB
+PackageVersion: "3.1419"
+PackageLocale: en-US
+Publisher: Netpack - Online Solutions
+PublisherUrl: https://netpack.pt/
+PublisherSupportUrl: https://github.com/netpack/XFB/issues
+Author: Frédéric Bogaerts
+PackageName: XFB
+PackageUrl: https://github.com/netpack/XFB
+License: GPL-3.0
+LicenseUrl: https://github.com/netpack/XFB/blob/main/LICENSE
+ShortDescription: Open-source radio automation software
+Description: |-
+  XFB is an open-source radio automation suite for broadcasters. It provides
+  scheduled playlists, jingles and advertising rotation, a live audio FX
+  engine (10-band equalizer, compressor, 432 Hz retune), DJ decks with
+  scratchable jog wheels, an Icecast/Shoutcast streaming client, playlist
+  waveform views with crossfade preparation and volume automation, and
+  comprehensive accessibility support including screen-reader integration
+  and full keyboard navigation.
+Moniker: xfb
+Tags:
+- accessibility
+- audio
+- automation
+- broadcast
+- open-source
+- radio
+ReleaseNotesUrl: https://github.com/netpack/XFB/releases/tag/v3.1419
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/n/Netpack/XFB/3.1419/Netpack.XFB.yaml
+++ b/manifests/n/Netpack/XFB/3.1419/Netpack.XFB.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: Netpack.XFB
+PackageVersion: "3.1419"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Adds Netpack.XFB version 3.1419.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/add?
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

These manifests were prepared on macOS, so `winget validate` and `winget install`
were not run locally — those two boxes are left unchecked deliberately rather
than claimed. The files are the accepted 3.1417 manifests with only the version,
the two installer URLs and their SHA256 values changed, so the schema and every
other field are unchanged from the previously merged manifest.

Both installers are published as assets of the upstream release
https://github.com/netpack/XFB/releases/tag/v3.1419, and the SHA256 values were
computed from those exact files:

| Architecture | Installer | SHA256 |
| --- | --- | --- |
| x64 | `XFB-3.1419-Setup.exe` | `D6FE553A03E8D1D0FD7A611935720630BDF0CA46840DE8AB3AE252FA1719327B` |
| arm64 | `XFB-3.1419-arm64-Setup.exe` | `C94643D4ED87DC311E438D37F9E1ACC7A0E2CCDBE45EFAA9099E8760EEA57ECD` |
