### PR TITLE
Update version: BlackwellSystems.agent-lsp version 0.18.0

### DIFF
--- a/manifests/b/BlackwellSystems/agent-lsp/0.18.0/BlackwellSystems.agent-lsp.installer.yaml
+++ b/manifests/b/BlackwellSystems/agent-lsp/0.18.0/BlackwellSystems.agent-lsp.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: BlackwellSystems.agent-lsp
+PackageVersion: 0.18.0
+Platform:
+- Windows.Desktop
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: agent-lsp.exe
+  PortableCommandAlias: agent-lsp
+ReleaseDate: 2026-08-18
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/blackwell-systems/agent-lsp/releases/download/v0.18.0/agent-lsp_windows_amd64.zip
+  InstallerSha256: 8C53A524BCE3E5B920555ED21CF0080F0615BDD8EACF657C1C69FE983C444952
+- Architecture: arm64
+  InstallerUrl: https://github.com/blackwell-systems/agent-lsp/releases/download/v0.18.0/agent-lsp_windows_arm64.zip
+  InstallerSha256: F073277D9E9654FE8B2B3EB99BDF61A428C6A602BE4B8B6D884AE1820B616E4A
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/b/BlackwellSystems/agent-lsp/0.18.0/BlackwellSystems.agent-lsp.locale.en-US.yaml
+++ b/manifests/b/BlackwellSystems/agent-lsp/0.18.0/BlackwellSystems.agent-lsp.locale.en-US.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: BlackwellSystems.agent-lsp
+PackageVersion: 0.18.0
+PackageLocale: en-US
+Publisher: Blackwell Systems
+PublisherUrl: https://github.com/blackwell-systems
+PublisherSupportUrl: https://github.com/blackwell-systems/agent-lsp/issues
+PackageName: agent-lsp
+PackageUrl: https://github.com/blackwell-systems/agent-lsp
+License: MIT
+LicenseUrl: https://github.com/blackwell-systems/agent-lsp/blob/main/LICENSE
+ShortDescription: MCP server giving AI agents reliable access to language server protocol
+Description: agent-lsp is a stateful MCP server over real language servers. It keeps the language server's semantic index warm and adds a skill layer that turns multi-step code operations into single, correct workflows. 50 tools, 30 languages, persistent sessions.
+Tags:
+- ai
+- code-intelligence
+- developer-tools
+- language-server
+- lsp
+- mcp
+ReleaseNotes: |-
+  Fixes a file-corruption bug in rename_symbol (#12, reported by @V0idk), makes speculative confidence honest about still-indexing servers, and upgrades gcf-go to v1.5.0.
+  Fixed
+  • rename_symbol file corruption (#12)：rename_symbol (non-dry-run) used to return the raw WorkspaceEdit and rely on the caller copying it back into apply_edit — the only edit tool that did so; replace_symbol_body, insert_after_symbol, insert_before_symbol, and safe_delete_symbol all apply server-side. That round-trip corrupted files: under AGENT_LSP_OUTPUT_FORMAT=gcf the edit was GCF-encoded (a summary format that flattens each TextEdit's range into positional path columns like range>end>character and requires the verbatim newText to be copied out of tool output and back into a tool argument), so LLM callers transposed the range offsets and truncated a large newText, overwriting the file. gcf-go itself encodes and decodes these WorkspaceEdits losslessly (verified), so this was an agent-lsp wire-format and round-trip bug, not a gcf-go bug. Reported by @V0idk.
+
+  Changed
+  • BREAKING：rename_symbol now applies the edit itself and returns a summary instead of returning a WorkspaceEdit for the caller to apply. The result is Renamed to "X" across N location(s) in M file(s): ... plus a post-rename diagnostics count, consistent with the other edit tools — the WorkspaceEdit never leaves the server as data to reconstruct, which eliminates the round-trip that corrupted files (#12). A separate apply_edit call after a non-dry-run rename is no longer needed (or wanted); apply_edit remains for its text-match mode. The dry_run=true preview is unchanged in intent (returns the edit for inspection) but now serializes as self-labeling JSON regardless of AGENT_LSP_OUTPUT_FORMAT, plus file/location counts. The lsp-rename skill's execute phase is updated accordingly.
+  • gcf-go upgraded to v1.5.0. Brings nested-null flatten losslessness (a nested object null at an intermediate level, e.g. {meta:{owner:null}}, is no longer silently dropped on round-trip) and deterministic graph edge ordering (edges sorted by source, then target, then type). Generic-profile delta encoding and labeled streaming trailer counts are available as opt-in APIs; agent-lsp does not use them yet, so default output is byte-identical. No API changes required.
+
+  Added
+  • confidence："low" for unindexed speculative results. evaluate_session / preview_edit now report confidence: "low" when a clean result (net_delta <= 0) is read while the language server still has active $/progress work (indexing, cache priming, cargo check). Previously such results were reported as confidence: "high", so a still-priming server (notably rust-analyzer) could return a false all-clear — "no errors introduced" when the diagnostics simply had not been computed yet. Results that surface errors (net_delta > 0) are never downgraded, since diagnostics do not appear spuriously. New LSPClient.HasActiveProgress() exposes the signal.
+
+  Tests
+  • Added a live end-to-end regression (TestRenameSymbol_LiveGopls) that drives a real textDocument/rename through gopls and the full handler, asserting the file is renamed on disk and the tool returns a summary with no raw edit leaked. Skips cleanly when gopls is absent; CI's unit-and-smoke job now installs gopls so it runs there. Added unit coverage for the apply path against the pathological single-big-edit shape from #12 (TestApplyWorkspaceEdit_*), the JSON edit-encoding guard (TestEncodeResultJSON_*), and the rename summary counter (TestSummarizeWorkspaceEdit_*).
+ReleaseNotesUrl: https://github.com/blackwell-systems/agent-lsp/releases/tag/v0.16.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/b/BlackwellSystems/agent-lsp/0.18.0/BlackwellSystems.agent-lsp.yaml
+++ b/manifests/b/BlackwellSystems/agent-lsp/0.18.0/BlackwellSystems.agent-lsp.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: BlackwellSystems.agent-lsp
+PackageVersion: 0.18.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update BlackwellSystems.agent-lsp to version 0.18.0.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/420405)