### PR TITLE
New version: Tomclanc.GestureSignV2 version 18.0.2.5

### DIFF
--- a/manifests/t/Tomclanc/GestureSignV2/18.0.2.5/Tomclanc.GestureSignV2.installer.yaml
+++ b/manifests/t/Tomclanc/GestureSignV2/18.0.2.5/Tomclanc.GestureSignV2.installer.yaml
@@ -1,0 +1,25 @@
+# Created for GestureSign V2 18.0.2.5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Tomclanc.GestureSignV2
+PackageVersion: 18.0.2.5
+InstallerType: wix
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{FF786D99-0F6F-4AC8-B94E-3E264F1C97A5}'
+AppsAndFeaturesEntries:
+- DisplayName: GestureSign V2
+  Publisher: TransposonY / WinUI rebuild
+  ProductCode: '{FF786D99-0F6F-4AC8-B94E-3E264F1C97A5}'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Tomclanc/GestureSignv2/releases/download/v18.0.2.5/GestureSign-V2-18.0.2.5-x64.msi
+  InstallerSha256: C52C33213F151C0877B4E4B785A41CD342E3D5FB50E3243943F85920DD65DD3F
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-08-19
+

--- a/manifests/t/Tomclanc/GestureSignV2/18.0.2.5/Tomclanc.GestureSignV2.locale.en-US.yaml
+++ b/manifests/t/Tomclanc/GestureSignV2/18.0.2.5/Tomclanc.GestureSignV2.locale.en-US.yaml
@@ -1,0 +1,38 @@
+# Created for GestureSign V2 18.0.2.5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Tomclanc.GestureSignV2
+PackageVersion: 18.0.2.5
+PackageLocale: en-US
+Publisher: Tomclanc
+PublisherUrl: https://github.com/Tomclanc
+PublisherSupportUrl: https://github.com/Tomclanc/GestureSignv2/issues
+Author: Tomclanc
+PackageName: GestureSign V2
+PackageUrl: https://github.com/Tomclanc/GestureSignv2
+License: GPL-2.0
+LicenseUrl: https://github.com/Tomclanc/GestureSignv2/blob/main/LICENSE
+Copyright: Copyright (C) 2026 Tomclanc
+ShortDescription: A Windows 11 focused rebuild of GestureSign for touchpad, touchscreen, and mouse gestures.
+Description: GestureSign V2 is a Windows 11 focused rebuild of the classic open-source GestureSign project. It supports touchpad gestures, touchscreen gestures, mouse gestures, per-app device selection, gesture trails, ignore rules, tray controls, Smart Close, Smart New Tab, and bundled Kando radial menu quick actions.
+Moniker: gesturesignv2
+Tags:
+- gesture
+- gestures
+- mouse
+- touchscreen
+- touchpad
+- windows-11
+ReleaseNotes: |-
+  - Added configurable touchscreen blocking zones for the left, top, right, and bottom edges (0% to 45%). Touches that begin in a blocked zone are passed to the current application instead of being captured by GestureSign.
+  - Improved near-simultaneous two-finger touchscreen taps and sends right clicks at the current gesture's first-finger release position.
+  - Fixed mouse actions occasionally reusing coordinates from the previous gesture.
+  - Preserved complete-path recognition for two-finger drawn gestures.
+  - Improved split-frame contact reporting, release synchronization, and stroke ordering on devices such as the H3C MegaBook.
+ReleaseNotesUrl: https://github.com/Tomclanc/GestureSignv2/releases/tag/v18.0.2.5
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/Tomclanc/GestureSignv2/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0
+

--- a/manifests/t/Tomclanc/GestureSignV2/18.0.2.5/Tomclanc.GestureSignV2.locale.zh-CN.yaml
+++ b/manifests/t/Tomclanc/GestureSignV2/18.0.2.5/Tomclanc.GestureSignV2.locale.zh-CN.yaml
@@ -1,0 +1,36 @@
+# Created for GestureSign V2 18.0.2.5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: Tomclanc.GestureSignV2
+PackageVersion: 18.0.2.5
+PackageLocale: zh-CN
+Publisher: Tomclanc
+PublisherUrl: https://github.com/Tomclanc
+PublisherSupportUrl: https://github.com/Tomclanc/GestureSignv2/issues
+Author: Tomclanc
+PackageName: GestureSign V2
+PackageUrl: https://github.com/Tomclanc/GestureSignv2
+License: GPL-2.0
+LicenseUrl: https://github.com/Tomclanc/GestureSignv2/blob/main/LICENSE
+Copyright: Copyright (C) 2026 Tomclanc
+ShortDescription: 面向 Windows 11 重构的 GestureSign，支持触控板、触摸屏和鼠标手势。
+Description: GestureSign V2 是经典开源项目 GestureSign 的 Windows 11 重构版本，支持触控板、触摸屏和鼠标手势、按动作选择输入设备、手势轨迹、忽略规则、托盘控制、智能关闭、智能新建标签页，以及内置的 Kando 径向菜单快捷动作。
+Tags:
+- 手势
+- 鼠标
+- 触摸屏
+- 触控板
+- Windows 11
+ReleaseNotes: |-
+  - 新增触摸屏左、上、右、下四边屏蔽区设置（0%～45%），从屏蔽区开始的触摸会交给当前应用而不会被 GestureSign 捕捉。
+  - 改进近乎同时落下的双指触摸屏点按，并在当前手势第一根手指松开的位置发送右键。
+  - 修复鼠标动作偶尔复用上一次手势坐标的问题。
+  - 保持双指绘制手势的完整轨迹识别，避免点按逻辑提前触发。
+  - 改进 H3C MegaBook 等设备的触点分帧、抬起同步和轨迹顺序处理。
+ReleaseNotesUrl: https://github.com/Tomclanc/GestureSignv2/releases/tag/v18.0.2.5
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/Tomclanc/GestureSignv2/wiki
+ManifestType: locale
+ManifestVersion: 1.12.0
+

--- a/manifests/t/Tomclanc/GestureSignV2/18.0.2.5/Tomclanc.GestureSignV2.yaml
+++ b/manifests/t/Tomclanc/GestureSignV2/18.0.2.5/Tomclanc.GestureSignV2.yaml
@@ -1,0 +1,9 @@
+# Created for GestureSign V2 18.0.2.5
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Tomclanc.GestureSignV2
+PackageVersion: 18.0.2.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0
+


### PR DESCRIPTION
更新 Tomclanc.GestureSignV2 至 18.0.2.5。新增触摸屏四边屏蔽区设置，并修复和完善触摸屏输入边界处理。Installer URL and SHA-256 were verified against the GitHub release asset.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/420438)