### PR TITLE
New version: RowAI.ReCall version 0.8.1

### DIFF
--- a/manifests/r/RowAI/ReCall/0.8.1/RowAI.ReCall.installer.yaml
+++ b/manifests/r/RowAI/ReCall/0.8.1/RowAI.ReCall.installer.yaml
@@ -1,0 +1,19 @@
+# Created with winget-pkgs format
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: RowAI.ReCall
+PackageVersion: '0.8.1'
+Installers:
+  - Architecture: x64
+    InstallerType: nullsoft
+    InstallerUrl: https://github.com/rowstudios/recall-releases/releases/download/v0.8.1/ReCall_0.8.1_x64-setup.exe
+    InstallerSha256: 17BE0D8C8D62B2D7D1A4AD7BCCCCDFA756F6EAFCAEBE633A335FBA8CFA1D6457
+    InstallerLocale: en-US
+    Scope: user
+    UpgradeBehavior: install
+    AppsAndFeaturesEntries:
+      - DisplayName: ReCall
+        Publisher: Row AI Technologies
+        ProductCode: ReCall
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/r/RowAI/ReCall/0.8.1/RowAI.ReCall.locale.en-US.yaml
+++ b/manifests/r/RowAI/ReCall/0.8.1/RowAI.ReCall.locale.en-US.yaml
@@ -6,7 +6,7 @@ PackageVersion: '0.8.1'
 PackageLocale: en-US
 Publisher: Row AI Technologies
 PublisherUrl: https://rowrecall.com
-PublisherSupportUrl: https://github.com/rowstudios/recall-releases/issues
+PublisherSupportUrl: https://rowrecall.com
 PrivacyUrl: https://rowrecall.com
 Author: Row AI Technologies
 PackageName: ReCall

--- a/manifests/r/RowAI/ReCall/0.8.1/RowAI.ReCall.locale.en-US.yaml
+++ b/manifests/r/RowAI/ReCall/0.8.1/RowAI.ReCall.locale.en-US.yaml
@@ -1,0 +1,39 @@
+# Created with winget-pkgs format
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: RowAI.ReCall
+PackageVersion: '0.8.1'
+PackageLocale: en-US
+Publisher: Row AI Technologies
+PublisherUrl: https://rowrecall.com
+PublisherSupportUrl: https://github.com/rowstudios/recall-releases/issues
+PrivacyUrl: https://rowrecall.com
+Author: Row AI Technologies
+PackageName: ReCall
+PackageUrl: https://rowrecall.com
+License: AGPL-3.0
+LicenseUrl: https://www.gnu.org/licenses/agpl-3.0.txt
+ShortDescription: Microsecond-precision, local-first version control for AI agentic workflows.
+Description: |
+  ReCall is a high-performance, local-first version control system built for the
+  speed and volume of AI agentic workflows. It hooks into OS kernel file events,
+  records every change as an immutable event with byte-level deltas, and stores
+  everything in a local SQLite database. A desktop UI (Tauri), a CLI (recall),
+  a VS Code extension, and a WebSocket agent API all share the same engine.
+  No Git, no commits, no cloud.
+Moniker: recall
+Tags:
+  - version-control
+  - git
+  - ai
+  - agents
+  - backup
+  - diff
+  - local-first
+  - undo-redo
+  - tauri
+  - rust
+ReleaseNotes: Fixes the Windows installer missing the OpenSSL runtime DLLs (libcrypto-4-x64.dll) which crashed at launch on clean installs.
+ReleaseNotesUrl: https://github.com/rowstudios/recall-releases/releases
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/r/RowAI/ReCall/0.8.1/RowAI.ReCall.yaml
+++ b/manifests/r/RowAI/ReCall/0.8.1/RowAI.ReCall.yaml
@@ -1,0 +1,8 @@
+# Created with winget-pkgs format
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: RowAI.ReCall
+PackageVersion: '0.8.1'
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary

  New version: RowAI.ReCall version 0.8.1

  ## Changelog

  - Fixed restored files being duplicated (1->2->4 lines) and deleted-file restore reporting success while the file stayed missing
  - Fixed workspace rollback on a delete event being a silent no-op
  - Fixed the Inspector showing stale diffs
  - Linux installers rebuilt on ubuntu-22.04 (glibc 2.34 floor) — v0.8.0 required glibc 2.39 and crashed at launch on Ubuntu 22.04 / Debian 12 / Fedora 37+

  ## Verification

  - \winget validate --manifest manifests/r/RowAI/ReCall/0.8.1\ succeeded
  - Installer SHA256 verified against the published ReCall_0.8.1_x64-setup.exe
  - URLs point at rowrecall.com / public rowstudios/recall-releases
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/418992)