### PR TITLE
New package: iainchesworthlabs.ac3forge version 0.8.0-beta.1

### DIFF
--- a/manifests/i/iainchesworthlabs/ac3forge/0.8.0-beta.1/iainchesworthlabs.ac3forge.installer.yaml
+++ b/manifests/i/iainchesworthlabs/ac3forge/0.8.0-beta.1/iainchesworthlabs.ac3forge.installer.yaml
@@ -1,0 +1,34 @@
+# Points at the win64.zip release asset (.github/workflows/release.yml's
+# windows-msvc leg), not an NSIS .exe: this release didn't produce one
+# (makensis wasn't on the runner - see cmake/Packaging.cmake), and the zip
+# already carries both end-user binaries (bin/ac3cli.exe, bin/ac3gui.exe -
+# CPack's "runtime" component, see docs/releasing.md#what-gets-published).
+# InstallerType zip + NestedInstallerType portable installs straight from
+# that archive with no separate installer to build - see
+# docs/releasing.md#winget-manifest for what changes this if a real NSIS
+# installer becomes available for a future release.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: iainchesworthlabs.ac3forge
+PackageVersion: 0.8.0-beta.1
+InstallerLocale: en-US
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: bin/ac3cli.exe
+    PortableCommandAlias: ac3cli
+  - RelativeFilePath: bin/ac3gui.exe
+    PortableCommandAlias: ac3gui
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/iainchesworthlabs/ac3forge/releases/download/v0.8.0-beta.1/ac3forge-0.8.0-win64.zip
+    # Computed directly (sha256sum) from the release asset - winget wants
+    # SHA256, unlike the SHA512SUMS release.yml publishes (see
+    # docs/releasing.md#what-gets-published). If `winget install` ever
+    # reports a mismatch, trust winget's reported hash over this one and
+    # update it here, same policy as the vcpkg port's SHA512 comment.
+    InstallerSha256: 18CEEC80A3BE305B44D7927D2B722EE82D35CB111A0BBFCC714C1EA3883F4E44
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/i/iainchesworthlabs/ac3forge/0.8.0-beta.1/iainchesworthlabs.ac3forge.locale.en-US.yaml
+++ b/manifests/i/iainchesworthlabs/ac3forge/0.8.0-beta.1/iainchesworthlabs.ac3forge.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: iainchesworthlabs.ac3forge
+PackageVersion: 0.8.0-beta.1
+PackageLocale: en-US
+Publisher: iainchesworthlabs
+PublisherUrl: https://github.com/iainchesworthlabs
+PublisherSupportUrl: https://github.com/iainchesworthlabs/ac3forge/issues
+PackageName: ac3forge
+PackageUrl: https://github.com/iainchesworthlabs/ac3forge
+License: GPL-3.0-or-later
+LicenseUrl: https://github.com/iainchesworthlabs/ac3forge/blob/main/LICENSE
+ShortDescription: Clean-room AC-3/E-AC-3 encoder, decoder and Atmos object-layer CLI/GUI
+Description: >-
+  ac3forge is a clean-room C++23 implementation of the AC-3 (ATSC A/52, "Dolby Digital") and
+  E-AC-3 ("Dolby Digital Plus") codecs, including a spatial object layer for Atmos-style
+  authoring and decode. This package installs ac3cli (the command-line encoder/decoder) and
+  ac3gui (the Qt6 desktop application) as portable executables.
+Moniker: ac3forge
+Tags:
+  - audio
+  - codec
+  - ac3
+  - dolby-digital
+  - atmos
+ReleaseNotesUrl: https://github.com/iainchesworthlabs/ac3forge/releases/tag/v0.8.0-beta.1
+# defaultLocale, not locale: this is the only locale manifest, and the
+# version manifest's DefaultLocale: en-US names it as such - winget-pkgs
+# requires the two to agree.
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/i/iainchesworthlabs/ac3forge/0.8.0-beta.1/iainchesworthlabs.ac3forge.yaml
+++ b/manifests/i/iainchesworthlabs/ac3forge/0.8.0-beta.1/iainchesworthlabs.ac3forge.yaml
@@ -1,0 +1,10 @@
+# Created with the winget-pkgs three-file manifest convention. Staged here
+# (packaging/winget/) at the exact manifests/<firstletter>/<publisher>/<package>/<version>/
+# path a microsoft/winget-pkgs submission uses, so this directory can be copied
+# straight into a winget-pkgs fork - see docs/releasing.md.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: iainchesworthlabs.ac3forge
+PackageVersion: 0.8.0-beta.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description
Adds a new package: ac3forge, a clean-room AC-3/E-AC-3/Dolby Atmos encoder and decoder. This
manifest installs ac3cli and ac3gui together as portable executables from the project's
win64.zip release asset.

## ✅ Checklist
- [ ] Signed the Contributor License Agreement
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist
- [x] Checked that there aren't other open pull requests for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>` — not run; requires
      enabling an admin-gated experimental winget setting (LocalManifestFiles) that changes a
      system trust setting, which wasn't done unattended.
- [x] Manifest conforms to the 1.12 schema
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/419594)