### PR TITLE
New package: EllipseSoftware.Bast version 0.9.0

### DIFF
--- a/manifests/e/EllipseSoftware/Bast/0.9.0/EllipseSoftware.Bast.installer.yaml
+++ b/manifests/e/EllipseSoftware/Bast/0.9.0/EllipseSoftware.Bast.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: EllipseSoftware.Bast
+PackageVersion: 0.9.0
+MinimumOSVersion: 10.0.22000.0
+InstallerType: zip
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/ellipse-software/bast/releases/download/v0.9.0/bast_0.9.0_windows_amd64.zip
+    InstallerSha256: 2BE3B4316C9AB6C45048A95F2C37D47C43C93EB4DE97B68FE10B901266FFBA50
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: bast_0.9.0_windows_amd64\bast.exe
+        PortableCommandAlias: bast
+  - Architecture: arm64
+    InstallerUrl: https://github.com/ellipse-software/bast/releases/download/v0.9.0/bast_0.9.0_windows_arm64.zip
+    InstallerSha256: E35447348096F975394285945E4AE4DE7117467050AC5DB3C118E741CBCE6D85
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: bast_0.9.0_windows_arm64\bast.exe
+        PortableCommandAlias: bast
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/e/EllipseSoftware/Bast/0.9.0/EllipseSoftware.Bast.locale.en-US.yaml
+++ b/manifests/e/EllipseSoftware/Bast/0.9.0/EllipseSoftware.Bast.locale.en-US.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: EllipseSoftware.Bast
+PackageVersion: 0.9.0
+PackageLocale: en-US
+Publisher: Ellipse Software
+PackageName: Bast
+PackageUrl: https://bast.sh
+License: MIT
+LicenseUrl: https://github.com/ellipse-software/bast/blob/master/LICENSE
+ShortDescription: Terminal-native OpenSSH host picker and key manager
+Tags:
+  - openssh
+  - sftp
+  - ssh
+  - terminal
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/e/EllipseSoftware/Bast/0.9.0/EllipseSoftware.Bast.yaml
+++ b/manifests/e/EllipseSoftware/Bast/0.9.0/EllipseSoftware.Bast.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: EllipseSoftware.Bast
+PackageVersion: 0.9.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Bast 0.9.0 is the first Windows release of Bast, a terminal-native OpenSSH host picker and key manager.

This PR adds the version, default locale, and installer manifests for `EllipseSoftware.Bast` version `0.9.0`. It publishes the official signed Windows x64 and arm64 portable ZIP releases from the Bast v0.9.0 GitHub release.

## Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)