### PR TITLE
New package: Orahu01.WidgetWall version 5.0.0

### DIFF
--- a/manifests/o/Orahu01/WidgetWall/5.0.0/Orahu01.WidgetWall.installer.yaml
+++ b/manifests/o/Orahu01/WidgetWall/5.0.0/Orahu01.WidgetWall.installer.yaml
@@ -5,7 +5,7 @@ InstallerLocale: ja-JP
 Platform:
 - Windows.Desktop
 MinimumOSVersion: 10.0.0.0
-InstallerType: nsis
+InstallerType: nullsoft
 Scope: user
 InstallModes:
 - interactive

--- a/manifests/o/Orahu01/WidgetWall/5.0.0/Orahu01.WidgetWall.installer.yaml
+++ b/manifests/o/Orahu01/WidgetWall/5.0.0/Orahu01.WidgetWall.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Orahu01.WidgetWall
+PackageVersion: 5.0.0
+InstallerLocale: ja-JP
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: nsis
+Scope: user
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Orahu01/wallpaper/releases/download/v5.0.0/WidgetWall-Setup-5.0.0.exe
+  InstallerSha256: F117AFBF0BBF8283B7DACD95B39ADA3B82D209FBDF2C6CFB6CD31DBEBBB33852
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/o/Orahu01/WidgetWall/5.0.0/Orahu01.WidgetWall.locale.en-US.yaml
+++ b/manifests/o/Orahu01/WidgetWall/5.0.0/Orahu01.WidgetWall.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
+PackageIdentifier: Orahu01.WidgetWall
+PackageVersion: 5.0.0
+PackageLocale: en-US
+Publisher: Orahu01
+PackageName: WidgetWall
+ShortDescription: Lightweight live-wallpaper app that pins clocks, weather, PC monitors and more behind your desktop icons
+Description: |-
+  WidgetWall is a live wallpaper app for Windows that places widgets such as
+  clocks, weather, agenda, hardware monitors, sticky notes and now-playing
+  info behind your desktop icons, with any font, size and position.
+  One-click themes, multi-monitor support, power-efficient design
+  (0% GPU when idle) and auto-updates included.
+Tags:
+- desktop
+- wallpaper
+- widget
+ManifestType: locale
+ManifestVersion: 1.6.0

--- a/manifests/o/Orahu01/WidgetWall/5.0.0/Orahu01.WidgetWall.locale.ja-JP.yaml
+++ b/manifests/o/Orahu01/WidgetWall/5.0.0/Orahu01.WidgetWall.locale.ja-JP.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Orahu01.WidgetWall
+PackageVersion: 5.0.0
+PackageLocale: ja-JP
+Publisher: Orahu01
+PublisherUrl: https://github.com/Orahu01
+PublisherSupportUrl: https://github.com/Orahu01/wallpaper/issues
+PackageName: WidgetWall
+PackageUrl: https://orahu01.github.io/wallpaper/
+License: MIT
+LicenseUrl: https://github.com/Orahu01/wallpaper/blob/main/LICENSE
+ShortDescription: 時計・天気・PC モニタなどをデスクトップアイコンの背面に自由に配置できる軽量ウィジェット壁紙アプリ
+Description: |-
+  WidgetWall は、時計・天気・予定表・ハードウェアモニタ・メモ・再生中の曲などの
+  ウィジェットを、デスクトップアイコンの背面に好きなフォント・サイズ・位置で
+  配置できる Windows 用のライブ壁紙アプリです。テーマのワンクリック適用、
+  マルチモニタ、省電力設計 (アイドル時 GPU 0%)、自動アップデートに対応しています。
+Moniker: widgetwall
+Tags:
+- desktop
+- wallpaper
+- widget
+- ウィジェット
+- 壁紙
+ReleaseNotesUrl: https://github.com/Orahu01/wallpaper/releases/tag/v5.0.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/o/Orahu01/WidgetWall/5.0.0/Orahu01.WidgetWall.yaml
+++ b/manifests/o/Orahu01/WidgetWall/5.0.0/Orahu01.WidgetWall.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Orahu01.WidgetWall
+PackageVersion: 5.0.0
+DefaultLocale: ja-JP
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: Orahu01.WidgetWall 5.0.0

WidgetWall is a free, open-source (MIT) live-wallpaper app for Windows that places widgets (clocks, weather, agenda, hardware monitors, sticky notes, now-playing info, etc.) behind desktop icons.

- Homepage: https://orahu01.github.io/wallpaper/
- Repository: https://github.com/Orahu01/wallpaper
- Release: https://github.com/Orahu01/wallpaper/releases/tag/v5.0.0
- Installer: NSIS (oneClick, per-user), silent install via `/S`

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/README.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/420486)