### PR TITLE
New package: yutat23.lsoff version 0.1.3

### DIFF
--- a/manifests/y/yutat23/lsoff/0.1.3/yutat23.lsoff.installer.yaml
+++ b/manifests/y/yutat23/lsoff/0.1.3/yutat23.lsoff.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: yutat23.lsoff
+PackageVersion: 0.1.3
+InstallerType: portable
+Commands:
+- lsoff
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/yutat23/lsoff/releases/download/v0.1.3/lsoff-windows-amd64.exe
+  InstallerSha256: F76C3414F8CD681EE6A7360B55C8918FBA4E1B6326417F2DB8B56CEA83D0A2E7
+- Architecture: arm64
+  InstallerUrl: https://github.com/yutat23/lsoff/releases/download/v0.1.3/lsoff-windows-arm64.exe
+  InstallerSha256: 5D9A3329F2379B45691812277DA1D17A26F737C5BF4C5D90226E12C77A788C4A
+- Architecture: x86
+  InstallerUrl: https://github.com/yutat23/lsoff/releases/download/v0.1.3/lsoff-windows-386.exe
+  InstallerSha256: 1108DDDF40113756FE234271B934CAB5FB151CCC5DEB6C0011FB8ADF045A5878
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/y/yutat23/lsoff/0.1.3/yutat23.lsoff.locale.en-US.yaml
+++ b/manifests/y/yutat23/lsoff/0.1.3/yutat23.lsoff.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: yutat23.lsoff
+PackageVersion: 0.1.3
+PackageLocale: en-US
+Publisher: yutat23
+PublisherUrl: https://github.com/yutat23
+PublisherSupportUrl: https://github.com/yutat23/lsoff/issues
+PackageName: lsoff
+PackageUrl: https://github.com/yutat23/lsoff
+License: MIT
+LicenseUrl: https://github.com/yutat23/lsoff/blob/v0.1.3/LICENSE
+Copyright: Copyright (c) 2026 yutat23
+ShortDescription: CLI and TUI for listing listening TCP and UDP ports
+Description: A port-focused lsof-like CLI and TUI for Windows, Linux, and macOS.
+Moniker: lsoff
+Tags:
+- ports
+- tcp
+- udp
+- cli
+- tui
+- lsof
+ReleaseNotesUrl: https://github.com/yutat23/lsoff/releases/tag/v0.1.3
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/y/yutat23/lsoff/0.1.3/yutat23.lsoff.yaml
+++ b/manifests/y/yutat23/lsoff/0.1.3/yutat23.lsoff.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: yutat23.lsoff
+PackageVersion: 0.1.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds the initial manifest for `yutat23.lsoff` version `0.1.3`.

- `lsoff` is a CLI/TUI for listing listening TCP/UDP ports.
- Adds portable Windows binaries for x64, ARM64, and x86.
- Installers are downloaded directly from the publisher's GitHub Release.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (not applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for `yutat23.lsoff` version `0.1.3`
- [x] This PR only modifies one manifest set: `yutat23.lsoff` version `0.1.3`
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the 1.12 schema
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/419475)