### PR TITLE
New package: DawidJozwiak.Sift version 0.5.0

### DIFF
--- a/manifests/d/DawidJozwiak/Sift/0.5.0/DawidJozwiak.Sift.installer.yaml
+++ b/manifests/d/DawidJozwiak/Sift/0.5.0/DawidJozwiak.Sift.installer.yaml
@@ -1,0 +1,13 @@
+PackageIdentifier: DawidJozwiak.Sift
+PackageVersion: 0.5.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/dawid-ai/sift/releases/download/v0.5.0/Sift-Setup.exe
+    InstallerSha256: A15A01051E83A51306B9F7D1B07244B3146CBC85EDDC4076A4E109F37015D7C9
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/d/DawidJozwiak/Sift/0.5.0/DawidJozwiak.Sift.locale.en-US.yaml
+++ b/manifests/d/DawidJozwiak/Sift/0.5.0/DawidJozwiak.Sift.locale.en-US.yaml
@@ -1,0 +1,23 @@
+PackageIdentifier: DawidJozwiak.Sift
+PackageVersion: 0.5.0
+PackageLocale: en-US
+Publisher: Dawid Jóźwiak
+PublisherUrl: https://dawid.ai
+PackageName: Sift
+PackageUrl: https://github.com/dawid-ai/sift
+License: MIT
+LicenseUrl: https://github.com/dawid-ai/sift/blob/master/LICENSE
+ShortDescription: Turns any video into a searchable, transcribed, summarized library — 100% local.
+Description: >-
+  Sift downloads media from yt-dlp-supported platforms, transcribes it locally with
+  whisper.cpp (offline, no cloud), and summarizes it with your own AI provider key.
+  Media and API keys never leave your machine.
+Tags:
+  - video
+  - transcription
+  - whisper
+  - summarization
+  - offline
+  - yt-dlp
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/d/DawidJozwiak/Sift/0.5.0/DawidJozwiak.Sift.yaml
+++ b/manifests/d/DawidJozwiak/Sift/0.5.0/DawidJozwiak.Sift.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: DawidJozwiak.Sift
+PackageVersion: 0.5.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package

- **Package:** DawidJozwiak.Sift
- **Version:** 0.5.0
- **Publisher:** Dawid Jóźwiak
- **Repo:** https://github.com/dawid-ai/sift (MIT)

Sift is an open-source Electron desktop app that downloads media from yt-dlp-supported platforms, transcribes it locally with whisper.cpp, and summarizes it with a user-supplied AI provider key. Media and API keys stay on the machine.

### Checklist

- [x] Manifest validated locally with `winget validate` — "Manifest validation succeeded."
- [x] `InstallerSha256` computed from the published release asset (downloaded from the immutable per-tag URL, verified 98.1 MB with an `MZ` header), not from a local build.
- [x] `InstallerUrl` points at the per-tag URL (`/download/v0.5.0/`), not `releases/latest`.
- [x] Installer is NSIS (electron-builder), per-user scope, supports interactive and silent modes.

The installer is not code-signed, so SmartScreen shows an unknown-publisher prompt on first run.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/418689)