### PR TITLE
New package: Knarrly.ArmadilloTV version 0.7.4

### DIFF
--- a/manifests/k/Knarrly/ArmadilloTV/0.7.4/Knarrly.ArmadilloTV.installer.yaml
+++ b/manifests/k/Knarrly/ArmadilloTV/0.7.4/Knarrly.ArmadilloTV.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Knarrly.ArmadilloTV
+PackageVersion: 0.7.4
+InstallerType: inno
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+AppsAndFeaturesEntries:
+  - ProductCode: "{6F3A2C1E-8B4D-4E7A-9C2F-CT0Y0TE7V000}_is1"
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/knarrlyllc/armadillotv-download/releases/download/v0.7.4/ArmadilloTV-Setup-0.7.4.exe
+    InstallerSha256: 4A1E66FCDCA74CA51789910A1D44EE7D847145023ADBDAD0824DD319B404E5E1
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/k/Knarrly/ArmadilloTV/0.7.4/Knarrly.ArmadilloTV.locale.en-US.yaml
+++ b/manifests/k/Knarrly/ArmadilloTV/0.7.4/Knarrly.ArmadilloTV.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Knarrly.ArmadilloTV
+PackageVersion: 0.7.4
+PackageLocale: en-US
+Publisher: Knarrly LLC
+PublisherUrl: https://armadillotv.com
+PublisherSupportUrl: https://github.com/knarrlyllc/armadillotv-download/issues
+PackageName: Armadillo TV
+PackageUrl: https://armadillotv.com
+License: Proprietary
+Copyright: Copyright (c) Knarrly LLC
+ShortDescription: Windows IPTV player and DVR with a phone companion. Bring your own sources.
+Description: |-
+  Armadillo TV is a Windows-first IPTV player and DVR: a live grid of up to
+  nine screens, full program guide, scheduled recordings and series passes,
+  catch-up, and VOD, plus a companion web app for browsing, watching,
+  recording, casting, and downloading from a phone on the home network. It
+  ships with no content - connect your own M3U playlist or Xtream portal
+  login, or try the built-in demo playlist of freely available channels.
+  Includes a free 30-day trial; collects no data.
+Moniker: armadillotv
+Tags:
+  - iptv
+  - dvr
+  - epg
+  - m3u
+  - player
+  - television
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/k/Knarrly/ArmadilloTV/0.7.4/Knarrly.ArmadilloTV.yaml
+++ b/manifests/k/Knarrly/ArmadilloTV/0.7.4/Knarrly.ArmadilloTV.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Knarrly.ArmadilloTV
+PackageVersion: 0.7.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)? *(first submission — will accept via the CLA bot on this PR)*
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`? *(the signed installer itself was installed and launch-verified directly; the manifest is hash-pinned to that exact file)*
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

New package: **Knarrly.ArmadilloTV 0.7.4** — Armadillo TV, a Windows IPTV player and DVR (bring-your-own playlist/portal) by Knarrly LLC. Installer is an Inno Setup exe, Authenticode-signed by Knarrly LLC, published via GitHub releases and hash-pinned in the manifest.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/419149)