### PR TITLE
New package: OxideComputer.OxideCLI version 0.17.0

### DIFF
--- a/manifests/o/OxideComputer/OxideCLI/0.17.0/OxideComputer.OxideCLI.installer.yaml
+++ b/manifests/o/OxideComputer/OxideCLI/0.17.0/OxideComputer.OxideCLI.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: OxideComputer.OxideCLI
+PackageVersion: 0.17.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: oxide.exe
+  PortableCommandAlias: oxide
+Commands:
+- oxide
+ReleaseDate: 2026-06-13
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/oxidecomputer/oxide.rs/releases/download/v0.17.0+2026060800.0.0/oxide-cli-x86_64-pc-windows-msvc.zip
+  InstallerSha256: 683E6F209377B7FDD0FD9ABE092DA4A0386BDDF5F14A62F9D054EDB076B396A2
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/o/OxideComputer/OxideCLI/0.17.0/OxideComputer.OxideCLI.locale.en-US.yaml
+++ b/manifests/o/OxideComputer/OxideCLI/0.17.0/OxideComputer.OxideCLI.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: OxideComputer.OxideCLI
+PackageVersion: 0.17.0
+PackageLocale: en-US
+Publisher: Oxide Computer Company
+PublisherUrl: https://oxide.computer/
+PublisherSupportUrl: https://github.com/oxidecomputer/oxide.rs/issues
+PackageName: Oxide CLI
+PackageUrl: https://github.com/oxidecomputer/oxide.rs
+License: MPL-2.0
+LicenseUrl: https://github.com/oxidecomputer/oxide.rs/blob/main/LICENSE
+ShortDescription: The Oxide command-line interface
+Description: The Oxide command-line interface, built on the Oxide Rust SDK. Provides terminal access to the Oxide API for managing resources in an Oxide rack.
+Moniker: oxide
+Tags:
+- oxide
+ReleaseNotesUrl: https://github.com/oxidecomputer/oxide.rs/releases/tag/v0.17.0+2026060800.0.0
+Documentations:
+- DocumentLabel: Docs
+  DocumentUrl: https://docs.oxide.computer/cli
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/o/OxideComputer/OxideCLI/0.17.0/OxideComputer.OxideCLI.yaml
+++ b/manifests/o/OxideComputer/OxideCLI/0.17.0/OxideComputer.OxideCLI.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: OxideComputer.OxideCLI
+PackageVersion: 0.17.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
First Party Submission on behalf of: "Oxide Computer Company"

InstallerSha256 was verified against the .sha256 asset published alongside the release.

## 📖 Description
Adds the Oxide CLI (https://github.com/oxidecomputer/oxide.rs), the command-line interface for the Oxide cloud computer.

Distributed as a zip archive containing oxide.exe at the root, so the manifest uses InstallerType: zip with NestedInstallerType: portable and a PortableCommandAlias of "oxide". Upstream ships a Windows build for x64 only, hence the single installer entry.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)