### PR TITLE
New package: gmhoward9289-ops.legbar version 0.2.0

### DIFF
--- a/manifests/g/gmhoward9289-ops/legbar/0.2.0/gmhoward9289-ops.legbar.installer.yaml
+++ b/manifests/g/gmhoward9289-ops/legbar/0.2.0/gmhoward9289-ops.legbar.installer.yaml
@@ -1,0 +1,17 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: gmhoward9289-ops.legbar
+PackageVersion: 0.2.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: legbar.exe
+  PortableCommandAlias: legbar
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/gmhoward9289-ops/legbar/releases/download/v0.2.0/legbar-0.2.0-windows-x64.zip
+  InstallerSha256: 299BF7339B63AED6EFA4BF6ADB40330FFDEAE39D87C9AA1D6450475BDD89AA45
+ManifestType: installer
+ManifestVersion: 1.9.0
+ReleaseDate: 2026-08-16

--- a/manifests/g/gmhoward9289-ops/legbar/0.2.0/gmhoward9289-ops.legbar.locale.en-US.yaml
+++ b/manifests/g/gmhoward9289-ops/legbar/0.2.0/gmhoward9289-ops.legbar.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: gmhoward9289-ops.legbar
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: George M. Howard
+PublisherUrl: https://github.com/gmhoward9289-ops
+PublisherSupportUrl: https://github.com/gmhoward9289-ops/legbar/issues
+PackageName: legbar
+PackageUrl: https://github.com/gmhoward9289-ops/legbar
+License: MIT
+LicenseUrl: https://github.com/gmhoward9289-ops/legbar/blob/main/LICENSE
+Copyright: Copyright (c) 2026 George M. Howard
+ShortDescription: One screen for the whole fleet - live agent sessions beside GitHub CI
+Moniker: legbar
+Tags:
+- claude
+- cursor
+- cli
+- monitoring
+- dashboard
+ReleaseNotesUrl: https://github.com/gmhoward9289-ops/legbar/releases/tag/v0.2.0
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/g/gmhoward9289-ops/legbar/0.2.0/gmhoward9289-ops.legbar.yaml
+++ b/manifests/g/gmhoward9289-ops/legbar/0.2.0/gmhoward9289-ops.legbar.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: gmhoward9289-ops.legbar
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
One screen for the whole fleet: live agent sessions beside GitHub CI. A console TUI, MIT licensed, source at https://github.com/gmhoward9289-ops/legbar. Ships as a frozen zip (portable exe, no installer). Same publisher account as the already-approved gmhoward9289-ops.roost (#411432).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/418490)