### PR TITLE
New package: Xcomart.Jdbgen version 0.3.2

### DIFF
--- a/manifests/x/Xcomart/Jdbgen/0.3.2/Xcomart.Jdbgen.installer.yaml
+++ b/manifests/x/Xcomart/Jdbgen/0.3.2/Xcomart.Jdbgen.installer.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Xcomart.Jdbgen
+PackageVersion: 0.3.2
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: wix
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/xcomart/jdbgen/releases/download/v0.3.2/jdbgen-0.3.2.msi
+  InstallerSha256: 4AE135FF74709A984A47BF864EA14EEB4750C53266E18E6A7CB9A50C07FE8569
+  ProductCode: '{D46282D5-6BD3-3D25-A378-F0EE6AA1595A}'
+  AppsAndFeaturesEntries:
+  - DisplayName: jdbgen
+    Publisher: Dennis Park
+    DisplayVersion: 0.3.2
+    ProductCode: '{D46282D5-6BD3-3D25-A378-F0EE6AA1595A}'
+    UpgradeCode: '{8D72AE64-426C-4194-A00A-BD2EAFF8A23A}'
+    InstallerType: wix
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/x/Xcomart/Jdbgen/0.3.2/Xcomart.Jdbgen.installer.yaml
+++ b/manifests/x/Xcomart/Jdbgen/0.3.2/Xcomart.Jdbgen.installer.yaml
@@ -21,7 +21,6 @@ Installers:
   AppsAndFeaturesEntries:
   - DisplayName: jdbgen
     Publisher: Dennis Park
-    DisplayVersion: 0.3.2
     ProductCode: '{D46282D5-6BD3-3D25-A378-F0EE6AA1595A}'
     UpgradeCode: '{8D72AE64-426C-4194-A00A-BD2EAFF8A23A}'
     InstallerType: wix

--- a/manifests/x/Xcomart/Jdbgen/0.3.2/Xcomart.Jdbgen.locale.en-US.yaml
+++ b/manifests/x/Xcomart/Jdbgen/0.3.2/Xcomart.Jdbgen.locale.en-US.yaml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Xcomart.Jdbgen
+PackageVersion: 0.3.2
+PackageLocale: en-US
+Publisher: Dennis Park
+PublisherUrl: https://github.com/xcomart
+PublisherSupportUrl: https://github.com/xcomart/jdbgen/issues
+Author: Dennis Park
+PackageName: jdbgen
+PackageUrl: https://github.com/xcomart/jdbgen
+License: MIT
+LicenseUrl: https://github.com/xcomart/jdbgen/blob/master/LICENSE
+Copyright: Copyright (c) Dennis Park
+ShortDescription: Generates source code and text files from database table metadata with a built-in template engine.
+Description: |-
+  jdbgen points at a database, reads the table metadata and writes one file per
+  table per template - model classes, DML statements, mapper XML, documentation,
+  or anything else expressible as text. It ships a template engine with loops,
+  conditionals, name-case decorators, padding, abbreviation rules and custom
+  variables, stock definitions for ten JDBC drivers with one-click download of
+  their jars from Maven Central, and a small H2 sample database with its driver
+  bundled to try it against. The user interface is available in English, Korean,
+  Spanish, Japanese and Simplified Chinese.
+Moniker: jdbgen
+Tags:
+- code-generation
+- code-generator
+- database
+- generator
+- jdbc
+- mybatis
+- sql
+- template
+ReleaseNotes: |-
+  Main window reworked into the single editor for generation options with a
+  menu bar, table filter, splitters and remembered window state; every dialog
+  rebuilt with MigLayout; the H2 driver bundled and one-click download of the
+  other stock drivers from Maven Central; unit and Docker-based integration
+  tests with the metadata and stock driver fixes they found.
+ReleaseNotesUrl: https://github.com/xcomart/jdbgen/releases/tag/v0.3.2
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/x/Xcomart/Jdbgen/0.3.2/Xcomart.Jdbgen.yaml
+++ b/manifests/x/Xcomart/Jdbgen/0.3.2/Xcomart.Jdbgen.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Xcomart.Jdbgen
+PackageVersion: 0.3.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description
New package: Xcomart.Jdbgen version 0.3.2 — jdbgen, a JDBC based source code generator (Windows MSI built by jpackage, bundled Java runtime, x64, machine scope). Resubmission of #416607, whose source fork was deleted before it was merged; the version has moved on to 0.3.2 since.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/418642)