### PR TITLE
Update version: Vathivis.paperq version 1.0.0

### DIFF
--- a/manifests/v/Vathivis/paperq/1.0.0/Vathivis.paperq.installer.yaml
+++ b/manifests/v/Vathivis/paperq/1.0.0/Vathivis.paperq.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: Vathivis.paperq
+PackageVersion: 1.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: paperq.exe
+  PortableCommandAlias: paperq
+ReleaseDate: 2026-08-14
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Vathivis/paperq/releases/download/v1.0.0/paperq-1.0.0-win-x64.zip
+  InstallerSha256: 444EE244B5FAC9B0728A82377619134CA730BCF3F10C88821DD8DC2AEEF67575
+- Architecture: arm64
+  InstallerUrl: https://github.com/Vathivis/paperq/releases/download/v1.0.0/paperq-1.0.0-win-arm64.zip
+  InstallerSha256: 371674A3E6551D801518416F84240C0A6FED5276F68272D4FCBED97E1EAD2DD2
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/v/Vathivis/paperq/1.0.0/Vathivis.paperq.locale.en-US.yaml
+++ b/manifests/v/Vathivis/paperq/1.0.0/Vathivis.paperq.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: Vathivis.paperq
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: Vathivis
+PublisherUrl: https://vojtahumpl.com/
+PublisherSupportUrl: https://github.com/Vathivis/paperq/issues
+Author: Vojtěch Humpl
+PackageName: paperq
+PackageUrl: https://github.com/Vathivis/paperq
+License: MIT License
+LicenseUrl: https://github.com/Vathivis/paperq/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Vojtěch Humpl
+ShortDescription: A repository-local papercut queue for coding agents.
+Description: paperq is a small, repository-local queue for recording and managing the minor problems coding agents encounter during real work. It stores transparent Markdown records and provides commands to add, claim, block, reopen, resolve, and list them without running a model, collecting transcripts, starting a service, or sending data to a server.
+Moniker: paperq
+Tags:
+- cli
+- developer-tools
+- productivity
+- coding-agents
+- codex
+- claude
+ReleaseNotes: Adds a resolution journal for resolved papercuts, preserves existing AGENTS.md content with `init --append-agents`, adds Windows ARM64 and Debian release packages, includes MIT license.
+ReleaseNotesUrl: https://github.com/Vathivis/paperq/releases/tag/v0.2.0
+InstallationNotes: Run `paperq init` from a repository root to create its local papercut queue.
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/Vathivis/paperq/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/v/Vathivis/paperq/1.0.0/Vathivis.paperq.yaml
+++ b/manifests/v/Vathivis/paperq/1.0.0/Vathivis.paperq.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: Vathivis.paperq
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update Vathivis.paperq to version 1.0.0.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/418399)