### PR TITLE
New package: UEH.UEH-DS version 1.0.0

### DIFF
--- a/manifests/u/UEH/UEH-DS/1.0.0/UEH.UEH-DS.installer.yaml
+++ b/manifests/u/UEH/UEH-DS/1.0.0/UEH.UEH-DS.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: UEH.UEH-DS
+PackageVersion: 1.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: UEH-DS-Launcher.exe
+    PortableCommandAlias: uehds
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/thinhdt-ueh/UEH-DS/releases/download/v1.0.0/UEH-DS-Launcher.zip
+    InstallerSha256: 853DE5B46D718939A1DAF55018A2C9C380106786060DA6B431D100AB5EAE95A8
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/u/UEH/UEH-DS/1.0.0/UEH.UEH-DS.locale.en-US.yaml
+++ b/manifests/u/UEH/UEH-DS/1.0.0/UEH.UEH-DS.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: UEH.UEH-DS
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: UEH
+PublisherUrl: https://github.com/thinhdt-ueh
+PublisherSupportUrl: https://github.com/thinhdt-ueh/UEH-DS/issues
+PackageName: UEH-DS
+PackageUrl: https://github.com/thinhdt-ueh/UEH-DS
+License: MIT
+LicenseUrl: https://github.com/thinhdt-ueh/UEH-DS/blob/master/LICENSE
+Copyright: Copyright (c) 2026 UEH
+ShortDescription: Statistics & econometrics workbench (Streamlit) for University of Economics Ho Chi Minh City.
+Description: >-
+  UEH-DS is a Python/Streamlit web application for statistics and
+  econometrics research and teaching at the University of Economics Ho Chi
+  Minh City. Upload a dataset and run a broad range of models through a
+  browser UI: linear models, panel data, time series, volatility/GARCH,
+  regime switching, discrete choice, causal inference, survival analysis,
+  shrinkage/ML, and simulation/bootstrap. On first run the launcher creates a
+  private Python environment next to itself and installs the app's
+  dependencies (requires Python 3.10+ already installed and an internet
+  connection for the one-time setup).
+Moniker: uehds
+Tags:
+  - econometrics
+  - statistics
+  - streamlit
+  - data-science
+  - research
+  - education
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/u/UEH/UEH-DS/1.0.0/UEH.UEH-DS.yaml
+++ b/manifests/u/UEH/UEH-DS/1.0.0/UEH.UEH-DS.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate-style manual authoring
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: UEH.UEH-DS
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## New package: UEH.UEH-DS version 1.0.0

- **PackageIdentifier**: UEH.UEH-DS
- **PackageVersion**: 1.0.0
- **License**: MIT

UEH-DS is a Python/Streamlit statistics & econometrics workbench built for
the University of Economics Ho Chi Minh City. The installer is a `zip`
containing a small (`portable`) launcher exe plus the app's Python source;
on first run it auto-detects a system Python 3.10+ install and bootstraps a
private virtual environment (no fixed/bundled interpreter path).

Manifest validated locally with `winget validate` (pass). Note: a local
`winget install --manifest` test against this zip was blocked by a Windows
Defender/winget archive malware heuristic (`Trojan:Win32/Wacatac.C!ml`) — a
known false-positive pattern for unsigned PyInstaller-built executables.
The launcher exe is not yet code-signed; flagging that here in case it
affects automated validation on this PR.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? (blocked by the Defender false-positive noted above)
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/418696)