### PR TITLE
New package: mar1mo-41414.ore2ca version 1.3

### DIFF
--- a/manifests/m/mar1mo-41414/ore2ca/1.3/mar1mo-41414.ore2ca.installer.yaml
+++ b/manifests/m/mar1mo-41414/ore2ca/1.3/mar1mo-41414.ore2ca.installer.yaml
@@ -1,23 +1,18 @@
-# Created with YamlCreate.ps1 v2.4.3
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
 PackageIdentifier: mar1mo-41414.ore2ca
 PackageVersion: "1.3"
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
-  - RelativeFilePath: ore2ca.exe
-    PortableCommandAlias: ore2ca
-Commands:
-  - ore2ca
-InstallModes:
-  - interactive
-  - silent
-  - silentWithProgress
+- RelativeFilePath: ore2ca.exe
+ReleaseDate: 2026-08-17
 Installers:
-  - Architecture: x64
-    InstallerUrl: https://github.com/mar1mo-41414/ore2ca/releases/download/v1.3/ore2ca_v1.3_windows_amd64.zip
-    InstallerSha256: 7EF50150970B750AE7B171791F712D7929F7E8675B55B5411F3AB141E9913BEC
-  - Architecture: arm64
-    InstallerUrl: https://github.com/mar1mo-41414/ore2ca/releases/download/v1.3/ore2ca_v1.3_windows_arm64.zip
-    InstallerSha256: C03FC6EF9E2CCD89BA810BD1F7E78A725065F08E4636E46BE6C698E715CCE0AB
+- Architecture: x64
+  InstallerUrl: https://github.com/mar1mo-41414/ore2ca/releases/download/v1.3/ore2ca_v1.3_windows_amd64.zip
+  InstallerSha256: 7EF50150970B750AE7B171791F712D7929F7E8675B55B5411F3AB141E9913BEC
+- Architecture: arm64
+  InstallerUrl: https://github.com/mar1mo-41414/ore2ca/releases/download/v1.3/ore2ca_v1.3_windows_arm64.zip
+  InstallerSha256: C03FC6EF9E2CCD89BA810BD1F7E78A725065F08E4636E46BE6C698E715CCE0AB
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/m/mar1mo-41414/ore2ca/1.3/mar1mo-41414.ore2ca.installer.yaml
+++ b/manifests/m/mar1mo-41414/ore2ca/1.3/mar1mo-41414.ore2ca.installer.yaml
@@ -1,0 +1,23 @@
+# Created with YamlCreate.ps1 v2.4.3
+PackageIdentifier: mar1mo-41414.ore2ca
+PackageVersion: "1.3"
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: ore2ca.exe
+    PortableCommandAlias: ore2ca
+Commands:
+  - ore2ca
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/mar1mo-41414/ore2ca/releases/download/v1.3/ore2ca_v1.3_windows_amd64.zip
+    InstallerSha256: 7EF50150970B750AE7B171791F712D7929F7E8675B55B5411F3AB141E9913BEC
+  - Architecture: arm64
+    InstallerUrl: https://github.com/mar1mo-41414/ore2ca/releases/download/v1.3/ore2ca_v1.3_windows_arm64.zip
+    InstallerSha256: C03FC6EF9E2CCD89BA810BD1F7E78A725065F08E4636E46BE6C698E715CCE0AB
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/mar1mo-41414/ore2ca/1.3/mar1mo-41414.ore2ca.locale.en-US.yaml
+++ b/manifests/m/mar1mo-41414/ore2ca/1.3/mar1mo-41414.ore2ca.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# Created with YamlCreate.ps1 v2.4.3
+PackageIdentifier: mar1mo-41414.ore2ca
+PackageVersion: "1.3"
+PackageLocale: en-US
+Publisher: mar1mo-41414
+PublisherUrl: https://github.com/mar1mo-41414
+PublisherSupportUrl: https://github.com/mar1mo-41414/ore2ca/issues
+PackageName: ore2ca
+PackageUrl: https://github.com/mar1mo-41414/ore2ca
+License: MIT
+LicenseUrl: https://github.com/mar1mo-41414/ore2ca/blob/main/LICENSE
+ShortDescription: Local CA management tool for HTTPS development environments
+Description: |-
+  ore2ca is a local Certificate Authority (CA) management tool for developers.
+  Create a local CA, register it with your OS and browsers (Firefox, Chrome, Edge),
+  and issue HTTPS certificates for local development — no OpenSSL required.
+  Supports macOS, Linux, and Windows. Certificates work with localhost, LAN IPs,
+  and wildcard domains.
+Tags:
+  - certificate
+  - ca
+  - https
+  - tls
+  - ssl
+  - pki
+  - development
+  - localhost
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/mar1mo-41414/ore2ca/1.3/mar1mo-41414.ore2ca.locale.en-US.yaml
+++ b/manifests/m/mar1mo-41414/ore2ca/1.3/mar1mo-41414.ore2ca.locale.en-US.yaml
@@ -1,4 +1,5 @@
-# Created with YamlCreate.ps1 v2.4.3
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
 PackageIdentifier: mar1mo-41414.ore2ca
 PackageVersion: "1.3"
 PackageLocale: en-US
@@ -17,13 +18,13 @@ Description: |-
   Supports macOS, Linux, and Windows. Certificates work with localhost, LAN IPs,
   and wildcard domains.
 Tags:
-  - certificate
-  - ca
-  - https
-  - tls
-  - ssl
-  - pki
-  - development
-  - localhost
+- certificate
+- ca
+- https
+- tls
+- ssl
+- pki
+- development
+- localhost
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0

--- a/manifests/m/mar1mo-41414/ore2ca/1.3/mar1mo-41414.ore2ca.yaml
+++ b/manifests/m/mar1mo-41414/ore2ca/1.3/mar1mo-41414.ore2ca.yaml
@@ -1,0 +1,6 @@
+# Created with YamlCreate.ps1 v2.4.3
+PackageIdentifier: mar1mo-41414.ore2ca
+PackageVersion: "1.3"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/manifests/m/mar1mo-41414/ore2ca/1.3/mar1mo-41414.ore2ca.yaml
+++ b/manifests/m/mar1mo-41414/ore2ca/1.3/mar1mo-41414.ore2ca.yaml
@@ -1,4 +1,5 @@
-# Created with YamlCreate.ps1 v2.4.3
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
 PackageIdentifier: mar1mo-41414.ore2ca
 PackageVersion: "1.3"
 DefaultLocale: en-US


### PR DESCRIPTION
## Description

New package submission: **ore2ca** — a local Certificate Authority (CA) management tool for HTTPS development environments.

- GitHub: https://github.com/mar1mo-41414/ore2ca
- License: MIT
- Version: 1.3

## What it does

ore2ca creates a local CA, registers it with the OS trust store and browsers (Firefox, Chrome, Edge), and issues HTTPS certificates for local development — no OpenSSL required.

## Installer notes

- InstallerType: `zip` (portable exe inside)
- NestedInstallerType: `portable`
- Architectures: `x64`, `arm64`
- Command: `ore2ca`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/418702)