### PR TITLE
Update version: CerberAuth.openapi-oathkeeper version 0.7.18

### DIFF
--- a/manifests/c/CerberAuth/openapi-oathkeeper/0.7.18/CerberAuth.openapi-oathkeeper.installer.yaml
+++ b/manifests/c/CerberAuth/openapi-oathkeeper/0.7.18/CerberAuth.openapi-oathkeeper.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: CerberAuth.openapi-oathkeeper
+PackageVersion: 0.7.18
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: openapi-oathkeeper.exe
+  PortableCommandAlias: openapi-oathkeeper
+UpgradeBehavior: uninstallPrevious
+ReleaseDate: 2026-08-13
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/cerberauth/openapi-oathkeeper/releases/download/v0.7.18/openapi-oathkeeper_Windows_x86_64.zip
+  InstallerSha256: 6309862EA527EBBDE19071313ED96E1316475CD80AB1F8D856C2173B34F1D391
+- Architecture: x86
+  InstallerUrl: https://github.com/cerberauth/openapi-oathkeeper/releases/download/v0.7.18/openapi-oathkeeper_Windows_i386.zip
+  InstallerSha256: AF596FDCAB810F242E7EF69A850FD20042D3C1145EC877F84B4A1C70991E23DC
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/CerberAuth/openapi-oathkeeper/0.7.18/CerberAuth.openapi-oathkeeper.locale.en-US.yaml
+++ b/manifests/c/CerberAuth/openapi-oathkeeper/0.7.18/CerberAuth.openapi-oathkeeper.locale.en-US.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: CerberAuth.openapi-oathkeeper
+PackageVersion: 0.7.18
+PackageLocale: en-US
+Publisher: CerberAuth
+PublisherUrl: https://cerberauth.com
+PackageName: openapi-oathkeeper
+PackageUrl: https://github.com/cerberauth/openapi-oathkeeper
+License: MIT
+LicenseUrl: https://github.com/cerberauth/openapi-oathkeeper/blob/main/LICENSE
+ShortDescription: Generate Ory Oathkeeper access rules from an OpenAPI 3 contract.
+Moniker: openapi-oathkeeper
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/CerberAuth/openapi-oathkeeper/0.7.18/CerberAuth.openapi-oathkeeper.yaml
+++ b/manifests/c/CerberAuth/openapi-oathkeeper/0.7.18/CerberAuth.openapi-oathkeeper.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: CerberAuth.openapi-oathkeeper
+PackageVersion: 0.7.18
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update CerberAuth.openapi-oathkeeper to version 0.7.18.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/419357)