### PR TITLE
Update metadata: Pantelis23.KernRift v2.8.26-v2.8.33 license is Apache-2.0

### DIFF
--- a/manifests/p/Pantelis23/KernRift/v2.8.26/Pantelis23.KernRift.locale.en-US.yaml
+++ b/manifests/p/Pantelis23/KernRift/v2.8.26/Pantelis23.KernRift.locale.en-US.yaml
@@ -8,7 +8,7 @@ PublisherSupportUrl: https://github.com/Pantelis23/KernRift/issues
 Author: Pantelis Christou
 PackageName: KernRift
 PackageUrl: https://github.com/Pantelis23/KernRift
-License: MIT
+License: Apache-2.0
 LicenseUrl: https://github.com/Pantelis23/KernRift/blob/HEAD/LICENSE
 Copyright: Copyright (c) 2025 Pantelis Christou
 ShortDescription: Self-hosted bare-metal systems programming language and compiler

--- a/manifests/p/Pantelis23/KernRift/v2.8.27/Pantelis23.KernRift.locale.en-US.yaml
+++ b/manifests/p/Pantelis23/KernRift/v2.8.27/Pantelis23.KernRift.locale.en-US.yaml
@@ -8,7 +8,7 @@ PublisherSupportUrl: https://github.com/Pantelis23/KernRift/issues
 Author: Pantelis Christou
 PackageName: KernRift
 PackageUrl: https://github.com/Pantelis23/KernRift
-License: MIT
+License: Apache-2.0
 LicenseUrl: https://github.com/Pantelis23/KernRift/blob/HEAD/LICENSE
 Copyright: Copyright (c) 2025 Pantelis Christou
 ShortDescription: Self-hosted bare-metal systems programming language and compiler

--- a/manifests/p/Pantelis23/KernRift/v2.8.28/Pantelis23.KernRift.locale.en-US.yaml
+++ b/manifests/p/Pantelis23/KernRift/v2.8.28/Pantelis23.KernRift.locale.en-US.yaml
@@ -8,7 +8,7 @@ PublisherSupportUrl: https://github.com/Pantelis23/KernRift/issues
 Author: Pantelis Christou
 PackageName: KernRift
 PackageUrl: https://github.com/Pantelis23/KernRift
-License: MIT
+License: Apache-2.0
 LicenseUrl: https://github.com/Pantelis23/KernRift/blob/HEAD/LICENSE
 Copyright: Copyright (c) 2025 Pantelis Christou
 ShortDescription: Self-hosted bare-metal systems programming language and compiler

--- a/manifests/p/Pantelis23/KernRift/v2.8.29/Pantelis23.KernRift.locale.en-US.yaml
+++ b/manifests/p/Pantelis23/KernRift/v2.8.29/Pantelis23.KernRift.locale.en-US.yaml
@@ -8,7 +8,7 @@ PublisherSupportUrl: https://github.com/Pantelis23/KernRift/issues
 Author: Pantelis Christou
 PackageName: KernRift
 PackageUrl: https://github.com/Pantelis23/KernRift
-License: MIT
+License: Apache-2.0
 LicenseUrl: https://github.com/Pantelis23/KernRift/blob/HEAD/LICENSE
 Copyright: Copyright (c) 2025 Pantelis Christou
 ShortDescription: Self-hosted bare-metal systems programming language and compiler

--- a/manifests/p/Pantelis23/KernRift/v2.8.30/Pantelis23.KernRift.locale.en-US.yaml
+++ b/manifests/p/Pantelis23/KernRift/v2.8.30/Pantelis23.KernRift.locale.en-US.yaml
@@ -8,7 +8,7 @@ PublisherSupportUrl: https://github.com/Pantelis23/KernRift/issues
 Author: Pantelis Christou
 PackageName: KernRift
 PackageUrl: https://github.com/Pantelis23/KernRift
-License: MIT
+License: Apache-2.0
 LicenseUrl: https://github.com/Pantelis23/KernRift/blob/HEAD/LICENSE
 Copyright: Copyright (c) 2025 Pantelis Christou
 ShortDescription: Self-hosted bare-metal systems programming language and compiler

--- a/manifests/p/Pantelis23/KernRift/v2.8.31/Pantelis23.KernRift.locale.en-US.yaml
+++ b/manifests/p/Pantelis23/KernRift/v2.8.31/Pantelis23.KernRift.locale.en-US.yaml
@@ -8,7 +8,7 @@ PublisherSupportUrl: https://github.com/Pantelis23/KernRift/issues
 Author: Pantelis Christou
 PackageName: KernRift
 PackageUrl: https://github.com/Pantelis23/KernRift
-License: MIT
+License: Apache-2.0
 LicenseUrl: https://github.com/Pantelis23/KernRift/blob/HEAD/LICENSE
 Copyright: Copyright (c) 2025 Pantelis Christou
 ShortDescription: Self-hosted bare-metal systems programming language and compiler

--- a/manifests/p/Pantelis23/KernRift/v2.8.32/Pantelis23.KernRift.locale.en-US.yaml
+++ b/manifests/p/Pantelis23/KernRift/v2.8.32/Pantelis23.KernRift.locale.en-US.yaml
@@ -8,7 +8,7 @@ PublisherSupportUrl: https://github.com/Pantelis23/KernRift/issues
 Author: Pantelis Christou
 PackageName: KernRift
 PackageUrl: https://github.com/Pantelis23/KernRift
-License: MIT
+License: Apache-2.0
 LicenseUrl: https://github.com/Pantelis23/KernRift/blob/HEAD/LICENSE
 Copyright: Copyright (c) 2025 Pantelis Christou
 ShortDescription: Self-hosted bare-metal systems programming language and compiler

--- a/manifests/p/Pantelis23/KernRift/v2.8.33/Pantelis23.KernRift.locale.en-US.yaml
+++ b/manifests/p/Pantelis23/KernRift/v2.8.33/Pantelis23.KernRift.locale.en-US.yaml
@@ -8,7 +8,7 @@ PublisherSupportUrl: https://github.com/Pantelis23/KernRift/issues
 Author: Pantelis Christou
 PackageName: KernRift
 PackageUrl: https://github.com/Pantelis23/KernRift
-License: MIT
+License: Apache-2.0
 LicenseUrl: https://github.com/Pantelis23/KernRift/blob/HEAD/LICENSE
 Copyright: Copyright (c) 2025 Pantelis Christou
 ShortDescription: Self-hosted bare-metal systems programming language and compiler


### PR DESCRIPTION
## 📖 Description

Corrects the `License` field on eight published versions of `Pantelis23.KernRift`.

I relicensed KernRift from MIT to Apache 2.0 upstream on 2026-05-19. The first
tag cut after that was `v2.8.26` (2026-06-11), so **v2.8.26 through v2.8.33 ship
Apache 2.0 but their manifests still say `License: MIT`**. Verified tag by tag
against the source tree.

These manifests currently contradict themselves: `LicenseUrl` points at
`blob/HEAD/LICENSE`, which serves the Apache 2.0 text, while `License` says MIT.

Not affected, and deliberately untouched:

| versions | manifest says | actually ships | |
|---|---|---|---|
| `2.3.0`, `v2.8.0`–`v2.8.25` | MIT | MIT | correct, left alone |
| **`v2.8.26`–`v2.8.33`** | **MIT** | **Apache 2.0** | **fixed here** |
| `v2.9.0`, `v2.10.0` | Apache-2.0 | Apache 2.0 | correct, left alone |

The diff is exactly eight lines, `-License: MIT` / `+License: Apache-2.0`, one
per version. No other field, file, or version is touched.

### Note on the one-manifest checklist item

This PR spans eight versions of a single package rather than one, because it is
the same mechanical one-field correction repeated. Eight near-identical PRs
seemed worse for reviewers than one, but I'm happy to split it if you'd prefer —
just say so and I'll close this and open them individually.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same manifest update/change
- [ ] This PR only modifies one (1) manifest — see the note above
- [x] Validated manifest locally with `winget validate --manifest <path>` — all eight, on Windows with winget v1.29.280: `Manifest validation succeeded`, exit 0 for each
- [ ] Tested manifest locally with `winget install --manifest` — not run deliberately: this PR changes one metadata string and touches no installer field, so an install test exercises nothing the change affects, and installing a superseded version would only disturb the machine's current install
- [x] Manifest conforms to the schema it already declared (`1.10.0`, unchanged)
