### PR TITLE
New version: Psynect.OmniMend version 2.0.3

### DIFF
--- a/manifests/p/Psynect/OmniMend/2.0.3/Psynect.OmniMend.installer.yaml
+++ b/manifests/p/Psynect/OmniMend/2.0.3/Psynect.OmniMend.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Psynect.OmniMend
+PackageVersion: 2.0.3
+InstallerType: nullsoft
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://crashpro-inference.psynect.workers.dev/releases/v2.0.3/OmniMend-v2.0.3-offline-setup.exe
+  InstallerSha256: 0991FE6F594BCD2654998B79FD8AAF3E58E222D3178912093833AB19D883932D
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/p/Psynect/OmniMend/2.0.3/Psynect.OmniMend.locale.en-US.yaml
+++ b/manifests/p/Psynect/OmniMend/2.0.3/Psynect.OmniMend.locale.en-US.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Psynect.OmniMend
+PackageVersion: 2.0.3
+PackageLocale: en-US
+Publisher: Psynect Corp
+PublisherUrl: https://omnimend.com/
+PublisherSupportUrl: https://omnimend.com/contact
+PrivacyUrl: https://omnimend.com/privacy
+Author: Psynect Corp
+PackageName: OmniMend
+PackageUrl: https://omnimend.com/
+License: Proprietary
+LicenseUrl: https://omnimend.com/terms
+Copyright: Copyright (c) 2026 Psynect Corp. All rights reserved.
+ShortDescription: AI-powered Windows diagnostics, controlled repair tools, and Security Vitals behavior monitoring.
+Description: |-
+  OmniMend is an AI-powered diagnostics and repair application for Windows PCs. It helps users investigate crashes, performance problems, driver failures, hardware issues, startup trouble, and other difficult computer problems through guided diagnosis and system-aware tools. Users can review findings and recommended actions before using controlled repair tools when an appropriate fix is available.
+
+  Security Vitals Beta adds behavior-based monitoring for suspicious Windows activity that may not have a known signature yet, including patterns associated with emerging and zero-day attacks. It works alongside Microsoft Defender or another registered antivirus, explains why an event deserves attention, and leaves the next step to the user. It does not replace antivirus or promise to detect every attack.
+Moniker: omnimend
+Tags:
+- ai
+- crash
+- diagnostics
+- maintenance
+- repair
+- security
+- system
+- troubleshooting
+- windows
+PurchaseUrl: https://omnimend.com/plans
+ReleaseNotes: |-
+  - Clarifies the one-month introductory pricing for new Starter and Personal subscriptions.
+  - Preserves the original terms for customers who joined through the earlier three-month offer.
+  - Improves Home navigation so existing chats remain visible when returning to the workspace.
+ReleaseNotesUrl: https://omnimend.com/changelog
+ReleaseDate: 2026-08-16
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/p/Psynect/OmniMend/2.0.3/Psynect.OmniMend.yaml
+++ b/manifests/p/Psynect/OmniMend/2.0.3/Psynect.OmniMend.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Psynect.OmniMend
+PackageVersion: 2.0.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
- Updates Psynect.OmniMend from 2.0.2 to the current stable 2.0.3 release.
- Uses the official version-pinned Psynect Corp installer URL.
- Installer size: 493,811,528 bytes.
- Installer SHA-256: 0991FE6F594BCD2654998B79FD8AAF3E58E222D3178912093833AB19D883932D.
- Local `winget validate --manifest` passed before submission.

The installer was freshly downloaded from the submitted URL and has a valid Authenticode signature for Psynect Corp with a Microsoft timestamp.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/418981)