### PR TITLE
New package: Sparcle.BoltEnterprise version 0.1.152

### DIFF
--- a/manifests/s/Sparcle/BoltEnterprise/0.1.152/Sparcle.BoltEnterprise.installer.yaml
+++ b/manifests/s/Sparcle/BoltEnterprise/0.1.152/Sparcle.BoltEnterprise.installer.yaml
@@ -1,0 +1,13 @@
+PackageIdentifier: Sparcle.BoltEnterprise
+PackageVersion: 0.1.152
+InstallerType: nullsoft
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/SparcleHQ/sparcle.app/releases/download/v0.1.152/Bolt-Enterprise-0.1.152-x86_64-pc-windows-msvc.exe
+    InstallerSha256: 44D03937AAE98C50477469A0FC02C0A02E1947363448D5A88CB9B9D2641291C8
+    AppsAndFeaturesEntries:
+      - DisplayName: Bolt
+        Publisher: Sparcle Inc.
+        ProductCode: Bolt
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/Sparcle/BoltEnterprise/0.1.152/Sparcle.BoltEnterprise.locale.en-US.yaml
+++ b/manifests/s/Sparcle/BoltEnterprise/0.1.152/Sparcle.BoltEnterprise.locale.en-US.yaml
@@ -1,0 +1,20 @@
+PackageIdentifier: Sparcle.BoltEnterprise
+PackageVersion: 0.1.152
+PackageLocale: en-US
+Publisher: Sparcle Inc.
+PublisherUrl: https://sparcle.app/
+PublisherSupportUrl: https://sparcle.app/trust/
+PackageName: Bolt
+PackageUrl: https://sparcle.app/download/
+License: Proprietary
+Copyright: Copyright (c) Sparcle Inc.
+ShortDescription: Local-first AI workspace with governed data egress
+Description: Bolt is a local-first AI workspace. Email, calendar, files and contacts stay on your machine, and a governed egress boundary controls what any AI model is allowed to see.
+Moniker: bolt
+Tags:
+  - ai
+  - productivity
+  - privacy
+  - local-first
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/Sparcle/BoltEnterprise/0.1.152/Sparcle.BoltEnterprise.yaml
+++ b/manifests/s/Sparcle/BoltEnterprise/0.1.152/Sparcle.BoltEnterprise.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Sparcle.BoltEnterprise
+PackageVersion: 0.1.152
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Sparcle.BoltEnterprise 0.1.152, a local-first AI workspace published by Sparcle Inc.

Installer is the NSIS bundle from the official release at https://github.com/SparcleHQ/sparcle.app/releases/tag/v0.1.152.
SHA-256s in the manifest were taken from that release; the same values are published in its
SHA256SUMS, signed with minisign, and each artifact carries a VirusTotal report link.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/418605)