### PR TITLE
New version: tsudev.SWICO version 26.8.18.2

### DIFF
--- a/manifests/t/tsudev/SWICO/26.8.18.2/tsudev.SWICO.installer.yaml
+++ b/manifests/t/tsudev/SWICO/26.8.18.2/tsudev.SWICO.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: tsudev.SWICO
+PackageVersion: 26.8.18.2
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-08-18
+# Cong cu doc ban quyen, Defender va chay DISM/SFC nen bat buoc can quyen
+# Administrator. Khai bao o day de winget xin nang quyen truoc khi chay setup.
+ElevationRequirement: elevatesSelf
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/tsudev-tsudev/swico/releases/download/v26.8.18.2/swico-setup-26.8.18.2.exe
+    InstallerSha256: C3D5B637C44341953ADA0ECE4BD16A949E91E14848FC059B753E750EE1585792
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/t/tsudev/SWICO/26.8.18.2/tsudev.SWICO.installer.yaml
+++ b/manifests/t/tsudev/SWICO/26.8.18.2/tsudev.SWICO.installer.yaml
@@ -16,6 +16,6 @@ ElevationRequirement: elevatesSelf
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/tsudev-tsudev/swico/releases/download/v26.8.18.2/swico-setup-26.8.18.2.exe
-    InstallerSha256: C3D5B637C44341953ADA0ECE4BD16A949E91E14848FC059B753E750EE1585792
+    InstallerSha256: 63833A50C758C69D1A466707C682754F647F0A09F6ABED6575FC9310B17EC1CA
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/t/tsudev/SWICO/26.8.18.2/tsudev.SWICO.locale.vi-VN.yaml
+++ b/manifests/t/tsudev/SWICO/26.8.18.2/tsudev.SWICO.locale.vi-VN.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: tsudev.SWICO
+PackageVersion: 26.8.18.2
+PackageLocale: vi-VN
+Publisher: tsudev
+PublisherUrl: https://github.com/tsudev-tsudev
+PublisherSupportUrl: https://github.com/tsudev-tsudev/swico/issues
+PackageName: tsudev SWICO
+PackageUrl: https://github.com/tsudev-tsudev/swico
+License: Apache-2.0
+LicenseUrl: https://github.com/tsudev-tsudev/swico/blob/main/LICENSE
+Copyright: Copyright (c) 2026 tsudev
+CopyrightUrl: https://github.com/tsudev-tsudev/swico/blob/main/NOTICE
+ShortDescription: Kiểm tra bản quyền Windows và thu thập cấu hình phần cứng
+Description: |-
+  tsudev SWICO kiểm tra tình trạng kích hoạt bản quyền Windows và Office, thu
+  thập cấu hình phần cứng, và rà soát các dấu hiệu kích hoạt bất thường trên máy.
+
+  Kết quả xuất ra bốn định dạng cùng lúc: HTML để đọc, JSON để tích hợp, XLSX và
+  CSV để xử lý tiếp. Quét nhiều máy thì copy các thư mục kết quả về cùng một chỗ,
+  công cụ tự gom thành một trang tổng hợp.
+
+  Toàn bộ dữ liệu chỉ ghi ra đĩa của chính máy đó. Công cụ không kết nối Internet
+  và không gửi bất kỳ thông tin nào đi.
+
+  Lưu ý: báo cáo là dữ liệu kỹ thuật để tham khảo, không phải kết luận pháp lý.
+Moniker: swico
+Tags:
+  - audit
+  - hardware
+  - inventory
+  - license
+  - windows
+ReleaseNotesUrl: https://github.com/tsudev-tsudev/swico/releases/tag/v26.8.18.2
+Documentations:
+  - DocumentLabel: Hướng dẫn sử dụng
+    DocumentUrl: https://github.com/tsudev-tsudev/swico/blob/main/README.md
+  - DocumentLabel: Tuyên bố quyền riêng tư
+    DocumentUrl: https://github.com/tsudev-tsudev/swico/blob/main/PRIVACY.md
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/t/tsudev/SWICO/26.8.18.2/tsudev.SWICO.yaml
+++ b/manifests/t/tsudev/SWICO/26.8.18.2/tsudev.SWICO.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: tsudev.SWICO
+PackageVersion: 26.8.18.2
+DefaultLocale: vi-VN
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: `tsudev.SWICO` version `26.8.18.2`

**tsudev SWICO** checks Windows/Office activation licensing state and collects
hardware inventory, producing HTML/JSON/XLSX/CSV reports.

- Repo: https://github.com/tsudev-tsudev/swico
- Release: https://github.com/tsudev-tsudev/swico/releases/tag/v26.8.18.2
- License: Apache-2.0 (open source)

---

- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

### On the unchecked boxes — being explicit rather than ticking them

This is a first submission and I want to be accurate about what has and has not
been done, rather than tick boxes by default:

- **CLA** — will be signed when the bot requests it on this PR.
- **`winget validate` / `winget install --manifest`** — not yet run. The manifest
  was generated and checked on Linux, so `winget` itself was not available. I will
  run both on Windows and report the results here before asking for merge.

**What *has* been verified:**

- Manifest conforms to schema 1.6 and parses as valid YAML.
- `InstallerSha256` (`C3D5B637C44341953ADA0ECE4BD16A949E91E14848FC059B753E750EE1585792`)
  was computed directly from the published installer and matches it exactly.
- `InstallerUrl` resolves and downloads (HTTP 200, 26,103,483 bytes — matching the
  release asset size).
- The hash is produced by the project's release pipeline from the same artifact it
  publishes, so it cannot drift from the file at `InstallerUrl`.

### Notes

- Installer type `inno`, machine scope, `ElevationRequirement: elevatesSelf` — the
  tool needs Administrator to read Windows licensing state, Defender status and to
  run DISM/SFC.
- Silent install is supported (`/VERYSILENT`), handled by the `inno` installer type.
- The installer is **not code-signed yet**. An application for a free OSS
  certificate via SignPath Foundation is in progress; a signed update will be
  submitted once granted. Flagging this up front since it affects SmartScreen
  behaviour for users installing via winget.
