### PR TITLE
New package: WatariLabs.MomentBackup version 1.0.17

### DIFF
--- a/manifests/w/WatariLabs/MomentBackup/1.0.17/WatariLabs.MomentBackup.installer.yaml
+++ b/manifests/w/WatariLabs/MomentBackup/1.0.17/WatariLabs.MomentBackup.installer.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: WatariLabs.MomentBackup
+PackageVersion: 1.0.17
+InstallerLocale: en-US
+InstallerType: wix
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-08-12
+Installers:
+- Architecture: x64
+  InstallerUrl: https://releases.momentbackup.com/v1.0.17/MomentBackup_1.0.17_x64_en-US.msi
+  InstallerSha256: 52AAC82EF8F8C04EB1C3005C74B0BEEDF4F537E6B81B2CE34EAE2D528E2A81E7
+  ProductCode: '{33E9FE08-2ACD-4843-8C31-A7B31E28E3E1}'
+  AppsAndFeaturesEntries:
+  - DisplayName: MomentBackup
+    Publisher: Watari Labs Pty Ltd
+    DisplayVersion: 1.0.1799
+    ProductCode: '{33E9FE08-2ACD-4843-8C31-A7B31E28E3E1}'
+    UpgradeCode: '{721CB2E2-3C09-58B0-9AFF-4B869D5348AE}'
+    InstallerType: wix
+- Architecture: arm64
+  InstallerUrl: https://releases.momentbackup.com/v1.0.17/MomentBackup_1.0.17_arm64_en-US.msi
+  InstallerSha256: A7B271F2132781FFE844AAF6F6B8995ED0C6537B345F68A17E5D1B64BD247512
+  ProductCode: '{890B9F7C-C444-4F1E-9886-DFD61BE5390C}'
+  AppsAndFeaturesEntries:
+  - DisplayName: MomentBackup
+    Publisher: Watari Labs Pty Ltd
+    DisplayVersion: 1.0.1799
+    ProductCode: '{890B9F7C-C444-4F1E-9886-DFD61BE5390C}'
+    UpgradeCode: '{721CB2E2-3C09-58B0-9AFF-4B869D5348AE}'
+    InstallerType: wix
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/w/WatariLabs/MomentBackup/1.0.17/WatariLabs.MomentBackup.locale.en-US.yaml
+++ b/manifests/w/WatariLabs/MomentBackup/1.0.17/WatariLabs.MomentBackup.locale.en-US.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: WatariLabs.MomentBackup
+PackageVersion: 1.0.17
+PackageLocale: en-US
+Publisher: Watari Labs Pty Ltd
+PublisherUrl: https://watari.dev/
+PublisherSupportUrl: https://momentbackup.com/support/
+PrivacyUrl: https://momentbackup.com/privacy/
+Author: Watari Labs Pty Ltd
+PackageName: MomentBackup
+PackageUrl: https://momentbackup.com/
+License: Proprietary
+LicenseUrl: https://momentbackup.com/terms/
+Copyright: Copyright (c) 2026 Watari Labs Pty Ltd. All rights reserved.
+CopyrightUrl: https://momentbackup.com/terms/
+ShortDescription: Personal backup and recovery. Encrypted file history on your own drive, NAS, Google Drive, or S3 storage, plus whole-computer images on Windows.
+Description: |-
+  MomentBackup keeps a browsable, encrypted history of your files on storage you already own: an external drive, a NAS, Google Drive, or an S3-compatible bucket. Encryption keys never leave your computer. Browse any past version of a file and restore it; on Windows you can also keep a whole-computer image and restore it to a replacement drive after hardware failure. Backups are verified, and restores always work whether or not a license is active.
+  Buy once ($49 for one computer) with no subscription and no hosted-storage bill. A 7-day trial needs a free account (email address only, no card).
+Moniker: momentbackup
+Tags:
+- backup
+- disaster-recovery
+- encryption
+- file-history
+- nas
+- recovery
+- restore
+- s3
+- system-image
+- versioning
+ReleaseNotesUrl: https://momentbackup.com/changelog/
+PurchaseUrl: https://momentbackup.com/pricing/
+Documentations:
+- DocumentLabel: Help
+  DocumentUrl: https://momentbackup.com/help/
+- DocumentLabel: Security
+  DocumentUrl: https://momentbackup.com/security/
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/w/WatariLabs/MomentBackup/1.0.17/WatariLabs.MomentBackup.yaml
+++ b/manifests/w/WatariLabs/MomentBackup/1.0.17/WatariLabs.MomentBackup.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: WatariLabs.MomentBackup
+PackageVersion: 1.0.17
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description
New package: WatariLabs.MomentBackup version 1.0.17 — MomentBackup, a personal backup and recovery app by Watari Labs Pty Ltd (https://momentbackup.com). Signed WiX MSI installers for x64 and arm64, hosted on the vendor's release host. The MSI ProductVersion is 1.0.1799 (build-numbered), so AppsAndFeaturesEntries carries DisplayVersion 1.0.1799 with the stable UpgradeCode.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` (validated against the 1.12.0 JSON schemas; installer hashes and ProductCodes read from the published MSIs)
- [ ] Tested manifest locally with `winget install --manifest <path>` (submitted from macOS; relying on the pipeline's install validation)
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/418799)