### PR TITLE
chore: update OpenTubeX.OpenTubeX to 0.32.0

### DIFF
--- a/manifests/o/OpenTubeX/OpenTubeX/0.32.0/OpenTubeX.OpenTubeX.installer.yaml
+++ b/manifests/o/OpenTubeX/OpenTubeX/0.32.0/OpenTubeX.OpenTubeX.installer.yaml
@@ -1,0 +1,45 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: OpenTubeX.OpenTubeX
+PackageVersion: 0.32.0
+InstallerLocale: en-US
+InstallerType: nullsoft
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+Protocols:
+- opentubex
+ProductCode: a38f022d-fec2-5f80-a7fe-620ccf1a2767
+ReleaseDate: 2026-08-18
+AppsAndFeaturesEntries:
+- DisplayName: OpenTubeX 0.32.0
+  ProductCode: a38f022d-fec2-5f80-a7fe-620ccf1a2767
+Installers:
+- Architecture: x64
+  Scope: user
+  InstallerUrl: https://github.com/OpenTubeX/OpenTubeX/releases/download/v0.32.0-beta/opentubex-0.32.0-beta-setup-x64.exe
+  InstallerSha256: 0EACF20787338AA78DD429F852967A178C145194F05399316EA25BFF2E532565
+  InstallerSwitches:
+    Custom: /CURRENTUSER
+- Architecture: x64
+  Scope: machine
+  InstallerUrl: https://github.com/OpenTubeX/OpenTubeX/releases/download/v0.32.0-beta/opentubex-0.32.0-beta-setup-x64.exe
+  InstallerSha256: 0EACF20787338AA78DD429F852967A178C145194F05399316EA25BFF2E532565
+  InstallerSwitches:
+    Custom: /ALLUSERS
+- Architecture: arm64
+  Scope: user
+  InstallerUrl: https://github.com/OpenTubeX/OpenTubeX/releases/download/v0.32.0-beta/opentubex-0.32.0-beta-setup-arm64.exe
+  InstallerSha256: C1B07DEF374F059F5D1E5878756988DB6F50B80D5A230904F691549C35E9FB68
+  InstallerSwitches:
+    Custom: /CURRENTUSER
+- Architecture: arm64
+  Scope: machine
+  InstallerUrl: https://github.com/OpenTubeX/OpenTubeX/releases/download/v0.32.0-beta/opentubex-0.32.0-beta-setup-arm64.exe
+  InstallerSha256: C1B07DEF374F059F5D1E5878756988DB6F50B80D5A230904F691549C35E9FB68
+  InstallerSwitches:
+    Custom: /ALLUSERS
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenTubeX/OpenTubeX/0.32.0/OpenTubeX.OpenTubeX.locale.en-US.yaml
+++ b/manifests/o/OpenTubeX/OpenTubeX/0.32.0/OpenTubeX.OpenTubeX.locale.en-US.yaml
@@ -1,0 +1,90 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: OpenTubeX.OpenTubeX
+PackageVersion: 0.32.0
+PackageLocale: en-US
+Publisher: OpenTubeX contributors
+PublisherUrl: https://github.com/OpenTubeX
+PublisherSupportUrl: https://github.com/OpenTubeX/OpenTubeX/issues
+Author: OpenTubeX contributors
+PackageName: OpenTubeX
+PackageUrl: https://opentubex.org/
+License: AGPL-3.0
+LicenseUrl: https://github.com/OpenTubeX/OpenTubeX/blob/HEAD/LICENSE
+Copyright: Copyleft © 2020-2026
+CopyrightUrl: https://github.com/OpenTubeX/OpenTubeX/blob/HEAD/LICENSE
+ShortDescription: A private YouTube client
+Description: OpenTubeX is a private YouTube client for desktop.
+Moniker: opentubex
+Tags:
+- cross-platform
+- electron
+- privacy
+- private-youtube
+- sponsorblock
+- subscriptions
+- tabbed-browsing
+- tabs
+- video
+- videos
+- youtube
+- youtube-client
+- youtube-player
+ReleaseNotes: |-
+  More improvements
+  - Saved channel playback preferences can now be synchronized through Settings sync (#720)
+  - Downloads can be retried, tracked when files change on disk, and played through the normal media player (#728)
+  - Added an option to keep background tabs in the order they were opened (#726)
+  - Subscription feed refresh progress now stays in one location throughout the app (#741, #752)
+  - Automatically download new uploads from selected channels using per-channel templates and filters (#626, #762)
+  - Optionally keep and review a local history of video titles, thumbnails, and descriptions (#546, #767)
+  - Choose whether tabs appear at the top, bottom, left, or right of the window (#677, #768)
+  - Custom themes support transparent colors, backdrop blur, clearer interaction colors, and an in-app color picker (#738, #740, #753)
+  - Choose which player elements remain visible while paused in full-window or fullscreen mode (#702, #754)
+  - Right-click the search filter button to clear all active filters (#585, #755)
+  - Added quick playback speed controls to the Shorts player (#742, #769)
+  - Choose the app font from installed system fonts or use the operating system default (#594, #765)
+  - Downloads and Settings can be moved independently from Quick Settings into the app header (#748)
+  - The New subscriptions feed can be sorted with the oldest content first (#789)
+  - Customize text selection colors in custom themes (#792)
+  - Added a global yt-dlp arguments setting for downloads (#804)
+  - Choose how managed yt-dlp and FFmpeg tools update (#791, #800)
+  - Skip Silence now jumps over silent sections instead of speeding through them (#563, #805)
+  - Added media playback controls to the macOS Dock menu (#810, #811)
+  - New installations use the built-in stream extraction method by default (#802)
+  - Switch between Subscriptions and channel feed tabs with the Left and Right Arrow keys (#771, #801)
+  - Failed downloads now link to recent yt-dlp YouTube issues and suggest alternate update channels (#824)
+  - New users can choose their tab layout, theme, and default video quality during onboarding (#794)
+  - Improved startup responsiveness and reduced background work in large feeds, transcripts, live chat, and overlays (#830)
+  - Middle-clicking collaborator channels opens them in background tabs (#814, #815)
+
+  Fixed bugs
+  - Show fallback channel metadata when channel thumbnails or details are unavailable (#721, #725)
+  - Hide transcript actions on videos without captions (#722)
+  - Show comment author photos returned by Invidious (#727, #729)
+  - Subscription cards update upcoming, premiere, and finished states after refreshes (#731)
+  - Fixed live chat scrolling and delayed new messages (#736)
+  - Fixed videos buffering indefinitely after switching quickly between Shorts (#732)
+  - Fixed watched styling, hover rounding, and initial scrolling in playlist panels (#743)
+  - Keep Search History open and unchanged when middle-clicking an entry (#739, #745)
+  - Restored sessions load the active video before background watch tabs (#750)
+  - Fixed automatic Picture-in-Picture return when another window closes (#773, #774)
+  - Running premieres keep their label, and stale channels no longer make subscription feeds appear outdated (#782)
+  - Fast-Forward Through Silence no longer affects videos in other tabs (#772, #778)
+  - Keep cached yt-dlp streams for open tabs when pruning the playback cache (#746)
+  - Retry yt-dlp extraction when a transient 403 prevents playback (#735, #775)
+  - Fixed playlist information being cut off in grid layout (#751)
+  - Completed downloads show the current title and thumbnail (#788)
+  - Fixed tab shifts with some custom fonts (#793, #808)
+  - Livestreams played through yt-dlp retain their DVR window and switch engines reliably (#817)
+  - Downloads no longer exhaust Flatpak temporary storage when the download drive has enough space (#816)
+  - Fixed missing Invidious thumbnails, blank Popular feeds, and an automatic comment loading error (#812)
+  - Fullscreen live chat no longer makes other dock animations stutter (#821)
+  - Setting the watched threshold to 0% removes videos from history immediately when marked unwatched (#770, #823)
+  - Fixed a search history race that could make the app unusable (#825)
+  - Fixed Settings lag and flicker at non-default UI scales (#828)
+  - Stale profile updates from another window no longer remove unrelated profiles or cause errors (#831)
+ReleaseNotesUrl: https://github.com/OpenTubeX/OpenTubeX/releases/tag/v0.32.0-beta
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenTubeX/OpenTubeX/0.32.0/OpenTubeX.OpenTubeX.yaml
+++ b/manifests/o/OpenTubeX/OpenTubeX/0.32.0/OpenTubeX.OpenTubeX.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: OpenTubeX.OpenTubeX
+PackageVersion: 0.32.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

The winget package is still on OpenTubeX 0.31.3, so Windows users do not receive the changes released in 0.32.0.

This updates `OpenTubeX.OpenTubeX` to 0.32.0 for x64 and ARM64. It keeps both user and machine installation scopes, the current repository-topic tags, and text-only release notes.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

Validated with Komac:

```text
komac submit --dry-run --yes manifests/o/OpenTubeX/OpenTubeX/0.32.0
```

> **Note:** `<path>` is the directory containing the manifest you're submitting.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/420453)