### PR TITLE
New version: Gentian28.PgpUtility version 1.1.0

### DIFF
--- a/manifests/g/Gentian28/PgpUtility/1.1.0/Gentian28.PgpUtility.installer.yaml
+++ b/manifests/g/Gentian28/PgpUtility/1.1.0/Gentian28.PgpUtility.installer.yaml
@@ -1,0 +1,33 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Gentian28.PgpUtility
+PackageVersion: 1.1.0
+
+# Velopack's Setup.exe is a custom installer, so "exe" with explicit switches. --silent is what
+# it actually accepts; winget's validation pipeline installs unattended, so getting this wrong
+# fails submission. Same installer machinery as Gentian28.ResumeBuilder.
+InstallerType: exe
+InstallerSwitches:
+  Silent: --silent
+  SilentWithProgress: --silent
+
+# Velopack installs per-user under %LocalAppData%, never machine-wide.
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+
+# The app updates itself through Velopack, so winget should reinstall over the top rather than
+# expect an uninstall/install cycle it does not control.
+UpgradeBehavior: install
+ReleaseDate: 2026-08-01
+
+# Pinned to the exact release. Deliberately NOT /releases/latest/download/ - the hash below is
+# only valid for this build, and a floating URL would break validation the moment a new version
+# ships.
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Gentian28/pgp-utility/releases/download/v1.1.0/PgpUtility-win-Setup.exe
+    InstallerSha256: CCDA40923A93041254FD59BB112CCB748B100E80056B247454AC4368747C26D8
+
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/g/Gentian28/PgpUtility/1.1.0/Gentian28.PgpUtility.locale.en-US.yaml
+++ b/manifests/g/Gentian28/PgpUtility/1.1.0/Gentian28.PgpUtility.locale.en-US.yaml
@@ -1,0 +1,43 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Gentian28.PgpUtility
+PackageVersion: 1.1.0
+PackageLocale: en-US
+Publisher: Gentian Shkembi
+PublisherUrl: https://www.gentianshkembi.com
+PublisherSupportUrl: https://github.com/Gentian28/pgp-utility/issues
+Author: Gentian Shkembi
+PackageName: PGP Utility
+PackageUrl: https://github.com/Gentian28/pgp-utility
+License: MIT
+LicenseUrl: https://github.com/Gentian28/pgp-utility/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Gentian Shkembi
+CopyrightUrl: https://github.com/Gentian28/pgp-utility/blob/main/LICENSE
+ShortDescription: Local OpenPGP tool for key management, file and text encryption, signing and verification.
+Description: |-
+  A desktop OpenPGP tool that runs entirely on your machine. Generate Ed25519 or RSA key pairs,
+  encrypt and decrypt files and text with AES-256, sign and verify with detached or clear-signed
+  signatures, and save a revocation certificate the moment a key is created.
+
+  Everything is interoperable with GnuPG in both directions: keys generated here import into
+  gpg, gpg can encrypt to them, and this app reads what gpg produces.
+
+  Nothing leaves your machine. There is no keyserver upload, no account, no telemetry and no
+  network use at all.
+Moniker: pgp-utility
+Tags:
+  - aes-256
+  - avalonia
+  - cryptography
+  - dotnet
+  - encryption
+  - gnupg
+  - gpg
+  - offline
+  - open-source
+  - openpgp
+  - pgp
+  - privacy
+  - security
+ReleaseNotesUrl: https://github.com/Gentian28/pgp-utility/releases/tag/v1.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/g/Gentian28/PgpUtility/1.1.0/Gentian28.PgpUtility.yaml
+++ b/manifests/g/Gentian28/PgpUtility/1.1.0/Gentian28.PgpUtility.yaml
@@ -1,0 +1,6 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Gentian28.PgpUtility
+PackageVersion: 1.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## 📖 Description

Version bump for `Gentian28.PgpUtility`, 1.0.0 to 1.1.0. The package identity was reviewed and merged in #410626; this adds the new version folder only and changes nothing else.

PGP Utility is a local OpenPGP desktop tool: key generation, AES-256 file and text encryption, signing and verification, interop-tested against GnuPG. Per-user install, no elevation, .NET runtime bundled.

Upstream release: https://github.com/Gentian28/pgp-utility/releases/tag/v1.1.0

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally
- [ ] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

### Verification performed

Stated explicitly, since the install was driven from the installer rather than through `winget install --manifest`: enabling local manifest files needs a one-time administrator step that was not available on the submitting machine.

- `winget validate --manifest` on the submitted folder: **succeeded**.
- Downloaded the exact asset the manifest points at, 54,754,051 bytes, and hashed it:
  `CCDA40923A93041254FD59BB112CCB748B100E80056B247454AC4368747C26D8`, matching `InstallerSha256` exactly.
- Installed that asset with the manifest's declared silent switch (`--silent`): exit code 0, per-user, no elevation.
- Confirmed the resulting install reports **1.1.0** (`1.1.0+a4dac6e`), upgrading a 1.0.0 that was present.
- Launched it: window titled "PGP Utility" appears at 975x672 and is fully on screen, then closes cleanly.

`ReleaseDate` is `2026-08-01`, the date v1.1.0 was published upstream, not the date this manifest was generated.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/419998)