### PR TITLE
New package: tikipiya.MOP version 0.1.2

### DIFF
--- a/manifests/t/tikipiya/MOP/0.1.2/tikipiya.MOP.installer.yaml
+++ b/manifests/t/tikipiya/MOP/0.1.2/tikipiya.MOP.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: tikipiya.MOP
+PackageVersion: 0.1.2
+InstallerType: portable
+Commands:
+- mop
+ReleaseDate: 2026-08-19
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/tikipiya/mop/releases/download/v0.1.2/mc-server-checker_v0.1.2_windows_amd64.exe
+  InstallerSha256: 4A7128E174DE65A975A03A4696E8345F76F090A5CD751CD6913C252F3ECF1509
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/t/tikipiya/MOP/0.1.2/tikipiya.MOP.locale.en-US.yaml
+++ b/manifests/t/tikipiya/MOP/0.1.2/tikipiya.MOP.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: tikipiya.MOP
+PackageVersion: 0.1.2
+PackageLocale: en-US
+Publisher: tikipiya
+PublisherUrl: https://github.com/tikipiya
+PublisherSupportUrl: https://github.com/tikipiya/mop/issues
+Author: tikipiya (tikisan)
+PackageName: MOP
+PackageUrl: https://github.com/tikipiya/mop
+License: MIT
+LicenseUrl: https://github.com/tikipiya/mop/blob/v0.1.2/LICENSE
+Copyright: Copyright (c) 2026 tikipiya (tikisan)
+ShortDescription: A Windows GUI for checking Minecraft Java Edition server status.
+Description: >-
+  MOP (Minecraft Observation Program) displays server availability, ping, version,
+  player count, MOTD, and detected MOD information.
+Moniker: mop
+Tags:
+- minecraft
+- minecraft-java
+- motd
+- ping
+- server-status
+ReleaseNotes: Displays the actual endpoint selected by Minecraft DNS SRV resolution and adds the MIT License.
+ReleaseNotesUrl: https://github.com/tikipiya/mop/releases/tag/v0.1.2
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/tikipiya/MOP/0.1.2/tikipiya.MOP.locale.ja-JP.yaml
+++ b/manifests/t/tikipiya/MOP/0.1.2/tikipiya.MOP.locale.ja-JP.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: tikipiya.MOP
+PackageVersion: 0.1.2
+PackageLocale: ja-JP
+Publisher: tikipiya
+PublisherUrl: https://github.com/tikipiya
+PublisherSupportUrl: https://github.com/tikipiya/mop/issues
+Author: tikipiya (tikisan)
+PackageName: MOP
+PackageUrl: https://github.com/tikipiya/mop
+License: MIT
+LicenseUrl: https://github.com/tikipiya/mop/blob/v0.1.2/LICENSE
+Copyright: Copyright (c) 2026 tikipiya (tikisan)
+ShortDescription: Minecraft Java Editionサーバーの状態を確認するWindows GUIです。
+Description: >-
+  MOP（Minecraft Observation Program）は、サーバーの稼働状況、Ping、バージョン、
+  プレイヤー数、MOTD、検出したMOD情報を表示します。
+Tags:
+- minecraft
+- minecraft-java
+- motd
+- ping
+- server-status
+ReleaseNotes: Minecraft DNS SRVで選択された実接続先の表示と、MIT Licenseを追加しました。
+ReleaseNotesUrl: https://github.com/tikipiya/mop/releases/tag/v0.1.2
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/t/tikipiya/MOP/0.1.2/tikipiya.MOP.yaml
+++ b/manifests/t/tikipiya/MOP/0.1.2/tikipiya.MOP.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: tikipiya.MOP
+PackageVersion: 0.1.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## What changed

- Adds the new `tikipiya.MOP` package at version 0.1.2.
- Uses the portable x64 executable published in the MOP GitHub Release.
- Includes English and Japanese package metadata.

## Why

This makes MOP (Minecraft Observation Program) installable through the Windows Package Manager community source.

## Validation

- `winget validate --manifest manifests/t/tikipiya/MOP/0.1.2` passes without warnings.
- The installer SHA-256 matches the published v0.1.2 release asset.
- The manifest contains exactly one package version.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/420276)