### PR TITLE
Update version: OpenCLICollective.google-readonly version 1.1.76

### DIFF
--- a/manifests/o/OpenCLICollective/google-readonly/1.1.76/OpenCLICollective.google-readonly.installer.yaml
+++ b/manifests/o/OpenCLICollective/google-readonly/1.1.76/OpenCLICollective.google-readonly.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: OpenCLICollective.google-readonly
+PackageVersion: 1.1.76
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: gro.exe
+  PortableCommandAlias: gro
+ReleaseDate: 2026-08-12
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/open-cli-collective/google-readonly/releases/download/v1.1.76/gro_v1.1.76_windows_amd64.zip
+  InstallerSha256: FB75D3A1ECDA5DE6949D9A17ED88B666EA6641F4B12F81FAF5759865A36F17C9
+- Architecture: arm64
+  InstallerUrl: https://github.com/open-cli-collective/google-readonly/releases/download/v1.1.76/gro_v1.1.76_windows_arm64.zip
+  InstallerSha256: CEDFC64AAD26F11212D0F58BC435B962C5D6EA814BE327C2466F18635C4EFA27
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenCLICollective/google-readonly/1.1.76/OpenCLICollective.google-readonly.locale.en-US.yaml
+++ b/manifests/o/OpenCLICollective/google-readonly/1.1.76/OpenCLICollective.google-readonly.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: OpenCLICollective.google-readonly
+PackageVersion: 1.1.76
+PackageLocale: en-US
+Publisher: Open CLI Collective
+PublisherUrl: https://github.com/open-cli-collective
+PublisherSupportUrl: https://github.com/open-cli-collective/google-readonly/issues
+PackageName: Google Readonly CLI
+PackageUrl: https://github.com/open-cli-collective/google-readonly
+License: MIT
+LicenseUrl: https://github.com/open-cli-collective/google-readonly/blob/main/LICENSE
+ShortDescription: Read-only command-line interface for Google services
+Description: |-
+  A read-only CLI for Google services. Provides secure, read-only access to
+  Gmail, Google Calendar, and Google Drive including searching messages,
+  reading emails, viewing calendar events, and browsing Drive files.
+Tags:
+- google
+- gmail
+- calendar
+- drive
+- cli
+- api
+- readonly
+- automation
+ReleaseNotesUrl: https://github.com/open-cli-collective/google-readonly/releases/tag/v1.1.74
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/open-cli-collective/google-readonly/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenCLICollective/google-readonly/1.1.76/OpenCLICollective.google-readonly.yaml
+++ b/manifests/o/OpenCLICollective/google-readonly/1.1.76/OpenCLICollective.google-readonly.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: OpenCLICollective.google-readonly
+PackageVersion: 1.1.76
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update OpenCLICollective.google-readonly to version 1.1.76.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/418601)