### PR TITLE
New version: DoiT.dci version 2.2.0

### DIFF
--- a/manifests/d/DoiT/dci/2.2.0/DoiT.dci.installer.yaml
+++ b/manifests/d/DoiT/dci/2.2.0/DoiT.dci.installer.yaml
@@ -1,0 +1,13 @@
+PackageIdentifier: DoiT.dci
+PackageVersion: 2.2.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: dci.exe
+    PortableCommandAlias: dci
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/doitintl/dci-cli/releases/download/v2.2.0/dci_2.2.0_windows_amd64.zip
+    InstallerSha256: 07fcb7e3a14506c3b008b23d19c90766daaba1f61ff060e99af1d94ae1a77079
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/d/DoiT/dci/2.2.0/DoiT.dci.locale.en-US.yaml
+++ b/manifests/d/DoiT/dci/2.2.0/DoiT.dci.locale.en-US.yaml
@@ -1,0 +1,18 @@
+PackageIdentifier: DoiT.dci
+PackageVersion: 2.2.0
+PackageLocale: en-US
+Publisher: DoiT
+PublisherUrl: https://github.com/doitintl
+PublisherSupportUrl: https://github.com/doitintl/dci-cli/issues
+PackageName: dci
+ShortDescription: Cloud Intelligence™ CLI
+Moniker: dci
+Tags:
+  - cli
+  - doit
+  - finops
+License: MIT
+LicenseUrl: https://github.com/doitintl/dci-cli/blob/main/LICENSE
+ReleaseNotesUrl: https://github.com/doitintl/dci-cli/releases/tag/v2.2.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/d/DoiT/dci/2.2.0/DoiT.dci.yaml
+++ b/manifests/d/DoiT/dci/2.2.0/DoiT.dci.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: DoiT.dci
+PackageVersion: 2.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## New version: DoiT.dci version 2.2.0

- **PackageIdentifier:** DoiT.dci
- **PackageVersion:** 2.2.0
- **InstallerUrl:** https://github.com/doitintl/dci-cli/releases/download/v2.2.0/dci_2.2.0_windows_amd64.zip

Auto-submitted by [dci-cli CI](https://github.com/doitintl/dci-cli/actions).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/419700)