### PR TITLE
Add package: LaFabrikNumerique.VoxCut version 1.5.3

### DIFF
--- a/manifests/l/LaFabrikNumerique/VoxCut/1.5.3/LaFabrikNumerique.VoxCut.installer.yaml
+++ b/manifests/l/LaFabrikNumerique/VoxCut/1.5.3/LaFabrikNumerique.VoxCut.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: LaFabrikNumerique.VoxCut
+PackageVersion: 1.5.3
+InstallerLocale: en-US
+InstallerType: inno
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/WgeorgeAssistantIA/Voxcut-downloads/releases/download/v1.5.3/VoxCut-Setup-1.5.3.exe
+  InstallerSha256: BE35DAAC13F7575453598F82B9BD600CF07237DEA9320BDF23617DEDA6C67197
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/l/LaFabrikNumerique/VoxCut/1.5.3/LaFabrikNumerique.VoxCut.locale.en-US.yaml
+++ b/manifests/l/LaFabrikNumerique/VoxCut/1.5.3/LaFabrikNumerique.VoxCut.locale.en-US.yaml
@@ -23,5 +23,5 @@ Tags:
 - silence-removal
 - podcast
 - audio-editor
-ManifestType: locale
+ManifestType: defaultLocale
 ManifestVersion: 1.6.0

--- a/manifests/l/LaFabrikNumerique/VoxCut/1.5.3/LaFabrikNumerique.VoxCut.locale.en-US.yaml
+++ b/manifests/l/LaFabrikNumerique/VoxCut/1.5.3/LaFabrikNumerique.VoxCut.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: LaFabrikNumerique.VoxCut
+PackageVersion: 1.5.3
+PackageLocale: en-US
+Publisher: La Fabrik Numérique
+PublisherUrl: https://lafabriknumerique.fr
+PublisherSupportUrl: https://voxcutpro.com
+PackageName: VoxCut
+PackageUrl: https://voxcutpro.com
+License: Proprietary
+LicenseUrl: https://voxcutpro.com/privacy
+Copyright: Copyright (c) La Fabrik Numerique
+ShortDescription: Automatically remove silences from audio and video files. 100% local processing, one-time payment.
+Description: |-
+  VoxCut is a Windows desktop app that automatically detects and removes
+  silences from audio and video files. All processing happens locally on
+  your computer -- no upload, no internet connection required. One-time
+  payment, no subscription.
+Tags:
+- audio
+- video
+- silence-removal
+- podcast
+- audio-editor
+ManifestType: locale
+ManifestVersion: 1.6.0

--- a/manifests/l/LaFabrikNumerique/VoxCut/1.5.3/LaFabrikNumerique.VoxCut.yaml
+++ b/manifests/l/LaFabrikNumerique/VoxCut/1.5.3/LaFabrikNumerique.VoxCut.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: LaFabrikNumerique.VoxCut
+PackageVersion: 1.5.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Description

Adds the initial manifest for VoxCut 1.5.3, a Windows desktop app that automatically removes silences from audio and video files. All processing happens locally, no upload or internet connection required.

- Installer type: Inno Setup, x64
- Silent install supported (`/SILENT`, `/VERYSILENT` via Inno Setup default switches)

## Checklist

- [x] I've read the [Authoring Manifests](https://github.com/microsoft/winget-pkgs/blob/master/doc/authoring/authoring-manifests.md) guidance
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? (passed after fixing the defaultLocale ManifestType)
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? (not run — requires enabling `LocalManifestFiles` as admin, left for a maintainer/CI to verify)
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/schemas/JSON/manifests/v1.6.0)?