### PR TITLE
New version: StudioCodeAI.LyaStudioCoder version 1.3.3

### DIFF
--- a/manifests/s/StudioCodeAI/LyaStudioCoder/1.3.3/StudioCodeAI.LyaStudioCoder.installer.yaml
+++ b/manifests/s/StudioCodeAI/LyaStudioCoder/1.3.3/StudioCodeAI.LyaStudioCoder.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: StudioCodeAI.LyaStudioCoder
+PackageVersion: 1.3.3
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+Installers:
+  - Architecture: x64
+    InstallerType: msi
+    InstallerUrl: https://github.com/StudioCodeAI/Lya-Studio-Coder/releases/download/v1.3.3/Lya.Studio.Coder_1.3.3_x64_en-US.msi
+    InstallerSha256: 7F8AD219DA39C83CE1F96E6B43C71EB9B48C84C11FFB0F2033A4E8519D951F1A
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/StudioCodeAI/LyaStudioCoder/1.3.3/StudioCodeAI.LyaStudioCoder.locale.en-US.yaml
+++ b/manifests/s/StudioCodeAI/LyaStudioCoder/1.3.3/StudioCodeAI.LyaStudioCoder.locale.en-US.yaml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: StudioCodeAI.LyaStudioCoder
+PackageVersion: 1.3.3
+PackageLocale: en-US
+Publisher: Studio Code AI
+PublisherUrl: https://github.com/StudioCodeAI
+PublisherSupportUrl: https://github.com/StudioCodeAI/Lya-Studio-Coder/issues
+PackageName: Lya Studio Coder
+PackageUrl: https://github.com/StudioCodeAI/Lya-Studio-Coder
+License: Proprietary
+LicenseUrl: https://github.com/StudioCodeAI/Lya-Studio-Coder/blob/main/LICENSE
+ShortDescription: AI-powered IDE with multi-agent orchestration (COSMOS), trilingual interface, and integrated terminal.
+Description: |-
+  Lya Studio Coder is a desktop IDE built with Tauri, React, and Monaco Editor.
+  It features COSMOS multi-agent orchestration with dynamic Star distribution,
+  a trilingual interface (Portuguese, English, Spanish), integrated terminal with
+  CLI quick-launch, ChromaDB-backed memory, n8n workflow automation, and a
+  built-in extension store. This release adds a live context meter with on-demand
+  compaction, a consent checkpoint before expensive turns, per-model context
+  limits, and two-way voice (dictation and read-aloud).
+Moniker: lyastudiocoder
+Tags:
+  - ai
+  - ide
+  - coding
+  - developer-tools
+  - multi-agent
+  - orchestration
+  - tauri
+  - react
+  - monaco
+  - terminal
+ReleaseNotesUrl: https://github.com/StudioCodeAI/Lya-Studio-Coder/releases/tag/v1.3.3
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/StudioCodeAI/LyaStudioCoder/1.3.3/StudioCodeAI.LyaStudioCoder.yaml
+++ b/manifests/s/StudioCodeAI/LyaStudioCoder/1.3.3/StudioCodeAI.LyaStudioCoder.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: StudioCodeAI.LyaStudioCoder
+PackageVersion: 1.3.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Manifest for StudioCodeAI.LyaStudioCoder version 1.3.3

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/addition?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Installer is the official MSI published by the publisher (Studio Code AI) on the project's GitHub Releases page. SHA-256 taken from the published artifact.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/419888)