### PR TITLE
New package: VeryGoodSoftware.MarkdownStyle version 0.6.2

### DIFF
--- a/manifests/v/VeryGoodSoftware/MarkdownStyle/0.6.2/VeryGoodSoftware.MarkdownStyle.installer.yaml
+++ b/manifests/v/VeryGoodSoftware/MarkdownStyle/0.6.2/VeryGoodSoftware.MarkdownStyle.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: VeryGoodSoftware.MarkdownStyle
+PackageVersion: 0.6.2
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: markdown-style.exe
+  PortableCommandAlias: markdown-style
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/very-good-software-ltd/markdown-style/releases/download/0.6.2/markdown-style-x86_64-pc-windows-msvc.zip
+  InstallerSha256: B421FE21C22ECF9B666869462A2DE6884A9E40942E96006EB1CABFC8FC616519
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-08-15

--- a/manifests/v/VeryGoodSoftware/MarkdownStyle/0.6.2/VeryGoodSoftware.MarkdownStyle.locale.en-US.yaml
+++ b/manifests/v/VeryGoodSoftware/MarkdownStyle/0.6.2/VeryGoodSoftware.MarkdownStyle.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: VeryGoodSoftware.MarkdownStyle
+PackageVersion: 0.6.2
+PackageLocale: en-US
+Publisher: Very Good Software
+PublisherUrl: https://github.com/very-good-software-ltd
+PublisherSupportUrl: https://github.com/very-good-software-ltd/markdown-style/issues
+Author: Christoph Gockel
+PackageName: markdown-style
+PackageUrl: https://github.com/very-good-software-ltd/markdown-style
+License: MIT
+LicenseUrl: https://github.com/very-good-software-ltd/markdown-style/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Christoph Gockel
+ShortDescription: An opinionated linter and formatter for Markdown.
+Description: |-
+  markdown-style checks Markdown against a fixed set of conventions.
+  The main one is a sentence per line, which keeps a diff to the sentences that actually changed rather than reflowing a whole paragraph.
+  The rest is ordinary tidiness: consistent heading and list markers, no trailing whitespace, predictable blank lines.
+  There is no configuration. You point it at a file, it tells you what is off and why, and it can fix most of it for you.
+Moniker: markdown-style
+Tags:
+- cli
+- formatter
+- linter
+- markdown
+ReleaseNotesUrl: https://github.com/very-good-software-ltd/markdown-style/releases/tag/0.6.2
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/v/VeryGoodSoftware/MarkdownStyle/0.6.2/VeryGoodSoftware.MarkdownStyle.yaml
+++ b/manifests/v/VeryGoodSoftware/MarkdownStyle/0.6.2/VeryGoodSoftware.MarkdownStyle.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: VeryGoodSoftware.MarkdownStyle
+PackageVersion: 0.6.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION

## 📖 Description
New package: `VeryGoodSoftware.MarkdownStyle` version 0.6.2.

  markdown-style is an opinionated linter and formatter for Markdown, with a fixed
  rule set and no configuration. It is a single self-contained CLI binary written
  in Rust, published as an x64 zip on the project's GitHub releases.

  The installer is `zip` with a `portable` nested installer, so the executable is
  aliased as `markdown-style` on the user's path.

  Upstream: https://github.com/very-good-software-ltd/markdown-style

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] ~~Linked to an issue (if applicable)~~ not applicable
  
## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/418572)