### PR TITLE
New version: LengxiQwQ.LivePhotoBox version 2.2.0

### DIFF
--- a/manifests/l/LengxiQwQ/LivePhotoBox/2.2.0/LengxiQwQ.LivePhotoBox.installer.yaml
+++ b/manifests/l/LengxiQwQ/LivePhotoBox/2.2.0/LengxiQwQ.LivePhotoBox.installer.yaml
@@ -15,6 +15,6 @@ NestedInstallerFiles:
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/LengxiQwQ/live-photo-box/releases/download/v2.2.0/Live-Photo-Box-v2.2.0-x64-cli.zip
-    InstallerSha256: CAE4396645BFFF575F57CB928B43A3AB8414C546DA4D5CDD8F0F60964F6995F3A
+    InstallerSha256: CAE4396645BFF575F57CB928B43A3AB8414C546DA4D5CDDAF0C60964F6995F3A
 ManifestType: installer
 ManifestVersion: 1.9.0

--- a/manifests/l/LengxiQwQ/LivePhotoBox/2.2.0/LengxiQwQ.LivePhotoBox.installer.yaml
+++ b/manifests/l/LengxiQwQ/LivePhotoBox/2.2.0/LengxiQwQ.LivePhotoBox.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: LengxiQwQ.LivePhotoBox
+PackageVersion: 2.2.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: livephotobox.exe
+    PortableCommandAlias: livephotobox
+  - RelativeFilePath: livebox.exe
+    PortableCommandAlias: livebox
+  - RelativeFilePath: lpb.exe
+    PortableCommandAlias: lpb
+  - RelativeFilePath: livephoto.exe
+    PortableCommandAlias: livephoto
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/LengxiQwQ/live-photo-box/releases/download/v2.2.0/Live-Photo-Box-v2.2.0-x64-cli.zip
+    InstallerSha256: CAE4396645BFFF575F57CB928B43A3AB8414C546DA4D5CDD8F0F60964F6995F3A
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/l/LengxiQwQ/LivePhotoBox/2.2.0/LengxiQwQ.LivePhotoBox.locale.en-US.yaml
+++ b/manifests/l/LengxiQwQ/LivePhotoBox/2.2.0/LengxiQwQ.LivePhotoBox.locale.en-US.yaml
@@ -12,10 +12,10 @@ License: GPL-3.0
 LicenseUrl: https://github.com/LengxiQwQ/live-photo-box/blob/master/LICENSE
 Copyright: Copyright (C) 2026 LengxiQwQ. Licensed under GPL v3.0.
 ShortDescription: Merge images & videos into live photos for smartphone galleries
-Description > 
+Description: >
   livephotobox is a command-line utility for merging image and video files
   into live photos compatible with HUAWEI, Samsung, Google, Apple, Xiaomi,
-  and vavo gallery applications. A live photo is a single file containing
+  and vivo gallery applications. A live photo is a single file containing
   both a still image and a short video — when viewed in a supported gallery,
   the video plays automatically.
 Moniker: livephotobox
@@ -38,6 +38,6 @@ Commands:
   - livephoto
 ReleaseNotesUrl: https://github.com/LengxiQwQ/live-photo-box/releases/tag/v2.2.0
 ReleaseNotes: >
-   See changelog at https://github.com/LengxiQwQ/live-photo-box/blob/master/changelogs/release-v2.2.0.md
+  See changelog at https://github.com/LengxiQwQ/live-photo-box/blob/master/changelogs/release-v2.2.0.md
 ManifestType: defaultLocale
 ManifestVersion: 1.9.0

--- a/manifests/l/LengxiQwQ/LivePhotoBox/2.2.0/LengxiQwQ.LivePhotoBox.locale.en-US.yaml
+++ b/manifests/l/LengxiQwQ/LivePhotoBox/2.2.0/LengxiQwQ.LivePhotoBox.locale.en-US.yaml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: LengxiQwQ.LivePhotoBox
+PackageVersion: 2.2.0
+PackageLocale: en-US
+Publisher: LengxiQwQ
+PublisherUrl: https://github.com/LengxiQwQ/live-photo-box
+PublisherSupportUrl: https://github.com/LengxiQwQ/live-photo-box/issues
+Author: LengxiQwQ
+PackageName: Live Photo Box CLI
+PackageUrl: https://github.com/LengxiQwQ/live-photo-box
+License: GPL-3.0
+LicenseUrl: https://github.com/LengxiQwQ/live-photo-box/blob/master/LICENSE
+Copyright: Copyright (C) 2026 LengxiQwQ. Licensed under GPL v3.0.
+ShortDescription: Merge images & videos into live photos for smartphone galleries
+Description > 
+  livephotobox is a command-line utility for merging image and video files
+  into live photos compatible with HUAWEI, Samsung, Google, Apple, Xiaomi,
+  and vavo gallery applications. A live photo is a single file containing
+  both a still image and a short video — when viewed in a supported gallery,
+  the video plays automatically.
+Moniker: livephotobox
+Tags:
+  - live-photo
+  - motion-photo
+  - media
+  - photo
+  - video
+  - merge
+  - cli
+  - huawei
+  - samsung
+  - google
+  - apple
+Commands:
+  - livephotobox
+  - livebox
+  - lpb
+  - livephoto
+ReleaseNotesUrl: https://github.com/LengxiQwQ/live-photo-box/releases/tag/v2.2.0
+ReleaseNotes: >
+   See changelog at https://github.com/LengxiQwQ/live-photo-box/blob/master/changelogs/release-v2.2.0.md
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/l/LengxiQwQ/LivePhotoBox/2.2.0/LengxiQwQ.LivePhotoBox.yaml
+++ b/manifests/l/LengxiQwQ/LivePhotoBox/2.2.0/LengxiQwQ.LivePhotoBox.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: LengxiQwQ.LivePhotoBox
+PackageVersion: 2.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Update from 2.1.5 to 2.2.0: supports HDR conversion, Apple Live Photo split output, split/repair CLI commands, `--json` structured output, and improved error messages.

- Installer SHA256: `CAE4396645BFF575F57CB928B43A3AB8414C546DA4D5CDDAF0C60964F6995F3A`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/420380)