### PR TITLE
New version: oipoistar.Tinta version 2.9.0

### DIFF
--- a/manifests/o/oipoistar/Tinta/2.9.0/oipoistar.Tinta.installer.yaml
+++ b/manifests/o/oipoistar/Tinta/2.9.0/oipoistar.Tinta.installer.yaml
@@ -1,0 +1,15 @@
+# Created with Claude Code
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: oipoistar.Tinta
+PackageVersion: 2.9.0
+InstallerType: portable
+Commands:
+- tinta
+ReleaseDate: 2026-08-19
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/oipoistar/tinta/releases/download/v2.9.0/tinta.exe
+  InstallerSha256: 502492EE68B3CC2393ABAFCD8C90827F57A3A36385DAFF5904269BCC1823BB4C
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/o/oipoistar/Tinta/2.9.0/oipoistar.Tinta.locale.en-US.yaml
+++ b/manifests/o/oipoistar/Tinta/2.9.0/oipoistar.Tinta.locale.en-US.yaml
@@ -1,0 +1,43 @@
+# Created with Claude Code
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: oipoistar.Tinta
+PackageVersion: 2.9.0
+PackageLocale: en-US
+Publisher: oipoistar
+PublisherUrl: https://github.com/oipoistar
+PublisherSupportUrl: https://github.com/oipoistar/tinta/issues
+PackageName: Tinta
+PackageUrl: https://tinta.cc
+License: MIT
+LicenseUrl: https://github.com/oipoistar/tinta/blob/master/LICENSE
+Copyright: Copyright (c) oipoistar
+ShortDescription: Fast, lightweight markdown and Mermaid viewer for Windows
+Description: |-
+  Tinta is a fast, lightweight markdown viewer and reader for Windows,
+  built with Direct2D and DirectWrite for hardware-accelerated rendering.
+  A single native executable of about 1.4 MB that starts in about 200 ms -
+  no Electron, no web engine, no installer. Features native LaTeX math,
+  native rendering for thirteen Mermaid diagram families (flowcharts,
+  sequence, class, state, ER, pie, git graphs, gantt, mindmaps,
+  timelines, journeys, quadrant and xy charts), custom themes with a
+  built-in editor, shortcut profiles, a UI in seven languages,
+  first-class CJK text layout, glyph-precise text selection, a table of
+  contents, folder browser, full-text search, zoom, and an edit mode
+  with live preview.
+Moniker: tinta
+Tags:
+- markdown
+- markdown-viewer
+- markdown-reader
+- markdown-editor
+- mermaid
+- latex
+- viewer
+- reader
+- direct2d
+- lightweight
+- portable
+ReleaseNotesUrl: https://github.com/oipoistar/tinta/releases/tag/v2.9.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/o/oipoistar/Tinta/2.9.0/oipoistar.Tinta.yaml
+++ b/manifests/o/oipoistar/Tinta/2.9.0/oipoistar.Tinta.yaml
@@ -1,0 +1,8 @@
+# Created with Claude Code
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: oipoistar.Tinta
+PackageVersion: 2.9.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
New version of oipoistar.Tinta (2.9.0).

- [x] Have you signed the Contributor License Agreement?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the 1.6 schema?

Release notes: https://github.com/oipoistar/tinta/releases/tag/v2.9.0
Portable, static CRT, no dependencies. Description updated for the native Mermaid diagram expansion (13 families) and Japanese/Korean UI languages.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/420531)