### PR TITLE
New version: SerZhyAle.FastMediaSorter version 26.8.19.0130

### DIFF
--- a/manifests/s/SerZhyAle/FastMediaSorter/26.8.19.0130/SerZhyAle.FastMediaSorter.installer.yaml
+++ b/manifests/s/SerZhyAle/FastMediaSorter/26.8.19.0130/SerZhyAle.FastMediaSorter.installer.yaml
@@ -1,0 +1,16 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: SerZhyAle.FastMediaSorter
+PackageVersion: 26.8.19.0130
+InstallerType: inno
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/SerZhyAle/FastMediaSorter_Lite/releases/download/v26.8.19.0130/FastMediaSorter-26.8.19.0130-windows-x64-setup.exe
+  InstallerSha256: 5D4743E906939155FEFEB6B7E2AD59C5B5E053E861F3AB19D2CE3E9D3BB21ABD
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-08-18

--- a/manifests/s/SerZhyAle/FastMediaSorter/26.8.19.0130/SerZhyAle.FastMediaSorter.locale.en-US.yaml
+++ b/manifests/s/SerZhyAle/FastMediaSorter/26.8.19.0130/SerZhyAle.FastMediaSorter.locale.en-US.yaml
@@ -1,0 +1,62 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: SerZhyAle.FastMediaSorter
+PackageVersion: 26.8.19.0130
+PackageLocale: en-US
+Publisher: SZA
+PublisherUrl: https://github.com/SerZhyAle
+PublisherSupportUrl: https://github.com/SerZhyAle/FastMediaSorter_Lite/issues
+Author: Serhii Zhyhunenko
+PackageName: FastMediaSorter LITE
+PackageUrl: https://github.com/SerZhyAle/FastMediaSorter_Lite
+License: MIT
+LicenseUrl: https://github.com/SerZhyAle/FastMediaSorter_Lite/blob/main/LICENSE
+Copyright: Copyright (c) 2025 SZA
+ShortDescription: Fast Media Sorter for Windows - keyboard-driven viewer and sorter for images and videos, now a modern 64-bit build that needs no .NET Framework.
+Description: |-
+  Fast Media Sorter for Windows (published here as "FastMediaSorter LITE") is a fast, keyboard-driven
+  viewer and sorter for images and video on Windows. Tick folders to browse, then move, copy, rename or
+  delete files with single-key hotkeys - built for photographers and creators who triage large media
+  folders quickly. It handles a wide range of formats, slideshow and random modes, EXIF auto-rotate, an
+  Ambilight-style background fill, and optional on-image OCR translation.
+
+  The main program is now a 64-bit .NET 10 build that carries its own runtime - there is nothing extra
+  to install and no .NET Framework requirement. It replaces the previous version in place and keeps
+  your settings. Video always plays through the built-in VLC engine (H.264/MP4, AVI, MKV, VP9, ZMBV and
+  more), and static and animated WEBP images open on their own, without the Windows "WebP Image
+  Extensions" codec that some editions of Windows lack.
+
+  A 32-bit build with the same feature set ships alongside it for Windows 7/8.1 and 32-bit machines.
+  The installer picks the right one for your PC automatically and points the shortcut and file
+  associations at it, so there is nothing to choose. The 64-bit main program requires Windows 10
+  version 1607 or newer, Windows 11, or Windows Server 2016 or newer.
+
+  The interface is available in 13 languages - English, Russian, Ukrainian, German, Italian,
+  Spanish, French, Portuguese, Arabic, Hindi, Bengali, Urdu and Chinese - and picks the one your
+  Windows display language uses on first run; a button on the toolbar switches it at any time.
+  The bundled Share Manager speaks the same 13 languages and follows the same choice. Only
+  English, Russian and Ukrainian are proofread by the author; the rest are machine translations,
+  and corrections are welcome through the issue tracker. The setup wizard itself stays English.
+Moniker: fastmediasorter
+Tags:
+- file-manager
+- hotkeys
+- images
+- media
+- organizer
+- photos
+- pictures
+- slideshow
+- sorter
+- triage
+- utility
+- videos
+- viewer
+- winforms
+ReleaseNotesUrl: https://github.com/SerZhyAle/FastMediaSorter_Lite/releases/tag/v26.8.19.0130
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/SerZhyAle/FastMediaSorter_Lite/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/SerZhyAle/FastMediaSorter/26.8.19.0130/SerZhyAle.FastMediaSorter.yaml
+++ b/manifests/s/SerZhyAle/FastMediaSorter/26.8.19.0130/SerZhyAle.FastMediaSorter.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: SerZhyAle.FastMediaSorter
+PackageVersion: 26.8.19.0130
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Version update for **SerZhyAle.FastMediaSorter** (Fast Media Sorter for Windows, published as `FastMediaSorter LITE`): `26.8.15.1510` -> `26.8.19.0130`.

Only `PackageVersion`, `InstallerUrl`, `InstallerSha256` and `ReleaseDate` changed. The installer shape is unchanged from the manifest that passed validation previously: the Inno `setup.exe` is referenced directly (`InstallerType: inno`), with **no** `Dependencies`, **no** `Scope` and **no** `NestedInstallerType`.

**What's new in this version** (full text: [CHANGELOG](https://github.com/SerZhyAle/FastMediaSorter_Lite/blob/main/CHANGELOG.md)):

- A new "Resume the last file" setting, off unless you switch it on: a plain start reopens the exact file that was on screen last time, with its folder listed behind it, and a video carries on from the position it was left at. The existing "Open at startup" -> "last file" only ever restored the file's *number* inside the folder, so anything deleted or re-sorted earlier in the list reopened a neighbour.
- Fixed: the recipients panel over the picture - the floating list of destination folders you click instead of pressing a digit - has not appeared since 26.8.13. It was made see-through in that release as a child panel, which Windows refuses to create at all, so it was silently never built. It is now a small window of its own: see-through as intended, and it floats over a playing video as well as over a picture.
- The optional Folder Share Server edition now puts its Start-menu shortcut in the same "Fast Media Sorter for Windows" group as the viewer and the Share Manager, instead of a second folder of its own; the former group is removed on upgrade. It remains a separate product with its own package identity.
- The project site gained a "HOW TO" section and five new guides - the key map, first-time setup, recognizing and translating text on a picture, the image editor, and reading a ZIP or CBZ as a folder.

Links:
- Release: https://github.com/SerZhyAle/FastMediaSorter_Lite/releases/tag/v26.8.19.0130
- Changelog: https://github.com/SerZhyAle/FastMediaSorter_Lite/blob/main/CHANGELOG.md

---

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/add?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/420251)