### PR TITLE
New package: SidharthKrishnan.HashGuardDesktop version 1.0.0

### DIFF
--- a/manifests/s/SidharthKrishnan/HashGuardDesktop/1.0.0/SidharthKrishnan.HashGuardDesktop.installer.yaml
+++ b/manifests/s/SidharthKrishnan/HashGuardDesktop/1.0.0/SidharthKrishnan.HashGuardDesktop.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: SidharthKrishnan.HashGuardDesktop
+PackageVersion: 1.0.0
+InstallerType: wix
+Scope: user
+UpgradeBehavior: install
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.10
+    MinimumVersion: 10.0.0
+ReleaseDate: 2026-08-17
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/RealSid08/SWE40006_Task1/releases/download/v1.0.0/HashGuard-Desktop-1.0.0-x64.msi
+  InstallerSha256: A947612491037D6512AFA6AECEC5838628D7A8B899F6520B476F42FE7AFE6A5B
+  ProductCode: '{C57B16A8-E9E5-4EE9-8020-EE069EB409A7}'
+  AppsAndFeaturesEntries:
+  - DisplayName: HashGuard Desktop
+    Publisher: Sidharth Krishnan
+    DisplayVersion: 1.0.0
+    ProductCode: '{C57B16A8-E9E5-4EE9-8020-EE069EB409A7}'
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/SidharthKrishnan/HashGuardDesktop/1.0.0/SidharthKrishnan.HashGuardDesktop.locale.en-US.yaml
+++ b/manifests/s/SidharthKrishnan/HashGuardDesktop/1.0.0/SidharthKrishnan.HashGuardDesktop.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: SidharthKrishnan.HashGuardDesktop
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: Sidharth Krishnan
+PublisherUrl: https://github.com/RealSid08
+PublisherSupportUrl: https://github.com/RealSid08/SWE40006_Task1/issues
+Author: Sidharth Krishnan
+PackageName: HashGuard Desktop
+PackageUrl: https://github.com/RealSid08/SWE40006_Task1
+License: MIT
+LicenseUrl: https://github.com/RealSid08/SWE40006_Task1/blob/v1.0.0/LICENSE
+Copyright: Copyright (c) 2026 Sidharth Krishnan
+ShortDescription: Calculate and verify SHA-256 and SHA-512 file checksums.
+Description: HashGuard Desktop is a Windows checksum utility with file hashing, expected-hash comparison, local audit history, and CSV export.
+Tags:
+- checksum
+- hash
+- security
+- sha256
+- sha512
+- winforms
+ReleaseNotes: Initial public release of HashGuard Desktop.
+ReleaseNotesUrl: https://github.com/RealSid08/SWE40006_Task1/releases/tag/v1.0.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/SidharthKrishnan/HashGuardDesktop/1.0.0/SidharthKrishnan.HashGuardDesktop.yaml
+++ b/manifests/s/SidharthKrishnan/HashGuardDesktop/1.0.0/SidharthKrishnan.HashGuardDesktop.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: SidharthKrishnan.HashGuardDesktop
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Adds the initial WinGet manifest for HashGuard Desktop 1.0.0, a Windows checksum utility distributed as a per-user WiX MSI.

## Checklist

- [ ] Signed the Contributor License Agreement (GitHub checks will report status)
- [x] Checked that there are no other open pull requests for this package
- [x] This pull request modifies one package manifest
- [x] Validated locally with `winget validate --manifest manifests/s/SidharthKrishnan/HashGuardDesktop/1.0.0`
- [x] Confirmed the published MSI downloads successfully and matches the manifest SHA-256
- [x] Installed and removed the published MSI successfully with Windows Installer
- [x] Manifest conforms to the 1.12 schema

The optional `winget install --manifest` test could not be run because the workstation's administrator-controlled `LocalManifestFiles` setting is disabled. The same published MSI was tested directly, and the multi-file manifest passes `winget validate`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/418824)