### PR TITLE
New package: Ud3g.darkbright-helper version 0.9.0

### DIFF
--- a/manifests/u/Ud3g/darkbright-helper/0.9.0/Ud3g.darkbright-helper.installer.yaml
+++ b/manifests/u/Ud3g/darkbright-helper/0.9.0/Ud3g.darkbright-helper.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Ud3g.darkbright-helper
+PackageVersion: 0.9.0
+MinimumOSVersion: 10.0.0.0
+InstallerType: zip
+NestedInstallerType: portable
+ReleaseDate: 2026-08-16
+Installers:
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: darkbright-helper.exe
+    PortableCommandAlias: darkbright-helper
+  InstallerUrl: https://github.com/Ud3g/darkbright-helper/releases/download/0.9.0/darkbright-helper-0.9.0-windows-x64.zip
+  InstallerSha256: C3129B02AAF43EA8EC9F215C97074E1743A55982AC92F83FFCB3F4B6E90035A8
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/u/Ud3g/darkbright-helper/0.9.0/Ud3g.darkbright-helper.locale.en-US.yaml
+++ b/manifests/u/Ud3g/darkbright-helper/0.9.0/Ud3g.darkbright-helper.locale.en-US.yaml
@@ -1,0 +1,49 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Ud3g.darkbright-helper
+PackageVersion: 0.9.0
+PackageLocale: en-US
+Publisher: Ud3g
+PublisherUrl: https://github.com/Ud3g
+PublisherSupportUrl: https://github.com/Ud3g/darkbright-helper/issues
+PackageName: darkbright-helper
+PackageUrl: https://github.com/Ud3g/darkbright-helper
+License: MIT OR Apache-2.0
+LicenseUrl: https://github.com/Ud3g/darkbright-helper/blob/main/README.md#license
+Copyright: Copyright (c) 2026 Ud3g
+ShortDescription: Hotkey brightness control for Windows monitors via DDC/CI, plus a dimming overlay for when 0% is still too bright.
+Description: |-
+  A hotkey-driven monitor brightness tool for Windows. From 100% down to 1% it sets the
+  hardware backlight over DDC/CI (VCP code 0x10), so the panel actually gets darker. Once
+  brightness reaches 0% and the screen is still too bright, a black fullscreen overlay with
+  variable opacity keeps dimming past the hardware minimum.
+
+  Multi-monitor aware: a hotkey affects the monitor the mouse pointer is currently on.
+  Monitors are identified by EDID rather than by OS handle, so the configuration survives
+  replugging and port changes. An OSD shows the current value, and a system tray icon
+  offers live per-monitor status plus warnings while degraded.
+
+  Performs no network I/O of any kind: no telemetry, no update checks, no crash reporting.
+
+  Note: the overlay does not cover exclusive-fullscreen games or certain Windows system UI
+  such as the taskbar and Start menu. Laptop internal panels do not speak DDC/CI and are
+  not supported. The binary is not code-signed, so Windows SmartScreen warns on first run.
+Moniker: darkbright-helper
+Tags:
+- brightness
+- ddc
+- ddc-ci
+- dimmer
+- display
+- eye-strain
+- hotkey
+- monitor
+- osd
+- rust
+- tray
+ReleaseNotesUrl: https://github.com/Ud3g/darkbright-helper/releases/tag/0.9.0
+Documentations:
+- DocumentLabel: Readme
+  DocumentUrl: https://github.com/Ud3g/darkbright-helper/blob/main/README.md
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/u/Ud3g/darkbright-helper/0.9.0/Ud3g.darkbright-helper.yaml
+++ b/manifests/u/Ud3g/darkbright-helper/0.9.0/Ud3g.darkbright-helper.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Ud3g.darkbright-helper
+PackageVersion: 0.9.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package: `Ud3g.darkbright-helper` version 0.9.0.

A hotkey-driven monitor brightness tool for Windows. It sets the hardware backlight over
DDC/CI (VCP code `0x10`) from 100% down to 1%, and once brightness reaches 0% it keeps
dimming with a black fullscreen overlay, below the hardware minimum. Multi-monitor aware —
a hotkey affects the monitor the mouse pointer is on.

- Source: https://github.com/Ud3g/darkbright-helper
- Release: https://github.com/Ud3g/darkbright-helper/releases/tag/0.9.0
- Licence: MIT OR Apache-2.0

The release asset is a zip containing the executable plus its licence files, so the manifest
uses `InstallerType: zip` with `NestedInstallerType: portable`.

Note for validation: the binary is not code-signed. The project documents this openly, along
with the SHA-256 of the asset and a build-provenance attestation produced by its release
workflow (`gh attestation verify ... --repo Ud3g/darkbright-helper`).

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/418952)