### PR TITLE
New version: LinkaiQi.NitTray version 0.1.5

### DIFF
--- a/manifests/l/LinkaiQi/NitTray/0.1.5/LinkaiQi.NitTray.installer.yaml
+++ b/manifests/l/LinkaiQi/NitTray/0.1.5/LinkaiQi.NitTray.installer.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: LinkaiQi.NitTray
+PackageVersion: 0.1.5
+InstallerLocale: en-US
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-08-16
+# ProductCode = Inno Setup AppId + "_is1" (this .iss sets AppId without braces).
+# Lets winget correlate the installed version for upgrade/uninstall.
+AppsAndFeaturesEntries:
+  - ProductCode: F6E903A8-2A56-4159-BB39-397845CF2F68_is1
+    InstallerType: inno
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/LinkaiQi/NitTray/releases/download/v0.1.5/NitTray-installer-x64.exe
+    InstallerSha256: D3CF89362DABB0B0DC3A48D418F6AE3D4DDCC6988B7D65274F96A66AC3793B35
+  - Architecture: arm64
+    InstallerUrl: https://github.com/LinkaiQi/NitTray/releases/download/v0.1.5/NitTray-installer-arm64.exe
+    InstallerSha256: 01593B845AAF0BE0B49784E102F4157AEB5D53F24E7C925B6CA7FA61A5F8809A
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/l/LinkaiQi/NitTray/0.1.5/LinkaiQi.NitTray.locale.en-US.yaml
+++ b/manifests/l/LinkaiQi/NitTray/0.1.5/LinkaiQi.NitTray.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: LinkaiQi.NitTray
+PackageVersion: 0.1.5
+PackageLocale: en-US
+Publisher: NitTray
+PublisherUrl: https://github.com/LinkaiQi/NitTray
+PublisherSupportUrl: https://github.com/LinkaiQi/NitTray/issues
+PackageName: NitTray
+PackageUrl: https://github.com/LinkaiQi/NitTray
+License: GPL-3.0
+LicenseUrl: https://github.com/LinkaiQi/NitTray/blob/main/LICENSE
+Copyright: Copyright © 2026 NitTray
+ShortDescription: Control Apple Studio Display and Pro Display XDR brightness from Windows.
+Description: >-
+  NitTray is a free, open-source Windows system-tray app that adjusts the brightness of
+  the Apple Studio Display and Pro Display XDR over USB — no Mac required. It lists each
+  connected Apple display with its own brightness slider and runs on Windows 10 and 11
+  (x64 and Arm64).
+Moniker: nittray
+Tags:
+  - apple
+  - brightness
+  - brightness-control
+  - display
+  - monitor
+  - pro-display-xdr
+  - studio-display
+  - system-tray
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/l/LinkaiQi/NitTray/0.1.5/LinkaiQi.NitTray.yaml
+++ b/manifests/l/LinkaiQi/NitTray/0.1.5/LinkaiQi.NitTray.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: LinkaiQi.NitTray
+PackageVersion: 0.1.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description
New version submission: **LinkaiQi.NitTray** version **0.1.5**.

NitTray is a free, open-source Windows system-tray app that adjusts the brightness
of the Apple Studio Display and Pro Display XDR over USB.

- Homepage: https://github.com/LinkaiQi/NitTray
- Release: https://github.com/LinkaiQi/NitTray/releases/tag/v0.1.5

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable) — N/A

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
