### PR TITLE
New version: Tomclanc.GestureSignV2 version 18.0.2.4

### DIFF
--- a/manifests/t/Tomclanc/GestureSignV2/18.0.2.4/Tomclanc.GestureSignV2.installer.yaml
+++ b/manifests/t/Tomclanc/GestureSignV2/18.0.2.4/Tomclanc.GestureSignV2.installer.yaml
@@ -1,0 +1,24 @@
+# Created for GestureSign V2 18.0.2.4
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Tomclanc.GestureSignV2
+PackageVersion: 18.0.2.4
+InstallerType: wix
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{FF786D99-0F6F-4AC8-B94E-3E264F1C97A5}'
+AppsAndFeaturesEntries:
+- DisplayName: GestureSign V2
+  Publisher: TransposonY / WinUI rebuild
+  ProductCode: '{FF786D99-0F6F-4AC8-B94E-3E264F1C97A5}'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Tomclanc/GestureSignv2/releases/download/v18.0.2.4/GestureSign-V2-18.0.2.4-x64.msi
+  InstallerSha256: 473F2CA188EE6F49E7BE239F9683D353C67E4904908F82AC53C8A47D028A8218
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-08-18

--- a/manifests/t/Tomclanc/GestureSignV2/18.0.2.4/Tomclanc.GestureSignV2.locale.en-US.yaml
+++ b/manifests/t/Tomclanc/GestureSignV2/18.0.2.4/Tomclanc.GestureSignV2.locale.en-US.yaml
@@ -1,0 +1,37 @@
+# Created for GestureSign V2 18.0.2.4
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Tomclanc.GestureSignV2
+PackageVersion: 18.0.2.4
+PackageLocale: en-US
+Publisher: Tomclanc
+PublisherUrl: https://github.com/Tomclanc
+PublisherSupportUrl: https://github.com/Tomclanc/GestureSignv2/issues
+Author: Tomclanc
+PackageName: GestureSign V2
+PackageUrl: https://github.com/Tomclanc/GestureSignv2
+License: GPL-2.0
+LicenseUrl: https://github.com/Tomclanc/GestureSignv2/blob/main/LICENSE
+Copyright: Copyright (C) 2026 Tomclanc
+ShortDescription: A Windows 11 focused rebuild of GestureSign for touchpad, touchscreen, and mouse gestures.
+Description: GestureSign V2 is a Windows 11 focused rebuild of the classic open-source GestureSign project. It supports touchpad gestures, touchscreen gestures, mouse gestures, per-app device selection, gesture trails, ignore rules, tray controls, Smart Close, Smart New Tab, and bundled Kando radial menu quick actions.
+Moniker: gesturesignv2
+Tags:
+- gesture
+- gestures
+- mouse
+- touchscreen
+- touchpad
+- windows-11
+ReleaseNotes: |-
+  - Added per-action device selection for touchscreen, touchpad, mouse, and pen.
+  - Improved near-simultaneous two-finger touchscreen taps and sends right clicks at the current gesture's first-finger release position.
+  - Fixed mouse actions occasionally reusing coordinates from the previous gesture.
+  - Preserved complete-path recognition for two-finger drawn gestures.
+  - Improved split-frame contact reporting, release synchronization, and stroke ordering on devices such as the H3C MegaBook.
+ReleaseNotesUrl: https://github.com/Tomclanc/GestureSignv2/releases/tag/v18.0.2.4
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/Tomclanc/GestureSignv2/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/Tomclanc/GestureSignV2/18.0.2.4/Tomclanc.GestureSignV2.locale.zh-CN.yaml
+++ b/manifests/t/Tomclanc/GestureSignV2/18.0.2.4/Tomclanc.GestureSignV2.locale.zh-CN.yaml
@@ -1,0 +1,35 @@
+# Created for GestureSign V2 18.0.2.4
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: Tomclanc.GestureSignV2
+PackageVersion: 18.0.2.4
+PackageLocale: zh-CN
+Publisher: Tomclanc
+PublisherUrl: https://github.com/Tomclanc
+PublisherSupportUrl: https://github.com/Tomclanc/GestureSignv2/issues
+Author: Tomclanc
+PackageName: GestureSign V2
+PackageUrl: https://github.com/Tomclanc/GestureSignv2
+License: GPL-2.0
+LicenseUrl: https://github.com/Tomclanc/GestureSignv2/blob/main/LICENSE
+Copyright: Copyright (C) 2026 Tomclanc
+ShortDescription: 面向 Windows 11 重构的 GestureSign，支持触控板、触摸屏和鼠标手势。
+Description: GestureSign V2 是经典开源项目 GestureSign 的 Windows 11 重构版本，支持触控板、触摸屏和鼠标手势、按动作选择输入设备、手势轨迹、忽略规则、托盘控制、智能关闭、智能新建标签页，以及内置的 Kando 径向菜单快捷动作。
+Tags:
+- 手势
+- 鼠标
+- 触摸屏
+- 触控板
+- Windows 11
+ReleaseNotes: |-
+  - 新增按动作选择触摸屏、触控板、鼠标和笔设备。
+  - 改进近乎同时落下的双指触摸屏点按，并在当前手势第一根手指松开的位置发送右键。
+  - 修复鼠标动作偶尔复用上一次手势坐标的问题。
+  - 保持双指绘制手势的完整轨迹识别，避免点按逻辑提前触发。
+  - 改进 H3C MegaBook 等设备的触点分帧、抬起同步和轨迹顺序处理。
+ReleaseNotesUrl: https://github.com/Tomclanc/GestureSignv2/releases/tag/v18.0.2.4
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/Tomclanc/GestureSignv2/wiki
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/t/Tomclanc/GestureSignV2/18.0.2.4/Tomclanc.GestureSignV2.yaml
+++ b/manifests/t/Tomclanc/GestureSignV2/18.0.2.4/Tomclanc.GestureSignV2.yaml
@@ -1,0 +1,8 @@
+# Created for GestureSign V2 18.0.2.4
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Tomclanc.GestureSignV2
+PackageVersion: 18.0.2.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Updates Tomclanc.GestureSignV2 to 18.0.2.4 using the x64 WiX installer published in the official GitHub release. Local `winget validate` completed successfully.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/419739)