### PR TITLE
Update version: OpenJS.Electron.41 version 43.4.0

### DIFF
--- a/manifests/o/OpenJS/Electron/41/43.4.0/OpenJS.Electron.41.installer.yaml
+++ b/manifests/o/OpenJS/Electron/41/43.4.0/OpenJS.Electron.41.installer.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: OpenJS.Electron.41
+PackageVersion: 43.4.0
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: electron.exe
+  PortableCommandAlias: electron
+UpgradeBehavior: install
+ReleaseDate: 2026-08-11
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/electron/electron/releases/download/v43.4.0/electron-v43.4.0-win32-ia32.zip
+  InstallerSha256: 3A61C1EB57F78C41528701BB30D96DD06D6BE68C14BA9E0D81D654CC8302508E
+- Architecture: x64
+  InstallerUrl: https://github.com/electron/electron/releases/download/v43.4.0/electron-v43.4.0-win32-x64.zip
+  InstallerSha256: EF0709CFA719739ACCE73DE6F9B684304BAF38C6454376638A70D34A7CECFFE0
+- Architecture: arm64
+  InstallerUrl: https://github.com/electron/electron/releases/download/v43.4.0/electron-v43.4.0-win32-arm64.zip
+  InstallerSha256: CEC4E502E5DB33B432ADCF1278072FB14B9EDEB88403E0952E4B864BDF51B0EF
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenJS/Electron/41/43.4.0/OpenJS.Electron.41.locale.en-US.yaml
+++ b/manifests/o/OpenJS/Electron/41/43.4.0/OpenJS.Electron.41.locale.en-US.yaml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: OpenJS.Electron.41
+PackageVersion: 43.4.0
+PackageLocale: en-US
+Publisher: OpenJS Foundation
+PublisherUrl: https://openjsf.org/
+PublisherSupportUrl: https://github.com/electron/electron/issues
+PrivacyUrl: https://privacy-policy.openjsf.org/
+PackageName: Electron
+PackageUrl: https://www.electronjs.org/
+License: MIT
+LicenseUrl: https://github.com/electron/electron/blob/HEAD/LICENSE
+ShortDescription: Build cross-platform desktop apps with JavaScript, HTML, and CSS.
+Moniker: electron
+Tags:
+- c-plus-plus
+- chrome
+- css
+- electron
+- html
+- javascript
+- nodejs
+- v8
+- works-with-codespaces
+ReleaseNotes: |-
+  Release Notes for v41.10.5
+  Fixes
+  • Fixed an issue where the Squirrel.Mac installer could resolve the target bundle path to different locations at different stages of an install. #50764 ^{(Also in 39, 42)}
+  Other Changes
+  • Backported fixes from upstream ANGLE, Chromium, Skia and V8. #52702
+  • No user-facing change; semver/none. #52734
+ReleaseNotesUrl: https://github.com/electron/electron/releases/tag/v41.10.5
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenJS/Electron/41/43.4.0/OpenJS.Electron.41.yaml
+++ b/manifests/o/OpenJS/Electron/41/43.4.0/OpenJS.Electron.41.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: OpenJS.Electron.41
+PackageVersion: 43.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update OpenJS.Electron.41 to version 43.4.0.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/418501)