### PR TITLE
Update version: murgatt.recode-converter version 2.1.1

### DIFF
--- a/manifests/m/murgatt/recode-converter/2.1.1/murgatt.recode-converter.installer.yaml
+++ b/manifests/m/murgatt/recode-converter/2.1.1/murgatt.recode-converter.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: murgatt.recode-converter
+PackageVersion: 2.1.1
+InstallerLocale: en-US
+InstallerType: nullsoft
+Scope: machine
+ProductCode: "{0E7C2196-9A3E-561D-A7F0-A767E56DF036}"
+ReleaseDate: 2026-03-09
+AppsAndFeaturesEntries:
+- DisplayName: Recode Converter 2.1.1
+  ProductCode: "{0E7C2196-9A3E-561D-A7F0-A767E56DF036}"
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/murgatt/recode-converter/releases/download/v2.1.1/Recode-Converter-Windows-2.1.1-Setup.exe
+  InstallerSha256: E574FB522DABABAE887966A50B05C57A028CF474B4C0621AB144B17AEF9D5982
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/murgatt/recode-converter/2.1.1/murgatt.recode-converter.locale.en-US.yaml
+++ b/manifests/m/murgatt/recode-converter/2.1.1/murgatt.recode-converter.locale.en-US.yaml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: murgatt.recode-converter
+PackageVersion: 2.1.1
+PackageLocale: en-US
+Publisher: murgatt
+PublisherUrl: https://github.com/murgatt
+PublisherSupportUrl: https://github.com/murgatt/recode-converter/issues
+PackageName: Recode Converter
+PackageUrl: https://github.com/murgatt/recode-converter
+License: GPL-3.0
+LicenseUrl: https://github.com/murgatt/recode-converter/blob/HEAD/LICENSE
+ShortDescription: A modern & simple audio converter for video files
+Tags:
+- audio-conversion
+- converter
+- electron
+- ffmpeg
+- react
+- subtitle-conversion
+- typescript
+- video-processing
+ReleaseNotes: |-
+  2.0.11 (2025-03-18)
+  Bug Fixes
+  • file drag & drop on Windows (#409) (d1cfc2a)
+  • deps-dev：bump electron from 34.1.1 to 34.2.0 (#382) (b569893)
+  • deps-dev：bump electron from 34.2.0 to 35.0.1 (#403) (12b83de)
+  • deps：bump @hookform/resolvers from 4.0.0 to 4.1.0 (#383) (36085ba)
+  • deps：bump lucide-react from 0.475.0 to 0.482.0 (#410) (986fe16)
+  • deps：bump react-router-dom from 7.1.1 to 7.2.0 (#391) (189c72b)
+  • deps：bump react-router-dom from 7.2.0 to 7.3.0 (#407) (8a74690)
+ReleaseNotesUrl: https://github.com/murgatt/recode-converter/releases/tag/v2.0.11
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/murgatt/recode-converter/2.1.1/murgatt.recode-converter.yaml
+++ b/manifests/m/murgatt/recode-converter/2.1.1/murgatt.recode-converter.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: murgatt.recode-converter
+PackageVersion: 2.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update murgatt.recode-converter to version 2.1.1.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/420391)