### PR TITLE
Add Sentinel 1.0.0 manifest

### DIFF
--- a/manifests/s/Sentinel/Sentinel/1.0.0/Sentinel.Sentinel.installer.yaml
+++ b/manifests/s/Sentinel/Sentinel/1.0.0/Sentinel.Sentinel.installer.yaml
@@ -1,0 +1,14 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Sentinel.Sentinel
+PackageVersion: 1.0.0
+InstallerLocale: en-US
+InstallerType: wix
+ProductCode: '{806AE4A7-1AC8-48BD-9F96-1D4BB5B087C2}'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Buffyxo/Sentinel/releases/download/v1.0.0/Sentinel.Installer.msi
+  InstallerSha256: 1599609C88F754B418B4E049C6B780D0A62691A0381DDF46AF1CF0D363842055
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/Sentinel/Sentinel/1.0.0/Sentinel.Sentinel.locale.en-US.yaml
+++ b/manifests/s/Sentinel/Sentinel/1.0.0/Sentinel.Sentinel.locale.en-US.yaml
@@ -1,0 +1,15 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Sentinel.Sentinel
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: Sentinel
+Author: Buffyxo
+PackageName: Sentinel
+PackageUrl: https://github.com/Buffyxo/Sentinel
+License: MIT License
+LicenseUrl: https://github.com/Buffyxo/Sentinel/blob/main/LICENSE
+ShortDescription: An infrastructure monitoring and IoT diagnostics toolkit.
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/Sentinel/Sentinel/1.0.0/Sentinel.Sentinel.yaml
+++ b/manifests/s/Sentinel/Sentinel/1.0.0/Sentinel.Sentinel.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Sentinel.Sentinel
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
New package: Sentinel.Sentinel version 1.0.0

## 📖 Description

Adds Sentinel version 1.0.0 to the Windows Package Manager community repository.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/419554)