### PR TITLE
New version: rulssss.CloudCostTree version 0.1.56

### DIFF
--- a/manifests/r/rulssss/CloudCostTree/0.1.56/rulssss.CloudCostTree.installer.yaml
+++ b/manifests/r/rulssss/CloudCostTree/0.1.56/rulssss.CloudCostTree.installer.yaml
@@ -1,0 +1,14 @@
+PackageIdentifier: rulssss.CloudCostTree
+PackageVersion: 0.1.56
+InstallerType: portable
+Commands:
+  - cloudcosttree
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/rulssss/cloudcosttree/releases/download/v0.1.56/cloudcosttree-windows-amd64.exe
+    InstallerSha256: D524C6F6AF6B42EFA6D7EB1E2791F9BA8171102685861B5A43130122AB6E43D9
+  - Architecture: arm64
+    InstallerUrl: https://github.com/rulssss/cloudcosttree/releases/download/v0.1.56/cloudcosttree-windows-arm64.exe
+    InstallerSha256: 7BA5A3900F1F3EE056F47BDA1D046BBB4FEDE41CB029B845E103285DDA3E81F4
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/r/rulssss/CloudCostTree/0.1.56/rulssss.CloudCostTree.locale.en-US.yaml
+++ b/manifests/r/rulssss/CloudCostTree/0.1.56/rulssss.CloudCostTree.locale.en-US.yaml
@@ -1,0 +1,10 @@
+PackageIdentifier: rulssss.CloudCostTree
+PackageVersion: 0.1.56
+PackageLocale: en-US
+Publisher: rulssss
+PackageName: CloudCostTree
+License: Proprietary
+ShortDescription: Estimate AWS infrastructure costs in a hierarchical tree before you apply
+PackageUrl: https://cloudcosttree.com
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/r/rulssss/CloudCostTree/0.1.56/rulssss.CloudCostTree.yaml
+++ b/manifests/r/rulssss/CloudCostTree/0.1.56/rulssss.CloudCostTree.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: rulssss.CloudCostTree
+PackageVersion: 0.1.56
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Update to 0.1.56. Installer URLs verified reachable; InstallerSha256 computed locally against the published release assets.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/420272)