### PR TITLE
New package: Roethlar.Blit version 0.1.2

### DIFF
--- a/manifests/r/Roethlar/Blit/0.1.2/Roethlar.Blit.installer.yaml
+++ b/manifests/r/Roethlar/Blit/0.1.2/Roethlar.Blit.installer.yaml
@@ -1,0 +1,16 @@
+PackageIdentifier: Roethlar.Blit
+PackageVersion: 0.1.2
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/roethlar/Blit/releases/download/v0.1.2/blit-x86_64-pc-windows-msvc.zip
+  InstallerSha256: 80745C7CF53E04F0502A48D322028261AB8E4ADA7823AE5688F601D4F4AEA577
+  NestedInstallerFiles:
+  - RelativeFilePath: blit-x86_64-pc-windows-msvc/blit.exe
+    PortableCommandAlias: blit
+  - RelativeFilePath: blit-x86_64-pc-windows-msvc/blit-daemon.exe
+    PortableCommandAlias: blit-daemon
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/r/Roethlar/Blit/0.1.2/Roethlar.Blit.locale.en-US.yaml
+++ b/manifests/r/Roethlar/Blit/0.1.2/Roethlar.Blit.locale.en-US.yaml
@@ -1,0 +1,10 @@
+PackageIdentifier: Roethlar.Blit
+PackageVersion: 0.1.2
+PackageLocale: en-US
+Publisher: Roethlar
+PackageName: Blit
+License: MIT
+ShortDescription: High-performance file transfer CLI and daemon
+PackageUrl: https://github.com/roethlar/Blit
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/r/Roethlar/Blit/0.1.2/Roethlar.Blit.yaml
+++ b/manifests/r/Roethlar/Blit/0.1.2/Roethlar.Blit.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Roethlar.Blit
+PackageVersion: 0.1.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Adds Roethlar.Blit 0.1.2 (fast file transfer tool). Manifests generated from the signed GitHub release archives.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/420041)