### PR TITLE
New package: patrick-1984.HandyTool version 1.1.0

### DIFF
--- a/manifests/p/patrick-1984/HandyTool/1.1.0/patrick-1984.HandyTool.installer.yaml
+++ b/manifests/p/patrick-1984/HandyTool/1.1.0/patrick-1984.HandyTool.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: patrick-1984.HandyTool
+PackageVersion: 1.1.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-08-17
+InstallationMetadata:
+  Files:
+  - RelativeFilePath: handy.exe
+    FileType: launch
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/patrick-1984/handy-tool/releases/download/v1.1.0/Handy.Tool_1.1.0_x64-setup.exe
+  InstallerSha256: F3D2B16FA79910426F867E53926109ED120255A347A4FB864C1498A0667D62FC
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/p/patrick-1984/HandyTool/1.1.0/patrick-1984.HandyTool.installer.yaml
+++ b/manifests/p/patrick-1984/HandyTool/1.1.0/patrick-1984.HandyTool.installer.yaml
@@ -10,10 +10,6 @@ InstallModes:
 - silentWithProgress
 UpgradeBehavior: install
 ReleaseDate: 2026-08-17
-InstallationMetadata:
-  Files:
-  - RelativeFilePath: handy.exe
-    FileType: launch
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/patrick-1984/handy-tool/releases/download/v1.1.0/Handy.Tool_1.1.0_x64-setup.exe

--- a/manifests/p/patrick-1984/HandyTool/1.1.0/patrick-1984.HandyTool.locale.en-US.yaml
+++ b/manifests/p/patrick-1984/HandyTool/1.1.0/patrick-1984.HandyTool.locale.en-US.yaml
@@ -1,0 +1,51 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: patrick-1984.HandyTool
+PackageVersion: 1.1.0
+PackageLocale: en-US
+Publisher: Patrick R
+PublisherUrl: https://github.com/patrick-1984
+PublisherSupportUrl: https://github.com/patrick-1984/handy-tool/issues
+Author: Patrick R
+PackageName: Handy Tool
+PackageUrl: https://github.com/patrick-1984/handy-tool
+License: MIT
+LicenseUrl: https://github.com/patrick-1984/handy-tool/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Patrick R
+ShortDescription: Local speech-to-text dictation for Windows. Press a key, speak, and the words land in the field you were typing in.
+Description: |-
+  Handy Tool is a local-first dictation tool for Windows. Press a key, speak, and the text is
+  delivered into whatever field you were working in.
+
+  Transcription runs on your machine using local Whisper, Parakeet, Moonshine or SenseVoice
+  models, with GPU acceleration through Vulkan. No account is required and no audio or
+  transcript leaves the machine unless you explicitly configure a remote provider.
+
+  It also includes push-to-talk, a transcribe-and-submit mode, a keyboard typer for contexts
+  where pasting is blocked, and a window-anchoring system for delivering dictation into a
+  specific window across multiple screens or remote desktop sessions.
+
+  Handy Tool is a fork of Handy by CJ Pais, developed independently.
+Moniker: handy-tool
+Tags:
+- dictation
+- speech-recognition
+- speech-to-text
+- transcription
+- voice
+- whisper
+ReleaseNotes: |-
+  Fixed: with the default "Don't Modify Clipboard" setting, previous transcriptions could be
+  left on the clipboard and displace copied content. Six separate faults caused this and all
+  are corrected, including a case where a transcript already on the clipboard was mistaken for
+  the user's own content and restored after every later dictation.
+
+  Changed: the Direct paste method now genuinely types the characters on Windows instead of
+  silently falling back to a clipboard paste. It is the only delivery method that never reads
+  or writes the clipboard.
+ReleaseNotesUrl: https://github.com/patrick-1984/handy-tool/releases/tag/v1.1.0
+Documentations:
+- DocumentLabel: Documentation
+  DocumentUrl: https://github.com/patrick-1984/handy-tool/blob/main/docs/README.md
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/p/patrick-1984/HandyTool/1.1.0/patrick-1984.HandyTool.yaml
+++ b/manifests/p/patrick-1984/HandyTool/1.1.0/patrick-1984.HandyTool.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: patrick-1984.HandyTool
+PackageVersion: 1.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
# New package: patrick-1984.HandyTool version 1.1.0

Replaces #413622, which is now closed. That PR was opened at 1.0.1 and edited forward to 1.0.4 while a real startup defect it surfaced was fixed; it accumulated superseded validation runs and no longer proposed the current version. This is a clean single-commit submission with no prior failed runs attached.

---

## Automated checklist

<!-- Machine-readable summary. Every claim below is independently checkable from the manifest and the public release. -->

| Field | Value |
| --- | --- |
| PackageIdentifier | `patrick-1984.HandyTool` |
| PackageVersion | `1.1.0` |
| ManifestVersion | `1.12.0` |
| ManifestType | multi-file (version + installer + defaultLocale) |
| InstallerType | `nullsoft` |
| Architecture | `x64` |
| Scope | `user` (per-user, no elevation) |
| Silent install | `/S` (NSIS default, handled by winget) |
| InstallerUrl | `https://github.com/patrick-1984/handy-tool/releases/download/v1.1.0/Handy.Tool_1.1.0_x64-setup.exe` |
| InstallerSha256 | `F3D2B16FA79910426F867E53926109ED120255A347A4FB864C1498A0667D62FC` |
| InstallerUrl host | GitHub Releases, immutable tag `v1.1.0` |
| License | MIT (OSI) |
| Dependencies declared | none required — see "no runtime prerequisite" below |
| Files added | 3 (manifests only) |
| Files modified | 0 |
| Files deleted | 0 |
| Prior versions in repo | none (new package) |

- [x] PR contains exactly one package and one version
- [x] PR contains only manifest files
- [x] Multi-file manifest (no singleton)
- [x] Directory path matches `PackageIdentifier` and `PackageVersion` exactly, case-sensitive
- [x] `# yaml-language-server: $schema=` header present on all three files
- [x] `winget validate` passes locally (winget v1.29.280) — `Manifest validation succeeded.`
- [x] `InstallerSha256` verified against the asset downloaded from the public `InstallerUrl`
- [x] Installer URL is a permanent GitHub release asset, not a redirect or a "latest" alias
- [x] No installer switches overridden; NSIS silent handled natively
- [x] CLA signed (previously, on #413622)

## Reproduce the hash

```powershell
$u = 'https://github.com/patrick-1984/handy-tool/releases/download/v1.1.0/Handy.Tool_1.1.0_x64-setup.exe'
Invoke-WebRequest $u -OutFile handy.exe -UseBasicParsing
(Get-FileHash handy.exe -Algorithm SHA256).Hash
# F3D2B16FA79910426F867E53926109ED120255A347A4FB864C1498A0667D62FC
# Length: 19,061,864 bytes
```

## The failure #413622 found, and why it will not recur

The validator on the earlier PR reported exit `-1073741515` when launching the installed application. Unsigned, that is `0xC0000135` — `STATUS_DLL_NOT_FOUND`. This was a genuine bug, not a validator artefact: the application depended on the Visual C++ 2015-2022 redistributable, which is absent from a clean image, and the process stayed alive behind a modal loader dialog long enough to look like a success to a liveness check.

**Fix:** Microsoft-signed, architecture-matched VC++ runtime DLLs are now deployed app-locally beside `handy.exe`. There is no runtime prerequisite and therefore no `Dependencies` entry to declare.

Verified in the 1.1.0 payload by extracting the NSIS archive:

```
msvcp140.dll              628 KB
msvcp140_1.dll             34 KB
msvcp140_atomic_wait.dll   56 KB
vcruntime140.dll          174 KB
vcruntime140_1.dll         48 KB
concrt140.dll             365 KB
```

The 1.0.4 package carrying this same fix completed the full clean-image install-and-launch test on 2026-08-07: install exit `0`, no loader dialog, all four required runtime modules loaded from the application directory, WebView2 initialised.

## Verification performed for 1.1.0

| Check | Result |
| --- | --- |
| `winget validate` on these manifests | **PASS** |
| Published asset SHA-256 matches the manifest | **PASS** — downloaded from the public URL and hashed |
| Published asset is byte-identical to the built artefact | **PASS** |
| VC++ runtime DLLs present in the NSIS payload | **PASS** — all six, listed above |
| Application unit tests | **PASS** — 245/245 |
| Clean-image install and launch | **Not completed for 1.1.0** — see below |

### Disclosure: the clean-image launch test could not be completed for 1.1.0

I want to be straight about this rather than imply a green run I do not have.

My test host now has **Smart App Control enforced**, which blocks unsigned installers from executing inside Windows Sandbox. To check whether that reflected a problem with 1.1.0, I ran a controlled comparison in the same sandbox image against **1.0.4 — the build that passed this exact test on 2026-08-07**:

| Installer | Result in sandbox (`SmartAppControl=1`) |
| --- | --- |
| 1.1.0 candidate | blocked: `An Application Control policy has blocked this file` |
| 1.0.4 known-good | **also blocked**, identically |

Both are blocked, so the block is a property of the test environment, not of this package. The package is not code-signed with an Authenticode certificate — that is disclosed below and is the underlying cause.

If the validation pipeline reports an install or launch failure, I will treat it as real and investigate immediately, as I did last time.

## Notes for the reviewer

**Publisher identity.** `PackageIdentifier` is `patrick-1984.HandyTool`; `Publisher` is `Patrick R`, the GitHub account owner at <https://github.com/patrick-1984>. I am the author and maintainer, submitting my own software. Both the repository and the release assets are under that account.

**Not code-signed.** The installer has no Authenticode signature, so SmartScreen will warn on first run. This is disclosed in the project README and is a cost issue, not an oversight; a signing certificate is on the roadmap. The package is otherwise conventional: per-user NSIS, no elevation, no drivers, no services, no scheduled tasks, no browser extensions.

**What the application does.** Local speech-to-text dictation for Windows. Transcription runs on-device via bundled-model inference; no account and no network calls are required for normal use. Remote transcription and LLM post-processing exist but are opt-in and unconfigured by default.

**Network behaviour out of the box.** One HTTPS GET against this repository's public `latest.json` for update checks, which can be turned off in settings. Model downloads happen only when a user explicitly chooses a model. No telemetry, analytics, crash reporting, or identifier of any kind.

**Uninstall.** Standard NSIS uninstaller registered under the per-user uninstall key.

Happy to make any change requested. If something here is wrong, tell me and I will fix it rather than argue.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/418980)