### PR TITLE
New version: jefuriiij.PingMeter version 0.5.0

### DIFF
--- a/manifests/j/jefuriiij/PingMeter/0.5.0/jefuriiij.PingMeter.installer.yaml
+++ b/manifests/j/jefuriiij/PingMeter/0.5.0/jefuriiij.PingMeter.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: jefuriiij.PingMeter
+PackageVersion: 0.5.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.22000.0
+InstallerType: portable
+Commands:
+- pingmeter
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.10
+ReleaseDate: 2026-08-16
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/jefuriiij/ping-meter/releases/download/v0.5.0/PingMeter.exe
+  InstallerSha256: 13C16875A76492D7E0B3408A7119EBBC14A35476664A30808C6FED5763E64672
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/j/jefuriiij/PingMeter/0.5.0/jefuriiij.PingMeter.locale.en-US.yaml
+++ b/manifests/j/jefuriiij/PingMeter/0.5.0/jefuriiij.PingMeter.locale.en-US.yaml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: jefuriiij.PingMeter
+PackageVersion: 0.5.0
+PackageLocale: en-US
+Publisher: jefuriiij
+PublisherUrl: https://github.com/jefuriiij
+PublisherSupportUrl: https://github.com/jefuriiij/ping-meter/issues
+PackageName: PingMeter
+PackageUrl: https://github.com/jefuriiij/ping-meter
+License: MIT
+LicenseUrl: https://github.com/jefuriiij/ping-meter/blob/main/LICENSE
+Copyright: Copyright (c) 2026 jefuriiij
+ShortDescription: Taskbar-embedded ping monitor with network repair and DNS tools
+Description: |-
+  PingMeter shows your live ping (ms) embedded directly in the Windows 11 taskbar, next
+  to the tray clock — on the primary taskbar, secondary-monitor taskbars, or all of them.
+  It replaces keeping "ping google.com -t" open in a terminal: color-coded latency with
+  configurable thresholds, a sparkline of recent pings, packet-loss percentage, hover
+  stats (min/avg/max/loss and current DNS servers), quick switching between the hosts you
+  save, and a daily log of outages, latency spikes and hourly summaries.
+
+  It also includes optional network tools you start yourself from the settings window:
+  a DNS cache flush, a full connection repair (the standard flush / release / renew /
+  winsock / TCP-IP sequence), and switching the active adapter's IPv4 DNS between
+  automatic, well-known public resolvers, or addresses you type and save. Encrypted DNS
+  (DNS over HTTPS) can be turned on per server, with the automatic or a manual template,
+  matching the choices Windows 11 offers. These actions use built-in Windows networking
+  features and require your approval at a Windows permission prompt; the app itself runs
+  without administrator rights, collects no personal data, and survives Explorer
+  restarts.
+Tags:
+- diagnostics
+- dns
+- doh
+- latency
+- monitor
+- network
+- ping
+- taskbar
+ReleaseNotesUrl: https://github.com/jefuriiij/ping-meter/releases/tag/v0.5.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/j/jefuriiij/PingMeter/0.5.0/jefuriiij.PingMeter.yaml
+++ b/manifests/j/jefuriiij/PingMeter/0.5.0/jefuriiij.PingMeter.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: jefuriiij.PingMeter
+PackageVersion: 0.5.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Version update for `jefuriiij.PingMeter` — 0.4.1 → 0.5.0. I'm the package author.

- **Installer:** unchanged shape — the same portable x64 exe published on the project's GitHub releases, with a new URL / SHA-256 / ReleaseDate. The `Microsoft.DotNet.DesktopRuntime.10` dependency is retained.
- **Locale:** description extended to cover encrypted DNS (DNS over HTTPS), and a `doh` tag added. Everything else is unchanged from the merged 0.4.1 manifests.

Verification on my side: the published asset was downloaded back from the release URL, its SHA-256 confirmed to match `InstallerSha256`, and that exact binary installed and run on Windows 11 before submitting.

### Checklist

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`? — `LocalManifestFiles` is disabled on this machine, so I verified the equivalent instead: downloaded the release asset, checked its hash against the manifest, and ran it.
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/418478)