### PR TITLE
Update metadata: Pantelis23.KernRift version v2.8.33 license is Apache-2.0

### DIFF
--- a/manifests/p/Pantelis23/KernRift/v2.8.33/Pantelis23.KernRift.locale.en-US.yaml
+++ b/manifests/p/Pantelis23/KernRift/v2.8.33/Pantelis23.KernRift.locale.en-US.yaml
@@ -8,7 +8,7 @@ PublisherSupportUrl: https://github.com/Pantelis23/KernRift/issues
 Author: Pantelis Christou
 PackageName: KernRift
 PackageUrl: https://github.com/Pantelis23/KernRift
-License: MIT
+License: Apache-2.0
 LicenseUrl: https://github.com/Pantelis23/KernRift/blob/HEAD/LICENSE
 Copyright: Copyright (c) 2025 Pantelis Christou
 ShortDescription: Self-hosted bare-metal systems programming language and compiler


### PR DESCRIPTION
## 📖 Description

Corrects the `License` field on `Pantelis23.KernRift` version `v2.8.33`.

I relicensed KernRift from MIT to Apache 2.0 on 2026-05-19. `v2.8.33` was tagged
after that, so it ships Apache 2.0 while its manifest still says `License: MIT`.
The manifest currently contradicts itself: its own `LicenseUrl` points at
`blob/HEAD/LICENSE`, which serves the Apache 2.0 text.

The diff is one line: `-License: MIT` / `+License: Apache-2.0`. No other field.

Eight versions are affected (v2.8.26–v2.8.33) and each now has its own PR, as
the validator requires. Versions `2.3.0` and `v2.8.0`–`v2.8.25` correctly say
MIT and are untouched; `v2.9.0` and `v2.10.0` are already correct.

Originally submitted as a single PR (#418529) covering all eight; closed and
split after `PullRequest-Error`.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` — winget v1.29.280 on Windows: `Manifest validation succeeded`, exit 0
- [ ] Tested manifest locally with `winget install --manifest` — not run deliberately: this changes one metadata string and touches no installer field, so an install test exercises nothing the change affects
- [x] Manifest conforms to the schema it already declared (`1.10.0`, unchanged)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/418541)