### PR TITLE
Update version: TrellisLab.Trellis version 1.5.2

### DIFF
--- a/manifests/t/TrellisLab/Trellis/1.5.2/TrellisLab.Trellis.installer.yaml
+++ b/manifests/t/TrellisLab/Trellis/1.5.2/TrellisLab.Trellis.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: TrellisLab.Trellis
+PackageVersion: 1.5.2
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: portable
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/trellis-lab/trellis/releases/download/v1.5.2/trellis-v1.5.2-windows-x86_64.exe
+  InstallerSha256: 400A4E3F769C1D0ADF4C77DABD285FDBBBFEB5FE5D3D87CA9B6A3F54767B25F5
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/t/TrellisLab/Trellis/1.5.2/TrellisLab.Trellis.locale.en-US.yaml
+++ b/manifests/t/TrellisLab/Trellis/1.5.2/TrellisLab.Trellis.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: TrellisLab.Trellis
+PackageVersion: 1.5.2
+PackageLocale: en-US
+Publisher: Trellis Lab
+PublisherUrl: https://github.com/trellis-lab
+PublisherSupportUrl: https://github.com/trellis-lab/trellis/issues
+PackageName: Trellis
+PackageUrl: https://github.com/trellis-lab/trellis
+License: Commercial License
+LicenseUrl: https://github.com/trellis-lab/trellis/blob/HEAD/heads/main/EULA.md
+Copyright: Copyright (c) Zoran Vukoszavlyev (TrellisLab)
+ShortDescription: Mermaid-compatible diagram renderer with overlap-free orthogonal edge routing
+Description: |-
+  Trellis is a Mermaid-compatible diagram renderer that uses custom routing
+  to produce overlap-free orthogonal SVG layouts. Supports flowchart, class, ER, C4 and architecture diagram types.
+Tags:
+- cli
+- diagram
+- mermaid
+- renderer
+- svg
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/TrellisLab/Trellis/1.5.2/TrellisLab.Trellis.locale.en-US.yaml
+++ b/manifests/t/TrellisLab/Trellis/1.5.2/TrellisLab.Trellis.locale.en-US.yaml
@@ -22,5 +22,17 @@ Tags:
 - mermaid
 - renderer
 - svg
+ReleaseNotes: |-
+  ## New features
+
+  * Added an "Inspect Diagram" command to the VS Code extension — render the current diagram to an interactive view and explore it directly in a webview panel.
+
+  ## Fixes
+
+  * Deploy-built CLI binaries and Docker images now report the correct version number instead of "0.0.0".
+  * Fixed the diagram inspector so nodes nested inside multiple levels of boundaries (e.g. a C4 deployment node inside another) correctly show their full boundary breadcrumb, and boundary counts in the legend are now accurate.
+  * Fixed labels containing a semicolon or `%%` being incorrectly split during parsing, which could break C4 diagrams and corrupt flowchart labels.
+  * Fixed C4 diagrams not rendering an inline `title` directive, and fixed diagram titles being silently dropped in other diagram types when no frontmatter title was set.
+ReleaseNotesUrl: https://github.com/trellis-lab/trellis/releases/tag/v1.5.2
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0

--- a/manifests/t/TrellisLab/Trellis/1.5.2/TrellisLab.Trellis.locale.en-US.yaml
+++ b/manifests/t/TrellisLab/Trellis/1.5.2/TrellisLab.Trellis.locale.en-US.yaml
@@ -10,7 +10,7 @@ PublisherSupportUrl: https://github.com/trellis-lab/trellis/issues
 PackageName: Trellis
 PackageUrl: https://github.com/trellis-lab/trellis
 License: Commercial License
-LicenseUrl: https://github.com/trellis-lab/trellis/blob/HEAD/heads/main/EULA.md
+LicenseUrl: https://github.com/trellis-lab/trellis/blob/HEAD/EULA.md
 Copyright: Copyright (c) Zoran Vukoszavlyev (TrellisLab)
 ShortDescription: Mermaid-compatible diagram renderer with overlap-free orthogonal edge routing
 Description: |-

--- a/manifests/t/TrellisLab/Trellis/1.5.2/TrellisLab.Trellis.yaml
+++ b/manifests/t/TrellisLab/Trellis/1.5.2/TrellisLab.Trellis.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: TrellisLab.Trellis
+PackageVersion: 1.5.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update TrellisLab.Trellis to version 1.5.2.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/419103)