### PR TITLE
New version: LucasHenriqueDiniz.SoundDeck version 0.2.1

### DIFF
--- a/manifests/l/LucasHenriqueDiniz/SoundDeck/0.2.1/LucasHenriqueDiniz.SoundDeck.installer.yaml
+++ b/manifests/l/LucasHenriqueDiniz/SoundDeck/0.2.1/LucasHenriqueDiniz.SoundDeck.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: LucasHenriqueDiniz.SoundDeck
+PackageVersion: 0.2.1
+MinimumOSVersion: 10.0.17763.0
+InstallModes:
+  - interactive
+  - silent
+UpgradeBehavior: install
+ReleaseDate: 2026-08-19
+Installers:
+  - Architecture: x64
+    InstallerType: nullsoft
+    Scope: user
+    InstallerUrl: https://github.com/LucasHenriqueDiniz/sounddeck/releases/download/v0.2.1/SoundDeck_0.2.1_x64-setup.exe
+    InstallerSha256: 62B641D71E0B7A38EE95E9B74DAFCF5D8030A1E1B41948A1DFEC31DF25DDC984
+  - Architecture: x64
+    InstallerType: wix
+    Scope: machine
+    InstallerUrl: https://github.com/LucasHenriqueDiniz/sounddeck/releases/download/v0.2.1/SoundDeck_0.2.1_x64_en-US.msi
+    InstallerSha256: B890DBD4853E3600EB3F5EB20E3C810F26DB5356B1494C283AB34A3656E19C0A
+    ProductCode: '{5162BE9A-46E1-4D3F-A2A4-F0FADD802489}'
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/l/LucasHenriqueDiniz/SoundDeck/0.2.1/LucasHenriqueDiniz.SoundDeck.locale.en-US.yaml
+++ b/manifests/l/LucasHenriqueDiniz/SoundDeck/0.2.1/LucasHenriqueDiniz.SoundDeck.locale.en-US.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: LucasHenriqueDiniz.SoundDeck
+PackageVersion: 0.2.1
+PackageLocale: en-US
+Publisher: Lucas Henrique Diniz Ostroski
+PublisherUrl: https://github.com/LucasHenriqueDiniz
+PublisherSupportUrl: https://github.com/LucasHenriqueDiniz/sounddeck/issues
+PackageName: SoundDeck
+PackageUrl: https://sounddeck.lucashdo.com
+License: MIT
+LicenseUrl: https://github.com/LucasHenriqueDiniz/sounddeck/blob/master/LICENSE
+Copyright: Copyright (c) 2026 Lucas Henrique Diniz Ostroski
+ShortDescription: A sound scheme picker for Windows 10 and 11.
+Description: |-
+  SoundDeck replaces the Windows sound scheme editor with a modern app. Browse a
+  library of sound packs, preview every event before committing, and apply a whole
+  scheme in one click. Includes real recreations of the Windows XP, Vista, 7, 8, 98
+  and 10 default schemes, the official Windows 7 bonus themes, Microsoft Plus!
+  packs, two originals, a per-event editor, and local custom pack creation.
+
+  The current scheme is backed up before every change, so any apply is reversible.
+  SoundDeck runs without administrator privileges, never modifies system files, and
+  writes only to the current user's registry hive (HKCU) — the same place the
+  official Control Panel applet uses.
+Moniker: sounddeck
+Tags:
+  - sound
+  - audio
+  - customization
+  - windows
+  - theme
+  - sound-scheme
+  - personalization
+ReleaseNotesUrl: https://github.com/LucasHenriqueDiniz/sounddeck/releases/tag/v0.2.1
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/l/LucasHenriqueDiniz/SoundDeck/0.2.1/LucasHenriqueDiniz.SoundDeck.yaml
+++ b/manifests/l/LucasHenriqueDiniz/SoundDeck/0.2.1/LucasHenriqueDiniz.SoundDeck.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: LucasHenriqueDiniz.SoundDeck
+PackageVersion: 0.2.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Pull request has been verified against the [manifest specification](https://github.com/microsoft/winget-pkgs/blob/master/doc/manifest/schema/1.6.0)

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/add?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

---

New version: **SoundDeck 0.2.1**

A sound scheme picker for Windows 10 and 11. This supersedes #419780
(0.1.0) and #420492 (0.2.0), both closed in favor of this single
submission — sorry for the earlier churn, this is the only PR I'll keep
open for the package going forward.

- Homepage: https://sounddeck.lucashdo.com
- Source: https://github.com/LucasHenriqueDiniz/sounddeck
- License: MIT
- Release: https://github.com/LucasHenriqueDiniz/sounddeck/releases/tag/v0.2.1

Both installers produced by the release build are included:

| Installer | Type | Scope |
|---|---|---|
| `SoundDeck_0.2.1_x64-setup.exe` | nullsoft | user |
| `SoundDeck_0.2.1_x64_en-US.msi` | wix | machine |

The MSI `ProductCode` was read from the package itself. Both `InstallerSha256`
values were computed from the downloaded release artifacts. The `UpgradeCode`
is pinned and unchanged since 0.1.0, so this installs as an in-place upgrade.

The app requires no administrator privileges, modifies no system files, and
writes only to `HKCU\AppEvents\Schemes\Apps`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/420519)