### PR TITLE
New package: TextTimeline.Importer version 0.1.7

### DIFF
--- a/manifests/t/TextTimeline/Importer/0.1.7/TextTimeline.Importer.installer.yaml
+++ b/manifests/t/TextTimeline/Importer/0.1.7/TextTimeline.Importer.installer.yaml
@@ -1,0 +1,61 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+#
+# InstallerSha256 was computed 2026-08-15 from the downloaded release asset
+# (77,797,656 bytes) with sha256sum, and it matches the value published on
+# https://texttimeline.com/download.
+#
+# InstallerType is "nullsoft", which is winget's enum value for an NSIS
+# installer. winget applies "/S" for a silent nullsoft install by default, so
+# no InstallerSwitches are needed.
+# VERIFIED 2026-08-17 on the founder's Windows PC, against this exact published
+# asset: `TextTimeline-Importer_0.1.7_x64-setup.exe /S` installs with no
+# window, no progress bar, and no UAC prompt. It writes tt-importer.exe,
+# tt-sidecar.exe and uninstall.exe to %LOCALAPPDATA%\TextTimeline Importer,
+# creates the Start menu shortcut "TextTimeline Importer.lnk" even in silent
+# mode, and the app launches.
+
+PackageIdentifier: TextTimeline.Importer
+PackageVersion: 0.1.7
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+# VERIFIED 2026-08-17 by reading the live HKCU uninstall key after a real
+# `winget install --manifest` on the founder's PC. All four values below are
+# copied from that key, not inferred:
+#   PSChildName (= ProductCode) : TextTimeline Importer
+#   DisplayName                 : TextTimeline Importer
+#   DisplayVersion              : 0.1.7
+#   Publisher                   : texttimeline
+# HKLM carries nothing, so the install is purely per-user as declared.
+#
+# DO NOT "correct" Publisher to EVANPARRA.AI LLC here. These fields describe
+# what the installer WRITES, not who we are. An earlier draft omitted
+# Publisher, so winget fell back to the locale manifest's legal name, could
+# not match "EVANPARRA.AI LLC" against "texttimeline", and reported
+# "No installed package found matching input criteria" after a successful
+# install. That breaks `winget upgrade` for every future version.
+#
+# The registry value itself is wrong for a different reason and should be
+# fixed in the APP, not here: tauri.conf.json sets no bundle.publisher, so
+# Tauri derives "texttimeline" from the identifier, and Windows Installed apps
+# shows that instead of the signed legal entity. Set bundle.publisher in the
+# next build, then update this block and bump the version.
+AppsAndFeaturesEntries:
+- DisplayName: TextTimeline Importer
+  DisplayVersion: 0.1.7
+  Publisher: texttimeline
+  ProductCode: TextTimeline Importer
+ReleaseDate: 2026-08-05
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/DevDizzle/texttimeline-downloads/releases/download/v0.1.7/TextTimeline-Importer_0.1.7_x64-setup.exe
+  InstallerSha256: E84E315F111A492BB2EADEBE7405A32C9C34401797937722E8541E53CF782FE4
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/t/TextTimeline/Importer/0.1.7/TextTimeline.Importer.locale.en-US.yaml
+++ b/manifests/t/TextTimeline/Importer/0.1.7/TextTimeline.Importer.locale.en-US.yaml
@@ -1,0 +1,49 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+#
+# Publisher is the legal name that signs the binary (Authenticode
+# CN=EVANPARRA.AI LLC), so a user who checks the file's Digital Signatures
+# tab sees the same name winget shows. "evanparra.ai" is the display name on
+# Google Play and Partner Center; the same company.
+
+PackageIdentifier: TextTimeline.Importer
+PackageVersion: 0.1.7
+PackageLocale: en-US
+Publisher: EVANPARRA.AI LLC
+PublisherUrl: https://texttimeline.com
+PublisherSupportUrl: https://texttimeline.com/download
+PrivacyUrl: https://texttimeline.com/privacy
+Author: EVANPARRA.AI LLC
+PackageName: TextTimeline Importer
+PackageUrl: https://texttimeline.com/download
+License: Proprietary
+LicenseUrl: https://texttimeline.com/terms
+Copyright: Copyright (c) 2026 EVANPARRA.AI LLC
+CopyrightUrl: https://texttimeline.com/terms
+ShortDescription: Copies the text messages off an iPhone into a CSV file you keep, on your own PC. Free, no upload.
+Description: |-
+  TextTimeline Importer copies your text messages off your iPhone into one CSV file you keep, with every date, time, and sender intact. Connect the iPhone by cable. The app makes a local backup of the phone, reads the SMS, MMS, and iMessage conversations from it, and writes texttimeline-messages.csv plus a custody manifest to your Documents folder. The manifest records what was read, when, by which version of the tool, and a checksum of the file it produced. The working copy of the backup is deleted when the export finishes.
+  Everything runs on your own PC. Nothing uploads unless you decide to upload the file afterward. The app has no sign-in, no accounts, no analytics, and no crash reporting. It cannot read a phone that is not in your hand and unlocked.
+  Requirements: Windows 10 or newer, the free Apple Devices app from the Microsoft Store (it carries Apple's USB driver), and your iPhone with its cable. The export needs about as much free disk space as the iPhone has used, because the phone sends a full backup. If the WebView2 runtime is missing, the installer downloads it from Microsoft.
+  Optional next step: upload the CSV to texttimeline.com to search years of messages and build a court-ready transcript for a custody, divorce, or harassment matter, or keep it for your own records. The app itself is free, with no cap on how much you export. Also available for Apple Silicon Macs, and as an Android app on Google Play.
+Moniker: texttimeline-importer
+Tags:
+- backup
+- court
+- csv
+- custody
+- evidence
+- export
+- family-law
+- imessage
+- iphone
+- messages
+- sms
+- text-messages
+- texttimeline
+- transcript
+ReleaseNotesUrl: https://github.com/DevDizzle/texttimeline-downloads/releases/tag/v0.1.7
+Documentations:
+- DocumentLabel: How it works
+  DocumentUrl: https://texttimeline.com/download
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/TextTimeline/Importer/0.1.7/TextTimeline.Importer.yaml
+++ b/manifests/t/TextTimeline/Importer/0.1.7/TextTimeline.Importer.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: TextTimeline.Importer
+PackageVersion: 0.1.7
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Package name and version
TextTimeline.Importer 0.1.7

### Checklist
- [x] Manifest passes `winget validate --manifest <path>` (run on Windows 11, 2026-08-17)
- [x] Installed and uninstalled locally with `winget install --manifest <path>` / `winget uninstall --manifest <path>`
- [x] Installer URL is a versioned, immutable release asset
- [x] `InstallerSha256` verified against the downloaded asset
- [x] This is a new package, one version per PR

### Notes for reviewers

**Publisher.** The installer is Authenticode signed `CN=EVANPARRA.AI LLC, L=Saint Augustine, ST=Florida, C=US`, issued through Microsoft ID Verified Code Signing and RFC 3161 timestamped.

**InstallerType `nullsoft`.** Tauri v2 NSIS installer, per-user (`Scope: user`), which is why `AppsAndFeaturesEntries` matches an HKCU uninstall key and nothing appears in HKLM. Silent install with `/S` was verified on real hardware: no window, no progress bar, no UAC prompt.

**`AppsAndFeaturesEntries` values are read from the live registry, not inferred.** `Publisher` is `texttimeline` rather than the legal entity because the app does not set `bundle.publisher`, so Tauri derives it from the identifier. It is declared here as-is so ARP correlation works. That is a known defect in the app and will be corrected in a later version, at which point this manifest will be updated to match the binary.

**WebView2.** The installer uses Tauri's `downloadBootstrapper` in silent mode, so a machine without the WebView2 runtime fetches it from Microsoft during install.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/419143)