### PR TITLE
Update version: OpenJS.Electron.39 version 43.4.0

### DIFF
--- a/manifests/o/OpenJS/Electron/39/43.4.0/OpenJS.Electron.39.installer.yaml
+++ b/manifests/o/OpenJS/Electron/39/43.4.0/OpenJS.Electron.39.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: OpenJS.Electron.39
+PackageVersion: 43.4.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: electron.exe
+UpgradeBehavior: install
+ReleaseDate: 2026-08-11
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/electron/electron/releases/download/v43.4.0/electron-v43.4.0-win32-ia32.zip
+  InstallerSha256: 3A61C1EB57F78C41528701BB30D96DD06D6BE68C14BA9E0D81D654CC8302508E
+- Architecture: x64
+  InstallerUrl: https://github.com/electron/electron/releases/download/v43.4.0/electron-v43.4.0-win32-x64.zip
+  InstallerSha256: EF0709CFA719739ACCE73DE6F9B684304BAF38C6454376638A70D34A7CECFFE0
+- Architecture: arm64
+  InstallerUrl: https://github.com/electron/electron/releases/download/v43.4.0/electron-v43.4.0-win32-arm64.zip
+  InstallerSha256: CEC4E502E5DB33B432ADCF1278072FB14B9EDEB88403E0952E4B864BDF51B0EF
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenJS/Electron/39/43.4.0/OpenJS.Electron.39.locale.en-US.yaml
+++ b/manifests/o/OpenJS/Electron/39/43.4.0/OpenJS.Electron.39.locale.en-US.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: OpenJS.Electron.39
+PackageVersion: 43.4.0
+PackageLocale: en-US
+Publisher: OpenJS Foundation
+PublisherUrl: https://openjsf.org/
+PublisherSupportUrl: https://github.com/electron/electron/issues
+PackageName: Electron
+PackageUrl: https://www.electronjs.org/
+License: MIT
+LicenseUrl: https://github.com/electron/electron/blob/HEAD/LICENSE
+ShortDescription: Build cross-platform desktop apps with JavaScript, HTML, and CSS.
+Moniker: electron
+Tags:
+- c-plus-plus
+- chrome
+- css
+- electron
+- html
+- javascript
+- nodejs
+- v8
+- works-with-codespaces
+ReleaseNotes: |-
+  Release Notes for v39.8.10
+  Warning
+  Electron 39.x.y has reached end-of-support as per the project's support policy. Developers and applications are encouraged to upgrade to a newer version of Electron.
+  Fixes
+  • Ensured cross-origin fetch() and XHR are blocked for custom protocols registered with supportFetchAPI：true unless corsEnabled: true is also set; cross-origin mode: 'no-cors' requests now receive an opaque response. #51272 ^{(Also in 40, 41, 42)}
+  • Fixed an issue where the Squirrel.Mac installer could resolve the target bundle path to different locations at different stages of an install. #50766 ^{(Also in 42)}
+  Other Changes
+  • Backported a fix for route_id validation in the GPU command buffer. #51327
+  • Backported security fixes for 493319454, 494158331, 493234757, 492736100, 493413432, 492668885, 496281816. #51257
+  • Backported several fixes in Skia, ANGLE, and WebRTC from upstream. #51266
+ReleaseNotesUrl: https://github.com/electron/electron/releases/tag/v39.8.10
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenJS/Electron/39/43.4.0/OpenJS.Electron.39.yaml
+++ b/manifests/o/OpenJS/Electron/39/43.4.0/OpenJS.Electron.39.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: OpenJS.Electron.39
+PackageVersion: 43.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update OpenJS.Electron.39 to version 43.4.0.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/418598)