### PR TITLE
New version: Takeshi.Sumifold version 1.0.0

### DIFF
--- a/manifests/t/Takeshi/Sumifold/1.0.0/Takeshi.Sumifold.installer.yaml
+++ b/manifests/t/Takeshi/Sumifold/1.0.0/Takeshi.Sumifold.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: =https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Takeshi.Sumifold
+PackageVersion: 1.0.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-08-17
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/TakeshiArai-18/Sumifold/releases/download/v1.0.0/Sumifold_1.0.0_x64-setup.exe
+  InstallerSha256: A6EFBA1850EB59B76252D011873CCB34E025E7428D759C791AD8F7BEB2049E17
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/t/Takeshi/Sumifold/1.0.0/Takeshi.Sumifold.installer.yaml
+++ b/manifests/t/Takeshi/Sumifold/1.0.0/Takeshi.Sumifold.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: =https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: Takeshi.Sumifold
 PackageVersion: 1.0.0

--- a/manifests/t/Takeshi/Sumifold/1.0.0/Takeshi.Sumifold.locale.en-US.yaml
+++ b/manifests/t/Takeshi/Sumifold/1.0.0/Takeshi.Sumifold.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: =https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: Takeshi.Sumifold
 PackageVersion: 1.0.0

--- a/manifests/t/Takeshi/Sumifold/1.0.0/Takeshi.Sumifold.locale.en-US.yaml
+++ b/manifests/t/Takeshi/Sumifold/1.0.0/Takeshi.Sumifold.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: =https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Takeshi.Sumifold
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: Takeshi Arai
+PublisherUrl: https://github.com/TakeshiArai-18
+PublisherSupportUrl: https://github.com/TakeshiArai-18/Sumifold/issues
+PackageName: Sumifold
+PackageUrl: https://github.com/TakeshiArai-18/Sumifold
+License: Proprietary
+LicenseUrl: https://github.com/TakeshiArai-18/Sumifold/blob/main/EULA.md
+Copyright: Copyright (c) 2026 Takeshi Arai. All Rights Reserved.
+ShortDescription: A Markdown editor for Windows with rich preview, full-text search, autosave, and crash recovery.
+Description: |-
+  Sumifold is a Markdown editor for Windows featuring rich preview (Mermaid, KaTeX,
+  Shiki syntax highlighting, Graphviz), workspace-wide full-text search, atomic
+  autosave with crash recovery, local Git integration, a command palette, in-editor
+  formatting, and a plugin system. This release is unsigned.
+Moniker: sumifold
+Tags:
+- markdown
+- editor
+- mermaid
+- katex
+- notes
+ReleaseNotesUrl: https://github.com/TakeshiArai-18/Sumifold/releases/tag/v1.0.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/Takeshi/Sumifold/1.0.0/Takeshi.Sumifold.locale.ja-JP.yaml
+++ b/manifests/t/Takeshi/Sumifold/1.0.0/Takeshi.Sumifold.locale.ja-JP.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: =https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: Takeshi.Sumifold
+PackageVersion: 1.0.0
+PackageLocale: ja-JP
+Publisher: Takeshi Arai
+PublisherUrl: https://github.com/TakeshiArai-18
+PublisherSupportUrl: https://github.com/TakeshiArai-18/Sumifold/issues
+PackageName: Sumifold
+PackageUrl: https://github.com/TakeshiArai-18/Sumifold
+License: Proprietary
+LicenseUrl: https://github.com/TakeshiArai-18/Sumifold/blob/main/EULA.md
+Copyright: Copyright (c) 2026 Takeshi Arai. All Rights Reserved.
+ShortDescription: リッチプレビュー・全文検索・自動保存・クラッシュリカバリを備えた Windows 向け Markdown エディタ。
+Description: |-
+  Sumifold は Windows 向けの Markdown エディタです。Mermaid / KaTeX / Shiki / Graphviz による
+  リッチプレビュー、ワークスペース全文検索、原子的な自動保存とクラッシュリカバリ、ローカル Git 連携、
+  コマンドパレット、エディタ内の書式表示、プラグイン機構を備えます。本リリースは未署名です。
+ReleaseNotesUrl: https://github.com/TakeshiArai-18/Sumifold/releases/tag/v1.0.0
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/t/Takeshi/Sumifold/1.0.0/Takeshi.Sumifold.locale.ja-JP.yaml
+++ b/manifests/t/Takeshi/Sumifold/1.0.0/Takeshi.Sumifold.locale.ja-JP.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: =https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
 
 PackageIdentifier: Takeshi.Sumifold
 PackageVersion: 1.0.0

--- a/manifests/t/Takeshi/Sumifold/1.0.0/Takeshi.Sumifold.yaml
+++ b/manifests/t/Takeshi/Sumifold/1.0.0/Takeshi.Sumifold.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: =https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Takeshi.Sumifold
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/manifests/t/Takeshi/Sumifold/1.0.0/Takeshi.Sumifold.yaml
+++ b/manifests/t/Takeshi/Sumifold/1.0.0/Takeshi.Sumifold.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: =https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: Takeshi.Sumifold
 PackageVersion: 1.0.0


### PR DESCRIPTION
### Pull request has been created with the following manifest

- `manifests/t/Takeshi/Sumifold/1.0.0/Takeshi.Sumifold.yaml`
- `manifests/t/Takeshi/Sumifold/1.0.0/Takeshi.Sumifold.installer.yaml`
- `manifests/t/Takeshi/Sumifold/1.0.0/Takeshi.Sumifold.locale.en-US.yaml`
- `manifests/t/Takeshi/Sumifold/1.0.0/Takeshi.Sumifold.locale.ja-JP.yaml`

Submitted by the package publisher (@TakeshiArai-18).

Release: https://github.com/TakeshiArai-18/Sumifold/releases/tag/v1.0.0

- `InstallerSha256` was computed from the published installer (`Sumifold_1.0.0_x64-setup.exe`, 15,121,573 bytes) and cross-checked against the GitHub release asset digest.
- Manifest schema `1.12.0`, matching the existing 0.9.1 manifests.

Note: the locale manifests also correct two fields that were carried over unchanged from 0.9.0 into the 0.9.1 manifests — `ReleaseNotesUrl` now points at the matching release tag, and `Description` no longer says "unsigned public beta (0.9.0)". The build remains unsigned, which is still stated in the description.

---

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/addition?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.0 schema](https://github.com/microsoft/winget-pkgs/blob/master/doc/manifest/schema/1.0.0)?

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/419178)