### PR TITLE
New package: ARX.ARX version 0.1.61

### DIFF
--- a/manifests/a/ARX/ARX/0.1.61/ARX.ARX.installer.yaml
+++ b/manifests/a/ARX/ARX/0.1.61/ARX.ARX.installer.yaml
@@ -1,0 +1,19 @@
+# Created with Microsoft WingetCreate 1.12.13.0 and validated against the
+# Windows Package Manager manifest schema.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: ARX.ARX
+PackageVersion: 0.1.61
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-08-16
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/SeverianRoth/ARX/releases/download/v0.1.61/ARX-Setup.exe
+    InstallerSha256: 00E5527DA59386C337942DEAEFFF5616242C4EED9BEB99723D26B88CE7D543FD
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/ARX/ARX/0.1.61/ARX.ARX.locale.en-US.yaml
+++ b/manifests/a/ARX/ARX/0.1.61/ARX.ARX.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# Created with Microsoft WingetCreate 1.12.13.0 and validated against the
+# Windows Package Manager manifest schema.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: ARX.ARX
+PackageVersion: 0.1.61
+PackageLocale: en-US
+Publisher: ARX
+PublisherUrl: https://github.com/SeverianRoth/ARX
+PublisherSupportUrl: https://github.com/SeverianRoth/ARX/issues
+PrivacyUrl: https://github.com/SeverianRoth/ARX#current-security-and-privacy-boundaries
+Author: ARX
+PackageName: ARX
+PackageUrl: https://github.com/SeverianRoth/ARX
+License: ARX Standard Source License
+LicenseUrl: https://github.com/SeverianRoth/ARX/blob/main/LICENSE.md
+Copyright: ARX
+ShortDescription: Open-source self-custody wallet for Windows with Simple and Privacy modes.
+Description: ARX is an open-source self-custody wallet for Windows. Simple mode keeps everyday wallet use clean and minimal; the opt-in Privacy mode adds separate privacy-focused workflows including Monero and RAILGUN 0zk assets.
+Moniker: arx
+Tags:
+  - crypto
+  - ethereum
+  - monero
+  - privacy
+  - railgun
+  - self-custody
+  - wallet
+ReleaseNotesUrl: https://github.com/SeverianRoth/ARX/releases/tag/v0.1.61
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/ARX/ARX/0.1.61/ARX.ARX.yaml
+++ b/manifests/a/ARX/ARX/0.1.61/ARX.ARX.yaml
@@ -1,0 +1,8 @@
+# Created with Microsoft WingetCreate 1.12.13.0 and validated against the
+# Windows Package Manager manifest schema.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: ARX.ARX
+PackageVersion: 0.1.61
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds the ARX 0.1.61 open-source Windows self-custody wallet as a new WinGet package.

The installer URL is version-pinned to the publisher's GitHub release. The manifest declares the per-user Nullsoft installer, x64 architecture, silent install modes, and the release SHA-256.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (not applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same manifest
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the 1.12 schema

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/418617)