### PR TITLE
New package: TradeSkillMaster.Application version 4.14.2

### DIFF
--- a/manifests/t/TradeSkillMaster/Application/4.14.2/TradeSkillMaster.Application.installer.yaml
+++ b/manifests/t/TradeSkillMaster/Application/4.14.2/TradeSkillMaster.Application.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: TradeSkillMaster.Application
+PackageVersion: 4.14.2
+InstallerType: inno
+Installers:
+- Architecture: x86
+  InstallerUrl: https://app-cdn.tradeskillmaster.xyz/legacyDesktopApp/setup.exe
+  InstallerSha256: 013BE05B0C4C7EF3410D9A2F4B2A7EC920AD822AF56D3EE3565EF37091FEE150
+ProductCode: '{c44da794-b956-4d50-8733-346d56ae63c7}_is1'
+AppsAndFeaturesEntries:
+- ProductCode: '{c44da794-b956-4d50-8733-346d56ae63c7}_is1'
+  DisplayVersion: "1.0"
+ElevationRequirement: elevationRequired
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/t/TradeSkillMaster/Application/4.14.2/TradeSkillMaster.Application.installer.yaml
+++ b/manifests/t/TradeSkillMaster/Application/4.14.2/TradeSkillMaster.Application.installer.yaml
@@ -2,6 +2,7 @@
 
 PackageIdentifier: TradeSkillMaster.Application
 PackageVersion: 4.14.2
+ReleaseDate: 2026-01-14
 InstallerType: inno
 Installers:
 - Architecture: x86

--- a/manifests/t/TradeSkillMaster/Application/4.14.2/TradeSkillMaster.Application.locale.en-US.yaml
+++ b/manifests/t/TradeSkillMaster/Application/4.14.2/TradeSkillMaster.Application.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: TradeSkillMaster.Application
+PackageVersion: "4.14.2"
+PackageLocale: en-US
+Publisher: TradeSkillMaster
+PackageName: TradeSkillMaster Application
+PackageUrl: https://support.tradeskillmaster.com/tsm-desktop-application/how-do-i-set-up-the-tsm-desktop-application
+License: Proprietary (Requires account)
+ShortDescription: Improve your World of Warcraft goldmaking with accessible data and powerful tools.
+Moniker: tradeskillmaster
+Tags:
+- tradeskillmaster-application
+- tradeskillmasterapplication
+- trade-skill-master-application
+- tsm-desktop-application
+- tsmdesktopapplication
+- tsmapplication
+- world-of-warcraft
+- worldofwarcraft
+- wow
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/TradeSkillMaster/Application/4.14.2/TradeSkillMaster.Application.yaml
+++ b/manifests/t/TradeSkillMaster/Application/4.14.2/TradeSkillMaster.Application.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: TradeSkillMaster.Application
+PackageVersion: "4.14.2"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
Added TradeSkillMaster.

For some reason, its MSI installer claims its version number is 1.0. However, running the post-installation `TSMApplication.exe` has its titlebar show the version as being v4.14.2.

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/419963)