### PR TITLE
New version: Haksolot.Ank version 0.3.0

### DIFF
--- a/manifests/h/Haksolot/Ank/0.3.0/Haksolot.Ank.installer.yaml
+++ b/manifests/h/Haksolot/Ank/0.3.0/Haksolot.Ank.installer.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+# Derived from the GitHub release by .github/scripts/winget-manifests.sh, which
+# .github/workflows/publish-winget.yml runs on every pull request and asserts
+# this file is exactly what deriving it produces. A hand edit turns that job red
+# instead of failing on somebody's machine -- in particular the sha256, which is
+# read from the .sha256 asset the release publishes and is never typed.
+PackageIdentifier: Haksolot.Ank
+PackageVersion: 0.3.0
+MinimumOSVersion: 10.0.0.0
+ReleaseDate: 2026-08-17
+# The release publishes a zip and not an installer, so winget unpacks it and
+# links the executable inside: `zip` with a `portable` nested type is that
+# shape. The relative path is inside the directory the archive wraps its
+# contents in, which release.yml names after the archive itself.
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: ank-0.3.0-x86_64-pc-windows-msvc\ank.exe
+    PortableCommandAlias: ank
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/haksolot/ank/releases/download/v0.3.0/ank-0.3.0-x86_64-pc-windows-msvc.zip
+    InstallerSha256: F6434AE1EF04A677985E28D4E70DB2435843A554642B72A6942C89BFD7C0BE26
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/h/Haksolot/Ank/0.3.0/Haksolot.Ank.locale.en-US.yaml
+++ b/manifests/h/Haksolot/Ank/0.3.0/Haksolot.Ank.locale.en-US.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+# Derived from the GitHub release by .github/scripts/winget-manifests.sh, which
+# .github/workflows/publish-winget.yml runs on every pull request and asserts
+# this file is exactly what deriving it produces. A hand edit turns that job red
+# instead of failing on somebody's machine -- in particular the sha256, which is
+# read from the .sha256 asset the release publishes and is never typed.
+PackageIdentifier: Haksolot.Ank
+PackageVersion: 0.3.0
+PackageLocale: en-US
+Publisher: haksolot
+PublisherUrl: https://github.com/haksolot
+PublisherSupportUrl: https://github.com/haksolot/ank/issues
+PackageName: ank
+PackageUrl: https://github.com/haksolot/ank
+License: GPL-3.0-only
+LicenseUrl: https://github.com/haksolot/ank/blob/main/LICENSE
+Copyright: Copyright (C) 2026 haksolot
+ShortDescription: Tasks and architecture decisions in your repo, behind one CLI agents can call
+Description: |-
+  ank keeps a project's tasks and architecture decisions in the repository
+  itself, as files an agent reads through one CLI. A decision carries a scope,
+  so it binds the work that matches it rather than the work that remembers it,
+  and a task's completion criterion is frozen by hash the moment it is claimed.
+Moniker: ank
+Tags:
+  - agent
+  - architecture
+  - cli
+  - decision-records
+  - developer-tools
+  - project-management
+  - rust
+  - tasks
+ReleaseNotesUrl: https://github.com/haksolot/ank/releases/tag/v0.3.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/h/Haksolot/Ank/0.3.0/Haksolot.Ank.yaml
+++ b/manifests/h/Haksolot/Ank/0.3.0/Haksolot.Ank.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+# Derived from the GitHub release by .github/scripts/winget-manifests.sh, which
+# .github/workflows/publish-winget.yml runs on every pull request and asserts
+# this file is exactly what deriving it produces. A hand edit turns that job red
+# instead of failing on somebody's machine -- in particular the sha256, which is
+# read from the .sha256 asset the release publishes and is never typed.
+PackageIdentifier: Haksolot.Ank
+PackageVersion: 0.3.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Automated submission from [`haksolot/ank`](https://github.com/haksolot/ank) on publishing [0.3.0](https://github.com/haksolot/ank/releases/tag/v0.3.0).

The three manifests are derived from the release by [`.github/scripts/winget-manifests.sh`](https://github.com/haksolot/ank/blob/master/.github/scripts/winget-manifests.sh); the `InstallerSha256` is read from the `.sha256` asset published beside the archive and is never typed by hand.

Before this request was opened, a Windows runner ran `winget validate` on these exact bytes, installed from them with `winget install --manifest`, and asserted that `ank --version` prints 0.3.0.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/418653)