### PR TITLE
New package: Tier1Settings.Tier1Suite version 1.0.4

### DIFF
--- a/manifests/t/Tier1Settings/Tier1Suite/1.0.4/Tier1Settings.Tier1Suite.installer.yaml
+++ b/manifests/t/Tier1Settings/Tier1Suite/1.0.4/Tier1Settings.Tier1Suite.installer.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+# Filled from the final signed 1.0.4 artifact on 2026-08-17; ready to submit.
+# InstallerSha256 was verified against the bytes actually served from InstallerUrl (not just the
+# local build output), and ProductCode was read from that same signed MSI. Rebuilding 1.0.4 would invalidate both,
+# since wix mints a fresh ProductCode on every build — re-fill these if that ever happens.
+#
+# Unlike Tier1Timer/Tier1Stretch (InstallerType: portable — a loose signed exe), Tier1Suite ships
+# a real per-machine MSI (WP-9), so this manifest uses InstallerType: msi + Scope: machine and
+# relies on the MSI's own UI (WixUI_InstallDir) rather than winget-driven silent switches for the
+# interactive case; /quiet and /passive are still declared for `winget install --silent` and
+# unattended/managed deployments.
+
+PackageIdentifier: Tier1Settings.Tier1Suite
+PackageVersion: 1.0.4
+InstallerType: msi
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: "/quiet"
+  SilentWithProgress: "/passive"
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    # Versioned object, immutable — never overwrite it once this hash is published. The custom
+    # domain rather than the raw s3.amazonaws.com host (both serve it) so the URL survives a bucket
+    # rename or a move behind a CDN.
+    InstallerUrl: https://downloads.tier1settings.com/tier1suite/downloads/Tier1Suite-1.0.4-x64.msi
+    InstallerSha256: "CF2DCFAF2AD34F9E72AAECCF15860386D7273B6F219C6B22667D4CCC512837D2"
+    # UpgradeCode is fixed (8C628175-7C7F-4685-B679-BFF064207FAA, see installer/Tier1Suite.wxs) and
+    # is not declared here — winget/MSI upgrade detection keys off ProductCode plus this manifest's
+    # PackageVersion.
+    ProductCode: "{4BD84ABD-1391-4254-8CAF-0552AA5D0D4C}"
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/t/Tier1Settings/Tier1Suite/1.0.4/Tier1Settings.Tier1Suite.locale.en-US.yaml
+++ b/manifests/t/Tier1Settings/Tier1Suite/1.0.4/Tier1Settings.Tier1Suite.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: Tier1Settings.Tier1Suite
+PackageVersion: 1.0.4
+PackageLocale: en-US
+Publisher: Tier1Settings
+PublisherUrl: https://tier1settings.com/
+PublisherSupportUrl: https://tier1settings.com/contact/
+PackageName: Tier1Suite
+PackageUrl: https://tier1settings.com/tier1suite/
+License: Freeware
+Copyright: Copyright Tier1Settings
+ShortDescription: Modular PC optimization suite — timer resolution, stretched/custom resolution, a tweak catalog, and system diagnostics in one installed app.
+Description: >-
+  Tier1Suite bundles Tier1Timer (timer-resolution + watchdog), Tier1Stretch (stretched and
+  custom resolution, EDID, scaling), Tier1Tune (a tweak catalog covering latency, Windows,
+  network, storage/memory, and display settings — every entry reversible), and Tier1Monitor
+  (DPC latency monitor and latency benchmark). Every tweak shows what it changes, its measured
+  impact, its risk level, and a one-click revert. No hooking, no injection, no kernel driver.
+Moniker: tier1suite
+Tags:
+  - gaming
+  - optimization
+  - fps
+  - timer-resolution
+  - stretched-resolution
+  - tweaks
+  - performance
+ReleaseNotesUrl: https://tier1settings.com/tier1suite/
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/t/Tier1Settings/Tier1Suite/1.0.4/Tier1Settings.Tier1Suite.yaml
+++ b/manifests/t/Tier1Settings/Tier1Suite/1.0.4/Tier1Settings.Tier1Suite.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+# See docs/RELEASING.md for the manual PR steps (mirrors the Tier1Timer manifest process:
+# Tier1Settings/Tier1Timer/1.1.0 in microsoft/winget-pkgs#399388). Bump the version folder (and
+# every field below) per release.
+
+PackageIdentifier: Tier1Settings.Tier1Suite
+PackageVersion: 1.0.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Updates Tier1Settings.Tier1Suite from 1.0.2 (the current published version) to 1.0.4.

- InstallerUrl, InstallerSha256 and ProductCode are read from the final signed 1.0.4 MSI, and the hash was verified against the bytes actually served from InstallerUrl, not just the local build.
- Manifest validated locally with `winget validate`.
- 1.0.4 adds 10 tweaks to the app's tweak catalog (33 → 43 entries): three free, seven Pro. No changes to installer behavior, silent switches, or scope from 1.0.2.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/418991)