### PR TITLE
Update version: Datadog.dd-trace-dotnet version 3.51.1

### DIFF
--- a/manifests/d/Datadog/dd-trace-dotnet/3.51.1/Datadog.dd-trace-dotnet.installer.yaml
+++ b/manifests/d/Datadog/dd-trace-dotnet/3.51.1/Datadog.dd-trace-dotnet.installer.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: Datadog.dd-trace-dotnet
+PackageVersion: 3.51.1
+InstallerLocale: en-US
+InstallerType: wix
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Custom: ALLUSERS="1" DD_DOTNET_LINK="https://docs.datadoghq.com/tracing/troubleshooting/dotnet_diagnostic_tool/" PATHSHORTCUT="1"
+UpgradeBehavior: install
+ProductCode: "{6BF5CF47-B28D-4BEF-BE04-73C0B1D51885}"
+ReleaseDate: 2026-08-12
+AppsAndFeaturesEntries:
+- DisplayName: Datadog .NET Tracer 64-bit
+  ProductCode: "{6BF5CF47-B28D-4BEF-BE04-73C0B1D51885}"
+  UpgradeCode: "{FC228E86-EAE2-4C2A-AE82-135B718C269E}"
+InstallationMetadata:
+  DefaultInstallLocation: "%ProgramFiles%/Datadog/.NET Tracer"
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/DataDog/dd-trace-dotnet/releases/download/v3.51.1/datadog-dotnet-apm-3.51.1-x64.msi
+  InstallerSha256: 432DF1DDBFCEF0B4B8D9CFD6173770B63A8925BE4968D401A9FD2B4FA25E1C08
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/d/Datadog/dd-trace-dotnet/3.51.1/Datadog.dd-trace-dotnet.installer.yaml
+++ b/manifests/d/Datadog/dd-trace-dotnet/3.51.1/Datadog.dd-trace-dotnet.installer.yaml
@@ -11,7 +11,7 @@ InstallModes:
 - silent
 - silentWithProgress
 InstallerSwitches:
-  Custom: ALLUSERS="1" DD_DOTNET_LINK="https://docs.datadoghq.com/tracing/troubleshooting/dotnet_diagnostic_tool/" PATHSHORTCUT="1"
+  Custom: ALLUSERS="1" PATHSHORTCUT="1"
 UpgradeBehavior: install
 ProductCode: "{6BF5CF47-B28D-4BEF-BE04-73C0B1D51885}"
 ReleaseDate: 2026-08-12

--- a/manifests/d/Datadog/dd-trace-dotnet/3.51.1/Datadog.dd-trace-dotnet.locale.en-US.yaml
+++ b/manifests/d/Datadog/dd-trace-dotnet/3.51.1/Datadog.dd-trace-dotnet.locale.en-US.yaml
@@ -21,74 +21,14 @@ Tags:
 - apm
 - tracing
 ReleaseNotes: |-
-  Summary
-  • [Tracing] Add experimental http/protobuf support for OTLP traces export (#8645)
-  • [AppSec] APPSEC-65483 Collect Datadog security-testing headers on entry spans (#8682)
-  • [Code Origin] DEBUG-4174 - Make Code Origin on by default (#8272)
-  Changes
-  Tracer
-  • [Tracing] Add experimental http/protobuf support for OTLP traces export (#8645)
-  • Handle invalid timestamps in Kafka consume integration (#8653)
-  • [Tracer] Tolerate clock skew when reparenting Activities to active Span (#8674)
-  • [Opentelemetry] Prevent OTLP array attribute stack overflow on cyclic/deep arrays (#8707)
-  CI Visibility
-  • [CI Visibility] propagate tests skipping enabled tag (#8582)
-  • Fix race condition in IpcTests (#8657)
-  • [CI Visibility] Fix coverage resolver assembly file locks (#8666)
-  ASM
-  • Fix ASM accessing HttpRequest.Headers on .NET Framework without guarding (#8611)
-  • Fix WAF Encoder child miscount bug (#8617)
-  • Refactor remote config for ASM to fix missing config (#8630)
-  • Fix off-by-one error in ASM Encoder (#8637)
-  • [AppSec] APPSEC-65483 Collect Datadog security-testing headers on entry spans (#8682)
-  Continuous Profiler
-  • [Profiler] Fix flacky tests possibly due to network errors (#8574)
-  • Load native loader in profiler via absolute path on Windows (#8646)
-  • [Profiler] Add Flaky attribute (#8648)
-  • [Profiler] Stop unwinding when unsafe (#8671)
-  • [Profiler] Add more context to timer_create call failure (#8686)
-  Debugger
-  • [SymDB] Increase SymDB upload batch default to 1MB (#8193)
-  • [Code Origin] DEBUG-4174 - Make Code Origin on by default (#8272)
-  • [Debugger] Add global rate limiter (#8480)
-  • [Dynamic Instrumentation] DEBUG-5101 line probe two segment fallback (#8543)
-  • [Debugger] Report retryable line probe resolution errors (#8603)
-  • fix(debugger)：apply redaction to dictionary iterator key/value (#8641)
-  • [Debugger] Preserve EMITTING diagnostics across probe change (#8654)
-  • [SymDB] Stream SymDB payload (#8691)
-  Serverless
-  • [Serverless] Bump Datadog.Serverless.Compat to 1.6.0 (#8660)
-  • Prevent invalid JSON in AWS Lambda payloads (#8662)
-  • [Serverless] Bump Datadog.Serverless.Compat to 1.7.0 (#8692)
-  Build / Test
-  • Refactor DiscoveryService polling loop to allow less-flaky testing (#8601)
-  • Introduce Datadog.Trace.Build.g.sln to reduce size of artifacts copied between stages (#8610)
-  • Tag gitlab include refs as migration touchpoints (#8624)
-  • Fix kafka flakiness (#8629)
-  • Use ArtifactsOutput in more places in the tracer build (#8636)
-  • Serialize RuntimeIdTests and HttpHeaderHelperTests to remove telemetry header flake (#8638)
-  • [Test Package Versions Bump] Updating package versions (#8649)
-  • [Smoke Test Docker Image Bump] Updating docker image tags (#8650)
-  • Add some more owners to the nullability file (#8656)
-  • [Code Origin] Fix smoke test path mismatches on macOS and Windows IIS (#8659)
-  • [Test Package Versions Bump] Updating package versions (#8661)
-  • Allocate 2 CPUs per microbenchmark item (#8663)
-  • Exclude OpenTelemetry.Api from baseline files in PR comment (#8664)
-  • [Test Package Versions Bump] Updating package versions (#8683)
-  • [Build] Retry git clone in exploration tests setup (#8685)
-  • Increase integration_tests_linux Test job timeout to 90 minutes (#8699)
-  • [Test Package Versions Bump] Updating package versions (#8700)
-  • use https to download authanywhere binary (#8704)
-  Miscellaneous
-  • Ensure we wrap the process path in quotes before running it (#8613)
-  • chore(ci) update one-pipeline (#8687)
-  • Tweak BatchingSink to remove flake (#8696)
-  • [DBM] Add dynamic_service propagation mode (#8701)
-  Data Streams Monitoring
-  • [DSM] Guard against future timestamps when extracting pathway context (#8672)
-ReleaseNotesUrl: https://github.com/DataDog/dd-trace-dotnet/releases/tag/v3.45.0
-Documentations:
-- DocumentLabel: Wiki
-  DocumentUrl: https://github.com/DataDog/dd-trace-dotnet/wiki
+  ## Summary
+
+  This is a technical release and is otherwise identical to the 3.51.0 release
+
+  ## Changes
+
+  [Changes since 3.50.0](https://github.com/DataDog/dd-trace-dotnet/compare/v3.50.0...v3.51.1)
+
+ReleaseNotesUrl: https://github.com/DataDog/dd-trace-dotnet/releases/tag/v3.51.1
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0

--- a/manifests/d/Datadog/dd-trace-dotnet/3.51.1/Datadog.dd-trace-dotnet.locale.en-US.yaml
+++ b/manifests/d/Datadog/dd-trace-dotnet/3.51.1/Datadog.dd-trace-dotnet.locale.en-US.yaml
@@ -1,0 +1,94 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: Datadog.dd-trace-dotnet
+PackageVersion: 3.51.1
+PackageLocale: en-US
+Publisher: Datadog, Inc.
+PublisherUrl: https://docs.datadoghq.com/
+PublisherSupportUrl: https://www.datadoghq.com/support
+PrivacyUrl: https://www.datadoghq.com/legal/privacy
+Author: Datadog
+PackageName: Datadog .NET Tracer
+PackageUrl: https://docs.datadoghq.com/tracing
+License: Apache-2.0
+LicenseUrl: https://github.com/DataDog/dd-trace-dotnet/blob/HEAD/LICENSE
+Copyright: Copyright 2017 Datadog, Inc.
+CopyrightUrl: https://github.com/DataDog/dd-trace-dotnet/blob/master/NOTICE
+ShortDescription: Automatic instrumentation for .NET applications
+Moniker: dd-trace-dotnet
+Tags:
+- apm
+- tracing
+ReleaseNotes: |-
+  Summary
+  • [Tracing] Add experimental http/protobuf support for OTLP traces export (#8645)
+  • [AppSec] APPSEC-65483 Collect Datadog security-testing headers on entry spans (#8682)
+  • [Code Origin] DEBUG-4174 - Make Code Origin on by default (#8272)
+  Changes
+  Tracer
+  • [Tracing] Add experimental http/protobuf support for OTLP traces export (#8645)
+  • Handle invalid timestamps in Kafka consume integration (#8653)
+  • [Tracer] Tolerate clock skew when reparenting Activities to active Span (#8674)
+  • [Opentelemetry] Prevent OTLP array attribute stack overflow on cyclic/deep arrays (#8707)
+  CI Visibility
+  • [CI Visibility] propagate tests skipping enabled tag (#8582)
+  • Fix race condition in IpcTests (#8657)
+  • [CI Visibility] Fix coverage resolver assembly file locks (#8666)
+  ASM
+  • Fix ASM accessing HttpRequest.Headers on .NET Framework without guarding (#8611)
+  • Fix WAF Encoder child miscount bug (#8617)
+  • Refactor remote config for ASM to fix missing config (#8630)
+  • Fix off-by-one error in ASM Encoder (#8637)
+  • [AppSec] APPSEC-65483 Collect Datadog security-testing headers on entry spans (#8682)
+  Continuous Profiler
+  • [Profiler] Fix flacky tests possibly due to network errors (#8574)
+  • Load native loader in profiler via absolute path on Windows (#8646)
+  • [Profiler] Add Flaky attribute (#8648)
+  • [Profiler] Stop unwinding when unsafe (#8671)
+  • [Profiler] Add more context to timer_create call failure (#8686)
+  Debugger
+  • [SymDB] Increase SymDB upload batch default to 1MB (#8193)
+  • [Code Origin] DEBUG-4174 - Make Code Origin on by default (#8272)
+  • [Debugger] Add global rate limiter (#8480)
+  • [Dynamic Instrumentation] DEBUG-5101 line probe two segment fallback (#8543)
+  • [Debugger] Report retryable line probe resolution errors (#8603)
+  • fix(debugger)：apply redaction to dictionary iterator key/value (#8641)
+  • [Debugger] Preserve EMITTING diagnostics across probe change (#8654)
+  • [SymDB] Stream SymDB payload (#8691)
+  Serverless
+  • [Serverless] Bump Datadog.Serverless.Compat to 1.6.0 (#8660)
+  • Prevent invalid JSON in AWS Lambda payloads (#8662)
+  • [Serverless] Bump Datadog.Serverless.Compat to 1.7.0 (#8692)
+  Build / Test
+  • Refactor DiscoveryService polling loop to allow less-flaky testing (#8601)
+  • Introduce Datadog.Trace.Build.g.sln to reduce size of artifacts copied between stages (#8610)
+  • Tag gitlab include refs as migration touchpoints (#8624)
+  • Fix kafka flakiness (#8629)
+  • Use ArtifactsOutput in more places in the tracer build (#8636)
+  • Serialize RuntimeIdTests and HttpHeaderHelperTests to remove telemetry header flake (#8638)
+  • [Test Package Versions Bump] Updating package versions (#8649)
+  • [Smoke Test Docker Image Bump] Updating docker image tags (#8650)
+  • Add some more owners to the nullability file (#8656)
+  • [Code Origin] Fix smoke test path mismatches on macOS and Windows IIS (#8659)
+  • [Test Package Versions Bump] Updating package versions (#8661)
+  • Allocate 2 CPUs per microbenchmark item (#8663)
+  • Exclude OpenTelemetry.Api from baseline files in PR comment (#8664)
+  • [Test Package Versions Bump] Updating package versions (#8683)
+  • [Build] Retry git clone in exploration tests setup (#8685)
+  • Increase integration_tests_linux Test job timeout to 90 minutes (#8699)
+  • [Test Package Versions Bump] Updating package versions (#8700)
+  • use https to download authanywhere binary (#8704)
+  Miscellaneous
+  • Ensure we wrap the process path in quotes before running it (#8613)
+  • chore(ci) update one-pipeline (#8687)
+  • Tweak BatchingSink to remove flake (#8696)
+  • [DBM] Add dynamic_service propagation mode (#8701)
+  Data Streams Monitoring
+  • [DSM] Guard against future timestamps when extracting pathway context (#8672)
+ReleaseNotesUrl: https://github.com/DataDog/dd-trace-dotnet/releases/tag/v3.45.0
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/DataDog/dd-trace-dotnet/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/d/Datadog/dd-trace-dotnet/3.51.1/Datadog.dd-trace-dotnet.yaml
+++ b/manifests/d/Datadog/dd-trace-dotnet/3.51.1/Datadog.dd-trace-dotnet.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: Datadog.dd-trace-dotnet
+PackageVersion: 3.51.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update Datadog.dd-trace-dotnet to version 3.51.1.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/420312)