### PR TITLE
New version: TraceCommons.Contributor version 0.3.0

### DIFF
--- a/manifests/t/TraceCommons/Contributor/0.3.0/TraceCommons.Contributor.installer.yaml
+++ b/manifests/t/TraceCommons/Contributor/0.3.0/TraceCommons.Contributor.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: TraceCommons.Contributor
+PackageVersion: 0.3.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: trace-commons-contributor.exe
+  PortableCommandAlias: trace-commons-contributor
+Commands:
+- trace-commons-contributor
+ReleaseDate: "2026-08-18"
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/TraceCommons/trace-commons-server/releases/download/contributor-v0.3.0/trace-commons-contributor-x86_64-pc-windows-msvc.zip
+  InstallerSha256: 7C8ABD8588C101A8CEC53142318901A554A7E6170FA952897EF01C47780A648E
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/t/TraceCommons/Contributor/0.3.0/TraceCommons.Contributor.locale.en-US.yaml
+++ b/manifests/t/TraceCommons/Contributor/0.3.0/TraceCommons.Contributor.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: TraceCommons.Contributor
+PackageVersion: 0.3.0
+PackageLocale: en-US
+Publisher: Iqlusion Inc
+PublisherUrl: https://tracecommons.ai
+PublisherSupportUrl: https://github.com/TraceCommons/trace-commons-server/issues
+PackageName: Trace Commons Contributor
+PackageUrl: https://tracecommons.ai/install/
+License: MIT OR Apache-2.0
+LicenseUrl: https://github.com/TraceCommons/trace-commons-server/blob/main/LICENSE
+ShortDescription: Share the traces your coding agents produce, on your terms, and earn credits.
+Description: |-
+  The Trace Commons contributor CLI finds the sessions your local coding agents
+  have already written, shows you exactly what would be sent before anything is,
+  and submits only what you approve. Discovery, parsing and redaction all happen
+  on your own machine; nothing leaves it until you run submit.
+Moniker: trace-commons
+Tags:
+- ai
+- agent
+- cli
+- developer-tools
+- llm
+- traces
+ReleaseNotesUrl: https://github.com/TraceCommons/trace-commons-server/releases/tag/contributor-v0.3.0
+Documentations:
+- DocumentLabel: Quickstart
+  DocumentUrl: https://docs.tracecommons.ai/cli/quickstart/
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/TraceCommons/Contributor/0.3.0/TraceCommons.Contributor.yaml
+++ b/manifests/t/TraceCommons/Contributor/0.3.0/TraceCommons.Contributor.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: TraceCommons.Contributor
+PackageVersion: 0.3.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Adds the TraceCommons.Contributor 0.3.0 portable installer manifest generated from the signed contributor-v0.3.0 release.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/420015)