### PR TITLE
New package: OriLabs.OriNotebook version 0.1.11

### DIFF
--- a/manifests/o/OriLabs/OriNotebook/0.1.11/OriLabs.OriNotebook.installer.yaml
+++ b/manifests/o/OriLabs/OriNotebook/0.1.11/OriLabs.OriNotebook.installer.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: OriLabs.OriNotebook
+PackageVersion: 0.1.11
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+Scope: user
+UpgradeBehavior: install
+ProductCode: Ori Notebook
+ReleaseDate: 2026-08-17
+AppsAndFeaturesEntries:
+- DisplayName: Ori Notebook
+  Publisher: Ori Labs
+  DisplayVersion: 0.1.11
+  ProductCode: Ori Notebook
+InstallationMetadata:
+  DefaultInstallLocation: '%LOCALAPPDATA%\Ori Notebook'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/dor-sr/ori-notebook-releases/releases/download/v0.1.11/Ori-Notebook-Setup-x64.exe
+  InstallerSha256: 8CE97A2BD6DAFFDB5FB83159D3E8FBC570199EE39FBEB954D84A617ECCF2A794
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/o/OriLabs/OriNotebook/0.1.11/OriLabs.OriNotebook.locale.en-US.yaml
+++ b/manifests/o/OriLabs/OriNotebook/0.1.11/OriLabs.OriNotebook.locale.en-US.yaml
@@ -1,0 +1,57 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: OriLabs.OriNotebook
+PackageVersion: 0.1.11
+PackageLocale: en-US
+Publisher: Ori Labs
+PublisherUrl: https://www.orinotebook.com
+PrivacyUrl: https://www.orinotebook.com/privacy
+Author: Ori Labs
+PackageName: Ori Notebook
+PackageUrl: https://www.orinotebook.com
+License: Proprietary
+LicenseUrl: https://www.orinotebook.com/terms
+Copyright: Copyright 2026 Ori Labs
+ShortDescription: A local-first notebook of plain Markdown you own, with native, scoped seats for Claude Code, Codex, and any MCP agent.
+Description: |-
+  Ori Notebook is a local-first notebook. Your notes are plain Markdown files in
+  folders you choose on your device, with no account and no cloud requirement.
+  Open that folder in any other tool, or leave Ori entirely, and the notes are
+  still yours.
+
+  - Real files: portable Markdown notes, wiki links and hashtags, and local
+    full-text search across the notebook.
+  - A rich editor: typeset math, Mermaid diagrams, charts, code blocks, and
+    tables with spreadsheet formulas.
+  - Spatial canvases: arrange notes as cards, connect them, and draw in ink.
+  - Import DOCX, PDF, HTML, spreadsheets and images with OCR. Export clean HTML
+    or a source pack for research tools.
+  - Ask across the notebook and get answers with citations that jump to the
+    exact paragraph they came from.
+  - Native, scoped seats for Claude Code, Codex and any MCP agent, pointed at
+    the parts of the notebook you choose.
+  - A 45-page manual inside the app, and first-class light and dark themes.
+
+  AI features connect to an agent CLI already signed in on the machine, or to an
+  API key you supply. Ori ships no model and no bundled key.
+Moniker: ori-notebook
+Tags:
+- markdown
+- notes
+- note-taking
+- notebook
+- local-first
+- offline
+- knowledge-base
+- pkm
+- editor
+- mermaid
+- diagrams
+- canvas
+- ocr
+- mcp
+- ai
+- productivity
+ReleaseNotesUrl: https://github.com/dor-sr/ori-notebook-releases/releases/tag/v0.1.11
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/o/OriLabs/OriNotebook/0.1.11/OriLabs.OriNotebook.yaml
+++ b/manifests/o/OriLabs/OriNotebook/0.1.11/OriLabs.OriNotebook.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: OriLabs.OriNotebook
+PackageVersion: 0.1.11
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
New package: **Ori Notebook** `0.1.11`, published by Ori Labs.

A local-first Markdown notebook. Per-user Nullsoft (Tauri) installer, x64.

- Homepage: https://www.orinotebook.com
- Release: https://github.com/dor-sr/ori-notebook-releases/releases/tag/v0.1.11

### Validation performed

- All three manifests validate against the `1.12.0` JSON schemas (version, installer, defaultLocale).
- `InstallerSha256` matches the digest GitHub records for the published release asset.
- Silent install verified on Windows 11 against the published installer using the default `nullsoft` switch (`/S`): exit code `0`, no UI required.
- `Scope`, `ProductCode`, `AppsAndFeaturesEntries` and `DefaultInstallLocation` were read from the real `HKCU\Software\Microsoft\Windows\CurrentVersion\Uninstall\Ori Notebook` key after that install, not inferred.

Submitted by the publisher.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/419066)