### PR TITLE
New version: Feci.ParleyDeckCli version 1.45.0

### DIFF
--- a/manifests/f/Feci/ParleyDeckCli/1.45.0/Feci.ParleyDeckCli.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.45.0/Feci.ParleyDeckCli.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.45.0
+InstallerType: portable
+Commands:
+- parley
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.45.0/parley-v1.45.0-windows-x64.exe
+  InstallerSha256: C50D1F51564D0334B145CB522503B545681D792EC89498450AFAA47296C9E6CE
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.45.0/parley-v1.45.0-windows-arm64.exe
+  InstallerSha256: 91F9600226C4A0617277DDCF9F714C8884625750AD7A3DBAFDAEE728A823C900
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.45.0/Feci.ParleyDeckCli.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.45.0/Feci.ParleyDeckCli.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.45.0
+PackageLocale: en-US
+Publisher: Feci
+PublisherUrl: https://github.com/feci
+PackageName: Parley Deck CLI
+PackageUrl: https://github.com/feci/parley-deck-cli
+License: Apache-2.0
+LicenseUrl: https://github.com/feci/parley-deck-cli/blob/main/LICENSE
+ShortDescription: CLI that orchestrates Parley Deck multi-agent cooperation workflows.
+Description: "parley orchestrates multi-agent Parley Deck cooperation across local CLI agents. v1.45.0 adds the zcode adapter, verified against the real binary, and closes the roster's remaining unknown cells. The roster reports what a launch actually passes, so an agent whose CLI has no model or effort flag used to show unknown. Three such cells are now read from the agent's own configuration, the same file the process reads at launch, under two new status terms that keep that weaker claim distinct from an argv-bound one. A value declared in a parley config for an adapter that cannot carry it still never reaches the cell. A new fail-closed spec bit strips a model or effort flag such a CLI would reject, at the single place every surface resolves arguments, so the roster, the inventory and the launch can no longer disagree."
+ReleaseNotesUrl: https://github.com/feci/parley-deck-cli/releases/tag/v1.45.0
+Tags:
+- ai
+- agents
+- automation
+- cli
+- codex
+- consensus
+- loop
+- multi-agent
+- orchestration
+- preflight
+- roster
+- tui
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.45.0/Feci.ParleyDeckCli.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.45.0/Feci.ParleyDeckCli.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.45.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Adds Feci.ParleyDeckCli 1.45.0.

Portable installer, x64 and arm64, published at https://github.com/feci/parley-deck-cli/releases/tag/v1.45.0

Single application per PR — my earlier combined CLI+Skill PRs were rejected for that reason; the skill update ships as its own PR.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/420440)