### PR TITLE
New package: yd-null.DateCalc version 0.1.0

### DIFF
--- a/manifests/y/yd-null/DateCalc/0.1.0/yd-null.DateCalc.installer.yaml
+++ b/manifests/y/yd-null/DateCalc/0.1.0/yd-null.DateCalc.installer.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: yd-null.DateCalc
+PackageVersion: 0.1.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.22000.0
+InstallerType: inno
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.WindowsAppRuntime.2
+    MinimumVersion: 2.2.0
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/yd-null/datacalc/releases/download/v0.1.0/DateCalc_0.1.0_x64.exe
+  InstallerSha256: 654653EFF3AF2CD325BE45F570DC47FA0FC56011F6F94D2066E1EBB67B646AEC
+- Architecture: arm64
+  InstallerUrl: https://github.com/yd-null/datacalc/releases/download/v0.1.0/DateCalc_0.1.0_arm64.exe
+  InstallerSha256: 137557B983FBF4DAA4AE7D376B93B6E8714F7A966768AB4B2961DF7A3B7FC5F3
+ReleaseDate: 2026-08-17
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/y/yd-null/DateCalc/0.1.0/yd-null.DateCalc.locale.en-US.yaml
+++ b/manifests/y/yd-null/DateCalc/0.1.0/yd-null.DateCalc.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: yd-null.DateCalc
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: yd-null
+PublisherUrl: https://github.com/yd-null
+PublisherSupportUrl: https://github.com/yd-null/datacalc/issues
+PackageName: DateCalc for Command Palette
+PackageUrl: https://github.com/yd-null/datacalc
+License: MIT
+LicenseUrl: https://github.com/yd-null/datacalc/blob/v0.1.0/LICENSE
+ShortDescription: Perform date arithmetic in the PowerToys Command Palette.
+Description: Add or subtract days, weeks, months, and years from regional-format dates and relative aliases in the PowerToys Command Palette.
+Tags:
+- date
+- date-calculator
+- powertoys
+- windows-commandpalette-extension
+ReleaseNotesUrl: https://github.com/yd-null/datacalc/releases/tag/v0.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/y/yd-null/DateCalc/0.1.0/yd-null.DateCalc.yaml
+++ b/manifests/y/yd-null/DateCalc/0.1.0/yd-null.DateCalc.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: yd-null.DateCalc
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Adds DateCalc for PowerToys Command Palette version 0.1.0 with x64 and ARM64 Inno installers.

Source and release: https://github.com/yd-null/datacalc/releases/tag/v0.1.0

## Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Checked that there are no other open pull requests for this package
- [x] This PR only modifies one manifest
- [ ] Validated locally with `winget validate` (submitted from macOS; repository validation will run)
- [ ] Tested locally with `winget install` (Windows runtime smoke test pending)
- [x] Manifest conforms to the 1.12 schema
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/418694)