### PR TITLE
New package: patrick-1984.HandyTool version 1.3.0

### DIFF
--- a/manifests/p/patrick-1984/HandyTool/1.3.0/patrick-1984.HandyTool.installer.yaml
+++ b/manifests/p/patrick-1984/HandyTool/1.3.0/patrick-1984.HandyTool.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: patrick-1984.HandyTool
+PackageVersion: 1.3.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-08-18
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/patrick-1984/handy-tool/releases/download/v1.3.0/Handy.Tool_1.3.0_x64-setup.exe
+  InstallerSha256: FCF8338DF809D056CFD6FDA77996E631A205BFADBE7B41F62A4AE919A3919ECE
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/p/patrick-1984/HandyTool/1.3.0/patrick-1984.HandyTool.locale.en-US.yaml
+++ b/manifests/p/patrick-1984/HandyTool/1.3.0/patrick-1984.HandyTool.locale.en-US.yaml
@@ -1,0 +1,60 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: patrick-1984.HandyTool
+PackageVersion: 1.3.0
+PackageLocale: en-US
+Publisher: Patrick R
+PublisherUrl: https://github.com/patrick-1984
+PublisherSupportUrl: https://github.com/patrick-1984/handy-tool/issues
+Author: Patrick R
+PackageName: Handy Tool
+PackageUrl: https://github.com/patrick-1984/handy-tool
+License: MIT
+LicenseUrl: https://github.com/patrick-1984/handy-tool/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Patrick R
+ShortDescription: Local speech-to-text dictation for Windows. Press a key, speak, and the words land in the field you were typing in.
+Description: |-
+  Handy Tool is a local-first dictation tool for Windows. Press a key, speak, and the text is
+  delivered into whatever field you were working in.
+
+  Transcription runs on your machine using local Whisper, Parakeet, Moonshine or SenseVoice
+  models, with GPU acceleration through Vulkan. No account is required and no audio or
+  transcript leaves the machine unless you explicitly configure a remote provider.
+
+  It also includes push-to-talk, a transcribe-and-submit mode, a keyboard typer for contexts
+  where pasting is blocked, and a window-anchoring system for delivering dictation into a
+  specific window across multiple screens or remote desktop sessions.
+
+  Handy Tool is a fork of Handy by CJ Pais, developed independently.
+Moniker: handy-tool
+Tags:
+- dictation
+- speech-recognition
+- speech-to-text
+- transcription
+- voice
+- whisper
+ReleaseNotes: |-
+  Changed: the automatic "type into remote desktops instead of pasting" behaviour introduced in
+  1.2.0 has been withdrawn. It delivered text unreliably over RDP and Citrix, producing missing
+  and jumbled characters, because each batch was a single instantaneous burst of input events
+  through the remote session's virtual channel. Keystroke delivery remains available as a
+  deliberate choice via the Direct paste method.
+
+  Fixed: the submit key could fire before the delivered text had landed in a remote window. The
+  remote timing values were only applied when the app had jumped to the target, so dictating
+  into a remote window that already had focus waited not at all. Remote targets now get their
+  remote timing whether or not the window was activated; an already-focused local target still
+  submits instantly.
+
+  Fixed: a failed submit no longer reports that the text was not delivered when it was, which
+  previously led to the transcript being inserted twice.
+
+  Added: an optional separate clipboard restore delay for remote desktop targets, unset by
+  default.
+ReleaseNotesUrl: https://github.com/patrick-1984/handy-tool/releases/tag/v1.3.0
+Documentations:
+- DocumentLabel: Documentation
+  DocumentUrl: https://github.com/patrick-1984/handy-tool/blob/main/docs/README.md
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/p/patrick-1984/HandyTool/1.3.0/patrick-1984.HandyTool.yaml
+++ b/manifests/p/patrick-1984/HandyTool/1.3.0/patrick-1984.HandyTool.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: patrick-1984.HandyTool
+PackageVersion: 1.3.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
# New package: patrick-1984.HandyTool version 1.3.0

Replaces #418980, which I closed myself. That PR proposed 1.1.0 and passed every validation stage, but the package has shipped twice since it was opened, so it no longer proposed a version worth a moderator's time. This is a clean single-commit submission for the current release, branched from `master` at `00af9d3`, with no prior failed runs attached.

I also want to correct my own noise on that PR: I pinged the bot three times asking for a `Policy-Test-2.7` recheck. I have since read the bot's reply properly — `run` and `waivers` require Moderator / WinGet Collaborators permissions, and `Policy-Test-2.7` is a routine label rather than an error. I will not repeat that here; if this PR needs anything from me, I will wait to be asked.

---

## Automated checklist

<!-- Machine-readable summary. Every claim below is independently checkable from the manifest and the public release. -->

| Field | Value |
| --- | --- |
| PackageIdentifier | `patrick-1984.HandyTool` |
| PackageVersion | `1.3.0` |
| ManifestVersion | `1.12.0` |
| ManifestType | multi-file (version + installer + defaultLocale) |
| InstallerType | `nullsoft` |
| Architecture | `x64` |
| Scope | `user` (per-user, no elevation) |
| Silent install | `/S` (NSIS default, handled by winget) |
| InstallerUrl | `https://github.com/patrick-1984/handy-tool/releases/download/v1.3.0/Handy.Tool_1.3.0_x64-setup.exe` |
| InstallerSha256 | `FCF8338DF809D056CFD6FDA77996E631A205BFADBE7B41F62A4AE919A3919ECE` |
| InstallerUrl host | GitHub Releases, immutable tag `v1.3.0` |
| License | MIT (OSI) |
| Dependencies declared | none required — see "no runtime prerequisite" below |
| Files added | 3 (manifests only) |
| Files modified | 0 |
| Files deleted | 0 |
| Prior versions in repo | none (new package) |

- [x] PR contains exactly one package and one version
- [x] PR contains only manifest files
- [x] Multi-file manifest (no singleton)
- [x] Directory path matches `PackageIdentifier` and `PackageVersion` exactly, case-sensitive
- [x] `# yaml-language-server: $schema=` header present on all three files
- [x] `InstallerSha256` verified against the asset downloaded from the public `InstallerUrl`
- [x] Installer URL is a permanent GitHub release asset, not a redirect or a `latest` alias
- [x] No installer switches overridden; NSIS silent handled natively
- [x] Every URL in the manifest returns HTTP 200 (checked immediately before opening this PR)
- [x] CLA already signed (on #413622, 2026-08-17)

## Reproduce the hash

```powershell
$u = 'https://github.com/patrick-1984/handy-tool/releases/download/v1.3.0/Handy.Tool_1.3.0_x64-setup.exe'
Invoke-WebRequest $u -OutFile handy.exe
(Get-FileHash -Algorithm SHA256 handy.exe).Hash
# FCF8338DF809D056CFD6FDA77996E631A205BFADBE7B41F62A4AE919A3919ECE
```

## Install verification

Verified on Windows 11 26200, x64, as a standard (non-elevated) user, against the asset downloaded from the public `InstallerUrl` in this manifest — not a local build:

- `Handy.Tool_1.3.0_x64-setup.exe /S` → exit code `0`
- installs to `%LOCALAPPDATA%\Handy Tool\handy.exe`
- `ProductVersion` / `FileVersion` on the installed binary report `1.3.0`
- launches and runs; no elevation prompt at any point
- uninstall entry registered per-user

---

## For a human reviewer

**What it is.** A local speech-to-text dictation tool for Windows. You press a key, speak, and the text is delivered into whatever field you were already typing in. Transcription runs on the machine with local Whisper / Parakeet / Moonshine / SenseVoice models.

**Why `Scope: user`.** The NSIS installer is per-user by design and needs no elevation, so declaring anything else would be inaccurate.

**No runtime prerequisite.** WebView2 is present on all supported Windows 11 builds and on Windows 10 since 2021 via the Evergreen runtime, so no `Dependencies` block is declared. Speech models are not bundled; the app downloads the one you choose, on your explicit action, after first run.

**Not code-signed.** I have no Authenticode certificate, so SmartScreen will warn on first run. The installer is signed for the app's own updater only (minisign, Ed25519 — unrelated to Authenticode). Flagging this openly rather than having it discovered during validation. A portable ZIP is published alongside the installer for anyone who prefers not to run an installer at all.

**Provenance.** A fork of [Handy](https://github.com/cjpais/Handy) by CJ Pais (MIT), developed independently, with a different bundle identifier and a separate release channel. The upstream project is not packaged in this repository, so there is no identity collision.

**What changed in 1.3.0.** It withdraws a behaviour from 1.2.0 that turned out to deliver text unreliably into remote desktop sessions, and fixes an older timing defect where the submit key could fire before the delivered text had landed in a remote window. Full notes: https://github.com/patrick-1984/handy-tool/releases/tag/v1.3.0

Happy to make any change a reviewer wants, including squashing, re-basing, or adjusting metadata.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/420491)