### PR TITLE
New package: LucasHenriqueDiniz.SoundDeck version 0.1.0

### DIFF
--- a/manifests/l/LucasHenriqueDiniz/SoundDeck/0.1.0/LucasHenriqueDiniz.SoundDeck.installer.yaml
+++ b/manifests/l/LucasHenriqueDiniz/SoundDeck/0.1.0/LucasHenriqueDiniz.SoundDeck.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: LucasHenriqueDiniz.SoundDeck
+PackageVersion: 0.1.0
+MinimumOSVersion: 10.0.17763.0
+InstallModes:
+  - interactive
+  - silent
+UpgradeBehavior: install
+ReleaseDate: 2026-07-26
+Installers:
+  - Architecture: x64
+    InstallerType: nullsoft
+    Scope: user
+    InstallerUrl: https://github.com/LucasHenriqueDiniz/sounddeck/releases/download/v0.1.0/SoundDeck_0.1.0_x64-setup.exe
+    InstallerSha256: 144CA3A17001119E0D3555E2DCFDD65BEFD2A8BC45F65DF42FFDCE2C02482052
+  - Architecture: x64
+    InstallerType: wix
+    Scope: machine
+    InstallerUrl: https://github.com/LucasHenriqueDiniz/sounddeck/releases/download/v0.1.0/SoundDeck_0.1.0_x64_en-US.msi
+    InstallerSha256: 342AD8E091C67C5AEBD985F8947EC60330AE41B41731F2A87B5F0A90EABA16B6
+    ProductCode: '{A3BF3099-67E9-464B-BABA-88FEB6B98D2D}'
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/l/LucasHenriqueDiniz/SoundDeck/0.1.0/LucasHenriqueDiniz.SoundDeck.locale.en-US.yaml
+++ b/manifests/l/LucasHenriqueDiniz/SoundDeck/0.1.0/LucasHenriqueDiniz.SoundDeck.locale.en-US.yaml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: LucasHenriqueDiniz.SoundDeck
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Lucas Henrique Diniz Ostroski
+PublisherUrl: https://github.com/LucasHenriqueDiniz
+PublisherSupportUrl: https://github.com/LucasHenriqueDiniz/sounddeck/issues
+PackageName: SoundDeck
+PackageUrl: https://sounddeck.lucashdo.com
+License: MIT
+LicenseUrl: https://github.com/LucasHenriqueDiniz/sounddeck/blob/master/LICENSE
+Copyright: Copyright (c) 2026 Lucas Henrique Diniz Ostroski
+ShortDescription: A sound scheme picker for Windows 10 and 11.
+Description: |-
+  SoundDeck replaces the Windows sound scheme editor with a modern app. Browse a
+  library of sound packs, preview every event before committing, and apply a whole
+  scheme in one click. Includes recreations of the Windows XP, Vista and 7 schemes
+  plus two originals, and a per-event editor for finer control.
+
+  The current scheme is backed up before every change, so any apply is reversible.
+  SoundDeck runs without administrator privileges, never modifies system files, and
+  writes only to the current user's registry hive (HKCU) — the same place the
+  official Control Panel applet uses.
+Moniker: sounddeck
+Tags:
+  - sound
+  - audio
+  - customization
+  - windows
+  - theme
+  - sound-scheme
+  - personalization
+ReleaseNotesUrl: https://github.com/LucasHenriqueDiniz/sounddeck/releases/tag/v0.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/l/LucasHenriqueDiniz/SoundDeck/0.1.0/LucasHenriqueDiniz.SoundDeck.yaml
+++ b/manifests/l/LucasHenriqueDiniz/SoundDeck/0.1.0/LucasHenriqueDiniz.SoundDeck.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: LucasHenriqueDiniz.SoundDeck
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Pull request has been verified against the [manifest specification](https://github.com/microsoft/winget-pkgs/blob/master/doc/manifest/schema/1.6.0)

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/add?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

---

New package: **SoundDeck 0.1.0**

A sound scheme picker for Windows 10 and 11. It replaces the legacy Control
Panel sound applet with a modern UI: browse sound packs, preview each system
event, and apply a whole scheme in one click, with an automatic backup of the
previous scheme before any change.

- Homepage: https://sounddeck.lucashdo.com
- Source: https://github.com/LucasHenriqueDiniz/sounddeck
- License: MIT
- Release: https://github.com/LucasHenriqueDiniz/sounddeck/releases/tag/v0.1.0

Both installers produced by the release build are included:

| Installer | Type | Scope |
|---|---|---|
| `SoundDeck_0.1.0_x64-setup.exe` | nullsoft | user |
| `SoundDeck_0.1.0_x64_en-US.msi` | wix | machine |

The MSI `ProductCode` was read from the package itself. Both `InstallerSha256`
values were computed from the downloaded release artifacts.

The app requires no administrator privileges, modifies no system files, and
writes only to `HKCU\AppEvents\Schemes\Apps`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/419780)