### PR TITLE
New version: Feci.ParleyDeckSkill version 2.9.0

### DIFF
--- a/manifests/f/Feci/ParleyDeckSkill/2.9.0/Feci.ParleyDeckSkill.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/2.9.0/Feci.ParleyDeckSkill.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 2.9.0
+InstallerType: portable
+Commands:
+- parley-deck-skill
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-skill/releases/download/v2.9.0/parley-deck-skill-v2.9.0-windows-x64.exe
+  InstallerSha256: 06674F43BD3883E5CCA526E9F8D37FF459D628EA31F06E54CA1CEED95377123B
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-skill/releases/download/v2.9.0/parley-deck-skill-v2.9.0-windows-arm64.exe
+  InstallerSha256: 2265945190DBA8E323BFB92298084AB981C6606E6E44965A8F42FD5ED07E2F14
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckSkill/2.9.0/Feci.ParleyDeckSkill.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/2.9.0/Feci.ParleyDeckSkill.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 2.9.0
+PackageLocale: en-US
+Publisher: Feci
+PublisherUrl: https://github.com/feci
+PackageName: Parley Deck Skill
+PackageUrl: https://github.com/feci/parley-deck-skill
+License: Apache-2.0
+LicenseUrl: https://github.com/feci/parley-deck-skill/blob/main/LICENSE
+ShortDescription: Installer for the Parley Deck multi-agent cooperation skill.
+Description: "Installs the vendor-neutral Parley Deck AI cooperation skill into Codex, Claude Code, zcode, Antigravity CLI, Hermes, Kimi Code, or a custom skill directory. v2.9.0 adds zcode as an install target, confirmed against the runtime bundle and against the vendor's own bundled configuration guide, bringing the target count to fifteen. It also documents two new roster status terms that mark a model or effort value read out of the agent's own configuration, because that CLI exposes no flag for it and the process reads that file itself at launch. The documented rule is unchanged, a roster cell must never show a value the launch does not carry, and these terms exist so the weaker claim is never mistaken for the stronger one. Such a row is never reported as healthy, and the explain view names the file that was read along with its limitation, the file can change before launch and these CLIs do not echo the model back, so the value is not confirmable after a run."
+ReleaseNotesUrl: https://github.com/feci/parley-deck-skill/releases/tag/v2.9.0
+Tags:
+- ai
+- agents
+- agy
+- antigravity
+- cli
+- codex
+- claude
+- kimi
+- multi-agent
+- skill
+- zcode
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckSkill/2.9.0/Feci.ParleyDeckSkill.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/2.9.0/Feci.ParleyDeckSkill.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 2.9.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Adds Feci.ParleyDeckSkill 2.9.0.

Portable installer, x64 and arm64, published at https://github.com/feci/parley-deck-skill/releases/tag/v2.9.0

Single application per PR — my earlier combined CLI+Skill PRs were rejected for that reason; the CLI update ships as its own PR.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/420442)