### PR TITLE
New package: yd-null.sbscraper version 1.0.20

### DIFF
--- a/manifests/y/yd-null/sbscraper/1.0.20/yd-null.sbscraper.installer.yaml
+++ b/manifests/y/yd-null/sbscraper/1.0.20/yd-null.sbscraper.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: yd-null.sbscraper
+PackageVersion: 1.0.20
+InstallerType: zip
+NestedInstallerType: portable
+Scope: user
+UpgradeBehavior: install
+Commands:
+  - sbscraper
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/yd-null/sbscraper/releases/download/v1.0.20/sbscraper-windows.zip
+    InstallerSha256: 304D7590D7CE8913FC54D52EAE0FBBBA6564AB1D177D58999D4C9213280F2DD2
+    NestedInstallerFiles:
+      - RelativeFilePath: sbscraper\sbscraper.exe
+        PortableCommandAlias: sbscraper
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/y/yd-null/sbscraper/1.0.20/yd-null.sbscraper.locale.en-US.yaml
+++ b/manifests/y/yd-null/sbscraper/1.0.20/yd-null.sbscraper.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: yd-null.sbscraper
+PackageVersion: 1.0.20
+PackageLocale: en-US
+Publisher: yd-null
+PublisherUrl: https://github.com/yd-null
+PublisherSupportUrl: https://github.com/yd-null/sbscraper/issues
+Author: yd-null
+PackageName: sbscraper
+PackageUrl: https://github.com/yd-null/sbscraper
+License: MIT
+LicenseUrl: https://github.com/yd-null/sbscraper/blob/v1.0.20/LICENSE
+Copyright: Copyright (c) 2026 yd-null
+ShortDescription: Scrape Structure Builder reports and export related CSV data.
+Moniker: sbscraper
+Tags:
+  - cli
+  - reports
+  - scraper
+ReleaseNotesUrl: https://github.com/yd-null/sbscraper/releases/tag/v1.0.20
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/y/yd-null/sbscraper/1.0.20/yd-null.sbscraper.yaml
+++ b/manifests/y/yd-null/sbscraper/1.0.20/yd-null.sbscraper.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: yd-null.sbscraper
+PackageVersion: 1.0.20
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Adds sbscraper 1.0.20 as a user-scoped x64 portable package. The manifest creates the `sbscraper` command alias and supports installation without elevation via `--scope user`.

Source and release: https://github.com/yd-null/sbscraper/releases/tag/v1.0.20

## Checklist

- [x] Signed the Contributor License Agreement
- [x] Checked that there are no existing manifests or open pull requests for this package
- [x] This PR contains one package version and only manifest files
- [x] Release workflow smoke-tested the packaged Windows executable with `--version` and `--help`
- [x] Published ZIP SHA-256 matches `InstallerSha256`
- [x] Manifest files parse as valid YAML and conform to the 1.12 schema structure
- [x] Validated locally with `winget validate` (tested manually through winget using #PR number)
- [x] Tested locally with `winget install` (tested manually through winget using #PR number)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/419437)