### PR TITLE
New version: oipoistar.Tinta version 2.8.0

### DIFF
--- a/manifests/o/oipoistar/Tinta/2.8.0/oipoistar.Tinta.installer.yaml
+++ b/manifests/o/oipoistar/Tinta/2.8.0/oipoistar.Tinta.installer.yaml
@@ -1,0 +1,15 @@
+# Created with Claude Code
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: oipoistar.Tinta
+PackageVersion: 2.8.0
+InstallerType: portable
+Commands:
+- tinta
+ReleaseDate: 2026-08-18
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/oipoistar/tinta/releases/download/v2.8.0/tinta.exe
+  InstallerSha256: ADFB3C12890ED93E3E1F524CE4414658F5525E2ACA5EBA0A534F6898E87954CF
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/o/oipoistar/Tinta/2.8.0/oipoistar.Tinta.locale.en-US.yaml
+++ b/manifests/o/oipoistar/Tinta/2.8.0/oipoistar.Tinta.locale.en-US.yaml
@@ -1,0 +1,40 @@
+# Created with Claude Code
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: oipoistar.Tinta
+PackageVersion: 2.8.0
+PackageLocale: en-US
+Publisher: oipoistar
+PublisherUrl: https://github.com/oipoistar
+PublisherSupportUrl: https://github.com/oipoistar/tinta/issues
+PackageName: Tinta
+PackageUrl: https://tinta.cc
+License: MIT
+LicenseUrl: https://github.com/oipoistar/tinta/blob/master/LICENSE
+Copyright: Copyright (c) oipoistar
+ShortDescription: Fast, lightweight markdown and Mermaid viewer for Windows
+Description: |-
+  Tinta is a fast, lightweight markdown viewer and reader for Windows,
+  built with Direct2D and DirectWrite for hardware-accelerated rendering.
+  A single native executable of about 1 MB that starts in about 200 ms -
+  no Electron, no web engine, no installer. Features native LaTeX math
+  and Mermaid flowchart rendering, custom themes with a built-in editor,
+  shortcut profiles, a UI in five languages, first-class CJK text layout,
+  glyph-precise text selection, a table of contents, folder browser,
+  full-text search, zoom, and an edit mode with live preview.
+Moniker: tinta
+Tags:
+- markdown
+- markdown-viewer
+- markdown-reader
+- markdown-editor
+- mermaid
+- latex
+- viewer
+- reader
+- direct2d
+- lightweight
+- portable
+ReleaseNotesUrl: https://github.com/oipoistar/tinta/releases/tag/v2.8.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/o/oipoistar/Tinta/2.8.0/oipoistar.Tinta.yaml
+++ b/manifests/o/oipoistar/Tinta/2.8.0/oipoistar.Tinta.yaml
@@ -1,0 +1,8 @@
+# Created with Claude Code
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: oipoistar.Tinta
+PackageVersion: 2.8.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New version of oipoistar.Tinta (2.8.0)

- Portable, static CRT - no dependencies
- InstallerSha256 verified against the GitHub release asset
- Release: https://github.com/oipoistar/tinta/releases/tag/v2.8.0

#### Checklist
- [x] Have you signed the Contributor License Agreement (CLA)?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`
- [x] Have you tested your manifest locally with `winget install --manifest <path>`
- [x] Does your manifest conform to the 1.6 schema?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/419959)