### PR TITLE
Add MediaHubNetwork.HIL v12.0.0

### DIFF
--- a/manifests/m/MediaHubNetwork/HIL/12.0.0/MediaHubNetwork.HIL.installer.yaml
+++ b/manifests/m/MediaHubNetwork/HIL/12.0.0/MediaHubNetwork.HIL.installer.yaml
@@ -1,0 +1,21 @@
+PackageIdentifier: MediaHubNetwork.HIL
+PackageVersion: 12.0.0
+MinimumOSVersion: 10.0.17763.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: hil-cli.exe
+  PortableCommandAlias: hil-cli
+- RelativeFilePath: hil-orchestrator.exe
+  PortableCommandAlias: hil-orchestrator
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/SRashwan/hilp/releases/download/v12.0.0/hil-os-full-windows-x64.zip
+  InstallerSha256: 0000000000000000000000000000000000000000000000000000000000000000
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/MediaHubNetwork/HIL/12.0.0/MediaHubNetwork.HIL.locale.en-US.yaml
+++ b/manifests/m/MediaHubNetwork/HIL/12.0.0/MediaHubNetwork.HIL.locale.en-US.yaml
@@ -1,0 +1,21 @@
+PackageIdentifier: MediaHubNetwork.HIL
+PackageVersion: 12.0.0
+PackageLocale: en-US
+Publisher: Media Hub Network
+PublisherUrl: https://hil.mediahubnetwork.net
+PublisherSupportUrl: https://github.com/SRashwan/hilp/issues
+PackageName: HIL
+PackageUrl: https://github.com/SRashwan/hilp
+License: MIT
+LicenseUrl: https://raw.githubusercontent.com/SRashwan/hilp/main/LICENSE
+ShortDescription: HIL LISP - Hardware Interfacing LISP for Arduino and media hardware
+Description: A complete LISP-based programming environment for Arduino and embedded systems. Write programs in a simple LISP dialect that run on real hardware, in the CRUMB circuit simulator, or headlessly on your PC.
+Tags:
+- lisp
+- arduino
+- embedded
+- hardware
+- programming
+- simulator
+ManifestType: localized
+ManifestVersion: 1.6.0

--- a/manifests/m/MediaHubNetwork/HIL/12.0.0/MediaHubNetwork.HIL.yaml
+++ b/manifests/m/MediaHubNetwork/HIL/12.0.0/MediaHubNetwork.HIL.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: MediaHubNetwork.HIL
+PackageVersion: 12.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Add HIL LISP package manager for Arduino and media hardware.

Package: MediaHubNetwork.HIL
Version: 12.0.0
Source: https://github.com/SRashwan/hilp
NPM: @srashwan/hilp
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/419126)