### PR TITLE
New package: Laurel.Launcher version 1.0.0.21

### DIFF
--- a/manifests/l/Laurel/Launcher/1.0.0.21/Laurel.Launcher.installer.yaml
+++ b/manifests/l/Laurel/Launcher/1.0.0.21/Laurel.Launcher.installer.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: Laurel.Launcher
+PackageVersion: 1.0.0.21
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: wix
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-06-09
+Installers:
+- Architecture: x64
+  InstallerUrl: https://download.laurel.ai/installer/windows/Launcher/Laurel.Launcher_1.0.0.21_x64.msi
+  InstallerSha256: 6BA06E92391AA0343393419D676356027E5DE4DE5D37054FEFC8C6B687E99680
+  ProductCode: '{9BC8B6DB-D3D8-40D6-A934-F2157AE0D7D3}'
+  AppsAndFeaturesEntries:
+  - DisplayName: Laurel Launcher
+    Publisher: Laurel
+    ProductCode: '{9BC8B6DB-D3D8-40D6-A934-F2157AE0D7D3}'
+    UpgradeCode: '{706A2606-A23E-43E1-9300-D1270AE94B38}'
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/l/Laurel/Launcher/1.0.0.21/Laurel.Launcher.locale.en-US.yaml
+++ b/manifests/l/Laurel/Launcher/1.0.0.21/Laurel.Launcher.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: Laurel.Launcher
+PackageVersion: 1.0.0.21
+PackageLocale: en-US
+Publisher: Laurel
+PublisherUrl: https://laurel.ai
+PublisherSupportUrl: https://help.laurel.ai
+Author: Time By Ping, Inc.
+PackageName: Laurel Launcher
+PackageUrl: https://help.laurel.ai/en/articles/15538858-windows-assistant-2-0-release-log
+License: Proprietary
+Copyright: Copyright (c) Time By Ping, Inc.
+ShortDescription: Installs and updates the Laurel Windows Assistant.
+Description: |-
+  Laurel Launcher is the progressive updater for the Laurel Windows Assistant.
+  After install, Launcher downloads and manages the Assistant package for the signed-in user.
+  Firm-specific MDM and VDI deployments should continue to use the documented MSI command line with CUSTOMERID / VIRTUALIZEDMODE rather than this generic WinGet package.
+Moniker: laurel-launcher
+Tags:
+- laurel
+- assistant
+- updater
+- launcher
+ReleaseNotesUrl: https://help.laurel.ai/en/articles/15538858-windows-assistant-2-0-release-log
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/l/Laurel/Launcher/1.0.0.21/Laurel.Launcher.yaml
+++ b/manifests/l/Laurel/Launcher/1.0.0.21/Laurel.Launcher.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: Laurel.Launcher
+PackageVersion: 1.0.0.21
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## Summary
- Adds a new WinGet community package for Laurel Launcher 1.0.0.21.
- Uses the public signed x64 MSI at `https://download.laurel.ai/installer/windows/Launcher/Laurel.Launcher_1.0.0.21_x64.msi`.
- Default scope is per-user to match the MSI default install behavior.

Replaces https://github.com/microsoft/winget-pkgs/pull/415935, which used `download.dev.timeautomation.com` and stalled on Validation-Domain.

## Test plan
- [x] `winget validate --manifest manifests/l/Laurel/Launcher/1.0.0.21` succeeded locally
- [x] Silent per-user MSI install/uninstall verified with msiexec
- [x] Public installer URL returns HTTP 200
- [x] SHA-256 matches `6BA06E92391AA0343393419D676356027E5DE4DE5D37054FEFC8C6B687E99680`
- [x] WinGet validation pipeline checks
- [x] Optional: `winget install --id Laurel.Launcher --exact` after merge
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/419118)