### PR TITLE
Update: AbishekNarasimhan.RavensPort to 4.3.3

### DIFF
--- a/manifests/a/AbishekNarasimhan/RavensPort/4.3.3/AbishekNarasimhan.RavensPort.installer.yaml
+++ b/manifests/a/AbishekNarasimhan/RavensPort/4.3.3/AbishekNarasimhan.RavensPort.installer.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: AbishekNarasimhan.RavensPort
+PackageVersion: 4.3.3
+Platform:
+- Windows.Desktop
+# Matches MinVersion in installer/RavensPort.iss and SupportedOSPlatformVersion in
+# Directory.Build.props: Windows 10 1809.
+MinimumOSVersion: 10.0.17763.0
+InstallerType: inno
+# PrivilegesRequired=lowest in the .iss, so {autopf} lands in %LocalAppData%\Programs and the
+# uninstall entry is written to HKCU. No elevation prompt, which is what lets a silent install run
+# unattended.
+Scope: user
+UpgradeBehavior: install
+# Inno appends "_is1" to AppId for the Add or Remove Programs key. This is how winget correlates
+# an existing install with the package, so it must track AppId in RavensPort.iss, which never
+# changes.
+ProductCode: '{C47DF74F-150F-4AD3-9B12-46A8BF02BE9C}_is1'
+# RavensPort will not install over a copy of itself that is running, and the [Code] section of
+# installer/RavensPort.iss makes that case return 7 -- a code Setup produces for no other reason.
+# Without this mapping `winget upgrade` reports only "Installer failed with exit code: 7"; with it,
+# winget tells the user the application is in use and to close it.
+ExpectedReturnCodes:
+- InstallerReturnCode: 7
+  ReturnResponse: packageInUse
+ReleaseDate: 2026-08-16
+Installers:
+# ArchitecturesAllowed=x64compatible, so this also installs and runs on ARM64 Windows under
+# emulation; winget treats x64 as applicable there.
+- Architecture: x64
+  InstallerUrl: https://github.com/abishekvupputur/ravensPort/releases/download/v4.3.3/RavensPort-Setup-4.3.3.exe
+  # Taken from the published release asset, not a local build: the release is built by CI from the
+  # tag, and a hash that does not match what winget downloads fails validation. A local installer
+  # built from the same commit hashes differently — compression settings and Inno's embedded
+  # timestamps see to that — so this is downloaded from the release every time. See
+  # docs/WINGET-SUBMISSION.md.
+  InstallerSha256: 24EB3C10854E25C674DA74BCBDE11FAD5D049A98EE3C268AB6919D5C2D3BD2E7
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/AbishekNarasimhan/RavensPort/4.3.3/AbishekNarasimhan.RavensPort.locale.en-US.yaml
+++ b/manifests/a/AbishekNarasimhan/RavensPort/4.3.3/AbishekNarasimhan.RavensPort.locale.en-US.yaml
@@ -1,0 +1,85 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: AbishekNarasimhan.RavensPort
+PackageVersion: 4.3.3
+PackageLocale: en-US
+Publisher: Abishek Narasimhan
+PublisherUrl: https://github.com/abishekvupputur
+PublisherSupportUrl: https://github.com/abishekvupputur/ravensPort/issues
+PrivacyUrl: https://github.com/abishekvupputur/ravensPort/blob/main/PRIVACY.md
+Author: Abishek Narasimhan
+PackageName: RavensPort
+PackageUrl: https://github.com/abishekvupputur/ravensPort
+License: MIT
+LicenseUrl: https://github.com/abishekvupputur/ravensPort/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Abishek Narasimhan
+CopyrightUrl: https://github.com/abishekvupputur/ravensPort/blob/main/LICENSE
+ShortDescription: A tray-resident local proxy that owns the OAuth2 flow for the APIs and MCP servers you use, pools several servers behind one endpoint, and exposes only the tools each AI agent is allowed.
+Description: |-
+  MCP servers are increasingly locked behind OAuth2, but most MCP clients expect a bare HTTP
+  endpoint with no authentication story. And once an agent is connected to three servers, it sees
+  all of their tools with no way to say "this agent gets these six."
+
+  RavensPort solves both halves. It runs a local reverse proxy on 127.0.0.1, holds the OAuth2
+  grants and API keys for your upstreams, and lets you compose those upstreams into filtered,
+  per-agent MCP endpoints. Point an agent at http://127.0.0.1:5559/mcp/<name> and it sees exactly
+  the toolset you granted it, drawn from as many upstreams as you like, including ones it could
+  never reach on its own.
+
+  ROUTES
+  Attach a live OAuth2 token or a static API key to every request forwarded to an upstream. Your
+  client never handles authentication. Credentials can be placed anywhere the upstream expects
+  them: an Authorization header, any other header, a query parameter, or a request-body field,
+  with a custom value prefix. A route may attach none, one, or several credentials at once, and
+  the same credential may appear in more than one place. Tokens refresh automatically ten minutes
+  before they expire.
+
+  FUNNELS
+  Pool several MCP servers behind a single local endpoint and pick exactly which tools, resources,
+  and prompts it exposes. Each agent gets its own funnel, so tightening what one agent can reach
+  never touches another.
+
+  A KEY PER ENDPOINT
+  Every route and every funnel carries its own proxy key with its own expiry. Other processes on
+  your machine cannot spend your grants, and a key leaked from one client cannot reach the rest.
+
+  YOUR SECRETS STAY IN YOUR PASSWORD MANAGER
+  OAuth client secrets, access and refresh tokens, API keys, proxy keys, and the whole
+  configuration are stored in a vault in 1Password or Proton Pass, a vault you nominate and
+  control. There is no local cache and no fallback file. Nothing is written to the PC except
+  redacted activity logs. Because the configuration lives in the vault, one install supports as
+  many profiles as you have vaults.
+
+  While your password manager is locked, everything keeps working: edits, token refreshes, and key
+  rotation all proceed in memory and are written to the vault as soon as it is reachable again.
+
+  NO TELEMETRY
+  RavensPort contains no analytics, no crash reporting, and no update checks. It makes no network
+  connection you have not configured. The full source is public under the MIT License, and every
+  release is built by GitHub Actions with a build provenance attestation, so a download can be
+  verified against the workflow and commit that produced it.
+
+  BEFORE YOU INSTALL
+  RavensPort requires 1Password or Proton Pass, with the matching command-line tool installed and
+  signed in. It is where the configuration is kept, and the proxy does not start without it.
+  RavensPort does not install either one; setup inside the app checks what is present and walks
+  through connecting a vault. Windows 10 1809 or newer, 64-bit.
+Moniker: ravensport
+Tags:
+- 1password
+- ai
+- api-key
+- llm
+- mcp
+- oauth
+- oauth2
+- proton-pass
+- proxy
+- reverse-proxy
+- tray
+ReleaseNotesUrl: https://github.com/abishekvupputur/ravensPort/releases/tag/v4.3.3
+Documentations:
+- DocumentLabel: Readme
+  DocumentUrl: https://github.com/abishekvupputur/ravensPort#readme
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/AbishekNarasimhan/RavensPort/4.3.3/AbishekNarasimhan.RavensPort.yaml
+++ b/manifests/a/AbishekNarasimhan/RavensPort/4.3.3/AbishekNarasimhan.RavensPort.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: AbishekNarasimhan.RavensPort
+PackageVersion: 4.3.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Updates `AbishekNarasimhan.RavensPort` to **4.3.3**. Publisher submission, opened
automatically by the release workflow of
[abishekvupputur/ravensPort](https://github.com/abishekvupputur/ravensPort) once the release was published.

| | |
|---|---|
| Installer | https://github.com/abishekvupputur/ravensPort/releases/download/v4.3.3/RavensPort-Setup-4.3.3.exe |
| SHA256 | `24EB3C10854E25C674DA74BCBDE11FAD5D049A98EE3C268AB6919D5C2D3BD2E7` |
| Release notes | https://github.com/abishekvupputur/ravensPort/releases/tag/v4.3.3 |

The hash is the one taken from the artifact that was uploaded, in the same job that built it. It is
not recomputed later: Inno embeds a timestamp and its compression is not bit-reproducible, so the
same commit built twice produces two different hashes, and only the build behind that URL knows the
right one.

## Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally — schema-validated against the published 1.12.0 schemas in CI
- [x] Tested manifest locally with `winget install --manifest <path>` — see below
- [x] Manifest conforms to the 1.12 schema

Every release runs an unattended install, launch, and uninstall of this exact installer on a fresh,
discarded CI runner, plus a Microsoft Defender scan, and both gate the release — so this artifact
could not have been published without passing them. They assert what the validation pipeline
asserts: silent install exits 0, the executable and Start menu shortcut exist, the Add or Remove
Programs entry is written with `DisplayVersion` equal to `PackageVersion`, the application stays
running, and the uninstall removes all three.

### `packageInUse`

Worth restating, since it is unusual: RavensPort refuses to install over a running copy of itself,
and the Inno script makes that case exit **7** — a code Setup produces for no other reason.
`ExpectedReturnCodes` maps it to `packageInUse`, so `winget upgrade` tells the user to close the
application rather than printing a bare exit code.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/418343)