### PR TITLE
New package: StarWhisper.StarWhisper version 1.3.296

### DIFF
--- a/manifests/s/StarWhisper/StarWhisper/1.3.296/StarWhisper.StarWhisper.installer.yaml
+++ b/manifests/s/StarWhisper/StarWhisper/1.3.296/StarWhisper.StarWhisper.installer.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: StarWhisper.StarWhisper
+PackageVersion: 1.3.296
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerLocale: en-US
+    InstallerUrl: https://starwhisper.ai/downloads/pkg/StarWhisper-Setup-Base-1.3.296.exe
+    InstallerSha256: 36837DBEC7FCB417128DFB20D7922CD8B154138332621B02781AA2D622B47647
+AppsAndFeaturesEntries:
+  - DisplayName: StarWhisper
+    Publisher: StarWhisper
+    DisplayVersion: 1.3.296
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/StarWhisper/StarWhisper/1.3.296/StarWhisper.StarWhisper.locale.en-US.yaml
+++ b/manifests/s/StarWhisper/StarWhisper/1.3.296/StarWhisper.StarWhisper.locale.en-US.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: StarWhisper.StarWhisper
+PackageVersion: 1.3.296
+PackageLocale: en-US
+Publisher: StarWhisper
+PublisherUrl: https://starwhisper.ai
+PublisherSupportUrl: https://starwhisper.ai/support
+PackageName: StarWhisper
+PackageUrl: https://starwhisper.ai
+License: Proprietary
+LicenseUrl: https://starwhisper.ai/terms
+Copyright: Copyright (c) 2024-2026 StarWhisper
+ShortDescription: AI-powered voice-to-text dictation for Windows using whisper.cpp. Works 100% offline.
+Description: |-
+  StarWhisper is an AI-powered voice dictation app for Windows that transcribes your speech into text
+  instantly using OpenAI's Whisper model running entirely on your device, with no cloud and no internet
+  connection required.
+
+  Key features:
+  - 100% offline transcription powered by whisper.cpp
+  - Press a hotkey to dictate into any app (email, Word, browser, chat)
+  - Supports 90+ languages with automatic language detection
+  - NVIDIA GPU acceleration for faster transcription (optional)
+  - Freemium: free tier with daily and weekly limits, Pro subscription for unlimited use
+  - Minimal, always-on-top floating UI that stays out of your way
+Moniker: starwhisper
+Tags:
+  - accessibility
+  - ai
+  - dictation
+  - offline
+  - speech-to-text
+  - transcription
+  - voice
+  - voice-dictation
+  - whisper
+ReleaseNotesUrl: https://starwhisper.ai/changelog
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/StarWhisper/StarWhisper/1.3.296/StarWhisper.StarWhisper.yaml
+++ b/manifests/s/StarWhisper/StarWhisper/1.3.296/StarWhisper.StarWhisper.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: StarWhisper.StarWhisper
+PackageVersion: 1.3.296
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: `StarWhisper.StarWhisper` version `1.3.296`

This is a **first-party submission**: this account is the publisher of StarWhisper.

StarWhisper is a voice-to-text dictation app for Windows. It runs OpenAI's Whisper
(via whisper.cpp) entirely on the local device, so transcription works with no network
connection and no account. Free tier plus an optional paid plan.

- Homepage: https://starwhisper.ai
- Installer: NSIS (`nullsoft`), x64, per-user scope, silent switch `/S`
- Installer URL is **version-pinned and immutable**, published specifically for
  package managers so the URL and its `InstallerSha256` do not drift:
  https://starwhisper.ai/downloads/pkg/StarWhisper-Setup-Base-1.3.296.exe
- A `.sha256` sidecar is published next to the installer.

`winget validate` passes locally against schema 1.6.0:

```
Manifest validation succeeded.
```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/418814)