### PR TITLE
New package: MudabbirulSaad.NetPulse version 1.0.0

### DIFF
--- a/manifests/m/MudabbirulSaad/NetPulse/1.0.0/MudabbirulSaad.NetPulse.installer.yaml
+++ b/manifests/m/MudabbirulSaad/NetPulse/1.0.0/MudabbirulSaad.NetPulse.installer.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: MudabbirulSaad.NetPulse
+PackageVersion: 1.0.0
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: msi
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.10
+      MinimumVersion: 10.0.0
+Installers:
+  - Architecture: x64
+    InstallerLocale: en-US
+    InstallerUrl: https://github.com/MudabbirulSaad/NetPulse/releases/download/v1.0.0/NetPulseSetup.msi
+    InstallerSha256: 8B7DD051FFF1DF0B28843246EB1775526C51C39D35FF50C1BE9F6AD08A9D0592
+    ProductCode: '{05FFADFC-5218-46B2-8466-019AD6B9FE48}'
+    AppsAndFeaturesEntries:
+      - DisplayName: NetPulse
+        Publisher: Mudabbirul Saad
+        ProductCode: '{05FFADFC-5218-46B2-8466-019AD6B9FE48}'
+        UpgradeCode: '{3E03781C-78F4-497C-BC86-F9E3FF497334}'
+    InstallationMetadata:
+      DefaultInstallLocation: '%ProgramFiles%\NetPulse'
+      Files:
+        - RelativeFilePath: NetPulse.App.exe
+          FileType: launch
+          DisplayName: NetPulse
+    ReleaseDate: 2026-08-16
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/MudabbirulSaad/NetPulse/1.0.0/MudabbirulSaad.NetPulse.locale.en-US.yaml
+++ b/manifests/m/MudabbirulSaad/NetPulse/1.0.0/MudabbirulSaad.NetPulse.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: MudabbirulSaad.NetPulse
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: Mudabbirul Saad
+PublisherUrl: https://github.com/MudabbirulSaad
+PublisherSupportUrl: https://github.com/MudabbirulSaad/NetPulse/issues
+PrivacyUrl: https://github.com/MudabbirulSaad/NetPulse/blob/v1.0.0/docs/privacy.md
+Author: Mudabbirul Saad
+PackageName: NetPulse
+PackageUrl: https://github.com/MudabbirulSaad/NetPulse
+License: MIT
+LicenseUrl: https://github.com/MudabbirulSaad/NetPulse/blob/v1.0.0/LICENSE
+Copyright: Copyright (c) 2026 Mudabbirul Saad
+ShortDescription: A compact Windows dashboard for HTTP and explicit-resolver DNS health.
+Description: >-
+  NetPulse monitors HTTP endpoints and DNS A queries through a selected resolver,
+  displays accessible health states and real latency, and retains a short local history.
+Moniker: netpulse
+Tags:
+  - dns
+  - http
+  - monitoring
+  - network
+  - wpf
+ReleaseNotes: >-
+  First stable release with HTTP, explicit-resolver DNS, independent ICMP signals,
+  rolling latency metrics, atomic local persistence, and a WiX MSI for Windows x64.
+ReleaseNotesUrl: https://github.com/MudabbirulSaad/NetPulse/releases/tag/v1.0.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/MudabbirulSaad/NetPulse/1.0.0/MudabbirulSaad.NetPulse.locale.en-US.yaml
+++ b/manifests/m/MudabbirulSaad/NetPulse/1.0.0/MudabbirulSaad.NetPulse.locale.en-US.yaml
@@ -13,7 +13,7 @@ PackageUrl: https://github.com/MudabbirulSaad/NetPulse
 License: MIT
 LicenseUrl: https://github.com/MudabbirulSaad/NetPulse/blob/v1.0.0/LICENSE
 Copyright: Copyright (c) 2026 Mudabbirul Saad
-ShortDescription: A compact Windows dashboard for HTTP and explicit-resolver DNS health.
+ShortDescription: A compact Windows dashboard for monitoring HTTP endpoints and DNS resolvers.
 Description: >-
   NetPulse monitors HTTP endpoints and DNS A queries through a selected resolver,
   displays accessible health states and real latency, and retains a short local history.

--- a/manifests/m/MudabbirulSaad/NetPulse/1.0.0/MudabbirulSaad.NetPulse.yaml
+++ b/manifests/m/MudabbirulSaad/NetPulse/1.0.0/MudabbirulSaad.NetPulse.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: MudabbirulSaad.NetPulse
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds the first WinGet manifest for NetPulse 1.0.0, a Windows x64 HTTP and explicit-resolver DNS health dashboard.

The manifest uses the version-specific GitHub Release MSI, declares the Microsoft .NET Desktop Runtime 10 dependency, and includes MSI ProductCode and UpgradeCode correlation data.

## ✅ Checklist

- [x] Signed the Contributor License Agreement
- [x] No other open pull request exists for this package version
- [x] This pull request modifies one package version only
- [x] Manifest passed `winget validate --manifest <path>`
- [x] Direct MSI installation completed successfully
- [x] WinGet local-manifest installation (the administrator-controlled LocalManifestFiles setting is disabled on the development computer)
- [x] Manifest conforms to the 1.12 schema
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/418335)