### PR TITLE
New package: Notula.Notula version 1.12.0

### DIFF
--- a/manifests/n/Notula/Notula/1.12.0/Notula.Notula.installer.yaml
+++ b/manifests/n/Notula/Notula/1.12.0/Notula.Notula.installer.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Notula.Notula
+PackageVersion: 1.12.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Protocols:
+- notula
+ReleaseDate: 2026-08-13
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/anetrebskii/notula-releases/releases/download/v1.12.0/Notula-Windows-x64.exe
+  InstallerSha256: A2261CA7A298466636EFD8CA9D66C3DB65889BA9260F0979C950DF9137C71F17
+  InstallerSwitches:
+    Custom: /currentuser
+- Architecture: arm64
+  InstallerUrl: https://github.com/anetrebskii/notula-releases/releases/download/v1.12.0/Notula-Windows-arm64.exe
+  InstallerSha256: 6E269579F04967F968F6406F15099588D013DE927CF21D3E5305DAFDC050D309
+  InstallerSwitches:
+    Custom: /currentuser
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/n/Notula/Notula/1.12.0/Notula.Notula.locale.en-US.yaml
+++ b/manifests/n/Notula/Notula/1.12.0/Notula.Notula.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Notula.Notula
+PackageVersion: 1.12.0
+PackageLocale: en-US
+Publisher: Notula
+PublisherUrl: https://notula.org/
+PublisherSupportUrl: https://github.com/anetrebskii/notula-releases/issues
+Author: Alex Netrebskiy
+PackageName: Notula
+PackageUrl: https://notula.org/
+License: Proprietary
+Copyright: Copyright (c) 2026 Alex Netrebskiy
+ShortDescription: Markdown editor with comments for the documentation in a git repository
+Description: |-
+  Notula edits the Markdown documentation that lives in a git repository, and adds the parts that were left behind when docs moved into the repo: comments on a passage, replies, resolving, and a document tree anyone can browse.
+  Comment threads are stored as plain files beside the documents and committed with them, so two people commenting at once cannot conflict and nothing is written into the Markdown itself - no anchors, no block IDs, no HTML comments. What lands on disk is ordinary Markdown that GitHub, Obsidian and Pandoc read unchanged and that reviews in a normal pull request.
+  There is no Notula server and no account. Documents, comments and history are files in your own repository, and the only things the app talks to are your git remote and the releases page it updates itself from.
+Moniker: notula
+Tags:
+- comments
+- docs-as-code
+- documentation
+- editor
+- git
+- markdown
+- markdown-editor
+- notes
+- technical-writing
+- wysiwyg
+ReleaseNotesUrl: https://github.com/anetrebskii/notula-releases/releases/tag/v1.12.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/n/Notula/Notula/1.12.0/Notula.Notula.locale.en-US.yaml
+++ b/manifests/n/Notula/Notula/1.12.0/Notula.Notula.locale.en-US.yaml
@@ -11,13 +11,20 @@ PackageName: Notula
 PackageUrl: https://notula.org/
 License: Proprietary
 Copyright: Copyright (c) 2026 Alex Netrebskiy
-ShortDescription: Markdown editor with comments for the documentation in a git repository
+ShortDescription: Markdown editor with comment threads committed beside the docs in your git repository
 Description: |-
-  Notula edits the Markdown documentation that lives in a git repository, and adds the parts that were left behind when docs moved into the repo: comments on a passage, replies, resolving, and a document tree anyone can browse.
-  Comment threads are stored as plain files beside the documents and committed with them, so two people commenting at once cannot conflict and nothing is written into the Markdown itself - no anchors, no block IDs, no HTML comments. What lands on disk is ordinary Markdown that GitHub, Obsidian and Pandoc read unchanged and that reviews in a normal pull request.
-  There is no Notula server and no account. Documents, comments and history are files in your own repository, and the only things the app talks to are your git remote and the releases page it updates itself from.
+  Notula is a desktop editor for the Markdown documentation that lives inside a git repository. It opens the repository as a tree of documents rather than a list of files, edits them with no syntax on screen, and adds the review layer a code editor has no answer for: comment on a passage, reply in a thread, mention someone, resolve.
+
+  Comments are committed next to the document as an append-only log with a union merge driver, so two people commenting at once cannot conflict. They arrive with a clone, survive a branch and outlive any account, and the documents stay clean: nothing is added to the Markdown, there is no proprietary format and no database. Delete the app and every document and every comment is still there, readable without it.
+
+  It drives the git already installed on the machine, so the SSH key or credential helper already configured is the one it uses and private repositories need no token. Every git command carries an explicit pathspec: it never stages the whole worktree, never stashes, never rewrites history and never switches a branch. Publishing is one sentence about what changed, and nobody is shown a rebase or a conflict marker.
+
+  Because the files stay plain .md in the repository, AI coding agents read and edit the same documents. Notula writes a workspace briefing and links it from CLAUDE.md or AGENTS.md, and ships a notula command with --json output so an agent can operate the workspace instead of guessing at files.
+
+  Free, with no account and no server. macOS on Apple Silicon and Intel, Windows on x64 and Arm. The builds are not code-signed yet, so the first launch takes one extra step on each platform.
 Moniker: notula
 Tags:
+- collaboration
 - comments
 - docs-as-code
 - documentation
@@ -25,7 +32,6 @@ Tags:
 - git
 - markdown
 - markdown-editor
-- notes
 - technical-writing
 - wysiwyg
 ReleaseNotesUrl: https://github.com/anetrebskii/notula-releases/releases/tag/v1.12.0

--- a/manifests/n/Notula/Notula/1.12.0/Notula.Notula.yaml
+++ b/manifests/n/Notula/Notula/1.12.0/Notula.Notula.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Notula.Notula
+PackageVersion: 1.12.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package: **Notula.Notula** version 1.12.0.

Notula is a Markdown editor with comments for the documentation kept in a git repository. Free, no account and no server; macOS and Windows. https://notula.org

Installers are the NSIS `.exe` for x64 and arm64 from the project's public releases repository, pinned to the versioned tag `v1.12.0` rather than to `releases/latest/download`.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

### On the two unchecked boxes

These manifests were authored on macOS, where `winget` does not exist, so I cannot honestly tick either box. What was done instead:

- each of the three files validated against its published JSON schema (`winget-manifest.{version,defaultLocale,installer}.1.12.0.schema.json`)
- `InstallerSha256` for the x64 installer verified by downloading the asset and hashing it, not by trusting an API field
- `InstallerType: nullsoft`, `Scope: user` and the `/currentuser` switch taken from the project's `electron-builder.yml` (`nsis: oneClick: false, perMachine: false, allowElevation: true`)
- no `ProductCode`: electron-builder's NSIS GUID could not be reproduced reliably here, and a wrong one seemed worse than none

Happy to correct anything the validation pipeline flags.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/418704)