### PR TITLE
New version: StudioCodeAI.LyaStudioCoder version 1.3.5

### DIFF
--- a/manifests/s/StudioCodeAI/LyaStudioCoder/1.3.5/StudioCodeAI.LyaStudioCoder.installer.yaml
+++ b/manifests/s/StudioCodeAI/LyaStudioCoder/1.3.5/StudioCodeAI.LyaStudioCoder.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: StudioCodeAI.LyaStudioCoder
+PackageVersion: 1.3.5
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+Installers:
+  - Architecture: x64
+    InstallerType: msi
+    InstallerUrl: https://github.com/StudioCodeAI/Lya-Studio-Coder/releases/download/v1.3.5/Lya.Studio.Coder_1.3.5_x64_en-US.msi
+    InstallerSha256: AF22ACFE1CC06AE8C347D676E1661AFFC61B7C9EB9843F6BA1BA37FF686922B5
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/StudioCodeAI/LyaStudioCoder/1.3.5/StudioCodeAI.LyaStudioCoder.locale.en-US.yaml
+++ b/manifests/s/StudioCodeAI/LyaStudioCoder/1.3.5/StudioCodeAI.LyaStudioCoder.locale.en-US.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: StudioCodeAI.LyaStudioCoder
+PackageVersion: 1.3.5
+PackageLocale: en-US
+Publisher: Studio Code AI
+PublisherUrl: https://github.com/StudioCodeAI
+PublisherSupportUrl: https://github.com/StudioCodeAI/Lya-Studio-Coder/issues
+PackageName: Lya Studio Coder
+PackageUrl: https://github.com/StudioCodeAI/Lya-Studio-Coder
+License: Proprietary
+LicenseUrl: https://github.com/StudioCodeAI/Lya-Studio-Coder/blob/main/LICENSE
+ShortDescription: AI-powered IDE with multi-agent orchestration (COSMOS), a 9-language interface, and an integrated terminal.
+Description: |-
+  Lya Studio Coder is a desktop IDE built with Tauri, React, and Monaco Editor.
+  It features COSMOS multi-agent orchestration with dynamic Star distribution,
+  an interface in 9 languages, an integrated terminal with CLI quick-launch,
+  local long-term memory embedded in the app (no external service or Python
+  required), two-way voice (dictation and read-aloud), a built-in browser panel,
+  n8n workflow automation, and a built-in extension store. Designed for
+  AI-assisted software development with real-time collaboration between multiple
+  AI agents.
+Moniker: lyastudiocoder
+Tags:
+  - ai
+  - ide
+  - coding
+  - developer-tools
+  - multi-agent
+  - orchestration
+  - tauri
+  - react
+  - monaco
+  - terminal
+ReleaseNotesUrl: https://github.com/StudioCodeAI/Lya-Studio-Coder/releases/tag/v1.3.5
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/StudioCodeAI/LyaStudioCoder/1.3.5/StudioCodeAI.LyaStudioCoder.yaml
+++ b/manifests/s/StudioCodeAI/LyaStudioCoder/1.3.5/StudioCodeAI.LyaStudioCoder.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: StudioCodeAI.LyaStudioCoder
+PackageVersion: 1.3.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Manifest for StudioCodeAI.LyaStudioCoder version 1.3.5

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/addition?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Installer is the official MSI published by the publisher (Studio Code AI) on the project's GitHub Releases page. SHA-256 taken from the published artifact.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/419885)