### PR TITLE
New version: Socoliuc.FollowFrame version 0.3.9

### DIFF
--- a/manifests/s/Socoliuc/FollowFrame/0.3.9/Socoliuc.FollowFrame.installer.yaml
+++ b/manifests/s/Socoliuc/FollowFrame/0.3.9/Socoliuc.FollowFrame.installer.yaml
@@ -1,0 +1,16 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Socoliuc.FollowFrame
+PackageVersion: 0.3.9
+InstallerType: portable
+UpgradeBehavior: install
+Commands:
+- followframe
+Installers:
+- Architecture: x64
+  InstallerUrl: https://followframe.com/downloads/FollowFrame-Single-Exe-0.3.9-win32-x64.exe
+  InstallerSha256: E480E64A3920D477A2F0AA558895C1912FA8062923DD718BF027F1E64D0B0214
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-08-08

--- a/manifests/s/Socoliuc/FollowFrame/0.3.9/Socoliuc.FollowFrame.locale.en-US.yaml
+++ b/manifests/s/Socoliuc/FollowFrame/0.3.9/Socoliuc.FollowFrame.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Socoliuc.FollowFrame
+PackageVersion: 0.3.9
+PackageLocale: en-US
+Publisher: Socoliuc
+PublisherUrl: https://followframe.com/
+PrivacyUrl: https://followframe.com/privacy/
+Author: Socoliuc
+PackageName: FollowFrame
+PackageUrl: https://followframe.com/
+License: Freeware
+Copyright: Copyright (c) 2026 Socoliuc
+ShortDescription: Private floating Windows media wall for Instagram and local folders.
+Description: FollowFrame is an independent Windows x64 desktop utility that turns recent media from accounts you follow and local folders into a floating 9:16 wall player. Instagram uses a local embedded web session and remains experimental; local-folder playback needs no account.
+Moniker: followframe
+Tags:
+- desktop
+- instagram
+- local-media
+- media-wall
+- portable
+- reels
+- stories
+ReleaseNotes: Cached content now appears immediately at startup, refresh capture stays hidden, manual refresh restarts at the newest item, Following-list membership filtering is authoritative, and pointer-opened Settings no longer receives keyboard-only focus styling.
+ReleaseNotesUrl: https://followframe.com/updates/
+InstallationNotes: Choose a local folder, or select Connect account to use the experimental Instagram source. Embedded session data stays in your Windows user profile.
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/Socoliuc/FollowFrame/0.3.9/Socoliuc.FollowFrame.yaml
+++ b/manifests/s/Socoliuc/FollowFrame/0.3.9/Socoliuc.FollowFrame.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Socoliuc.FollowFrame
+PackageVersion: 0.3.9
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Updates FollowFrame from 0.2.10 to 0.3.9.

The manifest uses the current publisher-hosted Windows x64 portable EXE and its exact SHA-256. The package description now reflects both supported source types, links to the dedicated privacy page, and includes the published 0.3.9 release notes.

Validation:

- `winget validate --manifest manifests/s/Socoliuc/FollowFrame/0.3.9`
- `wingetcreate update` downloaded the production installer and derived SHA-256 `E480E64A3920D477A2F0AA558895C1912FA8062923DD718BF027F1E64D0B0214`
- Production `release.json` reports the same version, URL, byte size, and SHA-256

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/418658)