### PR TITLE
New version: rulssss.CloudCostTree version 0.1.48

### DIFF
--- a/manifests/r/rulssss/CloudCostTree/0.1.48/rulssss.CloudCostTree.installer.yaml
+++ b/manifests/r/rulssss/CloudCostTree/0.1.48/rulssss.CloudCostTree.installer.yaml
@@ -1,0 +1,14 @@
+PackageIdentifier: rulssss.CloudCostTree
+PackageVersion: 0.1.48
+InstallerType: portable
+Commands:
+  - cloudcosttree
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/rulssss/cloudcosttree/releases/download/v0.1.48/cloudcosttree-windows-amd64.exe
+    InstallerSha256: DA8C2AD27231F97F5D5F8C8A231C53CB18460F2917A5852D225C32159DCE5072
+  - Architecture: arm64
+    InstallerUrl: https://github.com/rulssss/cloudcosttree/releases/download/v0.1.48/cloudcosttree-windows-arm64.exe
+    InstallerSha256: 4DF42B6F843DF28FBEEB1B0B058F0B573291B3D354BC25690F87A9A18A68459E
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/r/rulssss/CloudCostTree/0.1.48/rulssss.CloudCostTree.locale.en-US.yaml
+++ b/manifests/r/rulssss/CloudCostTree/0.1.48/rulssss.CloudCostTree.locale.en-US.yaml
@@ -1,0 +1,10 @@
+PackageIdentifier: rulssss.CloudCostTree
+PackageVersion: 0.1.48
+PackageLocale: en-US
+Publisher: rulssss
+PackageName: CloudCostTree
+License: Proprietary
+ShortDescription: Estimate AWS infrastructure costs in a hierarchical tree before you apply
+PackageUrl: https://cloudcosttree.com
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/r/rulssss/CloudCostTree/0.1.48/rulssss.CloudCostTree.yaml
+++ b/manifests/r/rulssss/CloudCostTree/0.1.48/rulssss.CloudCostTree.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: rulssss.CloudCostTree
+PackageVersion: 0.1.48
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Update to 0.1.48. Installer URLs verified reachable; InstallerSha256 computed locally against the published release assets.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/419227)